### PR TITLE
fix(terminal): raise agent scrollback multiplier to restore 5000-line default

### DIFF
--- a/src/utils/__tests__/scrollbackConfig.test.ts
+++ b/src/utils/__tests__/scrollbackConfig.test.ts
@@ -52,10 +52,18 @@ describe("getScrollbackForType", () => {
   });
 
   it("scales agent scrollback proportionally below the cap and clamps above it", () => {
-    const atLowBase = getScrollbackForType(true, 500);
-    const atDefaultBase = getScrollbackForType(true, 1000);
-    const atHighBase = getScrollbackForType(true, 5000);
-    expect(atLowBase).toBeLessThan(atDefaultBase);
-    expect(atDefaultBase).toBe(atHighBase);
+    // base=500 is the realistic memory-pressure restore base (SCROLLBACK_BACKGROUND)
+    expect(getScrollbackForType(true, 500)).toBe(2500);
+    expect(getScrollbackForType(true, 1000)).toBe(5000);
+    expect(getScrollbackForType(true, 5000)).toBe(5000);
+  });
+
+  it("keeps plain terminals on the small policy at the default base", () => {
+    expect(getScrollbackForType(false, 1000)).toBe(300);
+  });
+
+  it("applies the minLines floor for tiny bases", () => {
+    expect(getScrollbackForType(true, 1)).toBe(500);
+    expect(getScrollbackForType(false, 1)).toBe(200);
   });
 });

--- a/src/utils/__tests__/scrollbackConfig.test.ts
+++ b/src/utils/__tests__/scrollbackConfig.test.ts
@@ -1,22 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { estimateMemoryUsage } from "../scrollbackConfig";
+import { estimateMemoryUsage, getScrollbackForType } from "../scrollbackConfig";
 
 describe("estimateMemoryUsage", () => {
   it("computes per-type and total bytes for a typical 8-agent + 8-shell session", () => {
     const result = estimateMemoryUsage({ agent: 8, plain: 8 }, 1000);
-    // agent: 1000 * 1.5 = 1500 lines/term, 1500 * 1200 * 8 = 14,400,000
-    // plain: 1000 * 0.3 =  300 lines/term,  300 * 1200 * 8 =  2,880,000
-    // total = 17,280,000
-    expect(result.agent).toBe(14_400_000);
+    // agent: 1000 * 5 = 5000 lines/term, 5000 * 1200 * 8 = 48,000,000
+    // plain: 1000 * 0.3 = 300 lines/term, 300 * 1200 * 8 =  2,880,000
+    // total = 50,880,000
+    expect(result.agent).toBe(48_000_000);
     expect(result.plain).toBe(2_880_000);
-    expect(result.total).toBe(17_280_000);
+    expect(result.total).toBe(50_880_000);
   });
 
   it("computes a single agent terminal at default scrollback", () => {
     const result = estimateMemoryUsage({ agent: 1, plain: 0 }, 1000);
-    expect(result.agent).toBe(1_800_000);
+    expect(result.agent).toBe(6_000_000);
     expect(result.plain).toBe(0);
-    expect(result.total).toBe(1_800_000);
+    expect(result.total).toBe(6_000_000);
   });
 
   it("computes a single plain terminal at default scrollback", () => {
@@ -39,5 +39,23 @@ describe("estimateMemoryUsage", () => {
     expect(result.agent).toBe(0);
     expect(result.plain).toBe(0);
     expect(result.total).toBe(0);
+  });
+});
+
+describe("getScrollbackForType", () => {
+  it("gives agent terminals at least as much scrollback as plain terminals at any base", () => {
+    for (const base of [0, 1, 100, 500, 1000, 2000, 5000, 10000]) {
+      expect(getScrollbackForType(true, base)).toBeGreaterThanOrEqual(
+        getScrollbackForType(false, base)
+      );
+    }
+  });
+
+  it("scales agent scrollback proportionally below the cap and clamps above it", () => {
+    const atLowBase = getScrollbackForType(true, 500);
+    const atDefaultBase = getScrollbackForType(true, 1000);
+    const atHighBase = getScrollbackForType(true, 5000);
+    expect(atLowBase).toBeLessThan(atDefaultBase);
+    expect(atDefaultBase).toBe(atHighBase);
   });
 });

--- a/src/utils/scrollbackConfig.ts
+++ b/src/utils/scrollbackConfig.ts
@@ -6,7 +6,7 @@ interface ScrollbackPolicy {
   minLines: number;
 }
 
-const AGENT_POLICY: ScrollbackPolicy = { multiplier: 1.5, maxLines: 5000, minLines: 500 };
+const AGENT_POLICY: ScrollbackPolicy = { multiplier: 5, maxLines: 5000, minLines: 500 };
 const PLAIN_POLICY: ScrollbackPolicy = { multiplier: 0.3, maxLines: 2000, minLines: 200 };
 
 /**


### PR DESCRIPTION
## Summary

- Raises `AGENT_POLICY.multiplier` from 1.5 to 5 in `src/utils/scrollbackConfig.ts`, giving default users 5000 lines of agent scrollback instead of 1500
- The main-process PTY buffer already holds 10,000 lines per terminal, so the data is there — this just widens the renderer window into it
- Lazy-loading was investigated but xterm 6.1.0-beta has no prepend/inject API; loading older history would require `terminal.reset()` + full re-replay, which is functionally equivalent to raising the cap

Resolves #10352

## Changes

- `scrollbackConfig.ts`: `multiplier: 1.5` → `multiplier: 5` (one line; `maxLines: 5000` and `minLines: 500` caps unchanged, `PLAIN_POLICY` untouched)
- `scrollbackConfig.test.ts`: updated `estimateMemoryUsage` arithmetic, added behavioral invariants (agent ≥ plain at all bases, proportional-below-cap, clamped-above-cap), and exact-value pins (agent base 500→2500, 1000→5000, 5000→5000; plain 1000→300; `minLines` floors) so a future multiplier regression fails loudly

## Testing

Memory impact is acceptable. Worst case (8 focused agents) is ~48MB, but the existing background-tier reduction holds unfocused terminals to 500 lines, so realistic steady-state (1 focused + 7 background) is ~9MB. The incremental-restore indicator (256KB threshold) will now fire on most agent restores at ~6MB serialized — expected behavior, not a regression.

Targeted unit suites pass: `scrollbackConfig` (9 tests), `TerminalInstanceService.scrollback`, and `TerminalScrollbackController` — the latter two are unaffected because their assertions land on values under the cap. E2E scrollback specs cover plain terminals only and are unaffected.