### PR TITLE
test(e2e): give demo-engine specs a dedicated Playwright project

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,6 +52,7 @@ on:
           - full-plugins
           - online
           - nightly
+          - demo
       shard:
         description: "Optional single shard index to run, e.g. 2. Must be paired with shard_total."
         type: string
@@ -242,7 +243,9 @@ jobs:
     # nightly is unsharded and its serialized leak suite legitimately runs
     # long, so it keeps the generous ceiling; `full` (meta — all seven buckets on
     # one runner) gets a wider window than a single full-* shard.
-    timeout-minutes: ${{ (inputs.suite == 'nightly' && 180) || (inputs.suite == 'full' && 120) || ((inputs.suite == 'full-terminal' || inputs.suite == 'full-worktree') && matrix.name == 'Windows' && 90) || (startsWith(inputs.suite, 'full-') && 45) || 90 }}
+    # demo is unsharded, workers=1, and each spec records a 4K screencast with a
+    # 30min per-test ceiling, so it gets a wide window like nightly/full.
+    timeout-minutes: ${{ (inputs.suite == 'nightly' && 180) || (inputs.suite == 'demo' && 120) || (inputs.suite == 'full' && 120) || ((inputs.suite == 'full-terminal' || inputs.suite == 'full-worktree') && matrix.name == 'Windows' && 90) || (startsWith(inputs.suite, 'full-') && 45) || 90 }}
 
     steps:
       - name: Harden Windows for Electron E2E
@@ -398,9 +401,10 @@ jobs:
             PROJECT_ARGS="--project=$SUITE"
           fi
           # The `nightly` suite's leak heuristic depends on serialized
-          # launches; --workers=1 is mandatory.
+          # launches; --workers=1 is mandatory. The `demo` project already bakes
+          # workers:1 into its config, but we pass the flag too as a guard.
           EXTRA=""
-          if [ "$SUITE" = "nightly" ]; then
+          if [ "$SUITE" = "nightly" ] || [ "$SUITE" = "demo" ]; then
             EXTRA="--workers=1"
           fi
           # Keep the command-level watchdog a few minutes under the job timeout
@@ -408,6 +412,8 @@ jobs:
           WATCHDOG_TIMEOUT_MINUTES=80
           if [ "$SUITE" = "nightly" ]; then
             WATCHDOG_TIMEOUT_MINUTES=170
+          elif [ "$SUITE" = "demo" ]; then
+            WATCHDOG_TIMEOUT_MINUTES=110
           elif [ "$SUITE" = "full" ]; then
             WATCHDOG_TIMEOUT_MINUTES=110
           elif [ "${{ matrix.name }}" = "Windows" ] && { [ "$SUITE" = "full-terminal" ] || [ "$SUITE" = "full-worktree" ]; }; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -672,6 +672,7 @@ jobs:
             test-results/
             playwright-report/
             daintree-e2e-artifacts/
+            artifacts/demo/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -486,11 +486,25 @@ jobs:
       json_report: true
       enable_blob_report: true
 
+  # Demo-engine specs (workers=1, 4K screencast capture). Non-windows only —
+  # the 4K dimension assertion is skipped on hosted CI, so macOS is the primary
+  # target. Not a release gate: it reports into the nightly issue via notify,
+  # and deliberately does NOT block `publish` (a 30min capture job must not gate
+  # binary uploads).
+  e2e-demo:
+    needs: [check, test]
+    uses: ./.github/workflows/e2e.yml
+    with:
+      suite: demo
+      platform: ${{ inputs.platform || 'non-windows' }}
+      json_report: true
+      enable_blob_report: true
+
   # Merges Playwright blob reports from every nightly e2e shard into a single
   # unified HTML report. Runs independently of publish — a broken merge must
   # not block nightly binary publishing.
   merge-playwright-reports:
-    needs: [e2e-full, e2e-nightly]
+    needs: [e2e-full, e2e-nightly, e2e-demo]
     if: always()
     runs-on: ubuntu-22.04
     timeout-minutes: 15
