### PR TITLE
fix(dev-servers): clear errored rows, gate empty state on hydration

### DIFF
--- a/src/components/Portal/DevServerDashboard.tsx
+++ b/src/components/Portal/DevServerDashboard.tsx
@@ -22,10 +22,14 @@ const STATUS_PRESENTATION: Record<DevPreviewSessionStatus, { label: string; dotC
 // A plain "stopped" session has no row; "restored-stopped" stays visible because
 // it is an explicit restart offer the dashboard should surface.
 const HIDDEN_STATUSES: ReadonlySet<DevPreviewSessionStatus> = new Set(["stopped"]);
+// "error" is stoppable: errored sessions have no terminal, so stop() takes the
+// no-terminal branch — transitions to "stopped" and clears the error, which is
+// the only way to dismiss an errored row from the dashboard.
 const STOPPABLE_STATUSES: ReadonlySet<DevPreviewSessionStatus> = new Set([
   "starting",
   "installing",
   "running",
+  "error",
 ]);
 
 function extractPort(session: DevPreviewSessionState): string | null {
@@ -111,7 +115,7 @@ function DevServerRow({
 }
 
 export function DevServerDashboard() {
-  const allSessions = useAllDevSessions();
+  const { sessions: allSessions, hydrated, fetchError } = useAllDevSessions();
   const worktrees = useWorktreeStore((s) => s.worktrees);
 
   const visibleSessions = useMemo(
@@ -127,8 +131,10 @@ export function DevServerDashboard() {
       <header className="px-3 pt-2 pb-1 text-xs font-medium uppercase tracking-wide text-daintree-text/55">
         Dev servers
       </header>
-      {visibleSessions.length === 0 ? (
-        <p className="px-3 pb-3 text-xs text-daintree-text/50">No active dev servers</p>
+      {!hydrated ? null : visibleSessions.length === 0 ? (
+        <p className="px-3 pb-3 text-xs text-daintree-text/50">
+          {fetchError ? "Couldn't load dev servers" : "No active dev servers"}
+        </p>
       ) : (
         <ul className="flex flex-col pb-1">
           {visibleSessions.map((session) => (

--- a/src/components/Portal/__tests__/DevServerDashboard.test.tsx
+++ b/src/components/Portal/__tests__/DevServerDashboard.test.tsx
@@ -151,6 +151,21 @@ describe("DevServerDashboard", () => {
     expect(stopDevServerByWorktree).toHaveBeenCalledWith({ worktreeId: "wt-1" });
   });
 
+  it("disables both buttons when the session has no worktreeId", () => {
+    mockSessions([session({ status: "error", worktreeId: undefined })]);
+    render(<DevServerDashboard />);
+    const stopButton = screen.getByLabelText("Stop dev server for panel-1") as HTMLButtonElement;
+    const restartButton = screen.getByLabelText(
+      "Restart dev server for panel-1"
+    ) as HTMLButtonElement;
+    expect(stopButton.disabled).toBe(true);
+    expect(restartButton.disabled).toBe(true);
+    fireEvent.click(stopButton);
+    fireEvent.click(restartButton);
+    expect(stopDevServerByWorktree).not.toHaveBeenCalled();
+    expect(restartByWorktree).not.toHaveBeenCalled();
+  });
+
   it("disables stop for restored-stopped sessions", () => {
     mockSessions([session({ status: "restored-stopped" })]);
     render(<DevServerDashboard />);

--- a/src/components/Portal/__tests__/DevServerDashboard.test.tsx
+++ b/src/components/Portal/__tests__/DevServerDashboard.test.tsx
@@ -3,8 +3,22 @@ import { cleanup, render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
 
-const useAllDevSessions = vi.fn<() => DevPreviewSessionState[]>();
+const useAllDevSessions = vi.fn<
+  () => { sessions: DevPreviewSessionState[]; hydrated: boolean; fetchError: boolean }
+>();
 const useWorktreeStore = vi.fn();
+
+function mockSessions(
+  sessions: DevPreviewSessionState[],
+  overrides: { hydrated?: boolean; fetchError?: boolean } = {}
+) {
+  useAllDevSessions.mockReturnValue({
+    sessions,
+    hydrated: true,
+    fetchError: false,
+    ...overrides,
+  });
+}
 
 vi.mock("@/store/allDevSessionsStore", () => ({
   useAllDevSessions: () => useAllDevSessions(),
@@ -54,13 +68,27 @@ afterEach(() => {
 
 describe("DevServerDashboard", () => {
   it("shows the empty state when no active sessions", () => {
-    useAllDevSessions.mockReturnValue([]);
+    mockSessions([]);
     render(<DevServerDashboard />);
     expect(screen.getByText("No active dev servers")).toBeTruthy();
   });
 
+  it("renders no body before the store hydrates", () => {
+    mockSessions([], { hydrated: false });
+    render(<DevServerDashboard />);
+    expect(screen.queryByText("No active dev servers")).toBeNull();
+    expect(screen.queryByText("Couldn't load dev servers")).toBeNull();
+  });
+
+  it("shows a distinct message when the session fetch fails", () => {
+    mockSessions([], { fetchError: true });
+    render(<DevServerDashboard />);
+    expect(screen.getByText("Couldn't load dev servers")).toBeTruthy();
+    expect(screen.queryByText("No active dev servers")).toBeNull();
+  });
+
   it("hides plain stopped sessions but keeps restored-stopped", () => {
-    useAllDevSessions.mockReturnValue([
+    mockSessions([
       session({ panelId: "p-stopped", status: "stopped", worktreeId: "wt-stopped" }),
       session({ panelId: "p-restored", status: "restored-stopped", worktreeId: "wt-1" }),
     ]);
@@ -70,9 +98,7 @@ describe("DevServerDashboard", () => {
   });
 
   it("renders worktree label, port and last output", () => {
-    useAllDevSessions.mockReturnValue([
-      session({ url: "http://localhost:4321", lastOutput: "ready in 200ms" }),
-    ]);
+    mockSessions([session({ url: "http://localhost:4321", lastOutput: "ready in 200ms" })]);
     render(<DevServerDashboard />);
     expect(screen.getByText("feature-foo")).toBeTruthy();
     expect(screen.getByText(":4321")).toBeTruthy();
@@ -80,15 +106,13 @@ describe("DevServerDashboard", () => {
   });
 
   it("uses predictedUrl for the port when url is null", () => {
-    useAllDevSessions.mockReturnValue([
-      session({ url: null, predictedUrl: "http://localhost:5050" }),
-    ]);
+    mockSessions([session({ url: null, predictedUrl: "http://localhost:5050" })]);
     render(<DevServerDashboard />);
     expect(screen.getByText(":5050")).toBeTruthy();
   });
 
   it("omits the port when neither url has one", () => {
-    useAllDevSessions.mockReturnValue([session({ url: "http://localhost", predictedUrl: null })]);
+    mockSessions([session({ url: "http://localhost", predictedUrl: null })]);
     const { container } = render(<DevServerDashboard />);
     expect(container.textContent).not.toContain(":");
   });
@@ -97,27 +121,38 @@ describe("DevServerDashboard", () => {
     useWorktreeStore.mockImplementation((selector: (s: unknown) => unknown) =>
       selector({ worktrees: new Map() })
     );
-    useAllDevSessions.mockReturnValue([session({ worktreeId: "wt-unknown" })]);
+    mockSessions([session({ worktreeId: "wt-unknown" })]);
     render(<DevServerDashboard />);
     expect(screen.getByText("wt-unknown")).toBeTruthy();
   });
 
   it("restarts the worktree dev server on click", () => {
-    useAllDevSessions.mockReturnValue([session()]);
+    mockSessions([session()]);
     render(<DevServerDashboard />);
     fireEvent.click(screen.getByLabelText("Restart dev server for feature-foo"));
     expect(restartByWorktree).toHaveBeenCalledWith({ worktreeId: "wt-1" });
   });
 
   it("stops the worktree dev server on click", () => {
-    useAllDevSessions.mockReturnValue([session()]);
+    mockSessions([session()]);
     render(<DevServerDashboard />);
     fireEvent.click(screen.getByLabelText("Stop dev server for feature-foo"));
     expect(stopDevServerByWorktree).toHaveBeenCalledWith({ worktreeId: "wt-1" });
   });
 
-  it("disables stop for non-running sessions", () => {
-    useAllDevSessions.mockReturnValue([session({ status: "error" })]);
+  it("enables stop for errored sessions and fires the stop call", () => {
+    mockSessions([session({ status: "error", terminalId: null, url: null })]);
+    render(<DevServerDashboard />);
+    const stopButton = screen.getByLabelText(
+      "Stop dev server for feature-foo"
+    ) as HTMLButtonElement;
+    expect(stopButton.disabled).toBe(false);
+    fireEvent.click(stopButton);
+    expect(stopDevServerByWorktree).toHaveBeenCalledWith({ worktreeId: "wt-1" });
+  });
+
+  it("disables stop for restored-stopped sessions", () => {
+    mockSessions([session({ status: "restored-stopped" })]);
     render(<DevServerDashboard />);
     const stopButton = screen.getByLabelText(
       "Stop dev server for feature-foo"

--- a/src/components/Portal/__tests__/DevServerDashboard.test.tsx
+++ b/src/components/Portal/__tests__/DevServerDashboard.test.tsx
@@ -3,9 +3,8 @@ import { cleanup, render, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
 
-const useAllDevSessions = vi.fn<
-  () => { sessions: DevPreviewSessionState[]; hydrated: boolean; fetchError: boolean }
->();
+const useAllDevSessions =
+  vi.fn<() => { sessions: DevPreviewSessionState[]; hydrated: boolean; fetchError: boolean }>();
 const useWorktreeStore = vi.fn();
 
 function mockSessions(

--- a/src/store/__tests__/allDevSessionsStore.test.ts
+++ b/src/store/__tests__/allDevSessionsStore.test.ts
@@ -28,6 +28,7 @@ let unsubscribe: ReturnType<typeof vi.fn>;
 let onAllSessionsChanged: ReturnType<typeof vi.fn>;
 let getAllSessions: ReturnType<typeof vi.fn>;
 let resolveGetAll: (value: DevPreviewSessionState[]) => void;
+let rejectGetAll: (err: unknown) => void;
 
 beforeEach(() => {
   pushCallback = null;
@@ -38,8 +39,9 @@ beforeEach(() => {
   });
   getAllSessions = vi.fn(
     () =>
-      new Promise<DevPreviewSessionState[]>((resolve) => {
+      new Promise<DevPreviewSessionState[]>((resolve, reject) => {
         resolveGetAll = resolve;
+        rejectGetAll = reject;
       })
   );
   (globalThis as unknown as { window: unknown }).window = {
@@ -63,6 +65,37 @@ describe("allDevSessionsStore", () => {
       expect(useAllDevSessionsStore.getState().hydrated).toBe(true);
     });
     expect(useAllDevSessionsStore.getState().sessions).toHaveLength(1);
+    expect(useAllDevSessionsStore.getState().fetchError).toBe(false);
+  });
+
+  it("marks fetchError when the initial hydrate rejects", async () => {
+    acquireAllDevSessions();
+    rejectGetAll(new Error("ipc failed"));
+    await vi.waitFor(() => {
+      expect(useAllDevSessionsStore.getState().hydrated).toBe(true);
+    });
+    expect(useAllDevSessionsStore.getState().fetchError).toBe(true);
+    expect(useAllDevSessionsStore.getState().sessions).toHaveLength(0);
+  });
+
+  it("clears fetchError when a push arrives after a failed hydrate", async () => {
+    acquireAllDevSessions();
+    rejectGetAll(new Error("ipc failed"));
+    await vi.waitFor(() => expect(useAllDevSessionsStore.getState().fetchError).toBe(true));
+
+    pushCallback?.({ sessions: [makeSession()] });
+    expect(useAllDevSessionsStore.getState().fetchError).toBe(false);
+    expect(useAllDevSessionsStore.getState().sessions).toHaveLength(1);
+  });
+
+  it("resets fetchError on teardown", async () => {
+    const release = acquireAllDevSessions();
+    rejectGetAll(new Error("ipc failed"));
+    await vi.waitFor(() => expect(useAllDevSessionsStore.getState().fetchError).toBe(true));
+
+    release();
+    expect(useAllDevSessionsStore.getState().fetchError).toBe(false);
+    expect(useAllDevSessionsStore.getState().hydrated).toBe(false);
   });
 
   it("applies pushed snapshots", async () => {

--- a/src/store/__tests__/allDevSessionsStore.test.ts
+++ b/src/store/__tests__/allDevSessionsStore.test.ts
@@ -98,6 +98,31 @@ describe("allDevSessionsStore", () => {
     expect(useAllDevSessionsStore.getState().hydrated).toBe(false);
   });
 
+  it("does not let a late rejection set fetchError after a push", async () => {
+    acquireAllDevSessions();
+    pushCallback?.({ sessions: [makeSession({ panelId: "live" })] });
+
+    rejectGetAll(new Error("ipc failed"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useAllDevSessionsStore.getState().fetchError).toBe(false);
+    expect(useAllDevSessionsStore.getState().sessions[0]?.panelId).toBe("live");
+  });
+
+  it("hydrates cleanly on re-acquire after a failed first lifecycle", async () => {
+    const release = acquireAllDevSessions();
+    rejectGetAll(new Error("ipc failed"));
+    await vi.waitFor(() => expect(useAllDevSessionsStore.getState().fetchError).toBe(true));
+    release();
+
+    acquireAllDevSessions();
+    resolveGetAll([makeSession()]);
+    await vi.waitFor(() => expect(useAllDevSessionsStore.getState().hydrated).toBe(true));
+    expect(useAllDevSessionsStore.getState().fetchError).toBe(false);
+    expect(useAllDevSessionsStore.getState().sessions).toHaveLength(1);
+  });
+
   it("applies pushed snapshots", async () => {
     acquireAllDevSessions();
     resolveGetAll([]);

--- a/src/store/allDevSessionsStore.ts
+++ b/src/store/allDevSessionsStore.ts
@@ -47,7 +47,11 @@ function startSubscription(): void {
     // snapshot. Advance the token so a still-in-flight getAllSessions() that
     // resolves later can't overwrite this fresher state with stale data.
     hydrateToken++;
-    useAllDevSessionsStore.setState({ sessions: payload.sessions, hydrated: true, fetchError: false });
+    useAllDevSessionsStore.setState({
+      sessions: payload.sessions,
+      hydrated: true,
+      fetchError: false,
+    });
   });
 }
 

--- a/src/store/allDevSessionsStore.ts
+++ b/src/store/allDevSessionsStore.ts
@@ -1,16 +1,19 @@
 import { useEffect } from "react";
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 import type { DevPreviewSessionState } from "@shared/types/ipc/devPreview";
 import { logError } from "@/utils/logger";
 
 interface AllDevSessionsState {
   sessions: DevPreviewSessionState[];
   hydrated: boolean;
+  fetchError: boolean;
 }
 
 export const useAllDevSessionsStore = create<AllDevSessionsState>(() => ({
   sessions: [],
   hydrated: false,
+  fetchError: false,
 }));
 
 // Single shared IPC subscription guarded by a reference count. React 19
@@ -31,12 +34,12 @@ function startSubscription(): void {
     .getAllSessions()
     .then((sessions) => {
       if (token !== hydrateToken) return;
-      useAllDevSessionsStore.setState({ sessions, hydrated: true });
+      useAllDevSessionsStore.setState({ sessions, hydrated: true, fetchError: false });
     })
     .catch((err) => {
       if (token !== hydrateToken) return;
       logError("Failed to load dev-server sessions", err);
-      useAllDevSessionsStore.setState({ hydrated: true });
+      useAllDevSessionsStore.setState({ hydrated: true, fetchError: true });
     });
 
   unsubscribe = window.electron.devPreview.onAllSessionsChanged((payload) => {
@@ -44,7 +47,7 @@ function startSubscription(): void {
     // snapshot. Advance the token so a still-in-flight getAllSessions() that
     // resolves later can't overwrite this fresher state with stale data.
     hydrateToken++;
-    useAllDevSessionsStore.setState({ sessions: payload.sessions, hydrated: true });
+    useAllDevSessionsStore.setState({ sessions: payload.sessions, hydrated: true, fetchError: false });
   });
 }
 
@@ -54,7 +57,7 @@ function stopSubscription(): void {
   hydrateToken++;
   unsubscribe?.();
   unsubscribe = null;
-  useAllDevSessionsStore.setState({ sessions: [], hydrated: false });
+  useAllDevSessionsStore.setState({ sessions: [], hydrated: false, fetchError: false });
 }
 
 /**
@@ -79,9 +82,15 @@ export function acquireAllDevSessions(): () => void {
  * Subscribe to the live snapshot of every dev-preview session across all
  * worktrees. Mounting drives the shared IPC subscription via the ref count.
  */
-export function useAllDevSessions(): DevPreviewSessionState[] {
+export function useAllDevSessions(): {
+  sessions: DevPreviewSessionState[];
+  hydrated: boolean;
+  fetchError: boolean;
+} {
   useEffect(() => acquireAllDevSessions(), []);
-  return useAllDevSessionsStore((s) => s.sessions);
+  return useAllDevSessionsStore(
+    useShallow((s) => ({ sessions: s.sessions, hydrated: s.hydrated, fetchError: s.fetchError }))
+  );
 }
 
 // Test-only reset so suites can start from a clean module state.
@@ -90,5 +99,5 @@ export function _resetAllDevSessionsForTests(): void {
   hydrateToken = 0;
   unsubscribe?.();
   unsubscribe = null;
-  useAllDevSessionsStore.setState({ sessions: [], hydrated: false });
+  useAllDevSessionsStore.setState({ sessions: [], hydrated: false, fetchError: false });
 }


### PR DESCRIPTION
## Summary

- Errored rows in the Portal dev-servers dashboard can now be stopped and cleared. `"error"` was missing from `STOPPABLE_STATUSES` in `DevServerDashboard.tsx` — the backend `DevPreviewSessionService.stop()` already handled errored sessions via the no-terminal branch, so once stopped the row disappears. `restored-stopped` rows remain non-stoppable intentionally (`stopDevServerByWorktree` would silently no-op).
- The "No active dev servers" empty state no longer flashes before the store hydrates. `allDevSessionsStore` gains a `fetchError` flag; `useAllDevSessions` now returns `{ sessions, hydrated, fetchError }` via `useShallow`. The dashboard suppresses the section body until `hydrated` is true and shows "Couldn't load dev servers" when the fetch fails instead of the misleading empty copy.

Resolves #10365

## Changes

- `src/components/Portal/DevServerDashboard.tsx` — add `"error"` to `STOPPABLE_STATUSES`; gate section body render on `hydrated`; show fetch-error copy on failure
- `src/store/allDevSessionsStore.ts` — add `fetchError` flag, set/clear across `getAllSessions` reject/resolve/push/teardown paths, token guard against late rejections after a push
- `src/store/__tests__/allDevSessionsStore.test.ts` — coverage for `fetchError` set/clear, teardown reset, late-rejection token guard, re-acquire lifecycle
- `src/components/Portal/__tests__/DevServerDashboard.test.tsx` — pre-hydration suppression, fetch-error copy, errored-row stop enabled, `restored-stopped` and missing-`worktreeId` stop disabled

## Testing

Unit tests cover both fixes end-to-end. Full local CI passed (typecheck, lint, format, channel/IPC/confirm guards, 33 405 unit tests, build, smoke).