### PR TITLE
perf(boot): fold system temp dir into batched hydrate payload

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -328,6 +328,10 @@ describe("app:boot handler", () => {
     expect(result).toHaveProperty("agentSettings");
     expect(result).toHaveProperty("crashPending", null);
     expect(result).toHaveProperty("crashConfig", { autoRestoreOnCrash: false });
+    // Boot inherits systemTmpDir from the hydrate spread so the renderer can skip
+    // the standalone system:get-tmp-dir round-trip on cold boot.
+    expect(typeof (result as { systemTmpDir?: unknown }).systemTmpDir).toBe("string");
+    expect((result as { systemTmpDir: string }).systemTmpDir.length).toBeGreaterThan(0);
   });
 
   it("attaches a pending crash plus the live crashCount when one exists", async () => {

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -1,4 +1,5 @@
 // eager-import-allow: reads persisted app state via store.get synchronously in the IPC handler
+import os from "os";
 import { app } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { store, type StoreSchema, consumePendingSettingsRecovery } from "../../../store.js";
@@ -395,6 +396,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
         inSafeMode && guard.getQuarantinedStatePath()
           ? { quarantinedPath: guard.getQuarantinedStatePath()! }
           : null,
+      // Folded into the payload so the renderer skips a standalone
+      // `system:get-tmp-dir` round-trip on boot (matches `handleSystemGetTmpDir`).
+      systemTmpDir: os.tmpdir(),
     };
   };
   handlers.push(typedHandleWithContext(CHANNELS.APP_HYDRATE, handleAppHydrate));

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -1,4 +1,5 @@
 // eager-import-allow: reads persisted hydration state via store.get synchronously during startup
+import os from "os";
 import { app } from "electron";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
@@ -101,5 +102,8 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     projectStateRecovery: projectStateQuarantinedPath
       ? { quarantinedPath: projectStateQuarantinedPath }
       : null,
+    // Folded into the payload so the renderer skips a standalone
+    // `system:get-tmp-dir` round-trip on boot (matches `handleSystemGetTmpDir`).
+    systemTmpDir: os.tmpdir(),
   };
 }

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -1,3 +1,4 @@
+import os from "os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HydrateResult } from "../../../shared/types/ipc/app.js";
 
@@ -290,6 +291,16 @@ describe("AppHydrationService adversarial", () => {
     expect(result.appState.focusMode).toBe(true);
     expect(result.settingsRecovery).toBeNull();
     expect(result.projectStateRecovery).toBeNull();
+  });
+
+  it("folds the system temp dir into the payload so the renderer can skip the IPC call", async () => {
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    // The field must be present and wired to the live temp dir (not undefined),
+    // so the renderer can derive the clipboard directory without a round-trip.
+    expect(result.systemTmpDir).toBe(os.tmpdir());
+    expect(result.systemTmpDir!.length).toBeGreaterThan(0);
   });
 
   it("CONCURRENT_CALLS_READ_ONLY", async () => {

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -178,4 +178,12 @@ export interface HydrateResult {
    * corruption with no safe-mode trip is log-only.
    */
   crashLoopStateRecovery?: CrashLoopStateRecovery | null;
+  /**
+   * System temp directory (`os.tmpdir()`), folded into the batched boot payload
+   * so the renderer can derive the clipboard directory without a standalone
+   * `system:get-tmp-dir` IPC round-trip on the panel-restore critical path.
+   * Optional for backward compatibility: when absent (older main process, or the
+   * React 19 `use()` safe-boot fallback), the renderer falls back to the IPC call.
+   */
+  systemTmpDir?: string;
 }

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -5,6 +5,8 @@ const appClientMock = {
   hydrate: vi.fn(),
 };
 
+const getTmpDirMock = vi.fn().mockResolvedValue("/tmp");
+
 const terminalClientMock = {
   getForProject: vi.fn(),
   reconnect: vi.fn(),
@@ -60,7 +62,7 @@ vi.mock("@/clients", () => ({
   terminalClient: terminalClientMock,
   worktreeClient: worktreeClientMock,
   projectClient: projectClientMock,
-  systemClient: { getTmpDir: vi.fn().mockResolvedValue("/tmp") },
+  systemClient: { getTmpDir: getTmpDirMock },
 }));
 
 vi.mock("@/clients/terminalConfigClient", () => ({
@@ -3052,6 +3054,59 @@ describe("hydrateAppState", () => {
 
       expect(beginHydrationBatch).toHaveBeenCalled();
       expect(flushHydrationBatch).toHaveBeenCalledTimes(beginHydrationBatch.mock.calls.length);
+    });
+  });
+
+  describe("system temp dir folding", () => {
+    const baseOptions = () => ({
+      addPanel: vi.fn().mockResolvedValue("panel-1"),
+      setActiveWorktree: vi.fn(),
+      loadRecipes: vi.fn().mockResolvedValue(undefined),
+      openDiagnosticsDock: vi.fn(),
+    });
+
+    it("uses systemTmpDir from the prefetched payload and skips the getTmpDir IPC call", async () => {
+      await hydrateAppState({
+        ...baseOptions(),
+        prefetchedHydrateResult: {
+          appState: { terminals: [] },
+          terminalConfig,
+          project,
+          agentSettings,
+          gpuWebGLHardware: true,
+          systemTmpDir: "/payload-tmp",
+        } as unknown as import("@shared/types/ipc/app").HydrateResult,
+      });
+
+      expect(getTmpDirMock).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the getTmpDir IPC call when systemTmpDir is absent", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [] },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        // systemTmpDir intentionally omitted (older main process / safe-boot payload)
+      });
+
+      await hydrateAppState(baseOptions());
+
+      expect(getTmpDirMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("degrades without throwing when the getTmpDir fallback rejects", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [] },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+      });
+      getTmpDirMock.mockRejectedValueOnce(new Error("tmp dir unavailable"));
+
+      await expect(hydrateAppState(baseOptions())).resolves.not.toThrow();
     });
   });
 });

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -3081,6 +3081,21 @@ describe("hydrateAppState", () => {
       expect(getTmpDirMock).not.toHaveBeenCalled();
     });
 
