### PR TITLE
fix(terminal): make stall escalation and held-duration UI live in production

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -962,7 +962,27 @@ describe("pty-host adversarial", () => {
     expect(backpressure.hasPendingSegments("t1")).toBe(false);
     expect(backpressure.isSuspended("t1")).toBe(false);
     expect(runningPayloads).toHaveLength(1);
-    expect(runningPayloads[0].pauseDuration).toBe(750);
+    // The held duration now rides on the wire `pause-end` reliability metric
+    // (issue #9898: the source-of-truth for held duration moved from the
+    // SAB-only `backpressureManager.getPauseStartTime()` map to the
+    // multi-source closure `pausedTerminals` map maintained by
+    // `emitReliabilityMetricWithTracking`). The running status no longer
+    // carries `pauseDuration` — the renderer reads the metric, not the status.
+    expect(runningPayloads[0].pauseDuration).toBeUndefined();
+    // The held duration now rides on the wire `pause-end` reliability metric
+    // (issue #9898: the source-of-truth moved from the SAB-only
+    // `backpressureManager.getPauseStartTime()` map to the multi-source
+    // closure `pausedTerminals` map maintained by
+    // `emitReliabilityMetricWithTracking`). The manager's `emitReliabilityMetric`
+    // is the funnel entry point in production — assert it was called with a
+    // `pause-end` metric (the dep then populates `durationMs` and emits to the
+    // wire, which is tested in isolation at the funnel boundary).
+    expect(backpressure.emitReliabilityMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalId: "t1",
+        metricType: "pause-end",
+      })
+    );
   });
 
   it("PORT_REPLACE_DROPS_STALE_ACKS", async () => {

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -235,15 +235,7 @@ function getPausedDurationsSnapshot(): Array<{ terminalId: string; heldDurationM
  * Add new metric types here only when the renderer needs them to surface
  * a recovery affordance. Diagnostic-only metrics stay gated.
  */
-const LOAD_BEARING_RELIABILITY_METRICS = new Set<string>([
-  "pause-start",
-  "pause-end",
-  "suspend",
-  "pause-duration-gauge",
-]);
-function isLoadBearingReliabilityMetric(metricType: string): boolean {
-  return LOAD_BEARING_RELIABILITY_METRICS.has(metricType);
-}
+import { isLoadBearingReliabilityMetric } from "./pty-host/loadBearingMetrics.js";
 
 // Data-loss counter: closure-scoped accumulator of dropped-bytes and
 // drop-event counts since the last snapshot. The counter is incremented

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -223,6 +223,28 @@ function getPausedDurationsSnapshot(): Array<{ terminalId: string; heldDurationM
   return out;
 }
 
+/**
+ * Reliabilty-metric types whose wire emission is required for UI correctness
+ * (recovery affordances, Tier-3 escalations) and therefore MUST bypass the
+ * `DAINTREE_TERMINAL_METRICS` opt-in flag. The flag is preserved for the
+ * high-volume, per-tick gauges (throughput-rate, queue-depth-gauge,
+ * pending-bytes-gauge, data-loss-count) that exist purely for diagnostic
+ * telemetry — splitting the two keeps the user-facing recovery surfaces
+ * live in production while leaving diagnostic noise opt-in.
+ *
+ * Add new metric types here only when the renderer needs them to surface
+ * a recovery affordance. Diagnostic-only metrics stay gated.
+ */
+const LOAD_BEARING_RELIABILITY_METRICS = new Set<string>([
+  "pause-start",
+  "pause-end",
+  "suspend",
+  "pause-duration-gauge",
+]);
+function isLoadBearingReliabilityMetric(metricType: string): boolean {
+  return LOAD_BEARING_RELIABILITY_METRICS.has(metricType);
+}
+
 // Data-loss counter: closure-scoped accumulator of dropped-bytes and
 // drop-event counts since the last snapshot. The counter is incremented
 // unconditionally at the drop site so regression detection is observable
@@ -268,6 +290,24 @@ function emitReliabilityMetricWithTracking(
     payload.metricType === "pause-end" ||
     payload.metricType === "suspend"
   ) {
+    // For `null`-source `pause-end`/`suspend`, populate `durationMs` from the
+    // oldest recorded pause-start across sources — matches the gauge
+    // semantics at `getPausedDurationsSnapshot` (the user-meaningful
+    // "how long has this been paused?" answer). The `force-resume` handler
+    // previously read from `backpressureManager.getPauseStartTime()`, a
+    // SAB-only map that production pauses never populate. Computing the
+    // duration here from the closure map is the multi-source-of-truth path
+    // and makes the wire event correct in production (issue #9898).
+    if (payload.durationMs === undefined) {
+      const sources = pausedTerminals.get(payload.terminalId);
+      if (sources && sources.size > 0) {
+        let oldestStart = Number.POSITIVE_INFINITY;
+        for (const { startTime } of sources.values()) {
+          if (startTime < oldestStart) oldestStart = startTime;
+        }
+        payload.durationMs = Math.max(0, Date.now() - oldestStart);
+      }
+    }
     clearAllPauseSources(payload.terminalId);
   }
   // This funnel TERMINATES the chain: emit the wire event directly. We must
@@ -275,9 +315,15 @@ function emitReliabilityMetricWithTracking(
   // the manager is constructed with its `emitReliabilityMetric` dep wired
   // back to this funnel (see construction below), so re-entering it would
   // route straight back here and recurse until the stack overflows. The gate
-  // (`metricsEnabled()`, bypassed by `forceEmit` for the data-loss pulse)
-  // mirrors the manager's legacy default branch.
-  if (!forceEmit && !metricsEnabled()) return;
+  // splits: load-bearing recovery signals (pause-start/pause-end/suspend/
+  // pause-duration-gauge) emit unconditionally so UI recovery affordances
+  // work in production; `forceEmit` still bypasses the gate for the
+  // data-loss pulse; the rest of the metrics (throughput-rate,
+  // queue-depth-gauge, pending-bytes-gauge, data-loss-count) stay gated on
+  // `DAINTREE_TERMINAL_METRICS=1` to keep diagnostic noise opt-in.
+  if (!forceEmit && !isLoadBearingReliabilityMetric(payload.metricType) && !metricsEnabled()) {
+    return;
+  }
   sendEvent({
     type: "terminal-reliability-metric",
     payload,

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -450,7 +450,11 @@ export class ResourceGovernor {
   }
 
   private emitPausedDurationGauge(): void {
-    if (!metricsEnabled()) return;
+    // The pause-duration gauge is a load-bearing recovery signal (the renderer's
+    // Tier-1 paused-flow pill held-duration tooltip depends on it), so it
+    // bypasses the `DAINTREE_TERMINAL_METRICS` opt-in gate. Other ResourceGovernor
+    // gauges (pending-bytes-gauge, throughput-rate, queue-depth-gauge,
+    // data-loss-count) stay gated as diagnostic-only telemetry.
     if (!this.deps.getPausedDurationsSnapshot) return;
 
     const snapshot = this.deps.getPausedDurationsSnapshot();

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -455,6 +455,13 @@ export class ResourceGovernor {
     // bypasses the `DAINTREE_TERMINAL_METRICS` opt-in gate. Other ResourceGovernor
     // gauges (pending-bytes-gauge, throughput-rate, queue-depth-gauge,
     // data-loss-count) stay gated as diagnostic-only telemetry.
+    //
+    // Emits directly via `this.deps.sendEvent` rather than routing through
+    // the host funnel (`emitReliabilityMetricWithTracking`) because the
+    // gauge has no per-source pause attribution to track — the snapshot is
+    // already aggregated by `getPausedDurationsSnapshot` from the closure
+    // `pausedTerminals` map. Routing through the funnel would re-do the
+    // same aggregation the snapshot already performed.
     if (!this.deps.getPausedDurationsSnapshot) return;
 
     const snapshot = this.deps.getPausedDurationsSnapshot();

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -915,7 +915,13 @@ describe("ResourceGovernor", () => {
       governor.dispose();
     });
 
-    it("does not emit gauge when metrics are disabled", () => {
+    it("emits the gauge unconditionally — pause-duration is a load-bearing recovery signal (#9898)", () => {
+      // The pause-duration gauge feeds the renderer-side Tier-1 paused-flow
+      // pill's held-duration tooltip. It must reach the wire in production
+      // even when `DAINTREE_TERMINAL_METRICS=0` (the renderer needs the
+      // tooltip to surface recovery context). Other ResourceGovernor gauges
+      // (pending-bytes-gauge, throughput-rate, queue-depth-gauge,
+      // data-loss-count) stay gated as diagnostic-only telemetry.
       vi.mocked(metricsEnabled).mockReturnValue(false);
 
       const deps = createMockDeps({
@@ -935,7 +941,16 @@ describe("ResourceGovernor", () => {
           ((c[0] as Record<string, unknown>)?.payload as Record<string, unknown>)?.metricType ===
             "pause-duration-gauge"
       );
-      expect(gaugeCalls).toHaveLength(0);
+      expect(gaugeCalls).toHaveLength(1);
+      expect(gaugeCalls[0]).toMatchObject([
+        {
+          type: "terminal-reliability-metric",
+          payload: {
+            metricType: "pause-duration-gauge",
+            perTerminalHeld: [{ terminalId: "t1", heldDurationMs: 4000 }],
+          },
+        },
+      ]);
 
       governor.dispose();
     });

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -6,6 +6,7 @@ import {
   FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL,
   FUTURE_SAB_MAX_TOTAL_PENDING_BYTES,
 } from "../backpressure.js";
+import { isLoadBearingReliabilityMetric } from "../loadBearingMetrics.js";
 
 type CoordinatorLike = Pick<PtyPauseCoordinator, "pause" | "resume" | "isPaused">;
 
@@ -514,17 +515,21 @@ describe("BackpressureManager adversarial", () => {
     });
 
     describe("load-bearing metrics bypass the DAINTREE_TERMINAL_METRICS gate (#9898)", () => {
-      // Mirrors the production funnel at `electron/pty-host.ts:emitReliabilityMetricWithTracking`.
-      // The split at the funnel is what unblocks the Tier-3 stall-escalation
-      // banner (`useForceResumeCycleWatchdog`) and the held-duration tooltip —
-      // they were dead in production because every reliability-metric wire
-      // emission was filtered out by `metricsEnabled()`. Pin the contract: a
-      // load-bearing metric type emits unconditionally; diagnostic gauges
-      // remain gated.
-      const LOAD_BEARING = new Set(["pause-start", "pause-end", "suspend", "pause-duration-gauge"]);
+      // Pins the contract at the production funnel. The split at the funnel
+      // is what unblocks the Tier-3 stall-escalation banner
+      // (`useForceResumeCycleWatchdog`) and the held-duration tooltip — they
+      // were dead in production because every reliability-metric wire
+      // emission was filtered out by `metricsEnabled()`. The test imports
+      // the real `isLoadBearingReliabilityMetric` predicate from
+      // `pty-host/loadBearingMetrics.js` so a misconfigured set would fail
+      // this suite (rather than a copy of the set that would silently drift).
       function makeFunnel(opts: { metricsEnabled: () => boolean }) {
         return (payload: { metricType: string; [k: string]: unknown }, forceEmit = false) => {
-          if (!forceEmit && !LOAD_BEARING.has(payload.metricType) && !opts.metricsEnabled()) {
+          if (
+            !forceEmit &&
+            !isLoadBearingReliabilityMetric(payload.metricType) &&
+            !opts.metricsEnabled()
+          ) {
             return;
           }
           sendEvent({ type: "terminal-reliability-metric", payload });

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -7,6 +7,7 @@ import {
   FUTURE_SAB_MAX_TOTAL_PENDING_BYTES,
 } from "../backpressure.js";
 import { isLoadBearingReliabilityMetric } from "../loadBearingMetrics.js";
+import type { TerminalReliabilityMetricPayload } from "../../../shared/types/pty-host.js";
 
 type CoordinatorLike = Pick<PtyPauseCoordinator, "pause" | "resume" | "isPaused">;
 
@@ -524,7 +525,7 @@ describe("BackpressureManager adversarial", () => {
       // `pty-host/loadBearingMetrics.js` so a misconfigured set would fail
       // this suite (rather than a copy of the set that would silently drift).
       function makeFunnel(opts: { metricsEnabled: () => boolean }) {
-        return (payload: { metricType: string; [k: string]: unknown }, forceEmit = false) => {
+        return (payload: TerminalReliabilityMetricPayload, forceEmit = false) => {
           if (
             !forceEmit &&
             !isLoadBearingReliabilityMetric(payload.metricType) &&

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -512,5 +512,201 @@ describe("BackpressureManager adversarial", () => {
         })
       );
     });
+
+    describe("load-bearing metrics bypass the DAINTREE_TERMINAL_METRICS gate (#9898)", () => {
+      // Mirrors the production funnel at `electron/pty-host.ts:emitReliabilityMetricWithTracking`.
+      // The split at the funnel is what unblocks the Tier-3 stall-escalation
+      // banner (`useForceResumeCycleWatchdog`) and the held-duration tooltip —
+      // they were dead in production because every reliability-metric wire
+      // emission was filtered out by `metricsEnabled()`. Pin the contract: a
+      // load-bearing metric type emits unconditionally; diagnostic gauges
+      // remain gated.
+      const LOAD_BEARING = new Set(["pause-start", "pause-end", "suspend", "pause-duration-gauge"]);
+      function makeFunnel(opts: { metricsEnabled: () => boolean }) {
+        return (payload: { metricType: string; [k: string]: unknown }, forceEmit = false) => {
+          if (!forceEmit && !LOAD_BEARING.has(payload.metricType) && !opts.metricsEnabled()) {
+            return;
+          }
+          sendEvent({ type: "terminal-reliability-metric", payload });
+        };
+      }
+
+      it("emits pause-start when metrics are disabled (load-bearing)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        manager.emitReliabilityMetric({
+          terminalId: "term-1",
+          metricType: "pause-start",
+          timestamp: 1000,
+        });
+
+        expect(sendEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: "terminal-reliability-metric",
+            payload: expect.objectContaining({ metricType: "pause-start" }),
+          })
+        );
+      });
+
+      it("emits pause-end when metrics are disabled (load-bearing)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        manager.emitReliabilityMetric({
+          terminalId: "term-1",
+          metricType: "pause-end",
+          timestamp: 1000,
+          durationMs: 9950,
+        });
+
+        expect(sendEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({ metricType: "pause-end", durationMs: 9950 }),
+          })
+        );
+      });
+
+      it("emits suspend when metrics are disabled (load-bearing)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        manager.emitReliabilityMetric({
+          terminalId: "term-1",
+          metricType: "suspend",
+          timestamp: 1000,
+        });
+
+        expect(sendEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({ metricType: "suspend" }),
+          })
+        );
+      });
+
+      it("gates throughput-rate when metrics are disabled (diagnostic only)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        manager.emitReliabilityMetric({
+          terminalId: "term-1",
+          metricType: "throughput-rate",
+          timestamp: 1000,
+        });
+
+        expect(sendEvent).not.toHaveBeenCalled();
+      });
+
+      it("gates queue-depth-gauge when metrics are disabled (diagnostic only)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        manager.emitReliabilityMetric({
+          terminalId: "term-1",
+          metricType: "queue-depth-gauge",
+          timestamp: 1000,
+        });
+
+        expect(sendEvent).not.toHaveBeenCalled();
+      });
+
+      it("gates data-loss-count when metrics are disabled (diagnostic only)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        manager.emitReliabilityMetric({
+          terminalId: "term-1",
+          metricType: "data-loss-count",
+          timestamp: 1000,
+        });
+
+        expect(sendEvent).not.toHaveBeenCalled();
+      });
+
+      it("forceEmit bypasses the gate for non-load-bearing metrics (data-loss pulse)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        // data-loss-count is non-load-bearing but forceEmit: true must still
+        // reach the wire (the data-loss pulse has to surface in production
+        // even when the diagnostic flag is off — lesson #7590).
+        manager.emitReliabilityMetric(
+          { terminalId: "term-1", metricType: "data-loss-count", timestamp: 1000 },
+          true
+        );
+
+        expect(sendEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({ metricType: "data-loss-count" }),
+          })
+        );
+      });
+
+      it("emits pause-duration-gauge when metrics are disabled (load-bearing)", () => {
+        sendEvent.mockReset();
+        const manager = new BackpressureManager({
+          getTerminal: vi.fn(),
+          getPauseCoordinator: vi.fn(),
+          sendEvent,
+          metricsEnabled: () => false,
+          emitReliabilityMetric: makeFunnel({ metricsEnabled: () => false }),
+        });
+
+        manager.emitReliabilityMetric({
+          terminalId: "resource-governor",
+          metricType: "pause-duration-gauge",
+          timestamp: 1000,
+          perTerminalHeld: [{ terminalId: "term-1", heldDurationMs: 5000 }],
+        });
+
+        expect(sendEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            payload: expect.objectContaining({ metricType: "pause-duration-gauge" }),
+          })
+        );
+      });
+    });
   });
 });

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -228,11 +228,6 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
       }
       backpressureManager.clearPendingVisual(msg.id);
 
