### PR TITLE
perf(boot): restructure startup sequencing for faster time-to-interactive

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1318,
-  "moduleCount": 1318,
+  "count": 994,
+  "moduleCount": 994,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -10,7 +10,6 @@
     "electron/ipc/handlers/appTheme.ts",
     "electron/ipc/handlers/demo.ts",
     "electron/ipc/handlers/diagnostics.ts",
-    "electron/ipc/handlers/forge.ts",
     "electron/ipc/handlers/forgeResolution.ts",
     "electron/ipc/handlers/forgeSettings.ts",
     "electron/ipc/handlers/git-write.ts",
@@ -35,7 +34,6 @@
     "electron/main.ts",
     "electron/services/AppAgentService.ts",
     "electron/services/AppHydrationService.ts",
-    "electron/services/AutoUpdaterService.ts",
     "electron/services/CliAvailabilityService.ts",
     "electron/services/CliInstallService.ts",
     "electron/services/CrashLoopGuardService.ts",
@@ -53,6 +51,7 @@
     "electron/services/PanelSuspectLedgerService.ts",
     "electron/services/PeriodicCleanupService.ts",
     "electron/services/PluginActionAuditService.ts",
+    "electron/services/PluginService.ts",
     "electron/services/ProcessMemoryMonitor.ts",
     "electron/services/ProjectEnvSecureStorage.ts",
     "electron/services/ProjectFileStore.ts",
@@ -67,15 +66,17 @@
     "electron/services/TrashedPidTracker.ts",
     "electron/services/UserAgentRegistryService.ts",
     "electron/services/forge/forgeAuditService.ts",
+    "electron/services/forge/forgeCredentialUtils.ts",
     "electron/services/mcp-server/httpLifecycle.ts",
     "electron/services/persistence/db.ts",
     "electron/services/persistence/readLastProjectId.ts",
     "electron/services/plugin-mcp/instances.ts",
+    "electron/services/plugin/PluginDevWorkerHost.ts",
     "electron/services/plugin/PluginInstalledRecordsStore.ts",
-    "electron/services/pty/TerminalRegistry.ts",
     "electron/services/pty/agentSessionHistory.ts",
     "electron/services/pty/terminalSessionPersistence.ts",
     "electron/services/pty/terminalShell.ts",
+    "electron/services/runHistory/runHistoryService.ts",
     "electron/services/workspace-client/WorkspaceHostPool.ts",
     "electron/setup/devDiagnostics.ts",
     "electron/setup/environment.ts",