+    it("uses systemTmpDir from the appClient.hydrate() payload and skips the getTmpDir IPC call", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [] },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        systemTmpDir: "/hydrate-tmp",
+      });
+
+      await hydrateAppState(baseOptions());
+
+      expect(getTmpDirMock).not.toHaveBeenCalled();
+    });
+
     it("falls back to the getTmpDir IPC call when systemTmpDir is absent", async () => {
       appClientMock.hydrate.mockResolvedValue({
         appState: { terminals: [] },

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -173,12 +173,13 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
     // Use the pre-fetched hydration payload when available, eliminating a
     // ~50-150ms IPC round-trip. Fall back to the IPC pull model otherwise.
-    const [hydrateResult, tmpDir] = await Promise.all([
-      prefetchedHydrateResult
-        ? Promise.resolve(prefetchedHydrateResult)
-        : withRendererSpan(PERF_MARKS.HYDRATE_APP_CLIENT, () => appClient.hydrate()),
-      systemClient.getTmpDir().catch(() => ""),
-    ]);
+    const hydrateResult = prefetchedHydrateResult
+      ? prefetchedHydrateResult
+      : await withRendererSpan(PERF_MARKS.HYDRATE_APP_CLIENT, () => appClient.hydrate());
+    // The system temp dir now rides along in the batched hydrate payload, so the
+    // standalone `system:get-tmp-dir` call only fires as a fallback when the
+    // field is absent (older main process, or the safe-boot {ok:false} payload).
+    const tmpDir = hydrateResult.systemTmpDir ?? (await systemClient.getTmpDir().catch(() => ""));
     const {
       appState,
       terminalConfig,


### PR DESCRIPTION
## Summary

- On cold boot, `hydrateAppState` fired a `Promise.all` pairing the prefetched hydration result with a separate `systemClient.getTmpDir()` IPC call — just `os.tmpdir()` on main — placing an extra round-trip on the panel-restore critical path.
- Added an optional `systemTmpDir?: string` field to `HydrateResult` (`BootResult` inherits it via spread), populated from `os.tmpdir()` in `buildSwitchHydrateResult` and `handleAppHydrate`; the renderer reads it directly from the payload and only falls back to the standalone IPC call when the field is absent.
- The `system:get-tmp-dir` channel and `systemClient.getTmpDir()` stay intact for the other callers (`panelSpawning.ts`, `useAgentLauncher.ts`, `panelDuplicationService.ts`).

Resolves #10326

## Changes

- `shared/types/ipc/app.ts` — `systemTmpDir?: string` added to `HydrateResult`
- `electron/services/AppHydrationService.ts` — field populated via `os.tmpdir()` in both hydration paths
- `electron/ipc/handlers/app/state.ts` — same field wired into `handleAppHydrate`
- `src/utils/stateHydration/index.ts` — renderer reads from payload, falls back to standalone IPC when absent (safe for older main or React 19 `use()` safe-boot payload)

## Testing

- `src/utils/__tests__/stateHydration.test.ts` — covers: `getTmpDir` IPC skipped when `systemTmpDir` is present on both prefetch and `appClient.hydrate` paths; called as fallback when absent; degrades gracefully on rejection
- `electron/services/__tests__/AppHydrationService.adversarial.test.ts` — asserts main-side payload carries a non-empty `systemTmpDir`
- `electron/ipc/__tests__/app.state.test.ts` — `app:boot` result inherits the field
- Full local CI: check + 33,129 tests + build, all green