### PR TITLE
Scope Marketing Screenshots workflow to the marketing specs

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -144,13 +144,24 @@ jobs:
           heartbeat_pid=$!
           trap 'kill "$heartbeat_pid" 2>/dev/null || true' EXIT
 
+          # Scope to the marketing-asset specs by exact path. The screenshots
+          # project's testDir (./e2e/screenshots) also holds the demo-engine
+          # specs (demo-reel.spec.ts, demo-terminal-input.spec.ts), which are
+          # NOT marketing producers — demo-reel records a 4K .webm to
+          # artifacts/demo/ (never uploaded here) and asserts a 2160-tall frame
+          # that the hosted macos-14 runner's 885-logical-tall display cannot
+          # capture; both are flaky under workers=2 (crashpad Mach-port
+          # contention + shared /tmp/daintree-demos/brush-cms fixture race).
+          # Running them here turned the publish status red without affecting
+          # the PNG deliverable. They get a dedicated workers=1 project — see #10333.
+          #
           # Theme-review mode: capture one theme's chrome shots instead of the
           # marketing reel (theme-review.spec.ts self-skips unless
           # DAINTREE_SHOT_THEME is set, so the reel path is unchanged).
           if [ -n "$DAINTREE_SHOT_THEME" ]; then
-            npx playwright test --project=screenshots theme-review
+            npx playwright test --project=screenshots e2e/screenshots/theme-review.spec.ts
           else
-            npx playwright test --project=screenshots
+            npx playwright test --project=screenshots e2e/screenshots/store-reel.spec.ts
           fi
 
       - name: List captured screenshots


### PR DESCRIPTION
The `screenshots` Playwright project's `testDir` (`./e2e/screenshots`) also holds the demo-engine specs (`demo-reel.spec.ts`, `demo-terminal-input.spec.ts`), so `npx playwright test --project=screenshots` swept them into the Marketing Screenshots workflow. Neither produces a marketing asset, and both fail on the hosted `macos-14` runner — turning the publish status red even though all 6 store PNGs captured and uploaded fine.

- `demo-reel` records a 4K `.webm` to `artifacts/demo/` (never uploaded by this workflow) and asserts a 2160-tall frame. The runner's virtual display is `1176x885` logical, so `getDisplayMedia` can't capture anything tall enough — `expect(dims.height).toBe(2160)` got `1940`.
- Both are flaky under `workers: 2`: crashpad Mach-port contention on parallel cold Electron launches, plus a shared `/tmp/daintree-demos/brush-cms` fixture that `store-reel` scene-2 and `demo-reel` both delete and recreate.

This scopes the capture step to the marketing specs by exact path — `store-reel.spec.ts` for the reel, `theme-review.spec.ts` for theme mode. The workflow's status now reflects the actual marketing-asset outcome.

The demo specs get a dedicated `workers: 1` project (nightly/on-demand) in #10333 — they currently run nowhere else, but they were red regardless, so no working coverage is lost.

Verified on a manual dispatch: the marketing reel passed and published to `screenshots/0.18.1/`; the two demo specs were the only failures.