@@ -140,22 +141,22 @@
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 62,
+      "line": 106,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 361,
+      "line": 405,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 363,
+      "line": 407,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 417,
+      "line": 467,
       "pattern": "sync-store-get"
     },
     {
@@ -165,7 +166,7 @@
     },
     {
       "file": "electron/ipc/handlers/demo.ts",
-      "line": 234,
+      "line": 309,
       "pattern": "sync-fs"
     },
     {
@@ -179,13 +180,8 @@
       "pattern": "sync-fs"
     },
     {
-      "file": "electron/ipc/handlers/forge.ts",
-      "line": 193,
-      "pattern": "sync-store-get"
-    },
-    {
       "file": "electron/ipc/handlers/forgeResolution.ts",
-      "line": 60,
+      "line": 64,
       "pattern": "sync-store-get"
     },
     {
@@ -195,17 +191,17 @@
     },
     {
       "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 197,
+      "line": 200,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 212,
+      "line": 223,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 222,
+      "line": 233,
       "pattern": "sync-store-get"
     },
     {
@@ -250,12 +246,12 @@
     },
     {
       "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 99,
+      "line": 102,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/helpAssistant.ts",
-      "line": 138,
+      "line": 156,
       "pattern": "sync-store-get"
     },
     {
@@ -335,7 +331,7 @@
     },
     {
       "file": "electron/ipc/handlers/voiceInput.ts",
-      "line": 67,
+      "line": 68,
       "pattern": "sync-store-get"
     },
     {
@@ -355,22 +351,17 @@
     },
     {
       "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 58,
+      "line": 50,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
+      "line": 65,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/worktree/pull-requests.ts",
       "line": 73,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 85,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/ipc/handlers/worktree/pull-requests.ts",
-      "line": 92,
       "pattern": "sync-store-get"
     },
     {
@@ -395,12 +386,12 @@
     },
     {
       "file": "electron/main.ts",
-      "line": 179,
+      "line": 183,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/main.ts",
-      "line": 260,
+      "line": 262,
       "pattern": "sync-store-get"
     },
     {
@@ -425,67 +416,17 @@
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 25,
+      "line": 26,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 83,
+      "line": 93,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 85,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 217,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 361,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 362,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 482,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 491,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 529,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 587,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 587,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 606,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 616,
+      "line": 95,
       "pattern": "sync-store-get"
     },
     {
@@ -630,92 +571,37 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 113,
+      "line": 143,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 138,
+      "line": 193,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 274,
+      "line": 322,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 291,
+      "line": 339,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 400,
+      "line": 448,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 403,
+      "line": 451,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 467,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 533,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 535,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 542,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 545,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 572,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 574,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 578,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 595,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 611,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 615,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 618,
+      "line": 530,
       "pattern": "sync-fs"
     },
     {
@@ -725,12 +611,47 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 663,
+      "line": 649,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 664,
+      "line": 656,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 659,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 686,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 688,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 692,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 709,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 725,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 729,
       "pattern": "sync-fs"
     },
     {
@@ -740,97 +661,117 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 733,
+      "line": 766,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 763,
+      "line": 782,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 764,
+      "line": 783,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 791,
+      "line": 851,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 852,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 882,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 883,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 910,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 818,
+      "line": 980,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 819,
+      "line": 981,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 866,
+      "line": 1028,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 867,
+      "line": 1029,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 871,
+      "line": 1033,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 986,
+      "line": 1148,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1010,
+      "line": 1172,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1019,
+      "line": 1181,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1030,
+      "line": 1192,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1031,
+      "line": 1193,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1043,
+      "line": 1205,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1059,
+      "line": 1221,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1061,
+      "line": 1223,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1067,
+      "line": 1229,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1077,
+      "line": 1239,
       "pattern": "sync-fs"
     },
     {
@@ -856,6 +797,11 @@
     {
       "file": "electron/services/forge/forgeAuditService.ts",
       "line": 36,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/forge/forgeCredentialUtils.ts",
+      "line": 47,
       "pattern": "sync-store-get"
     },
     {
@@ -925,32 +871,32 @@
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 25,
+      "line": 27,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 40,
+      "line": 42,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 41,
+      "line": 43,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 46,
+      "line": 48,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 76,
+      "line": 78,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GpuCrashMonitorService.ts",
-      "line": 77,
+      "line": 79,
       "pattern": "sync-fs"
     },
     {
@@ -960,32 +906,32 @@
     },
     {
       "file": "electron/services/HelpSessionService.ts",
-      "line": 1207,
+      "line": 1212,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/HibernationService.ts",
-      "line": 373,
+      "line": 388,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 91,
+      "line": 92,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
-      "line": 261,
+      "line": 271,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/mcp-server/httpLifecycle.ts",
-      "line": 483,
+      "line": 550,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/McpServerService.ts",
-      "line": 295,
+      "line": 311,
       "pattern": "sync-store-get"
     },
     {
@@ -1109,6 +1055,16 @@
       "pattern": "sync-store-get"
     },
     {
+      "file": "electron/services/plugin/PluginDevWorkerHost.ts",
+      "line": 300,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/plugin/PluginDevWorkerHost.ts",
+      "line": 323,
+      "pattern": "sync-fs"
+    },
+    {
       "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
       "line": 19,
       "pattern": "sync-store-get"
@@ -1137,6 +1093,11 @@
       "file": "electron/services/PluginActionAuditService.ts",
       "line": 275,
       "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/PluginService.ts",
+      "line": 1015,
+      "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProcessMemoryMonitor.ts",
@@ -1170,7 +1131,7 @@
     },
     {
       "file": "electron/services/ProjectStateManager.ts",
-      "line": 157,
+      "line": 218,
       "pattern": "sync-fs"
     },
     {
@@ -1180,27 +1141,27 @@
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 357,
+      "line": 375,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 540,
+      "line": 558,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 547,
+      "line": 565,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 601,
+      "line": 619,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProjectStore.ts",
-      "line": 607,
+      "line": 628,
       "pattern": "sync-fs"
     },
     {
@@ -1211,41 +1172,6 @@
     {
       "file": "electron/services/pty/agentSessionHistory.ts",
       "line": 57,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 258,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 271,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 283,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 298,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 311,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 326,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/pty/TerminalRegistry.ts",
-      "line": 331,
       "pattern": "sync-fs"
     },
     {
@@ -1285,7 +1211,12 @@
     },
     {
       "file": "electron/services/PtyClient.ts",
-      "line": 166,
+      "line": 169,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/services/runHistory/runHistoryService.ts",
+      "line": 18,
       "pattern": "sync-store-get"
     },
     {
@@ -1330,22 +1261,22 @@
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 271,
+      "line": 279,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 297,
+      "line": 305,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 304,
+      "line": 312,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/TelemetryService.ts",
-      "line": 427,
+      "line": 435,
       "pattern": "sync-store-get"
     },
     {
@@ -1390,32 +1321,32 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 201,
+      "line": 208,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 202,
+      "line": 209,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 259,
+      "line": 269,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 260,
+      "line": 270,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 441,
+      "line": 453,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 442,
+      "line": 454,
       "pattern": "sync-store-get"
     },
     {
@@ -1425,77 +1356,52 @@
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 76,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/setup/environment.ts",
       "line": 77,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 79,
+      "line": 78,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 90,
+      "line": 80,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 102,
+      "line": 91,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 171,
+      "line": 103,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 267,
+      "line": 172,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 345,
+      "line": 268,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/setup/environment.ts",
-      "line": 659,
+      "line": 346,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/setup/environment.ts",
+      "line": 663,
       "pattern": "sync-sqlite"
     },
     {
       "file": "electron/setup/protocols.ts",
-      "line": 582,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 608,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 610,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 625,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 640,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/store.ts",
-      "line": 641,
+      "line": 624,
       "pattern": "sync-fs"
     },
     {
@@ -1505,28 +1411,63 @@
     },
     {
       "file": "electron/store.ts",
-      "line": 658,
+      "line": 645,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 660,
+      "line": 653,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 677,
+      "line": 667,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 686,
+      "line": 682,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 687,
+      "line": 683,
       "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 685,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 700,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 702,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 719,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 728,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 729,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/store.ts",
+      "line": 891,
+      "pattern": "sync-store-get"
     },
     {
       "file": "electron/utils/emergencyLog.ts",
@@ -1630,77 +1571,72 @@
     },
     {
       "file": "electron/utils/hostPerformance.ts",
-      "line": 59,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/hostPerformance.ts",
       "line": 60,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/hostPerformance.ts",
-      "line": 161,
+      "line": 61,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/hostPerformance.ts",
+      "line": 162,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 72,
+      "line": 73,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 76,
+      "line": 77,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 82,
+      "line": 83,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 138,
+      "line": 139,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 140,
+      "line": 141,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 152,
+      "line": 153,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 155,
+      "line": 156,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 185,
+      "line": 186,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 188,
+      "line": 189,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 192,
+      "line": 193,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 229,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/logger.ts",
-      "line": 231,
+      "line": 233,
       "pattern": "sync-fs"
     },
     {
@@ -1710,22 +1646,37 @@
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 237,
+      "line": 239,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 522,
+      "line": 241,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 523,
+      "line": 272,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/logger.ts",
-      "line": 529,
+      "line": 570,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 570,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 591,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/utils/logger.ts",
+      "line": 599,
       "pattern": "sync-fs"
     },
     {
@@ -1750,42 +1701,47 @@
     },
     {
       "file": "electron/window/createWindow.ts",
-      "line": 161,
+      "line": 166,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 98,
+      "line": 100,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 181,
+      "line": 236,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 272,
+      "line": 335,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 484,
+      "line": 548,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 685,
+      "line": 609,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 834,
+      "line": 721,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 912,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/skeletonCss.ts",
-      "line": 53,
+      "line": 74,
       "pattern": "sync-store-get"
     },
     {
@@ -1795,17 +1751,22 @@
     },
     {
       "file": "electron/window/skeletonCss.ts",
-      "line": 101,
+      "line": 103,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/skeletonCss.ts",
-      "line": 106,
+      "line": 126,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/skeletonCss.ts",
+      "line": 131,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 394,
+      "line": 429,
       "pattern": "sync-store-get"
     },
     {

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -130,6 +130,13 @@ vi.mock("../services/AutoUpdaterService.js", () => ({
   autoUpdaterService: autoUpdaterServiceMock,
 }));
 
+// menu.ts wires update-menu state through the deferred-loaded serviceRef, not
+// a static AutoUpdaterService import. Return the mock so wiring stays
+// synchronous in tests (mirrors the post-deferred-task state at runtime).
+vi.mock("../window/serviceRefs.js", () => ({
+  getAutoUpdaterServiceRef: vi.fn(() => autoUpdaterServiceMock),
+}));
+
 vi.mock("../services/pluginMenuRegistry.js", () => ({
   getPluginMenuItems: vi.fn(() => []),
 }));
@@ -430,7 +437,12 @@ describe("update menu lifecycle", () => {
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
-    it("calls checkForUpdatesManually when state is idle", () => {
+    // The click handler dynamic-imports AutoUpdaterService (keeping
+    // electron-updater off the boot path), so the branch runs a microtask
+    // after the click — flush before asserting.
+    const flushClick = () => new Promise((resolve) => setImmediate(resolve));
+
+    it("calls checkForUpdatesManually when state is idle", async () => {
       autoUpdaterServiceMock.__setMenuState("idle");
       const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
 
@@ -439,12 +451,13 @@ describe("update menu lifecycle", () => {
         mockBrowserWindow as unknown as Electron.BaseWindow,
         {} as Electron.KeyboardEvent
       );
+      await flushClick();
 
       expect(autoUpdaterServiceMock.checkForUpdatesManually).toHaveBeenCalledTimes(1);
       expect(autoUpdaterServiceMock.quitAndInstallIfReady).not.toHaveBeenCalled();
     });
 
-    it("calls checkForUpdatesManually when state is checking (defensive — item is also disabled)", () => {
+    it("calls checkForUpdatesManually when state is checking (defensive — item is also disabled)", async () => {
       autoUpdaterServiceMock.__setMenuState("checking");
       const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
 
@@ -453,12 +466,13 @@ describe("update menu lifecycle", () => {
         mockBrowserWindow as unknown as Electron.BaseWindow,
         {} as Electron.KeyboardEvent
       );
+      await flushClick();
 
       expect(autoUpdaterServiceMock.checkForUpdatesManually).toHaveBeenCalledTimes(1);
       expect(autoUpdaterServiceMock.quitAndInstallIfReady).not.toHaveBeenCalled();
     });
 
-    it("calls quitAndInstallIfReady when state is ready", () => {
+    it("calls quitAndInstallIfReady when state is ready", async () => {
       autoUpdaterServiceMock.__setMenuState("ready");
       const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
 
@@ -467,6 +481,7 @@ describe("update menu lifecycle", () => {
         mockBrowserWindow as unknown as Electron.BaseWindow,
         {} as Electron.KeyboardEvent
       );
+      await flushClick();
 
       expect(autoUpdaterServiceMock.quitAndInstallIfReady).toHaveBeenCalledTimes(1);
       expect(autoUpdaterServiceMock.checkForUpdatesManually).not.toHaveBeenCalled();

--- a/electron/__tests__/wslGitStore.test.ts
+++ b/electron/__tests__/wslGitStore.test.ts
@@ -23,7 +23,7 @@ describe("wslGitByWorktree store helpers (#9926)", () => {
     // Mirror the production defaults shape for the keys these tests touch
     // (electron-store returns the default for missing keys, so the in-shape
     // `wslGitByWorktree: {}` is what real callers see on first read).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     return {
       defaults: {
         _schemaVersion: 0,

--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -9,7 +9,7 @@ import { enableCompileCache, flushCompileCache, constants as moduleConstants } f
 import fs from "node:fs";
 import path from "node:path";
 import { app, dialog } from "electron";
-import { runBootMigrations } from "./boot/migrations/index.js";
+import { BOOT_MIGRATIONS, runBootMigrations } from "./boot/migrations/index.js";
 import { isSafeModeActive } from "./services/CrashLoopGuardService.js";
 import { setCompileCacheEnableStatus } from "./utils/hostPerformance.js";
 import { initializeStore, _peekStoreInstance } from "./store.js";
@@ -44,11 +44,15 @@ const cacheDir = path.join(app.getPath("userData"), "compile-cache");
 }
 
 // Run forward-only boot migrations before anything in main.ts touches state.
+// Guarded on the registry so the common empty-registry boot skips the
+// safe-mode file read, the marker-file ENOENT read, and the awaited hop —
+// registering a migration in BOOT_MIGRATIONS reactivates this automatically.
 // Failures are logged but non-fatal — forward-only idempotency means the
-// failing migration retries on the next boot, and the app should still be
-// usable as long as existing state is intact.
+// failing migration retries on the next boot.
 try {
-  await runBootMigrations({ isSafeMode: isSafeModeActive() });
+  if (BOOT_MIGRATIONS.length > 0) {
+    await runBootMigrations({ isSafeMode: isSafeModeActive() });
+  }
 } catch (err) {
   console.error("[Bootstrap] Boot migrations failed — continuing with existing state:", err);
 }

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -127,6 +127,8 @@ import { CRASH_CRITICAL_FIELDS, registerAppStateHandlers } from "../handlers/app
 import { consumePrefetchedHydrateResult } from "../../services/prefetchHydrateCache.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { getWindowForWebContents } from "../../window/webContentsRegistry.js";
+import { markPerformance } from "../../utils/performance.js";
+import { PERF_MARKS } from "../../../shared/perf/marks.js";
 import type { HandlerDependencies } from "../types.js";
 
 function shouldTriggerBackup(updates: Record<string, unknown>): boolean {
@@ -735,6 +737,141 @@ describe("app:boot handler", () => {
     expect(pvm.getProjectIdForWebContents).toHaveBeenCalledWith(42);
     expect(projectStore.getProjectStateWithRecovery).toHaveBeenCalledWith(urlProject.id);
     expect(projectStore.getCurrentProject).not.toHaveBeenCalled();
+  });
+
+  it("folds tabGroups/terminalSizes/draftInputs from the project state into the payload", async () => {
+    vi.mocked(projectStore.getCurrentProject).mockReturnValue({
+      id: "p1",
+      name: "P",
+      path: "/p",
+    } as unknown as ReturnType<typeof projectStore.getCurrentProject>);
+    const tabGroups = [
+      { id: "g1", location: "grid" as const, activeTabId: "t1", panelIds: ["t1", "t2"] },
+    ];
+    const terminalSizes = { t1: { cols: 80, rows: 24 } };
+    const draftInputs = { t1: "half-typed prompt" };
+    vi.mocked(projectStore.getProjectStateWithRecovery).mockResolvedValue({
+      state: {
+        projectId: "p1",
+        sidebarWidth: 350,
+        terminals: [],
+        tabGroups,
+        terminalSizes,
+        draftInputs,
+      },
+      quarantinedPath: undefined,
+    });
+
+    const result = await invokeBoot();
+    expect(result.tabGroups).toEqual(tabGroups);
+    expect(result.terminalSizes).toEqual(terminalSizes);
+    expect(result.draftInputs).toEqual(draftInputs);
+  });
+
+  it("defaults tabGroups/terminalSizes/draftInputs to empty when the project state is null", async () => {
+    vi.mocked(projectStore.getCurrentProject).mockReturnValue({
+      id: "p1",
+      name: "P",
+      path: "/p",
+    } as unknown as ReturnType<typeof projectStore.getCurrentProject>);
+
+    const result = await invokeBoot();
+    // Matches the standalone getTabGroups/getTerminalSizes/getDraftInputs
+    // handlers' null-state returns.
+    expect(result.tabGroups).toEqual([]);
+    expect(result.terminalSizes).toEqual({});
+    expect(result.draftInputs).toEqual({});
+  });
+
+  it("leaves tabGroups/terminalSizes/draftInputs undefined on the no-project fallback branch", async () => {
+    const result = await invokeBoot();
+    expect(result.tabGroups).toBeUndefined();
+    expect(result.terminalSizes).toBeUndefined();
+    expect(result.draftInputs).toBeUndefined();
+  });
+
+  describe("APP_HYDRATE_PREFETCH perf mark", () => {
+    const prefetchMarkCalls = () =>
+      vi
+        .mocked(markPerformance)
+        .mock.calls.filter(([mark]) => mark === PERF_MARKS.APP_HYDRATE_PREFETCH);
+
+    const setCurrentProject = () => {
+      vi.mocked(projectStore.getCurrentProject).mockReturnValue({
+        id: "p1",
+        name: "P",
+        path: "/p",
+      } as unknown as ReturnType<typeof projectStore.getCurrentProject>);
+    };
+
+    it("emits exactly one hit mark when the prefetch cache services the hydrate", async () => {
+      setCurrentProject();
+      vi.mocked(consumePrefetchedHydrateResult).mockReturnValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig: { resourceMonitoringEnabled: false },
+        project: null,
+        agentSettings: {},
+        gpuWebGLHardware: true,
+        gpuHardwareAccelerationDisabled: false,
+        gpuAngleFallbackActive: false,
+        safeMode: false,
+        isWindowsStore: false,
+      } as unknown as ReturnType<typeof consumePrefetchedHydrateResult>);
+
+      await invokeBoot();
+
+      const calls = prefetchMarkCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]![1]).toEqual({ hit: true, projectId: "p1", reason: "hit" });
+      // The fast path must not pay the full config.json parse — the cached
+      // HydrateResult already carries appState.
+      const storeModule = await import("../../store.js");
+      expect(storeModule.store.get).not.toHaveBeenCalledWith("appState");
+    });
+
+    it("emits a miss mark when the cache is eligible but empty", async () => {
+      setCurrentProject();
+
+      await invokeBoot();
+
+      const calls = prefetchMarkCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]![1]).toEqual({ hit: false, projectId: "p1", reason: "miss" });
+      expect(consumePrefetchedHydrateResult).toHaveBeenCalledWith("p1");
+    });
+
+    it("emits a no-project mark without probing the cache", async () => {
+      await invokeBoot();
+
+      const calls = prefetchMarkCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]![1]).toEqual({ hit: false, projectId: null, reason: "no-project" });
+      expect(consumePrefetchedHydrateResult).not.toHaveBeenCalled();
+    });
+
+    it("emits a safe-mode mark without probing (consume would destroy the entry)", async () => {
+      setCurrentProject();
+      crashGuard.isSafeMode.mockReturnValue(true);
+
+      await invokeBoot();
+
+      const calls = prefetchMarkCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]![1]).toEqual({ hit: false, projectId: "p1", reason: "safe-mode" });
+      expect(consumePrefetchedHydrateResult).not.toHaveBeenCalled();
+    });
+
+    it("emits a panel-filter mark without probing when crash recovery set a filter", async () => {
+      setCurrentProject();
+      crashService.consumePanelFilter.mockReturnValue(["panel-x"] as unknown as null);
+
+      await invokeBoot();
+
+      const calls = prefetchMarkCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0]![1]).toEqual({ hit: false, projectId: "p1", reason: "panel-filter" });
+      expect(consumePrefetchedHydrateResult).not.toHaveBeenCalled();
+    });
   });
 
   it("does not hydrate a closed URL project before the project view binding is ready", async () => {

--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -56,6 +56,11 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   // declared in IpcEventMap.
   "app-agent:confirmation-response",
   "app-agent:dispatch-action-response",
+
+  // fire-and-forget — renderer→main `ipcRenderer.send` reveal signal from
+  // public/skeleton-ready.js, consumed by a WebContents-scoped `ipc.once`
+  // in createWindow.ts loadRenderer.
+  "app:skeleton-parsed",
   "mcp:dispatch-action-response",
   "mcp:get-manifest-response",
   "plugin:dispatch-action-response",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -171,6 +171,7 @@ export const CHANNELS = {
   APP_FORCE_QUIT: "app:force-quit",
   APP_RESET_AND_RELAUNCH: "app:reset-and-relaunch",
   APP_CLEAR_QUARANTINED_PANEL: "app:clear-quarantined-panel",
+  APP_SKELETON_PARSED: "app:skeleton-parsed",
   APP_FIRST_INTERACTIVE: "app:first-interactive",
   APP_VIEW_PAINTED: "app:view-painted",
   APP_VIEW_WARM_PAINTED: "app:view-warm-painted",

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -60,36 +60,54 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
 
   const handleAppHydrate = async (ctx?: IpcContext) => {
     const currentProject = resolveProjectForHydration(ctx);
-    const globalAppState = store.get("appState");
     const projectId = currentProject?.id;
     const panelFilter = getCrashRecoveryService().consumePanelFilter();
-    const hasCrashRestoreTerminals =
-      panelFilter !== null &&
-      Array.isArray(globalAppState.terminals) &&
-      globalAppState.terminals.length > 0;
 
     // Hover-prefetch fast path: when a project switcher hover (or any other
     // pre-populated path) has primed the cache for this project, short-circuit
     // the disk read. Only safe when there's no in-flight crash recovery filter
     // and we aren't booting in safe mode — those scenarios layer constraints
     // (`panelFilter`, dropped terminals) that the prefetch built without.
+    // consumePrefetchedHydrateResult is destructive (return-and-delete), so the
+    // cache is only probed when the result is actually usable.
     const cacheGuard = getCrashLoopGuard();
     const cacheInSafeMode = cacheGuard.isSafeMode();
-    if (projectId && panelFilter === null && !cacheInSafeMode) {
-      const cached = consumePrefetchedHydrateResult(projectId);
-      if (cached) {
-        return {
-          ...cached,
-          skippedPanelCount: 0,
-          crashCount: cacheGuard.getCrashCount(),
-          lastCrashAt: cacheGuard.getLastCrashTimestamp(),
-          settingsRecovery: consumePendingSettingsRecovery(),
-          // Crash-loop quarantine notifications are gated on safe mode; the
-          // fast path runs only when safe mode is inactive, so clear the field.
-          crashLoopStateRecovery: null,
-        };
-      }
+    const cacheEligible = Boolean(projectId) && panelFilter === null && !cacheInSafeMode;
+    const cached = cacheEligible ? consumePrefetchedHydrateResult(projectId!) : undefined;
+    markPerformance(PERF_MARKS.APP_HYDRATE_PREFETCH, {
+      hit: Boolean(cached),
+      projectId: projectId ?? null,
+      reason: cached
+        ? "hit"
+        : !projectId
+          ? "no-project"
+          : cacheInSafeMode
+            ? "safe-mode"
+            : panelFilter !== null
+              ? "panel-filter"
+              : "miss",
+    });
+    if (cached) {
+      return {
+        ...cached,
+        skippedPanelCount: 0,
+        crashCount: cacheGuard.getCrashCount(),
+        lastCrashAt: cacheGuard.getLastCrashTimestamp(),
+        settingsRecovery: consumePendingSettingsRecovery(),
+        // Crash-loop quarantine notifications are gated on safe mode; the
+        // fast path runs only when safe mode is inactive, so clear the field.
+        crashLoopStateRecovery: null,
+      };
     }
+
+    // Read the global app state only after the fast path — the cached
+    // HydrateResult already carries appState, so reading it earlier would pay
+    // a redundant full config.json parse on every cache hit.
+    const globalAppState = store.get("appState");
+    const hasCrashRestoreTerminals =
+      panelFilter !== null &&
+      Array.isArray(globalAppState.terminals) &&
+      globalAppState.terminals.length > 0;
 
     // First, try to get terminals from per-project state (new model)
     // Fall back to global appState.terminals for migration
@@ -105,11 +123,22 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     // list so existing users keep their MRU on first open after upgrade.
     let mruListToUse = globalAppState.mruList;
     let projectStateQuarantinedPath: string | undefined;
+    // Per-project layout state folded into the payload so the renderer skips
+    // the standalone getTabGroups/getTerminalSizes/getDraftInputs round-trips
+    // during hydration. Left undefined on the no-project fallback branch so
+    // the renderer falls back to the standalone IPC calls.
+    let tabGroupsToUse: import("../../../../shared/types/panel.js").TabGroup[] | undefined;
+    let terminalSizesToUse: Record<string, { cols: number; rows: number }> | undefined;
+    let draftInputsToUse: Record<string, string> | undefined;
 
     if (projectId) {
       const { state: projectState, quarantinedPath } =
         await projectStore.getProjectStateWithRecovery(projectId);
       projectStateQuarantinedPath = quarantinedPath;
+      // Defaults match the standalone handlers' null-state returns.
+      tabGroupsToUse = projectState?.tabGroups ?? [];
+      terminalSizesToUse = projectState?.terminalSizes ?? {};
+      draftInputsToUse = projectState?.draftInputs ?? {};
       // undefined means "not migrated yet" — fall through to the global list.
       if (projectState?.mruList !== undefined) {
         mruListToUse = projectState.mruList;
@@ -399,6 +428,9 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       // Folded into the payload so the renderer skips a standalone
       // `system:get-tmp-dir` round-trip on boot (matches `handleSystemGetTmpDir`).
       systemTmpDir: os.tmpdir(),
+      tabGroups: tabGroupsToUse,
+      terminalSizes: terminalSizesToUse,
+      draftInputs: draftInputsToUse,
     };
   };
   handlers.push(typedHandleWithContext(CHANNELS.APP_HYDRATE, handleAppHydrate));

--- a/electron/ipc/handlers/commands.ts
+++ b/electron/ipc/handlers/commands.ts
@@ -6,6 +6,7 @@
 import { defineIpcNamespace, op } from "../define.js";
 import { COMMANDS_METHOD_CHANNELS } from "./commands.preload.js";
 import { commandService } from "../../services/CommandService.js";
+import { builtinCommandsReady } from "../../services/commands/index.js";
 import type {
   BuilderStep,
   CommandContext,
@@ -17,6 +18,9 @@ import type {
 import { AppError } from "../../utils/errorTypes.js";
 
 async function handleCommandsList(context?: CommandContext): Promise<CommandManifestEntry[]> {
+  // Built-in registration runs from the deferred queue's heavy group; await it
+  // so an early command-palette open can't observe an empty registry.
+  await builtinCommandsReady();
   return await commandService.list(context);
 }
 
@@ -25,6 +29,7 @@ async function handleCommandsGet(payload: CommandGetPayload): Promise<CommandMan
     console.warn("[CommandHandlers] Invalid commands:get payload", payload);
     return null;
   }
+  await builtinCommandsReady();
   return (await commandService.getManifest(payload.commandId, payload.context)) ?? null;
 }
 
@@ -56,6 +61,7 @@ async function handleCommandsExecute(payload: CommandExecutePayload): Promise<Co
     });
   }
 
+  await builtinCommandsReady();
   return commandService.execute(payload.commandId, context, args);
 }
 
@@ -65,6 +71,7 @@ async function handleCommandsGetBuilder(
   if (typeof commandId !== "string") {
     return null;
   }
+  await builtinCommandsReady();
   return commandService.getBuilder(commandId) ?? null;
 }
 

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -6,7 +6,6 @@ import { monitorEventLoopDelay, type IntervalHistogram } from "node:perf_hooks";
 import { promises as fs, createWriteStream } from "node:fs";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { ZipArchive } from "archiver";
 import { CHANNELS } from "../channels.js";
 import { resilientAtomicWriteFile } from "../../utils/fs.js";
 import type { HandlerDependencies } from "../types.js";
@@ -57,6 +56,7 @@ async function writeBundleZip(
   replacements: ReplacementRule[],
   timeWindowStartMs: number | null
 ): Promise<void> {
+  const { ZipArchive } = await import("archiver");
   const logDir = getLogDirectory();
   const logFile = getLogFilePath();
 

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -4,7 +4,7 @@ import { spawn } from "child_process";
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { projectStore } from "../../services/ProjectStore.js";
-import { VoiceTranscriptionService } from "../../services/VoiceTranscriptionService.js";
+import type { VoiceTranscriptionService } from "../../services/VoiceTranscriptionService.js";
 import { VoiceCorrectionService } from "../../services/VoiceCorrectionService.js";
 import type { HandlerDependencies, IpcContext } from "../types.js";
 import type {
@@ -26,6 +26,7 @@ import {
 } from "../../schemas/ipc.js";
 
 let service: VoiceTranscriptionService | null = null;
+let servicePromise: Promise<VoiceTranscriptionService> | null = null;
 let activeEventUnsubscribe: (() => void) | null = null;
 let activeDestroyListener: { sender: Electron.WebContents; fn: () => void } | null = null;
 let correctionService: VoiceCorrectionService | null = null;
@@ -134,11 +135,18 @@ export function getVoiceSettings(): VoiceInputSettings {
   return merged;
 }
 
-function getService(): VoiceTranscriptionService {
-  if (!service) {
-    service = new VoiceTranscriptionService();
+async function getService(): Promise<VoiceTranscriptionService> {
+  if (service) return service;
+  if (!servicePromise) {
+    servicePromise = import("../../services/VoiceTranscriptionService.js").then((mod) => {
+      service = new mod.VoiceTranscriptionService();
+      return service;
+    });
+    servicePromise.catch(() => {
+      servicePromise = null;
+    });
   }
-  return service;
+  return servicePromise;
 }
 
 function cleanupActiveSubscription(): void {
@@ -303,7 +311,12 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
   };
 
   const handleStart = async (ctx: IpcContext) => {
-    const svc = getService();
+    // Bump the start nonce for EVERY start so a later start of any provider
+    // (and the stop handler) supersedes a start still awaiting the service
+    // import or keyterm assembly. Captured before the first await so a stop
+    // landing during the dynamic import still wins.
+    const myNonce = ++voiceStartNonce;
+    const svc = await getService();
     // Snapshot transcription settings at session start (model, language, API key).
     // Correction settings are read live from store per-event so mid-session changes apply.
     const settings = getVoiceSettings();
@@ -321,10 +334,6 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
 
     // Capture project info at session start.
     sessionProjectInfo = getProjectInfo();
-
-    // Bump the start nonce for EVERY start so a later start of any provider
-    // (and the stop handler) supersedes a start still awaiting keyterm assembly.
-    const myNonce = ++voiceStartNonce;
 
     // Kick off keyterm assembly concurrently with the subscription/provider
     // setup below so leading speech isn't delayed waiting on git/terminal reads.
@@ -624,6 +633,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     cleanupActiveSubscription();
     service?.destroy();
     service = null;
+    servicePromise = null;
     correctionService = null;
     sessionController = null;
   };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -79,7 +79,6 @@ import { isDemoMode, isSmokeTest, kickOffEarlyPathRefresh } from "./setup/enviro
 import { store } from "./store.js";
 import { initializeLogger, registerLoggerTransport, setLogLevelOverrides } from "./utils/logger.js";
 import { broadcastToRenderer } from "./ipc/utils.js";
-import { registerCommands } from "./services/commands/index.js";
 import {
   initializeCrashRecoveryService,
   getCrashRecoveryService,
@@ -184,8 +183,6 @@ if (!gotTheLock) {
   setLogLevelOverrides(store.get("logLevelOverrides") ?? {});
 
   registerLoggerTransport(broadcastToRenderer, () => BrowserWindow.getAllWindows().length > 0);
-
-  registerCommands();
 
   crashReporter.start({ uploadToServer: false });
   initializeCrashLoopGuard();

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -15,8 +15,8 @@ import {
   getWorktreePortBrokerRef,
 } from "./window/windowServices.js";
 import { distributePortsToView } from "./window/portDistribution.js";
-import { autoUpdaterService } from "./services/AutoUpdaterService.js";
 import type { UpdateMenuState } from "./services/AutoUpdaterService.js";
+import { getAutoUpdaterServiceRef } from "./window/serviceRefs.js";
 import { getPluginMenuItems } from "./services/pluginMenuRegistry.js";
 import { evaluateWhen } from "./services/WhenClauseService.js";
 import { getAppWebContents } from "./window/webContentsRegistry.js";
@@ -63,13 +63,19 @@ function applyUpdateMenuState(state: UpdateMenuState): void {
 // handler reads the current state at invocation time and branches: Ready
 // triggers quitAndInstall; everything else (Idle, Checking) initiates a
 // manual check. Checking is also disabled, so the click only fires for the
-// other two anyway.
+// other two anyway. AutoUpdaterService is dynamically imported so the
+// electron-updater module graph stays off the boot path; clicks before the
+// deferred initialize() remain no-ops via the service's !initialized guard.
 function handleUpdateMenuClick(): void {
-  if (autoUpdaterService.getMenuState() === "ready") {
-    autoUpdaterService.quitAndInstallIfReady();
-  } else {
-    autoUpdaterService.checkForUpdatesManually();
-  }
+  void import("./services/AutoUpdaterService.js")
+    .then(({ autoUpdaterService }) => {
+      if (autoUpdaterService.getMenuState() === "ready") {
+        autoUpdaterService.quitAndInstallIfReady();
+      } else {
+        autoUpdaterService.checkForUpdatesManually();
+      }
+    })
+    .catch((err) => console.error("[MAIN] Failed to load AutoUpdaterService for menu click:", err));
 }
 
 // Each createApplicationMenu rebuild allocates new MenuItem instances, so the
@@ -545,12 +551,23 @@ export function createApplicationMenu(
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
 
-  unsubscribeUpdateMenuState?.();
-  unsubscribeUpdateMenuState = autoUpdaterService.onMenuStateChange(applyUpdateMenuState);
-  // Apply the current state immediately so a rebuild that completes mid-check
-  // (or with a downloaded update already staged) doesn't snap items back to
-  // the default "Check for Updates…" label.
-  applyUpdateMenuState(autoUpdaterService.getMenuState());
+  wireUpdateMenuState();
+}
+
+// Wire the update-state listener against the deferred-loaded singleton. A
+// no-op until the auto-updater deferred task sets the serviceRef — that task
+// calls this directly so the first wiring happens when the service loads,
+// keeping electron-updater off the menu-build path. Rebuilds after that find
+// the ref set and apply the current state synchronously, so a rebuild that
+// completes mid-check (or with a downloaded update already staged) doesn't
+// snap items back to the default "Check for Updates…" label.
+export function wireUpdateMenuState(): void {
+  const svc = getAutoUpdaterServiceRef();
+  if (svc) {
+    unsubscribeUpdateMenuState?.();
+    unsubscribeUpdateMenuState = svc.onMenuStateChange(applyUpdateMenuState);
+    applyUpdateMenuState(svc.getMenuState());
+  }
 }
 
 function buildRecentProjectsMenu(

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1278,6 +1278,8 @@ const api: ElectronAPI = {
     clearQuarantinedPanel: (panelId: string) =>
       _unwrappingInvoke(CHANNELS.APP_CLEAR_QUARANTINED_PANEL, panelId),
 
+    skeletonParsed: () => ipcRenderer.send(CHANNELS.APP_SKELETON_PARSED),
+
     notifyFirstInteractive: () => _unwrappingInvoke(CHANNELS.APP_FIRST_INTERACTIVE),
 
     notifyViewPainted: () => _unwrappingInvoke(CHANNELS.APP_VIEW_PAINTED),

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -105,5 +105,11 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     // Folded into the payload so the renderer skips a standalone
     // `system:get-tmp-dir` round-trip on boot (matches `handleSystemGetTmpDir`).
     systemTmpDir: os.tmpdir(),
+    // Per-project layout state folded in so the renderer skips the standalone
+    // getTabGroups/getTerminalSizes/getDraftInputs round-trips during hydration.
+    // Defaults match the standalone handlers' null-state returns.
+    tabGroups: projectState?.tabGroups ?? [],
+    terminalSizes: projectState?.terminalSizes ?? {},
+    draftInputs: projectState?.draftInputs ?? {},
   };
 }

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -78,6 +78,10 @@ export class CrashRecoveryService {
   // files are deleted, rotated, or overwritten between marker consumption and
   // the user resolving the recovery dialog.
   private cachedBackupSnapshot: SessionSnapshot | null = null;
+  // Memoized crash-recovery config — store.get re-reads and re-parses the
+  // whole config.json on every call, which is sync main-thread work inside
+  // the boot IPC handler. setConfig keeps the memo in sync with writes.
+  private cachedConfig: CrashRecoveryConfig | null = null;
 
   constructor() {
     this.userData = app.getPath("userData");
@@ -135,11 +139,13 @@ export class CrashRecoveryService {
   }
 
   getConfig(): CrashRecoveryConfig {
+    if (this.cachedConfig) return this.cachedConfig;
     const stored = store.get("crashRecovery");
-    return {
+    this.cachedConfig = {
       autoRestoreOnCrash:
         typeof stored?.autoRestoreOnCrash === "boolean" ? stored.autoRestoreOnCrash : true,
     };
+    return this.cachedConfig;
   }
 
   setConfig(patch: Partial<CrashRecoveryConfig>): CrashRecoveryConfig {
@@ -152,6 +158,7 @@ export class CrashRecoveryService {
       updated.autoRestoreOnCrash = patch.autoRestoreOnCrash;
     }
     store.set("crashRecovery", updated);
+    this.cachedConfig = updated;
     return updated;
   }
 

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -312,12 +312,13 @@ export class McpServerService {
   }
 
   private persistConfig(patch: Record<string, unknown>): void {
+    // The deprecated auditLog/turnOutcomeLog config.json keys ride along via
+    // the spread only while migration 022 hasn't stripped them; never re-add
+    // them explicitly or settings writes resurrect the rings in config.json.
     const current = this.getConfig();
     store.set("mcpServer", {
       ...current,
       ...patch,
-      auditLog: "auditLog" in patch ? patch.auditLog : current.auditLog,
-      turnOutcomeLog: "turnOutcomeLog" in patch ? patch.turnOutcomeLog : current.turnOutcomeLog,
     });
   }
 

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -2,7 +2,6 @@ import { createHash } from "crypto";
 import fs from "fs/promises";
 import { createWriteStream } from "fs";
 import path from "path";
-import { ZipArchive } from "archiver";
 import yauzl from "yauzl";
 import { getPluginManifestSchema } from "../schemas/plugin.js";
 import type { PluginManifest } from "../../shared/types/plugin.js";
@@ -144,6 +143,7 @@ export async function packPluginArchiveFromFiles(
   outputPath: string,
   files: readonly string[]
 ): Promise<string> {
+  const { ZipArchive } = await import("archiver");
   const sorted = sortEntries([...files]);
 
   if (!sorted.includes("plugin.json")) {

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { getCurrentDiskSpaceStatus } from "./DiskSpaceMonitor.js";
 
-export const LATEST_SCHEMA_VERSION = 21;
+export const LATEST_SCHEMA_VERSION = 22;
 
 export interface Migration {
   version: number;

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -30,6 +30,9 @@ const mockState = vi.hoisted(() => ({
         focusMode?: boolean;
         focusPanelState?: { sidebarWidth: number; diagnosticsOpen: boolean };
         mruList?: string[];
+        tabGroups?: unknown[];
+        terminalSizes?: Record<string, { cols: number; rows: number }>;
+        draftInputs?: Record<string, string>;
       }
     | undefined,
   projectStateQuarantinedPath: undefined as string | undefined,
@@ -301,6 +304,38 @@ describe("AppHydrationService adversarial", () => {
     // so the renderer can derive the clipboard directory without a round-trip.
     expect(result.systemTmpDir).toBe(os.tmpdir());
     expect(result.systemTmpDir!.length).toBeGreaterThan(0);
+  });
+
+  it("folds tabGroups/terminalSizes/draftInputs from project state into the payload", async () => {
+    const tabGroups = [{ id: "g1", location: "grid", activeTabId: "t1", panelIds: ["t1"] }];
+    const terminalSizes = { t1: { cols: 120, rows: 40 } };
+    const draftInputs = { t1: "draft text" };
+    mockState.projectState = {
+      terminals: [],
+      tabGroups,
+      terminalSizes,
+      draftInputs,
+    };
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.tabGroups).toEqual(tabGroups);
+    expect(result.terminalSizes).toEqual(terminalSizes);
+    expect(result.draftInputs).toEqual(draftInputs);
+  });
+
+  it("defaults tabGroups/terminalSizes/draftInputs to empty when project state is missing", async () => {
+    mockState.projectState = undefined;
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    // Must mirror the standalone IPC handlers' null-state returns so the
+    // renderer's payload-presence gate never re-fetches on a fresh project.
+    expect(result.tabGroups).toEqual([]);
+    expect(result.terminalSizes).toEqual({});
+    expect(result.draftInputs).toEqual({});
   });
 
   it("CONCURRENT_CALLS_READ_ONLY", async () => {

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -1228,6 +1228,28 @@ describe("CrashRecoveryService", () => {
       expect(result.autoRestoreOnCrash).toBe(false);
       expect(storeMock.set).toHaveBeenCalledWith("crashRecovery", { autoRestoreOnCrash: false });
     });
+
+    it("getConfig memoizes the store read so repeated calls don't re-parse config.json", () => {
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+      const svc = makeService();
+
+      expect(svc.getConfig()).toEqual({ autoRestoreOnCrash: false });
+      expect(svc.getConfig()).toEqual({ autoRestoreOnCrash: false });
+
+      expect(storeMock.get.mock.calls.filter(([key]) => key === "crashRecovery")).toHaveLength(1);
+    });
+
+    it("setConfig refreshes the memo so the settings tab round-trips the new value", () => {
+      storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
+      const svc = makeService();
+      expect(svc.getConfig().autoRestoreOnCrash).toBe(false);
+
+      svc.setConfig({ autoRestoreOnCrash: true });
+
+      // Even if the store mock still serves the stale value, the memo must
+      // reflect the write — otherwise a cached false would shadow the toggle.
+      expect(svc.getConfig().autoRestoreOnCrash).toBe(true);
+    });
   });
 
   describe("getLastBackupTimestamp", () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -110,7 +110,6 @@ const storeState = vi.hoisted(() => ({
     fullToolSurface: false,
     auditEnabled: true,
     auditMaxRecords: 500,
-    auditLog: [] as Array<Record<string, unknown>>,
   },
 }));
 
@@ -126,6 +125,26 @@ const storeMocks = vi.hoisted(() => ({
       throw new Error(`Unexpected store key: ${key}`);
     }
     storeState.mcpServer = value;
+  }),
+}));
+
+const auditLogsState = vi.hoisted(() => ({
+  mcpAuditLog: [] as Array<Record<string, unknown>>,
+  mcpTurnOutcomeLog: [] as Array<Record<string, unknown>>,
+}));
+
+const auditLogsStoreMocks = vi.hoisted(() => ({
+  get: vi.fn((key: string) => {
+    if (key !== "mcpAuditLog" && key !== "mcpTurnOutcomeLog") {
+      throw new Error(`Unexpected audit-logs store key: ${key}`);
+    }
+    return auditLogsState[key as keyof typeof auditLogsState];
+  }),
+  set: vi.fn((key: string, value: Array<Record<string, unknown>>) => {
+    if (key !== "mcpAuditLog" && key !== "mcpTurnOutcomeLog") {
+      throw new Error(`Unexpected audit-logs store key: ${key}`);
+    }
+    auditLogsState[key as keyof typeof auditLogsState] = value;
   }),
 }));
 
@@ -154,6 +173,10 @@ vi.mock("../../store.js", () => ({
   store: {
     get: storeMocks.get,
     set: storeMocks.set,
+  },
+  auditLogsStore: {
+    get: auditLogsStoreMocks.get,
+    set: auditLogsStoreMocks.set,
   },
 }));
 
@@ -542,10 +565,13 @@ describe("McpServerService", () => {
       fullToolSurface: false,
       auditEnabled: true,
       auditMaxRecords: 500,
-      auditLog: [],
     };
+    auditLogsState.mcpAuditLog = [];
+    auditLogsState.mcpTurnOutcomeLog = [];
     storeMocks.get.mockClear();
     storeMocks.set.mockClear();
+    auditLogsStoreMocks.get.mockClear();
+    auditLogsStoreMocks.set.mockClear();
     paneTokenTiers.clear();
     electronMocks.ipcMain.removeAllListeners();
     electronMocks.webContentsById.clear();
@@ -3283,15 +3309,12 @@ describe("McpServerService", () => {
 
       expect(getAuditRecords(service)).toHaveLength(1);
 
-      storeMocks.set.mockClear();
+      auditLogsStoreMocks.set.mockClear();
       (service as unknown as { clearAuditLog: () => void }).clearAuditLog();
 
       expect(getAuditRecords(service)).toHaveLength(0);
       // clearAuditLog must persist synchronously, not wait for the debounce.
-      expect(storeMocks.set).toHaveBeenCalled();
-      const lastCall = storeMocks.set.mock.calls[storeMocks.set.mock.calls.length - 1];
-      expect(lastCall[0]).toBe("mcpServer");
-      expect((lastCall[1] as { auditLog: unknown[] }).auditLog).toEqual([]);
+      expect(auditLogsStoreMocks.set).toHaveBeenCalledWith("mcpAuditLog", []);
     });
 
     it("does not record dispatches when capture is disabled", async () => {
@@ -3327,7 +3350,7 @@ describe("McpServerService", () => {
           durationMs: 5,
         },
       ];
-      storeState.mcpServer.auditLog = seeded;
+      auditLogsState.mcpAuditLog = seeded;
 
       const { window } = createMockWindow();
       await service.start(window);
@@ -3392,23 +3415,21 @@ describe("McpServerService", () => {
       });
       try {
         await client.callTool({ name: "actions.list", arguments: { x: 1 } });
-        storeMocks.set.mockClear();
+        auditLogsStoreMocks.set.mockClear();
 
         // Before the debounce window expires, no flush.
         vi.advanceTimersByTime(1000);
-        expect(storeMocks.set).not.toHaveBeenCalled();
+        expect(auditLogsStoreMocks.set).not.toHaveBeenCalled();
 
         // After the 2s window the debounced flush fires once.
         vi.advanceTimersByTime(1500);
-        const calls = storeMocks.set.mock.calls.filter((call) => call[0] === "mcpServer");
+        const calls = auditLogsStoreMocks.set.mock.calls.filter(
+          (call) => call[0] === "mcpAuditLog"
+        );
         expect(calls.length).toBeGreaterThanOrEqual(1);
         const last = calls[calls.length - 1];
-        expect(
-          (last[1] as unknown as { auditLog: Array<{ toolId: string }> }).auditLog
-        ).toHaveLength(1);
-        expect(
-          (last[1] as unknown as { auditLog: Array<{ toolId: string }> }).auditLog[0].toolId
-        ).toBe("actions.list");
+        expect(last[1] as Array<{ toolId: string }>).toHaveLength(1);
+        expect((last[1] as Array<{ toolId: string }>)[0].toolId).toBe("actions.list");
       } finally {
         vi.useRealTimers();
       }
@@ -3437,12 +3458,12 @@ describe("McpServerService", () => {
         await client.callTool({ name: ACTIONS_LIST_TOOL, arguments: {} });
         // Pending debounce timer is now set with the record in the buffer.
         (service as unknown as { clearAuditLog: () => void }).clearAuditLog();
-        storeMocks.set.mockClear();
+        auditLogsStoreMocks.set.mockClear();
 
         // Advance well past the original debounce window. The cancelled
         // timer must not fire and re-persist the cleared record.
         vi.advanceTimersByTime(5000);
-        expect(storeMocks.set).not.toHaveBeenCalled();
+        expect(auditLogsStoreMocks.set).not.toHaveBeenCalled();
         expect(getAuditRecords(service)).toHaveLength(0);
       } finally {
         vi.useRealTimers();
@@ -3468,9 +3489,11 @@ describe("McpServerService", () => {
 
       // Mutate config — historically this clobbered auditLog because the
       // setter wrote back the spread of getConfig() without the in-memory log.
+      // The ring now lives in the dedicated audit-logs store, so config
+      // writes are structurally unable to touch it.
       service.setAuditMaxRecords(750);
 
-      expect(storeState.mcpServer.auditLog).toHaveLength(1);
+      expect(auditLogsState.mcpAuditLog).toHaveLength(1);
       expect(getAuditRecords(service)).toHaveLength(1);
     });
   });

--- a/electron/services/commands/index.ts
+++ b/electron/services/commands/index.ts
@@ -1,16 +1,21 @@
 import { commandService } from "../CommandService.js";
 
+let registration: Promise<void> | null = null;
+
 /**
  * Register built-in Daintree commands.
  *
  * Both command modules are loaded via dynamic `import()` so they stay out of
- * the eager-import graph at app startup. Registration is fire-and-forget —
- * the command-service consumers (IPC handlers in `electron/ipc/handlers/commands.ts`)
- * only run after the renderer is interactive, by which time the registrations
- * have completed.
+ * the eager-import graph at app startup. Registration runs from the deferred
+ * queue's heavy group (post-first-interactive), so it is no longer guaranteed
+ * to finish before the renderer's first commands IPC — consumers await
+ * `builtinCommandsReady()` instead of relying on boot ordering. Failures are
+ * swallowed after logging so a broken registration can't wedge every commands
+ * IPC; the registry just stays empty.
  */
 export function registerCommands(): void {
-  void (async () => {
+  if (registration) return;
+  registration = (async () => {
     try {
       const [{ githubCreateIssueCommand }, { githubWorkIssueCommand }] = await Promise.all([
         import("./githubCreateIssue.js"),
@@ -22,4 +27,9 @@ export function registerCommands(): void {
       console.error("[CommandService] Failed to register built-in commands:", err);
     }
   })();
+}
+
+export function builtinCommandsReady(): Promise<void> {
+  registerCommands();
+  return registration ?? Promise.resolve();
 }

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { AuditService, type AuditOutcome } from "../auditLog.js";
+import { AuditService, type AuditOutcome, type McpAuditLogStore } from "../auditLog.js";
 import {
   type McpAuditResult,
   isAuditRecord,
   isGrantRecord,
 } from "../../../../shared/types/ipc/mcpServer.js";
 
-function makeFixture(initialConfig: Record<string, unknown> = {}) {
+function makeFixture(initialConfig: Record<string, unknown> = {}, initialLog: unknown[] = []) {
   const config: Record<string, unknown> = {
     auditEnabled: true,
     auditMaxRecords: 500,
@@ -15,8 +15,15 @@ function makeFixture(initialConfig: Record<string, unknown> = {}) {
   const saveConfig = vi.fn((patch: Record<string, unknown>) => {
     Object.assign(config, patch);
   });
-  const service = new AuditService(saveConfig, () => config);
-  return { service, saveConfig, config };
+  let persistedLog: unknown[] = [...initialLog];
+  const logStore = {
+    read: vi.fn(() => persistedLog),
+    write: vi.fn((records: unknown[]) => {
+      persistedLog = records;
+    }),
+  };
+  const service = new AuditService(saveConfig, () => config, logStore as McpAuditLogStore);
+  return { service, saveConfig, config, logStore, getPersistedLog: () => persistedLog };
 }
 
 const successOutcome: AuditOutcome = {
@@ -386,20 +393,18 @@ describe("AuditService.recordAuth401 pre-auth records", () => {
 
 describe("AuditService hydrate — backward compat", () => {
   it("tolerates persisted records missing schemaVersion and severity", () => {
-    const { service } = makeFixture({
-      auditLog: [
-        {
-          id: "old-1",
-          timestamp: 1000,
-          toolId: "agent.terminal",
-          sessionId: "sess-1",
-          tier: "action",
-          argsSummary: "{}",
-          result: "success",
-          durationMs: 5,
-        },
-      ],
-    });
+    const { service } = makeFixture({}, [
+      {
+        id: "old-1",
+        timestamp: 1000,
+        toolId: "agent.terminal",
+        sessionId: "sess-1",
+        tier: "action",
+        argsSummary: "{}",
+        result: "success",
+        durationMs: 5,
+      },
+    ]);
     const records = service.getRecords();
     expect(records).toHaveLength(1);
     expect(records[0]!.id).toBe("old-1");
@@ -417,7 +422,7 @@ describe("AuditService hydrate — backward compat", () => {
       errorCode: "EXECUTION_ERROR",
       durationMs: 50,
     };
-    const { service } = makeFixture({ auditLog: [oldRecord] });
+    const { service } = makeFixture({}, [oldRecord]);
     // hydrate() is called lazily — trigger it via getRecords.
     const records = service.getRecords();
     expect(records).toHaveLength(1);
@@ -439,7 +444,7 @@ describe("AuditService hydrate — backward compat", () => {
       schemaVersion: 1,
       severity: "info",
     };
-    const { service } = makeFixture({ auditLog: [currentRecord] });
+    const { service } = makeFixture({}, [currentRecord]);
     const records = service.getRecords();
     expect(records).toHaveLength(1);
     expect(records[0]!.schemaVersion).toBe(1);
@@ -462,7 +467,7 @@ describe("AuditService hydrate — backward compat", () => {
       durationMs: 50,
       type: "dispatch",
     };
-    const { service } = makeFixture({ auditLog: [malformed] });
+    const { service } = makeFixture({}, [malformed]);
     const records = service.getLogRecords();
     expect(records).toHaveLength(1);
     // The record survives hydrate (the string `type` field is preserved),
@@ -471,6 +476,34 @@ describe("AuditService hydrate — backward compat", () => {
     // "type" stays in the persisted shape for round-trip safety; the
     // union consumer narrows by isGrantRecord at read time.
     expect((records[0] as { type?: unknown }).type).toBe("dispatch");
+  });
+});
+
+describe("AuditService persistence routing", () => {
+  it("flushes the ring to the audit-logs store, never into the config patch", () => {
+    const { service, saveConfig, logStore, getPersistedLog } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    service.flushNow();
+    expect(logStore.write).toHaveBeenCalledTimes(1);
+    expect(getPersistedLog()).toHaveLength(1);
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+
+  it("setEnabled/setMaxRecords still persist config flags via saveConfig", () => {
+    const { service, saveConfig, config } = makeFixture();
+    service.setEnabled(false);
+    expect(saveConfig).toHaveBeenCalledWith({ auditEnabled: false });
+    service.setMaxRecords(250);
+    expect(saveConfig).toHaveBeenCalledWith({ auditMaxRecords: 250 });
+    expect("auditLog" in config).toBe(false);
   });
 });
 

--- a/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
+++ b/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
@@ -49,6 +49,8 @@ interface Fixture {
   config: Record<string, unknown>;
   service: TurnOutcomeService;
   saveConfig: ReturnType<typeof vi.fn>;
+  logStore: { read: ReturnType<typeof vi.fn>; write: ReturnType<typeof vi.fn> };
+  getPersistedLog: () => unknown[];
   getSessionIdForTerminal: (terminalId: string) => string | null;
   getRecentAuditRecords: () => readonly McpAuditRecord[];
   flushPersist: () => void;
@@ -57,6 +59,7 @@ interface Fixture {
 function makeFixture(
   opts: {
     initialConfig?: Record<string, unknown>;
+    initialLog?: unknown[];
     sessionId?: string | null;
     auditRecords?: McpAuditRecord[];
   } = {}
@@ -69,6 +72,13 @@ function makeFixture(
   const saveConfig = vi.fn((patch: Record<string, unknown>) => {
     Object.assign(config, patch);
   });
+  let persistedLog: unknown[] = [...(opts.initialLog ?? [])];
+  const logStore = {
+    read: vi.fn(() => persistedLog),
+    write: vi.fn((records: unknown[]) => {
+      persistedLog = records;
+    }),
+  };
   const sessionId = "sessionId" in opts ? opts.sessionId : "session-1";
   const getSessionIdForTerminal = vi.fn((_terminalId: string) => sessionId) as unknown as (
     terminalId: string
@@ -81,12 +91,15 @@ function makeFixture(
     readConfig: () => config,
     getSessionIdForTerminal,
     getRecentAuditRecords,
+    logStore,
   };
   const service = new TurnOutcomeService(deps);
   return {
     config,
     service,
     saveConfig,
+    logStore,
+    getPersistedLog: () => persistedLog,
     getSessionIdForTerminal,
     getRecentAuditRecords,
     flushPersist: () => {
@@ -506,19 +519,18 @@ describe("TurnOutcomeService.handleTransition", () => {
     expect(f.service.getRecords()[0]?.outcome).toBe("answered");
   });
 
-  it("flushNow persists pending records synchronously", () => {
+  it("flushNow persists pending records synchronously to the log store", () => {
     const f = makeFixture();
     f.service.appendOutput("term-1", "Done — the file was updated and the tests pass cleanly.");
     f.service.handleTransition(
       makeTransition({ previousState: "working", state: "idle", trigger: "output" })
     );
-    expect(f.saveConfig).not.toHaveBeenCalledWith(
-      expect.objectContaining({ turnOutcomeLog: expect.any(Array) })
-    );
+    expect(f.logStore.write).not.toHaveBeenCalled();
     f.flushPersist();
-    expect(f.saveConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ turnOutcomeLog: expect.any(Array) })
-    );
+    expect(f.logStore.write).toHaveBeenCalledTimes(1);
+    expect(f.getPersistedLog()).toHaveLength(1);
+    // The ring never travels through the config patch.
+    expect(f.saveConfig).not.toHaveBeenCalled();
   });
 
   it("hydrates persisted records on first read", () => {
@@ -531,13 +543,7 @@ describe("TurnOutcomeService.handleTransition", () => {
         outcome: "answered",
       },
     ];
-    const f = makeFixture({
-      initialConfig: {
-        auditEnabled: true,
-        auditMaxRecords: 500,
-        turnOutcomeLog: persisted,
-      },
-    });
+    const f = makeFixture({ initialLog: persisted });
     expect(f.service.getRecords()).toHaveLength(1);
     expect(f.service.getRecords()[0]?.id).toBe("rec-1");
   });

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -19,6 +19,7 @@ import {
   isAuditRecord,
   isGrantRecord,
 } from "../../../shared/types/ipc/mcpServer.js";
+import { auditLogsStore } from "../../store.js";
 import type { McpTier } from "./shared.js";
 import {
   AUDIT_FLUSH_DEBOUNCE_MS,
@@ -38,6 +39,20 @@ const FAILURE_CLUSTER_WINDOW = 10;
 const FAILURE_CLUSTER_MIN_FAILURES = 3;
 const MAD_SCALE_FACTOR = 0.6745;
 const P95_Z_SCORE_MIN_TOOLS = 5;
+
+export interface McpAuditLogStore {
+  read(): unknown;
+  write(records: McpLogRecord[]): void;
+}
+
+// Persists the ring in the dedicated audit-logs store so settings writes to
+// config.json stay decoupled from audit appends and bootstrap never pays the
+// parse cost of the rings. `auditEnabled` / `auditMaxRecords` stay in
+// config.json (`mcpServer`), read via the injected config closures.
+const defaultLogStore: McpAuditLogStore = {
+  read: () => auditLogsStore.get("mcpAuditLog"),
+  write: (records) => auditLogsStore.set("mcpAuditLog", records),
+};
 
 function percentile(values: number[], p: number): number {
   const sorted = [...values].sort((a, b) => a - b);
@@ -73,14 +88,15 @@ export class AuditService {
 
   constructor(
     private readonly saveConfig: (patch: Record<string, unknown>) => void,
-    private readonly readConfig: () => Record<string, unknown>
+    private readonly readConfig: () => Record<string, unknown>,
+    private readonly logStore: McpAuditLogStore = defaultLogStore
   ) {}
 
   hydrate(): void {
     if (this.hydrated) return;
-    const config = this.readConfig();
-    const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
-    const cap = this.normalizeMaxRecords(config.auditMaxRecords);
+    const stored = this.logStore.read();
+    const persisted = Array.isArray(stored) ? stored : [];
+    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     const safe = persisted.filter(
       (r: unknown): r is Record<string, unknown> => r !== null && typeof r === "object"
     );
@@ -536,7 +552,7 @@ export class AuditService {
   private flush(): void {
     if (!this.hydrated) return;
     try {
-      this.saveConfig({ auditLog: [...this.records] });
+      this.logStore.write([...this.records]);
     } catch (err) {
       console.error("[MCP] Failed to flush audit log:", err);
     }

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -10,7 +10,20 @@ import {
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
 } from "../../../shared/types/ipc/mcpServer.js";
+import { auditLogsStore } from "../../store.js";
 import { AUDIT_FLUSH_DEBOUNCE_MS, TIER_NOT_PERMITTED_CODE } from "./shared.js";
+
+export interface TurnOutcomeLogStore {
+  read(): unknown;
+  write(records: AssistantTurnRecord[]): void;
+}
+
+// Persists the ring in the dedicated audit-logs store; see the matching note
+// in auditLog.ts. Config flags stay in config.json.
+const defaultLogStore: TurnOutcomeLogStore = {
+  read: () => auditLogsStore.get("mcpTurnOutcomeLog"),
+  write: (records) => auditLogsStore.set("mcpTurnOutcomeLog", records),
+};
 
 /**
  * Per-terminal recent-output ring size. Mirrors the pty-host
@@ -198,6 +211,7 @@ export interface TurnOutcomeServiceDeps {
   readConfig: () => Record<string, unknown>;
   getSessionIdForTerminal: (terminalId: string) => string | null;
   getRecentAuditRecords: () => readonly McpAuditRecord[];
+  logStore?: TurnOutcomeLogStore;
 }
 
 export class TurnOutcomeService {
@@ -248,7 +262,11 @@ export class TurnOutcomeService {
     | ((outcome: TurnOutcomeAlertClass, helpSessionId: string, turnId: string | undefined) => void)
     | null = null;
 
-  constructor(private readonly deps: TurnOutcomeServiceDeps) {}
+  private readonly logStore: TurnOutcomeLogStore;
+
+  constructor(private readonly deps: TurnOutcomeServiceDeps) {
+    this.logStore = deps.logStore ?? defaultLogStore;
+  }
 
   /**
    * Wire the live alert push for `agent-stuck` / `reasoning-loop` outcomes
@@ -320,9 +338,9 @@ export class TurnOutcomeService {
 
   hydrate(): void {
     if (this.hydrated) return;
-    const config = this.deps.readConfig();
-    const persisted = Array.isArray(config.turnOutcomeLog) ? config.turnOutcomeLog : [];
-    const cap = this.normalizeMaxRecords(config.auditMaxRecords);
+    const stored = this.logStore.read();
+    const persisted = Array.isArray(stored) ? (stored as AssistantTurnRecord[]) : [];
+    const cap = this.normalizeMaxRecords(this.deps.readConfig().auditMaxRecords);
     this.records =
       persisted.length > cap ? persisted.slice(persisted.length - cap) : [...persisted];
     this.hydrated = true;
@@ -490,7 +508,7 @@ export class TurnOutcomeService {
   private flush(): void {
     if (!this.hydrated) return;
     try {
-      this.deps.saveConfig({ turnOutcomeLog: [...this.records] });
+      this.logStore.write([...this.records]);
     } catch (err) {
       console.error("[MCP] Failed to flush turn outcome log:", err);
     }

--- a/electron/services/migrations/022-audit-logs-store.ts
+++ b/electron/services/migrations/022-audit-logs-store.ts
@@ -1,0 +1,55 @@
+import type { Migration } from "../StoreMigrations.js";
+import { auditLogsStore } from "../../store.js";
+
+/**
+ * Move the MCP audit and turn-outcome ring buffers out of config.json into the
+ * dedicated lazily-constructed audit-logs store. The rings were the bulk of
+ * config.json, which bootstrap reads/parses twice and copies to .bak
+ * synchronously before main.js loads — boot cost scaled with audit volume.
+ * `auditEnabled` / `auditMaxRecords` (and `pendingErrors`, the crash-reporting
+ * path) intentionally stay in config.json.
+ */
+export const migration022: Migration = {
+  version: 22,
+  description: "Move MCP audit and turn-outcome logs to dedicated audit-logs store",
+  up: (store) => {
+    const mcpServer = store.get("mcpServer") as Record<string, unknown> | undefined;
+    if (!mcpServer || typeof mcpServer !== "object") return;
+    if (!("auditLog" in mcpServer) && !("turnOutcomeLog" in mcpServer)) return;
+
+    // path === "" means the audit-logs store fell back to in-memory — moving
+    // the rings there and stripping the config.json keys would silently lose
+    // them on the next restart. Leave the data in place instead; throwing here
+    // would trip StoreMigrations' restore-from-backup path, which is worse
+    // than deferring the move for diagnostics data.
+    if (auditLogsStore.path === "") {
+      console.warn(
+        "[Migrations] audit-logs store is not durable; leaving audit rings in config.json"
+      );
+      return;
+    }
+
+    const { auditLog, turnOutcomeLog, ...rest } = mcpServer;
+
+    if (Array.isArray(auditLog) && auditLog.length > 0) {
+      const existing = auditLogsStore.get("mcpAuditLog");
+      // Rings are oldest-first; migrated config.json records predate anything
+      // already in the audit-logs store, so they go first.
+      auditLogsStore.set("mcpAuditLog", [
+        ...auditLog,
+        ...(Array.isArray(existing) ? existing : []),
+      ] as never);
+    }
+    if (Array.isArray(turnOutcomeLog) && turnOutcomeLog.length > 0) {
+      const existing = auditLogsStore.get("mcpTurnOutcomeLog");
+      auditLogsStore.set("mcpTurnOutcomeLog", [
+        ...turnOutcomeLog,
+        ...(Array.isArray(existing) ? existing : []),
+      ] as never);
+    }
+
+    // Rebuild without the moved keys so they're dropped from the persisted
+    // object (electron-store delete only handles top-level keys).
+    store.set("mcpServer", rest as never);
+  },
+};

--- a/electron/services/migrations/__tests__/022-audit-logs-store.test.ts
+++ b/electron/services/migrations/__tests__/022-audit-logs-store.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { migration022 } from "../022-audit-logs-store.js";
+
+const auditLogsStoreMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+}));
+
+vi.mock("../../../store.js", () => ({
+  auditLogsStore: auditLogsStoreMock,
+}));
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    delete: vi.fn((key: string) => {
+      delete data[key];
+    }),
+  } as unknown as Parameters<typeof migration022.up>[0];
+}
+
+const auditRecord = {
+  id: "audit-1",
+  timestamp: 1000,
+  toolId: "actions.list",
+  sessionId: "sess-1",
+  tier: "action",
+  argsSummary: "{}",
+  result: "success",
+  durationMs: 5,
+};
+
+const turnRecord = {
+  id: "turn-1",
+  timestamp: 2000,
+  terminalId: "term-1",
+  sessionId: "help-1",
+  outcome: "answered",
+};
+
+describe("migration022 — audit logs store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auditLogsStoreMock.get.mockReturnValue([]);
+  });
+
+  it("moves auditLog and turnOutcomeLog records to the audit-logs store and strips the old keys", () => {
+    const data: Record<string, unknown> = {
+      mcpServer: {
+        enabled: true,
+        port: 45454,
+        apiKey: "key",
+        auditEnabled: true,
+        auditMaxRecords: 500,
+        auditLog: [auditRecord],
+        turnOutcomeLog: [turnRecord],
+      },
+    };
+    const store = makeStoreMock(data);
+
+    migration022.up(store);
+
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("mcpAuditLog", [auditRecord]);
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("mcpTurnOutcomeLog", [turnRecord]);
+    const after = data.mcpServer as Record<string, unknown>;
+    expect("auditLog" in after).toBe(false);
+    expect("turnOutcomeLog" in after).toBe(false);
+    // Config flags stay in config.json.
+    expect(after).toMatchObject({
+      enabled: true,
+      port: 45454,
+      apiKey: "key",
+      auditEnabled: true,
+      auditMaxRecords: 500,
+    });
+  });
+
+  it("prepends migrated records before any already in the audit-logs store", () => {
+    const existing = [{ ...auditRecord, id: "newer-1", timestamp: 5000 }];
+    auditLogsStoreMock.get.mockImplementation((key: string) =>
+      key === "mcpAuditLog" ? [...existing] : []
+    );
+    const store = makeStoreMock({
+      mcpServer: { auditLog: [auditRecord] },
+    });
+
+    migration022.up(store);
+
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("mcpAuditLog", [auditRecord, ...existing]);
+  });
+
+  it("strips empty-array rings without writing to the audit-logs store", () => {
+    const data: Record<string, unknown> = {
+      mcpServer: { auditEnabled: true, auditLog: [], turnOutcomeLog: [] },
+    };
+    const store = makeStoreMock(data);
+
+    migration022.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    const after = data.mcpServer as Record<string, unknown>;
+    expect("auditLog" in after).toBe(false);
+    expect("turnOutcomeLog" in after).toBe(false);
+    expect(after.auditEnabled).toBe(true);
+  });
+
+  it("leaves the store untouched when neither ring key is present", () => {
+    const store = makeStoreMock({
+      mcpServer: { enabled: false, auditEnabled: true },
+    });
+
+    migration022.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    expect((store as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+  });
+
+  it("handles a missing mcpServer object gracefully", () => {
+    const store = makeStoreMock({});
+
+    migration022.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    expect((store as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a corrupt audit-logs store value when merging", () => {
+    auditLogsStoreMock.get.mockReturnValue("not-an-array");
+    const store = makeStoreMock({
+      mcpServer: { auditLog: [auditRecord] },
+    });
+
+    migration022.up(store);
+
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("mcpAuditLog", [auditRecord]);
+  });
+
+  it("has version 22", () => {
+    expect(migration022.version).toBe(22);
+  });
+});

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -18,6 +18,7 @@ import { migration018 } from "./018-archive-notes.js";
 import { migration019 } from "./019-remove-fleet-deck-open.js";
 import { migration020 } from "./020-window-states-store.js";
 import { migration021 } from "./021-merge-disabled-plugins.js";
+import { migration022 } from "./022-audit-logs-store.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -40,4 +41,5 @@ export const migrations: Migration[] = [
   migration019,
   migration020,
   migration021,
+  migration022,
 ];

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -1,3 +1,4 @@
+// eager-import-allow: module-scope __dirname/__filename derivation only (fileURLToPath); no disk I/O at import
 import { utilityProcess, UtilityProcess, app } from "electron";
 import { EventEmitter } from "events";
 import { createHash } from "crypto";

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -196,9 +196,11 @@ export class WorkspaceHostPool {
     host.relayFetchThrottle(this.fetchThrottleMultiplierCache);
 
     const initPromise = (async () => {
-      await host.waitForReady();
+      const [, forgeSettings] = await Promise.all([
+        host.waitForReady(),
+        readForgeSettingsForProject(normalizedPath),
+      ]);
       const requestId = host.generateRequestId();
-      const forgeSettings = await readForgeSettingsForProject(normalizedPath);
       await host.sendWithResponse({
         type: "load-project",
         requestId,
@@ -255,9 +257,11 @@ export class WorkspaceHostPool {
     host.relayFetchThrottle(this.fetchThrottleMultiplierCache);
 
     const initPromise = (async () => {
-      await host.waitForReady();
+      const [, forgeSettings] = await Promise.all([
+        host.waitForReady(),
+        readForgeSettingsForProject(normalizedPath),
+      ]);
       const requestId = host.generateRequestId();
-      const forgeSettings = await readForgeSettingsForProject(normalizedPath);
       await host.sendWithResponse({
         type: "load-project",
         requestId,
@@ -436,10 +440,12 @@ export class WorkspaceHostPool {
 
   private async reloadProjectAfterRestart(entry: ProcessEntry): Promise<void> {
     const host = entry.host;
-    await host.waitForReady();
+    const [, forgeSettings] = await Promise.all([
+      host.waitForReady(),
+      readForgeSettingsForProject(entry.projectPath),
+    ]);
 
     const requestId = host.generateRequestId();
-    const forgeSettings = await readForgeSettingsForProject(entry.projectPath);
     await host.sendWithResponse({
       type: "load-project",
       requestId,

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -13,7 +13,11 @@ import type {
 import type { IssueAssociation } from "../shared/types/ipc/worktree.js";
 import type { InstalledPluginRecord } from "../shared/types/plugin.js";
 import type { ErrorRecord } from "../shared/types/ipc/errors.js";
-import type { AssistantTurnRecord, McpAuditRecord } from "../shared/types/ipc/mcpServer.js";
+import type {
+  AssistantTurnRecord,
+  McpAuditRecord,
+  McpLogRecord,
+} from "../shared/types/ipc/mcpServer.js";
 import { MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/mcpServer.js";
 import type { PluginActionAuditRecord } from "../shared/types/ipc/pluginAudit.js";
 import { PLUGIN_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/pluginAudit.js";
@@ -43,6 +47,11 @@ interface WindowStateEntry {
 
 interface WindowStatesStoreSchema {
   windowStates: Record<string, WindowStateEntry>;
+}
+
+interface AuditLogsStoreSchema {
+  mcpAuditLog: McpLogRecord[];
+  mcpTurnOutcomeLog: AssistantTurnRecord[];
 }
 
 export interface StoreSchema {
@@ -226,7 +235,9 @@ export interface StoreSchema {
     fullToolSurface: boolean;
     auditEnabled: boolean;
     auditMaxRecords: number;
+    /** @deprecated Moved to the audit-logs store by migration022. Read-only carryover. */
     auditLog?: McpAuditRecord[];
+    /** @deprecated Moved to the audit-logs store by migration022. Read-only carryover. */
     turnOutcomeLog?: AssistantTurnRecord[];
     abusePolicyEnabled: boolean;
     abusePolicyMaxDenials: number;
@@ -978,6 +989,59 @@ export const windowStatesStore = new Proxy({} as Store<WindowStatesStoreSchema>,
   },
   has(_target, prop) {
     const instance = initializeWindowStatesStore();
+    return Reflect.has(instance as object, prop);
+  },
+});
+
+let auditLogsInstance: Store<AuditLogsStoreSchema> | undefined;
+
+function initializeAuditLogsStore(): Store<AuditLogsStoreSchema> {
+  if (auditLogsInstance) return auditLogsInstance;
+  try {
+    const created = new Store<AuditLogsStoreSchema>({
+      name: "audit-logs",
+      cwd: storeOptions.cwd,
+      defaults: { mcpAuditLog: [], mcpTurnOutcomeLog: [] },
+      clearInvalidConfig: true,
+      configFileMode: 0o600,
+    });
+    tightenFilePermissions(created.path);
+    auditLogsInstance = created;
+    return created;
+  } catch (error) {
+    console.warn("[Store] Failed to initialize audit-logs store, using in-memory fallback:", error);
+    const memoryStore = new Map();
+    const fallback = {
+      get: (key: string) => memoryStore.get(key),
+      set: (key: string, value: unknown) => memoryStore.set(key, value),
+      delete: (key: string) => memoryStore.delete(key),
+      has: (key: string) => memoryStore.has(key),
+      clear: () => memoryStore.clear(),
+      store: {},
+      path: "",
+    } as unknown as Store<AuditLogsStoreSchema>;
+    auditLogsInstance = fallback;
+    return fallback;
+  }
+}
+
+// Lazy like the main `store` Proxy: the audit rings can grow to multiple MB
+// and are only needed when an MCP audit consumer reads or flushes — never
+// during bootstrap, so the sync read+parse of audit-logs.json is deferred.
+export const auditLogsStore = new Proxy({} as Store<AuditLogsStoreSchema>, {
+  get(_target, prop) {
+    const instance = initializeAuditLogsStore();
+    const value = Reflect.get(instance as object, prop, instance);
+    return typeof value === "function"
+      ? (value as (...args: unknown[]) => unknown).bind(instance)
+      : value;
+  },
+  set(_target, prop, value) {
+    const instance = initializeAuditLogsStore();
+    return Reflect.set(instance as object, prop, value, instance);
+  },
+  has(_target, prop) {
+    const instance = initializeAuditLogsStore();
     return Reflect.has(instance as object, prop);
   },
 });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1152,7 +1152,9 @@ export class ProjectViewManager {
         sandbox: true,
         webviewTag: true,
         navigateOnDragDrop: false,
-        v8CacheOptions: "code",
+        // Matches createWindow.ts: write the V8 code cache on first load so
+        // post-install/update launches warm up one launch sooner.
+        v8CacheOptions: app.isPackaged ? "bypassHeatCheck" : "code",
         // Seed the renderer with the persisted theme so project-switch cold
         // starts and LRU-evicted views paint the saved scheme on first frame
         // instead of a prefers-color-scheme default (#9169). The project id is

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -5,7 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // task-ordering assertions below.
 const registeredTaskNames: string[] = [];
 const registeredTaskRuns = new Map<string, () => unknown>();
-const setMcpRegistry = vi.fn();
+// Hoisted: the HelpSessionService mock factory now runs at import time
+// (globalServicesInit value-imports the singleton statically).
+const setMcpRegistry = vi.hoisted(() => vi.fn());
 let migrationCurrentVersion = 1;
 let migrationShouldThrow = false;
 let mockLogRetentionDays: number | undefined = 30;
@@ -27,6 +29,7 @@ const {
     getPluginMcpConsentStore: vi.fn(),
   };
 });
+const registerCommandsMock = vi.hoisted(() => vi.fn());
 const {
   pluginInitialize,
   pluginGetPluginDir,
@@ -244,10 +247,26 @@ vi.mock("../../setup/environment.js", () => ({
 vi.mock("../../services/HelpSessionService.js", () => ({
   helpSessionService: {
     setMcpRegistry,
+    setPendingHibernationStore: vi.fn(),
     setPtyClient: vi.fn(),
     validateToken: vi.fn(),
     gcStaleSessions: vi.fn(async () => {}),
   },
+}));
+
+vi.mock("../../services/PendingHelpHibernationStore.js", () => ({
+  getPendingHelpHibernationStore: vi.fn(() => ({ load: vi.fn(async () => {}) })),
+}));
+
+// globalServicesInit statically imports menu.ts (wireUpdateMenuState) and the
+// commands barrel (registerCommands); both pull electron/service graphs this
+// suite doesn't exercise — mock at the boundary.
+vi.mock("../../menu.js", () => ({
+  wireUpdateMenuState: vi.fn(),
+}));
+
+vi.mock("../../services/commands/index.js", () => ({
+  registerCommands: registerCommandsMock,
 }));
 
 vi.mock("../deferredInitQueue.js", () => ({
@@ -294,6 +313,7 @@ describe("initGlobalServices task ordering", () => {
     pluginActivateStartup.mockClear();
     setPluginDirResolver.mockClear();
     activateOpenFileInstaller.mockClear();
+    registerCommandsMock.mockClear();
     (app.exit as ReturnType<typeof vi.fn>).mockReset();
     migrationCurrentVersion = 1;
     migrationShouldThrow = false;
@@ -303,6 +323,92 @@ describe("initGlobalServices task ordering", () => {
 
   afterEach(() => {
     setGlobalServicesInitialized(false);
+  });
+
+  it("registers tasks in grouped order: cheap wires, then telemetry, then heavy dynamic-import tasks", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    // Group 1 — cheap synchronous wires. github-auth-validate is also group 1
+    // but conditional on a stored token; covered by its own test below.
+    const cheap = [
+      "crash-recovery-backup-timer",
+      "hibernation-service",
+      "system-sleep-service",
+      "os-dnd-service",
+      "database-maintenance",
+      "pre-agent-snapshot-service",
+      "disk-space-monitor",
+      "event-loop-lag-monitor",
+      "app-metrics-monitor",
+      "agent-connectivity",
+      "service-connectivity-registry",
+      "periodic-cleanup",
+    ];
+    // Group 3 — heavy dynamic-import tasks. Telemetry (group 2) sits between
+    // so Sentry is live before any heavy task can fail (trackEvent drops
+    // events while captureEventFn is null).
+    const heavy = [
+      "agent-notification-service",
+      "auto-updater",
+      "windows-store-notifier",
+      "ccr-config",
+      "builtin-commands",
+      "idle-terminal-notification-service",
+      "resource-profile-service",
+      "plugin-service",
+      "plugin-cli-server",
+      "plugin-mcp-audit-warm",
+      "mcp-server",
+      "help-session-gc",
+      "help-session-pty",
+      "session-eviction",
+      "prune-old-logs",
+      "trashed-pid-cleanup",
+      "scratch-cleanup",
+      "assistant-scratch-cleanup",
+    ];
+
+    const telemetryIdx = registeredTaskNames.indexOf("telemetry");
+    expect(telemetryIdx).toBeGreaterThanOrEqual(0);
+    for (const name of cheap) {
+      const idx = registeredTaskNames.indexOf(name);
+      expect(idx, `${name} should be registered`).toBeGreaterThanOrEqual(0);
+      expect(idx, `${name} should register before telemetry`).toBeLessThan(telemetryIdx);
+    }
+    for (const name of heavy) {
+      const idx = registeredTaskNames.indexOf(name);
+      expect(idx, `${name} should be registered`).toBeGreaterThanOrEqual(0);
+      expect(idx, `${name} should register after telemetry`).toBeGreaterThan(telemetryIdx);
+    }
+  });
+
+  it("registers github-auth-validate in the cheap group (before telemetry) when a token exists", async () => {
+    vi.mocked(GitHubAuth.hasToken).mockReturnValue(true);
+    vi.mocked(GitHubAuth.getToken).mockReturnValue("tok-123");
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const validateIdx = registeredTaskNames.indexOf("github-auth-validate");
+    const telemetryIdx = registeredTaskNames.indexOf("telemetry");
+    expect(validateIdx).toBeGreaterThanOrEqual(0);
+    expect(validateIdx).toBeLessThan(telemetryIdx);
+  });
+
+  it("registers builtin-commands as a deferred task that fires registerCommands only when run", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("builtin-commands");
+    expect(run).toBeDefined();
+    // Registration moved out of main-module eval (boot path) into the queue —
+    // the command-chunk imports must not fire before the drain.
+    expect(registerCommandsMock).not.toHaveBeenCalled();
+
+    run!();
+
+    expect(registerCommandsMock).toHaveBeenCalledTimes(1);
   });
 
   it("registers monitor tasks before resource-profile-service so the profile reads ready data", async () => {

--- a/electron/window/__tests__/windowShowSequence.test.ts
+++ b/electron/window/__tests__/windowShowSequence.test.ts
@@ -3,16 +3,26 @@ import { describe, it, expect, vi } from "vitest";
 type Handler = (...args: unknown[]) => void;
 type ListenerMap = Map<string, Handler[]>;
 
-function createMockAppView(listeners: ListenerMap) {
+const SKELETON_PARSED_CHANNEL = "app:skeleton-parsed";
+
+function createMockAppView(listeners: ListenerMap, ipcListeners: ListenerMap = new Map()) {
   const register = (event: string, handler: Handler) => {
     if (!listeners.has(event)) listeners.set(event, []);
     listeners.get(event)!.push(handler);
+  };
+  const registerIpc = (channel: string, handler: Handler) => {
+    if (!ipcListeners.has(channel)) ipcListeners.set(channel, []);
+    ipcListeners.get(channel)!.push(handler);
   };
   return {
     setBackgroundColor: vi.fn(),
     webContents: {
       on: vi.fn(register),
       once: vi.fn(register),
+      ipc: {
+        once: vi.fn(registerIpc),
+        removeAllListeners: vi.fn(),
+      },
       loadURL: vi.fn(),
     },
   };
@@ -29,7 +39,9 @@ interface SetupArgs {
   win: ReturnType<typeof createMockWindow>;
   appView: ReturnType<typeof createMockAppView>;
   windowBg: string;
-  injectSkeletonCss: (wc: unknown) => void;
+  buildSkeletonCss?: () => string;
+  insertSkeletonCss?: (wc: unknown, css: string) => void;
+  injectSkeletonCss?: (wc: unknown) => void;
 }
 
 const SHOW_FALLBACK_MS = 5_000;
@@ -39,7 +51,14 @@ const SHOW_FALLBACK_MS = 5_000;
  * `createWindow.ts` so the ordering can be verified without bringing the
  * whole Electron surface into the unit test.
  */
-function buildLoadRenderer({ win, appView, windowBg, injectSkeletonCss }: SetupArgs) {
+function buildLoadRenderer({
+  win,
+  appView,
+  windowBg,
+  buildSkeletonCss = () => "precomputed",
+  insertSkeletonCss = vi.fn(),
+  injectSkeletonCss = vi.fn(),
+}: SetupArgs) {
   appView.setBackgroundColor(windowBg);
   const appWebContents = appView.webContents;
 
@@ -48,8 +67,15 @@ function buildLoadRenderer({ win, appView, windowBg, injectSkeletonCss }: SetupA
     if (win.isDestroyed() || rendererLoadRequested) return;
     rendererLoadRequested = true;
 
+    const precomputedSkeletonCss = buildSkeletonCss();
+    let firstDomReady = true;
     appWebContents.on("dom-ready", () => {
-      injectSkeletonCss(appWebContents);
+      if (firstDomReady) {
+        firstDomReady = false;
+        insertSkeletonCss(appWebContents, precomputedSkeletonCss);
+      } else {
+        injectSkeletonCss(appWebContents);
+      }
     });
 
     let shown = false;
@@ -66,6 +92,7 @@ function buildLoadRenderer({ win, appView, windowBg, injectSkeletonCss }: SetupA
       fallbackTimer = null;
       showOnce();
     }, SHOW_FALLBACK_MS);
+    appWebContents.ipc.once(SKELETON_PARSED_CHANNEL, showOnce);
     appWebContents.once("dom-ready", showOnce);
 
     appWebContents.loadURL(`app://daintree/index.html?reason=${reason}`);
@@ -74,6 +101,11 @@ function buildLoadRenderer({ win, appView, windowBg, injectSkeletonCss }: SetupA
 
 function fireDomReady(listeners: ListenerMap): void {
   const handlers = listeners.get("dom-ready") ?? [];
+  for (const h of handlers) h();
+}
+
+function fireSkeletonParsed(ipcListeners: ListenerMap): void {
+  const handlers = ipcListeners.get(SKELETON_PARSED_CHANNEL) ?? [];
   for (const h of handlers) h();
 }
 
@@ -87,7 +119,6 @@ describe("window show sequence", () => {
       win,
       appView,
       windowBg: "#0e0e0d",
-      injectSkeletonCss: vi.fn(),
     });
 
     loadRenderer("startup");
@@ -108,17 +139,46 @@ describe("window show sequence", () => {
     expect(onceOrder).toBeLessThan(loadOrder);
   });
 
-  it("sets appView background before showing the window", () => {
+  it("shows the window on the skeleton-parsed IPC signal before dom-ready", () => {
     const listeners: ListenerMap = new Map();
+    const ipcListeners: ListenerMap = new Map();
     const win = createMockWindow();
-    const appView = createMockAppView(listeners);
-    const injectSkeletonCss = vi.fn();
+    const appView = createMockAppView(listeners, ipcListeners);
 
     const loadRenderer = buildLoadRenderer({
       win,
       appView,
       windowBg: "#0e0e0d",
-      injectSkeletonCss,
+    });
+
+    loadRenderer("startup");
+
+    expect(win.show).not.toHaveBeenCalled();
+
+    // The skeleton-parsed signal arrives before dom-ready (classic script
+    // runs as soon as the skeleton markup is parsed).
+    fireSkeletonParsed(ipcListeners);
+    expect(win.show).toHaveBeenCalledOnce();
+
+    // dom-ready arriving later must not re-show.
+    fireDomReady(listeners);
+    expect(win.show).toHaveBeenCalledOnce();
+
+    // The IPC gate is wired BEFORE loadURL.
+    const ipcOnceOrder = appView.webContents.ipc.once.mock.invocationCallOrder[0];
+    const loadOrder = appView.webContents.loadURL.mock.invocationCallOrder[0];
+    expect(ipcOnceOrder).toBeLessThan(loadOrder);
+  });
+
+  it("sets appView background before showing the window", () => {
+    const listeners: ListenerMap = new Map();
+    const win = createMockWindow();
+    const appView = createMockAppView(listeners);
+
+    const loadRenderer = buildLoadRenderer({
+      win,
+      appView,
+      windowBg: "#0e0e0d",
     });
 
     loadRenderer("startup");
@@ -134,18 +194,22 @@ describe("window show sequence", () => {
     const listeners: ListenerMap = new Map();
     const win = createMockWindow();
     const appView = createMockAppView(listeners);
+    const insertSkeletonCss = vi.fn();
     const injectSkeletonCss = vi.fn();
 
     const loadRenderer = buildLoadRenderer({
       win,
       appView,
       windowBg: "#0e0e0d",
+      buildSkeletonCss: () => "precomputed",
+      insertSkeletonCss,
       injectSkeletonCss,
     });
 
     loadRenderer("startup");
 
     // CSS is not injected before the document parses.
+    expect(insertSkeletonCss).not.toHaveBeenCalled();
     expect(injectSkeletonCss).not.toHaveBeenCalled();
 
     // Two dom-ready listeners are wired: one persistent (.on) for CSS
@@ -155,22 +219,27 @@ describe("window show sequence", () => {
     expect(appView.webContents.on).toHaveBeenCalledWith("dom-ready", expect.any(Function));
     expect(appView.webContents.once).toHaveBeenCalledWith("dom-ready", expect.any(Function));
 
-    // The persistent listener (registered via `.on`) is the CSS one.
+    // The persistent listener (registered via `.on`) is the CSS one — the
+    // first dom-ready uses the precomputed string (no config re-read).
     domReadyHandlers[0]();
-    expect(injectSkeletonCss).toHaveBeenCalledOnce();
-    expect(injectSkeletonCss).toHaveBeenCalledWith(appView.webContents);
+    expect(insertSkeletonCss).toHaveBeenCalledOnce();
+    expect(insertSkeletonCss).toHaveBeenCalledWith(appView.webContents, "precomputed");
+    expect(injectSkeletonCss).not.toHaveBeenCalled();
   });
 
-  it("re-injects skeleton CSS on every dom-ready so crash-reloads stay themed", () => {
+  it("rebuilds skeleton CSS on later dom-ready events so crash-reloads stay themed", () => {
     const listeners: ListenerMap = new Map();
     const win = createMockWindow();
     const appView = createMockAppView(listeners);
+    const insertSkeletonCss = vi.fn();
     const injectSkeletonCss = vi.fn();
 
     const loadRenderer = buildLoadRenderer({
       win,
       appView,
       windowBg: "#0e0e0d",
+      buildSkeletonCss: () => "precomputed",
+      insertSkeletonCss,
       injectSkeletonCss,
     });
 
@@ -184,7 +253,11 @@ describe("window show sequence", () => {
     persistentCssHandler();
     persistentCssHandler();
 
-    expect(injectSkeletonCss).toHaveBeenCalledTimes(2);
+    // First parse uses the precomputed string; the crash-reload re-resolves
+    // theme/sidebar/focus state via the full injection path.
+    expect(insertSkeletonCss).toHaveBeenCalledOnce();
+    expect(injectSkeletonCss).toHaveBeenCalledOnce();
+    expect(injectSkeletonCss).toHaveBeenCalledWith(appView.webContents);
   });
 
   it("shows the window via the 5s fallback timer when dom-ready never fires", () => {
@@ -198,7 +271,6 @@ describe("window show sequence", () => {
         win,
         appView,
         windowBg: "#0e0e0d",
-        injectSkeletonCss: vi.fn(),
       });
 
       loadRenderer("startup");
@@ -226,7 +298,6 @@ describe("window show sequence", () => {
         win,
         appView,
         windowBg: "#0e0e0d",
-        injectSkeletonCss: vi.fn(),
       });
 
       loadRenderer("startup");
@@ -252,7 +323,6 @@ describe("window show sequence", () => {
       win,
       appView,
       windowBg: "#0e0e0d",
-      injectSkeletonCss: vi.fn(),
     });
 
     loadRenderer("startup");
@@ -275,7 +345,6 @@ describe("window show sequence", () => {
       win,
       appView,
       windowBg: "#0e0e0d",
-      injectSkeletonCss: vi.fn(),
     });
 
     loadRenderer("startup");

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -28,6 +28,8 @@ import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { notifyError } from "../ipc/errorHandlers.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import {
+  buildSkeletonCss,
+  insertSkeletonCss,
   injectSkeletonCss,
   resolveInitialColorSchemeId,
   resolveInstanceRole,
@@ -165,7 +167,7 @@ export function setupBrowserWindow(
   // Daintree always defaults to its dark theme on first run, regardless of the
   // OS color-scheme preference. Users who want light or system-following
   // behavior can opt in via Settings → Appearance.
-  const colorSchemeId = resolveInitialColorSchemeId();
+  const colorSchemeId = resolveInitialColorSchemeId(themeConfig);
 
   // Apply lazy migration for legacy string-encoded customSchemes
   let customSchemes: AppColorScheme[] = [];
@@ -261,7 +263,11 @@ export function setupBrowserWindow(
       sandbox: true,
       webviewTag: true,
       navigateOnDragDrop: false,
-      v8CacheOptions: "code",
+      // bypassHeatCheck writes the V8 code cache on the first load instead of
+      // Chromium's default third-load heat check, so launch 2 after an
+      // install/update is already warm. Dev-server URLs churn constantly, so
+      // keep the default heuristic there.
+      v8CacheOptions: app.isPackaged ? "bypassHeatCheck" : "code",
       // Seed the renderer with the persisted theme so first paint applies the
       // saved scheme instead of a prefers-color-scheme default (#9169). The
       // instance role rides along so worker instances suppress automatic
@@ -356,18 +362,31 @@ export function setupBrowserWindow(
     // insertCSS is navigation-scoped, so re-inject once the new document has
     // parsed. Listen for every dom-ready (not once) so the skeleton survives
     // renderer-crash auto-reloads. Inline fallbacks in index.html cover the
-    // gap before dom-ready fires.
+    // gap before dom-ready fires. The CSS string is precomputed before
+    // loadURL so the boot-path dom-ready handler (which gates win.show())
+    // skips the synchronous config.json re-reads; later dom-ready events
+    // (crash auto-reloads) rebuild it so the skeleton reflects current
+    // theme/sidebar/focus state.
+    const precomputedSkeletonCss = buildSkeletonCss();
+    let firstDomReady = true;
     appWebContents.on("dom-ready", () => {
-      injectSkeletonCss(appWebContents);
+      if (firstDomReady) {
+        firstDomReady = false;
+        insertSkeletonCss(appWebContents, precomputedSkeletonCss);
+      } else {
+        injectSkeletonCss(appWebContents);
+      }
     });
 
-    // Gate win.show() on the WebContentsView's first dom-ready so the HTML
-    // skeleton is parsed before the OS maps the window — eliminates the
-    // blank-window flash. `ready-to-show` on BrowserWindow does NOT cover
-    // child WebContentsView paint, and fires immediately for the sentinel
-    // data: page; dom-ready on appWebContents is the correct signal.
-    // 5s timeout fallback ensures a hung renderer doesn't leave the window
-    // permanently hidden — strictly worse than a brief blank.
+    // Gate win.show() on the skeleton markup being parsed so the OS never
+    // maps a blank window. Primary signal: the APP_SKELETON_PARSED send from
+    // public/skeleton-ready.js, which fires as soon as the skeleton is in the
+    // DOM — well before dom-ready, which waits for the deferred module graph
+    // to evaluate. dom-ready stays as a backstop (`ready-to-show` on
+    // BrowserWindow does NOT cover child WebContentsView paint, and fires
+    // immediately for the sentinel data: page). 5s timeout fallback ensures a
+    // hung renderer doesn't leave the window permanently hidden — strictly
+    // worse than a brief blank.
     let shown = false;
     const showOnce = (viaFallback = false): void => {
       if (shown) return;
@@ -388,11 +407,17 @@ export function setupBrowserWindow(
       );
       showOnce(true);
     }, SHOW_FALLBACK_MS);
+    // WebContents-scoped ipc — project views loading the same index.html send
+    // on their own webContents and never reach this listener.
+    appWebContents.ipc.once(CHANNELS.APP_SKELETON_PARSED, () => showOnce(false));
     appWebContents.once("dom-ready", () => showOnce(false));
     win.once("closed", () => {
       if (fallbackTimer) {
         clearTimeout(fallbackTimer);
         fallbackTimer = null;
+      }
+      if (!appWebContents.isDestroyed()) {
+        appWebContents.ipc.removeAllListeners(CHANNELS.APP_SKELETON_PARSED);
       }
     });
 

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -29,6 +29,9 @@ import { initializeSystemSleepService } from "../services/SystemSleepService.js"
 import { initializeOsDndService } from "../services/OsDndService.js";
 import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
+// Free for eager import: PtyClient already value-imports HelpSessionService,
+// so this static edge adds zero boot cost — keep it that way.
+import { helpSessionService } from "../services/HelpSessionService.js";
 import {
   markPerformance,
   startEventLoopLagMonitor,
@@ -45,6 +48,7 @@ import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { sendToRenderer } from "../ipc/handlers.js";
+import { wireUpdateMenuState } from "../menu.js";
 import { getAppWebContents } from "./webContentsRegistry.js";
 import type { WindowRegistry } from "./WindowRegistry.js";
 import type { ProjectViewManager } from "./ProjectViewManager.js";
@@ -54,6 +58,7 @@ import { isSmokeTest } from "../setup/environment.js";
 import { setPluginDirResolver } from "../setup/protocols.js";
 import { activateOpenFileInstaller } from "../setup/openFileInstall.js";
 import { projectStore } from "../services/ProjectStore.js";
+import { registerCommands } from "../services/commands/index.js";
 import { store } from "../store.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import type { ResourceProfile } from "../../shared/types/resourceProfile.js";
@@ -167,18 +172,6 @@ export async function initGlobalServices(
     return "exit-requested";
   }
 
-  // Sentry and GitHub token validation are deferred to after the renderer
-  // reports first-interactive to avoid contending for the event loop while
-  // React hydrates. GitHubAuth.initializeStorage must stay eager because
-  // other services read tokens synchronously during startup.
-  registerDeferredTask({
-    name: "telemetry",
-    run: async () => {
-      await initializeTelemetry();
-      setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
-    },
-  });
-
   // Initialize GitHubAuth storage (must stay eager — synchronous reads)
   GitHubAuth.initializeStorage({
     get: () => secureStorage.get("userConfig.githubToken"),
@@ -186,51 +179,6 @@ export async function initGlobalServices(
     delete: () => secureStorage.delete("userConfig.githubToken"),
   });
   console.log("[MAIN] GitHubAuth initialized with storage");
-
-  // Skip startup token validation when the GitHub plugin is disabled — the
-  // /user fetch is GitHub network work the user opted out of. Read the
-  // persisted disabled list directly: this task is registered before the
-  // plugin-service deferred task runs, so the forge registry can't be
-  // consulted yet. (Re-enable validates on next launch or via set-token.)
-  const persistedPlugins = store.get("plugins") as { disabled?: unknown } | undefined;
-  const githubPluginDisabled =
-    Array.isArray(persistedPlugins?.disabled) &&
-    persistedPlugins.disabled.includes("daintree.github");
-
-  if (GitHubAuth.hasToken() && !githubPluginDisabled) {
-    const token = GitHubAuth.getToken();
-    if (token) {
-      const versionAtStart = GitHubAuth.getTokenVersion();
-      registerDeferredTask({
-        name: "github-auth-validate",
-        // Floated, not awaited: GitHubAuth.validate has an internal 10s
-        // AbortSignal.timeout, and no later task depends on the validated user
-        // info. Returning void lets drainNext advance immediately instead of
-        // stalling the whole queue on a slow/offline network. The versionAtStart
-        // guard makes setValidatedUserInfo a safe no-op if the token rotates
-        // mid-flight, and the shutdown hard-timeout budget (#4287) bounds any
-        // in-flight fetch still pending at quit.
-        run: () => {
-          void (async () => {
-            try {
-              const validation = await GitHubAuth.validate(token);
-              if (validation.valid && validation.username) {
-                GitHubAuth.setValidatedUserInfo(
-                  validation.username,
-                  validation.avatarUrl,
-                  validation.scopes,
-                  versionAtStart
-                );
-                console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
-              }
-            } catch (err) {
-              console.warn("[MAIN] Failed to validate stored GitHub token:", err);
-            }
-          })();
-        },
-      });
-    }
-  }
 
   // E2E hook: seed/clear an in-memory GitHub token so fault-mode tests can
   // reach IPC paths gated on `hasToken: true` without hitting the network.
@@ -288,141 +236,14 @@ export async function initGlobalServices(
     isPlaintextEnabled: () => store.get("appState")?.developerMode?.pluginAuditPlaintext === true,
   });
 
-  registerDeferredTask({
-    name: "agent-notification-service",
-    run: async () => {
-      const { agentNotificationService } = await import("../services/AgentNotificationService.js");
-      setAgentNotificationServiceRef(agentNotificationService);
-      agentNotificationService.initialize();
-    },
-  });
-
-  // Auto-updater
-  registerDeferredTask({
-    name: "auto-updater",
-    run: async () => {
-      const { autoUpdaterService } = await import("../services/AutoUpdaterService.js");
-      setAutoUpdaterServiceRef(autoUpdaterService);
-      autoUpdaterService.initialize();
-    },
-  });
-
-  // Windows Store update notifier — parallel path to electron-updater for
-  // builds where the Store owns the install but the user still wants to know
-  // a newer version is available.
-  registerDeferredTask({
-    name: "windows-store-notifier",
-    run: async () => {
-      const { windowsStoreNotifierService } =
-        await import("../services/WindowsStoreNotifierService.js");
-      setWindowsStoreNotifierServiceRef(windowsStoreNotifierService);
-      windowsStoreNotifierService.initialize();
-    },
-  });
-
-  // CCR config — discover Claude Code Router models as agent presets.
-  // Deferred: the renderer fetches presets via getCcrPresets() which falls
-  // through to [] when the cache is empty, and AGENT_PRESETS_UPDATED broadcasts
-  // populate the renderer store as soon as loadAndApply() completes.
-  registerDeferredTask({
-    name: "ccr-config",
-    run: async () => {
-      const { CcrConfigService } = await import("../services/CcrConfigService.js");
-      const ccr = CcrConfigService.getInstance();
-      setCcrConfigService(ccr);
-      try {
-        await ccr.loadAndApply();
-      } catch (err) {
-        console.warn("[MAIN] CcrConfigService loadAndApply failed (non-fatal):", err);
-      }
-      // Watcher is independent of initial load success — if the config file
-      // is malformed on first boot, polling lets us pick up the fix later.
-      // startWatching() is idempotent.
-      ccr.startWatching();
-      console.log("[MAIN] CcrConfigService initialized");
-    },
-  });
-
-  // Plugin service — IPC handlers are registered eagerly in windowServices.ts
-  // and return empty lists from internal Maps until initialize() populates them.
-  // Plugin contributions broadcast on registration, so late init is renderer-safe.
-  //
-  // Timing note (#10322): `initialize()` registers panel-kind contributions
-  // mid-chain, so the `plugin:panel-kinds-changed` broadcast can reach the
-  // renderer a microtask before `setPluginDirResolver()` below swaps the
-  // `plugin://` handler off its placeholder. A plugin panel restored from
-  // persisted state could therefore 404 its first asset fetch. That window is
-  // self-healing: `PluginViewHost`'s `ErrorBoundary` offers a "Try again" that
-  // re-imports once the live resolver is in place.
-  registerDeferredTask({
-    name: "plugin-service",
-    run: async () => {
-      const { pluginService } = await import("../services/PluginService.js");
-      try {
-        await pluginService.initialize();
-      } catch (err) {
-        console.error("[MAIN] PluginService initialization failed:", err);
-      }
-      // Point the already-registered `plugin://` handler at the live resolver
-      // (#10322). main.ts registers the handler before first paint with a
-      // placeholder that 404s; now that the singleton is initialized, swap in
-      // the real `getPluginDir` so plugin asset requests resolve.
-      setPluginDirResolver((pluginId) => pluginService.getPluginDir(pluginId));
-      // macOS: drain any `.dntr` paths queued during cold launch (Finder
-      // double-click / "Open With") and take over live open-file events now
-      // that PluginService can install them. Fire-and-forget — install runs
-      // concurrently with the remaining deferred tasks. #9293
-      void activateOpenFileInstaller(pluginService);
-      // Fire-and-forget — activations fan out in parallel and report errors
-      // via the per-plugin `loadError` provenance record. Awaiting here would
-      // delay subsequent deferred tasks behind the slowest plugin's activate().
-      void pluginService.activateStartupFinishedPlugins();
-    },
-  });
-
-  // CLI control socket (F32) — lets the `daintree-plugin` CLI install/uninstall
-  // into this running instance. Registered after `plugin-service` and gated
-  // internally on `pluginService.waitForInit()`, so the socket only accepts a
-  // `plugin.install` once activation has settled. Skipped under smoke test (no
-  // CLI driving a headless boot) to avoid leaving a socket behind.
-  if (!isSmokeTest) {
-    registerDeferredTask({
-      name: "plugin-cli-server",
-      run: async () => {
-        // Fire-and-forget: startPluginCliServer() internally awaits
-        // pluginService.waitForInit() (which only settles after startup
-        // activation), so awaiting it here would stall every later deferred
-        // task behind plugin activation. The waitForReady gate guarantees no
-        // CLI request is serviced before init settles, so binding async is safe.
-        const { startPluginCliServer } = await import("../services/PluginCliServer.js");
-        void startPluginCliServer()
-          .then(() => console.log("[MAIN] Plugin CLI control socket listening"))
-          .catch((err) =>
-            console.warn("[MAIN] Plugin CLI control socket failed to start (non-fatal):", err)
-          );
-      },
-    });
-  }
-
-  // Plugin-MCP inbound audit log (#9234) — warm the hydrate() store read off
-  // the cold-boot path (#10073). hydrate() is idempotent, and append() demand-
-  // hydrates anyway, so this is purely pre-warming for when the supervisor
-  // (#9233) lands. The consent service is not pre-warmed: its constructor is
-  // bare allocation and PluginInstaller already constructs it lazily on demand.
-  registerDeferredTask({
-    name: "plugin-mcp-audit-warm",
-    run: async () => {
-      const { getPluginMcpAuditService } = await import("../services/plugin-mcp/instances.js");
-      getPluginMcpAuditService().hydrate();
-    },
-  });
-
-  // ── Deferred global service starts ──
+  // ── Group 1: cheap synchronous wires ──
   // These were previously run on the same tick as loadRenderer(), contending
   // with the renderer for event-loop time while React hydrated and painted.
   // They now drain sequentially after the renderer signals first-interactive
   // (or after a fallback timeout), with `setImmediate` interleaved between
-  // tasks so IPC from the renderer stays responsive during drain.
+  // tasks so IPC from the renderer stays responsive during drain. Drain order
+  // is registration order: cheap synchronous wires first (this group), then
+  // telemetry, then the heavy dynamic-import tasks — see the group headers.
 
   registerDeferredTask({
     name: "crash-recovery-backup-timer",
@@ -435,15 +256,6 @@ export async function initGlobalServices(
     name: "hibernation-service",
     run: () => {
       initializeHibernationService();
-    },
-  });
-
-  registerDeferredTask({
-    name: "idle-terminal-notification-service",
-    run: async () => {
-      const { initializeIdleTerminalNotificationService } =
-        await import("../services/IdleTerminalNotificationService.js");
-      initializeIdleTerminalNotificationService();
     },
   });
 
@@ -703,6 +515,191 @@ export async function initGlobalServices(
     },
   });
 
+  // GitHub token-health probing is no longer started here — the
+  // daintree.github plugin owns it via activate()/dispose() (#9304
+  // follow-up), so a disabled plugin issues no background GitHub probes.
+  // Token STORAGE stays eager above (GitHubAuth.initializeStorage)
+  // regardless of plugin state.
+
+  // Background agent provider reachability probes (Claude, Gemini, Codex)
+  // and the registry that aggregates GitHub, agents, and MCP into a single
+  // per-service connectivity snapshot for renderers. Registry must register
+  // before mcp-server so it wires onStatusChange before MCP's first event —
+  // preserved by the group split (mcp-server drains in the heavy group 3).
+  registerDeferredTask({
+    name: "agent-connectivity",
+    run: () => {
+      agentConnectivityService.start();
+    },
+  });
+
+  registerDeferredTask({
+    name: "service-connectivity-registry",
+    run: () => {
+      getServiceConnectivityRegistry().start();
+    },
+  });
+
+  // Skip startup token validation when the GitHub plugin is disabled — the
+  // /user fetch is GitHub network work the user opted out of. Read the
+  // persisted disabled list directly: this task is registered before the
+  // plugin-service deferred task runs, so the forge registry can't be
+  // consulted yet. (Re-enable validates on next launch or via set-token.)
+  const persistedPlugins = store.get("plugins") as { disabled?: unknown } | undefined;
+  const githubPluginDisabled =
+    Array.isArray(persistedPlugins?.disabled) &&
+    persistedPlugins.disabled.includes("daintree.github");
+
+  if (GitHubAuth.hasToken() && !githubPluginDisabled) {
+    const token = GitHubAuth.getToken();
+    if (token) {
+      const versionAtStart = GitHubAuth.getTokenVersion();
+      registerDeferredTask({
+        name: "github-auth-validate",
+        // Floated, not awaited: GitHubAuth.validate has an internal 10s
+        // AbortSignal.timeout, and no later task depends on the validated user
+        // info. Returning void lets drainNext advance immediately instead of
+        // stalling the whole queue on a slow/offline network. The versionAtStart
+        // guard makes setValidatedUserInfo a safe no-op if the token rotates
+        // mid-flight, and the shutdown hard-timeout budget (#4287) bounds any
+        // in-flight fetch still pending at quit.
+        run: () => {
+          void (async () => {
+            try {
+              const validation = await GitHubAuth.validate(token);
+              if (validation.valid && validation.username) {
+                GitHubAuth.setValidatedUserInfo(
+                  validation.username,
+                  validation.avatarUrl,
+                  validation.scopes,
+                  versionAtStart
+                );
+                console.log("[MAIN] GitHubAuth user info cached for:", validation.username);
+              }
+            } catch (err) {
+              console.warn("[MAIN] Failed to validate stored GitHub token:", err);
+            }
+          })();
+        },
+      });
+    }
+  }
+
+  // Low-frequency re-invocation of the boot cleanup routines so on-disk state
+  // doesn't grow unbounded across a long session (#9537). Gated on system idle
+  // internally; disposed in shutdown.ts before the DB closes.
+  registerDeferredTask({
+    name: "periodic-cleanup",
+    run: () => {
+      getPeriodicCleanupService().start();
+    },
+  });
+
+  // ── Group 2: telemetry ──
+  // Registered immediately after the cheap group and BEFORE the heavy
+  // dynamic-import group: trackEvent silently drops events while
+  // captureEventFn is null, so telemetry-last would lose
+  // deferred_init_task_failed events from (and delay crash capture for) the
+  // heavy tasks below. Sentry's module graph is itself heavy, but one heavy
+  // eval ahead of the rest buys observability over all of them.
+  registerDeferredTask({
+    name: "telemetry",
+    run: async () => {
+      await initializeTelemetry();
+      setOnboardingCompleteTag(store.get("onboarding")?.completed === true);
+    },
+  });
+
+  // ── Group 3: heavy dynamic-import tasks ──
+  // Each task's first import() evals a large module graph (electron-updater,
+  // the ~2900-line PluginService + manifest scans) in one un-yieldable
+  // main-thread block. Registered last so the cheap wires above complete
+  // while the renderer's post-hydration IPC burst (terminal restore spawns,
+  // worktree fetches) is hottest, and the solid eval blocks land after it
+  // tails off.
+
+  registerDeferredTask({
+    name: "agent-notification-service",
+    run: async () => {
+      const { agentNotificationService } = await import("../services/AgentNotificationService.js");
+      setAgentNotificationServiceRef(agentNotificationService);
+      agentNotificationService.initialize();
+    },
+  });
+
+  // Auto-updater
+  registerDeferredTask({
+    name: "auto-updater",
+    run: async () => {
+      const { autoUpdaterService } = await import("../services/AutoUpdaterService.js");
+      setAutoUpdaterServiceRef(autoUpdaterService);
+      // First wiring of the menu's update-state listener — menu builds before
+      // this task are no-ops on the unset ref (see wireUpdateMenuState).
+      wireUpdateMenuState();
+      autoUpdaterService.initialize();
+    },
+  });
+
+  // Windows Store update notifier — parallel path to electron-updater for
+  // builds where the Store owns the install but the user still wants to know
+  // a newer version is available.
+  registerDeferredTask({
+    name: "windows-store-notifier",
+    run: async () => {
+      const { windowsStoreNotifierService } =
+        await import("../services/WindowsStoreNotifierService.js");
+      setWindowsStoreNotifierServiceRef(windowsStoreNotifierService);
+      windowsStoreNotifierService.initialize();
+    },
+  });
+
+  // CCR config — discover Claude Code Router models as agent presets.
+  // Deferred: the renderer fetches presets via getCcrPresets() which falls
+  // through to [] when the cache is empty, and AGENT_PRESETS_UPDATED broadcasts
+  // populate the renderer store as soon as loadAndApply() completes.
+  registerDeferredTask({
+    name: "ccr-config",
+    run: async () => {
+      const { CcrConfigService } = await import("../services/CcrConfigService.js");
+      const ccr = CcrConfigService.getInstance();
+      setCcrConfigService(ccr);
+      try {
+        await ccr.loadAndApply();
+      } catch (err) {
+        console.warn("[MAIN] CcrConfigService loadAndApply failed (non-fatal):", err);
+      }
+      // Watcher is independent of initial load success — if the config file
+      // is malformed on first boot, polling lets us pick up the fix later.
+      // startWatching() is idempotent.
+      ccr.startWatching();
+      console.log("[MAIN] CcrConfigService initialized");
+    },
+  });
+
+  // Built-in commands — registration fires the githubCreateIssue/githubWorkIssue
+  // chunk imports, so it belongs in the deferred queue, not main-module eval.
+  // Commands must register before the renderer's command picker first calls
+  // commands.list (post-first-interactive); loadCommands refetches on every
+  // picker open, so a near-drain race self-heals. registerCommands() is
+  // fire-and-forget internally and returns synchronously, never stalling the
+  // drain. Registered once per process (initGlobalServices runs once),
+  // matching the previous main.ts semantics.
+  registerDeferredTask({
+    name: "builtin-commands",
+    run: () => {
+      registerCommands();
+    },
+  });
+
+  registerDeferredTask({
+    name: "idle-terminal-notification-service",
+    run: async () => {
+      const { initializeIdleTerminalNotificationService } =
+        await import("../services/IdleTerminalNotificationService.js");
+      initializeIdleTerminalNotificationService();
+    },
+  });
+
   // Must register AFTER event-loop-lag and app-metrics monitors so it can
   // read their data once its own start() fires.
   registerDeferredTask({
@@ -729,64 +726,109 @@ export async function initGlobalServices(
     },
   });
 
-  // GitHub token-health probing is no longer started here — the
-  // daintree.github plugin owns it via activate()/dispose() (#9304
-  // follow-up), so a disabled plugin issues no background GitHub probes.
-  // Token STORAGE stays eager above (GitHubAuth.initializeStorage)
-  // regardless of plugin state.
-
-  // Background agent provider reachability probes (Claude, Gemini, Codex)
-  // and the registry that aggregates GitHub, agents, and MCP into a single
-  // per-service connectivity snapshot for renderers. Registry must register
-  // before mcp-server so it wires onStatusChange before MCP's first event.
+  // Plugin service — IPC handlers are registered eagerly in windowServices.ts
+  // and return empty lists from internal Maps until initialize() populates them.
+  // Plugin contributions broadcast on registration, so late init is renderer-safe.
+  //
+  // Timing note (#10322): `initialize()` registers panel-kind contributions
+  // mid-chain, so the `plugin:panel-kinds-changed` broadcast can reach the
+  // renderer a microtask before `setPluginDirResolver()` below swaps the
+  // `plugin://` handler off its placeholder. A plugin panel restored from
+  // persisted state could therefore 404 its first asset fetch. That window is
+  // self-healing: `PluginViewHost`'s `ErrorBoundary` offers a "Try again" that
+  // re-imports once the live resolver is in place.
   registerDeferredTask({
-    name: "agent-connectivity",
-    run: () => {
-      agentConnectivityService.start();
+    name: "plugin-service",
+    run: async () => {
+      const { pluginService } = await import("../services/PluginService.js");
+      try {
+        await pluginService.initialize();
+      } catch (err) {
+        console.error("[MAIN] PluginService initialization failed:", err);
+      }
+      // Point the already-registered `plugin://` handler at the live resolver
+      // (#10322). main.ts registers the handler before first paint with a
+      // placeholder that 404s; now that the singleton is initialized, swap in
+      // the real `getPluginDir` so plugin asset requests resolve.
+      setPluginDirResolver((pluginId) => pluginService.getPluginDir(pluginId));
+      // macOS: drain any `.dntr` paths queued during cold launch (Finder
+      // double-click / "Open With") and take over live open-file events now
+      // that PluginService can install them. Fire-and-forget — install runs
+      // concurrently with the remaining deferred tasks. #9293
+      void activateOpenFileInstaller(pluginService);
+      // Fire-and-forget — activations fan out in parallel and report errors
+      // via the per-plugin `loadError` provenance record. Awaiting here would
+      // delay subsequent deferred tasks behind the slowest plugin's activate().
+      void pluginService.activateStartupFinishedPlugins();
     },
   });
 
+  // CLI control socket (F32) — lets the `daintree-plugin` CLI install/uninstall
+  // into this running instance. Registered after `plugin-service` and gated
+  // internally on `pluginService.waitForInit()`, so the socket only accepts a
+  // `plugin.install` once activation has settled. Skipped under smoke test (no
+  // CLI driving a headless boot) to avoid leaving a socket behind.
+  if (!isSmokeTest) {
+    registerDeferredTask({
+      name: "plugin-cli-server",
+      run: async () => {
+        // Fire-and-forget: startPluginCliServer() internally awaits
+        // pluginService.waitForInit() (which only settles after startup
+        // activation), so awaiting it here would stall every later deferred
+        // task behind plugin activation. The waitForReady gate guarantees no
+        // CLI request is serviced before init settles, so binding async is safe.
+        const { startPluginCliServer } = await import("../services/PluginCliServer.js");
+        void startPluginCliServer()
+          .then(() => console.log("[MAIN] Plugin CLI control socket listening"))
+          .catch((err) =>
+            console.warn("[MAIN] Plugin CLI control socket failed to start (non-fatal):", err)
+          );
+      },
+    });
+  }
+
+  // Plugin-MCP inbound audit log (#9234) — warm the hydrate() store read off
+  // the cold-boot path (#10073). hydrate() is idempotent, and append() demand-
+  // hydrates anyway, so this is purely pre-warming for when the supervisor
+  // (#9233) lands. The consent service is not pre-warmed: its constructor is
+  // bare allocation and PluginInstaller already constructs it lazily on demand.
   registerDeferredTask({
-    name: "service-connectivity-registry",
-    run: () => {
-      getServiceConnectivityRegistry().start();
+    name: "plugin-mcp-audit-warm",
+    run: async () => {
+      const { getPluginMcpAuditService } = await import("../services/plugin-mcp/instances.js");
+      getPluginMcpAuditService().hydrate();
     },
   });
 
   if (windowRegistry) {
     const registryRef = windowRegistry;
-    // Wire `helpSessionService.mcpRegistry` synchronously, BEFORE the
-    // deferred queue drains. The renderer can call `help:provision-session`
-    // as soon as IPC handlers are registered (a few hundred ms before the
-    // first deferred task runs); without this synchronous wire-up,
-    // `ensureMcpServerReady()` would no-op on the null registry and the
-    // assistant would launch with a stub `.mcp.json` missing the daintree
-    // entry. The setter is just a reference store — no MCP SDK loaded.
-    try {
-      const { helpSessionService } = await import("../services/HelpSessionService.js");
-      helpSessionService.setMcpRegistry(registryRef);
-    } catch (err) {
-      console.error("[MAIN] Failed to wire HelpSessionService MCP registry:", err);
-    }
+    // Wire `helpSessionService.mcpRegistry` synchronously by construction (no
+    // import, no await). The renderer can call `help:provision-session` as
+    // soon as IPC handlers are registered (a few hundred ms before the first
+    // deferred task runs); without this wire-up, `ensureMcpServerReady()`
+    // would no-op on the null registry and the assistant would launch with a
+    // stub `.mcp.json` missing the daintree entry. The setter is just a
+    // reference store — no MCP SDK loaded.
+    helpSessionService.setMcpRegistry(registryRef);
 
-    // Load the pending-hibernation file and wire it into HelpSessionService
-    // synchronously, BEFORE the deferred queue drains. Project-view eviction
-    // fires inside `pvm.switchTo()` and can run as soon as the user does the
-    // first project switch — which can be before `APP_FIRST_INTERACTIVE`
-    // releases the deferred queue. A missed wire-up means the capture-on-
-    // eviction path silently no-ops and the user's first cross-project
-    // switch loses its hibernation entry. Wiring here mirrors the
-    // setMcpRegistry rationale above. Disk I/O is a single small JSON read.
-    try {
+    // Load the pending-hibernation file and wire it into HelpSessionService.
+    // Floated, not awaited: the deadline is the user's first project switch
+    // (project-view eviction fires inside `pvm.switchTo()`, possibly before
+    // `APP_FIRST_INTERACTIVE` releases the deferred queue) — a missed wire-up
+    // means the capture-on-eviction path silently no-ops and that switch
+    // loses its hibernation entry. The chain is a single small JSON read that
+    // finishes in single-digit ms, long before loadURL even resolves, so
+    // floating keeps the disk I/O off the renderer-load dispatch path while
+    // comfortably beating the deadline.
+    void (async () => {
       const { getPendingHelpHibernationStore } =
         await import("../services/PendingHelpHibernationStore.js");
       const pendingStore = getPendingHelpHibernationStore();
       await pendingStore.load();
-      const { helpSessionService } = await import("../services/HelpSessionService.js");
       helpSessionService.setPendingHibernationStore(pendingStore);
-    } catch (err) {
+    })().catch((err) => {
       console.warn("[MAIN] Failed to wire pending-hibernation store:", err);
-    }
+    });
 
     registerDeferredTask({
       name: "mcp-server",
@@ -903,16 +945,6 @@ export async function initGlobalServices(
       const { startAssistantScratchCleanup } =
         await import("../services/AssistantScratchService.js");
       await startAssistantScratchCleanup();
-    },
-  });
-
-  // Low-frequency re-invocation of the boot cleanup routines so on-disk state
-  // doesn't grow unbounded across a long session (#9537). Gated on system idle
-  // internally; disposed in shutdown.ts before the DB closes.
-  registerDeferredTask({
-    name: "periodic-cleanup",
-    run: () => {
-      getPeriodicCleanupService().start();
     },
   });
 

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -6,10 +6,7 @@ import { distributePortsToView } from "./portDistribution.js";
 import { resolveInitialColorSchemeId } from "./skeletonCss.js";
 import { resolveAppTheme } from "../../shared/theme/index.js";
 import { PtyClient } from "../services/PtyClient.js";
-import {
-  getMainProcessWatchdogClient,
-  type MainProcessWatchdogClient,
-} from "../services/MainProcessWatchdogClient.js";
+import type { MainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
 import { CliAvailabilityService } from "../services/CliAvailabilityService.js";
 import { AgentVersionService } from "../services/AgentVersionService.js";
 import { AgentModelCatalogService } from "../services/AgentModelCatalogService.js";
@@ -22,7 +19,7 @@ import { ProjectSwitchService } from "../services/ProjectSwitchService.js";
 import { notificationService } from "../services/NotificationService.js";
 import { logInfo } from "../utils/logger.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
-import { isDemoMode, isSmokeTest } from "../setup/environment.js";
+import { isDemoMode } from "../setup/environment.js";
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
 import { registerDeferredTask, finalizeDeferredRegistration } from "./deferredInitQueue.js";
 import { toDisposable } from "../utils/lifecycle.js";
@@ -31,8 +28,6 @@ import {
   setCliAvailabilityServiceRef,
   getPtyClient,
   setPtyClientRef,
-  getMainProcessWatchdogClientRef,
-  setMainProcessWatchdogClientRef,
   getAgentVersionService,
   setAgentVersionService,
   getAgentModelCatalogService,
@@ -44,9 +39,9 @@ import {
 
 /**
  * Run the per-window initialization steps that happen on every
- * `setupWindowServices` call: menu creation, the per-window CLI deferred task,
+ * `setupWindowServices` call: the per-window CLI deferred task,
  * deferred-queue arming, NotificationService wire-up, first-window-only
- * critical-services boot (PtyClient + watchdog), and per-window service
+ * critical-services boot (PtyClient), and per-window service
  * objects (EventBuffer, PortalManager, ProjectSwitchService, ctx.cleanup).
  *
  * Returns a partially-populated `HandlerDependencies` for the caller to extend
@@ -58,14 +53,11 @@ export async function initPerWindowServices(
   ctx: WindowContext,
   windowRegistry: WindowRegistry | undefined
 ): Promise<HandlerDependencies> {
-  // Menu & Notifications (per-window: menu references this window)
-  console.log("[MAIN] Creating application menu (initial, no agent availability yet)...");
   let cliAvailabilityService = getCliAvailabilityServiceRef();
   if (!cliAvailabilityService) {
     cliAvailabilityService = new CliAvailabilityService();
     setCliAvailabilityServiceRef(cliAvailabilityService);
   }
-  createApplicationMenu(win, cliAvailabilityService);
 
   // Per-window deferred work. Menu is window-specific, so each window queues
   // its own CLI check + menu rebuild. Registered here (before any awaits that
@@ -87,8 +79,9 @@ export async function initPerWindowServices(
   });
 
   // Native View/Help menus include plugin-contributed menu items via
-  // `getPluginMenuItems()` at build time, but `createApplicationMenu` ran above
-  // before any plugin's `activate()` had finished — so its first menu would
+  // `getPluginMenuItems()` at build time, but the initial `createApplicationMenu`
+  // (now in setupWindowServices, after the renderer-load kick-off) runs before
+  // any plugin's `activate()` has finished — so the first menu would
   // show none of them. Lazy-import `pluginService` to avoid the cyclic edge
   // (`PluginService` depends on services that may eventually reach window
   // code), then await init and rebuild once. Dynamic plugin load/unload does
@@ -135,24 +128,10 @@ export async function initPerWindowServices(
     // user-local bin dirs in packaged builds) while no longer gating the first
     // renderer load on the refresh (#8827). Constructing the client here keeps
     // a live `ptyClient` reference available to IPC handlers at registration
-    // time — only the host fork is deferred, not the client object.
-
-    // Start the external main-process watchdog before PtyClient so a deadlock
-    // during PTY host fork (worst case: a synchronous spawn that hangs) is
-    // still recoverable. The watchdog is fail-open: if its own fork throws,
-    // PtyClient still starts normally.
-    if (!isSmokeTest && !getMainProcessWatchdogClientRef()) {
-      try {
-        // Use the singleton accessor so `disposeMainProcessWatchdog()` in
-        // shutdown.ts reaches the running instance instead of a no-op.
-        const watchdog = getMainProcessWatchdogClient();
-        setMainProcessWatchdogClientRef(watchdog);
-        wireWatchdogDisabledBroadcast(watchdog, windowRegistry);
-      } catch (err) {
-        console.error("[MAIN] Failed to start main-process watchdog:", err);
-        setMainProcessWatchdogClientRef(null);
-      }
-    }
+    // time — only the host fork is deferred, not the client object. The
+    // main-process watchdog start moved to windowServices.ts alongside the
+    // fork: its ordering invariant is watchdog-before-ptyClient.start(), not
+    // watchdog-before-renderer-load.
 
     ptyClient = new PtyClient({
       healthCheckIntervalMs: 5000,
@@ -426,7 +405,8 @@ export async function initPerWindowServices(
  * Register the broadcast listener that turns a watchdog cap-hit into a
  * `watchdog:disabled` push to every renderer. The watchdog client is Electron-
  * agnostic and has no reference to the window registry; this helper is the
- * single seam that bridges them. Called both at first-window startup (above)
+ * single seam that bridges them. Called both at first-window startup (the
+ * watchdog start block in windowServices.ts, before ptyClient.start())
  * and from the `watchdog:restart` IPC handler after a manual restart, so a
  * second cap-hit cycle reaches the renderer instead of dying silently.
  */

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -35,7 +35,7 @@ export const INITIAL_COLOR_SCHEME_ARG = "--daintree-initial-color-scheme-id";
  * Command-line argument carrying the destination project id from the main
  * process into each project-switch `WebContentsView`. Replaces the former
  * `?projectId=` query string on `loadURL` so the document URL stays static
- * across projects, keeping the V8 bytecode cache (`v8CacheOptions: "code"`)
+ * across projects, keeping the V8 bytecode cache (`v8CacheOptions`)
  * keyed to a single URL instead of fragmenting one entry per project (#9162).
  * Read synchronously in preload.cts from `process.argv` and exposed as
  * `window.__DAINTREE_INITIAL_PROJECT__`.
@@ -117,13 +117,12 @@ export function resolveInitialCanvasBackgroundColor(): string {
 }
 
 /**
- * Inject the first-paint skeleton CSS custom properties. When a cold-start
- * project switch supplies the destination `project`, its accent color (when
- * set) overrides the theme's native accent tokens so the skeleton paints the
- * project's brand color before React mounts (#9162). Passing `null`/`undefined`
- * (the initial-window path) leaves the resolved scheme untouched.
+ * Builds the first-paint skeleton CSS custom-property block. Reads the
+ * persisted app state and theme config synchronously, so callers on the boot
+ * critical path can precompute the string once (before loadURL) instead of
+ * re-reading config.json inside the dom-ready handler that gates win.show().
  */
-export function injectSkeletonCss(wc: WebContents, project?: Pick<Project, "color"> | null): void {
+export function buildSkeletonCss(project?: Pick<Project, "color"> | null): string {
   const appState = store.get("appState");
   const sidebarWidth = appState?.sidebarWidth ?? 350;
   const focusMode = appState?.focusMode ?? false;
@@ -199,11 +198,29 @@ export function injectSkeletonCss(wc: WebContents, project?: Pick<Project, "colo
     lines.push("#startup-skeleton .skeleton-sidebar { display: none; }");
   }
 
-  void wc.insertCSS(lines.join("\n"), { cssOrigin: "user" }).catch(() => {
+  return lines.join("\n");
+}
+
+/**
+ * Insert a (possibly precomputed) skeleton CSS string into a WebContents.
+ */
+export function insertSkeletonCss(wc: WebContents, css: string): void {
+  void wc.insertCSS(css, { cssOrigin: "user" }).catch(() => {
     // Best-effort first-paint seed: a destroyed/navigated WebContents during
     // rapid project switching rejects here. Swallow — the index.html skeleton
     // styles carry hardcoded fallbacks, so the splash still paints.
   });
+}
+
+/**
+ * Inject the first-paint skeleton CSS custom properties. When a cold-start
+ * project switch supplies the destination `project`, its accent color (when
+ * set) overrides the theme's native accent tokens so the skeleton paints the
+ * project's brand color before React mounts (#9162). Passing `null`/`undefined`
+ * (the initial-window path) leaves the resolved scheme untouched.
+ */
+export function injectSkeletonCss(wc: WebContents, project?: Pick<Project, "color"> | null): void {
+  insertSkeletonCss(wc, buildSkeletonCss(project));
 }
 
 /**

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -7,7 +7,8 @@ import { distributePortsToView } from "./portDistribution.js";
 import { registerErrorHandlers, flushPendingErrors } from "../ipc/errorHandlers.js";
 import { getWorkspaceClient } from "../services/WorkspaceClient.js";
 import { CHANNELS } from "../ipc/channels.js";
-import { handleDirectoryOpen } from "../menu.js";
+import { createApplicationMenu, handleDirectoryOpen } from "../menu.js";
+import { getMainProcessWatchdogClient } from "../services/MainProcessWatchdogClient.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { scratchStore } from "../services/ScratchStore.js";
 import { initializeAgentAvailabilityStore } from "../services/AgentAvailabilityStore.js";
@@ -39,7 +40,7 @@ import {
 import type { WindowContext, WindowRegistry } from "./WindowRegistry.js";
 import { resetDeferredQueue } from "./deferredInitQueue.js";
 import { initGlobalServices } from "./globalServicesInit.js";
-import { initPerWindowServices } from "./perWindowInit.js";
+import { initPerWindowServices, wireWatchdogDisabledBroadcast } from "./perWindowInit.js";
 import {
   getPtyClient,
   getWorkspaceClientRef,
@@ -47,6 +48,8 @@ import {
   getWorktreePortBrokerRef,
   setWorktreePortBrokerRef,
   getCliAvailabilityServiceRef,
+  getMainProcessWatchdogClientRef,
+  setMainProcessWatchdogClientRef,
   getCleanupErrorHandlers,
   setCleanupErrorHandlers,
   setCleanupIpcHandlers,
@@ -200,6 +203,37 @@ export async function setupWindowServices(
     startRendererLoad("early-renderer");
   } else if (deferRendererLoadForE2E) {
     console.log("[MAIN] E2E renderer-load deferral enabled — waiting for services");
+  }
+
+  // Initial menu build, unconditional and synchronous: after the renderer-load
+  // kick-off so the native Menu.buildFromTemplate/setApplicationMenu work no
+  // longer delays the load dispatch, but before the first await so it can
+  // never lose a race with the deferred cli-availability-check /
+  // plugin-menu-rebuild rebuilds and clobber the availability-aware menu. On
+  // already-drained queues (second windows) those rebuilds may run first and
+  // this build harmlessly rebuilds from the same cached availability/plugin
+  // state. The smoke and DAINTREE_E2E_DEFER_RENDERER_LOAD paths get the menu
+  // here too, before their serial startRendererLoad below.
+  console.log("[MAIN] Creating application menu (initial, no agent availability yet)...");
+  createApplicationMenu(win, cliAvailabilityService ?? undefined);
+
+  // Start the external main-process watchdog before ptyClient.start() so a
+  // deadlock during PTY host fork (worst case: a synchronous spawn that
+  // hangs) is still recoverable — that pre-fork ordering is the watchdog's
+  // only invariant, which is why it lives here with the fork rather than
+  // pre-renderer-load in initPerWindowServices. The watchdog is fail-open:
+  // if its own fork throws, PtyClient still starts normally.
+  if (!isSmokeTest && !getMainProcessWatchdogClientRef()) {
+    try {
+      // Use the singleton accessor so `disposeMainProcessWatchdog()` in
+      // shutdown.ts reaches the running instance instead of a no-op.
+      const watchdog = getMainProcessWatchdogClient();
+      setMainProcessWatchdogClientRef(watchdog);
+      wireWatchdogDisabledBroadcast(watchdog, windowRegistry);
+    } catch (err) {
+      console.error("[MAIN] Failed to start main-process watchdog:", err);
+      setMainProcessWatchdogClientRef(null);
+    }
   }
 
   // Fork the PTY host now — *after* startRendererLoad — so first paint is no

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1186,
+  "count": 1171,
   "byRule": {
-    "@typescript-eslint/no-explicit-any": 54,
+    "@typescript-eslint/no-explicit-any": 53,
     "@typescript-eslint/no-floating-promises": 90,
-    "@typescript-eslint/no-unsafe-type-assertion": 500,
+    "@typescript-eslint/no-unsafe-type-assertion": 492,
     "no-restricted-imports": 8,
     "no-restricted-syntax": 406,
     "no-useless-assignment": 20,
-    "preserve-caught-error": 52,
+    "preserve-caught-error": 46,
     "react-compiler/react-compiler": 16,
     "react-hooks/exhaustive-deps": 40
   },
-  "updatedAt": "2026-06-07T03:04:01.248Z"
+  "updatedAt": "2026-06-10T07:26:12.223Z"
 }

--- a/first-render-chunk-baseline.json
+++ b/first-render-chunk-baseline.json
@@ -9,130 +9,120 @@
     ],
     "missing": []
   },
-  "chunkCount": 132,
+  "chunkCount": 130,
   "chunks": {
-    "_AccessibilityAnnouncer-CDfVFgQ-.js": {
-      "file": "assets/AccessibilityAnnouncer-CDfVFgQ-.js",
-      "raw": 1403,
-      "gzip": 700
+    "_AccessibilityAnnouncer-08ekXgO6.js": {
+      "file": "assets/AccessibilityAnnouncer-08ekXgO6.js",
+      "raw": 1360,
+      "gzip": 686
     },
-    "_ActionService-Beqsgx73.js": {
-      "file": "assets/ActionService-Beqsgx73.js",
-      "raw": 10989,
-      "gzip": 4221
+    "_ActionService-CTIThfwo.js": {
+      "file": "assets/ActionService-CTIThfwo.js",
+      "raw": 11544,
+      "gzip": 4443
     },
-    "_AgentShortcutCapture-dhff751h.js": {
-      "file": "assets/AgentShortcutCapture-dhff751h.js",
-      "raw": 1685,
-      "gzip": 894
+    "_AgentShortcutCapture-BR_zePum.js": {
+      "file": "assets/AgentShortcutCapture-BR_zePum.js",
+      "raw": 1643,
+      "gzip": 879
     },
-    "_DaintreeIcon-DDa5bNTl.js": {
-      "file": "assets/DaintreeIcon-DDa5bNTl.js",
-      "raw": 1858,
-      "gzip": 942
+    "_DaintreeIcon-BV1yfcdP.js": {
+      "file": "assets/DaintreeIcon-BV1yfcdP.js",
+      "raw": 1816,
+      "gzip": 927
     },
-    "_DiffViewer-BqNT53n1.js": {
-      "file": "assets/DiffViewer-BqNT53n1.js",
-      "raw": 31833,
-      "gzip": 11846
+    "_DiffViewer-C-jKrF9l.js": {
+      "file": "assets/DiffViewer-C-jKrF9l.js",
+      "raw": 36121,
+      "gzip": 13090
     },
-    "_GitHubDropdownSkeletons-5T1m4bJ1.js": {
-      "file": "assets/GitHubDropdownSkeletons-5T1m4bJ1.js",
-      "raw": 6499,
-      "gzip": 1995
+    "_FileViewerModal-CGBIhB_K.js": {
+      "file": "assets/FileViewerModal-CGBIhB_K.js",
+      "raw": 18132,
+      "gzip": 6603
     },
-    "_GitHubIcon-DVtG4h8j.js": {
-      "file": "assets/GitHubIcon-DVtG4h8j.js",
-      "raw": 1117,
-      "gzip": 701
+    "_GitHubDropdownSkeletons-CaG0mYWv.js": {
+      "file": "assets/GitHubDropdownSkeletons-CaG0mYWv.js",
+      "raw": 6457,
+      "gzip": 1982
     },
-    "_KeybindingService-Bff_chqf.js": {
-      "file": "assets/KeybindingService-Bff_chqf.js",
-      "raw": 42554,
-      "gzip": 9946
+    "_GitHubIcon-B7QqFIjz.js": {
+      "file": "assets/GitHubIcon-B7QqFIjz.js",
+      "raw": 1075,
+      "gzip": 688
     },
-    "_LiveTimeAgo-Cd4M8_gR.js": {
-      "file": "assets/LiveTimeAgo-Cd4M8_gR.js",
-      "raw": 3263,
-      "gzip": 1610
+    "_KeybindingService-BiXCnnZ3.js": {
+      "file": "assets/KeybindingService-BiXCnnZ3.js",
+      "raw": 42742,
+      "gzip": 10010
     },
-    "_McpServerIcon-BKA1zJ2B.js": {
-      "file": "assets/McpServerIcon-BKA1zJ2B.js",
-      "raw": 1048,
-      "gzip": 635
+    "_LiveTimeAgo-B87Hkt4E.js": {
+      "file": "assets/LiveTimeAgo-B87Hkt4E.js",
+      "raw": 3250,
+      "gzip": 1607
     },
-    "_PaletteStrip-mRoPMRSW.js": {
-      "file": "assets/PaletteStrip-mRoPMRSW.js",
-      "raw": 640,
-      "gzip": 439
+    "_McpServerIcon-DNR30SNp.js": {
+      "file": "assets/McpServerIcon-DNR30SNp.js",
+      "raw": 1006,
+      "gzip": 618
     },
-    "_RecipeEditor-Bh2VzzFi.js": {
-      "file": "assets/RecipeEditor-Bh2VzzFi.js",
-      "raw": 16862,
-      "gzip": 4485
+    "_PaletteStrip-Dd_PcE9U.js": {
+      "file": "assets/PaletteStrip-Dd_PcE9U.js",
+      "raw": 598,
+      "gzip": 422
     },
-    "_ReviewHubContent-Ba1pqu2E.js": {
-      "file": "assets/ReviewHubContent-Ba1pqu2E.js",
-      "raw": 130464,
-      "gzip": 35940
+    "_RecipeEditor-DuJTCPxj.js": {
+      "file": "assets/RecipeEditor-DuJTCPxj.js",
+      "raw": 16819,
+      "gzip": 4464
     },
-    "_SettingsSection-nQ6d22I6.js": {
-      "file": "assets/SettingsSection-nQ6d22I6.js",
-      "raw": 1570,
-      "gzip": 877
+    "_ReviewHubContent-cG_klXXK.js": {
+      "file": "assets/ReviewHubContent-cG_klXXK.js",
+      "raw": 82310,
+      "gzip": 22118
     },
-    "_SettingsShortcutCapture-BXKgEppd.js": {
-      "file": "assets/SettingsShortcutCapture-BXKgEppd.js",
-      "raw": 6552,
-      "gzip": 2371
+    "_SettingsLoadErrorBanner-B4EQlvEi.js": {
+      "file": "assets/SettingsLoadErrorBanner-B4EQlvEi.js",
+      "raw": 936,
+      "gzip": 545
     },
-    "_SettingsSubtabBar-BKrqzF0S.js": {
-      "file": "assets/SettingsSubtabBar-BKrqzF0S.js",
-      "raw": 1815,
-      "gzip": 961
+    "_SettingsShortcutCapture-06cYyVRs.js": {
+      "file": "assets/SettingsShortcutCapture-06cYyVRs.js",
+      "raw": 6549,
+      "gzip": 2374
     },
-    "_SettingsSwitch-DEhVM6sG.js": {
-      "file": "assets/SettingsSwitch-DEhVM6sG.js",
-      "raw": 2021,
-      "gzip": 878
+    "_SettingsValidationRegistry-Dc8XDGpe.js": {
+      "file": "assets/SettingsValidationRegistry-Dc8XDGpe.js",
+      "raw": 1358,
+      "gzip": 754
     },
-    "_SettingsSwitchCard-BfQNi5Oi.js": {
-      "file": "assets/SettingsSwitchCard-BfQNi5Oi.js",
-      "raw": 4134,
-      "gzip": 1962
+    "_Spinner-nRaK-b1X.js": {
+      "file": "assets/Spinner-nRaK-b1X.js",
+      "raw": 538,
+      "gzip": 385
     },
-    "_Spinner-CrAxZ4jm.js": {
-      "file": "assets/Spinner-CrAxZ4jm.js",
-      "raw": 580,
-      "gzip": 400
+    "_TerminalInstanceService-07oeNuYp.js": {
+      "file": "assets/TerminalInstanceService-07oeNuYp.js",
+      "raw": 244953,
+      "gzip": 63969
     },
-    "_TerminalInstanceService-zZ2hcbHA.js": {
-      "file": "assets/TerminalInstanceService-zZ2hcbHA.js",
-      "raw": 247981,
-      "gzip": 64909
+    "_WorktreeSidebarSearchBar-DrAP-NL3.js": {
+      "file": "assets/WorktreeSidebarSearchBar-DrAP-NL3.js",
+      "raw": 229631,
+      "gzip": 71052
     },
-    "_TruncatedTooltip-7Jw2eUX-.js": {
-      "file": "assets/TruncatedTooltip-7Jw2eUX-.js",
-      "raw": 2682,
-      "gzip": 1366
-    },
-    "_WorktreeSidebarSearchBar-BG8UM-NB.js": {
-      "file": "assets/WorktreeSidebarSearchBar-BG8UM-NB.js",
-      "raw": 228180,
-      "gzip": 70217
-    },
-    "_accessibilityAnnouncerStore-ajE887GM.js": {
-      "file": "assets/accessibilityAnnouncerStore-ajE887GM.js",
+    "_accessibilityAnnouncerStore-DWOx1R5D.js": {
+      "file": "assets/accessibilityAnnouncerStore-DWOx1R5D.js",
       "raw": 565,
-      "gzip": 341
+      "gzip": 339
     },
-    "_actionPaletteSearch-BJB4PU95.js": {
-      "file": "assets/actionPaletteSearch-BJB4PU95.js",
-      "raw": 2366,
-      "gzip": 1124
+    "_actionPaletteSearch-fFvPEbHO.js": {
+      "file": "assets/actionPaletteSearch-fFvPEbHO.js",
+      "raw": 2385,
+      "gzip": 1136
     },
-    "_actionPrefsStore-BLR2G0t3.js": {
-      "file": "assets/actionPrefsStore-BLR2G0t3.js",
+    "_actionPrefsStore-CtQ_tjPg.js": {
+      "file": "assets/actionPrefsStore-CtQ_tjPg.js",
       "raw": 2198,
       "gzip": 889
     },
@@ -141,20 +131,20 @@
       "raw": 284,
       "gzip": 212
     },
-    "_agentRegistry-CnFEYj6E.js": {
-      "file": "assets/agentRegistry-CnFEYj6E.js",
-      "raw": 41711,
-      "gzip": 9314
+    "_agentRegistry-D48mDg1B.js": {
+      "file": "assets/agentRegistry-D48mDg1B.js",
+      "raw": 41773,
+      "gzip": 9347
     },
-    "_agentSettingsStore-DdwXVBlo.js": {
-      "file": "assets/agentSettingsStore-DdwXVBlo.js",
-      "raw": 11063,
-      "gzip": 3717
+    "_agentSettingsStore-BtpHgmPn.js": {
+      "file": "assets/agentSettingsStore-BtpHgmPn.js",
+      "raw": 15398,
+      "gzip": 5303
     },
-    "_agents-B9RRxTZP.js": {
-      "file": "assets/agents-B9RRxTZP.js",
-      "raw": 56629,
-      "gzip": 18355
+    "_agents-DgdoufKd.js": {
+      "file": "assets/agents-DgdoufKd.js",
+      "raw": 56587,
+      "gzip": 18338
     },
     "_animationUtils-CjbAl3EI.js": {
       "file": "assets/animationUtils-CjbAl3EI.js",
@@ -171,55 +161,60 @@
       "raw": 732,
       "gzip": 229
     },
-    "_appThemeStore-DX3auRav.js": {
-      "file": "assets/appThemeStore-DX3auRav.js",
-      "raw": 99804,
-      "gzip": 23248
+    "_appThemeStore-BAVn95or.js": {
+      "file": "assets/appThemeStore-BAVn95or.js",
+      "raw": 99845,
+      "gzip": 23268
     },
-    "_appThemeViewTransition-JeRFoh_P.js": {
-      "file": "assets/appThemeViewTransition-JeRFoh_P.js",
-      "raw": 1398,
-      "gzip": 779
+    "_appThemeViewTransition-CzhEXV6-.js": {
+      "file": "assets/appThemeViewTransition-CzhEXV6-.js",
+      "raw": 1356,
+      "gzip": 764
     },
-    "_branchPrefixes-7aMa_TF3.js": {
-      "file": "assets/branchPrefixes-7aMa_TF3.js",
+    "_branchPrefixes-Cwl6DXEX.js": {
+      "file": "assets/branchPrefixes-Cwl6DXEX.js",
       "raw": 1358,
-      "gzip": 522
+      "gzip": 521
     },
-    "_button--txbbXNn.js": {
-      "file": "assets/button--txbbXNn.js",
-      "raw": 5989,
-      "gzip": 2132
+    "_builtinRendererRegistry-2cHhWzAE.js": {
+      "file": "assets/builtinRendererRegistry-2cHhWzAE.js",
+      "raw": 662,
+      "gzip": 421
+    },
+    "_button-C3IlGI0I.js": {
+      "file": "assets/button-C3IlGI0I.js",
+      "raw": 5946,
+      "gzip": 2116
     },
     "_categoryColors-BS5bIvxQ.js": {
       "file": "assets/categoryColors-BS5bIvxQ.js",
       "raw": 2599,
       "gzip": 655
     },
-    "_checklistItems-CphKuYPw.js": {
-      "file": "assets/checklistItems-CphKuYPw.js",
+    "_checklistItems-79lMWU5p.js": {
+      "file": "assets/checklistItems-79lMWU5p.js",
       "raw": 799,
-      "gzip": 456
+      "gzip": 457
     },
     "_clientAppError-jdvMvyXj.js": {
       "file": "assets/clientAppError-jdvMvyXj.js",
       "raw": 349,
       "gzip": 259
     },
+    "_clientGitError-Tu3vWCWX.js": {
+      "file": "assets/clientGitError-Tu3vWCWX.js",
+      "raw": 475,
+      "gzip": 320
+    },
     "_clients-BvpupytF.js": {
       "file": "assets/clients-BvpupytF.js",
       "raw": 21101,
       "gzip": 5372
     },
-    "_clike-BFiq8qGV.js": {
-      "file": "assets/clike-BFiq8qGV.js",
-      "raw": 768,
-      "gzip": 483
-    },
-    "_colorUtils-4uQ5q06O.js": {
-      "file": "assets/colorUtils-4uQ5q06O.js",
+    "_colorUtils-BlRjqoSH.js": {
+      "file": "assets/colorUtils-BlRjqoSH.js",
       "raw": 386,
-      "gzip": 258
+      "gzip": 255
     },
     "_commandsClient-DYWBRrwZ.js": {
       "file": "assets/commandsClient-DYWBRrwZ.js",
@@ -231,20 +226,20 @@
       "raw": 507,
       "gzip": 197
     },
-    "_css-Dq8_3G65.js": {
-      "file": "assets/css-Dq8_3G65.js",
-      "raw": 1295,
-      "gzip": 646
-    },
     "_devServerDetection-CsVYjR2e.js": {
       "file": "assets/devServerDetection-CsVYjR2e.js",
       "raw": 926,
       "gzip": 523
     },
-    "_diagnosticsReviewStore-B_gXowZr.js": {
-      "file": "assets/diagnosticsReviewStore-B_gXowZr.js",
+    "_diagnosticsReviewStore-CcWNv54Y.js": {
+      "file": "assets/diagnosticsReviewStore-CcWNv54Y.js",
       "raw": 1807,
-      "gzip": 881
+      "gzip": 878
+    },
+    "_distributionStore-C2sCMXY7.js": {
+      "file": "assets/distributionStore-C2sCMXY7.js",
+      "raw": 853,
+      "gzip": 448
     },
     "_errorContext-BVRF90hs.js": {
       "file": "assets/errorContext-BVRF90hs.js",
@@ -276,35 +271,30 @@
       "raw": 352,
       "gzip": 218
     },
-    "_gitPullRebaseConfirmStore-AxPLavdB.js": {
-      "file": "assets/gitPullRebaseConfirmStore-AxPLavdB.js",
+    "_gitPullRebaseConfirmStore-NSjH64Kh.js": {
+      "file": "assets/gitPullRebaseConfirmStore-NSjH64Kh.js",
       "raw": 361,
-      "gzip": 223
+      "gzip": 220
     },
-    "_gitPushConfirmStore-AxPLavdB.js": {
-      "file": "assets/gitPushConfirmStore-AxPLavdB.js",
+    "_gitPushConfirmStore-NSjH64Kh.js": {
+      "file": "assets/gitPushConfirmStore-NSjH64Kh.js",
       "raw": 361,
-      "gzip": 223
+      "gzip": 220
     },
-    "_githubConfigStore-WZS59oOC.js": {
-      "file": "assets/githubConfigStore-WZS59oOC.js",
-      "raw": 654,
-      "gzip": 332
-    },
-    "_githubRateLimitStore-Dg-_ZMHw.js": {
-      "file": "assets/githubRateLimitStore-Dg-_ZMHw.js",
-      "raw": 2823,
-      "gzip": 1388
+    "_githubRateLimitStore-CYGabv5e.js": {
+      "file": "assets/githubRateLimitStore-CYGabv5e.js",
+      "raw": 3427,
+      "gzip": 1624
     },
     "_globalEnvClient-CvP9Ykdb.js": {
       "file": "assets/globalEnvClient-CvP9Ykdb.js",
       "raw": 436,
       "gzip": 274
     },
-    "_helpPanelStore-cE1pmsfE.js": {
-      "file": "assets/helpPanelStore-cE1pmsfE.js",
+    "_helpPanelStore-q2mv5ceB.js": {
+      "file": "assets/helpPanelStore-q2mv5ceB.js",
       "raw": 2961,
-      "gzip": 1107
+      "gzip": 1098
     },
     "_kbdShortcut-DwZEG1yq.js": {
       "file": "assets/kbdShortcut-DwZEG1yq.js",
@@ -321,50 +311,45 @@
       "raw": 625,
       "gzip": 212
     },
-    "_markup-BoEddWVz.js": {
-      "file": "assets/markup-BoEddWVz.js",
-      "raw": 2941,
-      "gzip": 1177
-    },
-    "_mcpConfirmStore-BBd4KJKJ.js": {
-      "file": "assets/mcpConfirmStore-BBd4KJKJ.js",
+    "_mcpConfirmStore-DG9_A9dk.js": {
+      "file": "assets/mcpConfirmStore-DG9_A9dk.js",
       "raw": 806,
       "gzip": 430
     },
-    "_memoryLeakConfigStore-CIhaCtv2.js": {
-      "file": "assets/memoryLeakConfigStore-CIhaCtv2.js",
+    "_memoryLeakConfigStore-B1PuOOVI.js": {
+      "file": "assets/memoryLeakConfigStore-B1PuOOVI.js",
       "raw": 304,
-      "gzip": 199
+      "gzip": 198
     },
     "_normalizeErrorMessage-LQxevj8G.js": {
       "file": "assets/normalizeErrorMessage-LQxevj8G.js",
       "raw": 578,
       "gzip": 284
     },
-    "_notificationSettingsStore-BLFelR_e.js": {
-      "file": "assets/notificationSettingsStore-BLFelR_e.js",
+    "_notificationSettingsStore-CFC-vaxm.js": {
+      "file": "assets/notificationSettingsStore-CFC-vaxm.js",
       "raw": 2377,
-      "gzip": 724
+      "gzip": 723
     },
-    "_notify-C2V2mkpM.js": {
-      "file": "assets/notify-C2V2mkpM.js",
-      "raw": 12443,
-      "gzip": 4477
+    "_notify-DNAnrbwv.js": {
+      "file": "assets/notify-DNAnrbwv.js",
+      "raw": 12470,
+      "gzip": 4475
     },
-    "_panelKindRegistry-SrJ3IdPG.js": {
-      "file": "assets/panelKindRegistry-SrJ3IdPG.js",
+    "_panelKindRegistry-BDsGy-ze.js": {
+      "file": "assets/panelKindRegistry-BDsGy-ze.js",
       "raw": 3409,
-      "gzip": 1312
+      "gzip": 1310
     },
-    "_panelLimitStore-YISChPmp.js": {
-      "file": "assets/panelLimitStore-YISChPmp.js",
-      "raw": 3139,
+    "_panelLimitStore-B_gon5Ir.js": {
+      "file": "assets/panelLimitStore-B_gon5Ir.js",
+      "raw": 3144,
       "gzip": 1239
     },
-    "_panelSpawning-Ciluof5r.js": {
-      "file": "assets/panelSpawning-Ciluof5r.js",
-      "raw": 12797,
-      "gzip": 4891
+    "_panelSpawning-xQnSFOWL.js": {
+      "file": "assets/panelSpawning-xQnSFOWL.js",
+      "raw": 12651,
+      "gzip": 4827
     },
     "_path-CSFlL01-.js": {
       "file": "assets/path-CSFlL01-.js",
@@ -381,15 +366,20 @@
       "raw": 587,
       "gzip": 263
     },
-    "_pluginConfirmStore-7GXk117x.js": {
-      "file": "assets/pluginConfirmStore-7GXk117x.js",
+    "_pluginConfirmStore-BQZmDjc-.js": {
+      "file": "assets/pluginConfirmStore-BQZmDjc-.js",
       "raw": 833,
-      "gzip": 439
+      "gzip": 438
     },
-    "_pluginMcpConfirmStore-BwLu9d9g.js": {
-      "file": "assets/pluginMcpConfirmStore-BwLu9d9g.js",
+    "_pluginMcpConfirmStore-wAs9-I2X.js": {
+      "file": "assets/pluginMcpConfirmStore-wAs9-I2X.js",
       "raw": 654,
-      "gzip": 357
+      "gzip": 355
+    },
+    "_pluginRuntimeStore-Ca4147_h.js": {
+      "file": "assets/pluginRuntimeStore-Ca4147_h.js",
+      "raw": 965,
+      "gzip": 562
     },
     "_preload-helper-BuFhgTb3.js": {
       "file": "assets/preload-helper-BuFhgTb3.js",
@@ -401,105 +391,95 @@
       "raw": 224,
       "gzip": 170
     },
-    "_projectPresetsStore-g4kXMWyy.js": {
-      "file": "assets/projectPresetsStore-g4kXMWyy.js",
+    "_projectPresetsStore-CLr6W42l.js": {
+      "file": "assets/projectPresetsStore-CLr6W42l.js",
       "raw": 287,
-      "gzip": 175
+      "gzip": 173
     },
-    "_projectSettingsStore-DhKXAZIE.js": {
-      "file": "assets/projectSettingsStore-DhKXAZIE.js",
+    "_projectSettingsStore-rpjIbNWA.js": {
+      "file": "assets/projectSettingsStore-rpjIbNWA.js",
       "raw": 1920,
-      "gzip": 833
+      "gzip": 829
     },
-    "_projectStore-DBhBN1cX.js": {
-      "file": "assets/projectStore-DBhBN1cX.js",
-      "raw": 15231,
-      "gzip": 5099
+    "_projectStore-BHm4QwtC.js": {
+      "file": "assets/projectStore-BHm4QwtC.js",
+      "raw": 15479,
+      "gzip": 5194
     },
-    "_radix-loader-BvpL77U3.js": {
-      "file": "assets/radix-loader-BvpL77U3.js",
-      "raw": 1065,
-      "gzip": 587
+    "_radix-loader-D_IFZ7pg.js": {
+      "file": "assets/radix-loader-D_IFZ7pg.js",
+      "raw": 991,
+      "gzip": 565
     },
-    "_recipeConflictStore-DvfSuC1W.js": {
-      "file": "assets/recipeConflictStore-DvfSuC1W.js",
+    "_recipeConflictStore-BBQJVW6z.js": {
+      "file": "assets/recipeConflictStore-BBQJVW6z.js",
       "raw": 363,
-      "gzip": 220
+      "gzip": 218
     },
-    "_recipeNotify-DJ6zaNT7.js": {
-      "file": "assets/recipeNotify-DJ6zaNT7.js",
+    "_recipeNotify-CDh3VTDG.js": {
+      "file": "assets/recipeNotify-CDh3VTDG.js",
       "raw": 630,
-      "gzip": 362
+      "gzip": 364
     },
-    "_recipeStore-B2RHqDyD.js": {
-      "file": "assets/recipeStore-B2RHqDyD.js",
-      "raw": 15070,
-      "gzip": 4974
+    "_recipeStore-DMAIqico.js": {
+      "file": "assets/recipeStore-DMAIqico.js",
+      "raw": 15065,
+      "gzip": 4950
     },
-    "_resourceMonitoringStore-DirxJ2-L.js": {
-      "file": "assets/resourceMonitoringStore-DirxJ2-L.js",
+    "_resourceMonitoringStore-ADIz64mc.js": {
+      "file": "assets/resourceMonitoringStore-ADIz64mc.js",
       "raw": 3002,
-      "gzip": 1301
+      "gzip": 1299
     },
     "_rolldown-runtime-Cyuzqnbw.js": {
       "file": "assets/rolldown-runtime-Cyuzqnbw.js",
       "raw": 826,
       "gzip": 473
     },
-    "_safeStorage-Bvtq_U5I.js": {
-      "file": "assets/safeStorage-Bvtq_U5I.js",
-      "raw": 5449,
-      "gzip": 2042
+    "_safeStorage-k8b-Krxy.js": {
+      "file": "assets/safeStorage-k8b-Krxy.js",
+      "raw": 5395,
+      "gzip": 2005
     },
-    "_safeStringify-Dr5gG76m.js": {
-      "file": "assets/safeStringify-Dr5gG76m.js",
+    "_safeStringify-D5Yn0v8G.js": {
+      "file": "assets/safeStringify-D5Yn0v8G.js",
       "raw": 403,
-      "gzip": 276
+      "gzip": 275
     },
     "_scrollback-B04snv6N.js": {
       "file": "assets/scrollback-B04snv6N.js",
       "raw": 201,
       "gzip": 175
     },
-    "_settingsTabRegistry-DDJeUVIB.js": {
-      "file": "assets/settingsTabRegistry-DDJeUVIB.js",
-      "raw": 71828,
-      "gzip": 18504
+    "_sortableAnnouncements-BdANw27V.js": {
+      "file": "assets/sortableAnnouncements-BdANw27V.js",
+      "raw": 7556,
+      "gzip": 2936
     },
-    "_sortableAnnouncements-D1sWsZ0j.js": {
-      "file": "assets/sortableAnnouncements-D1sWsZ0j.js",
-      "raw": 7603,
-      "gzip": 2951
-    },
-    "_storeAccessors-DH_ZiOxi.js": {
-      "file": "assets/storeAccessors-DH_ZiOxi.js",
-      "raw": 7511,
-      "gzip": 2309
+    "_storeAccessors-CDYtKwTW.js": {
+      "file": "assets/storeAccessors-CDYtKwTW.js",
+      "raw": 7544,
+      "gzip": 2314
     },
     "_svg-DOXfJCEr.js": {
       "file": "assets/svg-DOXfJCEr.js",
       "raw": 121,
       "gzip": 127
     },
-    "_svgSanitizer-DLAuoI4G.js": {
-      "file": "assets/svgSanitizer-DLAuoI4G.js",
-      "raw": 1966,
-      "gzip": 999
+    "_systemWakeStore-C6SL4KQW.js": {
+      "file": "assets/systemWakeStore-C6SL4KQW.js",
+      "raw": 5324,
+      "gzip": 2407
     },
-    "_systemWakeStore-C-ila6Pz.js": {
-      "file": "assets/systemWakeStore-C-ila6Pz.js",
-      "raw": 5371,
-      "gzip": 2423
-    },
-    "_terminalChrome-D-1xqUi7.js": {
-      "file": "assets/terminalChrome-D-1xqUi7.js",
+    "_terminalChrome-KEpJ_ySv.js": {
+      "file": "assets/terminalChrome-KEpJ_ySv.js",
       "raw": 2526,
-      "gzip": 974
+      "gzip": 970
     },
-    "_terminalColorSchemeStore-DZUJdPiQ.js": {
-      "file": "assets/terminalColorSchemeStore-DZUJdPiQ.js",
+    "_terminalColorSchemeStore-DbkR43tK.js": {
+      "file": "assets/terminalColorSchemeStore-DbkR43tK.js",
       "raw": 18192,
-      "gzip": 5162
+      "gzip": 5160
     },
     "_terminalConfigClient-gwxZMd4Q.js": {
       "file": "assets/terminalConfigClient-gwxZMd4Q.js",
@@ -511,173 +491,183 @@
       "raw": 686,
       "gzip": 427
     },
-    "_terminalInputStore-OuBaRRDJ.js": {
-      "file": "assets/terminalInputStore-OuBaRRDJ.js",
-      "raw": 7703,
-      "gzip": 2749
+    "_terminalInputStore-DY0vWX03.js": {
+      "file": "assets/terminalInputStore-DY0vWX03.js",
+      "raw": 7670,
+      "gzip": 2733
     },
-    "_twoPaneSplitStore-BBuUQj-Y.js": {
-      "file": "assets/twoPaneSplitStore-BBuUQj-Y.js",
-      "raw": 2148,
-      "gzip": 951
+    "_twoPaneSplitStore-DYBU_Qlo.js": {
+      "file": "assets/twoPaneSplitStore-DYBU_Qlo.js",
+      "raw": 2153,
+      "gzip": 954
     },
-    "_uiStore-DzcVYjGo.js": {
-      "file": "assets/uiStore-DzcVYjGo.js",
+    "_uiStore-BbolOe_e.js": {
+      "file": "assets/uiStore-BbolOe_e.js",
       "raw": 7357,
-      "gzip": 2326
+      "gzip": 2324
     },
-    "_useAgentDiscoveryOnboarding-BLoWrhwx.js": {
-      "file": "assets/useAgentDiscoveryOnboarding-BLoWrhwx.js",
-      "raw": 2768,
-      "gzip": 1045
+    "_useAgentDiscoveryOnboarding-3UMVnCkU.js": {
+      "file": "assets/useAgentDiscoveryOnboarding-3UMVnCkU.js",
+      "raw": 2731,
+      "gzip": 1032
     },
-    "_useDebounce-CM3dYzsI.js": {
-      "file": "assets/useDebounce-CM3dYzsI.js",
-      "raw": 410,
-      "gzip": 286
+    "_useDebounce-BWFJHUvm.js": {
+      "file": "assets/useDebounce-BWFJHUvm.js",
+      "raw": 368,
+      "gzip": 269
     },
-    "_useEscapeStack-CufWCqdR.js": {
-      "file": "assets/useEscapeStack-CufWCqdR.js",
-      "raw": 2817,
-      "gzip": 1197
+    "_useEscapeStack-GZgn5zc_.js": {
+      "file": "assets/useEscapeStack-GZgn5zc_.js",
+      "raw": 2775,
+      "gzip": 1183
     },
-    "_useFindInPage-CJUqgPrm.js": {
-      "file": "assets/useFindInPage-CJUqgPrm.js",
-      "raw": 35236,
-      "gzip": 10297
+    "_useFindInPage-DjAO60Q_.js": {
+      "file": "assets/useFindInPage-DjAO60Q_.js",
+      "raw": 35188,
+      "gzip": 10312
     },
-    "_useMcpReadiness-D2ERJ6lz.js": {
-      "file": "assets/useMcpReadiness-D2ERJ6lz.js",
-      "raw": 1289,
-      "gzip": 724
+    "_useMcpReadiness-bC7CI2Qq.js": {
+      "file": "assets/useMcpReadiness-bC7CI2Qq.js",
+      "raw": 1247,
+      "gzip": 706
     },
-    "_useResizeObserverRaf-B1H1Zpw2.js": {
-      "file": "assets/useResizeObserverRaf-B1H1Zpw2.js",
-      "raw": 36907,
-      "gzip": 11437
+    "_useResizeObserverRaf-Ca8AyS-x.js": {
+      "file": "assets/useResizeObserverRaf-Ca8AyS-x.js",
+      "raw": 36844,
+      "gzip": 11410
     },
-    "_utils-_gwFrnzV.js": {
-      "file": "assets/utils-_gwFrnzV.js",
+    "_useTabLoad-BBKDkEq-.js": {
+      "file": "assets/useTabLoad-BBKDkEq-.js",
+      "raw": 1487,
+      "gzip": 788
+    },
+    "_utils-DT5hwILQ.js": {
+      "file": "assets/utils-DT5hwILQ.js",
       "raw": 218,
-      "gzip": 194
+      "gzip": 189
     },
-    "_vendor-BFOg8uMJ.js": {
-      "file": "assets/vendor-BFOg8uMJ.js",
-      "raw": 425518,
-      "gzip": 137378
+    "_vendor-Bkll0ks5.js": {
+      "file": "assets/vendor-Bkll0ks5.js",
+      "raw": 399172,
+      "gzip": 128969
     },
-    "_vendor-editor-B3sMcg9f.js": {
-      "file": "assets/vendor-editor-B3sMcg9f.js",
-      "raw": 450913,
-      "gzip": 145635
+    "_vendor-editor-DVGJXKje.js": {
+      "file": "assets/vendor-editor-DVGJXKje.js",
+      "raw": 443061,
+      "gzip": 142503
     },
-    "_vendor-icons-C8xWPkuE.js": {
-      "file": "assets/vendor-icons-C8xWPkuE.js",
-      "raw": 50252,
-      "gzip": 15025
+    "_vendor-icons-CUpNW74t.js": {
+      "file": "assets/vendor-icons-CUpNW74t.js",
+      "raw": 50250,
+      "gzip": 15026
     },
-    "_vendor-motion~App-VsZUhQx4.js": {
-      "file": "assets/vendor-motion~App-VsZUhQx4.js",
-      "raw": 1075,
-      "gzip": 605
+    "_vendor-motion~App-B0BPcFUa.js": {
+      "file": "assets/vendor-motion~App-B0BPcFUa.js",
+      "raw": 1072,
+      "gzip": 603
     },
-    "_vendor-motion~App~WorktreeOverviewModal-C6SQasSZ.js": {
-      "file": "assets/vendor-motion~App~WorktreeOverviewModal-C6SQasSZ.js",
-      "raw": 7612,
-      "gzip": 3358
+    "_vendor-motion~App~WorktreeOverviewModal-BkRfyTDs.js": {
+      "file": "assets/vendor-motion~App~WorktreeOverviewModal-BkRfyTDs.js",
+      "raw": 7610,
+      "gzip": 3356
     },
-    "_vendor-motion~App~motionFeatures~WorktreeOverviewModal-ywDVJ3sf.js": {
-      "file": "assets/vendor-motion~App~motionFeatures~WorktreeOverviewModal-ywDVJ3sf.js",
+    "_vendor-motion~App~motionFeatures~WorktreeOverviewModal-B5YOKNrE.js": {
+      "file": "assets/vendor-motion~App~motionFeatures~WorktreeOverviewModal-B5YOKNrE.js",
       "raw": 28096,
-      "gzip": 11064
+      "gzip": 11062
     },
-    "_vendor-motion~index-Cf42Vc4i.js": {
-      "file": "assets/vendor-motion~index-Cf42Vc4i.js",
-      "raw": 5584,
-      "gzip": 2430
+    "_vendor-motion~index-BN64pNCO.js": {
+      "file": "assets/vendor-motion~index-BN64pNCO.js",
+      "raw": 5581,
+      "gzip": 2425
     },
-    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-Dtc8Ys-k.js": {
-      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-Dtc8Ys-k.js",
-      "raw": 7911,
-      "gzip": 3421
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-g7SccTD6.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi-g7SccTD6.js",
+      "raw": 7908,
+      "gzip": 3417
     },
     "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Getti~bfe2l8g2-9cbmD0Xv.js": {
       "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Getti~bfe2l8g2-9cbmD0Xv.js",
       "raw": 269,
       "gzip": 201
     },
-    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-NRIFKczS.js": {
-      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-NRIFKczS.js",
-      "raw": 31315,
-      "gzip": 11246
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-BHtoxoXi.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl-BHtoxoXi.js",
+      "raw": 31313,
+      "gzip": 11245
     },
-    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-CiQn6fFx.js": {
-      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-CiQn6fFx.js",
-      "raw": 603,
-      "gzip": 416
+    "_vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-DDwssyuz.js": {
+      "file": "assets/vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h-DDwssyuz.js",
+      "raw": 601,
+      "gzip": 414
     },
-    "_vendor-radix-DqHrnn5A.js": {
-      "file": "assets/vendor-radix-DqHrnn5A.js",
-      "raw": 5056,
-      "gzip": 1917
+    "_vendor-radix-Qx_xFRxt.js": {
+      "file": "assets/vendor-radix-Qx_xFRxt.js",
+      "raw": 5057,
+      "gzip": 1914
     },
-    "_vendor-radix-utils-BoY3IfhJ.js": {
-      "file": "assets/vendor-radix-utils-BoY3IfhJ.js",
-      "raw": 14557,
-      "gzip": 3261
+    "_vendor-radix-utils-BIchhNwM.js": {
+      "file": "assets/vendor-radix-utils-BIchhNwM.js",
+      "raw": 14504,
+      "gzip": 3243
     },
-    "_vendor-react-Cjr9AYj0.js": {
-      "file": "assets/vendor-react-Cjr9AYj0.js",
-      "raw": 181960,
-      "gzip": 56453
+    "_vendor-react-Z4IRr5AJ.js": {
+      "file": "assets/vendor-react-Z4IRr5AJ.js",
+      "raw": 189835,
+      "gzip": 58856
     },
-    "_vendor-xterm-CHyutUX2.js": {
-      "file": "assets/vendor-xterm-CHyutUX2.js",
-      "raw": 458095,
-      "gzip": 116331
+    "_vendor-xterm-zvE5kmR-.js": {
+      "file": "assets/vendor-xterm-zvE5kmR-.js",
+      "raw": 458124,
+      "gzip": 116353
     },
     "_vendor-zod-CcQGOMcc.js": {
       "file": "assets/vendor-zod-CcQGOMcc.js",
       "raw": 74222,
       "gzip": 19584
     },
-    "_viewportPresets-BhRvLo4y.js": {
-      "file": "assets/viewportPresets-BhRvLo4y.js",
-      "raw": 5428,
-      "gzip": 2063
+    "_viewportPresets-B3hFt1sR.js": {
+      "file": "assets/viewportPresets-B3hFt1sR.js",
+      "raw": 5386,
+      "gzip": 2047
+    },
+    "_worktreeCIStatus-DdvJLkOx.js": {
+      "file": "assets/worktreeCIStatus-DdvJLkOx.js",
+      "raw": 37588,
+      "gzip": 11021
     },
     "index.html": {
-      "file": "assets/index-CQpzOhvi.js",
-      "raw": 481258,
-      "gzip": 151102
+      "file": "assets/index-CuUC-dZP.js",
+      "raw": 480947,
+      "gzip": 150925
     },
     "src/App.tsx": {
-      "file": "assets/App-CMAn25Km.js",
-      "raw": 1395396,
-      "gzip": 393497
+      "file": "assets/App-BUIVd6M0.js",
+      "raw": 1406527,
+      "gzip": 396559
     },
     "src/components/Browser/BrowserPane.tsx": {
-      "file": "assets/BrowserPane-DweyqPPV.js",
-      "raw": 21533,
-      "gzip": 6793
+      "file": "assets/BrowserPane-C9cYAVUD.js",
+      "raw": 21525,
+      "gzip": 6800
     },
     "src/components/DevPreview/DevPreviewPane.tsx": {
-      "file": "assets/DevPreviewPane-BxE2PJxz.js",
-      "raw": 87730,
-      "gzip": 26082
+      "file": "assets/DevPreviewPane-BSdZq_Qw.js",
+      "raw": 87589,
+      "gzip": 26066
     },
     "src/panels/review/ReviewPane.tsx": {
-      "file": "assets/ReviewPane-COvjQglw.js",
-      "raw": 1109,
-      "gzip": 667
+      "file": "assets/ReviewPane-BC3oOfsK.js",
+      "raw": 1066,
+      "gzip": 651
     }
   },
   "eagerTotals": {
-    "raw": 5058638,
-    "gzip": 1506171
+    "raw": 4973119,
+    "gzip": 1482221
   },
   "totals": {
-    "raw": 7872742,
-    "gzip": 2487002
+    "raw": 7883837,
+    "gzip": 2490945
   }
 }

--- a/index.html
+++ b/index.html
@@ -1317,6 +1317,7 @@
         <button type="button" class="skeleton-stuck-btn" id="skeleton-stuck-btn">Reload app</button>
       </div>
     </div>
+    <script src="/skeleton-ready.js"></script>
     <script src="/skeleton-heatmap.js"></script>
     <script src="/skeleton-stuck.js"></script>
     <script src="/skeleton-logo.js"></script>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "./electron/setup/deepLinkUrlQueue.ts",
     "./src/main.tsx",
     "./src/lib/trustedTypesPolicy.ts",
+    "./src/lib/bootIpcEager.ts",
     "./src/lib/e2eNotificationBackdoor.ts",
     "./src/config/terminalFont.ts",
     "./src/components/Fleet/fleetRawInputBroadcast.ts",

--- a/public/skeleton-ready.js
+++ b/public/skeleton-ready.js
@@ -1,0 +1,14 @@
+/* global window */
+// Fires the skeleton-parsed reveal signal as soon as the classic scripts run
+// (skeleton markup is parsed), so the main process can show the window without
+// waiting for the deferred module graph to evaluate. Fire-and-forget; the
+// dom-ready gate and 5s fallback in createWindow.ts remain as backstops.
+(function () {
+  try {
+    if (window.electron && window.electron.app && window.electron.app.skeletonParsed) {
+      window.electron.app.skeletonParsed();
+    }
+  } catch (_err) {
+    // Best-effort: dom-ready backstop covers this.
+  }
+})();

--- a/renderer-bundle-size-baseline.json
+++ b/renderer-bundle-size-baseline.json
@@ -2,396 +2,428 @@
   "entryChunk": "index",
   "chunks": {
     "AccessibilityAnnouncer": {
-      "raw": 1403,
-      "gzip": 699
+      "raw": 1360,
+      "gzip": 686
     },
     "ActionPalette": {
-      "raw": 14138,
-      "gzip": 5534
+      "raw": 14155,
+      "gzip": 5539
     },
     "ActionService": {
-      "raw": 10718,
-      "gzip": 4128
+      "raw": 11544,
+      "gzip": 4443
     },
     "AgentCard": {
-      "raw": 12536,
-      "gzip": 4634
+      "raw": 12494,
+      "gzip": 4672
     },
     "AgentSettings": {
-      "raw": 89323,
-      "gzip": 26430
+      "raw": 89432,
+      "gzip": 26447
     },
     "AgentShortcutCapture": {
-      "raw": 1685,
-      "gzip": 894
+      "raw": 1643,
+      "gzip": 879
     },
     "App": {
-      "raw": 1344703,
-      "gzip": 378364
+      "raw": 1406527,
+      "gzip": 396559
     },
     "AutomationTab": {
-      "raw": 33330,
-      "gzip": 9503
+      "raw": 33406,
+      "gzip": 9526
     },
     "BrowserPane": {
-      "raw": 25540,
-      "gzip": 8908
+      "raw": 21525,
+      "gzip": 6800
     },
     "CelebrationConfetti": {
-      "raw": 3056,
-      "gzip": 1546
+      "raw": 3013,
+      "gzip": 1530
     },
     "CloneRepoDialog": {
-      "raw": 7726,
-      "gzip": 2854
+      "raw": 7676,
+      "gzip": 2821
     },
     "CodeForgeSettingsTab": {
-      "raw": 28229,
-      "gzip": 8851
+      "raw": 37966,
+      "gzip": 11936
     },
     "CodeForgeTab": {
-      "raw": 4015,
-      "gzip": 1577
+      "raw": 3160,
+      "gzip": 1173
     },
     "CommandOverridesTab": {
-      "raw": 13039,
-      "gzip": 4255
+      "raw": 13001,
+      "gzip": 4241
     },
     "CommitList": {
-      "raw": 12902,
-      "gzip": 4990
+      "raw": 12880,
+      "gzip": 4991
     },
     "ContextTab": {
-      "raw": 11733,
-      "gzip": 2692
+      "raw": 12204,
+      "gzip": 2925
     },
     "CrashRecoveryDialog": {
-      "raw": 22601,
-      "gzip": 6987
+      "raw": 23951,
+      "gzip": 7486
     },
     "CreateProjectFolderDialog": {
-      "raw": 3588,
-      "gzip": 1521
+      "raw": 3585,
+      "gzip": 1518
     },
     "CrossWorktreeDiff": {
-      "raw": 9890,
-      "gzip": 3655
+      "raw": 9847,
+      "gzip": 3644
     },
     "DaintreeAssistantSettingsTab": {
-      "raw": 24076,
-      "gzip": 7689
+      "raw": 27961,
+      "gzip": 8812
     },
     "DaintreeIcon": {
-      "raw": 1858,
-      "gzip": 940
+      "raw": 1816,
+      "gzip": 927
+    },
+    "DemoCaptureBridge": {
+      "raw": 3578,
+      "gzip": 1431
+    },
+    "DemoCursor": {
+      "raw": 15286,
+      "gzip": 5238
+    },
+    "DemoOverlay": {
+      "raw": 7030,
+      "gzip": 2996
     },
     "DevPreviewPane": {
-      "raw": 84880,
-      "gzip": 25199
+      "raw": 87589,
+      "gzip": 26066
     },
     "DiagnosticsReviewDialogHost": {
-      "raw": 12587,
-      "gzip": 4663
+      "raw": 12545,
+      "gzip": 4653
     },
     "DiffViewer": {
-      "raw": 31779,
-      "gzip": 11830
+      "raw": 36121,
+      "gzip": 13090
     },
     "EnvironmentSettingsTab": {
-      "raw": 6394,
-      "gzip": 2530
+      "raw": 6386,
+      "gzip": 2539
     },
     "EnvironmentVariablesEditor": {
-      "raw": 7365,
-      "gzip": 2638
+      "raw": 7384,
+      "gzip": 2652
+    },
+    "FileViewerModal": {
+      "raw": 18132,
+      "gzip": 6603
     },
     "FileViewerModalHost": {
-      "raw": 5124,
-      "gzip": 2522
+      "raw": 5012,
+      "gzip": 2447
     },
     "GeneralTab": {
-      "raw": 20715,
-      "gzip": 5967
+      "raw": 20748,
+      "gzip": 5990
     },
     "GettingStartedChecklist": {
-      "raw": 8304,
-      "gzip": 3521
+      "raw": 8309,
+      "gzip": 3522
     },
     "GitHubDropdownSkeletons": {
-      "raw": 6511,
-      "gzip": 2000
+      "raw": 6457,
+      "gzip": 1982
     },
     "GitHubIcon": {
-      "raw": 1117,
-      "gzip": 697
+      "raw": 1075,
+      "gzip": 688
     },
     "GitHubResourceList": {
-      "raw": 51376,
-      "gzip": 17036
+      "raw": 50641,
+      "gzip": 16804
     },
     "GitInitDialog": {
-      "raw": 6297,
-      "gzip": 2257
+      "raw": 6249,
+      "gzip": 2228
     },
     "GitPullRebaseConfirmDialog": {
-      "raw": 4925,
-      "gzip": 2151
+      "raw": 5089,
+      "gzip": 2247
     },
     "GitPushConfirmDialog": {
-      "raw": 4849,
-      "gzip": 2137
+      "raw": 5013,
+      "gzip": 2231
     },
     "GlobalBannerCoordinator": {
-      "raw": 13054,
-      "gzip": 4979
+      "raw": 12986,
+      "gzip": 5051
     },
     "HybridInputBar": {
-      "raw": 132041,
-      "gzip": 39441
+      "raw": 137703,
+      "gzip": 41780
     },
     "IntegrationsTab": {
-      "raw": 11132,
-      "gzip": 3160
+      "raw": 11094,
+      "gzip": 3144
     },
     "KeybindingService": {
-      "raw": 40863,
-      "gzip": 9567
+      "raw": 42742,
+      "gzip": 10010
     },
     "KeyboardShortcutsTab": {
-      "raw": 8946,
-      "gzip": 3137
+      "raw": 8909,
+      "gzip": 3123
     },
     "LiveTimeAgo": {
-      "raw": 3263,
-      "gzip": 1610
+      "raw": 3250,
+      "gzip": 1607
     },
     "LogLevelPalette": {
-      "raw": 5367,
-      "gzip": 2272
+      "raw": 5324,
+      "gzip": 2259
     },
     "McpAuditLogViewer": {
-      "raw": 18407,
-      "gzip": 5364
+      "raw": 24213,
+      "gzip": 6625
     },
     "McpConfirmDialog": {
-      "raw": 3216,
-      "gzip": 1528
+      "raw": 3174,
+      "gzip": 1509
     },
     "McpServerIcon": {
-      "raw": 1048,
-      "gzip": 635
+      "raw": 1006,
+      "gzip": 618
     },
     "McpServerSettingsTab": {
-      "raw": 31394,
-      "gzip": 7458
+      "raw": 33502,
+      "gzip": 7724
     },
     "NewTerminalPalette": {
-      "raw": 4505,
-      "gzip": 2195
+      "raw": 4467,
+      "gzip": 2183
     },
     "NewWorktreeDialog": {
-      "raw": 49460,
-      "gzip": 14919
+      "raw": 49546,
+      "gzip": 14988
     },
     "NotificationSettingsTab": {
-      "raw": 16255,
-      "gzip": 5050
+      "raw": 16217,
+      "gzip": 5038
     },
     "OnboardingFlow": {
-      "raw": 49963,
-      "gzip": 15633
+      "raw": 49992,
+      "gzip": 15667
     },
     "PaletteOverflowNotice": {
-      "raw": 523,
-      "gzip": 378
+      "raw": 481,
+      "gzip": 362
     },
     "PaletteStrip": {
-      "raw": 640,
-      "gzip": 438
+      "raw": 598,
+      "gzip": 422
     },
     "PanelLimitConfirmDialog": {
-      "raw": 1524,
-      "gzip": 886
+      "raw": 1509,
+      "gzip": 879
     },
     "PanelPalette": {
-      "raw": 7811,
-      "gzip": 3721
+      "raw": 7784,
+      "gzip": 3720
     },
     "PluginActionsSettingsTab": {
-      "raw": 11395,
-      "gzip": 4036
+      "raw": 14110,
+      "gzip": 4728
     },
     "PluginConfirmDialog": {
-      "raw": 2546,
-      "gzip": 1254
+      "raw": 2504,
+      "gzip": 1234
+    },
+    "PluginManagerView": {
+      "raw": 51875,
+      "gzip": 16446
+    },
+    "PluginMcpConfirmDialog": {
+      "raw": 4912,
+      "gzip": 2031
     },
     "PluginsTab": {
-      "raw": 3039,
-      "gzip": 1418
+      "raw": 2389,
+      "gzip": 1131
     },
     "PortalSettingsTab": {
-      "raw": 14642,
-      "gzip": 5120
+      "raw": 14594,
+      "gzip": 5102
     },
     "PrivacyDataTab": {
-      "raw": 12586,
-      "gzip": 3824
+      "raw": 12573,
+      "gzip": 3819
     },
     "ProjectNotificationsTab": {
-      "raw": 9914,
-      "gzip": 3581
+      "raw": 9876,
+      "gzip": 3592
     },
     "ProjectSwitcherPalette": {
       "raw": 111,
-      "gzip": 119
+      "gzip": 122
     },
     "QuickCreatePalette": {
-      "raw": 6635,
-      "gzip": 2647
+      "raw": 6598,
+      "gzip": 2634
     },
     "QuickSwitcher": {
-      "raw": 5238,
-      "gzip": 2352
+      "raw": 5210,
+      "gzip": 2343
     },
     "RecipeConflictDialog": {
-      "raw": 2244,
-      "gzip": 1096
+      "raw": 2340,
+      "gzip": 1148
     },
     "RecipeEditor": {
-      "raw": 16862,
-      "gzip": 4482
-    },
-    "RecipesTab": {
-      "raw": 12803,
+      "raw": 16819,
       "gzip": 4464
     },
+    "RecipesTab": {
+      "raw": 12764,
+      "gzip": 4457
+    },
+    "ReviewHub": {
+      "raw": 2304,
+      "gzip": 1208
+    },
     "ReviewHubContent": {
-      "raw": 128283,
-      "gzip": 35617
+      "raw": 82310,
+      "gzip": 22118
     },
     "ReviewPane": {
-      "raw": 1109,
-      "gzip": 668
+      "raw": 1066,
+      "gzip": 651
+    },
+    "RunHistorySettingsTab": {
+      "raw": 8314,
+      "gzip": 3195
     },
     "SearchablePalette": {
-      "raw": 6004,
-      "gzip": 2976
+      "raw": 5994,
+      "gzip": 2980
     },
     "SendToAgentPalette": {
-      "raw": 4113,
-      "gzip": 1839
+      "raw": 4071,
+      "gzip": 1824
     },
     "SettingsCheckbox": {
-      "raw": 3183,
-      "gzip": 1556
+      "raw": 3140,
+      "gzip": 1544
     },
     "SettingsChoicebox": {
-      "raw": 4140,
-      "gzip": 1619
+      "raw": 4137,
+      "gzip": 1622
     },
     "SettingsDialog": {
-      "raw": 50805,
-      "gzip": 16669
+      "raw": 121797,
+      "gzip": 34314
     },
     "SettingsFlushRegistry": {
-      "raw": 1314,
-      "gzip": 704
+      "raw": 1276,
+      "gzip": 694
     },
     "SettingsInput": {
-      "raw": 2123,
-      "gzip": 971
+      "raw": 2120,
+      "gzip": 975
     },
     "SettingsLoadErrorBanner": {
-      "raw": 2400,
-      "gzip": 1188
+      "raw": 936,
+      "gzip": 545
     },
     "SettingsSection": {
-      "raw": 1570,
-      "gzip": 873
+      "raw": 1527,
+      "gzip": 861
     },
     "SettingsSelect": {
-      "raw": 2179,
-      "gzip": 1007
+      "raw": 2176,
+      "gzip": 1006
     },
     "SettingsShortcutCapture": {
-      "raw": 6557,
+      "raw": 6549,
       "gzip": 2374
     },
     "SettingsSubtabBar": {
-      "raw": 1815,
-      "gzip": 958
+      "raw": 1773,
+      "gzip": 946
     },
     "SettingsSwitch": {
-      "raw": 2021,
-      "gzip": 874
+      "raw": 1979,
+      "gzip": 864
     },
     "SettingsSwitchCard": {
-      "raw": 4134,
-      "gzip": 1959
+      "raw": 4092,
+      "gzip": 1947
     },
     "SettingsValidationRegistry": {
-      "raw": 1239,
-      "gzip": 687
+      "raw": 1358,
+      "gzip": 754
     },
     "ShortcutReferenceDialog": {
-      "raw": 5418,
-      "gzip": 2392
+      "raw": 5375,
+      "gzip": 2375
     },
     "Spinner": {
-      "raw": 580,
-      "gzip": 397
+      "raw": 538,
+      "gzip": 385
     },
     "TerminalAppearanceTab": {
-      "raw": 24615,
-      "gzip": 8165
+      "raw": 25912,
+      "gzip": 8747
     },
     "TerminalInstanceService": {
-      "raw": 224678,
-      "gzip": 59270
+      "raw": 244953,
+      "gzip": 63969
     },
     "TerminalSettingsTab": {
-      "raw": 20075,
-      "gzip": 5725
+      "raw": 20027,
+      "gzip": 5703
     },
     "ThemePalette": {
-      "raw": 5283,
-      "gzip": 2520
+      "raw": 5240,
+      "gzip": 2533
     },
     "ToolbarSettingsTab": {
-      "raw": 13472,
-      "gzip": 4949
+      "raw": 14641,
+      "gzip": 5742
     },
     "TroubleshootingTab": {
-      "raw": 11627,
-      "gzip": 3936
-    },
-    "TruncatedTooltip": {
-      "raw": 2667,
-      "gzip": 1356
+      "raw": 11579,
+      "gzip": 3917
     },
     "VoiceInputSettingsTab": {
-      "raw": 28775,
-      "gzip": 9393
+      "raw": 33149,
+      "gzip": 10995
     },
     "WorktreeOverviewModal": {
-      "raw": 33622,
-      "gzip": 11688
+      "raw": 34533,
+      "gzip": 11804
     },
     "WorktreePalette": {
-      "raw": 4008,
-      "gzip": 1835
+      "raw": 3961,
+      "gzip": 1814
     },
     "WorktreeSettingsTab": {
-      "raw": 8188,
-      "gzip": 2367
+      "raw": 8185,
+      "gzip": 2363
     },
     "WorktreeSidebarSearchBar": {
-      "raw": 221135,
-      "gzip": 68117
+      "raw": 229631,
+      "gzip": 71052
     },
     "accessibilityAnnouncerStore": {
       "raw": 565,
-      "gzip": 340
+      "gzip": 339
+    },
+    "actionPaletteSearch": {
+      "raw": 2385,
+      "gzip": 1136
     },
     "actionPrefsStore": {
       "raw": 2198,
@@ -402,40 +434,40 @@
       "gzip": 212
     },
     "agentRegistry": {
-      "raw": 41553,
-      "gzip": 9088
+      "raw": 41773,
+      "gzip": 9347
     },
     "agentSettingsStore": {
-      "raw": 10378,
-      "gzip": 3520
+      "raw": 15398,
+      "gzip": 5303
     },
     "agents": {
-      "raw": 56629,
-      "gzip": 18352
+      "raw": 56587,
+      "gzip": 18338
     },
     "animationUtils": {
-      "raw": 1088,
-      "gzip": 474
+      "raw": 1114,
+      "gzip": 490
     },
     "apl": {
       "raw": 2292,
       "gzip": 1194
     },
     "appClient": {
-      "raw": 364,
-      "gzip": 194
+      "raw": 420,
+      "gzip": 204
     },
     "appThemeClient": {
       "raw": 732,
       "gzip": 229
     },
     "appThemeStore": {
-      "raw": 88588,
-      "gzip": 20290
+      "raw": 99845,
+      "gzip": 23268
     },
     "appThemeViewTransition": {
-      "raw": 1398,
-      "gzip": 779
+      "raw": 1356,
+      "gzip": 764
     },
     "asciiarmor": {
       "raw": 792,
@@ -455,31 +487,39 @@
     },
     "branchPrefixes": {
       "raw": 1358,
-      "gzip": 525
+      "gzip": 521
+    },
+    "builtinRendererRegistry": {
+      "raw": 662,
+      "gzip": 421
     },
     "button": {
-      "raw": 5690,
-      "gzip": 2069
+      "raw": 5946,
+      "gzip": 2116
     },
     "c": {
-      "raw": 1973,
-      "gzip": 1031
+      "raw": 1978,
+      "gzip": 1037
     },
     "categoryColors": {
-      "raw": 1776,
-      "gzip": 525
+      "raw": 2599,
+      "gzip": 655
     },
     "checklistItems": {
       "raw": 799,
-      "gzip": 455
+      "gzip": 457
     },
     "clientAppError": {
       "raw": 349,
       "gzip": 259
     },
+    "clientGitError": {
+      "raw": 475,
+      "gzip": 320
+    },
     "clients": {
-      "raw": 20334,
-      "gzip": 5155
+      "raw": 21101,
+      "gzip": 5372
     },
     "clike": {
       "raw": 22061,
@@ -503,7 +543,7 @@
     },
     "colorUtils": {
       "raw": 386,
-      "gzip": 259
+      "gzip": 255
     },
     "commandsClient": {
       "raw": 203,
@@ -519,19 +559,19 @@
     },
     "cpp": {
       "raw": 2711,
-      "gzip": 1276
+      "gzip": 1274
     },
     "crystal": {
       "raw": 5020,
       "gzip": 2068
     },
     "csharp": {
-      "raw": 6491,
-      "gzip": 2544
+      "raw": 6496,
+      "gzip": 2550
     },
     "css": {
-      "raw": 1295,
-      "gzip": 646
+      "raw": 24708,
+      "gzip": 8241
     },
     "cypher": {
       "raw": 3182,
@@ -541,21 +581,29 @@
       "raw": 3673,
       "gzip": 1651
     },
+    "demoSpring": {
+      "raw": 794,
+      "gzip": 456
+    },
     "devServerDetection": {
-      "raw": 768,
-      "gzip": 437
+      "raw": 926,
+      "gzip": 523
     },
     "diagnosticsReviewStore": {
-      "raw": 1739,
-      "gzip": 852
+      "raw": 1807,
+      "gzip": 878
     },
     "diff": {
       "raw": 302,
       "gzip": 233
     },
     "dist": {
-      "raw": 19301,
-      "gzip": 7210
+      "raw": 25818,
+      "gzip": 11830
+    },
+    "distributionStore": {
+      "raw": 853,
+      "gzip": 448
     },
     "docker": {
       "raw": 1629,
@@ -572,6 +620,10 @@
     "dylan": {
       "raw": 4041,
       "gzip": 1624
+    },
+    "e2eNotificationBackdoor": {
+      "raw": 1811,
+      "gzip": 901
     },
     "ecl": {
       "raw": 5092,
@@ -595,7 +647,7 @@
     },
     "errorContext": {
       "raw": 2165,
-      "gzip": 908
+      "gzip": 909
     },
     "errorMessage": {
       "raw": 3457,
@@ -642,28 +694,24 @@
       "gzip": 4959
     },
     "gitPullRebaseConfirmStore": {
-      "raw": 317,
-      "gzip": 201
+      "raw": 361,
+      "gzip": 220
     },
     "gitPushConfirmStore": {
-      "raw": 317,
-      "gzip": 201
-    },
-    "githubConfigStore": {
-      "raw": 654,
-      "gzip": 333
+      "raw": 361,
+      "gzip": 220
     },
     "githubRateLimitStore": {
-      "raw": 893,
-      "gzip": 401
+      "raw": 3427,
+      "gzip": 1624
     },
     "globalEnvClient": {
       "raw": 436,
       "gzip": 274
     },
     "go": {
-      "raw": 1075,
-      "gzip": 682
+      "raw": 1080,
+      "gzip": 692
     },
     "graphql": {
       "raw": 2592,
@@ -681,17 +729,21 @@
       "raw": 7862,
       "gzip": 2889
     },
+    "helpPanelStore": {
+      "raw": 2961,
+      "gzip": 1098
+    },
     "idl": {
       "raw": 9826,
       "gzip": 4390
     },
     "index": {
-      "raw": 452902,
-      "gzip": 141935
+      "raw": 480947,
+      "gzip": 150925
     },
     "java": {
-      "raw": 2888,
-      "gzip": 1296
+      "raw": 2893,
+      "gzip": 1303
     },
     "javascript": {
       "raw": 17020,
@@ -706,20 +758,20 @@
       "gzip": 1123
     },
     "kotlin": {
-      "raw": 2053,
-      "gzip": 1019
+      "raw": 2058,
+      "gzip": 1026
     },
     "less": {
-      "raw": 793,
-      "gzip": 447
+      "raw": 800,
+      "gzip": 453
     },
     "livescript": {
       "raw": 4081,
       "gzip": 1612
     },
     "logger": {
-      "raw": 597,
-      "gzip": 305
+      "raw": 734,
+      "gzip": 389
     },
     "logsClient": {
       "raw": 625,
@@ -733,10 +785,6 @@
       "raw": 1008,
       "gzip": 596
     },
-    "markup": {
-      "raw": 2941,
-      "gzip": 1177
-    },
     "mathematica": {
       "raw": 1899,
       "gzip": 799
@@ -747,11 +795,11 @@
     },
     "mcpConfirmStore": {
       "raw": 806,
-      "gzip": 431
+      "gzip": 430
     },
     "memoryLeakConfigStore": {
       "raw": 304,
-      "gzip": 199
+      "gzip": 198
     },
     "mirc": {
       "raw": 5917,
@@ -787,11 +835,11 @@
     },
     "notificationSettingsStore": {
       "raw": 2377,
-      "gzip": 724
+      "gzip": 723
     },
     "notify": {
-      "raw": 11667,
-      "gzip": 4185
+      "raw": 12470,
+      "gzip": 4475
     },
     "nsis": {
       "raw": 6804,
@@ -810,16 +858,16 @@
       "gzip": 1260
     },
     "panelKindRegistry": {
-      "raw": 3371,
-      "gzip": 1300
+      "raw": 3409,
+      "gzip": 1310
     },
     "panelLimitStore": {
-      "raw": 3095,
-      "gzip": 1220
+      "raw": 3144,
+      "gzip": 1239
     },
     "panelSpawning": {
-      "raw": 12562,
-      "gzip": 4801
+      "raw": 12651,
+      "gzip": 4827
     },
     "pascal": {
       "raw": 2256,
@@ -842,8 +890,8 @@
       "gzip": 300
     },
     "php": {
-      "raw": 7581,
-      "gzip": 2527
+      "raw": 7585,
+      "gzip": 2536
     },
     "pig": {
       "raw": 2513,
@@ -855,7 +903,15 @@
     },
     "pluginConfirmStore": {
       "raw": 833,
-      "gzip": 439
+      "gzip": 438
+    },
+    "pluginMcpConfirmStore": {
+      "raw": 654,
+      "gzip": 355
+    },
+    "pluginRuntimeStore": {
+      "raw": 965,
+      "gzip": 562
     },
     "powershell": {
       "raw": 7699,
@@ -871,15 +927,15 @@
     },
     "projectPresetsStore": {
       "raw": 287,
-      "gzip": 174
+      "gzip": 173
     },
     "projectSettingsStore": {
       "raw": 1920,
-      "gzip": 833
+      "gzip": 829
     },
     "projectStore": {
-      "raw": 15030,
-      "gzip": 5009
+      "raw": 15479,
+      "gzip": 5194
     },
     "properties": {
       "raw": 664,
@@ -911,19 +967,23 @@
     },
     "radix-deferred": {
       "raw": 199,
-      "gzip": 153
+      "gzip": 152
     },
     "radix-loader": {
-      "raw": 1065,
-      "gzip": 587
+      "raw": 991,
+      "gzip": 565
     },
     "recipeConflictStore": {
-      "raw": 319,
-      "gzip": 198
+      "raw": 363,
+      "gzip": 218
+    },
+    "recipeNotify": {
+      "raw": 630,
+      "gzip": 364
     },
     "recipeStore": {
-      "raw": 13859,
-      "gzip": 4537
+      "raw": 15065,
+      "gzip": 4950
     },
     "recoveryCopy": {
       "raw": 1766,
@@ -950,20 +1010,20 @@
       "gzip": 1213
     },
     "safeStorage": {
-      "raw": 5335,
-      "gzip": 2044
+      "raw": 5395,
+      "gzip": 2005
     },
     "safeStringify": {
       "raw": 403,
-      "gzip": 277
+      "gzip": 275
     },
     "sas": {
       "raw": 9331,
       "gzip": 4065
     },
     "sass": {
-      "raw": 1203,
-      "gzip": 538
+      "raw": 1210,
+      "gzip": 545
     },
     "scheme": {
       "raw": 6363,
@@ -974,16 +1034,12 @@
       "gzip": 175
     },
     "scss": {
-      "raw": 1429,
-      "gzip": 698
+      "raw": 1436,
+      "gzip": 705
     },
     "select": {
-      "raw": 9624,
-      "gzip": 3394
-    },
-    "settingsTabRegistry": {
-      "raw": 70231,
-      "gzip": 18227
+      "raw": 9577,
+      "gzip": 3393
     },
     "shell": {
       "raw": 2449,
@@ -1002,8 +1058,8 @@
       "gzip": 849
     },
     "sortableAnnouncements": {
-      "raw": 7327,
-      "gzip": 2864
+      "raw": 7556,
+      "gzip": 2936
     },
     "sparql": {
       "raw": 3331,
@@ -1018,8 +1074,8 @@
       "gzip": 1172
     },
     "storeAccessors": {
-      "raw": 7252,
-      "gzip": 2220
+      "raw": 7544,
+      "gzip": 2314
     },
     "stylus": {
       "raw": 23526,
@@ -1029,17 +1085,13 @@
       "raw": 121,
       "gzip": 127
     },
-    "svgSanitizer": {
-      "raw": 1966,
-      "gzip": 999
-    },
     "swift": {
       "raw": 3762,
       "gzip": 1802
     },
     "systemWakeStore": {
-      "raw": 5371,
-      "gzip": 2420
+      "raw": 5324,
+      "gzip": 2407
     },
     "tcl": {
       "raw": 2353,
@@ -1047,23 +1099,23 @@
     },
     "terminalChrome": {
       "raw": 2526,
-      "gzip": 975
+      "gzip": 970
     },
     "terminalColorSchemeStore": {
       "raw": 18192,
-      "gzip": 5161
+      "gzip": 5160
     },
     "terminalConfigClient": {
       "raw": 944,
       "gzip": 268
     },
     "terminalFont": {
-      "raw": 473,
-      "gzip": 308
+      "raw": 686,
+      "gzip": 427
     },
     "terminalInputStore": {
-      "raw": 7635,
-      "gzip": 2717
+      "raw": 7670,
+      "gzip": 2733
     },
     "textile": {
       "raw": 6772,
@@ -1090,44 +1142,44 @@
       "gzip": 882
     },
     "twoPaneSplitStore": {
-      "raw": 2148,
-      "gzip": 953
+      "raw": 2153,
+      "gzip": 954
     },
     "uiStore": {
       "raw": 7357,
-      "gzip": 2326
+      "gzip": 2324
     },
     "useAgentDiscoveryOnboarding": {
-      "raw": 2768,
-      "gzip": 1043
+      "raw": 2731,
+      "gzip": 1032
     },
     "useDebounce": {
-      "raw": 410,
-      "gzip": 286
-    },
-    "useDeferredLoading": {
-      "raw": 1266,
-      "gzip": 612
+      "raw": 368,
+      "gzip": 269
     },
     "useEscapeStack": {
-      "raw": 2817,
-      "gzip": 1199
+      "raw": 2775,
+      "gzip": 1183
     },
     "useFindInPage": {
-      "raw": 34181,
-      "gzip": 10101
+      "raw": 35188,
+      "gzip": 10312
     },
     "useMcpReadiness": {
-      "raw": 698,
-      "gzip": 452
+      "raw": 1247,
+      "gzip": 706
     },
     "useResizeObserverRaf": {
-      "raw": 33264,
-      "gzip": 10747
+      "raw": 36844,
+      "gzip": 11410
+    },
+    "useTabLoad": {
+      "raw": 1487,
+      "gzip": 788
     },
     "utils": {
       "raw": 218,
-      "gzip": 192
+      "gzip": 189
     },
     "vb": {
       "raw": 3650,
@@ -1142,76 +1194,76 @@
       "gzip": 1100
     },
     "vendor": {
-      "raw": 425518,
-      "gzip": 137383
+      "raw": 399172,
+      "gzip": 128969
     },
     "vendor-editor": {
-      "raw": 450913,
-      "gzip": 145635
+      "raw": 443061,
+      "gzip": 142503
     },
     "vendor-icons": {
-      "raw": 49105,
-      "gzip": 14742
+      "raw": 50250,
+      "gzip": 15026
     },
     "vendor-motion~App": {
-      "raw": 1075,
-      "gzip": 605
+      "raw": 1072,
+      "gzip": 603
     },
     "vendor-motion~App~WorktreeOverviewModal": {
-      "raw": 7612,
-      "gzip": 3358
+      "raw": 7610,
+      "gzip": 3356
     },
     "vendor-motion~App~motionFeatures~WorktreeOverviewModal": {
       "raw": 28096,
-      "gzip": 11064
+      "gzip": 11062
     },
     "vendor-motion~index": {
-      "raw": 5584,
-      "gzip": 2430
+      "raw": 5581,
+      "gzip": 2425
     },
     "vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi": {
-      "raw": 7911,
-      "gzip": 3421
+      "raw": 7908,
+      "gzip": 3417
     },
     "vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Getti~bfe2l8g2": {
       "raw": 269,
       "gzip": 201
     },
     "vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~f3gnuexl": {
-      "raw": 31315,
-      "gzip": 11246
+      "raw": 31313,
+      "gzip": 11245
     },
     "vendor-motion~index~BrowserPane~DevPreviewPane~App~motionFeatures~CelebrationConfetti~Onboa~j1o0q54h": {
-      "raw": 603,
-      "gzip": 416
+      "raw": 601,
+      "gzip": 414
     },
     "vendor-motion~motionFeatures": {
-      "raw": 56991,
-      "gzip": 17288
+      "raw": 56988,
+      "gzip": 17286
     },
     "vendor-radix": {
-      "raw": 5056,
-      "gzip": 1917
+      "raw": 5057,
+      "gzip": 1914
     },
     "vendor-radix-overlay": {
-      "raw": 105042,
-      "gzip": 31875
+      "raw": 104999,
+      "gzip": 31855
     },
     "vendor-radix-utils": {
-      "raw": 14557,
-      "gzip": 3261
+      "raw": 14504,
+      "gzip": 3243
     },
     "vendor-react": {
-      "raw": 181960,
-      "gzip": 56453
+      "raw": 189835,
+      "gzip": 58856
     },
     "vendor-xterm": {
-      "raw": 483783,
-      "gzip": 127759
+      "raw": 458124,
+      "gzip": 116353
     },
     "vendor-xterm-webgl": {
-      "raw": 120961,
-      "gzip": 33517
+      "raw": 248320,
+      "gzip": 67250
     },
     "vendor-zod": {
       "raw": 74222,
@@ -1226,12 +1278,16 @@
       "gzip": 1498
     },
     "viewportPresets": {
-      "raw": 5176,
-      "gzip": 1934
+      "raw": 5386,
+      "gzip": 2047
     },
     "webidl": {
       "raw": 2449,
       "gzip": 1227
+    },
+    "worktreeCIStatus": {
+      "raw": 37588,
+      "gzip": 11021
     },
     "xquery": {
       "raw": 6225,
@@ -1252,12 +1308,12 @@
   },
   "totals": {
     "js": {
-      "raw": 7483094,
-      "gzip": 2375099
+      "raw": 7883948,
+      "gzip": 2491067
     },
     "css": {
-      "raw": 299262,
-      "gzip": 38812
+      "raw": 327209,
+      "gzip": 41783
     }
   }
 }

--- a/renderer-import-baseline.json
+++ b/renderer-import-baseline.json
@@ -1,6 +1,6 @@
 {
   "entryName": "index",
-  "eagerChunkCount": 69,
+  "eagerChunkCount": 68,
   "eagerChunks": [
     "AccessibilityAnnouncer",
     "ActionService",
@@ -60,7 +60,6 @@
     "useEscapeStack",
     "utils",
     "vendor",
-    "vendor-editor",
     "vendor-icons",
     "vendor-motion~index",
     "vendor-motion~index~BrowserPane~DevPreviewPane~App~CelebrationConfetti~OnboardingFlow~Workt~d1asc0vi",
@@ -72,12 +71,12 @@
     "vendor-xterm",
     "vendor-zod"
   ],
-  "eagerRaw": 2844444,
-  "eagerGzip": 850171,
+  "eagerRaw": 2376764,
+  "eagerGzip": 699229,
   "chunkGzip": {
-    "vendor-radix-utils": 3261,
-    "vendor-react": 56453,
-    "vendor-xterm": 116331
+    "vendor-radix-utils": 3243,
+    "vendor-react": 58856,
+    "vendor-xterm": 116353
   },
   "chunkModules": {
     "vendor-radix-utils": [
@@ -107,7 +106,11 @@
       "node_modules/react-dom/client.js",
       "node_modules/react-dom/index.js",
       "node_modules/react/cjs/react-compiler-runtime.production.js",
+      "node_modules/react/cjs/react-jsx-runtime.production.js",
+      "node_modules/react/cjs/react.production.js",
       "node_modules/react/compiler-runtime.js",
+      "node_modules/react/index.js",
+      "node_modules/react/jsx-runtime.js",
       "node_modules/scheduler/cjs/scheduler.production.js",
       "node_modules/scheduler/index.js"
     ],

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -50,6 +50,14 @@ export const PERF_MARKS = {
   WORKSPACE_HOST_READY_POSTED: "workspace_host_ready_posted",
 
   CRASH_RECOVERY_GATE: "crash_recovery_gate",
+  /**
+   * Emitted exactly once per `handleAppHydrate` (cold boot AND project-switch
+   * hydrates) with `hit`/`reason` metadata recording whether the prefetched
+   * HydrateResult cache serviced the request. Mirrors POOL_HIT/POOL_MISS so
+   * `perf:cold-start` can prove the whenReady boot-prime prefetch actually
+   * wins the race instead of inferring it from PROJECT_STATE_READ placement.
+   */
+  APP_HYDRATE_PREFETCH: "app_hydrate_prefetch",
   HYDRATE_START: "hydrate_start",
   HYDRATE_RESTORE_PANELS_START: "hydrate_restore_panels_start",
   HYDRATE_RESTORE_PANELS_END: "hydrate_restore_panels_end",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -412,6 +412,8 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * re-hydrate the panel in the current session.
      */
     clearQuarantinedPanel(panelId: string): Promise<{ cleared: boolean }>;
+    /** Fire-and-forget skeleton-parsed reveal signal sent before module-graph eval. */
+    skeletonParsed(): void;
     notifyFirstInteractive(): Promise<void>;
     notifyViewPainted(): Promise<void>;
     notifyWarmViewPainted(): Promise<void>;

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -186,4 +186,15 @@ export interface HydrateResult {
    * React 19 `use()` safe-boot fallback), the renderer falls back to the IPC call.
    */
   systemTmpDir?: string;
+  /**
+   * Per-project layout state folded into the hydrate payload so the renderer
+   * skips the standalone `getTabGroups`/`getTerminalSizes`/`getDraftInputs`
+   * round-trips on the panel-restore critical path. Populated (with the same
+   * null-state defaults as the standalone handlers) whenever a project is
+   * resolved; undefined on the no-project fallback branch and older payloads,
+   * where the renderer falls back to the standalone IPC calls.
+   */
+  tabGroups?: import("../panel.js").TabGroup[];
+  terminalSizes?: Record<string, { cols: number; rows: number }>;
+  draftInputs?: Record<string, string>;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -344,6 +344,16 @@ import { voiceRecordingService } from "./services/VoiceRecordingService";
 import { useRenderProfiler } from "./utils/renderProfiler";
 
 import { SidebarContent, preloadNewWorktreeDialog, E2EFaultInjector } from "./components/Sidebar";
+import { ensureHydrationBootstrap } from "./utils/stateHydration/bootstrapGuard";
+
+// Kick the hydration-bootstrap IPC pair (keybinding overrides + user-agent
+// registry) at module-eval time so the round-trips overlap App's first render
+// instead of starting in the post-commit hydration effect. The guard memoizes,
+// so the await inside hydrateAppState stays the synchronization point. The
+// `.catch` is required: the guard resets its memo and RETHROWS on failure, so
+// a bare void call would surface an unhandled rejection — the swallowed early
+// failure is retried by hydrateAppState's own await.
+void ensureHydrationBootstrap().catch(() => {});
 
 const loadMotionFeatures = () => import("./lib/motionFeatures").then((mod) => mod.default);
 
@@ -679,13 +689,21 @@ function AppInner() {
     });
     return () => unsubscribe?.();
   }, []);
-  useShortcutHints(isStateLoaded);
+  // Defers the post-hydration housekeeping IPC reads (shortcut-hint counts,
+  // milestones, GitHub-recommendation plugin/remotes probes) out of the
+  // synchronous isStateLoaded effect flush: their sends would otherwise land
+  // on main ahead of the loaded-frame paint and compete with the
+  // deferred-services drain. The flag flips from the background-priority task
+  // below, so the gated hooks hydrate at idle; each reconciles current store
+  // state on attach, so nothing observable is lost in the gap.
+  const [idleHousekeepingReady, setIdleHousekeepingReady] = useState(false);
+  useShortcutHints(isStateLoaded && idleHousekeepingReady);
   const gettingStarted = useGettingStartedChecklist(isStateLoaded);
   const onboardingOverlayActive = gettingStarted.visible || gettingStarted.showCelebration;
   useUpdateListener(onboardingOverlayActive);
-  useOrchestrationMilestones(isStateLoaded);
+  useOrchestrationMilestones(isStateLoaded && idleHousekeepingReady);
   useAgentWaitingNudge(isStateLoaded);
-  useGitHubEnableRecommendation(isStateLoaded);
+  useGitHubEnableRecommendation(isStateLoaded && idleHousekeepingReady);
   useNotificationHistoryPruning();
 
   useEffect(() => {
@@ -695,6 +713,7 @@ function AppInner() {
 
     const execute = () => {
       if (controller.signal.aborted) return;
+      setIdleHousekeepingReady(true);
       void preloadSettingsDialog();
       void preloadNewWorktreeDialog();
       void preloadActionPalette();

--- a/src/clients/__tests__/onboardingClient.test.ts
+++ b/src/clients/__tests__/onboardingClient.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const typedGlobal = globalThis as unknown as Record<string, unknown>;
+
+let getOnboardingState: typeof import("../onboardingClient").getOnboardingState;
+let getMock: ReturnType<typeof vi.fn>;
+
+describe("getOnboardingState", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    getMock = vi.fn().mockResolvedValue({ completed: true, waitingNudgeSeen: false });
+    typedGlobal.window = {
+      electron: {
+        onboarding: { get: getMock },
+      },
+    };
+
+    const mod = await import("../onboardingClient");
+    getOnboardingState = mod.getOnboardingState;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  it("dedupes same-tick callers into a single IPC fetch", async () => {
+    const a = getOnboardingState();
+    const b = getOnboardingState();
+
+    expect(b).toBe(a);
+    expect(getMock).toHaveBeenCalledTimes(1);
+    await expect(a).resolves.toEqual({ completed: true, waitingNudgeSeen: false });
+  });
+
+  it("refetches once the microtask checkpoint has passed", async () => {
+    const first = getOnboardingState();
+    await first;
+
+    const second = getOnboardingState();
+    expect(second).not.toBe(first);
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates rejections to all same-tick callers and clears the cache", async () => {
+    getMock.mockRejectedValueOnce(new Error("IPC down"));
+
+    const a = getOnboardingState();
+    const b = getOnboardingState();
+    await expect(a).rejects.toThrow("IPC down");
+    await expect(b).rejects.toThrow("IPC down");
+
+    getMock.mockResolvedValueOnce({ completed: false, waitingNudgeSeen: true });
+    await expect(getOnboardingState()).resolves.toEqual({
+      completed: false,
+      waitingNudgeSeen: true,
+    });
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/clients/onboardingClient.ts
+++ b/src/clients/onboardingClient.ts
@@ -1,0 +1,22 @@
+import type { OnboardingState } from "@shared/types";
+
+let inflight: Promise<OnboardingState> | null = null;
+
+/**
+ * Same-tick deduped read of onboarding state. The two `isStateLoaded`
+ * consumers (`useGettingStartedChecklist`, `useAgentWaitingNudge`) fire in the
+ * same effect flush, so sharing the promise for the current microtask
+ * checkpoint collapses their duplicate `onboarding:get` IPC into one with
+ * zero staleness surface — the cache is cleared before the round-trip even
+ * resolves, so any later caller (e.g. `OnboardingFlow` mutating onboarding
+ * mid-session) always refetches.
+ */
+export function getOnboardingState(): Promise<OnboardingState> {
+  if (inflight) return inflight;
+  const promise = window.electron.onboarding.get();
+  inflight = promise;
+  queueMicrotask(() => {
+    if (inflight === promise) inflight = null;
+  });
+  return promise;
+}

--- a/src/components/Settings/__tests__/settingsTabRegistry.test.ts
+++ b/src/components/Settings/__tests__/settingsTabRegistry.test.ts
@@ -13,6 +13,7 @@ import {
   type LazySettingsTabEntry,
   type SettingsTab,
 } from "../settingsTabRegistry";
+import { GLOBAL_SETTINGS_TAB_IDS, PROJECT_SETTINGS_TAB_IDS } from "../settingsTabIds";
 
 const allEntries: readonly AnySettingsTabEntry[] = SETTINGS_REGISTRY;
 const globalEntries = allEntries.filter((e) => e.scope === "global");
@@ -249,6 +250,16 @@ describe("getSettingsNavGroups", () => {
       "project:code-forge",
     ];
     expect(groups[0]!.entries.map((e) => e.id)).toEqual(expectedOrder);
+  });
+});
+
+describe("settingsTabIds drift guard", () => {
+  it("GLOBAL_SETTINGS_TAB_IDS matches the registry's global entries", () => {
+    expect([...GLOBAL_SETTINGS_TAB_IDS].sort()).toEqual(globalEntries.map((e) => e.id).sort());
+  });
+
+  it("PROJECT_SETTINGS_TAB_IDS matches the registry's project entries", () => {
+    expect([...PROJECT_SETTINGS_TAB_IDS].sort()).toEqual(projectEntries.map((e) => e.id).sort());
   });
 });
 

--- a/src/components/Settings/settingsTabIds.ts
+++ b/src/components/Settings/settingsTabIds.ts
@@ -1,0 +1,57 @@
+// Tab ids and the tiny validators derived from them, kept free of component
+// imports so boot-path consumers (useSettingsDialog) don't pull the full
+// settingsTabRegistry chunk (GeneralTab + settings stores) into App's eager
+// closure. settingsTabRegistry re-exports everything here and carries
+// compile-time drift guards in both directions.
+
+export const GLOBAL_SETTINGS_TAB_IDS = [
+  "general",
+  "terminalAppearance",
+  "keyboard",
+  "notifications",
+  "privacy",
+  "terminal",
+  "worktree",
+  "toolbar",
+  "environment",
+  "assistant",
+  "agents",
+  "code-forge",
+  "integrations",
+  "voice",
+  "portal",
+  "mcp",
+  "plugins",
+  "plugin-actions",
+  "run-history",
+  "troubleshooting",
+] as const;
+
+export const PROJECT_SETTINGS_TAB_IDS = [
+  "project:general",
+  "project:context",
+  "project:variables",
+  "project:automation",
+  "project:recipes",
+  "project:commands",
+  "project:notifications",
+  "project:code-forge",
+] as const;
+
+export type GlobalSettingsTab = (typeof GLOBAL_SETTINGS_TAB_IDS)[number];
+export type ProjectSettingsTab = (typeof PROJECT_SETTINGS_TAB_IDS)[number];
+export type SettingsTab = GlobalSettingsTab | ProjectSettingsTab;
+export type SettingsScope = "global" | "project";
+
+const ALL_SETTINGS_TAB_IDS: ReadonlySet<string> = new Set<string>([
+  ...GLOBAL_SETTINGS_TAB_IDS,
+  ...PROJECT_SETTINGS_TAB_IDS,
+]);
+
+export function scopeForTab(tab: SettingsTab): SettingsScope {
+  return tab.startsWith("project:") ? "project" : "global";
+}
+
+export function isSettingsTab(value: string): value is SettingsTab {
+  return ALL_SETTINGS_TAB_IDS.has(value);
+}

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -24,6 +24,17 @@ import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 import { AGENT_REGISTRY } from "@shared/config/agentRegistry";
 import { GeneralTab } from "./GeneralTab";
+import type {
+  GlobalSettingsTab,
+  ProjectSettingsTab,
+  SettingsScope,
+  SettingsTab,
+} from "./settingsTabIds";
+
+// Boot-path consumers import the ids/validators from settingsTabIds (no
+// component imports); re-export them so registry consumers are untouched.
+export { isSettingsTab, scopeForTab } from "./settingsTabIds";
+export type { GlobalSettingsTab, ProjectSettingsTab, SettingsScope, SettingsTab };
 
 // ── Entry types ─────────────────────────────────────────────────────────
 
@@ -43,7 +54,9 @@ export interface SettingsSectionMeta {
 }
 
 export interface SettingsTabEntry {
-  readonly id: string;
+  // Typed against the settingsTabIds tuples so an id added here without a
+  // matching tuple entry fails to compile (drift guard, direction 1).
+  readonly id: SettingsTab;
   readonly scope: "global" | "project";
   readonly group: string;
   readonly label: string;
@@ -1650,15 +1663,17 @@ export const SETTINGS_REGISTRY = [
   } satisfies LazySettingsTabEntry,
 ] as const satisfies readonly AnySettingsTabEntry[];
 
-// ── Tab id types (derived from registry by scope) ───────────────────────
+// ── Drift guards against settingsTabIds (direction 2) ───────────────────
+// Direction 1 (registry id must exist in the tuples) is the `id: SettingsTab`
+// field on SettingsTabEntry. Direction 2: every tuple id must have a
+// registered entry — `_Missing` is non-never (and this fails to compile) when
+// an id is added to settingsTabIds without a registry entry.
 
 type ProjectScopedEntry = Extract<(typeof SETTINGS_REGISTRY)[number], { scope: "project" }>;
-type GlobalScopedEntry = Extract<(typeof SETTINGS_REGISTRY)[number], { scope: "global" }>;
 
-export type ProjectSettingsTab = ProjectScopedEntry["id"];
-export type GlobalSettingsTab = GlobalScopedEntry["id"];
-export type SettingsTab = GlobalSettingsTab | ProjectSettingsTab;
-export type SettingsScope = "global" | "project";
+type _Missing = Exclude<SettingsTab, (typeof SETTINGS_REGISTRY)[number]["id"]>;
+const _assertAllRegistered: _Missing extends never ? true : never = true;
+void _assertAllRegistered;
 
 // ── Project tab search metadata (parallel to SETTINGS_REGISTRY entries) ──
 
@@ -1842,7 +1857,8 @@ export const PROJECT_TAB_IDS: readonly ProjectSettingsTab[] = SETTINGS_REGISTRY.
 
 // ── Derived maps ────────────────────────────────────────────────────────
 
-const _entryMap = new Map(SETTINGS_REGISTRY.map((e) => [e.id, e]));
+// Keyed as `string` so `getSettingsTabEntry` keeps accepting unvalidated ids.
+const _entryMap = new Map<string, AnySettingsTabEntry>(SETTINGS_REGISTRY.map((e) => [e.id, e]));
 
 export function getSettingsTabEntry(id: string): AnySettingsTabEntry | undefined {
   return _entryMap.get(id);
@@ -1893,14 +1909,6 @@ export const projectTabIcons: Record<ProjectSettingsTab, ReactNode> = {
   "project:notifications": <Bell className="w-5 h-5 text-text-secondary" />,
   "project:code-forge": <GitBranch className="w-5 h-5 text-text-secondary" />,
 };
-
-export function scopeForTab(tab: SettingsTab): SettingsScope {
-  return tab.startsWith("project:") ? "project" : "global";
-}
-
-export function isSettingsTab(value: string): value is SettingsTab {
-  return _entryMap.has(value);
-}
 
 export function preloadAllSettingsTabs(): void {
   for (const entry of SETTINGS_REGISTRY) {

--- a/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
@@ -1,11 +1,20 @@
+import { Suspense, lazy } from "react";
 import type { WorktreeState } from "@/types";
 import type { Issue } from "@shared/types/forge";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { WorktreeDeleteDialog } from "../WorktreeDeleteDialog";
 import { IssuePickerDialog } from "../IssuePickerDialog";
-import { ReviewHub } from "../ReviewHub/ReviewHub";
 import { PlanFileViewer } from "@/components/FileViewer/PlanFileViewer";
+import { useKeepMounted } from "@/hooks/useKeepMounted";
 import type { ConfirmDialogState } from "./hooks/useWorktreeActions";
+
+// Lazy boundary keeps ReviewHubContent/DiffViewer (~50KB gz) out of App's
+// first-paint eval closure — the hub only renders when a card opens it. The
+// chunk stays modulepreloaded via the ReviewPane seed, so the null fallback
+// covers eval-only time on first open.
+const LazyReviewHub = lazy(() =>
+  import("../ReviewHub/ReviewHub").then((m) => ({ default: m.ReviewHub }))
+);
 
 export interface WorktreeDialogsProps {
   worktree: WorktreeState;
@@ -42,6 +51,10 @@ export function WorktreeDialogs({
   showPlanViewer,
   onClosePlanViewer,
 }: WorktreeDialogsProps) {
+  // Keep-mounted is NOT for a close animation (ReviewHub returns null when
+  // !isOpen) — it avoids re-suspending on reopen and keeps focus-restore
+  // cleanup semantics identical to the previously-static mount.
+  const reviewHubMounted = useKeepMounted(showReviewHub);
   return (
     <>
       <ConfirmDialog
@@ -71,13 +84,17 @@ export function WorktreeDialogs({
         onDetach={onDetachIssue}
       />
 
-      <ReviewHub
-        isOpen={showReviewHub}
-        worktreePath={worktree.path}
-        onClose={onCloseReviewHub}
-        initialCommitMessage={reviewHubInitialCommitMessage}
-        autoStageOnOpen={reviewHubAutoStageOnOpen}
-      />
+      {reviewHubMounted && (
+        <Suspense fallback={null}>
+          <LazyReviewHub
+            isOpen={showReviewHub}
+            worktreePath={worktree.path}
+            onClose={onCloseReviewHub}
+            initialCommitMessage={reviewHubInitialCommitMessage}
+            autoStageOnOpen={reviewHubAutoStageOnOpen}
+          />
+        </Suspense>
+      )}
 
       <PlanFileViewer
         isOpen={showPlanViewer}

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -186,6 +186,15 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           /* non-critical — next pr-detection-state push corrects it */
         });
 
+      // Manual issue associations live in the electron store, not the
+      // workspace host — fetch them concurrently with the `get-all-states`
+      // round-trip instead of serializing behind it. The `.catch` at creation
+      // is load-bearing twice over: it preserves the #8079 "undefined = keep
+      // cached associations" failure semantics, and it prevents an unhandled
+      // rejection when the handler below returns early (generation/isReady
+      // guards) and never awaits the promise.
+      const associationsPromise = worktreeClient.getAllIssueAssociations().catch(() => undefined);
+
       worktreePort
         .request("get-all-states")
         .then(
@@ -205,9 +214,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
 
             // Hydrate the persistent watcher-degraded indicator from the
             // handshake so a late-mounting view reflects current state without
-            // waiting for a live event. Set before the async associations fetch
-            // so a degradation/recovery event delivered during that await wins
-            // over this now-stale snapshot value.
+            // waiting for a live event. Set before the associations await so a
+            // degradation/recovery event delivered during that await wins over
+            // this now-stale snapshot value.
             store.getState().setWatcherDegraded(response.watcherDegraded ?? false);
             // Hydrate the parallel topology-watcher-dark indicator the same way
             // (#9908), before the await, for the same race reason. A view that
@@ -244,16 +253,8 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             // cached". An empty object means "authoritatively no associations".
             // Defaulting to `{}` on failure would wipe cached manual
             // associations on a transient IPC error (#8079 review).
-            let associations:
-              | Record<string, { issueNumber: number; issueTitle?: string }>
-              | undefined;
-            try {
-              associations = await worktreeClient.getAllIssueAssociations();
-              if (thisGen !== generation) return;
-            } catch {
-              // Non-critical — keep cached associations (associations stays undefined)
-              if (thisGen !== generation) return;
-            }
+            const associations = await associationsPromise;
+            if (thisGen !== generation) return;
 
             // If the host crashed during the associations fetch (a separate IPC
             // that port-close cannot reject), skip applySnapshot so it does not

--- a/src/hooks/app/__tests__/useAgentWaitingNudge.test.tsx
+++ b/src/hooks/app/__tests__/useAgentWaitingNudge.test.tsx
@@ -92,6 +92,7 @@ vi.mock("../../useElectron", () => ({
 }));
 
 import { useAgentWaitingNudge } from "../useAgentWaitingNudge";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 
 function emitStoreUpdate(terminals: Terminal[]) {
   storeState = {
@@ -107,6 +108,9 @@ describe("useAgentWaitingNudge", () => {
     storeSubscribers = [];
     storeState = { panelsById: {}, panelIds: [] };
     notifyMock.mockReturnValue("notif-123");
+    // The hook reads waitingEnabled from the settings store (hydrated at App
+    // mount) rather than a per-hook getSettings IPC.
+    useNotificationSettingsStore.setState({ hydrated: true, waitingEnabled: false });
   });
 
   afterEach(() => {
@@ -164,20 +168,34 @@ describe("useAgentWaitingNudge", () => {
   });
 
   it("does not fire when waitingEnabled is already true", async () => {
-    notificationMock.getSettings.mockResolvedValueOnce({
-      enabled: true,
-      waitingEnabled: true,
-      completedEnabled: false,
-      soundEnabled: false,
-      waitingEscalationEnabled: false,
-      waitingEscalationMinutes: 5,
-    });
+    useNotificationSettingsStore.setState({ hydrated: true, waitingEnabled: true });
 
     renderHook(() => useAgentWaitingNudge(true));
     await act(async () => {});
 
     emitStoreUpdate([{ id: "t1", agentState: "waiting" }]);
     expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("waits for the settings store to hydrate before reading waitingEnabled", async () => {
+    storeState = {
+      panelsById: { t1: { id: "t1", agentState: "waiting" } },
+      panelIds: ["t1"],
+    };
+    // Pre-hydration default is waitingEnabled: true — an eager read here
+    // would wrongly suppress the nudge for a user whose persisted setting
+    // is false.
+    useNotificationSettingsStore.setState({ hydrated: false, waitingEnabled: true });
+
+    renderHook(() => useAgentWaitingNudge(true));
+    await act(async () => {});
+    expect(notifyMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      useNotificationSettingsStore.setState({ hydrated: true, waitingEnabled: false });
+    });
+
+    expect(notifyMock).toHaveBeenCalledOnce();
   });
 
   it("fires on first agent waiting transition when eligible", async () => {

--- a/src/hooks/app/__tests__/useSettingsDialog.test.ts
+++ b/src/hooks/app/__tests__/useSettingsDialog.test.ts
@@ -3,11 +3,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
-vi.mock("@/components/Settings/settingsTabRegistry", () => ({
+vi.mock("@/components/Settings/settingsTabIds", () => ({
   isSettingsTab: (tab: string) => ["general", "code-forge", "appearance"].includes(tab),
 }));
 
+import type { SettingsTab } from "@/components/Settings/settingsTabIds";
 import { useSettingsDialog } from "../useSettingsDialog";
+
+// Stale/fake ids exercised below sit outside the SettingsTab union by design —
+// the hook normalizes or validates them at runtime.
+const asTab = (tab: string) => tab as SettingsTab;
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -18,7 +23,7 @@ describe("useSettingsDialog — forge subtab normalization", () => {
     const { result } = renderHook(() => useSettingsDialog());
 
     act(() => {
-      result.current.handleOpenSettingsTab({ tab: "github" });
+      result.current.handleOpenSettingsTab({ tab: asTab("github") });
     });
 
     expect(result.current.settingsTab).toBe("code-forge");
@@ -61,7 +66,7 @@ describe("useSettingsDialog — forge subtab normalization", () => {
     const { result } = renderHook(() => useSettingsDialog());
 
     act(() => {
-      result.current.handleOpenSettingsTab({ tab: "forge" });
+      result.current.handleOpenSettingsTab({ tab: asTab("forge") });
     });
 
     expect(result.current.settingsTab).toBe("code-forge");
@@ -88,7 +93,7 @@ describe("useSettingsDialog — forge subtab normalization", () => {
     const { result } = renderHook(() => useSettingsDialog());
 
     act(() => {
-      result.current.handleOpenSettingsTab({ tab: "appearance", subtab: "github" });
+      result.current.handleOpenSettingsTab({ tab: asTab("appearance"), subtab: "github" });
     });
 
     expect(result.current.settingsTab).toBe("appearance");

--- a/src/hooks/app/useAgentWaitingNudge.ts
+++ b/src/hooks/app/useAgentWaitingNudge.ts
@@ -2,9 +2,28 @@ import { useEffect, useRef } from "react";
 import { usePanelStore } from "@/store/panelStore";
 import { isPtyPanel } from "@shared/types/panel";
 import { useNotificationStore } from "@/store/notificationStore";
+import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import { getOnboardingState } from "@/clients/onboardingClient";
 import { notify } from "@/lib/notify";
 import { isElectronAvailable } from "../useElectron";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
+
+/**
+ * Resolves once the notification-settings store has hydrated. App kicks
+ * `hydrate()` at mount, so by the time `isStateLoaded` flips this is normally
+ * already settled and the wait is a microtask.
+ */
+function waitForNotificationSettingsHydrated(): Promise<void> {
+  if (useNotificationSettingsStore.getState().hydrated) return Promise.resolve();
+  return new Promise((resolve) => {
+    const unsubscribe = useNotificationSettingsStore.subscribe((state) => {
+      if (state.hydrated) {
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
+}
 
 export function useAgentWaitingNudge(isStateLoaded: boolean): void {
   const removeNotification = useNotificationStore((s) => s.removeNotification);
@@ -70,16 +89,17 @@ export function useAgentWaitingNudge(isStateLoaded: boolean): void {
 
     async function hydrate() {
       try {
-        const [onboarding, notifSettings] = await Promise.all([
-          window.electron.onboarding.get(),
-          window.electron.notification.getSettings(),
-        ]);
-
+        // Shared same-tick onboarding fetch (deduped with the checklist
+        // hook's effect in the same flush); `waitingEnabled` comes from the
+        // settings store hydrated at App mount instead of a duplicate
+        // `notification:getSettings` round-trip.
+        const onboarding = await getOnboardingState();
         if (cancelled) return;
+        if (!onboarding.completed || onboarding.waitingNudgeSeen) return;
 
-        if (!onboarding.completed || onboarding.waitingNudgeSeen || notifSettings.waitingEnabled) {
-          return;
-        }
+        await waitForNotificationSettingsHydrated();
+        if (cancelled) return;
+        if (useNotificationSettingsStore.getState().waitingEnabled) return;
 
         eligibleRef.current = true;
 

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -4,6 +4,7 @@ import { isElectronAvailable } from "../useElectron";
 import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore } from "@/store/panelStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
+import { getOnboardingState } from "@/clients/onboardingClient";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
@@ -136,7 +137,9 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     if (!isElectronAvailable() || !isStateLoaded) return;
     if (!window.electron?.onboarding) return;
 
-    Promise.all([window.electron.onboarding.get(), window.electron.onboarding.getChecklist()])
+    // getOnboardingState shares the same-tick onboarding fetch with
+    // useAgentWaitingNudge's effect in the same flush.
+    Promise.all([getOnboardingState(), window.electron.onboarding.getChecklist()])
       .then(([onboarding, checklistState]) => {
         setOnboardingCompleted(onboarding.completed);
         setChecklist(checklistState);

--- a/src/hooks/app/useSettingsDialog.ts
+++ b/src/hooks/app/useSettingsDialog.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import type { SettingsTab, SettingsNavTarget } from "@/components/Settings";
-import { isSettingsTab } from "@/components/Settings/settingsTabRegistry";
+import { isSettingsTab } from "@/components/Settings/settingsTabIds";
 import { BUILTIN_GITHUB_PROVIDER_ID, normalizeProviderId } from "@shared/utils/forgeProviderIds";
 
 export function useSettingsDialog() {
@@ -18,8 +18,11 @@ export function useSettingsDialog() {
 
   const handleOpenSettingsTab = useCallback((target: SettingsNavTarget) => {
     // TODO(#8329): remove stale-ID normalization after 1 release
+    // Legacy callers can still emit ids outside the SettingsTab union at
+    // runtime; compare through `string` until the normalization window closes.
+    const rawTab: string = target.tab;
     let normalized = target;
-    if (target.tab === "github") {
+    if (rawTab === "github") {
       if (import.meta.env.DEV) {
         console.warn(
           "[useSettingsDialog] stale tab ID 'github' normalized to 'code-forge' — update the call site"
@@ -30,7 +33,7 @@ export function useSettingsDialog() {
         subtab: target.subtab ?? BUILTIN_GITHUB_PROVIDER_ID,
         sectionId: target.sectionId,
       };
-    } else if (target.tab === "forge") {
+    } else if (rawTab === "forge") {
       if (import.meta.env.DEV) {
         console.warn(
           "[useSettingsDialog] stale tab ID 'forge' normalized to 'code-forge' — update the call site"

--- a/src/lib/__tests__/bootPromise.test.ts
+++ b/src/lib/__tests__/bootPromise.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { BootResult } from "@shared/types/ipc/app";
+
+vi.mock("@/utils/performance", () => ({
+  markRendererPerformance: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+const { getBootPromise, releaseBootPayload, resetBootPromiseForTests } =
+  await import("../bootPromise");
+
+function makeBootResult(): BootResult {
+  return {
+    appState: { terminals: [], sidebarWidth: 350 },
+    terminalConfig: { scrollbackLines: 1000 },
+    project: null,
+    agentSettings: { agents: {} },
+    gpuWebGLHardware: true,
+    gpuHardwareAccelerationDisabled: false,
+    gpuAngleFallbackActive: false,
+    safeMode: false,
+    isWindowsStore: false,
+    crashPending: null,
+    crashConfig: { autoRestoreOnCrash: true },
+    tabGroups: [{ id: "g1", location: "grid", activeTabId: "t1", panelIds: ["t1"] }],
+    terminalSizes: { t1: { cols: 80, rows: 24 } },
+    draftInputs: { t1: "secret half-typed draft" },
+  } as unknown as BootResult;
+}
+
+describe("releaseBootPayload", () => {
+  beforeEach(() => {
+    resetBootPromiseForTests();
+    (window as unknown as { electron: unknown }).electron = {
+      app: { boot: vi.fn().mockResolvedValue(makeBootResult()) },
+    };
+  });
+
+  afterEach(() => {
+    resetBootPromiseForTests();
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("nulls the heavy sub-objects including tabGroups/terminalSizes/draftInputs, keeping crash fields", async () => {
+    const result = await getBootPromise();
+    // Settle the annotate() handler so the thenable's `value` field is populated.
+    await Promise.resolve();
+
+    releaseBootPayload();
+
+    expect(result.appState).toBeUndefined();
+    expect(result.terminalConfig).toBeUndefined();
+    expect(result.agentSettings).toBeUndefined();
+    // User draft text must not be retained for the renderer's lifetime.
+    expect(result.draftInputs).toBeUndefined();
+    expect(result.tabGroups).toBeUndefined();
+    expect(result.terminalSizes).toBeUndefined();
+    // Crash fields are still read from the cached payload after hydration.
+    expect(result.crashPending).toBeNull();
+    expect(result.crashConfig).toEqual({ autoRestoreOnCrash: true });
+  });
+});

--- a/src/lib/bootIpcEager.ts
+++ b/src/lib/bootIpcEager.ts
@@ -1,0 +1,14 @@
+// Fire `app:boot` as early as the module graph allows. Importing this module
+// first from `main.tsx` (right after the Trusted Types policy, which must stay
+// first) moves the IPC send ahead of the rest of the entry chunk's body, so
+// the round-trip overlaps that evaluation plus React parse and the first
+// commit; `App` reads the cached promise via `use()` (#8820). Warming the safe
+// wrapper (not just `getBootPromise`) means its derived `.then` chain is also
+// annotated before first render, so `use()` can read it synchronously when the
+// IPC beats React's parse + commit. Production caveat: Rollup hoists
+// cross-chunk static imports, so the entry chunk's vendor imports still
+// evaluate before this inlined body — the fire only moves ahead of the
+// remaining entry-chunk module bodies, not the vendor chunks.
+import { getSafeBootPromise } from "./bootPromise";
+
+void getSafeBootPromise();

--- a/src/lib/bootPromise.ts
+++ b/src/lib/bootPromise.ts
@@ -103,11 +103,13 @@ export function getSafeBootPromise(): Promise<SafeBootResult> {
  * Free the heavy boot payload once hydration has copied it into Zustand. The
  * resolved `BootResult` is reachable for the renderer's life via the cached
  * thenables' `value` fields (React `use()` reads them synchronously), so its
- * large sub-objects (`appState`, `terminalConfig`, `agentSettings`) would
- * otherwise leak forever. The promise references themselves stay stable — only
- * the consumed sub-fields are nulled. The crash fields (`crashPending`,
- * `crashConfig`) are intentionally left intact: they are still read from the
- * cached payload after hydration. Call exactly once, after hydration settles.
+ * large sub-objects (`appState`, `terminalConfig`, `agentSettings`, and the
+ * per-project `tabGroups`/`terminalSizes`/`draftInputs` — the latter holding
+ * user-typed draft text) would otherwise leak forever. The promise references
+ * themselves stay stable — only the consumed sub-fields are nulled. The crash
+ * fields (`crashPending`, `crashConfig`) are intentionally left intact: they
+ * are still read from the cached payload after hydration. Call exactly once,
+ * after hydration settles.
  */
 export function releaseBootPayload(): void {
   const releaseFrom = (result: BootResult | undefined): void => {
@@ -115,6 +117,9 @@ export function releaseBootPayload(): void {
     result.appState = undefined as unknown as BootResult["appState"];
     result.terminalConfig = undefined as unknown as BootResult["terminalConfig"];
     result.agentSettings = undefined as unknown as BootResult["agentSettings"];
+    result.tabGroups = undefined;
+    result.terminalSizes = undefined;
+    result.draftInputs = undefined;
   };
 
   releaseFrom((bootPromise as ReactThenable<BootResult> | null)?.value);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,10 @@
 // a Portal throws.
 import "./lib/trustedTypesPolicy";
 
+// Fires the `app:boot` IPC at the top of entry-graph evaluation — see the
+// module comment for ordering semantics (#8820).
+import "./lib/bootIpcEager";
+
 import { initBuiltInPanelKinds } from "./panels/registry";
 initBuiltInPanelKinds();
 
@@ -32,15 +36,6 @@ import {
   onRecoverableError,
 } from "./utils/reactRootErrorCallbacks";
 import { WorktreeStoreProvider } from "./contexts/WorktreeStoreContext";
-import { getSafeBootPromise } from "./lib/bootPromise";
-
-// Fire `app:boot` at module-eval time, before `bootstrap()` imports App and
-// calls `createRoot`. The IPC round-trip then overlaps React parse and the
-// first commit; `App` reads the cached promise via `use()` (#8820). Warming the
-// safe wrapper (not just `getBootPromise`) means its derived `.then` chain is
-// also annotated before first render, so `use()` can read it synchronously when
-// the IPC beats React's parse + commit.
-void getSafeBootPromise();
 
 let cleanupGlobalErrorHandlers: (() => void) | undefined;
 let cleanupOrchestrator: (() => void) | undefined;

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 import { BUILT_IN_AGENT_IDS, BUILT_IN_TERMINAL_TYPES } from "@shared/config/agentIds";
+import {
+  GLOBAL_SETTINGS_TAB_IDS,
+  PROJECT_SETTINGS_TAB_IDS,
+} from "@/components/Settings/settingsTabIds";
 
 export const AgentIdSchema = z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser", "dev-preview"]);
 
@@ -25,32 +29,16 @@ export const TerminalSpawnSourceSchema = z.enum(["quickrun", "recipe", "agent", 
  */
 export const AddPanelFocusPolicySchema = z.enum(["auto", "preserve", "take"]);
 
+// Derived from the settingsTabIds tuples so the action schema can't drift from
+// the registry (the previous hand-written enum was missing plugins,
+// plugin-actions, and run-history). The legacy aliases stay accepted because
+// ActionService validates argsSchema BEFORE dispatch reaches the handler —
+// useSettingsDialog normalizes them to "code-forge" (TODO #8329).
 export const SettingsTabSchema = z.enum([
-  "general",
-  "keyboard",
-  "terminal",
-  "terminalAppearance",
-  "worktree",
-  "agents",
-  "assistant",
-  "code-forge",
-  "portal",
-  "toolbar",
-  "integrations",
-  "notifications",
-  "voice",
-  "mcp",
-  "environment",
-  "privacy",
-  "troubleshooting",
-  "project:general",
-  "project:context",
-  "project:variables",
-  "project:automation",
-  "project:recipes",
-  "project:commands",
-  "project:notifications",
-  "project:code-forge",
+  ...GLOBAL_SETTINGS_TAB_IDS,
+  ...PROJECT_SETTINGS_TAB_IDS,
+  "github",
+  "forge",
 ]);
 
 export const SettingsNavTargetSchema = z.object({

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -2,7 +2,7 @@ import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { defineAction } from "../defineAction";
 import { z } from "zod";
 import type { ActionContext } from "@shared/types/actions";
-// eslint-disable-next-line no-restricted-imports
+
 import { worktreeClient, copyTreeClient, forgeClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
 import { useRecipeStore } from "@/store/recipeStore";

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -12,7 +12,13 @@ const registryMock = vi.hoisted(() => ({
   getEffectiveAgentIds: vi.fn(() => ["claude", "codex"]),
 }));
 
+const bootMock = vi.hoisted(() => ({
+  getSafeBootPromise: vi.fn(async () => ({ ok: false as const, error: new Error("no boot") })),
+}));
+
 vi.mock("@/clients", () => ({ agentSettingsClient: clientMock }));
+
+vi.mock("@/lib/bootPromise", () => ({ getSafeBootPromise: bootMock.getSafeBootPromise }));
 
 vi.mock("../../../shared/config/agentRegistry", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../shared/config/agentRegistry")>();
@@ -90,7 +96,10 @@ describe("agentSettingsStore adversarial", () => {
     const p1 = useAgentSettingsStore.getState().initialize();
     const p2 = useAgentSettingsStore.getState().initialize();
 
-    expect(clientMock.get).toHaveBeenCalledTimes(1);
+    // initialize() consults the boot payload before the live client, so the
+    // client fetch lands a few microtasks in — wait for it before asserting
+    // the dedupe.
+    await vi.waitFor(() => expect(clientMock.get).toHaveBeenCalledTimes(1));
 
     resolveGet({ agents: { claude: { pinned: true, enabled: true, flags: {} } } });
     await Promise.all([p1, p2]);
@@ -665,6 +674,58 @@ describe("agentSettingsStore adversarial", () => {
     expect(state.settings?.agents.claude?.pinned).toBeUndefined();
   });
 
+  it("initialize seeds from the boot payload without a live client fetch", async () => {
+    registryMock.getEffectiveAgentIds.mockReturnValue(["claude", "codex"]);
+    bootMock.getSafeBootPromise.mockResolvedValueOnce({
+      ok: true,
+      result: {
+        agentSettings: {
+          settingsVersion: 1,
+          agents: {
+            claude: { pinned: true, customFlags: "--from-boot" },
+            codex: { pinned: false, customFlags: "" },
+          },
+        },
+      },
+    } as never);
+
+    await useAgentSettingsStore.getState().initialize();
+
+    expect(clientMock.get).not.toHaveBeenCalled();
+    const state = useAgentSettingsStore.getState();
+    expect(state.isInitialized).toBe(true);
+    expect(state.settings?.agents.claude?.customFlags).toBe("--from-boot");
+  });
+
+  it("initialize falls back to the live client when the boot payload failed", async () => {
+    bootMock.getSafeBootPromise.mockResolvedValueOnce({
+      ok: false,
+      error: new Error("boot IPC down"),
+    } as never);
+    clientMock.get.mockResolvedValue({ settingsVersion: 1, agents: {} });
+
+    await useAgentSettingsStore.getState().initialize();
+
+    expect(clientMock.get).toHaveBeenCalledTimes(1);
+    expect(useAgentSettingsStore.getState().isInitialized).toBe(true);
+  });
+
+  it("initialize falls back to the live client when the boot payload was released", async () => {
+    // `releaseBootPayload()` nulls `agentSettings` after hydration — a
+    // re-initialize after cleanup must hit the live client, not crash on the
+    // released field.
+    bootMock.getSafeBootPromise.mockResolvedValueOnce({
+      ok: true,
+      result: { agentSettings: undefined },
+    } as never);
+    clientMock.get.mockResolvedValue({ settingsVersion: 1, agents: {} });
+
+    await useAgentSettingsStore.getState().initialize();
+
+    expect(clientMock.get).toHaveBeenCalledTimes(1);
+    expect(useAgentSettingsStore.getState().isInitialized).toBe(true);
+  });
+
   it("initialize after a concurrent refresh flips isInitialized even when the result is stale", async () => {
     registryMock.getEffectiveAgentIds.mockReturnValue(["claude"]);
     setAvailability({ claude: "ready" }, true);
@@ -679,9 +740,12 @@ describe("agentSettingsStore adversarial", () => {
       )
       .mockResolvedValueOnce({ agents: { claude: { pinned: false } } });
 
-    // Kick off init; it holds initPromise. While in-flight, another caller
-    // triggers a refresh (bumping the epoch and invalidating init).
+    // Kick off init; it holds initPromise. Wait for it to reach the client
+    // (it consults the boot payload first) so the mocked `get` order below
+    // stays init-then-refresh. While in-flight, another caller triggers a
+    // refresh (bumping the epoch and invalidating init).
     const initPending = useAgentSettingsStore.getState().initialize();
+    await vi.waitFor(() => expect(clientMock.get).toHaveBeenCalledTimes(1));
     useAgentSettingsStore.setState({ isInitialized: false, isLoading: true });
     const concurrent = useAgentSettingsStore.getState().refresh();
     await concurrent;

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { AgentSettings, AgentSettingsEntry, CliAvailability } from "@shared/types";
 import { agentSettingsClient } from "@/clients";
+import { getSafeBootPromise } from "@/lib/bootPromise";
 import { DEFAULT_AGENT_SETTINGS } from "@shared/types";
 import { getEffectiveAgentIds } from "../../shared/config/agentRegistry";
 import { BUILT_IN_AGENT_IDS } from "../../shared/config/agentIds";
@@ -265,7 +266,21 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       try {
         set({ isLoading: true, error: null });
 
-        const raw = (await agentSettingsClient.get()) ?? DEFAULT_AGENT_SETTINGS;
+        // Seed from the in-flight `app:boot` payload instead of firing a
+        // duplicate `agentSettings:get` round-trip — the payload carries the
+        // same `store.get("agentSettings")` snapshot. BootResult types
+        // `agentSettings` as non-optional, but `releaseBootPayload()` nulls it
+        // at runtime after hydration — treat it as possibly undefined. The
+        // live-IPC fallback intentionally covers three cases: boot failure
+        // ({ ok: false }), a re-initialize after `releaseBootPayload()`, and
+        // fresh installs where the persisted store has no `agentSettings` key
+        // (the payload field is undefined, so the fallback IPC fires — same
+        // cost as the old path, not a regression).
+        const boot = await getSafeBootPromise();
+        const fromBoot = boot.ok
+          ? (boot.result.agentSettings as AgentSettings | undefined)
+          : undefined;
+        const raw = fromBoot ?? (await agentSettingsClient.get()) ?? DEFAULT_AGENT_SETTINGS;
         if (myEpoch !== normalizeEpoch) {
           // A concurrent refresh/update bumped the epoch — its result is
           // authoritative. Flip `isInitialized` anyway so the store exits the

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -3057,6 +3057,90 @@ describe("hydrateAppState", () => {
     });
   });
 
+  describe("per-project layout payload folding", () => {
+    const baseOptions = () => ({
+      addPanel: vi.fn().mockResolvedValue("panel-1"),
+      setActiveWorktree: vi.fn(),
+      loadRecipes: vi.fn().mockResolvedValue(undefined),
+      openDiagnosticsDock: vi.fn(),
+    });
+
+    it("uses tabGroups/terminalSizes/draftInputs from the hydrate payload and skips the standalone IPC calls", async () => {
+      const payloadTabGroups = [
+        {
+          id: "group-payload",
+          location: "grid",
+          activeTabId: "terminal-1",
+          panelIds: ["terminal-1"],
+        },
+      ];
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        tabGroups: payloadTabGroups,
+        terminalSizes: { "terminal-1": { cols: 100, rows: 30 } },
+        draftInputs: { "terminal-1": "payload draft" },
+      });
+
+      const hydrateTabGroups = vi.fn();
+      await hydrateAppState({ ...baseOptions(), hydrateTabGroups });
+
+      expect(projectClientMock.getTabGroups).not.toHaveBeenCalled();
+      expect(projectClientMock.getTerminalSizes).not.toHaveBeenCalled();
+      expect(projectClientMock.getDraftInputs).not.toHaveBeenCalled();
+      expect(hydrateTabGroups).toHaveBeenCalledWith(payloadTabGroups);
+
+      const { useTerminalInputStore } = await import("@/store/terminalInputStore");
+      expect(useTerminalInputStore.getState().draftInputs.get("project-1:terminal-1")).toBe(
+        "payload draft"
+      );
+    });
+
+    it("falls back to the standalone IPC calls when the payload fields are absent", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        // tabGroups/terminalSizes/draftInputs intentionally omitted (older
+        // main process, or the safe-boot {ok:false} payload).
+      });
+
+      const hydrateTabGroups = vi.fn();
+      await hydrateAppState({ ...baseOptions(), hydrateTabGroups });
+
+      expect(projectClientMock.getTabGroups).toHaveBeenCalledWith("project-1");
+      expect(projectClientMock.getTerminalSizes).toHaveBeenCalledWith("project-1");
+      expect(projectClientMock.getDraftInputs).toHaveBeenCalledWith("project-1");
+    });
+
+    it("treats empty payload fields as authoritative (no IPC fallback, stale groups cleared)", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        tabGroups: [],
+        terminalSizes: {},
+        draftInputs: {},
+      });
+
+      const hydrateTabGroups = vi.fn();
+      await hydrateAppState({ ...baseOptions(), hydrateTabGroups });
+
+      expect(projectClientMock.getTabGroups).not.toHaveBeenCalled();
+      expect(projectClientMock.getTerminalSizes).not.toHaveBeenCalled();
+      expect(projectClientMock.getDraftInputs).not.toHaveBeenCalled();
+      // Empty array still clears stale groups (mirrors the IPC path).
+      expect(hydrateTabGroups).toHaveBeenCalledWith([]);
+    });
+  });
+
   describe("system temp dir folding", () => {
     const baseOptions = () => ({
       addPanel: vi.fn().mockResolvedValue("panel-1"),

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -235,38 +235,48 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
       return null;
     });
 
+    // Each of these rides along in the batched hydrate payload when the main
+    // process is new enough; the standalone IPC calls only fire as a fallback
+    // when the field is absent (older main process, or the safe-boot
+    // {ok:false} payload). Mirrors the systemTmpDir fallback above.
     const tabGroupsPromise =
       currentProjectId && options.hydrateTabGroups
-        ? projectClient
-            .getTabGroups(currentProjectId)
-            .then((tabGroups) => tabGroups ?? [])
-            .catch((error) => {
-              logWarn("Failed to prefetch tab groups", { error });
-              return null;
-            })
+        ? hydrateResult.tabGroups !== undefined
+          ? Promise.resolve(hydrateResult.tabGroups)
+          : projectClient
+              .getTabGroups(currentProjectId)
+              .then((tabGroups) => tabGroups ?? [])
+              .catch((error) => {
+                logWarn("Failed to prefetch tab groups", { error });
+                return null;
+              })
         : null;
 
     type TerminalSizeMap = Record<string, { cols: number; rows: number }>;
     const emptyTerminalSizes: TerminalSizeMap = {};
     const terminalSizesPromise: Promise<TerminalSizeMap> = currentProjectId
-      ? projectClient
-          .getTerminalSizes(currentProjectId)
-          .then((sizes) => sizes ?? emptyTerminalSizes)
-          .catch((error) => {
-            logWarn("Failed to prefetch terminal sizes", { error });
-            return emptyTerminalSizes;
-          })
+      ? hydrateResult.terminalSizes !== undefined
+        ? Promise.resolve(hydrateResult.terminalSizes)
+        : projectClient
+            .getTerminalSizes(currentProjectId)
+            .then((sizes) => sizes ?? emptyTerminalSizes)
+            .catch((error) => {
+              logWarn("Failed to prefetch terminal sizes", { error });
+              return emptyTerminalSizes;
+            })
       : Promise.resolve(emptyTerminalSizes);
 
     const emptyDraftInputs: Record<string, string> = {};
     const draftInputsPromise: Promise<Record<string, string>> = currentProjectId
-      ? projectClient
-          .getDraftInputs(currentProjectId)
-          .then((drafts) => drafts ?? emptyDraftInputs)
-          .catch((error) => {
-            logWarn("Failed to prefetch draft inputs", { error });
-            return emptyDraftInputs;
-          })
+      ? hydrateResult.draftInputs !== undefined
+        ? Promise.resolve(hydrateResult.draftInputs)
+        : projectClient
+            .getDraftInputs(currentProjectId)
+            .then((drafts) => drafts ?? emptyDraftInputs)
+            .catch((error) => {
+              logWarn("Failed to prefetch draft inputs", { error });
+              return emptyDraftInputs;
+            })
       : Promise.resolve(emptyDraftInputs);
 
     const emptyProjectPresets: Record<string, AgentPreset[]> = {};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -533,6 +533,86 @@ function chunkModulesPlugin(): Plugin {
   };
 }
 
+// Prepends the V8 explicit-compile-hints magic comment (Chrome >=136; we ship
+// Chromium 148) to a curated set of boot-hot chunks so V8 eagerly compiles all
+// their functions in one background pass instead of lazily re-parsing each
+// function at first call during boot. Biggest win on a cold app:// code cache
+// (first launch, post-update). Curated on purpose, per V8 guidance to annotate
+// only files where most functions actually run on load: the entry chunk, the
+// App chunk, vendor-react, vendor-xterm, TerminalInstanceService, and
+// appThemeStore. Everything else — explicitly including vendor-editor (~451KB
+// of CodeMirror that is mostly uncalled at boot) and palette/settings/
+// per-language chunks — is excluded to avoid wasted background compile and
+// bytecode memory. Expand to the full first-render closure only if cold-cache
+// perf samples confirm a win.
+//
+// Must run in generateBundle (NOT renderChunk, NOT the `banner` option):
+// rolldown's native oxc minifier runs after renderChunk and would strip or
+// displace the comment, and V8 only honors it on line 1. generateBundle runs
+// post-minify, so the comment lands as the first line of the emitted file.
+//
+// The raw prepend is sourcemap-unsafe (it shifts every line by one without
+// adjusting mappings). Acceptable here because production maps are not
+// shipped — build.sourcemap is false in this config. If sourcemaps are ever
+// enabled, this must move to a magic-string-based edit that remaps.
+function compileHintsPlugin(): Plugin {
+  const COMPILE_HINT = "//# allFunctionsCalledOnLoad\n";
+  // Stable codeSplitting group / facade-derived chunk names.
+  const hintedChunkNames = new Set([
+    "vendor-react",
+    "vendor-xterm",
+    "TerminalInstanceService",
+    "appThemeStore",
+  ]);
+  // Fallback for chunks whose name could drift: match the facade module.
+  const hintedFacadeSuffixes = [
+    "src/App.tsx",
+    "src/services/TerminalInstanceService.ts",
+    "src/store/appThemeStore.ts",
+  ];
+
+  const isHinted = (chunk: {
+    isEntry: boolean;
+    name: string;
+    facadeModuleId?: string | null;
+  }): boolean => {
+    const facade = chunk.facadeModuleId?.split(path.sep).join("/");
+    return (
+      chunk.isEntry ||
+      hintedChunkNames.has(chunk.name) ||
+      (facade != null && hintedFacadeSuffixes.some((suffix) => facade.endsWith(suffix)))
+    );
+  };
+
+  return {
+    name: "v8-compile-hints",
+    apply: "build",
+    // generateBundle mutations happen after [hash] placeholders are resolved,
+    // so the prepended hint would not by itself change a chunk's filename.
+    // Folding the hint into the hash here keeps hinted-set/comment changes
+    // cache-correct for any consumer keyed on the chunk URL.
+    augmentChunkHash(chunk) {
+      return isHinted(chunk) ? COMPILE_HINT : undefined;
+    },
+    // `order: "post"` is required: vite:build-import-analysis also mutates
+    // chunk code in generateBundle (prepending the `__vite__mapDeps` const to
+    // chunks with dynamic imports), and it runs after default-order hooks. A
+    // default-order hook here left the hint on line 2 for the entry/App/
+    // TerminalInstanceService chunks, where V8 ignores it.
+    generateBundle: {
+      order: "post",
+      handler(_options, bundle) {
+        for (const output of Object.values(bundle)) {
+          if (output.type !== "chunk") continue;
+          if (isHinted(output) && !output.code.startsWith(COMPILE_HINT)) {
+            output.code = COMPILE_HINT + output.code;
+          }
+        }
+      },
+    },
+  };
+}
+
 // Minimal view of a Rolldown OutputChunk passed to the preload helper. The
 // bundle's `imports[]` / `dynamicImports[]` hold output FILE NAMES (other bundle
 // keys), not the source-path keys the manifest uses — these are JS getters on
@@ -703,6 +783,7 @@ export default defineConfig(({ command, mode }) => {
       latin400FontPreloadPlugin(),
       firstRenderModulePreloadPlugin(),
       chunkModulesPlugin(),
+      compileHintsPlugin(),
       xtermMinifyIdentifiersGuardPlugin(),
       ...(process.env.ANALYZE === "true"
         ? [visualizer({ filename: "stats.html", gzipSize: true, brotliSize: true }) as Plugin]
@@ -736,6 +817,20 @@ export default defineConfig(({ command, mode }) => {
         output: {
           codeSplitting: {
             groups: [
+              {
+                // Top priority on purpose: this must exceed every group whose
+                // captured packages depend on React, because rolldown
+                // advancedChunks groups capture their modules' dependency
+                // closure unless a higher-priority group claims them first. At
+                // priority 15, react/index.js + react/jsx-runtime.js were
+                // captured into vendor-editor (priority 60), dragging the whole
+                // CodeMirror runtime into the entry's eager static closure.
+                // Any future group added above 80 must not match React-dependent
+                // packages, or react core leaks back into that group's chunk.
+                name: "vendor-react",
+                test: /node_modules[\\/](react|react-dom|scheduler|use-sync-external-store)[\\/]/,
+                priority: 80,
+              },
               {
                 name: "vendor-xterm-webgl",
                 test: /node_modules[\\/]@xterm[\\/]addon-webgl[\\/]/,
@@ -786,11 +881,6 @@ export default defineConfig(({ command, mode }) => {
                 priority: 20,
               },
               {
-                name: "vendor-react",
-                test: /node_modules[\\/](react|react-dom|scheduler|use-sync-external-store)[\\/]/,
-                priority: 15,
-              },
-              {
                 // Shared Radix utility deps used by both the eager primitives
                 // (slot/checkbox/switch) and the deferred overlay primitives.
                 // Splitting these out of `vendor-radix-overlay` prevents the
@@ -821,11 +911,16 @@ export default defineConfig(({ command, mode }) => {
                 // parser packages so each per-language parser (and its
                 // grammar dependency) stays in its own async chunk instead
                 // of being swept into this catch-all (which is part of the
-                // eager closure). `@lezer/common`, `@lezer/lr`, and
-                // `@lezer/highlight` stay in this `vendor` group because
-                // `@codemirror/language` depends on them eagerly.
+                // eager closure). `@lezer/common` and `@lezer/highlight` are
+                // allowed here as @codemirror/language deps (in practice the
+                // vendor-editor closure capture claims them). `@lezer/lr` is
+                // deliberately NOT allowed: its only importers are the lazy
+                // per-language parser chunks, and pinning it into this eager
+                // chunk made `vendor` statically import vendor-editor (via
+                // @lezer/lr -> @lezer/common), dragging CodeMirror back into
+                // the entry's eager closure after the vendor-react pin.
                 name: "vendor",
-                test: /node_modules[\\/](?!(refractor[\\/]lang[\\/]|@codemirror[\\/](lang-|legacy-modes)|@lezer[\\/](?!(common|lr|highlight)[\\/])))/,
+                test: /node_modules[\\/](?!(refractor[\\/]lang[\\/]|@codemirror[\\/](lang-|legacy-modes)|@lezer[\\/](?!(common|highlight)[\\/])))/,
                 priority: 10,
               },
             ],


### PR DESCRIPTION
This is a large cold-start performance branch. It came out of a multi-agent audit of the entire boot path, which surfaced 46 candidate optimizations and adversarially verified 30 of them; this PR implements roughly 25 after merging duplicates.

The headline numbers:

- Main process now boots with 994 eagerly loaded modules, down from 1318 (-24.6%).
- Renderer eager JS drops from 850KB gzip to 699KB gzip (-17.8%).

### Notable changes

- React core was incorrectly grouped into the editor vendor chunk, which meant 450KB of CodeMirror was being dragged onto every single boot. It's now pinned into `vendor-react` at top priority.
- The window now reveals as soon as a tiny classic script signals that the HTML skeleton has parsed, rather than waiting for `dom-ready` (which for a module entry only fires after the entire bundle evaluates). The `dom-ready` show and 5s fallback remain as backstops.
- Added V8 explicit compile hints (`//# allFunctionsCalledOnLoad`) to six boot-hot chunks, and set `v8CacheOptions` to `bypassHeatCheck` in packaged builds so launch 2 after an install/update is already cache-warm.
- Moved `electron-updater` (155 modules), `archiver` (97), and `ws` (24) to dynamic imports.
- Moved the app menu build and the watchdog fork off the pre-renderer-load path, and reordered the deferred-task drain into cheap, telemetry, then heavy groups so Sentry/updater/plugin evals stop front-loading right after first-interactive.
- The hydrate payload now carries tab groups, terminal sizes, and draft inputs, removing three IPC round-trips from the hydration window. A new `app_hydrate_prefetch` perf mark proves whether the boot-prime prefetch actually wins the race.
- Moved the MCP audit and turn-outcome rings out of `config.json` into their own lazily-constructed `audit-logs` store, with a schema v22 migration. Bootstrap reads and backs up `config.json` synchronously before `main.js` loads, so boot cost was scaling with audit volume.

A second-pass review caught a tree-shaking bug where the early boot IPC module was silently dropped from the production bundle (missing `sideEffects` entry), plus a command-registration race and a migration durability hole. All fixed in this branch.

Full typecheck and all guards pass, the entire 33,000-test unit suite is green, and all budget baselines have been regenerated. The remaining step is a packaged `perf:cold-start` run to put real-world timing numbers against these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)