### PR TITLE
fix(pty-host): include external memory in resource governor signal

### DIFF
--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -206,7 +206,15 @@ export class ResourceGovernor {
     // this governor actually manages — queued PTY output and xterm backing
     // stores live in external, outside the --max-old-space-size cap (#9905).
     const combinedMb = heapUsedMb + externalMb;
-    const utilizationPercent = (combinedMb / TOTAL_PROCESS_BUDGET_MB) * 100;
+    // Utilization is the binding constraint: heap against its own V8 cap AND
+    // combined against the total process budget. The combined ratio alone can
+    // never reach the engage thresholds on pure heap pressure — heap is capped
+    // at HEAP_BUDGET_MB, only ~67% of the total budget — so a runaway JS heap
+    // must be measured against its own ceiling. max() keeps this a single
+    // continuous signal feeding one EMA, and the disengage hysteresis then
+    // requires BOTH ratios to clear the resume threshold.
+    const utilizationPercent =
+      Math.max(combinedMb / TOTAL_PROCESS_BUDGET_MB, heapUsedMb / HEAP_BUDGET_MB) * 100;
 
     // EMA smoothing — rejects single-tick GC sawtooth spikes. Seeded with the
     // first real reading (not 0) to avoid a warmup ramp that falsely stays

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -1,4 +1,3 @@
-import v8 from "node:v8";
 import type { AgentState } from "../../shared/types/agent.js";
 import type {
   PtyHostEvent,
@@ -74,6 +73,16 @@ export interface ResourceGovernorDeps {
     dataLossCountDelta: number;
   };
 }
+
+// Process memory budget for the combined heap + external signal. The pty-host
+// is forked with --max-old-space-size matching PtyClient's DEFAULT_CONFIG
+// memoryLimitMb (512) — keep HEAP_BUDGET_MB in sync with it. That flag bounds
+// only the V8 heap; ArrayBuffer backing stores (queued PTY output slabs,
+// xterm typed arrays) are allocated outside it and show up in
+// process.memoryUsage().external, so the governor budgets them separately.
+const HEAP_BUDGET_MB = 512;
+const EXTERNAL_HEADROOM_MB = 256;
+const TOTAL_PROCESS_BUDGET_MB = HEAP_BUDGET_MB + EXTERNAL_HEADROOM_MB;
 
 export class ResourceGovernor {
   private readonly MEMORY_LIMIT_PERCENT = 85;
@@ -190,9 +199,14 @@ export class ResourceGovernor {
   private checkResources(): void {
     const memory = process.memoryUsage();
     const heapUsedMb = memory.heapUsed / 1024 / 1024;
-    const heapStats = v8.getHeapStatistics();
-    const heapLimitMb = heapStats.heap_size_limit / 1024 / 1024;
-    const utilizationPercent = (heapUsedMb / heapLimitMb) * 100;
+    // `external` already includes all ArrayBuffer/Buffer backing stores —
+    // memory.arrayBuffers is a subset of it, so adding it would double-count.
+    const externalMb = (memory.external ?? 0) / 1024 / 1024;
+    // Combined signal: V8 heap + external. Heap-only was blind to the memory
+    // this governor actually manages — queued PTY output and xterm backing
+    // stores live in external, outside the --max-old-space-size cap (#9905).
+    const combinedMb = heapUsedMb + externalMb;
+    const utilizationPercent = (combinedMb / TOTAL_PROCESS_BUDGET_MB) * 100;
 
     // EMA smoothing — rejects single-tick GC sawtooth spikes. Seeded with the
     // first real reading (not 0) to avoid a warmup ramp that falsely stays
@@ -217,24 +231,30 @@ export class ResourceGovernor {
     if (!this.isWarning && utilizationPercent > warnThreshold) {
       this.isWarning = true;
       console.warn(
-        `[ResourceGovernor] Memory warning: ${utilizationPercent.toFixed(1)}% heap used ` +
-          `(threshold: ${warnThreshold}%).`
+        `[ResourceGovernor] Memory warning: ${utilizationPercent.toFixed(1)}% of process budget ` +
+          `(heap ${Math.round(heapUsedMb)}MB + external ${Math.round(externalMb)}MB, ` +
+          `threshold: ${warnThreshold}%).`
       );
       this.deps.sendEvent({
         type: "host-memory-warning",
         isWarning: true,
         utilizationPercent: Math.round(utilizationPercent),
+        heapMb: Math.round(heapUsedMb),
+        externalMb: Math.round(externalMb),
         timestamp: Date.now(),
       });
     } else if (this.isWarning && utilizationPercent < warnClear) {
       this.isWarning = false;
       console.log(
-        `[ResourceGovernor] Memory warning cleared: ${utilizationPercent.toFixed(1)}% heap used.`
+        `[ResourceGovernor] Memory warning cleared: ${utilizationPercent.toFixed(1)}% of process budget ` +
+          `(heap ${Math.round(heapUsedMb)}MB + external ${Math.round(externalMb)}MB).`
       );
       this.deps.sendEvent({
         type: "host-memory-warning",
         isWarning: false,
         utilizationPercent: Math.round(utilizationPercent),
+        heapMb: Math.round(heapUsedMb),
+        externalMb: Math.round(externalMb),
         timestamp: Date.now(),
       });
     }
@@ -254,8 +274,9 @@ export class ResourceGovernor {
       if (isCritical || (aboveThreshold && warmedUp && cooledDown)) {
         if (!isCritical && !this.trimAttemptedForCurrentPressure && this.deps.trimBuffers) {
           // Trim first as a one-shot reclaim — drops JS references synchronously
-          // so the next GC can collect old-gen scrollback strings. heapUsed won't
-          // drop in this tick (GC hasn't run yet) so we wait one tick before
+          // so the next GC can collect old-gen scrollback strings and ArrayBuffer
+          // backing stores. Neither heapUsed nor external drops in this tick (GC
+          // hasn't run yet) so we wait one tick before
           // escalating to pause. Wrapped in try/catch because trim is best-effort:
           // a failure shouldn't block the eventual pause path.
           try {
@@ -269,7 +290,7 @@ export class ResourceGovernor {
           }
           this.trimAttemptedForCurrentPressure = true;
         } else {
-          this.engageThrottle(heapUsedMb, utilizationPercent);
+          this.engageThrottle(combinedMb, utilizationPercent);
         }
       } else if (!aboveThreshold && this.trimAttemptedForCurrentPressure) {
         // Pressure cleared after trim but before engage — preserve the
@@ -287,7 +308,7 @@ export class ResourceGovernor {
       const belowThreshold = utilizationPercent < resumePercent;
 
       if (maxPauseExceeded || belowThreshold) {
-        this.disengageThrottle(heapUsedMb, utilizationPercent, maxPauseExceeded);
+        this.disengageThrottle(combinedMb, utilizationPercent, maxPauseExceeded);
       }
     }
 

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -21,14 +21,6 @@ vi.mock("../metrics.js", () => ({
   metricsEnabled: vi.fn().mockReturnValue(false),
 }));
 
-vi.mock("node:v8", () => ({
-  default: {
-    getHeapStatistics: vi.fn().mockReturnValue({
-      heap_size_limit: 1024 * 1024 * 1024,
-    }),
-  },
-}));
-
 import { ResourceGovernor, type ResourceGovernorDeps } from "../ResourceGovernor.js";
 import { PtyPauseCoordinator } from "../PtyPauseCoordinator.js";
 import { metricsEnabled } from "../metrics.js";
@@ -50,6 +42,19 @@ function createMockDeps(overrides?: Partial<ResourceGovernorDeps>): ResourceGove
     trimBuffers: vi.fn(),
     ...overrides,
   };
+}
+
+// Mock process.memoryUsage with MB-denominated values. The governor budgets
+// combined heap + external against TOTAL_PROCESS_BUDGET_MB (768), so e.g.
+// mockMemoryUsage(675) = 87.9% and mockMemoryUsage(300, 276) = 75%.
+// Re-invoking returns the same spy, so later calls re-mock in place.
+function mockMemoryUsage(heapMb: number, externalMb = 0, arrayBuffersMb = 0) {
+  return vi.spyOn(process, "memoryUsage").mockReturnValue({
+    heapUsed: heapMb * 1024 * 1024,
+    rss: 1024 * 1024 * 1024,
+    external: externalMb * 1024 * 1024,
+    arrayBuffers: arrayBuffersMb * 1024 * 1024,
+  } as ReturnType<typeof process.memoryUsage>);
 }
 
 // After the EMA + warmup + trim-first changes, engage requires 6 ticks:
@@ -179,12 +184,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -221,12 +221,7 @@ describe("ResourceGovernor", () => {
           .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -234,12 +229,7 @@ describe("ResourceGovernor", () => {
 
       // Drop memory below resume threshold — disengage uses raw utilization
       // so a single low tick resumes immediately.
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 500 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(375);
       vi.advanceTimersByTime(2000);
 
       const event = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls.find(
@@ -266,12 +256,7 @@ describe("ResourceGovernor", () => {
 
     it("disengages on raw utilization even when smoothed is still elevated", () => {
       const { coordinator } = createMockCoordinator();
-      const memSpy = vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
@@ -290,15 +275,10 @@ describe("ResourceGovernor", () => {
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       expect(coordinator.hasToken("resource-governor")).toBe(true);
 
-      // Drop raw to 53.7% (550MB) in a single tick — well below the 60%
+      // Drop raw to 53.6% (412MB) in a single tick — well below the 60%
       // resume threshold. Smoothed will only decay to ~81.7% on this tick,
       // still above 60%. Disengage must still fire because it uses RAW.
-      memSpy.mockReturnValue({
-        heapUsed: 550 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(412);
       vi.advanceTimersByTime(2000);
 
       expect(coordinator.hasToken("resource-governor")).toBe(false);
@@ -320,12 +300,7 @@ describe("ResourceGovernor", () => {
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -356,12 +331,7 @@ describe("ResourceGovernor", () => {
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -473,12 +443,7 @@ describe("ResourceGovernor", () => {
           .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1327,12 +1292,7 @@ describe("ResourceGovernor", () => {
   describe("host-memory-warning", () => {
     it("emits host-memory-warning when crossing warning threshold", () => {
       const deps = createMockDeps();
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 750 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(563);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1351,24 +1311,14 @@ describe("ResourceGovernor", () => {
 
     it("clears warning when memory drops below clear threshold", () => {
       const deps = createMockDeps();
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 750 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(563);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
       vi.advanceTimersByTime(2000);
 
       // Drop below clear threshold
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 600 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(450);
       vi.advanceTimersByTime(2000);
 
       expect(deps.sendEvent).toHaveBeenCalledWith(
@@ -1383,12 +1333,7 @@ describe("ResourceGovernor", () => {
 
     it("does not re-emit warning on consecutive ticks above threshold", () => {
       const deps = createMockDeps();
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 750 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(563);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1400,6 +1345,123 @@ describe("ResourceGovernor", () => {
         (c: unknown[]) => (c[0] as Record<string, unknown>)?.type === "host-memory-warning"
       );
       expect(warningCalls).toHaveLength(1);
+
+      governor.dispose();
+    });
+  });
+
+  describe("external memory signal", () => {
+    it("engages from external-only pressure invisible to the heap signal", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([
+            { id: "t1", lastOutputTime: 100, lastInputTime: 100, agentState: "idle" },
+          ]),
+      });
+
+      // 64MB heap + 620MB external = 684MB → 89.1% of the 768MB budget.
+      // A heap-only signal would read far below every threshold.
+      mockMemoryUsage(64, 620);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
+
+      expect(coordinator.hasToken("resource-governor")).toBe(true);
+
+      governor.dispose();
+    });
+
+    it("engages immediately when external pushes combined past critical", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([
+            { id: "t1", lastOutputTime: 100, lastInputTime: 100, agentState: "idle" },
+          ]),
+      });
+
+      // 100MB heap + 640MB external = 740MB → 96.4%: the critical bypass
+      // fires on the first tick with no warmup or trim.
+      mockMemoryUsage(100, 640);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      expect(coordinator.hasToken("resource-governor")).toBe(true);
+      expect(deps.trimBuffers).not.toHaveBeenCalled();
+
+      governor.dispose();
+    });
+
+    it("computes utilizationPercent from combined heap + external and reports both in the payload", () => {
+      const deps = createMockDeps();
+      // 300MB heap + 276MB external = 576MB → exactly 75% of 768MB.
+      mockMemoryUsage(300, 276);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "host-memory-warning",
+          isWarning: true,
+          utilizationPercent: 75,
+          heapMb: 300,
+          externalMb: 276,
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("includes heapMb and externalMb on the warning-cleared event", () => {
+      const deps = createMockDeps();
+      mockMemoryUsage(300, 276);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      // 200MB heap + 100MB external = 300MB → 39.1%, below the clear band.
+      mockMemoryUsage(200, 100);
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "host-memory-warning",
+          isWarning: false,
+          heapMb: 200,
+          externalMb: 100,
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("does not double-count arrayBuffers (a subset of external)", () => {
+      const deps = createMockDeps();
+      // 200MB heap + 200MB external (all of it ArrayBuffers) = 400MB → 52%.
+      // Summing arrayBuffers on top would read 600MB → 78% and falsely warn.
+      mockMemoryUsage(200, 200, 200);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const warningCalls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c: unknown[]) => (c[0] as Record<string, unknown>)?.type === "host-memory-warning"
+      );
+      expect(warningCalls).toHaveLength(0);
 
       governor.dispose();
     });
@@ -1426,12 +1488,7 @@ describe("ResourceGovernor", () => {
         ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1465,12 +1522,7 @@ describe("ResourceGovernor", () => {
         ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 980 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(735);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1499,13 +1551,8 @@ describe("ResourceGovernor", () => {
       governor.setResourceProfile("efficiency");
       governor.start();
 
-      // 75% heap — below default 85% but above efficiency 70%
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 768 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      // 75% of budget — below default 85% but above efficiency 70%
+      mockMemoryUsage(576);
 
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
 
@@ -1529,13 +1576,8 @@ describe("ResourceGovernor", () => {
       governor.setResourceProfile("balanced");
       governor.start();
 
-      // 75% heap — above efficiency 70% but below default 85%
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 768 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      // 75% of budget — above efficiency 70% but below default 85%
+      mockMemoryUsage(576);
 
       // Advance past warmup to verify no throttle ever fires on balanced.
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
@@ -1552,13 +1594,8 @@ describe("ResourceGovernor", () => {
       governor.setResourceProfile("efficiency");
       governor.start();
 
-      // 60% heap — below default warning 70% but above efficiency warning 55%
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 614 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      // 60% of budget — below default warning 70% but above efficiency warning 55%
+      mockMemoryUsage(460);
 
       vi.advanceTimersByTime(2000);
 
@@ -1587,12 +1624,7 @@ describe("ResourceGovernor", () => {
       });
 
       // Baseline at 50% for first 5 ticks (warmup), then a single spike to 90%.
-      const memSpy = vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 512 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(384);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1602,21 +1634,11 @@ describe("ResourceGovernor", () => {
       expect(coordinator.hasToken("resource-governor")).toBe(false);
 
       // Single-tick spike to 90%.
-      memSpy.mockReturnValue({
-        heapUsed: 922 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(692);
       vi.advanceTimersByTime(2000);
 
       // Drop back. EMA pushes smoothed to ~0.18*90 + 0.82*50 = 57.2 — well below 85.
-      memSpy.mockReturnValue({
-        heapUsed: 512 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(384);
       vi.advanceTimersByTime(4000);
 
       // No throttle, no trim — smoothed never crossed 85%.
@@ -1638,12 +1660,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1668,12 +1685,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1702,12 +1714,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1735,12 +1742,7 @@ describe("ResourceGovernor", () => {
         trimBuffers,
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1754,12 +1756,7 @@ describe("ResourceGovernor", () => {
 
     it("re-arms trim attempt when pressure clears without ever engaging", () => {
       const { coordinator } = createMockCoordinator();
-      const memSpy = vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
@@ -1781,23 +1778,13 @@ describe("ResourceGovernor", () => {
 
       // Pressure clears. EMA decays so smoothed eventually crosses below the
       // engage threshold and the re-arm branch fires.
-      memSpy.mockReturnValue({
-        heapUsed: 256 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(192);
       vi.advanceTimersByTime(40000);
       expect(coordinator.hasToken("resource-governor")).toBe(false);
 
       // Pressure returns. EMA needs ~16 ticks to climb from ~25% back above
       // the 85% engage threshold; trim must fire again for the new episode.
-      memSpy.mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
       vi.advanceTimersByTime(40000);
       expect(deps.trimBuffers).toHaveBeenCalledTimes(2);
 
@@ -1816,12 +1803,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 980 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(735);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1847,12 +1829,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1891,12 +1868,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1917,12 +1889,7 @@ describe("ResourceGovernor", () => {
 
     it("threshold-based disengage also sets the cooldown gate", () => {
       const { coordinator, raw } = createMockCoordinator();
-      const memSpy = vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
@@ -1941,22 +1908,12 @@ describe("ResourceGovernor", () => {
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       expect(coordinator.hasToken("resource-governor")).toBe(true);
 
-      memSpy.mockReturnValue({
-        heapUsed: 500 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(375);
       vi.advanceTimersByTime(2000);
       expect(coordinator.hasToken("resource-governor")).toBe(false);
 
       // Pressure returns immediately. Cooldown gate must still block re-engage.
-      memSpy.mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
       raw.pause.mockClear();
       vi.advanceTimersByTime(10000);
       expect(coordinator.hasToken("resource-governor")).toBe(false);
@@ -1977,12 +1934,7 @@ describe("ResourceGovernor", () => {
         t3: c3,
       };
 
-      const memSpy = vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1", "t2", "t3"]),
@@ -2001,12 +1953,7 @@ describe("ResourceGovernor", () => {
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mockClear();
 
-      memSpy.mockReturnValue({
-        heapUsed: 500 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(375);
       vi.advanceTimersByTime(2000);
 
       const resumeEmits = (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mock.calls
@@ -2027,12 +1974,7 @@ describe("ResourceGovernor", () => {
         t2: c2,
       };
 
-      const memSpy = vi.spyOn(process, "memoryUsage").mockReturnValue({
-        heapUsed: 900 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(675);
 
       const deps = createMockDeps({
         // Only t1 is visible to the governor when engage fires.
@@ -2054,12 +1996,7 @@ describe("ResourceGovernor", () => {
       // t2 came online while paused, governed by another pause holder.
       c2.coordinator.pause("backpressure");
 
-      memSpy.mockReturnValue({
-        heapUsed: 500 * 1024 * 1024,
-        rss: 1024 * 1024 * 1024,
-        external: 0,
-        arrayBuffers: 0,
-      } as ReturnType<typeof process.memoryUsage>);
+      mockMemoryUsage(375);
       c2.raw.resume.mockClear();
       vi.advanceTimersByTime(2000);
 

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -377,12 +377,7 @@ describe("ResourceGovernor", () => {
             .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
         });
 
-        vi.spyOn(process, "memoryUsage").mockReturnValue({
-          heapUsed: 900 * 1024 * 1024,
-          rss: 1024 * 1024 * 1024,
-          external: 0,
-          arrayBuffers: 0,
-        } as ReturnType<typeof process.memoryUsage>);
+        mockMemoryUsage(450);
 
         const governor = new ResourceGovernor(deps);
         governor.start();
@@ -395,12 +390,7 @@ describe("ResourceGovernor", () => {
         coordinator.pause(queueToken);
 
         // Now lower memory to trigger disengage
-        vi.spyOn(process, "memoryUsage").mockReturnValue({
-          heapUsed: 500 * 1024 * 1024,
-          rss: 1024 * 1024 * 1024,
-          external: 0,
-          arrayBuffers: 0,
-        } as ReturnType<typeof process.memoryUsage>);
+        mockMemoryUsage(250);
 
         raw.resume.mockClear();
         (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mockClear();

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -44,9 +44,10 @@ function createMockDeps(overrides?: Partial<ResourceGovernorDeps>): ResourceGove
   };
 }
 
-// Mock process.memoryUsage with MB-denominated values. The governor budgets
-// combined heap + external against TOTAL_PROCESS_BUDGET_MB (768), so e.g.
-// mockMemoryUsage(675) = 87.9% and mockMemoryUsage(300, 276) = 75%.
+// Mock process.memoryUsage with MB-denominated values. Utilization is the
+// binding constraint: max(heap / 512 heap budget, combined / 768 process
+// budget) — so mockMemoryUsage(450) = 87.9% (heap-bound) and
+// mockMemoryUsage(300, 276) = 75% (combined-bound).
 // Re-invoking returns the same spy, so later calls re-mock in place.
 function mockMemoryUsage(heapMb: number, externalMb = 0, arrayBuffersMb = 0) {
   return vi.spyOn(process, "memoryUsage").mockReturnValue({
@@ -184,7 +185,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -221,7 +222,7 @@ describe("ResourceGovernor", () => {
           .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -229,7 +230,7 @@ describe("ResourceGovernor", () => {
 
       // Drop memory below resume threshold — disengage uses raw utilization
       // so a single low tick resumes immediately.
-      mockMemoryUsage(375);
+      mockMemoryUsage(250);
       vi.advanceTimersByTime(2000);
 
       const event = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls.find(
@@ -256,7 +257,7 @@ describe("ResourceGovernor", () => {
 
     it("disengages on raw utilization even when smoothed is still elevated", () => {
       const { coordinator } = createMockCoordinator();
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
@@ -275,10 +276,10 @@ describe("ResourceGovernor", () => {
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       expect(coordinator.hasToken("resource-governor")).toBe(true);
 
-      // Drop raw to 53.6% (412MB) in a single tick — well below the 60%
+      // Drop raw to 53.7% (275MB) in a single tick — well below the 60%
       // resume threshold. Smoothed will only decay to ~81.7% on this tick,
       // still above 60%. Disengage must still fire because it uses RAW.
-      mockMemoryUsage(412);
+      mockMemoryUsage(275);
       vi.advanceTimersByTime(2000);
 
       expect(coordinator.hasToken("resource-governor")).toBe(false);
@@ -300,7 +301,7 @@ describe("ResourceGovernor", () => {
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -331,7 +332,7 @@ describe("ResourceGovernor", () => {
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -443,7 +444,7 @@ describe("ResourceGovernor", () => {
           .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1292,7 +1293,7 @@ describe("ResourceGovernor", () => {
   describe("host-memory-warning", () => {
     it("emits host-memory-warning when crossing warning threshold", () => {
       const deps = createMockDeps();
-      mockMemoryUsage(563);
+      mockMemoryUsage(375);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1311,14 +1312,14 @@ describe("ResourceGovernor", () => {
 
     it("clears warning when memory drops below clear threshold", () => {
       const deps = createMockDeps();
-      mockMemoryUsage(563);
+      mockMemoryUsage(375);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
       vi.advanceTimersByTime(2000);
 
       // Drop below clear threshold
-      mockMemoryUsage(450);
+      mockMemoryUsage(300);
       vi.advanceTimersByTime(2000);
 
       expect(deps.sendEvent).toHaveBeenCalledWith(
@@ -1333,7 +1334,7 @@ describe("ResourceGovernor", () => {
 
     it("does not re-emit warning on consecutive ticks above threshold", () => {
       const deps = createMockDeps();
-      mockMemoryUsage(563);
+      mockMemoryUsage(375);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1448,6 +1449,103 @@ describe("ResourceGovernor", () => {
       governor.dispose();
     });
 
+    it("still engages on heap-only pressure near the V8 cap (heap budget is the binding constraint)", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([
+            { id: "t1", lastOutputTime: 100, lastInputTime: 100, agentState: "idle" },
+          ]),
+      });
+
+      // 440MB heap + 5MB external = 445MB → only 57.9% of the 768MB process
+      // budget, but 440/512 = 85.9% of the heap cap. A combined-only signal
+      // would never see a runaway JS heap (heap maxes out at 67% of 768).
+      mockMemoryUsage(440, 5);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
+
+      expect(coordinator.hasToken("resource-governor")).toBe(true);
+
+      governor.dispose();
+    });
+
+    it("routes external-only pressure through warmup and trim, not a raw bypass", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([
+            { id: "t1", lastOutputTime: 100, lastInputTime: 100, agentState: "idle" },
+          ]),
+      });
+
+      // 89.1% from external — above engage, below critical.
+      mockMemoryUsage(64, 620);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      // 4 ticks — below WARMUP_TICKS=5: no trim, no pause.
+      vi.advanceTimersByTime(8000);
+      expect(deps.trimBuffers).not.toHaveBeenCalled();
+      expect(coordinator.hasToken("resource-governor")).toBe(false);
+
+      // Tick 5: warmup satisfied, one-shot trim fires, still no pause.
+      vi.advanceTimersByTime(2000);
+      expect(deps.trimBuffers).toHaveBeenCalledTimes(1);
+      expect(coordinator.hasToken("resource-governor")).toBe(false);
+
+      // Tick 6: escalates to pause.
+      vi.advanceTimersByTime(2000);
+      expect(coordinator.hasToken("resource-governor")).toBe(true);
+
+      governor.dispose();
+    });
+
+    it("does not warn just below the external-driven warning boundary", () => {
+      const deps = createMockDeps();
+      // 537/768 = 69.9% — below the 70% warning threshold (strict >).
+      mockMemoryUsage(0, 537);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const warningCalls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c: unknown[]) => (c[0] as Record<string, unknown>)?.type === "host-memory-warning"
+      );
+      expect(warningCalls).toHaveLength(0);
+
+      governor.dispose();
+    });
+
+    it("warns just above the external-driven warning boundary", () => {
+      const deps = createMockDeps();
+      // 538/768 = 70.05% — crosses the 70% warning threshold.
+      mockMemoryUsage(0, 538);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "host-memory-warning",
+          isWarning: true,
+        })
+      );
+
+      governor.dispose();
+    });
+
     it("does not double-count arrayBuffers (a subset of external)", () => {
       const deps = createMockDeps();
       // 200MB heap + 200MB external (all of it ArrayBuffers) = 400MB → 52%.
@@ -1488,7 +1586,7 @@ describe("ResourceGovernor", () => {
         ]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1522,7 +1620,7 @@ describe("ResourceGovernor", () => {
         ]),
       });
 
-      mockMemoryUsage(735);
+      mockMemoryUsage(490);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1552,7 +1650,7 @@ describe("ResourceGovernor", () => {
       governor.start();
 
       // 75% of budget — below default 85% but above efficiency 70%
-      mockMemoryUsage(576);
+      mockMemoryUsage(384);
 
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
 
@@ -1577,7 +1675,7 @@ describe("ResourceGovernor", () => {
       governor.start();
 
       // 75% of budget — above efficiency 70% but below default 85%
-      mockMemoryUsage(576);
+      mockMemoryUsage(384);
 
       // Advance past warmup to verify no throttle ever fires on balanced.
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
@@ -1595,7 +1693,7 @@ describe("ResourceGovernor", () => {
       governor.start();
 
       // 60% of budget — below default warning 70% but above efficiency warning 55%
-      mockMemoryUsage(460);
+      mockMemoryUsage(307);
 
       vi.advanceTimersByTime(2000);
 
@@ -1624,7 +1722,7 @@ describe("ResourceGovernor", () => {
       });
 
       // Baseline at 50% for first 5 ticks (warmup), then a single spike to 90%.
-      mockMemoryUsage(384);
+      mockMemoryUsage(256);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1634,11 +1732,11 @@ describe("ResourceGovernor", () => {
       expect(coordinator.hasToken("resource-governor")).toBe(false);
 
       // Single-tick spike to 90%.
-      mockMemoryUsage(692);
+      mockMemoryUsage(461);
       vi.advanceTimersByTime(2000);
 
       // Drop back. EMA pushes smoothed to ~0.18*90 + 0.82*50 = 57.2 — well below 85.
-      mockMemoryUsage(384);
+      mockMemoryUsage(256);
       vi.advanceTimersByTime(4000);
 
       // No throttle, no trim — smoothed never crossed 85%.
@@ -1660,7 +1758,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1685,7 +1783,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1714,7 +1812,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1742,7 +1840,7 @@ describe("ResourceGovernor", () => {
         trimBuffers,
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1756,7 +1854,7 @@ describe("ResourceGovernor", () => {
 
     it("re-arms trim attempt when pressure clears without ever engaging", () => {
       const { coordinator } = createMockCoordinator();
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
@@ -1778,13 +1876,13 @@ describe("ResourceGovernor", () => {
 
       // Pressure clears. EMA decays so smoothed eventually crosses below the
       // engage threshold and the re-arm branch fires.
-      mockMemoryUsage(192);
+      mockMemoryUsage(128);
       vi.advanceTimersByTime(40000);
       expect(coordinator.hasToken("resource-governor")).toBe(false);
 
       // Pressure returns. EMA needs ~16 ticks to climb from ~25% back above
       // the 85% engage threshold; trim must fire again for the new episode.
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
       vi.advanceTimersByTime(40000);
       expect(deps.trimBuffers).toHaveBeenCalledTimes(2);
 
@@ -1803,7 +1901,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      mockMemoryUsage(735);
+      mockMemoryUsage(490);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1829,7 +1927,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1868,7 +1966,7 @@ describe("ResourceGovernor", () => {
           ]),
       });
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const governor = new ResourceGovernor(deps);
       governor.start();
@@ -1889,7 +1987,7 @@ describe("ResourceGovernor", () => {
 
     it("threshold-based disengage also sets the cooldown gate", () => {
       const { coordinator, raw } = createMockCoordinator();
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
@@ -1908,12 +2006,12 @@ describe("ResourceGovernor", () => {
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       expect(coordinator.hasToken("resource-governor")).toBe(true);
 
-      mockMemoryUsage(375);
+      mockMemoryUsage(250);
       vi.advanceTimersByTime(2000);
       expect(coordinator.hasToken("resource-governor")).toBe(false);
 
       // Pressure returns immediately. Cooldown gate must still block re-engage.
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
       raw.pause.mockClear();
       vi.advanceTimersByTime(10000);
       expect(coordinator.hasToken("resource-governor")).toBe(false);
@@ -1934,7 +2032,7 @@ describe("ResourceGovernor", () => {
         t3: c3,
       };
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1", "t2", "t3"]),
@@ -1953,7 +2051,7 @@ describe("ResourceGovernor", () => {
       vi.advanceTimersByTime(ADVANCE_TO_ENGAGE_MS);
       (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mockClear();
 
-      mockMemoryUsage(375);
+      mockMemoryUsage(250);
       vi.advanceTimersByTime(2000);
 
       const resumeEmits = (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mock.calls
@@ -1974,7 +2072,7 @@ describe("ResourceGovernor", () => {
         t2: c2,
       };
 
-      mockMemoryUsage(675);
+      mockMemoryUsage(450);
 
       const deps = createMockDeps({
         // Only t1 is visible to the governor when engage fires.
@@ -1996,7 +2094,7 @@ describe("ResourceGovernor", () => {
       // t2 came online while paused, governed by another pause holder.
       c2.coordinator.pause("backpressure");
 
-      mockMemoryUsage(375);
+      mockMemoryUsage(250);
       c2.raw.resume.mockClear();
       vi.advanceTimersByTime(2000);
 

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -266,6 +266,8 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       emitter.emit("host-memory-warning", {
         isWarning: event.isWarning,
         utilizationPercent: event.utilizationPercent,
+        heapMb: event.heapMb,
+        externalMb: event.externalMb,
         timestamp: event.timestamp,
       });
       return true;

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -89,6 +89,33 @@ describe("routeHostEvent", () => {
     expect(dataListener).not.toHaveBeenCalled();
   });
 
+  it("forwards heapMb and externalMb on host-memory-warning", () => {
+    const { deps, emitter } = makeDeps();
+    const warningListener = vi.fn();
+    emitter.on("host-memory-warning", warningListener);
+
+    const handled = routeHostEvent(
+      {
+        type: "host-memory-warning",
+        isWarning: true,
+        utilizationPercent: 75,
+        heapMb: 300,
+        externalMb: 276,
+        timestamp: 1000,
+      } as PtyHostEvent,
+      deps
+    );
+
+    expect(handled).toBe(true);
+    expect(warningListener).toHaveBeenCalledWith({
+      isWarning: true,
+      utilizationPercent: 75,
+      heapMb: 300,
+      externalMb: 276,
+      timestamp: 1000,
+    });
+  });
+
   it("delegates domain events to bridgePtyEvent first", () => {
     const { deps } = makeDeps();
     const agentStateEvents: unknown[] = [];

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -249,10 +249,14 @@ export async function initPerWindowServices(
       if (payload.isWarning) {
         logInfo("pty-host-memory-warning", {
           utilizationPercent: payload.utilizationPercent,
+          heapMb: payload.heapMb,
+          externalMb: payload.externalMb,
         });
       } else {
         logInfo("pty-host-memory-warning-cleared", {
           utilizationPercent: payload.utilizationPercent,
+          heapMb: payload.heapMb,
+          externalMb: payload.externalMb,
         });
       }
       // Broadcast to all windows so renderer can surface the warning
@@ -266,6 +270,8 @@ export async function initPerWindowServices(
                 payload: {
                   isWarning: payload.isWarning,
                   utilizationPercent: payload.utilizationPercent,
+                  heapMb: payload.heapMb,
+                  externalMb: payload.externalMb,
                 },
               });
             } catch {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -414,7 +414,12 @@ export type PtyHostEvent =
   | {
       type: "host-memory-warning";
       isWarning: boolean;
+      /** Combined heap + external utilization against the pty-host process budget. */
       utilizationPercent: number;
+      /** V8 heap used, MB. */
+      heapMb?: number;
+      /** Off-heap external memory (includes all ArrayBuffer backing stores), MB. */
+      externalMb?: number;
       timestamp: number;
     }
   | {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -414,7 +414,11 @@ export type PtyHostEvent =
   | {
       type: "host-memory-warning";
       isWarning: boolean;
-      /** Combined heap + external utilization against the pty-host process budget. */
+      /**
+       * Utilization of the binding memory budget — the max of V8 heap against
+       * its --max-old-space-size cap and combined heap + external against the
+       * total pty-host process budget.
+       */
       utilizationPercent: number;
       /** V8 heap used, MB. */
       heapMb?: number;


### PR DESCRIPTION
## Summary

- `ResourceGovernor` was measuring memory pressure using V8 heap utilization only — `heapUsed / heap_size_limit` — leaving the process blind to `external` memory where xterm typed-array buffers and queued PTY output slabs actually live. A host whose RSS climbed from scrollback growth would never trip warning/engage/critical thresholds.
- Utilization is now the binding constraint: `max((heapUsed + external) / 768MB, heapUsed / 512MB)`. The 512MB heap term matches `PtyClient.DEFAULT_CONFIG.memoryLimitMb` (`--max-old-space-size`) and prevents a runaway JS heap from being invisible (at 512MB it's already 67% of the 768MB process budget). 256MB external headroom sits between the two caps.
- `host-memory-warning` payload gains optional `heapMb`/`externalMb` fields, forwarded through `PtyEventRouter` and the `perWindowInit` manual reconstructions.

Resolves #9905

## Changes

- `electron/pty-host/ResourceGovernor.ts` — combined signal, both budget terms, updated `MemoryMetrics` type
- `shared/types/pty-host.ts` — optional `heapMb`/`externalMb` on `HostMemoryWarningPayload`
- `electron/services/pty/PtyEventRouter.ts` — forward new fields
- `electron/window/perWindowInit.ts` — forward new fields in manual event reconstruction
- `electron/pty-host/__tests__/ResourceGovernor.test.ts` — `mockMemoryUsage` helper, all mocks recalibrated to realistic sub-512MB heap values, new cases for external-only engage, critical from external, combined math, warning boundary, `arrayBuffers` no-double-count, heap-only engage near V8 cap, external routed through warmup/trim
- `electron/services/pty/__tests__/PtyEventRouter.test.ts` — field-forwarding coverage

## Testing

99 targeted tests pass. The engage-on-smoothed / disengage-on-raw / 95% critical-bypass invariants from #8660 are unchanged. Full suite is green except two environmental items confirmed on GitHub CI: Linux-only smoke test and `better-sqlite3` binding failures in `db.openDb` tests (unrelated to this change).