### PR TITLE
feat(plugins): make the GitHub plugin authoritative — disabling it actually removes GitHub

### DIFF
--- a/electron/ipc/handlers/__tests__/github.providerGate.test.ts
+++ b/electron/ipc/handlers/__tests__/github.providerGate.test.ts
@@ -20,6 +20,7 @@ const gitHubServiceMock = vi.hoisted(() => ({
     .fn()
     .mockResolvedValue({ valid: true, scopes: [], username: "user", avatarUrl: null }),
   clearTokenAndSync: vi.fn().mockResolvedValue(undefined),
+  getGitHubConfig: vi.fn().mockReturnValue({ hasToken: true }),
   getGitHubConfigAsync: vi.fn().mockResolvedValue({ hasToken: true }),
   hasGitHubToken: vi.fn().mockReturnValue(true),
   listGitHubRemotes: vi.fn().mockResolvedValue([]),
@@ -60,6 +61,7 @@ vi.mock("../../../services/github/index.js", () => ({
   listPullRequests: gitHubServiceMock.listPullRequests,
   unassignIssue: gitHubServiceMock.unassignIssue,
   getRepoStatsComplete: gitHubServiceMock.getRepoStatsComplete,
+  getGitHubConfig: gitHubServiceMock.getGitHubConfig,
   getGitHubConfigAsync: gitHubServiceMock.getGitHubConfigAsync,
   hasGitHubToken: gitHubServiceMock.hasGitHubToken,
   listGitHubRemotes: gitHubServiceMock.listGitHubRemotes,
@@ -147,7 +149,10 @@ describe("github handlers — provider gate (plugin authoritative)", () => {
 
     it("keeps token-state reads live: github:get-config and github:clear-token", async () => {
       await getInvokeHandler(CHANNELS.GITHUB_GET_CONFIG)({} as never);
-      expect(gitHubServiceMock.getGitHubConfigAsync).toHaveBeenCalled();
+      // While disabled, config answers from local token state — the async
+      // variant lazily validates against /user, which is GitHub network.
+      expect(gitHubServiceMock.getGitHubConfig).toHaveBeenCalled();
+      expect(gitHubServiceMock.getGitHubConfigAsync).not.toHaveBeenCalled();
 
       await getInvokeHandler(CHANNELS.GITHUB_CLEAR_TOKEN)({} as never);
       expect(gitHubServiceMock.clearTokenAndSync).toHaveBeenCalled();

--- a/electron/ipc/handlers/__tests__/github.providerGate.test.ts
+++ b/electron/ipc/handlers/__tests__/github.providerGate.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const shellMock = vi.hoisted(() => ({
+  openExternal: vi.fn().mockResolvedValue(undefined),
+}));
+
+const gitHubServiceMock = vi.hoisted(() => ({
+  listIssues: vi.fn().mockResolvedValue({ issues: [], nextCursor: null }),
+  listPullRequests: vi.fn().mockResolvedValue({ prs: [], nextCursor: null }),
+  unassignIssue: vi.fn().mockResolvedValue(undefined),
+  getRepoStatsComplete: vi.fn().mockResolvedValue({
+    stats: { commitCount: 0, issueCount: null, prCount: null, loading: false },
+  }),
+  setTokenAndSync: vi
+    .fn()
+    .mockResolvedValue({ valid: true, scopes: [], username: "user", avatarUrl: null }),
+  clearTokenAndSync: vi.fn().mockResolvedValue(undefined),
+  getGitHubConfigAsync: vi.fn().mockResolvedValue({ hasToken: true }),
+  hasGitHubToken: vi.fn().mockReturnValue(true),
+  listGitHubRemotes: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("electron", () => ({
+  ipcMain: ipcMainMock,
+  shell: shellMock,
+  BrowserWindow: {
+    fromWebContents: vi.fn().mockReturnValue(null),
+  },
+}));
+
+vi.mock("../../utils.js", () => ({
+  checkRateLimit: vi.fn(),
+  broadcastToRenderer: vi.fn(),
+  typedHandle: (channel: string, handler: unknown) => {
+    ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
+      (handler as (...a: unknown[]) => unknown)(...args)
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
+}));
+
+vi.mock("../../../services/github/index.js", () => ({
+  gitHubRateLimitService: {
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+  },
+  gitHubTokenHealthService: {
+    onStateChange: vi.fn().mockReturnValue(() => {}),
+    getState: vi.fn().mockReturnValue({ status: "unknown", tokenVersion: -1, checkedAt: 0 }),
+  },
+  fetchRateLimitDetails: vi.fn().mockResolvedValue(null),
+  resolveAuthorAvatar: vi.fn().mockResolvedValue(null),
+  setTokenAndSync: gitHubServiceMock.setTokenAndSync,
+  clearTokenAndSync: gitHubServiceMock.clearTokenAndSync,
+  listIssues: gitHubServiceMock.listIssues,
+  listPullRequests: gitHubServiceMock.listPullRequests,
+  unassignIssue: gitHubServiceMock.unassignIssue,
+  getRepoStatsComplete: gitHubServiceMock.getRepoStatsComplete,
+  getGitHubConfigAsync: gitHubServiceMock.getGitHubConfigAsync,
+  hasGitHubToken: gitHubServiceMock.hasGitHubToken,
+  listGitHubRemotes: gitHubServiceMock.listGitHubRemotes,
+}));
+
+import { CHANNELS } from "../../channels.js";
+import { registerGithubHandlers, githubUnassignIssueNamespace } from "../github.js";
+import {
+  registerForgeProviderImpl,
+  unregisterForgeProviderImpls,
+} from "../../../services/forgeProviderRegistry.js";
+import type { ForgeProviderImpl } from "../../../../shared/types/forge.js";
+
+function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const call = (ipcMainMock.handle as Mock).mock.calls.find(
+    ([registered]) => registered === channel
+  );
+  if (!call) {
+    throw new Error(`No handler registered for channel: ${channel}`);
+  }
+  return call[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+function activateGitHubProvider(): void {
+  registerForgeProviderImpl("daintree.github", "github", {} as ForgeProviderImpl);
+}
+
+describe("github handlers — provider gate (plugin authoritative)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unregisterForgeProviderImpls("daintree.github");
+    registerGithubHandlers({} as never);
+  });
+
+  afterEach(() => {
+    unregisterForgeProviderImpls("daintree.github");
+  });
+
+  describe("with the GitHub plugin disabled (no provider impl registered)", () => {
+    it("rejects github:list-issues with FORGE_PROVIDER_UNAVAILABLE before reaching plugin code", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_LIST_ISSUES);
+
+      await expect(handler({} as never, { cwd: "/tmp/project" })).rejects.toHaveProperty(
+        "code",
+        "FORGE_PROVIDER_UNAVAILABLE"
+      );
+      expect(gitHubServiceMock.listIssues).not.toHaveBeenCalled();
+    });
+
+    it("rejects github:get-repo-stats without invoking the plugin fetch", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_GET_REPO_STATS);
+
+      await expect(handler({} as never, "/tmp/project")).rejects.toHaveProperty(
+        "code",
+        "FORGE_PROVIDER_UNAVAILABLE"
+      );
+      expect(gitHubServiceMock.getRepoStatsComplete).not.toHaveBeenCalled();
+    });
+
+    it("rejects github:set-token (network validation requires the provider)", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_SET_TOKEN);
+
+      await expect(handler({} as never, "ghp_token")).rejects.toHaveProperty(
+        "code",
+        "FORGE_PROVIDER_UNAVAILABLE"
+      );
+      expect(gitHubServiceMock.setTokenAndSync).not.toHaveBeenCalled();
+    });
+
+    it("rejects the namespace-registered github:unassign-issue", async () => {
+      const handler = githubUnassignIssueNamespace.ops.unassignIssue.handler;
+
+      await expect(
+        handler({ cwd: "/tmp/project", issueNumber: 1, username: "octocat" })
+      ).rejects.toHaveProperty("code", "FORGE_PROVIDER_UNAVAILABLE");
+      expect(gitHubServiceMock.unassignIssue).not.toHaveBeenCalled();
+    });
+
+    it("keeps purely-local handlers live: github:open-pr opens externally", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_OPEN_PR);
+
+      await handler({} as never, "https://github.com/owner/repo/pull/1");
+      expect(shellMock.openExternal).toHaveBeenCalled();
+    });
+
+    it("keeps token-state reads live: github:get-config and github:clear-token", async () => {
+      await getInvokeHandler(CHANNELS.GITHUB_GET_CONFIG)({} as never);
+      expect(gitHubServiceMock.getGitHubConfigAsync).toHaveBeenCalled();
+
+      await getInvokeHandler(CHANNELS.GITHUB_CLEAR_TOKEN)({} as never);
+      expect(gitHubServiceMock.clearTokenAndSync).toHaveBeenCalled();
+    });
+
+    it("keeps provider-agnostic project:list-remotes live", async () => {
+      await getInvokeHandler(CHANNELS.PROJECT_LIST_REMOTES)({} as never, "/tmp/project");
+      expect(gitHubServiceMock.listGitHubRemotes).toHaveBeenCalled();
+    });
+  });
+
+  describe("provider activation transitions (live toggle)", () => {
+    it("serves data once the impl registers, and rejects again after it unregisters", async () => {
+      const handler = getInvokeHandler(CHANNELS.GITHUB_LIST_ISSUES);
+
+      activateGitHubProvider();
+      await handler({} as never, { cwd: "/tmp/project" });
+      expect(gitHubServiceMock.listIssues).toHaveBeenCalledTimes(1);
+
+      unregisterForgeProviderImpls("daintree.github");
+      await expect(handler({} as never, { cwd: "/tmp/project" })).rejects.toHaveProperty(
+        "code",
+        "FORGE_PROVIDER_UNAVAILABLE"
+      );
+      expect(gitHubServiceMock.listIssues).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 const ipcMainMock = vi.hoisted(() => ({
   handle: vi.fn(),
@@ -154,6 +154,11 @@ vi.mock("../../../utils/git.js", () => ({
 
 import { CHANNELS } from "../../channels.js";
 import { registerGithubHandlers } from "../github.js";
+import {
+  registerForgeProviderImpl,
+  unregisterForgeProviderImpls,
+} from "../../../services/forgeProviderRegistry.js";
+import type { ForgeProviderImpl } from "../../../../shared/types/forge.js";
 
 function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
   const call = (ipcMainMock.handle as Mock).mock.calls.find(
@@ -176,7 +181,16 @@ describe("github handlers — rate limiting", () => {
       username: "user",
       avatarUrl: null,
     });
+    // Data/network handlers gate on the GitHub forge provider being active;
+    // this suite exercises rate limiting, so bind a stub impl in the real
+    // registry to satisfy the gate (gating itself is covered in
+    // github.providerGate.test.ts).
+    registerForgeProviderImpl("daintree.github", "github", {} as ForgeProviderImpl);
     registerGithubHandlers({} as never);
+  });
+
+  afterEach(() => {
+    unregisterForgeProviderImpls("daintree.github");
   });
 
   describe("rate-limit state relay to workspace hosts", () => {

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -120,6 +120,7 @@ vi.mock("../../../services/github/index.js", () => ({
   getPRsByNumbers: gitHubServiceMock.getPRsByNumbers,
   getPRReviewThreads: vi.fn().mockResolvedValue({}),
   hasGitHubToken: gitHubServiceMock.hasGitHubToken,
+  getGitHubConfig: vi.fn().mockReturnValue({ hasToken: true }),
   getGitHubConfigAsync: gitHubServiceMock.getGitHubConfigAsync,
   getProjectHealth: gitHubServiceMock.getProjectHealth,
   buildEmptyProjectHealthData: vi.fn().mockReturnValue({

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -27,7 +27,10 @@ import {
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
 import { toRateLimitInfo } from "../../../shared/utils/rateLimitUtils.js";
-import { assertGitHubProviderActive } from "../../services/github/availability.js";
+import {
+  assertGitHubProviderActive,
+  isGitHubProviderActive,
+} from "../../services/github/availability.js";
 
 // Relay the fetch-throttle multiplier into every workspace host so worktree
 // monitor polling backs off as the shared GraphQL budget depletes. The hosts
@@ -360,7 +363,15 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
   const handleGitHubGetConfig = async (): Promise<GitHubTokenConfig> => {
     checkRateLimit(CHANNELS.GITHUB_GET_CONFIG, 10, 10_000);
-    const { getGitHubConfigAsync } = await import("../../services/github/index.js");
+    const { getGitHubConfig, getGitHubConfigAsync } =
+      await import("../../services/github/index.js");
+    // getConfigAsync lazily validates against /user when a token exists but
+    // user info isn't cached — that's GitHub network. While the plugin is
+    // disabled, answer from local token state only (the channel stays
+    // ungated so Settings can still show token presence).
+    if (!isGitHubProviderActive()) {
+      return getGitHubConfig();
+    }
     return getGitHubConfigAsync();
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_CONFIG, handleGitHubGetConfig));

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -27,6 +27,7 @@ import {
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
 import { toRateLimitInfo } from "../../../shared/utils/rateLimitUtils.js";
+import { assertGitHubProviderActive } from "../../services/github/availability.js";
 
 // Relay the fetch-throttle multiplier into every workspace host so worktree
 // monitor polling backs off as the shared GraphQL budget depletes. The hosts
@@ -47,6 +48,9 @@ async function handleGitHubUnassignIssue(payload: {
   issueNumber: number;
   username: string;
 }): Promise<void> {
+  // Same gate as the `gated()` wrapper in registerGithubHandlers — this
+  // handler lives outside that scope because it registers via the namespace.
+  assertGitHubProviderActive();
   checkRateLimit(CHANNELS.GITHUB_UNASSIGN_ISSUE, 5, 10_000);
   if (!payload || typeof payload !== "object") {
     throw new Error("Invalid payload");
@@ -82,6 +86,19 @@ export const githubUnassignIssueNamespace = defineIpcNamespace({
 export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
+  // Gate a data/network handler on the GitHub plugin being active. Channels
+  // stay registered unconditionally (the renderer must be able to call and get
+  // a clean "disabled" rejection), but when the plugin is off these fail fast
+  // before reaching plugin code — making the toggle authoritative. Purely-local
+  // handlers (URL builders, token-state reads, provider-agnostic list-remotes)
+  // are intentionally left unwrapped.
+  const gated =
+    <A extends unknown[], R>(fn: (...args: A) => Promise<R>) =>
+    async (...args: A): Promise<R> => {
+      assertGitHubProviderActive();
+      return fn(...args);
+    };
+
   // Main-process transport: push rate-limit state changes to every renderer.
   // The provider-keyed forge channel is what `githubClient.onRateLimitChanged`
   // now subscribes to, so main-process-sourced GitHub blocks (REST 403/429,
@@ -114,14 +131,18 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     checkRateLimit(CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS, 30, 60_000);
     return fetchRateLimitDetails();
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS, handleGetRateLimitDetails));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS, gated(handleGetRateLimitDetails))
+  );
 
   const handleResolveAuthorAvatar = async (email: string): Promise<string | null> => {
     checkRateLimit(CHANNELS.GITHUB_RESOLVE_AUTHOR_AVATAR, 30, 60_000);
     if (typeof email !== "string" || !email.trim()) return null;
     return resolveAuthorAvatar(email.trim().toLowerCase());
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_RESOLVE_AUTHOR_AVATAR, handleResolveAuthorAvatar));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_RESOLVE_AUTHOR_AVATAR, gated(handleResolveAuthorAvatar))
+  );
 
   const handleGitHubGetRepoStats = async (
     cwd: string,
@@ -161,7 +182,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
     return result.stats;
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_REPO_STATS, handleGitHubGetRepoStats));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_REPO_STATS, gated(handleGitHubGetRepoStats)));
 
   const handleGitHubGetFirstPageCache = async (
     cwd: string
@@ -173,7 +194,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getFirstPageCache } = await import("../../services/github/index.js");
     return getFirstPageCache(cwd);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_FIRST_PAGE_CACHE, handleGitHubGetFirstPageCache));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_GET_FIRST_PAGE_CACHE, gated(handleGitHubGetFirstPageCache))
+  );
 
   const handleGitHubGetProjectHealth = async (
     cwd: string,
@@ -212,7 +235,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       return buildEmptyProjectHealthData({ error: message });
     }
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PROJECT_HEALTH, handleGitHubGetProjectHealth));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_GET_PROJECT_HEALTH, gated(handleGitHubGetProjectHealth))
+  );
 
   const handleGitHubOpenIssues = async (cwd: string, query?: string, state?: string) => {
     checkRateLimit(CHANNELS.GITHUB_OPEN_ISSUES, 20, 10_000);
@@ -347,7 +372,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     }
     return setTokenAndSync(token);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_SET_TOKEN, handleGitHubSetToken));
+  handlers.push(typedHandle(CHANNELS.GITHUB_SET_TOKEN, gated(handleGitHubSetToken)));
 
   const handleGitHubClearToken = async (): Promise<void> => {
     checkRateLimit(CHANNELS.GITHUB_CLEAR_TOKEN, 5, 10_000);
@@ -363,7 +388,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { validateGitHubToken } = await import("../../services/github/index.js");
     return validateGitHubToken(token.trim());
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_VALIDATE_TOKEN, handleGitHubValidateToken));
+  handlers.push(typedHandle(CHANNELS.GITHUB_VALIDATE_TOKEN, gated(handleGitHubValidateToken)));
 
   const handleGitHubListIssues = async (options: {
     cwd: string;
@@ -383,7 +408,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { listIssues } = await import("../../services/github/index.js");
     return listIssues(options);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_LIST_ISSUES, handleGitHubListIssues));
+  handlers.push(typedHandle(CHANNELS.GITHUB_LIST_ISSUES, gated(handleGitHubListIssues)));
 
   const handleGitHubListPRs = async (options: {
     cwd: string;
@@ -403,7 +428,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { listPullRequests } = await import("../../services/github/index.js");
     return listPullRequests(options);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_LIST_PRS, handleGitHubListPRs));
+  handlers.push(typedHandle(CHANNELS.GITHUB_LIST_PRS, gated(handleGitHubListPRs)));
 
   const handleGitHubAssignIssue = async (payload: {
     cwd: string;
@@ -434,7 +459,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { assignIssue } = await import("../../services/github/index.js");
     await assignIssue(payload.cwd.trim(), payload.issueNumber, trimmedUsername);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_ASSIGN_ISSUE, handleGitHubAssignIssue));
+  handlers.push(typedHandle(CHANNELS.GITHUB_ASSIGN_ISSUE, gated(handleGitHubAssignIssue)));
 
   handlers.push(githubUnassignIssueNamespace.register());
 
@@ -452,7 +477,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getIssueTooltip } = await import("../../services/github/index.js");
     return getIssueTooltip(payload.cwd.trim(), payload.issueNumber);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, handleGitHubGetIssueTooltip));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, gated(handleGitHubGetIssueTooltip)));
 
   const handleGitHubGetPRTooltip = async (payload: { cwd: string; prNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PR_TOOLTIP, 20, 10_000);
@@ -468,7 +493,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getPRTooltip } = await import("../../services/github/index.js");
     return getPRTooltip(payload.cwd.trim(), payload.prNumber);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_TOOLTIP, handleGitHubGetPRTooltip));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_TOOLTIP, gated(handleGitHubGetPRTooltip)));
 
   const handleGitHubGetIssueUrl = async (payload: {
     cwd: string;
@@ -503,7 +528,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getIssueByNumber } = await import("../../services/github/index.js");
     return getIssueByNumber(payload.cwd.trim(), payload.issueNumber);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, handleGitHubGetIssueByNumber));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, gated(handleGitHubGetIssueByNumber))
