### PR TITLE
fix(terminal): defer wake fan-out to double-rAF so geometry settles before refresh

### DIFF
--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -687,17 +687,27 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // triggers redundant `get-all-states` fetches.
     // De-dupe guard: on warm reactivation Chromium fires the Page Lifecycle
     // `resume` event immediately before `visibilitychange` in the same turn
-    // (#9702). Coalesce both into a single wake fan-out via a microtask so a
-    // resume+visibilitychange pair doesn't run the fan-out twice.
+    // (#9702). Coalesce both into a single wake fan-out.
+    // Double-rAF, not a microtask: a microtask runs before the unfrozen
+    // renderer's first layout pass, so the wake's geometry reads and
+    // terminal.refresh() execute while xterm's IntersectionObserver hasn't
+    // re-fired and its render service is still paused — leaving agent
+    // terminals garbled until a click re-fits them (#10362). The first rAF
+    // fires before ResizeObserver/IntersectionObserver callbacks and paint;
+    // the second is post-paint with settled layout (same idiom as
+    // warmReactivationGate). Visibility is re-checked at execution time in
+    // case the view was re-hidden between scheduling and the second frame.
     let wakePending = false;
     function scheduleWake() {
       if (wakePending) return;
       wakePending = true;
-      void Promise.resolve().then(() => {
-        wakePending = false;
-        if (document.visibilityState === "visible") {
-          void wakeActiveWorktreeTerminals();
-        }
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          wakePending = false;
+          if (document.visibilityState === "visible") {
+            void wakeActiveWorktreeTerminals();
+          }
+        });
       });
     }
 

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -698,11 +698,13 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     // warmReactivationGate). Visibility is re-checked at execution time in
     // case the view was re-hidden between scheduling and the second frame.
     let wakePending = false;
