### PR TITLE
fix(worktree): fade quick state filter icons when count is zero

### DIFF
--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -14,11 +14,21 @@ const FILTER_OPTIONS: { value: QuickStateFilter; label: string }[] = [
 
 const FILTER_VISUALS: Record<
   Exclude<QuickStateFilter, "all">,
-  { Icon: React.ComponentType<{ className?: string }>; color: string }
+  { Icon: React.ComponentType<{ className?: string }>; color: string; colorFaded: string }
 > = {
-  working: { Icon: SpinnerCircle, color: STATE_COLORS.working },
-  waiting: { Icon: HollowCircle, color: STATE_COLORS.waiting },
-  finished: { Icon: CheckCircle2, color: "text-category-blue" },
+  // colorFaded must stay a complete class literal — Tailwind's scanner can't
+  // see dynamically assembled `${color}/40` strings.
+  working: {
+    Icon: SpinnerCircle,
+    color: STATE_COLORS.working,
+    colorFaded: "text-state-working/40",
+  },
+  waiting: { Icon: HollowCircle, color: STATE_COLORS.waiting, colorFaded: "text-state-waiting/40" },
+  finished: {
+    Icon: CheckCircle2,
+    color: "text-category-blue",
+    colorFaded: "text-category-blue/40",
+  },
 };
 
 interface QuickStateFilterBarProps {
@@ -50,6 +60,9 @@ export function QuickStateFilterBar({
         const isActive = option.value === value;
         const rawCount = counts ? counts[option.value] : undefined;
         const hasCount = rawCount !== undefined;
+        // An empty bucket keeps its icon and "0" digit but mutes the icon so
+        // the zero registers at a glance; no counts at all means no fade.
+        const shouldFadeIcon = hasCount && rawCount === 0;
         const visual = option.value === "all" ? null : FILTER_VISUALS[option.value];
         const isSpinningWorking = option.value === "working" && workingActive;
         const Icon = isSpinningWorking ? SpinnerCircle : visual?.Icon;
@@ -82,8 +95,8 @@ export function QuickStateFilterBar({
                 {Icon && visual ? (
                   <Icon
                     className={cn(
-                      "w-3 h-3 shrink-0",
-                      visual.color,
+                      "w-3 h-3 shrink-0 transition-colors",
+                      shouldFadeIcon ? visual.colorFaded : visual.color,
                       isSpinningWorking && "animate-spin-slow motion-reduce:animate-none"
                     )}
                   />

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -269,6 +269,45 @@ describe("QuickStateFilterBar", () => {
     expect(inactiveClass).toContain("text-daintree-text/60");
   });
 
+  it("fades the icon of every empty bucket — issue #10353", () => {
+    renderBar(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ all: 9, working: 0, waiting: 0, finished: 0 }}
+      />
+    );
+    for (const name of [/Working/, /Waiting/, /Finished/]) {
+      const svg = screen.getByRole("button", { name }).querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg?.getAttribute("class") ?? "").toContain("/40");
+    }
+  });
+
+  it("keeps icons at full color when their count is positive", () => {
+    renderBar(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ all: 9, working: 3, waiting: 1, finished: 2 }}
+      />
+    );
+    for (const name of [/Working/, /Waiting/, /Finished/]) {
+      const svg = screen.getByRole("button", { name }).querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg?.getAttribute("class") ?? "").not.toContain("/40");
+    }
+  });
+
+  it("does not fade icons when the counts prop is omitted", () => {
+    renderBar(<QuickStateFilterBar value="all" onChange={() => {}} />);
+    for (const name of ["Working", "Waiting", "Finished"]) {
+      const svg = screen.getByRole("button", { name }).querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg?.getAttribute("class") ?? "").not.toContain("/40");
+    }
+  });
+
   it("renders the optional trailing slot past a divider", () => {
     renderBar(
       <QuickStateFilterBar

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -269,7 +269,7 @@ describe("QuickStateFilterBar", () => {
     expect(inactiveClass).toContain("text-daintree-text/60");
   });
 
-  it("fades the icon of every empty bucket — issue #10353", () => {
+  it("fades each empty bucket's icon with its own state color — issue #10353", () => {
     renderBar(
       <QuickStateFilterBar
         value="all"
@@ -277,14 +277,19 @@ describe("QuickStateFilterBar", () => {
         counts={{ all: 9, working: 0, waiting: 0, finished: 0 }}
       />
     );
-    for (const name of [/Working/, /Waiting/, /Finished/]) {
+    const fadedBySegment: [RegExp, string][] = [
+      [/Working/, "text-state-working/40"],
+      [/Waiting/, "text-state-waiting/40"],
+      [/Finished/, "text-category-blue/40"],
+    ];
+    for (const [name, fadedClass] of fadedBySegment) {
       const svg = screen.getByRole("button", { name }).querySelector("svg");
       expect(svg).not.toBeNull();
-      expect(svg?.getAttribute("class") ?? "").toContain("/40");
+      expect(svg?.getAttribute("class") ?? "").toContain(fadedClass);
     }
   });
 
-  it("keeps icons at full color when their count is positive", () => {
+  it("keeps icons at their full state color when their count is positive", () => {
     renderBar(
       <QuickStateFilterBar
         value="all"
@@ -292,11 +297,47 @@ describe("QuickStateFilterBar", () => {
         counts={{ all: 9, working: 3, waiting: 1, finished: 2 }}
       />
     );
-    for (const name of [/Working/, /Waiting/, /Finished/]) {
+    const colorBySegment: [RegExp, string][] = [
+      [/Working/, "text-state-working"],
+      [/Waiting/, "text-state-waiting"],
+      [/Finished/, "text-category-blue"],
+    ];
+    for (const [name, colorClass] of colorBySegment) {
       const svg = screen.getByRole("button", { name }).querySelector("svg");
       expect(svg).not.toBeNull();
-      expect(svg?.getAttribute("class") ?? "").not.toContain("/40");
+      const svgClass = svg?.getAttribute("class") ?? "";
+      expect(svgClass).toContain(colorClass);
+      expect(svgClass).not.toContain("/40");
     }
+  });
+
+  it("fades only the segments whose count is zero in a mixed-count bar", () => {
+    renderBar(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ all: 2, working: 0, waiting: 2, finished: 0 }}
+      />
+    );
+    const workingClass =
+      screen
+        .getByRole("button", { name: /Working/ })
+        .querySelector("svg")
+        ?.getAttribute("class") ?? "";
+    const waitingClass =
+      screen
+        .getByRole("button", { name: /Waiting/ })
+        .querySelector("svg")
+        ?.getAttribute("class") ?? "";
+    const finishedClass =
+      screen
+        .getByRole("button", { name: /Finished/ })
+        .querySelector("svg")
+        ?.getAttribute("class") ?? "";
+    expect(workingClass).toContain("text-state-working/40");
+    expect(finishedClass).toContain("text-category-blue/40");
+    expect(waitingClass).toContain("text-state-waiting");
+    expect(waitingClass).not.toContain("/40");
   });
 
   it("does not fade icons when the counts prop is omitted", () => {
@@ -306,6 +347,47 @@ describe("QuickStateFilterBar", () => {
       expect(svg).not.toBeNull();
       expect(svg?.getAttribute("class") ?? "").not.toContain("/40");
     }
+  });
+
+  it("fades the active segment's icon when its own count is zero", () => {
+    // Active styling lives on the button, the fade lives on the icon — they
+    // must compose rather than conflict.
+    renderBar(
+      <QuickStateFilterBar
+        value="waiting"
+        onChange={() => {}}
+        counts={{ all: 2, working: 1, waiting: 0, finished: 1 }}
+      />
+    );
+    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    expect(waiting.getAttribute("aria-pressed")).toBe("true");
+    expect(waiting.querySelector("svg")?.getAttribute("class") ?? "").toContain(
+      "text-state-waiting/40"
+    );
+    const workingClass =
+      screen
+        .getByRole("button", { name: /Working/ })
+        .querySelector("svg")
+        ?.getAttribute("class") ?? "";
+    expect(workingClass).toContain("animate-spin-slow");
+    expect(workingClass).not.toContain("/40");
+  });
+
+  it("renders the zero-count working icon faded and not spinning", () => {
+    renderBar(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ all: 0, working: 0, waiting: 0, finished: 0 }}
+      />
+    );
+    const svgClass =
+      screen
+        .getByRole("button", { name: /Working/ })
+        .querySelector("svg")
+        ?.getAttribute("class") ?? "";
+    expect(svgClass).toContain("text-state-working/40");
+    expect(svgClass).not.toContain("animate-spin-slow");
   });
 
   it("renders the optional trailing slot past a divider", () => {


### PR DESCRIPTION
## Summary

- Icons in the quick state filter bar now fade to 40% opacity when their count is zero, giving a clear visual signal that no worktrees are in that state
- Full color is restored when the count is positive, with a `transition-colors` animation (Tier 1, 150ms)
- The "0" count digit still renders; no fade applied when the `counts` prop is omitted entirely

Resolves #10353

## Changes

- `src/components/Worktree/QuickStateFilterBar.tsx`: added `colorFaded` static class literals to `FILTER_VISUALS` (`text-state-working/40`, `text-state-waiting/40`, `text-category-blue/40` — full literals for Tailwind v4 JIT scanning; `/40` follows the `STATE_COLORS.idle` precedent), derived `shouldFadeIcon = hasCount && rawCount === 0`, applied faded color conditionally on the segment icon
- `src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx`: 6 new behavioral test cases covering per-segment fading on zero, full color on positive counts, mixed-count selectivity, counts-omitted passthrough, active-segment-with-zero composition, and zero-working faded but not spinning

## Testing

- 24/24 unit tests pass for the changed component
- `npm run check` passes (typecheck, lint, format, IPC/channel guards)
- Production build clean