### PR TITLE
fix(dev-preview): keep crash/unresponsive banners up until a real URL change

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1261,6 +1261,13 @@ export function DevPreviewPane({
 
   // Blank the webview and clear timers before React unmounts it for faster memory reclamation
   useEffect(() => {
+    if (isEvicted) {
+      // Clear crash state so a restored panel doesn't surface a stale banner.
+      // The eviction placeholder owns the visual signal in that window.
+      setCrashState("none");
+      setCrashDetails(null);
+      crashTimestampsRef.current = [];
+    }
     if (isEvicted && webviewRef.current) {
       try {
         // Save scroll position before eviction. Use the main-process CDP
@@ -1291,11 +1298,6 @@ export function DevPreviewPane({
       }
       clearLoadTimers();
       clearRetryState();
-      // Clear crash state so a restored panel doesn't surface a stale banner.
-      // The eviction placeholder owns the visual signal in that window.
-      setCrashState("none");
-      setCrashDetails(null);
-      crashTimestampsRef.current = [];
     }
   }, [isEvicted, id, setDevPreviewScrollPosition, clearLoadTimers, clearRetryState]);
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -601,7 +601,6 @@ export function DevPreviewPane({
     setIsWebviewReady,
     isLoading,
     setIsLoading,
-    setIsSlowLoad,
     webviewLoadError,
     setWebviewLoadError,
     reconnectAttempt,
@@ -767,13 +766,11 @@ export function DevPreviewPane({
 
   const handleReload = useCallback(() => {
     setWebviewLoadError(null);
-    setIsSlowLoad(false);
     webviewRef.current?.reload();
-  }, [setWebviewLoadError, setIsSlowLoad]);
+  }, [setWebviewLoadError]);
 
   const handleCancelLoad = useCallback(() => {
     clearLoadTimers();
-    setIsSlowLoad(false);
     setIsLoading(false);
     try {
       webviewRef.current?.stop();
@@ -781,11 +778,10 @@ export function DevPreviewPane({
       // Webview detached
     }
     setWebviewLoadError({ code: "aborted", message: "Load cancelled." });
-  }, [clearLoadTimers, setIsSlowLoad, setIsLoading, setWebviewLoadError]);
+  }, [clearLoadTimers, setIsLoading, setWebviewLoadError]);
 
   const handleRetryWebviewLoad = useCallback(() => {
     setWebviewLoadError(null);
-    setIsSlowLoad(false);
     setIsLoading(true);
     if (currentUrl) {
       // Swallow ERR_ABORTED-class rejections — did-fail-load is the source
@@ -797,13 +793,12 @@ export function DevPreviewPane({
     } else {
       webviewRef.current?.reload();
     }
-  }, [currentUrl, setWebviewLoadError, setIsSlowLoad, setIsLoading]);
+  }, [currentUrl, setWebviewLoadError, setIsLoading]);
 
   const performReload = useCallback(() => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
     setWebviewLoadError(null);
-    setIsSlowLoad(false);
     try {
       const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
       safeFireAndForget(window.electron.webview.reloadIgnoringCache(wcId, id), {
@@ -812,7 +807,7 @@ export function DevPreviewPane({
     } catch {
       webview.reload();
     }
-  }, [isWebviewReady, id, setWebviewLoadError, setIsSlowLoad]);
+  }, [isWebviewReady, id, setWebviewLoadError]);
 
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
@@ -946,7 +941,6 @@ export function DevPreviewPane({
     setWebviewSeedUrl("");
     lastSetUrlRef.current = "";
     setIsLoading(false);
-    setIsSlowLoad(false);
     setIsWebviewReady(false);
     setWebviewLoadError(null);
     setCrashState("none");
@@ -958,7 +952,6 @@ export function DevPreviewPane({
     setDevPreviewScrollPosition,
     clearLoadTimers,
     setIsLoading,
-    setIsSlowLoad,
     setIsWebviewReady,
     setWebviewLoadError,
   ]);
@@ -1298,6 +1291,11 @@ export function DevPreviewPane({
       }
       clearLoadTimers();
       clearRetryState();
+      // Clear crash state so a restored panel doesn't surface a stale banner.
+      // The eviction placeholder owns the visual signal in that window.
+      setCrashState("none");
+      setCrashDetails(null);
+      crashTimestampsRef.current = [];
     }
   }, [isEvicted, id, setDevPreviewScrollPosition, clearLoadTimers, clearRetryState]);
 
@@ -1427,14 +1425,23 @@ export function DevPreviewPane({
     };
   }, [id]);
 
-  // Clear crash state on successful navigation
+  // Clear crash state when the user navigates to a fresh URL. Depending on
+  // crashState here would create an instant-reset loop: the effect would fire
+  // the moment crashState transitions from "none" and clear it back. Track the
+  // last URL we cleared at via a ref so this effect runs only on real URL
+  // transitions.
+  const lastClearedCrashUrlRef = useRef<string>(currentUrl);
   useEffect(() => {
-    if (crashState === "none") return;
+    if (currentUrl === lastClearedCrashUrlRef.current) return;
+    lastClearedCrashUrlRef.current = currentUrl;
     if (currentUrl && currentUrl !== "about:blank") {
       setCrashState("none");
       setCrashDetails(null);
+      // Don't carry the prior URL's crash history into the new URL's 60s
+      // window — that would mis-throttle the first auto-recovery there.
+      crashTimestampsRef.current = [];
     }
-  }, [currentUrl, crashState]);
+  }, [currentUrl]);
 
   // Listen for the reload shortcut (Cmd/Ctrl+R) forwarded from the focused
   // webview guest. When the guest has focus, the outer renderer's keybinding

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -2014,6 +2014,108 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
       expect(container.textContent).not.toContain("Preview is not responding");
     });
+
+    it("does not clear a crashed banner when a stale responsive event arrives", () => {
+      let responsiveCb: ((data: { panelId: string }) => void) | undefined;
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      electron.webview.onResponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
+        responsiveCb = cb;
+        return vi.fn();
+      });
+
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+      });
+
+      act(() => {
+        responsiveCb?.({ panelId: "dev-preview-panel-1" });
+      });
+      expect(container.textContent).toContain("Preview process crashed");
+    });
+
+    it("ignores unresponsive events targeting a different panel", () => {
+      let unresponsiveCb: ((data: { panelId: string }) => void) | undefined;
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      electron.webview.onUnresponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
+        unresponsiveCb = cb;
+        return vi.fn();
+      });
+
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      getWebviewElement(container);
+
+      act(() => {
+        unresponsiveCb?.({ panelId: "some-other-panel" });
+      });
+      expect(container.textContent).not.toContain("Preview is not responding");
+    });
+
+    it("clears the crash banner on a confirmed navigation to a new URL", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+      });
+      expect(container.textContent).toContain("Preview process crashed");
+
+      act(() => {
+        emitWebviewEvent(webview, "did-navigate", { url: "http://localhost:5173/about" });
+      });
+      expect(container.textContent).not.toContain("Preview process crashed");
+    });
+
+    it("does not resurface a stale crash banner after eviction and restore", async () => {
+      terminalStoreState.activeDockTerminalId = "dev-preview-panel-1";
+      let destroyHandler: ((payload: { tier: 1 | 2 }) => void) | undefined;
+      const electron = (window as unknown as { electron: { window: Record<string, unknown> } })
+        .electron;
+      electron.window.onDestroyHiddenWebviews = vi.fn(
+        (handler: (payload: { tier: 1 | 2 }) => void) => {
+          destroyHandler = handler;
+          return vi.fn();
+        }
+      );
+
+      const { container, rerender } = render(<DevPreviewPane {...baseProps} location="dock" />);
+      const webview = getWebviewElement(container);
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      act(() => {
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+      });
+      expect(container.textContent).toContain("Preview process crashed");
+
+      // Panel is no longer the active dock panel — eviction is now valid.
+      terminalStoreState.activeDockTerminalId = "other-panel";
+      rerender(<DevPreviewPane {...baseProps} location="dock" />);
+      await act(async () => {
+        destroyHandler?.({ tier: 1 });
+        await Promise.resolve();
+      });
+      expect(container.textContent).not.toContain("Preview process crashed");
+
+      // Reactivate the panel — eviction auto-clears and the webview remounts.
+      terminalStoreState.activeDockTerminalId = "dev-preview-panel-1";
+      rerender(<DevPreviewPane {...baseProps} location="dock" />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(container.textContent).not.toContain("Preview process crashed");
+    });
   });
 
   describe("header script picker", () => {

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1948,6 +1948,74 @@ describe("DevPreviewPane webview lifecycle regression", () => {
     });
   });
 
