### PR TITLE
feat(git-init): pre-fill initial commit message with editable default

### DIFF
--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -149,11 +149,12 @@ export function registerGitInitHandlers(): () => void {
         completedSteps.push("add");
         emitProgress("add", "success", "Files staged");
 
+        const commitMessage = initialCommitMessage.trim() || "Initial commit";
         emitProgress("commit", "start", "Creating initial commit...");
         try {
-          await git.commit(initialCommitMessage);
+          await git.commit(commitMessage);
           completedSteps.push("commit");
-          emitProgress("commit", "success", `Committed: ${initialCommitMessage}`);
+          emitProgress("commit", "success", `Committed: ${commitMessage}`);
         } catch (commitError) {
           const errorMsg = formatErrorMessage(commitError, "Failed to create initial commit");
           if (errorMsg.includes("user.email") || errorMsg.includes("user.name")) {

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -30,7 +30,7 @@ const TEMPLATE_OPTIONS: Array<{ value: GitignoreTemplate; label: string; descrip
 export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: GitInitDialogProps) {
   const [gitignoreTemplate, setGitignoreTemplate] = useState<GitignoreTemplate>("node");
   const [createInitialCommit, setCreateInitialCommit] = useState(true);
-  const [initialCommitMessage, setInitialCommitMessage] = useState("");
+  const [initialCommitMessage, setInitialCommitMessage] = useState("Initial commit");
   const [progressEvents, setProgressEvents] = useState<GitInitProgressEvent[]>([]);
   const [isInitializing, setIsInitializing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -52,7 +52,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
     if (!isOpen) {
       setGitignoreTemplate("node");
       setCreateInitialCommit(true);
-      setInitialCommitMessage("");
+      setInitialCommitMessage("Initial commit");
       setProgressEvents([]);
       setIsInitializing(false);
       setError(null);
@@ -86,10 +86,6 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
   }, [progressEvents]);
 
   const startInitialization = useCallback(async () => {
-    const trimmedMessage = initialCommitMessage.trim();
-    if (createInitialCommit && trimmedMessage === "") {
-      return;
-    }
     if (inFlightRef.current) {
       return;
     }
@@ -106,7 +102,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
       await projectClient.initGitGuided({
         directoryPath,
         createInitialCommit,
-        initialCommitMessage: trimmedMessage,
+        initialCommitMessage: initialCommitMessage.trim(),
         createGitignore: gitignoreTemplate !== "none",
         gitignoreTemplate,
       });
@@ -161,8 +157,6 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
   const showConnecting = useDohertyGate(isInitializing && progressEvents.length === 0);
   const showProgress = showConnecting || progressEvents.length > 0;
   const configDisabled = isInitializing || isComplete;
-  const trimmedMessage = initialCommitMessage.trim();
-  const canStart = !createInitialCommit || trimmedMessage !== "";
 
   return (
     <AppDialog isOpen={isOpen} onClose={handleClose} size="md" dismissible={!isInitializing}>
@@ -306,7 +300,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
             </Button>
             <Button
               onClick={() => void startInitialization()}
-              disabled={!canStart}
+              disabled={isInitializing}
               loading={isInitializing}
             >
               Initialize repository

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -73,6 +73,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
         setIsInitializing(false);
       } else if (event.step === "complete" && event.status === "success") {
         sawTerminalEventRef.current = true;
+        setError(null);
         setIsComplete(true);
         setIsInitializing(false);
       }
@@ -157,6 +158,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
   const showConnecting = useDohertyGate(isInitializing && progressEvents.length === 0);
   const showProgress = showConnecting || progressEvents.length > 0;
   const configDisabled = isInitializing || isComplete;
+  const canStart = !createInitialCommit || initialCommitMessage.trim() !== "";
 
   return (
     <AppDialog isOpen={isOpen} onClose={handleClose} size="md" dismissible={!isInitializing}>
@@ -289,7 +291,10 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
             <Button variant="outline" onClick={onCancel}>
               Cancel
             </Button>
-            <Button onClick={() => void startInitialization()} disabled={isInitializing}>
+            <Button
+              onClick={() => void startInitialization()}
+              disabled={isInitializing || !canStart}
+            >
               Try again
             </Button>
           </>
@@ -300,7 +305,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
             </Button>
             <Button
               onClick={() => void startInitialization()}
-              disabled={isInitializing}
+              disabled={isInitializing || !canStart}
               loading={isInitializing}
             >
               Initialize repository

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -142,6 +142,67 @@ describe("GitInitDialog", () => {
     });
   });
 
+  it("disables submit when the commit message is cleared", () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "   " },
+    });
+
+    const button = screen.getByRole("button", {
+      name: /initialize repository/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    fireEvent.click(button);
+    expect(initGitGuidedMock).not.toHaveBeenCalled();
+  });
+
+  it("resets the commit message to the default when reopened", () => {
+    const onSuccess = vi.fn();
+    const onCancel = vi.fn();
+    const dialogProps = {
+      directoryPath: "/tmp/new-repo",
+      onSuccess,
+      onCancel,
+    };
+    const { rerender } = render(<GitInitDialog isOpen={true} {...dialogProps} />);
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: custom" },
+    });
+
+    rerender(<GitInitDialog isOpen={false} {...dialogProps} />);
+    rerender(<GitInitDialog isOpen={true} {...dialogProps} />);
+
+    const input = screen.getByLabelText(/initial commit message/i) as HTMLInputElement;
+    expect(input.value).toBe("Initial commit");
+  });
+
+  it("clears the missing-status warning when a late success event arrives", async () => {
+    renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/without a status update/i)).toBeTruthy();
+    });
+
+    act(() => {
+      progressHandler?.({
+        step: "complete",
+        status: "success",
+        message: "Git initialization complete",
+        timestamp: Date.now(),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/without a status update/i)).toBeNull();
+      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+    });
+  });
+
   it("passes the selected template and edited commit message", async () => {
     initGitGuidedMock.mockImplementationOnce(() => new Promise(() => {}));
 

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -107,7 +107,7 @@ describe("GitInitDialog", () => {
     const button = screen.getByRole("button", {
       name: /initialize repository/i,
     }) as HTMLButtonElement;
-    expect(button.disabled).toBe(true);
+    expect(button.disabled).toBe(false);
 
     fireEvent.change(screen.getByLabelText(/initial commit message/i), {
       target: { value: "feat: init" },
@@ -123,6 +123,21 @@ describe("GitInitDialog", () => {
           gitignoreTemplate: "node",
           initialCommitMessage: "feat: init",
         })
+      );
+    });
+  });
+
+  it("pre-fills the commit message and submits the default without editing", async () => {
+    renderDialog();
+
+    const input = screen.getByLabelText(/initial commit message/i) as HTMLInputElement;
+    expect(input.value).toBe("Initial commit");
+
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+    await waitFor(() => {
+      expect(initGitGuidedMock).toHaveBeenCalledWith(
+        expect.objectContaining({ initialCommitMessage: "Initial commit" })
       );
     });
   });


### PR DESCRIPTION
## Summary

- The git init dialog showed `"Initial commit"` as placeholder text only, so the submit button stayed disabled until the user typed something. The field is now pre-filled with `"Initial commit"` as a real editable value — the dialog submits with zero keystrokes.
- Clearing the field disables submit rather than silently falling back to a derived value, which keeps this consistent with the no-silent-fallback rule from #7880.
- The backend normalizes blank/whitespace input to `"Initial commit"` as defense-in-depth (`git commit -m ""` hard-fails; the previous destructuring default only fired when the value was `undefined`, not when an empty string was passed through).
- Fixed a stale "finished without a status update" error that didn't clear when a late success progress event arrived after a retry.

Resolves #10360

## Changes

- `GitInitDialog.tsx` — pre-fills commit message state with `"Initial commit"`, resets on close, gates both "Initialize repository" and "Try again" on `canStart`, and clears error state on success progress events
- `gitInit.ts` — normalizes `initialCommitMessage.trim() || "Initial commit"` before passing to `git.commit` and the progress message
- `GitInitDialog.test.tsx` — inverted the disabled-on-mount assertion; added four new tests: submit with default, cleared message blocks submit, reopen resets to default, late success clears stale error

## Testing

`npm run check` passes, 33,400 unit tests pass, build passes, preload-backdoors clean.