-      // Calculate pause duration if we have a start time
-      const pauseStart = backpressureManager.getPauseStartTime(msg.id);
-      const pauseDuration = pauseStart ? Date.now() - pauseStart : undefined;
-      backpressureManager.deletePauseStartTime(msg.id);
-
       // Clear suspended flag to allow output to flow again
       backpressureManager.clearSuspended(msg.id);
 
@@ -247,24 +242,33 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
         conn.portQueueManager.clearQueue(msg.id);
       }
 
-      // Emit resume status (uses current visualBuffers via ctx getter)
+      // Compute resume status with the actual held duration from the visual
+      // buffer (SAB path) when available. The wire `pause-end` metric gets
+      // its `durationMs` from the canonical funnel's closure map (the
+      // multi-source-of-truth path) — see `emitReliabilityMetricWithTracking`.
+      // We intentionally do NOT read from `backpressureManager.getPauseStartTime()`
+      // (SAB-only, dead in production) for the metric; the funnel does that
+      // work and clears all sources for this terminal atomically.
       const buffers = ctx.visualBuffers;
       const utilization =
         buffers.length > 0
           ? buffers[selectShard(msg.id, buffers.length)].getUtilization()
           : undefined;
-      backpressureManager.emitTerminalStatus(msg.id, "running", utilization, pauseDuration);
+      backpressureManager.emitTerminalStatus(msg.id, "running", utilization);
 
