### PR TITLE
fix(github): stop the toolbar PR count badge oscillating back to stale counts

### DIFF
--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -69,6 +69,8 @@ function buildForgeRepositoryStats(
     error: counts.error,
     stale: counts.stale,
     lastUpdated: counts.lastUpdated,
+    issueCountRefreshedAt: counts.issueCountRefreshedAt,
+    prCountRefreshedAt: counts.prCountRefreshedAt,
     rateLimitResetAt: counts.rateLimitResetAt,
     rateLimitKind: counts.rateLimitKind,
     nextPollIntervalMs: counts.nextPollIntervalMs,

--- a/plugins/builtin/github/main/GitHubCaches.ts
+++ b/plugins/builtin/github/main/GitHubCaches.ts
@@ -189,6 +189,17 @@ export function getETagCacheVersion(): number {
 }
 
 /**
+ * Invalidate the ETag baselines of any in-flight conditional fetch. Bumped by
+ * the cache-clear paths below and by `updateRepoStatsCount` when a list
+ * query's observed total disagrees with a stored count baseline — without the
+ * bump, a `fetchRestCounts` already past its cache read could 304-recommit
+ * the just-invalidated counts and resurrect the stale value.
+ */
+export function bumpETagCacheVersion(): void {
+  etagCacheVersion++;
+}
+
+/**
  * Per-repo, per-type list-cache epochs for the count-as-cache-buster
  * (#10122 family). Bumped by {@link invalidateRepoListCachesForCountChange}
  * when the cheap REST count poll observes a changed open count. List fetchers

--- a/plugins/builtin/github/main/GitHubPRs.ts
+++ b/plugins/builtin/github/main/GitHubPRs.ts
@@ -14,6 +14,9 @@ import { parseGitHubError } from "./GitHubErrors.js";
 import { withRepoContextRetry } from "./GitHubRepoContext.js";
 import {
   repoStatsCache,
+  repoStatsAndPageSnapshotCache,
+  restCountsCache,
+  bumpETagCacheVersion,
   prListCache,
   prTooltipCache,
   prTooltipWrittenAt,
@@ -55,16 +58,23 @@ export function buildListCacheKey(
 }
 
 export function updateRepoStatsCount(cacheKey: string, type: "issue" | "pr", count: number): void {
+  const now = Date.now();
   const cached = repoStatsCache.get(cacheKey);
+  // Stamp only the updated kind's refreshed-at: a PR list write-back says
+  // nothing about the issue count, and a shared stamp would make a stale
+  // issue count look freshly read — outranking a real issue-list observation
+  // in the renderer arbitration and suppressing its dropdown-open refresh.
   if (cached) {
     const updated: RepoStats = {
       ...cached,
-      lastUpdated: Date.now(),
+      lastUpdated: now,
     };
     if (type === "issue") {
       updated.issueCount = count;
+      updated.issueCountRefreshedAt = now;
     } else {
       updated.prCount = count;
+      updated.prCountRefreshedAt = now;
     }
     repoStatsCache.set(cacheKey, updated);
   } else {
@@ -74,9 +84,49 @@ export function updateRepoStatsCount(cacheKey: string, type: "issue" | "pr", cou
     const newStats: RepoStats = {
       issueCount: type === "issue" ? count : (diskCached?.issueCount ?? 0),
       prCount: type === "pr" ? count : (diskCached?.prCount ?? 0),
-      lastUpdated: Date.now(),
+      lastUpdated: now,
     };
+    if (type === "issue") {
+      newStats.issueCountRefreshedAt = now;
+    } else {
+      newStats.prCountRefreshedAt = now;
+    }
     repoStatsCache.set(cacheKey, newStats);
+  }
+
+  // A list query's `totalCount` is a direct GitHub observation. The background
+  // poll keeps re-serving `repoStatsAndPageSnapshotCache` (10 min TTL) and
+  // `restCountsCache` (1 h TTL) for as long as the `/events` probe reports no
+  // change, so a disagreeing entry must drop here — otherwise the next poll
+  // resurrects the stale count (rolling the toolbar badge back) until the
+  // entry's own TTL expires. A disagreeing snapshot's first-page items are
+  // stale by the same evidence, so the whole entry goes, and dropping the
+  // REST entry discards its ETag baselines, forcing the next count poll to an
+  // unconditional re-read instead of a 304 replay of the stale value.
+  let droppedBaseline = false;
+  const snapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
+  if (snapshot) {
+    const snapshotCount = type === "issue" ? snapshot.stats.issueCount : snapshot.stats.prCount;
+    if (snapshotCount !== count) {
+      repoStatsAndPageSnapshotCache.invalidate(cacheKey);
+      droppedBaseline = true;
+    }
+  }
+  const restCounts = restCountsCache.get(cacheKey);
+  if (restCounts) {
+    const restCount =
+      type === "issue" ? restCounts.combinedCount - restCounts.prCount : restCounts.prCount;
+    if (restCount !== count) {
+      restCountsCache.invalidate(cacheKey);
+      droppedBaseline = true;
+    }
+  }
+  // Defend the invalidation against in-flight conditional fetches: a
+  // `fetchRestCounts` that read its baseline before the drop would otherwise
+  // 304-recommit the stale counts. The version bump makes its pre-commit
+  // check discard the result, so the next poll re-reads unconditionally.
+  if (droppedBaseline) {
+    bumpETagCacheVersion();
   }
 }
 

--- a/plugins/builtin/github/main/GitHubStats.ts
+++ b/plugins/builtin/github/main/GitHubStats.ts
@@ -368,7 +368,16 @@ async function fetchRestCountsImpl(
       });
     }
 
-    return { issueCount, prCount, lastUpdated };
+    // The refreshed-at stamps match `lastUpdated` here even on a 304 replay:
+    // a 304 is a direct GitHub confirmation that the count endpoint's content
+    // is unchanged, so the counts were genuinely re-verified now.
+    return {
+      issueCount,
+      prCount,
+      lastUpdated,
+      issueCountRefreshedAt: lastUpdated,
+      prCountRefreshedAt: lastUpdated,
+    };
   } catch {
     return null;
   }
@@ -488,28 +497,34 @@ export async function getRepoStatsAndPageForContext(
   } else {
     const token = GitHubAuth.getToken();
     if (token) {
-      const preProbeSnapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
+      const hadCountBaseline =
+        repoStatsAndPageSnapshotCache.get(cacheKey) !== undefined ||
+        restCountsCache.get(cacheKey) !== undefined;
       // Skip the network probe entirely while inside the adaptive window: never
       // poll `/events` faster than the server-advertised `X-Poll-Interval`, and
       // back off further on an idle repo. The cached snapshot (or, on the
       // background-only path, the last REST counts) stands in for the
       // "unchanged" result we'd otherwise pay a request to confirm.
       const withinBackoff =
-        (preProbeSnapshot !== undefined || restCountsCache.get(cacheKey) !== undefined) &&
+        hadCountBaseline &&
         Date.now() - (repoEventsLastProbeAt.get(cacheKey) ?? 0) < eventsProbeDelayMs(cacheKey);
       const probe: ActivityProbeResult = withinBackoff
         ? { status: "unchanged" }
         : await fetchActivityProbe(token, context.owner, context.repo);
 
+      // Read the count baselines only AFTER the probe await — two independent
+      // concurrent mutations can land during it: (1) a list query's write-back
+      // (`updateRepoStatsCount`) may have reconciled a stale snapshot/REST
+      // entry away, and (2) a concurrent poll's count-buster can drop the
+      // snapshot mid-probe. Serving a pre-await capture would resurrect the
+      // just-invalidated counts or re-warm the list caches from pages the bust
+      // already removed.
+      const snapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
+      const restCounts = restCountsCache.get(cacheKey);
+
       if (probe.status === "changed") {
         pendingEventsEtag = probe.etag;
       }
-
-      // Re-read AFTER the probe await: a concurrent poll's count-buster can
-      // drop the snapshot mid-probe, and re-warming the list caches from the
-      // pre-await reference would resurrect the exact pages the bust removed.
-      const snapshot = repoStatsAndPageSnapshotCache.get(cacheKey);
-      const restCounts = restCountsCache.get(cacheKey);
 
       if (probe.status === "unchanged" && snapshot) {
         // The cheap REST poll may have observed fresher counts after this
@@ -518,13 +533,28 @@ export async function getRepoStatsAndPageForContext(
         // so an unchanged probe can't roll the pill back to pre-REST counts.
         const restCountsFresher =
           restCounts !== undefined && restCounts.lastUpdated >= (snapshot.stats.lastUpdated ?? 0);
+        // `lastUpdated` is re-stamped to now — the probe just confirmed the
+        // data is still current, and the freshness pill keys off it. The
+        // per-count refreshed-at stamps are NOT: the counts themselves were
+        // last read at the source's commit time, and claiming otherwise lets
+        // a stale cached count outrank a fresher dropdown-observed total in
+        // the renderer's recency arbitration (and permanently suppress the
+        // dropdown-open force refresh).
         const freshStats: RepoStats = restCountsFresher
           ? {
               issueCount: restCounts.combinedCount - restCounts.prCount,
               prCount: restCounts.prCount,
               lastUpdated: Date.now(),
+              issueCountRefreshedAt: restCounts.lastUpdated,
+              prCountRefreshedAt: restCounts.lastUpdated,
             }
-          : { ...snapshot.stats, lastUpdated: Date.now() };
+          : {
+              ...snapshot.stats,
+              lastUpdated: Date.now(),
+              issueCountRefreshedAt:
+                snapshot.stats.issueCountRefreshedAt ?? snapshot.stats.lastUpdated,
+              prCountRefreshedAt: snapshot.stats.prCountRefreshedAt ?? snapshot.stats.lastUpdated,
+            };
         repoStatsCache.set(cacheKey, freshStats);
         issueListCache.set(issuesListCacheKey, {
           items: snapshot.issues.items,
@@ -573,6 +603,8 @@ export async function getRepoStatsAndPageForContext(
           issueCount: restCounts.combinedCount - restCounts.prCount,
           prCount: restCounts.prCount,
           lastUpdated: Date.now(),
+          issueCountRefreshedAt: restCounts.lastUpdated,
+          prCountRefreshedAt: restCounts.lastUpdated,
         };
         repoStatsCache.set(cacheKey, freshStats);
         persistentCache.set(cacheKey, freshStats, projectPath);
@@ -718,10 +750,13 @@ export async function getRepoStatsAndPageForContext(
 
     const issueCount = issuesData?.totalCount ?? 0;
     const prCount = prsData?.totalCount ?? 0;
+    const fetchedAt = Date.now();
     const stats: RepoStats = {
       issueCount,
       prCount,
-      lastUpdated: Date.now(),
+      lastUpdated: fetchedAt,
+      issueCountRefreshedAt: fetchedAt,
+      prCountRefreshedAt: fetchedAt,
     };
 
     repoStatsCache.set(cacheKey, stats);
@@ -947,6 +982,8 @@ export async function getRepoStatsComplete(
       ghError: statsResult.error,
       stale: statsResult.stats?.stale,
       lastUpdated: statsResult.stats?.lastUpdated,
+      issueCountRefreshedAt: statsResult.stats?.issueCountRefreshedAt,
+      prCountRefreshedAt: statsResult.stats?.prCountRefreshedAt,
       rateLimitResetAt:
         rateLimitState.blocked && rateLimitState.resetAt ? rateLimitState.resetAt : undefined,
       rateLimitKind: rateLimitState.blocked ? (rateLimitState.kind ?? undefined) : undefined,

--- a/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubPRs.test.ts
@@ -39,8 +39,14 @@ vi.mock("../GitHubCaches.js", async () => {
   };
 });
 
-import { getPRReviewThreads, parsePRNode } from "../GitHubPRs.js";
-import { MAX_REVIEW_THREAD_PAGES } from "../GitHubCaches.js";
+import { getPRReviewThreads, parsePRNode, updateRepoStatsCount } from "../GitHubPRs.js";
+import {
+  MAX_REVIEW_THREAD_PAGES,
+  repoStatsCache,
+  repoStatsAndPageSnapshotCache,
+  restCountsCache,
+  getETagCacheVersion,
+} from "../GitHubCaches.js";
 
 function makeThreadNode(path: string, isResolved = false, isOutdated = false) {
   return { path, isResolved, isOutdated };
@@ -462,5 +468,116 @@ describe("parsePRNode — global CI aggregates", () => {
   it("normalises lowercase mergeStateStatus to uppercase", () => {
     const pr = parsePRNode(makeBaseNode({ mergeStateStatus: "clean" }));
     expect(pr.mergeStateStatus).toBe("CLEAN");
+  });
+});
+
+describe("updateRepoStatsCount — long-lived count cache reconciliation", () => {
+  const KEY = "owner/repo";
+
+  beforeEach(() => {
+    repoStatsCache.clear();
+    repoStatsAndPageSnapshotCache.clear();
+    restCountsCache.clear();
+    // Seed the in-memory stats entry so the function takes the cached-update
+    // branch and never touches the real on-disk GitHubStatsCache.
+    repoStatsCache.set(KEY, {
+      issueCount: 5,
+      prCount: 1,
+      lastUpdated: 1_000,
+      issueCountRefreshedAt: 1_000,
+      prCountRefreshedAt: 1_000,
+    });
+  });
+
+  function seedSnapshot(issueCount: number, prCount: number): void {
+    repoStatsAndPageSnapshotCache.set(KEY, {
+      stats: {
+        issueCount,
+        prCount,
+        lastUpdated: 1_000,
+        issueCountRefreshedAt: 1_000,
+        prCountRefreshedAt: 1_000,
+      },
+      issues: { items: [], endCursor: null, hasNextPage: false, totalCount: issueCount },
+      prs: { items: [], endCursor: null, hasNextPage: false, totalCount: prCount },
+    });
+  }
+
+  function seedRestCounts(combinedCount: number, prCount: number): void {
+    restCountsCache.set(KEY, {
+      combinedCount,
+      prCount,
+      repoEtag: '"r1"',
+      prEtag: '"p1"',
+      lastUpdated: 1_000,
+    });
+  }
+
+  it("applies the observed count and stamps only that kind's refreshed-at", () => {
+    updateRepoStatsCount(KEY, "pr", 2);
+
+    const updated = repoStatsCache.get(KEY);
+    expect(updated?.prCount).toBe(2);
+    expect(updated?.issueCount).toBe(5);
+    expect(updated?.prCountRefreshedAt).toBeGreaterThan(1_000);
+    // A PR list write-back says nothing about the issue count — refreshing
+    // its recency too would let a stale issue count outrank a real
+    // issue-list observation and suppress the issue dropdown's forced
+    // refresh.
+    expect(updated?.issueCountRefreshedAt).toBe(1_000);
+  });
+
+  it("drops a page snapshot whose PR count disagrees with the list-observed total", () => {
+    seedSnapshot(5, 1);
+
+    updateRepoStatsCount(KEY, "pr", 2);
+
+    // The snapshot's first-page items are stale by the same evidence as its
+    // count — the whole entry must go, or the next unchanged-probe poll
+    // resurrects the old count for up to the snapshot's 10-minute TTL.
+    expect(repoStatsAndPageSnapshotCache.get(KEY)).toBeUndefined();
+  });
+
+  it("keeps a page snapshot that agrees with the list-observed total", () => {
+    seedSnapshot(5, 2);
+
+    updateRepoStatsCount(KEY, "pr", 2);
+
+    expect(repoStatsAndPageSnapshotCache.get(KEY)).not.toBeUndefined();
+  });
+
+  it("drops a REST count baseline whose PR count disagrees, forcing an unconditional re-read", () => {
+    seedRestCounts(6, 1);
+    const versionBefore = getETagCacheVersion();
+
+    updateRepoStatsCount(KEY, "pr", 2);
+
+    // Dropping the entry discards its ETags too — the next background poll
+    // must re-read both REST legs instead of 304-replaying the stale count.
+    expect(restCountsCache.get(KEY)).toBeUndefined();
+    // The version bump invalidates any in-flight conditional fetch that read
+    // its baseline before the drop, so it can't 304-recommit the stale value.
+    expect(getETagCacheVersion()).toBeGreaterThan(versionBefore);
+  });
+
+  it("keeps a REST count baseline that agrees with the list-observed total", () => {
+    seedRestCounts(6, 2);
+    const versionBefore = getETagCacheVersion();
+
+    updateRepoStatsCount(KEY, "pr", 2);
+
+    expect(restCountsCache.get(KEY)).not.toBeUndefined();
+    // No baseline dropped — in-flight conditional fetches stay valid.
+    expect(getETagCacheVersion()).toBe(versionBefore);
+  });
+
+  it("compares issue updates against the derived REST issue count (combined − PRs)", () => {
+    seedRestCounts(6, 1);
+
+    updateRepoStatsCount(KEY, "issue", 5);
+    expect(restCountsCache.get(KEY)).not.toBeUndefined();
+
+    updateRepoStatsCount(KEY, "issue", 7);
+    expect(restCountsCache.get(KEY)).toBeUndefined();
   });
 });

--- a/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubStats.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { formatErrorMessage } from "../../../../../shared/utils/errorMessage.js";
 
 // `getRepoStatsAndPage` is an orchestration boundary — mock the
@@ -716,6 +716,106 @@ describe("getRepoStatsAndPage — decoupled REST count poll (issue #10122)", () 
         .filter((c) => /\/repos\/testowner\/testrepo$/.test(String(c[0])))
         .map((c) => c[1] as { headers: Record<string, string> });
       expect(repoInits[1].headers["If-None-Match"]).toBeUndefined();
+    });
+  });
+
+  describe("count refreshed-at stamps — honest count recency on probe re-serves", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("preserves the refreshed-at stamps when an unchanged probe re-serves the last REST counts", async () => {
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(304)],
+        repo: [repoOk(8)],
+        pulls: [pullsOk(3)],
+      });
+
+      const first = await getRepoStatsAndPage("/test", false);
+      const baseline = first.stats?.prCountRefreshedAt;
+      expect(baseline).toBe(first.stats?.lastUpdated);
+      expect(first.stats?.issueCountRefreshedAt).toBe(baseline);
+
+      expireMemoryCaches();
+      expireBackoffWindow();
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 60_000);
+      const second = await getRepoStatsAndPage("/test", false);
+      // `lastUpdated` re-stamps (the probe confirmed freshness) but the
+      // count-recency signals must keep the original count fetch time —
+      // re-stamping them is what let stale cached counts outrank a fresher
+      // dropdown-observed total in the renderer arbitration.
+      expect(second.stats?.prCountRefreshedAt).toBe(baseline);
+      expect(second.stats?.issueCountRefreshedAt).toBe(baseline);
+      expect(second.stats?.lastUpdated).toBeGreaterThan(baseline!);
+    });
+
+    it("preserves the refreshed-at stamps when an unchanged probe re-serves the snapshot", async () => {
+      mockClient.mockResolvedValue(statsResponse(5, 3));
+      routeFetch({ events: [eventsResponse(304)] });
+
+      const first = await getRepoStatsAndPage("/test", true);
+      const baseline = first.stats?.prCountRefreshedAt;
+      expect(baseline).toBe(first.stats?.lastUpdated);
+
+      expireMemoryCaches();
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 60_000);
+      const result = await getRepoStatsAndPage("/test", false);
+      expect(result.stats?.prCountRefreshedAt).toBe(baseline);
+      expect(result.stats?.issueCountRefreshedAt).toBe(baseline);
+      expect(result.stats?.lastUpdated).toBeGreaterThan(baseline!);
+    });
+
+    it("advances the refreshed-at stamps on a 304 count replay — the endpoints were re-verified", async () => {
+      routeFetch({
+        events: [eventsResponse(200, { etag: '"e1"' }), eventsResponse(200, { etag: '"e2"' })],
+        repo: [repoOk(8, '"r1"'), restResponse(304)],
+        pulls: [pullsOk(3, '"p1"'), restResponse(304)],
+      });
+
+      const first = await getRepoStatsAndPage("/test", false);
+      const baseline = first.stats?.prCountRefreshedAt;
+
+      expireMemoryCaches();
+      expireBackoffWindow();
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 60_000);
+      const second = await getRepoStatsAndPage("/test", false);
+      // A 304 is a direct GitHub confirmation that the count endpoint's
+      // content is unchanged — unlike a probe re-serve, the counts were
+      // genuinely re-checked, so recency advances.
+      expect(second.stats?.prCountRefreshedAt).toBeGreaterThan(baseline!);
+      expect(second.stats?.issueCountRefreshedAt).toBeGreaterThan(baseline!);
+    });
+
+    it("re-reads the count baselines after the probe await so a concurrent reconciliation sticks", async () => {
+      // Seed the snapshot (1 PR) via an explicit refresh.
+      mockClient.mockResolvedValue(statsResponse(5, 1));
+      routeFetch({});
+      await getRepoStatsAndPage("/test", true);
+      expireMemoryCaches();
+      expireBackoffWindow();
+
+      // While the /events probe is in flight, a dropdown list write-back
+      // reconciles the stale snapshot away (updateRepoStatsCount's drop).
+      // The poll must not serve its pre-await capture of that snapshot.
+      mockFetch.mockImplementation((input: unknown) => {
+        const url = String(input);
+        if (url.includes("/events")) {
+          repoStatsAndPageSnapshotCache.invalidate(CACHE_KEY);
+          return Promise.resolve(eventsResponse(304));
+        }
+        if (url.includes("/pulls")) return Promise.resolve(pullsOk(2));
+        return Promise.resolve(repoOk(7));
+      });
+
+      const result = await getRepoStatsAndPage("/test", false);
+
+      // Fell through to a fresh REST count read instead of resurrecting the
+      // captured snapshot's stale PR count.
+      expect(result.stats?.prCount).toBe(2);
+      expect(result.stats?.issueCount).toBe(5);
     });
   });
 

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -1367,6 +1367,8 @@ function toForgeRepoCounts(result: RepoStatsAndPageResult): ForgeRepoCounts {
     prCount: result.stats?.prCount ?? null,
     stale: result.stats?.stale,
     lastUpdated: result.stats?.lastUpdated,
+    issueCountRefreshedAt: result.stats?.issueCountRefreshedAt,
+    prCountRefreshedAt: result.stats?.prCountRefreshedAt,
     error: result.error,
     rateLimitResetAt:
       rateLimitState.blocked && rateLimitState.resetAt ? rateLimitState.resetAt : undefined,

--- a/plugins/builtin/github/main/types.ts
+++ b/plugins/builtin/github/main/types.ts
@@ -11,6 +11,19 @@ export interface RepoStats {
   prCount: number;
   stale?: boolean;
   lastUpdated?: number;
+  /**
+   * Wall-clock ms when each count was last read from a GitHub count endpoint
+   * (GraphQL `totalCount`, the REST count pair, or a list query's
+   * write-back). Unlike `lastUpdated`, these are NOT re-stamped when an
+   * activity-probe "unchanged" result re-serves cached counts — they are the
+   * honest recency signals for the renderer's badge arbitration and the
+   * dropdown-open force-refresh gate, both of which must distinguish "we
+   * asked GitHub about this count" from "we assumed nothing changed".
+   * Per-count because a list query refreshes only its own kind: a PR
+   * write-back must not make a stale issue count look freshly read.
+   */
+  issueCountRefreshedAt?: number;
+  prCountRefreshedAt?: number;
 }
 
 /** One connection page (issues or PRs) as returned by `getRepoStatsAndPage`. */

