### PR TITLE
fix(git-init): trust invoke result instead of progress-event timing to determine success

### DIFF
--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -169,14 +169,14 @@ export function registerGitInitHandlers(): () => void {
               "Repository initialized — initial commit skipped",
               identityHelp
             );
-            return { completedSteps };
+            return { outcome: "error" as const, completedSteps };
           }
           throw commitError;
         }
       }
 
       emitProgress("complete", "success", "Git initialization complete");
-      return { completedSteps };
+      return { outcome: "success" as const, completedSteps };
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Git initialization failed");
       emitProgress("error", "error", "Git initialization failed", errorMessage);

--- a/shared/types/ipc/gitInit.ts
+++ b/shared/types/ipc/gitInit.ts
@@ -32,6 +32,8 @@ export interface GitInitProgressEvent {
  * `context.completedSteps` carries the partial progress for diagnostics.
  */
 export interface GitInitResult {
+  /** "success" when the workflow finished cleanly; "error" when it resolved with a terminal error (e.g. initial commit skipped). Named to avoid the forbidden `ok`/`success` envelope keys. */
+  outcome: "success" | "error";
   /** Steps completed during a successful init */
   completedSteps: GitInitStepType[];
 }

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -39,6 +39,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
   const hasFinalizedSuccessRef = useRef(false);
   const inFlightRef = useRef(false);
   const sawTerminalEventRef = useRef(false);
+  const sawErrorEventRef = useRef(false);
 
   const finalizeSuccess = useCallback(() => {
     if (hasFinalizedSuccessRef.current) {
@@ -60,6 +61,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
       hasFinalizedSuccessRef.current = false;
       inFlightRef.current = false;
       sawTerminalEventRef.current = false;
+      sawErrorEventRef.current = false;
       return;
     }
 
@@ -68,14 +70,18 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
 
       if (event.status === "error") {
         sawTerminalEventRef.current = true;
+        sawErrorEventRef.current = true;
         setError(event.error || event.message || "Unknown error");
         setIsComplete(false);
         setIsInitializing(false);
       } else if (event.step === "complete" && event.status === "success") {
         sawTerminalEventRef.current = true;
-        setError(null);
-        setIsComplete(true);
-        setIsInitializing(false);
+        // A success event never follows an error event within one run — treat it as stale/foreign
+        if (!sawErrorEventRef.current) {
+          setError(null);
+          setIsComplete(true);
+          setIsInitializing(false);
+        }
       }
     });
 
@@ -92,6 +98,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
     }
     inFlightRef.current = true;
     sawTerminalEventRef.current = false;
