### PR TITLE
perf(store): eliminate a redundant config.json read on cold boot

### DIFF
--- a/electron/__tests__/storeBackupRestore.test.ts
+++ b/electron/__tests__/storeBackupRestore.test.ts
@@ -239,6 +239,18 @@ describe("initializeStore", () => {
     expect(fs.existsSync(`${configPath}.bak`)).toBe(true);
   });
 
+  it("does not trip wipe detection on a pretty-printed valid config (reused-buffer byte identity)", () => {
+    const configPath = path.join(tempDir, "config.json");
+    // Whitespace-heavy formatting: the reused preflight buffer must match the
+    // on-disk bytes exactly, or detectStoreWipe's byte fast-path would diverge.
+    fs.writeFileSync(configPath, `${JSON.stringify({ _schemaVersion: 5 }, null, 2)}\n`, "utf8");
+    const instance = initializeStore(testOptions(tempDir));
+    expect(instance.get("_schemaVersion")).toBe(5);
+    // A benign load must not be misreported as a silent reset.
+    expect(consumePendingSettingsRecovery()).toBeNull();
+    expect(fs.existsSync(`${configPath}.bak`)).toBe(true);
+  });
+
   it("recovers from corrupt config with valid backup", () => {
     const configPath = path.join(tempDir, "config.json");
     fs.writeFileSync(configPath, "{corrupt!", "utf8");

--- a/electron/__tests__/storeBackupRestore.test.ts
+++ b/electron/__tests__/storeBackupRestore.test.ts
@@ -48,44 +48,67 @@ describe("Store backup/restore helpers", () => {
 
   describe("preflightValidateConfig", () => {
     it("returns 'missing' when file does not exist", () => {
-      expect(preflightValidateConfig(configPath)).toBe("missing");
+      expect(preflightValidateConfig(configPath).status).toBe("missing");
     });
 
     it("returns 'valid' for valid JSON", () => {
       fs.writeFileSync(configPath, JSON.stringify({ foo: "bar" }), "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("valid");
+      expect(preflightValidateConfig(configPath).status).toBe("valid");
+    });
+
+    it("carries the raw bytes it read so the caller can skip a second read", () => {
+      fs.writeFileSync(configPath, JSON.stringify({ foo: "bar", n: 42 }), "utf8");
+      const result = preflightValidateConfig(configPath);
+      expect(result.status).toBe("valid");
+      expect(result.status === "valid" && Buffer.isBuffer(result.rawBuffer)).toBe(true);
+      // The reused buffer must be byte-identical to a fresh raw read so it can
+      // serve as the pre-construction wipe-detection snapshot.
+      expect(
+        result.status === "valid" && result.rawBuffer?.equals(fs.readFileSync(configPath))
+      ).toBe(true);
+    });
+
+    it("carries byte-identical bytes for non-ASCII (CJK + emoji) content", () => {
+      fs.writeFileSync(configPath, JSON.stringify({ greeting: "你好", emoji: "🚀" }), "utf8");
+      const result = preflightValidateConfig(configPath);
+      expect(
+        result.status === "valid" && result.rawBuffer?.equals(fs.readFileSync(configPath))
+      ).toBe(true);
     });
 
     it("returns 'corrupt' for invalid JSON", () => {
       fs.writeFileSync(configPath, "{invalid json", "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("corrupt");
+      expect(preflightValidateConfig(configPath).status).toBe("corrupt");
     });
 
     it("returns 'corrupt' for empty file", () => {
       fs.writeFileSync(configPath, "", "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("corrupt");
+      expect(preflightValidateConfig(configPath).status).toBe("corrupt");
     });
 
     it("returns 'corrupt' for partial JSON", () => {
       fs.writeFileSync(configPath, "{", "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("corrupt");
+      expect(preflightValidateConfig(configPath).status).toBe("corrupt");
     });
 
     it("returns 'corrupt' for non-object JSON values", () => {
       fs.writeFileSync(configPath, '"a string"', "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("corrupt");
+      expect(preflightValidateConfig(configPath).status).toBe("corrupt");
       fs.writeFileSync(configPath, "42", "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("corrupt");
+      expect(preflightValidateConfig(configPath).status).toBe("corrupt");
       fs.writeFileSync(configPath, "[]", "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("corrupt");
+      expect(preflightValidateConfig(configPath).status).toBe("corrupt");
       fs.writeFileSync(configPath, "null", "utf8");
-      expect(preflightValidateConfig(configPath)).toBe("corrupt");
+      expect(preflightValidateConfig(configPath).status).toBe("corrupt");
     });
 
-    it("returns 'valid' on non-SyntaxError read failures", () => {
+    it("returns 'valid' with no raw bytes on non-SyntaxError read failures", () => {
       const dirPath = path.join(tempDir, "not-a-file");
       fs.mkdirSync(dirPath);
-      expect(preflightValidateConfig(dirPath)).toBe("valid");
+      const result = preflightValidateConfig(dirPath);
+      expect(result.status).toBe("valid");
+      // Fail-open: no usable bytes, so the caller must fall back to a fresh read.
+      expect(result.status === "valid" && result.rawBuffer).toBeUndefined();
     });
   });
 

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -636,8 +636,13 @@ function preflightValidateConfig(configPath: string): ConfigPreflightResult {
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       return { status: "corrupt" };
     }
-    // A valid parse guarantees a BOM-free string (a BOM throws SyntaxError),
-    // so re-encoding is byte-identical to fs.readFileSync(configPath) raw.
+    // Re-encode the bytes preflight just decoded so the caller can use them as
+    // the pre-construction wipe snapshot without reading the file again. For
+    // well-formed UTF-8 (BOM-free — a BOM throws SyntaxError above) this is
+    // byte-identical to fs.readFileSync(configPath) raw. The lone edge is a
+    // file with invalid UTF-8 byte sequences that still parses as JSON: those
+    // bytes round-trip through U+FFFD, so rawBuffer matches what electron-store
+    // itself decodes and rewrites — which is exactly what detectStoreWipe needs.
     return { status: "valid", rawBuffer: Buffer.from(raw, "utf8") };
   } catch (err) {
     if (err instanceof SyntaxError) return { status: "corrupt" };

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -619,18 +619,29 @@ function resolveConfigPath(cwd: string | undefined): string | null {
   return path.join(dir, "config.json");
 }
 
-function preflightValidateConfig(configPath: string): "valid" | "missing" | "corrupt" {
-  if (!fs.existsSync(configPath)) return "missing";
+// On the valid path, `rawBuffer` carries the bytes already read here so the
+// caller can use them as the pre-construction wipe-detection snapshot instead
+// of reading config.json a second time. It is absent only on the fail-open
+// branch below, where no usable bytes were obtained.
+type ConfigPreflightResult =
+  | { status: "valid"; rawBuffer?: Buffer }
+  | { status: "missing" }
+  | { status: "corrupt" };
+
+function preflightValidateConfig(configPath: string): ConfigPreflightResult {
+  if (!fs.existsSync(configPath)) return { status: "missing" };
   try {
     const raw = fs.readFileSync(configPath, "utf8");
     const parsed = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return "corrupt";
+      return { status: "corrupt" };
     }
-    return "valid";
+    // A valid parse guarantees a BOM-free string (a BOM throws SyntaxError),
+    // so re-encoding is byte-identical to fs.readFileSync(configPath) raw.
+    return { status: "valid", rawBuffer: Buffer.from(raw, "utf8") };
   } catch (err) {
-    if (err instanceof SyntaxError) return "corrupt";
-    return "valid";
+    if (err instanceof SyntaxError) return { status: "corrupt" };
+    return { status: "valid" };
   }
 }
 
@@ -775,20 +786,26 @@ export function initializeStore(options: typeof storeOptions = storeOptions): St
 
   const configPath = resolveConfigPath(options.cwd);
 
-  if (configPath) {
-    const status = preflightValidateConfig(configPath);
-    if (status === "corrupt") {
-      console.warn("[Store] Detected corrupt config.json");
-      const quarantinedPath = quarantineCorruptConfig(configPath) ?? undefined;
-      const restored = restoreFromBackup(configPath);
-      pendingSettingsRecovery = restored
-        ? { kind: "restored-from-backup", quarantinedPath }
-        : { kind: "reset-to-defaults", quarantinedPath };
-    }
+  const preflight = configPath ? preflightValidateConfig(configPath) : null;
+  if (preflight?.status === "corrupt") {
+    console.warn("[Store] Detected corrupt config.json");
+    const quarantinedPath = quarantineCorruptConfig(configPath!) ?? undefined;
+    const restored = restoreFromBackup(configPath!);
+    pendingSettingsRecovery = restored
+      ? { kind: "restored-from-backup", quarantinedPath }
+      : { kind: "reset-to-defaults", quarantinedPath };
   }
 
   try {
-    const preSnapshot = configPath ? readRawSnapshot(configPath) : null;
+    // Reuse the bytes preflight already read on the valid path; the corrupt
+    // branch mutated the file (quarantine + restore), so fall through to a
+    // fresh read there so the snapshot reflects the post-recovery bytes.
+    const preSnapshot =
+      preflight?.status === "valid" && preflight.rawBuffer
+        ? preflight.rawBuffer
+        : configPath
+          ? readRawSnapshot(configPath)
+          : null;
     const created = new Store<StoreSchema>({
       ...options,
       clearInvalidConfig: true,


### PR DESCRIPTION
## Summary

- On every cold launch, `initializeStore()` was reading and parsing `config.json` twice on the valid path — the pre-construction wipe-detection snapshot read was a pure duplicate of the earlier preflight validation read, since nothing mutates the file between them.
- `preflightValidateConfig` now returns a discriminated union: the valid path carries the raw `Buffer` it already decoded; `initializeStore` reuses it as the snapshot instead of re-reading.
- The corrupt path is unchanged — it still re-reads after quarantine+restore mutates `config.json`, so wipe-detection semantics are fully preserved.

Resolves #10324

## Changes

- `electron/store.ts` — `preflightValidateConfig` return type changed to a discriminated union (`{ status: "valid", buffer: Buffer, ... } | { status: "corrupt", ... }`); `initializeStore` reuses the returned buffer as the pre-construction snapshot on the valid path
- `electron/__tests__/storeBackupRestore.test.ts` — guards added for the reused-buffer byte identity on the valid path; UTF-8 decode comment clarified

## Testing

Typecheck, lint, format check, all guard scripts, and build pass. The 43 tests in `storeBackupRestore.test.ts` all pass. The 156 baseline failures in the full unit suite are pre-existing and isolated to `PtyClient`/shutdown/database — unrelated to this change.