### PR TITLE
perf(startup): unblock deferred-init drain from slow github-auth and sync log prune

### DIFF
--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -435,5 +435,17 @@ describe("logger", () => {
       const missingBase = join(TEST_LOG_DIR, "does-not-exist");
       await expect(pruneOldLogsAsync(missingBase, 30)).resolves.toBeUndefined();
     });
+
+    it("skips non-file entries (subdirectories) without deleting them", async () => {
+      const nestedDir = join(logsDir, "archive");
+      mkdirSync(nestedDir, { recursive: true });
+      // Backdate the directory so an age-only check would target it.
+      const oldSeconds = (Date.now() - 40 * DAY_MS) / 1000;
+      utimesSync(nestedDir, oldSeconds, oldSeconds);
+
+      await expect(pruneOldLogsAsync(TEST_LOG_DIR, 30)).resolves.toBeUndefined();
+
+      expect(existsSync(nestedDir)).toBe(true);
+    });
   });
 });

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { join } from "path";
-import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from "fs";
+import { mkdirSync, rmSync, existsSync, writeFileSync, readFileSync, utimesSync } from "fs";
 import {
   initializeLogger,
   getLogFilePath,
+  pruneOldLogsAsync,
   logInfo,
   logWarn,
   logError,
@@ -393,6 +394,46 @@ describe("logger", () => {
       const content = readFileSync(getLogFilePath(), "utf8");
       expect(content).toContain("[REDACTED]");
       expect(content).not.toContain(ANTHROPIC_KEY);
+    });
+  });
+
+  describe("pruneOldLogsAsync", () => {
+    const logsDir = join(TEST_LOG_DIR, "logs");
+    const debugDir = join(TEST_LOG_DIR, "debug");
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    function seedFile(dir: string, name: string, ageDays: number): string {
+      mkdirSync(dir, { recursive: true });
+      const filePath = join(dir, name);
+      writeFileSync(filePath, "x");
+      const mtimeSeconds = (Date.now() - ageDays * DAY_MS) / 1000;
+      utimesSync(filePath, mtimeSeconds, mtimeSeconds);
+      return filePath;
+    }
+
+    it("deletes files older than the retention window and keeps newer ones", async () => {
+      const stale = seedFile(logsDir, "stale.log", 40);
+      const fresh = seedFile(logsDir, "fresh.log", 1);
+      const staleDebug = seedFile(debugDir, "stale-debug.log", 40);
+
+      await pruneOldLogsAsync(TEST_LOG_DIR, 30);
+
+      expect(existsSync(stale)).toBe(false);
+      expect(existsSync(staleDebug)).toBe(false);
+      expect(existsSync(fresh)).toBe(true);
+    });
+
+    it("is a no-op when retentionDays is 0 (retention disabled)", async () => {
+      const stale = seedFile(logsDir, "stale.log", 999);
+
+      await pruneOldLogsAsync(TEST_LOG_DIR, 0);
+
+      expect(existsSync(stale)).toBe(true);
+    });
+
+    it("resolves without throwing when the log directories don't exist", async () => {
+      const missingBase = join(TEST_LOG_DIR, "does-not-exist");
+      await expect(pruneOldLogsAsync(missingBase, 30)).resolves.toBeUndefined();
     });
   });
 });

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -12,6 +12,7 @@ import {
   openSync,
   readSync,
   closeSync,
+  promises as fsp,
 } from "fs";
 import { join } from "path";
 import { logBuffer, type LogEntry } from "../services/LogBuffer.js";