+    sawErrorEventRef.current = false;
 
     setIsInitializing(true);
     setError(null);

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -100,14 +100,17 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
     hasFinalizedSuccessRef.current = false;
 
     try {
-      await projectClient.initGitGuided({
+      const result = await projectClient.initGitGuided({
         directoryPath,
         createInitialCommit,
         initialCommitMessage: initialCommitMessage.trim(),
         createGitignore: gitignoreTemplate !== "none",
         gitignoreTemplate,
       });
-      if (!sawTerminalEventRef.current) {
+      if (result.outcome === "success") {
+        setError(null);
+        setIsComplete(true);
+      } else if (!sawTerminalEventRef.current) {
         setError(
           "Initialization finished without a status update — check the repository to confirm the result."
         );

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -180,6 +180,9 @@ describe("GitInitDialog", () => {
   });
 
   it("clears the missing-status warning when a late success event arrives", async () => {
+    // The invoke resolves without a "success" outcome and no terminal event,
+    // so the dialog shows the missing-status warning until a late event arrives.
+    initGitGuidedMock.mockResolvedValueOnce({ outcome: "error", completedSteps: [] });
     renderDialog();
 
     fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
@@ -297,6 +300,88 @@ describe("GitInitDialog", () => {
     });
 
     await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 3000 });
+  });
+
+  it("auto-continues from a completion event while the invoke is still pending", async () => {
+    initGitGuidedMock.mockImplementationOnce(() => new Promise(() => {}));
+    const onSuccess = vi.fn();
+    renderDialog({ onSuccess });
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    act(() => {
+      progressHandler?.({
+        step: "complete",
+        status: "success",
+        message: "Git initialization complete",
+        timestamp: Date.now(),
+      });
+    });
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 3000 });
+  });
+
+  it("ignores a stray success event after an error event", async () => {
+    initGitGuidedMock.mockImplementationOnce(() => new Promise(() => {}));
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    act(() => {
+      progressHandler?.({
+        step: "complete",
+        status: "error",
+        message: "Repository initialized — initial commit skipped",
+        error: "identity not configured",
+        timestamp: Date.now(),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+    });
+
+    act(() => {
+      progressHandler?.({
+        step: "complete",
+        status: "success",
+        message: "Git initialization complete",
+        timestamp: Date.now(),
+      });
+    });
+
+    expect(screen.queryByRole("button", { name: /continue/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+  });
+
+  it("recovers cleanly when a retry succeeds", async () => {
+    initGitGuidedMock.mockResolvedValueOnce({ outcome: "error", completedSteps: [] });
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/finished without a status update/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+    });
+    expect(screen.queryByText(/finished without a status update/i)).toBeNull();
+    expect(screen.queryByText(/initialization failed/i)).toBeNull();
   });
 
   it("completes from the invoke result when no progress events arrive", async () => {

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -76,7 +76,7 @@ describe("GitInitDialog", () => {
       return vi.fn();
     });
 
-    initGitGuidedMock.mockResolvedValue({ success: true, completedSteps: [] });
+    initGitGuidedMock.mockResolvedValue({ outcome: "success", completedSteps: [] });
   });
 
   afterEach(() => {
@@ -297,6 +297,104 @@ describe("GitInitDialog", () => {
     });
 
     await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 3000 });
+  });
+
+  it("completes from the invoke result when no progress events arrive", async () => {
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+    });
+    expect(screen.queryByText(/initialization failed/i)).toBeNull();
+  });
+
+  it("shows the fallback error when init resolves unsuccessfully without a status event", async () => {
+    initGitGuidedMock.mockResolvedValue({ outcome: "error", completedSteps: [] });
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/finished without a status update/i)).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+  });
+
+  it("clears a stale fallback error when the success event arrives late", async () => {
+    initGitGuidedMock.mockResolvedValue({ outcome: "error", completedSteps: [] });
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/finished without a status update/i)).toBeTruthy();
+    });
+
+    act(() => {
+      progressHandler?.({
+        step: "complete",
+        status: "success",
+        message: "Git initialization complete",
+        timestamp: Date.now(),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /continue/i })).toBeTruthy();
+    });
+    expect(screen.queryByText(/finished without a status update/i)).toBeNull();
+    expect(screen.queryByText(/initialization failed/i)).toBeNull();
+  });
+
+  it("keeps the specific identity error when init resolves unsuccessfully after error events", async () => {
+    const identityHelp =
+      "Set your git identity, then create the initial commit manually:\n" +
+      '  git config --global user.name "Your Name"\n' +
+      '  git config --global user.email "you@example.com"';
+
+    initGitGuidedMock.mockImplementationOnce(() => {
+      progressHandler?.({
+        step: "commit",
+        status: "error",
+        message: "Git user identity not configured",
+        error: identityHelp,
+        timestamp: Date.now(),
+      });
+      progressHandler?.({
+        step: "complete",
+        status: "error",
+        message: "Repository initialized — initial commit skipped",
+        error: identityHelp,
+        timestamp: Date.now(),
+      });
+      return Promise.resolve({ outcome: "error", completedSteps: ["init", "gitignore", "add"] });
+    });
+
+    renderDialog();
+
+    fireEvent.change(screen.getByLabelText(/initial commit message/i), {
+      target: { value: "feat: init" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /initialize repository/i }));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/git config --global user\.name/i).length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText(/finished without a status update/i)).toBeNull();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
   });
 
   it("surfaces the git config commands and offers Try again on identity error", async () => {

--- a/src/store/__tests__/projectStore.addProject.test.ts
+++ b/src/store/__tests__/projectStore.addProject.test.ts
@@ -17,7 +17,7 @@ const projectClientMock = {
   close: vi.fn(),
   getStats: vi.fn(),
   initGit: vi.fn().mockResolvedValue(undefined),
-  initGitGuided: vi.fn().mockResolvedValue({ success: true, completedSteps: [] }),
+  initGitGuided: vi.fn().mockResolvedValue({ outcome: "success", completedSteps: [] }),
   onInitGitProgress: vi.fn(() => () => {}),
 };
 

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -35,7 +35,7 @@ const createMockProjectClient = () => ({
   getBulkStats: vi.fn().mockResolvedValue({}),
   getNotificationOverrides: vi.fn().mockResolvedValue({}),
   initGit: vi.fn().mockResolvedValue(undefined),
-  initGitGuided: vi.fn().mockResolvedValue({ success: true, completedSteps: [] }),
+  initGitGuided: vi.fn().mockResolvedValue({ outcome: "success", completedSteps: [] }),
   onInitGitProgress: vi.fn().mockReturnValue(() => {}),
   getRecipes: vi.fn().mockResolvedValue({ recipes: [], collisions: [] }),
   saveRecipes: vi.fn().mockResolvedValue(undefined),

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -27,7 +27,7 @@ const createMockProjectClient = () => ({
   getBulkStats: vi.fn().mockResolvedValue({}),
   getNotificationOverrides: vi.fn().mockResolvedValue({}),
   initGit: vi.fn().mockResolvedValue(undefined),
-  initGitGuided: vi.fn().mockResolvedValue({ success: true, completedSteps: [] }),
+  initGitGuided: vi.fn().mockResolvedValue({ outcome: "success", completedSteps: [] }),
   onInitGitProgress: vi.fn().mockReturnValue(() => {}),
   getRecipes: vi.fn().mockResolvedValue({ recipes: [], collisions: [] }),
   saveRecipes: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary

- `GitInitDialog` was inferring success from progress-event timing (`sawTerminalEventRef`) rather than the invoke result, so a fully successful init could still show a spurious "Initialization failed" banner if the renderer processed the reply before any terminal events landed — and a late `complete`/`success` event never cleared an already-set error
- `GitInitResult` now has an authoritative `outcome: "success" | "error"` field (named to comply with the `ForbidIpcEnvelopeKeys` ban on `ok`/`success` keys, #6020), populated on both resolved paths of the guided-init handler
- The dialog trusts the invoke result: `outcome:"success"` completes the flow and clears any stale error; late-arriving `complete`/`success` progress events also clear stale errors, but are guarded by `sawErrorEventRef` so a stray broadcast can't overwrite a real error

Resolves #10361

## Changes

- `shared/types/ipc/gitInit.ts` — added `outcome` field to `GitInitResult`
- `electron/ipc/handlers/projectCrud/gitInit.ts` — populate `outcome` on both resolve paths
- `src/components/Project/GitInitDialog.tsx` — read `outcome` from invoke result; clear stale errors on late success events; guard stray-success rejection with `sawErrorEventRef`
- `src/components/Project/__tests__/GitInitDialog.test.tsx` — 7 new regression tests (invoke-result-only completion, fallback firing, late-success clearing, identity-error preservation, progress-event-only completion, stray-success rejection, clean retry recovery)
- Three store-level test mocks updated from `{success:true}` to `{outcome:"success"}`

## Testing

Full local CI passed: `npm run check`, 33406-test unit suite, build, and preload backdoor checks all green on the gated SHA (`edba2a8e9`).