+  );
 
   const handleGitHubGetPRByNumber = async (payload: { cwd: string; prNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PR_BY_NUMBER, 25, 10_000);
@@ -519,7 +546,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getPRByNumber } = await import("../../services/github/index.js");
     return getPRByNumber(payload.cwd.trim(), payload.prNumber);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_BY_NUMBER, handleGitHubGetPRByNumber));
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_BY_NUMBER, gated(handleGitHubGetPRByNumber)));
 
   const handleGitHubGetIssuesByNumbers = async (payload: { cwd: string; numbers: number[] }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_ISSUES_BY_NUMBERS, 20, 10_000);
@@ -530,7 +557,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getIssuesByNumbers } = await import("../../services/github/index.js");
     return getIssuesByNumbers(payload.cwd.trim(), payload.numbers);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUES_BY_NUMBERS, handleGitHubGetIssuesByNumbers));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_GET_ISSUES_BY_NUMBERS, gated(handleGitHubGetIssuesByNumbers))
+  );
 
   const handleGitHubGetPRsByNumbers = async (payload: { cwd: string; numbers: number[] }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PRS_BY_NUMBERS, 20, 10_000);
@@ -541,7 +570,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getPRsByNumbers } = await import("../../services/github/index.js");
     return getPRsByNumbers(payload.cwd.trim(), payload.numbers);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PRS_BY_NUMBERS, handleGitHubGetPRsByNumbers));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_GET_PRS_BY_NUMBERS, gated(handleGitHubGetPRsByNumbers))
+  );
 
   const handleGitHubGetPRReviewThreads = async (payload: { cwd: string; prNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PR_REVIEW_THREADS, 10, 10_000);
@@ -565,7 +596,9 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     const { getPRReviewThreads } = await import("../../services/github/index.js");
     return getPRReviewThreads(payload.cwd.trim(), payload.prNumber);
   };