@@ -242,6 +243,42 @@ export function pruneOldLogs(basePath: string, retentionDays: number | 0): void 
       }
     } catch {
       // Directory read failed — non-fatal
+    }
+  }
+}
+
+/**
+ * Async twin of {@link pruneOldLogs}. Uses `fs/promises` so the scan/delete pass
+ * yields to the event loop between files instead of blocking it with sync fs.
+ * Use this from async contexts (e.g. the deferred-init queue); keep the sync
+ * version for callers that run in a synchronous context (DiskSpaceMonitor).
+ */
+export async function pruneOldLogsAsync(
+  basePath: string,
+  retentionDays: number | 0
+): Promise<void> {
+  if (retentionDays === 0) return;
+
+  const threshold = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  const dirs = [join(basePath, "logs"), join(basePath, "debug")];
+
+  for (const dir of dirs) {
+    try {
+      const handle = await fsp.opendir(dir);
+      for await (const dirent of handle) {
+        if (!dirent.isFile()) continue;
+        try {
+          const filePath = join(dir, dirent.name);
+          const stats = await fsp.stat(filePath);
+          if (stats.mtimeMs < threshold) {
+            await fsp.unlink(filePath);
+          }
+        } catch {
+          // Skip locked or inaccessible files
+        }
+      }
+    } catch {
+      // Directory read failed or doesn't exist — non-fatal
     }
   }
 }

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -266,6 +266,9 @@ export async function pruneOldLogsAsync(
     try {
       const handle = await fsp.opendir(dir);
       for await (const dirent of handle) {
+        // dirent.isFile() (unlike the sync twin's statSync().isFile()) does not
+        // follow symlinks; log dirs in userData never contain symlinks, so this
+        // is equivalent in practice while avoiding an extra stat per entry.
         if (!dirent.isFile()) continue;
         try {
           const filePath = join(dir, dirent.name);

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -252,7 +252,7 @@ describe("initGlobalServices task ordering", () => {
     pruneOldLogs.mockReset();
     pruneOldLogsAsync.mockReset();
     vi.mocked(GitHubAuth.hasToken).mockReturnValue(false);
-    vi.mocked(GitHubAuth.getToken).mockReturnValue(null);
+    vi.mocked(GitHubAuth.getToken).mockReturnValue(undefined);
     vi.mocked(GitHubAuth.getTokenVersion).mockReturnValue(0);
     vi.mocked(GitHubAuth.validate).mockReset();
     vi.mocked(GitHubAuth.setValidatedUserInfo).mockReset();
@@ -518,12 +518,10 @@ describe("initGlobalServices task ordering", () => {
     vi.mocked(GitHubAuth.hasToken).mockReturnValue(true);
     vi.mocked(GitHubAuth.getToken).mockReturnValue("tok-123");
     // A validate() that never resolves models a slow/offline network. The task
-    // must not return this promise, otherwise drainNext would await it.
-    let resolveValidate: ((value: unknown) => void) | undefined;
+    // must not return this promise, otherwise drainNext would await it. The
+    // pending promise has no backing timer/IO, so it won't keep the loop alive.
     vi.mocked(GitHubAuth.validate).mockReturnValue(
-      new Promise((resolve) => {
-        resolveValidate = resolve;
-      }) as ReturnType<typeof GitHubAuth.validate>
+      new Promise<never>(() => {}) as ReturnType<typeof GitHubAuth.validate>
     );
 
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
@@ -534,9 +532,6 @@ describe("initGlobalServices task ordering", () => {
     // run() must complete (return a non-thenable) even while validate hangs.
     const result = run?.();
     expect(result).toBeUndefined();
-
-    // Cleanup: let the floated validation settle to avoid an open handle.
-    resolveValidate?.({ valid: false });
   });
 
   it("github-auth-validate contains a rejected validate() so it can't surface as an unhandled rejection (#10325)", async () => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -539,6 +539,62 @@ describe("initGlobalServices task ordering", () => {
     resolveValidate?.({ valid: false });
   });
 
+  it("github-auth-validate contains a rejected validate() so it can't surface as an unhandled rejection (#10325)", async () => {
+    vi.mocked(GitHubAuth.hasToken).mockReturnValue(true);
+    vi.mocked(GitHubAuth.getToken).mockReturnValue("tok-123");
+    vi.mocked(GitHubAuth.validate).mockRejectedValue(new Error("network down"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+      await initGlobalServices(fakeRegistry);
+
+      const run = registeredTaskRuns.get("github-auth-validate");
+      expect(run).toBeDefined();
+      expect(run?.()).toBeUndefined();
+
+      // Let the floated IIFE's catch run and any (absent) rejection propagate.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(warnSpy).toHaveBeenCalled();
+      expect(unhandled).toHaveLength(0);
+      expect(GitHubAuth.setValidatedUserInfo).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("github-auth-validate forwards the captured token version so a stale write can be rejected (#10325)", async () => {
+    vi.mocked(GitHubAuth.hasToken).mockReturnValue(true);
+    vi.mocked(GitHubAuth.getToken).mockReturnValue("tok-123");
+    // Version 7 captured at registration; the guard inside setValidatedUserInfo
+    // compares against this. validate resolves valid, so the task tries to cache.
+    vi.mocked(GitHubAuth.getTokenVersion).mockReturnValue(7);
+    vi.mocked(GitHubAuth.validate).mockResolvedValue({
+      valid: true,
+      username: "octocat",
+      avatarUrl: undefined,
+      scopes: ["repo"],
+    } as Awaited<ReturnType<typeof GitHubAuth.validate>>);
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("github-auth-validate");
+    expect(run).toBeDefined();
+    run?.();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // The task forwards the captured version so GitHubAuth can reject a stale write.
+    expect(GitHubAuth.setValidatedUserInfo).toHaveBeenCalledWith("octocat", undefined, ["repo"], 7);
+  });
+
   it("returns 'ok' on the happy path", async () => {
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
     const result = await initGlobalServices(fakeRegistry);

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -9,7 +9,10 @@ const setMcpRegistry = vi.fn();
 let migrationCurrentVersion = 1;
 let migrationShouldThrow = false;
 let mockLogRetentionDays: number | undefined = 30;
-const { pruneOldLogs } = vi.hoisted(() => ({ pruneOldLogs: vi.fn() }));
+const { pruneOldLogs, pruneOldLogsAsync } = vi.hoisted(() => ({
+  pruneOldLogs: vi.fn(),
+  pruneOldLogsAsync: vi.fn(),
+}));
 const {
   pluginMcpHydrate,
   getPluginMcpAuditService,
@@ -59,6 +62,7 @@ vi.mock("../../store.js", () => ({
 
 vi.mock("../../utils/logger.js", () => ({
   pruneOldLogs,
+  pruneOldLogsAsync,
   logError: vi.fn(),
   logWarn: vi.fn(),
   logInfo: vi.fn(),
@@ -73,9 +77,9 @@ vi.mock("../../services/TelemetryService.js", () => ({
 vi.mock("../../services/github/GitHubAuth.js", () => ({
   GitHubAuth: {
     initializeStorage: vi.fn(),
-    hasToken: () => false,
-    getToken: () => null,
-    getTokenVersion: () => 0,
+    hasToken: vi.fn(() => false),
+    getToken: vi.fn(() => null),
+    getTokenVersion: vi.fn(() => 0),
     setMemoryToken: vi.fn(),
     setValidatedUserInfo: vi.fn(),
     validate: vi.fn(),
@@ -236,6 +240,7 @@ import { initGlobalServices } from "../globalServicesInit.js";
 import { getGlobalServicesInitialized, setGlobalServicesInitialized } from "../serviceRefs.js";
 import type { WindowRegistry } from "../WindowRegistry.js";
 import { app } from "electron";
+import { GitHubAuth } from "../../services/github/GitHubAuth.js";
 
 describe("initGlobalServices task ordering", () => {
   beforeEach(() => {
@@ -245,6 +250,12 @@ describe("initGlobalServices task ordering", () => {
     // leak into the next — keeps tests independent as the suite grows.
     setMcpRegistry.mockReset();
     pruneOldLogs.mockReset();
+    pruneOldLogsAsync.mockReset();
+    vi.mocked(GitHubAuth.hasToken).mockReturnValue(false);
+    vi.mocked(GitHubAuth.getToken).mockReturnValue(null);
+    vi.mocked(GitHubAuth.getTokenVersion).mockReturnValue(0);
+    vi.mocked(GitHubAuth.validate).mockReset();
+    vi.mocked(GitHubAuth.setValidatedUserInfo).mockReset();
     pluginMcpHydrate.mockClear();
     getPluginMcpAuditService.mockClear();
     getPluginMcpConsentService.mockClear();
@@ -464,28 +475,31 @@ describe("initGlobalServices task ordering", () => {
     expect(assistantSpy).toHaveBeenCalled();
   });
 
-  it("prune-old-logs task invokes pruneOldLogs with retentionDays from privacy settings", async () => {
+  it("prune-old-logs task invokes pruneOldLogsAsync with retentionDays from privacy settings", async () => {
     mockLogRetentionDays = 14;
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
     await initGlobalServices(fakeRegistry);
 
     const run = registeredTaskRuns.get("prune-old-logs");
     expect(run).toBeDefined();
-    run?.();
+    await run?.();
 
-    expect(pruneOldLogs).toHaveBeenCalledWith("/tmp/userData", 14);
+    expect(pruneOldLogsAsync).toHaveBeenCalledWith("/tmp/userData", 14);
+    // The async twin replaces the sync version in the deferred drain so the
+    // fs scan no longer blocks the main-process event loop (#10325).
+    expect(pruneOldLogs).not.toHaveBeenCalled();
   });
 
-  it("prune-old-logs task skips pruning when retentionDays is 0", async () => {
+  it("prune-old-logs task delegates retentionDays 0 to pruneOldLogsAsync (which skips internally)", async () => {
     mockLogRetentionDays = 0;
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
     await initGlobalServices(fakeRegistry);
 
     const run = registeredTaskRuns.get("prune-old-logs");
     expect(run).toBeDefined();
-    run?.();
+    await run?.();
 
-    expect(pruneOldLogs).not.toHaveBeenCalled();
+    expect(pruneOldLogsAsync).toHaveBeenCalledWith("/tmp/userData", 0);
   });
 
   it("prune-old-logs task defaults retentionDays to 30 when privacy setting is missing", async () => {
@@ -495,9 +509,34 @@ describe("initGlobalServices task ordering", () => {
 
     const run = registeredTaskRuns.get("prune-old-logs");
     expect(run).toBeDefined();
-    run?.();
+    await run?.();
 
-    expect(pruneOldLogs).toHaveBeenCalledWith("/tmp/userData", 30);
+    expect(pruneOldLogsAsync).toHaveBeenCalledWith("/tmp/userData", 30);
+  });
+
+  it("github-auth-validate task returns void synchronously so a slow validate can't stall the drain (#10325)", async () => {
+    vi.mocked(GitHubAuth.hasToken).mockReturnValue(true);
+    vi.mocked(GitHubAuth.getToken).mockReturnValue("tok-123");
+    // A validate() that never resolves models a slow/offline network. The task
+    // must not return this promise, otherwise drainNext would await it.
+    let resolveValidate: ((value: unknown) => void) | undefined;
+    vi.mocked(GitHubAuth.validate).mockReturnValue(
+      new Promise((resolve) => {
+        resolveValidate = resolve;
+      }) as ReturnType<typeof GitHubAuth.validate>
+    );
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("github-auth-validate");
+    expect(run).toBeDefined();
+    // run() must complete (return a non-thenable) even while validate hangs.
+    const result = run?.();
+    expect(result).toBeUndefined();
+
+    // Cleanup: let the floated validation settle to avoid an open handle.
+    resolveValidate?.({ valid: false });
   });
 
   it("returns 'ok' on the happy path", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -41,7 +41,7 @@ import { startDiskSpaceMonitor } from "../services/DiskSpaceMonitor.js";
 import { runScratchCleanup } from "../services/ScratchCleanupService.js";
 import { runAssistantScratchCleanup } from "../services/AssistantScratchService.js";
 import { getPeriodicCleanupService } from "../services/PeriodicCleanupService.js";
-import { pruneOldLogs, logError } from "../utils/logger.js";
+import { pruneOldLogs, pruneOldLogsAsync, logError } from "../utils/logger.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -192,21 +192,30 @@ export async function initGlobalServices(
       const versionAtStart = GitHubAuth.getTokenVersion();
       registerDeferredTask({
         name: "github-auth-validate",
-        run: async () => {
-          try {
-            const validation = await GitHubAuth.validate(token);
-            if (validation.valid && validation.username) {
-              GitHubAuth.setValidatedUserInfo(
-                validation.username,
-                validation.avatarUrl,
-                validation.scopes,
-                versionAtStart
-              );
-              console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
+        // Floated, not awaited: GitHubAuth.validate has an internal 10s
+        // AbortSignal.timeout, and no later task depends on the validated user
+        // info. Returning void lets drainNext advance immediately instead of
+        // stalling the whole queue on a slow/offline network. The versionAtStart
+        // guard makes setValidatedUserInfo a safe no-op if the token rotates
+        // mid-flight, and the shutdown hard-timeout budget (#4287) bounds any
+        // in-flight fetch still pending at quit.
+        run: () => {
+          void (async () => {
+            try {
+              const validation = await GitHubAuth.validate(token);
+              if (validation.valid && validation.username) {
+                GitHubAuth.setValidatedUserInfo(
+                  validation.username,
+                  validation.avatarUrl,
+                  validation.scopes,
+                  versionAtStart
+                );
+                console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
+              }
+            } catch (err) {
+              console.warn("[MAIN] Failed to validate stored GitHub token:", err);
             }
-          } catch (err) {
-            console.warn("[MAIN] Failed to validate stored GitHub token:", err);
-          }
+          })();
         },
       });
     }
@@ -825,17 +834,16 @@ export async function initGlobalServices(
 
   registerDeferredTask({
     name: "prune-old-logs",
-    run: () => {
-      // Deferred (post first-interactive) so the synchronous fs scan doesn't
-      // block cold start. Note: `userData/debug/*.log` files have their mtimes
-      // refreshed by `clearDebugLogs` during `initializeLogger` (pre-deferral),
-      // so debug stubs effectively survive each prune cycle. They're empty
-      // (0 bytes) so the accumulation is harmless; `userData/logs/` is still
-      // pruned correctly because its files are appended-to, not truncated.
+    run: async () => {
+      // Deferred (post first-interactive) and async (pruneOldLogsAsync yields to
+      // the event loop between files) so the fs scan doesn't block the main
+      // process. Note: `userData/debug/*.log` files have their mtimes refreshed
+      // by `clearDebugLogs` during `initializeLogger` (pre-deferral), so debug
+      // stubs effectively survive each prune cycle. They're empty (0 bytes) so
+      // the accumulation is harmless; `userData/logs/` is still pruned correctly
+      // because its files are appended-to, not truncated.
       const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
-      if (retentionDays > 0) {
-        pruneOldLogs(app.getPath("userData"), retentionDays);
-      }
+      await pruneOldLogsAsync(app.getPath("userData"), retentionDays);
     },
   });
 


### PR DESCRIPTION
## Summary

- The `github-auth-validate` task in `globalServicesInit.ts` now runs its `GitHubAuth.validate()` call inside a detached `void (async () => { ... })()` rather than as an `async run()`. The task returns synchronously so the drain advances immediately, instead of waiting up to 10 s on `AbortSignal.timeout(10_000)` on a slow or offline network. No downstream task reads GitHub auth state, so nothing depended on the await.
- `prune-old-logs` now delegates to a new `pruneOldLogsAsync` in `logger.ts` that uses `fs/promises` `opendir` + `for await` + `stat`/`unlink`. Each `await` yields back to the event loop, replacing the `readdirSync`/`statSync`/`unlinkSync` loop that blocked the main process for the full scan. The synchronous `pruneOldLogs` is kept for the `DiskSpaceMonitor` callsite that needs it.

Resolves #10325

## Changes

- `electron/window/globalServicesInit.ts` — detach the `validate()` call; guard `setValidatedUserInfo` with the captured `versionAtStart` so a mid-flight token rotation is a safe no-op.
- `electron/utils/logger.ts` — add `pruneOldLogsAsync`; existing `pruneOldLogs` unchanged.
- `electron/utils/__tests__/logger.test.ts` — new tests for `pruneOldLogsAsync`: age-based deletion, `retentionDays=0` no-op, missing-dir resilience, non-file-entry skip.
- `electron/window/__tests__/globalServicesInit.order.test.ts` — assert the prune task delegates to `pruneOldLogsAsync`; assert `github-auth-validate` `run()` returns `void` synchronously, contains a rejected `validate()` with no unhandled rejection, and forwards the captured token version.

## Testing

Static checks (`npm run check` — typecheck, lint, format, IPC + confirm-wiring guards) pass. Build passes. Changed-file unit tests pass. Full vitest suite is blocked in this worktree environment by a missing `node_modules/electron/path.txt` that triggers a binary download for ~35 unrelated infra files; GitHub CI on Ubuntu confirms.