### PR TITLE
feat(github): treat the background count poll as a cache buster for list pages

### DIFF
--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -188,6 +188,81 @@ export function getETagCacheVersion(): number {
   return etagCacheVersion;
 }
 
+/**
+ * Per-repo, per-type list-cache epochs for the count-as-cache-buster
+ * (#10122 family). Bumped by {@link invalidateRepoListCachesForCountChange}
+ * when the cheap REST count poll observes a changed open count. List fetchers
+ * capture the epoch before their network call and skip the shared-cache write
+ * when it moved — without this, a list query already in flight when the count
+ * delta lands would repopulate the just-busted cache with a page fetched
+ * before the change, pinning it for the full 60s TTL.
+ *
+ * Deliberately separate from `etagCacheVersion`: that guards REST/event ETag
+ * commit baselines in `fetchRestCounts`, and bumping it here would discard
+ * unrelated in-flight count commits.
+ *
+ * Keyed `${type}:${owner}/${repo}`. A plain Map (not a TTL cache): entries are
+ * one integer per repo the session has polled, and an epoch must never be
+ * evicted mid-flight or the guard would compare against a fresh zero.
+ */
+const repoListCacheEpochs = new Map<string, number>();
+
+export function getRepoListEpoch(type: "issue" | "pr", owner: string, repo: string): number {
+  return repoListCacheEpochs.get(`${type}:${owner}/${repo}`) ?? 0;
+}
+
+function bumpRepoListEpoch(type: "issue" | "pr", owner: string, repo: string): void {
+  const key = `${type}:${owner}/${repo}`;
+  repoListCacheEpochs.set(key, (repoListCacheEpochs.get(key) ?? 0) + 1);
+}
+
+/** Drop every entry whose key starts with `prefix`. `Cache.forEach` snapshots
+ *  entries up front, so invalidating inside the walk is safe. */
+function invalidateByPrefix(cache: Cache<string, unknown>, prefix: string): void {
+  const keys: string[] = [];
+  cache.forEach((_value, key) => {
+    if (key.startsWith(prefix)) keys.push(key);
+  });
+  for (const key of keys) cache.invalidate(key);
+}
+
+/**
+ * Count-as-cache-buster: the cheap REST count poll observed a different open
+ * count, so every cached list page for the changed type is provably stale —
+ * drop it (zero network; the next read refetches) and bump the type's epoch so
+ * in-flight list queries can't write a pre-change page back.
+ *
+ * Per-type on purpose: issue churn must not evict PR pages (and vice versa) —
+ * busting both on any delta would double the refetch volume on active repos.
+ * The combined stats-and-page snapshot embeds BOTH first pages, so any delta
+ * drops it; same for the legacy list caches that the `window.electron.github`
+ * dropdown IPC path still reads alongside the forge caches.
+ *
+ * List keys are `${type}:${owner}/${repo}:${state}:${search}:${sort}:${cursor}`
+ * (see `buildListCacheKey`), so the repo prefix sweeps every state/sort/cursor
+ * variant — a close/merge/reopen changes the closed and all views too.
+ */
+export function invalidateRepoListCachesForCountChange(
+  owner: string,
+  repo: string,
+  changed: { issues: boolean; prs: boolean }
+): void {
+  if (!changed.issues && !changed.prs) return;
+  if (changed.issues) {
+    const prefix = `issue:${owner}/${repo}:`;
+    invalidateByPrefix(forgeIssueListCache as Cache<string, unknown>, prefix);
+    invalidateByPrefix(issueListCache as Cache<string, unknown>, prefix);
+    bumpRepoListEpoch("issue", owner, repo);
+  }
+  if (changed.prs) {
+    const prefix = `pr:${owner}/${repo}:`;
+    invalidateByPrefix(forgePRListCache as Cache<string, unknown>, prefix);
+    invalidateByPrefix(prListCache as Cache<string, unknown>, prefix);
+    bumpRepoListEpoch("pr", owner, repo);
+  }
+  repoStatsAndPageSnapshotCache.invalidate(`${owner}/${repo}`);
+}
+
 export interface PRRequiredStatusEntry {
   ciStatus: GitHubPRCIStatus | undefined;
   ciSummary: GitHubPRCISummary | undefined;

--- a/plugins/builtin/github/main/GitHubIssues.ts
+++ b/plugins/builtin/github/main/GitHubIssues.ts
@@ -15,6 +15,7 @@ import {
   issueListCache,
   issueTooltipCache,
   issueTooltipWrittenAt,
+  getRepoListEpoch,
 } from "./GitHubCaches.js";
 import { GitHubStatsCache } from "./GitHubStatsCache.js";
 import { buildListCacheKey, updateRepoStatsCount } from "./GitHubPRs.js";
@@ -564,6 +565,11 @@ export async function listIssues(
       if (cached) return cached;
     }
 
+    // Captured before the network call: if the count-as-cache-buster bumps
+    // the epoch mid-flight, this page predates the observed change and must
+    // not repopulate the just-busted cache.
+    const epochAtStart = getRepoListEpoch("issue", context.owner, context.repo);
+
     try {
       let result: GitHubListResponse<GitHubIssue>;
 
@@ -631,27 +637,34 @@ export async function listIssues(
           totalCount,
         };
 
-        issueListCache.set(cacheKey, result);
+        // Mid-flight count-buster guard — see `getRepoListEpoch`. The stats
+        // updates sit behind the same guard: a response too old to repopulate
+        // the list cache is also too old to roll `repoStatsCache` (or the
+        // disk stats) back to its pre-change total under a fresh
+        // `lastUpdated`.
+        if (getRepoListEpoch("issue", context.owner, context.repo) === epochAtStart) {
+          issueListCache.set(cacheKey, result);
 
-        if (
-          (!options.state || options.state === "open") &&
-          !options.cursor &&
-          totalCount !== undefined
-        ) {
-          const statsCacheKey = `${context.owner}/${context.repo}`;
-          updateRepoStatsCount(statsCacheKey, "issue", totalCount);
+          if (
+            (!options.state || options.state === "open") &&
+            !options.cursor &&
+            totalCount !== undefined
+          ) {
+            const statsCacheKey = `${context.owner}/${context.repo}`;
+            updateRepoStatsCount(statsCacheKey, "issue", totalCount);
 
-          const memoryStats = repoStatsCache.get(statsCacheKey);
-          if (memoryStats && memoryStats.issueCount > 0 && memoryStats.prCount > 0) {
-            const persistentCache = GitHubStatsCache.getInstance();
-            persistentCache.set(
-              statsCacheKey,
-              {
-                issueCount: memoryStats.issueCount,
-                prCount: memoryStats.prCount,
-              },
-              options.cwd
-            );
+            const memoryStats = repoStatsCache.get(statsCacheKey);
+            if (memoryStats && memoryStats.issueCount > 0 && memoryStats.prCount > 0) {
+              const persistentCache = GitHubStatsCache.getInstance();
+              persistentCache.set(
+                statsCacheKey,
+                {
+                  issueCount: memoryStats.issueCount,
+                  prCount: memoryStats.prCount,
+                },
+                options.cwd
+              );
+            }
           }
         }
       }

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -21,6 +21,7 @@ import {
   prRequiredStatusCache,
   truncateBody,
   isoToEpochMs,
+  getRepoListEpoch,
   MAX_REVIEW_THREAD_PAGES,
   REVIEW_THREADS_PER_PAGE,
   type PRRequiredStatusEntry,
@@ -439,6 +440,11 @@ export async function listPullRequests(
       if (cached) return cached;
     }
 
+    // Captured before the network call: if the count-as-cache-buster bumps
+    // the epoch mid-flight, this page predates the observed change and must
+    // not repopulate the just-busted cache.
+    const epochAtStart = getRepoListEpoch("pr", context.owner, context.repo);
+
     try {
       let result: GitHubListResponse<GitHubPR>;
 
@@ -525,27 +531,34 @@ export async function listPullRequests(
           totalCount,
         };
 
-        prListCache.set(cacheKey, result);
+        // Mid-flight count-buster guard — see `getRepoListEpoch`. The stats
+        // updates sit behind the same guard: a response too old to repopulate
+        // the list cache is also too old to roll `repoStatsCache` (or the
+        // disk stats) back to its pre-change total under a fresh
+        // `lastUpdated`.
+        if (getRepoListEpoch("pr", context.owner, context.repo) === epochAtStart) {
+          prListCache.set(cacheKey, result);
 
-        if (
-          (!options.state || options.state === "open") &&
-          !options.cursor &&
-          totalCount !== undefined
-        ) {
-          const statsCacheKey = `${context.owner}/${context.repo}`;
-          updateRepoStatsCount(statsCacheKey, "pr", totalCount);
+          if (
+            (!options.state || options.state === "open") &&
+            !options.cursor &&
+            totalCount !== undefined
+          ) {
+            const statsCacheKey = `${context.owner}/${context.repo}`;
+            updateRepoStatsCount(statsCacheKey, "pr", totalCount);
 
-          const memoryStats = repoStatsCache.get(statsCacheKey);
-          if (memoryStats && memoryStats.issueCount > 0 && memoryStats.prCount > 0) {
-            const persistentCache = GitHubStatsCache.getInstance();
-            persistentCache.set(
-              statsCacheKey,
-              {
-                issueCount: memoryStats.issueCount,
-                prCount: memoryStats.prCount,
-              },
-              options.cwd
-            );
+            const memoryStats = repoStatsCache.get(statsCacheKey);
+            if (memoryStats && memoryStats.issueCount > 0 && memoryStats.prCount > 0) {
+              const persistentCache = GitHubStatsCache.getInstance();
+              persistentCache.set(
+                statsCacheKey,
+                {
+                  issueCount: memoryStats.issueCount,
+                  prCount: memoryStats.prCount,
+                },
+                options.cwd
+              );
+            }
           }
         }
       }

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -19,6 +19,8 @@ import {
   repoEventsNoChangeCount,
   repoEventsLastProbeAt,
   getETagCacheVersion,
+  getRepoListEpoch,
+  invalidateRepoListCachesForCountChange,
 } from "./GitHubCaches.js";
 import { GitHubStatsCache } from "./GitHubStatsCache.js";
 import { GitHubFirstPageCache } from "./GitHubFirstPageCache.js";
@@ -236,8 +238,32 @@ export async function fetchRestCounts(
   owner: string,
   repo: string
 ): Promise<RepoStats | null> {
+  // Per-repo singleflight: concurrent polls (multi-window — each
+  // `WebContentsView` runs its own poll loop) must not interleave. Two
+  // overlapping fetches read the same `prior` baseline, so the slower one can
+  // commit a stale `304` replay over the faster one's fresh counts and
+  // double-fire the count-buster (the second epoch bump would discard a list
+  // fetch that started after the first, forcing a redundant GraphQL refetch).
   const cacheKey = `${owner}/${repo}`;
+  const pending = restCountsInflight.get(cacheKey);
+  if (pending) return pending;
+  const promise = fetchRestCountsImpl(token, owner, repo, cacheKey);
+  restCountsInflight.set(cacheKey, promise);
+  const cleanup = () => {
+    if (restCountsInflight.get(cacheKey) === promise) restCountsInflight.delete(cacheKey);
+  };
+  promise.then(cleanup, cleanup);
+  return promise;
+}
 
+const restCountsInflight = new Map<string, Promise<RepoStats | null>>();
+
+async function fetchRestCountsImpl(
+  token: string,
+  owner: string,
+  repo: string,
+  cacheKey: string
+): Promise<RepoStats | null> {
   const block = gitHubRateLimitService.shouldBlockRequest("core");
   if (block.blocked) return null;
 
@@ -323,6 +349,25 @@ export async function fetchRestCounts(
     const lastUpdated = Date.now();
     const snapshot: RestCountsSnapshot = { combinedCount, prCount, repoEtag, prEtag, lastUpdated };
     restCountsCache.set(cacheKey, snapshot);
+
+    // Count-as-cache-buster: a committed count that differs from the prior
+    // committed pair means cached list pages for the changed type are provably
+    // stale — drop them (zero network) so no path can serve a pre-change page
+    // for the rest of its 60s TTL. Per-type comparison: the derived issue
+    // count and the PR count move independently, and busting the unchanged
+    // type would just multiply refetch volume. First-ever commit (`!prior`)
+    // busts nothing — there is no baseline to have diverged from. Note the
+    // inverse does NOT hold: equal counts don't prove the pages are fresh
+    // (close-one-open-one), which is why the dropdown's own revalidation
+    // stays the correctness backstop.
+    if (prior) {
+      const priorIssueCount = prior.combinedCount - prior.prCount;
+      invalidateRepoListCachesForCountChange(owner, repo, {
+        issues: priorIssueCount !== issueCount,
+        prs: prior.prCount !== prCount,
+      });
+    }
+
     return { issueCount, prCount, lastUpdated };
   } catch {
     return null;
@@ -443,15 +488,14 @@ export async function getRepoStatsAndPageForContext(
   } else {
     const token = GitHubAuth.getToken();
     if (token) {
-      const snapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
-      const restCounts = restCountsCache.get(cacheKey);
+      const preProbeSnapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
       // Skip the network probe entirely while inside the adaptive window: never
       // poll `/events` faster than the server-advertised `X-Poll-Interval`, and
       // back off further on an idle repo. The cached snapshot (or, on the
       // background-only path, the last REST counts) stands in for the
       // "unchanged" result we'd otherwise pay a request to confirm.
       const withinBackoff =
-        (snapshot !== undefined || restCounts !== undefined) &&
+        (preProbeSnapshot !== undefined || restCountsCache.get(cacheKey) !== undefined) &&
         Date.now() - (repoEventsLastProbeAt.get(cacheKey) ?? 0) < eventsProbeDelayMs(cacheKey);
       const probe: ActivityProbeResult = withinBackoff
         ? { status: "unchanged" }
@@ -460,6 +504,12 @@ export async function getRepoStatsAndPageForContext(
       if (probe.status === "changed") {
         pendingEventsEtag = probe.etag;
       }
+
+      // Re-read AFTER the probe await: a concurrent poll's count-buster can
+      // drop the snapshot mid-probe, and re-warming the list caches from the
+      // pre-await reference would resurrect the exact pages the bust removed.
+      const snapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
+      const restCounts = restCountsCache.get(cacheKey);
 
       if (probe.status === "unchanged" && snapshot) {
         // The cheap REST poll may have observed fresher counts after this
@@ -614,6 +664,15 @@ export async function getRepoStatsAndPageForContext(
     return { stats: null, issues: null, prs: null, error: message };
   }
 
+  // Mid-flight count-buster guard for the page-cache writes below — same
+  // discipline as the list fetchers: a concurrent background poll can commit
+  // a count change (and bust the list caches) while the heavy query is in
+  // flight, and server-side ordering between the two reads is unknowable.
+  // On an epoch move the page/snapshot writes are skipped (the next read
+  // refetches); the response is still returned and broadcast for display.
+  const issueEpochAtStart = getRepoListEpoch("issue", context.owner, context.repo);
+  const prEpochAtStart = getRepoListEpoch("pr", context.owner, context.repo);
+
   try {
     const result = (await client(REPO_STATS_AND_PAGE_QUERY, {
       owner: context.owner,
@@ -700,25 +759,35 @@ export async function getRepoStatsAndPageForContext(
       hasNextPage: prsData?.pageInfo?.hasNextPage ?? false,
       totalCount: prCount,
     };
-    issueListCache.set(issuesListCacheKey, {
-      items: issuesPage.items,
-      pageInfo: { hasNextPage: issuesPage.hasNextPage, endCursor: issuesPage.endCursor },
-      totalCount: issuesPage.totalCount,
-    });
-    prListCache.set(prsListCacheKey, {
-      items: prsPage.items,
-      pageInfo: { hasNextPage: prsPage.hasNextPage, endCursor: prsPage.endCursor },
-      totalCount: prsPage.totalCount,
-    });
+    const issueEpochUnchanged =
+      getRepoListEpoch("issue", context.owner, context.repo) === issueEpochAtStart;
+    const prEpochUnchanged = getRepoListEpoch("pr", context.owner, context.repo) === prEpochAtStart;
+    if (issueEpochUnchanged) {
+      issueListCache.set(issuesListCacheKey, {
+        items: issuesPage.items,
+        pageInfo: { hasNextPage: issuesPage.hasNextPage, endCursor: issuesPage.endCursor },
+        totalCount: issuesPage.totalCount,
+      });
+    }
+    if (prEpochUnchanged) {
+      prListCache.set(prsListCacheKey, {
+        items: prsPage.items,
+        pageInfo: { hasNextPage: prsPage.hasNextPage, endCursor: prsPage.endCursor },
+        totalCount: prsPage.totalCount,
+      });
+    }
 
     // Record the snapshot so the next poll can skip the heavy query when the
     // activity probe reports no change. Written only on a successful network
-    // fetch — a failed fetch must not advance it.
-    repoStatsAndPageSnapshotCache.set(cacheKey, {
-      stats,
-      issues: issuesPage,
-      prs: prsPage,
-    });
+    // fetch — a failed fetch must not advance it — and only when neither
+    // type's epoch moved mid-query (the snapshot embeds both first pages).
+    if (issueEpochUnchanged && prEpochUnchanged) {
+      repoStatsAndPageSnapshotCache.set(cacheKey, {
+        stats,
+        issues: issuesPage,
+        prs: prsPage,
+      });
+    }
 
     return {
       stats,

--- a/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubCaches.test.ts
@@ -11,9 +11,17 @@ import {
   repoEventsNoChangeCount,
   repoEventsLastProbeAt,
   repoStatsAndPageSnapshotCache,
+  forgeIssueListCache,
+  forgePRListCache,
+  issueListCache,
+  prListCache,
+  getRepoListEpoch,
+  invalidateRepoListCachesForCountChange,
   MAX_REVIEW_THREAD_PAGES,
   REVIEW_THREADS_PER_PAGE,
 } from "../GitHubCaches.js";
+import type { Issue, PR, Page } from "../../../../../shared/types/forge.js";
+import type { GitHubIssue, GitHubPR, GitHubListResponse } from "../../shared/types.js";
 
 describe("GitHubCaches ETag caches", () => {
   beforeEach(() => {
@@ -154,6 +162,121 @@ describe("polling-optimization caches (issues #8757, #9041)", () => {
       120: 2,
       180: 3,
     });
+  });
+});
+
+describe("invalidateRepoListCachesForCountChange (count-as-cache-buster)", () => {
+  const forgePage = { items: [], nextCursor: null, hasMore: false } as Page<Issue> & Page<PR>;
+  const legacyPage = {
+    items: [],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  } as GitHubListResponse<GitHubIssue> & GitHubListResponse<GitHubPR>;
+
+  beforeEach(() => {
+    forgeIssueListCache.clear();
+    forgePRListCache.clear();
+    issueListCache.clear();
+    prListCache.clear();
+    repoStatsAndPageSnapshotCache.clear();
+  });
+
+  function seedLists(): void {
+    // Every state/sort/cursor variant for the target repo, in both the forge
+    // and legacy cache families, plus a second repo that must survive.
+    forgeIssueListCache.set("issue:owner/repo:open::created:", forgePage);
+    forgeIssueListCache.set("issue:owner/repo:closed::updated:cursor123", forgePage);
+    issueListCache.set("issue:owner/repo:open::created:", legacyPage);
+    issueListCache.set("issue:owner/repo:all:search-term:created:", legacyPage);
+    forgeIssueListCache.set("issue:other/repo:open::created:", forgePage);
+    issueListCache.set("issue:other/repo:open::created:", legacyPage);
+
+    forgePRListCache.set("pr:owner/repo:open::created:", forgePage);
+    forgePRListCache.set("pr:owner/repo:merged::updated:", forgePage);
+    prListCache.set("pr:owner/repo:open::created:", legacyPage);
+    forgePRListCache.set("pr:other/repo:open::created:", forgePage);
+
+    repoStatsAndPageSnapshotCache.set("owner/repo", {
+      stats: { issueCount: 4, prCount: 5, lastUpdated: 1 },
+      issues: { items: [], endCursor: null, hasNextPage: false, totalCount: 4 },
+      prs: { items: [], endCursor: null, hasNextPage: false, totalCount: 5 },
+    });
+    repoStatsAndPageSnapshotCache.set("other/repo", {
+      stats: { issueCount: 1, prCount: 1, lastUpdated: 1 },
+      issues: { items: [], endCursor: null, hasNextPage: false, totalCount: 1 },
+      prs: { items: [], endCursor: null, hasNextPage: false, totalCount: 1 },
+    });
+  }
+
+  it("an issue-count change drops every issue variant for the repo but no PR pages", () => {
+    seedLists();
+    invalidateRepoListCachesForCountChange("owner", "repo", { issues: true, prs: false });
+
+    expect(forgeIssueListCache.get("issue:owner/repo:open::created:")).toBeUndefined();
+    expect(forgeIssueListCache.get("issue:owner/repo:closed::updated:cursor123")).toBeUndefined();
+    expect(issueListCache.get("issue:owner/repo:open::created:")).toBeUndefined();
+    expect(issueListCache.get("issue:owner/repo:all:search-term:created:")).toBeUndefined();
+
+    expect(forgePRListCache.get("pr:owner/repo:open::created:")).toBe(forgePage);
+    expect(forgePRListCache.get("pr:owner/repo:merged::updated:")).toBe(forgePage);
+    expect(prListCache.get("pr:owner/repo:open::created:")).toBe(legacyPage);
+  });
+
+  it("a PR-count change drops every PR variant but no issue pages", () => {
+    seedLists();
+    invalidateRepoListCachesForCountChange("owner", "repo", { issues: false, prs: true });
+
+    expect(forgePRListCache.get("pr:owner/repo:open::created:")).toBeUndefined();
+    expect(forgePRListCache.get("pr:owner/repo:merged::updated:")).toBeUndefined();
+    expect(prListCache.get("pr:owner/repo:open::created:")).toBeUndefined();
+
+    expect(forgeIssueListCache.get("issue:owner/repo:open::created:")).toBe(forgePage);
+    expect(issueListCache.get("issue:owner/repo:open::created:")).toBe(legacyPage);
+  });
+
+  it("other repos' entries always survive", () => {
+    seedLists();
+    invalidateRepoListCachesForCountChange("owner", "repo", { issues: true, prs: true });
+
+    expect(forgeIssueListCache.get("issue:other/repo:open::created:")).toBe(forgePage);
+    expect(issueListCache.get("issue:other/repo:open::created:")).toBe(legacyPage);
+    expect(forgePRListCache.get("pr:other/repo:open::created:")).toBe(forgePage);
+    expect(repoStatsAndPageSnapshotCache.get("other/repo")).toBeDefined();
+  });
+
+  it("drops the combined stats-and-page snapshot on any delta — it embeds both first pages", () => {
+    seedLists();
+    invalidateRepoListCachesForCountChange("owner", "repo", { issues: true, prs: false });
+    expect(repoStatsAndPageSnapshotCache.get("owner/repo")).toBeUndefined();
+  });
+
+  it("is a no-op when nothing changed", () => {
+    seedLists();
+    const issueEpoch = getRepoListEpoch("issue", "owner", "repo");
+    const prEpoch = getRepoListEpoch("pr", "owner", "repo");
+
+    invalidateRepoListCachesForCountChange("owner", "repo", { issues: false, prs: false });
+
+    expect(forgeIssueListCache.get("issue:owner/repo:open::created:")).toBe(forgePage);
+    expect(forgePRListCache.get("pr:owner/repo:open::created:")).toBe(forgePage);
+    expect(repoStatsAndPageSnapshotCache.get("owner/repo")).toBeDefined();
+    expect(getRepoListEpoch("issue", "owner", "repo")).toBe(issueEpoch);
+    expect(getRepoListEpoch("pr", "owner", "repo")).toBe(prEpoch);
+  });
+
+  it("bumps only the changed type's epoch so in-flight writes of the other type stay valid", () => {
+    const issueBefore = getRepoListEpoch("issue", "owner", "repo");
+    const prBefore = getRepoListEpoch("pr", "owner", "repo");
+
+    invalidateRepoListCachesForCountChange("owner", "repo", { issues: true, prs: false });
+
+    expect(getRepoListEpoch("issue", "owner", "repo")).toBe(issueBefore + 1);
+    expect(getRepoListEpoch("pr", "owner", "repo")).toBe(prBefore);
+  });
+
+  it("epochs are scoped per repo", () => {
+    const before = getRepoListEpoch("issue", "unrelated", "repo");
+    invalidateRepoListCachesForCountChange("owner", "repo", { issues: true, prs: true });
+    expect(getRepoListEpoch("issue", "unrelated", "repo")).toBe(before);
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/GitHubIssues.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubIssues.test.ts
@@ -40,7 +40,13 @@ vi.mock("../GitHubRepoContext.js", () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { assignIssue, extractLinkedPR } from "../GitHubIssues.js";
+import { assignIssue, extractLinkedPR, listIssues } from "../GitHubIssues.js";
+import { GitHubAuth } from "../GitHubAuth.js";
+import {
+  issueListCache,
+  repoStatsCache,
+  invalidateRepoListCachesForCountChange,
+} from "../GitHubCaches.js";
 
 describe("assignIssue error handling", () => {
   beforeEach(() => {
@@ -393,5 +399,70 @@ describe("assignIssue — tooltip cache preserved on failure", () => {
 
     await expect(assignIssue("/test", 42, "someuser")).rejects.toThrow();
     expect(issueTooltipCache.get(tooltipKey)).toEqual(tooltipEntry);
+  });
+});
+
+describe("listIssues — mid-flight count-buster guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearGitHubCaches();
+  });
+
+  it("a response that started before a count bust neither repopulates the list cache nor rolls back the stats count", async () => {
+    let resolveQuery!: (value: unknown) => void;
+    const clientMock = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveQuery = resolve;
+        })
+    );
+    vi.mocked(GitHubAuth.createClient).mockReturnValueOnce(clientMock as never);
+
+    // The count poll has already committed the post-change total.
+    repoStatsCache.set("testowner/testrepo", { issueCount: 6, prCount: 0, lastUpdated: 1 });
+
+    const pending = listIssues({ cwd: "/test", bypassCache: true });
+    // The count buster fires while the list query is in flight.
+    invalidateRepoListCachesForCountChange("testowner", "testrepo", { issues: true, prs: false });
+
+    // The stale response carries the pre-change total.
+    resolveQuery({
+      repository: {
+        issues: {
+          totalCount: 5,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    });
+    const result = await pending;
+
+    // The caller still receives the page…
+    expect(result.totalCount).toBe(5);
+    // …but it must not be committed anywhere shared: the cache write would pin
+    // a pre-change page for 60s, and the stats write would roll the toolbar
+    // count back under a fresh lastUpdated.
+    expect(issueListCache.get("issue:testowner/testrepo:open::created:")).toBeUndefined();
+    expect(repoStatsCache.get("testowner/testrepo")?.issueCount).toBe(6);
+  });
+
+  it("an undisturbed response commits both the list cache and the stats count", async () => {
+    const clientMock = vi.fn(async () => ({
+      repository: {
+        issues: {
+          totalCount: 5,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [],
+        },
+      },
+    }));
+    vi.mocked(GitHubAuth.createClient).mockReturnValueOnce(clientMock as never);
+    repoStatsCache.set("testowner/testrepo", { issueCount: 6, prCount: 0, lastUpdated: 1 });
+
+    const result = await listIssues({ cwd: "/test", bypassCache: true });
+
+    expect(result.totalCount).toBe(5);
+    expect(issueListCache.get("issue:testowner/testrepo:open::created:")).toBeDefined();
+    expect(repoStatsCache.get("testowner/testrepo")?.issueCount).toBe(5);
   });
 });

--- a/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
@@ -65,17 +65,20 @@ vi.mock("../GitHubFirstPageCache.js", () => ({
   GitHubFirstPageCache: { getInstance: () => mockFirstPageCache },
 }));
 
-import { getRepoStatsAndPage, parseLinkLastPage } from "../GitHubStats.js";
+import { fetchRestCounts, getRepoStatsAndPage, parseLinkLastPage } from "../GitHubStats.js";
 import {
   repoStatsCache,
   issueListCache,
   prListCache,
+  forgeIssueListCache,
+  forgePRListCache,
   repoStatsAndPageSnapshotCache,
   restCountsCache,
   repoEventsETagCache,
   repoEventsPollIntervalCache,
   repoEventsNoChangeCount,
   repoEventsLastProbeAt,
+  getRepoListEpoch,
   clearPRCaches,
 } from "../GitHubCaches.js";
 import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
@@ -830,5 +833,124 @@ describe("getRepoStatsAndPage — decoupled REST count poll (issue #10122)", () 
     await getRepoStatsAndPage("/test", false); // 200 without etag -> invalidate
 
     expect(repoEventsETagCache.get(CACHE_KEY)).toBeUndefined();
+  });
+
+  describe("count-as-cache-buster on the background poll", () => {
+    const forgePage = { items: [], nextCursor: null, hasMore: false };
+    const legacyPage = { items: [], pageInfo: { hasNextPage: false, endCursor: null } };
+
+    function seedListPages(): void {
+      forgeIssueListCache.set("issue:testowner/testrepo:open::created:", forgePage as never);
+      issueListCache.set("issue:testowner/testrepo:open::created:", legacyPage as never);
+      forgePRListCache.set("pr:testowner/testrepo:open::created:", forgePage as never);
+      prListCache.set("pr:testowner/testrepo:open::created:", legacyPage as never);
+      repoStatsAndPageSnapshotCache.set(CACHE_KEY, {
+        stats: { issueCount: 5, prCount: 3, lastUpdated: 1 },
+        issues: { items: [], endCursor: null, hasNextPage: false, totalCount: 5 },
+        prs: { items: [], endCursor: null, hasNextPage: false, totalCount: 3 },
+      });
+    }
+
+    it("busts only the changed type's pages when a poll commits a moved count", async () => {
+      // Poll 1 establishes the baseline: combined 8, PRs 3 → issues 5.
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' })],
+        repo: [repoOk(8, '"r1"')],
+        pulls: [pullsOk(3, '"p1"')],
+      });
+      await getRepoStatsAndPage("/test", false);
+
+      // Expire first — `expireMemoryCaches` clears the legacy list caches, so
+      // the warm pages under test are seeded after it. `repoStatsCache` stays
+      // cleared, so the memory-cache fast path still misses.
+      expireMemoryCaches();
+      expireBackoffWindow();
+      seedListPages();
+      const issueEpochBefore = getRepoListEpoch("issue", "testowner", "testrepo");
+      const prEpochBefore = getRepoListEpoch("pr", "testowner", "testrepo");
+
+      // Poll 2: a new issue opened — combined 9 (200), PR leg replays via 304.
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e2"' })],
+        repo: [repoOk(9, '"r2"')],
+        pulls: [restResponse(304)],
+      });
+      const result = await getRepoStatsAndPage("/test", false);
+      expect(result.stats?.issueCount).toBe(6);
+      expect(result.stats?.prCount).toBe(3);
+
+      // Issue pages (both cache families) dropped; PR pages untouched.
+      expect(forgeIssueListCache.get("issue:testowner/testrepo:open::created:")).toBeUndefined();
+      expect(issueListCache.get("issue:testowner/testrepo:open::created:")).toBeUndefined();
+      expect(forgePRListCache.get("pr:testowner/testrepo:open::created:")).toBeDefined();
+      expect(prListCache.get("pr:testowner/testrepo:open::created:")).toBeDefined();
+      // The combined snapshot embeds both first pages — dropped on any delta.
+      expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toBeUndefined();
+      // Only the issue epoch moved, so in-flight PR writes stay valid.
+      expect(getRepoListEpoch("issue", "testowner", "testrepo")).toBe(issueEpochBefore + 1);
+      expect(getRepoListEpoch("pr", "testowner", "testrepo")).toBe(prEpochBefore);
+    });
+
+    it("does not bust anything when both legs replay unchanged counts via 304", async () => {
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' })],
+        repo: [repoOk(8, '"r1"')],
+        pulls: [pullsOk(3, '"p1"')],
+      });
+      await getRepoStatsAndPage("/test", false);
+
+      expireMemoryCaches();
+      expireBackoffWindow();
+      seedListPages();
+      const issueEpochBefore = getRepoListEpoch("issue", "testowner", "testrepo");
+
+      // Probe sees activity (e.g. a push), but the counts themselves replay.
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e2"' })],
+        repo: [restResponse(304)],
+        pulls: [restResponse(304)],
+      });
+      const result = await getRepoStatsAndPage("/test", false);
+      expect(result.stats?.issueCount).toBe(5);
+
+      expect(forgeIssueListCache.get("issue:testowner/testrepo:open::created:")).toBeDefined();
+      expect(issueListCache.get("issue:testowner/testrepo:open::created:")).toBeDefined();
+      expect(forgePRListCache.get("pr:testowner/testrepo:open::created:")).toBeDefined();
+      expect(repoStatsAndPageSnapshotCache.get(CACHE_KEY)).toBeDefined();
+      expect(getRepoListEpoch("issue", "testowner", "testrepo")).toBe(issueEpochBefore);
+    });
+
+    it("concurrent count polls singleflight — one REST pair, one shared result", async () => {
+      routeFetch({
+        repo: [repoOk(8, '"r1"')],
+        pulls: [pullsOk(3, '"p1"')],
+      });
+
+      const [a, b] = await Promise.all([
+        fetchRestCounts("test-token", "testowner", "testrepo"),
+        fetchRestCounts("test-token", "testowner", "testrepo"),
+      ]);
+
+      expect(a).toEqual(b);
+      expect(a?.issueCount).toBe(5);
+      // One request per endpoint — the second caller joined the first's
+      // in-flight promise instead of racing it (a racing pair could commit a
+      // stale 304 replay over fresh counts and double-fire the count buster).
+      expect(repoCallCount()).toBe(1);
+      expect(pullsCallCount()).toBe(1);
+    });
+
+    it("the first-ever commit (no prior baseline) busts nothing", async () => {
+      seedListPages();
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' })],
+        repo: [repoOk(8)],
+        pulls: [pullsOk(3)],
+      });
+      await getRepoStatsAndPage("/test", false);
+
+      expect(forgeIssueListCache.get("issue:testowner/testrepo:open::created:")).toBeDefined();
+      expect(forgePRListCache.get("pr:testowner/testrepo:open::created:")).toBeDefined();
+    });
   });
 });

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -88,6 +88,7 @@ import { toRateLimitInfo } from "./rateLimitUtils.js";
 import {
   forgeIssueListCache,
   forgePRListCache,
+  getRepoListEpoch,
   issueTooltipCache,
   prRequiredStatusCache,
   truncateBody,
@@ -751,6 +752,10 @@ async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Is
   return dedupe(listIssuesInflight, cacheKey, bypass, async (isCurrent) => {
     const limit = opts.perPage ?? 20;
     const orderBy = buildOrderBy(opts);
+    // Captured before the network call: if the count-as-cache-buster bumps
+    // the epoch mid-flight, this page predates the observed change and must
+    // not repopulate the just-busted cache.
+    const epochAtStart = getRepoListEpoch("issue", repo.owner, repo.repo);
 
     const response = await runQuery(
       LIST_ISSUES_QUERY,
@@ -785,9 +790,13 @@ async function listIssuesImpl(repo: RepoRef, opts: ListOptions): Promise<Page<Is
       ...(typeof issues?.totalCount === "number" ? { totalCount: issues.totalCount } : {}),
     };
 
-    // Skip the shared-cache write when a newer bypass call has superseded us,
-    // so a slow stale fetch can't clobber the fresher committed result.
-    if (isCurrent()) {
+    // Skip the shared-cache write when a newer bypass call has superseded us
+    // or the count buster invalidated this repo's issue pages mid-flight, so
+    // a slow stale fetch can't clobber the fresher committed result. The
+    // stats-count update sits behind the same epoch guard: a response too old
+    // to repopulate the list cache is also too old to roll `repoStatsCache`
+    // back to its pre-change total under a fresh `lastUpdated`.
+    if (isCurrent() && getRepoListEpoch("issue", repo.owner, repo.repo) === epochAtStart) {
       forgeIssueListCache.set(cacheKey, page);
       if (state === "open" && !opts.cursor && typeof issues?.totalCount === "number") {
         updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "issue", issues.totalCount);
@@ -822,6 +831,8 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
   return dedupe(listPRsInflight, cacheKey, bypass, async (isCurrent) => {
     const limit = opts.perPage ?? 20;
     const orderBy = buildOrderBy(opts);
+    // Same mid-flight count-buster guard as the issues list above.
+    const epochAtStart = getRepoListEpoch("pr", repo.owner, repo.repo);
 
     const response = await runQuery(
       LIST_PRS_QUERY,
@@ -856,7 +867,7 @@ async function listPRsImpl(repo: RepoRef, opts: ListOptions): Promise<Page<PR>> 
       ...(typeof prs?.totalCount === "number" ? { totalCount: prs.totalCount } : {}),
     };
 
-    if (isCurrent()) {
+    if (isCurrent() && getRepoListEpoch("pr", repo.owner, repo.repo) === epochAtStart) {
       forgePRListCache.set(cacheKey, page);
       if (state === "open" && !opts.cursor && typeof prs?.totalCount === "number") {
         updateRepoStatsCount(`${repo.owner}/${repo.repo}`, "pr", prs.totalCount);

--- a/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubResourceList.swr.test.tsx
@@ -5,7 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, waitFor, act } from "@testing-library/react";
 import React, { Activity, type ReactNode } from "react";
 import type { Issue, ListOptions, Page } from "@shared/types/forge";
-import { setCache, buildCacheKey, _resetForTests } from "@/lib/forgeResourceCache";
+import { setCache, getCache, buildCacheKey, _resetForTests } from "@/lib/forgeResourceCache";
 import { useGitHubFilterStore } from "../stores/githubFilterStore";
 import { useIssueSelectionStore } from "@/store/issueSelectionStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
@@ -245,6 +245,211 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+});
+
+describe("open-time fetch policy (count-as-cache-buster, #10122 family)", () => {
+  const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+
+  it("skips the mount revalidate when the entry was written by a bypass fetch <10s ago", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+      countAtWrite: 1,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(screen.getByTestId("item-10")).toBeTruthy();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+    expect(mockListIssues).not.toHaveBeenCalled();
+  });
+
+  it("stale wins over the skip window — a count delta after a hover prefetch still bypasses", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+      countAtWrite: 1,
+      stale: true,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalled());
+    expect(mockListIssues).toHaveBeenCalledWith(expect.objectContaining({ bypassCache: true }));
+  });
+
+  it("a fresh `timestamp` alone does NOT skip — broadcast-seeded entries still revalidate", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalled());
+  });
+
+  it("downgrades the issues revalidate to bypassCache:false while the count fingerprint holds", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10), makeIssue(11)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+      countAtWrite: 2,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10), makeIssue(11)], 2));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalled());
+    expect(mockListIssues).toHaveBeenCalledWith(expect.objectContaining({ bypassCache: false }));
+  });
+
+  it("keeps bypassCache:true when the count buster marked the entry stale", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+      countAtWrite: 2,
+      stale: true,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalled());
+    expect(mockListIssues).toHaveBeenCalledWith(expect.objectContaining({ bypassCache: true }));
+  });
+
+  it("keeps bypassCache:true for entries with no count fingerprint (disk hydration, old writers)", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalled());
+    expect(mockListIssues).toHaveBeenCalledWith(expect.objectContaining({ bypassCache: true }));
+  });
+
+  it("the PR list never downgrades — CI rollup flips are invisible to the count signal", async () => {
+    const prKey = buildCacheKey("/test/proj", "pr", "open", "created");
+    setCache(prKey, {
+      items: [makeIssue(40)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+      countAtWrite: 1,
+    });
+    mockListPRs.mockResolvedValue(makeResponse([makeIssue(40)]));
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await waitFor(() => expect(mockListPRs).toHaveBeenCalled());
+    expect(mockListPRs).toHaveBeenCalledWith(expect.objectContaining({ bypassCache: true }));
+  });
+
+  it("manual refresh still bypasses even when the entry is inside the skip window", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+      countAtWrite: 1,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(mockListIssues).not.toHaveBeenCalled();
+
+    screen.getByRole("button", { name: /refresh issues/i }).click();
+
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalled());
+    expect(mockListIssues).toHaveBeenCalledWith(expect.objectContaining({ bypassCache: true }));
+  });
+
+  it("does not fire onFreshFetch for a downgraded (non-bypass) revalidate", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+      countAtWrite: 1,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)], 1));
+    const onFreshFetch = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onFreshFetch={onFreshFetch} />
+    );
+
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalled());
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(onFreshFetch).not.toHaveBeenCalled();
+  });
+
+  it("fires onFreshFetch when the revalidate actually bypassed", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+      countAtWrite: 1,
+      stale: true,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10)], 1));
+    const onFreshFetch = vi.fn();
+
+    render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" onFreshFetch={onFreshFetch} />
+    );
+
+    await waitFor(() => expect(onFreshFetch).toHaveBeenCalled());
+  });
+
+  it("a downgraded revalidate re-stamps the count fingerprint from the response", async () => {
+    setCache(cacheKey, {
+      items: [makeIssue(10)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now() - 30_000,
+      countAtWrite: 1,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(10), makeIssue(11)], 2));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => expect(screen.getByTestId("item-11")).toBeTruthy());
+    const entry = (await import("@/lib/forgeResourceCache")).getCache(cacheKey);
+    expect(entry?.countAtWrite).toBe(2);
+    // Non-bypass responses may come from the backend cache — they must not
+    // arm the skip-revalidate gate.
+    expect(entry?.freshBypassAt).toBeUndefined();
+  });
 });
 
 describe("GitHubResourceList SWR behavior", () => {
@@ -1666,6 +1871,12 @@ describe("GitHubResourceList Activity reveal vs filter change — PR #6288", () 
 
     // Hide via Activity — effects clean up but state + refs survive.
     rerender(<Harness mode="hidden" />);
+    // The mount revalidate stamped `freshBypassAt`, and a reveal inside the
+    // 10s window deliberately skips the refetch (hide/reveal must not
+    // double-spend GraphQL). Age the stamp past the window so this test keeps
+    // pinning the reveal-time revalidate itself.
+    const entry = getCache(cacheKey)!;
+    setCache(cacheKey, { ...entry, freshBypassAt: Date.now() - 11_000 });
     // Re-reveal — the load effect re-fires with the same effectKey, hitting
     // the isActivityRevealOfSameInputs branch: no skeleton, no row clear,
     // background revalidate runs.

--- a/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
+++ b/plugins/builtin/github/renderer/hooks/useGitHubResourceListSWR.ts
@@ -14,6 +14,7 @@ import {
   setCache,
   nextGeneration,
   getGeneration,
+  type ForgeResourceCacheEntry,
 } from "@/lib/forgeResourceCache";
 import { isRateLimitError, isTokenRelatedError, isTransientNetworkError } from "@/lib/forgeErrors";
 import { forgeClient } from "@/clients/forgeClient";
@@ -33,6 +34,60 @@ type StateFilter = string;
 
 const FETCH_MAX_ATTEMPTS = 3;
 const FETCH_RETRY_DELAYS_MS = [500, 1500];
+
+// Open-time fetch policy windows (quota guards, #10122 family).
+//
+// FRESH_REVALIDATE_SKIP_MS: an entry whose `freshBypassAt` is this recent was
+// just fetched from GitHub with `bypassCache: true` (hover prefetch landing
+// right before the click is the canonical case) — firing the usual mount-time
+// bypass revalidate would be a second GraphQL query for the same data within
+// seconds. Mirrors the toolbar's PREFETCH_FRESHNESS_MS so hover→click costs
+// one query, not two. Only `freshBypassAt` qualifies; `timestamp` alone can
+// describe broadcast-seeded snapshot content.
+const FRESH_REVALIDATE_SKIP_MS = 10_000;
+
+/**
+ * Open-time fetch policy for warm-cache hydrations in the mount effect. Never
+ * consulted by manual refresh, focus, or wake revalidation — those keep their
+ * unconditional `bypassCache: true`.
+ *
+ * - `"skip"`: the entry was written by a real bypass fetch (hover prefetch /
+ *   bypass revalidate) under FRESH_REVALIDATE_SKIP_MS ago — refetching now
+ *   would double-spend GraphQL on data that just left GitHub.
+ * - `"cached"`: issues-only downgrade. The cheap REST count poll fingerprints
+ *   open-issue counts; while the entry's `countAtWrite` matches every fresh
+ *   poll (no `stale` mark), the revalidate may honor the backend's 60s list
+ *   cache. Issues only: PR rows render CI rollup state, and check-run flips
+ *   never surface in the `/events` feed or the counts, so the PR list keeps
+ *   its unconditional bypass. Count equality can also miss same-count row
+ *   churn (close one, open one) — the 45s renderer TTL and the backend's 60s
+ *   TTL bound that staleness, and manual/focus/wake bypass stays the escape
+ *   hatch.
+ * - `"bypass"`: today's behavior (fresh GraphQL).
+ */
+function planWarmRevalidate(
+  cached: ForgeResourceCacheEntry,
+  type: "issue" | "pr",
+  filterState: string,
+  hasSearch: boolean
+): "skip" | "cached" | "bypass" {
+  if (hasSearch) return "bypass";
+  // Stale wins over everything: a count delta can land between a hover
+  // prefetch and the click, marking the just-prefetched entry stale — the
+  // fresh `freshBypassAt` must not let a provably-diverged page skip its
+  // revalidate.
+  if (cached.stale) return "bypass";
+  if (
+    cached.freshBypassAt != null &&
+    Date.now() - cached.freshBypassAt < FRESH_REVALIDATE_SKIP_MS
+  ) {
+    return "skip";
+  }
+  if (type === "issue" && filterState === "open" && cached.countAtWrite != null) {
+    return "cached";
+  }
+  return "bypass";
+}
 
 function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -188,7 +243,20 @@ export function useGitHubResourceListSWR({
       currentCursor: string | null | undefined,
       append: boolean = false,
       abortSignal?: AbortSignal,
-      options?: { revalidating?: boolean; generation?: number; cacheKey?: string }
+      options?: {
+        revalidating?: boolean;
+        generation?: number;
+        cacheKey?: string;
+        /**
+         * Override the revalidate default of `bypassCache: true`. Set to
+         * `false` by the mount effect's downgraded path when the count signal
+         * says the cached page is still consistent — the request then honors
+         * the backend's 60s list cache instead of forcing fresh GraphQL.
+         * Manual refresh, focus, and wake revalidation never pass this, so
+         * they keep their unconditional bypass.
+         */
+        bypass?: boolean;
+      }
     ) => {
       if (!projectPath) return;
       // Skip the fetch entirely when no token is configured. The render path
@@ -235,20 +303,23 @@ export function useGitHubResourceListSWR({
       try {
         const searchOverride =
           numberQuery?.kind === "open-ended" ? `number:>=${numberQuery.from}` : undefined;
+        // Append (load-more) always wants the next page from network.
+        // SWR revalidates default to bypassing the backend cache — that's
+        // the point of a revalidate — unless the mount effect downgraded
+        // this one via `options.bypass: false` (count signal says the
+        // cached page is still consistent). Cold-mount fetches (no cache,
+        // no revalidating flag) honor the backend's 60s in-memory cache
+        // instead of bypassing — same data either way, but the cached path
+        // returns synchronously and avoids the click-time round-trip the
+        // user sees as "reload".
+        const usedBypass = append ? false : (options?.bypass ?? isRevalidate);
         // `merged` is a GitHub-supported PR state the provider accepts beyond
         // the contract's documented set — pass it through with a cast.
         const fetchOptions: ListOptions = {
           search: searchOverride || debouncedSearch || undefined,
           state: filterState as ListOptions["state"],
           cursor: currentCursor || undefined,
-          // Append (load-more) always wants the next page from network.
-          // SWR revalidates also bypass cache — that's the whole point of
-          // a revalidate. Cold-mount fetches (no cache, no revalidating
-          // flag) honor the backend's 60s in-memory cache instead of
-          // bypassing — same data either way, but the cached path returns
-          // synchronously and avoids the click-time round-trip the user
-          // sees as "reload".
-          bypassCache: append ? false : isRevalidate ? true : false,
+          bypassCache: usedBypass,
           sort: sortOrder,
         };
 
@@ -288,6 +359,16 @@ export function useGitHubResourceListSWR({
                 nextCursor: result.nextCursor,
                 hasMore: result.hasMore,
                 timestamp: now,
+                // `freshBypassAt` only when this request actually skipped the
+                // backend cache — a downgraded/cold fetch may have been served
+                // a cached page, which must not arm the skip-revalidate gate.
+                ...(usedBypass ? { freshBypassAt: now } : {}),
+                // Open-count fingerprint for the count-as-cache-buster: only
+                // the open filter tracks a polled count, so other states stay
+                // un-fingerprinted (and therefore never downgrade).
+                ...(filterState === "open" && result.totalCount != null
+                  ? { countAtWrite: result.totalCount }
+                  : {}),
               });
               setLastUpdatedAt(now);
               // Bind the toolbar count badge to the authoritative server total
@@ -320,15 +401,15 @@ export function useGitHubResourceListSWR({
                 );
               }
               // Notify parent (toolbar count badge) that fresh first-page data
-              // landed. Gated on `isRevalidate` so it fires only when
-              // `bypassCache: true` was sent — the main process's
+              // landed. Gated on the request actually having sent
+              // `bypassCache: true` — the main process's
               // `updateRepoStatsCount` runs on the GraphQL path that follows a
               // bypass, so the toolbar's `refresh()` call is guaranteed to see
-              // an updated `repoStatsCache` entry. Cold-mount fetches
-              // (`bypassCache: false`) may hit the main-process cache and
-              // skip the count update entirely; firing onFreshFetch there
-              // would be a wasted IPC round-trip.
-              if (isRevalidate) {
+              // an updated `repoStatsCache` entry. Cold-mount and downgraded
+              // revalidate fetches (`bypassCache: false`) may hit the
+              // main-process cache and skip the count update entirely; firing
+              // onFreshFetch there would be a wasted IPC round-trip.
+              if (usedBypass) {
                 onFreshFetch?.();
               }
             }
@@ -455,11 +536,23 @@ export function useGitHubResourceListSWR({
         setLastUpdatedAt(cached.timestamp);
         setError(null);
         setExactNumberNotFound(null);
-        fetchData(null, false, abortController.signal, {
-          revalidating: true,
-          generation: gen,
-          cacheKey,
-        });
+        const plan = planWarmRevalidate(cached, type, filterState, debouncedSearch !== "");
+        if (plan === "skip") {
+          // No fetch will run its `finally` cleanup — clear the activity
+          // flags here. An Activity hide aborts an in-flight revalidate,
+          // whose aborted `finally` deliberately skips `setRefreshing(false)`;
+          // without this, a skip on reveal would leave the header spinner
+          // stuck forever.
+          setLoading(false);
+          setRefreshing(false);
+        } else {
+          fetchData(null, false, abortController.signal, {
+            revalidating: true,
+            generation: gen,
+            cacheKey,
+            ...(plan === "cached" ? { bypass: false } : {}),
+          });
+        }
         lastLoadedEffectKeyRef.current = effectKey;
         return () => abortController.abort();
       }
@@ -502,11 +595,18 @@ export function useGitHubResourceListSWR({
         setLastUpdatedAt(targetCached.timestamp);
         setExactNumberNotFound(null);
         setError(null);
-        fetchData(null, false, abortController.signal, {
-          revalidating: true,
-          generation: gen,
-          cacheKey,
-        });
+        const plan = planWarmRevalidate(targetCached, type, filterState, false);
+        if (plan === "skip") {
+          // Same activity-flag cleanup as the mount/reveal skip above.
+          setRefreshing(false);
+        } else {
+          fetchData(null, false, abortController.signal, {
+            revalidating: true,
+            generation: gen,
+            cacheKey,
+            ...(plan === "cached" ? { bypass: false } : {}),
+          });
+        }
         lastLoadedEffectKeyRef.current = effectKey;
         return () => abortController.abort();
       }

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -50,12 +50,17 @@ const HOVER_PREFETCH_DELAY_MS = 150;
 const PREFETCH_FRESHNESS_MS = 10_000;
 
 // When the user opens the dropdown and the polled stats are older than this,
-// fire a click-time forced refresh — cache may still be valid in the strict
+// fire a click-time count refresh — cache may still be valid in the strict
 // TTL sense, but the user opening the dropdown is a strong signal that they
-// want fresh-enough data, and 2 minutes is the threshold beyond which CI
-// status / PR state could be visibly out of date. Within this window, trust
-// the cache and let the existing 30s poll keep things fresh in background.
-const OPEN_FORCE_REFRESH_STALENESS_MS = 2 * 60 * 1000;
+// want fresh-enough data, and 2 minutes is the threshold beyond which counts
+// could be visibly out of date. Deliberately NOT a forced refresh: `force`
+// maps to `bypassCache: true` in main, which runs the ~6-point welded
+// `REPO_STATS_AND_PAGE_QUERY` on top of the list query the open itself
+// fires — a hidden double-spend on every stale-open (#10122 family). The
+// non-forced path is the probe-gated REST count pair (often free via 304),
+// and the dropdown's own list revalidate reconciles the badge through
+// `onCountUpdate`/`onFreshFetch`, so the heavy query buys nothing here.
+const OPEN_REFRESH_STALENESS_MS = 2 * 60 * 1000;
 
 // Lifetime of the corner activity chip after the most recent count increase,
 // measured in visible time. The chip is a glanceable "something new arrived"
@@ -567,9 +572,10 @@ export const ForgeStatsToolbarButton = memo(
         if (cached && Date.now() - cached.timestamp < PREFETCH_FRESHNESS_MS) return;
 
         // Hover prefetch primes the list cache silently. The count badge stays
-        // fresh via the 30s background poll and the click-time forced refresh
-        // — refreshing stats here would flicker the toolbar status indicator.
+        // fresh via the 30s background poll and the click-time refresh —
+        // refreshing stats here would flicker the toolbar status indicator.
         inFlightRef.current = true;
+        const startedAt = Date.now();
         const fetchOptions = {
           state: "open" as const,
           sort: "created",
@@ -581,11 +587,27 @@ export const ForgeStatsToolbarButton = memo(
             : forgeClient.listPRs(currentProject.path, fetchOptions);
         void request
           .then((result) => {
+            // Ownership guard: the dropdown may have opened mid-flight and
+            // committed a fresher page (its own bypass revalidate). A slower
+            // hover response must not clobber it — `timestamp` is the write
+            // time of the competing entry, so anything written after this
+            // request started wins.
+            const existing = getCache(cacheKey);
+            if (existing && existing.timestamp > startedAt) return;
+            const now = Date.now();
             setCache(cacheKey, {
               items: result.items,
               nextCursor: result.nextCursor,
               hasMore: result.hasMore,
-              timestamp: Date.now(),
+              timestamp: now,
+              // This request bypassed the backend cache, so the entry
+              // qualifies for the SWR hook's skip-revalidate window — the
+              // whole point of the prefetch: hover→click costs one GraphQL
+              // query, not two.
+              freshBypassAt: now,
+              // The prefetch always targets the `open` slot (see `cacheKey`),
+              // so the count fingerprint arms the count-as-cache-buster.
+              ...(result.totalCount != null ? { countAtWrite: result.totalCount } : {}),
             });
           })
           .catch(() => {
@@ -856,10 +878,9 @@ export const ForgeStatsToolbarButton = memo(
                 if (willOpen) setIssuesPulseAt(null);
                 if (
                   willOpen &&
-                  (lastUpdated == null ||
-                    Date.now() - lastUpdated > OPEN_FORCE_REFRESH_STALENESS_MS)
+                  (lastUpdated == null || Date.now() - lastUpdated > OPEN_REFRESH_STALENESS_MS)
                 ) {
-                  refreshStats({ force: true });
+                  refreshStats();
                 }
               }}
               onOpenChange={(open) => {
@@ -938,10 +959,9 @@ export const ForgeStatsToolbarButton = memo(
                 if (willOpen) setPrsPulseAt(null);
                 if (
                   willOpen &&
-                  (lastUpdated == null ||
-                    Date.now() - lastUpdated > OPEN_FORCE_REFRESH_STALENESS_MS)
+                  (lastUpdated == null || Date.now() - lastUpdated > OPEN_REFRESH_STALENESS_MS)
                 ) {
-                  refreshStats({ force: true });
+                  refreshStats();
                 }
               }}
               onOpenChange={(open) => {

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
@@ -503,4 +503,66 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
+
+  it("stamps freshBypassAt and the open-count fingerprint on the prefetched entry", async () => {
+    mockListIssues.mockResolvedValue({
+      items: [makeIssue(11)],
+      nextCursor: "c1",
+      hasMore: true,
+      totalCount: 7,
+    });
+    const { container } = renderToolbar();
+
+    pointerEnter(getIssuesButton(container));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const cached = getCache(buildCacheKey("/test/proj", "issue", "open", "created"));
+    expect(typeof cached?.freshBypassAt).toBe("number");
+    expect(cached?.countAtWrite).toBe(7);
+  });
+
+  it("a slow prefetch response never clobbers a fresher cache write (ownership guard)", async () => {
+    let resolvePrefetch!: (value: Page<Issue>) => void;
+    mockListIssues.mockImplementation(
+      () =>
+        new Promise<Page<Issue>>((resolve) => {
+          resolvePrefetch = resolve;
+        })
+    );
+    const { container } = renderToolbar();
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+
+    pointerEnter(getIssuesButton(container));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150); // prefetch request starts
+    });
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+
+    // While the prefetch hangs, a competing path (the dropdown's own bypass
+    // revalidate) commits a fresher page.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20);
+    });
+    setCache(cacheKey, {
+      items: [makeIssue(99)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+      freshBypassAt: Date.now(),
+    });
+
+    // The slow prefetch finally lands — it must not overwrite the newer entry.
+    await act(async () => {
+      resolvePrefetch(makeIssuePage([makeIssue(11)]));
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const cached = getCache(cacheKey);
+    expect(cached?.items.map((i) => i.number)).toEqual([99]);
+  });
 });

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -361,6 +361,85 @@ describe("useRepositoryStats", () => {
       });
     });
 
+    it("marks diverged open list entries stale on a count push without removing rows (count buster)", async () => {
+      const project = { id: "p", path: "/repo/buster" };
+      getCurrentMock.mockResolvedValue(project);
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 0,
+        issueCount: 2,
+        prCount: 3,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      let pushHandler: ((payload: unknown) => void) | undefined;
+      onRepoCountsUpdatedMock.mockImplementation((cb: (p: unknown) => void) => {
+        pushHandler = cb;
+        return () => {};
+      });
+
+      const issuesKey = buildCacheKey(project.path, "issue", "open", "created");
+      const prsKey = buildCacheKey(project.path, "pr", "open", "created");
+      const row: Issue = {
+        number: 1,
+        title: "t",
+        body: "",
+        url: "",
+        state: "open",
+        rawState: "OPEN",
+        author: { login: "u", avatarUrl: "", rawData: null },
+        assignees: [],
+        labels: [],
+        commentCount: 0,
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      };
+      setCache(issuesKey, {
+        items: [row],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: Date.now(),
+        countAtWrite: 2,
+      });
+      setCache(prsKey, {
+        items: [row],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: Date.now(),
+        countAtWrite: 3,
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => {
+        expect(result.current.stats?.issueCount).toBe(2);
+      });
+
+      // Issue count moved 2 → 7; PR count is unchanged at 3.
+      await act(async () => {
+        pushHandler?.(
+          countsPayload(project.path, {
+            commitCount: 0,
+            issueCount: 7,
+            prCount: 3,
+            loading: false,
+            stale: false,
+            lastUpdated: 2000,
+          })
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(getCache(issuesKey)?.stale).toBe(true);
+      });
+      expect(getCache(issuesKey)?.items).toHaveLength(1);
+      expect(getCache(prsKey)?.stale).toBeUndefined();
+    });
+
     it("ignores count pushes for a different project", async () => {
       const project = { id: "p", path: "/repo/current" };
       getCurrentMock.mockResolvedValue(project);

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -4,7 +4,7 @@ import { projectClient } from "@/clients";
 import { forgeClient } from "@/clients/forgeClient";
 import { isTokenRelatedError } from "@/lib/forgeErrors";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { buildCacheKey, getCache, setCache } from "@/lib/forgeResourceCache";
+import { buildCacheKey, getCache, markCountStale, setCache } from "@/lib/forgeResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
 import { useResolvedForgeProvider } from "@/hooks/useResolvedForgeProvider";
@@ -167,6 +167,19 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
         if (repoStats.prCount !== null) {
           lastKnownCountsRef.current.prCount = repoStats.prCount;
+        }
+
+        // Count-as-cache-buster: a fresh count that diverges from what a
+        // cached dropdown page recorded at write time means the page is
+        // provably stale — flag it (metadata only, rows stay) so the next
+        // open revalidates with `bypassCache: true` instead of the
+        // downgraded cached read. Stale/errored polls are excluded: their
+        // counts are fallbacks, not observations.
+        if (repoStats.issueCount !== null) {
+          markCountStale(opts.projectPath, "issue", repoStats.issueCount);
+        }
+        if (repoStats.prCount !== null) {
+          markCountStale(opts.projectPath, "pr", repoStats.prCount);
         }
       }
 
@@ -483,12 +496,18 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
           const prsKey = buildCacheKey(payload.projectPath, "pr", "open", "created");
           const existingIssues = getCache(issuesKey);
           const existingPRs = getCache(prsKey);
+          // `countAtWrite` is stamped so the count-as-cache-buster can compare
+          // later REST polls against it; `freshBypassAt` is deliberately NOT
+          // stamped — this payload can carry a re-stamped main-process
+          // snapshot (probe-unchanged path), so it must never satisfy the
+          // "just fetched from GitHub, skip the open revalidate" gate.
           if (!existingIssues || existingIssues.timestamp < payload.fetchedAt) {
             setCache(issuesKey, {
               items: payload.issues.items,
               nextCursor: payload.issues.endCursor,
               hasMore: payload.issues.hasNextPage,
               timestamp: payload.fetchedAt,
+              countAtWrite: payload.issues.totalCount,
             });
           }
           if (!existingPRs || existingPRs.timestamp < payload.fetchedAt) {
@@ -497,6 +516,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
               nextCursor: payload.prs.endCursor,
               hasMore: payload.prs.hasNextPage,
               timestamp: payload.fetchedAt,
+              countAtWrite: payload.prs.totalCount,
             });
           }
 

--- a/src/lib/__tests__/forgeResourceCache.test.ts
+++ b/src/lib/__tests__/forgeResourceCache.test.ts
@@ -5,6 +5,7 @@ import {
   setCache,
   nextGeneration,
   getGeneration,
+  markCountStale,
   mutateCacheEntries,
   _resetForTests,
 } from "../forgeResourceCache";
@@ -226,6 +227,99 @@ describe("forgeResourceCache", () => {
       expect(() =>
         mutateCacheEntries("/proj", "issue", (e) => ({ ...e, items: [] }))
       ).not.toThrow();
+    });
+  });
+
+  describe("markCountStale (count-as-cache-buster)", () => {
+    function seedOpenSlot(countAtWrite?: number, stale?: boolean): string {
+      const key = buildCacheKey("/proj", "issue", "open", "created");
+      setCache(key, {
+        items: [makeIssue(1), makeIssue(2)],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: Date.now(),
+        ...(countAtWrite != null ? { countAtWrite } : {}),
+        ...(stale ? { stale } : {}),
+      });
+      return key;
+    }
+
+    it("marks a diverged open slot stale without removing its rows, and bumps its generation", () => {
+      const key = seedOpenSlot(2);
+      const genBefore = getGeneration(key);
+
+      markCountStale("/proj", "issue", 3);
+
+      const cached = getCache(key);
+      expect(cached?.stale).toBe(true);
+      expect(cached?.items.map((i) => i.number)).toEqual([1, 2]);
+      expect(getGeneration(key)).toBe(genBefore + 1);
+    });
+
+    it("leaves a slot alone when the count still matches", () => {
+      const key = seedOpenSlot(2);
+      const genBefore = getGeneration(key);
+
+      markCountStale("/proj", "issue", 2);
+
+      expect(getCache(key)?.stale).toBeUndefined();
+      expect(getGeneration(key)).toBe(genBefore);
+    });
+
+    it("leaves a slot alone when it has no count fingerprint", () => {
+      const key = seedOpenSlot(undefined);
+      const genBefore = getGeneration(key);
+
+      markCountStale("/proj", "issue", 3);
+
+      expect(getCache(key)?.stale).toBeUndefined();
+      expect(getGeneration(key)).toBe(genBefore);
+    });
+
+    it("does not re-bump the generation of an already-stale slot", () => {
+      const key = seedOpenSlot(2, true);
+      const genBefore = getGeneration(key);
+
+      markCountStale("/proj", "issue", 5);
+
+      expect(getCache(key)?.stale).toBe(true);
+      expect(getGeneration(key)).toBe(genBefore);
+    });
+
+    it("only touches open-filter slots — closed/merged views have no count signal", () => {
+      const closedKey = buildCacheKey("/proj", "issue", "closed", "created");
+      setCache(closedKey, {
+        items: [makeIssue(9)],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: Date.now(),
+        countAtWrite: 2,
+      });
+
+      markCountStale("/proj", "issue", 7);
+
+      expect(getCache(closedKey)?.stale).toBeUndefined();
+    });
+
+    it("is scoped to the given project and type", () => {
+      const issueKey = seedOpenSlot(2);
+      const prKey = buildCacheKey("/proj", "pr", "open", "created");
+      const otherProjectKey = buildCacheKey("/other", "issue", "open", "created");
+      const base = {
+        items: [makeIssue(1)],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: Date.now(),
+        countAtWrite: 2,
+      };
+      setCache(prKey, base);
+      setCache(otherProjectKey, base);
+
+      markCountStale("/proj", "issue", 4);
+
+      expect(getCache(issueKey)?.stale).toBe(true);
+      expect(getCache(prKey)?.stale).toBeUndefined();
+      expect(getCache(otherProjectKey)?.stale).toBeUndefined();
     });
   });
 

--- a/src/lib/forgeResourceCache.ts
+++ b/src/lib/forgeResourceCache.ts
@@ -19,6 +19,29 @@ export interface ForgeResourceCacheEntry {
   nextCursor: string | null;
   hasMore: boolean;
   timestamp: number;
+  /**
+   * Wall-clock ms of the last write that came from a request which actually
+   * sent `bypassCache: true` (hover prefetch, SWR bypass revalidate). Distinct
+   * from `timestamp`: broadcast-seeded entries carry a fresh `timestamp` over
+   * content that may be a re-stamped main-process snapshot, so only this field
+   * may gate "skip the open-time revalidate, the data just came from the forge".
+   */
+  freshBypassAt?: number;
+  /**
+   * The server-reported open total for this entry's resource type at write
+   * time. The cheap REST count poll compares its fresh counts against this to
+   * mark the entry stale (`markCountStale`) — the count-as-cache-buster signal.
+   * Only meaningful on `open`-filter slots; undefined when the write had no
+   * authoritative total.
+   */
+  countAtWrite?: number;
+  /**
+   * Set when a fresh count poll observed a different open count than
+   * `countAtWrite` — rows are still shown (SWR), but the open-time revalidate
+   * must not be downgraded to a cached read. Cleared implicitly by the next
+   * full entry write.
+   */
+  stale?: boolean;
 }
 
 const CACHE_MAX_SIZE = 20;
@@ -88,6 +111,28 @@ export function mutateCacheEntries(
     setCache(key, next);
     nextGeneration(key);
   }
+}
+
+/**
+ * Count-as-cache-buster: called whenever a fresh (non-stale, non-errored)
+ * count for `type` lands from the cheap REST poll or a stats push. Marks every
+ * `open`-filter slot whose `countAtWrite` no longer matches as stale and bumps
+ * its generation so an in-flight downgraded (non-bypass) revalidate can't
+ * commit a page the count delta just disproved. Rows are never removed — the
+ * dropdown keeps showing them and the next open revalidates with
+ * `bypassCache: true`.
+ *
+ * Zero network: this only flips metadata. Equal counts do NOT prove freshness
+ * (close-one-open-one, edits), which is why only `open`-slot reads get
+ * downgraded — and only behind the SWR open-time revalidate that remains the
+ * correctness backstop for closed/merged/search views.
+ */
+export function markCountStale(projectPath: string, type: "issue" | "pr", openCount: number): void {
+  mutateCacheEntries(projectPath, type, (entry, keyRemainder) => {
+    if (!keyRemainder.startsWith("open:")) return null;
+    if (entry.stale || entry.countAtWrite == null || entry.countAtWrite === openCount) return null;
+    return { ...entry, stale: true };
+  });
 }
 
 export function _resetForTests(): void {


### PR DESCRIPTION
This makes the cheap background count poll act as a cache buster for the GitHub integration. When the polled open issue or PR count changes, the main process drops that repo's cached list pages for the changed type (the forge and legacy list caches plus the stats-and-page snapshot), so no surface can serve a page that predates the change. A per-repo, per-type epoch (`getRepoListEpoch`) guards the write-back path, so a list request already in flight when the bust lands can't repopulate the cache with a pre-change page.

It also fixes a double GraphQL fetch: hovering a toolbar pill prefetched the list, then opening the dropdown immediately refetched the same data. Opening within 10 seconds of a real bypass fetch now skips the refetch, so hover-then-click costs one query instead of two.

The issues dropdown's open-time refresh is downgraded to a cached read while the count fingerprint is unchanged. The PR list always refetches because CI status changes don't show up in the counts. And the click-time stats refresh used to run the heavy ~6-point `REPO_STATS_AND_PAGE_QUERY` on top of the list query the open already fires; it now uses the cheap conditional REST count path instead.

The hard constraint throughout is never increasing GraphQL quota spend (#10122 family). Count equality can't prove freshness in the other direction (close one, open one between polls), so manual refresh, focus, and wake revalidation keep their unconditional bypass as the correctness backstop.

A review pass hardened a few races: concurrent count polls now share one request (`fetchRestCounts` is singleflighted per repo), a count delta landing right after a hover prefetch can't ride the 10-second skip window, and a stale in-flight list response can neither repopulate a busted cache nor roll the toolbar count back under a fresh `lastUpdated`.

Tests cover both sides: main process (`GitHubStats`, `GitHubCaches`, `GitHubIssues`) and renderer (`githubResourceCache`, `useRepositoryStats`, the SWR open-time policy, and hover prefetch).