@@ -684,6 +698,7 @@ jobs:
         e2e-full,
         e2e-online,
         e2e-nightly,
+        e2e-demo,
         publish,
       ]
     runs-on: ubuntu-22.04
@@ -844,6 +859,7 @@ jobs:
         e2e-full,
         e2e-online,
         e2e-nightly,
+        e2e-demo,
         publish,
       ]
     runs-on: ubuntu-22.04

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -144,16 +144,13 @@ jobs:
           heartbeat_pid=$!
           trap 'kill "$heartbeat_pid" 2>/dev/null || true' EXIT
 
-          # Scope to the marketing-asset specs by exact path. The screenshots
-          # project's testDir (./e2e/screenshots) also holds the demo-engine
-          # specs (demo-reel.spec.ts, demo-terminal-input.spec.ts), which are
-          # NOT marketing producers — demo-reel records a 4K .webm to
-          # artifacts/demo/ (never uploaded here) and asserts a 2160-tall frame
-          # that the hosted macos-14 runner's 885-logical-tall display cannot
-          # capture; both are flaky under workers=2 (crashpad Mach-port
-          # contention + shared /tmp/daintree-demos/brush-cms fixture race).
-          # Running them here turned the publish status red without affecting
-          # the PNG deliverable. They get a dedicated workers=1 project — see #10333.
+          # Scope to the marketing-asset specs by exact path. The demo-engine
+          # specs (demo-reel.spec.ts, demo-terminal-input.spec.ts) used to share
+          # this project's testDir but were moved to ./e2e/demo with their own
+          # workers=1 project (#10333) — they are NOT marketing producers and
+          # were flaky under workers=2 here (crashpad Mach-port contention +
+          # shared /tmp/daintree-demos/brush-cms fixture race). The explicit path
+          # below keeps this workflow scoped to the PNG deliverable regardless.
           #
           # Theme-review mode: capture one theme's chrome shots instead of the
           # marketing reel (theme-review.spec.ts self-skips unless

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -25,7 +25,7 @@ PWDEBUG=1 npx playwright test --project=core                         # Debug mod
 
 ## Test Suites
 
