### PR TITLE
fix(github): CI status icons disappear from PR dropdown after list refresh

### DIFF
--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -64,7 +64,8 @@ beforeEach(() => {
 function makePRNode(
   number: number,
   headRefName: string,
-  reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null
+  reviewDecision?: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null,
+  commits?: unknown
 ) {
   return {
     number,
@@ -82,7 +83,12 @@ function makePRNode(
     mergedAt: null,
     author: { login: "user", avatarUrl: "" },
     ...(reviewDecision !== undefined ? { reviewDecision } : {}),
+    ...(commits !== undefined ? { commits } : {}),
   };
+}
+
+function makeCommitsRollup(state: string | null) {
+  return { nodes: [{ commit: { statusCheckRollup: state === null ? null : { state } } }] };
 }
 
 describe("findPRsByBranches", () => {
@@ -385,6 +391,71 @@ describe("listPRs reviewDecision", () => {
 
     const page = await githubForgeProvider.listPRs(repo, {});
     expect(page.items[0].reviewDecision).toBeUndefined();
+  });
+});
+
+describe("listPRs ciStatus", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+  });
+
+  function prListResponse(nodes: unknown[]) {
+    return {
+      repository: {
+        pullRequests: {
+          nodes,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          totalCount: nodes.length,
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    };
+  }
+
+  it("maps the statusCheckRollup state from the list shape onto ciStatus", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListResponse([
+        makePRNode(1, "feature/a", undefined, makeCommitsRollup("SUCCESS")),
+        makePRNode(2, "feature/b", undefined, makeCommitsRollup("FAILURE")),
+        makePRNode(3, "feature/c", undefined, makeCommitsRollup("ERROR")),
+        makePRNode(4, "feature/d", undefined, makeCommitsRollup("PENDING")),
+        makePRNode(5, "feature/e", undefined, makeCommitsRollup("EXPECTED")),
+      ])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+
+    expect(page.items[0].ciStatus).toBe("success");
+    expect(page.items[1].ciStatus).toBe("failure");
+    // ERROR folds into failure and EXPECTED into pending — the forge set is
+    // boolean-ish by design (see mapListCIStatus).
+    expect(page.items[2].ciStatus).toBe("failure");
+    expect(page.items[3].ciStatus).toBe("pending");
+    expect(page.items[4].ciStatus).toBe("pending");
+  });
+
+  it("omits ciStatus when the head commit has no statusCheckRollup", async () => {
+    // No rollup means "no CI configured" — the field must stay absent rather
+    // than default to a state (absence !== passing).
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListResponse([makePRNode(1, "feature/a", undefined, makeCommitsRollup(null))])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect("ciStatus" in page.items[0]).toBe(false);
+  });
+
+  it("omits ciStatus when the commits field is missing or empty", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListResponse([
+        makePRNode(1, "feature/a"),
+        makePRNode(2, "feature/b", undefined, { nodes: [] }),
+      ])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect("ciStatus" in page.items[0]).toBe(false);
+    expect("ciStatus" in page.items[1]).toBe(false);
   });
 });
 

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -457,6 +457,38 @@ describe("listPRs ciStatus", () => {
     expect("ciStatus" in page.items[0]).toBe(false);
     expect("ciStatus" in page.items[1]).toBe(false);
   });
+
+  it("tolerates malformed commits shapes without throwing or emitting ciStatus", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListResponse([
+        makePRNode(1, "feature/a", undefined, { nodes: [null] }),
+        makePRNode(2, "feature/b", undefined, { nodes: [{ commit: null }] }),
+        makePRNode(3, "feature/c", undefined, makeCommitsRollup("SUCCESS")),
+      ])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect("ciStatus" in page.items[0]).toBe(false);
+    expect("ciStatus" in page.items[1]).toBe(false);
+    expect(page.items[2].ciStatus).toBe("success");
+  });
+
+  it("drops unrecognized rollup states instead of guessing a mapping", async () => {
+    // Non-string and unknown-enum states fall through to "absent" — the
+    // conservative behavior if GitHub ever widens the rollup enum.
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListResponse([
+        makePRNode(1, "feature/a", undefined, makeCommitsRollup("NEUTRAL")),
+        makePRNode(2, "feature/b", undefined, {
+          nodes: [{ commit: { statusCheckRollup: { state: 123 } } }],
+        }),
+      ])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect("ciStatus" in page.items[0]).toBe(false);
+    expect("ciStatus" in page.items[1]).toBe(false);
+  });
 });
 
 function issueListResponse(totalCount?: number) {

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -302,6 +302,13 @@ function restToForgeIssue(raw: Record<string, unknown>): Issue {
 function toForgePR(node: Record<string, unknown>): PR {
   const merged = node.merged === true;
   const rawState = typeof node.state === "string" ? node.state : "OPEN";
+  const commits = node.commits as
+    | { nodes?: Array<{ commit?: { statusCheckRollup?: { state?: unknown } | null } | null }> }
+    | undefined;
+  const rollupState = commits?.nodes?.[0]?.commit?.statusCheckRollup?.state;
+  const ciStatus = mapListCIStatus(
+    typeof rollupState === "string" ? (rollupState as GitHubPRCIStatus) : undefined
+  );
   return {
     number: node.number as number,
     title: (node.title as string) ?? "",
@@ -316,6 +323,7 @@ function toForgePR(node: Record<string, unknown>): PR {
     headRef: (node.headRefName as string) ?? "",
     mergeable: undefined,
     reviewDecision: node.reviewDecision as NormalizedReviewDecision | undefined,
+    ...(ciStatus ? { ciStatus } : {}),
     createdAt: isoToMs(node.createdAt ?? node.updatedAt),
     updatedAt: isoToMs(node.updatedAt),
     closedAt: isoToMsOrNull(node.closedAt),


### PR DESCRIPTION
## Summary

- The PR dropdown briefly showed CI status icons then lost them on refresh: the initial render came from a cached shape (via `gitHubPRToForgePR`, which maps `ciStatus`), then the fresh GraphQL list response replaced it — and `toForgePR` in `plugins/builtin/github/main/forgeProvider.ts` never read `node.commits` even though `LIST_PRS_QUERY` already fetches `commits(last:1) → statusCheckRollup.state`.
- Fixed `toForgePR` to extract the rollup state via the same optional chain `parsePRNode` uses, mapping it through the existing `mapListCIStatus` helper. No query, cache, or renderer changes needed.
- Spreads `...(ciStatus ? { ciStatus } : {})` so a null/absent rollup leaves the field absent — no CI configured is not the same as passing.

Resolves #10357

## Changes

- `plugins/builtin/github/main/forgeProvider.ts`: `toForgePR` now reads `node.commits.nodes[0]?.commit.statusCheckRollup?.state` and maps it through `mapListCIStatus`
- `plugins/builtin/github/main/__tests__/forgeProvider.test.ts`: new `listPRs ciStatus` suite covering all five rollup states (`SUCCESS`, `FAILURE`, `ERROR`, `PENDING`, `EXPECTED`), null rollup, missing commits, empty nodes, malformed shapes (null node, null commit, non-string state), and unknown enum values — all exercised through the public `listPRs` path; `makePRNode` fixture gained an optional `commits` param with no impact on existing callsites

## Testing

- 99 targeted unit tests passing via `vitest`
- Full `npm run check` (typecheck, lint, format, channel/IPC/confirm-wiring guards) passing
- `npm run build` clean