### PR TITLE
feat(plugins): hot-reload dev plugins + live built-in enable/disable

### DIFF
--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -75,7 +75,7 @@ async function handleList(): Promise<LoadedPluginInfo[]> {
 }
 
 async function handleSetEnabled(pluginId: string, enabled: boolean): Promise<void> {
-  pluginService.setEnabled(pluginId, enabled);
+  await pluginService.setEnabled(pluginId, enabled);
 }
 
 // Local-file-header signature that prefixes every ZIP (and therefore every

--- a/electron/plugin-dev-worker-bootstrap.ts
+++ b/electron/plugin-dev-worker-bootstrap.ts
@@ -1,0 +1,36 @@
+import { enableCompileCache } from "node:module";
+import fs from "node:fs";
+import path from "node:path";
+import { installBootstrapErrorGuard } from "./utils/bootstrapErrorGuard.js";
+
+const userData = process.env.DAINTREE_USER_DATA;
+if (userData) {
+  try {
+    const cacheDir = path.join(userData, "compile-cache");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    enableCompileCache(cacheDir);
+  } catch {
+    enableCompileCache();
+  }
+} else {
+  enableCompileCache();
+}
+
+// Guard the dynamic import below: a failure while loading the worker module
+// would otherwise hang the parent's start()/waitForReady() forever, since
+// Electron 37+ only WARNS on unhandled rejections in utility processes instead
+// of crashing. Convert that silent hang into a fast, observable exit.
+const removeBootstrapGuard = installBootstrapErrorGuard({
+  label: "[PluginDevWorkerBootstrap]",
+  postError: (error) => {
+    // Shape must match the `error` variant of PluginWorkerToHostMessage.
+    const port = process.parentPort as unknown as MessagePort | undefined;
+    port?.postMessage({ type: "error", error });
+  },
+});
+
+await import("./plugin-dev-worker.js");
+
+// Import succeeded — plugin-dev-worker.ts installs its own lifetime handlers
+// during evaluation, so drop the bootstrap guard to avoid double-reporting.
+removeBootstrapGuard();

--- a/electron/plugin-dev-worker.ts
+++ b/electron/plugin-dev-worker.ts
@@ -1,0 +1,126 @@
+// Entry module for the plugin dev-mode hot-reload worker (#9304), run inside a
+// `utilityProcess.fork` child. It imports the plugin's built bundle, calls
+// `activate(proxyHost)`, and relays every host-API call back to the main
+// process over the parent MessagePort. A reload kills this whole process and
+// forks a fresh one, so module-scope state never leaks across reloads (the
+// robust fix for Vite #14438).
+
+import { PluginDevWorkerHostProxy } from "./services/plugin/pluginDevWorkerHostProxy.js";
+import { formatErrorMessage } from "../shared/utils/errorMessage.js";
+import type { PluginActivate } from "../shared/types/plugin.js";
+import type {
+  PluginHostToWorkerMessage,
+  PluginWorkerToHostMessage,
+} from "../shared/types/pluginDevWorker.js";
+
+if (!process.parentPort) {
+  throw new Error("[PluginDevWorker] Must run in a UtilityProcess context");
+}
+
+const port = process.parentPort as unknown as {
+  on: (event: "message", listener: (msg: unknown) => void) => void;
+  postMessage: (msg: PluginWorkerToHostMessage) => void;
+};
+
+const post = (msg: PluginWorkerToHostMessage): void => {
+  port.postMessage(msg);
+};
+
+// Unhandled rejections / uncaught exceptions are only WARNED about in Electron
+// utility processes (37+), not fatal — so a bad plugin `activate()` would
+// silently corrupt state instead of triggering a reload. Force a fast exit so
+// the parent's `exit` handler supervises a respawn.
+process.on("unhandledRejection", (reason) => {
+  console.error("[PluginDevWorker] Unhandled rejection:", reason);
+  setImmediate(() => process.exit(1));
+});
+process.on("uncaughtException", (err) => {
+  console.error("[PluginDevWorker] Uncaught exception:", err);
+  setImmediate(() => process.exit(1));
+});
+
+let proxy: PluginDevWorkerHostProxy | null = null;
+let cleanup: (() => void) | null = null;
+let started = false;
+
+async function start(bundleUrl: string, pluginId: string): Promise<void> {
+  if (started) return;
+  started = true;
+
+  proxy = new PluginDevWorkerHostProxy(pluginId, post);
+
+  let mod: { activate?: unknown };
+  try {
+    mod = (await import(bundleUrl)) as { activate?: unknown };
+  } catch (err) {
+    post({
+      type: "activate-error",
+      error: formatErrorMessage(err, "failed to import plugin bundle"),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+    return;
+  }
+
+  if (typeof mod.activate !== "function") {
+    // A plugin with no `activate` export is valid (contributions only).
+    proxy.revoke();
+    post({ type: "activated", hasCleanup: false });
+    return;
+  }
+
+  const activate = mod.activate as PluginActivate;
+  try {
+    const result = await activate(proxy.host);
+    if (typeof result === "function") {
+      cleanup = result;
+    }
+    post({ type: "activated", hasCleanup: cleanup !== null });
+  } catch (err) {
+    post({
+      type: "activate-error",
+      error: formatErrorMessage(err, "activate() threw"),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
+  } finally {
+    // Close the registration window once activate settles, mirroring the real
+    // host's revoke. Post-activation callbacks (toasts, dispatch, settings) stay
+    // callable — only the register* surface is revoked.
+    proxy.revoke();
+  }
+}
+
+function disposeAndExit(): void {
+  try {
+    cleanup?.();
+  } catch (err) {
+    console.error("[PluginDevWorker] Plugin cleanup threw:", err);
+  } finally {
+    cleanup = null;
+    proxy?.dispose();
+    proxy = null;
+    setImmediate(() => process.exit(0));
+  }
+}
+
+port.on("message", (rawMsg: unknown) => {
+  const msg = (
+    rawMsg && typeof rawMsg === "object" && "data" in rawMsg
+      ? (rawMsg as { data: unknown }).data
+      : rawMsg
+  ) as PluginHostToWorkerMessage;
+
+  switch (msg.type) {
+    case "start":
+      void start(msg.bundleUrl, msg.pluginId);
+      return;
+    case "dispose":
+      disposeAndExit();
+      return;
+    default:
+      proxy?.handleMessage(msg);
+  }
+});
+
+// Announce readiness only after the message listener is attached, so the
+// parent's `start` (sent on `ready`) can never race ahead of the listener.
+post({ type: "ready" });

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2886,21 +2886,34 @@ export class PluginService {
 
       const entry = this.disabledPlugins.get(pluginId);
       if (!entry) return; // already running — nothing to load
-      // Release the reservation + skipped entry before re-loading; otherwise the
-      // duplicate guard in loadPlugin() sees the reserved name and bails.
-      this.disabledPlugins.delete(pluginId);
+      // Release ONLY the name reservation up front (the duplicate guard's actual
+      // gate), but keep the disabledPlugins entry in place across the async load.
+      // This keeps the id resolvable as a built-in at every await point, so a
+      // concurrent setEnabled can't slip past the isBuiltin check into the
+      // persist-only path while the load is mid-flight. loadPlugin() with an
+      // empty disabled set never touches disabledPlugins, so the entry is safe.
       this.reservedNames.delete(pluginId);
-      const loaded = await this.loadPlugin(path.dirname(entry.dir), path.basename(entry.dir), {
-        isBuiltin: true,
-        disabled: new Set<string>(),
-      });
+      let loaded: LoadedPlugin | null = null;
+      try {
+        loaded = await this.loadPlugin(path.dirname(entry.dir), path.basename(entry.dir), {
+          isBuiltin: true,
+          disabled: new Set<string>(),
+        });
+      } catch (err) {
+        // A throw (e.g. a malformed `when` expression in the manifest) must not
+        // strand the plugin in neither map — fall through to the restore path.
+        console.error(`[PluginService] Re-load of built-in "${pluginId}" threw:`, err);
+      }
       if (!loaded) {
-        // Engine gate or manifest error: restore the skipped state so the row
-        // stays visible. Persisted intent stays "enabled" → pendingRestart:true.
-        this.disabledPlugins.set(pluginId, entry);
+        // Engine gate, manifest error, or a throw: restore the reservation. The
+        // disabledPlugins entry was never removed, so the row stays visible.
+        // Persisted intent stays "enabled" → pendingRestart:true.
         this.reservedNames.add(pluginId);
         return;
       }
+      // Loaded: it's now in `plugins`. Drop the skipped entry synchronously
+      // (no await before this line) so the two maps never both miss the id.
+      this.disabledPlugins.delete(pluginId);
       await this.activatePlugin(pluginId);
     } finally {
       this.broadcaster.broadcastProvenanceChanged();

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1432,10 +1432,28 @@ export class PluginService {
       clearPriorRegistrations: () => {
         // Drop the prior generation's activate-time registrations before the
         // reloaded worker re-registers, so a handler the new code stopped
-        // registering doesn't linger. Manifest-level contributions are unchanged
-        // by a code rebuild and stay registered.
+        // registering doesn't linger. Manifest-declared commands are registered
+        // once at load time and NOT replayed on reload, so only imperative
+        // (`host.registerAction`) actions are cleared — clearing all of them
+        // would erase the plugin's palette commands after the first reload.
         this.removeHandlers(pluginId);
-        this.unregisterPluginActions(pluginId);
+        this.unregisterImperativePluginActions(pluginId);
+      },
+      // Fires on every activation outcome (initial + each reload). Keeps the
+      // provenance `loadError` in sync so a fix-and-save clears a stale error
+      // and a freshly-introduced one is recorded — the first-activation promise
+      // alone can't see post-reload outcomes.
+      onActivationResult: (result) => {
+        if (plugin.isBuiltin) return;
+        if (result.ok) {
+          if (!this.pluginsWithLoadTimeErrors.has(pluginId)) {
+            this.records.upsertInstalledRecord(pluginId, { loadError: null });
+          }
+        } else {
+          this.records.upsertInstalledRecord(pluginId, {
+            loadError: { message: result.error, at: Date.now() },
+          });
+        }
       },
     });
 
@@ -1473,19 +1491,32 @@ export class PluginService {
       return;
     }
 
+    // Bound the first activation so a plugin with a hanging `activate()` (or a
+    // never-resolving top-level await in the worker) can't stall the
+    // `Promise.allSettled` startup gate forever. On timeout the worker stays
+    // alive and watching — `onActivationResult` will clear/record the error if
+    // activation eventually settles or a reload follows. Mirrors the in-process
+    // ACTIVATE_TIMEOUT_MS contract. The provenance `loadError` is owned by
+    // `onActivationResult`; this catch only logs and unblocks startup.
+    let timer: NodeJS.Timeout | undefined;
     try {
-      await bridge.waitForActivation();
-      if (!plugin.isBuiltin && !this.pluginsWithLoadTimeErrors.has(pluginId)) {
-        this.records.upsertInstalledRecord(pluginId, { loadError: null });
-      }
+      await Promise.race([
+        bridge.waitForActivation(),
+        new Promise<void>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new Error(
+                `Dev plugin "${pluginId}" activate() did not settle within ${ACTIVATE_TIMEOUT_MS}ms`
+              )
+            );
+          }, ACTIVATE_TIMEOUT_MS);
+          timer.unref?.();
+        }),
+      ]);
     } catch (err) {
-      // activate() threw inside the worker. Surface it, but keep the worker
-      // watching so an edit + save reloads it — do NOT rethrow or unload.
-      const loadError = toPluginLoadError(err);
-      if (!plugin.isBuiltin) {
-        this.records.upsertInstalledRecord(pluginId, { loadError });
-      }
-      console.error(`[PluginService] Dev plugin "${pluginId}" activate() failed:`, err);
+      console.error(`[PluginService] Dev plugin "${pluginId}" activation:`, err);
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   }
 
