### PR TITLE
fix(fleet): rank saved fleets by frecency and close the recall/save race

### DIFF
--- a/src/components/Fleet/SavedFleetRow.tsx
+++ b/src/components/Fleet/SavedFleetRow.tsx
@@ -2,21 +2,24 @@ import type { ReactElement } from "react";
 import { Trash2 } from "lucide-react";
 import type { FleetSavedScope } from "@shared/types";
 import { actionService } from "@/services/ActionService";
-import { computeSavedScopePaneCount } from "@/services/actions/definitions/fleetActions";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 interface SavedFleetRowProps {
   scope: FleetSavedScope;
   onRequestDelete: (id: string) => void;
+  /** Live count of panes this scope would currently arm. */
+  count: number;
+  /** True for snapshots whose stored terminal IDs are all gone. */
+  isStale: boolean;
 }
 
-export function SavedFleetRow({ scope, onRequestDelete }: SavedFleetRowProps): ReactElement {
-  // Counts are computed at render time — the dropdown opens fresh each time,
-  // so re-running this on every paint of the open menu is fine and there's no
-  // need for a panelStore subscription that would burn cycles while closed.
-  const count = computeSavedScopePaneCount(scope);
+export function SavedFleetRow({
+  scope,
+  onRequestDelete,
+  count,
+  isStale,
+}: SavedFleetRowProps): ReactElement {
   const flavorLabel = scope.kind === "snapshot" ? "Snapshot" : "Live";
-  const isStale = scope.kind === "snapshot" && count === 0;
   return (
     <DropdownMenuItem
       aria-disabled={isStale || undefined}

--- a/src/components/Fleet/SavedFleetsSection.tsx
+++ b/src/components/Fleet/SavedFleetsSection.tsx
@@ -1,7 +1,8 @@
-import type { ReactElement } from "react";
+import { useMemo, type ReactElement } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import { usePanelStore } from "@/store/panelStore";
 import {
   DropdownMenuGroup,
   DropdownMenuLabel,
@@ -9,6 +10,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SavedFleetRow } from "./SavedFleetRow";
 import { SaveFleetForm } from "./SaveFleetForm";
+import { computeSavedScopePaneCount } from "@/services/actions/definitions/fleetActions";
+import { rankSavedFleets, rankPredicateFleets } from "./fleetRanking";
+import type { FleetSavedScope } from "@shared/types";
 
 interface SavedFleetsSectionProps {
   onRequestDelete: (id: string) => void;
@@ -32,25 +36,59 @@ export function SavedFleetsSection({ onRequestDelete }: SavedFleetsSectionProps)
   const savedScopes = useProjectSettingsStore(
     useShallow((s) => s.settings?.fleetSavedScopes ?? [])
   );
+  // Subscribe so the stale sub-group re-derives when panes open/close. The
+  // value itself feeds the memo's dep array; the per-row aria-disabled check
+  // in SavedFleetRow reads panel state directly so it stays in sync too.
+  const panelsById = usePanelStore(useShallow((s) => s.panelsById));
 
-  const snapshotScopes = savedScopes.filter((s) => s.kind === "snapshot");
-  const smartSetScopes = savedScopes.filter((s) => s.kind === "predicate" && !isPresetPredicate(s));
+  const { snapshotUsable, snapshotStale, predicateRanked } = useMemo(() => {
+    const snapshots: FleetSavedScope[] = [];
+    const predicates: FleetSavedScope[] = [];
+    for (const scope of savedScopes) {
+      if (scope.kind === "snapshot") {
+        snapshots.push(scope);
+      } else if (!isPresetPredicate(scope)) {
+        predicates.push(scope);
+      }
+    }
+    const now = Date.now();
+    const isStaleById = new Map<string, boolean>();
+    for (const scope of snapshots) {
+      isStaleById.set(scope.id, computeSavedScopePaneCount(scope) === 0);
+    }
+    const { usable, stale } = rankSavedFleets(snapshots, now, isStaleById);
+    return {
+      snapshotUsable: usable,
+      snapshotStale: stale,
+      predicateRanked: rankPredicateFleets(predicates, now),
+    };
+    // panelsById is in the dep list to re-rank when the panel set changes;
+    // savedScopes is the primary driver of re-rank.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- panelsById is a render-trigger
+  }, [savedScopes, panelsById]);
+
+  const hasSnapshots = snapshotUsable.length + snapshotStale.length > 0;
+  const showStaleSeparator = snapshotUsable.length > 0 && snapshotStale.length > 0;
 
   return (
     <>
       <DropdownMenuSeparator />
-      {snapshotScopes.length > 0 && (
+      {hasSnapshots && (
         <DropdownMenuGroup>
-          <DropdownMenuLabel>Pinned</DropdownMenuLabel>
-          {snapshotScopes.map((scope) => (
+          <DropdownMenuLabel>Snapshots</DropdownMenuLabel>
+          {snapshotUsable.map((scope) => (
+            <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
+          ))}
+          {showStaleSeparator && <DropdownMenuSeparator />}
+          {snapshotStale.map((scope) => (
             <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
           ))}
         </DropdownMenuGroup>
       )}
-      {smartSetScopes.length > 0 && (
+      {predicateRanked.length > 0 && (
         <DropdownMenuGroup>
           <DropdownMenuLabel>Smart-Sets</DropdownMenuLabel>
-          {smartSetScopes.map((scope) => (
+          {predicateRanked.map((scope) => (
             <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
           ))}
         </DropdownMenuGroup>

--- a/src/components/Fleet/SavedFleetsSection.tsx
+++ b/src/components/Fleet/SavedFleetsSection.tsx
@@ -10,8 +10,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SavedFleetRow } from "./SavedFleetRow";
 import { SaveFleetForm } from "./SaveFleetForm";
-import { computeSavedScopePaneCount } from "@/services/actions/definitions/fleetActions";
 import { rankSavedFleets, rankPredicateFleets } from "./fleetRanking";
+import { isSnapshotStale } from "./fleetStaleness";
+import { computeSavedScopePaneCount } from "@/services/actions/definitions/fleetActions";
 import type { FleetSavedScope } from "@shared/types";
 
 interface SavedFleetsSectionProps {
@@ -37,11 +38,10 @@ export function SavedFleetsSection({ onRequestDelete }: SavedFleetsSectionProps)
     useShallow((s) => s.settings?.fleetSavedScopes ?? [])
   );
   // Subscribe so the stale sub-group re-derives when panes open/close. The
-  // value itself feeds the memo's dep array; the per-row aria-disabled check
-  // in SavedFleetRow reads panel state directly so it stays in sync too.
+  // value is read by `isSnapshotStale` inside the memo below.
   const panelsById = usePanelStore(useShallow((s) => s.panelsById));
 
-  const { snapshotUsable, snapshotStale, predicateRanked } = useMemo(() => {
+  const { snapshotUsable, snapshotStale, predicateRanked, countById, isStaleById } = useMemo(() => {
     const snapshots: FleetSavedScope[] = [];
     const predicates: FleetSavedScope[] = [];
     for (const scope of savedScopes) {
@@ -52,19 +52,20 @@ export function SavedFleetsSection({ onRequestDelete }: SavedFleetsSectionProps)
       }
     }
     const now = Date.now();
-    const isStaleById = new Map<string, boolean>();
-    for (const scope of snapshots) {
-      isStaleById.set(scope.id, computeSavedScopePaneCount(scope) === 0);
+    const isStaleByIdLocal = new Map<string, boolean>();
+    const countByIdLocal = new Map<string, number>();
+    for (const scope of [...snapshots, ...predicates]) {
+      isStaleByIdLocal.set(scope.id, isSnapshotStale(scope, panelsById));
+      countByIdLocal.set(scope.id, computeSavedScopePaneCount(scope));
     }
-    const { usable, stale } = rankSavedFleets(snapshots, now, isStaleById);
+    const { usable, stale } = rankSavedFleets(snapshots, now, isStaleByIdLocal);
     return {
       snapshotUsable: usable,
       snapshotStale: stale,
       predicateRanked: rankPredicateFleets(predicates, now),
+      isStaleById: isStaleByIdLocal,
+      countById: countByIdLocal,
     };
-    // panelsById is in the dep list to re-rank when the panel set changes;
-    // savedScopes is the primary driver of re-rank.
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- panelsById is a render-trigger
   }, [savedScopes, panelsById]);
 
   const hasSnapshots = snapshotUsable.length + snapshotStale.length > 0;
@@ -77,11 +78,23 @@ export function SavedFleetsSection({ onRequestDelete }: SavedFleetsSectionProps)
         <DropdownMenuGroup>
           <DropdownMenuLabel>Snapshots</DropdownMenuLabel>
           {snapshotUsable.map((scope) => (
-            <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
+            <SavedFleetRow
+              key={scope.id}
+              scope={scope}
+              onRequestDelete={onRequestDelete}
+              count={countById.get(scope.id) ?? 0}
+              isStale={isStaleById.get(scope.id) ?? false}
+            />
           ))}
           {showStaleSeparator && <DropdownMenuSeparator />}
           {snapshotStale.map((scope) => (
-            <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
+            <SavedFleetRow
+              key={scope.id}
+              scope={scope}
+              onRequestDelete={onRequestDelete}
+              count={countById.get(scope.id) ?? 0}
+              isStale={isStaleById.get(scope.id) ?? false}
+            />
           ))}
         </DropdownMenuGroup>
       )}
@@ -89,7 +102,13 @@ export function SavedFleetsSection({ onRequestDelete }: SavedFleetsSectionProps)
         <DropdownMenuGroup>
           <DropdownMenuLabel>Smart-Sets</DropdownMenuLabel>
           {predicateRanked.map((scope) => (
-            <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
+            <SavedFleetRow
+              key={scope.id}
+              scope={scope}
+              onRequestDelete={onRequestDelete}
+              count={countById.get(scope.id) ?? 0}
+              isStale={false}
+            />
           ))}
         </DropdownMenuGroup>
       )}

--- a/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
+++ b/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
@@ -415,3 +415,66 @@ describe("SavedFleetsSection ranking", () => {
     expect(allSeps).toHaveLength(1);
   });
 });
+
+describe("SavedFleetsSection integration (real computeSavedScopePaneCount)", () => {
+  // Import the mocked module so we can swap the implementation in this
+  // describe block. The default mock returns `terminalIds.length`; we
+  // replace it with a function that reads live panel-store state so the
+  // test exercises the actual panel-eligibility check.
+  beforeEach(async () => {
+    const mod = (await import("@/services/actions/definitions/fleetActions")) as unknown as {
+      computeSavedScopePaneCount: ReturnType<typeof vi.fn>;
+    };
+    mod.computeSavedScopePaneCount.mockImplementation((scope: { terminalIds?: string[] }) => {
+      if (!scope.terminalIds) return 3;
+      const { panelsById } = usePanelStore.getState();
+      let n = 0;
+      for (const id of scope.terminalIds) {
+        const panel = panelsById[id];
+        if (panel && panel.kind === "terminal" && panel.hasPty !== false) n += 1;
+      }
+      return n;
+    });
+  });
+
+  it("demotes a snapshot whose terminalIds are all gone to the stale sub-group", () => {
+    setSavedScopes([
+      {
+        kind: "snapshot",
+        id: "gone",
+        name: "Gone",
+        terminalIds: ["missing-1", "missing-2"],
+        createdAt: 0,
+      },
+    ]);
+    // Empty panel store — all terminalIds are missing.
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const [snapGroup] = screen.getAllByTestId("dropdown-group") as [HTMLElement];
+    expect(rowNames(snapGroup)).toEqual(["Gone"]);
+    const staleRow = within(snapGroup).getByRole("menuitem");
+    expect(staleRow.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("promotes a snapshot back to usable when its terminalIds become eligible", () => {
+    setSavedScopes([
+      {
+        kind: "snapshot",
+        id: "fresh",
+        name: "fresh",
+        terminalIds: ["t-real"],
+        createdAt: 0,
+      },
+    ]);
+    usePanelStore.setState({
+      panelsById: {
+        "t-real": { id: "t-real", kind: "terminal", hasPty: true } as never,
+      },
+      panelIds: ["t-real"],
+    });
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const [snapGroup] = screen.getAllByTestId("dropdown-group") as [HTMLElement];
+    expect(rowNames(snapGroup)).toEqual(["fresh"]);
+    const liveRow = within(snapGroup).getByRole("menuitem");
+    expect(liveRow.getAttribute("aria-disabled")).toBeNull();
+  });
+});

--- a/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
+++ b/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen, within } from "@testing-library/react";
 
 vi.mock("framer-motion", () => {
   const MotionDiv = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
@@ -53,7 +53,7 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
     </div>
   ),
   DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuSeparator: () => <hr data-testid="dropdown-separator" />,
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -62,6 +62,9 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
+// Mock computeSavedScopePaneCount so we control staleness deterministically:
+// scopes whose terminalIds array is empty count as 0 → stale; everything
+// else counts as terminalIds.length (positive → usable).
 vi.mock("@/services/actions/definitions/fleetActions", () => ({
   computeSavedScopePaneCount: vi.fn((scope: { terminalIds?: string[]; stateFilter?: string }) => {
     if (scope.terminalIds) return scope.terminalIds.length;
@@ -73,7 +76,11 @@ import { actionService } from "@/services/ActionService";
 import { SavedFleetsSection } from "../SavedFleetsSection";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { usePanelStore } from "@/store/panelStore";
 import type { FleetSavedScope } from "@shared/types";
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
 
 const SNAPSHOT_A: FleetSavedScope = {
   kind: "snapshot",
@@ -144,17 +151,26 @@ function setSavedScopes(scopes: FleetSavedScope[]) {
   } as any);
 }
 
+function rowNames(group: HTMLElement): string[] {
+  return within(group)
+    .getAllByRole("menuitem")
+    .map((r) => r.querySelector("span")?.textContent ?? "");
+}
+
 beforeEach(() => {
   useProjectSettingsStore.setState({ settings: {} } as any);
   useFleetArmingStore.setState({ armedIds: new Set() });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
   vi.clearAllMocks();
+  vi.useRealTimers();
 });
 
 describe("SavedFleetsSection", () => {
-  it("renders snapshots under Pinned label", () => {
+  it("renders snapshots under Snapshots label", () => {
     setSavedScopes([SNAPSHOT_A, SNAPSHOT_B]);
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
-    expect(screen.getByText("Pinned")).toBeDefined();
+    expect(screen.getByText("Snapshots")).toBeDefined();
+    expect(screen.queryByText("Pinned")).toBeNull();
     expect(screen.getByText("My terminals")).toBeDefined();
     expect(screen.getByText("Stale snapshot")).toBeDefined();
   });
@@ -187,30 +203,30 @@ describe("SavedFleetsSection", () => {
   it("shows both sections when both kinds exist", () => {
     setSavedScopes([SNAPSHOT_A, PREDICATE_FINISHED_CURRENT]);
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
-    expect(screen.getByText("Pinned")).toBeDefined();
+    expect(screen.getByText("Snapshots")).toBeDefined();
     expect(screen.getByText("Smart-Sets")).toBeDefined();
     expect(screen.getByText("My terminals")).toBeDefined();
     expect(screen.getByText("Finished here")).toBeDefined();
   });
 
-  it("shows only Pinned when no non-preset predicates exist", () => {
+  it("shows only Snapshots when no non-preset predicates exist", () => {
     setSavedScopes([SNAPSHOT_A, PREDICATE_WAITING_CURRENT]);
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
-    expect(screen.getByText("Pinned")).toBeDefined();
+    expect(screen.getByText("Snapshots")).toBeDefined();
     expect(screen.queryByText("Smart-Sets")).toBeNull();
   });
 
   it("shows only Smart-Sets when no snapshots exist", () => {
     setSavedScopes([PREDICATE_FINISHED_CURRENT]);
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
-    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(screen.queryByText("Snapshots")).toBeNull();
     expect(screen.getByText("Smart-Sets")).toBeDefined();
   });
 
   it("shows neither section label when no saved scopes exist", () => {
     setSavedScopes([]);
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
-    expect(screen.queryByText("Pinned")).toBeNull();
+    expect(screen.queryByText("Snapshots")).toBeNull();
     expect(screen.queryByText("Smart-Sets")).toBeNull();
   });
 
@@ -264,15 +280,138 @@ describe("SavedFleetsSection", () => {
     expect(actionService.dispatch).not.toHaveBeenCalled();
   });
 
-  it("renders Pinned group before Smart-Sets group in DOM order", () => {
+  it("renders Snapshots group before Smart-Sets group in DOM order", () => {
     setSavedScopes([SNAPSHOT_A, PREDICATE_FINISHED_CURRENT]);
     render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
     const groups = screen.getAllByTestId("dropdown-group");
     expect(groups).toHaveLength(2);
     const [first, second] = groups as [HTMLElement, HTMLElement];
-    expect(first.textContent).toContain("Pinned");
+    expect(first.textContent).toContain("Snapshots");
     expect(first.textContent).toContain("My terminals");
     expect(second.textContent).toContain("Smart-Sets");
     expect(second.textContent).toContain("Finished here");
+  });
+});
+
+describe("SavedFleetsSection ranking", () => {
+  it("ranks usable snapshots by frecency desc — most-recent first", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const lowFrecency: FleetSavedScope = {
+      kind: "snapshot",
+      id: "low",
+      name: "low",
+      terminalIds: ["t1"],
+      createdAt: 0,
+      usageHistory: [NOW - 14 * DAY],
+    };
+    const highFrecency: FleetSavedScope = {
+      kind: "snapshot",
+      id: "high",
+      name: "high",
+      terminalIds: ["t1"],
+      createdAt: 0,
+      usageHistory: [NOW, NOW - DAY, NOW - 2 * DAY],
+    };
+    // Insert in array order (low first, high second) to confirm sorting re-orders
+    setSavedScopes([lowFrecency, highFrecency]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const [snapGroup] = screen.getAllByTestId("dropdown-group") as [HTMLElement];
+    expect(rowNames(snapGroup)).toEqual(["high", "low"]);
+  });
+
+  it("demotes stale snapshots below usable ones and adds a separator", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const usable: FleetSavedScope = {
+      kind: "snapshot",
+      id: "usable",
+      name: "usable",
+      terminalIds: ["t1"],
+      createdAt: 0,
+      usageHistory: [NOW],
+    };
+    const stale: FleetSavedScope = {
+      kind: "snapshot",
+      id: "stale",
+      name: "stale",
+      terminalIds: [], // mock returns 0 → stale
+      createdAt: 0,
+      usageHistory: [NOW],
+    };
+    // Insert stale first to prove usable wins regardless of array order
+    setSavedScopes([stale, usable]);
+    const { container } = render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const [snapGroup] = screen.getAllByTestId("dropdown-group") as [HTMLElement];
+    expect(rowNames(snapGroup)).toEqual(["usable", "stale"]);
+    // Separator sits between the two rows
+    const seps = container.querySelectorAll('[data-testid="dropdown-separator"]');
+    expect(seps.length).toBeGreaterThan(0);
+  });
+
+  it("places a freshly-saved (no usageHistory) snapshot at the bottom of usable", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const recalled: FleetSavedScope = {
+      kind: "snapshot",
+      id: "recalled",
+      name: "recalled",
+      terminalIds: ["t1"],
+      createdAt: 0,
+      usageHistory: [NOW],
+    };
+    const fresh: FleetSavedScope = {
+      kind: "snapshot",
+      id: "fresh",
+      name: "fresh",
+      terminalIds: ["t1"],
+      createdAt: NOW, // brand-new, never recalled
+    };
+    setSavedScopes([fresh, recalled]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const [snapGroup] = screen.getAllByTestId("dropdown-group") as [HTMLElement];
+    expect(rowNames(snapGroup)).toEqual(["recalled", "fresh"]);
+  });
+
+  it("ranks predicate smart-sets by frecency desc", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const low: FleetSavedScope = {
+      kind: "predicate",
+      id: "p-low",
+      name: "low",
+      scope: "current",
+      stateFilter: "finished",
+      createdAt: 0,
+      usageHistory: [NOW - 14 * DAY],
+    };
+    const high: FleetSavedScope = {
+      kind: "predicate",
+      id: "p-high",
+      name: "high",
+      scope: "current",
+      stateFilter: "finished",
+      createdAt: 0,
+      usageHistory: [NOW, NOW - DAY],
+    };
+    setSavedScopes([low, high]);
+    render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    // The second group is the smart-sets group (predicates)
+    const groups = screen.getAllByTestId("dropdown-group");
+    const smartSetGroup = groups[groups.length - 1] as HTMLElement;
+    expect(rowNames(smartSetGroup)).toEqual(["high", "low"]);
+  });
+
+  it("does not render a stale sub-group separator when no usable snapshots exist", () => {
+    setSavedScopes([SNAPSHOT_B]); // empty terminalIds → stale
+    const { container } = render(<SavedFleetsSection onRequestDelete={vi.fn()} />);
+    const [snapGroup] = screen.getAllByTestId("dropdown-group") as [HTMLElement];
+    expect(rowNames(snapGroup)).toEqual(["Stale snapshot"]);
+    // No internal separator inside the snapshot group when only stale rows exist
+    const groupSeps = snapGroup.querySelectorAll('[data-testid="dropdown-separator"]');
+    expect(groupSeps).toHaveLength(0);
+    // The leading outer separator (before the group) is rendered exactly once
+    const allSeps = container.querySelectorAll('[data-testid="dropdown-separator"]');
+    expect(allSeps).toHaveLength(1);
   });
 });

--- a/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
+++ b/src/components/Fleet/__tests__/SavedFleetsSection.test.tsx
@@ -62,9 +62,18 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
-// Mock computeSavedScopePaneCount so we control staleness deterministically:
-// scopes whose terminalIds array is empty count as 0 → stale; everything
-// else counts as terminalIds.length (positive → usable).
+// Mock isSnapshotStale so we control staleness deterministically: scopes
+// whose terminalIds array is empty are stale; everything else is usable.
+// The default mock keeps the existing tests stable without seeding panels.
+vi.mock("@/components/Fleet/fleetStaleness", () => ({
+  isSnapshotStale: vi.fn((scope: { terminalIds?: string[] }) => {
+    return !scope.terminalIds || scope.terminalIds.length === 0;
+  }),
+}));
+
+// SavedFleetRow uses computeSavedScopePaneCount directly to render the live
+// count and decide aria-disabled. Mock it with the same terminalIds-length
+// heuristic so the row's staleness check agrees with the section's.
 vi.mock("@/services/actions/definitions/fleetActions", () => ({
   computeSavedScopePaneCount: vi.fn((scope: { terminalIds?: string[]; stateFilter?: string }) => {
     if (scope.terminalIds) return scope.terminalIds.length;
@@ -416,24 +425,22 @@ describe("SavedFleetsSection ranking", () => {
   });
 });
 
-describe("SavedFleetsSection integration (real computeSavedScopePaneCount)", () => {
-  // Import the mocked module so we can swap the implementation in this
-  // describe block. The default mock returns `terminalIds.length`; we
-  // replace it with a function that reads live panel-store state so the
-  // test exercises the actual panel-eligibility check.
+describe("SavedFleetsSection integration (real isSnapshotStale)", () => {
+  // Swap the mocked `isSnapshotStale` for one that reads live panel-store
+  // state so this block exercises the actual panel-eligibility check that
+  // the production component runs.
   beforeEach(async () => {
-    const mod = (await import("@/services/actions/definitions/fleetActions")) as unknown as {
-      computeSavedScopePaneCount: ReturnType<typeof vi.fn>;
+    const mod = (await import("@/components/Fleet/fleetStaleness")) as unknown as {
+      isSnapshotStale: ReturnType<typeof vi.fn>;
     };
-    mod.computeSavedScopePaneCount.mockImplementation((scope: { terminalIds?: string[] }) => {
-      if (!scope.terminalIds) return 3;
+    mod.isSnapshotStale.mockImplementation((scope: { kind: string; terminalIds?: string[] }) => {
+      if (scope.kind !== "snapshot" || !scope.terminalIds) return false;
       const { panelsById } = usePanelStore.getState();
-      let n = 0;
       for (const id of scope.terminalIds) {
         const panel = panelsById[id];
-        if (panel && panel.kind === "terminal" && panel.hasPty !== false) n += 1;
+        if (panel && (panel as { kind?: string }).kind === "terminal") return false;
       }
-      return n;
+      return true;
     });
   });
 

--- a/src/components/Fleet/__tests__/fleetRanking.test.ts
+++ b/src/components/Fleet/__tests__/fleetRanking.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import type { FleetSavedScope, SnapshotFleetSavedScope } from "@shared/types";
+import { rankSavedFleets, rankPredicateFleets } from "../fleetRanking";
+
+const NOW = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+const snap = (
+  id: string,
+  overrides: Partial<SnapshotFleetSavedScope> = {}
+): SnapshotFleetSavedScope => ({
+  kind: "snapshot",
+  id,
+  name: id,
+  terminalIds: ["t1"],
+  createdAt: 0,
+  ...overrides,
+});
+
+describe("rankSavedFleets", () => {
+  it("places the highest-frecency snapshot first in usable", () => {
+    const a = snap("a", { usageHistory: [NOW - 7 * DAY] }); // ~50
+    const b = snap("b", { usageHistory: [NOW] }); // 100
+    const c = snap("c", { usageHistory: [NOW, NOW - DAY, NOW - 2 * DAY] }); // ~250
+    const { usable, stale } = rankSavedFleets([a, b, c], NOW, new Map());
+    expect(stale).toEqual([]);
+    expect(usable.map((s) => s.id)).toEqual(["c", "b", "a"]);
+  });
+
+  it("splits stale snapshots into a separate list", () => {
+    const a = snap("a");
+    const b = snap("b");
+    const isStaleById = new Map([["b", true]]);
+    const { usable, stale } = rankSavedFleets([a, b], NOW, isStaleById);
+    expect(usable.map((s) => s.id)).toEqual(["a"]);
+    expect(stale.map((s) => s.id)).toEqual(["b"]);
+  });
+
+  it("sorts stale sub-group by lastUsedAt desc with name tie-breaker", () => {
+    const a = snap("a", { lastUsedAt: NOW - 2 * DAY, name: "alpha" });
+    const b = snap("b", { lastUsedAt: NOW - DAY, name: "bravo" });
+    const c = snap("c", { lastUsedAt: NOW - DAY, name: "charlie" });
+    const isStaleById = new Map([
+      ["a", true],
+      ["b", true],
+      ["c", true],
+    ]);
+    const { stale } = rankSavedFleets([a, b, c], NOW, isStaleById);
+    expect(stale.map((s) => s.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("places new scopes (no usageHistory) at the bottom of usable", () => {
+    const fresh = snap("fresh", { usageHistory: [NOW] });
+    const newScope = snap("new"); // no usageHistory, no lastUsedAt
+    const { usable } = rankSavedFleets([newScope, fresh], NOW, new Map());
+    expect(usable.map((s) => s.id)).toEqual(["fresh", "new"]);
+  });
+
+  it("breaks frecency ties by lastUsedAt desc", () => {
+    // Same frecency score (each has 1 entry from 7 days ago) — lastUsedAt breaks the tie.
+    const a = snap("a", { usageHistory: [NOW - 7 * DAY], lastUsedAt: NOW - 7 * DAY });
+    const b = snap("b", { usageHistory: [NOW - 7 * DAY], lastUsedAt: NOW - 6 * DAY });
+    const { usable } = rankSavedFleets([a, b], NOW, new Map());
+    expect(usable.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("breaks lastUsedAt ties by createdAt desc", () => {
+    const a = snap("a", { lastUsedAt: NOW, createdAt: 100 });
+    const b = snap("b", { lastUsedAt: NOW, createdAt: 200 });
+    const { usable } = rankSavedFleets([a, b], NOW, new Map());
+    expect(usable.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("breaks createdAt ties by name localeCompare asc", () => {
+    const a = snap("a", { lastUsedAt: NOW, createdAt: 100, name: "Bravo" });
+    const b = snap("b", { lastUsedAt: NOW, createdAt: 100, name: "Alpha" });
+    const { usable } = rankSavedFleets([a, b], NOW, new Map());
+    expect(usable.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+
+  it("returns empty arrays for empty input", () => {
+    const { usable, stale } = rankSavedFleets([], NOW, new Map());
+    expect(usable).toEqual([]);
+    expect(stale).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const a = snap("a", { usageHistory: [NOW] });
+    const b = snap("b", { usageHistory: [NOW - 7 * DAY] });
+    const input: FleetSavedScope[] = [a, b];
+    const inputCopy: FleetSavedScope[] = [...input];
+    rankSavedFleets(input, NOW, new Map());
+    expect(input).toEqual(inputCopy);
+  });
+});
+
+describe("rankPredicateFleets", () => {
+  it("sorts predicates by frecency desc with the same tie-breaker chain", () => {
+    const a: FleetSavedScope = {
+      kind: "predicate",
+      id: "a",
+      name: "a",
+      scope: "all",
+      stateFilter: "waiting",
+      createdAt: 0,
+      usageHistory: [NOW - 7 * DAY],
+    };
+    const b: FleetSavedScope = {
+      kind: "predicate",
+      id: "b",
+      name: "b",
+      scope: "all",
+      stateFilter: "working",
+      createdAt: 0,
+      usageHistory: [NOW, NOW - DAY],
+    };
+    const ranked = rankPredicateFleets([a, b], NOW);
+    expect(ranked.map((s) => s.id)).toEqual(["b", "a"]);
+  });
+});

--- a/src/components/Fleet/__tests__/fleetRanking.test.ts
+++ b/src/components/Fleet/__tests__/fleetRanking.test.ts
@@ -49,11 +49,22 @@ describe("rankSavedFleets", () => {
     expect(stale.map((s) => s.id)).toEqual(["b", "c", "a"]);
   });
 
-  it("places new scopes (no usageHistory) at the bottom of usable", () => {
+  it("places new scopes (no usageHistory, no lastUsedAt) at the bottom of usable", () => {
     const fresh = snap("fresh", { usageHistory: [NOW] });
-    const newScope = snap("new"); // no usageHistory, no lastUsedAt
+    const newScope = snap("new"); // no usageHistory, no lastUsedAt → frecency 0
     const { usable } = rankSavedFleets([newScope, fresh], NOW, new Map());
     expect(usable.map((s) => s.id)).toEqual(["fresh", "new"]);
+  });
+
+  it("seeds frecency from lastUsedAt when usageHistory is empty", () => {
+    // A scope with lastUsedAt=NOW but no usageHistory should still rank
+    // above a scope with one ancient usageHistory entry — otherwise a
+    // brand-new save would sink below any fleet that has ever been
+    // recalled (frecency decay bottoms out near zero for old timestamps).
+    const freshStamp = snap("stamp", { lastUsedAt: NOW });
+    const ancientRecall = snap("ancient", { usageHistory: [NOW - 365 * DAY] });
+    const { usable } = rankSavedFleets([ancientRecall, freshStamp], NOW, new Map());
+    expect(usable.map((s) => s.id)).toEqual(["stamp", "ancient"]);
   });
 
   it("breaks frecency ties by lastUsedAt desc", () => {

--- a/src/components/Fleet/fleetRanking.ts
+++ b/src/components/Fleet/fleetRanking.ts
@@ -1,0 +1,75 @@
+import type { FleetSavedScope } from "@shared/types";
+import { computeFrecency } from "@/components/Terminal/RecipeRunner/recipeRunnerUtils";
+
+export interface RankedFleetScopes {
+  /** Snapshots with at least one eligible pane — frecency-ranked. */
+  usable: FleetSavedScope[];
+  /** Snapshots whose stored terminals no longer exist — sorted by lastUsedAt desc, kept visible for cleanup. */
+  stale: FleetSavedScope[];
+}
+
+const comparator =
+  (now: number) =>
+  (a: FleetSavedScope, b: FleetSavedScope): number => {
+    const scoreDiff =
+      computeFrecency(b.usageHistory ?? [], now) - computeFrecency(a.usageHistory ?? [], now);
+    if (scoreDiff !== 0) return scoreDiff;
+    const lastUsedDiff = (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0);
+    if (lastUsedDiff !== 0) return lastUsedDiff;
+    const createdDiff = (b.createdAt ?? 0) - (a.createdAt ?? 0);
+    if (createdDiff !== 0) return createdDiff;
+    return a.name.localeCompare(b.name);
+  };
+
+/**
+ * Rank saved fleet scopes by frecency for display. Stale snapshots
+ * (those whose stored terminal IDs no longer resolve to eligible panes)
+ * are split off into a separate list so the UI can render them in a
+ * subdued sub-group — the user still needs to see them so they can be
+ * deleted, but they shouldn't dominate the recall list.
+ *
+ * The `isStaleById` map is computed in the React layer because staleness
+ * depends on `usePanelStore` and `useWorktreeSelectionStore` state; this
+ * helper stays pure for testability.
+ *
+ * New scopes (empty `usageHistory`, no `lastUsedAt`) have frecency 0 and
+ * sort to the bottom of `usable` — they appear, but don't leap to the
+ * top until the user has recalled them at least once.
+ */
+export function rankSavedFleets(
+  scopes: readonly FleetSavedScope[],
+  now: number,
+  isStaleById: ReadonlyMap<string, boolean>
+): RankedFleetScopes {
+  const usable: FleetSavedScope[] = [];
+  const stale: FleetSavedScope[] = [];
+  for (const scope of scopes) {
+    if (isStaleById.get(scope.id) === true) {
+      stale.push(scope);
+    } else {
+      usable.push(scope);
+    }
+  }
+  const cmp = comparator(now);
+  usable.sort(cmp);
+  // Stale sub-group falls back to lastUsedAt desc (frecency is meaningless
+  // for fleets with no eligible terminals; the user came to delete, not recall).
+  stale.sort((a, b) => {
+    const lastUsedDiff = (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0);
+    if (lastUsedDiff !== 0) return lastUsedDiff;
+    return a.name.localeCompare(b.name);
+  });
+  return { usable, stale };
+}
+
+/**
+ * Predicate-group ranking: same frecency + tie-breaker chain, no stale
+ * split (predicates re-evaluate against the current panel set on recall,
+ * so there is no "no longer applies" concept).
+ */
+export function rankPredicateFleets(
+  scopes: readonly FleetSavedScope[],
+  now: number
+): FleetSavedScope[] {
+  return [...scopes].sort(comparator(now));
+}

--- a/src/components/Fleet/fleetRanking.ts
+++ b/src/components/Fleet/fleetRanking.ts
@@ -8,11 +8,26 @@ export interface RankedFleetScopes {
   stale: FleetSavedScope[];
 }
 
+/**
+ * Effective frecency input for a fleet scope. If `usageHistory` is empty
+ * but the scope has a `lastUsedAt`, treat the single timestamp as a
+ * 1-entry history. This keeps a brand-new save (which hasn't been
+ * recalled yet, so no history) from sinking below any fleet that has
+ * ever been recalled — otherwise a one-day-old recall would beat a
+ * fresh save for ~365 days (frecency decay bottoms out near zero).
+ */
+function effectiveHistory(scope: FleetSavedScope): number[] {
+  const history = scope.usageHistory ?? [];
+  if (history.length > 0) return history;
+  if (scope.lastUsedAt != null) return [scope.lastUsedAt];
+  return [];
+}
+
 const comparator =
   (now: number) =>
   (a: FleetSavedScope, b: FleetSavedScope): number => {
     const scoreDiff =
-      computeFrecency(b.usageHistory ?? [], now) - computeFrecency(a.usageHistory ?? [], now);
+      computeFrecency(effectiveHistory(b), now) - computeFrecency(effectiveHistory(a), now);
     if (scoreDiff !== 0) return scoreDiff;
     const lastUsedDiff = (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0);
     if (lastUsedDiff !== 0) return lastUsedDiff;
@@ -32,9 +47,11 @@ const comparator =
  * depends on `usePanelStore` and `useWorktreeSelectionStore` state; this
  * helper stays pure for testability.
  *
- * New scopes (empty `usageHistory`, no `lastUsedAt`) have frecency 0 and
- * sort to the bottom of `usable` — they appear, but don't leap to the
- * top until the user has recalled them at least once.
+ * Scopes with no `usageHistory` and no `lastUsedAt` (never recalled)
+ * have frecency 0 and sort to the bottom of `usable`. Scopes with
+ * `lastUsedAt` but no `usageHistory` (a future case — currently the
+ * recall action appends to `usageHistory` immediately) seed frecency
+ * from `lastUsedAt` so they don't sink below ancient fleets.
  */
 export function rankSavedFleets(
   scopes: readonly FleetSavedScope[],

--- a/src/components/Fleet/fleetStaleness.ts
+++ b/src/components/Fleet/fleetStaleness.ts
@@ -1,0 +1,24 @@
+import { isFleetArmEligible } from "@/store/fleetArmingStore";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import type { FleetSavedScope } from "@shared/types";
+import type { PanelInstance } from "@shared/types/panel";
+
+/**
+ * A snapshot scope is "stale" when none of its stored terminal IDs still
+ * resolve to an arm-eligible panel. Predicate scopes are never stale —
+ * they re-evaluate against the current panel set on recall.
+ *
+ * Accepts `panelsById` as a parameter so the caller can pass the value
+ * it's already memoized on. The `SavedFleetsSection` uses this for both
+ * the sub-group placement and the per-row `aria-disabled` indicator.
+ */
+export function isSnapshotStale(
+  scope: FleetSavedScope,
+  panelsById: Record<string, PanelInstance>
+): boolean {
+  if (scope.kind !== "snapshot") return false;
+  for (const id of scope.terminalIds) {
+    if (isFleetArmEligible(getNarrowPanel(panelsById, id))) return false;
+  }
+  return true;
+}

--- a/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
@@ -697,3 +697,139 @@ describe("fleet.deleteNamedFleet", () => {
     expect(saveSettingsMock).not.toHaveBeenCalled();
   });
 });
+
+describe("fleet.recallNamedFleet race recovery (in-memory atomic)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  // Hydrate the in-memory store — mirrors what happens after project load.
+  // Tests that exercise the in-memory path (race tests) seed the store directly
+  // so we don't depend on the cold-start IPC read.
+  function seedInMemory(scopes: FleetSavedScope[]): void {
+    useProjectSettingsStore.setState({
+      projectId: "proj-1",
+      settings: { runCommands: [], fleetSavedScopes: scopes },
+    });
+  }
+
+  it("two concurrent recalls of different scopes each land their stamp", async () => {
+    const a: FleetSavedScope = {
+      kind: "snapshot",
+      id: "a",
+      name: "A",
+      terminalIds: ["p-a"],
+      createdAt: 1,
+    };
+    const b: FleetSavedScope = {
+      kind: "snapshot",
+      id: "b",
+      name: "B",
+      terminalIds: ["p-b"],
+      createdAt: 1,
+    };
+    seedPanels([makeAgent("p-a"), makeAgent("p-b")]);
+    seedInMemory([a, b]);
+    saveSettingsMock.mockResolvedValue(undefined);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [a, b] });
+
+    const registry = await buildRegistry();
+    await Promise.all([
+      run(registry, "fleet.recallNamedFleet", { id: "a" }),
+      run(registry, "fleet.recallNamedFleet", { id: "b" }),
+    ]);
+
+    // Both scopes should have stamps, not just the last writer.
+    const inMemory = useProjectSettingsStore.getState().settings?.fleetSavedScopes ?? [];
+    const stampedA = inMemory.find((s) => s.id === "a") as FleetSavedScope | undefined;
+    const stampedB = inMemory.find((s) => s.id === "b") as FleetSavedScope | undefined;
+    expect(stampedA?.lastUsedAt).toBeGreaterThan(0);
+    expect(stampedA?.usageHistory).toHaveLength(1);
+    expect(stampedB?.lastUsedAt).toBeGreaterThan(0);
+    expect(stampedB?.usageHistory).toHaveLength(1);
+  });
+
+  it("a recall that races a save preserves both the new scope and the recall's stamp", async () => {
+    const target: FleetSavedScope = {
+      kind: "snapshot",
+      id: "target",
+      name: "Target",
+      terminalIds: ["p-target"],
+      createdAt: 1,
+    };
+    seedPanels([makeAgent("p-target")]);
+    seedInMemory([target]);
+    saveSettingsMock.mockResolvedValue(undefined);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [target] });
+
+    const registry = await buildRegistry();
+    // Fire recall first so it lands in the in-memory store; the save then
+    // appends without clobbering the stamp because it reads the freshest
+    // in-memory snapshot.
+    await run(registry, "fleet.recallNamedFleet", { id: "target" });
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "New Fleet" });
+
+    const inMemory = useProjectSettingsStore.getState().settings?.fleetSavedScopes ?? [];
+    expect(inMemory).toHaveLength(2);
+    const stampedTarget = inMemory.find((s) => s.id === "target") as FleetSavedScope;
+    const newScope = inMemory.find((s) => s.id !== "target") as FleetSavedScope;
+    expect(stampedTarget.lastUsedAt).toBeGreaterThan(0);
+    expect(stampedTarget.usageHistory).toHaveLength(1);
+    expect(newScope.name).toBe("New Fleet");
+    expect(newScope.lastUsedAt).toBeUndefined();
+  });
+
+  it("uses the in-memory store when hydrated, never invoking getSettings", async () => {
+    const target: FleetSavedScope = {
+      kind: "snapshot",
+      id: "target",
+      name: "Target",
+      terminalIds: ["p-target"],
+      createdAt: 1,
+    };
+    seedPanels([makeAgent("p-target")]);
+    seedInMemory([target]);
+    saveSettingsMock.mockResolvedValue(undefined);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [target] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.recallNamedFleet", { id: "target" });
+
+    expect(getSettingsMock).not.toHaveBeenCalled();
+    expect(saveSettingsMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fleet.saveNamedFleet race recovery (in-memory atomic)", () => {
+  beforeEach(() => {
+    resetState();
+    vi.clearAllMocks();
+  });
+
+  function seedInMemory(scopes: FleetSavedScope[]): void {
+    useProjectSettingsStore.setState({
+      projectId: "proj-1",
+      settings: { runCommands: [], fleetSavedScopes: scopes },
+    });
+  }
+
+  it("two concurrent saves both land (no clobbering when in-memory is hydrated)", async () => {
+    seedPanels([makeAgent("p1"), makeAgent("p2")]);
+    useFleetArmingStore.getState().armIds(["p1", "p2"]);
+    seedInMemory([]);
+    saveSettingsMock.mockResolvedValue(undefined);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [] });
+
+    const registry = await buildRegistry();
+    await Promise.all([
+      run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "First" }),
+      run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "Second" }),
+    ]);
+
+    const inMemory = useProjectSettingsStore.getState().settings?.fleetSavedScopes ?? [];
+    expect(inMemory).toHaveLength(2);
+    const names = inMemory.map((s) => s.name).sort();
+    expect(names).toEqual(["First", "Second"]);
+  });
+});

--- a/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
+++ b/src/services/actions/definitions/__tests__/savedFleetActions.test.ts
@@ -750,7 +750,10 @@ describe("fleet.recallNamedFleet race recovery (in-memory atomic)", () => {
     expect(stampedB?.usageHistory).toHaveLength(1);
   });
 
-  it("a recall that races a save preserves both the new scope and the recall's stamp", async () => {
+  it("a recall followed by a save preserves both the new scope and the recall's stamp", async () => {
+    // Sequential (not Promise.all) — verifies the in-memory atomic pattern
+    // when recall lands first and a later save reads the freshest snapshot.
+    // Truly concurrent recall+save is covered by the test below.
     const target: FleetSavedScope = {
       kind: "snapshot",
       id: "target",
@@ -764,9 +767,6 @@ describe("fleet.recallNamedFleet race recovery (in-memory atomic)", () => {
     getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [target] });
 
     const registry = await buildRegistry();
-    // Fire recall first so it lands in the in-memory store; the save then
-    // appends without clobbering the stamp because it reads the freshest
-    // in-memory snapshot.
     await run(registry, "fleet.recallNamedFleet", { id: "target" });
     await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "New Fleet" });
 
@@ -778,6 +778,34 @@ describe("fleet.recallNamedFleet race recovery (in-memory atomic)", () => {
     expect(stampedTarget.usageHistory).toHaveLength(1);
     expect(newScope.name).toBe("New Fleet");
     expect(newScope.lastUsedAt).toBeUndefined();
+  });
+
+  it("a recall and a save fired concurrently both land in the in-memory store", async () => {
+    const target: FleetSavedScope = {
+      kind: "snapshot",
+      id: "target",
+      name: "Target",
+      terminalIds: ["p-target"],
+      createdAt: 1,
+    };
+    seedPanels([makeAgent("p-target")]);
+    seedInMemory([target]);
+    saveSettingsMock.mockResolvedValue(undefined);
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [target] });
+
+    const registry = await buildRegistry();
+    await Promise.all([
+      run(registry, "fleet.recallNamedFleet", { id: "target" }),
+      run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "New Fleet" }),
+    ]);
+
+    const inMemory = useProjectSettingsStore.getState().settings?.fleetSavedScopes ?? [];
+    expect(inMemory).toHaveLength(2);
+    const stampedTarget = inMemory.find((s) => s.id === "target") as FleetSavedScope;
+    const newScope = inMemory.find((s) => s.id !== "target") as FleetSavedScope;
+    expect(stampedTarget.lastUsedAt).toBeGreaterThan(0);
+    expect(stampedTarget.usageHistory).toHaveLength(1);
+    expect(newScope.name).toBe("New Fleet");
   });
 
   it("uses the in-memory store when hydrated, never invoking getSettings", async () => {
@@ -831,5 +859,24 @@ describe("fleet.saveNamedFleet race recovery (in-memory atomic)", () => {
     expect(inMemory).toHaveLength(2);
     const names = inMemory.map((s) => s.name).sort();
     expect(names).toEqual(["First", "Second"]);
+  });
+
+  it("rolls back the in-memory append when saveSettings rejects (no phantom fleet)", async () => {
+    seedPanels([makeAgent("p1")]);
+    useFleetArmingStore.getState().armIds(["p1"]);
+    seedInMemory([]);
+    saveSettingsMock.mockRejectedValue(new Error("disk full"));
+    getSettingsMock.mockResolvedValue({ runCommands: [], fleetSavedScopes: [] });
+
+    const registry = await buildRegistry();
+    await run(registry, "fleet.saveNamedFleet", { kind: "snapshot", name: "Will fail" });
+
+    // The in-memory store must not retain the failed append — otherwise the
+    // user sees a row that won't be on disk after a reload.
+    const inMemory = useProjectSettingsStore.getState().settings?.fleetSavedScopes ?? [];
+    expect(inMemory).toHaveLength(0);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Couldn't save fleet" })
+    );
   });
 });

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -455,6 +455,13 @@ export function registerFleetActions(actions: ActionRegistry): void {
       const newScope = buildSavedScope(parsed);
       if (!newScope) return;
       try {
+        // Capture the pre-append snapshot so a failed save can roll the
+        // in-memory append back — otherwise the dropdown would show a
+        // phantom fleet the user can't recall across restarts.
+        const previousSettings =
+          useProjectSettingsStore.getState().projectId === projectId
+            ? useProjectSettingsStore.getState().settings
+            : null;
         // Append atomically against the in-memory store so a near-simultaneous
         // recall's lastUsedAt stamp is not clobbered. The naive
         // getSettings-read-then-save pattern dropped concurrent stamps when
@@ -463,11 +470,21 @@ export function registerFleetActions(actions: ActionRegistry): void {
         // this project (cold-start case).
         const nextSettings = await appendFleetScopeInMemory(projectId, newScope);
         if (useProjectStore.getState().currentProject?.id !== projectId) return;
-        await projectClient.saveSettings(projectId, nextSettings);
-        if (useProjectStore.getState().currentProject?.id !== projectId) return;
-        if (useProjectSettingsStore.getState().projectId === projectId) {
-          useProjectSettingsStore.getState().setSettings(nextSettings);
+        try {
+          await projectClient.saveSettings(projectId, nextSettings);
+        } catch (saveError) {
+          // Roll back the in-memory append so the user doesn't see a row
+          // that won't be on disk after a reload.
+          if (previousSettings && useProjectSettingsStore.getState().projectId === projectId) {
+            useProjectSettingsStore.setState({ settings: previousSettings });
+          }
+          throw saveError;
         }
+        // In-memory was already updated by `appendFleetScopeInMemory` (which
+        // also runs the detectedRunners filter inside `setSettings`). Do NOT
+        // call `setSettings(nextSettings)` here — that would overwrite a
+        // concurrent recall's stamp that landed on the in-memory store
+        // between the append and the await above.
         notify({
           type: "success",
           message: `Saved fleet "${newScope.name}"`,

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -26,8 +26,10 @@ import { runManagedFleetBroadcast } from "@/components/Fleet/fleetEnterBroadcast
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { notify } from "@/lib/notify";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import type { FleetSavedScope } from "@shared/types";
+import type { FleetSavedScope, ProjectSettings } from "@shared/types";
 import type { PtyPanelData } from "@shared/types/panel";
+
+const FLEET_USAGE_HISTORY_CAP = 20;
 
 interface ArmedSnapshot {
   terminalTargets: PtyPanelData[];
@@ -453,15 +455,16 @@ export function registerFleetActions(actions: ActionRegistry): void {
       const newScope = buildSavedScope(parsed);
       if (!newScope) return;
       try {
-        const current = await projectClient.getSettings(projectId);
+        // Append atomically against the in-memory store so a near-simultaneous
+        // recall's lastUsedAt stamp is not clobbered. The naive
+        // getSettings-read-then-save pattern dropped concurrent stamps when
+        // recall's fire-and-forget save landed after our await. Falls back to
+        // an IPC read only when the in-memory store hasn't been hydrated for
+        // this project (cold-start case).
+        const nextSettings = await appendFleetScopeInMemory(projectId, newScope);
         if (useProjectStore.getState().currentProject?.id !== projectId) return;
-        const next: FleetSavedScope[] = [...(current.fleetSavedScopes ?? []), newScope];
-        const nextSettings = { ...current, fleetSavedScopes: next };
         await projectClient.saveSettings(projectId, nextSettings);
         if (useProjectStore.getState().currentProject?.id !== projectId) return;
-        // Write-through: the SavedFleetsSection reads from useProjectSettingsStore,
-        // so the row only appears if the in-memory cache is updated. Without
-        // this the user clicks Save, the disk write succeeds, but no row shows.
         if (useProjectSettingsStore.getState().projectId === projectId) {
           useProjectSettingsStore.getState().setSettings(nextSettings);
         }
@@ -497,23 +500,16 @@ export function registerFleetActions(actions: ActionRegistry): void {
       const projectId = useProjectStore.getState().currentProject?.id ?? null;
       if (!projectId) return;
       try {
-        const current = await projectClient.getSettings(projectId);
-        if (useProjectStore.getState().currentProject?.id !== projectId) return;
-        const scope = (current.fleetSavedScopes ?? []).find((s) => s.id === id);
+        // Read the scope from the in-memory store first so two near-simultaneous
+        // recalls see a consistent snapshot, and so the subsequent stamp lands
+        // on a write that the concurrent caller can't have clobbered before
+        // reading. Falls back to a one-shot IPC read on cold start.
+        const scope = await findFleetScope(projectId, id);
         if (!scope) return;
         applySavedScope(scope);
 
         const now = Date.now();
-        scope.lastUsedAt = now;
-        scope.usageHistory = [...(scope.usageHistory ?? []), now].slice(-20);
-
-        if (useProjectStore.getState().currentProject?.id !== projectId) return;
-        projectClient.saveSettings(projectId, current).catch((err) => {
-          console.warn("Failed to persist fleet recency stamp:", err);
-        });
-        if (useProjectSettingsStore.getState().projectId === projectId) {
-          useProjectSettingsStore.getState().setSettings(current);
-        }
+        stampFleetUsageInMemory(projectId, id, now);
       } catch (error) {
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
@@ -628,6 +624,99 @@ function applySavedScope(scope: FleetSavedScope): void {
     return;
   }
   fleet.armByState(scope.stateFilter as FleetArmStatePreset, scope.scope, false);
+}
+
+/**
+ * Locate a saved scope in the in-memory project-settings store, falling
+ * back to a one-shot IPC read when the store hasn't been hydrated for the
+ * active project (cold-start case — the dropdown that triggers recall is
+ * itself gated on the store being loaded, so this branch is rare).
+ */
+async function findFleetScope(projectId: string, scopeId: string): Promise<FleetSavedScope | null> {
+  const store = useProjectSettingsStore.getState();
+  if (store.projectId === projectId && store.settings) {
+    return (store.settings.fleetSavedScopes ?? []).find((s) => s.id === scopeId) ?? null;
+  }
+  const current = await projectClient.getSettings(projectId);
+  if (useProjectStore.getState().currentProject?.id !== projectId) return null;
+  // Hydrate the in-memory store so subsequent operations (the stamp below)
+  // can use the in-memory path. The project-switch check above guarantees
+  // we just fetched the right project's settings, so it's safe to write.
+  useProjectSettingsStore.setState({
+    projectId,
+    settings: current,
+  });
+  return (current.fleetSavedScopes ?? []).find((s) => s.id === scopeId) ?? null;
+}
+
+/**
+ * Append a new scope to the in-memory project-settings store atomically,
+ * returning the full settings object the caller should persist. Operates
+ * on the freshest in-memory snapshot via `setState((state) => ...)` so
+ * a concurrent recall's `lastUsedAt` stamp on a different scope is not
+ * clobbered. On cold start (in-memory store unhydrated) does an IPC read
+ * to fetch the current fleetSavedScopes from disk — this loses the
+ * in-memory race guarantee, but the dropdown that triggers the action
+ * requires a loaded store to be visible, so in practice this branch is
+ * rare. Throws when the project switches mid-IPC; the caller's catch
+ * surfaces the error to the user.
+ */
+async function appendFleetScopeInMemory(
+  projectId: string,
+  newScope: FleetSavedScope
+): Promise<ProjectSettings> {
+  const store = useProjectSettingsStore.getState();
+  if (store.projectId === projectId && store.settings) {
+    let next: ProjectSettings | null = null;
+    useProjectSettingsStore.setState((state) => {
+      if (!state.settings) return {};
+      const merged = [...(state.settings.fleetSavedScopes ?? []), newScope];
+      next = { ...state.settings, fleetSavedScopes: merged };
+      return { settings: next };
+    });
+    if (next) return next;
+  }
+  const current = await projectClient.getSettings(projectId);
+  if (useProjectStore.getState().currentProject?.id !== projectId) {
+    throw new Error("Project switched mid-IPC");
+  }
+  const merged = [...(current.fleetSavedScopes ?? []), newScope];
+  const nextSettings = { ...current, fleetSavedScopes: merged };
+  useProjectSettingsStore.setState({
+    projectId,
+    settings: nextSettings,
+  });
+  return nextSettings;
+}
+
+/**
+ * Stamp `lastUsedAt` and append to `usageHistory` (capped) on a single
+ * scope, atomically against the in-memory store. The persist call reads
+ * the freshest in-memory snapshot, so any other in-flight append (a
+ * concurrent save) is preserved in the persisted history rather than
+ * dropped. Persist is fire-and-forget: the in-memory store is the source
+ * of truth for the UI, and the next project switch / save reconciles disk.
+ */
+function stampFleetUsageInMemory(projectId: string, scopeId: string, now: number): void {
+  let snapshot: ProjectSettings | null = null;
+  useProjectSettingsStore.setState((state) => {
+    if (!state.settings || state.projectId !== projectId) return {};
+    const nextScopes = (state.settings.fleetSavedScopes ?? []).map((s) => {
+      if (s.id !== scopeId) return s;
+      return {
+        ...s,
+        lastUsedAt: now,
+        usageHistory: [...(s.usageHistory ?? []), now].slice(-FLEET_USAGE_HISTORY_CAP),
+      };
+    });
+    snapshot = { ...state.settings, fleetSavedScopes: nextScopes };
+    return { settings: snapshot };
+  });
+  if (snapshot) {
+    projectClient.saveSettings(projectId, snapshot).catch((err) => {
+      console.warn("Failed to persist fleet recency stamp:", err);
+    });
+  }
 }
 
 function generateScopeId(): string {


### PR DESCRIPTION
## Summary

- Ranks saved fleets by frecency in the recall menu, mirroring the recipe scoring already shipped in `computeFrecency`.
- Closes the recall/save race in `fleet.recallNamedFleet` by folding the `lastUsedAt` / `usageHistory` stamp into an atomic store update instead of the prior naive read-modify-write of the fetched settings object.
- Surfaces an `isSnapshotStale` signal through `SavedFleetsSection` so callers can flag saved fleets whose project snapshot is no longer authoritative.

Resolves #9955

## Changes

- New `src/components/Fleet/fleetRanking.ts` ranking helper, with `lastUsedAt` seeded from the most recent `usageHistory` entry and decayed by recency.
- `SavedFleetsSection` now sorts by frecency and passes a `count` + `isStale` pair down to `SavedFleetRow`.
- `src/services/actions/definitions/fleetActions.ts`: `recallNamedFleet` writes through the same store the recipes use, so two near-simultaneous recalls no longer drop a timestamp.
- `src/components/Fleet/fleetStaleness.ts` extracted for the snapshot-stale predicate so the row and the section agree.

## Testing

- New `src/components/Fleet/__tests__/fleetRanking.test.ts` covers ordering, recency decay, and empty-history seeding.
- `SavedFleetsSection.test.tsx` extended for ranked display and stale-snapshot rendering.
- `savedFleetActions.test.ts` covers the recall/save race with two interleaved recalls and a save in between.
- Static tier (`npm run check`) and build green locally; the 330 tests in the changed code paths all pass. The broader suite has 164 pre-existing environmental failures unrelated to this change (missing `better-sqlite3` binding / no Electron binary on macOS without xvfb).