### PR TITLE
fix(plugins): use the exported border-interactive token in catalog cards

### DIFF
--- a/src/components/Plugin/PluginCatalog.tsx
+++ b/src/components/Plugin/PluginCatalog.tsx
@@ -17,7 +17,7 @@ function PluginCard({ plugin, onSelect }: { plugin: LoadedPluginInfo; onSelect: 
       onClick={onSelect}
       className={cn(
         "flex items-start gap-3 p-4 text-left rounded-[var(--radius-lg)] border border-daintree-border bg-overlay-subtle transition-colors",
-        "hover:bg-overlay-soft hover:border-daintree-border-interactive",
+        "hover:bg-overlay-soft hover:border-border-interactive",
         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
       )}
     >


### PR DESCRIPTION
## Summary

Develop's CI has been red since `7b9183a4b` (plugin catalog view): the `colorSystem.contract` test fails because `PluginCatalog.tsx` uses `hover:border-daintree-border-interactive`, a utility with no matching `--color-daintree-border-interactive` export in `src/index.css`. The exported token is `--color-border-interactive`, so the correct utility is `hover:border-border-interactive` (same convention as `border-border-default` used across the app).

One-line fix; the previous class silently produced no CSS, so this also makes the intended hover border actually render.

## Verification

- `npx vitest run src/config/__tests__/colorSystem.contract.test.ts` — 15/15 pass with this change (failed before).

This unblocks `ci-ok` for every PR based on current develop, including #10355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)