@@ -2967,6 +2998,32 @@ export class PluginService {
     this.pluginActionOwners.delete(pluginId);
 
     this.broadcaster.broadcastPluginActions();
+  }
+
+  /**
+   * Unregister only the IMPERATIVE actions a plugin registered via
+   * `host.registerAction` during `activate()`, leaving manifest-declared
+   * commands intact. Used by the dev hot-reload path (#9304): a reload re-runs
+   * only `activate()`, not the manifest registration, so wiping every action
+   * (as {@link unregisterPluginActions} does) would erase the plugin's palette
+   * commands after the first reload.
+   */
+  unregisterImperativePluginActions(pluginId: string): void {
+    const owners = this.pluginActionOwners.get(pluginId);
+    if (!owners || owners.size === 0) return;
+
+    let changed = false;
+    for (const id of [...owners]) {
+      if (this.manifestCommandIds.has(id)) continue; // keep manifest commands
+      this.pluginActions.delete(id);
+      this.actionValidators.delete(id);
+      this.pluginActionHandlers.delete(id);
+      this.commandModulePaths.delete(id);
+      owners.delete(id);
+      changed = true;
+    }
+    if (owners.size === 0) this.pluginActionOwners.delete(pluginId);
+    if (changed) this.broadcaster.broadcastPluginActions();
   }
 
   /** Flattened snapshot of all plugin-registered actions (for renderer pull-on-mount). */

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -537,6 +537,14 @@ export class PluginService {
     string,
     { manifest: PluginManifest; dir: string; isBuiltin: boolean }
   >();
+  /**
+   * Per-plugin transition chain for live built-in enable/disable (#9304). A
+   * rapid disable→enable→disable on the same id must not interleave the
+   * unload/load mutations to `plugins`/`disabledPlugins`/`reservedNames`, so
+   * each `setEnabled` for a built-in chains onto the prior transition for that
+   * id. Keyed by `manifest.name`; the entry is dropped once its chain settles.
+   */
+  private readonly enableTransitions = new Map<string, Promise<void>>();
   private records = new PluginInstalledRecordsStore();
   /**
    * Live dev-mode hot-reload workers, keyed by pluginId (#9304). Each holds the
@@ -2732,11 +2740,14 @@ export class PluginService {
   }
 
   listPlugins(): LoadedPluginInfo[] {
-    // Desired state is the live persisted list; the running state is fixed for
-    // the session (`this.plugins` = loaded at launch, `this.disabledPlugins` =
-    // skipped at launch — disabling never unloads at runtime). Reporting both
-    // lets the renderer show the correct switch position and a "restart
-    // required" cue that survives a tab remount (#9284).
+    // Desired state is the live persisted list; the running state is
+    // `this.plugins` (loaded) vs `this.disabledPlugins` (skipped). For user
+    // plugins these are fixed for the session, so a toggle diverges them and
+    // raises a "restart required" cue (#9284). Built-ins transition live
+    // (#9304): `setEnabled` moves the entry between the two maps immediately, so
+    // the running state already matches the desired state and pendingRestart is
+    // false. Reporting both keeps the switch position and the cue correct across
+    // a tab remount.
     const desiredDisabled = this.records.getDisabledIds();
     const installed = this.records.getInstalledRecords();
 
@@ -2810,14 +2821,90 @@ export class PluginService {
 
   /**
    * Toggle a plugin's disabled state in Preferences (#9284). Persists to
-   * `plugins.disabled` in electron-store; the change takes effect on next
-   * launch (no synchronous unload — the renderer surfaces a restart-required
-   * cue). Idempotent: enabling an already-enabled plugin or disabling an
-   * already-disabled one is a no-op write. Permissive by design — the store is
-   * a declared-intent list, not a live registry, so no existence check.
+   * `plugins.disabled` in electron-store, then — for built-in plugins only —
+   * applies the change live (#9304): disabling unloads the running plugin,
+   * enabling re-registers and re-activates it, so the toggle takes effect
+   * without an app restart. User plugins stay persist-only and surface the
+   * restart-required cue, because their on-disk code can change between toggles
+   * and Node's ESM module cache has no eviction API (the dev-worker fork path
+   * exists precisely to sidestep that for recompiling dev plugins) — re-running
+   * a built-in's bundled, immutable `activate()` carries no such risk.
+   *
+   * Persists first so a crash mid-transition is recoverable: next launch reads
+   * the persisted intent and reaches the same state. Idempotent: toggling to
+   * the current state is a no-op write and a no-op transition. Permissive by
+   * design — the store is a declared-intent list, so no existence check.
    */
-  setEnabled(pluginId: string, enabled: boolean): void {
+  async setEnabled(pluginId: string, enabled: boolean): Promise<void> {
+    // Persist intent first (throws on an empty id, validated in the store).
     this.records.setEnabled(pluginId, enabled);
+
+    const isBuiltin =
+      this.plugins.get(pluginId)?.isBuiltin ??
+      this.disabledPlugins.get(pluginId)?.isBuiltin ??
+      false;
+    if (!isBuiltin) return;
+
+    // Serialise live transitions per id so concurrent toggles can't interleave
+    // their unload/load map mutations. Swallow the prior chain's rejection —
+    // `_applyBuiltinToggle` never rejects, but the guard keeps the chain alive.
+    const prior = this.enableTransitions.get(pluginId) ?? Promise.resolve();
+    const next = prior.catch(() => {}).then(() => this._applyBuiltinToggle(pluginId, enabled));
+    this.enableTransitions.set(pluginId, next);
+    try {
+      await next;
+    } finally {
+      if (this.enableTransitions.get(pluginId) === next) {
+        this.enableTransitions.delete(pluginId);
+      }
+    }
+  }
+
+  /**
+   * Apply a live enable/disable transition for a built-in plugin (#9304).
+   * Disable: tear the running plugin down through the full `unloadPlugin()`
+   * cascade, then move its manifest into `disabledPlugins` so `listPlugins()`
+   * keeps surfacing it for the toggle. Enable: clear the name reservation and
+   * skipped entry (so `loadPlugin`'s duplicate guard doesn't reject the
+   * re-load), re-register from the cached manifest dir, then activate. Always
+   * broadcasts provenance so every view re-pulls `listPlugins()` and the
+   * restart-required cue clears. Never throws — activation errors are persisted
+   * to `loadError` inside `activatePlugin`, and a failed re-register restores
+   * the skipped state.
+   */
+  private async _applyBuiltinToggle(pluginId: string, enabled: boolean): Promise<void> {
+    try {
+      if (!enabled) {
+        const running = this.plugins.get(pluginId);
+        if (!running) return; // already not running — nothing to unload
+        const { manifest, dir } = running;
+        this.unloadPlugin(pluginId);
+        this.disabledPlugins.set(pluginId, { manifest, dir, isBuiltin: true });
+        this.reservedNames.add(pluginId);
+        return;
+      }
+
+      const entry = this.disabledPlugins.get(pluginId);
+      if (!entry) return; // already running — nothing to load
+      // Release the reservation + skipped entry before re-loading; otherwise the
+      // duplicate guard in loadPlugin() sees the reserved name and bails.
+      this.disabledPlugins.delete(pluginId);
+      this.reservedNames.delete(pluginId);
+      const loaded = await this.loadPlugin(path.dirname(entry.dir), path.basename(entry.dir), {
+        isBuiltin: true,
+        disabled: new Set<string>(),
+      });
+      if (!loaded) {
+        // Engine gate or manifest error: restore the skipped state so the row
+        // stays visible. Persisted intent stays "enabled" → pendingRestart:true.
+        this.disabledPlugins.set(pluginId, entry);
+        this.reservedNames.add(pluginId);
+        return;
+      }
+      await this.activatePlugin(pluginId);
+    } finally {
+      this.broadcaster.broadcastProvenanceChanged();
+    }
   }
 
   /**

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1,5 +1,6 @@
 // eager-import-allow: reads plugin settings via store.get synchronously during service init
 import fs from "fs/promises";
+import { existsSync } from "node:fs";
 import path from "path";
 import os from "os";
 import { pathToFileURL } from "url";
@@ -56,6 +57,8 @@ import { PluginRendererDispatcher } from "./plugin/PluginRendererDispatcher.js";
 import { PluginSettingsManager, assertSettingsKey } from "./plugin/PluginSettingsManager.js";
 import { PluginChannelRegistry, isChannelSchema } from "./plugin/PluginChannelRegistry.js";
 import { PluginInstaller } from "./plugin/PluginInstaller.js";
+import { PluginDevWorkerHost } from "./plugin/PluginDevWorkerHost.js";
+import { PluginDevWorkerMainBridge } from "./plugin/PluginDevWorkerMainBridge.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
@@ -256,7 +259,21 @@ interface LoadedPlugin {
   isBuiltin: boolean;
   /** SHA-256 hex digest of the `.dntr` archive, set by the installer at install time. */
   archiveHash?: string;
+  /**
+   * True when the plugin dir carries a {@link DEV_MARKER_FILENAME} (written by
+   * `daintree-plugin dev`). Dev plugins activate inside a `utilityProcess.fork`
+   * worker that hot-reloads on `dist/index.js` rebuilds (#9304), instead of the
+   * in-process `import()` loader.
+   */
+  devMode?: boolean;
 }
+
+/**
+ * Marker file `daintree-plugin dev` writes at the symlinked plugin dir root to
+ * flag it for the hot-reload worker path (#9304). Presence alone is the signal;
+ * the file's contents are not read.
+ */
+const DEV_MARKER_FILENAME = ".dev-marker";
 
 const ACTIVATE_TIMEOUT_MS = 5000;
 /**
@@ -521,6 +538,17 @@ export class PluginService {
     { manifest: PluginManifest; dir: string; isBuiltin: boolean }
   >();
   private records = new PluginInstalledRecordsStore();
+  /**
+   * Live dev-mode hot-reload workers, keyed by pluginId (#9304). Each holds the
+   * forked `utilityProcess` lifecycle, the message bridge to the real host, and
+   * the host `revoke` to call on unload. Disposed via the {@link cleanupMap}
+   * disposer registered at activation, so `unloadPlugin` tears the worker down
+   * through its normal cascade.
+   */
+  private devWorkers = new Map<
+    string,
+    { workerHost: PluginDevWorkerHost; bridge: PluginDevWorkerMainBridge; revoke: () => void }
+  >();
   private pluginsRoot: string;
   /**
    * Optional override for the built-in plugins directory. When unset, the
@@ -965,6 +993,35 @@ export class PluginService {
       }
     }
 
+    // Dev-mode detection (#9304): a `.dev-marker` at the plugin dir root (written
+    // by `daintree-plugin dev`) routes this plugin through the hot-reload worker
+    // instead of the in-process loader. Built-ins are never dev plugins. Persist
+    // `devMode` to the provenance record so `listPlugins()` surfaces the "DEV"
+    // badge (#9290). A dev plugin needs a `main` entry to run in the worker.
+    //
+    // Synchronous `existsSync` on purpose: an `await` here would split the
+    // synchronous critical section between the duplicate-name check above and
+    // the `this.plugins.set` below, letting two concurrent loads of the same
+    // name both slip past dedup.
+    if (!opts.isBuiltin) {
+      const isDev = existsSync(path.join(pluginDir, DEV_MARKER_FILENAME));
+      if (isDev && plugin.resolvedMain) {
+        plugin.devMode = true;
+        this.records.upsertInstalledRecord(manifest.name, { devMode: true });
+      } else {
+        // Clear a stale dev flag if the marker was removed since last launch.
+        const record = this.records.getInstalledRecord(manifest.name);
+        if (record?.devMode) {
+          this.records.upsertInstalledRecord(manifest.name, { devMode: false });
+        }
+        if (isDev && !plugin.resolvedMain) {
+          console.warn(
+            `[PluginService] Plugin "${manifest.name}" has a ${DEV_MARKER_FILENAME} but no resolvable main entry — loading without hot-reload`
+          );
+        }
+      }
+    }
+
     // Index views by bare id so the panels loop can attach `componentPath` in
     // a single registerPanelKind pass (#9229). View ids are pre-namespace; the
     // runtime panel id is `${manifest.name}.${panel.id}`.
@@ -1291,6 +1348,11 @@ export class PluginService {
   private async _doActivate(pluginId: string): Promise<void> {
     const plugin = this.plugins.get(pluginId);
     if (!plugin || !plugin.resolvedMain) return;
+    // Dev-mode plugins run inside a hot-reload worker instead of the in-process
+    // import() loader (#9304).
+    if (plugin.devMode) {
+      return this.activateViaDevWorker(pluginId, plugin);
+    }
     try {
       // Bound the dynamic import — a plugin with a hanging top-level await
       // would otherwise pin this promise forever and stall `Promise.allSettled`
@@ -1331,6 +1393,99 @@ export class PluginService {
       }
       console.error(`[PluginService] Failed to load main entry for ${pluginId}:`, err);
       throw err;
+    }
+  }
+
+  /**
+   * Activate a dev-mode plugin inside a hot-reload worker (#9304). The plugin's
+   * code runs in a `utilityProcess.fork` child; the real host (from
+   * {@link createHost}) is bridged to the worker over MessagePort. The worker
+   * watches `dist/index.js` and respawns on every rebuild, so module-scope state
+   * never leaks across reloads (the robust fix for the Vite ESM cache leak).
+   *
+   * The host is left un-revoked for the worker's lifetime — unlike the
+   * in-process path, the worker legitimately re-registers on every reload, and
+   * the activation-window contract is enforced worker-side by its own proxy.
+   *
+   * A failed `activate()` is recorded but does NOT tear the worker down: the
+   * worker keeps watching so the author can fix the error and save to reload.
+   * Only a fork failure (no worker at all) rejects.
+   */
+  private async activateViaDevWorker(pluginId: string, plugin: LoadedPlugin): Promise<void> {
+    if (!plugin.resolvedMain) return;
+    // A re-activation while a worker is already live is a no-op — the worker
+    // owns its own reload cycle; activatePlugin's idempotency normally prevents
+    // this, but guard defensively against the unload-race re-entry path.
+    if (this.devWorkers.has(pluginId)) return;
+
+    const { host, revoke } = this.createHost(pluginId);
+    const workerHost = new PluginDevWorkerHost({
+      pluginId,
+      pluginDir: plugin.dir,
+      bundlePath: plugin.resolvedMain,
+    });
+    const bridge = new PluginDevWorkerMainBridge({
+      pluginId,
+      host,
+      workerHost,
+      getCapabilities: () => this.plugins.get(pluginId)?.manifest.capabilities ?? [],
+      clearPriorRegistrations: () => {
+        // Drop the prior generation's activate-time registrations before the
+        // reloaded worker re-registers, so a handler the new code stopped
+        // registering doesn't linger. Manifest-level contributions are unchanged
+        // by a code rebuild and stay registered.
+        this.removeHandlers(pluginId);
+        this.unregisterPluginActions(pluginId);
+      },
+    });
+
+    const entry = { workerHost, bridge, revoke };
+    this.devWorkers.set(pluginId, entry);
+
+    // Register the teardown disposer up front so a concurrent unloadPlugin()
+    // during fork/activation tears the worker down through the normal cascade.
+    const cleanup = (): void => {
+      bridge.dispose();
+      workerHost.dispose();
+      revoke();
+      if (this.devWorkers.get(pluginId) === entry) {
+        this.devWorkers.delete(pluginId);
+      }
+    };
+    this.cleanupMap.set(pluginId, cleanup);
+
+    try {
+      await workerHost.start();
+    } catch (err) {
+      // Fork failure — no worker exists, so this is a hard activation failure.
+      cleanup();
+      const loadError = toPluginLoadError(err);
+      if (!plugin.isBuiltin) {
+        this.records.upsertInstalledRecord(pluginId, { loadError });
+      }
+      console.error(`[PluginService] Failed to start dev worker for ${pluginId}:`, err);
+      throw err;
+    }
+
+    // If an unload raced the fork, the cleanup already disposed everything.
+    if (!this.plugins.has(pluginId) || this.devWorkers.get(pluginId) !== entry) {
+      cleanup();
+      return;
+    }
+
+    try {
+      await bridge.waitForActivation();
+      if (!plugin.isBuiltin && !this.pluginsWithLoadTimeErrors.has(pluginId)) {
+        this.records.upsertInstalledRecord(pluginId, { loadError: null });
+      }
+    } catch (err) {
+      // activate() threw inside the worker. Surface it, but keep the worker
+      // watching so an edit + save reloads it — do NOT rethrow or unload.
+      const loadError = toPluginLoadError(err);
+      if (!plugin.isBuiltin) {
+        this.records.upsertInstalledRecord(pluginId, { loadError });
+      }
+      console.error(`[PluginService] Dev plugin "${pluginId}" activate() failed:`, err);
     }
   }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2032,6 +2032,49 @@ describe("PluginService built-in plugin loading", () => {
       expect(rows).toHaveLength(1);
       expect(rows[0]).toMatchObject({ disabled: true, pendingRestart: false, isBuiltin: true });
     });
+
+    it("a failed built-in re-enable restores the skipped state (no lost row)", async () => {
+      // Launch-disabled built-in whose engine range can never be satisfied by
+      // the running app version, so the re-enable's loadPlugin() returns null at
+      // the engine gate and must fall through to the restore path.
+      storeMock._state.set("plugins", { disabled: ["daintree.future"] });
+      await writeBuiltinPlugin("daintree.future", {
+        name: "daintree.future",
+        version: "1.0.0",
+        engines: { daintree: ">=99.0.0" },
+      });
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+      expect(service.listPlugins()).toHaveLength(1);
+
+      await service.setEnabled("daintree.future", true);
+
+      // Intent persisted as enabled, but the load failed: the row stays visible,
+      // not running, flagged pendingRestart — never silently dropped.
+      const rows = service.listPlugins();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        disabled: false,
+        pendingRestart: true,
+        isBuiltin: true,
+      });
+      expect(rows[0].loadedAt).toBe(0);
+    });
+
+    it("an unknown plugin id is treated as a user plugin (persist-only, no transition)", async () => {
+      storeMock._state.set("plugins", { disabled: [] });
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      broadcastToRendererMock.mockClear();
+
+      await service.setEnabled("unknown.plugin", false);
+
+      // Persisted, but no live transition runs and no provenance broadcast fires.
+      expect(storeMock._state.get("plugins")).toEqual({ disabled: ["unknown.plugin"] });
+      expect(broadcastToRendererMock).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: "plugin:provenance-changed" })
+      );
+    });
   });
 
   describe("uninstallPlugin", () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -124,6 +124,47 @@ vi.mock("../PluginMcpSupervisor.js", () => ({
   getPluginMcpSupervisor: () => mockPluginMcpSupervisor,
 }));
 
+// Dev-mode hot-reload worker (#9304) is mocked so activation doesn't fork a
+// real utilityProcess; tests assert routing/lifecycle via the captured spies.
+const devWorkerMock = vi.hoisted(() => {
+  interface DevWorkerOpts {
+    pluginId: string;
+    pluginDir: string;
+    bundlePath: string;
+  }
+  const instances: MockPluginDevWorkerHost[] = [];
+  const bridges: MockPluginDevWorkerMainBridge[] = [];
+  class MockPluginDevWorkerHost {
+    opts: DevWorkerOpts;
+    start = vi.fn(async () => undefined);
+    dispose = vi.fn();
+    isReady = (): boolean => true;
+    on = vi.fn();
+    off = vi.fn();
+    constructor(opts: DevWorkerOpts) {
+      this.opts = opts;
+      instances.push(this);
+    }
+  }
+  class MockPluginDevWorkerMainBridge {
+    deps: unknown;
+    waitForActivation = vi.fn(async () => undefined);
+    dispose = vi.fn();
+    constructor(deps: unknown) {
+      this.deps = deps;
+      bridges.push(this);
+    }
+  }
+  return { instances, bridges, MockPluginDevWorkerHost, MockPluginDevWorkerMainBridge };
+});
+vi.mock("../plugin/PluginDevWorkerHost.js", () => ({
+  PluginDevWorkerHost: devWorkerMock.MockPluginDevWorkerHost,
+  CRASH_WINDOW_MS: 30 * 60 * 1000,
+}));
+vi.mock("../plugin/PluginDevWorkerMainBridge.js", () => ({
+  PluginDevWorkerMainBridge: devWorkerMock.MockPluginDevWorkerMainBridge,
+}));
+
 import { z } from "zod";
 import { PluginService } from "../PluginService.js";
 import { getPluginManifestSchema, isPrivateOrLoopbackHostname } from "../../schemas/plugin.js";
@@ -7347,5 +7388,74 @@ describe("init gate — waitForInit() and pushSnapshotTo() (#9285)", () => {
     service.dispose();
     await inFlight;
     expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe("dev-mode hot reload (#9304)", () => {
+  beforeEach(() => {
+    devWorkerMock.instances.length = 0;
+    devWorkerMock.bridges.length = 0;
+  });
+
+  async function writeDevPlugin(name: string, pluginName: string): Promise<void> {
+    const dir = path.join(tmpDir, name);
+    await fs.mkdir(path.join(dir, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "plugin.json"),
+      JSON.stringify({ name: pluginName, version: "1.0.0", main: "dist/index.js" })
+    );
+    await fs.writeFile(path.join(dir, "dist", "index.js"), "export function activate() {}");
+    await fs.writeFile(path.join(dir, ".dev-marker"), "");
+  }
+
+  it("flags a .dev-marker plugin as devMode in listPlugins (drives the DEV badge)", async () => {
+    await writeDevPlugin("dev-plugin", "acme.dev");
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    const info = service.listPlugins().find((p) => p.manifest.name === "acme.dev");
+    expect(info?.devMode).toBe(true);
+  });
+
+  it("routes activation of a dev plugin through the hot-reload worker", async () => {
+    await writeDevPlugin("dev-plugin", "acme.dev");
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    await service.activatePlugin("acme.dev");
+
+    expect(devWorkerMock.instances).toHaveLength(1);
+    expect(devWorkerMock.instances[0].opts.pluginId).toBe("acme.dev");
+    expect(devWorkerMock.instances[0].opts.bundlePath).toMatch(/dist[/\\]index\.js$/);
+    expect(devWorkerMock.instances[0].start).toHaveBeenCalledTimes(1);
+    expect(devWorkerMock.bridges[0].waitForActivation).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fork a worker for a plugin without a marker", async () => {
+    const dir = path.join(tmpDir, "prod-plugin");
+    await fs.mkdir(path.join(dir, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "plugin.json"),
+      JSON.stringify({ name: "acme.prod", version: "1.0.0", main: "dist/index.js" })
+    );
+    await fs.writeFile(path.join(dir, "dist", "index.js"), "export function activate() {}");
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    await service.activatePlugin("acme.prod");
+
+    expect(devWorkerMock.instances).toHaveLength(0);
+    const info = service.listPlugins().find((p) => p.manifest.name === "acme.prod");
+    expect(info?.devMode).toBe(false);
+  });
+
+  it("disposes the worker and bridge when the dev plugin is unloaded", async () => {
+    await writeDevPlugin("dev-plugin", "acme.dev");
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    await service.activatePlugin("acme.dev");
+
+    const worker = devWorkerMock.instances[0];
+    const bridge = devWorkerMock.bridges[0];
+    service.unloadPlugin("acme.dev");
+    expect(bridge.dispose).toHaveBeenCalled();
+    expect(worker.dispose).toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1894,49 +1894,49 @@ describe("PluginService built-in plugin loading", () => {
   });
 
   describe("setEnabled", () => {
-    it("adds a plugin id to plugins.disabled when disabling", () => {
+    it("adds a plugin id to plugins.disabled when disabling", async () => {
       storeMock._state.set("plugins", { disabled: [] });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
 
-      service.setEnabled("acme.foo", false);
+      await service.setEnabled("acme.foo", false);
 
       expect(storeMock._state.get("plugins")).toEqual({ disabled: ["acme.foo"] });
     });
 
-    it("removes a plugin id from plugins.disabled when enabling", () => {
+    it("removes a plugin id from plugins.disabled when enabling", async () => {
       storeMock._state.set("plugins", { disabled: ["acme.foo", "acme.bar"] });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
 
-      service.setEnabled("acme.foo", true);
+      await service.setEnabled("acme.foo", true);
 
       expect(storeMock._state.get("plugins")).toEqual({ disabled: ["acme.bar"] });
     });
 
-    it("is idempotent — disabling an already-disabled plugin does not duplicate it", () => {
+    it("is idempotent — disabling an already-disabled plugin does not duplicate it", async () => {
       storeMock._state.set("plugins", { disabled: ["acme.foo"] });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
 
-      service.setEnabled("acme.foo", false);
+      await service.setEnabled("acme.foo", false);
 
       expect(storeMock._state.get("plugins")).toEqual({ disabled: ["acme.foo"] });
     });
 
-    it("preserves other keys in the plugins object", () => {
+    it("preserves other keys in the plugins object", async () => {
       storeMock._state.set("plugins", { disabled: [], other: "keep" });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
 
-      service.setEnabled("acme.foo", false);
+      await service.setEnabled("acme.foo", false);
 
       expect(storeMock._state.get("plugins")).toEqual({ disabled: ["acme.foo"], other: "keep" });
     });
 
-    it("throws on an empty or whitespace-only plugin id", () => {
+    it("throws on an empty or whitespace-only plugin id", async () => {
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
-      expect(() => service.setEnabled("", false)).toThrow(/non-empty string/);
-      expect(() => service.setEnabled("   ", false)).toThrow(/non-empty string/);
+      await expect(service.setEnabled("", false)).rejects.toThrow(/non-empty string/);
+      await expect(service.setEnabled("   ", false)).rejects.toThrow(/non-empty string/);
     });
 
-    it("listPlugins reflects a runtime disable as disabled+pendingRestart without restart", async () => {
+    it("user plugin disable diverges desired/running state and raises pendingRestart", async () => {
       storeMock._state.set("plugins", { disabled: [] });
       await writePlugin("acme.runtime", { name: "acme.runtime", version: "1.0.0" });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
@@ -1944,13 +1944,14 @@ describe("PluginService built-in plugin loading", () => {
 
       expect(service.listPlugins()[0]).toMatchObject({ disabled: false, pendingRestart: false });
 
-      service.setEnabled("acme.runtime", false);
+      await service.setEnabled("acme.runtime", false);
 
-      // Still running this session, but the desired state is now off.
+      // User plugin stays loaded this session (no live unload); the desired
+      // state is now off, so the restart-required cue is raised.
       expect(service.listPlugins()[0]).toMatchObject({ disabled: true, pendingRestart: true });
     });
 
-    it("listPlugins reflects a runtime re-enable of a launch-disabled plugin", async () => {
+    it("user plugin re-enable of a launch-disabled plugin stays pendingRestart", async () => {
       storeMock._state.set("plugins", { disabled: ["acme.off"] });
       await writePlugin("acme.off", { name: "acme.off", version: "1.0.0" });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
@@ -1958,10 +1959,78 @@ describe("PluginService built-in plugin loading", () => {
 
       expect(service.listPlugins()[0]).toMatchObject({ disabled: true, pendingRestart: false });
 
-      service.setEnabled("acme.off", true);
+      await service.setEnabled("acme.off", true);
 
-      // Not running this session, but the desired state is now on.
+      // User plugin is not loaded live; desired state is on, so it's pending.
       expect(service.listPlugins()[0]).toMatchObject({ disabled: false, pendingRestart: true });
+    });
+
+    it("built-in disable unloads live — disabled, not pending, no longer running", async () => {
+      storeMock._state.set("plugins", { disabled: [] });
+      await writeBuiltinPlugin("daintree.live", { name: "daintree.live", version: "1.0.0" });
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+      expect(service.listPlugins()[0]).toMatchObject({
+        disabled: false,
+        pendingRestart: false,
+        isBuiltin: true,
+      });
+      broadcastToRendererMock.mockClear();
+
+      await service.setEnabled("daintree.live", false);
+
+      // Applied immediately: the plugin is unloaded (loadedAt resets to 0 since
+      // it's now surfaced from the skipped map) and no restart is required.
+      const row = service.listPlugins()[0];
+      expect(row).toMatchObject({ disabled: true, pendingRestart: false, isBuiltin: true });
+      expect(row.loadedAt).toBe(0);
+      expect(broadcastToRendererMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: "plugin:provenance-changed" })
+      );
+    });
+
+    it("built-in re-enable loads live — enabled, not pending, running again", async () => {
+      storeMock._state.set("plugins", { disabled: ["daintree.off"] });
+      await writeBuiltinPlugin("daintree.off", { name: "daintree.off", version: "1.0.0" });
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+      expect(service.listPlugins()[0]).toMatchObject({
+        disabled: true,
+        pendingRestart: false,
+        isBuiltin: true,
+      });
+      broadcastToRendererMock.mockClear();
+
+      await service.setEnabled("daintree.off", true);
+
+      // Applied immediately: now running (loadedAt is set) and no restart cue.
+      const row = service.listPlugins()[0];
+      expect(row).toMatchObject({ disabled: false, pendingRestart: false, isBuiltin: true });
+      expect(row.loadedAt).toBeGreaterThan(0);
+      expect(broadcastToRendererMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: "plugin:provenance-changed" })
+      );
+    });
+
+    it("built-in survives a rapid disable→enable→disable without a stuck state", async () => {
+      storeMock._state.set("plugins", { disabled: [] });
+      await writeBuiltinPlugin("daintree.flap", { name: "daintree.flap", version: "1.0.0" });
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+
+      // Fire all three without awaiting between them — the per-id chain must
+      // serialise them so the final state is a clean, applied disable.
+      await Promise.all([
+        service.setEnabled("daintree.flap", false),
+        service.setEnabled("daintree.flap", true),
+        service.setEnabled("daintree.flap", false),
+      ]);
+
+      const rows = service.listPlugins();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ disabled: true, pendingRestart: false, isBuiltin: true });
     });
   });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -7458,4 +7458,48 @@ describe("dev-mode hot reload (#9304)", () => {
     expect(bridge.dispose).toHaveBeenCalled();
     expect(worker.dispose).toHaveBeenCalled();
   });
+
+  it("keeps manifest commands registered across a reload (clearPriorRegistrations)", async () => {
+    const dir = path.join(tmpDir, "dev-cmd");
+    await fs.mkdir(path.join(dir, "dist"), { recursive: true });
+    await fs.writeFile(
+      path.join(dir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.dev",
+        version: "1.0.0",
+        main: "dist/index.js",
+        contributes: {
+          commands: [
+            {
+              id: "do-thing",
+              title: "Do Thing",
+              description: "Run the thing",
+              category: "Dev",
+              kind: "command",
+              danger: "safe",
+            },
+          ],
+        },
+      })
+    );
+    await fs.writeFile(path.join(dir, "dist", "index.js"), "export function activate() {}");
+    await fs.writeFile(path.join(dir, ".dev-marker"), "");
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    await service.activatePlugin("acme.dev");
+
+    // Manifest command is registered at load time.
+    expect(service.listPluginActions().some((a) => a.id === "acme.dev.do-thing")).toBe(true);
+
+    // Simulate a hot reload: the bridge calls clearPriorRegistrations before the
+    // worker re-registers. Manifest commands must survive — only imperative
+    // (host.registerAction) actions are dropped.
+    const clearPriorRegistrations = (
+      devWorkerMock.bridges[0].deps as { clearPriorRegistrations: () => void }
+    ).clearPriorRegistrations;
+    clearPriorRegistrations();
+
+    expect(service.listPluginActions().some((a) => a.id === "acme.dev.do-thing")).toBe(true);
+  });
 });

--- a/electron/services/__tests__/crashGuardAlignment.test.ts
+++ b/electron/services/__tests__/crashGuardAlignment.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-// The three crash-loop guards intentionally duplicate their decay-window
+// The four crash-loop guards intentionally duplicate their decay-window
 // constant rather than sharing a module — they operate at independent layers
 // (disk-persisted app-level vs. in-memory utility-process) and must remain
 // decoupled. This alignment test is the failure mechanism the source comments
-// promise: any future tuning of one constant fails this test until the other
-// two are updated to match. If the desired policy genuinely diverges, this
+// promise: any future tuning of one constant fails this test until the others
+// are updated to match. If the desired policy genuinely diverges, this
 // test should be deleted in the same PR that introduces the divergence.
 
 vi.mock("electron", () => ({
@@ -29,15 +29,17 @@ vi.mock("../../utils/logger.js", () => ({
 }));
 
 describe("crash-loop guard alignment", () => {
-  it("the three guards share a single CRASH_WINDOW_MS value", async () => {
-    const [guard, ptyLifecycle, workspaceHost] = await Promise.all([
+  it("the four guards share a single CRASH_WINDOW_MS value", async () => {
+    const [guard, ptyLifecycle, workspaceHost, pluginDevWorker] = await Promise.all([
       import("../CrashLoopGuardService.js"),
       import("../pty/PtyHostLifecycle.js"),
       import("../WorkspaceHostProcess.js"),
+      import("../plugin/PluginDevWorkerHost.js"),
     ]);
 
     expect(guard.CRASH_WINDOW_MS).toBe(ptyLifecycle.CRASH_WINDOW_MS);
     expect(ptyLifecycle.CRASH_WINDOW_MS).toBe(workspaceHost.CRASH_WINDOW_MS);
+    expect(workspaceHost.CRASH_WINDOW_MS).toBe(pluginDevWorker.CRASH_WINDOW_MS);
     // Sanity check the policy itself — three rapid crashes (~few seconds
     // apart) still trip the cap, and a 6-minute-cadence slow flap (the #8683
     // blind spot) does too. Bumping below 18 minutes would let chronic

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -1,0 +1,480 @@
+import { utilityProcess, UtilityProcess, app } from "electron";
+import { EventEmitter } from "events";
+import { createHash } from "crypto";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath, pathToFileURL } from "url";
+import { createLogger } from "../../utils/logger.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { PLUGIN_DEV_WORKER_KIND } from "../../../shared/types/pluginDevWorker.js";
+import type {
+  PluginHostToWorkerMessage,
+  PluginWorkerToHostMessage,
+} from "../../../shared/types/pluginDevWorker.js";
+
+const logger = createLogger("main:PluginDevWorker");
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** Debounce for `dist/index.js` change events. Vite emits a write (and often a
+ * rename) per rebuild; coalesce them so one rebuild triggers one reload. */
+const RELOAD_DEBOUNCE_MS = 200;
+
+/** Graceful-dispose grace period before SIGKILL, matching WorkspaceHostProcess. */
+const DISPOSE_TIMEOUT_MS = 1000;
+
+// Time-windowed crash-loop guard. Mirrors the constants in PtyHostLifecycle,
+// WorkspaceHostProcess, and CrashLoopGuardService so all guards follow the same
+// policy: three crashes within the window trip the cap, and crashes spread
+// further apart decay out lazily at crash-record-time. Duplicated rather than
+// imported because the guards operate at independent layers. The alignment test
+// (`crashGuardAlignment.test.ts`) asserts the values stay in lockstep.
+//
+// Crucially, an intentional reload (mtime change → kill → respawn) is NOT a
+// crash: `reload()` clears the crash window before killing, so a developer
+// doing rapid saves can never trip the cap. Only an unintended worker exit
+// (plugin bootstrap throw, segfault) accumulates toward it.
+const CRASH_THRESHOLD = 3;
+export const CRASH_WINDOW_MS = 30 * 60 * 1000;
+
+export interface PluginDevWorkerHostOptions {
+  pluginId: string;
+  /** Plugin directory root (the symlink target). Used as the worker `cwd`. */
+  pluginDir: string;
+  /** Absolute path to the built bundle (`dist/index.js`) the worker imports. */
+  bundlePath: string;
+}
+
+/**
+ * Owns the `utilityProcess.fork` lifecycle for one dev-mode plugin: fork the
+ * worker, hand it the bundle to import, watch `bundlePath` for rebuilds, and
+ * kill + respawn on each change. Crash supervision mirrors
+ * {@link WorkspaceHostProcess} (sliding crash window, `child-process-gone`
+ * filtering, exit/gone ordering defer).
+ *
+ * Messages from the worker are re-emitted as `worker-message` events; the
+ * {@link PluginDevWorkerMainBridge} consumes them and replies via {@link send}.
+ * Lifecycle signals are emitted as `ready`, `reloading`, `exit`, and
+ * `crash-loop`.
+ */
+export class PluginDevWorkerHost extends EventEmitter {
+  private child: UtilityProcess | null = null;
+  private isDisposed = false;
+  private isReloading = false;
+  readonly pluginId: string;
+  private readonly pluginDir: string;
+  private readonly bundlePath: string;
+  private readonly serviceName: string;
+
+  private watcher: fs.FSWatcher | null = null;
+  private reloadTimer: NodeJS.Timeout | null = null;
+  private disposeTimer: NodeJS.Timeout | null = null;
+
+  /**
+   * Sliding window of recent UNINTENTIONAL crash timestamps. Lazy-pruned to
+   * entries within `CRASH_WINDOW_MS` on each crash. Reload-driven exits clear
+   * it (see {@link reload}) so deliberate kills never count toward the cap.
+   */
+  private crashTimestamps: number[] = [];
+  /** Set true around an intentional kill so the exit handler skips crash accounting. */
+  private expectingExit = false;
+
+  private pendingChildProcessGoneReason: { reason: string; exitCode: number } | null = null;
+  private childProcessGoneHandler:
+    | ((event: Electron.Event, details: Electron.Details) => void)
+    | null = null;
+
+  private readyPromise: Promise<void>;
+  private readyResolve: (() => void) | null = null;
+  private readyReject: ((error: Error) => void) | null = null;
+
+  constructor(options: PluginDevWorkerHostOptions) {
+    super();
+    this.pluginId = options.pluginId;
+    this.pluginDir = options.pluginDir;
+    this.bundlePath = options.bundlePath;
+
+    const safeName = options.pluginId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 40);
+    // Hash the plugin dir so two dev plugins sharing a sanitized name still get
+    // distinct service names — otherwise the per-instance `child-process-gone`
+    // filter would cross-attribute crashes.
+    const dirHash = createHash("sha1").update(options.pluginDir).digest("hex").slice(0, 8);
+    this.serviceName = `daintree-plugin-dev:${safeName}-${dirHash}`;
+
+    this.readyPromise = new Promise((resolve, reject) => {
+      this.readyResolve = resolve;
+      this.readyReject = reject;
+    });
+    this.readyPromise.catch(() => undefined);
+
+    this.registerChildProcessGoneListener();
+  }
+
+  /** Fork the worker and begin watching the bundle. Resolves when the worker
+   * posts `ready`; rejects on fork failure or premature exit. */
+  async start(): Promise<void> {
+    this.startWorker();
+    this.startWatching();
+    return this.readyPromise;
+  }
+
+  isReady(): boolean {
+    return this.child !== null;
+  }
+
+  /** Send a message to the worker. Returns false if no live worker. */
+  send(message: PluginHostToWorkerMessage): boolean {
+    if (!this.child || this.isDisposed) return false;
+    try {
+      this.child.postMessage(message);
+      return true;
+    } catch (error) {
+      logger.warn(`[${this.serviceName}] Failed to send message`, {
+        error: formatErrorMessage(error, "post failed"),
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Reload the worker: clear the crash window (this is an intentional restart,
+   * not a crash), kill the current child, and fork a fresh one once it exits.
+   * The new worker re-imports the rebuilt bundle and re-runs `activate`.
+   */
+  reload(): void {
+    if (this.isDisposed) return;
+    if (this.isReloading) return;
+    this.isReloading = true;
+
+    // Deliberate restart — give future crashes a fresh budget so rapid saves
+    // can't trip the crash-loop cap (#7917 manualRestart parallel).
+    this.crashTimestamps = [];
+
+    this.emit("reloading");
+
+    if (!this.child) {
+      // No live child (e.g. a prior crash gave up); just fork a new one.
+      this.isReloading = false;
+      this.startFresh();
+      return;
+    }
+
+    this.killChild(() => {
+      if (this.isDisposed) return;
+      this.isReloading = false;
+      this.startFresh();
+    });
+  }
+
+  /** Re-arm the ready promise and fork a new worker. */
+  private startFresh(): void {
+    if (this.isDisposed) return;
+    this.readyPromise = new Promise((resolve, reject) => {
+      this.readyResolve = resolve;
+      this.readyReject = reject;
+    });
+    this.readyPromise.catch(() => undefined);
+    this.startWorker();
+  }
+
+  /** Promise that resolves on the next `ready` after a reload. */
+  waitForReady(): Promise<void> {
+    return this.readyPromise;
+  }
+
+  dispose(): void {
+    if (this.isDisposed) return;
+    this.isDisposed = true;
+
+    if (this.watcher) {
+      try {
+        this.watcher.close();
+      } catch {
+        // ignore — watcher may already be closed
+      }
+      this.watcher = null;
+    }
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+      this.reloadTimer = null;
+    }
+    if (this.childProcessGoneHandler) {
+      app.off("child-process-gone", this.childProcessGoneHandler);
+      this.childProcessGoneHandler = null;
+    }
+    this.pendingChildProcessGoneReason = null;
+
+    if (this.readyReject) {
+      this.readyReject(new Error(`Plugin dev worker "${this.pluginId}" disposed`));
+      this.readyReject = null;
+      this.readyResolve = null;
+    }
+
+    if (this.child) {
+      this.expectingExit = true;
+      // Post directly — `send()` bails once `isDisposed` is set (which we just
+      // did), so route around it for the cooperative shutdown message.
+      try {
+        this.child.postMessage({ type: "dispose" });
+      } catch {
+        // worker may already be gone; the kill backstop below still fires
+      }
+      this.disposeTimer = setTimeout(() => {
+        this.disposeTimer = null;
+        if (this.child) {
+          try {
+            this.child.kill();
+          } catch (error) {
+            logger.warn(`[${this.serviceName}] Failed to kill worker during dispose`, {
+              error: formatErrorMessage(error, "kill failed"),
+            });
+          } finally {
+            this.child = null;
+          }
+        }
+      }, DISPOSE_TIMEOUT_MS);
+      this.disposeTimer.unref?.();
+    }
+
+    this.removeAllListeners();
+  }
+
+  /** Kill the current child, invoking `onExit` once it's gone. */
+  private killChild(onExit: () => void): void {
+    const child = this.child;
+    if (!child) {
+      onExit();
+      return;
+    }
+    this.expectingExit = true;
+
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      if (this.disposeTimer) {
+        clearTimeout(this.disposeTimer);
+        this.disposeTimer = null;
+      }
+      onExit();
+    };
+
+    // Prefer a cooperative dispose, fall back to kill after the grace period.
+    this.send({ type: "dispose" });
+    this.disposeTimer = setTimeout(() => {
+      this.disposeTimer = null;
+      if (this.child === child) {
+        try {
+          child.kill();
+        } catch {
+          // already gone
+        }
+      }
+    }, DISPOSE_TIMEOUT_MS);
+    this.disposeTimer.unref?.();
+
+    child.once("exit", () => finish());
+  }
+
+  private startWatching(): void {
+    if (this.watcher || this.isDisposed) return;
+    // `fs.watch` on a not-yet-existing file throws ENOENT — watch the parent
+    // `dist/` dir and filter for the bundle filename instead. This also
+    // survives editors/Vite that replace the file via rename (the inode the
+    // file watch held would otherwise go stale).
+    const dir = path.dirname(this.bundlePath);
+    const base = path.basename(this.bundlePath);
+    try {
+      this.watcher = fs.watch(dir, { persistent: false }, (_event, filename) => {
+        if (filename && filename !== base) return;
+        this.scheduleReload();
+      });
+      this.watcher.on("error", (error) => {
+        logger.warn(`[${this.serviceName}] Bundle watcher error`, {
+          error: formatErrorMessage(error, "watch failed"),
+        });
+      });
+    } catch (error) {
+      logger.warn(`[${this.serviceName}] Failed to watch bundle dir ${dir}`, {
+        error: formatErrorMessage(error, "watch failed"),
+      });
+    }
+  }
+
+  private scheduleReload(): void {
+    if (this.isDisposed) return;
+    if (this.reloadTimer) clearTimeout(this.reloadTimer);
+    this.reloadTimer = setTimeout(() => {
+      this.reloadTimer = null;
+      this.reload();
+    }, RELOAD_DEBOUNCE_MS);
+    this.reloadTimer.unref?.();
+  }
+
+  private startWorker(): void {
+    if (this.isDisposed) return;
+    this.pendingChildProcessGoneReason = null;
+    this.expectingExit = false;
+
+    const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
+    // PluginDevWorkerHost lives in electron/services/plugin/, but at build time
+    // every host bundle is flattened into electron/ (or electron/chunks/), so
+    // the bootstrap resolves relative to the runtime dir, not the source tree.
+    const bootstrapPath = path.join(electronDir, "plugin-dev-worker-bootstrap.js");
+
+    try {
+      this.child = utilityProcess.fork(bootstrapPath, [], {
+        serviceName: this.serviceName,
+        stdio: "pipe",
+        cwd: this.pluginDir || os.homedir(),
+        env: {
+          // env REPLACES process.env in a utility process (#6081) — spread first.
+          ...(process.env as Record<string, string>),
+          DAINTREE_USER_DATA: app.getPath("userData"),
+          DAINTREE_UTILITY_PROCESS_KIND: PLUGIN_DEV_WORKER_KIND,
+          // io_uring disabled on Linux for utility-process stability (#6081).
+          ...(process.platform === "linux" ? { UV_USE_IO_URING: "0" } : {}),
+        },
+      });
+    } catch (error) {
+      logger.error(`[${this.serviceName}] Failed to fork`, {
+        error: formatErrorMessage(error, "fork failed"),
+      });
+      if (this.readyReject) {
+        this.readyReject(
+          new Error(`Plugin dev worker failed to fork: ${formatErrorMessage(error, "fork failed")}`)
+        );
+        this.readyReject = null;
+      }
+      this.emit("crash-loop", -1);
+      return;
+    }
+
+    this.installLogForwarding();
+
+    this.child.on("message", (msg: PluginWorkerToHostMessage) => {
+      this.handleWorkerMessage(msg);
+    });
+
+    this.child.on("exit", (code) => {
+      this.handleExit(code);
+    });
+  }
+
+  private handleWorkerMessage(msg: PluginWorkerToHostMessage): void {
+    if (this.isDisposed) return;
+    if (msg.type === "ready") {
+      // Re-import the bundle and re-run activate on every (re)start.
+      this.send({
+        type: "start",
+        bundleUrl: pathToBundleUrl(this.bundlePath),
+        pluginId: this.pluginId,
+      });
+      if (this.readyResolve) {
+        this.readyResolve();
+        this.readyResolve = null;
+      }
+      this.emit("ready");
+      return;
+    }
+    // All other messages (host-call, host-notify, subscribe, invoke-result,
+    // activated, activate-error, error) are routed to the bridge.
+    this.emit("worker-message", msg);
+  }
+
+  private handleExit(code: number | undefined): void {
+    const wasExpected = this.expectingExit;
+    this.expectingExit = false;
+    this.child = null;
+
+    if (this.readyReject) {
+      this.readyReject(new Error(`Plugin dev worker exited (code ${code ?? "unknown"})`));
+      this.readyReject = null;
+    }
+
+    if (this.isDisposed) {
+      this.pendingChildProcessGoneReason = null;
+      return;
+    }
+
+    // An intentional kill (reload/dispose) is not a crash — emit exit and stop.
+    if (wasExpected) {
+      this.pendingChildProcessGoneReason = null;
+      this.emit("exit", code ?? 0, /* expected */ true);
+      return;
+    }
+
+    this.emit("exit", code ?? 0, /* expected */ false);
+
+    // `exit`/`child-process-gone` ordering race (electron/electron#42283):
+    // defer one tick so the authoritative reason/exit code can arrive.
+    setImmediate(() => {
+      if (this.isDisposed) {
+        this.pendingChildProcessGoneReason = null;
+        return;
+      }
+      const gone = this.pendingChildProcessGoneReason;
+      this.pendingChildProcessGoneReason = null;
+      const reportedCode = gone ? gone.exitCode : (code ?? -1);
+
+      const crashAt = Date.now();
+      this.crashTimestamps = this.crashTimestamps.filter((t) => crashAt - t < CRASH_WINDOW_MS);
+      this.crashTimestamps.push(crashAt);
+
+      if (this.crashTimestamps.length >= CRASH_THRESHOLD) {
+        logger.error(
+          `[${this.serviceName}] Worker crashed ${CRASH_THRESHOLD} times within the window — giving up; edit + save to retry`
+        );
+        this.emit("crash-loop", reportedCode);
+        return;
+      }
+
+      logger.warn(
+        `[${this.serviceName}] Worker crashed (code ${reportedCode}); respawning (${this.crashTimestamps.length}/${CRASH_THRESHOLD} in window)`
+      );
+      this.startFresh();
+    });
+  }
+
+  private registerChildProcessGoneListener(): void {
+    if (this.childProcessGoneHandler) return;
+    const handler = (_event: Electron.Event, details: Electron.Details): void => {
+      if (this.isDisposed) return;
+      if (details.type !== "Utility") return;
+      // Electron 41+ populates `name` from `serviceName`; accept either for
+      // resilience (mirrors WorkspaceHostProcess).
+      const matches = details.name === this.serviceName || details.serviceName === this.serviceName;
+      if (!matches) return;
+      this.pendingChildProcessGoneReason = {
+        reason: details.reason,
+        exitCode: details.exitCode,
+      };
+    };
+    this.childProcessGoneHandler = handler;
+    app.on("child-process-gone", handler);
+  }
+
+  private installLogForwarding(): void {
+    if (!this.child) return;
+    const stdout = (this.child as unknown as { stdout?: NodeJS.ReadableStream }).stdout;
+    const stderr = (this.child as unknown as { stderr?: NodeJS.ReadableStream }).stderr;
+    const forward = (kind: "stdout" | "stderr", chunk: Buffer): void => {
+      const text = chunk.toString("utf8").trimEnd();
+      if (!text) return;
+      const line = `[plugin-dev:${this.pluginId}] ${text}`;
+      if (kind === "stderr") logger.warn(line);
+      else logger.info(line);
+    };
+    stdout?.on("data", (chunk: Buffer) => forward("stdout", chunk));
+    stderr?.on("data", (chunk: Buffer) => forward("stderr", chunk));
+    stdout?.on("error", () => {});
+    stderr?.on("error", () => {});
+  }
+}
+
+/** Resolve a filesystem path to a `file://` URL the worker can `import()`. */
+function pathToBundleUrl(p: string): string {
+  return pathToFileURL(path.resolve(p)).href;
+}

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -1,7 +1,7 @@
 import { utilityProcess, UtilityProcess, app } from "electron";
 import { EventEmitter } from "events";
 import { createHash } from "crypto";
-import fs from "fs";
+import fs, { existsSync } from "fs";
 import path from "path";
 import os from "os";
 import { fileURLToPath, pathToFileURL } from "url";
@@ -280,24 +280,59 @@ export class PluginDevWorkerHost extends EventEmitter {
 
   private startWatching(): void {
     if (this.watcher || this.isDisposed) return;
-    // `fs.watch` on a not-yet-existing file throws ENOENT — watch the parent
-    // `dist/` dir and filter for the bundle filename instead. This also
-    // survives editors/Vite that replace the file via rename (the inode the
-    // file watch held would otherwise go stale).
     const dir = path.dirname(this.bundlePath);
     const base = path.basename(this.bundlePath);
+
+    // `fs.watch` on the `dist/` dir is preferred — watching the file directly
+    // would go stale when Vite replaces it via rename, and filtering by
+    // filename coalesces rename+write. But `dist/` may not exist yet when
+    // Daintree loads the plugin (Vite hasn't produced the first build). In that
+    // case watch the plugin root for `dist/` appearing, then re-arm the real
+    // watcher. A single-dir watch is one fd — no recursive-watch fd leak.
+    if (existsSync(dir)) {
+      try {
+        this.watcher = fs.watch(dir, { persistent: false }, (_event, filename) => {
+          if (filename && filename !== base) return;
+          this.scheduleReload();
+        });
+        this.watcher.on("error", (error) => {
+          logger.warn(`[${this.serviceName}] Bundle watcher error`, {
+            error: formatErrorMessage(error, "watch failed"),
+          });
+        });
+      } catch (error) {
+        logger.warn(`[${this.serviceName}] Failed to watch bundle dir ${dir}`, {
+          error: formatErrorMessage(error, "watch failed"),
+        });
+      }
+      return;
+    }
+
+    const distName = path.basename(dir);
     try {
-      this.watcher = fs.watch(dir, { persistent: false }, (_event, filename) => {
-        if (filename && filename !== base) return;
+      this.watcher = fs.watch(this.pluginDir, { persistent: false }, (_event, filename) => {
+        if (filename && filename !== distName) return;
+        if (!existsSync(dir)) return;
+        // `dist/` now exists — swap to watching it for real, then reload to pick
+        // up the freshly-built bundle.
+        if (this.watcher) {
+          try {
+            this.watcher.close();
+          } catch {
+            // ignore
+          }
+          this.watcher = null;
+        }
+        this.startWatching();
         this.scheduleReload();
       });
       this.watcher.on("error", (error) => {
-        logger.warn(`[${this.serviceName}] Bundle watcher error`, {
+        logger.warn(`[${this.serviceName}] Plugin-dir watcher error`, {
           error: formatErrorMessage(error, "watch failed"),
         });
       });
     } catch (error) {
-      logger.warn(`[${this.serviceName}] Failed to watch bundle dir ${dir}`, {
+      logger.warn(`[${this.serviceName}] Failed to watch plugin dir ${this.pluginDir}`, {
         error: formatErrorMessage(error, "watch failed"),
       });
     }

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -113,8 +113,16 @@ export class PluginDevWorkerHost extends EventEmitter {
   }
 
   /** Fork the worker and begin watching the bundle. Resolves when the worker
-   * posts `ready`; rejects on fork failure or premature exit. */
-  async start(): Promise<void> {
+   * posts `ready`; rejects on fork failure or premature exit.
+   *
+   * Deliberately NOT `async`: an async wrapper would adopt `readyPromise`'s
+   * state in a *fresh* promise that bypasses the `readyPromise.catch` guard
+   * (constructor / {@link startFresh}), so a fire-and-forget caller
+   * (`void host.start()`) would surface an unhandled rejection when dispose or
+   * a premature exit rejects ready. Returning `readyPromise` directly keeps the
+   * guard in effect; `startWorker`/`startWatching` swallow their own errors and
+   * never throw synchronously, so awaiting callers still observe rejections. */
+  start(): Promise<void> {
     this.startWorker();
     this.startWatching();
     return this.readyPromise;

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -1,0 +1,392 @@
+// Main-side bridge for the plugin dev hot-reload worker (#9304). It owns the
+// translation between the worker's MessagePort protocol and the real
+// `PluginHostApi` returned by `PluginService.createHost`:
+//
+//   - worker `host-call`     → real host async method  → `host-result`
+//   - worker `host-notify`   → real host sync method (register*/broadcast/log)
+//   - worker `subscribe`     → real host onDidChange*   → `subscription-event`
+//   - real action/IPC dispatch → `invoke` → worker handler → `invoke-result`
+//
+// Handlers the plugin registers live in the worker; the bridge registers thin
+// wrappers on the real host that round-trip each invocation back to the worker.
+// Reusing the real host (rather than re-implementing every method against raw
+// service refs) keeps all the host's validation, provenance, and revoke
+// semantics intact for free.
+
+import { createLogger } from "../../utils/logger.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import type { PluginHostApi, PluginIpcContext } from "../../../shared/types/plugin.js";
+import type {
+  BroadcastToRendererParams,
+  DispatchParams,
+  InvalidateFileDecorationsParams,
+  LoggerParams,
+  PluginWorkerToHostMessage,
+  RegisterActionParams,
+  RegisterHandlerParams,
+  SettingsGetParams,
+  SettingsSetParams,
+  ShowToastParams,
+} from "../../../shared/types/pluginDevWorker.js";
+import type { PluginDevWorkerHost } from "./PluginDevWorkerHost.js";
+
+const logger = createLogger("main:PluginDevWorkerBridge");
+
+export interface PluginDevWorkerMainBridgeDeps {
+  pluginId: string;
+  /** Real host from `PluginService.createHost` — kept un-revoked for the dev
+   * plugin's whole lifetime so the worker can re-register on every reload. */
+  host: PluginHostApi;
+  workerHost: PluginDevWorkerHost;
+  /** Declared manifest capabilities, for the typed-handler fail-closed gate. */
+  getCapabilities: () => readonly string[];
+  /** Clear activate-time registrations (actions + IPC handlers) before a reload
+   * re-registers them, so a handler the new code drops doesn't linger. */
+  clearPriorRegistrations: () => void;
+}
+
+interface PendingInvoke {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+export class PluginDevWorkerMainBridge {
+  private readonly pluginId: string;
+  private readonly host: PluginHostApi;
+  private readonly workerHost: PluginDevWorkerHost;
+  private readonly getCapabilities: () => readonly string[];
+  private readonly clearPriorRegistrations: () => void;
+
+  private disposed = false;
+  private invokeSeq = 1;
+  private readonly pendingInvokes = new Map<string, PendingInvoke>();
+  private readonly subscriptionDisposers = new Map<string, () => void>();
+
+  /** First-activation gate. Resolved on `activated`, rejected on activate/crash
+   * errors. Subsequent reload activations don't re-await this. */
+  private activationSettled = false;
+  private activationResolve: (() => void) | null = null;
+  private activationReject: ((error: Error) => void) | null = null;
+  private readonly activationPromise: Promise<void>;
+
+  constructor(deps: PluginDevWorkerMainBridgeDeps) {
+    this.pluginId = deps.pluginId;
+    this.host = deps.host;
+    this.workerHost = deps.workerHost;
+    this.getCapabilities = deps.getCapabilities;
+    this.clearPriorRegistrations = deps.clearPriorRegistrations;
+
+    this.activationPromise = new Promise<void>((resolve, reject) => {
+      this.activationResolve = resolve;
+      this.activationReject = reject;
+    });
+
+    this.workerHost.on("worker-message", this.onWorkerMessage);
+    this.workerHost.on("reloading", this.onReloading);
+    this.workerHost.on("crash-loop", this.onCrashLoop);
+  }
+
+  /** Resolves once the worker's first `activate()` completes (or rejects). */
+  waitForActivation(): Promise<void> {
+    return this.activationPromise;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.workerHost.off("worker-message", this.onWorkerMessage);
+    this.workerHost.off("reloading", this.onReloading);
+    this.workerHost.off("crash-loop", this.onCrashLoop);
+    for (const dispose of this.subscriptionDisposers.values()) {
+      try {
+        dispose();
+      } catch {
+        // best-effort
+      }
+    }
+    this.subscriptionDisposers.clear();
+    for (const pending of this.pendingInvokes.values()) {
+      pending.reject(new Error("Plugin dev worker bridge disposed"));
+    }
+    this.pendingInvokes.clear();
+    this.rejectActivation(new Error(`Plugin dev worker "${this.pluginId}" disposed`));
+  }
+
+  private onReloading = (): void => {
+    // The new worker generation will re-register from scratch; drop the prior
+    // generation's activate-time registrations and tear down subscriptions so
+    // they don't double up. Pending invokes target a now-dead worker — fail them.
+    this.clearPriorRegistrations();
+    for (const dispose of this.subscriptionDisposers.values()) {
+      try {
+        dispose();
+      } catch {
+        // best-effort
+      }
+    }
+    this.subscriptionDisposers.clear();
+    for (const pending of this.pendingInvokes.values()) {
+      pending.reject(new Error("Plugin reloaded before invocation completed"));
+    }
+    this.pendingInvokes.clear();
+  };
+
+  private onCrashLoop = (code: number): void => {
+    logger.error(
+      `[${this.pluginId}] dev worker entered a crash loop (code ${code}); reload halted until next edit`
+    );
+    this.rejectActivation(new Error(`Plugin "${this.pluginId}" dev worker crash loop`));
+  };
+
+  private onWorkerMessage = (msg: PluginWorkerToHostMessage): void => {
+    if (this.disposed) return;
+    switch (msg.type) {
+      case "activated":
+        this.resolveActivation();
+        return;
+      case "activate-error":
+        logger.error(`[${this.pluginId}] activate() failed: ${msg.error}`, {
+          stack: msg.stack,
+        });
+        this.rejectActivation(new Error(msg.error));
+        return;
+      case "error":
+        logger.error(`[${this.pluginId}] worker error: ${msg.error}`);
+        this.rejectActivation(new Error(msg.error));
+        return;
+      case "host-call":
+        void this.handleHostCall(msg);
+        return;
+      case "host-notify":
+        this.handleHostNotify(msg);
+        return;
+      case "subscribe":
+        this.handleSubscribe(msg);
+        return;
+      case "unsubscribe": {
+        const dispose = this.subscriptionDisposers.get(msg.subscriptionId);
+        if (dispose) {
+          this.subscriptionDisposers.delete(msg.subscriptionId);
+          try {
+            dispose();
+          } catch {
+            // best-effort
+          }
+        }
+        return;
+      }
+      case "invoke-result": {
+        const pending = this.pendingInvokes.get(msg.requestId);
+        if (!pending) return;
+        this.pendingInvokes.delete(msg.requestId);
+        if (msg.ok) pending.resolve(msg.result);
+        else pending.reject(new Error(msg.error));
+        return;
+      }
+      case "ready":
+        // Handled inside PluginDevWorkerHost; never re-emitted here.
+        return;
+    }
+  };
+
+  private async handleHostCall(
+    msg: Extract<PluginWorkerToHostMessage, { type: "host-call" }>
+  ): Promise<void> {
+    try {
+      const result = await this.dispatchHostCall(msg.method, msg.params);
+      this.workerHost.send({ type: "host-result", requestId: msg.requestId, ok: true, result });
+    } catch (err) {
+      this.workerHost.send({
+        type: "host-result",
+        requestId: msg.requestId,
+        ok: false,
+        error: formatErrorMessage(err, "host call failed"),
+      });
+    }
+  }
+
+  private async dispatchHostCall(method: string, params: unknown): Promise<unknown> {
+    switch (method) {
+      case "getActiveWorktree":
+        return this.host.getActiveWorktree();
+      case "getWorktrees":
+        return this.host.getWorktrees();
+      case "showToast": {
+        const p = params as ShowToastParams;
+        // `type` is validated against the NotificationType enum by the host's
+        // PluginToastOptionsSchema, so an invalid value rejects there.
+        await this.host.showToast({
+          message: p.message,
+          type: p.type as Parameters<PluginHostApi["showToast"]>[0]["type"],
+          durationMs: p.durationMs,
+        });
+        return undefined;
+      }
+      case "dispatch": {
+        const p = params as DispatchParams;
+        return this.host.dispatch(p.actionId, p.args);
+      }
+      case "settings.get": {
+        const p = params as SettingsGetParams;
+        return this.host.settings.get(p.key, p.scope);
+      }
+      case "settings.set": {
+        const p = params as SettingsSetParams;
+        await this.host.settings.set(p.key, p.value, p.scope);
+        return undefined;
+      }
+      default:
+        throw new Error(`Unknown host-call method "${method}"`);
+    }
+  }
+
+  private handleHostNotify(msg: Extract<PluginWorkerToHostMessage, { type: "host-notify" }>): void {
+    try {
+      this.dispatchHostNotify(msg.method, msg.params);
+    } catch (err) {
+      const error = formatErrorMessage(err, "registration failed");
+      if (msg.registrationKey) {
+        // The proxy call already returned synchronously in the worker — this is
+        // the only channel for a deep-validation rejection.
+        this.workerHost.send({
+          type: "register-error",
+          registrationKey: msg.registrationKey,
+          error,
+        });
+      } else {
+        logger.warn(`[${this.pluginId}] host-notify "${msg.method}" threw: ${error}`);
+      }
+    }
+  }
+
+  private dispatchHostNotify(method: string, params: unknown): void {
+    switch (method) {
+      case "registerAction": {
+        const { descriptor } = params as RegisterActionParams;
+        const namespacedId = `${this.pluginId}.${descriptor.id}`;
+        this.host.registerAction(descriptor, (args) =>
+          this.invoke({ kind: "action", namespacedId, args })
+        );
+        return;
+      }
+      case "registerHandler": {
+        const p = params as RegisterHandlerParams;
+        if (p.hasSchema && p.requires && p.requires.length > 0) {
+          // Fail-closed capability gate — the untyped wrapper we register on the
+          // host doesn't carry the schema's `requires`, so enforce it here to
+          // match the typed overload's contract.
+          const declared = new Set(this.getCapabilities());
+          const missing = p.requires.filter((cap) => !declared.has(cap));
+          if (missing.length > 0) {
+            throw new Error(
+              `PERMISSION_REQUIRED: channel "${p.channel}" requires capabilities not declared in the manifest: ${missing.join(", ")}`
+            );
+          }
+        }
+        const handler = (ctx: PluginIpcContext, ...args: unknown[]) =>
+          this.invoke({ kind: "handler", channel: p.channel, ctx, args });
+        this.host.registerHandler(p.channel, handler);
+        return;
+      }
+      case "broadcastToRenderer": {
+        const p = params as BroadcastToRendererParams;
+        this.host.broadcastToRenderer(p.channel, p.payload);
+        return;
+      }
+      case "invalidateFileDecorations": {
+        const p = params as InvalidateFileDecorationsParams;
+        this.host.invalidateFileDecorations(p.scope, p.paths);
+        return;
+      }
+      case "logger.info":
+      case "logger.warn":
+      case "logger.error": {
+        const p = params as LoggerParams;
+        const level = method.split(".")[1] as "info" | "warn" | "error";
+        this.host.logger[level](p.message, p.fields);
+        return;
+      }
+      default:
+        logger.warn(`[${this.pluginId}] unknown host-notify method "${method}"`);
+    }
+  }
+
+  private handleSubscribe(msg: Extract<PluginWorkerToHostMessage, { type: "subscribe" }>): void {
+    const { subscriptionId, kind } = msg;
+    const push = (payload: unknown): void => {
+      if (this.disposed) return;
+      this.workerHost.send({ type: "subscription-event", subscriptionId, payload });
+    };
+    try {
+      let dispose: () => void;
+      if (kind === "active-worktree") {
+        dispose = this.host.onDidChangeActiveWorktree((snapshot) => push(snapshot));
+      } else if (kind === "worktrees") {
+        dispose = this.host.onDidChangeWorktrees((snapshots) => push(snapshots));
+      } else {
+        // settings
+        if (!msg.key) {
+          logger.warn(`[${this.pluginId}] settings subscribe missing key`);
+          return;
+        }
+        dispose = this.host.settings.onDidChange(msg.key, (value) => push(value), msg.scope);
+      }
+      this.subscriptionDisposers.set(subscriptionId, dispose);
+    } catch (err) {
+      logger.warn(
+        `[${this.pluginId}] subscribe "${kind}" failed: ${formatErrorMessage(err, "subscribe failed")}`
+      );
+    }
+  }
+
+  private invoke(
+    target:
+      | { kind: "action"; namespacedId: string; args: unknown }
+      | { kind: "handler"; channel: string; ctx: PluginIpcContext; args: unknown[] }
+  ): Promise<unknown> {
+    if (this.disposed || !this.workerHost.isReady()) {
+      return Promise.reject(new Error(`Plugin "${this.pluginId}" dev worker is not running`));
+    }
+    const requestId = `i${this.invokeSeq++}`;
+    return new Promise<unknown>((resolve, reject) => {
+      this.pendingInvokes.set(requestId, { resolve, reject });
+      const sent =
+        target.kind === "action"
+          ? this.workerHost.send({
+              type: "invoke",
+              requestId,
+              kind: "action",
+              namespacedId: target.namespacedId,
+              args: target.args,
+            })
+          : this.workerHost.send({
+              type: "invoke",
+              requestId,
+              kind: "handler",
+              channel: target.channel,
+              ctx: target.ctx,
+              args: target.args,
+            });
+      if (!sent) {
+        this.pendingInvokes.delete(requestId);
+        reject(new Error(`Plugin "${this.pluginId}" dev worker is not running`));
+      }
+    });
+  }
+
+  private resolveActivation(): void {
+    if (this.activationSettled) return;
+    this.activationSettled = true;
+    this.activationResolve?.();
+    this.activationResolve = null;
+    this.activationReject = null;
+  }
+
+  private rejectActivation(error: Error): void {
+    if (this.activationSettled) return;
+    this.activationSettled = true;
+    this.activationReject?.(error);
+    this.activationResolve = null;
+    this.activationReject = null;
+  }
+}

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -43,6 +43,12 @@ export interface PluginDevWorkerMainBridgeDeps {
   /** Clear activate-time registrations (actions + IPC handlers) before a reload
    * re-registers them, so a handler the new code drops doesn't linger. */
   clearPriorRegistrations: () => void;
+  /**
+   * Fires on EVERY activation outcome — the initial activation and each reload.
+   * Lets the owner keep the provenance `loadError` in sync across reloads (the
+   * first-activation promise settles once and can't observe later outcomes).
+   */
+  onActivationResult?: (result: { ok: true } | { ok: false; error: string }) => void;
 }
 
 interface PendingInvoke {
@@ -56,6 +62,9 @@ export class PluginDevWorkerMainBridge {
   private readonly workerHost: PluginDevWorkerHost;
   private readonly getCapabilities: () => readonly string[];
   private readonly clearPriorRegistrations: () => void;
+  private readonly onActivationResult?: (
+    result: { ok: true } | { ok: false; error: string }
+  ) => void;
 
   private disposed = false;
   private invokeSeq = 1;
@@ -75,6 +84,7 @@ export class PluginDevWorkerMainBridge {
     this.workerHost = deps.workerHost;
     this.getCapabilities = deps.getCapabilities;
     this.clearPriorRegistrations = deps.clearPriorRegistrations;
+    this.onActivationResult = deps.onActivationResult;
 
     this.activationPromise = new Promise<void>((resolve, reject) => {
       this.activationResolve = resolve;
@@ -142,16 +152,21 @@ export class PluginDevWorkerMainBridge {
     if (this.disposed) return;
     switch (msg.type) {
       case "activated":
+        // Fires on initial activation and every reload — keep the owner's
+        // provenance in sync on each, not just the first.
+        this.onActivationResult?.({ ok: true });
         this.resolveActivation();
         return;
       case "activate-error":
         logger.error(`[${this.pluginId}] activate() failed: ${msg.error}`, {
           stack: msg.stack,
         });
+        this.onActivationResult?.({ ok: false, error: msg.error });
         this.rejectActivation(new Error(msg.error));
         return;
       case "error":
         logger.error(`[${this.pluginId}] worker error: ${msg.error}`);
+        this.onActivationResult?.({ ok: false, error: msg.error });
         this.rejectActivation(new Error(msg.error));
         return;
       case "host-call":

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -87,7 +87,7 @@ interface PluginInstallerDeps {
   unloadPlugin: (pluginId: string) => void;
   activatePlugin: (pluginId: string) => Promise<void>;
   setPluginArchiveHash: (pluginId: string, archiveHash: string) => void;
-  setEnabled: (pluginId: string, enabled: boolean) => void;
+  setEnabled: (pluginId: string, enabled: boolean) => Promise<void>;
   broadcastProvenanceChanged: () => void;
   /** Lookup for the running or skipped-at-launch plugin (only `isBuiltin` is consumed). */
   getPlugin: (pluginId: string) => InstallerPluginInfo | undefined;
@@ -979,7 +979,7 @@ export class PluginInstaller {
       this.deps.reservedNames.delete(pluginId);
       // Clear it from the persisted `plugins.disabled` intent list so a disabled
       // plugin can't resurrect itself on the next launch's disabled-dir re-scan.
-      this.deps.setEnabled(pluginId, true);
+      await this.deps.setEnabled(pluginId, true);
       const records = this.records.getInstalledRecords();
       if (pluginId in records) {
         delete records[pluginId];

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -1,0 +1,229 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import { Readable } from "node:stream";
+
+const { forkMock, mockChildren, appMock, watchMock, watchCalls } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+  const forkMock = vi.fn();
+  const mockChildren: any[] = [];
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, { getPath: vi.fn(() => "/tmp/userData") });
+  const watchCalls: { dir: string; cb: (event: string, filename: string | null) => void }[] = [];
+  const watchMock = vi.fn((dir: string, _opts: unknown, cb: any) => {
+    const watcher = Object.assign(new EventEmitter(), { close: vi.fn() });
+    watchCalls.push({ dir, cb });
+    return watcher;
+  });
+  return { forkMock, mockChildren, appMock, watchMock, watchCalls };
+});
+
+class MockUtilityChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  postMessage = vi.fn();
+  kill = vi.fn(() => true);
+  pid = 99;
+  constructor() {
+    super();
+    this.stdout = new Readable({ read() {} });
+    this.stderr = new Readable({ read() {} });
+    mockChildren.push(this);
+  }
+}
+
+vi.mock("electron", () => ({
+  utilityProcess: { fork: forkMock },
+  app: appMock,
+  UtilityProcess: class {},
+}));
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return { ...actual, default: { ...actual.default, watch: watchMock }, watch: watchMock };
+});
+
+vi.mock("../../../utils/logger.js", () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+async function loadModule(): Promise<typeof import("../PluginDevWorkerHost.js")> {
+  return import("../PluginDevWorkerHost.js");
+}
+
+const OPTS = {
+  pluginId: "acme.demo",
+  pluginDir: "/plugins/acme.demo",
+  bundlePath: "/plugins/acme.demo/dist/index.js",
+};
+
+/** Flush microtasks + the host's setImmediate deferrals. */
+async function flush(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe("PluginDevWorkerHost", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    forkMock.mockReset();
+    mockChildren.length = 0;
+    watchCalls.length = 0;
+    watchMock.mockClear();
+    appMock.removeAllListeners();
+    forkMock.mockImplementation(() => new MockUtilityChild());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("forks the worker with the dev-worker kind, piped stdio, and the plugin dir as cwd", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    host.waitForReady().catch(() => {});
+    void host.start();
+
+    expect(forkMock).toHaveBeenCalledTimes(1);
+    const [, , options] = forkMock.mock.calls[0];
+    expect(options.stdio).toBe("pipe");
+    expect(options.cwd).toBe(OPTS.pluginDir);
+    expect(options.env.DAINTREE_UTILITY_PROCESS_KIND).toBe("plugin-dev-worker");
+    // env must spread process.env (REPLACES, not merges — #6081).
+    expect(options.env.DAINTREE_USER_DATA).toBe("/tmp/userData");
+    host.dispose();
+  });
+
+  it("exports CRASH_WINDOW_MS aligned with the other guards (30 minutes)", async () => {
+    const mod = await loadModule();
+    expect(mod.CRASH_WINDOW_MS).toBe(30 * 60 * 1000);
+  });
+
+  it("on worker `ready`, sends `start` with the bundle file:// URL and resolves ready", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    const ready = host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+    await ready;
+
+    const startMsg = child.postMessage.mock.calls.find((c) => c[0]?.type === "start")?.[0];
+    expect(startMsg).toBeTruthy();
+    expect(startMsg.pluginId).toBe("acme.demo");
+    expect(startMsg.bundleUrl).toMatch(/^file:\/\/.*\/dist\/index\.js$/);
+    host.dispose();
+  });
+
+  it("watches the bundle's dist directory and debounces a rebuild into one reload", async () => {
+    vi.useFakeTimers();
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    void host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    expect(watchCalls).toHaveLength(1);
+    expect(watchCalls[0].dir).toBe("/plugins/acme.demo/dist");
+
+    // Two rapid change events for index.js → one reload after debounce.
+    watchCalls[0].cb("change", "index.js");
+    watchCalls[0].cb("change", "index.js");
+    vi.advanceTimersByTime(250);
+
+    // Reload sends a dispose to the old child, then the old child exits.
+    const disposeSent = child.postMessage.mock.calls.some((c) => c[0]?.type === "dispose");
+    expect(disposeSent).toBe(true);
+    host.dispose();
+  });
+
+  it("ignores change events for unrelated files in the dist dir", async () => {
+    vi.useFakeTimers();
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    void host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+    child.postMessage.mockClear();
+
+    watchCalls[0].cb("change", "style.css");
+    vi.advanceTimersByTime(250);
+
+    const disposeSent = child.postMessage.mock.calls.some((c) => c[0]?.type === "dispose");
+    expect(disposeSent).toBe(false);
+    host.dispose();
+  });
+
+  it("a reload clears the crash window so deliberate restarts never trip the cap", async () => {
+    vi.useFakeTimers();
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    const crashLoop = vi.fn();
+    host.on("crash-loop", crashLoop);
+    void host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    // Trigger a reload (deliberate kill).
+    watchCalls[0].cb("change", "index.js");
+    vi.advanceTimersByTime(250);
+    // Old child exits as a result of the reload's dispose/kill.
+    child.emit("exit", 0);
+    await vi.runOnlyPendingTimersAsync();
+
+    // A fresh worker was forked for the reload.
+    expect(forkMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(crashLoop).not.toHaveBeenCalled();
+    host.dispose();
+  });
+
+  it("gives up after the crash threshold of unexpected exits", async () => {
+    const { PluginDevWorkerHost, CRASH_WINDOW_MS } = await loadModule();
+    expect(CRASH_WINDOW_MS).toBeGreaterThan(0);
+    const host = new PluginDevWorkerHost(OPTS);
+    const crashLoop = vi.fn();
+    host.on("crash-loop", crashLoop);
+    void host.start();
+    mockChildren[0].emit("message", { type: "ready" });
+
+    // Three unexpected crashes in a row (each respawns until the cap).
+    for (let i = 0; i < 3; i++) {
+      const child = mockChildren[mockChildren.length - 1] as MockUtilityChild;
+      child.emit("exit", 1);
+      await flush();
+    }
+
+    expect(crashLoop).toHaveBeenCalledTimes(1);
+    host.dispose();
+  });
+
+  it("dispose sends a cooperative dispose then force-kills after the grace period", async () => {
+    vi.useFakeTimers();
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    void host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    host.dispose();
+    expect(child.postMessage.mock.calls.some((c) => c[0]?.type === "dispose")).toBe(true);
+    expect(child.kill).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1100);
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it("re-emits non-lifecycle worker messages as `worker-message`", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    const seen: any[] = [];
+    host.on("worker-message", (m) => seen.push(m));
+    void host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+    child.emit("message", { type: "host-call", requestId: "c1", method: "getWorktrees" });
+
+    expect(seen).toContainEqual({ type: "host-call", requestId: "c1", method: "getWorktrees" });
+    host.dispose();
+  });
+});

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -41,7 +41,16 @@ vi.mock("electron", () => ({
 
 vi.mock("fs", async (importOriginal) => {
   const actual = (await importOriginal()) as any;
-  return { ...actual, default: { ...actual.default, watch: watchMock }, watch: watchMock };
+  // existsSync → true so the watcher targets the dist dir directly (the fake
+  // test paths don't exist on the real fs, which would otherwise route through
+  // the "dist not created yet" plugin-root fallback).
+  const existsSync = () => true;
+  return {
+    ...actual,
+    default: { ...actual.default, watch: watchMock, existsSync },
+    watch: watchMock,
+    existsSync,
+  };
 });
 
 vi.mock("../../../utils/logger.js", () => ({

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -43,18 +43,26 @@ function makeHost() {
   };
 }
 
-function makeBridge(overrides?: Partial<{ capabilities: string[]; clear: () => void }>) {
+function makeBridge(
+  overrides?: Partial<{
+    capabilities: string[];
+    clear: () => void;
+    onActivationResult: (r: { ok: true } | { ok: false; error: string }) => void;
+  }>
+) {
   const host = makeHost();
   const workerHost = new FakeWorkerHost();
   const clear = overrides?.clear ?? vi.fn();
+  const onActivationResult = overrides?.onActivationResult ?? vi.fn();
   const bridge = new PluginDevWorkerMainBridge({
     pluginId: "acme.demo",
     host: host as any,
     workerHost: workerHost as any,
     getCapabilities: () => overrides?.capabilities ?? [],
     clearPriorRegistrations: clear,
+    onActivationResult,
   });
-  return { host, workerHost, bridge, clear };
+  return { host, workerHost, bridge, clear, onActivationResult };
 }
 
 const flush = () => new Promise((r) => setImmediate(r));
@@ -190,6 +198,21 @@ describe("PluginDevWorkerMainBridge", () => {
     const badPromise = bad.bridge.waitForActivation();
     bad.workerHost.emit("worker-message", { type: "activate-error", error: "nope" });
     await expect(badPromise).rejects.toThrow("nope");
+  });
+
+  it("reports every activation outcome, including post-reload, via onActivationResult", async () => {
+    const onActivationResult = vi.fn();
+    const { workerHost, bridge } = makeBridge({ onActivationResult });
+    bridge.waitForActivation().catch(() => {});
+
+    // Initial activation succeeds.
+    workerHost.emit("worker-message", { type: "activated", hasCleanup: false });
+    // Reload, then the reloaded generation fails to activate.
+    workerHost.emit("reloading");
+    workerHost.emit("worker-message", { type: "activate-error", error: "broke on reload" });
+
+    expect(onActivationResult).toHaveBeenNthCalledWith(1, { ok: true });
+    expect(onActivationResult).toHaveBeenNthCalledWith(2, { ok: false, error: "broke on reload" });
   });
 
   it("clears prior registrations and fails pending invokes on reload", async () => {

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -1,0 +1,221 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+
+vi.mock("../../../utils/logger.js", () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { PluginDevWorkerMainBridge } from "../PluginDevWorkerMainBridge.js";
+
+class FakeWorkerHost extends EventEmitter {
+  sent: any[] = [];
+  ready = true;
+  send = vi.fn((msg: any) => {
+    this.sent.push(msg);
+    return this.ready;
+  });
+  isReady = () => this.ready;
+  off = this.removeListener;
+}
+
+function makeHost() {
+  return {
+    pluginId: "acme.demo",
+    registerAction: vi.fn(),
+    registerHandler: vi.fn(),
+    broadcastToRenderer: vi.fn(),
+    getActiveWorktree: vi.fn(async () => null),
+    getWorktrees: vi.fn(async () => [{ id: "w1" }]),
+    onDidChangeActiveWorktree: vi.fn((_cb: any) => vi.fn()),
+    onDidChangeWorktrees: vi.fn((_cb: any) => vi.fn()),
+    registerForgeProvider: vi.fn(() => vi.fn()),
+    registerFileDecorationProvider: vi.fn(() => vi.fn()),
+    invalidateFileDecorations: vi.fn(),
+    showToast: vi.fn(async () => {}),
+    dispatch: vi.fn(async () => ({ ok: true, result: undefined })),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    settings: {
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+      onDidChange: vi.fn(() => vi.fn()),
+    },
+  };
+}
+
+function makeBridge(overrides?: Partial<{ capabilities: string[]; clear: () => void }>) {
+  const host = makeHost();
+  const workerHost = new FakeWorkerHost();
+  const clear = overrides?.clear ?? vi.fn();
+  const bridge = new PluginDevWorkerMainBridge({
+    pluginId: "acme.demo",
+    host: host as any,
+    workerHost: workerHost as any,
+    getCapabilities: () => overrides?.capabilities ?? [],
+    clearPriorRegistrations: clear,
+  });
+  return { host, workerHost, bridge, clear };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+describe("PluginDevWorkerMainBridge", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("routes a host-call to the real host and replies with host-result", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "c1",
+      method: "getWorktrees",
+      params: undefined,
+    });
+    await flush();
+    expect(host.getWorktrees).toHaveBeenCalled();
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "c1");
+    expect(result).toMatchObject({ ok: true, result: [{ id: "w1" }] });
+  });
+
+  it("replies host-result ok:false when the host method throws", async () => {
+    const { host, workerHost } = makeBridge();
+    host.getWorktrees.mockRejectedValueOnce(new Error("boom"));
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "c2",
+      method: "getWorktrees",
+      params: undefined,
+    });
+    await flush();
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "c2");
+    expect(result).toMatchObject({ ok: false, error: "boom" });
+  });
+
+  it("registerAction wires a wrapper that round-trips invocation to the worker", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "registerAction",
+      registrationKey: "action:acme.demo.greet",
+      params: {
+        descriptor: {
+          id: "greet",
+          title: "Greet",
+          description: "",
+          category: "Demo",
+          kind: "command",
+          danger: "safe",
+        },
+      },
+    });
+    expect(host.registerAction).toHaveBeenCalledTimes(1);
+    const wrapper = host.registerAction.mock.calls[0][1] as (a: unknown) => Promise<unknown>;
+
+    const resultPromise = wrapper({ name: "world" });
+    const invoke = workerHost.sent.find((m) => m.type === "invoke" && m.kind === "action");
+    expect(invoke).toMatchObject({ namespacedId: "acme.demo.greet", args: { name: "world" } });
+
+    // Worker replies.
+    workerHost.emit("worker-message", {
+      type: "invoke-result",
+      requestId: invoke.requestId,
+      ok: true,
+      result: "hello world",
+    });
+    await expect(resultPromise).resolves.toBe("hello world");
+  });
+
+  it("fails closed on a typed handler whose required capability is undeclared", async () => {
+    const { host, workerHost } = makeBridge({ capabilities: [] });
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "registerHandler",
+      registrationKey: "handler:secret",
+      params: { channel: "secret", hasSchema: true, requires: ["worktree:read"] },
+    });
+    expect(host.registerHandler).not.toHaveBeenCalled();
+    const err = workerHost.sent.find((m) => m.type === "register-error");
+    expect(err).toMatchObject({ registrationKey: "handler:secret" });
+    expect(err.error).toMatch(/PERMISSION_REQUIRED/);
+  });
+
+  it("registers a typed handler when its required capability is declared", async () => {
+    const { host, workerHost } = makeBridge({ capabilities: ["worktree:read"] });
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "registerHandler",
+      params: { channel: "ok", hasSchema: true, requires: ["worktree:read"] },
+    });
+    expect(host.registerHandler).toHaveBeenCalledWith("ok", expect.any(Function));
+  });
+
+  it("opens a worktree subscription and pushes events to the worker", async () => {
+    const { host, workerHost } = makeBridge();
+    let emitActive: ((s: unknown) => void) | undefined;
+    host.onDidChangeActiveWorktree.mockImplementation((cb: any) => {
+      emitActive = cb;
+      return vi.fn();
+    });
+    workerHost.emit("worker-message", {
+      type: "subscribe",
+      subscriptionId: "s1",
+      kind: "active-worktree",
+    });
+    expect(host.onDidChangeActiveWorktree).toHaveBeenCalled();
+    emitActive?.({ id: "w9" });
+    const evt = workerHost.sent.find((m) => m.type === "subscription-event");
+    expect(evt).toMatchObject({ subscriptionId: "s1", payload: { id: "w9" } });
+  });
+
+  it("disposes a subscription on unsubscribe", async () => {
+    const { host, workerHost } = makeBridge();
+    const dispose = vi.fn();
+    host.onDidChangeWorktrees.mockReturnValueOnce(dispose);
+    workerHost.emit("worker-message", {
+      type: "subscribe",
+      subscriptionId: "s2",
+      kind: "worktrees",
+    });
+    workerHost.emit("worker-message", { type: "unsubscribe", subscriptionId: "s2" });
+    expect(dispose).toHaveBeenCalled();
+  });
+
+  it("resolves waitForActivation on `activated` and rejects on `activate-error`", async () => {
+    const ok = makeBridge();
+    const okPromise = ok.bridge.waitForActivation();
+    ok.workerHost.emit("worker-message", { type: "activated", hasCleanup: false });
+    await expect(okPromise).resolves.toBeUndefined();
+
+    const bad = makeBridge();
+    const badPromise = bad.bridge.waitForActivation();
+    bad.workerHost.emit("worker-message", { type: "activate-error", error: "nope" });
+    await expect(badPromise).rejects.toThrow("nope");
+  });
+
+  it("clears prior registrations and fails pending invokes on reload", async () => {
+    const { host, workerHost, bridge, clear } = makeBridge();
+    bridge.waitForActivation().catch(() => {});
+    // Register an action and start an invocation that never gets a reply.
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "registerAction",
+      params: {
+        descriptor: {
+          id: "greet",
+          title: "Greet",
+          description: "",
+          category: "Demo",
+          kind: "command",
+          danger: "safe",
+        },
+      },
+    });
+    const wrapper = host.registerAction.mock.calls[0][1] as (a: unknown) => Promise<unknown>;
+    const pending = wrapper({});
+    pending.catch(() => {});
+
+    workerHost.emit("reloading");
+    expect(clear).toHaveBeenCalled();
+    await expect(pending).rejects.toThrow(/reloaded/);
+  });
+});

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -1,0 +1,416 @@
+// Worker-side `PluginHostApi` implementation for the dev hot-reload worker
+// (#9304). Plugin code running in the `utilityProcess.fork` child receives this
+// proxy as its `host`. Every call is relayed over the parent MessagePort to
+// `PluginDevWorkerMainBridge`, which forwards to the real host. Handlers the
+// plugin registers (actions, IPC) stay HERE in the worker — main invokes them
+// back over the port — so a reload (whole-worker respawn) discards them cleanly
+// and there is no ESM module-cache leak (Vite #14438).
+//
+// Fidelity note: the real in-process host throws synchronously from
+// `registerAction`/`registerHandler` during `activate()`. Over IPC, deep
+// validation happens in main *after* the proxy call returns, so the proxy
+// re-runs the host's structural checks locally (object/function/id shape) to
+// preserve synchronous authoring feedback; deeper rejections (id format,
+// capability gate) arrive asynchronously as a `register-error` and are logged
+// loudly rather than thrown.
+
+import type {
+  ActionHandler,
+  PluginChannelSchema,
+  PluginHostApi,
+  PluginIpcContext,
+  PluginIpcHandler,
+  PluginSettingsScope,
+  PluginToastOptions,
+  PluginTypedIpcHandler,
+  PluginWorktreeSnapshot,
+} from "../../../shared/types/plugin.js";
+import type {
+  FileDecorationProviderDescriptor,
+  FileDecorationProviderImpl,
+  ForgeProviderDescriptor,
+  ForgeProviderImpl,
+} from "../../../shared/types/forge.js";
+import type { ActionDispatchResult } from "../../../shared/types/actions.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import type {
+  PluginHostCallMethod,
+  PluginHostNotifyMethod,
+  PluginHostToWorkerMessage,
+  PluginWorkerToHostMessage,
+} from "../../../shared/types/pluginDevWorker.js";
+
+type Post = (message: PluginWorkerToHostMessage) => void;
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+}
+
+interface RegisteredHandler {
+  handler: PluginIpcHandler | PluginTypedIpcHandler<unknown, unknown>;
+  schema?: PluginChannelSchema<unknown, unknown>;
+}
+
+export class PluginDevWorkerHostProxy {
+  readonly host: PluginHostApi;
+  private readonly post: Post;
+  private readonly pluginId: string;
+
+  private nextId = 1;
+  private revoked = false;
+  private disposed = false;
+
+  private readonly pendingCalls = new Map<string, PendingCall>();
+  private readonly actionHandlers = new Map<string, ActionHandler>();
+  private readonly ipcHandlers = new Map<string, RegisteredHandler>();
+  private readonly subscriptions = new Map<string, (payload: unknown) => void>();
+
+  constructor(pluginId: string, post: Post) {
+    this.pluginId = pluginId;
+    this.post = post;
+    this.host = this.buildHost();
+  }
+
+  /** Revoke the host registration surface once `activate()` resolves/times out,
+   * mirroring the real host's revoke semantics. */
+  revoke(): void {
+    this.revoked = true;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    for (const pending of this.pendingCalls.values()) {
+      pending.reject(new Error("Plugin dev worker disposed"));
+    }
+    this.pendingCalls.clear();
+    this.actionHandlers.clear();
+    this.ipcHandlers.clear();
+    this.subscriptions.clear();
+  }
+
+  /** Route a message received from main. Returns true if it was consumed. */
+  handleMessage(msg: PluginHostToWorkerMessage): boolean {
+    switch (msg.type) {
+      case "host-result": {
+        const pending = this.pendingCalls.get(msg.requestId);
+        if (!pending) return true;
+        this.pendingCalls.delete(msg.requestId);
+        if (msg.ok) pending.resolve(msg.result);
+        else pending.reject(new Error(msg.error));
+        return true;
+      }
+      case "invoke":
+        void this.handleInvoke(msg);
+        return true;
+      case "subscription-event": {
+        const cb = this.subscriptions.get(msg.subscriptionId);
+        if (cb) {
+          try {
+            cb(msg.payload);
+          } catch (err) {
+            console.error(`[plugin-dev:${this.pluginId}] subscription callback threw:`, err);
+          }
+        }
+        return true;
+      }
+      case "register-error":
+        console.error(
+          `[plugin-dev:${this.pluginId}] registration "${msg.registrationKey}" rejected by host: ${msg.error}`
+        );
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private async handleInvoke(
+    msg: Extract<PluginHostToWorkerMessage, { type: "invoke" }>
+  ): Promise<void> {
+    try {
+      if (msg.kind === "action") {
+        const handler = this.actionHandlers.get(msg.namespacedId);
+        if (!handler) {
+          throw new Error(`No action handler registered for "${msg.namespacedId}"`);
+        }
+        const result = await handler(msg.args);
+        this.post({ type: "invoke-result", requestId: msg.requestId, ok: true, result });
+        return;
+      }
+      // kind === "handler"
+      const entry = this.ipcHandlers.get(msg.channel);
+      if (!entry) {
+        throw new Error(`No handler registered for channel "${msg.channel}"`);
+      }
+      const result = await this.invokeIpcHandler(entry, msg.ctx, msg.args);
+      this.post({ type: "invoke-result", requestId: msg.requestId, ok: true, result });
+    } catch (err) {
+      this.post({
+        type: "invoke-result",
+        requestId: msg.requestId,
+        ok: false,
+        error: formatErrorMessage(err, "invocation failed"),
+      });
+    }
+  }
+
+  private async invokeIpcHandler(
+    entry: RegisteredHandler,
+    ctx: PluginIpcContext,
+    args: unknown[]
+  ): Promise<unknown> {
+    if (entry.schema) {
+      // Typed overload: validate the single args payload, invoke, validate result.
+      const parsedArgs = entry.schema.args.safeParse(args[0]);
+      if (!parsedArgs.success) {
+        throw new Error(`SCHEMA_ERROR: ${formatZodIssues(parsedArgs.error)}`);
+      }
+      const typed = entry.handler as PluginTypedIpcHandler<unknown, unknown>;
+      const result = await typed(ctx, parsedArgs.data);
+      const parsedResult = entry.schema.result.safeParse(result);
+      if (!parsedResult.success) {
+        throw new Error(`SCHEMA_ERROR: ${formatZodIssues(parsedResult.error)}`);
+      }
+      return parsedResult.data;
+    }
+    const legacy = entry.handler as PluginIpcHandler;
+    return legacy(ctx, ...args);
+  }
+
+  private call<T>(method: PluginHostCallMethod, params: unknown): Promise<T> {
+    if (this.disposed) {
+      return Promise.reject(new Error("Plugin dev worker disposed"));
+    }
+    const requestId = `c${this.nextId++}`;
+    return new Promise<T>((resolve, reject) => {
+      this.pendingCalls.set(requestId, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      this.post({ type: "host-call", requestId, method, params });
+    });
+  }
+
+  private notify(method: PluginHostNotifyMethod, params: unknown, registrationKey?: string): void {
+    if (this.disposed) return;
+    this.post({ type: "host-notify", method, params, registrationKey });
+  }
+
+  private assertActivationOpen(name: string): void {
+    if (this.revoked) {
+      throw new Error(
+        `Plugin "${this.pluginId}" host revoked: ${name} called after activate() returned or timed out`
+      );
+    }
+  }
+
+  private buildHost(): PluginHostApi {
+    // Captured for the `pluginId` getter, whose own `this` would be the host
+    // object literal, not this class instance. Every other member is an arrow
+    // function that closes over the class `this` lexically.
+    const pluginId = this.pluginId;
+    const host: PluginHostApi = {
+      get pluginId() {
+        return pluginId;
+      },
+      registerAction: (descriptor, handler) => {
+        this.assertActivationOpen("registerAction");
+        if (!descriptor || typeof descriptor !== "object") {
+          throw new Error(`Plugin "${this.pluginId}" registerAction: descriptor must be an object`);
+        }
+        if (typeof handler !== "function") {
+          throw new Error(`Plugin "${this.pluginId}" registerAction: handler must be a function`);
+        }
+        if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+          throw new Error(
+            `Plugin "${this.pluginId}" registerAction: descriptor.id must be a non-empty string`
+          );
+        }
+        if (descriptor.id.startsWith(`${this.pluginId}.`)) {
+          throw new Error(
+            `Plugin "${this.pluginId}" registerAction: descriptor.id "${descriptor.id}" must not include the plugin prefix — Daintree adds it`
+          );
+        }
+        const namespacedId = `${this.pluginId}.${descriptor.id}`;
+        // Replace semantics mirror the real host: re-registering the same id
+        // overwrites the prior handler.
+        this.actionHandlers.set(namespacedId, handler);
+        this.notify(
+          "registerAction",
+          {
+            descriptor: {
+              id: descriptor.id,
+              title: descriptor.title,
+              description: descriptor.description,
+              category: descriptor.category,
+              kind: descriptor.kind,
+              danger: descriptor.danger,
+              keywords: descriptor.keywords,
+              inputSchema: descriptor.inputSchema,
+            },
+          },
+          `action:${namespacedId}`
+        );
+      },
+      registerHandler: ((
+        channel: string,
+        schemaOrHandler:
+          | PluginChannelSchema<unknown, unknown>
+          | PluginIpcHandler
+          | PluginTypedIpcHandler<unknown, unknown>,
+        typedHandler?: PluginTypedIpcHandler<unknown, unknown>
+      ) => {
+        this.assertActivationOpen("registerHandler");
+        if (typeof channel !== "string" || channel.length === 0) {
+          throw new Error(`Plugin "${this.pluginId}" registerHandler: channel must be a string`);
+        }
+        if (typedHandler !== undefined) {
+          if (!isChannelSchema(schemaOrHandler)) {
+            throw new Error(
+              `Plugin "${this.pluginId}" registerHandler: second argument must be a channel schema { args, result } when a typed handler is provided`
+            );
+          }
+          const schema = schemaOrHandler;
+          this.ipcHandlers.set(channel, { handler: typedHandler, schema });
+          this.notify(
+            "registerHandler",
+            {
+              channel,
+              hasSchema: true,
+              requires: schema.requires ? [...schema.requires] : undefined,
+            },
+            `handler:${channel}`
+          );
+        } else {
+          if (typeof schemaOrHandler !== "function") {
+            throw new Error(
+              `Plugin "${this.pluginId}" registerHandler: handler must be a function`
+            );
+          }
+          this.ipcHandlers.set(channel, { handler: schemaOrHandler as PluginIpcHandler });
+          this.notify("registerHandler", { channel, hasSchema: false }, `handler:${channel}`);
+        }
+      }) as PluginHostApi["registerHandler"],
+      broadcastToRenderer: (channel, payload) => {
+        this.assertActivationOpen("broadcastToRenderer");
+        if (typeof channel !== "string" || channel.includes(":")) {
+          throw new Error(
+            `Plugin broadcast channel must be a string without colons: ${String(channel)}`
+          );
+        }
+        this.notify("broadcastToRenderer", { channel, payload });
+      },
+      getActiveWorktree: () =>
+        this.call<PluginWorktreeSnapshot | null>("getActiveWorktree", undefined),
+      getWorktrees: () => this.call<PluginWorktreeSnapshot[]>("getWorktrees", undefined),
+      onDidChangeActiveWorktree: (callback) => {
+        this.assertActivationOpen("onDidChangeActiveWorktree");
+        return this.subscribe("active-worktree", (payload) =>
+          callback(payload as PluginWorktreeSnapshot | null)
+        );
+      },
+      onDidChangeWorktrees: (callback) => {
+        this.assertActivationOpen("onDidChangeWorktrees");
+        return this.subscribe("worktrees", (payload) =>
+          callback(payload as PluginWorktreeSnapshot[])
+        );
+      },
+      registerForgeProvider: (descriptor: ForgeProviderDescriptor, _impl: ForgeProviderImpl) => {
+        // Forge providers require bidirectional impl proxying (callbacks the host
+        // invokes per PR/CI/rate-limit query) not yet supported in dev mode.
+        console.warn(
+          `[plugin-dev:${this.pluginId}] registerForgeProvider("${descriptor?.id}") is not supported in dev mode — package + install the plugin to test forge providers`
+        );
+        return () => {};
+      },
+      registerFileDecorationProvider: (
+        descriptor: FileDecorationProviderDescriptor,
+        _impl: FileDecorationProviderImpl
+      ) => {
+        console.warn(
+          `[plugin-dev:${this.pluginId}] registerFileDecorationProvider("${descriptor?.id}") is not supported in dev mode — package + install the plugin to test decoration providers`
+        );
+        return () => {};
+      },
+      invalidateFileDecorations: (scope, paths) => {
+        if (typeof scope !== "string" || scope.length === 0) {
+          throw new Error(
+            `Plugin "${this.pluginId}" invalidateFileDecorations: scope must be a non-empty string`
+          );
+        }
+        this.notify("invalidateFileDecorations", { scope, paths });
+      },
+      showToast: (options: PluginToastOptions) =>
+        this.call<void>("showToast", {
+          message: options?.message,
+          type: options?.type,
+          durationMs: options?.durationMs,
+        }),
+      dispatch: (actionId, args) => this.call<ActionDispatchResult>("dispatch", { actionId, args }),
+      logger: {
+        info: (message, fields) => this.notify("logger.info", { message, fields }),
+        warn: (message, fields) => this.notify("logger.warn", { message, fields }),
+        error: (message, fields) => this.notify("logger.error", { message, fields }),
+      },
+      settings: {
+        get: <T = unknown>(key: string, scope: PluginSettingsScope = "user") =>
+          this.call<T | undefined>("settings.get", { key, scope }),
+        set: <T = unknown>(key: string, value: T, scope: PluginSettingsScope = "user") =>
+          this.call<void>("settings.set", { key, value, scope }),
+        onDidChange: <T = unknown>(
+          key: string,
+          callback: (value: T | undefined) => void,
+          scope: PluginSettingsScope = "user"
+        ) => {
+          this.assertActivationOpen("settings.onDidChange");
+          return this.subscribe(
+            "settings",
+            (payload) => callback(payload as T | undefined),
+            key,
+            scope
+          );
+        },
+      },
+    };
+    return host;
+  }
+
+  private subscribe(
+    kind: "active-worktree" | "worktrees" | "settings",
+    callback: (payload: unknown) => void,
+    key?: string,
+    scope?: PluginSettingsScope
+  ): () => void {
+    const subscriptionId = `s${this.nextId++}`;
+    this.subscriptions.set(subscriptionId, callback);
+    this.post({ type: "subscribe", subscriptionId, kind, key, scope });
+    let disposed = false;
+    return () => {
+      if (disposed) return;
+      disposed = true;
+      this.subscriptions.delete(subscriptionId);
+      this.post({ type: "unsubscribe", subscriptionId });
+    };
+  }
+}
+
+/** Structural guard mirroring `isChannelSchema` from PluginChannelRegistry,
+ * duplicated worker-side to avoid pulling main-process deps into the worker. */
+function isChannelSchema(value: unknown): value is PluginChannelSchema<unknown, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "args" in value &&
+    "result" in value &&
+    typeof (value as { args?: unknown }).args === "object" &&
+    typeof (value as { result?: unknown }).result === "object"
+  );
+}
+
+function formatZodIssues(error: {
+  issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey>; message: string }>;
+}): string {
+  return error.issues
+    .map((i) => `${i.path.map(String).join(".") || "(root)"}: ${i.message}`)
+    .join("; ");
+}

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -397,13 +397,18 @@ export class PluginDevWorkerHostProxy {
 /** Structural guard mirroring `isChannelSchema` from PluginChannelRegistry,
  * duplicated worker-side to avoid pulling main-process deps into the worker. */
 function isChannelSchema(value: unknown): value is PluginChannelSchema<unknown, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as { args?: { safeParse?: unknown }; result?: { safeParse?: unknown } };
+  // Require `safeParse` on both sides so a plain `{ args: {}, result: {} }`
+  // object is rejected at registration with a clear error instead of throwing an
+  // opaque "safeParse is not a function" TypeError at the first dispatch.
   return (
-    typeof value === "object" &&
-    value !== null &&
-    "args" in value &&
-    "result" in value &&
-    typeof (value as { args?: unknown }).args === "object" &&
-    typeof (value as { result?: unknown }).result === "object"
+    typeof v.args === "object" &&
+    v.args !== null &&
+    typeof v.args.safeParse === "function" &&
+    typeof v.result === "object" &&
+    v.result !== null &&
+    typeof v.result.safeParse === "function"
   );
 }
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -14,6 +14,8 @@ const config: KnipConfig = {
     "electron/workspace-host-bootstrap.ts",
     "electron/watchdog-host.ts",
     "electron/watchdog-host-bootstrap.ts",
+    "electron/plugin-dev-worker.ts",
+    "electron/plugin-dev-worker-bootstrap.ts",
     "electron/preload.cts",
     "electron/services/voice/openaiVadWorker.ts",
 

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -191,6 +191,10 @@ async function run() {
       "electron/workspace-host-bootstrap.ts",
       "electron/watchdog-host.ts",
       "electron/watchdog-host-bootstrap.ts",
+      // Plugin dev-mode hot-reload worker (#9304): runs a dev-symlinked plugin's
+      // code in a utilityProcess.fork child and respawns on each Vite rebuild.
+      "electron/plugin-dev-worker.ts",
+      "electron/plugin-dev-worker-bootstrap.ts",
       // VAD side-chain worker for OpenAI transcription (#9177). Loaded via
       // `new Worker()` from OpenAITranscriptionProvider; needs its own entry so
       // esbuild emits a standalone bundle at the resolved worker path.

--- a/scripts/ci/check-crash-loop-constants.mjs
+++ b/scripts/ci/check-crash-loop-constants.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-// Asserts the crash-loop constants stay equal across the three guards:
+// Asserts the crash-loop constants stay equal across the four guards:
 // `electron/services/pty/PtyHostLifecycle.ts`,
-// `electron/services/WorkspaceHostProcess.ts`, and
-// `electron/services/CrashLoopGuardService.ts`.
+// `electron/services/WorkspaceHostProcess.ts`,
+// `electron/services/CrashLoopGuardService.ts`, and
+// `electron/services/plugin/PluginDevWorkerHost.ts`.
 //
 // The constants are deliberately duplicated, not imported — the guards
 // operate at independent layers (disk-persisted app-level vs. in-memory
@@ -23,6 +24,7 @@ const FILES = [
   path.join(root, "electron/services/pty/PtyHostLifecycle.ts"),
   path.join(root, "electron/services/WorkspaceHostProcess.ts"),
   path.join(root, "electron/services/CrashLoopGuardService.ts"),
+  path.join(root, "electron/services/plugin/PluginDevWorkerHost.ts"),
 ];
 
 const CONSTANTS = ["CRASH_THRESHOLD", "CRASH_WINDOW_MS"];

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -1,0 +1,199 @@
+// IPC protocol for the plugin dev-mode hot-reload worker (#9304).
+//
+// A dev-symlinked plugin (one carrying a `.dev-marker` file, written by
+// `daintree-plugin dev`) runs its code inside a `utilityProcess.fork` child
+// instead of the in-process `import()` loader. This avoids the Node ESM
+// module-cache leak (Vite issue #14438) — cache-busting query params leave
+// module-scope state behind, so the only robust reload is to kill the whole
+// worker and fork a fresh one on every `dist/index.js` rebuild.
+//
+// The worker can't hold the real `PluginHostApi` (the host's closures, Zod
+// schemas, and service references all live in the main process), so the worker
+// constructs a *proxy* host whose every call is relayed over the MessagePort to
+// `PluginDevWorkerMainBridge`, which forwards to the real host returned by
+// `PluginService.createHost`. Handlers the plugin registers (action handlers,
+// IPC handlers) stay in the worker; main invokes them back over the same port.
+//
+// Every message is structured-clone-safe: no functions, no Zod instances, no
+// class instances. Requests that expect a reply carry a `requestId`.
+
+import type { PluginIpcContext, PluginSettingsScope } from "./plugin.js";
+
+/** Async host methods the worker proxy relays to main and awaits a reply for. */
+export type PluginHostCallMethod =
+  | "getActiveWorktree"
+  | "getWorktrees"
+  | "showToast"
+  | "dispatch"
+  | "settings.get"
+  | "settings.set";
+
+/** Fire-and-forget host methods (no reply needed). */
+export type PluginHostNotifyMethod =
+  | "registerAction"
+  | "registerHandler"
+  | "broadcastToRenderer"
+  | "invalidateFileDecorations"
+  | "logger.info"
+  | "logger.warn"
+  | "logger.error";
+
+/** Event subscriptions the worker proxy can open against the host. */
+export type PluginWorkerSubscriptionKind = "active-worktree" | "worktrees" | "settings";
+
+/** Callback kinds main invokes back in the worker. */
+export type PluginWorkerInvokeKind = "action" | "handler";
+
+/** Messages sent main → worker. */
+export type PluginHostToWorkerMessage =
+  /** Kick off: import the plugin bundle at `bundleUrl` and call `activate(proxy)`. */
+  | { type: "start"; bundleUrl: string; pluginId: string }
+  /** Graceful shutdown request — worker runs the plugin's cleanup then exits. */
+  | { type: "dispose" }
+  /** Reply to a worker `host-call`. */
+  | { type: "host-result"; requestId: string; ok: true; result: unknown }
+  | { type: "host-result"; requestId: string; ok: false; error: string }
+  /**
+   * Invoke a worker-held callback (action or IPC handler) and await its result
+   * via a matching `invoke-result` from the worker.
+   */
+  | {
+      type: "invoke";
+      requestId: string;
+      kind: "action";
+      namespacedId: string;
+      args: unknown;
+    }
+  | {
+      type: "invoke";
+      requestId: string;
+      kind: "handler";
+      channel: string;
+      ctx: PluginIpcContext;
+      args: unknown[];
+    }
+  /** Deliver a subscription event to a worker-held callback (fire-and-forget). */
+  | { type: "subscription-event"; subscriptionId: string; payload: unknown }
+  /**
+   * Async outcome of a fire-and-forget registration (`registerAction` /
+   * `registerHandler`). Lets the worker surface a registration that the real
+   * host rejected — the proxy call already returned synchronously, so this is
+   * the only channel for a deep-validation failure.
+   */
+  | { type: "register-error"; registrationKey: string; error: string };
+
+/** Messages sent worker → main. */
+export type PluginWorkerToHostMessage =
+  /** Worker booted, parent-port listener attached, ready for `start`. */
+  | { type: "ready" }
+  /** `activate(proxy)` resolved. `hasCleanup` records whether it returned a disposer. */
+  | { type: "activated"; hasCleanup: boolean }
+  /** `activate(proxy)` threw or rejected. */
+  | { type: "activate-error"; error: string; stack?: string }
+  /** Bootstrap / uncaught error before or after activation. */
+  | { type: "error"; error: string }
+  /** Async host method call expecting a `host-result`. */
+  | {
+      type: "host-call";
+      requestId: string;
+      method: PluginHostCallMethod;
+      params: unknown;
+    }
+  /** Fire-and-forget host method call. `registrationKey` correlates `register-error`. */
+  | {
+      type: "host-notify";
+      method: PluginHostNotifyMethod;
+      params: unknown;
+      registrationKey?: string;
+    }
+  /** Open an event subscription against the host. */
+  | {
+      type: "subscribe";
+      subscriptionId: string;
+      kind: PluginWorkerSubscriptionKind;
+      key?: string;
+      scope?: PluginSettingsScope;
+    }
+  /** Close a previously opened subscription. */
+  | { type: "unsubscribe"; subscriptionId: string }
+  /** Reply to a main `invoke`. */
+  | { type: "invoke-result"; requestId: string; ok: true; result: unknown }
+  | { type: "invoke-result"; requestId: string; ok: false; error: string };
+
+/** Params for `registerAction` (`host-notify`). Mirrors `PluginActionContribution`. */
+export interface RegisterActionParams {
+  descriptor: {
+    id: string;
+    title: string;
+    description: string;
+    category: string;
+    kind: "command" | "query";
+    danger: "safe" | "confirm";
+    keywords?: string[];
+    inputSchema?: Record<string, unknown>;
+  };
+}
+
+/**
+ * Params for `registerHandler` (`host-notify`). The Zod schema can't cross the
+ * port, so only the declared `requires` capabilities travel — the bridge
+ * registers an untyped wrapper and the worker keeps the schema for local
+ * `safeParse` validation. `hasSchema` distinguishes the typed overload (so the
+ * bridge can fail-closed on the capability gate) from the legacy untyped one.
+ */
+export interface RegisterHandlerParams {
+  channel: string;
+  hasSchema: boolean;
+  requires?: string[];
+}
+
+/** Params for `broadcastToRenderer` (`host-notify`). */
+export interface BroadcastToRendererParams {
+  channel: string;
+  payload: unknown;
+}
+
+/** Params for `invalidateFileDecorations` (`host-notify`). */
+export interface InvalidateFileDecorationsParams {
+  scope: string;
+  paths?: string[];
+}
+
+/** Params for a `logger.*` call (`host-notify`). */
+export interface LoggerParams {
+  message: string;
+  fields?: Record<string, unknown>;
+}
+
+/** Params for `settings.get` (`host-call`). */
+export interface SettingsGetParams {
+  key: string;
+  scope: PluginSettingsScope;
+}
+
+/** Params for `settings.set` (`host-call`). */
+export interface SettingsSetParams {
+  key: string;
+  value: unknown;
+  scope: PluginSettingsScope;
+}
+
+/** Params for `showToast` (`host-call`). */
+export interface ShowToastParams {
+  message: string;
+  type?: string;
+  durationMs?: number;
+}
+
+/** Params for `dispatch` (`host-call`). */
+export interface DispatchParams {
+  actionId: string;
+  args?: unknown;
+}
+
+/**
+ * Env var name set on the forked worker so the worker module can assert it is
+ * running in the intended utility-process kind (mirrors the
+ * `DAINTREE_UTILITY_PROCESS_KIND` convention used by the other hosts).
+ */
+export const PLUGIN_DEV_WORKER_KIND = "plugin-dev-worker";


### PR DESCRIPTION
## Summary

- Dev-symlinked plugins (carrying a `.dev-marker` file written by `daintree-plugin dev`) now run inside a `utilityProcess.fork` worker and hot-reload on every `dist/index.js` rebuild. This avoids the Node ESM module-cache leak ([Vite #14438](https://github.com/vitejs/vite/issues/14438)) that makes naive unimport+re-import loops accumulate stale module-scope state.
- Built-in plugins can now be enabled and disabled at runtime without an app restart. `setEnabled()` is async: for built-ins it unloads or re-registers+activates live; user plugins remain persist-only (restart required, since their on-disk code can change between toggles and there's no ESM cache eviction API).

Resolves #9304

## Changes

**Dev hot-reload (original scope)**

- `PluginDevWorkerHost` — fork/crash-guard/mtime-watch/respawn lifecycle, modelled on `WorkspaceHostProcess`. `reload()` clears the crash window so deliberate restarts never trip the cap.
- `pluginDevWorkerHostProxy` — relays every `PluginHostApi` call over `MessagePort` from the worker side.
- `PluginDevWorkerMainBridge` — routes those calls to the real host from `PluginService.createHost`; thin wrappers invoke plugin handlers back in the worker.
- Worker bootstrap installs an `unhandledRejection`/`uncaughtException` guard (Electron 42 swallows these in utility processes) so plugin errors trigger a reload rather than silent corruption.
- `forge-provider` and `file-decoration-provider` are stubbed in dev mode (log + no-op disposer) — bidirectional proxy is deferred.
- Crash-loop guard constants added to the alignment test and `check-crash-loop-constants` (now four guards).
- `shared/types/pluginDevWorker.ts` defines the `MessagePort` protocol between worker and main.

**Built-in live enable/disable (new scope)**

- `setEnabled()` is now async; `handleSetEnabled` in the IPC handler awaits it.
- Per-id transitions are serialised via an `enableTransitions` chain so rapid disable→enable→disable sequences can't interleave the `plugins`/`disabledPlugins`/`reservedNames` mutations.
- Re-enable path keeps the `disabledPlugins` entry in place across the async load, releasing only the name reservation up front — prevents a concurrent `setEnabled` from slipping past the `isBuiltin` check into the persist-only path mid-flight.
- `loadPlugin()` call is wrapped in try/catch so a throwing manifest (e.g. malformed `when` expression) restores the reservation instead of stranding the plugin in neither map.
- `pendingRestart` naturally computes false for built-ins once runtime state matches desired state; `broadcastProvenanceChanged()` clears the banner.

## Testing

19 new unit tests for `PluginDevWorkerHost` and `PluginDevWorkerMainBridge`, plus an expanded `PluginService.test.ts` covering: marker → `devMode`, routes to worker, no-marker → in-process, unload disposes, manifest commands survive reload, per-reload activation reporting, built-in live disable/re-enable/rapid-flap, user-plugin pending-restart path, failed re-enable restores skipped row, unknown id treated as user plugin. Local CI (`npm run check` + build) green. Full end-to-end reload against a live Vite rebuild isn't CI-exercisable, consistent with `WorkspaceHostProcess` whose E2E is nightly-only.