### PR TITLE
fix(layout): suppress sidebar width transition during initial hydration

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -116,6 +116,15 @@ export function AppLayout({
   // reset still animate.
   const [isSidebarResizing, setIsSidebarResizing] = useState(false);
   const [isAssistantResizing, setIsAssistantResizing] = useState(false);
+  // Issue #10321: sidebarWidth boots at DEFAULT_SIDEBAR_WIDTH and is only
+  // replaced once the async appClient.getState() restore (restoreState below)
+  // resolves ~50-100ms later. With the width transition live from first paint,
+  // that late setSidebarWidth animates the sidebar from 350px to the persisted
+  // width on every project switch — an animation the user never triggered.
+  // Suppress the transition until the restore lands, then clear the flag in the
+  // same synchronous post-await block so React batches both updates into one
+  // paint (the new width arrives with the class already gone — no animation).
+  const [isSidebarWidthHydrating, setIsSidebarWidthHydrating] = useState(true);
   const currentProject = useProjectStore((state) => state.currentProject);
   const layout = useLayoutState();
   const isThemeBrowserOpen = useOverlayOpen("theme-browser");
@@ -157,10 +166,26 @@ export function AppLayout({
     const prefersReducedMotion =
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduceAnimations || isSidebarResizing || prefersReducedMotion || layout.performanceMode) {
+    // #10321: while the width transition is suppressed during the initial
+    // hydration window, transitionend never fires on a hide, so flush directly
+    // here — otherwise sidebarFullyHidden stays false and a 6px clip-margin
+    // strip lingers.
+    if (
+      reduceAnimations ||
+      isSidebarResizing ||
+      isSidebarWidthHydrating ||
+      prefersReducedMotion ||
+      layout.performanceMode
+    ) {
       setSidebarFullyHidden(true);
     }
-  }, [showSidebar, reduceAnimations, isSidebarResizing, layout.performanceMode]);
+  }, [
+    showSidebar,
+    reduceAnimations,
+    isSidebarResizing,
+    isSidebarWidthHydrating,
+    layout.performanceMode,
+  ]);
 
   const handleSidebarTransitionEnd = useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {
@@ -221,8 +246,15 @@ export function AppLayout({
           popoverHeight: appState.dockedPopoverHeight,
         });
         useFleetScopeFlagStore.getState().hydrate(appState.fleetScopeMode);
+        // #10321: clear unconditionally (even when sidebarWidth is null) so a
+        // session without a persisted width still gets a live transition. React
+        // batches this with the setSidebarWidth above into a single paint.
+        setIsSidebarWidthHydrating(false);
       } catch (error) {
         logError("Failed to restore app state", error);
+        // #10321: a failed restore must still re-enable the transition, else
+        // every later user resize/collapse would be silently suppressed.
+        setIsSidebarWidthHydrating(false);
       }
     };
     restoreState();
@@ -595,6 +627,7 @@ export function AppLayout({
               "relative h-full shrink-0 overflow-clip",
               !reduceAnimations &&
                 !isSidebarResizing &&
+                !isSidebarWidthHydrating &&
                 "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
               !showSidebar && "pointer-events-none"
             )}

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -390,7 +390,7 @@ describe("AppLayout sidebar clip-margin state machine — issue #9864", () => {
     // else the 6px strip persists for reduced-motion users until re-show.
     expect(source).toMatch(/window\.matchMedia\("\(prefers-reduced-motion: reduce\)"\)/);
     expect(source).toMatch(
-      /reduceAnimations \|\|\s*isSidebarResizing \|\|\s*prefersReducedMotion \|\|\s*layout\.performanceMode[\s\S]{0,80}setSidebarFullyHidden\(true\)/
+      /reduceAnimations \|\|\s*isSidebarResizing \|\|\s*isSidebarWidthHydrating \|\|\s*prefersReducedMotion \|\|\s*layout\.performanceMode[\s\S]{0,80}setSidebarFullyHidden\(true\)/
     );
   });
 