-Tests are split into eleven Playwright projects:
+Tests are split into twelve Playwright projects:
 
 - **core** — Lightweight deterministic release-gate smoke (5 specs). This is the Playwright e2e smoke suite (`npm run test:e2e:core`), distinct from the Electron stability soak (`npm run test:smoke`). See [test:smoke vs Playwright core](#testsmoke-vs-playwright-core) below.
 - **full-terminal** — PTY mechanics, scrollback, search, layout, recipes, output flood, context injection, fleet broadcast.

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -38,7 +38,7 @@ Tests are split into eleven Playwright projects:
 - **online** — Tests that interact with real agent CLIs (requires `ANTHROPIC_API_KEY`).
 - **nightly** — Long-running memory-leak detection (workers=1, no retries).
 - **screenshots** — Marketing screenshot pipeline. Run on demand via `screenshots.yml`, not part of the PR/release gates.
-- **demo** — Demo-engine specs that exercise the in-app demo automation API (`window.electron.demo`) — screencast recording and scripted terminal input (workers=1, no retries). Runs nightly and on demand via the `demo` suite in `e2e.yml`; not a release gate. The 4K dimension assertion in `demo-reel` is skipped on hosted CI (where the virtual display can't reach 4K) unless `DAINTREE_DEMO_STRICT_DIMS` is set.
+- **demo** — Demo-engine specs that exercise the in-app demo automation API (`window.electron.demo`) — screencast recording and scripted terminal input (workers=1, no retries). Runs nightly and on demand via the `demo` suite in `e2e.yml`; not a release gate. The 4K dimension assertion in `demo-reel` is skipped on hosted CI (where the virtual display can't reach 4K) unless `DAINTREE_DEMO_STRICT_DIMS=1` is set.
 
 ## Configuration
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -18,6 +18,7 @@ npm run test:e2e:full-terminal     # Run a single bucket — substitute any of:
                                    #   full-plugins
 npm run test:e2e:online            # Claude/OpenCode-dependent online tests
 npm run test:e2e:nightly           # Soak / memory-leak nightly tests
+npm run test:e2e:demo              # Demo-engine specs (workers=1, screencast capture)
 npx playwright test e2e/full/terminal/core-terminal-search.spec.ts  # Single file
 PWDEBUG=1 npx playwright test --project=core                         # Debug mode
 ```
@@ -37,6 +38,7 @@ Tests are split into eleven Playwright projects:
 - **online** — Tests that interact with real agent CLIs (requires `ANTHROPIC_API_KEY`).
 - **nightly** — Long-running memory-leak detection (workers=1, no retries).
 - **screenshots** — Marketing screenshot pipeline. Run on demand via `screenshots.yml`, not part of the PR/release gates.
+- **demo** — Demo-engine specs that exercise the in-app demo automation API (`window.electron.demo`) — screencast recording and scripted terminal input (workers=1, no retries). Runs nightly and on demand via the `demo` suite in `e2e.yml`; not a release gate. The 4K dimension assertion in `demo-reel` is skipped on hosted CI (where the virtual display can't reach 4K) unless `DAINTREE_DEMO_STRICT_DIMS` is set.
 
 ## Configuration
 
@@ -57,6 +59,7 @@ Tests are split into eleven Playwright projects:
 | online          | `./e2e/online`          | 1            | 1-2     |
 | nightly         | `./e2e/nightly`         | 0            | 1       |
 | screenshots     | `./e2e/screenshots`     | 0            | 1-2     |
+| demo            | `./e2e/demo`            | 0            | 1       |
 
 ## Directory Structure
 
@@ -80,8 +83,14 @@ e2e/
 │   └── resilience/      # errors, IPC, crashes, races, perf
 ├── online/              # agent-integration specs (release gate)
 │   └── *.spec.ts
-└── nightly/             # 2 memory-leak specs (nightly only)
-    └── nightly-*.spec.ts
+├── nightly/             # 2 memory-leak specs (nightly only)
+│   └── nightly-*.spec.ts
+├── screenshots/         # marketing screenshot pipeline (on demand)
+│   ├── store-reel.spec.ts
+│   └── theme-review.spec.ts
+└── demo/                # demo-engine specs (nightly + on demand)
+    ├── demo-reel.spec.ts
+    └── demo-terminal-input.spec.ts
 ```
 
 ## Shared Helpers
@@ -149,7 +158,7 @@ Components have `data-testid` and `data-worktree-branch` attributes for reliable
 
 ### `e2e.yml` (unified runner)
 
-A single reusable workflow runs every E2E suite. Pick one via the `suite` input: `full` (meta — all seven buckets sequentially on one runner; workflow_dispatch default), `core`, any of the seven `full-*` buckets (`full-terminal`, `full-worktree`, `full-presets`, `full-platform`, `full-panels`, `full-resilience`, `full-plugins`), `online`, or `nightly`.
+A single reusable workflow runs every E2E suite. Pick one via the `suite` input: `full` (meta — all seven buckets sequentially on one runner; workflow_dispatch default), `core`, any of the seven `full-*` buckets (`full-terminal`, `full-worktree`, `full-presets`, `full-platform`, `full-panels`, `full-resilience`, `full-plugins`), `online`, `nightly`, or `demo`.
 
 - **Triggers:** workflow_dispatch, workflow_call
 - **Matrix:** macOS-14, ubuntu-22.04, windows-latest (selectable via `platform`)

--- a/e2e/demo/demo-reel.spec.ts
+++ b/e2e/demo/demo-reel.spec.ts
@@ -11,7 +11,7 @@
  *
  * Run locally:
  *   npm run build:e2e
- *   npx playwright test e2e/screenshots/demo-reel.spec.ts --project=screenshots
+ *   npx playwright test e2e/demo/demo-reel.spec.ts --project=demo
  *
  * The scene needs NO ANTHROPIC_API_KEY — it shows the worktree dashboard,
  * which is fully populated by the brush-cms fixture.
@@ -159,7 +159,7 @@ async function bootDemoProject(repo: DemoRepo): Promise<{
 
 test.describe.serial("Demo Video — worktree dashboard", () => {
   test("worktree-dashboard-reel", async () => {
-    const repo = createBrushCmsRepo();
+    const repo = createBrushCmsRepo(String(process.env.TEST_WORKER_INDEX ?? "0"));
     let app: Awaited<ReturnType<typeof bootDemoProject>>["app"] | undefined;
     try {
       const booted = await bootDemoProject(repo);
@@ -324,8 +324,18 @@ test.describe.serial("Demo Video — worktree dashboard", () => {
       }
       if (dims) {
         console.log(`[demo-reel] recorded dimensions ${dims.width}×${dims.height}`);
-        expect(dims.width).toBe(CAPTURE_W);
-        expect(dims.height).toBe(CAPTURE_H);
+        // Hosted CI runners cap the virtual display below 4K, so the exact
+        // preset dimensions are unreachable there. Keep the strict pin (the
+        // #10152 regression guard) for local runs and self-hosted runners that
+        // opt in via DAINTREE_DEMO_STRICT_DIMS; elsewhere assert only that a
+        // non-degenerate frame was recorded.
+        if (!process.env.CI || process.env.DAINTREE_DEMO_STRICT_DIMS) {
+          expect(dims.width).toBe(CAPTURE_W);
+          expect(dims.height).toBe(CAPTURE_H);
+        } else {
+          expect(dims.width).toBeGreaterThan(0);
+          expect(dims.height).toBeGreaterThan(0);
+        }
       } else {
         console.warn("[demo-reel] ffmpeg unavailable — skipped dimension assertion");
       }

--- a/e2e/demo/demo-reel.spec.ts
+++ b/e2e/demo/demo-reel.spec.ts
@@ -327,9 +327,11 @@ test.describe.serial("Demo Video — worktree dashboard", () => {
         // Hosted CI runners cap the virtual display below 4K, so the exact
         // preset dimensions are unreachable there. Keep the strict pin (the
         // #10152 regression guard) for local runs and self-hosted runners that
-        // opt in via DAINTREE_DEMO_STRICT_DIMS; elsewhere assert only that a
-        // non-degenerate frame was recorded.
-        if (!process.env.CI || process.env.DAINTREE_DEMO_STRICT_DIMS) {
+        // opt in with DAINTREE_DEMO_STRICT_DIMS=1; elsewhere assert only that a
+        // non-degenerate frame was recorded. The opt-in checks for "1"
+        // explicitly so DAINTREE_DEMO_STRICT_DIMS=0 reads as off, not on.
+        const strictDims = process.env.DAINTREE_DEMO_STRICT_DIMS === "1";
+        if (!process.env.CI || strictDims) {
           expect(dims.width).toBe(CAPTURE_W);
           expect(dims.height).toBe(CAPTURE_H);
         } else {

--- a/e2e/demo/demo-terminal-input.spec.ts
+++ b/e2e/demo/demo-terminal-input.spec.ts
@@ -10,7 +10,7 @@
  *
  * Run locally:
  *   npm run build:e2e
- *   npx playwright test e2e/screenshots/demo-terminal-input.spec.ts --project=screenshots
+ *   npx playwright test e2e/demo/demo-terminal-input.spec.ts --project=demo
  */
 
 import { test, expect } from "@playwright/test";

--- a/e2e/helpers/screenshotFixtures.ts
+++ b/e2e/helpers/screenshotFixtures.ts
@@ -219,9 +219,9 @@ export interface Charge {
 }
 
 /** Scene 2 — 🎨 brush-cms — content management with mixed-state worktrees. */
-export function createBrushCmsRepo(): DemoRepo {
+export function createBrushCmsRepo(suffix = ""): DemoRepo {
   return createDemoRepo({
-    slug: "brush-cms",
+    slug: suffix ? `brush-cms-${suffix}` : "brush-cms",
     files: {
       "README.md": `# 🎨 brush-cms
 

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test:e2e:online": "npx playwright test --project=online",
     "test:e2e:nightly": "npx playwright test --project=nightly --workers=1",
     "test:e2e:screenshots": "npx playwright test --project=screenshots",
+    "test:e2e:demo": "npx playwright test --project=demo --workers=1",
     "screenshots:dev": "cross-env DAINTREE_SCREENSHOT_SCALE=2 npx playwright test --project=screenshots",
     "perf:smoke": "tsx scripts/perf/run.ts --mode smoke",
     "perf:ci": "tsx scripts/perf/run.ts --mode ci",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -145,5 +145,25 @@ export default defineConfig({
       timeout: 1_800_000,
       retries: 0,
     },
+    {
+      // Demo-engine pipeline — exercises the in-app demo automation API
+      // (window.electron.demo) to record screencasts and drive scripted
+      // terminal input. Runs nightly and on demand via the `demo` suite in
+      // .github/workflows/e2e.yml; not a release gate.
+      //
+      // workers:1 is mandatory and baked into the project (not a CLI flag):
+      // these specs cold-launch Electron and record at 4K, so parallel
+      // workers contend on the crashpad Mach port and the shared demo repo
+      // fixtures. Keeping it here guarantees serialization even for a bare
+      // local `npx playwright test --project=demo`.
+      //
+      // 1800s (30 min) — demo recording choreography plus Electron cold
+      // launch on Windows justifies the same budget as `screenshots`.
+      name: "demo",
+      testDir: "./e2e/demo",
+      timeout: 1_800_000,
+      workers: 1,
+      retries: 0,
+    },
   ],
 });


### PR DESCRIPTION
## Summary

- Moves `demo-reel.spec.ts` and `demo-terminal-input.spec.ts` out of the `screenshots` Playwright project into a new dedicated `demo` project, so demo-engine flakiness can't destabilise the marketing screenshot pipeline
- Root cause was `workers=2` causing Mach-port contention and shared fixture races — fixed by baking `workers: 1` into the `demo` project config
- Wires the new `demo` suite into `e2e.yml` (120min timeout) and `nightly.yml` (non-Windows `e2e-demo` job); deliberately excluded from `publish.needs` so a 30min capture job can't gate binary publish

Resolves #10333

## Changes

- New `demo` Playwright project in `playwright.config.ts`: `testDir: ./e2e/demo`, `workers: 1`, 30min timeout, `retries: 0`
- Moved specs from `e2e/screenshots/` to `e2e/demo/` via `git mv` (history preserved); updated run-locally comments to `--project=demo`
- Exact 4K dimension assertion in `demo-reel.spec.ts` gated behind `!CI || DAINTREE_DEMO_STRICT_DIMS=1` — hosted CI still checks a non-degenerate frame, local runs and strict self-hosted runners keep the #10152 regression guard intact
- `createBrushCmsRepo` gained an optional `suffix` param; `demo-reel.spec.ts` passes `TEST_WORKER_INDEX` to avoid `/tmp/daintree-demos/brush-cms` collisions
- `e2e.yml`: added `demo` suite option, 120min job timeout, 110min watchdog, `--workers=1` belt-and-suspenders, `artifacts/demo/` upload
- `nightly.yml`: added non-Windows `e2e-demo` job with blob+json reports, report-merge, and notify/notify-success wiring
- Added `test:e2e:demo` npm script; updated `docs/e2e-testing.md` suite list, project table, directory tree, and run command
- Updated now-stale comment in `screenshots.yml` to reflect the completed move

## Testing

- `npx playwright test --list --project=demo` lists exactly `demo-reel.spec.ts` + `demo-terminal-input.spec.ts`
- `npx playwright test --list --project=screenshots` lists exactly `store-reel.spec.ts` + `theme-review.spec.ts` (no demo specs)
- `npm run check`, `npm run test`, `npm run build` all pass locally
- `screenshots.yml` unaffected — it scopes `store-reel` by exact path