### PR TITLE
feat(agents): add per-agent external links to the agent button context menu

### DIFF
--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -1563,6 +1563,53 @@ describe("aider detection patterns", () => {
   });
 });
 
+describe("externalLinks", () => {
+  it("every declared link has a non-empty label and an https URL", () => {
+    for (const id of getAgentIds()) {
+      for (const link of getAgentConfig(id)?.externalLinks ?? []) {
+        expect(link.label.trim().length).toBeGreaterThan(0);
+        expect(link.url).toMatch(/^https:\/\/\S+$/);
+      }
+    }
+  });
+
+  it("no agent declares an empty externalLinks array (omit over empty)", () => {
+    for (const id of getAgentIds()) {
+      const links = getAgentConfig(id)?.externalLinks;
+      if (links !== undefined) {
+        expect(links.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("labels follow menu microcopy — no trailing period or ellipsis", () => {
+    for (const id of getAgentIds()) {
+      for (const link of getAgentConfig(id)?.externalLinks ?? []) {
+        expect(link.label).not.toMatch(/[.…]$/);
+      }
+    }
+  });
+
+  it("link URLs are unique within each agent", () => {
+    for (const id of getAgentIds()) {
+      const urls = (getAgentConfig(id)?.externalLinks ?? []).map((l) => l.url);
+      expect(new Set(urls).size).toBe(urls.length);
+    }
+  });
+
+  it("agents with a genuine usage dashboard label it 'View usage'", () => {
+    // claude and codex point usageUrl at real usage dashboards; their context
+    // menu link must reuse that exact destination rather than drifting to a
+    // separate URL.
+    for (const id of ["claude", "codex"]) {
+      const config = getAgentConfig(id);
+      const usageLink = config?.externalLinks?.find((l) => l.label === "View usage");
+      expect(usageLink).toBeDefined();
+      expect(usageLink?.url).toBe(config?.usageUrl);
+    }
+  });
+});
+
 describe("UserAgentConfigSchema supports field", () => {
   it("preserves supports:false through validation", () => {
     const result = UserAgentConfigSchema.safeParse({

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -21,6 +21,18 @@ export interface AgentInstallHelp {
 }
 
 /**
+ * A curated external link surfaced in the agent button context menu.
+ * Labels are sentence case with no trailing period ("View usage",
+ * "View docs", "Billing settings"). Only declare links to genuinely
+ * useful destinations — omit the field rather than pointing at a
+ * product homepage.
+ */
+export interface AgentExternalLink {
+  label: string;
+  url: string;
+}
+
+/**
  * Configuration for pattern-based working state detection.
  * Patterns are matched against terminal output to detect when an agent is actively working.
  */
@@ -353,6 +365,8 @@ export interface AgentConfig {
   shortcut?: string | null;
   tooltip?: string;
   usageUrl?: string;
+  /** Curated links shown in the agent button context menu; omit when none apply */
+  externalLinks?: AgentExternalLink[];
   help?: AgentHelpConfig;
   install?: AgentInstallHelp;
   capabilities?: {

--- a/shared/config/agents/aider.ts
+++ b/shared/config/agents/aider.ts
@@ -18,6 +18,7 @@ export const config: AgentConfig = {
   supports: false,
   tooltip: "Pip-distributed, git-aware coding agent",
   usageUrl: "https://aider.chat/",
+  externalLinks: [{ label: "View docs", url: "https://aider.chat/docs/" }],
   // packages.pypi triggers uv/pipx path synthesis in CliAvailabilityService,
   // which already covers ~/.local/bin/aider on POSIX hosts. nativePaths only
   // adds destinations not synthesized automatically: macOS Homebrew bins and

--- a/shared/config/agents/amp.ts
+++ b/shared/config/agents/amp.ts
@@ -9,6 +9,7 @@ export const config: AgentConfig = {
   supportsContextInjection: true,
   tooltip: "Sourcegraph's agentic coding tool",
   usageUrl: "https://ampcode.com/",
+  externalLinks: [{ label: "View docs", url: "https://ampcode.com/manual" }],
   packages: {
     npm: "@ampcode/cli",
   },

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -26,6 +26,7 @@ export const config: AgentConfig = {
   assistantMinVersion: "1.0.0",
   shortcut: "Cmd/Ctrl+Alt+C",
   usageUrl: "https://claude.ai/settings/usage",
+  externalLinks: [{ label: "View usage", url: "https://claude.ai/settings/usage" }],
   version: {
     args: ["--version"],
     githubRepo: "anthropics/claude-code",

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -23,6 +23,7 @@ export const config: AgentConfig = {
   shortcut: "Cmd/Ctrl+Alt+X",
   tooltip: "careful, methodical runs",
   usageUrl: "https://chatgpt.com/codex/settings/usage",
+  externalLinks: [{ label: "View usage", url: "https://chatgpt.com/codex/settings/usage" }],
   version: {
     args: ["--version"],
     githubRepo: "openai/codex",

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -26,6 +26,7 @@ export const config: AgentConfig = {
   assistantMinVersion: "1.0.40",
   tooltip: "GitHub's AI coding agent",
   usageUrl: "https://github.com/features/copilot",
+  externalLinks: [{ label: "Billing settings", url: "https://github.com/settings/billing" }],
   contextWindow: 160_000,
   models: [
     { id: "claude-sonnet-4.6", name: "Claude Sonnet 4.6", shortLabel: "Sonnet 4.6" },

--- a/shared/config/agents/goose.ts
+++ b/shared/config/agents/goose.ts
@@ -15,6 +15,7 @@ export const config: AgentConfig = {
   supportsContextInjection: true,
   tooltip: "provider-agnostic, by Block Inc.",
   usageUrl: "https://block.github.io/goose/",
+  externalLinks: [{ label: "View docs", url: "https://block.github.io/goose/docs/" }],
   version: {
     args: ["--version"],
     githubRepo: "block/goose",

--- a/shared/config/agents/goose.ts
+++ b/shared/config/agents/goose.ts
@@ -15,7 +15,7 @@ export const config: AgentConfig = {
   supportsContextInjection: true,
   tooltip: "provider-agnostic, by Block Inc.",
   usageUrl: "https://block.github.io/goose/",
-  externalLinks: [{ label: "View docs", url: "https://block.github.io/goose/docs/" }],
+  externalLinks: [{ label: "View docs", url: "https://goose-docs.ai/docs/" }],
   version: {
     args: ["--version"],
     githubRepo: "block/goose",

--- a/shared/config/agents/interpreter.ts
+++ b/shared/config/agents/interpreter.ts
@@ -14,6 +14,7 @@ export const config: AgentConfig = {
   supports: false,
   tooltip: "general code execution — runs Python, shell, and JS on the host",
   usageUrl: "https://docs.openinterpreter.com/",
+  externalLinks: [{ label: "View docs", url: "https://docs.openinterpreter.com/" }],
   packages: {
     pypi: "open-interpreter",
   },

--- a/shared/config/agents/kiro.ts
+++ b/shared/config/agents/kiro.ts
@@ -9,6 +9,7 @@ export const config: AgentConfig = {
   supportsContextInjection: true,
   tooltip: "Amazon's AI coding agent",
   usageUrl: "https://kiro.dev/",
+  externalLinks: [{ label: "View docs", url: "https://kiro.dev/docs/" }],
   version: {
     args: ["--version"],
   },

--- a/shared/config/agents/opencode.ts
+++ b/shared/config/agents/opencode.ts
@@ -13,6 +13,7 @@ export const config: AgentConfig = {
   supportsContextInjection: true,
   tooltip: "provider-agnostic, open source",
   usageUrl: "https://opencode.ai/",
+  externalLinks: [{ label: "View docs", url: "https://opencode.ai/docs/" }],
   version: {
     args: ["--version"],
     githubRepo: "opencode-ai/opencode",

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -34,8 +34,9 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { MenuActionSourceContext, useMenuActionSource } from "@/components/ui/menu-source";
-import { ChevronDown, PanelBottom } from "lucide-react";
+import { ChevronDown, ExternalLink, PanelBottom } from "lucide-react";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
+import type { AgentExternalLink } from "@shared/config/agentRegistry";
 import type { AgentAvailabilityState, AgentState } from "@shared/types";
 import {
   isAgentLaunchable,
@@ -77,6 +78,27 @@ interface AgentButtonProps {
 const stopPointer = (e: ReactPointerEvent) => {
   e.stopPropagation();
 };
+
+// Owns its own leading separator so both ContextMenuContent blocks stay
+// symmetrical — agents without links render nothing, including the separator.
+function AgentExternalLinkItems({ links }: { links?: AgentExternalLink[] }) {
+  if (!links || links.length === 0) return null;
+  return (
+    <>
+      <ContextMenuSeparator />
+      {links.map((link) => (
+        <ContextMenuActionItem
+          key={link.url}
+          actionId="system.openExternal"
+          args={{ url: link.url }}
+        >
+          <ExternalLink className="mr-2 h-3.5 w-3.5" />
+          {link.label}
+        </ContextMenuActionItem>
+      ))}
+    </>
+  );
+}
 
 interface WorktreeMenuItemsProps {
   agentType: AgentType;
@@ -447,6 +469,7 @@ export function AgentButton({
           >
             {config.name} Settings...
           </ContextMenuActionItem>
+          <AgentExternalLinkItems links={config.externalLinks} />
         </ContextMenuContent>
       </ContextMenu>
     );
@@ -743,6 +766,7 @@ export function AgentButton({
         >
           {config.name} Settings...
         </ContextMenuActionItem>
+        <AgentExternalLinkItems links={config.externalLinks} />
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -39,6 +39,7 @@ let mockCcrPresetsByAgent: Record<string, Array<{ id: string; name: string }>> =
 let mockMergedPresetsFn: (
   agentId: string
 ) => Array<{ id: string; name: string; color?: string }> = () => [];
+let mockExternalLinks: Array<{ label: string; url: string }> | undefined;
 
 vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
@@ -125,6 +126,7 @@ vi.mock("@/config/agents", () => ({
     id,
     name: id.charAt(0).toUpperCase() + id.slice(1),
     icon: () => null,
+    externalLinks: mockExternalLinks,
   }),
   getMergedPresets: (agentId: string) => mockMergedPresetsFn(agentId),
 }));
@@ -351,6 +353,7 @@ vi.mock("@/components/ui/context-menu", () => ({
 
 vi.mock("lucide-react", () => ({
   ChevronDown: () => <span data-testid="chevron-icon" />,
+  ExternalLink: () => <span data-testid="external-link-icon" />,
   PanelBottom: () => <span data-testid="panel-bottom-icon" />,
   Unplug: () => <span data-testid="unplug-icon" />,
   // terminalStateConfig.tsx (imported transitively for STATE_LABELS — #9823)
@@ -383,6 +386,7 @@ describe("AgentButton preset UX", () => {
     mockPanelIds = [];
     mockPanelIdsByWorktreeId = {};
     mockWorktrees = [];
+    mockExternalLinks = undefined;
     dropdownCloseAutoFocusSpy = null;
     dropdownPointerDownOutsideSpy = null;
   });
@@ -1596,6 +1600,7 @@ describe("AgentButton right-click unpin — issue #9825", () => {
     mockPanelIds = [];
     mockPanelIdsByWorktreeId = {};
     mockWorktrees = [];
+    mockExternalLinks = undefined;
   });
 
   it("routes the no-presets branch's unpin to setAgentPinned (not pinnedButtons)", () => {
@@ -1646,5 +1651,66 @@ describe("AgentButton right-click unpin — issue #9825", () => {
       el.textContent?.includes("Customize toolbar")
     );
     expect(customizeHasPresets, "Customize entry missing in has-presets branch").toBeTruthy();
+  });
+});
+
+describe("AgentButton external links — issue #10350", () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+    mockSettings = null;
+    mockActiveWorktreeId = null;
+    mockCcrPresetsByAgent = {};
+    mockMergedPresetsFn = () => [];
+    mockCliDetails = {};
+    mockDominantState = null;
+    mockDotColor = "";
+    mockPanelsById = {};
+    mockPanelIds = [];
+    mockPanelIdsByWorktreeId = {};
+    mockWorktrees = [];
+    mockExternalLinks = [{ label: "View usage", url: "https://example.com/usage" }];
+  });
+
+  function findLinkItem() {
+    const items = screen.getAllByTestId("context-menu-item");
+    return items.find((el) => el.textContent?.includes("View usage"));
+  }
+
+  it("renders the link in the no-presets context menu and dispatches system.openExternal", () => {
+    render(
+      <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+    );
+    const link = findLinkItem();
+    expect(link, "external link missing in no-presets branch").toBeTruthy();
+    fireEvent.click(link!);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://example.com/usage" },
+      expect.objectContaining({ source: "user" })
+    );
+  });
+
+  it("renders the link in the has-presets context menu too", () => {
+    mockMergedPresetsFn = (id: string) => [{ id: `${id}-blue`, name: "Blue" }];
+    render(
+      <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+    );
+    const link = findLinkItem();
+    expect(link, "external link missing in has-presets branch").toBeTruthy();
+    fireEvent.click(link!);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://example.com/usage" },
+      expect.objectContaining({ source: "user" })
+    );
+  });
+
+  it("renders no link item or icon when the agent declares no externalLinks", () => {
+    mockExternalLinks = undefined;
+    render(
+      <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+    );
+    expect(findLinkItem()).toBeUndefined();
+    expect(screen.queryByTestId("external-link-icon")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds an `externalLinks` field (`{ label, url }[]`) to `AgentConfig` in `shared/config/agentRegistry.ts`, purely additive alongside `usageUrl`. Nine agents declare links: claude and codex get "View usage" (pointing at their genuine usage dashboards), copilot gets "Billing settings", and amp, aider, opencode, goose, kiro, and interpreter each get "View docs". Agents with no genuinely useful destination omit the field and render nothing.
- `AgentButton.tsx` renders the links as a final group in both context menu branches (no-presets and has-presets) via a local `AgentExternalLinkItems` helper. All opens go through `ContextMenuActionItem` with `actionId="system.openExternal"` — the validated protocol-allowlist path established in #9316.
- Review caught one defect: the goose docs URL had moved from `block.github.io` to `https://goose-docs.ai/docs/` (the old path 404s). Fixed.

Resolves #10350

## Changes

- `shared/config/agentRegistry.ts` — new optional `externalLinks` field on `AgentConfig`
- `shared/config/agents/{claude,codex,copilot,amp,aider,opencode,goose,kiro,interpreter}.ts` — links declared per agent
- `src/components/Layout/AgentButton.tsx` — `AgentExternalLinkItems` helper, wired into both menu branches with `ExternalLink` icon (`mr-2 h-3.5 w-3.5`)
- `shared/config/__tests__/agentRegistry.test.ts` — 5 shape-invariant tests (https-only URLs, no empty arrays, no trailing periods, unique URLs, claude/codex usage link matches `usageUrl`)
- `src/components/Layout/__tests__/AgentButton.test.tsx` — 3 component tests covering both menu branches and the no-links case

## Testing

`npm run check`, targeted vitest, build, and preload-backdoor gate all pass locally.