-  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_REVIEW_THREADS, handleGitHubGetPRReviewThreads));
+  handlers.push(
+    typedHandle(CHANNELS.GITHUB_GET_PR_REVIEW_THREADS, gated(handleGitHubGetPRReviewThreads))
+  );
 
   // Lists all git remotes (origin, upstream, …) with an optional parsed
   // owner/repo for remotes whose URL looks like a forge repo. The data is

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2635,6 +2635,15 @@ export class PluginService {
     runUnloadStep(pluginId, "unregisterForgeProviderImpls", () =>
       unregisterForgeProviderImpls(pluginId)
     );
+    // Mirror the load-path notify (loadPlugin, ~line 1152): a runtime disable
+    // removes forge descriptors/impls from the registry, so workspace hosts
+    // whose PR polling resolved (or no-matched) against this provider must
+    // re-evaluate. A spurious notify for a plugin that contributed no forge
+    // provider is harmless — PullRequestService only invalidates a cached
+    // no-match. Without this, live-disable left stale provider resolution.
+    runUnloadStep(pluginId, "notifyForgeProviderRegistryUpdated", () =>
+      this.workspaceClient?.notifyForgeProviderRegistryUpdated()
+    );
     runUnloadStep(pluginId, "unregisterFileDecorationProviders", () =>
       unregisterFileDecorationProviders(pluginId)
     );

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -461,13 +461,15 @@ class PullRequestService {
 
   /**
    * Main pushed `forge:provider-registry-updated` — a forge provider
-   * descriptor was registered (startup scan or runtime plugin
-   * install/enable). A cached "no-match"/"not-ready" miss may now resolve, so
-   * drop it and re-check. A resolved provider is left alone: provider-affecting
-   * settings changes arrive via `setForgeSettings()`, which always invalidates.
+   * descriptor was registered OR removed (startup scan, runtime plugin
+   * install/enable, or live disable). A cached "no-match"/"not-ready" miss
+   * may now resolve, and a resolved provider may no longer exist (the
+   * registry-updated signal covers removals since live built-in disable,
+   * #9304 follow-up), so always drop the cached resolution and re-check —
+   * re-resolving to the same provider is cheap, but keeping a resolution for
+   * an unregistered provider strands polling on RPC failures.
    */
   public notifyForgeProviderRegistryUpdated(): void {
-    if (this.providerResolutionStatus === "resolved") return;
     this.invalidateProvider();
     if (!this.isPolling || this.startupDelayTimer !== null) return;
     // Re-enter the poll loop: "no-match" pauses without an armed timer, so a

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2014,6 +2014,31 @@ describe("PluginService built-in plugin loading", () => {
       );
     });
 
+    it("built-in disable notifies workspace hosts that the forge registry changed", async () => {
+      storeMock._state.set("plugins", { disabled: [] });
+      await writeBuiltinPlugin("daintree.forgey", {
+        name: "daintree.forgey",
+        version: "1.0.0",
+        contributes: {
+          forgeProviders: [{ id: "forgey", name: "Forgey", matches: ["forgey.example.com"] }],
+        },
+      });
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+      const notifyForgeProviderRegistryUpdated = vi.fn();
+      service.setWorkspaceClient({
+        notifyForgeProviderRegistryUpdated,
+      } as never);
+
+      await service.setEnabled("daintree.forgey", false);
+
+      // The unload removed the forge descriptor from the registry, so PR
+      // polling in every workspace host must re-resolve — without this notify,
+      // a live disable left hosts polling against a provider that no longer
+      // exists (the load path has always notified; see loadPlugin).
+      expect(notifyForgeProviderRegistryUpdated).toHaveBeenCalled();
+    });
+
     it("built-in survives a rapid disable→enable→disable without a stuck state", async () => {
       storeMock._state.set("plugins", { disabled: [] });
       await writeBuiltinPlugin("daintree.flap", { name: "daintree.flap", version: "1.0.0" });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1837,7 +1837,11 @@ describe("PullRequestService", () => {
       pullRequestService.destroy();
     });
 
-    it("leaves an already-resolved provider untouched on forge:provider-registry-updated", async () => {
+    it("re-resolves an already-resolved provider on forge:provider-registry-updated", async () => {
+      // Registry updates now also signal provider REMOVAL (live built-in
+      // disable, #9304 follow-up), so a cached resolution can't be trusted —
+      // it must be dropped and re-resolved. In the still-registered case the
+      // re-resolution lands on the same provider.
       vi.doMock("../GitHubService.js", () => ({ clearPRCaches: vi.fn() }));
       mockForgeProviderResolved();
       const bridge = lastMockBridge!;
@@ -1853,12 +1857,21 @@ describe("PullRequestService", () => {
 
       await pullRequestService.refresh();
       const callsAfterRefresh = bridge.resolveProvider.mock.calls.length;
+      expect(pullRequestService.getProviderContext()).not.toBeNull();
 
       pullRequestService.notifyForgeProviderRegistryUpdated();
-      await vi.advanceTimersByTimeAsync(1_000);
+      // Invalidation is immediate — the stale resolution must not survive
+      // even before any re-check fires. (When the provider was removed, this
+      // is what stops further RPCs against an unregistered provider.)
+      expect(pullRequestService.getProviderContext()).toBeNull();
 
-      expect(bridge.resolveProvider.mock.calls.length).toBe(callsAfterRefresh);
-      expect(pullRequestService.getProviderContext()).not.toBeNull();
+      // Next check re-resolves; with the provider still registered it lands
+      // back on the same provider.
+      await pullRequestService.refresh();
+      expect(bridge.resolveProvider.mock.calls.length).toBeGreaterThan(callsAfterRefresh);
+      expect(pullRequestService.getProviderContext()).toMatchObject({
+        providerId: "daintree.github.github",
+      });
 
       pullRequestService.destroy();
     });

--- a/electron/services/commands/githubCreateIssue.ts
+++ b/electron/services/commands/githubCreateIssue.ts
@@ -1,6 +1,7 @@
 import type { DaintreeCommand, CommandResult } from "../../../shared/types/commands.js";
 import type { CreateIssueInput } from "../../../shared/types/forge.js";
 import { getGitHubToken, clearGitHubCaches } from "../GitHubService.js";
+import { hasActivatedForgeProvider } from "../forgeProviderRegistry.js";
 import { resolveForCwd } from "../../ipc/handlers/forgeResolution.js";
 import { auditForgeCall, summarizeForgeArgs } from "../forge/forgeAuditService.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
@@ -94,12 +95,18 @@ export const githubCreateIssueCommand: DaintreeCommand<CreateIssueArgs, CreateIs
   },
 
   isEnabled: () => {
-    return !!getGitHubToken();
+    // Mirrors githubWorkIssue: a stored token alone isn't enough — the forge
+    // provider must be activated (GitHub plugin enabled), or execute() dies
+    // in resolveForCwd with a misleading not-a-git-repo classification.
+    return !!getGitHubToken() && hasActivatedForgeProvider();
   },
 
   disabledReason: () => {
     if (!getGitHubToken()) {
       return "GitHub token not configured. Set it in Settings.";
+    }
+    if (!hasActivatedForgeProvider()) {
+      return "GitHub plugin is disabled. Enable it in Settings to create issues.";
     }
     return undefined;
   },

--- a/electron/services/github/availability.ts
+++ b/electron/services/github/availability.ts
@@ -1,0 +1,37 @@
+// Authoritative "is GitHub usable right now" predicate for main-process code.
+//
+// GitHub functionality lives in the `daintree.github` built-in plugin. Its
+// forge-provider impl is bound into the registry during plugin `activate()`
+// and removed on disable/unload, so `getForgeProviderImpl(...) !== undefined`
+// is the single source of truth for whether GitHub is active — it tracks the
+// user's enable/disable choice without reaching into PluginService state.
+//
+// This helper deliberately imports the registry (host-owned), NOT the github
+// plugin barrel, so callers can gate on availability without forcing the
+// plugin module to load.
+import { getForgeProviderImpl } from "../forgeProviderRegistry.js";
+import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
+
+/** True when the built-in GitHub forge provider is registered and activated. */
+export function isGitHubProviderActive(): boolean {
+  return getForgeProviderImpl(BUILTIN_GITHUB_PROVIDER_ID) !== undefined;
+}
+
+/**
+ * Thrown by native `github:*` data/network handlers when the GitHub plugin is
+ * disabled. The `code` lets the renderer distinguish "provider off" from token
+ * or network failures — though the renderer normally gates proactively on the
+ * availability signal, so this is a backstop for direct/agent IPC callers.
+ */
+export class GitHubProviderUnavailableError extends Error {
+  readonly code = "FORGE_PROVIDER_UNAVAILABLE";
+  constructor() {
+    super("GitHub is disabled. Enable the GitHub plugin to use this feature.");
+    this.name = "GitHubProviderUnavailableError";
+  }
+}
+
+/** Throw {@link GitHubProviderUnavailableError} unless the GitHub provider is active. */
+export function assertGitHubProviderActive(): void {
+  if (!isGitHubProviderActive()) throw new GitHubProviderUnavailableError();
+}

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -7,7 +7,6 @@ import {
 } from "../services/StoreMigrations.js";
 import { initializeTelemetry, setOnboardingCompleteTag } from "../services/TelemetryService.js";
 import { GitHubAuth } from "../services/github/GitHubAuth.js";
-import { gitHubTokenHealthService } from "../services/github/GitHubTokenHealthService.js";
 import {
   agentConnectivityService,
   getServiceConnectivityRegistry,
@@ -720,15 +719,11 @@ export async function initGlobalServices(
     },
   });
 
-  // Background token-health polling (30-minute interval + focus/wake
-  // re-checks). The service guards itself with the GitHubAuth.tokenVersion
-  // so a stale probe cannot clobber a freshly-set token.
-  registerDeferredTask({
-    name: "github-token-health",
-    run: () => {
-      gitHubTokenHealthService.start();
-    },
-  });
+  // GitHub token-health probing is no longer started here — the
+  // daintree.github plugin owns it via activate()/dispose() (#9304
+  // follow-up), so a disabled plugin issues no background GitHub probes.
+  // Token STORAGE stays eager above (GitHubAuth.initializeStorage)
+  // regardless of plugin state.
 
   // Background agent provider reachability probes (Claude, Gemini, Codex)
   // and the registry that aggregates GitHub, agents, and MCP into a single

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -187,7 +187,17 @@ export async function initGlobalServices(
   });
   console.log("[MAIN] GitHubAuth initialized with storage");
 
-  if (GitHubAuth.hasToken()) {
+  // Skip startup token validation when the GitHub plugin is disabled — the
+  // /user fetch is GitHub network work the user opted out of. Read the
+  // persisted disabled list directly: this task is registered before the
+  // plugin-service deferred task runs, so the forge registry can't be
+  // consulted yet. (Re-enable validates on next launch or via set-token.)
+  const persistedPlugins = store.get("plugins") as { disabled?: unknown } | undefined;
+  const githubPluginDisabled =
+    Array.isArray(persistedPlugins?.disabled) &&
+    persistedPlugins.disabled.includes("daintree.github");
+
+  if (GitHubAuth.hasToken() && !githubPluginDisabled) {
     const token = GitHubAuth.getToken();
     if (token) {
       const versionAtStart = GitHubAuth.getTokenVersion();

--- a/plugins/builtin/github/main/GitHubTokenHealthService.ts
+++ b/plugins/builtin/github/main/GitHubTokenHealthService.ts
@@ -49,6 +49,13 @@ class GitHubTokenHealthServiceImpl {
   private tokenVersionAtLastCheck = -1;
   private pendingCheck: Promise<void> | null = null;
   private readonly listeners = new Set<StateChangeListener>();
+  /**
+   * Lifecycle gate owned by GitHub plugin activation (#9304 follow-up).
+   * Probes only run between start() and stop(): powerMonitor focus/wake
+   * refresh() calls arrive unconditionally from core, and without this gate
+   * a disabled plugin would keep probing GitHub in the background.
+   */
+  private started = false;
 
   private fetchImpl: FetchFn;
   private now: () => number;
@@ -90,16 +97,20 @@ class GitHubTokenHealthServiceImpl {
    * GitHub guidance is to use response headers rather than polling `/rate_limit`.
    */
   start(): void {
+    this.started = true;
     void this.runCheck({ reason: "start" });
   }
 
-  /** Stop polling and tear down listeners. Safe to call multiple times. */
+  /**
+   * Stop probing. Safe to call multiple times. Listeners are kept — they
+   * belong to host transports (renderer broadcast relays) that outlive a
+   * plugin disable/enable cycle; only `dispose()` clears them at shutdown.
+   */
   stop(): void {
-    // No recurring timer to clear; kept for API compatibility. The `dispose()`
-    // alias still clears listeners and resets state.
+    this.started = false;
   }
 
-  /** Alias for {@link stop} — matches the lifecycle naming used elsewhere. */
+  /** Full teardown for app shutdown — also clears host transport listeners. */
   dispose(): void {
     this.stop();
     this.listeners.clear();
@@ -112,6 +123,10 @@ class GitHubTokenHealthServiceImpl {
    * without hammering the API when the user is toggling windows rapidly.
    */
   refresh(options: { force?: boolean } = {}): Promise<void> {
+    if (!this.started) {
+      logDebug("GitHub token health: skipping refresh while stopped");
+      return Promise.resolve();
+    }
     const force = options.force === true;
     if (!force) {
       const elapsed = this.now() - this.lastCheckedAt;
@@ -138,12 +153,14 @@ class GitHubTokenHealthServiceImpl {
 
   /** Test-only helper. */
   _resetForTests(): void {
-    this.stop();
     this.listeners.clear();
     this.status = "unknown";
     this.lastCheckedAt = 0;
     this.tokenVersionAtLastCheck = -1;
     this.pendingCheck = null;
+    // Reset into the operational (started) posture: probe-behavior tests
+    // exercise a running service; the lifecycle gate has its own tests.
+    this.started = true;
   }
 
   /** Test-only helper. */

--- a/plugins/builtin/github/main/GitHubTokenHealthService.ts
+++ b/plugins/builtin/github/main/GitHubTokenHealthService.ts
@@ -216,6 +216,16 @@ class GitHubTokenHealthServiceImpl {
           signal: AbortSignal.timeout(HEALTH_CHECK_FETCH_TIMEOUT_MS),
         });
 
+        // Probe completed after stop() (plugin disabled mid-flight): discard
+        // so a late result can't re-publish healthy/unhealthy state over the
+        // disabled reset and resurrect a banner for an off integration.
+        if (!this.started) {
+          logDebug("GitHub token health: probe result discarded after stop", {
+            reason: context.reason,
+          });
+          return;
+        }
+
         // Late-arriving probe from a previous token: discard so it can't
         // clobber state — including `lastAuthMetadata` — set by the
         // currently-configured token. Must be checked *before* passive

--- a/plugins/builtin/github/main/__tests__/GitHubTokenHealthService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubTokenHealthService.test.ts
@@ -289,4 +289,41 @@ describe("GitHubTokenHealthService", () => {
       expect(state.ssoUrl).toBe("https://github.com/orgs/acme/sso?authorization_request=abc123");
     });
   });
+
+  describe("plugin-owned lifecycle gate", () => {
+    beforeEach(() => {
+      GitHubAuth.setToken("ghp_testtoken0000000000000000000000000000000");
+      fetchMock.mockResolvedValue(buildResponse(200));
+    });
+
+    it("skips probes while stopped — even forced focus/wake refreshes", async () => {
+      gitHubTokenHealthService.stop();
+
+      await gitHubTokenHealthService.refresh({ force: true });
+      await gitHubTokenHealthService.refresh();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("probes again after a stop → start cycle (plugin re-enable)", async () => {
+      gitHubTokenHealthService.stop();
+      await gitHubTokenHealthService.refresh({ force: true });
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      gitHubTokenHealthService.start();
+      await gitHubTokenHealthService.refresh({ force: true });
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    it("stop() keeps host transport listeners wired for a later re-enable", async () => {
+      gitHubTokenHealthService.stop();
+      gitHubTokenHealthService.start();
+
+      await gitHubTokenHealthService.refresh({ force: true });
+
+      // The relay listener registered in beforeEach must still observe the
+      // healthy transition — a disable/enable cycle must not orphan it.
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ status: "healthy" }));
+    });
+  });
 });

--- a/plugins/builtin/github/main/__tests__/GitHubTokenHealthService.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubTokenHealthService.test.ts
@@ -325,5 +325,26 @@ describe("GitHubTokenHealthService", () => {
       // healthy transition — a disable/enable cycle must not orphan it.
       expect(listener).toHaveBeenCalledWith(expect.objectContaining({ status: "healthy" }));
     });
+
+    it("discards a probe that completes after stop() — no late state publish", async () => {
+      let resolveProbe: (r: Response) => void = () => {};
+      fetchMock.mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveProbe = resolve;
+          })
+      );
+
+      const inFlight = gitHubTokenHealthService.refresh({ force: true });
+      // Plugin disabled while the probe is on the wire.
+      gitHubTokenHealthService.stop();
+      resolveProbe(buildResponse(401));
+      await inFlight;
+
+      // A late 401 must not resurrect an unhealthy banner for an integration
+      // the user just turned off.
+      expect(gitHubTokenHealthService.getState().status).toBe("unknown");
+      expect(listener).not.toHaveBeenCalledWith(expect.objectContaining({ status: "unhealthy" }));
+    });
   });
 });

--- a/plugins/builtin/github/main/index.ts
+++ b/plugins/builtin/github/main/index.ts
@@ -1,7 +1,8 @@
 import type { PluginHostApi } from "../../../../shared/types/plugin.js";
 import { githubForgeProvider } from "./forgeProvider.js";
 import { registerReviewDecorationProvider } from "./reviewDecorationProvider.js";
-import { startCacheSweep, stopCacheSweep } from "./GitHubCaches.js";
+import { startCacheSweep, stopCacheSweep, clearGitHubCaches } from "./GitHubCaches.js";
+import { gitHubTokenHealthService } from "./GitHubTokenHealthService.js";
 
 /**
  * Plugin activation entry point — called by `PluginService` after manifest
@@ -21,10 +22,25 @@ export function activate(host: PluginHostApi): () => void {
   // Periodic sweep of the data caches' expired entries (lazy get()-time
   // eviction can pin entries that stop being read). Cleared on deactivation.
   startCacheSweep();
+  // Background token-health probing is plugin-owned (#9304 follow-up): it
+  // starts with activation (previously a core deferred task) and stops on
+  // deactivation, so a disabled plugin issues no GitHub network. Token
+  // STORAGE stays host-owned and eager (GitHubAuth.initializeStorage in
+  // globalServicesInit) — a stored token must survive disable/enable.
+  gitHubTokenHealthService.start();
   return () => {
     disposeForge();
     disposeDecorations();
     stopCacheSweep();
+    // stop(), not dispose(): the renderer-broadcast listeners registered by
+    // the host transport (registerGithubHandlers) must survive a disable →
+    // enable cycle. resetState() retires any visible unhealthy badge so a
+    // banner for a now-off integration can't linger.
+    gitHubTokenHealthService.stop();
+    gitHubTokenHealthService.resetState();
+    // Drop cached issue/PR/stat pages so a later re-enable (possibly under a
+    // different token) starts from the network, not stale data.
+    clearGitHubCaches();
   };
 }
 

--- a/plugins/builtin/github/renderer/__tests__/GitHubSettingsTab.a11y.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubSettingsTab.a11y.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { GitHubSettingsTab } from "../GitHubSettingsTab";
-import { SettingsValidationProvider } from "../SettingsValidationRegistry";
+import { GitHubSettingsTab } from "../components/GitHubSettingsTab";
+import { SettingsValidationProvider } from "@/components/Settings/SettingsValidationRegistry";
 
 vi.mock("@github-renderer/stores/githubConfigStore", () => ({
   useGitHubConfigStore: vi.fn(),

--- a/plugins/builtin/github/renderer/__tests__/GitHubSettingsTab.tokenSave.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubSettingsTab.tokenSave.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { GitHubSettingsTab } from "../GitHubSettingsTab";
-import { SettingsValidationProvider } from "../SettingsValidationRegistry";
+import { GitHubSettingsTab } from "../components/GitHubSettingsTab";
+import { SettingsValidationProvider } from "@/components/Settings/SettingsValidationRegistry";
 
 vi.mock("@github-renderer/stores/githubConfigStore", () => ({
   useGitHubConfigStore: vi.fn(),

--- a/plugins/builtin/github/renderer/components/GitHubSettingsTab.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubSettingsTab.tsx
@@ -2,13 +2,12 @@ import { useState, useEffect, type ComponentType, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { Key, Check, AlertCircle, FlaskConical, ExternalLink } from "lucide-react";
 import { GitHubIcon } from "@/components/icons/brands";
-// TODO(#8061): replace with plugin settings contribution when forge settings UI lands
-import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
+import { useGitHubConfigStore } from "../stores/githubConfigStore";
 import { actionService } from "@/services/ActionService";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import type { GitHubTokenConfig, GitHubTokenValidation } from "@/types";
-import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
-import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { SettingsLoadErrorBanner } from "@/components/Settings/SettingsLoadErrorBanner";
+import { useSettingsTabValidation } from "@/components/Settings/SettingsValidationRegistry";
 import { useTabLoad } from "@/hooks";
 import { logError } from "@/utils/logger";
 

--- a/plugins/builtin/github/renderer/index.tsx
+++ b/plugins/builtin/github/renderer/index.tsx
@@ -1,10 +1,18 @@
 import { registerBuiltinView } from "@/registry/builtinRendererRegistry";
 import { BulkCreateWorktreeDialog } from "./components/BulkCreateWorktreeDialog";
 import { IssueSelector } from "./components/IssueSelector";
+import { GitHubSettingsTab } from "./components/GitHubSettingsTab";
 
 // Registration runs at module-load time. The host bootstrap imports this
 // module once at app start so plugin slots are populated before any host
 // dialog tries to resolve them. Slot ids stay dot-namespaced by plugin so
-// future forge plugins can fill the same seams without colliding.
-registerBuiltinView("github.bulkCreateWorktreeDialog", BulkCreateWorktreeDialog);
-registerBuiltinView("github.issueSelector", IssueSelector);
+// future forge plugins can fill the same seams without colliding. The
+// `pluginId` ties each slot to the daintree.github enable state — resolution
+// returns null while the plugin is disabled, so these views drop out live.
+registerBuiltinView("github.bulkCreateWorktreeDialog", BulkCreateWorktreeDialog, {
+  pluginId: "daintree.github",
+});
+registerBuiltinView("github.issueSelector", IssueSelector, { pluginId: "daintree.github" });
+registerBuiltinView("github.forgeSettingsTab", GitHubSettingsTab, {
+  pluginId: "daintree.github",
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import {
   useGettingStartedChecklist,
   useOrchestrationMilestones,
   useAgentWaitingNudge,
+  useGitHubEnableRecommendation,
   useFocusOnActivateIntent,
   usePluginDeepLink,
   useNotificationHistoryPruning,
@@ -684,6 +685,7 @@ function AppInner() {
   useUpdateListener(onboardingOverlayActive);
   useOrchestrationMilestones(isStateLoaded);
   useAgentWaitingNudge(isStateLoaded);
+  useGitHubEnableRecommendation(isStateLoaded);
   useNotificationHistoryPruning();
 
   useEffect(() => {

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -45,6 +45,7 @@ import {
   RateLimitDetailsPanel,
 } from "./RateLimitDetails";
 import { GitHubStatPill } from "./GitHubStatPill";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 
 // Hover-to-prefetch tuning. 150ms matches the codebase's Tier 1 state-change
 // timing and is long enough to filter mouse traversal across the toolbar pill
@@ -123,6 +124,7 @@ export const GitHubStatsToolbarButton = memo(
       rateLimitKind,
       freshnessLevel,
     } = useRepositoryStats();
+    const githubEnabled = useGitHubPluginEnabled();
 
     useGitHubTokenExpiryNotification(isTokenError);
 
@@ -823,7 +825,9 @@ export const GitHubStatsToolbarButton = memo(
       [stats, isTokenError, openSettingsForToken]
     );
 
-    if (!currentProject) return null;
+    // With the GitHub plugin disabled the pills have no data source — the
+    // toolbar slot collapses entirely rather than showing dead affordances.
+    if (!currentProject || !githubEnabled) return null;
 
     return (
       <ContextMenu>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -88,6 +88,7 @@ import { ProjectSwitcherPalette } from "@/components/Project/ProjectSwitcherPale
 import { VoiceRecordingToolbarButton } from "./VoiceRecordingToolbarButton";
 import { useUIStore } from "@/store/uiStore";
 import { GitHubStatsToolbarButton, type GitHubStatsHandle } from "./GitHubStatsToolbarButton";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 import { NotificationCenterToolbarButton } from "./NotificationCenterToolbarButton";
 import { ToolbarLauncherButton } from "./ToolbarLauncherButton";
 import { ToolbarCommandPaletteButton } from "./ToolbarCommandPaletteButton";
@@ -245,6 +246,9 @@ function OverflowMenu({
   shortcutById,
 }: OverflowMenuProps) {
   const [open, setOpen] = useState(false);
+  // The hard-coded GitHub group below has no data source while the GitHub
+  // plugin is disabled — skip it entirely instead of showing dead items.
+  const githubEnabled = useGitHubPluginEnabled();
   // Snapshot of the GitHub stats taken when the menu opens. The stats live in
   // GitHubStatsToolbarButton's hook and are exposed through its imperative
   // handle, so they can't be read during render (refs aren't reactive — the
@@ -338,6 +342,7 @@ function OverflowMenu({
       >
         {overflowIds.flatMap((id, idx) => {
           if (id === "github-stats") {
+            if (!githubEnabled) return [];
             const isLast = idx === overflowIds.length - 1;
             return [
               <DropdownMenuGroup key="gh-group">
@@ -469,6 +474,7 @@ export function Toolbar({
   const currentProject = useProjectStore((state) => state.currentProject);
   const loadProjects = useProjectStore((state) => state.loadProjects);
   const getCurrentProject = useProjectStore((state) => state.getCurrentProject);
+  const githubEnabled = useGitHubPluginEnabled();
   const projectSwitcher = projectSwitcherPalette;
 
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
@@ -930,8 +936,12 @@ export function Toolbar({
         isAvailable: true,
       },
       "github-stats": {
+        // Placeholder (not removal) when the GitHub plugin is disabled: the
+        // slot's no-drag rectangle must exist on first paint regardless
+        // (PROJECT_SCOPED_TOOLBAR_IDS), and the placeholder keeps the
+        // footprint stable across a live enable.
         render: () =>
-          currentProject ? (
+          currentProject && githubEnabled ? (
             <GitHubStatsToolbarButton
               key="github-stats"
               ref={githubStatsRef}
@@ -1079,6 +1089,7 @@ export function Toolbar({
       topologyWatcherDark,
       showDeveloperTools,
       notificationsEnabled,
+      githubEnabled,
       pluginButtonIds,
       pluginConfigs,
       devServerShortcut,

--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -56,21 +56,26 @@ export function CodeForgeTab({
 
   useEffect(() => {
     let cancelled = false;
+    // Sequence overlapping fetches: rapid enable/disable toggles can leave an
+    // older getForgeProviders() response resolving after a newer one, and the
+    // stale list must not win.
+    let requestSeq = 0;
 
     const loadProviders = () => {
+      const seq = ++requestSeq;
       setProvidersLoading(true);
       setProvidersError(null);
 
       window.electron.plugin
         .getForgeProviders()
         .then((result) => {
-          if (!cancelled) {
+          if (!cancelled && seq === requestSeq) {
             setProviders(result);
             setProvidersLoading(false);
           }
         })
         .catch((err) => {
-          if (!cancelled) {
+          if (!cancelled && seq === requestSeq) {
             setProvidersError(formatErrorMessage(err, "Failed to load forge providers"));
             setProvidersLoading(false);
           }

--- a/src/components/Project/CodeForgeTab.tsx
+++ b/src/components/Project/CodeForgeTab.tsx
@@ -56,26 +56,37 @@ export function CodeForgeTab({
 
   useEffect(() => {
     let cancelled = false;
-    setProvidersLoading(true);
-    setProvidersError(null);
 
-    window.electron.plugin
-      .getForgeProviders()
-      .then((result) => {
-        if (!cancelled) {
-          setProviders(result);
-          setProvidersLoading(false);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setProvidersError(formatErrorMessage(err, "Failed to load forge providers"));
-          setProvidersLoading(false);
-        }
-      });
+    const loadProviders = () => {
+      setProvidersLoading(true);
+      setProvidersError(null);
+
+      window.electron.plugin
+        .getForgeProviders()
+        .then((result) => {
+          if (!cancelled) {
+            setProviders(result);
+            setProvidersLoading(false);
+          }
+        })
+        .catch((err) => {
+          if (!cancelled) {
+            setProvidersError(formatErrorMessage(err, "Failed to load forge providers"));
+            setProvidersLoading(false);
+          }
+        });
+    };
+
+    loadProviders();
+    // Refetch when a plugin is enabled/disabled at runtime so the provider
+    // list reflects live forge-provider registry changes (e.g. toggling the
+    // built-in GitHub plugin) without a remount. `provenance-changed` is the
+    // same broadcast PluginsTab/usePluginManager listen to.
+    const unsubscribe = window.electron.plugin.onProvenanceChanged(loadProviders);
 
     return () => {
       cancelled = true;
+      unsubscribe();
     };
   }, []);
 

--- a/src/components/Project/__tests__/CodeForgeTab.test.tsx
+++ b/src/components/Project/__tests__/CodeForgeTab.test.tsx
@@ -1,15 +1,26 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, waitFor } from "@testing-library/react";
+import { render, waitFor, act } from "@testing-library/react";
 import { CodeForgeTab } from "../CodeForgeTab";
 
+let provenanceCallbacks: Array<() => void>;
+let getForgeProvidersMock: ReturnType<typeof vi.fn>;
+
 beforeEach(() => {
+  provenanceCallbacks = [];
+  getForgeProvidersMock = vi.fn(async () => []);
   window.electron = {
     project: {
       listRemotes: vi.fn(async () => []),
     },
     plugin: {
-      getForgeProviders: vi.fn(async () => []),
+      getForgeProviders: getForgeProvidersMock,
+      onProvenanceChanged: vi.fn((callback: () => void) => {
+        provenanceCallbacks.push(callback);
+        return () => {
+          provenanceCallbacks = provenanceCallbacks.filter((cb) => cb !== callback);
+        };
+      }),
     },
   } as unknown as typeof window.electron;
 });
@@ -32,5 +43,32 @@ describe("CodeForgeTab — DOM anchors for settings deep-links", () => {
     await waitFor(() => {
       expect(container.querySelector("#project-code-forge-remote")).not.toBeNull();
     });
+  });
+});
+
+describe("CodeForgeTab — live forge-provider refresh", () => {
+  it("refetches providers when plugin provenance changes (live enable/disable)", async () => {
+    renderCodeForgeTab();
+    await waitFor(() => {
+      expect(getForgeProvidersMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      provenanceCallbacks.forEach((cb) => cb());
+    });
+
+    await waitFor(() => {
+      expect(getForgeProvidersMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("unsubscribes from provenance changes on unmount", async () => {
+    const { unmount } = renderCodeForgeTab();
+    await waitFor(() => {
+      expect(provenanceCallbacks).toHaveLength(1);
+    });
+
+    unmount();
+    expect(provenanceCallbacks).toHaveLength(0);
   });
 });

--- a/src/components/Recovery/GitHubTokenBanner.tsx
+++ b/src/components/Recovery/GitHubTokenBanner.tsx
@@ -3,13 +3,17 @@ import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
 import { actionService } from "@/services/ActionService";
 import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 
 export function GitHubTokenBanner() {
   const isUnhealthy = useGitHubTokenHealthStore((s) => s.isUnhealthy);
   const isDismissed = useGitHubTokenHealthStore((s) => s.isDismissed);
   const dismiss = useGitHubTokenHealthStore((s) => s.dismiss);
+  const githubEnabled = useGitHubPluginEnabled();
 
-  if (!isUnhealthy || isDismissed) return null;
+  // A disabled GitHub plugin must not warn about its token expiring — the
+  // integration is off, so there's nothing to reconnect.
+  if (!githubEnabled || !isUnhealthy || isDismissed) return null;
 
   const handleReconnect = () => {
     // Route through the action service with `sectionId` so the user lands on

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -48,11 +48,15 @@ interface CodeForgeSettingsTabProps {
 
 export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForgeSettingsTabProps) {
   const [providers, setProviders] = useState<ForgeProviderEntry[]>([]);
+  // Sequence overlapping fetches (initial load + provenance refetches) so a
+  // slow older response can't overwrite a newer provider list.
+  const providersSeqRef = useRef(0);
 
   const loadProviders = useCallback(async () => {
+    const seq = ++providersSeqRef.current;
     try {
       const loaded = await window.electron.forge.getProviders();
-      setProviders(loaded);
+      if (seq === providersSeqRef.current) setProviders(loaded);
     } catch (err) {
       logError("Failed to load forge providers for CodeForgeSettingsTab", err);
       throw err;

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -19,7 +19,7 @@ import {
   ForgeProviderSelectorDropdown,
   type ForgeProviderOption,
 } from "./ForgeProviderSelectorDropdown";
-import { GitHubSettingsTab } from "./GitHubSettingsTab";
+import { useBuiltinView } from "@/registry/builtinRendererRegistry";
 import { ForgeIntegrationsTab } from "./ForgeIntegrationsTab";
 import { SettingsLoadErrorBanner } from "./SettingsLoadErrorBanner";
 import { SettingsSection } from "./SettingsSection";
@@ -64,6 +64,24 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
     errorMessage: "Couldn't load forge providers",
     timeoutMessage: "Forge providers took too long to load.",
   });
+
+  // Refetch on plugin enable/disable so the provider dropdown (and the
+  // GitHub subtab below) track the live forge registry, not a mount-time
+  // snapshot — same broadcast PluginsTab follows.
+  useEffect(() => {
+    return window.electron.plugin.onProvenanceChanged(() => {
+      void loadProviders().catch(() => {
+        // useTabLoad owns initial-load errors; a failed live refresh keeps
+        // the previous list rather than tearing down the tab.
+      });
+    });
+  }, [loadProviders]);
+
+  // The GitHub settings panel is contributed by the daintree.github plugin
+  // (slot resolves null while the plugin is disabled), so disabling the
+  // plugin genuinely removes its settings interface instead of the host
+  // rendering a panel for a provider that no longer exists.
+  const GitHubSettingsView = useBuiltinView<Record<string, never>>("github.forgeSettingsTab");
 
   const [auditRecords, setAuditRecords] = useState<ForgeAuditRecord[]>([]);
   const [auditEnabled, setAuditEnabled] = useState(true);
@@ -198,11 +216,18 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
     [providers]
   );
 
+  // Fall back to the GitHub subtab only while its provider is actually
+  // registered — with the GitHub plugin disabled the provider list omits it,
+  // and defaulting to a panel for an absent provider is exactly the "disable
+  // does nothing" bug (#9304 follow-up). General settings always exist.
+  const githubAvailable = providerOptions.some((p) => p.id === GITHUB_ID);
   const effectiveSubtab =
     activeSubtab &&
     (activeSubtab === GENERAL_ID || providerOptions.some((p) => p.id === activeSubtab))
       ? activeSubtab
-      : GITHUB_ID;
+      : githubAvailable
+        ? GITHUB_ID
+        : GENERAL_ID;
 
   useSettingsTabValidation("code-forge", Boolean(loadError));
 
@@ -266,9 +291,9 @@ export function CodeForgeSettingsTab({ activeSubtab, onSubtabChange }: CodeForge
           </>
         )}
 
-        {isGitHub && (
+        {isGitHub && GitHubSettingsView && (
           <ForgeProviderCard name="GitHub" Icon={GitHubIcon}>
-            <GitHubSettingsTab />
+            <GitHubSettingsView />
           </ForgeProviderCard>
         )}
 

--- a/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
+++ b/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
@@ -327,6 +327,27 @@ describe("CodeForgeSettingsTab — canonical subtab routing", () => {
     expect(onSubtabChange).not.toHaveBeenCalled();
   });
 
+  it("deep-link to the GitHub subtab falls back to General when GitHub is unregistered", async () => {
+    // The realistic disabled-plugin dead-end: a stale deep-link (token
+    // banner, UpstreamSyncBadge) targets daintree.github.github after the
+    // plugin was disabled. The provider list omits GitHub, so the subtab
+    // must fall back to General rather than rendering an empty shell.
+    installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+    });
+
+    render(<CodeForgeSettingsTab activeSubtab="daintree.github.github" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("forge-integrations-tab")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("github-settings-tab")).toBeNull();
+  });
+
   it("falls back to General when GitHub is not registered (plugin disabled)", async () => {
     installForgeMocks({
       providers: [

--- a/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
+++ b/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
@@ -13,9 +13,15 @@ vi.mock("@/utils/logger", () => ({
 }));
 
 // Isolate the generic credential form: the sibling tabs pull heavy stores
-// (githubConfigStore, project routing) that are out of scope here.
-vi.mock("../GitHubSettingsTab", () => ({
-  GitHubSettingsTab: () => <div data-testid="github-settings-tab" />,
+// (githubConfigStore, project routing) that are out of scope here. The
+// GitHub panel is a plugin-contributed slot, so stub the registry hook.
+vi.mock("@/registry/builtinRendererRegistry", () => ({
+  useBuiltinView: (slotId: string) =>
+    slotId === "github.forgeSettingsTab"
+      ? function GitHubSettingsStub() {
+          return <div data-testid="github-settings-tab" />;
+        }
+      : null,
 }));
 vi.mock("../ForgeIntegrationsTab", () => ({
   ForgeIntegrationsTab: () => <div data-testid="forge-integrations-tab" />,
@@ -74,6 +80,9 @@ function installForgeMocks(opts: ForgeMockOptions) {
     },
     app: {
       getState: vi.fn(async () => ({ developerMode: { enabled: false } })),
+    },
+    plugin: {
+      onProvenanceChanged: vi.fn(() => () => {}),
     },
   } as unknown as typeof window.electron;
   return { setCredential, getCredentialStatus, clearCredential };
@@ -296,9 +305,10 @@ describe("CodeForgeSettingsTab — canonical subtab routing", () => {
     expect(screen.queryByTestId("github-settings-tab")).toBeNull();
   });
 
-  it("falls back to the GitHub subtab for an unrecognized bare subtab id", async () => {
+  it("falls back to the GitHub subtab for an unrecognized subtab while GitHub is registered", async () => {
     installForgeMocks({
       providers: [
+        makeProvider("daintree.github", "github", "GitHub"),
         makeProvider("acme", "gitea", "Gitea", [
           { id: "token", label: "API token", type: "password" },
         ]),
@@ -314,6 +324,28 @@ describe("CodeForgeSettingsTab — canonical subtab routing", () => {
     expect(screen.queryByTestId("forge-credential-form")).toBeNull();
     // The fallback is display-only — the component must not rewrite the
     // caller's subtab state.
+    expect(onSubtabChange).not.toHaveBeenCalled();
+  });
+
+  it("falls back to General when GitHub is not registered (plugin disabled)", async () => {
+    installForgeMocks({
+      providers: [
+        makeProvider("acme", "gitea", "Gitea", [
+          { id: "token", label: "API token", type: "password" },
+        ]),
+      ],
+    });
+
+    const onSubtabChange = vi.fn();
+    render(<CodeForgeSettingsTab activeSubtab="gitea" onSubtabChange={onSubtabChange} />);
+
+    // With the GitHub plugin disabled its provider is absent, so defaulting
+    // to a GitHub settings panel would resurrect the "disable does nothing"
+    // bug — General is the only subtab guaranteed to exist.
+    await waitFor(() => {
+      expect(screen.getByTestId("forge-integrations-tab")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("github-settings-tab")).toBeNull();
     expect(onSubtabChange).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -35,7 +35,7 @@ import {
 } from "@/hooks";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { WorktreeSidebarSearchBar, QuickStateFilterBar } from "@/components/Worktree";
-import { getBuiltinView } from "@/registry/builtinRendererRegistry";
+import { useBuiltinView } from "@/registry/builtinRendererRegistry";
 import type { BulkCreateWorktreeDialogProps } from "@github-renderer/components/BulkCreateWorktreeDialog";
 import { FleetPickerPalette } from "@/components/Fleet/FleetPickerPalette";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -501,6 +501,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       bulkCreateDialog: state.bulkCreateDialog,
       closeBulkCreateDialog: state.closeBulkCreateDialog,
     }))
+  );
+  // Resolved reactively so the dialog drops out (and back in) live with the
+  // GitHub plugin's enable state instead of holding a stale slot reference.
+  const BulkCreateWorktreeDialog = useBuiltinView<BulkCreateWorktreeDialogProps>(
+    "github.bulkCreateWorktreeDialog"
   );
   // Direct subscription (no useDeferredValue) so the skeleton renders the
   // moment the dialog submits — defer would make the placeholder lag the
@@ -1905,22 +1910,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         componentName="BulkCreateWorktreeDialog"
         resetKeys={[Number(bulkCreateDialog.isOpen)]}
       >
-        {(() => {
-          const BulkCreateWorktreeDialog = getBuiltinView<BulkCreateWorktreeDialogProps>(
-            "github.bulkCreateWorktreeDialog"
-          );
-          if (!BulkCreateWorktreeDialog) return null;
-          return (
-            <BulkCreateWorktreeDialog
-              isOpen={bulkCreateDialog.isOpen}
-              onClose={closeBulkCreateDialog}
-              mode={bulkCreateDialog.mode}
-              selectedIssues={bulkCreateDialog.selectedIssues}
-              selectedPRs={bulkCreateDialog.selectedPRs}
-              onComplete={closeBulkCreateDialog}
-            />
-          );
-        })()}
+        {BulkCreateWorktreeDialog && (
+          <BulkCreateWorktreeDialog
+            isOpen={bulkCreateDialog.isOpen}
+            onClose={closeBulkCreateDialog}
+            mode={bulkCreateDialog.mode}
+            selectedIssues={bulkCreateDialog.selectedIssues}
+            selectedPRs={bulkCreateDialog.selectedPRs}
+            onComplete={closeBulkCreateDialog}
+          />
+        )}
       </ErrorBoundary>
 
       <ErrorBoundary

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -217,6 +217,7 @@ vi.mock("@/components/ui/Spinner", () => ({
 
 vi.mock("@/registry/builtinRendererRegistry", () => ({
   getBuiltinView: () => () => <div data-testid="issue-selector" />,
+  useBuiltinView: () => () => <div data-testid="issue-selector" />,
   registerBuiltinView: vi.fn(),
   unregisterBuiltinView: vi.fn(),
 }));

--- a/src/components/Worktree/views/IssueSelectorView.tsx
+++ b/src/components/Worktree/views/IssueSelectorView.tsx
@@ -1,5 +1,5 @@
 import type { GitHubIssue } from "@shared/types/github";
-import { getBuiltinView } from "@/registry/builtinRendererRegistry";
+import { useBuiltinView } from "@/registry/builtinRendererRegistry";
 import type { IssueSelectorProps } from "@github-renderer/components/IssueSelector";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Info, UserPlus } from "lucide-react";
@@ -28,7 +28,7 @@ export function IssueLinkerView({
   currentUserAvatar,
   disabled,
 }: IssueLinkerViewProps) {
-  const IssueSelector = getBuiltinView<IssueSelectorProps>("github.issueSelector");
+  const IssueSelector = useBuiltinView<IssueSelectorProps>("github.issueSelector");
   return (
     <>
       <div className="space-y-2">

--- a/src/hooks/app/__tests__/useGitHubEnableRecommendation.test.tsx
+++ b/src/hooks/app/__tests__/useGitHubEnableRecommendation.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import {
+  useGitHubEnableRecommendation,
+  _resetGitHubEnableRecommendationForTest,
+} from "../useGitHubEnableRecommendation";
+
+const notifyMock = vi.hoisted(() => vi.fn((_payload: unknown) => "notif-1"));
+
+interface NotifiedPayload {
+  actions: Array<{ label: string; onClick: () => void }>;
+}
+
+function lastNotifyPayload(): NotifiedPayload {
+  const payload = notifyMock.mock.calls.at(-1)?.[0];
+  if (!payload) throw new Error("notify was not called");
+  return payload as NotifiedPayload;
+}
+const removeNotificationMock = vi.hoisted(() => vi.fn());
+const currentProjectRef = vi.hoisted(() => ({ value: null as { path: string } | null }));
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject: { path: string } | null }) => unknown) =>
+    selector({ currentProject: currentProjectRef.value }),
+}));
+vi.mock("@/store/notificationStore", () => ({
+  useNotificationStore: (selector: (s: { removeNotification: () => void }) => unknown) =>
+    selector({ removeNotification: removeNotificationMock }),
+}));
+vi.mock("../useElectron", () => ({ isElectronAvailable: () => true }));
+vi.mock("@/utils/safeFireAndForget", () => ({
+  safeFireAndForget: (p: Promise<unknown>) => void p.catch(() => {}),
+}));
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+}));
+
+const listMock = vi.fn();
+const listRemotesMock = vi.fn();
+const setEnabledMock = vi.fn(async () => {});
+
+function installElectronMocks(opts: { githubDisabled: boolean; remotes: string[] }) {
+  listMock.mockResolvedValue([
+    { manifest: { name: "daintree.github" }, disabled: opts.githubDisabled },
+  ]);
+  listRemotesMock.mockResolvedValue(opts.remotes.map((fetchUrl) => ({ fetchUrl })));
+  window.electron = {
+    plugin: { list: listMock, setEnabled: setEnabledMock },
+    project: { listRemotes: listRemotesMock },
+  } as unknown as typeof window.electron;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  notifyMock.mockReturnValue("notif-1");
+  _resetGitHubEnableRecommendationForTest();
+  currentProjectRef.value = { path: "/Users/test/Projects/sample" };
+});
+
+describe("useGitHubEnableRecommendation", () => {
+  it("recommends once for a github.com repo while the plugin is disabled", async () => {
+    installElectronMocks({
+      githubDisabled: true,
+      remotes: ["git@github.com:owner/repo.git"],
+    });
+
+    const { rerender } = renderHook(() => useGitHubEnableRecommendation(true));
+
+    await waitFor(() => {
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+    });
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ placement: "grid-bar", title: "GitHub integration is off" })
+    );
+
+    // Same project re-render: no duplicate nudge.
+    rerender();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never fires when the plugin is enabled", async () => {
+    installElectronMocks({
+      githubDisabled: false,
+      remotes: ["git@github.com:owner/repo.git"],
+    });
+
+    renderHook(() => useGitHubEnableRecommendation(true));
+
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("never fires for a non-GitHub remote", async () => {
+    installElectronMocks({
+      githubDisabled: true,
+      remotes: ["git@gitlab.com:owner/repo.git"],
+    });
+
+    renderHook(() => useGitHubEnableRecommendation(true));
+
+    await waitFor(() => expect(listRemotesMock).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("enables only on the explicit action click, never autonomously", async () => {
+    installElectronMocks({
+      githubDisabled: true,
+      remotes: ["https://github.com/owner/repo.git"],
+    });
+
+    renderHook(() => useGitHubEnableRecommendation(true));
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+
+    // The hook itself must never flip the toggle.
+    expect(setEnabledMock).not.toHaveBeenCalled();
+
+    const enableAction = lastNotifyPayload().actions.find((a) => a.label === "Enable GitHub");
+    expect(enableAction).toBeDefined();
+    enableAction?.onClick();
+    expect(setEnabledMock).toHaveBeenCalledWith("daintree.github", true);
+    expect(removeNotificationMock).toHaveBeenCalledWith("notif-1");
+  });
+
+  it("does not re-fire for a project dismissed this session", async () => {
+    installElectronMocks({
+      githubDisabled: true,
+      remotes: ["git@github.com:owner/repo.git"],
+    });
+
+    const { unmount } = renderHook(() => useGitHubEnableRecommendation(true));
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+
+    lastNotifyPayload()
+      .actions.find((a) => a.label === "Not now")
+      ?.onClick();
+    unmount();
+
+    renderHook(() => useGitHubEnableRecommendation(true));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -18,6 +18,7 @@ export { useErrorRetry } from "./useErrorRetry";
 export { useActiveWorktreeSync } from "./useActiveWorktreeSync";
 export { useOrchestrationMilestones } from "./useOrchestrationMilestones";
 export { useAgentWaitingNudge } from "./useAgentWaitingNudge";
+export { useGitHubEnableRecommendation } from "./useGitHubEnableRecommendation";
 export { useFocusOnActivateIntent } from "./useFocusOnActivateIntent";
 export { usePluginDeepLink } from "./usePluginDeepLink";
 export type { PluginDeepLinkState } from "./usePluginDeepLink";

--- a/src/hooks/app/useGitHubEnableRecommendation.ts
+++ b/src/hooks/app/useGitHubEnableRecommendation.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef } from "react";
+import { useProjectStore } from "@/store/projectStore";
+import { GITHUB_PLUGIN_ID } from "@/store/pluginRuntimeStore";
+import { useNotificationStore } from "@/store/notificationStore";
+import { notify } from "@/lib/notify";
+import { isElectronAvailable } from "../useElectron";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { logError } from "@/utils/logger";
+
+/**
+ * Recommends enabling the GitHub plugin when the user opens a project whose
+ * remotes point at github.com while the plugin is disabled. Recommendation
+ * only — enabling is always the user's explicit click; a persisted disable is
+ * never overridden automatically (the auto-enable alternative was rejected:
+ * it resurrects a deliberately disabled integration behind the user's back).
+ *
+ * Evaluation runs on project switch, not on toggle: a user who just disabled
+ * the plugin must not be immediately nudged to undo their own action. Fired
+ * or dismissed projects are remembered for the session.
+ */
+const handledProjectPaths = new Set<string>();
+
+function hasGitHubRemote(remotes: Array<{ fetchUrl: string }>): boolean {
+  return remotes.some((remote) => {
+    const url = remote.fetchUrl.toLowerCase();
+    return url.includes("github.com:") || url.includes("github.com/") || url.endsWith("github.com");
+  });
+}
+
+export function useGitHubEnableRecommendation(isStateLoaded: boolean): void {
+  const currentProjectPath = useProjectStore((s) => s.currentProject?.path ?? null);
+  const removeNotification = useNotificationStore((s) => s.removeNotification);
+  const notificationIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isElectronAvailable() || !isStateLoaded || !currentProjectPath) return;
+    if (handledProjectPaths.has(currentProjectPath)) return;
+
+    let cancelled = false;
+
+    async function evaluate(projectPath: string) {
+      // Query main directly rather than the pluginRuntimeStore snapshot — on
+      // cold start the project can load before the store's first pull lands,
+      // and a missed evaluation here never re-runs for this project. The
+      // trigger stays the project switch; a mid-session toggle must not
+      // re-run this.
+      const plugins = await window.electron.plugin.list();
+      if (cancelled) return;
+      const githubRow = plugins.find((p) => p.manifest.name === GITHUB_PLUGIN_ID);
+      if (!githubRow || !githubRow.disabled) return;
+
+      let remotes: Array<{ fetchUrl: string }>;
+      try {
+        remotes = await window.electron.project.listRemotes(projectPath);
+      } catch {
+        return; // not a git repo / remotes unavailable — nothing to recommend
+      }
+      if (cancelled || !hasGitHubRemote(remotes)) return;
+
+      handledProjectPaths.add(projectPath);
+
+      const id = notify({
+        type: "info",
+        placement: "grid-bar",
+        title: "GitHub integration is off",
+        message:
+          "This repository is hosted on GitHub, but the GitHub plugin is disabled — issues, pull requests, and repo stats are unavailable.",
+        inboxMessage:
+          "This repository is hosted on GitHub, but the GitHub plugin is disabled — issues, pull requests, and repo stats are unavailable.",
+        duration: 0,
+        supersedeKey: `github-enable-recommendation:${projectPath}`,
+        actions: [
+          {
+            label: "Enable GitHub",
+            variant: "primary",
+            onClick: () => {
+              safeFireAndForget(window.electron.plugin.setEnabled(GITHUB_PLUGIN_ID, true), {
+                context: "Enabling GitHub plugin from recommendation",
+              });
+              if (notificationIdRef.current) {
+                removeNotification(notificationIdRef.current);
+                notificationIdRef.current = null;
+              }
+            },
+          },
+          {
+            label: "Not now",
+            variant: "secondary",
+            onClick: () => {
+              if (notificationIdRef.current) {
+                removeNotification(notificationIdRef.current);
+                notificationIdRef.current = null;
+              }
+            },
+          },
+        ],
+      });
+      notificationIdRef.current = id || null;
+    }
+
+    evaluate(currentProjectPath).catch((err) => {
+      logError("GitHub enable recommendation evaluation failed", err);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isStateLoaded, currentProjectPath, removeNotification]);
+
+  useEffect(() => {
+    return () => {
+      if (notificationIdRef.current) {
+        removeNotification(notificationIdRef.current);
+      }
+    };
+  }, [removeNotification]);
+}
+
+/** Test-only: reset the per-session fired/dismissed project memory. */
+export function _resetGitHubEnableRecommendationForTest(): void {
+  handledProjectPaths.clear();
+}

--- a/src/hooks/app/useGitHubEnableRecommendation.ts
+++ b/src/hooks/app/useGitHubEnableRecommendation.ts
@@ -20,17 +20,41 @@ import { logError } from "@/utils/logger";
  */
 const handledProjectPaths = new Set<string>();
 
+/**
+ * Extract the host from an HTTPS or scp-like SSH remote URL. Substring
+ * matching is not enough — `git@notgithub.com:x/y.git` and path segments
+ * containing `github.com/` must not count as GitHub remotes.
+ */
+function remoteHost(fetchUrl: string): string | null {
+  const url = fetchUrl.trim();
+  try {
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(url)) {
+      return new URL(url).hostname.toLowerCase();
+    }
+  } catch {
+    return null;
+  }
+  // scp-like SSH form: [user@]host:path
+  const scpMatch = /^(?:[^@/\s]+@)?([^:/\s]+):/.exec(url);
+  return scpMatch?.[1]?.toLowerCase() ?? null;
+}
+
 function hasGitHubRemote(remotes: Array<{ fetchUrl: string }>): boolean {
   return remotes.some((remote) => {
-    const url = remote.fetchUrl.toLowerCase();
-    return url.includes("github.com:") || url.includes("github.com/") || url.endsWith("github.com");
+    const host = remoteHost(remote.fetchUrl);
+    return host === "github.com" || host?.endsWith(".github.com") === true;
   });
 }
 
 export function useGitHubEnableRecommendation(isStateLoaded: boolean): void {
   const currentProjectPath = useProjectStore((s) => s.currentProject?.path ?? null);
   const removeNotification = useNotificationStore((s) => s.removeNotification);
-  const notificationIdRef = useRef<string | null>(null);
+  // All notification ids created by this hook instance. Project switches can
+  // leave an earlier project's recommendation visible while a new one fires —
+  // each action closure must remove ITS notification (not a shared "latest"
+  // ref, which would let project A's "Not now" dismiss project B's nudge),
+  // and unmount cleanup sweeps whatever remains.
+  const notificationIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (!isElectronAvailable() || !isStateLoaded || !currentProjectPath) return;
@@ -59,7 +83,15 @@ export function useGitHubEnableRecommendation(isStateLoaded: boolean): void {
 
       handledProjectPaths.add(projectPath);
 
-      const id = notify({
+      const dismissSelf = (id: string | undefined) => {
+        if (!id) return;
+        removeNotification(id);
+        notificationIdsRef.current.delete(id);
+      };
+
+      // Action closures reference `notificationId` after notify() returns —
+      // safe because actions only fire on user click, never synchronously.
+      const notificationId: string | undefined = notify({
         type: "info",
         placement: "grid-bar",
         title: "GitHub integration is off",
@@ -77,25 +109,17 @@ export function useGitHubEnableRecommendation(isStateLoaded: boolean): void {
               safeFireAndForget(window.electron.plugin.setEnabled(GITHUB_PLUGIN_ID, true), {
                 context: "Enabling GitHub plugin from recommendation",
               });
-              if (notificationIdRef.current) {
-                removeNotification(notificationIdRef.current);
-                notificationIdRef.current = null;
-              }
+              dismissSelf(notificationId);
             },
           },
           {
             label: "Not now",
             variant: "secondary",
-            onClick: () => {
-              if (notificationIdRef.current) {
-                removeNotification(notificationIdRef.current);
-                notificationIdRef.current = null;
-              }
-            },
+            onClick: () => dismissSelf(notificationId),
           },
         ],
       });
-      notificationIdRef.current = id || null;
+      if (notificationId) notificationIdsRef.current.add(notificationId);
     }
 
     evaluate(currentProjectPath).catch((err) => {
@@ -108,10 +132,12 @@ export function useGitHubEnableRecommendation(isStateLoaded: boolean): void {
   }, [isStateLoaded, currentProjectPath, removeNotification]);
 
   useEffect(() => {
+    const ids = notificationIdsRef.current;
     return () => {
-      if (notificationIdRef.current) {
-        removeNotification(notificationIdRef.current);
+      for (const id of ids) {
+        removeNotification(id);
       }
+      ids.clear();
     };
   }, [removeNotification]);
 }

--- a/src/hooks/useForgeAuthorAvatar.ts
+++ b/src/hooks/useForgeAuthorAvatar.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { BUILTIN_GITHUB_PROVIDER_ID, normalizeProviderId } from "@shared/utils/forgeProviderIds";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 
 /**
  * Resolve a commit author's forge avatar URL for the committer chip (#8514).
@@ -23,6 +24,7 @@ export function useForgeAuthorAvatar({
   linkedProviderId: string | undefined;
 }): string | undefined {
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
+  const githubEnabled = useGitHubPluginEnabled();
 
   useEffect(() => {
     setAvatarUrl(undefined);
@@ -32,7 +34,10 @@ export function useForgeAuthorAvatar({
 
     // Only GitHub has a provider today. A worktree linked to a different
     // forge falls straight through to Gravatar until that provider ships —
-    // adding one is a new registry entry, no change here.
+    // adding one is a new registry entry, no change here. Same Gravatar
+    // fall-through while the GitHub plugin is disabled — the gated IPC
+    // would only reject.
+    if (!githubEnabled) return;
     if (normalizeProviderId(linkedProviderId) !== BUILTIN_GITHUB_PROVIDER_ID) return;
 
     let cancelled = false;
@@ -48,7 +53,7 @@ export function useForgeAuthorAvatar({
     return () => {
       cancelled = true;
     };
-  }, [email, linkedProviderId]);
+  }, [email, linkedProviderId, githubEnabled]);
 
   return avatarUrl;
 }

--- a/src/hooks/useGitHubRateLimit.ts
+++ b/src/hooks/useGitHubRateLimit.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 // eslint-disable-next-line no-restricted-imports
 import { githubClient } from "@/clients/githubClient";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 import type { GitHubRateLimitDetails, GitHubRateLimitPayload } from "@shared/types/ipc/github";
 
 /**
@@ -12,6 +13,7 @@ import type { GitHubRateLimitDetails, GitHubRateLimitPayload } from "@shared/typ
  * desynchronize. Mirrors the `useGitHubTokenHealth` wiring pattern.
  */
 export function useGitHubRateLimit(): void {
+  const githubEnabled = useGitHubPluginEnabled();
   useEffect(() => {
     let cancelled = false;
     let pushApplied = false;
@@ -28,23 +30,27 @@ export function useGitHubRateLimit(): void {
     // Replay current state on mount so secondary windows / late mounts see the
     // blocked flag without waiting for the next transition. `/rate_limit` is
     // free, so we infer primary-block state from the `core` bucket; secondary
-    // blocks aren't visible in the snapshot but will arrive via push.
-    void githubClient
-      .getRateLimitDetails()
-      .then((details) => {
-        if (!details) return;
-        const payload = inferReplayPayload(details);
-        apply(payload, "replay");
-      })
-      .catch(() => {
-        // Best-effort replay; pushes still drive transitions.
-      });
+    // blocks aren't visible in the snapshot but will arrive via push. Skipped
+    // while the GitHub plugin is disabled — the gated IPC would only reject;
+    // the push subscription stays live so a re-enable flows through.
+    if (githubEnabled) {
+      void githubClient
+        .getRateLimitDetails()
+        .then((details) => {
+          if (!details) return;
+          const payload = inferReplayPayload(details);
+          apply(payload, "replay");
+        })
+        .catch(() => {
+          // Best-effort replay; pushes still drive transitions.
+        });
+    }
 
     return () => {
       cancelled = true;
       cleanup();
     };
-  }, []);
+  }, [githubEnabled]);
 }
 
 function inferReplayPayload(details: GitHubRateLimitDetails): GitHubRateLimitPayload {

--- a/src/hooks/useGitHubTooltip.ts
+++ b/src/hooks/useGitHubTooltip.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { IssueTooltipData, PRTooltipData } from "@shared/types/github";
 import { TtlCache } from "@/utils/ttlCache";
 import { useGitHubConfigStore } from "@github-renderer/stores/githubConfigStore";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 
 type TooltipState<T> = {
   data: T | null;
@@ -26,6 +27,7 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
   const mountedRef = useRef(true);
   const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
   const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
+  const githubEnabled = useGitHubPluginEnabled();
 
   const missingToken = useMemo(() => storeInitialized && !hasToken, [storeInitialized, hasToken]);
 
@@ -40,7 +42,7 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
   }, [storeInitialized]);
 
   const fetchTooltip = useCallback(async () => {
-    if (!cwd || !issueNumber || missingToken) return;
+    if (!cwd || !issueNumber || missingToken || !githubEnabled) return;
 
     const cacheKey = `${cwd}:${issueNumber}`;
     const cached = issueCache.get(cacheKey);
@@ -99,7 +101,7 @@ export function useIssueTooltip(cwd: string | undefined, issueNumber: number | u
       if (!mountedRef.current) return;
       setState({ data: null, loading: false, error: true });
     }
-  }, [cwd, issueNumber, missingToken]);
+  }, [cwd, issueNumber, missingToken, githubEnabled]);
 
   const reset = useCallback(() => {
     setState({ data: null, loading: false, error: false });
@@ -119,6 +121,7 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
   const mountedRef = useRef(true);
   const hasToken = useGitHubConfigStore((s) => s.config?.hasToken);
   const storeInitialized = useGitHubConfigStore((s) => s.isInitialized);
+  const githubEnabled = useGitHubPluginEnabled();
 
   const missingToken = useMemo(() => storeInitialized && !hasToken, [storeInitialized, hasToken]);
 
@@ -133,7 +136,7 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
   }, [storeInitialized]);
 
   const fetchTooltip = useCallback(async () => {
-    if (!cwd || !prNumber || missingToken) return;
+    if (!cwd || !prNumber || missingToken || !githubEnabled) return;
 
     const cacheKey = `${cwd}:${prNumber}`;
     const cached = prCache.get(cacheKey);
@@ -192,7 +195,7 @@ export function usePRTooltip(cwd: string | undefined, prNumber: number | undefin
       if (!mountedRef.current) return;
       setState({ data: null, loading: false, error: true });
     }
-  }, [cwd, prNumber, missingToken]);
+  }, [cwd, prNumber, missingToken, githubEnabled]);
 
   const reset = useCallback(() => {
     setState({ data: null, loading: false, error: false });

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -4,6 +4,7 @@ import type { ProjectHealthData } from "../types";
 import { githubClient, projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 
@@ -50,9 +51,12 @@ export function useProjectHealth(): UseProjectHealthReturn {
   // Worker instances suppress automatic background polling to conserve
   // GitHub GraphQL quota (#10123) — on-demand `refresh()` stays functional.
   const isWorkerInstance = window.__DAINTREE_INSTANCE_ROLE__?.role === "worker";
+  // With the GitHub plugin disabled the gated health IPC rejects anyway —
+  // don't poll into a wall of FORGE_PROVIDER_UNAVAILABLE errors.
+  const githubEnabled = useGitHubPluginEnabled();
 
   const polling = usePollingLifecycle({
-    enabled: !isWorkerInstance,
+    enabled: !isWorkerInstance && githubEnabled,
     fetchFn: async ({ force, isInvalidated }) => {
       try {
         const project = await projectClient.getCurrent();

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -7,6 +7,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
+import { useGitHubPluginEnabled } from "@/store/pluginRuntimeStore";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 
@@ -223,9 +224,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   // Worker instances suppress automatic background polling to conserve
   // GitHub GraphQL quota (#10123) — on-demand `refresh()` stays functional.
   const isWorkerInstance = window.__DAINTREE_INSTANCE_ROLE__?.role === "worker";
+  // With the GitHub plugin disabled the gated stats IPC rejects anyway —
+  // don't poll into a wall of FORGE_PROVIDER_UNAVAILABLE errors.
+  const githubEnabled = useGitHubPluginEnabled();
 
   const polling = usePollingLifecycle({
-    enabled: !isWorkerInstance,
+    enabled: !isWorkerInstance && githubEnabled,
     fetchFn: async ({ force, isInvalidated }) => {
       try {
         const project = await projectClient.getCurrent();

--- a/src/registry/__tests__/builtinRendererRegistry.test.ts
+++ b/src/registry/__tests__/builtinRendererRegistry.test.ts
@@ -5,6 +5,7 @@ import {
   registerBuiltinView,
   unregisterBuiltinView,
 } from "../builtinRendererRegistry";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 
 function StubComponent(): null {
   return null;
@@ -42,5 +43,41 @@ describe("builtinRendererRegistry", () => {
     expect(unregisterBuiltinView("github.issueSelector")).toBe(true);
     expect(unregisterBuiltinView("github.issueSelector")).toBe(false);
     expect(getBuiltinView("github.issueSelector")).toBeNull();
+  });
+
+  describe("plugin enable-state gating", () => {
+    afterEach(() => {
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });
+    });
+
+    it("resolves null while the owning plugin is disabled, and again after re-enable", () => {
+      registerBuiltinView("github.issueSelector", StubComponent, {
+        pluginId: "daintree.github",
+      });
+      expect(getBuiltinView("github.issueSelector")).toBe(StubComponent);
+
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set(["daintree.github"]) });
+      expect(getBuiltinView("github.issueSelector")).toBeNull();
+
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });
+      expect(getBuiltinView("github.issueSelector")).toBe(StubComponent);
+    });
+
+    it("never gates slots registered without an owning plugin", () => {
+      registerBuiltinView("host.someView", StubComponent);
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set(["daintree.github"]) });
+      expect(getBuiltinView("host.someView")).toBe(StubComponent);
+    });
+
+    it("only gates slots owned by the disabled plugin", () => {
+      registerBuiltinView("github.issueSelector", StubComponent, {
+        pluginId: "daintree.github",
+      });
+      registerBuiltinView("other.view", OtherStubComponent, { pluginId: "acme.other" });
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set(["acme.other"]) });
+
+      expect(getBuiltinView("github.issueSelector")).toBe(StubComponent);
+      expect(getBuiltinView("other.view")).toBeNull();
+    });
   });
 });

--- a/src/registry/__tests__/builtinRendererRegistry.test.ts
+++ b/src/registry/__tests__/builtinRendererRegistry.test.ts
@@ -1,9 +1,11 @@
+// @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __resetBuiltinRendererRegistryForTests,
   getBuiltinView,
   registerBuiltinView,
   unregisterBuiltinView,
+  useBuiltinView,
 } from "../builtinRendererRegistry";
 import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 
