### PR TITLE
fix(browser): gate screenshot success feedback on actual capture outcome

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -621,20 +621,21 @@ export function BrowserPane({
 
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
-    if (!webview || !isWebviewReady) return;
+    if (!webview || !isWebviewReady) return false;
     let url: string;
     try {
       url = webview.getURL();
     } catch {
-      return;
+      return false;
     }
-    if (!url || url === "about:blank") return;
-    if (screenshotInFlightRef.current) return;
+    if (!url || url === "about:blank") return false;
+    if (screenshotInFlightRef.current) return false;
     screenshotInFlightRef.current = true;
     try {
       const image = await webview.capturePage();
       const pngData = new Uint8Array(image.toPNG());
       await window.electron.clipboard.writeImage(pngData);
+      return true;
     } catch {
       // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
       notify({
@@ -642,6 +643,7 @@ export function BrowserPane({
         title: "Screenshot failed",
         message: "Couldn't copy the screenshot to clipboard",
       });
+      return false;
     } finally {
       screenshotInFlightRef.current = false;
     }
@@ -815,13 +817,7 @@ export function BrowserPane({
           { source: "user" }
         )
       }
-      onCaptureScreenshot={() =>
-        void actionService.dispatch(
-          "browser.captureScreenshot",
-          { terminalId: id },
-          { source: "user" }
-        )
-      }
+      onCaptureScreenshot={handleCaptureScreenshot}
       onToggleDevTools={() =>
         void actionService.dispatch(
           "browser.toggleDevTools",

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -468,9 +468,12 @@ export function BrowserToolbar({
     } catch (err) {
       logError("Failed to capture screenshot", err);
     }
-    if (!success) return;
-    setScreenshotCopied(true);
     if (screenshotCopiedTimerRef.current) clearTimeout(screenshotCopiedTimerRef.current);
+    if (!success) {
+      setScreenshotCopied(false);
+      return;
+    }
+    setScreenshotCopied(true);
     screenshotCopiedTimerRef.current = setTimeout(
       () => setScreenshotCopied(false),
       COPIED_FEEDBACK_RESET_MS

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -74,7 +74,7 @@ interface BrowserToolbarProps {
   onOpenExternal: () => void;
   onPromoteToPortal?: () => void;
   onZoomChange?: (zoomFactor: number) => void;
-  onCaptureScreenshot?: () => void | Promise<void>;
+  onCaptureScreenshot?: () => Promise<boolean>;
   onToggleConsole?: () => void;
   onToggleDevTools?: () => void;
   onViewportPresetChange?: (preset: ViewportPresetId | undefined) => void;
@@ -462,7 +462,13 @@ export function BrowserToolbar({
 
   const handleCaptureScreenshot = useCallback(async () => {
     if (!onCaptureScreenshot) return;
-    await onCaptureScreenshot();
+    let success = false;
+    try {
+      success = await onCaptureScreenshot();
+    } catch (err) {
+      logError("Failed to capture screenshot", err);
+    }
+    if (!success) return;
     setScreenshotCopied(true);
     if (screenshotCopiedTimerRef.current) clearTimeout(screenshotCopiedTimerRef.current);
     screenshotCopiedTimerRef.current = setTimeout(

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -1121,6 +1121,59 @@ describe("BrowserPane webview lifecycle regression", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((window as any).electron.clipboard.writeImage).not.toHaveBeenCalled();
     });
+
+    it("resolves false and notifies when capturePage rejects", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      webview.capturePage.mockRejectedValueOnce(new Error("capture failed"));
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(false);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Screenshot failed" })
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((window as any).electron.clipboard.writeImage).not.toHaveBeenCalled();
+    });
+
+    it("resolves false for a second capture while the first is still in flight", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      let resolveCapture: (value: { toPNG: () => Uint8Array }) => void;
+      webview.capturePage.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveCapture = resolve;
+        })
+      );
+
+      let first: Promise<boolean>;
+      let second: boolean | undefined;
+      await act(async () => {
+        first = getToolbarCapture()();
+        second = await getToolbarCapture()();
+        resolveCapture!({ toPNG: () => new Uint8Array([0x89]) });
+        await first;
+      });
+
+      expect(second).toBe(false);
+      await expect(first!).resolves.toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((window as any).electron.clipboard.writeImage).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("stale URL detection on initial load", () => {

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -1051,6 +1051,78 @@ describe("BrowserPane webview lifecycle regression", () => {
     });
   });
 
+  describe("screenshot capture via toolbar prop", () => {
+    const getToolbarCapture = () => {
+      const props = browserToolbarPropsSpy.mock.calls.at(-1)?.[0] as {
+        onCaptureScreenshot: () => Promise<boolean>;
+      };
+      return props.onCaptureScreenshot;
+    };
+
+    it("resolves true after a successful capture and clipboard write", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((window as any).electron.clipboard.writeImage).toHaveBeenCalledTimes(1);
+    });
+
+    it("resolves false and notifies when the clipboard write fails", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).electron.clipboard.writeImage.mockRejectedValueOnce(
+        new Error("clipboard unavailable")
+      );
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(false);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Screenshot failed" })
+      );
+    });
+
+    it("resolves false without notifying when the URL is about:blank", async () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      webview.getURL.mockReturnValue("about:blank");
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(false);
+      expect(notifyMock).not.toHaveBeenCalled();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((window as any).electron.clipboard.writeImage).not.toHaveBeenCalled();
+    });
+  });
+
   describe("stale URL detection on initial load", () => {
     it("shows stale URL message on ERR_CONNECTION_REFUSED during initial restored load", () => {
       const { container } = render(<BrowserPane {...baseProps} />);

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -362,7 +362,7 @@ describe("BrowserToolbar ARIA semantics", () => {
   });
 
   it("screenshot capture announces success in a polite live region and flips to a check", async () => {
-    const onCaptureScreenshot = vi.fn(() => Promise.resolve());
+    const onCaptureScreenshot = vi.fn(() => Promise.resolve(true));
     const { container, getByRole } = renderToolbar({
       onCaptureScreenshot,
       isWebviewReady: true,
@@ -378,6 +378,40 @@ describe("BrowserToolbar ARIA semantics", () => {
       const texts = Array.from(liveRegions).map((node) => node.textContent);
       expect(texts).toContain("Screenshot copied to clipboard");
     });
+  });
+
+  it("screenshot capture shows no success feedback when the handler reports failure", async () => {
+    const onCaptureScreenshot = vi.fn(() => Promise.resolve(false));
+    const { container, getByRole } = renderToolbar({
+      onCaptureScreenshot,
+      isWebviewReady: true,
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole("button", { name: "Copy screenshot to clipboard" }));
+    });
+
+    expect(onCaptureScreenshot).toHaveBeenCalledOnce();
+    const liveRegions = container.querySelectorAll('[role="status"]');
+    const texts = Array.from(liveRegions).map((node) => node.textContent);
+    expect(texts).not.toContain("Screenshot copied to clipboard");
+  });
+
+  it("screenshot capture shows no success feedback when the handler rejects", async () => {
+    const onCaptureScreenshot = vi.fn(() => Promise.reject(new Error("capture failed")));
+    const { container, getByRole } = renderToolbar({
+      onCaptureScreenshot,
+      isWebviewReady: true,
+    });
+
+    await act(async () => {
+      fireEvent.click(getByRole("button", { name: "Copy screenshot to clipboard" }));
+    });
+
+    expect(onCaptureScreenshot).toHaveBeenCalledOnce();
+    const liveRegions = container.querySelectorAll('[role="status"]');
+    const texts = Array.from(liveRegions).map((node) => node.textContent);
+    expect(texts).not.toContain("Screenshot copied to clipboard");
   });
 
   it("Shift+Delete on a highlighted suggestion announces removal", async () => {

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -397,6 +397,37 @@ describe("BrowserToolbar ARIA semantics", () => {
     expect(texts).not.toContain("Screenshot copied to clipboard");
   });
 
+  it("screenshot capture clears prior success feedback when a retry fails", async () => {
+    const onCaptureScreenshot = vi
+      .fn()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    const { container, getByRole } = renderToolbar({
+      onCaptureScreenshot,
+      isWebviewReady: true,
+    });
+    const button = getByRole("button", { name: "Copy screenshot to clipboard" });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    await waitFor(() => {
+      const texts = Array.from(container.querySelectorAll('[role="status"]')).map(
+        (node) => node.textContent
+      );
+      expect(texts).toContain("Screenshot copied to clipboard");
+    });
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    const texts = Array.from(container.querySelectorAll('[role="status"]')).map(
+      (node) => node.textContent
+    );
+    expect(texts).not.toContain("Screenshot copied to clipboard");
+  });
+
   it("screenshot capture shows no success feedback when the handler rejects", async () => {
     const onCaptureScreenshot = vi.fn(() => Promise.reject(new Error("capture failed")));
     const { container, getByRole } = renderToolbar({

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -398,10 +398,7 @@ describe("BrowserToolbar ARIA semantics", () => {
   });
 
   it("screenshot capture clears prior success feedback when a retry fails", async () => {
-    const onCaptureScreenshot = vi
-      .fn()
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+    const onCaptureScreenshot = vi.fn().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     const { container, getByRole } = renderToolbar({
       onCaptureScreenshot,
       isWebviewReady: true,

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -398,6 +398,7 @@ export function DevPreviewPane({
   } | null>(null);
   const crashTimestampsRef = useRef<number[]>([]);
   const crashReloadRef = useRef<() => void>(() => {});
+  const screenshotInFlightRef = useRef(false);
   const blockedNavTimerRef = useRef<NodeJS.Timeout | null>(null);
   const CLIPBOARD_FEEDBACK_MS = 2000;
   const [certCopied, setCertCopied] = useState(false);
@@ -811,20 +812,32 @@ export function DevPreviewPane({
 
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
-    if (!webview || !isWebviewReady) return;
+    if (!webview || !isWebviewReady) return false;
     let url: string;
     try {
       url = webview.getURL();
     } catch {
-      return;
+      return false;
     }
-    if (!url || url === "about:blank") return;
+    if (!url || url === "about:blank") return false;
+    if (screenshotInFlightRef.current) return false;
+    screenshotInFlightRef.current = true;
     try {
       const image = await webview.capturePage();
       const pngData = new Uint8Array(image.toPNG());
       await window.electron.clipboard.writeImage(pngData);
+      return true;
     } catch (err) {
       logError("[DevPreviewPane] Screenshot capture failed", err);
+      // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+      notify({
+        type: "error",
+        title: "Screenshot failed",
+        message: "Couldn't copy the screenshot to clipboard",
+      });
+      return false;
+    } finally {
+      screenshotInFlightRef.current = false;
     }
   }, [isWebviewReady]);
 

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -1913,6 +1913,28 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       );
     });
 
+    it("resolves false and notifies when capturePage rejects", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      webview.capturePage.mockRejectedValueOnce(new Error("capture failed"));
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(false);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Screenshot failed" })
+      );
+      expect(getWriteImageMock()).not.toHaveBeenCalled();
+    });
+
     it("resolves false for a second capture while the first is still in flight", async () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       const webview = getWebviewElement(container);

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -27,6 +27,7 @@ type MockWebviewElement = HTMLElement & {
   executeJavaScript: ReturnType<typeof vi.fn>;
   getWebContentsId: ReturnType<typeof vi.fn>;
   getWebContents: () => MockWebContents;
+  capturePage: ReturnType<typeof vi.fn>;
   setMockLoading: (value: boolean) => void;
 };
 
@@ -63,6 +64,9 @@ function decorateWebviewElement(element: HTMLElement): MockWebviewElement {
     disableDeviceEmulation: vi.fn(),
   };
   webview.getWebContents = vi.fn(() => mockWc);
+  webview.capturePage = vi.fn(() =>
+    Promise.resolve({ toPNG: () => new Uint8Array([0x89, 0x50, 0x4e, 0x47]) })
+  );
   webview.setMockLoading = (value: boolean) => {
     loading = value;
   };
@@ -249,8 +253,14 @@ vi.mock("@/hooks/useFindInPage", () => ({
   }),
 }));
 
+const { browserToolbarPropsSpy } = vi.hoisted(() => ({
+  browserToolbarPropsSpy: vi.fn(),
+}));
 vi.mock("@/components/Browser/BrowserToolbar", () => ({
-  BrowserToolbar: () => <div data-testid="browser-toolbar" />,
+  BrowserToolbar: (props: Record<string, unknown>) => {
+    browserToolbarPropsSpy(props);
+    return <div data-testid="browser-toolbar" />;
+  },
 }));
 
 vi.mock("@/components/Panel", () => ({
@@ -385,6 +395,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       },
       clipboard: {
         writeText: vi.fn().mockResolvedValue(undefined),
+        writeImage: vi.fn().mockResolvedValue(undefined),
       },
       webview: {
         registerPanel: vi.fn(() => Promise.resolve()),
@@ -1825,6 +1836,110 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
 
       expect(container.textContent).not.toContain("Taking longer than usual");
+    });
+  });
+
+  describe("screenshot capture", () => {
+    const getToolbarCapture = () => {
+      const props = browserToolbarPropsSpy.mock.calls.at(-1)?.[0] as {
+        onCaptureScreenshot: () => Promise<boolean>;
+      };
+      return props.onCaptureScreenshot;
+    };
+
+    const getWriteImageMock = () => {
+      const electron = (window as unknown as { electron: { clipboard: Record<string, unknown> } })
+        .electron;
+      return electron.clipboard.writeImage as ReturnType<typeof vi.fn>;
+    };
+
+    it("resolves true after a successful capture and clipboard write", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(true);
+      expect(getWriteImageMock()).toHaveBeenCalledTimes(1);
+      expect(getWriteImageMock().mock.calls[0]![0]).toBeInstanceOf(Uint8Array);
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("resolves false without notifying when the URL is about:blank", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      webview.getURL.mockReturnValue("about:blank");
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(false);
+      expect(getWriteImageMock()).not.toHaveBeenCalled();
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("resolves false and notifies when the clipboard write fails", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      getWriteImageMock().mockRejectedValueOnce(new Error("clipboard unavailable"));
+
+      let result: boolean | undefined;
+      await act(async () => {
+        result = await getToolbarCapture()();
+      });
+
+      expect(result).toBe(false);
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Screenshot failed" })
+      );
+    });
+
+    it("resolves false for a second capture while the first is still in flight", async () => {
+      const { container } = render(<DevPreviewPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "dom-ready");
+      });
+
+      let resolveCapture: (value: { toPNG: () => Uint8Array }) => void;
+      webview.capturePage.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveCapture = resolve;
+        })
+      );
+
+      let first: Promise<boolean>;
+      let second: boolean | undefined;
+      await act(async () => {
+        first = getToolbarCapture()();
+        second = await getToolbarCapture()();
+        resolveCapture!({ toPNG: () => new Uint8Array([0x89]) });
+        await first;
+      });
+
+      expect(second).toBe(false);
+      await expect(first!).resolves.toBe(true);
+      expect(getWriteImageMock()).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/hooks/useBrowserActionListeners.ts
+++ b/src/hooks/useBrowserActionListeners.ts
@@ -54,7 +54,7 @@ export function useBrowserActionListeners(id: string, callbacks: BrowserActionCa
         if (typeof detail.zoomFactor === "number") callbacks.onSetZoom(detail.zoomFactor);
         return;
       case "daintree:browser-capture-screenshot":
-        callbacks.onCaptureScreenshot();
+        void callbacks.onCaptureScreenshot();
         return;
       case "daintree:browser-toggle-console":
         callbacks.onToggleConsole?.();

--- a/src/hooks/useBrowserActionListeners.ts
+++ b/src/hooks/useBrowserActionListeners.ts
@@ -6,7 +6,8 @@ export type BrowserActionCallbacks = {
   onBack: () => void;
   onForward: () => void;
   onSetZoom: (rawZoom: number) => void;
-  onCaptureScreenshot: () => void;
+  // Result is discarded on this path; the toolbar prop is where it matters.
+  onCaptureScreenshot: () => void | Promise<boolean>;
   onToggleConsole?: () => void;
   onClearConsole?: () => void;
   onToggleDevTools: () => void;


### PR DESCRIPTION
## Summary

- The screenshot button was showing a green check and firing a screen-reader success announcement unconditionally after awaiting `onCaptureScreenshot`, even when the capture or clipboard write failed
- `onCaptureScreenshot` prop contract changed to `() => Promise<boolean>`; the toolbar now only shows success when the handler resolves `true`, and clears stale success feedback if a retry fails
- `DevPreviewPane` was only logging errors on failure; it now surfaces them with the same "Screenshot failed" error toast as `BrowserPane` and gains the same in-flight guard

Resolves #10364

## Changes

- `BrowserToolbar`: success feedback gated on handler returning `true`; stale check cleared on failed retry
- `BrowserPane`: passes `handleCaptureScreenshot` directly to the toolbar; the action-dispatch path (keyboard/palette via `useBrowserActionListeners`) explicitly voids the floating promise to satisfy the lint rule
- `DevPreviewPane`: surfaces `capturePage()` and clipboard failures with an error toast; adds in-flight guard against double-clicks
- Tests cover success, silent no-op (`about:blank`), `capturePage` rejection, clipboard-write rejection, in-flight double-click guard, and failed-retry feedback reset across `BrowserToolbar`, `BrowserPane`, and `DevPreviewPane`

## Testing

Full unit suite (1598 files), `npm run check`, build, and preload-backdoors audit all passed at the gated SHA. Smoke test is Linux/xvfb-only and blocked locally on macOS.