+    let wakeRafId: number | null = null;
     function scheduleWake() {
       if (wakePending) return;
       wakePending = true;
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
+      wakeRafId = requestAnimationFrame(() => {
+        wakeRafId = requestAnimationFrame(() => {
+          wakeRafId = null;
           wakePending = false;
           if (document.visibilityState === "visible") {
             void wakeActiveWorktreeTerminals();
@@ -710,6 +712,9 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         });
       });
     }
+    cleanups.push(() => {
+      if (wakeRafId !== null) cancelAnimationFrame(wakeRafId);
+    });
 
     function handleVisibilityChange() {
       if (document.visibilityState !== "visible") return;

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -1234,6 +1234,32 @@ describe("WorktreeStoreProvider visibilitychange (#8066 consolidation)", () => {
 });
 
 describe("WorktreeStoreProvider resume event (#9702)", () => {
+  const rafQueue: FrameRequestCallback[] = [];
+  const realRaf = globalThis.requestAnimationFrame;
+
+  beforeEach(() => {
+    rafQueue.length = 0;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    }) as typeof globalThis.requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = realRaf;
+  });
+
+  // The wake fan-out is deferred behind a double-rAF so it runs after the
+  // unfrozen renderer's first settled layout pass (#10362).
+  function flushWakeFrames(): void {
+    for (let i = 0; i < 2; i++) {
+      act(() => {
+        const pending = rafQueue.splice(0, rafQueue.length);
+        for (const cb of pending) cb(0);
+      });
+    }
+  }
+
   function setVisibility(state: "visible" | "hidden"): void {
     Object.defineProperty(document, "visibilityState", {
       configurable: true,
@@ -1249,10 +1275,7 @@ describe("WorktreeStoreProvider resume event (#9702)", () => {
     act(() => {
       document.dispatchEvent(new Event("resume"));
     });
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    flushWakeFrames();
 
     expect(wakeMock).not.toHaveBeenCalled();
   });
@@ -1265,10 +1288,7 @@ describe("WorktreeStoreProvider resume event (#9702)", () => {
     act(() => {
       document.dispatchEvent(new Event("resume"));
     });
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    flushWakeFrames();
 
     expect(wakeMock).toHaveBeenCalledTimes(1);
   });
@@ -1284,10 +1304,7 @@ describe("WorktreeStoreProvider resume event (#9702)", () => {
       document.dispatchEvent(new Event("resume"));
       document.dispatchEvent(new Event("visibilitychange"));
     });
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+    flushWakeFrames();
 
     expect(wakeMock).toHaveBeenCalledTimes(1);
   });

--- a/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+
+import { useProjectStore } from "@/store/projectStore";
+import type { WorktreeSnapshot } from "@shared/types";
+import type { Project } from "@shared/types/project";
+
+const wakeMock = vi.fn<() => Promise<void>>(() => Promise.resolve());
+vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
+  wakeActiveWorktreeTerminals: () => wakeMock(),
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn(() => "notif-id") }));
+vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
+
+const rafQueue: FrameRequestCallback[] = [];
+
+function flushFrame(): void {
+  const pending = rafQueue.splice(0, rafQueue.length);
+  for (const cb of pending) cb(0);
+}
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+beforeEach(() => {
+  rafQueue.length = 0;
+  wakeMock.mockClear();
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  }) as typeof globalThis.requestAnimationFrame;
+  setVisibilityState("visible");
+  useProjectStore.setState({
+    currentProject: { id: "p1", name: "p1", path: "/repo/proj" } as unknown as Project,
+  });
+
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      isReady: () => true,
+      request: (_name: string) => Promise.resolve({ states: [] as WorktreeSnapshot[] }),
+      onEvent: (_name: string, _cb: (data: unknown) => void) => () => {},
+      onReady: (_cb: () => void) => () => {},
+      onDisconnected: (_cb: () => void) => () => {},
+      onFatalDisconnect: (_cb: () => void) => () => {},
+    },
+    worktree: {
+      getAllIssueAssociations: () => Promise.resolve({}),
+      getPRStatus: () => Promise.resolve(null),
+    },
+  } as unknown as typeof window.electron;
+});
+
+afterEach(() => {
+  // Restore the prototype getter shadowed by setVisibilityState.
+  delete (document as unknown as Record<string, unknown>)["visibilityState"];
+  useProjectStore.setState({ currentProject: null });
+  vi.restoreAllMocks();
+});
+
+async function renderProvider() {
+  const { WorktreeStoreProvider, WorktreeStoreContext } = await import("../WorktreeStoreContext");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
+  );
+  const { result } = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  if (!result.current) throw new Error("WorktreeStoreContext is null");
+  return result.current;
+}
+
+describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
+  it("runs the missed-event guard synchronously on mount when already visible", async () => {
+    await renderProvider();
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+    expect(rafQueue.length).toBe(0);
+  });
+
+  it("defers the wake to the second animation frame, not a microtask or first frame", async () => {
+    await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    // Microtask checkpoint: the pre-#10362 scheduler fired here, before the
+    // unfrozen renderer's first layout pass.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(wakeMock).not.toHaveBeenCalled();
+
+    act(() => flushFrame());
+    expect(wakeMock).not.toHaveBeenCalled();
+
+    act(() => flushFrame());
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces a same-turn resume + visibilitychange pair into one wake", async () => {
+    await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("resume"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    act(() => flushFrame());
+    act(() => flushFrame());
+
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the wake when the view is re-hidden before the second frame", async () => {
+    await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    act(() => flushFrame());
+    setVisibilityState("hidden");
+    act(() => flushFrame());
+
+    expect(wakeMock).not.toHaveBeenCalled();
+  });
+
+  it("clears the pending flag after a skipped wake so the next cycle fires", async () => {
+    await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    setVisibilityState("hidden");
+    act(() => flushFrame());
+    act(() => flushFrame());
+    expect(wakeMock).not.toHaveBeenCalled();
+
+    setVisibilityState("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    act(() => flushFrame());
+    act(() => flushFrame());
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores visibilitychange dispatched while hidden", async () => {
+    await renderProvider();
+    wakeMock.mockClear();
+
+    setVisibilityState("hidden");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      document.dispatchEvent(new Event("resume"));
+    });
+    act(() => flushFrame());
+    act(() => flushFrame());
+
+    expect(wakeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
@@ -15,10 +15,12 @@ vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
 vi.mock("@/lib/notify", () => ({ notify: vi.fn(() => "notif-id") }));
 vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
 
-const rafQueue: FrameRequestCallback[] = [];
+const rafQueue = new Map<number, FrameRequestCallback>();
+let rafIdCounter = 0;
 
 function flushFrame(): void {
-  const pending = rafQueue.splice(0, rafQueue.length);
+  const pending = [...rafQueue.values()];
+  rafQueue.clear();
   for (const cb of pending) cb(0);
 }
 
@@ -30,12 +32,17 @@ function setVisibilityState(state: DocumentVisibilityState): void {
 }
 
 beforeEach(() => {
-  rafQueue.length = 0;
+  rafQueue.clear();
+  rafIdCounter = 0;
   wakeMock.mockClear();
   globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
-    rafQueue.push(cb);
-    return rafQueue.length;
+    const id = ++rafIdCounter;
+    rafQueue.set(id, cb);
+    return id;
   }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number): void => {
+    rafQueue.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
   setVisibilityState("visible");
   useProjectStore.setState({
     currentProject: { id: "p1", name: "p1", path: "/repo/proj" } as unknown as Project,
@@ -69,20 +76,20 @@ async function renderProvider() {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
   );
-  const { result } = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  const { result, unmount } = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
   });
   if (!result.current) throw new Error("WorktreeStoreContext is null");
-  return result.current;
+  return { store: result.current, unmount };
 }
 
 describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
   it("runs the missed-event guard synchronously on mount when already visible", async () => {
     await renderProvider();
     expect(wakeMock).toHaveBeenCalledTimes(1);
-    expect(rafQueue.length).toBe(0);
+    expect(rafQueue.size).toBe(0);
   });
 
   it("defers the wake to the second animation frame, not a microtask or first frame", async () => {
@@ -152,6 +159,39 @@ describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
     });
     act(() => flushFrame());
     act(() => flushFrame());
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a pending wake when the provider unmounts mid-schedule", async () => {
+    const { unmount } = await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    unmount();
+    act(() => flushFrame());
+    act(() => flushFrame());
+
+    expect(wakeMock).not.toHaveBeenCalled();
+  });
+
+  it("services a show arriving mid-dedup window with the already-pending wake", async () => {
+    await renderProvider();
+    wakeMock.mockClear();
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    act(() => flushFrame());
+    setVisibilityState("hidden");
+    setVisibilityState("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    act(() => flushFrame());
+    act(() => flushFrame());
+
     expect(wakeMock).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- `scheduleWake()` in `WorktreeStoreContext` was coalescing the Page Lifecycle `resume` + `visibilitychange` pair via a `Promise.resolve().then()` microtask, which executes before the unfrozen renderer's first layout pass. The wake sequence (`fullWakeForVisibilityRestore` → `applyDeferredResize` → `terminal.refresh()`) was therefore running while xterm's `IntersectionObserver` hadn't re-fired and its render service was still paused, leaving terminals with garbled line wrapping until a click re-fit them.
- Deferred the fan-out behind a double `requestAnimationFrame` (the same layout-settle idiom used by `warmReactivationGate`), re-checking `document.visibilityState` at execution time so a quick re-hide is a no-op.
- Cancels the pending rAF pair in the effect cleanup so an unmounted or evicted provider can't fire a stale wake.

Resolves #10362

## Changes

- `src/contexts/WorktreeStoreContext.tsx` — replaced microtask coalescing with a double-rAF defer, visibility recheck, and cleanup cancellation
- `src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx` — new suite (8 tests): mount-guard sync wake, microtask/1-frame/2-frame timing, resume+visibilitychange dedup, re-hide skip, pending-flag clearance, hidden-event ignore, post-unmount cancellation, mid-dedup show
- `src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx` — updated three existing `#9702` resume tests to flush the new wake frames

## Testing

`npm run check`, build, preload backdoor guard, and both unit suites pass locally. Smoke requires the CI runner (xvfb).