@@ -400,7 +400,54 @@ describe("AppLayout sidebar clip-margin state machine — issue #9864", () => {
     // 6px strip persists in performance mode — the original #9864 regression.
     expect(source).toMatch(/\|\|\s*layout\.performanceMode/);
     expect(source).toMatch(
-      /\[showSidebar, reduceAnimations, isSidebarResizing, layout\.performanceMode\]/
+      /\[\s*showSidebar,\s*reduceAnimations,\s*isSidebarResizing,\s*isSidebarWidthHydrating,\s*layout\.performanceMode,?\s*\]/
     );
+  });
+});
+
+describe("AppLayout sidebar-width hydration transition gating — issue #10321", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("tracks an initially-suppressed hydration flag so the boot width-restore doesn't animate", () => {
+    // sidebarWidth boots at DEFAULT_SIDEBAR_WIDTH and is replaced once the async
+    // appClient.getState() restore resolves ~50-100ms later. Starting the flag
+    // at true keeps the width transition off until that restore lands, so the
+    // late setSidebarWidth doesn't animate 350px -> persisted on project switch.
+    expect(source).toContain(
+      "const [isSidebarWidthHydrating, setIsSidebarWidthHydrating] = useState(true)"
+    );
+  });
+
+  it("gates the sidebar width transition on the hydration flag alongside the resize guard", () => {
+    // The new flag must join the existing gate, not replace it — drag-resize
+    // suppression (#7627) and reduced-motion must still hold.
+    expect(source).toMatch(
+      /!reduceAnimations\s*&&\s*!isSidebarResizing\s*&&\s*!isSidebarWidthHydrating\s*&&/
+    );
+  });
+
+  it("clears the hydration flag in both the restore success and failure paths", () => {
+    // Unconditional clear in the try block (after the getState restore) so a
+    // session without a persisted width still re-enables the transition, and a
+    // clear in catch so a failed IPC doesn't permanently suppress every later
+    // user resize/collapse.
+    // One clear inside the try (before the catch) and one inside the catch.
+    expect(source).toMatch(
+      /setIsSidebarWidthHydrating\(false\);[\s\S]*?\} catch \(error\) \{[\s\S]*?setIsSidebarWidthHydrating\(false\)/
+    );
+    // Both clears must live within the restoreState effect's try/catch, not the
+    // initial useState — so there are exactly two setter calls total.
+    expect(source.match(/setIsSidebarWidthHydrating\(false\)/g)?.length).toBe(2);
+  });
+
+  it("does not need flushSync to clear the flag — the post-await batch is enough", () => {
+    // Unlike drag-resize start (which races the first mousemove), the clear runs
+    // in the same synchronous continuation as setSidebarWidth after the await,
+    // so React batches both into one paint. A flushSync here would be wrong.
+    expect(source).not.toMatch(/flushSync\([^)]*setIsSidebarWidthHydrating/);
   });
 });


### PR DESCRIPTION
## Summary

- On project switch, `AppLayout` mounts with `sidebarWidth=DEFAULT_SIDEBAR_WIDTH` (350px) and the `transition-[width]` class active from first paint. The async `restoreState()` effect (`appClient.getState()` IPC, ~50-100ms) then sets the persisted width, so the live CSS transition animated 350px→persisted on every switch — a spurious animation the user never asked for.
- Fix adds an `isSidebarWidthHydrating` flag (`useState(true)`) that suppresses the sidebar width transition until the async restore resolves. React 19 batches `setSidebarWidth` + the flag clear into one paint, so the new width arrives with the class already removed.
- Also extends the `sidebarFullyHidden` synchronous-flush guard with the same flag: during hydration `transitionend` won't fire on a hide, so without this a 6px clip-margin strip would linger.

Resolves #10321

## Changes

- `src/components/Layout/AppLayout.tsx` — `isSidebarWidthHydrating` state; transition class gated on the flag; `restoreState` clears it unconditionally in both `try` and `catch`; `sidebarFullyHidden` flush guard extended with the flag
- `src/components/Layout/__tests__/AppLayout.sidebar.test.ts` — 4 new regression tests for #10321; updated two existing #9864 flush-guard assertions to account for the hydrating flag

## Testing

- `npm run check` passed (typecheck, lint, format, channel/IPC/confirm-wiring guards)
- Changed-file tests: 39/39 green
- Full production build: clean
- 250ms ease-out-expo transition preserved for genuine user-driven resize, collapse/expand, and double-click reset
- `helpPanelWidth` deliberately unchanged — it restores synchronously via Zustand persist merge and doesn't share the root cause