@@ -78,6 +80,30 @@ describe("builtinRendererRegistry", () => {
 
       expect(getBuiltinView("github.issueSelector")).toBe(StubComponent);
       expect(getBuiltinView("other.view")).toBeNull();
+    });
+
+    it("useBuiltinView re-resolves reactively when the owner's enable state flips", async () => {
+      const { renderHook, waitFor, act } = await import("@testing-library/react");
+      registerBuiltinView("github.issueSelector", StubComponent, {
+        pluginId: "daintree.github",
+      });
+
+      const { result } = renderHook(() => useBuiltinView("github.issueSelector"));
+      expect(result.current).toBe(StubComponent);
+
+      act(() => {
+        usePluginRuntimeStore.setState({ disabledPluginIds: new Set(["daintree.github"]) });
+      });
+      await waitFor(() => {
+        expect(result.current).toBeNull();
+      });
+
+      act(() => {
+        usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });
+      });
+      await waitFor(() => {
+        expect(result.current).toBe(StubComponent);
+      });
     });
   });
 });

--- a/src/registry/builtinRendererRegistry.ts
+++ b/src/registry/builtinRendererRegistry.ts
@@ -1,4 +1,5 @@
-import type { ComponentType } from "react";
+import { useEffect, type ComponentType } from "react";
+import { usePluginRuntimeStore } from "@/store/pluginRuntimeStore";
 
 /**
  * Slot registry for renderer-side views contributed by built-in plugins. The
@@ -7,27 +8,70 @@ import type { ComponentType } from "react";
  * preserving the plugin boundary while `contributes.experimental_views` from the plugin
  * manifest is unimplemented. Slot ids are dot-namespaced by plugin
  * (`github.bulkCreateWorktreeDialog`) so the host can grep the seam.
+ *
+ * Registration is unconditional (plugin renderer bundles are imported eagerly
+ * at app start), but resolution is enable-aware: a slot registered with an
+ * owning `pluginId` resolves to `null` while that plugin is disabled, so host
+ * UI drops plugin-contributed views live with the Preferences toggle. React
+ * consumers must use {@link useBuiltinView}; {@link getBuiltinView} reads the
+ * same gate non-reactively and won't re-render on toggle.
  */
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- slot props vary per consumer; the cast site at getBuiltinView() preserves type safety
 type AnyComponent = ComponentType<any>;
 
