### PR TITLE
feat(dev-preview): copy affordances for console panel

### DIFF
--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -55,12 +55,14 @@ const FILTER_BUTTONS: { filter: LevelFilter; label: string }[] = [
 
 // Each line is sanitized individually — sanitizeForClipboard strips newlines
 // along with the other C0 controls, so sanitizing the joined output would
-// collapse the intentional row/frame line structure.
+// collapse the intentional row/frame line structure. Multi-line summaries
+// (e.g. exception text with embedded frames) are split first so their line
+// structure survives sanitization, matching the whitespace-pre-wrap display.
 export function serializeConsoleMessage(msg: ConsoleMessage): string {
+  const [firstLine = "", ...restLines] = msg.summaryText.split("\n");
   const lines = [
-    sanitizeForClipboard(
-      `[${msg.timeLabel}] [${LEVEL_STYLES[msg.level].label}] ${msg.summaryText}`
-    ),
+    sanitizeForClipboard(`[${msg.timeLabel}] [${LEVEL_STYLES[msg.level].label}] ${firstLine}`),
+    ...restLines.map((line) => sanitizeForClipboard(line)),
   ];
   if (msg.stackTrace) {
     for (const frame of msg.stackTrace.callFrames) {
@@ -99,7 +101,10 @@ const ConsoleRow = memo(function ConsoleRow({
   }, [copy, msg]);
 
   return (
+    // tabIndex makes the row itself focusable so keyboard users can reach the
+    // focus-within-revealed copy button on rows with no other focusable child.
     <div
+      tabIndex={0}
       className={cn(
         "group/row flex items-start gap-2 px-2 py-0.5 border-b border-overlay/30 hover:bg-overlay-subtle",
         style.row

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
-import { Trash2, ChevronDown } from "lucide-react";
+import { Trash2, ChevronDown, Copy, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   useConsoleCaptureStore,
@@ -10,6 +10,8 @@ import {
   ZERO_COUNTS,
 } from "@/store/consoleCaptureStore";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
+import { sanitizeForClipboard } from "@/lib/clipboardSanitize";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { ObjectInspector } from "./ObjectInspector";
 import { StackTrace } from "./StackTrace";
@@ -51,6 +53,32 @@ const FILTER_BUTTONS: { filter: LevelFilter; label: string }[] = [
   { filter: "log", label: "Log" },
 ];
 
+// Each line is sanitized individually — sanitizeForClipboard strips newlines
+// along with the other C0 controls, so sanitizing the joined output would
+// collapse the intentional row/frame line structure.
+export function serializeConsoleMessage(msg: ConsoleMessage): string {
+  const lines = [
+    sanitizeForClipboard(
+      `[${msg.timeLabel}] [${LEVEL_STYLES[msg.level].label}] ${msg.summaryText}`
+    ),
+  ];
+  if (msg.stackTrace) {
+    for (const frame of msg.stackTrace.callFrames) {
+      const name = frame.functionName || "(anonymous)";
+      const location = frame.url ? ` (${frame.url}:${frame.lineNumber}:${frame.columnNumber})` : "";
+      lines.push(sanitizeForClipboard(`  at ${name}${location}`));
+    }
+  }
+  return lines.join("\n");
+}
+
+export function serializeConsoleMessages(messages: ConsoleMessage[]): string {
+  return messages.map(serializeConsoleMessage).join("\n");
+}
+
+const COPY_REVEAL_CLASS =
+  "shrink-0 invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 delay-75 group-hover/row:visible group-hover/row:opacity-100 group-hover/row:pointer-events-auto group-focus-within/row:visible group-focus-within/row:opacity-100 group-focus-within/row:pointer-events-auto motion-reduce:transition-none";
+
 const ConsoleRow = memo(function ConsoleRow({
   msg,
   webContentsId,
@@ -65,11 +93,15 @@ const ConsoleRow = memo(function ConsoleRow({
   const style = LEVEL_STYLES[msg.level];
   const indentPx = msg.groupDepth * 12;
   const handleToggle = useCallback(() => onToggleGroup?.(msg.id), [onToggleGroup, msg.id]);
+  const { copied, copy } = useCopyWithFeedback();
+  const handleCopy = useCallback(() => {
+    void copy(serializeConsoleMessage(msg));
+  }, [copy, msg]);
 
   return (
     <div
       className={cn(
-        "flex items-start gap-2 px-2 py-0.5 border-b border-overlay/30 hover:bg-overlay-subtle",
+        "group/row flex items-start gap-2 px-2 py-0.5 border-b border-overlay/30 hover:bg-overlay-subtle",
         style.row
       )}
       style={indentPx > 0 ? { paddingLeft: `${8 + indentPx}px` } : undefined}
@@ -110,6 +142,25 @@ const ConsoleRow = memo(function ConsoleRow({
           )}
         </div>
         {msg.stackTrace && <StackTrace stackTrace={msg.stackTrace} />}
+      </div>
+      <div className={COPY_REVEAL_CLASS}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="p-0.5 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
+              aria-label="Copy console message"
+            >
+              {copied ? (
+                <Check className="w-3 h-3 text-status-success animate-badge-bump" />
+              ) : (
+                <Copy className="w-3 h-3" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="left">Copy message</TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );
@@ -248,6 +299,11 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
     setIsAtBottom(true);
   }, []);
 
+  const { copied: allCopied, copy: copyAll } = useCopyWithFeedback();
+  const handleCopyVisible = useCallback(() => {
+    void copyAll(serializeConsoleMessages(filtered));
+  }, [copyAll, filtered]);
+
   const toggleGroup = useCallback((msgId: number) => {
     setCollapsedGroups((prev) => {
       const next = new Set(prev);
@@ -325,6 +381,26 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
             <TooltipContent side="bottom">Scroll to bottom</TooltipContent>
           </Tooltip>
         )}
+
+        {/* Copy visible */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={handleCopyVisible}
+              disabled={filtered.length === 0}
+              className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-daintree-text/50"
+              aria-label="Copy visible console messages"
+            >
+              {allCopied ? (
+                <Check className="w-3.5 h-3.5 text-status-success animate-badge-bump" />
+              ) : (
+                <Copy className="w-3.5 h-3.5" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Copy visible messages</TooltipContent>
+        </Tooltip>
 
         {/* Clear */}
         <Tooltip>

--- a/src/components/DevPreview/__tests__/ConsolePanel.test.tsx
+++ b/src/components/DevPreview/__tests__/ConsolePanel.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConsolePanel, serializeConsoleMessage, serializeConsoleMessages } from "../ConsolePanel";
+import { useConsoleCaptureStore, type ConsoleMessage } from "@/store/consoleCaptureStore";
+import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({
+    data,
+    itemContent,
+  }: {
+    data: unknown[];
+    itemContent: (index: number, item: unknown) => React.ReactNode;
+  }) => (
+    <div data-testid="virtuoso">
+      {data.map((item, i) => (
+        <div key={i}>{itemContent(i, item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const mockPaneId = "test-pane-id";
+
+const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined);
+
+let nextId = 1;
+
+function seedConsoleRow(overrides: Partial<SerializedConsoleRow> = {}): void {
+  const level = overrides.level ?? "log";
+  const row: SerializedConsoleRow = {
+    id: nextId++,
+    paneId: mockPaneId,
+    level,
+    cdpType: level,
+    args: [],
+    summaryText: "boom",
+    timestamp: Date.now(),
+    navigationGeneration: 0,
+    groupDepth: 0,
+    ...overrides,
+  };
+  useConsoleCaptureStore.getState().addStructuredMessage(row);
+}
+
+function makeMessage(overrides: Partial<ConsoleMessage> = {}): ConsoleMessage {
+  return {
+    id: 1,
+    paneId: mockPaneId,
+    level: "error",
+    cdpType: "error",
+    args: [],
+    summaryText: "boom",
+    timestamp: 0,
+    navigationGeneration: 0,
+    groupDepth: 0,
+    isStale: false,
+    timeLabel: "12:34:56.789",
+    isGroupHeader: false,
+    ...overrides,
+  };
+}
+
+function renderPanel() {
+  return render(<ConsolePanel paneId={mockPaneId} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  nextId = 1;
+  useConsoleCaptureStore.setState({ messages: new Map(), counters: new Map() });
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("serializeConsoleMessage", () => {
+  it("formats a row as [time] [level] summary", () => {
+    expect(serializeConsoleMessage(makeMessage())).toBe("[12:34:56.789] [ERR] boom");
+  });
+
+  it("uses the level badge labels", () => {
+    expect(serializeConsoleMessage(makeMessage({ level: "warning" }))).toContain("[WRN]");
+    expect(serializeConsoleMessage(makeMessage({ level: "info" }))).toContain("[INF]");
+    expect(serializeConsoleMessage(makeMessage({ level: "log" }))).toContain("[LOG]");
+  });
+
+  it("appends stack frames in Chrome's text format", () => {
+    const msg = makeMessage({
+      stackTrace: {
+        callFrames: [
+          { functionName: "doThing", url: "http://x/app.js", lineNumber: 10, columnNumber: 5 },
+          { functionName: "", url: "", lineNumber: 0, columnNumber: 0 },
+        ],
+      },
+    });
+    expect(serializeConsoleMessage(msg)).toBe(
+      "[12:34:56.789] [ERR] boom\n  at doThing (http://x/app.js:10:5)\n  at (anonymous)"
+    );
+  });
+
+  it("strips control and Bidi characters but keeps line structure", () => {
+    const msg = makeMessage({
+      summaryText: "safe\u001b[31m\u202etext\nsecond",
+      stackTrace: {
+        callFrames: [{ functionName: "fn", url: "http://x/a.js", lineNumber: 1, columnNumber: 2 }],
+      },
+    });
+    const out = serializeConsoleMessage(msg);
+    expect(out).not.toContain("\u001b");
+    expect(out).not.toContain("\u202e");
+    // Untrusted newlines inside summaryText are stripped; the serializer's own
+    // row/frame line structure survives.
+    expect(out.split("\n")).toEqual([
+      "[12:34:56.789] [ERR] safe[31mtextsecond",
+      "  at fn (http://x/a.js:1:2)",
+    ]);
+  });
+
+  it("joins multiple messages with newlines", () => {
+    const out = serializeConsoleMessages([
+      makeMessage({ summaryText: "first" }),
+      makeMessage({ summaryText: "second", level: "log" }),
+    ]);
+    expect(out).toBe("[12:34:56.789] [ERR] first\n[12:34:56.789] [LOG] second");
+  });
+});
+
+describe("per-row copy", () => {
+  it("copies the serialized row text on click", () => {
+    seedConsoleRow({ level: "error", summaryText: "row text" });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy console message" }));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[\d{2}:\d{2}:\d{2}\.\d{3}\] \[ERR\] row text$/)
+    );
+  });
+
+  it("includes stack frames in the copied text", () => {
+    seedConsoleRow({
+      level: "error",
+      summaryText: "with stack",
+      stackTrace: {
+        callFrames: [
+          { functionName: "handler", url: "http://x/main.js", lineNumber: 3, columnNumber: 7 },
+        ],
+      },
+    });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy console message" }));
+
+    expect(writeText).toHaveBeenCalledWith(
+      expect.stringContaining("with stack\n  at handler (http://x/main.js:3:7)")
+    );
+  });
+});
+
+describe("toolbar copy visible", () => {
+  const getCopyVisibleButton = () =>
+    screen.getByRole("button", { name: "Copy visible console messages" });
+
+  it("is disabled when there are no visible messages", () => {
+    renderPanel();
+    expect(getCopyVisibleButton().hasAttribute("disabled")).toBe(true);
+  });
+
+  it("copies all visible messages in order", () => {
+    seedConsoleRow({ summaryText: "one" });
+    seedConsoleRow({ summaryText: "two" });
+    seedConsoleRow({ summaryText: "three" });
+    renderPanel();
+
+    fireEvent.click(getCopyVisibleButton());
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const text = writeText.mock.calls[0]![0];
+    const lines = text.split("\n");
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("one");
+    expect(lines[1]).toContain("two");
+    expect(lines[2]).toContain("three");
+  });
+
+  it("respects the active level filter", () => {
+    seedConsoleRow({ level: "error", summaryText: "bad" });
+    seedConsoleRow({ level: "log", summaryText: "fine" });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /errors/i }));
+    fireEvent.click(getCopyVisibleButton());
+
+    const text = writeText.mock.calls[0]![0];
+    expect(text).toContain("bad");
+    expect(text).not.toContain("fine");
+  });
+
+  it("respects the search filter", () => {
+    seedConsoleRow({ summaryText: "alpha event" });
+    seedConsoleRow({ summaryText: "beta event" });
+    renderPanel();
+
+    fireEvent.change(screen.getByLabelText("Filter console messages"), {
+      target: { value: "alpha" },
+    });
+    fireEvent.click(getCopyVisibleButton());
+
+    const text = writeText.mock.calls[0]![0];
+    expect(text).toContain("alpha event");
+    expect(text).not.toContain("beta event");
+  });
+
+  it("excludes children of collapsed groups", () => {
+    seedConsoleRow({ cdpType: "startGroupCollapsed", summaryText: "group header" });
+    seedConsoleRow({ summaryText: "hidden child", groupDepth: 1 });
+    renderPanel();
+
+    fireEvent.click(getCopyVisibleButton());
+
+    const text = writeText.mock.calls[0]![0];
+    expect(text).toContain("group header");
+    expect(text).not.toContain("hidden child");
+  });
+});
+
+describe("accessibility", () => {
+  it("labels the filter input", () => {
+    renderPanel();
+    const input = screen.getByLabelText("Filter console messages");
+    expect(input.tagName).toBe("INPUT");
+  });
+
+  it("exposes expand state on the group toggle", () => {
+    seedConsoleRow({ cdpType: "startGroupCollapsed", summaryText: "group header" });
+    renderPanel();
+
+    const toggle = screen.getByRole("button", { name: "Toggle console group" });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(toggle);
+    const expanded = screen.getByRole("button", { name: "Toggle console group" });
+    expect(expanded.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("keeps the row copy button label constant after copying", () => {
+    seedConsoleRow({ summaryText: "stable label" });
+    renderPanel();
+
+    const button = screen.getByRole("button", { name: "Copy console message" });
+    fireEvent.click(button);
+    expect(screen.getByRole("button", { name: "Copy console message" })).toBeTruthy();
+  });
+});

--- a/src/components/DevPreview/__tests__/ConsolePanel.test.tsx
+++ b/src/components/DevPreview/__tests__/ConsolePanel.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ConsolePanel, serializeConsoleMessage, serializeConsoleMessages } from "../ConsolePanel";
 import { useConsoleCaptureStore, type ConsoleMessage } from "@/store/consoleCaptureStore";
 import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
@@ -124,12 +124,20 @@ describe("serializeConsoleMessage", () => {
     const out = serializeConsoleMessage(msg);
     expect(out).not.toContain("\u001b");
     expect(out).not.toContain("\u202e");
-    // Untrusted newlines inside summaryText are stripped; the serializer's own
-    // row/frame line structure survives.
+    // Multi-line summaries keep their line structure (matching the
+    // whitespace-pre-wrap display); other controls are stripped per line.
     expect(out.split("\n")).toEqual([
-      "[12:34:56.789] [ERR] safe[31mtextsecond",
+      "[12:34:56.789] [ERR] safe[31mtext",
+      "second",
       "  at fn (http://x/a.js:1:2)",
     ]);
+  });
+
+  it("preserves multi-line exception text without a stack trace", () => {
+    const msg = makeMessage({ summaryText: "TypeError: x\n  at foo (app.js:1:1)" });
+    expect(serializeConsoleMessage(msg)).toBe(
+      "[12:34:56.789] [ERR] TypeError: x\n  at foo (app.js:1:1)"
+    );
   });
 
   it("joins multiple messages with newlines", () => {
@@ -171,6 +179,43 @@ describe("per-row copy", () => {
     expect(writeText).toHaveBeenCalledWith(
       expect.stringContaining("with stack\n  at handler (http://x/main.js:3:7)")
     );
+  });
+
+  it("copies the clicked row, not another row", () => {
+    seedConsoleRow({ summaryText: "first row" });
+    seedConsoleRow({ summaryText: "second row" });
+    seedConsoleRow({ summaryText: "third row" });
+    renderPanel();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Copy console message" })[1]!);
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const text = writeText.mock.calls[0]![0];
+    expect(text).toContain("second row");
+    expect(text).not.toContain("first row");
+    expect(text).not.toContain("third row");
+  });
+
+  it("shows the copied check after a successful copy", async () => {
+    seedConsoleRow({ summaryText: "feedback" });
+    renderPanel();
+
+    const button = screen.getByRole("button", { name: "Copy console message" });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(button.querySelector(".animate-badge-bump")).toBeTruthy());
+  });
+
+  it("does not show the copied check when the clipboard write fails", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    seedConsoleRow({ summaryText: "rejected" });
+    renderPanel();
+
+    const button = screen.getByRole("button", { name: "Copy console message" });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(button.querySelector(".animate-badge-bump")).toBeNull();
   });
 });
 
@@ -238,6 +283,34 @@ describe("toolbar copy visible", () => {
     const text = writeText.mock.calls[0]![0];
     expect(text).toContain("group header");
     expect(text).not.toContain("hidden child");
+  });
+
+  it("excludes the whole nested subtree of a collapsed group but keeps siblings", () => {
+    seedConsoleRow({ cdpType: "startGroupCollapsed", summaryText: "outer group" });
+    seedConsoleRow({ cdpType: "startGroup", summaryText: "inner group", groupDepth: 1 });
+    seedConsoleRow({ summaryText: "grandchild", groupDepth: 2 });
+    seedConsoleRow({ summaryText: "sibling after" });
+    renderPanel();
+
+    fireEvent.click(getCopyVisibleButton());
+
+    const text = writeText.mock.calls[0]![0];
+    expect(text).toContain("outer group");
+    expect(text).toContain("sibling after");
+    expect(text).not.toContain("inner group");
+    expect(text).not.toContain("grandchild");
+  });
+
+  it("is disabled and copies nothing when the filter matches no rows", () => {
+    seedConsoleRow({ level: "error", summaryText: "only an error" });
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "Warn" }));
+
+    const button = getCopyVisibleButton();
+    expect(button.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(button);
+    expect(writeText).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

The dev preview console uses a virtualized list (`react-virtuoso`), which makes DOM text selection impossible — offscreen rows aren't in the DOM, and collapsed stack traces drop out entirely. There was no path to get a console error plus stack trace into an agent terminal without opening DevTools.

Serializes from `consoleCaptureStore` data rather than the DOM, so the copy text matches what's visible regardless of virtualization state.

Resolves #10366

## Changes

- Per-row copy button, revealed on hover and `focus-within` (uses the three-class visibility cluster so it stays out of the tab order when hidden; rows are focusable so keyboard users can reach it)
- Toolbar "Copy visible" button that respects the level filter, search filter, and collapsed group children — disabled when nothing is visible
- Copy format: `[HH:MM:SS.mmm] [LVL] message` with `  at fn (url:line:col)` frames, matching the rendered `StackTrace` format
- Clipboard text sanitized per line via `sanitizeForClipboard` (strips C0/Bidi controls per-line to preserve intentional multi-line structure)
- Both copy buttons use `useCopyWithFeedback` (Copy→Check feedback with live-region SR announce)
- `aria-label` on the filter input; `aria-label` + `aria-expanded` on the group expand/collapse toggle

## Testing

21 unit tests in `src/components/DevPreview/__tests__/ConsolePanel.test.tsx` — covers serialization format, stack frames, `(anonymous)` fallback, sanitization, multi-line preservation, per-row copy identity, copy success/failure feedback, toolbar copy with level/search/collapsed-group filters, disabled empty state, and the aria fixes.