### PR TITLE
fix(terminal): ack held ingest bytes on hibernate, skip flush after replay

### DIFF
--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -359,6 +359,34 @@ describe("terminalClient MessagePort data routing", () => {
     });
   });
 
+  it("discardPortAcks sums the stored pty-host byte counts, not renderer string lengths", () => {
+    const port = acquirePort();
+
+    terminalClient.onData("term-1", () => {});
+    // UTF-8 multi-byte content: msg.bytes (pty-host count) differs from
+    // data.length (UTF-16 code units). The FIFO stores msg.bytes.
+    port.postMessage({ type: "data", id: "term-1", data: "a", bytes: 300 });
+    port.postMessage({ type: "data", id: "term-1", data: "b", bytes: 7 });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const acks: Record<string, unknown>[] = [];
+        port.addEventListener("message", (event: MessageEvent) => {
+          const msg = event.data as Record<string, unknown>;
+          if (msg?.type === "ack" && msg.id === "term-1") acks.push(msg);
+        });
+        port.start();
+
+        terminalClient.discardPortAcks("term-1");
+
+        setTimeout(() => {
+          expect(acks).toEqual([{ type: "ack", id: "term-1", bytes: 307 }]);
+          resolve();
+        }, 100);
+      }, 50);
+    });
+  });
+
   it("discardPortAcks is a no-op when the FIFO is empty", () => {
     const port = acquirePort();
 

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -328,6 +328,93 @@ describe("terminalClient MessagePort data routing", () => {
     });
   });
 
