### PR TITLE
perf(startup): defer PluginService import off first-paint path

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -76,7 +76,6 @@ import { getProjectStatsService } from "./ipc/handlers/projectCrud/index.js";
 import { getIdleTerminalNotificationService } from "./services/IdleTerminalNotificationService.js";
 import { preAgentSnapshotService } from "./services/PreAgentSnapshotService.js";
 import { isDemoMode, isSmokeTest, kickOffEarlyPathRefresh } from "./setup/environment.js";
-import { activateOpenFileInstaller } from "./setup/openFileInstall.js";
 import { store } from "./store.js";
 import { initializeLogger, registerLoggerTransport, setLogLevelOverrides } from "./utils/logger.js";
 import { broadcastToRenderer } from "./ipc/utils.js";
@@ -516,13 +515,16 @@ if (!gotTheLock) {
       registerDeepLinkProtocolClient();
       registerAppProtocol(distPath, { allowDisplayCapture: isDemoMode });
       registerDaintreeFileProtocol();
-      const { pluginService } = await import("./services/PluginService.js");
-      registerPluginProtocol((pluginId) => pluginService.getPluginDir(pluginId));
-      // macOS: drain any `.dntr` paths queued during cold launch (Finder
-      // double-click / "Open With") and take over live open-file events now
-      // that PluginService can install them. Fire-and-forget — install runs
-      // concurrently with the rest of startup. #9293
-      void activateOpenFileInstaller(pluginService);
+      // Register `plugin://` with a placeholder resolver that 404s every
+      // request, keeping the heavy ~2900-line PluginService module off the
+      // first-paint critical path (#10322). The handler must exist before
+      // `createWindow()` so `registerProtocolsForSession` wires per-session
+      // handlers; the deferred `plugin-service` task later calls
+      // `setPluginDirResolver()` to point it at the real `getPluginDir` and
+      // drains queued `.dntr` paths via `activateOpenFileInstaller`. plugin://
+      // requests only arrive after the renderer mounts and plugins activate —
+      // well after first paint — so the placeholder window is never observed.
+      registerPluginProtocol(() => undefined);
       // Wire the `daintree://` deep-link path (#9559): take over live macOS
       // `open-url` events and drain any cold-launch URL (queued `open-url` on
       // macOS, `process.argv` on Windows/Linux). Routed to the primary window

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1296,6 +1296,45 @@ describe("protocol registration", () => {
     const after = await handler(new Request("plugin://live-plugin/dist/index.js") as GlobalRequest);
     expect(after.status).toBe(200);
   });
+
+  it("setPluginDirResolver swap reaches a per-session handler wired before init (#10322)", async () => {
+    const fs = await import("fs/promises");
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.open).mockResolvedValue({
+      readFile: vi.fn().mockResolvedValue(Buffer.from("data")),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Awaited<ReturnType<typeof fs.open>>);
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("text/javascript");
+
+    const PLUGIN_ROOT = path.resolve("/plugins/installed/session-plugin");
+
+    // Placeholder registered before first paint flips the gate true, so the
+    // per-session handler is wired during createWindow → registerProtocolsForSession.
+    registerPluginProtocol(() => undefined);
+
+    const handle = vi.fn();
+    const mockSession = { protocol: { handle } } as unknown as Electron.Session;
+    registerProtocolsForSession(mockSession, "/tmp/dist");
+
+    const call = handle.mock.calls.find((c) => c[0] === "plugin");
+    expect(call).toBeDefined();
+    const handler = call![1] as (req: GlobalRequest) => Promise<Response>;
+
+    const before = await handler(
+      new Request("plugin://session-plugin/dist/index.js") as GlobalRequest
+    );
+    expect(before.status).toBe(404);
+
+    setPluginDirResolver((id) => (id === "session-plugin" ? PLUGIN_ROOT : undefined));
+
+    // The per-session handler — created before the resolver existed — now serves
+    // via the resolvePluginDir indirection, not just the default-session handler.
+    const after = await handler(
+      new Request("plugin://session-plugin/dist/index.js") as GlobalRequest
+    );
+    expect(after.status).toBe(200);
+  });
 });
 
 describe("createDaintreeFileProtocolHandler — symlink containment", () => {

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -138,6 +138,7 @@ import {
   registerDaintreeFileProtocol,
   registerPluginProtocol,
   registerProtocolsForSession,
+  setPluginDirResolver,
   setupWebviewCSP,
 } from "../protocols.js";
 import { getWebviewDialogService } from "../../services/WebviewDialogService.js";
@@ -1257,6 +1258,43 @@ describe("protocol registration", () => {
     registerPluginProtocol(() => undefined);
 
     expect(protocol.handle).toHaveBeenCalledWith("plugin", expect.any(Function));
+  });
+
+  it("setPluginDirResolver swaps the live resolver for an already-registered handler (#10322)", async () => {
+    const { protocol } = await import("electron");
+    const fs = await import("fs/promises");
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(fs.realpath).mockImplementation((p) => Promise.resolve(p as string));
+    vi.mocked(fs.open).mockResolvedValue({
+      readFile: vi.fn().mockResolvedValue(Buffer.from("data")),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Awaited<ReturnType<typeof fs.open>>);
+    vi.mocked(appProtocol.getMimeType).mockReturnValue("text/javascript");
+
+    const PLUGIN_ROOT = path.resolve("/plugins/installed/live-plugin");
+
+    // main.ts registers the handler before first paint with the placeholder
+    // resolver — every request 404s while the heavy PluginService import is
+    // still deferred.
+    registerPluginProtocol(() => undefined);
+    const call = vi.mocked(protocol.handle).mock.calls.find((c) => c[0] === "plugin");
+    expect(call).toBeDefined();
+    const handler = call![1] as (req: GlobalRequest) => Promise<Response>;
+
+    const before = await handler(
+      new Request("plugin://live-plugin/dist/index.js") as GlobalRequest
+    );
+    expect(before.status).toBe(404);
+
+    // The deferred plugin-service task settles and swaps in the real resolver.
+    setPluginDirResolver((id) => (id === "live-plugin" ? PLUGIN_ROOT : undefined));
+
+    // The SAME handler instance now resolves — proving the swap reaches handlers
+    // registered before init, not just ones created afterward. This guards the
+    // frozen-capture regression: a handler that closed over the placeholder
+    // directly would still 404 here.
+    const after = await handler(new Request("plugin://live-plugin/dist/index.js") as GlobalRequest);
+    expect(after.status).toBe(200);
   });
 });
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -526,7 +526,7 @@ export function registerProtocolsForSession(ses: Electron.Session, distPath: str
   ses.protocol.handle("app", createAppProtocolHandler(distPath));
   ses.protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
   if (cachedGetPluginDir) {
-    ses.protocol.handle("plugin", createPluginProtocolHandler(cachedGetPluginDir));
+    ses.protocol.handle("plugin", createPluginProtocolHandler(resolvePluginDir));
   }
 }
 
@@ -567,9 +567,34 @@ export function registerDaintreeFileProtocol(): void {
   protocol.handle("daintree-file", createDaintreeFileProtocolHandler());
 }
 
+// Stable indirection so the live `plugin://` resolver can be swapped after the
+// deferred PluginService import settles (#10322) without re-registering the
+// handler. Both the default-session handler and per-session handlers are wired
+// to this function once; it reads `cachedGetPluginDir` at request time, so a
+// later `setPluginDirResolver` is picked up live — no `protocol.unhandle`/
+// re-`handle` (which would open a micro-tick `ERR_UNKNOWN_URL_SCHEME` gap).
+function resolvePluginDir(pluginId: string): string | undefined {
+  return cachedGetPluginDir ? cachedGetPluginDir(pluginId) : undefined;
+}
+
 export function registerPluginProtocol(getPluginDir: GetPluginDir): void {
   cachedGetPluginDir = getPluginDir;
-  protocol.handle("plugin", createPluginProtocolHandler(getPluginDir));
+  protocol.handle("plugin", createPluginProtocolHandler(resolvePluginDir));
+}
+
+/**
+ * Swap the live `plugin://` directory resolver after the deferred PluginService
+ * import settles (#10322). `registerPluginProtocol` runs before `createWindow`
+ * with a placeholder resolver that returns `undefined` (every request 404s),
+ * keeping the heavy ~2900-line PluginService module off the first-paint path.
+ * Once the deferred `plugin-service` task initializes the singleton, it calls
+ * this to point the already-registered handler at the real `getPluginDir`. The
+ * handler delegates through `resolvePluginDir`, which reads `cachedGetPluginDir`
+ * live, so the swap reaches every handler already registered (default session
+ * plus any per-session handlers wired during `createWindow`).
+ */
+export function setPluginDirResolver(getPluginDir: GetPluginDir): void {
+  cachedGetPluginDir = getPluginDir;
 }
 
 /**

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -442,6 +442,24 @@ describe("initGlobalServices task ordering", () => {
     expect(activateOpenFileInstaller.mock.calls[0]![0]).toBeDefined();
   });
 
+  it("plugin-service task still wires resolver + installer when initialize() rejects (#10322)", async () => {
+    // initialize() failure is non-fatal: the resolver must still go live so any
+    // plugins that did load serve assets, and the installer must still drain
+    // queued .dntr paths. This locks the intentional partial-failure posture.
+    pluginInitialize.mockRejectedValueOnce(new Error("init boom"));
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("plugin-service");
+    expect(run).toBeDefined();
+
+    await run!();
+
+    expect(setPluginDirResolver).toHaveBeenCalledTimes(1);
+    expect(activateOpenFileInstaller).toHaveBeenCalledTimes(1);
+  });
+
   it("does not touch plugin-MCP audit/consent services eagerly during initGlobalServices() (#10073)", async () => {
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
     await initGlobalServices(fakeRegistry);

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -27,6 +27,19 @@ const {
     getPluginMcpConsentStore: vi.fn(),
   };
 });
+const {
+  pluginInitialize,
+  pluginGetPluginDir,
+  pluginActivateStartup,
+  setPluginDirResolver,
+  activateOpenFileInstaller,
+} = vi.hoisted(() => ({
+  pluginInitialize: vi.fn(async () => {}),
+  pluginGetPluginDir: vi.fn((id: string) => `/plugins/${id}`),
+  pluginActivateStartup: vi.fn(),
+  setPluginDirResolver: vi.fn(),
+  activateOpenFileInstaller: vi.fn(async () => {}),
+}));
 
 vi.mock("../../utils/performance.js", () => ({
   markPerformance: vi.fn(),
@@ -118,6 +131,22 @@ vi.mock("../../services/plugin-mcp/instances.js", () => ({
   getPluginMcpAuditService,
   getPluginMcpConsentService,
   getPluginMcpConsentStore,
+}));
+
+vi.mock("../../services/PluginService.js", () => ({
+  pluginService: {
+    initialize: pluginInitialize,
+    getPluginDir: pluginGetPluginDir,
+    activateStartupFinishedPlugins: pluginActivateStartup,
+  },
+}));
+
+vi.mock("../../setup/protocols.js", () => ({
+  setPluginDirResolver,
+}));
+
+vi.mock("../../setup/openFileInstall.js", () => ({
+  activateOpenFileInstaller,
 }));
 
 vi.mock("../../services/HibernationService.js", () => ({
@@ -260,6 +289,11 @@ describe("initGlobalServices task ordering", () => {
     getPluginMcpAuditService.mockClear();
     getPluginMcpConsentService.mockClear();
     getPluginMcpConsentStore.mockClear();
+    pluginInitialize.mockClear();
+    pluginGetPluginDir.mockClear();
+    pluginActivateStartup.mockClear();
+    setPluginDirResolver.mockClear();
+    activateOpenFileInstaller.mockClear();
     (app.exit as ReturnType<typeof vi.fn>).mockReset();
     migrationCurrentVersion = 1;
     migrationShouldThrow = false;
@@ -372,6 +406,40 @@ describe("initGlobalServices task ordering", () => {
 
     expect(registeredTaskNames).toContain("ccr-config");
     expect(registeredTaskNames).toContain("plugin-service");
+  });
+
+  it("plugin-service task swaps in the live plugin:// resolver after initialize() (#10322)", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("plugin-service");
+    expect(run).toBeDefined();
+    expect(setPluginDirResolver).not.toHaveBeenCalled();
+
+    await run!();
+
+    expect(pluginInitialize).toHaveBeenCalled();
+    expect(setPluginDirResolver).toHaveBeenCalledTimes(1);
+    // The resolver handed to protocols.ts must delegate to the live singleton —
+    // calling it routes through pluginService.getPluginDir, not a frozen value.
+    const resolver = setPluginDirResolver.mock.calls[0]![0] as (id: string) => string | undefined;
+    expect(resolver("acme.tool")).toBe("/plugins/acme.tool");
+    expect(pluginGetPluginDir).toHaveBeenCalledWith("acme.tool");
+  });
+
+  it("plugin-service task drains queued open-file installs after initialize() (#10322)", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("plugin-service");
+    expect(run).toBeDefined();
+    expect(activateOpenFileInstaller).not.toHaveBeenCalled();
+
+    await run!();
+
+    expect(activateOpenFileInstaller).toHaveBeenCalledTimes(1);
+    // Installer receives the initialized singleton (its PluginInstaller surface).
+    expect(activateOpenFileInstaller.mock.calls[0]![0]).toBeDefined();
   });
 
   it("does not touch plugin-MCP audit/consent services eagerly during initGlobalServices() (#10073)", async () => {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -38,7 +38,7 @@ const {
   pluginGetPluginDir: vi.fn((id: string) => `/plugins/${id}`),
   pluginActivateStartup: vi.fn(),
   setPluginDirResolver: vi.fn(),
-  activateOpenFileInstaller: vi.fn(async () => {}),
+  activateOpenFileInstaller: vi.fn(async (_svc?: unknown) => {}),
 }));
 
 vi.mock("../../utils/performance.js", () => ({

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -52,6 +52,8 @@ import type { ProjectViewManager } from "./ProjectViewManager.js";
 import { getProjectStatsService } from "../ipc/handlers/projectCrud/index.js";
 import { registerDeferredTask } from "./deferredInitQueue.js";
 import { isSmokeTest } from "../setup/environment.js";
+import { setPluginDirResolver } from "../setup/protocols.js";
+import { activateOpenFileInstaller } from "../setup/openFileInstall.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { store } from "../store.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -344,6 +346,16 @@ export async function initGlobalServices(
       } catch (err) {
         console.error("[MAIN] PluginService initialization failed:", err);
       }
+      // Point the already-registered `plugin://` handler at the live resolver
+      // (#10322). main.ts registers the handler before first paint with a
+      // placeholder that 404s; now that the singleton is initialized, swap in
+      // the real `getPluginDir` so plugin asset requests resolve.
+      setPluginDirResolver((pluginId) => pluginService.getPluginDir(pluginId));
+      // macOS: drain any `.dntr` paths queued during cold launch (Finder
+      // double-click / "Open With") and take over live open-file events now
+      // that PluginService can install them. Fire-and-forget — install runs
+      // concurrently with the remaining deferred tasks. #9293
+      void activateOpenFileInstaller(pluginService);
       // Fire-and-forget — activations fan out in parallel and report errors
       // via the per-plugin `loadError` provenance record. Awaiting here would
       // delay subsequent deferred tasks behind the slowest plugin's activate().

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -337,6 +337,14 @@ export async function initGlobalServices(
   // Plugin service — IPC handlers are registered eagerly in windowServices.ts
   // and return empty lists from internal Maps until initialize() populates them.
   // Plugin contributions broadcast on registration, so late init is renderer-safe.
+  //
+  // Timing note (#10322): `initialize()` registers panel-kind contributions
+  // mid-chain, so the `plugin:panel-kinds-changed` broadcast can reach the
+  // renderer a microtask before `setPluginDirResolver()` below swaps the
+  // `plugin://` handler off its placeholder. A plugin panel restored from
+  // persisted state could therefore 404 its first asset fetch. That window is
+  // self-healing: `PluginViewHost`'s `ErrorBoundary` offers a "Try again" that
+  // re-imports once the live resolver is in place.
   registerDeferredTask({
     name: "plugin-service",
     run: async () => {


### PR DESCRIPTION
## Summary

- `app.whenReady()` was awaiting `import("./services/PluginService.js")` before `createWindow()`, placing a ~2900-line module (semver, zod, `PluginMcpSupervisor`, ~6 plugin submodules) on the first-paint critical path. The only immediate need was a `getPluginDir` resolver for the `plugin://` protocol handler — requests to that protocol don't arrive until after the renderer mounts and plugins activate.
- Registers `plugin://` before first paint with a placeholder resolver (`() => undefined`, 404s every request); both the default-session and per-session handlers route through a module-scoped `resolvePluginDir` indirection that reads `cachedGetPluginDir` live. The deferred post-first-interactive task does the actual import + `initialize()`, then calls `setPluginDirResolver()` to swap in the real resolver and drains queued `.dntr` open-file installs via `activateOpenFileInstaller`.
- No `protocol.unhandle`/re-handle on the swap (avoids the `ERR_UNKNOWN_URL_SCHEME` micro-tick gap). The indirection is necessary because `createPluginProtocolHandler` freezes its resolver argument at registration — a bare setter wouldn't reach already-registered handlers.

Resolves #10322

## Changes

- `electron/main.ts` — move `PluginService` import into a deferred task; register `plugin://` early with placeholder resolver
- `electron/setup/protocols.ts` — add `setPluginDirResolver()` and the `resolvePluginDir` indirection; both default-session and per-session handler paths read the module-scoped `cachedGetPluginDir` live
- `electron/window/globalServicesInit.ts` — deferred task wires resolver + open-file installer after `initialize()`, including when `initialize()` rejects (partial-failure posture)
- `electron/setup/__tests__/protocols.test.ts` — live-swap reaches an already-registered handler for both default and per-session paths (frozen-capture regression guard)
- `electron/window/__tests__/globalServicesInit.order.test.ts` — deferred task wires resolver + installer after init, including partial-init posture

## Testing

A plugin panel restored from persisted state could 404 its first asset in the microtask window before the resolver swaps in — `PluginViewHost`'s `ErrorBoundary` "Try again" recovers it. This is documented inline and covered by the narrow-window note in the protocols tests.

Unit tests added for the two new behaviours: live-swap propagating to already-registered handlers (guards against the frozen-capture regression), and the deferred task correctly wiring the resolver and installer under both normal and partial-init (rejected `initialize()`) conditions.