-const REGISTRY = new Map<string, AnyComponent>();
+interface SlotEntry {
+  component: AnyComponent;
+  /** Owning plugin id (manifest name). Slots registered without one are never gated. */
+  pluginId: string | null;
+}
 
-export function registerBuiltinView(slotId: string, component: AnyComponent): void {
+const REGISTRY = new Map<string, SlotEntry>();
+
+export function registerBuiltinView(
+  slotId: string,
+  component: AnyComponent,
+  opts?: { pluginId?: string }
+): void {
   if (REGISTRY.has(slotId)) {
     console.warn(`[builtinRendererRegistry] Slot "${slotId}" already registered, overwriting`);
   }
-  REGISTRY.set(slotId, component);
+  REGISTRY.set(slotId, { component, pluginId: opts?.pluginId ?? null });
 }
 
 export function unregisterBuiltinView(slotId: string): boolean {
   return REGISTRY.delete(slotId);
 }
 
+function resolveSlot<P>(
+  slotId: string,
+  disabledPluginIds: ReadonlySet<string>
+): ComponentType<P> | null {
+  const entry = REGISTRY.get(slotId);
+  if (!entry) return null;
+  if (entry.pluginId !== null && disabledPluginIds.has(entry.pluginId)) return null;
+  return entry.component as ComponentType<P>;
+}
+
+/**
+ * Non-reactive resolution — reads the current disabled set once. For callers
+ * outside React render; components should use {@link useBuiltinView} so a
+ * live plugin toggle re-renders them.
+ */
 export function getBuiltinView<P>(slotId: string): ComponentType<P> | null {
-  const component = REGISTRY.get(slotId);
-  return (component as ComponentType<P> | undefined) ?? null;
+  return resolveSlot<P>(slotId, usePluginRuntimeStore.getState().disabledPluginIds);
+}
+
+/**
+ * Reactive slot resolution: re-renders when the owning plugin is enabled or
+ * disabled at runtime. Also initializes the plugin-runtime mirror on first
+ * mount (idempotent), so any slot consumer is enough to start tracking.
+ */
+export function useBuiltinView<P>(slotId: string): ComponentType<P> | null {
+  const disabledPluginIds = usePluginRuntimeStore((s) => s.disabledPluginIds);
+  const init = usePluginRuntimeStore((s) => s.init);
+  useEffect(() => init(), [init]);
+  return resolveSlot<P>(slotId, disabledPluginIds);
 }
 
 export function __resetBuiltinRendererRegistryForTests(): void {

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { create } from "zustand";
 import { logError } from "@/utils/logger";
 
@@ -39,12 +40,38 @@ export const usePluginRuntimeStore = create<PluginRuntimeState>((set) => ({
     if (initialized) return;
     initialized = true;
 
-    unsubscribe = window.electron.plugin.onProvenanceChanged(() => {
+    // Consumed from many leaf components (toolbar pills, banners, tooltips,
+    // slot hooks), so tolerate a partially-stubbed bridge instead of pushing
+    // a plugin-namespace mock into every component test. Absent bridge ⇒ the
+    // disabled set stays empty (plugins read as enabled), matching prod
+    // optimism before the first snapshot.
+    const plugin = window.electron?.plugin;
+    if (typeof plugin?.onProvenanceChanged !== "function" || typeof plugin.list !== "function") {
+      return;
+    }
+
+    unsubscribe = plugin.onProvenanceChanged(() => {
       void pullDisabledSet(set);
     });
     void pullDisabledSet(set);
   },
 }));
+
+export const GITHUB_PLUGIN_ID = "daintree.github";
+
+/**
+ * Live GitHub plugin enable state for gating GitHub-shaped UI (stats pills,
+ * health cards, token banner, tooltips). Initializes the mirror on first
+ * mount; until the snapshot lands the plugin reads as enabled, matching the
+ * registry-side optimism — main independently rejects gated IPC if it's
+ * actually off.
+ */
+export function useGitHubPluginEnabled(): boolean {
+  const disabledPluginIds = usePluginRuntimeStore((s) => s.disabledPluginIds);
+  const init = usePluginRuntimeStore((s) => s.init);
+  useEffect(() => init(), [init]);
+  return !disabledPluginIds.has(GITHUB_PLUGIN_ID);
+}
 
 /** Test-only: reset the module-level init guard between cases. */
 export function _resetPluginRuntimeStoreForTest(): void {

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -22,10 +22,15 @@ interface PluginRuntimeState {
 
 let initialized = false;
 let unsubscribe: (() => void) | null = null;
+// Monotonic pull sequence: rapid provenance events can interleave list()
+// round-trips, and a slow older response must not overwrite a newer set.
+let pullSeq = 0;
 
 async function pullDisabledSet(set: (state: Partial<PluginRuntimeState>) => void): Promise<void> {
+  const seq = ++pullSeq;
   try {
     const list = await window.electron.plugin.list();
+    if (seq !== pullSeq) return;
     set({
       disabledPluginIds: new Set(list.filter((p) => p.disabled).map((p) => p.manifest.name)),
     });
@@ -78,5 +83,6 @@ export function _resetPluginRuntimeStoreForTest(): void {
   unsubscribe?.();
   unsubscribe = null;
   initialized = false;
+  pullSeq = 0;
   usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });
 }

--- a/src/store/pluginRuntimeStore.ts
+++ b/src/store/pluginRuntimeStore.ts
@@ -1,0 +1,55 @@
+import { create } from "zustand";
+import { logError } from "@/utils/logger";
+
+/**
+ * Renderer mirror of which plugins are currently disabled, so plugin-gated UI
+ * (builtin view slots, plugin-owned settings panels) can drop out live when a
+ * plugin is toggled in Preferences. Source of truth is `plugin.list()` in
+ * main; refreshed on every `plugin:provenance-changed` broadcast — the same
+ * signal PluginsTab/usePluginManager follow. Not persisted.
+ *
+ * Until the first snapshot lands, the disabled set is empty — unknown state
+ * treats plugins as enabled, matching the pre-gating behavior (and the main
+ * process independently gates plugin-backed IPC, so a brief optimistic render
+ * cannot reach a disabled plugin's data).
+ */
+interface PluginRuntimeState {
+  disabledPluginIds: ReadonlySet<string>;
+  /** Idempotent: pulls the current snapshot and subscribes to live updates. */
+  init: () => void;
+}
+
+let initialized = false;
+let unsubscribe: (() => void) | null = null;
+
+async function pullDisabledSet(set: (state: Partial<PluginRuntimeState>) => void): Promise<void> {
+  try {
+    const list = await window.electron.plugin.list();
+    set({
+      disabledPluginIds: new Set(list.filter((p) => p.disabled).map((p) => p.manifest.name)),
+    });
+  } catch (err) {
+    logError("Failed to load plugin disabled state", err);
+  }
+}
+
+export const usePluginRuntimeStore = create<PluginRuntimeState>((set) => ({
+  disabledPluginIds: new Set<string>(),
+  init: () => {
+    if (initialized) return;
+    initialized = true;
+
+    unsubscribe = window.electron.plugin.onProvenanceChanged(() => {
+      void pullDisabledSet(set);
+    });
+    void pullDisabledSet(set);
+  },
+}));
+
+/** Test-only: reset the module-level init guard between cases. */
+export function _resetPluginRuntimeStoreForTest(): void {
+  unsubscribe?.();
+  unsubscribe = null;
+  initialized = false;
+  usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });
+}


### PR DESCRIPTION
Disabling the built-in `daintree.github` plugin didn't actually disable anything. Issues, PRs, repo stats, the settings panel — it was all still there, even after a restart. The legacy `github:*` IPC handlers register unconditionally, and the renderer plugin boundary never checks enable state, so the toggle was effectively cosmetic.

This PR makes the plugin authoritative. Disabling it genuinely removes GitHub, live, without a restart — and re-enabling brings everything back the same way.

One architectural note up front: the `electron/services/github/*` files turned out to be two-line re-export shims of the plugin code, not duplicate implementations. So this was a gating job, not a merge.

## Native IPC gating

The 17 data/network `github:*` handlers (list issues/PRs, repo stats, project health, tooltips, token network ops, etc.) are now gated on the forge provider being active, rejecting with a typed `FORGE_PROVIDER_UNAVAILABLE` error before reaching plugin code. Local URL builders and token-state reads stay ungated — they're cheap, local, and `get-config` now answers from local token state while disabled instead of lazily validating against `/user`.

## Enable-aware renderer slots

View slots in `builtinRendererRegistry` now carry an owning `pluginId`, and a new `useBuiltinView` hook resolves them reactively — a slot returns `null` while its plugin is disabled, and consumers re-render on a live toggle. A small `pluginRuntimeStore` mirrors disabled plugin ids off `plugin:provenance-changed`.

## Plugin-owned settings

`GitHubSettingsTab` moves into the plugin and is contributed through a `github.forgeSettingsTab` slot, so the plugin defines its own settings interface — the host just offers the seam. With the plugin disabled, the Code Forge subtab falls back to General instead of rendering a panel for a provider that no longer exists.

## Quiet surfaces, explicit recovery

When disabled, the toolbar pills, health cards, token banner, and issue/PR tooltips all drop out rather than erroring into gated IPC. Opening a `github.com` repo with the plugin off surfaces a dismissible "Enable GitHub" recommendation — it never auto-enables; a persisted disable is the user's call.

## Lifecycle-owned probing

Token-health probing moves under the plugin's `activate()`/`dispose()`, so a disabled plugin issues no background GitHub network (including the startup token validation, which previously leaked a `/user` fetch regardless of plugin state). Token *storage* stays eager — a stored token survives a disable/enable cycle.

## Live-disable propagation

`unloadPlugin` now notifies workspace hosts that the forge registry changed (the load path always did), and `PullRequestService` invalidates even a resolved provider on registry updates, since updates now signal removals.

## Testing

Full suite passes — 33,220 unit tests across 1,592 files, plus new coverage for the handler gate (off → rejection, on → data, live transition), slot reactivity, the in-flight probe race on `stop()`, the settings deep-link fallback, and the live-disable notify. The branch also went through a Codex review, which caught the startup validation leak and the stale PR-polling invalidation among others.