+  it("discardPortAcks posts a single batched ack with the summed FIFO total and clears the queue", () => {
+    const port = acquirePort();
+
+    // Live path: queue three pending ack entries (10 + 20 + 12 bytes).
+    terminalClient.onData("term-1", () => {});
+    port.postMessage({ type: "data", id: "term-1", data: "aaaaaaaaaa", bytes: 10 });
+    port.postMessage({ type: "data", id: "term-1", data: "bbbbbbbbbbbbbbbbbbbb", bytes: 20 });
+    port.postMessage({ type: "data", id: "term-1", data: "cccccccccccc", bytes: 12 });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const acks: Record<string, unknown>[] = [];
+        port.addEventListener("message", (event: MessageEvent) => {
+          const msg = event.data as Record<string, unknown>;
+          if (msg?.type === "ack" && msg.id === "term-1") acks.push(msg);
+        });
+        port.start();
+
+        terminalClient.discardPortAcks("term-1");
+        // The FIFO is now empty — a follow-up acknowledgePortData must not
+        // double-ack the discarded bytes.
+        terminalClient.acknowledgePortData("term-1", 999);
+
+        setTimeout(() => {
+          expect(acks).toEqual([{ type: "ack", id: "term-1", bytes: 42 }]);
+          resolve();
+        }, 100);
+      }, 50);
+    });
+  });
+
+  it("discardPortAcks is a no-op when the FIFO is empty", () => {
+    const port = acquirePort();
+
+    return new Promise<void>((resolve) => {
+      const acks: Record<string, unknown>[] = [];
+      port.addEventListener("message", (event: MessageEvent) => {
+        const msg = event.data as Record<string, unknown>;
+        if (msg?.type === "ack") acks.push(msg);
+      });
+      port.start();
+
+      terminalClient.discardPortAcks("term-1");
+
+      setTimeout(() => {
+        expect(acks).toEqual([]);
+        resolve();
+      }, 100);
+    });
+  });
+
+  it("discardPortAcks does not throw when no port is connected", () => {
+    expect(() => terminalClient.discardPortAcks("term-1")).not.toThrow();
+  });
+
+  it("discardPortAcks does not leak the FIFO across terminals", () => {
+    const port = acquirePort();
+
+    terminalClient.onData("term-1", () => {});
+    terminalClient.onData("term-2", () => {});
+    port.postMessage({ type: "data", id: "term-1", data: "aaaa", bytes: 4 });
+    port.postMessage({ type: "data", id: "term-2", data: "bbbbbb", bytes: 6 });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const acks: Record<string, unknown>[] = [];
+        port.addEventListener("message", (event: MessageEvent) => {
+          const msg = event.data as Record<string, unknown>;
+          if (msg?.type === "ack") acks.push(msg);
+        });
+        port.start();
+
+        terminalClient.discardPortAcks("term-1");
+        // term-2's entry must survive and ack normally.
+        terminalClient.acknowledgePortData("term-2", 999);
+
+        setTimeout(() => {
+          expect(acks).toEqual([
+            { type: "ack", id: "term-1", bytes: 4 },
+            { type: "ack", id: "term-2", bytes: 6 },
+          ]);
+          resolve();
+        }, 100);
+      }, 50);
+    });
+  });
+
   it("dispatches to correct terminal only", () => {
     const port = acquirePort();
     const received1: string[] = [];

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -412,6 +412,33 @@ export const terminalClient = {
   },
 
   /**
+   * Drain the entire pending port-ack FIFO for a terminal as one batched ack.
+   * Called when held ingest bytes are discarded without ever reaching xterm
+   * (hibernation reset, post-replay discard on wake) — the pty-host's
+   * queuedBytes ledger still counts them, so dropping the queue without
+   * acking leaves a permanent deficit that degrades every backpressure pause
+   * to the 10s safety timeout (#9910). The FIFO entry is always deleted, even
+   * when the port is gone or postMessage throws: stale entries would be
+   * re-summed into phantom acks on the next discard.
+   */
+  discardPortAcks: (id: string): void => {
+    const queue = pendingPortAckBytes.get(id);
+    if (!queue) return;
+    pendingPortAckBytes.delete(id);
+    if (!messagePort) return;
+    let bytes = 0;
+    for (const entry of queue) {
+      bytes += entry;
+    }
+    if (bytes === 0) return;
+    try {
+      messagePort.postMessage({ type: "ack", id, bytes });
+    } catch {
+      // Port closed — ack lost, safety timeout will resume PTY
+    }
+  },
+
+  /**
    * Query backend for terminals belonging to a specific project.
    * Used during state hydration to reconcile UI with backend processes.
    */

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -171,7 +171,14 @@ class TerminalInstanceService {
     this.hibernationManager = new TerminalHibernationManager({
       getInstance: (id) => this.instances.get(id),
       destroyRestoreState: (id) => this.restoreController.destroy(id),
-      resetBufferedOutput: (id) => this.dataBuffer.resetForTerminal(id),
+      resetBufferedOutput: (id) => {
+        // Ack bytes held in the ingest queue before wiping it: the pty-host's
+        // queuedBytes ledger counts them, and a silent discard leaves a
+        // permanent deficit that degrades backpressure to the 10s safety
+        // timeout (#9910).
+        terminalClient.discardPortAcks(id);
+        this.dataBuffer.resetForTerminal(id);
+      },
       releaseWebGL: (id) => this.webGLManager.onTerminalDestroyed(id),
       clearResizeJob: (managed) => this.resizeController.clearResizeJob(managed),
       clearSettledTimer: (id) => this.resizeController.clearSettledTimer(id),
@@ -209,6 +216,7 @@ class TerminalInstanceService {
       },
       onPostWake: (id) => this.handlePostWake(id),
       onResumeFlush: (id) => this.dataBuffer.resumeFlush(id),
+      onDiscardHeld: (id) => this.discardHeldOutput(id),
       applyDeferredResize: (id) => this.resizeController.applyDeferredResize(id),
       onBackgrounded: (id) => this.wakeManager.cancelPendingWake(id),
       onTierApplied: (id, tier, managed) => {
@@ -953,7 +961,7 @@ class TerminalInstanceService {
     // clears it in place. No-op for DOM-renderer terminals.
     this.webGLManager.repairAtlasForReactivation(id);
 
-    const ok = await this.wakeManager.wakeAndRestore(id);
+    const { ok, replayedMainBuffer } = await this.wakeManager.wakeAndRestore(id);
 
     // Re-check after async: terminal may have been destroyed, hibernated, or
     // replaced while wakeAndRestore was in flight.
@@ -966,7 +974,24 @@ class TerminalInstanceService {
     if (ok) {
       this.handlePostWake(id);
     }
-    this.dataBuffer.resumeFlush(id);
+    if (replayedMainBuffer) {
+      // The replayed snapshot already contains the held bytes — flushing
+      // would double-paint them (#9910).
+      this.discardHeldOutput(id);
+    } else {
+      this.dataBuffer.resumeFlush(id);
+    }
+  }
+
+  /**
+   * Drop bytes held in the ingest queue while backgrounded and ack them to
+   * the pty-host. Used after a successful main-buffer replay: the snapshot
+   * already contains those bytes, so flushing them would double-paint the
+   * tail, but the host's queuedBytes ledger still needs the acks (#9910).
+   */
+  private discardHeldOutput(id: string): void {
+    terminalClient.discardPortAcks(id);
+    this.dataBuffer.resetForTerminal(id);
   }
 
   /**

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -2891,6 +2891,11 @@ class TerminalInstanceService {
     this.resizeController.clearResizeJob(managed);
     this.resizeController.clearResizeLock(id);
     this.resizeController.clearSettledTimer(id);
+    // Renderer-side destroy without a prior kill (project close, LRU
+    // eviction of an exited terminal) must still drain the port-ack FIFO
+    // before the held queue is wiped (#9910). kill/gracefulKill/trash clear
+    // the FIFO themselves, so this is a no-op on those paths.
+    terminalClient.discardPortAcks(id);
     this.dataBuffer.resetForTerminal(id);
     this.unseenTracker.destroy(id);
     this.hibernationListeners.delete(id);

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -234,6 +234,10 @@ export class TerminalOutputIngestService {
         globalThis.setTimeout(() => {
           if (this.queues.get(id) !== queue) return;
           queue.drainScheduled = false;
+          // Tier may have flipped to BACKGROUND between scheduling and firing —
+          // draining now would parse into a hidden pane. The held bytes are
+          // flushed by resumeFlush on the next tier upgrade.
+          if (this.isBackgrounded(id)) return;
           this.tryDrain(id, queue);
         }, 0);
         return;

--- a/src/services/terminal/TerminalRendererPolicy.ts
+++ b/src/services/terminal/TerminalRendererPolicy.ts
@@ -1,13 +1,22 @@
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier } from "@/types";
 import type { ManagedTerminal } from "./types";
+import type { WakeResult } from "./TerminalWakeManager";
 import { TIER_DOWNGRADE_HYSTERESIS_MS } from "./types";
 
 export interface RendererPolicyDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
-  wakeAndRestore: (id: string) => Promise<boolean>;
+  wakeAndRestore: (id: string) => Promise<WakeResult>;
   onPostWake?: (id: string) => void;
   onResumeFlush?: (id: string) => void;
+  /**
+   * Discard bytes held while backgrounded instead of flushing them: the wake
+   * replayed the host's main-buffer snapshot, which already contains every
+   * byte the renderer has received — flushing would paint the tail twice
+   * (#9910). Implementations must also ack the discarded bytes so the
+   * pty-host's queuedBytes ledger drains.
+   */
+  onDiscardHeld?: (id: string) => void;
   onTierApplied?: (id: string, tier: TerminalRefreshTier, managed: ManagedTerminal) => void;
   applyDeferredResize?: (id: string) => void;
   onBackgrounded?: (id: string) => void;
@@ -183,7 +192,7 @@ export class TerminalRendererPolicy {
         const wakeTarget = managed;
         void this.deps
           .wakeAndRestore(id)
-          .then((ok) => {
+          .then(({ ok, replayedMainBuffer }) => {
             if (this.wakeGeneration.get(id) !== wakeGeneration) return;
             const current = this.deps.getInstance(id);
             if (!current || current !== wakeTarget) return;
@@ -200,10 +209,18 @@ export class TerminalRendererPolicy {
               this.deps.onPostWake?.(id);
             }
 
-            // Flush bytes held while backgrounded AFTER scrollback restore +
-            // refresh. wakeAndRestore calls terminal.reset() during replay;
-            // flushing earlier would wipe these bytes.
-            this.deps.onResumeFlush?.(id);
+            if (replayedMainBuffer) {
+              // The replayed snapshot already contains every held byte —
+              // flushing on top would double-paint the tail (#9910). Discard
+              // the queue and ack the bytes instead.
+              this.deps.onDiscardHeld?.(id);
+            } else {
+              // No replay happened (alt-buffer wake, selection skip, missing
+              // state, restore failure) — flush bytes held while backgrounded
+              // AFTER refresh. wakeAndRestore calls terminal.reset() during
+              // replay; flushing earlier would wipe these bytes.
+              this.deps.onResumeFlush?.(id);
+            }
           })
           .catch(() => {
             if (this.wakeGeneration.get(id) !== wakeGeneration) return;

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -38,12 +38,26 @@ export interface WakeManagerDeps {
   onDeclined?: (id: string) => void;
 }
 
+export interface WakeResult {
+  ok: boolean;
+  /**
+   * True only when the host's serialized main-buffer snapshot was actually
+   * replayed into xterm (restoreFromSerialized / incremental succeeded). The
+   * alt-buffer early return, selection skips, missing state, and failures all
+   * resolve with `false` — xterm was not reset+replayed, so bytes held while
+   * backgrounded must still be flushed. Callers use this to choose between
+   * flushing the held ingest queue and discarding it (the snapshot already
+   * contains those bytes — flushing would double-paint them, #9910).
+   */
+  replayedMainBuffer: boolean;
+}
+
 export class TerminalWakeManager {
   private lastWakeTime = new Map<string, number>();
   private pendingWakes = new Map<string, { retries: number; timeoutId: NodeJS.Timeout }>();
   private pendingRateLimitedWakes = new Map<string, NodeJS.Timeout>();
   private declineRetries = new Map<string, { attempt: number; timeoutId: NodeJS.Timeout }>();
-  private inFlightWakes = new Map<string, Promise<boolean>>();
+  private inFlightWakes = new Map<string, Promise<WakeResult>>();
   private deps: WakeManagerDeps;
 
   constructor(deps: WakeManagerDeps) {
@@ -70,16 +84,16 @@ export class TerminalWakeManager {
     );
   }
 
-  async wakeAndRestore(id: string): Promise<boolean> {
+  async wakeAndRestore(id: string): Promise<WakeResult> {
     const inFlight = this.inFlightWakes.get(id);
     if (inFlight) {
       return inFlight;
     }
 
-    const wakePromise = (async () => {
+    const wakePromise = (async (): Promise<WakeResult> => {
       try {
         const managed = this.deps.getInstance(id);
-        if (!managed) return false;
+        if (!managed) return { ok: false, replayedMainBuffer: false };
 
         // xterm v6 clears selection when terminal.reset() is called during
         // restoreFromSerialized. Skip the restore if the user has an active
@@ -88,7 +102,7 @@ export class TerminalWakeManager {
         // is protecting) so the resync lands once the selection is released.
         if (managed.terminal.hasSelection()) {
           this.noteDecline(id, false);
-          return false;
+          return { ok: false, replayedMainBuffer: false };
         }
 
         const { state } = await terminalClient.wake(id);
@@ -96,7 +110,7 @@ export class TerminalWakeManager {
         // Re-check after async: selection may have started while we were awaiting.
         if (managed.terminal.hasSelection()) {
           this.noteDecline(id, false);
-          return false;
+          return { ok: false, replayedMainBuffer: false };
         }
 
         // No serialized snapshot to replay. The host discarded the buffered
@@ -104,10 +118,10 @@ export class TerminalWakeManager {
         // retry in case the snapshot becomes available. Alternate-screen TUIs
         // fall through here too: addon-serialize includes the alt-buffer frame
         // (\x1b[?1049h + content), so a present snapshot correctly repaints the
-        // TUI rather than being silently treated as a no-op resync.
+        // TUI rather than being silently treated as a no-op resync (#9894).
         if (!state) {
           this.noteDecline(id, true);
-          return false;
+          return { ok: false, replayedMainBuffer: false };
         }
 
         const restoreOk =
@@ -130,7 +144,7 @@ export class TerminalWakeManager {
             usePanelStore.getState().setScrollbackRestoreError(id, restoreError);
             logWarn(`Scrollback restore failed for wake of ${id}`, { error: restoreError });
           }
-          return false;
+          return { ok: false, replayedMainBuffer: false };
         }
 
         if (this.deps.getInstance(id) === managed) {
@@ -146,10 +160,10 @@ export class TerminalWakeManager {
         // visibility-restore wakes don't run triggerWake's success branch).
         // Otherwise the stale timer fires a redundant reset on an active pane.
         this.clearDeclineRetry(id);
-        return true;
+        return { ok: true, replayedMainBuffer: true };
       } catch (error) {
         console.warn(`[TerminalWakeManager] Failed to wake terminal ${id}:`, error);
-        return false;
+        return { ok: false, replayedMainBuffer: false };
       }
     })();
 
@@ -164,8 +178,8 @@ export class TerminalWakeManager {
 
   private triggerWake(id: string): void {
     const startedAt = Date.now();
-    void this.wakeAndRestore(id).then((success) => {
-      if (success) {
+    void this.wakeAndRestore(id).then(({ ok }) => {
+      if (ok) {
         // wakeAndRestore already cancels any pending decline retry on success.
         this.lastWakeTime.set(id, startedAt);
       } else {
@@ -216,8 +230,8 @@ export class TerminalWakeManager {
     }
 
     const startedAt = Date.now();
-    const success = await this.wakeAndRestore(id);
-    if (success) {
+    const { ok } = await this.wakeAndRestore(id);
+    if (ok) {
       this.lastWakeTime.set(id, startedAt);
       this.declineRetries.delete(id);
       return;

--- a/src/services/terminal/TerminalWakeManager.ts
+++ b/src/services/terminal/TerminalWakeManager.ts
@@ -42,10 +42,12 @@ export interface WakeResult {
   ok: boolean;
   /**
    * True only when the host's serialized main-buffer snapshot was actually
-   * replayed into xterm (restoreFromSerialized / incremental succeeded). The
-   * alt-buffer early return, selection skips, missing state, and failures all
-   * resolve with `false` — xterm was not reset+replayed, so bytes held while
-   * backgrounded must still be flushed. Callers use this to choose between
+   * replayed into the still-current xterm instance (restoreFromSerialized /
+   * incremental succeeded). Selection skips, missing state, failures, and a
+   * mid-wake instance swap all resolve with `false` — xterm was not
+   * reset+replayed for the live instance, so bytes held while backgrounded
+   * must still be flushed. Alt-buffer wakes replay like any main-buffer
+   * snapshot (#9894) and so resolve `true`. Callers use this to choose between
    * flushing the held ingest queue and discarding it (the snapshot already
    * contains those bytes — flushing would double-paint them, #9910).
    */
@@ -147,20 +149,26 @@ export class TerminalWakeManager {
           return { ok: false, replayedMainBuffer: false };
         }
 
-        if (this.deps.getInstance(id) === managed) {
-          managed.terminal.refresh(0, managed.terminal.rows - 1);
-          // A previous failed wake of this terminal may have left a banner
-          // in the panel store. Mirror the hydration retry path's cleanup
-          // (#8535): clear it now that the replay has succeeded.
-          usePanelStore.getState().clearScrollbackRestoreError(id);
-        }
         // A successful replay resynced the pane — cancel any decline retry left
         // over from an earlier declined wake of this terminal, regardless of
         // which caller invoked wakeAndRestore (direct RendererPolicy /
         // visibility-restore wakes don't run triggerWake's success branch).
         // Otherwise the stale timer fires a redundant reset on an active pane.
         this.clearDeclineRetry(id);
-        return { ok: true, replayedMainBuffer: true };
+
+        if (this.deps.getInstance(id) === managed) {
+          managed.terminal.refresh(0, managed.terminal.rows - 1);
+          // A previous failed wake of this terminal may have left a banner
+          // in the panel store. Mirror the hydration retry path's cleanup
+          // (#8535): clear it now that the replay has succeeded.
+          usePanelStore.getState().clearScrollbackRestoreError(id);
+          return { ok: true, replayedMainBuffer: true };
+        }
+        // Instance replaced mid-wake (LRU eviction + respawn under the same
+        // id): the replay landed in a stale terminal, so don't claim a
+        // main-buffer replay for the id — callers would wrongly discard the
+        // replacement's held bytes.
+        return { ok: true, replayedMainBuffer: false };
       } catch (error) {
         console.warn(`[TerminalWakeManager] Failed to wake terminal ${id}:`, error);
         return { ok: false, replayedMainBuffer: false };

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -24,6 +24,7 @@ const testState = vi.hoisted(() => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
 }));
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.detach.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.e2eGate.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/clients", () => ({
     getSharedBuffer: vi.fn(() => null),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     getSerializedState: vi.fn(),
     getSharedBuffer: vi.fn(() => null),
+    discardPortAcks: vi.fn(),
   },
   systemClient: {
     openExternal: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },
@@ -83,12 +84,14 @@ type ManagedTerminalMock = {
 
 type FullWakeTestService = {
   instances: Map<string, ManagedTerminalMock>;
-  wakeManager: { wakeAndRestore: (id: string) => Promise<boolean> };
+  wakeManager: {
+    wakeAndRestore: (id: string) => Promise<{ ok: boolean; replayedMainBuffer: boolean }>;
+  };
   resizeController: {
     applyDeferredResize: (id: string) => void;
     lockResize: (id: string, locked: boolean, ms?: number) => void;
   };
-  dataBuffer: { resumeFlush: (id: string) => void };
+  dataBuffer: { resumeFlush: (id: string) => void; resetForTerminal: (id: string) => void };
   webGLManager: { repairAtlasForReactivation: (id: string) => boolean };
   handlePostWake: (id: string) => void;
   unhibernate: (id: string) => void;
@@ -134,7 +137,7 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     if (service) service.instances.clear();
   });
 
-  it("runs applyDeferredResize → forceXtermReflow → wakeAndRestore → refresh → handlePostWake → resumeFlush in order on success", async () => {
+  it("runs applyDeferredResize → forceXtermReflow → wakeAndRestore → refresh → handlePostWake → discard in order on replay success", async () => {
     const id = "fw-1";
     const instance = makeInstance();
     service.instances.set(id, instance);
@@ -152,7 +155,7 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
       .spyOn(service.wakeManager, "wakeAndRestore")
       .mockImplementation(async () => {
         calls.push("wakeAndRestore");
-        return true;
+        return { ok: true, replayedMainBuffer: true };
       });
     const handlePostWake = vi.spyOn(service, "handlePostWake").mockImplementation(() => {
       calls.push("handlePostWake");
@@ -160,26 +163,60 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     const resumeFlush = vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {
       calls.push("resumeFlush");
     });
+    const resetForTerminal = vi
+      .spyOn(service.dataBuffer, "resetForTerminal")
+      .mockImplementation(() => {
+        calls.push("resetForTerminal");
+      });
     (instance.terminal.refresh as ReturnType<typeof vi.fn>).mockImplementation(() => {
       calls.push("refresh");
     });
 
     await service.fullWakeForVisibilityRestore(id);
 
+    // The replayed snapshot already contains the held bytes, so the sequence
+    // ends with the discard (resetForTerminal), not a flush (#9910).
     expect(calls).toEqual([
       "applyDeferredResize",
       "forceXtermReflow",
       "wakeAndRestore",
       "refresh",
       "handlePostWake",
-      "resumeFlush",
+      "resetForTerminal",
     ]);
 
     expect(applyDeferredResize).toHaveBeenCalledWith(id);
     expect(forceXtermReflowMock).toHaveBeenCalledWith(instance.terminal.element);
     expect(wakeAndRestore).toHaveBeenCalledWith(id);
     expect(handlePostWake).toHaveBeenCalledWith(id);
+    expect(resetForTerminal).toHaveBeenCalledWith(id);
+    expect(resumeFlush).not.toHaveBeenCalled();
+
+    const { terminalClient } = await import("@/clients");
+    expect(terminalClient.discardPortAcks).toHaveBeenCalledWith(id);
+  });
+
+  it("flushes (no discard) when the wake succeeds without a main-buffer replay (alt-buffer)", async () => {
+    const id = "fw-1b";
+    const instance = makeInstance();
+    service.instances.set(id, instance);
+
+    vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue({
+      ok: true,
+      replayedMainBuffer: false,
+    });
+    const handlePostWake = vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
+    const resumeFlush = vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
+    const resetForTerminal = vi
+      .spyOn(service.dataBuffer, "resetForTerminal")
+      .mockImplementation(() => {});
+
+    await service.fullWakeForVisibilityRestore(id);
+
+    expect(handlePostWake).toHaveBeenCalledWith(id);
     expect(resumeFlush).toHaveBeenCalledWith(id);
+    expect(resetForTerminal).not.toHaveBeenCalled();
   });
 
   it("repairs the WebGL atlas before the async wakeAndRestore IPC (#9679)", async () => {
@@ -197,10 +234,11 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
       });
     vi.spyOn(service.wakeManager, "wakeAndRestore").mockImplementation(async () => {
       calls.push("wakeAndRestore");
-      return true;
+      return { ok: true, replayedMainBuffer: true };
     });
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
+    vi.spyOn(service.dataBuffer, "resetForTerminal").mockImplementation(() => {});
 
     await service.fullWakeForVisibilityRestore(id);
 
@@ -217,7 +255,9 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
 
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
     vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(false);
-    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: true });
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
@@ -233,7 +273,10 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     service.instances.set(id, instance);
 
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
-    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(false);
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue({
+      ok: false,
+      replayedMainBuffer: false,
+    });
     const handlePostWake = vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     const resumeFlush = vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
@@ -256,7 +299,10 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
       .spyOn(service.resizeController, "lockResize")
       .mockImplementation(() => {});
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
-    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue({
+      ok: true,
+      replayedMainBuffer: true,
+    });
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
@@ -289,7 +335,10 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {
       calls.push("applyDeferredResize");
     });
-    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue({
+      ok: true,
+      replayedMainBuffer: true,
+    });
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
@@ -311,7 +360,10 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
       .spyOn(service.resizeController, "lockResize")
       .mockImplementation(() => {});
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
-    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue({
+      ok: true,
+      replayedMainBuffer: true,
+    });
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
@@ -328,7 +380,9 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     const applyDeferredResize = vi
       .spyOn(service.resizeController, "applyDeferredResize")
       .mockImplementation(() => {});
-    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: true });
 
     await service.fullWakeForVisibilityRestore(id);
 
@@ -344,7 +398,9 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     const applyDeferredResize = vi
       .spyOn(service.resizeController, "applyDeferredResize")
       .mockImplementation(() => {});
-    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: true });
 
     await service.fullWakeForVisibilityRestore(id);
 
@@ -366,7 +422,9 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {
       throw new Error("terminal disposed mid-wake");
     });
-    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: true });
 
     // The throw propagates, but the deferred-wake flag must already be set so
     // notifyAttachSettledWaiters re-runs the wake once attach settles.
@@ -396,7 +454,9 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {
       calls.push("applyDeferredResize");
     });
-    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: true });
 
     await service.fullWakeForVisibilityRestore(id);
 
@@ -415,7 +475,10 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     service.instances.set(id, instance);
 
     vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
-    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue({
+      ok: true,
+      replayedMainBuffer: true,
+    });
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
@@ -439,7 +502,9 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     const applyDeferredResize = vi
       .spyOn(service.resizeController, "applyDeferredResize")
       .mockImplementation(() => {});
-    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: true });
     vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
 
@@ -462,7 +527,9 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     const instance = makeInstance({ isAttaching: false, hostElement });
     service.instances.set(id, instance);
 
-    const wakeAndRestore = vi.spyOn(service.wakeManager, "wakeAndRestore").mockResolvedValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: true });
 
     service.notifyAttachSettledWaiters(id);
     await Promise.resolve();
@@ -486,14 +553,18 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     vi.spyOn(service.wakeManager, "wakeAndRestore").mockImplementation(async () => {
       // Replace the managed terminal mid-flight
       service.instances.set(id, makeInstance());
-      return true;
+      return { ok: true, replayedMainBuffer: true };
     });
     const handlePostWake = vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
     const resumeFlush = vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
+    const resetForTerminal = vi
+      .spyOn(service.dataBuffer, "resetForTerminal")
+      .mockImplementation(() => {});
 
     await service.fullWakeForVisibilityRestore(id);
 
     expect(handlePostWake).not.toHaveBeenCalled();
     expect(resumeFlush).not.toHaveBeenCalled();
+    expect(resetForTerminal).not.toHaveBeenCalled();
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -171,17 +171,23 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     (instance.terminal.refresh as ReturnType<typeof vi.fn>).mockImplementation(() => {
       calls.push("refresh");
     });
+    const { terminalClient } = await import("@/clients");
+    vi.mocked(terminalClient.discardPortAcks).mockImplementation(() => {
+      calls.push("discardPortAcks");
+    });
 
     await service.fullWakeForVisibilityRestore(id);
 
     // The replayed snapshot already contains the held bytes, so the sequence
-    // ends with the discard (resetForTerminal), not a flush (#9910).
+    // ends with the discard (ack the FIFO, then wipe the queue), not a flush
+    // (#9910).
     expect(calls).toEqual([
       "applyDeferredResize",
       "forceXtermReflow",
       "wakeAndRestore",
       "refresh",
       "handlePostWake",
+      "discardPortAcks",
       "resetForTerminal",
     ]);
 
@@ -191,8 +197,6 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     expect(handlePostWake).toHaveBeenCalledWith(id);
     expect(resetForTerminal).toHaveBeenCalledWith(id);
     expect(resumeFlush).not.toHaveBeenCalled();
-
-    const { terminalClient } = await import("@/clients");
     expect(terminalClient.discardPortAcks).toHaveBeenCalledWith(id);
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -14,6 +14,7 @@ const mockTerminalClient = {
   getSharedBuffer: vi.fn(() => null),
   acknowledgeData: vi.fn(),
   acknowledgePortData: vi.fn(),
+  discardPortAcks: vi.fn(),
 };
 
 vi.mock("@/clients", () => ({
@@ -319,6 +320,34 @@ describe("TerminalInstanceService - Hibernation", () => {
       service.hibernate("t1");
 
       expect(managed.hibernationTimer).toBeUndefined();
+    });
+
+    it("should ack held port bytes before discarding the ingest queue (#9910)", () => {
+      const managed = makeMockManaged();
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      const order: string[] = [];
+      mockTerminalClient.discardPortAcks.mockImplementation(() => {
+        order.push("discardPortAcks");
+      });
+      const dataBuffer = (
+        service as unknown as { dataBuffer: { resetForTerminal: (id: string) => void } }
+      ).dataBuffer;
+      const resetForTerminal = vi.spyOn(dataBuffer, "resetForTerminal").mockImplementation(() => {
+        order.push("resetForTerminal");
+      });
+
+      service.hibernate("t1");
+
+      // The ack must drain the pendingPortAckBytes FIFO BEFORE the held
+      // queue is wiped, otherwise the pty-host's queuedBytes ledger keeps a
+      // permanent deficit and backpressure degrades to the 10s safety timeout.
+      expect(mockTerminalClient.discardPortAcks).toHaveBeenCalledWith("t1");
+      expect(resetForTerminal).toHaveBeenCalledWith("t1");
+      expect(order).toEqual(["discardPortAcks", "resetForTerminal"]);
+
+      resetForTerminal.mockRestore();
+      mockTerminalClient.discardPortAcks.mockReset();
     });
 
     it("should keep hostElement in DOM for reuse during unhibernation", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
@@ -24,6 +24,7 @@ const mockTerminalClient = {
   getSharedBuffer: vi.fn(() => null),
   acknowledgeData: vi.fn(),
   acknowledgePortData: vi.fn(),
+  discardPortAcks: vi.fn(),
 };
 
 vi.mock("@/clients", () => ({

--- a/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/clients", () => ({
     resize: vi.fn(),
     getSerializedState: vi.fn(),
     getSharedBuffer: vi.fn(() => null),
+    discardPortAcks: vi.fn(),
   },
   systemClient: {
     openExternal: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.postWake.test.ts
@@ -16,6 +16,7 @@ const { mockTerminalClient } = vi.hoisted(() => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
 }));
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.reflow.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     wake: vi.fn(),
     getSerializedState: vi.fn(),
     getSharedBuffer: vi.fn(() => null),
+    discardPortAcks: vi.fn(),
   },
   systemClient: {
     openExternal: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.scrollback.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.selection.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.selection.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.settle.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -18,6 +18,7 @@ const mockTerminalClient = {
   getSerializedState: vi.fn(),
   getSharedBuffer: vi.fn(() => null),
   acknowledgePortData: vi.fn(),
+  discardPortAcks: vi.fn(),
   acknowledgeData: vi.fn(),
 };
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.viewportPinning.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.viewportPinning.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
     })),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
   },
   systemClient: { openExternal: vi.fn() },
   appClient: { getHydrationState: vi.fn() },

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -53,7 +53,7 @@ describe("WebGL lease through tier transitions", () => {
 
     mockDeps = {
       getInstance: vi.fn(() => mockManagedTerminal as ManagedTerminal),
-      wakeAndRestore: vi.fn(() => Promise.resolve(true)),
+      wakeAndRestore: vi.fn(() => Promise.resolve({ ok: true, replayedMainBuffer: true })),
       onTierApplied: onTierApplied as RendererPolicyDeps["onTierApplied"],
     };
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -14,6 +14,7 @@ const mockTerminalClient = {
   getSharedBuffer: vi.fn(() => null),
   acknowledgeData: vi.fn(),
   acknowledgePortData: vi.fn(),
+  discardPortAcks: vi.fn(),
 };
 
 vi.mock("@/clients", () => ({

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -614,6 +614,35 @@ describe("TerminalOutputIngestService", () => {
       vi.useRealTimers();
     });
 
+    it("ink-erase drain scheduled while foreground does not fire into a terminal backgrounded before the timer (#9910)", () => {
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const tiers = new Map<string, TerminalRefreshTier>([["term-1", TerminalRefreshTier.FOCUSED]]);
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        (id) => tiers.get(id) ?? TerminalRefreshTier.FOCUSED
+      );
+
+      // Complete ink-erase pattern in ONE foreground chunk: the chunk stays
+      // queued and the deferred drain is scheduled with it still in the queue.
+      service.bufferData("term-1", "\x1b[2K\x1b[1Acontent");
+      expect(writeToTerminal).not.toHaveBeenCalled();
+
+      // Tier flips to BACKGROUND between scheduling and firing — the timer
+      // must not drain the held chunk into the hidden pane.
+      tiers.set("term-1", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(0);
+      expect(writeToTerminal).not.toHaveBeenCalled();
+
+      // Back to active + resume → held bytes flush normally.
+      tiers.set("term-1", TerminalRefreshTier.FOCUSED);
+      service.resumeFlush("term-1");
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-1", "\x1b[2K\x1b[1Acontent");
+
+      vi.useRealTimers();
+    });
+
     it("isolates the background gate per terminal", () => {
       const writeToTerminal = vi.fn();
       const tiers = new Map<string, TerminalRefreshTier>([

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.adversarial.test.ts
@@ -62,7 +62,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     const managed = createManagedTerminal();
     const deps: RendererPolicyDeps = {
       getInstance: vi.fn(() => managed),
-      wakeAndRestore: vi.fn(async () => true),
+      wakeAndRestore: vi.fn(async () => ({ ok: true, replayedMainBuffer: true })),
       onTierApplied: vi.fn(),
     };
 
@@ -85,7 +85,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     const managed = createManagedTerminal();
     const deps: RendererPolicyDeps = {
       getInstance: vi.fn(() => managed),
-      wakeAndRestore: vi.fn(async () => true),
+      wakeAndRestore: vi.fn(async () => ({ ok: true, replayedMainBuffer: true })),
       onTierApplied: vi.fn(),
     };
 
@@ -103,7 +103,7 @@ describe("TerminalRendererPolicy adversarial", () => {
   });
 
   it("WAKE_AFTER_INSTANCE_SWAP_NO_WRONG_REFRESH", async () => {
-    const wake = deferred<boolean>();
+    const wake = deferred<{ ok: boolean; replayedMainBuffer: boolean }>();
     const original = createManagedTerminal({
       lastAppliedTier: TerminalRefreshTier.BACKGROUND,
       needsWake: true,
@@ -124,7 +124,7 @@ describe("TerminalRendererPolicy adversarial", () => {
 
     policy.applyRendererPolicy("terminal-1", TerminalRefreshTier.FOCUSED);
     currentManaged = replacement;
-    wake.resolve(true);
+    wake.resolve({ ok: true, replayedMainBuffer: true });
     await wake.promise;
     await Promise.resolve();
 
@@ -138,7 +138,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     const managed = createManagedTerminal();
     const deps: RendererPolicyDeps = {
       getInstance: vi.fn(() => managed),
-      wakeAndRestore: vi.fn(async () => true),
+      wakeAndRestore: vi.fn(async () => ({ ok: true, replayedMainBuffer: true })),
       onTierApplied: vi.fn(),
     };
 
@@ -169,7 +169,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     ]);
     const deps: RendererPolicyDeps = {
       getInstance: vi.fn((id: string) => managedById.get(id)),
-      wakeAndRestore: vi.fn(async () => true),
+      wakeAndRestore: vi.fn(async () => ({ ok: true, replayedMainBuffer: true })),
       onTierApplied: vi.fn(),
     };
 
@@ -186,7 +186,7 @@ describe("TerminalRendererPolicy adversarial", () => {
   });
 
   it("WAKE_REJECTION_AFTER_REMOVAL_SILENT", async () => {
-    const wake = deferred<boolean>();
+    const wake = deferred<{ ok: boolean; replayedMainBuffer: boolean }>();
     const managed = createManagedTerminal({
       lastAppliedTier: TerminalRefreshTier.BACKGROUND,
       needsWake: true,
@@ -210,11 +210,14 @@ describe("TerminalRendererPolicy adversarial", () => {
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
-  it("BACKGROUND_SEEDED_TERMINAL_FLUSHES_ON_FIRST_ACTIVATION", async () => {
+  it("BACKGROUND_SEEDED_TERMINAL_RELEASES_HELD_BYTES_ON_FIRST_ACTIVATION", async () => {
     // Mirrors the initial-BACKGROUND wiring: TerminalInstanceService seeds
     // the backend tier via initializeBackendTier("id","background") so the
-    // first promotion is a real BACKGROUND→active transition that flushes.
-    const wake = deferred<boolean>();
+    // first promotion is a real BACKGROUND→active transition that releases
+    // the held bytes. A successful main-buffer replay routes through
+    // onDiscardHeld (the snapshot already contains them, #9910); a no-replay
+    // wake routes through onResumeFlush.
+    const wake = deferred<{ ok: boolean; replayedMainBuffer: boolean }>();
     const managed = createManagedTerminal({
       lastAppliedTier: TerminalRefreshTier.BACKGROUND,
       getRefreshTier: () => TerminalRefreshTier.FOCUSED,
@@ -224,6 +227,7 @@ describe("TerminalRendererPolicy adversarial", () => {
       getInstance: vi.fn(() => managed),
       wakeAndRestore: vi.fn(() => wake.promise),
       onResumeFlush: vi.fn(),
+      onDiscardHeld: vi.fn(),
       onPostWake: vi.fn(),
     };
 
@@ -234,17 +238,18 @@ describe("TerminalRendererPolicy adversarial", () => {
     policy.applyRendererPolicy("terminal-1", TerminalRefreshTier.FOCUSED);
     expect(deps.wakeAndRestore).toHaveBeenCalledTimes(1);
 
-    wake.resolve(true);
+    wake.resolve({ ok: true, replayedMainBuffer: true });
     await wake.promise;
     await Promise.resolve();
     await Promise.resolve();
 
     expect(managed.terminal.refresh).toHaveBeenCalled();
-    expect(deps.onResumeFlush).toHaveBeenCalledWith("terminal-1");
+    expect(deps.onDiscardHeld).toHaveBeenCalledWith("terminal-1");
+    expect(deps.onResumeFlush).not.toHaveBeenCalled();
   });
 
   it("REBACKGROUND_DURING_WAKE_DOES_NOT_FLUSH_HIDDEN_PANE", async () => {
-    const wake = deferred<boolean>();
+    const wake = deferred<{ ok: boolean; replayedMainBuffer: boolean }>();
     const managed = createManagedTerminal({
       lastAppliedTier: TerminalRefreshTier.BACKGROUND,
       getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
@@ -254,6 +259,7 @@ describe("TerminalRendererPolicy adversarial", () => {
       getInstance: vi.fn(() => managed),
       wakeAndRestore: vi.fn(() => wake.promise),
       onResumeFlush: vi.fn(),
+      onDiscardHeld: vi.fn(),
       onPostWake: vi.fn(),
     };
 
@@ -270,8 +276,10 @@ describe("TerminalRendererPolicy adversarial", () => {
     vi.advanceTimersByTime(1000);
 
     // The previously in-flight wake now resolves — it must be a no-op:
-    // the terminal is hidden again, so no refresh/flush into a dead pane.
-    wake.resolve(true);
+    // the terminal is hidden again, so no refresh/flush/discard into a dead
+    // pane (a stale-generation discard would drop bytes the next real wake's
+    // snapshot may not yet contain).
+    wake.resolve({ ok: true, replayedMainBuffer: true });
     await wake.promise;
     await Promise.resolve();
     await Promise.resolve();
@@ -279,6 +287,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
     expect(deps.onPostWake).not.toHaveBeenCalled();
     expect(deps.onResumeFlush).not.toHaveBeenCalled();
+    expect(deps.onDiscardHeld).not.toHaveBeenCalled();
   });
 
   it("HOST_PUSHED_BACKGROUND_REARMS_DEDUPE_SO_NEXT_ACTIVE_RESENDS", async () => {
@@ -292,7 +301,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     const managed = createManagedTerminal();
     const deps: RendererPolicyDeps = {
       getInstance: vi.fn(() => managed),
-      wakeAndRestore: vi.fn(async () => true),
+      wakeAndRestore: vi.fn(async () => ({ ok: true, replayedMainBuffer: true })),
     };
 
     const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
@@ -334,7 +343,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     const managed = createManagedTerminal();
     const deps: RendererPolicyDeps = {
       getInstance: vi.fn(() => managed),
-      wakeAndRestore: vi.fn(async () => true),
+      wakeAndRestore: vi.fn(async () => ({ ok: true, replayedMainBuffer: true })),
     };
 
     const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
@@ -365,7 +374,7 @@ describe("TerminalRendererPolicy adversarial", () => {
     const managed = createManagedTerminal();
     const deps: RendererPolicyDeps = {
       getInstance: vi.fn(() => managed),
-      wakeAndRestore: vi.fn(async () => true),
+      wakeAndRestore: vi.fn(async () => ({ ok: true, replayedMainBuffer: true })),
     };
 
     const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
@@ -386,7 +395,7 @@ describe("TerminalRendererPolicy adversarial", () => {
   });
 
   it("CLEAR_TIER_STATE_CANCELS_PENDING_WAKE_AND_RELEASES_GENERATION", async () => {
-    const wake = deferred<boolean>();
+    const wake = deferred<{ ok: boolean; replayedMainBuffer: boolean }>();
     const managed = createManagedTerminal({
       lastAppliedTier: TerminalRefreshTier.BACKGROUND,
       needsWake: true,
@@ -402,7 +411,7 @@ describe("TerminalRendererPolicy adversarial", () => {
 
     policy.applyRendererPolicy("terminal-1", TerminalRefreshTier.FOCUSED);
     policy.clearTierState("terminal-1");
-    wake.resolve(true);
+    wake.resolve({ ok: true, replayedMainBuffer: true });
     await wake.promise;
     await Promise.resolve();
 

--- a/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
+++ b/src/services/terminal/__tests__/TerminalRendererPolicy.test.ts
@@ -33,7 +33,7 @@ describe("TerminalRendererPolicy", () => {
 
     mockDeps = {
       getInstance: vi.fn(() => mockManagedTerminal as ManagedTerminal),
-      wakeAndRestore: vi.fn(() => Promise.resolve(true)),
+      wakeAndRestore: vi.fn(() => Promise.resolve({ ok: true, replayedMainBuffer: true })),
     };
 
     const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
@@ -216,7 +216,9 @@ describe("TerminalRendererPolicy", () => {
     it("does not call onPostWake when wake fails", async () => {
       const onPostWake = vi.fn();
       mockDeps.onPostWake = onPostWake;
-      mockDeps.wakeAndRestore = vi.fn(() => Promise.resolve(false));
+      mockDeps.wakeAndRestore = vi.fn(() =>
+        Promise.resolve({ ok: false, replayedMainBuffer: false })
+      );
       mockManagedTerminal.isAltBuffer = true;
       mockManagedTerminal.needsWake = true;
       mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
@@ -257,6 +259,80 @@ describe("TerminalRendererPolicy", () => {
       });
 
       expect(terminal.scrollToBottom).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("wake-result flush dispatch (#9910)", () => {
+    let onResumeFlush: ReturnType<typeof vi.fn>;
+    let onDiscardHeld: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      onResumeFlush = vi.fn();
+      onDiscardHeld = vi.fn();
+      mockDeps.onResumeFlush = onResumeFlush as unknown as ((id: string) => void) | undefined;
+      mockDeps.onDiscardHeld = onDiscardHeld as unknown as ((id: string) => void) | undefined;
+      mockManagedTerminal.needsWake = true;
+      mockManagedTerminal.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+    });
+
+    async function applyActiveUpgrade(): Promise<void> {
+      const { TerminalRendererPolicy } = await import("../TerminalRendererPolicy");
+      policy = new TerminalRendererPolicy(mockDeps);
+      policy.initializeBackendTier("test-id", "background");
+      policy.applyRendererPolicy("test-id", TerminalRefreshTier.FOCUSED);
+      await vi.waitFor(() => {
+        expect(mockDeps.wakeAndRestore).toHaveBeenCalled();
+      });
+    }
+
+    it("discards held bytes (no flush) after a successful main-buffer replay", async () => {
+      mockDeps.wakeAndRestore = vi.fn(() =>
+        Promise.resolve({ ok: true, replayedMainBuffer: true })
+      );
+
+      await applyActiveUpgrade();
+
+      await vi.waitFor(() => {
+        expect(onDiscardHeld).toHaveBeenCalledExactlyOnceWith("test-id");
+      });
+      expect(onResumeFlush).not.toHaveBeenCalled();
+    });
+
+    it("flushes held bytes on an alt-buffer wake (ok without replay)", async () => {
+      mockDeps.wakeAndRestore = vi.fn(() =>
+        Promise.resolve({ ok: true, replayedMainBuffer: false })
+      );
+
+      await applyActiveUpgrade();
+
+      await vi.waitFor(() => {
+        expect(onResumeFlush).toHaveBeenCalledExactlyOnceWith("test-id");
+      });
+      expect(onDiscardHeld).not.toHaveBeenCalled();
+    });
+
+    it("flushes held bytes when the wake fails", async () => {
+      mockDeps.wakeAndRestore = vi.fn(() =>
+        Promise.resolve({ ok: false, replayedMainBuffer: false })
+      );
+
+      await applyActiveUpgrade();
+
+      await vi.waitFor(() => {
+        expect(onResumeFlush).toHaveBeenCalledExactlyOnceWith("test-id");
+      });
+      expect(onDiscardHeld).not.toHaveBeenCalled();
+    });
+
+    it("flushes held bytes when the wake rejects", async () => {
+      mockDeps.wakeAndRestore = vi.fn(() => Promise.reject(new Error("boom")));
+
+      await applyActiveUpgrade();
+
+      await vi.waitFor(() => {
+        expect(onResumeFlush).toHaveBeenCalledExactlyOnceWith("test-id");
+      });
+      expect(onDiscardHeld).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -225,6 +225,41 @@ describe("TerminalWakeManager", () => {
     manager.dispose();
   });
 
+  it("does not claim a main-buffer replay when the instance was replaced mid-wake", async () => {
+    wakeMock.mockResolvedValueOnce({ state: "serialized-state" });
+    const original: MockManagedTerminal = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+      terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+      isAltBuffer: false,
+    };
+    const replacement: MockManagedTerminal = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+      terminal: { rows: 24, refresh: vi.fn(), hasSelection: vi.fn(() => false) } as any,
+      isAltBuffer: false,
+    };
+    let current = original;
+    const deps: WakeManagerDeps = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+      getInstance: vi.fn(() => current as unknown as ManagedTerminal),
+      hasInstance: vi.fn(() => true),
+      restoreFromSerialized: vi.fn(() => {
+        // LRU eviction + respawn under the same id while the replay runs.
+        current = replacement;
+        return true;
+      }),
+      restoreFromSerializedIncremental: vi.fn(async () => true),
+    };
+    const manager = new TerminalWakeManager(deps);
+
+    const result = await manager.wakeAndRestore("term-swapped");
+
+    // The replay landed in a stale terminal — claiming replayedMainBuffer
+    // would make callers discard the replacement's held bytes.
+    expect(result).toEqual({ ok: true, replayedMainBuffer: false });
+    expect(original.terminal.refresh).not.toHaveBeenCalled();
+    expect(replacement.terminal.refresh).not.toHaveBeenCalled();
+  });
+
   it("deduplicates overlapping wake() triggers while restore is in flight", async () => {
     let resolveWake!: (value: { state: string }) => void;
     const wakePromise = new Promise<{ state: string }>((resolve) => {

--- a/src/services/terminal/__tests__/TerminalWakeManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWakeManager.test.ts
@@ -57,7 +57,10 @@ describe("TerminalWakeManager", () => {
     };
     const manager = new TerminalWakeManager(deps);
 
-    await expect(manager.wakeAndRestore("term-1")).resolves.toBe(false);
+    await expect(manager.wakeAndRestore("term-1")).resolves.toEqual({
+      ok: false,
+      replayedMainBuffer: false,
+    });
   });
 
   it("allows retry after a failed wakeAndRestore call", async () => {
@@ -107,8 +110,8 @@ describe("TerminalWakeManager", () => {
 
     resolveWake({ state: "serialized-state" });
 
-    await expect(first).resolves.toBe(true);
-    await expect(second).resolves.toBe(true);
+    await expect(first).resolves.toEqual({ ok: true, replayedMainBuffer: true });
+    await expect(second).resolves.toEqual({ ok: true, replayedMainBuffer: true });
     expect(deps.restoreFromSerialized).toHaveBeenCalledTimes(1);
   });
 
@@ -134,7 +137,10 @@ describe("TerminalWakeManager", () => {
 
     const result = await manager.wakeAndRestore("term-alt");
 
-    expect(result).toBe(true);
+    // The alt-buffer snapshot is replayed like any main-buffer snapshot
+    // (#9894): replayedMainBuffer is true, so the policy discards the held
+    // bytes (the snapshot already contains them) rather than double-painting.
+    expect(result).toEqual({ ok: true, replayedMainBuffer: true });
     expect(deps.restoreFromSerialized).toHaveBeenCalledWith("term-alt", "serialized-state");
   });
 
@@ -161,7 +167,7 @@ describe("TerminalWakeManager", () => {
 
     const result = await manager.wakeAndRestore("term-alt-null-state");
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ ok: false, replayedMainBuffer: false });
     expect(deps.restoreFromSerialized).not.toHaveBeenCalled();
     expect(deps.restoreFromSerializedIncremental).not.toHaveBeenCalled();
     // A null snapshot is a user-visible gap — the marker is drawn once.
@@ -188,7 +194,7 @@ describe("TerminalWakeManager", () => {
 
     const result = await manager.wakeAndRestore("term-normal");
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ok: true, replayedMainBuffer: true });
     expect(deps.restoreFromSerialized).toHaveBeenCalledWith("term-normal", "serialized-state");
   });
 
@@ -210,7 +216,7 @@ describe("TerminalWakeManager", () => {
 
     const result = await manager.wakeAndRestore("term-normal-null-state");
 
-    expect(result).toBe(false);
+    expect(result).toEqual({ ok: false, replayedMainBuffer: false });
     expect(deps.restoreFromSerialized).not.toHaveBeenCalled();
     expect(deps.restoreFromSerializedIncremental).not.toHaveBeenCalled();
 
@@ -700,7 +706,7 @@ describe("TerminalWakeManager", () => {
 
       const result = await manager.wakeAndRestore("term-fail-small");
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ ok: false, replayedMainBuffer: false });
       expect(setScrollbackRestoreErrorMock).toHaveBeenCalledTimes(1);
       expect(setScrollbackRestoreErrorMock).toHaveBeenCalledWith("term-fail-small", restoreError);
       // The buffer refresh that success would perform is skipped on failure.
@@ -726,7 +732,7 @@ describe("TerminalWakeManager", () => {
 
       const result = await manager.wakeAndRestore("term-fail-incr");
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ ok: false, replayedMainBuffer: false });
       expect(setScrollbackRestoreErrorMock).toHaveBeenCalledTimes(1);
       expect(setScrollbackRestoreErrorMock).toHaveBeenCalledWith("term-fail-incr", restoreError);
     });
@@ -744,7 +750,7 @@ describe("TerminalWakeManager", () => {
 
       const result = await manager.wakeAndRestore("term-success");
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ ok: true, replayedMainBuffer: true });
       expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
       expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
     });
@@ -764,7 +770,7 @@ describe("TerminalWakeManager", () => {
 
       const result = await manager.wakeAndRestore("term-fail-no-error");
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ ok: false, replayedMainBuffer: false });
       expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
     });
 
@@ -801,7 +807,7 @@ describe("TerminalWakeManager", () => {
         const first = manager.wakeAndRestore("term-rate-fail");
         await vi.advanceTimersByTimeAsync(0);
         const firstResult = await first;
-        expect(firstResult).toBe(false); // signals failure to triggerWake
+        expect(firstResult.ok).toBe(false); // signals failure to triggerWake
 
         // Second wake fires immediately (no rate-limit coalescing) because
         // triggerWake observed `false` and did not record lastWakeTime.
@@ -834,7 +840,7 @@ describe("TerminalWakeManager", () => {
 
       const result = await manager.wakeAndRestore("term-recover");
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ ok: true, replayedMainBuffer: true });
       expect(setScrollbackRestoreErrorMock).not.toHaveBeenCalled();
       expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledTimes(1);
       expect(clearScrollbackRestoreErrorMock).toHaveBeenCalledWith("term-recover");
@@ -859,7 +865,7 @@ describe("TerminalWakeManager", () => {
 
       const result = await manager.wakeAndRestore("term-fail-no-clear");
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ ok: false, replayedMainBuffer: false });
       expect(clearScrollbackRestoreErrorMock).not.toHaveBeenCalled();
     });
   });
@@ -902,7 +908,7 @@ describe("TerminalWakeManager", () => {
         const manager = new TerminalWakeManager(deps);
 
         const first = await manager.wakeAndRestore("term-decline-sel");
-        expect(first).toBe(false);
+        expect(first).toEqual({ ok: false, replayedMainBuffer: false });
         // The selection guard fires before the wake IPC — no snapshot fetched.
         expect(wakeMock).not.toHaveBeenCalled();
         // No marker for a selection decline — it would write into the terminal
@@ -932,7 +938,7 @@ describe("TerminalWakeManager", () => {
         const manager = new TerminalWakeManager(makeDeclineDeps(managed, onDeclined));
 
         const first = await manager.wakeAndRestore("term-decline-null");
-        expect(first).toBe(false);
+        expect(first).toEqual({ ok: false, replayedMainBuffer: false });
         expect(onDeclined).toHaveBeenCalledTimes(1);
         expect(wakeMock).toHaveBeenCalledTimes(1);
 
@@ -1076,7 +1082,7 @@ describe("TerminalWakeManager", () => {
 
         // A direct wake (e.g. from RendererPolicy) succeeds before the retry.
         const result = await manager.wakeAndRestore("term-decline-direct");
-        expect(result).toBe(true);
+        expect(result).toEqual({ ok: true, replayedMainBuffer: true });
         expect(manager.hasPendingWake("term-decline-direct")).toBe(false);
 
         // The leftover decline timer must not fire another wake.

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/clients", () => ({
     submit: mockSubmit,
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),
   },

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -21,6 +21,7 @@ vi.mock("@/clients", () => ({
     submit: vi.fn().mockResolvedValue(undefined),
     acknowledgeData: vi.fn(),
     acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
     setActivityTier: vi.fn(),
     wake: vi.fn(),
   },


### PR DESCRIPTION
## Summary

- When a terminal hibernated, held ingest bytes were never acked back to the pty-host, letting the `queuedBytes` ledger accumulate a permanent deficit that grows across hibernate/wake cycles.
- On wake, `TerminalRendererPolicy` always flushed the held ingest queue — but when the main buffer was replayed from a snapshot, those bytes were already baked in, causing a double-paint.
- Adds `terminalClient.discardPortAcks(id)`, which drains the `pendingPortAckBytes` FIFO as one batched ack (entry always deleted; post only when total > 0). The hibernate path (`resetBufferedOutput`) acks before wiping. `TerminalWakeManager.wakeAndRestore` now returns `{ ok, replayedMainBuffer }` — true only when `restoreFromSerialized`/`restoreFromIncremental` actually ran and succeeded; the policy dispatches discard vs flush based on that.

Resolves #9910

## Changes

- `terminalClient.discardPortAcks(id)` — batched ack drain, no-op when FIFO is empty
- `TerminalHibernationManager.resetBufferedOutput` — acks before clearing the held queue
- `TerminalWakeManager.wakeAndRestore` returns `WakeResult` with `replayedMainBuffer`; alt-buffer early-return, selection skips, null state, and failures all return `false`
- `TerminalRendererPolicy` — dispatches `discardPortAcks` on replay, `flushHeldIngestBytes` otherwise; `fullWakeForVisibilityRestore` gets the same dispatch
- Ink-erase deferred drain re-checks the background gate before `tryDrain`
- Follow-up commit: `wakeAndRestore` no longer claims `replayedMainBuffer` on mid-wake instance swap; `destroy()` drains the port-ack FIFO before wiping the ingest queue

## Testing

- 4 new `discardPortAcks` client tests covering multi-byte FIFO sums and cross-terminal isolation
- `WakeResult` shape assertions + mid-wake instance-swap case
- New policy dispatch block: replay→discard, alt-buffer→flush, fail→flush, reject→flush
- Adversarial update: stale-generation wake neither flushes nor discards
- Hibernate ack-before-reset ordering test
- Single-chunk ink-erase race test
- `fullWake` discard-ordering test