+  describe("crash banner persistence (#10363)", () => {
+    it("keeps the crash banner visible while the URL is unchanged", () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "render-process-gone", {
+          details: { reason: "crashed", exitCode: 1 },
+        });
+      });
+
+      // The clearing effect must not self-reset crash state while currentUrl
+      // is unchanged — the banner has to survive the post-crash render flush
+      // so its Reload / Hard restart actions stay reachable.
+      expect(container.textContent).toContain("Preview process crashed");
+      expect(container.textContent).toContain("Reason: crashed (exit code 1)");
+    });
+
+    it("keeps the unresponsive banner visible while the URL is unchanged", () => {
+      let unresponsiveCb: ((data: { panelId: string }) => void) | undefined;
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      electron.webview.onUnresponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
+        unresponsiveCb = cb;
+        return vi.fn();
+      });
+
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      getWebviewElement(container);
+
+      expect(unresponsiveCb).toBeDefined();
+
+      act(() => {
+        unresponsiveCb?.({ panelId: "dev-preview-panel-1" });
+      });
+
+      expect(container.textContent).toContain("Preview is not responding");
+    });
+
+    it("clears the unresponsive banner when the guest becomes responsive again", () => {
+      let unresponsiveCb: ((data: { panelId: string }) => void) | undefined;
+      let responsiveCb: ((data: { panelId: string }) => void) | undefined;
+      const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+        .electron;
+      electron.webview.onUnresponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
+        unresponsiveCb = cb;
+        return vi.fn();
+      });
+      electron.webview.onResponsive = vi.fn((cb: (data: { panelId: string }) => void) => {
+        responsiveCb = cb;
+        return vi.fn();
+      });
+
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      getWebviewElement(container);
+
+      act(() => {
+        unresponsiveCb?.({ panelId: "dev-preview-panel-1" });
+      });
+      expect(container.textContent).toContain("Preview is not responding");
+
+      act(() => {
+        responsiveCb?.({ panelId: "dev-preview-panel-1" });
+      });
+      expect(container.textContent).not.toContain("Preview is not responding");
+    });
+  });
+
   describe("header script picker", () => {
     beforeEach(() => {
       projectClientGetSettingsMock.mockResolvedValue({

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -77,22 +77,13 @@ interface UseDevPreviewLoadLifecycleParams {
   onRenderProcessGone?: (details: { reason: string; exitCode: number }) => void;
 }
 
-export interface WebviewCrashInfo {
-  reason: string;
-  exitCode: number;
-}
-
 interface UseDevPreviewLoadLifecycleResult {
   isWebviewReady: boolean;
   setIsWebviewReady: React.Dispatch<React.SetStateAction<boolean>>;
   isLoading: boolean;
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
-  isSlowLoad: boolean;
-  setIsSlowLoad: React.Dispatch<React.SetStateAction<boolean>>;
   webviewLoadError: WebviewLoadError | null;
   setWebviewLoadError: React.Dispatch<React.SetStateAction<WebviewLoadError | null>>;
-  webviewCrashed: WebviewCrashInfo | null;
-  setWebviewCrashed: React.Dispatch<React.SetStateAction<WebviewCrashInfo | null>>;
   reconnectAttempt: number;
   clearLoadTimers: () => void;
   clearRetryState: () => void;
@@ -113,9 +104,7 @@ export function useDevPreviewLoadLifecycle({
 }: UseDevPreviewLoadLifecycleParams): UseDevPreviewLoadLifecycleResult {
   const [isWebviewReady, setIsWebviewReady] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isSlowLoad, setIsSlowLoad] = useState(false);
   const [webviewLoadError, setWebviewLoadError] = useState<WebviewLoadError | null>(null);
-  const [webviewCrashed, setWebviewCrashed] = useState<WebviewCrashInfo | null>(null);
   const [reconnectAttempt, setReconnectAttempt] = useState<number>(0);
 
   // Read projectId through a ref so a late project-hydration transition
@@ -124,7 +113,6 @@ export function useDevPreviewLoadLifecycle({
   const projectIdRef = useRef(projectId);
 
   const loadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const slowLoadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const failLoadRetryRef = useRef<NodeJS.Timeout | null>(null);
   const failLoadRetryCountRef = useRef<number>(0);
 
@@ -174,10 +162,6 @@ export function useDevPreviewLoadLifecycle({
   });
 
   const clearLoadTimers = useCallback(() => {
-    if (slowLoadTimeoutRef.current) {
-      clearTimeout(slowLoadTimeoutRef.current);
-      slowLoadTimeoutRef.current = null;
-    }
     if (loadTimeoutRef.current) {
       clearTimeout(loadTimeoutRef.current);
       loadTimeoutRef.current = null;
@@ -237,11 +221,6 @@ export function useDevPreviewLoadLifecycle({
     const handleRenderProcessGone = (e: Electron.RenderProcessGoneEvent) => {
       const { reason, exitCode } = e.details;
       setIsLoading(false);
-      setIsSlowLoad(false);
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -258,7 +237,6 @@ export function useDevPreviewLoadLifecycle({
       proxyRetryCountRef.current = 0;
       pendingHttpErrorRef.current = false;
       if (reason === "clean-exit") return;
-      setWebviewCrashed({ reason, exitCode });
       setWebviewLoadError(null);
       onRenderProcessGone?.({ reason, exitCode });
     };
@@ -266,9 +244,7 @@ export function useDevPreviewLoadLifecycle({
     const handleDidStartLoading = () => {
       setIsLoading(true);
       setWebviewLoadError(null);
-      setWebviewCrashed(null);
       setReconnectAttempt(0);
-      setIsSlowLoad(false);
       // Fresh navigation: drop any stale HTTP-error latch. did-frame-navigate,
       // which fires after this for the same navigation, re-sets it if needed.
       pendingHttpErrorRef.current = false;
@@ -279,9 +255,6 @@ export function useDevPreviewLoadLifecycle({
         clearTimeout(proxyRetryRef.current);
         proxyRetryRef.current = null;
       }
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
       }
@@ -290,21 +263,11 @@ export function useDevPreviewLoadLifecycle({
         failLoadRetryRef.current = null;
       }
       failLoadRetryCountRef.current = 0;
-      slowLoadTimeoutRef.current = setTimeout(() => {
-        try {
-          if (webview.isLoading()) {
-            setIsSlowLoad(true);
-          }
-        } catch {
-          // Webview detached before timeout fired
-        }
-      }, 5000);
       loadTimeoutRef.current = setTimeout(() => {
         loadTimeoutRef.current = null;
         try {
           if (webview.isLoading()) {
             webview.stop();
-            setIsSlowLoad(false);
             setIsLoading(false);
             setWebviewLoadError({
               code: "timeout",
@@ -319,11 +282,6 @@ export function useDevPreviewLoadLifecycle({
 
     const handleDidStopLoading = () => {
       setIsLoading(false);
-      setIsSlowLoad(false);
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -332,11 +290,6 @@ export function useDevPreviewLoadLifecycle({
 
     const handleDidFinishLoad = () => {
       setIsLoading(false);
-      setIsSlowLoad(false);
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -352,7 +305,6 @@ export function useDevPreviewLoadLifecycle({
       }
 
       setWebviewLoadError(null);
-      setWebviewCrashed(null);
       setReconnectAttempt(0);
       failLoadRetryCountRef.current = 0;
       proxyRetryCountRef.current = 0;
@@ -405,11 +357,6 @@ export function useDevPreviewLoadLifecycle({
       if (!e.isMainFrame) return;
 
       setIsLoading(false);
-      setIsSlowLoad(false);
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -559,16 +506,11 @@ export function useDevPreviewLoadLifecycle({
       if (e.httpResponseCode !== 502) return;
       pendingHttpErrorRef.current = true;
       setIsLoading(false);
-      setIsSlowLoad(false);
       setReconnectAttempt(0);
       failLoadRetryCountRef.current = 0;
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
-      }
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
       }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
@@ -690,10 +632,6 @@ export function useDevPreviewLoadLifecycle({
         clearTimeout(proxyRetryRef.current);
         proxyRetryRef.current = null;
       }
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
-      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
@@ -728,10 +666,6 @@ export function useDevPreviewLoadLifecycle({
         }
       } catch {
         // WebContents not available yet
-      }
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-        slowLoadTimeoutRef.current = null;
       }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
@@ -802,9 +736,6 @@ export function useDevPreviewLoadLifecycle({
 
   useEffect(() => {
     return () => {
-      if (slowLoadTimeoutRef.current) {
-        clearTimeout(slowLoadTimeoutRef.current);
-      }
       if (loadTimeoutRef.current) {
         clearTimeout(loadTimeoutRef.current);
       }
@@ -822,12 +753,8 @@ export function useDevPreviewLoadLifecycle({
     setIsWebviewReady,
     isLoading,
     setIsLoading,
-    isSlowLoad,
-    setIsSlowLoad,
     webviewLoadError,
     setWebviewLoadError,
-    webviewCrashed,
-    setWebviewCrashed,
     reconnectAttempt,
     clearLoadTimers,
     clearRetryState,


### PR DESCRIPTION
## Summary

- Crash and unresponsive recovery banners in `DevPreviewPane` were self-clearing instantly. Lint cleanup in `11f2d99fe` added `crashState` to the dep array of the "clear crash state on successful navigation" effect, which meant setting `crashState` re-fired the effect immediately while `currentUrl` was still a valid proxy URL, resetting everything back to `"none"` before the banner was ever visible.
- Fix mirrors the guard already in `BrowserPane`: the effect now runs on `[currentUrl]` only, clearing `crashState`, `crashDetails`, and the crash-timestamp history on real URL transitions. Eviction also now clears crash state outside the `webviewRef` guard (the pane previously had no eviction crash-clear at all, so a restored panel could surface a stale banner).
- Removed dead plumbing from `useDevPreviewLoadLifecycle`: `webviewCrashed`/`setWebviewCrashed` (written, never read), the orphaned `WebviewCrashInfo` export, and the entire `isSlowLoad` apparatus (state + `slowLoadTimeoutRef` 5s timer + all setter call sites).

Resolves #10363

## Changes

- `DevPreviewPane.tsx`: tightened effect deps to `[currentUrl]`, added eviction crash-clear outside the `webviewRef` guard
- `useDevPreviewLoadLifecycle.ts`: removed `webviewCrashed`, `WebviewCrashInfo`, and the `isSlowLoad`/`slowLoadTimeoutRef` apparatus
- `DevPreviewPane.webview.test.tsx`: 7 new tests in the "crash banner persistence (#10363)" describe block

## Testing

Added 7 tests covering: banner persistence while URL is unchanged, `responsive` event clearing the banner, a stale `responsive` event not clearing a `crashed` banner, cross-panel isolation, URL-transition clearing state, and evict/restore not surfacing a stale banner. The 3 core persistence tests were confirmed to fail against the broken effect and pass with the fix. Full DevPreview suite (264 tests) and `npm run check` pass.