--- a/plugins/builtin/github/shared/types.ts
+++ b/plugins/builtin/github/shared/types.ts
@@ -198,6 +198,17 @@ export interface RepositoryStats {
   stale?: boolean;
   /** Timestamp when stats were last successfully fetched from API */
   lastUpdated?: number;
+  /**
+   * Timestamps when the issue/PR counts were last read from a GitHub count
+   * endpoint. `lastUpdated` is re-stamped when the main-process activity
+   * probe confirms "nothing changed" and re-serves cached counts; these are
+   * not — consumers that need true count recency (badge arbitration,
+   * dropdown-open force refresh) read them, treating absence on a
+   * `stale: true` payload as unknown rather than fresh. Per-count because a
+   * list query's write-back refreshes only its own kind.
+   */
+  issueCountRefreshedAt?: number;
+  prCountRefreshedAt?: number;
   /** Unix epoch milliseconds when a GitHub rate limit resumes */
   rateLimitResetAt?: number;
   /** Kind of active GitHub rate limit (primary quota vs secondary abuse) */

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -542,6 +542,15 @@ export interface ForgeRepoCounts {
   stale?: boolean;
   /** Epoch milliseconds of the last successful forge fetch. */
   lastUpdated?: number;
+  /**
+   * Epoch ms when each count was last read from a forge count endpoint. Unlike
+   * `lastUpdated`, these are NOT re-stamped when an "unchanged" probe re-serves
+   * cached counts — the host uses them for true count recency (badge
+   * arbitration, dropdown-open refresh). Per-count because a list write-back
+   * refreshes only its own kind.
+   */
+  issueCountRefreshedAt?: number;
+  prCountRefreshedAt?: number;
   /** Human-readable error when the forge fetch failed (counts may be cached). */
   error?: string;
   /** Epoch milliseconds when an active rate-limit block resumes. */

--- a/shared/types/ipc/forge.ts
+++ b/shared/types/ipc/forge.ts
@@ -113,6 +113,17 @@ export interface ForgeRepositoryStats {
   stale?: boolean;
   /** Epoch ms when stats were last successfully fetched from the forge. */
   lastUpdated?: number;
+  /**
+   * Epoch ms when the issue/PR counts were last read from a forge count
+   * endpoint. `lastUpdated` is re-stamped when the main process confirms
+   * "nothing changed" and re-serves cached counts; these are not — consumers
+   * that need true count recency (badge arbitration, dropdown-open refresh)
+   * read them, treating absence on a `stale: true` payload as unknown rather
+   * than fresh. Per-count because a list query's write-back refreshes only its
+   * own kind.
+   */
+  issueCountRefreshedAt?: number;
+  prCountRefreshedAt?: number;
   /** Epoch ms when an active rate-limit block resumes. */
   rateLimitResetAt?: number;
   /** Kind of active rate limit (primary quota vs secondary abuse throttle). */

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -49,17 +49,21 @@ import { ForgeStatPill } from "./ForgeStatPill";
 const HOVER_PREFETCH_DELAY_MS = 150;
 const PREFETCH_FRESHNESS_MS = 10_000;
 
-// When the user opens the dropdown and the polled stats are older than this,
-// fire a click-time count refresh — cache may still be valid in the strict
-// TTL sense, but the user opening the dropdown is a strong signal that they
-// want fresh-enough data, and 2 minutes is the threshold beyond which counts
-// could be visibly out of date. Deliberately NOT a forced refresh: `force`
-// maps to `bypassCache: true` in main, which runs the ~6-point welded
-// `REPO_STATS_AND_PAGE_QUERY` on top of the list query the open itself
-// fires — a hidden double-spend on every stale-open (#10122 family). The
-// non-forced path is the probe-gated REST count pair (often free via 304),
-// and the dropdown's own list revalidate reconciles the badge through
-// `onCountUpdate`/`onFreshFetch`, so the heavy query buys nothing here.
+// When the user opens a dropdown and its count hasn't been read from the forge
+// within this window, fire a click-time count refresh — cache may still be
+// valid in the strict TTL sense, but the user opening the dropdown is a strong
+// signal that they want fresh-enough data, and 2 minutes is the threshold
+// beyond which counts could be visibly out of date. The gate keys off the
+// per-count refreshed-at stamp (when the forge was actually asked about that
+// count), NOT the probe-re-stamped `lastUpdated` — re-stamped staleness let a
+// stale poll count permanently suppress this open-time refresh. Deliberately
+// NOT a forced refresh: `force` maps to `bypassCache: true` in main, which
+// runs the ~6-point welded `REPO_STATS_AND_PAGE_QUERY` on top of the list
+// query the open itself fires — a hidden double-spend on every stale-open
+// (#10122 family). The non-forced path is the probe-gated REST count pair
+// (often free via 304), and the dropdown's own list revalidate reconciles the
+// badge through `onCountUpdate`/`onFreshFetch`, so the heavy query buys
+// nothing here.
 const OPEN_REFRESH_STALENESS_MS = 2 * 60 * 1000;
 
 // Lifetime of the corner activity chip after the most recent count increase,
@@ -167,6 +171,21 @@ export const ForgeStatsToolbarButton = memo(
     const prCount = stats?.prCount ?? null;
     const commitCount = stats?.commitCount ?? null;
 
+    // True per-count recency. `lastUpdated` is re-stamped by the main process
+    // when the activity probe confirms "nothing changed" and re-serves cached
+    // counts; the refreshed-at stamps only advance when the forge was actually
+    // asked about that count. The badge arbitration and the dropdown-open
+    // force refresh below must use the honest signal — re-stamped staleness
+    // was how a stale poll count kept outranking the dropdown's real total
+    // and rolled the badge back on every poll. Per-count because a PR list
+    // write-back says nothing about the issue count (and vice versa). Stale
+    // disk fallbacks carry a re-stamped `lastUpdated` with no honest stamp —
+    // treat those as unknown recency (null) rather than fresh, so a direct
+    // list observation always outranks them and an open retries the fetch.
+    const statsRecencyFallback = stats?.stale ? null : lastUpdated;
+    const issueCountRefreshedAt = stats?.issueCountRefreshedAt ?? statsRecencyFallback;
+    const prCountRefreshedAt = stats?.prCountRefreshedAt ?? statsRecencyFallback;
+
     // List-loaded counts reported by each dropdown's `onCountUpdate`. These
     // track what the dropdown actually lists (loaded first-page length +
     // whether more pages exist) so the badge can bind to the visible count
@@ -227,14 +246,14 @@ export const ForgeStatsToolbarButton = memo(
     // in render is fine — they're only written from event callbacks).
     const issueDisplayCount: number | string | null = resolveForgeDisplayCount(
       issueCount,
-      lastUpdated,
+      issueCountRefreshedAt,
       issueListCount,
       issueListHasMore,
       issueListTimestampRef.current
     );
     const prDisplayCount: number | string | null = resolveForgeDisplayCount(
       prCount,
-      lastUpdated,
+      prCountRefreshedAt,
       prListCount,
       prListHasMore,
       prListTimestampRef.current
@@ -878,7 +897,8 @@ export const ForgeStatsToolbarButton = memo(
                 if (willOpen) setIssuesPulseAt(null);
                 if (
                   willOpen &&
-                  (lastUpdated == null || Date.now() - lastUpdated > OPEN_REFRESH_STALENESS_MS)
+                  (issueCountRefreshedAt == null ||
+                    Date.now() - issueCountRefreshedAt > OPEN_REFRESH_STALENESS_MS)
                 ) {
                   refreshStats();
                 }
@@ -959,7 +979,8 @@ export const ForgeStatsToolbarButton = memo(
                 if (willOpen) setPrsPulseAt(null);
                 if (
                   willOpen &&
-                  (lastUpdated == null || Date.now() - lastUpdated > OPEN_REFRESH_STALENESS_MS)
+                  (prCountRefreshedAt == null ||
+                    Date.now() - prCountRefreshedAt > OPEN_REFRESH_STALENESS_MS)
                 ) {
                   refreshStats();
                 }

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshFetch.test.tsx
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.freshFetch.test.tsx
@@ -304,13 +304,28 @@ describe("ForgeStatsToolbarButton list-count badge wiring", () => {
   it("derives the display count via the recency resolver (issue #9741)", () => {
     // The badge no longer prefers the list count unconditionally — it defers to
     // `resolveForgeDisplayCount`, which arbitrates the list count against the
-    // stats poll's `lastUpdated` so a fresher poll wins.
+    // stats poll's count recency. The stats side must be the per-count
+    // refreshed-at stamp (when the forge was actually asked about that count)
+    // rather than `lastUpdated`, which the main process re-stamps on
+    // probe-confirmed "unchanged" polls — arbitrating on `lastUpdated` let a
+    // stale cached count outrank a fresher dropdown-observed total on every
+    // poll. Stale disk fallbacks carry no honest stamp and must resolve to
+    // null recency, not the re-stamped `lastUpdated`.
     expect(source).toContain('from "./forgeStatsCountDisplay"');
     expect(source).toMatch(
-      /issueDisplayCount[\s\S]{0,80}?=\s*resolveForgeDisplayCount\(\s*issueCount,\s*lastUpdated,\s*issueListCount,\s*issueListHasMore,\s*issueListTimestampRef\.current/
+      /statsRecencyFallback\s*=\s*stats\?\.stale\s*\?\s*null\s*:\s*lastUpdated/
     );
     expect(source).toMatch(
-      /prDisplayCount[\s\S]{0,80}?=\s*resolveForgeDisplayCount\(\s*prCount,\s*lastUpdated,\s*prListCount,\s*prListHasMore,\s*prListTimestampRef\.current/
+      /issueCountRefreshedAt\s*=\s*stats\?\.issueCountRefreshedAt\s*\?\?\s*statsRecencyFallback/
+    );
+    expect(source).toMatch(
+      /prCountRefreshedAt\s*=\s*stats\?\.prCountRefreshedAt\s*\?\?\s*statsRecencyFallback/
+    );
+    expect(source).toMatch(
+      /issueDisplayCount[\s\S]{0,80}?=\s*resolveForgeDisplayCount\(\s*issueCount,\s*issueCountRefreshedAt,\s*issueListCount,\s*issueListHasMore,\s*issueListTimestampRef\.current/
+    );
+    expect(source).toMatch(
+      /prDisplayCount[\s\S]{0,80}?=\s*resolveForgeDisplayCount\(\s*prCount,\s*prCountRefreshedAt,\s*prListCount,\s*prListHasMore,\s*prListTimestampRef\.current/
     );
   });
 

--- a/src/components/Layout/forgeStatsCountDisplay.ts
+++ b/src/components/Layout/forgeStatsCountDisplay.ts
@@ -12,11 +12,17 @@
  * still wins immediately after a fresh dropdown fetch (its timestamp is newer);
  * it just yields once a later stats poll lands. Both timestamps are epoch ms
  * from the same `Date.now()` clock — the toolbar stamps the list timestamp when
- * `onCountUpdate` fires, and `lastUpdated` is set by the stats fetch.
+ * `onCountUpdate` fires, and the stats timestamp is the per-count
+ * `issueCountRefreshedAt` / `prCountRefreshedAt`: the last time that count was
+ * actually read from a forge count endpoint. NOT `lastUpdated`, which the main
+ * process re-stamps when its activity probe re-serves cached counts —
+ * arbitrating on that let a stale cached count outrank a fresher
+ * dropdown-observed total on every background poll.
  *
  * @param statsCount       Total from the stats poll, or null when unavailable.
- * @param statsLastUpdated Epoch ms of the last stats fetch, or null before the
- *                         first poll resolves (no stats baseline yet).
+ * @param statsLastUpdated Epoch ms when this count was last read from the forge
+ *                         (the per-count refreshed-at stamp), or null when
+ *                         there is no honest stats baseline yet.
  * @param listCount        Count reported by the dropdown list, or null before
  *                         the dropdown has loaded.
  * @param listApproximate  Whether the list count is approximate (cache hit


### PR DESCRIPTION
The pull request count in the toolbar badge was oscillating. Opening the dropdown showed the real count (2), then a few seconds later the badge rolled back to a stale 1, and the cycle repeated on every background poll.

## Root cause

The background stats poll is gated by the `/events` activity probe. When the probe reports no change, `getRepoStatsAndPage` re-serves cached counts from `repoStatsAndPageSnapshotCache` (10 min TTL) or `restCountsCache` (1 h TTL), re-stamped with `lastUpdated: Date.now()`. The badge arbitrates between the poll count and the dropdown's observed count by timestamp recency (`resolveGitHubDisplayCount`), so the stale count always looked fresher and won. Meanwhile the dropdown's real `totalCount` was only ever written to `repoStatsCache` (60s TTL), so the correction died within a minute while the longer-lived caches kept resurrecting the stale value. The re-stamping also kept `lastUpdated` permanently fresh, which suppressed the dropdown-open force refresh that would have healed it.

## Fixes

- Honest per-count recency stamps (`issueCountRefreshedAt` / `prCountRefreshedAt`) that only advance when GitHub is actually asked about that count. Probe re-serves preserve them; `lastUpdated` keeps its re-stamped freshness semantics for the pill display.
- The badge arbitration and the dropdown-open force-refresh gate now read the honest stamps. Stale disk fallbacks resolve to null recency instead of trusting the re-stamped disk timestamp.
- `updateRepoStatsCount` now reconciles the long-lived caches: when the dropdown's observed total disagrees with a stored snapshot or REST baseline, the entry is dropped, forcing an unconditional re-read on the next poll.
- Hardening against an in-flight poll race: count baselines are re-read after the probe await, and dropping a baseline bumps the ETag cache version so an in-flight `fetchRestCounts` can't 304-recommit the stale value.

A second-opinion review caught two of these: the shared timestamp cross-contaminating issue and PR recency (a PR write-back would have made a stale issue count look freshly read), and the in-flight race.

## Tests

- Probe re-serve recency tests, including the in-flight reconciliation race (`GitHubStats.test.ts`).
- Cache reconciliation tests for `updateRepoStatsCount`, including the per-count stamping guard (`GitHubPRs.test.ts`).
- Updated toolbar source assertions (`GitHubStatsToolbarButton.freshFetch.test.tsx`).
- Full `npm run check` passes; affected suites green (189 files / 3,307 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)