### PR TITLE
Align the notifications dropdown to the shared 12px gutter

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -833,7 +833,10 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   return (
     <div className="w-[360px] max-h-[420px] flex flex-col">
-      <div className="flex items-start justify-between px-3 py-2 border-b border-divider gap-2">
+      {/* pr-2, not px-3: the right-side icon buttons carry 4px of internal p-1
+          touch padding, so an 8px container edge lands their glyphs at the same
+          12px optical inset as the title text on the left. */}
+      <div className="flex items-start justify-between pl-3 pr-2 py-2 border-b border-divider gap-2">
         <div className="flex flex-1 flex-wrap items-center gap-1.5 min-w-0">
           <span className="text-xs font-medium text-daintree-text/80">Notifications</span>
           {entries.length > 0 && (
@@ -912,10 +915,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               aria-pressed={groupByContext}
               title="Group by project or worktree"
               onClick={() => setGroupByContext(!groupByContext)}
-              className={cn(
-                "toolbar-icon-button p-1 rounded-[var(--radius-sm)] border text-daintree-text/50",
-                groupByContext ? "border-transparent" : "border-daintree-text/15"
-              )}
+              className="toolbar-icon-button p-1 rounded-[var(--radius-sm)] text-daintree-text/50"
             >
               <Layers className="w-3 h-3" aria-hidden="true" />
             </button>

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -185,15 +185,17 @@ export function NotificationCenterEntry({
           "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-daintree-accent/50"
       )}
     >
-      <span
-        aria-hidden="true"
-        className={cn(
-          "w-1.5 shrink-0 self-start mt-1.5",
-          isNew && "h-1.5 rounded-full bg-status-info"
+      <div className={cn("relative shrink-0", config.className)}>
+        {/* The unread dot floats in the row's px-3 gutter (absolute, anchored
+            to the icon) so read rows don't carry a phantom spacer column and
+            the icon shares the 12px gutter with the header and section labels. */}
+        {isNew && (
+          <span
+            aria-hidden="true"
+            className="absolute right-full mr-[3px] top-1/2 -translate-y-1/2 h-1.5 w-1.5 rounded-full bg-status-info"
+          />
         )}
-      />
-      <div className={cn("mt-0.5 shrink-0", config.className)}>
-        <Icon className="h-3.5 w-3.5" />
+        <Icon className="h-4 w-4" />
       </div>
       <div className="flex-1 min-w-0">
         {entry.title && (

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1171,42 +1171,23 @@ describe("NotificationCenter — Group by context toggle", () => {
     );
   });
 
-  it("carries an off-state border outline that flips to transparent when pressed", async () => {
+  it("uses aria-pressed as the sole state signal — no border outline in either state", async () => {
     setEntries([makeEntry()]);
     render(<NotificationCenter open onClose={vi.fn()} />);
 
+    // The shared toolbar-icon-button armed styling keys off aria-pressed; a
+    // per-state border class would be a contradictory second signal and make
+    // the toggle's geometry differ from its sibling icon buttons.
     const toggle = screen.getByLabelText("Group by project or worktree");
-    expect(toggle.className).toContain("border");
-    expect(toggle.className).toContain("border-daintree-text/15");
-    expect(toggle.className).not.toContain("border-transparent");
+    expect(toggle.className).not.toMatch(/\bborder\b|border-daintree-text\/15|border-transparent/);
 
     await act(async () => {
       fireEvent.click(toggle);
     });
 
     const pressed = screen.getByLabelText("Group by project or worktree");
-    expect(pressed.className).toContain("border-transparent");
-    expect(pressed.className).not.toContain("border-daintree-text/15");
-  });
-
-  it("starts in on-state with border-transparent and flips to /15 outline when toggled off", async () => {
-    useNotificationSettingsStore.setState({ groupByContext: true });
-    setEntries([makeEntry()]);
-    render(<NotificationCenter open onClose={vi.fn()} />);
-
-    const toggle = screen.getByLabelText("Group by project or worktree");
-    expect(toggle.getAttribute("aria-pressed")).toBe("true");
-    expect(toggle.className).toContain("border-transparent");
-    expect(toggle.className).not.toContain("border-daintree-text/15");
-
-    await act(async () => {
-      fireEvent.click(toggle);
-    });
-
-    const released = screen.getByLabelText("Group by project or worktree");
-    expect(released.getAttribute("aria-pressed")).toBe("false");
-    expect(released.className).toContain("border-daintree-text/15");
-    expect(released.className).not.toContain("border-transparent");
+    expect(pressed.getAttribute("aria-pressed")).toBe("true");
+    expect(pressed.className).not.toMatch(/\bborder\b|border-daintree-text\/15|border-transparent/);
   });
 
   it("renders context section headers with worktree names when groupByContext is on", () => {

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -120,33 +120,33 @@ describe("NotificationCenterEntry unread signal", () => {
     }
   });
 
-  it("renders the unread dot at the leading edge, as the first child of the row", () => {
+  it("renders the unread dot out of flow, inside the leading icon wrapper", () => {
     const { container } = render(<NotificationCenterEntry entry={makeEntry()} isNew />);
-    const slot = container.firstElementChild?.firstElementChild;
-    expect(slot).not.toBeNull();
-    if (slot instanceof HTMLElement) {
-      expect(slot.tagName).toBe("SPAN");
-      expect(slot.className).toMatch(/bg-status-info/);
-      expect(slot.className).toMatch(/rounded-full/);
-      // Stable spacer classes must be present in both states so the leading
-      // slot reserves the same horizontal width regardless of read/unread.
-      expect(slot.className).toMatch(/\bw-1\.5\b/);
-      expect(slot.className).toMatch(/\bshrink-0\b/);
+    const iconWrapper = container.firstElementChild?.firstElementChild;
+    expect(iconWrapper).not.toBeNull();
+    const dot = container.querySelector(".bg-status-info.rounded-full");
+    expect(dot).not.toBeNull();
+    if (iconWrapper instanceof HTMLElement && dot instanceof HTMLElement) {
+      // The dot lives in the gutter via absolute positioning — it must not
+      // participate in the row's flex flow, or read/unread toggles would
+      // shift the icon column.
+      expect(iconWrapper.contains(dot)).toBe(true);
+      expect(dot.className).toMatch(/\babsolute\b/);
     }
   });
 
-  it("renders an invisible leading slot (no dot styling) when isNew is false", () => {
-    const { container } = render(<NotificationCenterEntry entry={makeEntry()} />);
-    const slot = container.firstElementChild?.firstElementChild;
-    expect(slot).not.toBeNull();
-    if (slot instanceof HTMLElement) {
-      expect(slot.tagName).toBe("SPAN");
-      expect(slot.className).not.toMatch(/bg-status-info/);
-      expect(slot.className).not.toMatch(/rounded-full/);
-      // The spacer must always reserve the leading width — losing these
-      // classes would re-introduce the layout shift on read/unread toggle.
-      expect(slot.className).toMatch(/\bw-1\.5\b/);
-      expect(slot.className).toMatch(/\bshrink-0\b/);
+  it("keeps the same leading in-flow child whether read or unread (no layout shift)", () => {
+    const read = render(<NotificationCenterEntry entry={makeEntry()} />);
+    const unread = render(<NotificationCenterEntry entry={makeEntry()} isNew />);
+    const readFirst = read.container.firstElementChild?.firstElementChild;
+    const unreadFirst = unread.container.firstElementChild?.firstElementChild;
+    expect(readFirst).not.toBeNull();
+    expect(unreadFirst).not.toBeNull();
+    if (readFirst instanceof HTMLElement && unreadFirst instanceof HTMLElement) {
+      // No spacer node may reappear ahead of the icon in either state.
+      expect(readFirst.querySelector("svg")).not.toBeNull();
+      expect(unreadFirst.querySelector("svg")).not.toBeNull();
+      expect(readFirst.className).toBe(unreadFirst.className);
     }
   });
 


### PR DESCRIPTION
This is a fairly minor polish to the notifications dropdown. It's meant to look like the other dropdowns (issues, pull requests, commits), but the left side was off.

Each row reserved a 6px spacer for the unread dot, even on read rows. That pushed the status icon to ~26px from the left edge while the header and section labels sat at 12px, so the left side looked misaligned. The dot is now absolutely positioned within the existing `px-3` padding, anchored to the icon, so the icon sits on the same 12px gutter as everything else, and read rows no longer carry dead space. Since the dot is out of flow, toggling read/unread doesn't shift the icon column.

A few related cleanups while in there:

- The row icon goes from `h-3.5` to `h-4` to match the issue/PR and commit rows.
- The header right padding drops to `pr-2` so the icon buttons' internal `p-1` padding lands their glyphs at the same 12px optical inset as the title text.
- The group-by toggle had a border in its off state, which made one icon button look framed while its neighbours were borderless. `aria-pressed` already drives the shared `toolbar-icon-button` armed styling, so the border was a redundant second signal. Removed.

This is a purely visual change, no behaviour changes. Tests were updated to assert the new layout invariants (dot out of flow, no leading spacer in either state, no border on the toggle).