-      // Emit metrics for pause-end (user force-resume path)
-      if (pauseDuration !== undefined) {
-        backpressureManager.emitReliabilityMetric({
-          terminalId: msg.id,
-          metricType: "pause-end",
-          timestamp: Date.now(),
-          durationMs: pauseDuration,
-          bufferUtilization: utilization,
-        });
-      }
+      // Emit the user force-resume's `pause-end` via the canonical funnel
+      // (null source). The funnel populates `durationMs` from the closure
+      // `pausedTerminals` map (or skips it when the terminal had no recorded
+      // pause) and clears the map. This routes the wire event through the
+      // load-bearing split so it always reaches the renderer in production
+      // (issue #9898: the previous `backpressureManager.emitReliabilityMetric`
+      // path was gated by `metricsEnabled()` and never fired).
+      backpressureManager.emitReliabilityMetric({
+        terminalId: msg.id,
+        metricType: "pause-end",
+        timestamp: Date.now(),
+        bufferUtilization: utilization,
+      });
     },
 
     "pause-all": () => {

--- a/electron/pty-host/index.ts
+++ b/electron/pty-host/index.ts
@@ -15,6 +15,7 @@ export { IpcQueueManager, type IpcQueueDeps } from "./ipcQueue.js";
 export { PortQueueManager, type PortQueueDeps } from "./portQueue.js";
 export { PortBatcher, type PortBatcherDeps, type PortBatcherFailedBatch } from "./portBatcher.js";
 export { FdMonitor, isProcessAlive, type FdCheckResult } from "./FdMonitor.js";
+export { isLoadBearingReliabilityMetric } from "./loadBearingMetrics.js";
 export { metricsEnabled } from "./metrics.js";
 export { parseSpawnError } from "./spawnErrors.js";
 export { toHostSnapshot, type SnapshotProvider } from "./snapshots.js";

--- a/electron/pty-host/loadBearingMetrics.ts
+++ b/electron/pty-host/loadBearingMetrics.ts
@@ -1,0 +1,22 @@
+/**
+ * Reliabilty-metric types whose wire emission is required for UI correctness
+ * (recovery affordances, Tier-3 escalations) and therefore MUST bypass the
+ * `DAINTREE_TERMINAL_METRICS` opt-in flag. The flag is preserved for the
+ * high-volume, per-tick gauges (throughput-rate, queue-depth-gauge,
+ * pending-bytes-gauge, data-loss-count) that exist purely for diagnostic
+ * telemetry — splitting the two keeps the user-facing recovery surfaces
+ * live in production while leaving diagnostic noise opt-in.
+ *
+ * Add new metric types here only when the renderer needs them to surface
+ * a recovery affordance. Diagnostic-only metrics stay gated.
+ */
+const LOAD_BEARING_RELIABILITY_METRICS = new Set<string>([
+  "pause-start",
+  "pause-end",
+  "suspend",
+  "pause-duration-gauge",
+]);
+
+export function isLoadBearingReliabilityMetric(metricType: string): boolean {
+  return LOAD_BEARING_RELIABILITY_METRICS.has(metricType);
+}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -1335,7 +1335,7 @@ function TerminalPaneComponent({
         />
       </BannerSlot>
 
-      <BannerSlot visible={showForceResumeStall}>
+      <BannerSlot visible={!suppressBackendDependent && showForceResumeStall}>
         <InlineStatusBanner
           icon={OctagonAlert}
           severity="error"


### PR DESCRIPTION
## Summary

- The Tier-3 stall-escalation banner and the held-duration tooltip on the paused-flow pill were both dead in production. Every event they depend on (`pause-start`, `pause-end`, `suspend`, `pause-duration-gauge`) was filtered by `metricsEnabled()` in `electron/pty-host/metrics.ts`, which gates on `DAINTREE_TERMINAL_METRICS=1`. Nothing in the repo sets that variable, so a genuinely wedged renderer just sat on the small `Paused` pill forever.
- Split the gate at the canonical `emitReliabilityMetricWithTracking` funnel: the four UI-recovery-relevant metric types now emit unconditionally, the high-volume diagnostic gauges stay gated.
- Routed the manual force-resume's `pause-end` through the same funnel with `source: null` and `durationMs` from the closure map. The old handler read from `backpressureManager.getPauseStartTime()`, a SharedArrayBuffer-only map that doesn't work inside Electron's `utilityProcess` (lesson #7030).
- Gated the stall banner with `useShouldSuppressLocalError("backend-dependent")` for parity with the restart/spawn/reconnect banners; its only recovery action runs through the host, so it should stay hidden while a global recovery cause is active.

Resolves #9898

## Changes

- `electron/pty-host.ts` — split the gate at `emitReliabilityMetricWithTracking`; the four load-bearing metric types bypass `metricsEnabled()`, diagnostic gauges stay gated
- `electron/pty-host/handlers/backpressure.ts` — route manual force-resume `pause-end` through the funnel with `source: null` and `durationMs` from the closure map; drop the SAB-only `getPauseStartTime` read
- `electron/pty-host/ResourceGovernor.ts` — drop `metricsEnabled()` from `emitPausedDurationGauge` (load-bearing)
- `src/components/Terminal/TerminalPane.tsx` — gate the stall banner with `useShouldSuppressLocalError("backend-dependent")`
- 7 new adversarial tests pinning the load-bearing split, plus a ResourceGovernor pause-duration-gauge test update for the new contract

## Testing

- `npm run check` (typecheck + lint + format + channel/IPC/confirm-wiring guards) passed
- `npm run test` passed
- `npm run build` passed
- New adversarial coverage in `electron/__tests__/pty-host.adversarial.test.ts` and `electron/pty-host/handlers/__tests__/backpressure.adversarial.test.ts` pins the split and the funnel routing