### PR TITLE
Design consistency sweep + usability polish completion

### DIFF
--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -34,7 +34,7 @@ This document maps each interactive component role to its canonical Tailwind cla
 "hover:bg-overlay-subtle hover:text-daintree-text";
 ```
 
-**Usage:** For selected state, use `aria-selected:bg-overlay-soft aria-selected:border-overlay` with a `before:` pseudo-element for the 2px accent rail (`aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2 aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent`). Used in `QuickSwitcherItem.tsx`.
+**Usage:** For selected state, use `aria-selected:bg-overlay-raised aria-selected:border-overlay` with a `before:` pseudo-element for the 2px accent rail (`aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2 aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent`). The raised token follows the `bondi.ts` "elevate-to-select for menu/palette rows" rationale (#9727) — `overlay-soft` is sub-threshold on near-white surfaces. Used in `QuickSwitcherItem.tsx`.
 
 ---
 
@@ -75,7 +75,7 @@ This document maps each interactive component role to its canonical Tailwind cla
 **Role:** Selected list item in a picker. Uses background fill with accent rail via pseudo-element.
 
 ```tsx
-"aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2 aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']";
+"aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2 aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']";
 ```
 
 **Usage:** Selected items do not add hover overlay — the background fill and accent rail provide sufficient state distinction. Unselected items get `hover:bg-overlay-subtle`. Used in `QuickSwitcherItem.tsx`.

--- a/e2e/full/platform/core-global-env-inheritance.spec.ts
+++ b/e2e/full/platform/core-global-env-inheritance.spec.ts
@@ -77,7 +77,7 @@ test.describe.serial("Full: Global Environment Variable Inheritance", () => {
     await window.waitForTimeout(T_SETTLE);
 
     // Verify save button disappears (isDirty becomes false)
-    await expect(window.locator("button", { hasText: "Saving..." })).not.toBeVisible({
+    await expect(window.locator("button", { hasText: "Saving…" })).not.toBeVisible({
       timeout: T_MEDIUM,
     });
 

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -228,9 +228,11 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
         timeout: T_SHORT,
       });
 
-      // Cancel without saving (dirty → confirm dialog).
-      window.once("dialog", (d) => d.accept());
+      // Cancel without saving (dirty → discard-changes confirm dialog).
       await editor.locator(SEL.recipeEditor.cancelButton).click();
+      const discardDialog = window.getByRole("alertdialog").filter({ hasText: "Discard changes" });
+      await expect(discardDialog).toBeVisible({ timeout: T_SHORT });
+      await discardDialog.locator(SEL.confirmDialog.confirm).click();
       await expect(editor).not.toBeVisible({ timeout: T_MEDIUM });
       await expect(window.locator('[role="dialog"]')).toHaveCount(0, { timeout: T_MEDIUM });
     });

--- a/e2e/full/presets/recipe-e2e-coverage.spec.ts
+++ b/e2e/full/presets/recipe-e2e-coverage.spec.ts
@@ -386,7 +386,7 @@ test.describe.serial("Recipe & onboarding coverage (#9597)", () => {
     test("marking an item via IPC persists and reflects on re-show", async () => {
       const { window } = ctx;
       const panel = await showChecklist(window);
-      await expect(panel.getByText("Getting Started")).toBeVisible({ timeout: T_SHORT });
+      await expect(panel.getByText("Getting started")).toBeVisible({ timeout: T_SHORT });
 
       // createdWorktree won't auto-complete in a single-worktree project.
       const item = panel.locator(SEL.checklist.item("createdWorktree"));

--- a/e2e/full/terminal/core-terminal-recipes.spec.ts
+++ b/e2e/full/terminal/core-terminal-recipes.spec.ts
@@ -141,14 +141,18 @@ test.describe.serial("Core: Terminal Recipes", () => {
       // Make a change to trigger dirty state
       await editor.locator(SEL.recipeEditor.nameInput).fill("Modified Recipe");
 
-      // Cancel but dismiss the confirm (stay in editor)
-      window.once("dialog", (dialog) => dialog.dismiss());
+      // Cancel but keep editing via the discard-changes confirm (stay in editor)
       await editor.locator(SEL.recipeEditor.cancelButton).click();
+      const discardDialog = window.getByRole("alertdialog").filter({ hasText: "Discard changes" });
+      await expect(discardDialog).toBeVisible({ timeout: T_SHORT });
+      await discardDialog.locator(SEL.confirmDialog.cancel).click();
+      await expect(discardDialog).not.toBeVisible({ timeout: T_SHORT });
       await expect(editor).toBeVisible({ timeout: T_SHORT });
 
-      // Cancel again and accept the confirm (close editor without saving)
-      window.once("dialog", (dialog) => dialog.accept());
+      // Cancel again and confirm the discard (close editor without saving)
       await editor.locator(SEL.recipeEditor.cancelButton).click();
+      await expect(discardDialog).toBeVisible({ timeout: T_SHORT });
+      await discardDialog.locator(SEL.confirmDialog.confirm).click();
       await expect(editor).not.toBeVisible({ timeout: T_SHORT });
 
       // Re-select recipes tab and reopen to verify original name was preserved

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -322,7 +322,7 @@ export const SEL = {
     mutedEmptyState: '[data-testid="notification-muted-empty-state"]',
   },
   actionPalette: {
-    dialog: '[role="dialog"][aria-label="Action palette"]',
+    dialog: '[role="dialog"][aria-label="Command palette"]',
     searchInput: '[aria-label="Search actions"]',
     list: "#action-palette-list",
     options: '#action-palette-list [role="option"]',
@@ -484,7 +484,7 @@ export const SEL = {
     // Footer affordance listing the @/#/:/> prefixes; rendered only on empty query.
     discoverabilityRow: '[aria-label="Prefix shortcuts"]',
     // Mode chip (e.g. "Commands") rendered as the action-palette input prefix.
-    modeChip: '[role="dialog"][aria-label="Action palette"] [role="status"][aria-live="polite"]',
+    modeChip: '[role="dialog"][aria-label="Command palette"] [role="status"][aria-live="polite"]',
     // Sectioned-body header in the action palette MRU rail.
     recentlyUsedHeader: '#action-palette-list [aria-label="Recently used"]',
     // Non-divider rows in the action-palette listbox (excludes aria-disabled headers).

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -278,7 +278,7 @@ describe("createApplicationMenu", () => {
 
   describe("File menu Clone Repository item", () => {
     it("has a Clone Repository... item that sends clone-repo action", () => {
-      const item = findMenuItem(capturedTemplate, "File", "Clone Repository...");
+      const item = findMenuItem(capturedTemplate, "File", "Clone Repository…");
       expect(item).toBeDefined();
       item!.click!(
         {} as Electron.MenuItem,
@@ -362,7 +362,7 @@ describe("update menu lifecycle", () => {
 
       const item = menuItemRegistry.get("check-for-updates-mac");
       expect(item).toBeDefined();
-      expect(item!.label).toBe("Restart to install update");
+      expect(item!.label).toBe("Restart to Install Update");
       expect(item!.enabled).toBe(true);
     });
 
@@ -542,7 +542,7 @@ describe("update menu lifecycle", () => {
       const items = fileMenu!.submenu as Electron.MenuItemConstructorOptions[];
       expect(items.some((i) => i.label === "Exit")).toBe(false);
       const fileSettings = items.find(
-        (i) => i.label === "Settings..." && i.accelerator === "CommandOrControl+,"
+        (i) => i.label === "Settings…" && i.accelerator === "CommandOrControl+,"
       );
       expect(fileSettings).toBeUndefined();
     });
@@ -560,7 +560,7 @@ describe("update menu lifecycle", () => {
       expect(last.role).toBe("quit");
       expect(penultimate.type).toBe("separator");
 
-      const settings = items.find((i) => i.label === "Settings...");
+      const settings = items.find((i) => i.label === "Settings…");
       expect(settings).toBeDefined();
       expect(settings!.accelerator).toBe("CommandOrControl+,");
 
@@ -578,7 +578,7 @@ describe("update menu lifecycle", () => {
       expect(last.label).toBe("Exit");
       expect(last.role).toBe("quit");
 
-      const settings = items.find((i) => i.label === "Settings...");
+      const settings = items.find((i) => i.label === "Settings…");
       expect(settings).toBeDefined();
       expect(settings!.accelerator).toBe("CommandOrControl+,");
     });
@@ -589,7 +589,7 @@ describe("update menu lifecycle", () => {
 
       const fileMenu = capturedTemplate.find((m) => m.label === "File");
       const items = fileMenu!.submenu as Electron.MenuItemConstructorOptions[];
-      const settings = items.find((i) => i.label === "Settings...");
+      const settings = items.find((i) => i.label === "Settings…");
       expect(settings).toBeDefined();
 
       settings!.click!(
@@ -674,7 +674,7 @@ describe("update menu lifecycle", () => {
     it("ready state sets restart label", () => {
       dispatchUpdate("ready");
       const item = menuItemRegistry.get("check-for-updates-mac");
-      expect(item!.label).toBe("Restart to install update");
+      expect(item!.label).toBe("Restart to Install Update");
       expect(item!.enabled).toBe(true);
     });
 

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -44,7 +44,7 @@ const UPDATE_MENU_ITEM_IDS = ["check-for-updates-mac", "check-for-updates-help"]
 const UPDATE_MENU_STATE_LABELS: Record<UpdateMenuState, { label: string; enabled: boolean }> = {
   idle: { label: "Check for Updates…", enabled: true },
   checking: { label: "Checking…", enabled: false },
-  ready: { label: "Restart to install update", enabled: true },
+  ready: { label: "Restart to Install Update", enabled: true },
 };
 
 function applyUpdateMenuState(state: UpdateMenuState): void {
@@ -162,7 +162,7 @@ export function createApplicationMenu(
       label: "File",
       submenu: [
         {
-          label: "Open Directory...",
+          label: "Open Directory…",
           accelerator: "CommandOrControl+O",
           click: async (_item, browserWindow) => {
             const win = getTargetBrowserWindow(browserWindow);
@@ -179,7 +179,7 @@ export function createApplicationMenu(
           },
         },
         {
-          label: "Clone Repository...",
+          label: "Clone Repository…",
           click: (_item, browserWindow) =>
             sendAction("project.cloneRepo", getTargetBrowserWindow(browserWindow)),
         },
@@ -190,7 +190,7 @@ export function createApplicationMenu(
             sendAction("app.newWindow", getTargetBrowserWindow(browserWindow)),
         },
         {
-          label: "New Worktree...",
+          label: "New Worktree…",
           accelerator: "CommandOrControl+N",
           click: (_item, browserWindow) =>
             sendAction("worktree.createDialog.open", getTargetBrowserWindow(browserWindow)),
@@ -203,13 +203,13 @@ export function createApplicationMenu(
         ...(process.platform !== "darwin"
           ? [
               {
-                label: "Settings...",
+                label: "Settings…",
                 accelerator: "CommandOrControl+,",
                 click: (_item: Electron.MenuItem, browserWindow: Electron.BaseWindow | undefined) =>
                   sendAction("app.settings", getTargetBrowserWindow(browserWindow)),
               },
               {
-                label: "Plugin Manager...",
+                label: "Plugin Manager…",
                 click: (_item: Electron.MenuItem, browserWindow: Electron.BaseWindow | undefined) =>
                   sendAction("app.pluginManager", getTargetBrowserWindow(browserWindow)),
               },
@@ -411,13 +411,13 @@ export function createApplicationMenu(
           ? [...terminalPluginItems, { type: "separator" as const }]
           : []),
         {
-          label: "Quick Switcher...",
+          label: "Quick Switcher…",
           accelerator: "CommandOrControl+P",
           click: (_item, browserWindow) =>
             sendAction("nav.quickSwitcher", getTargetBrowserWindow(browserWindow)),
         },
         {
-          label: "Command Palette...",
+          label: "Command Palette…",
           accelerator: "CommandOrControl+Shift+P",
           click: (_item, browserWindow) =>
             sendAction("action.palette.open", getTargetBrowserWindow(browserWindow)),
@@ -526,13 +526,13 @@ export function createApplicationMenu(
           : []),
         { type: "separator" },
         {
-          label: "Settings...",
+          label: "Settings…",
           accelerator: "CommandOrControl+,",
           click: (_item, browserWindow) =>
             sendAction("app.settings", getTargetBrowserWindow(browserWindow)),
         },
         {
-          label: "Plugin Manager...",
+          label: "Plugin Manager…",
           click: (_item, browserWindow) =>
             sendAction("app.pluginManager", getTargetBrowserWindow(browserWindow)),
         },

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -434,7 +434,7 @@ export function ActionPalette({
       renderBody={showSections ? renderSectionedBody : undefined}
       label="Actions"
       shortcut={actionPaletteShortcut}
-      ariaLabel="Action palette"
+      ariaLabel="Command palette"
       searchPlaceholder="Find an action"
       searchAriaLabel="Search actions"
       listId="action-palette-list"

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -134,7 +134,7 @@ function ActionPaletteItemInner({
         "aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text",
         "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
         "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
-        !item.enabled && "opacity-40"
+        !item.enabled && "opacity-50"
       )}
       id={`action-option-${item.id}`}
       role="option"

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -571,7 +571,7 @@ export function BrowserToolbar({
         {longPressDir === "back" && recentBackEntries.length > 0 && (
           <div
             ref={longPressDropdownRef}
-            className="absolute left-0 top-full mt-1 z-50 min-w-[220px] bg-daintree-bg border border-overlay rounded shadow-[var(--theme-shadow-floating)] overflow-hidden"
+            className="absolute left-0 top-full mt-1 z-50 min-w-[220px] rounded-[var(--radius-lg)] surface-overlay shadow-overlay overflow-hidden"
           >
             {recentBackEntries.map((entry) => (
               <button
@@ -617,7 +617,7 @@ export function BrowserToolbar({
         {longPressDir === "forward" && recentForwardEntries.length > 0 && (
           <div
             ref={longPressDropdownRef}
-            className="absolute left-0 top-full mt-1 z-50 min-w-[220px] bg-daintree-bg border border-overlay rounded shadow-[var(--theme-shadow-floating)] overflow-hidden"
+            className="absolute left-0 top-full mt-1 z-50 min-w-[220px] rounded-[var(--radius-lg)] surface-overlay shadow-overlay overflow-hidden"
           >
             {recentForwardEntries.map((entry) => (
               <button
@@ -906,7 +906,7 @@ export function BrowserToolbar({
                 "bg-daintree-bg border border-overlay",
                 "focus:outline-hidden focus:border-border-strong",
                 "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
-                "text-daintree-text placeholder:text-daintree-text/40",
+                "text-daintree-text placeholder:text-text-placeholder",
                 error && "border-status-error/50"
               )}
               placeholder="localhost:3000"
@@ -924,7 +924,7 @@ export function BrowserToolbar({
             ref={dropdownRef}
             id={listboxId}
             role="listbox"
-            className="absolute left-0 right-0 top-full mt-1 z-50 bg-daintree-bg border border-overlay rounded shadow-[var(--theme-shadow-floating)] overflow-hidden"
+            className="absolute left-0 right-0 top-full mt-1 z-50 rounded-[var(--radius-lg)] surface-overlay shadow-overlay overflow-hidden"
           >
             {suggestions.map((entry, index) => (
               <div

--- a/src/components/Browser/FindBar.tsx
+++ b/src/components/Browser/FindBar.tsx
@@ -72,7 +72,7 @@ export function FindBar({ find }: FindBarProps) {
         aria-label="Find in page"
         aria-describedby={counterId}
         data-testid="find-bar-input"
-        className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-daintree-text/40 outline-hidden border border-transparent focus:border-border-strong transition-colors"
+        className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder outline-hidden border border-transparent focus:border-border-strong transition-colors"
         spellCheck={false}
       />
       <span
@@ -111,7 +111,7 @@ export function FindBar({ find }: FindBarProps) {
               type="button"
               onClick={goPrev}
               disabled={matchCount === 0}
-              className="p-0.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors text-daintree-text/70"
+              className="p-1 rounded hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none transition-colors text-daintree-text/70"
               aria-label="Previous match"
             >
               <ChevronUp className="w-3.5 h-3.5" />
@@ -127,7 +127,7 @@ export function FindBar({ find }: FindBarProps) {
               type="button"
               onClick={goNext}
               disabled={matchCount === 0}
-              className="p-0.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed disabled:pointer-events-none transition-colors text-daintree-text/70"
+              className="p-1 rounded hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none transition-colors text-daintree-text/70"
               aria-label="Next match"
             >
               <ChevronDown className="w-3.5 h-3.5" />
@@ -141,7 +141,7 @@ export function FindBar({ find }: FindBarProps) {
           <button
             type="button"
             onClick={close}
-            className="p-0.5 rounded hover:bg-overlay-medium transition-colors text-daintree-text/70"
+            className="p-1 rounded hover:bg-overlay-medium transition-colors text-daintree-text/70"
             aria-label="Close find bar"
           >
             <X className="w-3.5 h-3.5" />

--- a/src/components/Commands/CommandBuilder.tsx
+++ b/src/components/Commands/CommandBuilder.tsx
@@ -108,7 +108,7 @@ function BuilderTextField({
         aria-invalid={error ? "true" : undefined}
         className={cn(
           "w-full px-3 py-2 text-sm rounded-[var(--radius-md)]",
-          "bg-daintree-bg border text-daintree-text placeholder:text-text-muted",
+          "bg-daintree-bg border text-daintree-text placeholder:text-text-placeholder",
           "focus:outline-hidden focus:ring-1",
           error
             ? "border-status-error focus:border-status-error focus:ring-status-error"
@@ -160,7 +160,7 @@ function BuilderTextareaField({
         aria-invalid={error ? "true" : undefined}
         className={cn(
           "w-full px-3 py-2 text-sm rounded-[var(--radius-md)] resize-y min-h-[100px]",
-          "bg-daintree-bg border text-daintree-text placeholder:text-text-muted",
+          "bg-daintree-bg border text-daintree-text placeholder:text-text-placeholder",
           "focus:outline-hidden focus:ring-1",
           error
             ? "border-status-error focus:border-status-error focus:ring-status-error"

--- a/src/components/Commands/CommandPickerHost.tsx
+++ b/src/components/Commands/CommandPickerHost.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import { useCommandStore } from "@/store/commandStore";
 import { CommandPicker } from "./CommandPicker";
 import { CommandBuilder } from "./CommandBuilder";
@@ -51,6 +52,11 @@ export function CommandPickerHost({ context, onCommandExecuted }: CommandPickerH
     }))
   );
 
+  // Sub-400ms builder loads go straight from the picker to CommandBuilder with
+  // a single dialog enter animation; the spinner dialog only mounts for
+  // genuinely slow loads.
+  const showBuilderLoading = useDohertyGate(isLoadingBuilder);
+
   useEffect(() => {
     if (isPickerOpen) {
       loadCommands(context);
@@ -101,7 +107,7 @@ export function CommandPickerHost({ context, onCommandExecuted }: CommandPickerH
         onDismiss={closePicker}
       />
 
-      {activeCommand && isLoadingBuilder && (
+      {activeCommand && showBuilderLoading && (
         <AppDialog isOpen={true} onClose={handleBuilderCancel} size="md">
           <AppDialog.Header>
             <AppDialog.Title>{activeCommand.label}</AppDialog.Title>
@@ -109,8 +115,8 @@ export function CommandPickerHost({ context, onCommandExecuted }: CommandPickerH
           </AppDialog.Header>
           <AppDialog.Body>
             <div className="flex flex-col items-center justify-center py-8 space-y-4">
-              <Spinner size="2xl" className="text-daintree-accent" />
-              <p className="text-sm text-daintree-text/70">Loading command configuration...</p>
+              <Spinner size="2xl" className="text-daintree-text/40" />
+              <p className="text-sm text-daintree-text/70">Loading command configuration…</p>
             </div>
           </AppDialog.Body>
         </AppDialog>

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -91,9 +91,11 @@ const ConsoleRow = memo(function ConsoleRow({
             <button
               type="button"
               onClick={handleToggle}
+              aria-expanded={!isGroupCollapsed}
+              aria-label="Toggle console group"
               className="text-daintree-text/40 mr-1 select-none hover:text-daintree-text/60"
             >
-              {isGroupCollapsed ? "▶" : "▼"}
+              <span aria-hidden="true">{isGroupCollapsed ? "▶" : "▼"}</span>
             </button>
           )}
           {msg.args.length > 0 ? (
@@ -276,6 +278,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
               key={filter}
               type="button"
               onClick={() => setLevelFilter(filter)}
+              aria-pressed={levelFilter === filter}
               className={cn(
                 buttonClass,
                 levelFilter === filter
@@ -300,6 +303,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Filter…"
+          aria-label="Filter console messages"
           className="flex-1 min-w-0 max-w-[160px] px-2 py-0.5 text-[11px] rounded bg-daintree-bg border border-overlay focus:outline-hidden focus:border-border-strong text-daintree-text placeholder:text-daintree-text/30"
         />
 
@@ -313,6 +317,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
                 type="button"
                 onClick={handleScrollToBottom}
                 className="p-1 rounded hover:bg-overlay-medium text-daintree-text/50 hover:text-daintree-text transition-colors"
+                aria-label="Scroll to bottom"
               >
                 <ChevronDown className="w-3.5 h-3.5" />
               </button>

--- a/src/components/DevPreview/ConsolePanel.tsx
+++ b/src/components/DevPreview/ConsolePanel.tsx
@@ -304,7 +304,7 @@ export function ConsolePanel({ paneId, webContentsId }: ConsolePanelProps) {
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Filter…"
           aria-label="Filter console messages"
-          className="flex-1 min-w-0 max-w-[160px] px-2 py-0.5 text-[11px] rounded bg-daintree-bg border border-overlay focus:outline-hidden focus:border-border-strong text-daintree-text placeholder:text-daintree-text/30"
+          className="flex-1 min-w-0 max-w-[160px] px-2 py-0.5 text-[11px] rounded bg-daintree-bg border border-overlay focus:outline-hidden focus:border-border-strong text-daintree-text placeholder:text-text-placeholder"
         />
 
         <div className="flex-1" />

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1727,7 +1727,7 @@ export function DevPreviewPane({
                             }
                           }}
                           placeholder="npm run dev"
-                          className="w-full px-2.5 py-1.5 text-xs font-mono bg-overlay-subtle border border-overlay/30 rounded text-daintree-text/70 placeholder:text-daintree-text/30 focus:outline-hidden focus:border-overlay/50 transition-[border-color,box-shadow]"
+                          className="w-full px-2.5 py-1.5 text-xs font-mono bg-overlay-subtle border border-overlay/30 rounded text-daintree-text/70 placeholder:text-text-placeholder focus:outline-hidden focus:border-overlay/50 transition-[border-color,box-shadow]"
                         />
                         <Button
                           onClick={() => void handleSaveCommand()}

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -7,6 +7,7 @@ import {
   useContext,
   useEffect,
   type MouseEvent as ReactMouseEvent,
+  type TouchEvent as ReactTouchEvent,
   type MutableRefObject,
 } from "react";
 import {
@@ -31,6 +32,7 @@ import {
   type Announcements,
   type MeasuringConfiguration,
   type MouseSensorOptions,
+  type TouchSensorOptions,
   type Over,
   type ScreenReaderInstructions,
 } from "@dnd-kit/core";
@@ -150,6 +152,27 @@ export class NoDndMouseSensor extends MouseSensor {
   ];
 }
 
+// TouchSensor variant with the same [data-no-dnd] opt-out as NoDndMouseSensor,
+// so a long-press on an opted-out element doesn't start the drag the mouse
+// path deliberately suppresses. Mirrors the upstream TouchSensor.activators
+// shape (including the multi-touch bail) so options flow through unchanged.
+export class NoDndTouchSensor extends TouchSensor {
+  static activators: {
+    eventName: "onTouchStart";
+    handler: (event: ReactTouchEvent, options: TouchSensorOptions) => boolean;
+  }[] = [
+    {
+      eventName: "onTouchStart",
+      handler: ({ nativeEvent: event }, { onActivation }) => {
+        if (event.touches.length > 1) return false;
+        if (isNoDndTarget(event.target)) return false;
+        onActivation?.({ event });
+        return true;
+      },
+    },
+  ];
+}
+
 // Cursor offset from top of preview (positions cursor in title bar area)
 const TITLE_BAR_CURSOR_OFFSET = 12;
 
@@ -201,8 +224,18 @@ function getDragLabel(data: unknown): string {
  * Resolve the announcement label for a droppable. Worktree-sort uses
  * `worktree-sort-{id}` for the sortable handle and `worktree-drop-{id}` for
  * the row's drop target — both should announce the same human-readable label.
+ * The synthetic droppables (trash pill, grid/dock placeholders) register no
+ * panel data, so without explicit labels they'd all announce as "panel" —
+ * worst on trash, where the drop closes the panel. Exported for unit tests.
  */
-function getOverDragLabel(over: Over): string {
+export function getOverDragLabel(over: Over): string {
+  if (over.id === TRASH_DROPPABLE_ID) return "trash — drop to close panel";
+  const overData = over.data.current as
+    | { container?: "grid" | "dock"; isPlaceholder?: boolean }
+    | undefined;
+  if (overData?.isPlaceholder) {
+    return overData.container === "dock" ? "the dock" : "empty grid slot";
+  }
   const sortDragId = parseWorktreeSortDragId(over.id);
   if (sortDragId) return resolveWorktreeLabel(sortDragId);
   if (typeof over.id === "string" && over.id.startsWith("worktree-drop-")) {
@@ -539,7 +572,7 @@ export function DndProvider({ children }: DndProviderProps) {
     useSensor(NoDndMouseSensor, {
       activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE },
     }),
-    useSensor(TouchSensor, {
+    useSensor(NoDndTouchSensor, {
       activationConstraint: { delay: 150, tolerance: 5 },
     }),
     useSensor(KeyboardSensor, {

--- a/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
+++ b/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from "vitest";
 import type { MutableRefObject } from "react";
 import type { Active, Over } from "@dnd-kit/core";
-import { createDragAnnouncements, type DragAnnouncementRefs } from "../DndProvider";
+import {
+  createDragAnnouncements,
+  getOverDragLabel,
+  GRID_PLACEHOLDER_ID,
+  TRASH_DROPPABLE_ID,
+  type DragAnnouncementRefs,
+} from "../DndProvider";
+import { DOCK_PLACEHOLDER_ID } from "../DockPlaceholder";
 import { makeSortableAnnouncements } from "../sortableAnnouncements";
 
 // Build a refs harness with controlled values so the factory's pickup-time
@@ -416,5 +423,31 @@ describe("makeSortableAnnouncements — nested DndContext factory", () => {
         "Picked up browser tab tab-z. Press arrow keys to move, Space to drop, Escape to cancel."
       );
     });
+  });
+});
+
+describe("getOverDragLabel — synthetic droppables", () => {
+  it("names the trash droppable instead of falling back to the generic panel label", () => {
+    const label = getOverDragLabel(makeOver(TRASH_DROPPABLE_ID, undefined));
+    expect(label).not.toBe("panel");
+    expect(label).toContain("trash");
+  });
+
+  it("distinguishes the grid and dock placeholders by their container data", () => {
+    const grid = getOverDragLabel(
+      makeOver(GRID_PLACEHOLDER_ID, { container: "grid", isPlaceholder: true })
+    );
+    const dock = getOverDragLabel(
+      makeOver(DOCK_PLACEHOLDER_ID, { container: "dock", isPlaceholder: true })
+    );
+    expect(grid).not.toBe(dock);
+    expect(grid).toContain("grid");
+    expect(dock).toContain("dock");
+  });
+
+  it("still resolves panel data for ordinary droppables", () => {
+    expect(getOverDragLabel(makeOver("term-1", { terminal: { title: "Terminal" } }))).toBe(
+      "Terminal"
+    );
   });
 });

--- a/src/components/EventInspector/EventDetail.tsx
+++ b/src/components/EventInspector/EventDetail.tsx
@@ -4,6 +4,7 @@ import { useEventStore, type EventRecord, type EventFilterOptions } from "@/stor
 import { Copy, Check, ChevronDown, ChevronRight, Filter, X } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { logError } from "@/utils/logger";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { sanitizeErrorText } from "@/utils/errorText";
 
 interface EventDetailProps {
@@ -120,6 +121,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
     try {
       await navigator.clipboard.writeText(sanitizeErrorText(formattedPayload));
       setCopied(true);
+      useAnnouncerStore.getState().announce("Payload copied");
 
       if (copyTimeoutRef.current) {
         clearTimeout(copyTimeoutRef.current);
@@ -166,6 +168,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
             <TooltipTrigger asChild>
               <button
                 onClick={copyPayload}
+                aria-label="Copy payload"
                 className="flex-shrink-0 p-2 hover:bg-muted rounded transition-colors"
               >
                 {copied ? (
@@ -183,6 +186,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
       <div className="flex-shrink-0 border-b">
         <button
           onClick={() => toggleSection("metadata")}
+          aria-expanded={expandedSections.has("metadata")}
           className="w-full px-4 py-2 flex items-center gap-2 hover:bg-muted/50 transition-colors"
         >
           {expandedSections.has("metadata") ? (
@@ -233,6 +237,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
       <div className="flex-1 flex flex-col border-b">
         <button
           onClick={() => toggleSection("payload")}
+          aria-expanded={expandedSections.has("payload")}
           className="flex-shrink-0 px-4 py-2 flex items-center gap-2 hover:bg-muted/50 transition-colors"
         >
           {expandedSections.has("payload") ? (
@@ -261,6 +266,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
           <div className="flex-shrink-0">
             <button
               onClick={() => toggleSection("context")}
+              aria-expanded={expandedSections.has("context")}
               className="w-full px-4 py-2 flex items-center gap-2 hover:bg-muted/50 transition-colors"
             >
               {expandedSections.has("context") ? (

--- a/src/components/EventInspector/EventFilters.tsx
+++ b/src/components/EventInspector/EventFilters.tsx
@@ -171,7 +171,7 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
               "w-full pl-9 pr-9 py-2 text-sm rounded-[var(--radius-md)]",
               "bg-muted/50 border border-transparent",
               "focus:bg-background focus:border-primary focus:outline-hidden",
-              "placeholder:text-muted-foreground",
+              "placeholder:text-text-placeholder",
               "[&::-webkit-search-cancel-button]:hidden"
             )}
           />
@@ -202,7 +202,7 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
                 "w-full pl-3 pr-9 py-2 text-sm rounded-[var(--radius-md)] font-mono",
                 "bg-muted/50 border border-transparent",
                 "focus:bg-background focus:border-primary focus:outline-hidden",
-                "placeholder:text-muted-foreground placeholder:font-sans"
+                "placeholder:text-text-placeholder placeholder:font-sans"
               )}
             />
             {traceIdInput && (

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -1010,7 +1010,7 @@ export function FileViewerModal({
             the diff; Enter / Shift+Enter cycle matches. */}
         {searchActive && (
           <div
-            className="absolute top-2 right-7 z-20 flex items-center gap-1.5 pl-2 pr-1 py-1 rounded-md surface-overlay shadow-lg focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
+            className="absolute top-2 right-7 z-20 flex items-center gap-1 pl-2 pr-1 py-1 rounded-md surface-overlay shadow-[var(--theme-shadow-floating)] focus-within:border-daintree-accent focus-within:ring-1 focus-within:ring-daintree-accent/20"
             data-testid="diff-search-bar"
           >
             <Search className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
@@ -1021,7 +1021,7 @@ export function FileViewerModal({
               onKeyDown={handleSearchKeyDown}
               placeholder="Find in diff"
               aria-label="Find in diff"
-              className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-muted-foreground focus:outline-hidden"
+              className="w-44 bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
             />
             <span
               className="text-xs text-muted-foreground tabular-nums shrink-0 min-w-0"
@@ -1041,7 +1041,7 @@ export function FileViewerModal({
               onClick={() => stepSearchMatch(-1)}
               disabled={searchMatchCount === 0}
               aria-label="Previous match"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none"
             >
               <ChevronUp className="w-3.5 h-3.5" />
             </button>
@@ -1050,7 +1050,7 @@ export function FileViewerModal({
               onClick={() => stepSearchMatch(1)}
               disabled={searchMatchCount === 0}
               aria-label="Next match"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
+              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium disabled:opacity-40 disabled:pointer-events-none"
             >
               <ChevronDown className="w-3.5 h-3.5" />
             </button>
@@ -1058,7 +1058,7 @@ export function FileViewerModal({
               type="button"
               onClick={closeSearch}
               aria-label="Close search"
-              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-daintree-border"
+              className="p-1 rounded transition-colors text-muted-foreground hover:text-daintree-text hover:bg-overlay-medium"
             >
               <X className="w-3.5 h-3.5" />
             </button>

--- a/src/components/FileViewer/FileViewerModalHost.tsx
+++ b/src/components/FileViewer/FileViewerModalHost.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy, useEffect, useState } from "react";
-import { Spinner } from "@/components/ui/Spinner";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useProjectStore } from "@/store";
 import { useBranchForPath } from "@/hooks/useBranchForPath";
@@ -50,11 +50,16 @@ export function FileViewerModalHost() {
 
   return (
     <ErrorBoundary variant="component" componentName="FileViewerModal" resetKeys={[openSeq]}>
+      {/* Mirrors FileDiffModal's fallback: a Doherty-gated bone in a
+          modal-shaped frame, so fast chunk loads show only the scrim. */}
       <Suspense
         fallback={
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-scrim-medium">
-            <Spinner size="xl" className="text-text-inverse" />
-          </div>
+          <Skeleton
+            label="Loading file viewer"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-scrim-medium"
+          >
+            <SkeletonBone className="w-[min(80vw,720px)] h-[min(70vh,480px)]" />
+          </Skeleton>
         }
       >
         <LazyFileViewerModal

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, type ReactElement } from "react";
 import * as Checkbox from "@radix-ui/react-checkbox";
 import { CheckIcon, MinusIcon, Search } from "lucide-react";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import { Kbd } from "@/components/ui/Kbd";
 import { isMac } from "@/lib/platform";
 import { cn } from "@/lib/utils";
@@ -106,26 +107,17 @@ export function FleetPickerContent({
   return (
     <div className="flex flex-1 flex-col min-h-0" data-testid={`${testIdPrefix}-root`}>
       <div className="px-4 py-3 border-b border-daintree-border shrink-0">
-        <div className="relative">
-          <Search
-            className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-daintree-text/40 pointer-events-none"
-            aria-hidden="true"
-          />
-          <input
-            autoFocus={autoFocusSearch}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search terminals, worktrees, branches, or recent output"
-            aria-label="Search terminals"
-            className={cn(
-              "w-full rounded border border-daintree-border bg-daintree-bg pl-8 pr-3 py-1.5 text-[13px] text-daintree-text",
-              "placeholder:text-daintree-text/40",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-            )}
-            data-testid={`${testIdPrefix}-search`}
-          />
-        </div>
+        <AppPaletteDialog.Input
+          inputPrefix={
+            <Search className="h-3.5 w-3.5 shrink-0 text-text-muted" aria-hidden="true" />
+          }
+          autoFocus={autoFocusSearch}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search terminals, worktrees, branches, or recent output"
+          aria-label="Search terminals"
+          data-testid={`${testIdPrefix}-search`}
+        />
         {headerSlot}
       </div>
 
@@ -207,13 +199,13 @@ export function FleetPickerFooterHint({
   return (
     <>
       <span className="inline-flex items-center gap-1">
-        <Kbd>↑</Kbd>
-        <Kbd>↓</Kbd>
+        <kbd className={KBD_CLASS}>↑</kbd>
+        <kbd className={KBD_CLASS}>↓</kbd>
         <span>Move</span>
       </span>
       <span className="text-daintree-text/30">·</span>
       <span className="inline-flex items-center gap-1">
-        <Kbd>Space</Kbd>
+        <kbd className={KBD_CLASS}>Space</kbd>
         <span>Toggle</span>
       </span>
       <ShortcutsPopover />

--- a/src/components/Fleet/SaveFleetForm.tsx
+++ b/src/components/Fleet/SaveFleetForm.tsx
@@ -146,7 +146,7 @@ export function SaveFleetForm({ armedCount }: SaveFleetFormProps): ReactElement 
                 : "Arm panes first…"
               : "Name…"
           }
-          className="flex-1 rounded bg-tint/[0.08] px-2 py-1 text-[11px] text-daintree-text placeholder:text-daintree-text/40 outline-hidden focus:bg-tint/[0.14]"
+          className="flex-1 rounded bg-tint/[0.08] px-2 py-1 text-[11px] text-daintree-text placeholder:text-text-placeholder outline-hidden focus:bg-tint/[0.14]"
           data-testid="fleet-save-form-name"
         />
         <button

--- a/src/components/HelpPanel/FigureLightbox.tsx
+++ b/src/components/HelpPanel/FigureLightbox.tsx
@@ -67,7 +67,7 @@ export function FigureLightbox({
     <AppDialog
       isOpen={isOpen}
       onClose={onClose}
-      size="xl"
+      size="5xl"
       maxHeight="max-h-[90vh]"
       data-testid="figure-lightbox"
     >

--- a/src/components/HelpPanel/HelpIntroBanner.tsx
+++ b/src/components/HelpPanel/HelpIntroBanner.tsx
@@ -21,9 +21,9 @@ export function HelpIntroBanner({ onDismiss }: HelpIntroBannerProps) {
         type="button"
         onClick={onDismiss}
         aria-label="Dismiss"
-        className="text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
+        className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
       >
-        <X className="w-3.5 h-3.5" />
+        <X className="w-3 h-3" />
       </button>
     </div>
   );

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -807,7 +807,7 @@ export function HelpPanel({
                 className={cn(
                   "flex items-start gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
                   "rounded-[var(--radius-md)]",
-                  "bg-status-warning/10 border border-status-warning/40",
+                  "bg-status-warning/10 border border-status-warning/20",
                   "text-xs text-daintree-text/85"
                 )}
                 data-testid="help-dropped-agent-banner"

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -901,7 +901,7 @@ export function HelpPanel({
                     "rounded-[var(--radius-sm)]",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                   )}
-                  title="Switch to the worktree this assistant is pinned to."
+                  title="Switch to the worktree this assistant is pinned to"
                 >
                   <span
                     aria-hidden
@@ -948,7 +948,7 @@ export function HelpPanel({
                   "bg-status-danger/10 text-status-danger hover:bg-status-danger/15 transition-colors duration-150",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 )}
-                title="The pinned terminal has closed — start a new session."
+                title="The pinned terminal has closed — start a new session"
               >
                 Start new session
               </button>

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -302,7 +302,7 @@ export function HelpPanelBanners({
           className={cn(
             "flex flex-col gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
             "rounded-[var(--radius-md)]",
-            "bg-status-warning/10 border border-status-warning/40",
+            "bg-status-warning/10 border border-status-warning/20",
             "text-xs text-daintree-text/85"
           )}
           data-testid="help-tier-mismatch-banner"
@@ -380,7 +380,7 @@ export function HelpPanelBanners({
           className={cn(
             "flex flex-col gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
             "rounded-[var(--radius-md)]",
-            "bg-status-error/10 border border-status-error/40",
+            "bg-status-error/10 border border-status-error/20",
             "text-xs text-daintree-text/85"
           )}
           data-testid="help-launch-error-banner"
@@ -440,7 +440,7 @@ export function HelpPanelBanners({
           className={cn(
             "flex flex-col gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
             "rounded-[var(--radius-md)]",
-            "bg-status-error/10 border border-status-error/40",
+            "bg-status-error/10 border border-status-error/20",
             "text-xs text-daintree-text/85"
           )}
           data-testid="help-session-revoked-banner"

--- a/src/components/HelpPanel/RecentCallsPopover.tsx
+++ b/src/components/HelpPanel/RecentCallsPopover.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { ChevronRight } from "lucide-react";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import type { McpAuditRecord, McpAuditResult } from "@shared/types";
@@ -77,11 +78,11 @@ export function RecentCallsPopover({ records, loading, error }: RecentCallsPopov
 
       <div className="max-h-[min(360px,var(--radix-popover-content-available-height,360px))] overflow-y-auto px-1 pb-1">
         {loading ? (
-          <div className="space-y-1.5 px-2 py-1.5" aria-hidden>
-            <div className="h-3 w-5/6 rounded bg-daintree-text/10 animate-pulse" />
-            <div className="h-3 w-4/6 rounded bg-daintree-text/10 animate-pulse" />
-            <div className="h-3 w-3/4 rounded bg-daintree-text/10 animate-pulse" />
-          </div>
+          <Skeleton label="Loading recent calls" className="space-y-1.5 px-2 py-1.5">
+            <SkeletonBone className="h-3 w-5/6" />
+            <SkeletonBone className="h-3 w-4/6" />
+            <SkeletonBone className="h-3 w-3/4" />
+          </Skeleton>
         ) : error ? (
           <p className="px-2 py-3 text-daintree-text/50">Couldn't load recent calls</p>
         ) : records.length === 0 ? (

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -453,7 +453,7 @@ export function SettingsShortcutCapture({
             onClick={handleSave}
             disabled={Boolean(validationError)}
             className={cn(
-              "bg-daintree-accent text-daintree-bg rounded hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
+              "bg-daintree-accent text-text-inverse rounded hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed",
               compact ? "px-2 py-0.5 text-xs" : "px-3 py-1.5 text-sm"
             )}
           >

--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -139,7 +139,7 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
     <AppDialog isOpen={isOpen} onClose={onClose} size="lg">
       <AppDialog.Header className="flex-col items-stretch gap-4">
         <div className="flex items-center justify-between">
-          <AppDialog.Title className="text-2xl">Keyboard Shortcuts</AppDialog.Title>
+          <AppDialog.Title>Keyboard shortcuts</AppDialog.Title>
           <AppDialog.CloseButton />
         </div>
         <input
@@ -150,7 +150,7 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
           onChange={(e) => setSearchQuery(e.target.value)}
           aria-label="Search shortcuts"
           aria-controls={resultsId}
-          className="w-full px-4 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
+          className="w-full px-4 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
         />
       </AppDialog.Header>
 
@@ -222,7 +222,7 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
         )}
       </AppDialog.Body>
 
-      <AppDialog.Footer className="justify-center bg-daintree-bg/50">
+      <AppDialog.Footer className="justify-center">
         <div className="text-sm text-daintree-text/60">
           Press <Kbd>Esc</Kbd> to close
         </div>

--- a/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
@@ -109,7 +109,7 @@ describe("ShortcutReferenceDialog", () => {
   it("renders all categories with no query", () => {
     render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
 
-    expect(screen.getByText("Keyboard Shortcuts")).toBeTruthy();
+    expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
     expect(screen.getByText("Terminal")).toBeTruthy();
     expect(screen.getByText("System")).toBeTruthy();
     expect(screen.getByText("Stash Current Input")).toBeTruthy();

--- a/src/components/Layout/ChordIndicator.tsx
+++ b/src/components/Layout/ChordIndicator.tsx
@@ -90,7 +90,7 @@ export function ChordIndicator() {
     >
       <div
         className={cn(
-          "rounded-[var(--radius-lg)] bg-daintree-sidebar/95 border border-[var(--border-overlay)] shadow-xl",
+          "rounded-[var(--radius-lg)] surface-overlay shadow-overlay",
           "transition duration-150",
           "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
           isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-[0.96]"

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -5,12 +5,18 @@ import {
   closestCenter,
   useSensor,
   useSensors,
+  KeyboardSensor,
   PointerSensor,
   TouchSensor,
   type DragEndEvent,
   type UniqueIdentifier,
 } from "@dnd-kit/core";
-import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import { LayoutGroup, AnimatePresence, m } from "framer-motion";
 import { ChevronDown, CopyPlus } from "lucide-react";
@@ -271,8 +277,19 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     }),
     useSensor(TouchSensor, {
       activationConstraint: { delay: 150, tolerance: 5 },
-    })
+    }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+
+  // While a tab drag is live (keyboard pickup), the tablist arrow handler must
+  // not also move focus — dnd-kit's sensor owns the arrow keys.
+  const isTabDragActiveRef = useRef(false);
+  const handleTabDragStart = useCallback(() => {
+    isTabDragActiveRef.current = true;
+  }, []);
+  const handleTabDragCancel = useCallback(() => {
+    isTabDragActiveRef.current = false;
+  }, []);
 
   // Tab IDs for sortable context
   const tabIds = useMemo(() => panels.map((p) => p.id), [panels]);
@@ -287,6 +304,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // Handle tab reorder drag end
   const handleTabDragEnd = useCallback(
     (event: DragEndEvent) => {
+      isTabDragActiveRef.current = false;
       const { active, over } = event;
       if (!over || active.id === over.id) return;
 
@@ -344,6 +362,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   // do not handle those keys here — doing so would double-activate.
   const handleTabListKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      if (isTabDragActiveRef.current) return;
       if (panels.length < 2) return;
 
       // Anchor arrow movement to the currently focused tab when one is
@@ -605,7 +624,9 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           <DndContext
             sensors={tabSensors}
             collisionDetection={closestCenter}
+            onDragStart={handleTabDragStart}
             onDragEnd={handleTabDragEnd}
+            onDragCancel={handleTabDragCancel}
             modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
             autoScroll={tabAutoScroll}
             accessibility={{ announcements: tabAnnouncements }}

--- a/src/components/Layout/RateLimitDetails.tsx
+++ b/src/components/Layout/RateLimitDetails.tsx
@@ -123,7 +123,7 @@ function RateLimitBucketRow({ label, bucket, now }: RateLimitBucketRowProps) {
         <span
           className={cn(
             "text-[13px] font-medium leading-none",
-            exhausted ? "text-text-primary" : "text-daintree-text"
+            exhausted ? "text-text-primary" : "text-text-secondary"
           )}
         >
           {label}

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -208,7 +208,7 @@ export function Sidebar({
       <ContextMenuContent>
         <ContextMenuActionItem actionId="worktree.createDialog.open">
           <GitBranchPlus className={ICON_CLASS} />
-          New Worktree...
+          New Worktree…
         </ContextMenuActionItem>
         <ContextMenuActionItem actionId="worktree.refresh">
           <RefreshCw className={ICON_CLASS} />
@@ -225,7 +225,7 @@ export function Sidebar({
         </ContextMenuActionItem>
         <ContextMenuActionItem actionId="project.settings.open" disabled={!currentProject}>
           <Settings className={ICON_CLASS} />
-          Project Settings...
+          Project Settings…
         </ContextMenuActionItem>
         <ContextMenuSeparator />
         <ContextMenuActionItem actionId="ui.sidebar.resetWidth">
@@ -234,7 +234,7 @@ export function Sidebar({
         </ContextMenuActionItem>
         <ContextMenuActionItem actionId="app.settings.openTab" args={{ tab: "worktree" }}>
           <SlidersHorizontal className={ICON_CLASS} />
-          Worktree Settings...
+          Worktree Settings…
         </ContextMenuActionItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -100,6 +100,10 @@ export function Sidebar({
     };
   }, []);
 
+  const handleResetWidth = useCallback(() => {
+    onResize(DEFAULT_SIDEBAR_WIDTH);
+  }, [onResize]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "ArrowLeft") {
@@ -108,14 +112,13 @@ export function Sidebar({
       } else if (e.key === "ArrowRight") {
         e.preventDefault();
         onResize(width + RESIZE_STEP);
+      } else if (e.key === "Enter" || e.key === " " || e.key === "Home") {
+        e.preventDefault();
+        handleResetWidth();
       }
     },
-    [width, onResize]
+    [width, onResize, handleResetWidth]
   );
-
-  const handleResetWidth = useCallback(() => {
-    onResize(DEFAULT_SIDEBAR_WIDTH);
-  }, [onResize]);
 
   const resize = useCallback(
     (e: MouseEvent) => {
@@ -174,7 +177,7 @@ export function Sidebar({
 
           <div
             role="separator"
-            aria-label="Resize sidebar"
+            aria-label="Resize sidebar (double-click to reset)"
             aria-orientation="vertical"
             aria-valuenow={width}
             aria-valuemin={200}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -341,7 +341,7 @@ function OverflowMenu({
                 <DropdownMenuGroup key="forge-group">
                   <DropdownMenuLabel>Git</DropdownMenuLabel>
                   <DropdownMenuItem key="forge-commits" disabled>
-                    <GitCommit className="mr-2 h-4 w-4" />
+                    <GitCommit className="mr-2 h-3.5 w-3.5" />
                     Commits {repoStats?.commitCount != null ? `(${repoStats.commitCount})` : ""}
                   </DropdownMenuItem>
                 </DropdownMenuGroup>,
@@ -355,18 +355,18 @@ function OverflowMenu({
                   key="forge-issues"
                   onClick={() => forgeStatsRef.current?.openIssues()}
                 >
-                  <CircleDot className="mr-2 h-4 w-4 text-pr-open" />
+                  <CircleDot className="mr-2 h-3.5 w-3.5 text-pr-open" />
                   Issues {repoStats?.issueCount != null ? `(${repoStats.issueCount})` : ""}
                 </DropdownMenuItem>
                 <DropdownMenuItem key="forge-prs" onClick={() => forgeStatsRef.current?.openPrs()}>
-                  <GitPullRequest className="mr-2 h-4 w-4 text-pr-merged" />
+                  <GitPullRequest className="mr-2 h-3.5 w-3.5 text-pr-merged" />
                   Pull Requests {repoStats?.prCount != null ? `(${repoStats.prCount})` : ""}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   key="forge-commits"
                   onClick={() => forgeStatsRef.current?.openCommits()}
                 >
-                  <GitCommit className="mr-2 h-4 w-4" />
+                  <GitCommit className="mr-2 h-3.5 w-3.5" />
                   Commits {repoStats?.commitCount != null ? `(${repoStats.commitCount})` : ""}
                 </DropdownMenuItem>
               </DropdownMenuGroup>,
@@ -397,7 +397,7 @@ function OverflowMenu({
           const disabled = id === "copy-tree" && !hasActiveWorktree;
           return [
             <DropdownMenuItem key={id} disabled={disabled} onClick={() => overflowActions[id]?.()}>
-              <Icon className="mr-2 h-4 w-4" />
+              <Icon className="mr-2 h-3.5 w-3.5" />
               <span className="flex-1">
                 {meta.label}
                 {countSuffix(id)}
@@ -432,8 +432,8 @@ function AgentOverflowItem({
   const shortcut = useKeybindingDisplay(`agent.${id}`);
   return (
     <DropdownMenuItem onClick={onSelect}>
-      <span className="relative mr-2 inline-flex h-4 w-4 items-center justify-center">
-        <Icon className="h-4 w-4" />
+      <span className="relative mr-2 inline-flex h-3.5 w-3.5 items-center justify-center">
+        <Icon className="h-3.5 w-3.5" />
         {dotColor && (
           <span
             aria-hidden="true"

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -216,6 +216,7 @@ vi.mock("@dnd-kit/core", () => ({
   closestCenter: vi.fn(),
   useSensor: vi.fn(() => ({})),
   useSensors: vi.fn(() => []),
+  KeyboardSensor: class {},
   PointerSensor: class {},
   TouchSensor: class {},
 }));
@@ -223,6 +224,7 @@ vi.mock("@dnd-kit/core", () => ({
 vi.mock("@dnd-kit/sortable", () => ({
   SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   horizontalListSortingStrategy: vi.fn(),
+  sortableKeyboardCoordinates: vi.fn(),
   arrayMove: <T,>(arr: T[]) => arr,
 }));
 

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -215,6 +215,7 @@ vi.mock("@dnd-kit/core", () => ({
   closestCenter: vi.fn(),
   useSensor: vi.fn(() => ({})),
   useSensors: vi.fn(() => []),
+  KeyboardSensor: class {},
   PointerSensor: class {},
   TouchSensor: class {},
 }));
@@ -222,6 +223,7 @@ vi.mock("@dnd-kit/core", () => ({
 vi.mock("@dnd-kit/sortable", () => ({
   SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   horizontalListSortingStrategy: vi.fn(),
+  sortableKeyboardCoordinates: vi.fn(),
   arrayMove: <T,>(arr: T[]) => arr,
 }));
 

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -126,7 +126,7 @@ export function McpConfirmDialog() {
         <div className="space-y-3">
           {callerInfo && (
             <div className="space-y-2">
-              <div className="text-xs text-daintree-text/60 uppercase tracking-wide">
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
                 Requested by
               </div>
               <div className="text-xs text-daintree-text/80 break-words">
@@ -135,7 +135,9 @@ export function McpConfirmDialog() {
             </div>
           )}
           <div className="space-y-2">
-            <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+              Arguments
+            </div>
             <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
               {current.argsSummary || "(none)"}
             </pre>

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -976,7 +976,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                     onClose();
                   }}
                 >
-                  <Trash2 className="w-3 h-3 mr-2" aria-hidden="true" />
+                  <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   Clear all
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -520,7 +520,7 @@ function RowOptionsMenu({
                 onUnsnooze?.();
               }}
             >
-              <Clock className="mr-2 h-3 w-3" aria-hidden="true" />
+              <Clock className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
               {snoozedUntil !== undefined
                 ? `Snoozed until ${formatSnoozedUntil(snoozedUntil)} · Unsnooze`
                 : "Unsnooze"}
@@ -528,7 +528,7 @@ function RowOptionsMenu({
           ) : (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger>
-                <Clock className="mr-2 h-3 w-3" aria-hidden="true" />
+                <Clock className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
                 Snooze
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
@@ -548,13 +548,13 @@ function RowOptionsMenu({
         {supportsSnooze && hasDiagnosticsActions && <DropdownMenuSeparator />}
         {supportsCopyCorrelationId && (
           <DropdownMenuItem onSelect={handleCopyCorrelationId}>
-            <Copy className="mr-2 h-3 w-3" aria-hidden="true" />
+            <Copy className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
             Copy correlation ID
           </DropdownMenuItem>
         )}
         {supportsGoToSource && (
           <DropdownMenuItem onSelect={handleGoToSource}>
-            <ArrowRight className="mr-2 h-3 w-3" aria-hidden="true" />
+            <ArrowRight className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
             Go to source
           </DropdownMenuItem>
         )}
@@ -565,7 +565,7 @@ function RowOptionsMenu({
               void handleReportOnGitHub();
             }}
           >
-            <Bug className="mr-2 h-3 w-3" aria-hidden="true" />
+            <Bug className="mr-2 h-3.5 w-3.5" aria-hidden="true" />
             Report on GitHub
           </DropdownMenuItem>
         )}

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { Check, ChevronDown, ChevronUp, X } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, Download, X } from "lucide-react";
 import { useReducedMotion } from "framer-motion";
 import { DURATION_200 } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
@@ -130,9 +130,13 @@ export function GettingStartedChecklist({
   };
 
   const completedCount = Object.values(items).filter(Boolean).length;
-  const totalCount = CHECKLIST_ITEMS.length;
-  const allComplete = completedCount === totalCount;
-  const counterLabel = allComplete ? "All set" : `${completedCount}/${totalCount}`;
+  const allComplete = completedCount === CHECKLIST_ITEMS.length;
+  // Endowed-progress accounting (real items + always-complete "Install
+  // Daintree") mirrors WelcomeScreen's inline checklist so visible progress
+  // never regresses across the surface transition.
+  const counterLabel = allComplete
+    ? "All set"
+    : `${1 + completedCount}/${CHECKLIST_ITEMS.length + 1}`;
   const counterAnimateKey = allComplete ? "all-set" : String(completedCount);
 
   const panelRef = useRef<HTMLDivElement>(null);
@@ -192,7 +196,7 @@ export function GettingStartedChecklist({
                 className="flex items-center gap-2 text-left flex-1 min-w-0"
               >
                 <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-daintree-accent">
-                  Getting Started
+                  Getting started
                 </h4>
                 <AnimatedLabel
                   label={counterLabel}
@@ -228,7 +232,9 @@ export function GettingStartedChecklist({
                 <X className="h-3.5 w-3.5" />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="bottom">Hide checklist</TooltipContent>
+            <TooltipContent side="bottom">
+              Dismiss — reopen from Help → Getting Started
+            </TooltipContent>
           </Tooltip>
         </div>
 
@@ -243,6 +249,14 @@ export function GettingStartedChecklist({
           {...(collapsed ? { inert: true } : {})}
         >
           <div className="px-3 pb-3 space-y-1.5">
+            {/* Endowed progress: Install Daintree (always complete) */}
+            <div className="flex items-start gap-2.5 rounded-[var(--radius-xs)] px-2 py-1.5 opacity-60">
+              <div className="h-4 w-4 rounded-full bg-daintree-accent border border-daintree-accent flex items-center justify-center shrink-0">
+                <Check className="h-2.5 w-2.5 text-daintree-bg" />
+              </div>
+              <Download className="h-3.5 w-3.5 text-daintree-text/40 shrink-0" />
+              <span className="text-xs leading-snug text-daintree-text/40">Install Daintree</span>
+            </div>
             {CHECKLIST_ITEMS.map(
               ({ id, label, description, icon: Icon, actionId, actionArgs, markOnClick }) => {
                 const done = items[id];

--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -163,16 +163,23 @@ describe("GettingStartedChecklist", () => {
     expect(defaultProps.onToggleCollapse).not.toHaveBeenCalled();
   });
 
-  it("renders the n/n counter while the checklist is incomplete", () => {
+  it("renders the endowed n/n counter while the checklist is incomplete", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={mixedState} />);
-    expect(screen.getByText("1/4")).toBeTruthy();
+    // 1 real item done + the always-complete "Install Daintree" row, over 4+1.
+    expect(screen.getByText("2/5")).toBeTruthy();
     expect(screen.queryByText("All set")).toBeNull();
   });
 
   it("renders the 'All set' milestone label when every item is complete", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
     expect(screen.getByText("All set")).toBeTruthy();
-    expect(screen.queryByText("4/4")).toBeNull();
+    expect(screen.queryByText("5/5")).toBeNull();
+  });
+
+  it("renders the endowed 'Install Daintree' row as a non-interactive div", () => {
+    render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+    expect(screen.getByText("Install Daintree")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /install daintree/i })).toBeNull();
   });
 
   describe("accessibility", () => {
@@ -234,7 +241,7 @@ describe("GettingStartedChecklist", () => {
       const { rerender } = render(
         <GettingStartedChecklist {...defaultProps} checklist={mixedState} />
       );
-      const muted = screen.getByText("1/4");
+      const muted = screen.getByText("2/5");
       expect(muted.className).toContain("text-daintree-text/50");
       expect(muted.className).not.toContain("text-daintree-accent");
 

--- a/src/components/Onboarding/checklistItems.ts
+++ b/src/components/Onboarding/checklistItems.ts
@@ -18,21 +18,21 @@ export const CHECKLIST_ITEMS: ChecklistItemDef[] = [
   {
     id: "openedProject",
     label: "Open your project",
-    description: "Connect a local folder — everything else flows from here.",
+    description: "Connect a local folder — everything else flows from here",
     icon: FolderOpen,
     actionId: "project.openDialog",
   },
   {
     id: "launchedAgent",
     label: "Ask AI to help with your code",
-    description: "Agents can write code, fix bugs, and answer questions about your codebase.",
+    description: "Agents can write code, fix bugs, and answer questions about your codebase",
     icon: Sprout,
     actionId: "panel.palette",
   },
   {
     id: "createdWorktree",
     label: "Start a parallel task",
-    description: "Work on two things at once without switching branches.",
+    description: "Work on two things at once without switching branches",
     icon: FolderGit2,
     actionId: "worktree.createDialog.open",
   },
@@ -40,7 +40,7 @@ export const CHECKLIST_ITEMS: ChecklistItemDef[] = [
     id: "ranSecondParallelAgent",
     label: "Run two agents in parallel",
     description:
-      "Kick off a second agent while the first keeps working — that's the Daintree superpower.",
+      "Kick off a second agent while the first keeps working — that's the Daintree superpower",
     icon: Plug,
     actionId: "panel.palette",
   },

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -2,6 +2,7 @@ import React, {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -33,11 +34,18 @@ import {
   closestCenter,
   useSensor,
   useSensors,
+  KeyboardSensor,
   PointerSensor,
   TouchSensor,
   type DragEndEvent,
+  type UniqueIdentifier,
 } from "@dnd-kit/core";
-import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
+import {
+  SortableContext,
+  horizontalListSortingStrategy,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import { PanelTabList } from "./PanelTabList";
 import type { PanelKind } from "@/types";
@@ -49,6 +57,7 @@ import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { BellDot, FolderGit2 } from "@/components/icons";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
+import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import {
   useAriaKeyshortcuts,
   useBackgroundPanelStats,
@@ -448,12 +457,45 @@ function PanelHeaderComponent({
     }),
     useSensor(TouchSensor, {
       activationConstraint: { delay: 150, tolerance: 5 },
-    })
+    }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
+
+  // Surface-specific ARIA announcements — without this dnd-kit reads the
+  // generic English defaults ("Picked up draggable item <id>").
+  const getTabLabel = useCallback(
+    (tabId: UniqueIdentifier) => {
+      const tab = tabs?.find((t) => t.id === tabId);
+      return tab ? getBaseTitle(tab.title) : null;
+    },
+    [tabs]
+  );
+  const tabAnnouncements = useMemo(
+    () => makeSortableAnnouncements(getTabLabel, "tab"),
+    [getTabLabel]
+  );
+
+  // Restrict dnd-kit's autoscroller to the horizontal tab strip itself so its
+  // scrollable-ancestor walk doesn't scroll the surrounding panel content.
+  const tabAutoScroll = useMemo(
+    () => ({ canScroll: (el: Element) => el === tabListEl }),
+    [tabListEl]
+  );
+
+  // While a tab drag is live (keyboard pickup), the tablist arrow handler must
+  // not also move focus/selection — dnd-kit's sensor owns the arrow keys.
+  const isTabDragActiveRef = useRef(false);
+  const handleTabDragStart = useCallback(() => {
+    isTabDragActiveRef.current = true;
+  }, []);
+  const handleTabDragCancel = useCallback(() => {
+    isTabDragActiveRef.current = false;
+  }, []);
 
   // Handle tab reorder drag end
   const handleTabDragEnd = useCallback(
     (event: DragEndEvent) => {
+      isTabDragActiveRef.current = false;
       const { active, over } = event;
       if (!over || active.id === over.id || !tabs || !onTabReorder) return;
 
@@ -475,6 +517,7 @@ function PanelHeaderComponent({
   // Arrow key navigation for tabs (standard tablist behavior)
   const handleTabListKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      if (isTabDragActiveRef.current) return;
       if (!tabs || tabs.length < 2 || !onTabClick) return;
 
       const currentIndex = tabs.findIndex((t) => t.isActive);
@@ -620,8 +663,12 @@ function PanelHeaderComponent({
           <DndContext
             sensors={tabSensors}
             collisionDetection={closestCenter}
+            onDragStart={handleTabDragStart}
             onDragEnd={handleTabDragEnd}
+            onDragCancel={handleTabDragCancel}
             modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
+            autoScroll={tabAutoScroll}
+            accessibility={{ announcements: tabAnnouncements }}
           >
             <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
               <PanelTabList

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -949,7 +949,7 @@ function PanelHeaderComponent({
                   }
                   data-testid="panel-redraw"
                 >
-                  <RefreshCw className="w-3 h-3 mr-2" aria-hidden="true" />
+                  <RefreshCw className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   Redraw
                 </DropdownMenuItem>
               )}
@@ -967,7 +967,7 @@ function PanelHeaderComponent({
                       : "Restart Session"
                   }
                 >
-                  <RotateCcw className="w-3 h-3 mr-2" aria-hidden="true" />
+                  <RotateCcw className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   {armedRestartId === id
                     ? `Confirm Restart (${countdown ?? 0}s)`
                     : "Restart Session"}
@@ -984,7 +984,7 @@ function PanelHeaderComponent({
                     )
                   }
                 >
-                  <FolderGit2 className="w-3 h-3 mr-2" aria-hidden="true" />
+                  <FolderGit2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   Move to New Worktree…
                 </DropdownMenuItem>
               )}
@@ -993,7 +993,7 @@ function PanelHeaderComponent({
               {((canRestart && onRestart) || hasPty || agentId) && <DropdownMenuSeparator />}
               {location === "dock" && onRestore && (
                 <DropdownMenuItem onSelect={() => onRestore()}>
-                  <PanelTopClose className="w-3 h-3 mr-2" aria-hidden="true" />
+                  <PanelTopClose className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   Move to grid
                 </DropdownMenuItem>
               )}
@@ -1006,7 +1006,7 @@ function PanelHeaderComponent({
                   )
                 }
               >
-                <Pencil className="w-3 h-3 mr-2" aria-hidden="true" />
+                <Pencil className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                 Rename
               </DropdownMenuItem>
               <DropdownMenuItem
@@ -1018,7 +1018,7 @@ function PanelHeaderComponent({
                   )
                 }
               >
-                <CopyPlus className="w-3 h-3 mr-2" aria-hidden="true" />
+                <CopyPlus className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                 Duplicate
               </DropdownMenuItem>
               {hasPty && (
@@ -1032,9 +1032,9 @@ function PanelHeaderComponent({
                   }
                 >
                   {isInputLocked ? (
-                    <Unlock className="w-3 h-3 mr-2" aria-hidden="true" />
+                    <Unlock className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   ) : (
-                    <Lock className="w-3 h-3 mr-2" aria-hidden="true" />
+                    <Lock className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   )}
                   {isInputLocked ? "Unlock Input" : "Lock Input"}
                 </DropdownMenuItem>
@@ -1042,9 +1042,9 @@ function PanelHeaderComponent({
               {showWatchButton && (
                 <DropdownMenuItem onSelect={handleWatchToggle}>
                   {isWatched ? (
-                    <BellOff className="w-3 h-3 mr-2" aria-hidden="true" />
+                    <BellOff className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   ) : (
-                    <Bell className="w-3 h-3 mr-2" aria-hidden="true" />
+                    <Bell className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                   )}
                   {isWatched ? "Cancel Watch" : "Watch"}
                 </DropdownMenuItem>
@@ -1066,7 +1066,7 @@ function PanelHeaderComponent({
                   )
                 }
               >
-                <Trash2 className="w-3 h-3 mr-2" aria-hidden="true" />
+                <Trash2 className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
                 Trash
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -254,14 +254,27 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     onClick();
   }, [isEditing, onClick]);
 
+  // dnd-kit's KeyboardSensor activator arrives via sortableListeners.onKeyDown
+  // and would otherwise clobber tab activation (both want Space/Enter). Split
+  // it out and compose: Space/Enter on an inactive tab activates it (APG
+  // manual activation); on the already-active tab they fall through to the
+  // sensor so the focused tab can be picked up and reordered without a mouse.
+  const { onKeyDown: sortableKeyDownListener, ...sortablePointerListeners } =
+    sortableListeners ?? {};
+  const sortableKeyDown = sortableKeyDownListener as ((e: React.KeyboardEvent) => void) | undefined;
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "Enter" || e.key === " ") {
+        if (isActive && sortableKeyDown) {
+          sortableKeyDown(e);
+          return;
+        }
         e.preventDefault();
         onClick();
       }
     },
-    [onClick]
+    [isActive, onClick, sortableKeyDown]
   );
 
   const displayAgentState = getTerminalAgentDisplayState(chrome, agentState);
@@ -288,7 +301,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
           )}
           data-tab-id={id}
           {...mergedAttributes}
-          {...sortableListeners}
+          {...sortablePointerListeners}
         >
           {isActive && (
             <m.div

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -625,4 +625,45 @@ describe("TabButton", () => {
       expect(screen.queryByText(/^Agent /)).toBeNull();
     });
   });
+
+  describe("keyboard drag pickup composition", () => {
+    it("activates an inactive tab on Space instead of forwarding to the sortable sensor", () => {
+      const onClick = vi.fn();
+      const sensorKeyDown = vi.fn();
+      render(
+        <TabButton
+          {...defaultProps}
+          isActive={false}
+          onClick={onClick}
+          sortableListeners={{ onKeyDown: sensorKeyDown }}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole("tab"), { key: " " });
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(sensorKeyDown).not.toHaveBeenCalled();
+    });
+
+    it("forwards Space/Enter on the active tab to the sortable keydown so dnd-kit can pick it up", () => {
+      const onClick = vi.fn();
+      const sensorKeyDown = vi.fn();
+      render(
+        <TabButton
+          {...defaultProps}
+          isActive
+          onClick={onClick}
+          sortableListeners={{ onKeyDown: sensorKeyDown }}
+        />
+      );
+      fireEvent.keyDown(screen.getByRole("tab"), { key: "Enter" });
+      expect(sensorKeyDown).toHaveBeenCalledTimes(1);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("keeps Space activation on the active tab when no sortable listeners are wired", () => {
+      const onClick = vi.fn();
+      render(<TabButton {...defaultProps} isActive onClick={onClick} />);
+      fireEvent.keyDown(screen.getByRole("tab"), { key: " " });
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -126,7 +126,7 @@ export function PanelPalette({
         className={cn(
           "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
           index === selectedIndex
-            ? "bg-overlay-soft border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+            ? "bg-overlay-raised border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
             : "border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text",
           isUnavailable && "opacity-50"
         )}
@@ -166,7 +166,7 @@ export function PanelPalette({
       elements.push(
         <div
           key={`header-${key}`}
-          className="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wider text-daintree-text/40 select-none"
+          className="px-3 pt-3 pb-1 text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none"
           aria-hidden="true"
         >
           {SECTION_LABELS[key]}

--- a/src/components/Plugin/PluginConfirmDialog.tsx
+++ b/src/components/Plugin/PluginConfirmDialog.tsx
@@ -78,7 +78,9 @@ export function PluginConfirmDialog() {
         cooldownKey={current.requestId}
       >
         <div className="space-y-2">
-          <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
+            Arguments
+          </div>
           <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">
             {current.argsSummary || "(none)"}
           </pre>

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -557,7 +557,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Search plugins"
                 aria-label="Search plugins"
-                className="w-full px-3 py-2 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-daintree-text/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                className="w-full px-3 py-2 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-text-placeholder focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
               />
               <div className="flex flex-wrap gap-1">
                 {PLUGIN_FILTER_CHIPS.map(({ token, label }) => {
@@ -868,7 +868,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
               if (e.key === "Enter" && pm.urlInput.trim()) void pm.handleInstallFromUrl();
             }}
             placeholder="https://example.com/plugin.dntr"
-            className="w-full px-3 py-2 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-daintree-text/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+            className="w-full px-3 py-2 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-text-placeholder focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
             aria-label="Plugin URL"
           />
         </AppDialog.Body>

--- a/src/components/Plugin/PluginMcpConfirmDialog.tsx
+++ b/src/components/Plugin/PluginMcpConfirmDialog.tsx
@@ -80,18 +80,18 @@ export function PluginMcpConfirmDialog() {
           <div className="flex items-center gap-2 text-xs">
             <DangerTierBadge tier={current.dangerTier} />
             {current.reason === "raw-changed" && (
-              <span className="text-amber-500 font-medium">Tool description changed</span>
+              <span className="text-status-warning font-medium">Tool description changed</span>
             )}
             {current.reason === "schema-changed" && (
-              <span className="text-amber-500 font-medium">Tool inputs changed</span>
+              <span className="text-status-warning font-medium">Tool inputs changed</span>
             )}
             {current.reason === "revoked" && (
-              <span className="text-amber-500 font-medium">Previously revoked</span>
+              <span className="text-status-warning font-medium">Previously revoked</span>
             )}
           </div>
 
           <div>
-            <div className="text-xs text-daintree-text/60 uppercase tracking-wide mb-1">
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
               Tool description
             </div>
             <p className="text-sm text-daintree-text/80 whitespace-pre-wrap break-words">
@@ -101,7 +101,7 @@ export function PluginMcpConfirmDialog() {
 
           {current.declaredCapabilities.length > 0 && (
             <div>
-              <div className="text-xs text-daintree-text/60 uppercase tracking-wide mb-1">
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
                 Plugin capabilities
               </div>
               <ul className="text-xs font-mono text-daintree-text/70 space-y-0.5">
@@ -114,7 +114,7 @@ export function PluginMcpConfirmDialog() {
 
           {showArgsPreview && (
             <div>
-              <div className="text-xs text-daintree-text/60 uppercase tracking-wide mb-1">
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
                 Arguments
               </div>
               <pre className="text-xs font-mono whitespace-pre-wrap break-words bg-overlay-subtle rounded px-2 py-1.5 text-daintree-text/80">

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -282,7 +282,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             onKeyDown={handleKeyDown}
             placeholder="owner/repo or repository URL"
             disabled={isCloning || isComplete}
-            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
+            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
           />
         </div>
 
@@ -295,7 +295,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
               value={parentPath}
               readOnly
               placeholder="Select a directory..."
-              className="flex-1 rounded-md border border-daintree-border bg-muted/50 px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 disabled:opacity-50 select-all"
+              className="flex-1 rounded-md border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder disabled:opacity-50 select-all"
             />
             <Button
               variant="outline"
@@ -325,7 +325,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             onKeyDown={handleKeyDown}
             disabled={isCloning || isComplete}
             aria-invalid={folderNameError != null}
-            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
+            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
           />
           {folderNameError && (
             <p role="alert" className="text-xs text-status-error">
@@ -453,38 +453,37 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
               </div>
             );
           })()}
-
-        {/* Actions */}
-        <div className="flex justify-end gap-2">
-          {isComplete ? (
-            <Button onClick={handleClose} className="gap-2">
-              <Check className="h-4 w-4" />
-              Open Project
-            </Button>
-          ) : error ? (
-            <>
-              <Button variant="outline" onClick={onCancel}>
-                Close
-              </Button>
-              <Button onClick={() => void startClone()} disabled={isCloning}>
-                Retry
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button
-                variant="outline"
-                onClick={isCloning ? () => void projectClient.cancelClone() : onCancel}
-              >
-                {isCloning ? "Stop clone" : "Cancel"}
-              </Button>
-              <Button onClick={() => void startClone()} disabled={!canClone} loading={isCloning}>
-                Clone
-              </Button>
-            </>
-          )}
-        </div>
       </AppDialog.Body>
+
+      <AppDialog.Footer>
+        {isComplete ? (
+          <Button onClick={handleClose} className="gap-2">
+            <Check className="h-4 w-4" />
+            Open Project
+          </Button>
+        ) : error ? (
+          <>
+            <Button variant="outline" onClick={onCancel}>
+              Close
+            </Button>
+            <Button onClick={() => void startClone()} disabled={isCloning}>
+              Retry
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              variant="outline"
+              onClick={isCloning ? () => void projectClient.cancelClone() : onCancel}
+            >
+              {isCloning ? "Stop clone" : "Cancel"}
+            </Button>
+            <Button onClick={() => void startClone()} disabled={!canClone} loading={isCloning}>
+              Clone
+            </Button>
+          </>
+        )}
+      </AppDialog.Footer>
     </AppDialog>
   );
 }

--- a/src/components/Project/CreateProjectFolderDialog.tsx
+++ b/src/components/Project/CreateProjectFolderDialog.tsx
@@ -135,7 +135,7 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
               readOnly
               aria-readonly="true"
               value={parentPath}
-              className="flex-1 rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-2 text-sm font-mono text-daintree-text/70 truncate"
+              className="flex-1 rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm font-mono text-daintree-text/70 truncate"
               placeholder="Select parent directory..."
             />
             <Button
@@ -167,7 +167,7 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
             onKeyDown={handleKeyDown}
             aria-invalid={error != null}
             aria-describedby={error ? errorId : undefined}
-            className="w-full rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-2 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent aria-invalid:border-status-error"
+            className="w-full rounded-[var(--radius-md)] border border-daintree-border bg-muted/50 px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 focus:border-daintree-accent aria-invalid:border-status-error"
             placeholder="my-project"
             disabled={isCreating}
           />
@@ -182,16 +182,16 @@ export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFold
             </p>
           )}
         </div>
-
-        <div className="flex justify-end gap-2 pt-2">
-          <Button variant="outline" onClick={onClose} disabled={isCreating}>
-            Cancel
-          </Button>
-          <Button onClick={handleCreate} disabled={isCreating || !parentPath || !folderName.trim()}>
-            {isCreating ? "Creating…" : "Create"}
-          </Button>
-        </div>
       </AppDialog.Body>
+
+      <AppDialog.Footer>
+        <Button variant="outline" onClick={onClose} disabled={isCreating}>
+          Cancel
+        </Button>
+        <Button onClick={handleCreate} disabled={isCreating || !parentPath || !folderName.trim()}>
+          {isCreating ? "Creating…" : "Create"}
+        </Button>
+      </AppDialog.Footer>
     </AppDialog>
   );
 }

--- a/src/components/Project/EnvironmentVariablesEditor.tsx
+++ b/src/components/Project/EnvironmentVariablesEditor.tsx
@@ -334,7 +334,7 @@ export function EnvironmentVariablesEditor({
         <div className="flex items-center gap-2 pt-3">
           <Button onClick={handleSave} disabled={isSaving} size="sm">
             <Save className="h-4 w-4" />
-            {isSaving ? "Saving..." : "Save"}
+            {isSaving ? "Saving…" : "Save"}
           </Button>
           <Button variant="outline" onClick={handleDiscard} size="sm">
             Discard

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -354,7 +354,7 @@ export function GeneralTab({
                 type="text"
                 value={name}
                 onChange={(e) => onNameChange(e.target.value)}
-                className="w-full bg-transparent border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
+                className="w-full bg-transparent border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-placeholder"
                 placeholder="My Awesome Project"
               />
             </div>
@@ -420,7 +420,7 @@ export function GeneralTab({
               autoComplete="off"
               aria-label="Hex color value"
               className={cn(
-                "w-28 bg-daintree-bg border rounded px-3 py-1.5 text-sm text-daintree-text font-mono focus:outline-hidden focus:ring-1 transition placeholder:text-text-muted",
+                "w-28 bg-daintree-bg border rounded px-3 py-1.5 text-sm text-daintree-text font-mono focus:outline-hidden focus:ring-1 transition placeholder:text-text-placeholder",
                 hexInput && !isValidHexColor(hexInput)
                   ? "border-status-error/50 focus:border-status-error focus:ring-status-error/30"
                   : "border-daintree-border focus:border-daintree-accent focus:ring-daintree-accent/30"
@@ -479,7 +479,7 @@ export function GeneralTab({
           type="text"
           value={devServerCommand}
           onChange={(e) => onDevServerCommandChange(e.target.value)}
-          className="w-full bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
+          className="w-full bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-placeholder"
           placeholder="npm run dev"
           spellCheck={false}
           autoCapitalize="off"
@@ -509,7 +509,7 @@ export function GeneralTab({
                 onDevServerLoadTimeoutChange(num);
               }
             }}
-            className="w-28 bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
+            className="w-28 bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-placeholder"
             placeholder="30"
             aria-label="Dev server load timeout in seconds"
           />

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -183,7 +183,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
             value={gitignoreTemplate}
             onChange={(e) => setGitignoreTemplate(e.target.value as GitignoreTemplate)}
             disabled={configDisabled}
-            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
+            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
           >
             {TEMPLATE_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
@@ -221,7 +221,7 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
               onChange={(e) => setInitialCommitMessage(e.target.value)}
               disabled={configDisabled}
               placeholder="Initial commit"
-              className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
+              className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
             />
           </div>
         )}

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { projectClient, systemClient } from "@/clients";
 import { useProjectStatsStore } from "@/store/projectStatsStore";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { logError } from "@/utils/logger";
 import type { ProcessMetricEntry, HeapStats, DiagnosticsInfo } from "@shared/types/ipc/system";
 import type { BulkProjectStatsEntry } from "@shared/types/ipc/project";
@@ -315,11 +316,10 @@ export function ProjectResourceBadge() {
     };
   }, [fetchStats]);
 
+  // Stale-while-revalidate: keep the last snapshot across closes so reopening
+  // shows data instantly; the poll below refreshes it silently.
   useEffect(() => {
-    if (!open) {
-      setPopoverData(null);
-      return;
-    }
+    if (!open) return;
 
     let cancelled = false;
 
@@ -391,7 +391,15 @@ export function ProjectResourceBadge() {
               />
             </>
           ) : (
-            <div className="text-[10px] text-daintree-text/30 text-center py-2">Loading...</div>
+            <Skeleton label="Loading resource details" className="space-y-3">
+              <div className="space-y-1.5">
+                <SkeletonBone className="h-3 w-16" />
+                <SkeletonBone className="h-3 w-full" />
+                <SkeletonBone className="h-3 w-5/6" />
+                <SkeletonBone className="h-3 w-3/4" />
+              </div>
+              <SkeletonBone className="h-1.5 w-full rounded-full" />
+            </Skeleton>
           )}
         </div>
       </PopoverContent>

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -17,13 +17,13 @@ const renderIcon = (emoji: string, color?: string, sizeClass = "h-9 w-9 text-lg"
   <div
     className={cn(
       // Wash/shadow var fallbacks keep themes without the overrides byte-identical.
-      "flex items-center justify-center rounded-[var(--radius-xl)] shadow-[var(--project-tile-shadow,inset_0_1px_2px_rgba(0,0,0,0.18))] shrink-0 transition duration-150",
+      "flex items-center justify-center rounded-[var(--radius-xl)] shadow-[var(--project-tile-shadow,inset_0_1px_2px_rgba(0,0,0,0.3))] shrink-0 transition duration-150",
       sizeClass
     )}
     style={{
       background: color
         ? `var(--project-tile-wash, linear-gradient(to bottom, rgba(0,0,0,0.1), rgba(0,0,0,0.2))), ${getProjectGradient(color)}`
-        : "var(--project-tile-wash, linear-gradient(to bottom, rgba(0,0,0,0.08), rgba(0,0,0,0.16))), var(--color-surface-panel)",
+        : "var(--project-tile-wash, linear-gradient(to bottom, rgba(0,0,0,0.1), rgba(0,0,0,0.2))), var(--color-surface-panel)",
     }}
   >
     <span className="leading-none select-none filter drop-shadow-sm">{emoji}</span>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1,5 +1,4 @@
-import { useMemo, useEffect, useLayoutEffect, useRef, useState, useCallback } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useEffect, useRef, useState, useCallback } from "react";
 import {
   BellOff,
   ChevronDown,
@@ -22,7 +21,6 @@ import {
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
 import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
-import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   ContextMenu,
@@ -36,7 +34,6 @@ import { formatTimeAgo } from "@/utils/timeAgo";
 import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useModifierKeys } from "@/hooks/useModifierKeys";
 import { useOverlayClaim } from "@/hooks";
-import { usePaletteStore } from "@/store/paletteStore";
 import type {
   ProjectSwitcherMode,
   SearchableProject,
@@ -200,16 +197,17 @@ function ProjectListItem({
       aria-disabled={project.isMissing || undefined}
       className={cn(
         "group relative w-full flex items-center gap-2 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border border-transparent",
+        "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2 aria-selected:before:w-[2px] aria-selected:before:rounded-r aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
         project.isActive
-          ? cn("text-daintree-text", isSelected && "bg-overlay-raised border-border-subtle")
+          ? cn("text-daintree-text", isSelected && "bg-overlay-raised border-overlay")
           : project.isMissing
             ? cn(
                 "text-daintree-text/50",
-                isSelected ? "bg-overlay-raised border-border-subtle" : "hover:bg-overlay-soft"
+                isSelected ? "bg-overlay-raised border-overlay" : "hover:bg-overlay-subtle"
               )
             : isSelected
-              ? "bg-overlay-raised border-border-subtle text-daintree-text cursor-pointer"
-              : "text-daintree-text/70 hover:bg-overlay-soft hover:text-daintree-text cursor-pointer"
+              ? "bg-overlay-raised border-overlay text-daintree-text cursor-pointer"
+              : "text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text cursor-pointer"
       )}
       onClick={() => !project.isActive && !project.isMissing && onSelect(project)}
       onPointerEnter={onHoverProject ? (e) => onHoverProject(project.id, e.pointerType) : undefined}
@@ -624,7 +622,7 @@ function ScratchSection({
                         {onSaveAsProject && (
                           <ContextMenuItem onSelect={() => onSaveAsProject(scratch.id)}>
                             <FolderUp className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
-                            Save as project...
+                            Save as project…
                           </ContextMenuItem>
                         )}
                         {onSaveAsProject && onRemove && <ContextMenuSeparator />}
@@ -844,7 +842,7 @@ function ProjectPaletteInner({
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="Search projects..."
+          placeholder="Search projects…"
           role="combobox"
           aria-expanded={true}
           aria-haspopup="listbox"
@@ -898,9 +896,7 @@ function ProjectPaletteInner({
                 <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] bg-tint/[0.04] text-muted-foreground">
                   <Settings2 className="h-4 w-4" />
                 </div>
-                <span className="font-medium text-sm text-muted-foreground">
-                  Project Settings...
-                </span>
+                <span className="font-medium text-sm text-muted-foreground">Project Settings…</span>
               </button>
             )}
             {onAddProject && (
@@ -913,7 +909,7 @@ function ProjectPaletteInner({
                 <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
                   <Plus className="h-4 w-4" />
                 </div>
-                <span className="font-medium text-sm text-muted-foreground">Add Project...</span>
+                <span className="font-medium text-sm text-muted-foreground">Add Project…</span>
               </button>
             )}
             {onCloneRepo && (
@@ -926,9 +922,7 @@ function ProjectPaletteInner({
                 <div className="flex h-8 w-8 items-center justify-center rounded-[var(--radius-lg)] border border-dashed border-muted-foreground/30 bg-muted/20 text-muted-foreground">
                   <Download className="h-4 w-4" />
                 </div>
-                <span className="font-medium text-sm text-muted-foreground">
-                  Clone Repository...
-                </span>
+                <span className="font-medium text-sm text-muted-foreground">Clone Repository…</span>
               </button>
             )}
             {onCreateFolder && (
@@ -941,7 +935,7 @@ function ProjectPaletteInner({
                   <FolderPlus className="h-4 w-4" />
                 </div>
                 <span className="font-medium text-sm text-muted-foreground">
-                  Create New Folder...
+                  Create New Folder…
                 </span>
               </button>
             )}
@@ -965,115 +959,45 @@ function ModalContent({
   useOverlayClaim("project-switcher", isOpen);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  useLayoutEffect(() => {
-    if (isOpen) {
-      previousFocusRef.current = document.activeElement as HTMLElement;
-      requestAnimationFrame(() => inputRef.current?.focus());
-    } else if (previousFocusRef.current) {
-      if (!usePaletteStore.getState().activePaletteId) {
-        previousFocusRef.current.focus();
-      }
-      previousFocusRef.current = null;
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        onClose();
-        return;
-      }
-      if (e.key === "Tab" && dialogRef.current) {
-        const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
-          'input, button, [tabindex]:not([tabindex="-1"])'
-        );
-        const firstEl = focusableElements[0];
-        const lastEl = focusableElements[focusableElements.length - 1];
-
-        if (e.shiftKey && document.activeElement === firstEl) {
-          e.preventDefault();
-          lastEl?.focus();
-        } else if (!e.shiftKey && document.activeElement === lastEl) {
-          e.preventDefault();
-          firstEl?.focus();
-        }
-      }
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
-
-  const handleBackdropClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (e.target === e.currentTarget) {
-        onClose();
-      }
-    },
-    [onClose]
-  );
-
-  if (!isOpen) return null;
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-[var(--z-modal)] flex items-start justify-center pt-[15vh] bg-scrim-medium backdrop-blur-sm backdrop-saturate-[var(--theme-material-saturation)]"
-      onClick={handleBackdropClick}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Project switcher"
+  return (
+    <AppPaletteDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      ariaLabel="Project switcher"
+      className={PALETTE_WIDTH}
     >
-      <div
-        ref={dialogRef}
-        className={cn(
-          PALETTE_WIDTH,
-          "mx-4 surface-overlay shadow-overlay rounded-[var(--radius-lg)] overflow-hidden",
-          "animate-in fade-in slide-in-from-top-4 duration-150"
-        )}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <ProjectPaletteInner
-          inputRef={inputRef}
-          listRef={listRef}
-          query={innerProps.query}
-          results={innerProps.results}
-          selectedIndex={innerProps.selectedIndex}
-          mode={mode}
-          onQueryChange={innerProps.onQueryChange}
-          onSelect={innerProps.onSelect}
-          onClose={onClose}
-          onSelectPrevious={innerProps.onSelectPrevious}
-          onSelectNext={innerProps.onSelectNext}
-          onAddProject={innerProps.onAddProject}
-          onCloneRepo={innerProps.onCloneRepo}
-          onCreateFolder={innerProps.onCreateFolder}
-          onOpenProjectSettings={innerProps.onOpenProjectSettings}
-          onStopProject={innerProps.onStopProject}
-          onCloseProject={innerProps.onCloseProject}
-          onLocateProject={innerProps.onLocateProject}
-          onTogglePinProject={innerProps.onTogglePinProject}
-          onCopyPath={innerProps.onCopyPath}
-          onSelectNewWindow={innerProps.onSelectNewWindow}
-          onHoverProject={innerProps.onHoverProject}
-          onHoverProjectEnd={innerProps.onHoverProjectEnd}
-          scratchResults={innerProps.scratchResults}
-          onCreateScratch={innerProps.onCreateScratch}
-          onSelectScratch={innerProps.onSelectScratch}
-          onRemoveScratch={innerProps.onRemoveScratch}
-          onSaveAsProject={innerProps.onSaveAsProject}
-        />
-        {/* Co-located live region: this palette manages its own
-            `aria-modal` and does not pass through `AppPaletteDialog`, so
-            VoiceOver would otherwise suppress external `aria-live`
-            updates when `document.ariaNotify` is unavailable
-            (Chromium 354736464). */}
-        <AccessibilityAnnouncer />
-      </div>
-    </div>,
-    document.body
+      <ProjectPaletteInner
+        inputRef={inputRef}
+        listRef={listRef}
+        query={innerProps.query}
+        results={innerProps.results}
+        selectedIndex={innerProps.selectedIndex}
+        mode={mode}
+        onQueryChange={innerProps.onQueryChange}
+        onSelect={innerProps.onSelect}
+        onClose={onClose}
+        onSelectPrevious={innerProps.onSelectPrevious}
+        onSelectNext={innerProps.onSelectNext}
+        onAddProject={innerProps.onAddProject}
+        onCloneRepo={innerProps.onCloneRepo}
+        onCreateFolder={innerProps.onCreateFolder}
+        onOpenProjectSettings={innerProps.onOpenProjectSettings}
+        onStopProject={innerProps.onStopProject}
+        onCloseProject={innerProps.onCloseProject}
+        onLocateProject={innerProps.onLocateProject}
+        onTogglePinProject={innerProps.onTogglePinProject}
+        onCopyPath={innerProps.onCopyPath}
+        onSelectNewWindow={innerProps.onSelectNewWindow}
+        onHoverProject={innerProps.onHoverProject}
+        onHoverProjectEnd={innerProps.onHoverProjectEnd}
+        scratchResults={innerProps.scratchResults}
+        onCreateScratch={innerProps.onCreateScratch}
+        onSelectScratch={innerProps.onSelectScratch}
+        onRemoveScratch={innerProps.onRemoveScratch}
+        onSaveAsProject={innerProps.onSaveAsProject}
+      />
+    </AppPaletteDialog>
   );
 }
 

--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -417,7 +417,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
                   placeholder="Execute command..."
                   aria-label="Command input"
                   className={cn(
-                    "flex-1 bg-transparent py-2.5 text-xs font-mono text-daintree-text placeholder:text-text-muted",
+                    "flex-1 bg-transparent py-2.5 text-xs font-mono text-daintree-text placeholder:text-text-placeholder",
                     "focus:outline-hidden min-w-0"
                   )}
                   autoComplete="off"

--- a/src/components/Project/WelcomeScreen.tsx
+++ b/src/components/Project/WelcomeScreen.tsx
@@ -207,7 +207,7 @@ export function WelcomeScreen({ gettingStarted }: WelcomeScreenProps) {
         {visibleShortcutTips.length > 0 && (
           <div className="w-full">
             <h3 className="text-xs font-medium text-daintree-text/50 uppercase tracking-wider mb-3">
-              Keyboard Shortcuts
+              Keyboard shortcuts
             </h3>
             <div className="grid grid-cols-2 gap-x-8 gap-y-2">
               {visibleShortcutTips.map(({ label, actionId }) => {
@@ -331,7 +331,7 @@ function RecentProjects({
   return (
     <div className="w-full">
       <h3 className="text-xs font-medium text-daintree-text/50 uppercase tracking-wider mb-3">
-        Recent Projects
+        Recent projects
       </h3>
       <div className="space-y-1">
         {projects.map((project) => (
@@ -576,7 +576,7 @@ function InlineChecklist({
     <div className="w-full">
       <div className="flex items-center gap-3 mb-3">
         <h3 className="text-xs font-medium text-daintree-text/50 uppercase tracking-wider">
-          Getting Started
+          Getting started
         </h3>
         <span className="text-[10px] text-daintree-text/40 font-mono">
           {progressDone}/{progressTotal}

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -91,6 +91,7 @@ vi.mock("@/components/ui/AppDialog", () => {
   AppDialog.Title = ({ children }: AppDialogSectionProps) => <h2>{children}</h2>;
   AppDialog.CloseButton = () => <button type="button">close</button>;
   AppDialog.Body = ({ children, className: _ }: AppDialogSectionProps) => <div>{children}</div>;
+  AppDialog.Footer = ({ children, className: _ }: AppDialogSectionProps) => <div>{children}</div>;
 
   return { AppDialog };
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -66,7 +66,20 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
     <div data-testid="palette-footer">{children}</div>
   );
 
-  const Dialog = () => null;
+  const Dialog = ({
+    isOpen,
+    children,
+    ariaLabel,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    ariaLabel: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-modal="true" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null;
   Dialog.Header = Header;
   Dialog.Input = Input;
   Dialog.Body = Body;
@@ -209,53 +222,6 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     expect(screen.queryByLabelText("Stop project")).toBeNull();
     expect(screen.queryByLabelText("Locate project folder")).toBeNull();
     expect(screen.queryByLabelText("Remove project")).toBeNull();
-  });
-
-  it("Tab from last footer button wraps focus to the input (focus trap)", () => {
-    const propsWithButtons = {
-      ...defaultProps,
-      onOpenProjectSettings: vi.fn(),
-      onAddProject: vi.fn(),
-      onCreateFolder: vi.fn(),
-    };
-    render(<ProjectSwitcherPalette {...propsWithButtons} />);
-
-    const dialog = document.querySelector('[role="dialog"]');
-    expect(dialog).toBeTruthy();
-
-    const focusable = dialog!.querySelectorAll<HTMLElement>(
-      'input, button, [tabindex]:not([tabindex="-1"])'
-    );
-    expect(focusable.length).toBeGreaterThanOrEqual(2);
-
-    const lastEl = focusable[focusable.length - 1]!;
-    lastEl.focus();
-    expect(document.activeElement).toBe(lastEl);
-
-    fireEvent.keyDown(window, { key: "Tab" });
-    expect(document.activeElement).toBe(focusable[0]);
-  });
-
-  it("Shift+Tab from input wraps focus to last footer button (focus trap)", () => {
-    const propsWithButtons = {
-      ...defaultProps,
-      onOpenProjectSettings: vi.fn(),
-      onAddProject: vi.fn(),
-      onCreateFolder: vi.fn(),
-    };
-    render(<ProjectSwitcherPalette {...propsWithButtons} />);
-
-    const dialog = document.querySelector('[role="dialog"]');
-    const focusable = dialog!.querySelectorAll<HTMLElement>(
-      'input, button, [tabindex]:not([tabindex="-1"])'
-    );
-
-    const firstEl = focusable[0]!;
-    firstEl.focus();
-    expect(document.activeElement).toBe(firstEl);
-
-    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
-    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
   });
 
   it("displays condensed footer with switch and right-click hints in modal mode", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -66,7 +66,20 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
     <div data-testid="palette-footer">{children}</div>
   );
 
-  const Dialog = () => null;
+  const Dialog = ({
+    isOpen,
+    children,
+    ariaLabel,
+  }: {
+    isOpen: boolean;
+    children: React.ReactNode;
+    ariaLabel: string;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-modal="true" aria-label={ariaLabel}>
+        {children}
+      </div>
+    ) : null;
   Dialog.Header = Header;
   Dialog.Input = Input;
   Dialog.Body = Body;
@@ -260,7 +273,7 @@ describe("ProjectSwitcherPalette clone repo button", () => {
       <ProjectSwitcherPalette {...baseProps} onCloneRepo={vi.fn()} results={[makeProject()]} />
     );
     expect(screen.getByTestId("project-clone-button")).toBeTruthy();
-    expect(screen.getByText("Clone Repository...")).toBeTruthy();
+    expect(screen.getByText("Clone Repository…")).toBeTruthy();
   });
 
   it("calls onCloneRepo when Clone Repository button is clicked", () => {
@@ -332,10 +345,10 @@ describe("ProjectSwitcherPalette modal mode", () => {
 
   it("does not show management action buttons in modal mode", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={multiProjects} />);
-    expect(screen.queryByText("Project Settings...")).toBeNull();
-    expect(screen.queryByText("Add Project...")).toBeNull();
-    expect(screen.queryByText("Clone Repository...")).toBeNull();
-    expect(screen.queryByText("Create New Folder...")).toBeNull();
+    expect(screen.queryByText("Project Settings…")).toBeNull();
+    expect(screen.queryByText("Add Project…")).toBeNull();
+    expect(screen.queryByText("Clone Repository…")).toBeNull();
+    expect(screen.queryByText("Create New Folder…")).toBeNull();
   });
 
   it("shows Right-click hint but not Remove shortcut in modal mode footer", () => {

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -311,7 +311,7 @@ describe("WelcomeScreen", () => {
   it("renders recent projects sorted by frecencyScore descending", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    expect(screen.getByText("Recent Projects")).toBeTruthy();
+    expect(screen.getByText("Recent projects")).toBeTruthy();
 
     const projectNames = screen
       .getAllByText(/Project (Alpha|Beta|Gamma)/)
@@ -323,7 +323,7 @@ describe("WelcomeScreen", () => {
     storeState = { ...storeState, projects: [] };
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    expect(screen.queryByText("Recent Projects")).toBeNull();
+    expect(screen.queryByText("Recent projects")).toBeNull();
   });
 
   it("calls switchProject when a recent project is clicked", () => {
@@ -364,7 +364,7 @@ describe("WelcomeScreen", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
     expect(screen.getByText("Install Daintree")).toBeTruthy();
-    expect(screen.getByText("Getting Started")).toBeTruthy();
+    expect(screen.getByText("Getting started")).toBeTruthy();
   });
 
   it("shows correct progress ratio with endowed item", () => {
@@ -422,26 +422,26 @@ describe("WelcomeScreen", () => {
   it("hides checklist when dismissed", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted(dismissed)} />);
 
-    expect(screen.queryByText("Getting Started")).toBeNull();
+    expect(screen.queryByText("Getting started")).toBeNull();
     expect(screen.queryByText("Install Daintree")).toBeNull();
   });
 
   it("hides checklist when all items are complete", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted(allComplete)} />);
 
-    expect(screen.queryByText("Getting Started")).toBeNull();
+    expect(screen.queryByText("Getting started")).toBeNull();
   });
 
   it("hides checklist when checklist is null", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted(null)} />);
 
-    expect(screen.queryByText("Getting Started")).toBeNull();
+    expect(screen.queryByText("Getting started")).toBeNull();
   });
 
   it("hides checklist when visible is false", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete, false)} />);
 
-    expect(screen.queryByText("Getting Started")).toBeNull();
+    expect(screen.queryByText("Getting started")).toBeNull();
     expect(screen.queryByText("Install Daintree")).toBeNull();
   });
 
@@ -455,7 +455,7 @@ describe("WelcomeScreen", () => {
 
     render(<WelcomeScreen gettingStarted={makeGettingStarted(allComplete)} />);
     // All done — checklist is hidden (showChecklist is false when allDone)
-    expect(screen.queryByText("Getting Started")).toBeNull();
+    expect(screen.queryByText("Getting started")).toBeNull();
   });
 
   it("renders progress at 100% width when all items complete", () => {
@@ -633,7 +633,7 @@ describe("WelcomeScreen", () => {
 
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    expect(screen.queryByText("Keyboard Shortcuts")).toBeNull();
+    expect(screen.queryByText("Keyboard shortcuts")).toBeNull();
   });
 
   it("renders Keyboard Shortcuts section when only one combo is available", () => {
@@ -644,7 +644,7 @@ describe("WelcomeScreen", () => {
 
     render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    expect(screen.getByText("Keyboard Shortcuts")).toBeTruthy();
+    expect(screen.getByText("Keyboard shortcuts")).toBeTruthy();
     const kbdElements = document.querySelectorAll("kbd");
     expect(kbdElements.length).toBe(1);
     expect(kbdElements[0]!.textContent).toBe("⌘N");
@@ -762,7 +762,7 @@ describe("WelcomeScreen", () => {
   it("renders keyboard shortcuts inside kbd elements", () => {
     const { container } = render(<WelcomeScreen gettingStarted={makeGettingStarted()} />);
 
-    expect(screen.getAllByText("Keyboard Shortcuts").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Keyboard shortcuts").length).toBeGreaterThanOrEqual(1);
 
     const kbdElements = container.querySelectorAll("kbd");
     expect(kbdElements.length).toBeGreaterThanOrEqual(6);
@@ -790,13 +790,13 @@ describe("WelcomeScreen", () => {
   it("shows recent projects before checklist for returning users", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete)} />);
 
-    const recentProjects = screen.getByText("Recent Projects");
+    const recentProjects = screen.getByText("Recent projects");
 
     // Recent Projects should appear before Getting Started in DOM order
     const container = recentProjects.closest("[class*='max-w-2xl']")!;
     const headings = Array.from(container.querySelectorAll("h3"));
-    const recentIdx = headings.findIndex((h) => h.textContent?.includes("Recent Projects"));
-    const checklistIdx = headings.findIndex((h) => h.textContent?.includes("Getting Started"));
+    const recentIdx = headings.findIndex((h) => h.textContent?.includes("Recent projects"));
+    const checklistIdx = headings.findIndex((h) => h.textContent?.includes("Getting started"));
     expect(recentIdx).toBeLessThan(checklistIdx);
   });
 
@@ -804,8 +804,8 @@ describe("WelcomeScreen", () => {
     storeState = { ...storeState, projects: [] };
     render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete)} />);
 
-    expect(screen.queryByText("Recent Projects")).toBeNull();
-    expect(screen.getByText("Getting Started")).toBeTruthy();
+    expect(screen.queryByText("Recent projects")).toBeNull();
+    expect(screen.getByText("Getting started")).toBeTruthy();
   });
 
   // --- Agent Welcome Card (#5111) ---
@@ -994,7 +994,7 @@ describe("WelcomeScreen", () => {
 
       expect(screen.getByTestId("agent-setup-banner")).toBeTruthy();
       expect(screen.queryByText(/Installed agents found/)).toBeNull();
-      expect(screen.queryByText("Getting Started")).toBeNull();
+      expect(screen.queryByText("Getting started")).toBeNull();
     });
 
     it("shows the welcome card and suppresses the checklist once the setup banner is dismissed", () => {
@@ -1008,7 +1008,7 @@ describe("WelcomeScreen", () => {
       render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete)} />);
 
       expect(screen.getByText(/Installed agents found/)).toBeTruthy();
-      expect(screen.queryByText("Getting Started")).toBeNull();
+      expect(screen.queryByText("Getting started")).toBeNull();
     });
 
     it("falls through to the checklist when no agents are installed and the banner is dismissed", () => {
@@ -1019,7 +1019,7 @@ describe("WelcomeScreen", () => {
 
       render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete)} />);
 
-      expect(screen.getByText("Getting Started")).toBeTruthy();
+      expect(screen.getByText("Getting started")).toBeTruthy();
     });
 
     it("falls through to the checklist when scan finished but no agents are launchable", () => {
@@ -1032,7 +1032,7 @@ describe("WelcomeScreen", () => {
       render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete)} />);
 
       expect(screen.queryByText(/Installed agents found/)).toBeNull();
-      expect(screen.getByText("Getting Started")).toBeTruthy();
+      expect(screen.getByText("Getting started")).toBeTruthy();
     });
 
     it("falls through to the checklist when an agent is already pinned", () => {
@@ -1046,7 +1046,7 @@ describe("WelcomeScreen", () => {
       render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete)} />);
 
       expect(screen.queryByText(/Installed agents found/)).toBeNull();
-      expect(screen.getByText("Getting Started")).toBeTruthy();
+      expect(screen.getByText("Getting started")).toBeTruthy();
     });
 
     it("renders nothing while onboarding state is hydrating", () => {
@@ -1061,7 +1061,7 @@ describe("WelcomeScreen", () => {
 
       expect(screen.queryByTestId("agent-setup-banner")).toBeNull();
       expect(screen.queryByText(/Installed agents found/)).toBeNull();
-      expect(screen.queryByText("Getting Started")).toBeNull();
+      expect(screen.queryByText("Getting started")).toBeNull();
     });
   });
 

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -301,7 +301,7 @@ export function CrashRecoveryDialog({
               </div>
 
               {suspectCount > 0 && (
-                <div data-testid="suspect-warning" className="rounded-md overflow-hidden">
+                <div data-testid="suspect-warning" className="rounded-lg overflow-hidden">
                   <InlineStatusBanner
                     severity="warning"
                     icon={AlertTriangle}
@@ -392,7 +392,7 @@ export function CrashRecoveryDialog({
           )}
 
           {recoveryError && (
-            <div className="rounded-md overflow-hidden" data-testid="recovery-error">
+            <div className="rounded-lg overflow-hidden" data-testid="recovery-error">
               <InlineStatusBanner
                 severity="error"
                 icon={AlertTriangle}

--- a/src/components/Settings/AddPresetDialog.tsx
+++ b/src/components/Settings/AddPresetDialog.tsx
@@ -125,7 +125,7 @@ export function AddPresetDialog({
             <select
               value={selectedTemplateId}
               onChange={(e) => setSelectedTemplateId(e.target.value)}
-              className="w-full rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg px-3 py-2 text-sm focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50"
+              className="w-full rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg px-3 py-1.5 text-sm focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50"
               data-testid="template-select"
             >
               {templates.map((t) => (

--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -117,7 +117,7 @@ export function BehavioralControls({
           )}
         </div>
         <input
-          className="w-full rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg px-3 py-2 text-sm font-mono focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 placeholder:text-text-muted"
+          className="w-full rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg px-3 py-2 text-sm font-mono focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 placeholder:text-text-placeholder"
           value={customArgsValue}
           onChange={(e) => onCustomFlagsChange(e.target.value)}
           placeholder={customArgsPlaceholder}

--- a/src/components/Settings/AgentSelectorDropdown.tsx
+++ b/src/components/Settings/AgentSelectorDropdown.tsx
@@ -172,7 +172,7 @@ export function AgentSelectorDropdown({
             aria-activedescendant={
               items[activeIndex] ? `agent-selector-item-${items[activeIndex].id}` : undefined
             }
-            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden"
+            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
           />
         </div>
         <div

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -568,7 +568,7 @@ function GenericCredentialForm({ providerId, providerName, fields }: GenericCred
               placeholder={field.placeholder}
               aria-label={field.label}
               autoComplete={field.type === "password" ? "new-password" : "off"}
-              className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent transition-colors"
+              className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent transition-colors"
               disabled={isSaving}
             />
             {field.helpText && (

--- a/src/components/Settings/ColorSchemePicker.tsx
+++ b/src/components/Settings/ColorSchemePicker.tsx
@@ -183,7 +183,7 @@ export function ColorSchemePicker() {
               }}
               placeholder="Filter schemes..."
               aria-label="Filter color schemes"
-              className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden"
+              className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
             />
           </div>
           <div className="flex rounded-[var(--radius-md)] border border-daintree-border overflow-hidden shrink-0">

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -250,8 +250,8 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
   return (
     <div className="space-y-2">
       <div className="mb-4">
-        <h3 className="text-sm font-semibold text-daintree-text/80 mb-2">Command Overrides</h3>
-        <p className="text-xs text-daintree-text/60 select-text">
+        <h3 className="text-sm font-medium text-daintree-text mb-2">Command Overrides</h3>
+        <p className="text-xs text-daintree-text/50 select-text">
           Customize command behavior for this project. Set default argument values, define custom
           prompts, or disable commands entirely.
         </p>
@@ -265,14 +265,14 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
       {/* Search and Filters */}
       <div className="flex items-center gap-3 mb-3">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-daintree-text/60" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-daintree-text/40" />
           <input
             type="text"
             placeholder="Search commands..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             disabled={isLoading}
-            className="w-full pl-9 pr-3 py-2 bg-daintree-bg border border-border-strong rounded text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent disabled:opacity-60 disabled:cursor-not-allowed"
+            className="w-full pl-9 pr-3 py-2 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent disabled:opacity-60 disabled:cursor-not-allowed"
             aria-label="Search commands"
           />
         </div>
@@ -336,7 +336,7 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
                       <ChevronRight
                         data-animated-chevron
                         className={cn(
-                          "h-4 w-4 text-daintree-text/60 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                          "w-3.5 h-3.5 text-daintree-text/60 transition-transform duration-150",
                           isExpanded && "rotate-90"
                         )}
                       />

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -518,8 +518,8 @@ export function DaintreeAssistantSettingsTab() {
       <header className="flex items-start gap-3 pb-4 border-b border-daintree-border">
         <DaintreeIcon className="w-6 h-6 text-daintree-text shrink-0 mt-0.5" size={24} />
         <div>
-          <h3 className="text-base font-medium text-daintree-text">Daintree Assistant</h3>
-          <p className="text-xs text-daintree-text/60 mt-1 select-text">
+          <h3 className="text-sm font-medium text-daintree-text">Daintree Assistant</h3>
+          <p className="text-xs text-daintree-text/50 mt-1 select-text">
             Controls the help assistant launched from the dock — the tools it can call and how its
             activity is recorded. Changes apply to new help sessions.
           </p>
@@ -895,6 +895,7 @@ function BlastRadiusPreview({ tier, isOpen, onToggle }: BlastRadiusPreviewProps)
       >
         <span className="flex items-center gap-2">
           <ChevronRight
+            data-animated-chevron
             className={cn(
               "w-3.5 h-3.5 transition-transform duration-150",
               isOpen ? "rotate-90" : "rotate-0"

--- a/src/components/Settings/DiagnosticsReviewDialog.tsx
+++ b/src/components/Settings/DiagnosticsReviewDialog.tsx
@@ -220,7 +220,7 @@ export function DiagnosticsReviewDialog({
                   checked={enabledSections[key]}
                   onCheckedChange={() => toggleSection(key)}
                   className={cn(
-                    "flex shrink-0 w-3.5 h-3.5 rounded border transition-colors",
+                    "flex shrink-0 w-3.5 h-3.5 rounded-sm border transition-colors",
                     "bg-daintree-bg border-border-strong",
                     "data-[state=checked]:bg-daintree-text data-[state=checked]:border-daintree-text",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
@@ -248,7 +248,7 @@ export function DiagnosticsReviewDialog({
             }}
             aria-label="Log time window"
             className={cn(
-              "h-8 text-xs w-full px-2 rounded border border-daintree-border bg-daintree-bg",
+              "h-8 text-xs w-full px-2 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg",
               "text-daintree-text focus:outline-hidden focus:border-daintree-accent"
             )}
           >
@@ -280,7 +280,7 @@ export function DiagnosticsReviewDialog({
                   checked={prebuiltIds.has(preset.id)}
                   onCheckedChange={() => togglePrebuilt(preset.id)}
                   className={cn(
-                    "flex shrink-0 w-3.5 h-3.5 rounded border transition-colors",
+                    "flex shrink-0 w-3.5 h-3.5 rounded-sm border transition-colors",
                     "bg-daintree-bg border-border-strong",
                     "data-[state=checked]:bg-daintree-text data-[state=checked]:border-daintree-text",
                     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
@@ -315,8 +315,8 @@ export function DiagnosticsReviewDialog({
                   onChange={(e) => updateReplacement(i, "find", e.target.value)}
                   placeholder="Find text"
                   className={cn(
-                    "h-7 text-xs flex-1 px-2 rounded border border-daintree-border bg-daintree-bg",
-                    "text-daintree-text placeholder:text-daintree-text/30",
+                    "h-7 text-xs flex-1 px-2 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg",
+                    "text-daintree-text placeholder:text-text-placeholder",
                     "focus:outline-hidden focus:border-daintree-accent"
                   )}
                 />
@@ -327,8 +327,8 @@ export function DiagnosticsReviewDialog({
                   onChange={(e) => updateReplacement(i, "replace", e.target.value)}
                   placeholder="Replace with"
                   className={cn(
-                    "h-7 text-xs flex-1 px-2 rounded border border-daintree-border bg-daintree-bg",
-                    "text-daintree-text placeholder:text-daintree-text/30",
+                    "h-7 text-xs flex-1 px-2 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg",
+                    "text-daintree-text placeholder:text-text-placeholder",
                     "focus:outline-hidden focus:border-daintree-accent"
                   )}
                 />
@@ -367,7 +367,7 @@ export function DiagnosticsReviewDialog({
 
       <AppDialog.Footer
         primaryAction={{
-          label: isSaving ? "Saving..." : "Save Bundle",
+          label: isSaving ? "Saving…" : "Save Bundle",
           onClick: handleSave,
           disabled: isSaving,
           loading: isSaving,

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -265,7 +265,7 @@ export function EditorIntegrationTab() {
             <button
               onClick={handleSave}
               disabled={isSaving || !activeProjectId}
-              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
+              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
             >
               {isSaving ? "Saving…" : "Save"}
             </button>

--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useId } from "react";
 import { Code2, CheckCircle, AlertCircle, RefreshCw, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { editorClient } from "@/clients/editorClient";
 import type { EditorConfig, DiscoveredEditor, KnownEditorId } from "@shared/types/editor";
 import { useProjectStore } from "@/store";
@@ -181,14 +182,19 @@ export function EditorIntegrationTab() {
                   );
                 })}
               </select>
-              <button
-                onClick={handleRescan}
-                disabled={isRescanning}
-                title="Re-scan for installed editors"
-                className="p-2 rounded-[var(--radius-md)] border border-daintree-border hover:bg-tint/5 text-daintree-text/60 hover:text-daintree-text transition-colors disabled:opacity-40 disabled:pointer-events-none"
-              >
-                <RefreshCw className={cn("w-4 h-4", isRescanning && "animate-spin")} />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleRescan}
+                    disabled={isRescanning}
+                    aria-label="Re-scan for installed editors"
+                    className="p-2 rounded-[var(--radius-md)] border border-daintree-border hover:bg-tint/5 text-daintree-text/60 hover:text-daintree-text transition-colors disabled:opacity-40 disabled:pointer-events-none"
+                  >
+                    <RefreshCw className={cn("w-4 h-4", isRescanning && "animate-spin")} />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Re-scan for installed editors</TooltipContent>
+              </Tooltip>
             </div>
           </div>
 

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -230,7 +230,7 @@ export function EnvironmentSettingsTab() {
         description="Global environment variables injected into all new terminals. Project-level variables override globals with the same name."
         id="environment-variables"
       >
-        <div className="text-sm text-status-error/90 py-8 px-4 border border-status-error/40 rounded-[var(--radius-md)] bg-status-error/5">
+        <div className="text-sm text-status-error/90 py-8 px-4 border border-status-error/20 rounded-[var(--radius-md)] bg-status-error/5">
           Couldn't load saved environment variables. Close and reopen settings to try again. Editing
           isn't available right now to avoid overwriting your stored values.
         </div>
@@ -347,7 +347,7 @@ export function EnvironmentSettingsTab() {
           <div className="flex items-center gap-2 pt-2">
             <Button onClick={handleSave} disabled={isSaving} size="sm">
               <Save className="w-4 h-4" />
-              {isSaving ? "Saving..." : "Save"}
+              {isSaving ? "Saving…" : "Save"}
             </Button>
             <Button variant="ghost" onClick={handleDiscard} disabled={isSaving} size="sm">
               Discard

--- a/src/components/Settings/ForgeAuditLogViewer.tsx
+++ b/src/components/Settings/ForgeAuditLogViewer.tsx
@@ -166,7 +166,7 @@ export function ForgeAuditLogViewer({
           onChange={(e) => setMethodFilter(e.target.value)}
           placeholder="Filter by method or provider"
           aria-label="Filter audit by method or provider"
-          className="flex-1 min-w-[180px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          className="flex-1 min-w-[180px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <input
           type="text"
@@ -174,7 +174,7 @@ export function ForgeAuditLogViewer({
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search arguments"
           aria-label="Search audit arguments"
-          className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <select
           value={resultFilter}

--- a/src/components/Settings/ForgeIntegrationsTab.tsx
+++ b/src/components/Settings/ForgeIntegrationsTab.tsx
@@ -256,7 +256,7 @@ export function ForgeIntegrationsTab() {
   );
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <SettingsSection
         icon={GitBranch}
         title="Default forge provider"

--- a/src/components/Settings/ForgeProviderSelectorDropdown.tsx
+++ b/src/components/Settings/ForgeProviderSelectorDropdown.tsx
@@ -159,7 +159,7 @@ export function ForgeProviderSelectorDropdown({
                 ? `forge-provider-selector-item-${items[activeIndex].id}`
                 : undefined
             }
-            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden"
+            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
           />
         </div>
         <div

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -699,7 +699,7 @@ export function GeneralTab({
               <ChevronRight
                 data-animated-chevron
                 className={cn(
-                  "w-4 h-4 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                  "w-3.5 h-3.5 transition-transform duration-150",
                   isShortcutsOpen && "rotate-90"
                 )}
               />
@@ -710,7 +710,7 @@ export function GeneralTab({
               <div id="keyboard-shortcuts-content" className="space-y-4">
                 {shortcuts.map((category) => (
                   <div key={category.category} className="space-y-2">
-                    <h5 className="text-xs font-medium text-text-secondary uppercase tracking-wide">
+                    <h5 className="text-xs font-semibold text-daintree-text/60 uppercase tracking-wider">
                       {category.category}
                     </h5>
                     <dl className="space-y-1">

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -639,7 +639,7 @@ export function GeneralTab({
               <SettingsSwitchCard
                 icon={RefreshCw}
                 title="Notify when a new version is available"
-                subtitle="Show an inbox notification with a link to the Microsoft Store."
+                subtitle="Show an inbox notification with a link to the Microsoft Store"
                 isEnabled={storeUpdateNotificationsEnabled ?? true}
                 onChange={() => void handleStoreUpdateNotificationsToggle()}
                 ariaLabel="Toggle Microsoft Store update notifications"

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -179,7 +179,7 @@ export function ImageViewerTab() {
             <button
               onClick={handleSave}
               disabled={isSaving || isLoading || Boolean(loadError)}
-              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
+              className="px-4 py-2 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium hover:bg-daintree-accent/90 disabled:opacity-50 disabled:pointer-events-none transition-colors"
             >
               {isSaving ? "Saving…" : "Save"}
             </button>

--- a/src/components/Settings/ImportEnvDialog.tsx
+++ b/src/components/Settings/ImportEnvDialog.tsx
@@ -126,7 +126,7 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
         <AppDialog.CloseButton />
       </AppDialog.Header>
 
-      <AppDialog.Body className="space-y-3">
+      <AppDialog.Body className="space-y-4">
         {step === "paste" ? (
           <>
             <AppDialog.Description>
@@ -141,13 +141,13 @@ export function ImportEnvDialog({ isOpen, onClose, env, onImport }: ImportEnvDia
               spellCheck={false}
               autoCapitalize="off"
               autoCorrect="off"
-              className="w-full h-56 resize-y font-mono text-[12px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 outline-hidden focus:ring-2 focus:ring-daintree-accent/40 text-daintree-text"
+              className="w-full h-56 resize-y font-mono text-[12px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 text-daintree-text"
               aria-label="Paste .env content"
               data-testid="import-env-textarea"
             />
             {hasErrors && (
               <div
-                className="rounded-[var(--radius-md)] border border-status-warning/40 bg-status-warning/10 px-3 py-2 text-[12px] text-status-warning"
+                className="rounded-[var(--radius-md)] border border-status-warning/20 bg-status-warning/10 px-3 py-2 text-[12px] text-status-warning"
                 data-testid="import-env-errors"
               >
                 <div className="flex items-center gap-1.5 font-medium mb-1">

--- a/src/components/Settings/IntegrationsTab.tsx
+++ b/src/components/Settings/IntegrationsTab.tsx
@@ -3,7 +3,7 @@ import { ImageViewerTab } from "./ImageViewerTab";
 
 export function IntegrationsTab() {
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <EditorIntegrationTab />
       <ImageViewerTab />
     </div>

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -243,7 +243,7 @@ export function KeyboardShortcutsTab() {
             onChange={(e) => setSearchQuery(e.target.value)}
             onKeyDown={handleSearchKeyDown}
             aria-label="Search shortcuts"
-            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-muted focus:outline-hidden"
+            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
           />
           {searchQuery && (
             <button

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { Search, X, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { keybindingService, type RegisteredKeybindingConfig } from "@/services/KeybindingService";
+import { formatShortcutForTooltip } from "@/lib/platform";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -300,6 +301,40 @@ export function KeyboardShortcutsTab() {
             No shortcuts found matching "{searchQuery}"
           </div>
         )}
+
+        {/* Keyboard drag-and-drop is otherwise only discoverable through
+            screen-reader ARIA hints; surface it for sighted keyboard users.
+            Static — dnd-kit sensor interactions, not rebindable actions. */}
+        <div data-testid="list-reordering-help">
+          <h4 className="text-xs font-semibold text-daintree-text/60 uppercase tracking-wider mb-2">
+            List reordering
+          </h4>
+          <div className="space-y-0">
+            <div className="flex items-center justify-between gap-4 py-2 border-b border-daintree-border/50">
+              <span className="text-sm text-daintree-text shrink-0">Reorder panel</span>
+              <span className="text-xs text-daintree-text/60 text-right">
+                Focus the panel header, then Space to pick up, arrows to move, Space to drop, Esc to
+                cancel
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-4 py-2 border-b border-daintree-border/50">
+              <span className="text-sm text-daintree-text shrink-0">Reorder tab</span>
+              <span className="text-xs text-daintree-text/60 text-right">
+                Focus the active tab, then Space to pick up, arrows to move, Space to drop
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-4 py-2 border-b border-daintree-border/50">
+              <span className="text-sm text-daintree-text shrink-0">Reorder worktree</span>
+              <span className="text-xs text-daintree-text/60 text-right">
+                {formatShortcutForTooltip("Alt+Up")} / {formatShortcutForTooltip("Alt+Down")} in the
+                sidebar
+              </span>
+            </div>
+          </div>
+          <p className="text-xs text-daintree-text/40 mt-2">
+            These shortcuts are fixed and can't be rebound
+          </p>
+        </div>
       </div>
 
       <ConfirmDialog

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -393,7 +393,7 @@ export function McpAuditLogViewer({
           onChange={(e) => setToolFilter(e.target.value)}
           placeholder="Filter by tool ID"
           aria-label="Filter audit by tool name"
-          className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <input
           type="text"
@@ -401,7 +401,7 @@ export function McpAuditLogViewer({
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search arguments"
           aria-label="Search audit arguments"
-          className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <select
           value={resultFilter}

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -618,6 +618,7 @@ export function McpServerSettingsTab() {
                       className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
                     >
                       <ChevronRight
+                        data-animated-chevron
                         className={cn(
                           "w-3.5 h-3.5 shrink-0 transition-transform duration-150",
                           bearersExpanded && "rotate-90"
@@ -670,6 +671,7 @@ export function McpServerSettingsTab() {
                       className="flex w-full items-center gap-2 px-3 py-2 text-xs font-medium text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
                     >
                       <ChevronRight
+                        data-animated-chevron
                         className={cn(
                           "w-3.5 h-3.5 shrink-0 transition-transform duration-150",
                           helpBearersExpanded && "rotate-90"
@@ -731,7 +733,7 @@ export function McpServerSettingsTab() {
                 }}
                 placeholder="45454"
                 aria-label="MCP server port"
-                className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-sm text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
               />
               <button
                 onClick={handlePortSave}
@@ -861,7 +863,7 @@ export function McpServerSettingsTab() {
                     if (e.key === "Enter") void handleMaxRecordsSave();
                   }}
                   placeholder={MCP_AUDIT_DEFAULT_MAX_RECORDS.toString()}
-                  className="w-24 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  className="w-24 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 />
                 <button
                   type="button"

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useId } from "react";
 import { Play, Bell, BellOff, Volume2, AudioLines, Moon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsCheckbox } from "./SettingsCheckbox";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
@@ -119,6 +121,10 @@ type LoadState = "loading" | "ready" | "error";
 export function NotificationSettingsTab() {
   const [settings, setSettings] = useState<NotificationSettings>(DEFAULT_SETTINGS);
   const [loadState, setLoadState] = useState<LoadState>("loading");
+  const loading = loadState === "loading";
+  // Gate the inline "Loading…" hint past the Doherty threshold so fast IPC
+  // resolutions don't flash a loading state for sub-400ms work.
+  const showInlineLoading = useDeferredLoading(loading, UI_DOHERTY_THRESHOLD);
   const escalationDelayId = useId();
   const activeDaysId = useId();
 
@@ -218,10 +224,6 @@ export function NotificationSettingsTab() {
     window.electron?.notification?.playSound(soundFile).catch(() => {});
   };
 
-  if (loadState === "loading") {
-    return <div className="text-sm text-daintree-text/50">Loading…</div>;
-  }
-
   if (loadState === "error") {
     return (
       <div className="text-sm text-daintree-text/60">
@@ -232,6 +234,7 @@ export function NotificationSettingsTab() {
 
   return (
     <div className="space-y-6">
+      {showInlineLoading && <p className="text-xs text-daintree-text/50">Loading…</p>}
       <SettingsSwitchCard
         variant="compact"
         title="Enable notifications"
@@ -240,9 +243,15 @@ export function NotificationSettingsTab() {
         onChange={() => update({ enabled: !settings.enabled })}
         ariaLabel="Enable notifications"
         icon={settings.enabled ? Bell : BellOff}
+        disabled={loading}
       />
 
-      <div className={cn("space-y-6", !settings.enabled && "opacity-50 pointer-events-none")}>
+      <div
+        className={cn(
+          "space-y-6",
+          (!settings.enabled || loading) && "opacity-50 pointer-events-none"
+        )}
+      >
         <SettingsSection
           icon={Bell}
           title="Agent notifications"

--- a/src/components/Settings/OverrideField.tsx
+++ b/src/components/Settings/OverrideField.tsx
@@ -90,7 +90,7 @@ export function OverrideField({
         className={cn(
           "w-full bg-daintree-bg border rounded px-3 py-2 text-sm text-daintree-text font-mono",
           "focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30",
-          "transition-colors placeholder:text-text-muted disabled:opacity-50 disabled:cursor-not-allowed",
+          "transition-colors placeholder:text-text-placeholder disabled:opacity-50 disabled:cursor-not-allowed",
           isOverriding ? "border-status-info/40" : "border-daintree-border",
           error && "border-status-error",
           inputClassName

--- a/src/components/Settings/PluginActionAuditLogViewer.tsx
+++ b/src/components/Settings/PluginActionAuditLogViewer.tsx
@@ -132,7 +132,7 @@ export function PluginActionAuditLogViewer({
           onChange={(e) => setPluginFilter(e.target.value)}
           placeholder="Filter by plugin or action ID"
           aria-label="Filter audit by plugin or action ID"
-          className="flex-1 min-w-[180px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          className="flex-1 min-w-[180px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <input
           type="text"
@@ -140,7 +140,7 @@ export function PluginActionAuditLogViewer({
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search arguments"
           aria-label="Search audit arguments"
-          className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <select
           value={resultFilter}

--- a/src/components/Settings/PluginSettingsForm.tsx
+++ b/src/components/Settings/PluginSettingsForm.tsx
@@ -18,7 +18,7 @@ const SCOPE_BADGE_LABEL: Record<PluginSettingsScope, string> = {
 };
 
 const INPUT_CLASS =
-  "w-full px-2.5 py-1.5 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-daintree-text/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed";
+  "w-full px-2.5 py-1.5 text-sm rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border text-daintree-text placeholder:text-text-placeholder focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent disabled:opacity-50 disabled:cursor-not-allowed";
 
 function settingScope(def: SettingDefinition): PluginSettingsScope {
   return def.scope ?? "user";

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -373,7 +373,7 @@ export function PortalSettingsTab() {
                 type="button"
                 onClick={handleCustomUrlSave}
                 aria-label="Save custom URL"
-                className="px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm hover:bg-daintree-accent/90 transition-colors"
+                className="px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm hover:bg-daintree-accent/90 transition-colors"
               >
                 <Check className="w-4 h-4" />
               </button>
@@ -450,7 +450,7 @@ export function PortalSettingsTab() {
             <button
               onClick={handleAddLink}
               disabled={!newLinkName.trim() || !newLinkUrl.trim()}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-daintree-bg text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none hover:bg-daintree-accent/90 transition-colors"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)] bg-daintree-accent text-text-inverse text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none hover:bg-daintree-accent/90 transition-colors"
             >
               <Plus className="w-4 h-4" />
               Add

--- a/src/components/Settings/PrivacyDataTab.tsx
+++ b/src/components/Settings/PrivacyDataTab.tsx
@@ -132,8 +132,8 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           } catch (retryErr) {
             notify({
               type: "error",
-              title: "Failed to load settings",
-              message: "Privacy settings could not be loaded.",
+              title: "Couldn't load settings",
+              message: "Privacy settings couldn't be loaded.",
               actions: [{ label: "Try again", variant: "primary", onClick: retry }],
             });
             logError("Failed to load privacy settings", retryErr);
@@ -141,8 +141,8 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
         };
         notify({
           type: "error",
-          title: "Failed to load settings",
-          message: "Privacy settings could not be loaded.",
+          title: "Couldn't load settings",
+          message: "Privacy settings couldn't be loaded.",
           actions: [{ label: "Try again", variant: "primary", onClick: retry }],
         });
         logError("Failed to load privacy settings", err);
@@ -171,8 +171,8 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           setTelemetryLevel(prev);
           notify({
             type: "error",
-            title: "Failed to save setting",
-            message: "Telemetry level could not be saved.",
+            title: "Couldn't save setting",
+            message: "Telemetry level couldn't be saved.",
             actions: [{ label: "Try again", variant: "primary", onClick: retry }],
           });
           logError("Failed to set telemetry level", retryErr);
@@ -180,8 +180,8 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
       };
       notify({
         type: "error",
-        title: "Failed to save setting",
-        message: "Telemetry level could not be saved.",
+        title: "Couldn't save setting",
+        message: "Telemetry level couldn't be saved.",
         actions: [{ label: "Try again", variant: "primary", onClick: retry }],
       });
       logError("Failed to set telemetry level", err);
@@ -203,8 +203,8 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
           setLogRetentionDays(prev);
           notify({
             type: "error",
-            title: "Failed to save setting",
-            message: "Log retention could not be saved.",
+            title: "Couldn't save setting",
+            message: "Log retention couldn't be saved.",
             actions: [{ label: "Try again", variant: "primary", onClick: retry }],
           });
           logError("Failed to set log retention", retryErr);
@@ -212,8 +212,8 @@ export function PrivacyDataTab({ activeSubtab, onSubtabChange }: PrivacyDataTabP
       };
       notify({
         type: "error",
-        title: "Failed to save setting",
-        message: "Log retention could not be saved.",
+        title: "Couldn't save setting",
+        message: "Log retention couldn't be saved.",
         actions: [{ label: "Try again", variant: "primary", onClick: retry }],
       });
       logError("Failed to set log retention", err);

--- a/src/components/Settings/ResourceEnvironmentsSection.tsx
+++ b/src/components/Settings/ResourceEnvironmentsSection.tsx
@@ -319,10 +319,10 @@ export function ResourceEnvironmentsSection({
             <button
               type="button"
               onClick={() => setPendingDeleteEnvironment(currentEnvName)}
-              className="p-1.5 rounded hover:bg-status-error/15 transition-colors"
+              className="p-1 rounded hover:bg-status-error/15 transition-colors"
               aria-label={`Remove ${currentEnvName} environment`}
             >
-              <X className="h-4 w-4 text-status-error/60" />
+              <X className="h-4 w-4 text-status-error" />
             </button>
           )}
           <button

--- a/src/components/Settings/RunHistorySettingsTab.tsx
+++ b/src/components/Settings/RunHistorySettingsTab.tsx
@@ -15,8 +15,8 @@ function CountPill({ tone, label }: { tone: "success" | "danger" | "muted"; labe
     <span
       className={cn(
         "inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium",
-        tone === "success" && "bg-emerald-500/15 text-emerald-400",
-        tone === "danger" && "bg-red-500/15 text-red-400",
+        tone === "success" && "bg-status-success/15 text-status-success",
+        tone === "danger" && "bg-status-error/15 text-status-error",
         tone === "muted" && "bg-overlay-subtle text-daintree-text/70"
       )}
     >
@@ -54,7 +54,7 @@ function RecipeRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "r
         </time>
       </div>
       {failed.length > 0 ? (
-        <ul className="mt-2 space-y-0.5 pl-6.5 text-xs text-red-400/90">
+        <ul className="mt-2 space-y-0.5 pl-6.5 text-xs text-status-error/90">
           {failed.map((f) => (
             <li key={f.index} className="truncate">
               #{f.index}: {f.error}
@@ -93,7 +93,7 @@ function FleetRunRow({ record }: { record: Extract<RunHistoryRecord, { kind: "fl
         </time>
       </div>
       {rejected.length > 0 ? (
-        <ul className="mt-2 space-y-0.5 pl-6.5 text-xs text-red-400/90">
+        <ul className="mt-2 space-y-0.5 pl-6.5 text-xs text-status-error/90">
           {rejected.map((t) => (
             <li key={t.terminalId} className="truncate">
               {t.title ?? t.terminalId}

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -38,7 +38,7 @@ export function SettingsCheckbox({
 
   const scopeBadge = scope ? (
     <span
-      className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+      className={`text-[10px] px-1.5 py-0.5 rounded-sm font-medium ${
         scope === "project"
           ? "bg-status-info/10 text-status-info"
           : scope === "global"

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -126,7 +126,7 @@ export function SettingsChoicebox<T extends string = string>({
     <div className={cn("group grid grid-cols-subgrid gap-2 col-span-full", className)} {...props}>
       {label && (
         <div className="flex items-center gap-2">
-          <label id={labelId} htmlFor={id} className="text-sm text-daintree-text/70">
+          <label id={labelId} htmlFor={id} className="text-sm text-text-secondary">
             {label}
           </label>
           {isModified && (
@@ -137,7 +137,7 @@ export function SettingsChoicebox<T extends string = string>({
               type="button"
               aria-label={resetAriaLabel ?? `Reset ${label} to default`}
               className={cn(
-                "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text",
+                "p-0.5 rounded-sm text-text-muted hover:text-daintree-text",
                 "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
                 "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
                 "transition-colors"
@@ -155,7 +155,7 @@ export function SettingsChoicebox<T extends string = string>({
             type="button"
             aria-label="Reset to default"
             className={cn(
-              "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text",
+              "p-0.5 rounded-sm text-text-muted hover:text-daintree-text",
               "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               "transition-colors"
@@ -214,14 +214,14 @@ export function SettingsChoicebox<T extends string = string>({
             >
               <div className="font-medium">{option.label}</div>
               {option.description && (
-                <div className="text-xs text-daintree-text/50 mt-0.5">{option.description}</div>
+                <div className="text-xs text-text-muted mt-0.5">{option.description}</div>
               )}
             </button>
           );
         })}
       </div>
       {description && (
-        <p id={descriptionId} className="text-xs text-daintree-text/40 select-text">
+        <p id={descriptionId} className="text-xs text-text-muted select-text">
           {description}
         </p>
       )}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -84,6 +84,10 @@ const SETTINGS_HIGHLIGHT_DECAY_MS = 1500;
 // doesn't mount every tab at once.
 export const SETTINGS_TAB_HOVER_INTENT_MS = 150;
 
+// The app version is immutable for the process lifetime — fetch it once and
+// reuse across dialog opens so the sidebar slot never shows a placeholder.
+let cachedAppVersion: string | null = null;
+
 // Lowercase the first letter so the label reads naturally mid-sentence
 // ("Requires voice input"), unless it starts with an initialism like
 // MCP / AI / API — those stay uppercase.
@@ -191,7 +195,7 @@ function SettingsDialogInner({
     }
   }, [isOpen, setPortalOpen]);
 
-  const [appVersion, setAppVersion] = useState<string>("Loading...");
+  const [appVersion, setAppVersion] = useState<string>(cachedAppVersion ?? "");
 
   const [hiddenSettingBanner, setHiddenSettingBanner] = useState<{
     label: string;
@@ -241,10 +245,13 @@ function SettingsDialogInner({
   }, [isOpen, defaultTab, defaultSubtab, defaultSectionId]);
 
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && cachedAppVersion === null) {
       appClient
         .getVersion()
-        .then(setAppVersion)
+        .then((version) => {
+          cachedAppVersion = version;
+          setAppVersion(version);
+        })
         .catch((error) => {
           logError("Failed to fetch app version", error);
           setAppVersion("Unavailable");

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -673,8 +673,8 @@ function SettingsDialogInner({
         </div>
 
         <div className="settings-shell flex-1 flex flex-col min-w-0">
-          <div className="dialog-header flex items-center justify-between px-6 py-4 border-b border-daintree-border shrink-0">
-            <h3 className="text-lg font-medium text-daintree-text flex items-center gap-2">
+          <div className="dialog-header flex items-center justify-between px-6 py-4 border-b border-border-strong shrink-0">
+            <h3 className="text-lg font-semibold text-daintree-text flex items-center gap-2">
               {isSearching ? (
                 <>
                   <Search className="w-5 h-5 text-text-secondary" />
@@ -689,7 +689,7 @@ function SettingsDialogInner({
             </h3>
             <button
               onClick={handleClose}
-              className="text-daintree-text/60 hover:text-daintree-text transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              className="text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-raised transition-colors p-1 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
               aria-label="Close settings"
             >
               <X className="h-5 w-5" />

--- a/src/components/Settings/SettingsInput.tsx
+++ b/src/components/Settings/SettingsInput.tsx
@@ -44,7 +44,7 @@ export function SettingsInput({
 
   const scopeBadge = scope ? (
     <span
-      className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+      className={`text-[10px] px-1.5 py-0.5 rounded-sm font-medium ${
         scope === "project"
           ? "bg-status-info/10 text-status-info"
           : scope === "global"

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -64,7 +64,7 @@ export function SettingsSelect({
 
   const scopeBadge = scope ? (
     <span
-      className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+      className={`text-[10px] px-1.5 py-0.5 rounded-sm font-medium ${
         scope === "project"
           ? "bg-status-info/10 text-status-info"
           : scope === "global"
@@ -79,7 +79,7 @@ export function SettingsSelect({
   return (
     <div className="group grid grid-cols-subgrid gap-2 col-span-full">
       <div className="flex items-center gap-2">
-        <label htmlFor={id} className="text-sm text-daintree-text/70">
+        <label htmlFor={id} className="text-sm text-text-secondary">
           {label}
         </label>
         {scopeBadge}
@@ -91,7 +91,7 @@ export function SettingsSelect({
             type="button"
             aria-label={resetAriaLabel ?? `Reset ${label} to default`}
             className={cn(
-              "p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text",
+              "p-0.5 rounded-sm text-text-muted hover:text-daintree-text",
               "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
               "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
               "transition-colors"
@@ -125,7 +125,7 @@ export function SettingsSelect({
         </SelectContent>
       </Select>
       {description && (
-        <p id={descriptionId} className="text-xs text-daintree-text/40 select-text">
+        <p id={descriptionId} className="text-xs text-text-muted select-text">
           {description}
         </p>
       )}

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -58,7 +58,7 @@ export function SettingsSwitchCard({
 
   const scopeBadge = scope ? (
     <span
-      className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+      className={`text-[10px] px-1.5 py-0.5 rounded-sm font-medium ${
         scope === "project"
           ? "bg-status-info/10 text-status-info"
           : scope === "global"

--- a/src/components/Settings/SettingsTextarea.tsx
+++ b/src/components/Settings/SettingsTextarea.tsx
@@ -4,7 +4,7 @@ import { RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const TEXTAREA_CLASSES =
-  "w-full bg-surface-input border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-xs font-mono text-daintree-text placeholder:text-text-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 transition-colors resize-y disabled:opacity-50 disabled:cursor-not-allowed";
+  "w-full bg-surface-input border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-xs font-mono text-daintree-text placeholder:text-text-placeholder focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 transition-colors resize-y disabled:opacity-50 disabled:cursor-not-allowed";
 
 interface SettingsTextareaProps extends Omit<ComponentPropsWithoutRef<"textarea">, "id"> {
   label: string;

--- a/src/components/Settings/ThemeSelector.tsx
+++ b/src/components/Settings/ThemeSelector.tsx
@@ -156,7 +156,7 @@ export function ThemeSelector<T extends { id: string }>({
             }}
             placeholder="Filter themes..."
             aria-label="Filter themes"
-            className="w-full pl-7 pr-2 py-1.5 text-xs rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:border-daintree-accent"
+            className="w-full pl-7 pr-2 py-1.5 text-xs rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent"
           />
         </div>
       </div>

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -92,15 +92,20 @@ function ToolbarButtonCard({
         isOverlay && "shadow-md bg-daintree-bg cursor-grabbing"
       )}
     >
+      {/* When draggable, gripProps carries dnd-kit's role/tabIndex/describedby —
+          the grip must stay in the accessibility tree (aria-hidden on a
+          focusable element is an axe violation) and needs an accessible name. */}
       <div
         {...(draggable && gripProps ? gripProps : {})}
         className={cn(
           draggable ? "cursor-grab active:cursor-grabbing" : "cursor-default",
           "shrink-0"
         )}
-        aria-hidden="true"
+        aria-hidden={draggable && gripProps ? undefined : true}
+        aria-label={draggable && gripProps ? `Reorder ${metadata.label}` : undefined}
       >
         <GripVertical
+          aria-hidden="true"
           className={cn("h-4 w-4", draggable ? "text-daintree-text/50" : "text-daintree-text/20")}
         />
       </div>

--- a/src/components/Settings/TurnOutcomeDiagnostics.tsx
+++ b/src/components/Settings/TurnOutcomeDiagnostics.tsx
@@ -231,6 +231,7 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
             >
               <span className="flex items-center gap-2">
                 <ChevronRight
+                  data-animated-chevron
                   className={cn(
                     "w-3.5 h-3.5 transition-transform duration-150",
                     outcomeSectionOpen ? "rotate-90" : "rotate-0"
@@ -292,6 +293,7 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
             >
               <span className="flex items-center gap-2">
                 <ChevronRight
+                  data-animated-chevron
                   className={cn(
                     "w-3.5 h-3.5 transition-transform duration-150",
                     toolErrorOpen ? "rotate-90" : "rotate-0"
@@ -358,6 +360,7 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
             >
               <span className="flex items-center gap-2">
                 <ChevronRight
+                  data-animated-chevron
                   className={cn(
                     "w-3.5 h-3.5 transition-transform duration-150",
                     tierRejectedOpen ? "rotate-90" : "rotate-0"
@@ -426,6 +429,7 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
             >
               <span className="flex items-center gap-2">
                 <ChevronRight
+                  data-animated-chevron
                   className={cn(
                     "w-3.5 h-3.5 transition-transform duration-150",
                     agentStuckOpen ? "rotate-90" : "rotate-0"

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -12,8 +12,7 @@ import {
   AlertCircle,
   ExternalLink,
   Sparkles,
-  ChevronDown,
-  ChevronUp,
+  ChevronRight,
   FileSearch,
   RotateCcw,
 } from "lucide-react";
@@ -565,7 +564,7 @@ function ApiKeyRow({
               }
             }}
             placeholder={value ? "Enter new key to replace" : placeholder}
-            className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 pr-8 font-mono text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent transition-colors"
+            className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 pr-8 font-mono text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent transition-colors"
             autoComplete="new-password"
             spellCheck={false}
             disabled={validation === "testing"}
@@ -636,7 +635,10 @@ function AdvancedSection({
         onClick={() => setExpanded((v) => !v)}
         className="flex items-center gap-1.5 text-xs text-daintree-text/40 hover:text-daintree-text/60 transition-colors"
       >
-        {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        <ChevronRight
+          data-animated-chevron
+          className={cn("w-3.5 h-3.5 transition-transform duration-150", expanded && "rotate-90")}
+        />
         Advanced
       </button>
       {expanded && (
@@ -656,7 +658,7 @@ function AdvancedSection({
               onBlur={(e) => update({ organizationId: e.target.value.trim() })}
               placeholder={isLegacyKey ? "org-..." : ""}
               disabled={!isLegacyKey}
-              className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 font-mono text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/50 transition-colors disabled:opacity-50"
+              className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 font-mono text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent transition-colors disabled:opacity-50"
               autoComplete="off"
               spellCheck={false}
             />
@@ -673,7 +675,7 @@ function AdvancedSection({
               onBlur={(e) => update({ projectId: e.target.value.trim() })}
               placeholder={isLegacyKey ? "proj_..." : ""}
               disabled={!isLegacyKey}
-              className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 font-mono text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/50 transition-colors disabled:opacity-50"
+              className="w-full bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 font-mono text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent transition-colors disabled:opacity-50"
               autoComplete="off"
               spellCheck={false}
             />
@@ -966,7 +968,7 @@ function DictionarySection({
             }
           }}
           placeholder="Add term…"
-          className="flex-1 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/50 transition-colors"
+          className="flex-1 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent transition-colors"
         />
         <Button
           onClick={onAdd}
@@ -1042,7 +1044,10 @@ function CorePromptViewer() {
         onClick={() => setExpanded((v) => !v)}
         className="flex items-center gap-1.5 text-xs text-daintree-text/40 hover:text-daintree-text/60 transition-colors"
       >
-        {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        <ChevronRight
+          data-animated-chevron
+          className={cn("w-3.5 h-3.5 transition-transform duration-150", expanded && "rotate-90")}
+        />
         Inspect core prompt
       </button>
       {expanded && (

--- a/src/components/Settings/WorktreeSettingsTab.tsx
+++ b/src/components/Settings/WorktreeSettingsTab.tsx
@@ -297,11 +297,11 @@ export function WorktreeSettingsTab() {
               className={cn(
                 "px-4 py-1.5 text-sm font-medium rounded-[var(--radius-md)] transition-colors",
                 hasChanges && validation.valid
-                  ? "bg-daintree-accent text-daintree-bg hover:bg-daintree-accent/90"
+                  ? "bg-daintree-accent text-text-inverse hover:bg-daintree-accent/90"
                   : "bg-daintree-border text-daintree-text/50 cursor-not-allowed"
               )}
             >
-              {isSaving ? "Saving..." : "Save Changes"}
+              {isSaving ? "Saving…" : "Save Changes"}
             </button>
           </div>
 

--- a/src/components/Settings/__tests__/PrivacyDataTab.test.tsx
+++ b/src/components/Settings/__tests__/PrivacyDataTab.test.tsx
@@ -98,7 +98,7 @@ describe("PrivacyDataTab", () => {
 
     expect(window.electron.privacy.setTelemetryLevel).toHaveBeenCalledWith("errors");
     expect(mockNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "error", title: "Failed to save setting" })
+      expect.objectContaining({ type: "error", title: "Couldn't save setting" })
     );
   });
 
@@ -203,7 +203,7 @@ describe("PrivacyDataTab", () => {
 
     expect(window.electron.privacy.setLogRetention).toHaveBeenCalledWith(90);
     expect(mockNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "error", title: "Failed to save setting" })
+      expect.objectContaining({ type: "error", title: "Couldn't save setting" })
     );
   });
 });

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -578,7 +578,7 @@ export function AgentSetupWizard({
     notify({
       type: "info",
       title: "Crash reporting off by default",
-      message: "Crash reporting is off. Enable it in Settings → Privacy & Data",
+      message: "Enable it anytime in Settings → Privacy & Data",
       priority: "low",
       countable: false,
     });
@@ -709,6 +709,13 @@ export function AgentSetupWizard({
             ))}
           </div>
           <div className="flex items-center gap-2">
+            {state.step.type === "agents" &&
+              !showLoadingSelections &&
+              selectedAgentIds.length === 0 && (
+                <span aria-live="polite" className="text-xs text-daintree-text/50">
+                  Select at least one agent to continue
+                </span>
+              )}
             {state.step.type !== "complete" &&
               (state.history.length > 0 ? (
                 <Button
@@ -784,9 +791,7 @@ function AppearanceStep({
   return (
     <section>
       <h3 className="text-base font-semibold text-daintree-text mb-2">Appearance</h3>
-      <p className="text-sm text-daintree-text/60 mb-4">
-        Choose your preferred theme. More options available in Settings.
-      </p>
+      <p className="text-sm text-daintree-text/60 mb-4">Choose your preferred theme</p>
       <div className="grid grid-cols-2 gap-4" role="listbox" aria-label="Select theme">
         {schemes.map((scheme) => {
           const isSelected = selectedSchemeId === scheme.id;
@@ -873,7 +878,7 @@ function AgentsStep({
         <p className="text-sm text-daintree-text/60 mb-4">
           Select the agents you want in your workflow. Already-installed agents are pre-selected.
           You can change this anytime from{" "}
-          <span className="text-daintree-text/80">Settings &gt; Agents</span>.
+          <span className="text-daintree-text/80">Settings → Agents</span>.
         </p>
         {isLoading ? (
           <Skeleton label="Loading agents" className="space-y-2">
@@ -1027,7 +1032,7 @@ export function CompleteStep({
         <p className="text-sm text-daintree-text/60">
           {hasAgents
             ? `You have ${installedAgents.length} agent${installedAgents.length === 1 ? "" : "s"} ready to use. Launch them from the toolbar or with keyboard shortcuts.`
-            : "No agents were installed. You can install them later from Settings > Agents."}
+            : "No agents were installed. You can install them later from Settings → Agents."}
         </p>
       </div>
 
@@ -1077,7 +1082,7 @@ export function CompleteStep({
       )}
 
       <p className="text-xs text-daintree-text/40">
-        You can re-run this wizard from Settings &gt; Agents
+        You can re-run this wizard from Settings → Agents
       </p>
     </div>
   );

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronDown, CircleCheck, Loader2, RotateCw, CircleX } from "lucide-react";
 import { m, useReducedMotion } from "framer-motion";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { UI_ENTER_DURATION } from "@/lib/animationUtils";
 import { useSystemHealthCheck } from "./useSystemHealthCheck";
 import { PrerequisiteCard } from "./SystemToolsStep";
@@ -141,14 +142,18 @@ export function SystemRequirementsSection({
           )}
 
           {visibleSpecs.length === 0 && isChecking && (
-            <div className="grid grid-cols-2 gap-2">
+            <Skeleton label="Checking system requirements" className="grid grid-cols-2 gap-2">
+              {/* `immediate` — spawning version-check processes reliably
+                  exceeds the 400ms gate. */}
               {Array.from({ length: 4 }, (_, i) => (
-                <div
+                <SkeletonBone
                   key={i}
-                  className="rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30 px-3 py-2.5 animate-pulse h-[52px]"
+                  immediate
+                  heightPx={52}
+                  className="rounded-[var(--radius-md)]"
                 />
               ))}
-            </div>
+            </Skeleton>
           )}
 
           {allDone && hasFatalFailure && (

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1532,11 +1532,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               { source: "user" }
             );
           }}
-          className={`inline-flex items-center justify-center self-stretch px-1.5 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent ${
-            canArmMatching
-              ? "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]"
-              : "text-daintree-text/25 cursor-not-allowed"
-          }`}
+          className="inline-flex items-center justify-center self-stretch px-1.5 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06] aria-disabled:opacity-40 aria-disabled:cursor-not-allowed aria-disabled:hover:bg-transparent aria-disabled:hover:text-daintree-text/60"
           aria-label={armMatchingLabel}
         >
           <Zap className="w-3 h-3" aria-hidden="true" />

--- a/src/components/Terminal/ArtifactOverlay.tsx
+++ b/src/components/Terminal/ArtifactOverlay.tsx
@@ -429,7 +429,7 @@ export function ArtifactOverlay({ terminalId, worktreeId, cwd, className }: Arti
         <button
           onClick={() => setIsExpanded(true)}
           className={cn(
-            "px-3 py-2 rounded-[var(--radius-md)] shadow-lg",
+            "px-3 py-2 rounded-[var(--radius-md)] bg-daintree-bg shadow-[var(--theme-shadow-floating)]",
             "border border-status-info/30 text-status-info hover:bg-status-info/10",
             "text-sm font-medium transition-colors",
             "flex items-center gap-2"

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -51,7 +51,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
       <div
         ref={ref}
         className={cn(
-          "absolute bottom-full mb-0 w-[420px] max-w-[calc(100vw-16px)] overflow-hidden rounded-md border border-tint/10 bg-surface shadow-[var(--theme-shadow-floating)]",
+          "absolute bottom-full mb-0 w-[420px] max-w-[calc(100vw-16px)] overflow-hidden rounded-lg border border-tint/10 bg-surface shadow-[var(--theme-shadow-floating)]",
           "z-50"
         )}
         style={style}

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -165,7 +165,7 @@ export function ContentGridEmptyState({
             variant="zero-data"
             scale="canvas"
             icon={<FolderOpen />}
-            title="Open a Git repository"
+            title="Open a project folder"
             description="Worktrees let you work on multiple tasks in isolated environments"
             action={
               <Button
@@ -175,7 +175,7 @@ export function ContentGridEmptyState({
                   void actionService.dispatch("project.add", undefined, { source: "user" });
                 }}
               >
-                Open directory...
+                Open folder…
               </Button>
             }
           />

--- a/src/components/Terminal/GridNotificationBar.tsx
+++ b/src/components/Terminal/GridNotificationBar.tsx
@@ -307,7 +307,7 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
                   void action.onClick();
                 }}
                 className={cn(
-                  "h-7 rounded-[var(--radius-sm)] px-3 text-xs font-medium transition-colors",
+                  "h-7 rounded-[var(--radius-xs)] px-3 text-xs font-medium transition-colors",
                   "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/60",
                   action.variant === "secondary"
                     ? "border border-tint/15 bg-tint/5 text-daintree-text/80 hover:bg-tint/10 hover:text-daintree-text"
@@ -327,7 +327,7 @@ export function GridNotificationBar({ className }: GridNotificationBarProps) {
             type="button"
             onClick={() => removeNotification(displayedNotification.id)}
             className={cn(
-              "h-7 shrink-0 rounded-[var(--radius-sm)] border border-tint/10 bg-tint/5 px-2 text-xs text-daintree-text/60 transition-colors hover:bg-tint/10 hover:text-daintree-text/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/60",
+              "h-7 shrink-0 rounded-[var(--radius-xs)] border border-tint/10 bg-tint/5 px-2 text-xs text-daintree-text/60 transition-colors hover:bg-tint/10 hover:text-daintree-text/80 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent/60",
               buttonPointerClass
             )}
             {...interactionGuard}

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -738,7 +738,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             ref={inputShellRef}
             className={cn(
               "group/shell relative",
-              "flex w-full items-center gap-1.5 rounded-sm border py-2 transition-[border-color,background-color,box-shadow] duration-150",
+              "flex w-full items-center gap-1.5 rounded-md border py-2 transition-[border-color,background-color,box-shadow] duration-150",
               !isSpecialState && [
                 "bg-[var(--ib-bg)] border-[var(--ib-border)] shadow-[var(--ib-shadow)]",
                 "hover:border-[var(--ib-border-hover)] hover:bg-[var(--ib-hover-bg)]",
@@ -785,12 +785,12 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               }
             />
             {isDragOverFiles && (
-              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-sm bg-daintree-bg/80 pointer-events-none">
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-daintree-bg/80 pointer-events-none">
                 <span className="text-xs font-medium text-daintree-accent">Drop to attach</span>
               </div>
             )}
             {isVoiceSubmitting && (
-              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-sm bg-daintree-bg/80 pointer-events-none">
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-daintree-bg/80 pointer-events-none">
                 <Loader2 className="h-4 w-4 animate-spin text-daintree-accent" />
               </div>
             )}
@@ -879,7 +879,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         <AppDialog
           isOpen={isExpanded}
           onClose={collapseEditor}
-          size="xl"
+          size="5xl"
           maxHeight="max-h-[70vh]"
           dismissible
         >

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -54,7 +54,7 @@ export function PromptHistoryRow({
         "group relative w-full flex items-center justify-between gap-2 px-3 py-2 rounded-[var(--radius-md)] text-sm text-left transition-colors",
         "border border-transparent text-daintree-text/80",
         "hover:bg-overlay-subtle hover:text-daintree-text",
-        "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+        "aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text",
         "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
         "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
       )}

--- a/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx
@@ -100,7 +100,7 @@ export function RecipeRunnerList({
               value={searchQuery}
               onChange={(e) => onSearchChange(e.target.value)}
               placeholder="Search recipes…"
-              className="w-full pl-8 pr-3 py-2 text-sm bg-daintree-sidebar border border-daintree-border rounded-[var(--radius-md)] text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/40 focus:border-daintree-accent/40"
+              className="w-full pl-8 pr-3 py-2 text-sm bg-daintree-sidebar border border-daintree-border rounded-[var(--radius-md)] text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:ring-1 focus:ring-daintree-accent/40 focus:border-daintree-accent/40"
             />
           </div>
         </div>

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -41,11 +41,11 @@ function SendToAgentItemRow({
       className={cn(
         "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
         item.isInputLocked
-          ? "opacity-40 cursor-not-allowed border border-transparent"
+          ? "opacity-50 cursor-not-allowed border border-transparent"
           : [
               "border border-transparent text-daintree-text/70",
               "hover:bg-overlay-subtle hover:text-daintree-text",
-              "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+              "aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text",
               "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
               "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
             ]

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -19,6 +19,7 @@ import type { WhenClauseContext } from "@shared/utils/whenClause";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { closeAndAnnounce } from "@/lib/accessibility";
 import { terminalHasRunningAgentSession } from "@/utils/destructiveSessionConfirm";
+import { KILL_RUNNING_AGENT_DIALOG_COPY } from "@/components/Terminal/TerminalDestructiveActionConfirmDialog";
 import {
   ArrowDownFromLine,
   Bell,
@@ -398,13 +399,7 @@ export function TerminalContextMenu({
           break;
         case "kill":
           if (terminalHasRunningAgentSession(terminal)) {
-            setDestructiveConfirm({
-              kind: "kill",
-              title: "Kill terminal with running agent?",
-              description:
-                "An agent is mid-work in this terminal. Killing it stops the agent and discards its scrollback. The PTY process and any unsaved output will be lost.",
-              confirmLabel: "Kill terminal",
-            });
+            setDestructiveConfirm({ kind: "kill", ...KILL_RUNNING_AGENT_DIALOG_COPY });
             return;
           }
           void actionService.dispatch(
@@ -598,7 +593,7 @@ export function TerminalContextMenu({
           </ContextMenuItem>
           <ContextMenuItem onSelect={() => handleAction("trash")}>
             <Trash2 className={ICON_CLASS} aria-hidden="true" />
-            Close browser
+            Trash browser
           </ContextMenuItem>
           <ContextMenuItem destructive onSelect={() => handleAction("kill")}>
             <OctagonX className={ICON_CLASS} aria-hidden="true" />
@@ -655,7 +650,7 @@ export function TerminalContextMenu({
           </ContextMenuItem>
           <ContextMenuItem onSelect={() => handleAction("trash")}>
             <Trash2 className={ICON_CLASS} aria-hidden="true" />
-            Close dev preview
+            Trash dev preview
           </ContextMenuItem>
           <ContextMenuItem destructive onSelect={() => handleAction("kill")}>
             <OctagonX className={ICON_CLASS} aria-hidden="true" />
@@ -698,7 +693,7 @@ export function TerminalContextMenu({
           </ContextMenuItem>
           <ContextMenuItem onSelect={() => handleAction("trash")}>
             <Trash2 className={ICON_CLASS} aria-hidden="true" />
-            Close review
+            Trash review
           </ContextMenuItem>
           <ContextMenuItem destructive onSelect={() => handleAction("kill")}>
             <OctagonX className={ICON_CLASS} aria-hidden="true" />

--- a/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
+++ b/src/components/Terminal/TerminalDestructiveActionConfirmDialog.tsx
@@ -13,15 +13,18 @@ interface DialogCopy {
   confirmLabel: string;
 }
 
+// Shared with TerminalContextMenu's local kill dialog so the two copies can't drift.
+export const KILL_RUNNING_AGENT_DIALOG_COPY: DialogCopy = {
+  title: "Kill terminal with running agent?",
+  description:
+    "An agent is mid-work in this terminal. Killing it stops the agent and discards its scrollback. The terminal process and any unsaved output will be lost.",
+  confirmLabel: "Kill terminal",
+};
+
 function buildCopy(pending: TerminalPendingDestructiveActionSnapshot): DialogCopy {
   switch (pending.kind) {
     case "kill":
-      return {
-        title: "Kill terminal with running agent?",
-        description:
-          "An agent is mid-work in this terminal. Killing it stops the agent and discards its scrollback. The PTY process and any unsaved output will be lost.",
-        confirmLabel: "Kill terminal",
-      };
+      return KILL_RUNNING_AGENT_DIALOG_COPY;
     case "restart":
       return {
         title: "Restart terminal with running agent?",

--- a/src/components/Terminal/TerminalSearchBar.tsx
+++ b/src/components/Terminal/TerminalSearchBar.tsx
@@ -312,7 +312,7 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
     <div
       className={cn(
         "absolute top-2 right-2 z-20",
-        "flex items-center gap-1 px-2 py-1.5",
+        "flex items-center gap-1 px-2 py-1",
         "bg-daintree-sidebar border border-daintree-border rounded-[var(--radius-md)] shadow-[var(--theme-shadow-floating)]",
         className
       )}
@@ -334,7 +334,7 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
               "w-44 px-2 py-1 text-sm rounded transition-colors",
               "bg-daintree-bg border",
               "focus:outline-hidden focus:ring-1",
-              "text-daintree-text placeholder:text-text-muted",
+              "text-daintree-text placeholder:text-text-placeholder",
               searchStatus === "invalidRegex"
                 ? "border-status-error/50 focus:border-status-error focus:ring-status-error/30"
                 : "border-daintree-border focus:ring-status-info"
@@ -354,7 +354,7 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
               "px-1.5 py-1 text-xs rounded transition-colors",
               caseSensitive
                 ? "bg-status-info text-daintree-bg"
-                : "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+                : "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-medium"
             )}
             aria-label="Toggle case sensitivity"
             aria-pressed={caseSensitive}
@@ -373,7 +373,7 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
               "px-1.5 py-1 text-xs font-mono rounded transition-colors",
               regexEnabled
                 ? "bg-status-info text-daintree-bg"
-                : "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+                : "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-medium"
             )}
             aria-label="Toggle regex mode"
             aria-pressed={regexEnabled}
@@ -392,7 +392,7 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
               "px-1.5 py-1 text-xs rounded transition-colors",
               wholeWord
                 ? "bg-status-info text-daintree-bg"
-                : "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+                : "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-medium"
             )}
             aria-label="Toggle whole word"
             aria-pressed={wholeWord}
@@ -445,12 +445,12 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
               disabled={!searchTerm}
               className={cn(
                 "p-1 rounded transition-colors",
-                "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg",
-                "disabled:opacity-30 disabled:cursor-not-allowed"
+                "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-medium",
+                "disabled:opacity-40 disabled:pointer-events-none"
               )}
               aria-label="Previous match"
             >
-              <ChevronUp className="w-4 h-4" />
+              <ChevronUp className="w-3.5 h-3.5" />
             </button>
           </span>
         </TooltipTrigger>
@@ -465,12 +465,12 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
               disabled={!searchTerm}
               className={cn(
                 "p-1 rounded transition-colors",
-                "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg",
-                "disabled:opacity-30 disabled:cursor-not-allowed"
+                "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-medium",
+                "disabled:opacity-40 disabled:pointer-events-none"
               )}
               aria-label="Next match"
             >
-              <ChevronDown className="w-4 h-4" />
+              <ChevronDown className="w-3.5 h-3.5" />
             </button>
           </span>
         </TooltipTrigger>
@@ -483,11 +483,11 @@ export function TerminalSearchBar({ terminalId, onClose, className }: TerminalSe
             onClick={handleClose}
             className={cn(
               "p-1 rounded transition-colors",
-              "text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-bg"
+              "text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-medium"
             )}
             aria-label="Close search"
           >
-            <X className="w-4 h-4" />
+            <X className="w-3.5 h-3.5" />
           </button>
         </TooltipTrigger>
         <TooltipContent side="bottom">Close (Esc)</TooltipContent>

--- a/src/components/Terminal/UpdateCwdDialog.tsx
+++ b/src/components/Terminal/UpdateCwdDialog.tsx
@@ -46,7 +46,7 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
     try {
       const exists = await systemClient.checkDirectory(newCwd);
       if (!exists) {
-        setValidationError("Directory does not exist");
+        setValidationError("Directory doesn't exist");
         return;
       }
 
@@ -57,7 +57,7 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
 
       onClose();
     } catch (error) {
-      setValidationError("Could not restart terminal. Please try again.");
+      setValidationError("Couldn't restart terminal. Try again.");
       logError("Failed to update CWD and restart", error);
     } finally {
       setValidating(false);
@@ -92,7 +92,7 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
         <div className="space-y-4">
           <div>
             <label className="block text-sm font-medium text-daintree-text/70 mb-1">
-              Current (invalid):
+              Current directory
             </label>
             <code className="block p-2 bg-[color-mix(in_oklab,var(--color-status-error)_10%,transparent)] border border-status-error/30 rounded text-sm text-status-error font-mono truncate">
               {currentCwd}
@@ -104,7 +104,7 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
               htmlFor="new-cwd-input"
               className="block text-sm font-medium text-daintree-text/70 mb-1"
             >
-              New Directory:
+              New directory
             </label>
             <input
               ref={inputRef}
@@ -140,7 +140,7 @@ export function UpdateCwdDialog({ isOpen, terminalId, currentCwd, onClose }: Upd
           Cancel
         </Button>
         <Button onClick={handleUpdate} disabled={validating}>
-          {validating ? "Updating..." : "Update & Restart"}
+          {validating ? "Updating…" : "Update and restart"}
         </Button>
       </AppDialog.Footer>
     </AppDialog>

--- a/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
+++ b/src/components/Terminal/__tests__/contentGridEmptyState.test.ts
@@ -62,9 +62,9 @@ describe("ContentGrid EmptyState — quiet no-worktree variants (issue #6935)", 
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain("Select a worktree");
     expect(content).toContain("Choose a worktree from the sidebar to open it in the canvas");
-    expect(content).toContain("Open a Git repository");
+    expect(content).toContain("Open a project folder");
     expect(content).toContain("Worktrees let you work on multiple tasks in isolated environments");
-    expect(content).toContain("Open directory...");
+    expect(content).toContain("Open folder…");
     expect(content).toContain('"project.add"');
   });
 
@@ -117,7 +117,7 @@ describe("ContentGrid EmptyState — structured empty state integration (issue #
     const content = await readFile(EMPTY_STATE_PATH, "utf-8");
     expect(content).toContain('variant="outline"');
     expect(content).toContain('size="sm"');
-    expect(content).toContain("Open directory...");
+    expect(content).toContain("Open folder…");
   });
 
   it("dispatches project.add via actionService with source: user", async () => {

--- a/src/components/Terminal/__tests__/contentGridTips.test.tsx
+++ b/src/components/Terminal/__tests__/contentGridTips.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../../../../shared/utils/agentAvailability", () => ({
 }));
 
 import { RotatingTip, TIPS } from "../contentGridTips";
+import { keybindingService } from "@/services/KeybindingService";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 
@@ -115,6 +116,28 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     const { container } = render(<RotatingTip />);
     setHydrated(counts);
     expect(container.querySelector("button")?.textContent).toBe("Inject Context");
+  });
+
+  it("excludes shortcut-dependent tips whose binding has been removed", () => {
+    // terminal.inject is the unique zero-count tip, so it would win the bias —
+    // but its binding is gone, so it must be filtered from the candidate pool
+    // instead of rendering the hardcoded ⌘-glyph fallback.
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const realGetDisplayCombo = keybindingService.getDisplayCombo.bind(keybindingService);
+    vi.spyOn(keybindingService, "getDisplayCombo").mockImplementation((actionId: string) =>
+      actionId === "terminal.inject" ? "" : realGetDisplayCombo(actionId)
+    );
+    const counts: Record<string, number> = {};
+    for (const tip of TIPS) {
+      const key = tip.shortcutActionId ?? tip.actionId;
+      if (key && key !== "terminal.inject") {
+        counts[key] = 999;
+      }
+    }
+    const { container } = render(<RotatingTip />);
+    setHydrated(counts);
+    expect(container.querySelector("button")?.textContent).not.toBe("Inject Context");
+    expect(container.textContent ?? "").not.toContain("⌘⇧I");
   });
 
   it("limits selection to the lowest-count subset (high-count tips never win)", () => {

--- a/src/components/Terminal/contentGridTips.tsx
+++ b/src/components/Terminal/contentGridTips.tsx
@@ -3,6 +3,7 @@ import { useStore } from "zustand";
 import { Kbd } from "@/components/ui/Kbd";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { actionService } from "@/services/ActionService";
+import { keybindingService } from "@/services/KeybindingService";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
@@ -20,6 +21,8 @@ export interface TipEntry {
   shortcutActionId?: ActionId;
   actionLabel?: string;
   requiredAgents?: BuiltInAgentId[];
+  /** The fallback message hardcodes a key combo — skip the tip when the binding is gone. */
+  requiresShortcut?: boolean;
 }
 
 export const TIPS: TipEntry[] = [
@@ -37,6 +40,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "nav.quickSwitcher",
     actionLabel: "Open Quick Switcher",
+    requiresShortcut: true,
   },
   {
     id: "new-terminal",
@@ -52,6 +56,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "terminal.new",
     actionLabel: "New Terminal",
+    requiresShortcut: true,
   },
   {
     id: "panel-palette",
@@ -68,6 +73,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "panel.palette",
     actionLabel: "Open Panel Palette",
+    requiresShortcut: true,
   },
   {
     id: "launch-claude",
@@ -83,6 +89,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "agent.terminal",
     actionLabel: "Launch Agent",
+    requiresShortcut: true,
     requiredAgents: ["claude"],
   },
   {
@@ -99,6 +106,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "agent.terminal",
     actionLabel: "Launch Agent",
+    requiresShortcut: true,
     requiredAgents: ["gemini"],
   },
   {
@@ -115,21 +123,23 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "terminal.inject",
     actionLabel: "Inject Context",
+    requiresShortcut: true,
   },
   {
     id: "action-palette",
     message: (
       <>
-        Press <Kbd>⌘⇧P</Kbd> to open the action palette and search all available commands
+        Press <Kbd>⌘⇧P</Kbd> to open the command palette and search all available commands
       </>
     ),
     messageWithShortcut: (shortcut) => (
       <>
-        Press <Kbd>{shortcut}</Kbd> to open the action palette and search all available commands
+        Press <Kbd>{shortcut}</Kbd> to open the command palette and search all available commands
       </>
     ),
     actionId: "action.palette.open",
-    actionLabel: "Open Action Palette",
+    actionLabel: "Open Command Palette",
+    requiresShortcut: true,
   },
   {
     id: "worktree-palette",
@@ -145,6 +155,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "worktree.openPalette",
     actionLabel: "Open Worktree Palette",
+    requiresShortcut: true,
   },
   {
     id: "worktree-overview",
@@ -161,6 +172,7 @@ export const TIPS: TipEntry[] = [
     actionId: "worktree.overview.open",
     shortcutActionId: "worktree.overview",
     actionLabel: "Open Worktrees Overview",
+    requiresShortcut: true,
   },
   {
     id: "agent-switcher",
@@ -176,6 +188,7 @@ export const TIPS: TipEntry[] = [
     ),
     actionId: "agent.palette",
     actionLabel: "Open Agent Switcher",
+    requiresShortcut: true,
   },
   {
     id: "recipes",
@@ -217,7 +230,12 @@ export function RotatingTip() {
     () =>
       TIPS.filter(
         (tip) =>
-          !tip.requiredAgents || tip.requiredAgents.some((a) => isAgentLaunchable(availability[a]))
+          (!tip.requiredAgents ||
+            tip.requiredAgents.some((a) => isAgentLaunchable(availability[a]))) &&
+          // Mirrors WelcomeScreen's SHORTCUT_TIPS filter: never teach a combo
+          // the user has unbound or rebound away.
+          (!tip.requiresShortcut ||
+            Boolean(keybindingService.getDisplayCombo(tip.shortcutActionId ?? tip.actionId ?? "")))
       ),
     [availability]
   );

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -138,7 +138,7 @@ export function NewTerminalPalette({
                   "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
                   "border border-transparent text-daintree-text/70",
                   "hover:bg-overlay-subtle hover:text-daintree-text",
-                  "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+                  "aria-selected:bg-overlay-raised aria-selected:border-overlay aria-selected:text-daintree-text",
                   "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
                   "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
                 )}

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -675,7 +675,7 @@ export function RecipeEditor({
             Cancel
           </Button>
           <Button onClick={handleSave} disabled={isSaving}>
-            {isSaving ? "Saving..." : recipe ? "Update Recipe" : "Create Recipe"}
+            {isSaving ? "Saving…" : recipe ? "Update Recipe" : "Create Recipe"}
           </Button>
         </AppDialog.Footer>
       </AppDialog>

--- a/src/components/TerminalRecipe/RecipeEditor.tsx
+++ b/src/components/TerminalRecipe/RecipeEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import type { TerminalRecipe, RecipeTerminal, RecipeTerminalType } from "@/types";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { useRecipeStore, MAX_TERMINALS_PER_RECIPE } from "@/store/recipeStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
@@ -145,12 +146,16 @@ export function RecipeEditor({
     [recipeName, terminals, showInEmptyState, autoAssign]
   );
 
-  const { onBeforeClose } = useUnsavedChanges({ isDirty });
+  const { onBeforeClose, isConfirmOpen, closeConfirm } = useUnsavedChanges({ isDirty });
 
-  const handleCancel = useCallback(async () => {
-    const canClose = await onBeforeClose();
-    if (canClose) onClose();
+  const handleCancel = useCallback(() => {
+    if (onBeforeClose()) onClose();
   }, [onBeforeClose, onClose]);
+
+  const handleDiscard = useCallback(() => {
+    closeConfirm();
+    onClose();
+  }, [closeConfirm, onClose]);
 
   useEffect(() => {
     if (isOpen) {
@@ -247,427 +252,446 @@ export function RecipeEditor({
     }
   };
 
+  const recipeDisplayName = (recipe?.name ?? recipeName).trim();
+
   return (
-    <AppDialog
-      isOpen={isOpen}
-      onClose={onClose}
-      onBeforeClose={onBeforeClose}
-      size="lg"
-      dismissible={!isSaving}
-    >
-      <AppDialog.Header>
-        <AppDialog.Title>{recipe ? "Edit Recipe" : "Create Recipe"}</AppDialog.Title>
-      </AppDialog.Header>
+    <>
+      <AppDialog
+        isOpen={isOpen}
+        onClose={onClose}
+        onBeforeClose={onBeforeClose}
+        size="lg"
+        dismissible={!isSaving}
+      >
+        <AppDialog.Header>
+          <AppDialog.Title>{recipe ? "Edit Recipe" : "Create Recipe"}</AppDialog.Title>
+        </AppDialog.Header>
 
-      <AppDialog.Body>
-        <div className="mb-4">
-          <label
-            htmlFor="recipe-name"
-            className="block text-sm font-medium text-daintree-text mb-1"
-          >
-            Recipe Name
-          </label>
-          <input
-            ref={recipeNameInputRef}
-            id="recipe-name"
-            type="text"
-            value={recipeName}
-            onChange={(e) => setRecipeName(e.target.value)}
-            placeholder="e.g., Full Stack Dev"
-            className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
-          />
-        </div>
+        <AppDialog.Body>
+          <div className="mb-4">
+            <label
+              htmlFor="recipe-name"
+              className="block text-sm font-medium text-daintree-text mb-1"
+            >
+              Recipe Name
+            </label>
+            <input
+              ref={recipeNameInputRef}
+              id="recipe-name"
+              type="text"
+              value={recipeName}
+              onChange={(e) => setRecipeName(e.target.value)}
+              placeholder="e.g., Full Stack Dev"
+              className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
+            />
+          </div>
 
-        <div className="mb-4">
-          <label
-            htmlFor="recipe-scope"
-            className="block text-sm font-medium text-daintree-text mb-1"
-          >
-            Scope
-          </label>
-          {recipe ? (
-            <div className="px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text text-sm opacity-75">
-              {isInRepoRecipeId(recipe) || recipe.projectId !== undefined
-                ? "Project"
-                : "Global (all projects)"}
-            </div>
-          ) : (
+          <div className="mb-4">
+            <label
+              htmlFor="recipe-scope"
+              className="block text-sm font-medium text-daintree-text mb-1"
+            >
+              Scope
+            </label>
+            {recipe ? (
+              <div className="px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text text-sm opacity-75">
+                {isInRepoRecipeId(recipe) || recipe.projectId !== undefined
+                  ? "Project"
+                  : "Global (all projects)"}
+              </div>
+            ) : (
+              <select
+                id="recipe-scope"
+                value={scope}
+                onChange={(e) => setScope(e.target.value as "global" | "project")}
+                className="w-full px-3 pr-8 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
+              >
+                <option value="project">Project (current project only)</option>
+                <option value="global">Global (all projects)</option>
+              </select>
+            )}
+          </div>
+
+          <div className="mb-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                id="show-in-empty-state"
+                type="checkbox"
+                checked={showInEmptyState}
+                onChange={(e) => setShowInEmptyState(e.target.checked)}
+                aria-describedby="show-in-empty-state-help"
+                className="w-4 h-4 rounded border-daintree-border bg-daintree-bg checked:bg-daintree-accent checked:border-daintree-accent focus:ring-2 focus:ring-daintree-accent"
+              />
+              <span className="text-sm font-medium text-daintree-text">Show in Empty State</span>
+            </label>
+            <p
+              id="show-in-empty-state-help"
+              className="text-xs text-text-muted mt-1 ml-6 select-text"
+            >
+              Display this recipe as a primary launcher when the worktree has no active terminals
+            </p>
+          </div>
+
+          <div className="mb-4">
+            <label
+              htmlFor="auto-assign"
+              className="block text-sm font-medium text-daintree-text mb-1"
+            >
+              Auto-assign Issue
+            </label>
             <select
-              id="recipe-scope"
-              value={scope}
-              onChange={(e) => setScope(e.target.value as "global" | "project")}
+              id="auto-assign"
+              value={autoAssign}
+              onChange={(e) => setAutoAssign(e.target.value as "always" | "never" | "prompt")}
+              aria-describedby="auto-assign-help"
               className="w-full px-3 pr-8 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
             >
-              <option value="project">Project (current project only)</option>
-              <option value="global">Global (all projects)</option>
+              <option value="always">Always assign to me</option>
+              <option value="prompt">Ask before assigning</option>
+              <option value="never">Never assign</option>
             </select>
-          )}
-        </div>
-
-        <div className="mb-4">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              id="show-in-empty-state"
-              type="checkbox"
-              checked={showInEmptyState}
-              onChange={(e) => setShowInEmptyState(e.target.checked)}
-              aria-describedby="show-in-empty-state-help"
-              className="w-4 h-4 rounded border-daintree-border bg-daintree-bg checked:bg-daintree-accent checked:border-daintree-accent focus:ring-2 focus:ring-daintree-accent"
-            />
-            <span className="text-sm font-medium text-daintree-text">Show in Empty State</span>
-          </label>
-          <p
-            id="show-in-empty-state-help"
-            className="text-xs text-text-muted mt-1 ml-6 select-text"
-          >
-            Display this recipe as a primary launcher when the worktree has no active terminals
-          </p>
-        </div>
-
-        <div className="mb-4">
-          <label
-            htmlFor="auto-assign"
-            className="block text-sm font-medium text-daintree-text mb-1"
-          >
-            Auto-assign Issue
-          </label>
-          <select
-            id="auto-assign"
-            value={autoAssign}
-            onChange={(e) => setAutoAssign(e.target.value as "always" | "never" | "prompt")}
-            aria-describedby="auto-assign-help"
-            className="w-full px-3 pr-8 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
-          >
-            <option value="always">Always assign to me</option>
-            <option value="prompt">Ask before assigning</option>
-            <option value="never">Never assign</option>
-          </select>
-          <p id="auto-assign-help" className="text-xs text-text-muted mt-1 select-text">
-            Controls whether the linked GitHub issue is automatically assigned to you during quick
-            worktree creation
-          </p>
-        </div>
-
-        <div className="mb-4">
-          <div className="flex items-center justify-between mb-2">
-            <label className="block text-sm font-medium text-daintree-text">
-              Terminals ({terminals.length}/{MAX_TERMINALS_PER_RECIPE})
-            </label>
-            <Button
-              size="sm"
-              onClick={handleAddTerminal}
-              disabled={terminals.length >= MAX_TERMINALS_PER_RECIPE}
-            >
-              + Add Terminal
-            </Button>
+            <p id="auto-assign-help" className="text-xs text-text-muted mt-1 select-text">
+              Controls whether the linked GitHub issue is automatically assigned to you during quick
+              worktree creation
+            </p>
           </div>
 
-          <div className="space-y-3">
-            {terminals.map((terminal, index) => (
-              <div
-                key={index}
-                className="bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] p-3"
+          <div className="mb-4">
+            <div className="flex items-center justify-between mb-2">
+              <label className="block text-sm font-medium text-daintree-text">
+                Terminals ({terminals.length}/{MAX_TERMINALS_PER_RECIPE})
+              </label>
+              <Button
+                size="sm"
+                onClick={handleAddTerminal}
+                disabled={terminals.length >= MAX_TERMINALS_PER_RECIPE}
               >
-                <div className="flex items-start gap-3">
-                  <div className="flex-1">
-                    <label
-                      htmlFor={`terminal-type-${index}`}
-                      className="block text-xs font-medium text-daintree-text mb-1"
-                    >
-                      Type
-                    </label>
-                    <select
-                      id={`terminal-type-${index}`}
-                      value={terminal.type}
-                      onChange={(e) => {
-                        const newType = e.target.value as RecipeTerminalType;
-                        setTerminals((prev) => {
-                          const updated = [...prev];
-                          const current = updated[index];
-                          if (!current) return prev;
-                          const prevType = current.type;
-                          updated[index] = {
-                            ...current,
-                            type: newType,
-                            // Clear command when switching between types so the new type uses its default
-                            command: newType === prevType ? current.command : "",
-                            // Clear initialPrompt and args when switching to terminal or dev-preview
-                            initialPrompt:
-                              newType === "terminal" || newType === "dev-preview"
-                                ? ""
-                                : current.initialPrompt,
-                            args:
-                              newType === "terminal" || newType === "dev-preview"
-                                ? ""
-                                : current.args,
-                            // Clear devCommand when switching away from dev-preview
-                            devCommand: newType !== "dev-preview" ? "" : current.devCommand,
-                          };
-                          return updated;
-                        });
-                      }}
-                      className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                    >
-                      {TERMINAL_TYPES.map((type) => (
-                        <option key={type} value={type}>
-                          {TYPE_LABELS[type]}
-                        </option>
-                      ))}
-                    </select>
+                + Add Terminal
+              </Button>
+            </div>
+
+            <div className="space-y-3">
+              {terminals.map((terminal, index) => (
+                <div
+                  key={index}
+                  className="bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] p-3"
+                >
+                  <div className="flex items-start gap-3">
+                    <div className="flex-1">
+                      <label
+                        htmlFor={`terminal-type-${index}`}
+                        className="block text-xs font-medium text-daintree-text mb-1"
+                      >
+                        Type
+                      </label>
+                      <select
+                        id={`terminal-type-${index}`}
+                        value={terminal.type}
+                        onChange={(e) => {
+                          const newType = e.target.value as RecipeTerminalType;
+                          setTerminals((prev) => {
+                            const updated = [...prev];
+                            const current = updated[index];
+                            if (!current) return prev;
+                            const prevType = current.type;
+                            updated[index] = {
+                              ...current,
+                              type: newType,
+                              // Clear command when switching between types so the new type uses its default
+                              command: newType === prevType ? current.command : "",
+                              // Clear initialPrompt and args when switching to terminal or dev-preview
+                              initialPrompt:
+                                newType === "terminal" || newType === "dev-preview"
+                                  ? ""
+                                  : current.initialPrompt,
+                              args:
+                                newType === "terminal" || newType === "dev-preview"
+                                  ? ""
+                                  : current.args,
+                              // Clear devCommand when switching away from dev-preview
+                              devCommand: newType !== "dev-preview" ? "" : current.devCommand,
+                            };
+                            return updated;
+                          });
+                        }}
+                        className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                      >
+                        {TERMINAL_TYPES.map((type) => (
+                          <option key={type} value={type}>
+                            {TYPE_LABELS[type]}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+
+                    <div className="flex-1">
+                      <label
+                        htmlFor={`terminal-title-${index}`}
+                        className="block text-xs font-medium text-daintree-text mb-1"
+                      >
+                        Title (optional)
+                      </label>
+                      <input
+                        id={`terminal-title-${index}`}
+                        type="text"
+                        value={terminal.title || ""}
+                        onChange={(e) => handleTerminalChange(index, "title", e.target.value)}
+                        placeholder="Default"
+                        className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                      />
+                    </div>
+
+                    <div className="pt-5">
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => handleRemoveTerminal(index)}
+                        disabled={terminals.length === 1}
+                      >
+                        Remove
+                      </Button>
+                    </div>
                   </div>
 
-                  <div className="flex-1">
-                    <label
-                      htmlFor={`terminal-title-${index}`}
-                      className="block text-xs font-medium text-daintree-text mb-1"
-                    >
-                      Title (optional)
-                    </label>
-                    <input
-                      id={`terminal-title-${index}`}
-                      type="text"
-                      value={terminal.title || ""}
-                      onChange={(e) => handleTerminalChange(index, "title", e.target.value)}
-                      placeholder="Default"
-                      className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                    />
-                  </div>
+                  {terminal.type === "terminal" && (
+                    <>
+                      <div className="mt-2">
+                        <label
+                          htmlFor={`terminal-command-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          Command (optional)
+                        </label>
+                        <input
+                          id={`terminal-command-${index}`}
+                          type="text"
+                          value={terminal.command || ""}
+                          onChange={(e) => handleTerminalChange(index, "command", e.target.value)}
+                          placeholder="e.g., npm run dev"
+                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        />
+                      </div>
+                      <div className="mt-2">
+                        <label
+                          htmlFor={`terminal-exit-behavior-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          After Exit
+                        </label>
+                        <select
+                          id={`terminal-exit-behavior-${index}`}
+                          value={terminal.exitBehavior || "trash"}
+                          onChange={(e) =>
+                            handleTerminalChange(
+                              index,
+                              "exitBehavior",
+                              e.target.value === "trash" ? "" : e.target.value
+                            )
+                          }
+                          aria-describedby={`terminal-exit-behavior-help-${index}`}
+                          className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        >
+                          <option value="trash">Send to Trash (default)</option>
+                          <option value="keep">Keep for Review</option>
+                          <option value="remove">Remove Completely</option>
+                        </select>
+                        <p
+                          id={`terminal-exit-behavior-help-${index}`}
+                          className="text-xs text-text-muted mt-1 select-text"
+                        >
+                          {FAILURE_PRESERVE_CAPTION}
+                        </p>
+                      </div>
+                    </>
+                  )}
 
-                  <div className="pt-5">
-                    <Button
-                      size="sm"
-                      variant="destructive"
-                      onClick={() => handleRemoveTerminal(index)}
-                      disabled={terminals.length === 1}
-                    >
-                      Remove
-                    </Button>
-                  </div>
+                  {terminal.type !== "terminal" && terminal.type !== "dev-preview" && (
+                    <>
+                      <div className="mt-2">
+                        <label
+                          htmlFor={`terminal-args-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          Arguments (optional)
+                        </label>
+                        <input
+                          id={`terminal-args-${index}`}
+                          type="text"
+                          value={terminal.args || ""}
+                          onChange={(e) => handleTerminalChange(index, "args", e.target.value)}
+                          placeholder="e.g., --model claude-opus-4-5"
+                          aria-describedby={`terminal-args-help-${index}`}
+                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        />
+                        <p
+                          id={`terminal-args-help-${index}`}
+                          className="text-xs text-text-muted mt-1 select-text"
+                        >
+                          Additional CLI arguments passed to the agent at launch
+                        </p>
+                      </div>
+                      <div className="mt-2">
+                        <label
+                          htmlFor={`terminal-initial-prompt-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          Initial Prompt (optional)
+                        </label>
+                        <textarea
+                          id={`terminal-initial-prompt-${index}`}
+                          value={terminal.initialPrompt || ""}
+                          onChange={(e) =>
+                            handleTerminalChange(index, "initialPrompt", e.target.value)
+                          }
+                          placeholder="e.g., Review the latest changes and suggest improvements"
+                          rows={2}
+                          aria-describedby={`terminal-initial-prompt-help-${index}`}
+                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text resize-y min-h-[60px]"
+                        />
+                        <RecipeVariablePreview
+                          initialPrompt={terminal.initialPrompt || ""}
+                          worktreeId={worktreeId ?? recipe?.worktreeId}
+                        />
+                        <p
+                          id={`terminal-initial-prompt-help-${index}`}
+                          className="text-xs text-text-muted mt-1 select-text"
+                        >
+                          Variables:{" "}
+                          <code className="text-daintree-text/70">{"{{issue_number}}"}</code>,{" "}
+                          <code className="text-daintree-text/70">{"{{pr_number}}"}</code>,{" "}
+                          <code className="text-daintree-text/70">{"{{number}}"}</code>,{" "}
+                          <code className="text-daintree-text/70">{"{{worktree_path}}"}</code>,{" "}
+                          <code className="text-daintree-text/70">{"{{branch_name}}"}</code>
+                        </p>
+                      </div>
+                      <div className="mt-2">
+                        <label
+                          htmlFor={`terminal-agent-exit-behavior-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          After Exit
+                        </label>
+                        <select
+                          id={`terminal-agent-exit-behavior-${index}`}
+                          value={terminal.exitBehavior || "keep"}
+                          onChange={(e) =>
+                            handleTerminalChange(
+                              index,
+                              "exitBehavior",
+                              e.target.value === "keep" ? "" : e.target.value
+                            )
+                          }
+                          aria-describedby={`terminal-agent-exit-behavior-help-${index}`}
+                          className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        >
+                          <option value="keep">Keep for Review (default)</option>
+                          <option value="trash">Send to Trash</option>
+                          <option value="remove">Remove Completely</option>
+                        </select>
+                        <p
+                          id={`terminal-agent-exit-behavior-help-${index}`}
+                          className="text-xs text-text-muted mt-1 select-text"
+                        >
+                          {FAILURE_PRESERVE_CAPTION}
+                        </p>
+                      </div>
+                    </>
+                  )}
+
+                  {terminal.type === "dev-preview" && (
+                    <>
+                      <div className="mt-2">
+                        <label
+                          htmlFor={`terminal-dev-command-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          Dev Command (optional)
+                        </label>
+                        <input
+                          id={`terminal-dev-command-${index}`}
+                          type="text"
+                          value={terminal.devCommand || ""}
+                          onChange={(e) =>
+                            handleTerminalChange(index, "devCommand", e.target.value)
+                          }
+                          placeholder="e.g., npm run dev"
+                          aria-describedby={`terminal-dev-command-help-${index}`}
+                          className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        />
+                        <p
+                          id={`terminal-dev-command-help-${index}`}
+                          className="text-xs text-text-muted mt-1 select-text"
+                        >
+                          Leave empty to use project default or auto-detect from package.json
+                        </p>
+                      </div>
+                      <div className="mt-2">
+                        <label
+                          htmlFor={`terminal-dev-exit-behavior-${index}`}
+                          className="block text-xs font-medium text-daintree-text mb-1"
+                        >
+                          After Exit
+                        </label>
+                        <select
+                          id={`terminal-dev-exit-behavior-${index}`}
+                          value={terminal.exitBehavior || "trash"}
+                          onChange={(e) =>
+                            handleTerminalChange(
+                              index,
+                              "exitBehavior",
+                              e.target.value === "trash" ? "" : e.target.value
+                            )
+                          }
+                          aria-describedby={`terminal-dev-exit-behavior-help-${index}`}
+                          className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
+                        >
+                          <option value="trash">Send to Trash (default)</option>
+                          <option value="keep">Keep for Review</option>
+                          <option value="remove">Remove Completely</option>
+                        </select>
+                        <p
+                          id={`terminal-dev-exit-behavior-help-${index}`}
+                          className="text-xs text-text-muted mt-1 select-text"
+                        >
+                          {FAILURE_PRESERVE_CAPTION}
+                        </p>
+                      </div>
+                    </>
+                  )}
                 </div>
-
-                {terminal.type === "terminal" && (
-                  <>
-                    <div className="mt-2">
-                      <label
-                        htmlFor={`terminal-command-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        Command (optional)
-                      </label>
-                      <input
-                        id={`terminal-command-${index}`}
-                        type="text"
-                        value={terminal.command || ""}
-                        onChange={(e) => handleTerminalChange(index, "command", e.target.value)}
-                        placeholder="e.g., npm run dev"
-                        className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      />
-                    </div>
-                    <div className="mt-2">
-                      <label
-                        htmlFor={`terminal-exit-behavior-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        After Exit
-                      </label>
-                      <select
-                        id={`terminal-exit-behavior-${index}`}
-                        value={terminal.exitBehavior || "trash"}
-                        onChange={(e) =>
-                          handleTerminalChange(
-                            index,
-                            "exitBehavior",
-                            e.target.value === "trash" ? "" : e.target.value
-                          )
-                        }
-                        aria-describedby={`terminal-exit-behavior-help-${index}`}
-                        className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      >
-                        <option value="trash">Send to Trash (default)</option>
-                        <option value="keep">Keep for Review</option>
-                        <option value="remove">Remove Completely</option>
-                      </select>
-                      <p
-                        id={`terminal-exit-behavior-help-${index}`}
-                        className="text-xs text-text-muted mt-1 select-text"
-                      >
-                        {FAILURE_PRESERVE_CAPTION}
-                      </p>
-                    </div>
-                  </>
-                )}
-
-                {terminal.type !== "terminal" && terminal.type !== "dev-preview" && (
-                  <>
-                    <div className="mt-2">
-                      <label
-                        htmlFor={`terminal-args-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        Arguments (optional)
-                      </label>
-                      <input
-                        id={`terminal-args-${index}`}
-                        type="text"
-                        value={terminal.args || ""}
-                        onChange={(e) => handleTerminalChange(index, "args", e.target.value)}
-                        placeholder="e.g., --model claude-opus-4-5"
-                        aria-describedby={`terminal-args-help-${index}`}
-                        className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      />
-                      <p
-                        id={`terminal-args-help-${index}`}
-                        className="text-xs text-text-muted mt-1 select-text"
-                      >
-                        Additional CLI arguments passed to the agent at launch
-                      </p>
-                    </div>
-                    <div className="mt-2">
-                      <label
-                        htmlFor={`terminal-initial-prompt-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        Initial Prompt (optional)
-                      </label>
-                      <textarea
-                        id={`terminal-initial-prompt-${index}`}
-                        value={terminal.initialPrompt || ""}
-                        onChange={(e) =>
-                          handleTerminalChange(index, "initialPrompt", e.target.value)
-                        }
-                        placeholder="e.g., Review the latest changes and suggest improvements"
-                        rows={2}
-                        aria-describedby={`terminal-initial-prompt-help-${index}`}
-                        className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text resize-y min-h-[60px]"
-                      />
-                      <RecipeVariablePreview
-                        initialPrompt={terminal.initialPrompt || ""}
-                        worktreeId={worktreeId ?? recipe?.worktreeId}
-                      />
-                      <p
-                        id={`terminal-initial-prompt-help-${index}`}
-                        className="text-xs text-text-muted mt-1 select-text"
-                      >
-                        Variables:{" "}
-                        <code className="text-daintree-text/70">{"{{issue_number}}"}</code>,{" "}
-                        <code className="text-daintree-text/70">{"{{pr_number}}"}</code>,{" "}
-                        <code className="text-daintree-text/70">{"{{number}}"}</code>,{" "}
-                        <code className="text-daintree-text/70">{"{{worktree_path}}"}</code>,{" "}
-                        <code className="text-daintree-text/70">{"{{branch_name}}"}</code>
-                      </p>
-                    </div>
-                    <div className="mt-2">
-                      <label
-                        htmlFor={`terminal-agent-exit-behavior-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        After Exit
-                      </label>
-                      <select
-                        id={`terminal-agent-exit-behavior-${index}`}
-                        value={terminal.exitBehavior || "keep"}
-                        onChange={(e) =>
-                          handleTerminalChange(
-                            index,
-                            "exitBehavior",
-                            e.target.value === "keep" ? "" : e.target.value
-                          )
-                        }
-                        aria-describedby={`terminal-agent-exit-behavior-help-${index}`}
-                        className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      >
-                        <option value="keep">Keep for Review (default)</option>
-                        <option value="trash">Send to Trash</option>
-                        <option value="remove">Remove Completely</option>
-                      </select>
-                      <p
-                        id={`terminal-agent-exit-behavior-help-${index}`}
-                        className="text-xs text-text-muted mt-1 select-text"
-                      >
-                        {FAILURE_PRESERVE_CAPTION}
-                      </p>
-                    </div>
-                  </>
-                )}
-
-                {terminal.type === "dev-preview" && (
-                  <>
-                    <div className="mt-2">
-                      <label
-                        htmlFor={`terminal-dev-command-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        Dev Command (optional)
-                      </label>
-                      <input
-                        id={`terminal-dev-command-${index}`}
-                        type="text"
-                        value={terminal.devCommand || ""}
-                        onChange={(e) => handleTerminalChange(index, "devCommand", e.target.value)}
-                        placeholder="e.g., npm run dev"
-                        aria-describedby={`terminal-dev-command-help-${index}`}
-                        className="w-full px-2 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      />
-                      <p
-                        id={`terminal-dev-command-help-${index}`}
-                        className="text-xs text-text-muted mt-1 select-text"
-                      >
-                        Leave empty to use project default or auto-detect from package.json
-                      </p>
-                    </div>
-                    <div className="mt-2">
-                      <label
-                        htmlFor={`terminal-dev-exit-behavior-${index}`}
-                        className="block text-xs font-medium text-daintree-text mb-1"
-                      >
-                        After Exit
-                      </label>
-                      <select
-                        id={`terminal-dev-exit-behavior-${index}`}
-                        value={terminal.exitBehavior || "trash"}
-                        onChange={(e) =>
-                          handleTerminalChange(
-                            index,
-                            "exitBehavior",
-                            e.target.value === "trash" ? "" : e.target.value
-                          )
-                        }
-                        aria-describedby={`terminal-dev-exit-behavior-help-${index}`}
-                        className="w-full px-2 pr-8 py-1.5 bg-daintree-sidebar border border-daintree-border rounded text-sm text-daintree-text"
-                      >
-                        <option value="trash">Send to Trash (default)</option>
-                        <option value="keep">Keep for Review</option>
-                        <option value="remove">Remove Completely</option>
-                      </select>
-                      <p
-                        id={`terminal-dev-exit-behavior-help-${index}`}
-                        className="text-xs text-text-muted mt-1 select-text"
-                      >
-                        {FAILURE_PRESERVE_CAPTION}
-                      </p>
-                    </div>
-                  </>
-                )}
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
 
-        {error && (
-          <div className="mb-4 p-3 bg-status-error/10 border border-status-error/30 rounded-[var(--radius-md)] text-status-error text-sm">
-            {error}
-          </div>
-        )}
-      </AppDialog.Body>
+          {error && (
+            <div className="mb-4 p-3 bg-status-error/10 border border-status-error/30 rounded-[var(--radius-md)] text-status-error text-sm">
+              {error}
+            </div>
+          )}
+        </AppDialog.Body>
 
-      <AppDialog.Footer>
-        <Button variant="outline" onClick={() => void handleCancel()} disabled={isSaving}>
-          Cancel
-        </Button>
-        <Button onClick={handleSave} disabled={isSaving}>
-          {isSaving ? "Saving..." : recipe ? "Update Recipe" : "Create Recipe"}
-        </Button>
-      </AppDialog.Footer>
-    </AppDialog>
+        <AppDialog.Footer>
+          <Button variant="outline" onClick={handleCancel} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving}>
+            {isSaving ? "Saving..." : recipe ? "Update Recipe" : "Create Recipe"}
+          </Button>
+        </AppDialog.Footer>
+      </AppDialog>
+
+      <ConfirmDialog
+        isOpen={isConfirmOpen}
+        onClose={closeConfirm}
+        variant="destructive"
+        zIndex="nested"
+        title={
+          recipeDisplayName ? `Discard changes to '${recipeDisplayName}'?` : "Discard changes?"
+        }
+        description="Your edits to this recipe won't be saved"
+        confirmLabel="Discard changes"
+        onConfirm={handleDiscard}
+      />
+    </>
   );
 }

--- a/src/components/ThemeBrowser/ThemeBrowser.tsx
+++ b/src/components/ThemeBrowser/ThemeBrowser.tsx
@@ -489,7 +489,7 @@ export function ThemeBrowser() {
             onKeyDown={handleSearchKeyDown}
             placeholder="Filter themes..."
             aria-label="Filter themes"
-            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden"
+            className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden"
           />
         </div>
         <div className="flex rounded-[var(--radius-md)] border border-daintree-border overflow-hidden shrink-0">

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -43,7 +43,7 @@ function ThemeListItem({
         "group relative w-full text-left px-3 py-2 rounded-[var(--radius-md)] border flex items-center gap-3 transition-colors",
         "border-daintree-border/40 hover:border-daintree-border/60 hover:bg-surface",
         isSelected &&
-          "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
+          "border-overlay bg-overlay-raised text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
       )}
     >
       <PaletteStrip scheme={scheme} />

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -209,7 +209,7 @@ export function IssuePickerDialog({
             onChange={(e) => setSearch(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Search issues by title or number..."
-            className="w-full pl-10 pr-4 py-2 bg-tint/5 border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent"
+            className="w-full pl-10 pr-4 py-2 bg-tint/5 border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent"
           />
         </div>
 
@@ -221,7 +221,7 @@ export function IssuePickerDialog({
               className={cn(
                 "px-3 py-1 text-xs rounded-full transition-colors capitalize",
                 stateFilter === state
-                  ? "bg-overlay-medium text-daintree-text border border-border-strong"
+                  ? "bg-filter-selected-bg-strong text-daintree-text border border-transparent"
                   : "border border-transparent text-daintree-text/50 hover:text-daintree-text/80 hover:bg-tint/5"
               )}
             >

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -605,7 +605,7 @@ export function NewWorktreeDialog({
                   notify({
                     type: "warning",
                     title: "Couldn't undo assignment",
-                    message: `${formatErrorMessage(err, "Failed to unassign issue")} — you can unassign manually on ${forgeName}`,
+                    message: `${formatErrorMessage(err, "Couldn't unassign issue")} — you can unassign manually on ${forgeName}`,
                   });
                 });
             };
@@ -622,11 +622,11 @@ export function NewWorktreeDialog({
               },
             });
           } catch (assignErr) {
-            const message = formatErrorMessage(assignErr, "Failed to assign issue");
+            const message = formatErrorMessage(assignErr, "Couldn't assign issue");
             const issueUrl = snapIssue.url;
             notify({
               type: "warning",
-              title: "Could not assign issue",
+              title: "Couldn't assign issue",
               message: `${message} — you can assign it manually on ${forgeName}`,
               actions: issueUrl
                 ? [
@@ -647,11 +647,11 @@ export function NewWorktreeDialog({
               .generateRecipeFromActiveTerminals(sourceWorktreeId);
             await spawnPanelsFromRecipe({ terminals, worktreeId, cwd: snapWorktreePath });
           } catch (cloneErr) {
-            const message = formatErrorMessage(cloneErr, "Failed to clone layout");
+            const message = formatErrorMessage(cloneErr, "Couldn't clone layout");
             notify({
               type: "warning",
-              title: "Could not clone layout",
-              message: `${message} — worktree was created successfully`,
+              title: "Couldn't clone layout",
+              message: `${message} — the worktree itself was created`,
             });
           }
         } else if (snapSelectedRecipe) {
@@ -672,7 +672,7 @@ export function NewWorktreeDialog({
               projectId,
             });
           } catch (recipeErr) {
-            const message = formatErrorMessage(recipeErr, "Failed to run recipe");
+            const message = formatErrorMessage(recipeErr, "Couldn't run recipe");
             const recipeId = snapSelectedRecipe.id;
             const recipePath = snapWorktreePath;
             const recipeWorktreeId = worktreeId;
@@ -684,8 +684,8 @@ export function NewWorktreeDialog({
             };
             notify({
               type: "warning",
-              title: "Could not run recipe",
-              message: `${message} — worktree was created successfully`,
+              title: "Couldn't run recipe",
+              message: `${message} — the worktree itself was created`,
               actions: [
                 {
                   label: "Retry recipe",
@@ -708,7 +708,7 @@ export function NewWorktreeDialog({
         onWorktreeCreated?.(worktreeId);
         useAnnouncerStore.getState().announce(`Created worktree ${fullBranchName}`);
       } catch (err: unknown) {
-        const message = formatErrorMessage(err, "Failed to create worktree");
+        const message = formatErrorMessage(err, "Couldn't create worktree");
         if (placeholderPath) {
           useWorktreeSelectionStore.getState().failPendingCreation(placeholderPath, message);
         } else {

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -41,7 +41,7 @@ function RecipeListItem({
           "border-daintree-border/40 hover:border-daintree-border/60",
           "bg-daintree-bg hover:bg-surface transition-colors",
           isSelected &&
-            "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+            "border-overlay bg-overlay-raised text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
         )}
         aria-selected={isSelected}
         role="option"
@@ -68,7 +68,7 @@ function RecipeListItem({
         "border-daintree-border/40 hover:border-daintree-border/60",
         "bg-daintree-bg hover:bg-surface transition-colors",
         isSelected &&
-          "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+          "border-overlay bg-overlay-raised text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
       )}
       aria-selected={isSelected}
       role="option"

--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -387,7 +387,7 @@ export function CommitPanel({
           // Fallback keeps themes without --review-commit-input-bg byte-identical.
           "w-full resize-none rounded-md border border-divider bg-[var(--review-commit-input-bg,var(--color-daintree-bg))] px-3 py-2 text-xs font-mono",
           "min-h-[calc(2lh+1rem)] max-h-[calc(6lh+1rem)] overflow-y-auto",
-          "placeholder:text-daintree-text/30 text-daintree-text",
+          "placeholder:text-text-placeholder text-daintree-text",
           "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent focus:border-transparent",
           "disabled:opacity-50 disabled:cursor-not-allowed"
         )}

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1540,7 +1540,7 @@ export function ReviewHubContent({
                         "inline-flex items-center justify-center p-0.5 rounded",
                         "text-daintree-text/60 hover:bg-tint/5 hover:text-daintree-text",
                         "transition-colors cursor-pointer",
-                        "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
+                        "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
                       )}
                       aria-label={`View pull request #${worktreePR.prNumber}`}
                     >
@@ -1568,7 +1568,7 @@ export function ReviewHubContent({
                 onClick={() => handleDiffModeChange("working-tree")}
                 className={cn(
                   "px-2 py-1 transition-colors",
-                  "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent",
+                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
                   diffMode === "working-tree"
                     ? "bg-filter-selected-bg-strong text-daintree-text"
                     : "text-daintree-text/50 hover:text-daintree-text hover:bg-tint/[0.06]"
@@ -1582,7 +1582,7 @@ export function ReviewHubContent({
                 disabled={!status?.currentBranch || status.currentBranch === mainBranch}
                 className={cn(
                   "px-2 py-1 transition-colors border-l border-tint/[0.08]",
-                  "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent",
+                  "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent",
                   "disabled:opacity-40 disabled:cursor-not-allowed",
                   diffMode === "base-branch"
                     ? "bg-filter-selected-bg-strong text-daintree-text"
@@ -1979,7 +1979,7 @@ export function ReviewHubContent({
                                 className={cn(
                                   "w-[120px] h-5 pl-6 pr-1.5 rounded text-[11px]",
                                   "bg-tint/[0.04] border border-tint/[0.08]",
-                                  "text-daintree-text placeholder:text-daintree-text/25",
+                                  "text-daintree-text placeholder:text-text-placeholder",
                                   "focus:outline-hidden focus:border-daintree-accent/40",
                                   "hover:bg-tint/[0.06] transition-colors"
                                 )}
@@ -2217,7 +2217,7 @@ export function ReviewHubContent({
                                 className={cn(
                                   "w-[120px] h-5 pl-6 pr-1.5 rounded text-[11px]",
                                   "bg-tint/[0.04] border border-tint/[0.08]",
-                                  "text-daintree-text placeholder:text-daintree-text/25",
+                                  "text-daintree-text placeholder:text-text-placeholder",
                                   "focus:outline-hidden focus:border-daintree-accent/40",
                                   "hover:bg-tint/[0.06] transition-colors"
                                 )}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -876,8 +876,7 @@ export function WorktreeCard({
                       ref={dragHandleActivatorRef}
                       data-worktree-row-drag-handle=""
                       className="shrink-0 w-4 flex items-center justify-center cursor-not-allowed opacity-30 touch-none select-none transition-colors motion-reduce:transition-none"
-                      aria-label="Manual reorder paused while filter is active"
-                      aria-disabled="true"
+                      aria-hidden="true"
                     >
                       <GripVertical className="w-3 h-3" />
                     </div>
@@ -896,7 +895,11 @@ export function WorktreeCard({
                       ? "bg-overlay-emphasis text-text-primary"
                       : "text-text-primary/25 group-hover/card:text-text-primary/40 group-hover/card:bg-overlay-soft"
                   )}
-                  aria-label="Drag to reorder"
+                  // Pointer-only affordance: the grip is non-focusable (the row
+                  // strips dnd-kit's role/tabIndex), so an aria-label here is
+                  // dead ARIA claiming a phantom control. Keyboard reorder is
+                  // the row's Alt+Arrow path (aria-keyshortcuts on the row).
+                  aria-hidden="true"
                   {...dragHandleListeners}
                 >
                   <GripVertical className="w-3 h-3" />

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -157,12 +157,12 @@ describe("WorktreeCard disabled drag handle (issue #8395)", () => {
     expect(cardSource).toContain("cursor-not-allowed opacity-30");
   });
 
-  it("sets aria-disabled on the disabled grip", () => {
-    expect(cardSource).toContain('aria-disabled="true"');
-  });
-
-  it("labels the disabled grip for screen readers", () => {
-    expect(cardSource).toContain('aria-label="Manual reorder paused while filter is active"');
+  it("hides the pointer-only grips from assistive tech instead of dead aria-labels", () => {
+    // The grips are role-less and non-focusable (SortableWorktreeCard strips
+    // dnd-kit's role/tabIndex), so an aria-label would claim a phantom
+    // control — keyboard reorder is the row's Alt+Arrow path.
+    expect(cardSource).not.toContain('aria-label="Drag to reorder"');
+    expect(cardSource).not.toContain('aria-label="Manual reorder paused while filter is active"');
   });
 
   it("shows the disabled explanation in a TooltipContent", () => {
@@ -176,7 +176,7 @@ describe("WorktreeCard disabled drag handle (issue #8395)", () => {
 
   it("keeps the enabled grip with cursor-grab and dragHandleListeners", () => {
     expect(cardSource).toContain("cursor-grab active:cursor-grabbing");
-    expect(cardSource).toContain('aria-label="Drag to reorder"');
+    expect(cardSource).toContain("{...dragHandleListeners}");
   });
 
   it("preserves the group-hover delay on the enabled grip", () => {

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -148,7 +148,7 @@ export function WorktreeDetails({
                       href={segment.content}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-status-info underline hover:brightness-110 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                      className="text-text-link underline hover:brightness-110 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                       onClick={(e) => handleLinkClick(e, segment.content)}
                     >
                       {segment.content}

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -29,7 +29,7 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
           "border-daintree-border/40 hover:border-daintree-border/60",
           "bg-daintree-bg hover:bg-surface transition-colors",
           isSelected &&
-            "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
+            "border-overlay bg-overlay-raised text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
         )}
         aria-selected={isSelected}
         role="option"

--- a/src/components/Worktree/views/BaseBranchCombobox.tsx
+++ b/src/components/Worktree/views/BaseBranchCombobox.tsx
@@ -97,7 +97,7 @@ export function BaseBranchCombobox({
             <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
             <input
               ref={branchInputRef}
-              className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-daintree-accent/40"
+              className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-text-placeholder disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-daintree-accent/40"
               placeholder="Search branches..."
               value={branchQuery}
               onChange={(e) => onQueryChange(e.target.value)}
@@ -149,7 +149,7 @@ export function BaseBranchCombobox({
                       <div
                         key={`section-${row.label}`}
                         role="presentation"
-                        className="px-2 py-1 text-xs font-medium text-daintree-text/50 uppercase tracking-wider"
+                        className="px-2 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50"
                       >
                         {row.label}
                       </div>

--- a/src/components/Worktree/views/ExistingBranchPicker.tsx
+++ b/src/components/Worktree/views/ExistingBranchPicker.tsx
@@ -60,7 +60,7 @@ export function ExistingBranchPicker({
           <div className="flex items-center border-b border-daintree-border px-3">
             <Search className="mr-2 h-4 w-4 opacity-50 shrink-0" />
             <input
-              className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-daintree-accent/40"
+              className="flex h-10 w-full rounded-[var(--radius-md)] bg-transparent py-3 text-sm outline-hidden placeholder:text-text-placeholder disabled:cursor-not-allowed disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-daintree-accent/40"
               placeholder="Search local branches..."
               value={query}
               onChange={(e) => onQueryChange(e.target.value)}

--- a/src/components/Worktree/views/NewBranchInput.tsx
+++ b/src/components/Worktree/views/NewBranchInput.tsx
@@ -3,6 +3,7 @@ import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { Spinner } from "@/components/ui/Spinner";
 import { Info } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 import type { PrefixSuggestion } from "../branchPrefixUtils";
 
 interface NewBranchInputProps {
@@ -40,6 +41,10 @@ export function NewBranchInput({
   prefixListRef,
   inputRef,
 }: NewBranchInputProps) {
+  // isCheckingBranch goes true on every keystroke (it also gates submit), but
+  // the debounced check usually resolves fast — only show the spinner for
+  // genuinely slow validations.
+  const showCheckingSpinner = useDohertyGate(isCheckingBranch);
   return (
     <div className="space-y-2">
       <label htmlFor="new-branch" className="block text-sm font-medium text-daintree-text">
@@ -73,7 +78,7 @@ export function NewBranchInput({
               aria-controls="prefix-list"
               aria-expanded={prefixPickerOpen}
             />
-            {isCheckingBranch && (
+            {showCheckingSpinner && (
               <Spinner
                 size="md"
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"

--- a/src/components/Worktree/views/NewBranchInput.tsx
+++ b/src/components/Worktree/views/NewBranchInput.tsx
@@ -88,7 +88,7 @@ export function NewBranchInput({
         </PopoverTrigger>
         <PopoverContent
           align="start"
-          className="w-[var(--radix-popover-trigger-width)] p-0 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] shadow-[var(--theme-shadow-floating)]"
+          className="w-[var(--radix-popover-trigger-width)] p-0"
           onOpenAutoFocus={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => e.stopPropagation()}
         >

--- a/src/components/Worktree/views/WorktreePathPicker.tsx
+++ b/src/components/Worktree/views/WorktreePathPicker.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/Spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { FolderOpen, Info } from "lucide-react";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
 
 interface WorktreePathPickerProps {
   value: string;
@@ -24,6 +25,10 @@ export function WorktreePathPicker({
   onBrowseClick,
   disabled,
 }: WorktreePathPickerProps) {
+  // isGeneratingPath goes true on every keystroke (it also gates submit), but
+  // the debounced generation usually resolves fast — only show the spinner for
+  // genuinely slow lookups.
+  const showGeneratingSpinner = useDohertyGate(isGeneratingPath);
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
@@ -61,7 +66,7 @@ export function WorktreePathPicker({
             aria-invalid={errorField === "worktree-path" ? true : undefined}
             aria-describedby={errorField === "worktree-path" ? "validation-error" : undefined}
           />
-          {isGeneratingPath && (
+          {showGeneratingSpinner && (
             <Spinner
               size="md"
               className="absolute right-3 top-1/2 -translate-y-1/2 text-daintree-text/40 pointer-events-none"

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useCallback, useId, createContext, useContext } from "react";
+import {
+  useEffect,
+  useRef,
+  useCallback,
+  useId,
+  createContext,
+  useContext,
+  type CSSProperties,
+} from "react";
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
@@ -25,7 +33,7 @@ import {
 import { X } from "lucide-react";
 import { Button } from "./button";
 
-type DialogSize = "sm" | "md" | "lg" | "xl" | "2xl" | "4xl" | "6xl" | "7xl";
+type DialogSize = "sm" | "md" | "lg" | "4xl" | "5xl" | "6xl" | "7xl";
 type DialogVariant = "default" | "destructive" | "info";
 type DialogZIndex = "modal" | "nested";
 type DialogInitialFocus = "first" | "cancel" | "confirm" | "none";
@@ -90,9 +98,8 @@ const sizeClasses: Record<DialogSize, string> = {
   sm: "max-w-md",
   md: "max-w-xl",
   lg: "max-w-2xl",
-  xl: "max-w-5xl",
-  "2xl": "max-w-4xl",
   "4xl": "max-w-4xl",
+  "5xl": "max-w-5xl",
   "6xl": "max-w-6xl",
   "7xl": "max-w-[min(96rem,92vw)]",
 };
@@ -343,7 +350,7 @@ export function AppDialog({
     <AppDialogContext.Provider value={{ onClose: handleClose, titleId, descriptionId, variant }}>
       <div
         className={cn(
-          "fixed inset-0 flex items-center justify-center bg-scrim-medium backdrop-blur-md backdrop-saturate-[1.25]",
+          "fixed inset-0 flex items-center justify-center bg-scrim-medium backdrop-blur-md backdrop-saturate-[var(--theme-material-saturation)]",
           zIndex === "nested" ? "z-[var(--z-nested-dialog)]" : "z-[var(--z-modal)]",
           "transition-opacity",
           "motion-reduce:transition-none motion-reduce:duration-0",
@@ -378,10 +385,13 @@ export function AppDialog({
             "outline-hidden",
             className
           )}
-          style={{
-            transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
-            transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
-          }}
+          style={
+            {
+              transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
+              transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
+              "--scroll-shadow-color": "var(--color-surface-dialog)",
+            } as CSSProperties
+          }
           onClick={(e) => e.stopPropagation()}
         >
           {children}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { EmptyState } from "@/components/ui/EmptyState";
-import { KbdChord } from "@/components/ui/Kbd";
+import { KBD_CLASS, KbdChord } from "@/components/ui/Kbd";
 import { AccessibilityAnnouncer } from "@/components/Accessibility/AccessibilityAnnouncer";
 import { useOverlayState, useEscapeStack } from "@/hooks";
 import {
@@ -31,8 +31,7 @@ import {
   getUiPaletteTransitionDuration,
 } from "@/lib/animationUtils";
 
-export const KBD_CLASS =
-  "px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/75";
+export { KBD_CLASS };
 
 export interface AppPaletteDialogProps {
   isOpen: boolean;
@@ -185,7 +184,7 @@ export function AppPaletteDialog({
   return createPortal(
     <div
       className={cn(
-        "fixed inset-0 z-[var(--z-modal)] flex items-start justify-center pt-[15vh] bg-scrim-medium backdrop-blur-sm backdrop-saturate-[1.25]",
+        "fixed inset-0 z-[var(--z-modal)] flex items-start justify-center pt-[15vh] bg-scrim-medium backdrop-blur-sm backdrop-saturate-[var(--theme-material-saturation)]",
         "transition-opacity",
         "motion-reduce:transition-none motion-reduce:duration-0",
         isVisible ? "opacity-100" : "opacity-0"
@@ -205,7 +204,7 @@ export function AppPaletteDialog({
         aria-label={ariaLabel}
         tabIndex={-1}
         className={cn(
-          "w-full max-w-xl mx-4 bg-surface-dialog border border-[var(--border-overlay)] rounded-[var(--radius-xl)] shadow-modal overflow-hidden origin-top",
+          "w-full max-w-xl mx-4 bg-surface-dialog border border-border-default rounded-[var(--radius-xl)] shadow-[var(--theme-shadow-dialog)] overflow-hidden origin-top",
           "transition-[opacity,transform]",
           "motion-reduce:transition-opacity motion-reduce:scale-100",
           isVisible ? "opacity-100 scale-100" : "opacity-0 scale-[0.96]",
@@ -439,7 +438,7 @@ AppPaletteDialog.Input = function AppPaletteInput({
           type="text"
           className={cn(
             "flex-1 min-w-0 bg-transparent px-0 py-0 text-sm",
-            "text-daintree-text placeholder:text-text-muted",
+            "text-daintree-text placeholder:text-text-placeholder",
             "focus:outline-hidden focus:border-transparent focus:ring-0",
             className
           )}
@@ -455,7 +454,7 @@ AppPaletteDialog.Input = function AppPaletteInput({
       className={cn(
         "w-full px-3 py-2 text-sm",
         "bg-surface-input border border-daintree-border rounded-[var(--radius-md)]",
-        "text-daintree-text placeholder:text-text-muted",
+        "text-daintree-text placeholder:text-text-placeholder",
         "focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/20",
         className
       )}

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -3,24 +3,16 @@ import { cn } from "@/lib/utils";
 import { isMac } from "@/lib/platform";
 import { parseChord } from "@/lib/kbdShortcut";
 
+export const KBD_CLASS =
+  "px-1.5 py-0.5 rounded-sm text-xs font-mono tabular-nums leading-none bg-overlay-subtle text-daintree-text/70 border border-border-subtle";
+
 export interface KbdProps {
   children: React.ReactNode;
   className?: string;
 }
 
 export function Kbd({ children, className }: KbdProps) {
-  return (
-    <kbd
-      className={cn(
-        "px-1.5 py-0.5 rounded text-xs font-mono tabular-nums",
-        "bg-daintree-border text-daintree-text/70",
-        "border border-daintree-border/60",
-        className
-      )}
-    >
-      {children}
-    </kbd>
-  );
+  return <kbd className={cn(KBD_CLASS, className)}>{children}</kbd>;
 }
 
 export interface KbdChordProps {
@@ -32,7 +24,7 @@ export interface KbdChordProps {
 }
 
 /**
- * Renders a keyboard chord as per-key pills using the neutral overlay surface.
+ * Renders a keyboard chord as per-key chips using the neutral overlay surface.
  * macOS uses glyph keys with no `+` separator; Win/Linux uses spelled-out keys
  * separated by a small `+` character. Two-step chords (`Cmd+K T`) are joined
  * by a comma+space.
@@ -65,14 +57,7 @@ export function KbdChord({
                     +
                   </span>
                 )}
-                <kbd
-                  aria-hidden="true"
-                  className={cn(
-                    "px-1.5 py-0.5 rounded text-xs font-mono tabular-nums leading-none",
-                    "bg-overlay-subtle text-daintree-text/70",
-                    "border border-border-subtle"
-                  )}
-                >
+                <kbd aria-hidden="true" className={KBD_CLASS}>
                   {token}
                 </kbd>
               </Fragment>

--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -18,10 +18,10 @@ const SEVERITY_ICON: Record<NotificationHistoryEntry["type"], typeof AlertCircle
 };
 
 const SEVERITY_CLASS: Record<NotificationHistoryEntry["type"], string> = {
-  error: "text-red-400",
-  warning: "text-amber-400",
-  info: "text-blue-400",
-  success: "text-green-400",
+  error: "text-status-error",
+  warning: "text-status-warning",
+  info: "text-status-info",
+  success: "text-status-success",
 };
 
 export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {

--- a/src/components/ui/ShortcutHint.tsx
+++ b/src/components/ui/ShortcutHint.tsx
@@ -105,8 +105,8 @@ export function ShortcutHint() {
           <div
             className={cn(
               "flex items-center gap-2 px-3 py-1.5",
-              "rounded-[var(--radius-lg)] bg-daintree-sidebar/95 border border-[var(--border-overlay)] shadow-[var(--theme-shadow-floating)]",
-              "text-xs text-daintree-text/70",
+              "rounded-[var(--radius-md)] surface-overlay shadow-overlay",
+              "text-xs text-daintree-text",
               "transition duration-150",
               "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
               isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-1"

--- a/src/components/ui/TypedNameConfirmInput.tsx
+++ b/src/components/ui/TypedNameConfirmInput.tsx
@@ -61,7 +61,7 @@ export function TypedNameConfirmInput({
         aria-invalid={value.length > 0 && !isMatched}
         autoComplete="off"
         spellCheck={false}
-        className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-border-strong rounded focus:outline-hidden focus:ring-2 focus:ring-status-error"
+        className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] focus:outline-hidden focus:ring-2 focus:ring-status-error"
         data-testid={testId}
       />
       <span className="sr-only" aria-live="polite">

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
-import { render, act, screen } from "@testing-library/react";
+import { render, act, screen, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppPaletteDialog } from "../AppPaletteDialog";
 import { usePaletteStore } from "@/store/paletteStore";
 import { _resetForTests } from "@/lib/escapeStack";
+import { TABBABLE_SELECTOR } from "@/lib/accessibility";
 import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
 
 vi.mock("@/hooks", async (importOriginal) => {
@@ -68,6 +69,45 @@ describe("AppPaletteDialog ARIA placement", () => {
     for (const el of scrims) {
       expect(el.getAttribute("role")).not.toBe("dialog");
     }
+  });
+});
+
+describe("AppPaletteDialog focus trap", () => {
+  function renderTrapPalette() {
+    render(
+      <>
+        <Dispatcher />
+        <AppPaletteDialog isOpen onClose={() => {}} ariaLabel="Trap palette">
+          <input type="text" placeholder="Palette input" />
+          <button type="button">Middle action</button>
+          <button type="button">Last action</button>
+        </AppPaletteDialog>
+      </>
+    );
+    const dialog = screen.getByRole("dialog", { name: "Trap palette" });
+    const focusable = dialog.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
+    expect(focusable.length).toBeGreaterThanOrEqual(2);
+    return focusable;
+  }
+
+  it("wraps focus from the last tabbable to the first on Tab", () => {
+    const focusable = renderTrapPalette();
+    const lastEl = focusable[focusable.length - 1]!;
+    lastEl.focus();
+    expect(document.activeElement).toBe(lastEl);
+
+    fireEvent.keyDown(window, { key: "Tab" });
+    expect(document.activeElement).toBe(focusable[0]);
+  });
+
+  it("wraps focus from the first tabbable to the last on Shift+Tab", () => {
+    const focusable = renderTrapPalette();
+    const firstEl = focusable[0]!;
+    firstEl.focus();
+    expect(document.activeElement).toBe(firstEl);
+
+    fireEvent.keyDown(window, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
   });
 });
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -34,7 +34,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground ring-1 ring-tint/[0.08] shadow-[var(--theme-shadow-ambient)] hover:bg-secondary/90 active:shadow-none",
         ghost:
           "text-text-secondary hover:bg-overlay-soft hover:text-daintree-text focus-visible:text-daintree-text",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-text-link underline-offset-4 hover:underline",
         subtle:
           "bg-surface-panel text-text-secondary ring-1 ring-border-strong hover:bg-surface-panel-elevated hover:ring-border-default hover:text-daintree-text",
         pill: "rounded-full bg-surface-panel backdrop-blur-md ring-1 ring-border-strong text-text-secondary hover:bg-surface-panel-elevated hover:ring-border-default hover:text-daintree-text",

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -160,7 +160,7 @@ const ContextMenuSubTrigger = React.forwardRef<
     <SubTrigger
       ref={ref}
       className={cn(
-        "flex cursor-default select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1.5 text-xs outline-hidden focus:bg-overlay-raised data-[state=open]:bg-overlay-raised",
+        "flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1.5 text-xs outline-hidden transition-colors focus:bg-overlay-raised data-[highlighted]:bg-overlay-raised data-[state=open]:bg-overlay-raised",
         inset && "pl-8",
         className
       )}
@@ -347,7 +347,7 @@ const ContextMenuLabel = React.forwardRef<
     <Label
       ref={ref}
       className={cn(
-        "px-2 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
+        "px-2.5 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
         inset && "pl-8",
         className
       )}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -199,7 +199,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     <SubTrigger
       ref={ref}
       className={cn(
-        "flex cursor-default select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1.5 text-xs outline-hidden focus:bg-overlay-raised data-[state=open]:bg-overlay-raised",
+        "flex cursor-pointer select-none items-center rounded-[var(--radius-sm)] px-2.5 py-1.5 text-xs outline-hidden transition-colors focus:bg-overlay-raised data-[highlighted]:bg-overlay-raised data-[state=open]:bg-overlay-raised",
         inset && "pl-8",
         className
       )}
@@ -388,7 +388,7 @@ const DropdownMenuLabel = React.forwardRef<
     <Label
       ref={ref}
       className={cn(
-        "px-2 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
+        "px-2.5 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
         inset && "pl-8",
         className
       )}

--- a/src/components/ui/emoji-picker.tsx
+++ b/src/components/ui/emoji-picker.tsx
@@ -14,7 +14,7 @@ export function EmojiPicker({ className, onEmojiSelect }: EmojiPickerProps) {
       emojibaseUrl="/emojibase"
     >
       <EmojiPickerPrimitive.Search
-        className="z-10 mx-2 mt-2 appearance-none rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border px-3 py-2 text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
+        className="z-10 mx-2 mt-2 appearance-none rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border px-3 py-2 text-sm text-daintree-text placeholder:text-text-placeholder focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
         placeholder="Search emojis..."
       />
       <EmojiPickerPrimitive.Viewport className="relative flex-1 outline-hidden">

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -112,7 +112,7 @@ const SelectTrigger = React.forwardRef<
         onClick={intentClick}
       >
         {children}
-        <ChevronDown className="h-4 w-4 shrink-0 text-daintree-text/50" aria-hidden="true" />
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-daintree-text/40" aria-hidden="true" />
       </button>
     );
   }
@@ -135,7 +135,10 @@ const SelectTrigger = React.forwardRef<
     >
       {children}
       <Icon asChild>
-        <ChevronDown className="h-4 w-4 shrink-0 text-daintree-text/50" aria-hidden="true" />
+        <ChevronDown
+          className="h-3.5 w-3.5 shrink-0 text-daintree-text/40 transition-transform in-data-[state=open]:rotate-180"
+          aria-hidden="true"
+        />
       </Icon>
     </Trigger>
   );
@@ -255,7 +258,7 @@ const SelectLabel = React.forwardRef<
     <Label
       ref={ref}
       className={cn(
-        "px-2 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
+        "px-2.5 py-1.5 text-[11px] font-bold tracking-wider uppercase text-daintree-text/50",
         className
       )}
       {...props}

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -127,6 +127,9 @@ const DURABLE_ALLOWLIST = new Set([
   // PanelPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
   "src/components/PanelPalette/PanelPalette.tsx",
 
+  // ProjectSwitcherPalette selected-row left-edge accent stripe (single primary anchor per active focus region)
+  "src/components/Project/ProjectSwitcherPalette.tsx",
+
   // PluginManagerView selected-row left-edge accent stripe in the master-detail
   // list, plus the detail subtab active-tab underline (single primary anchor per
   // active focus region)

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -160,7 +160,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Browser/WebviewDialog.tsx",
     "src/components/Commands/CommandBuilder.tsx",
     "src/components/Commands/CommandPicker.tsx",
-    "src/components/Commands/CommandPickerHost.tsx",
     "src/components/DevPreview/DevPreviewPane.tsx",
     "src/components/Diagnostics/DiagnosticsDock.tsx",
     "src/components/Diagnostics/TelemetryContent.tsx",

--- a/src/config/__tests__/focusRingFallback.contract.test.ts
+++ b/src/config/__tests__/focusRingFallback.contract.test.ts
@@ -335,7 +335,7 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
   {
     file: "src/components/Settings/KeyboardShortcutsTab.tsx",
     fragment:
-      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-muted focus:outline-hidden",
+      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",
     reason:
       "Parent shows focus: wrapper at line 230 has `focus-within:border-daintree-accent focus-within:ring-1`",
   },
@@ -349,7 +349,7 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
   {
     file: "src/components/FileViewer/FileViewerModal.tsx",
     fragment:
-      "w-44 bg-transparent text-xs text-daintree-text placeholder:text-muted-foreground focus:outline-hidden",
+      "w-44 bg-transparent text-xs text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",
     reason:
       "Parent shows focus: the diff search bar wrapper has `focus-within:border-daintree-accent focus-within:ring-1`",
   },
@@ -368,13 +368,13 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
   {
     file: "src/components/Settings/ColorSchemePicker.tsx",
     fragment:
-      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden",
+      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",
     reason: "Parent shows focus: wrapper at line 172 has `focus-within:border-daintree-accent`",
   },
   {
     file: "src/components/ThemeBrowser/ThemeBrowser.tsx",
     fragment:
-      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden",
+      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",
     reason: "Parent shows focus: wrapper at line 477 has `focus-within:border-daintree-accent`",
   },
   {
@@ -393,14 +393,14 @@ const ALLOWLIST: FocusRingAllowlistEntry[] = [
   {
     file: "src/components/Settings/AgentSelectorDropdown.tsx",
     fragment:
-      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden",
+      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",
     reason:
       "PRE-EXISTING #8940: autoFocus filter input inside popover lacks a focus indicator — follow-up",
   },
   {
     file: "src/components/Settings/ForgeProviderSelectorDropdown.tsx",
     fragment:
-      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden",
+      "flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-text-placeholder focus:outline-hidden",
     reason:
       "PRE-EXISTING #8940: autoFocus filter input inside popover lacks a focus indicator — follow-up",
   },

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -499,7 +499,7 @@ describe("useProjectSwitcherPalette", () => {
       expect(notifyMock).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "error",
-          title: "Failed to close project",
+          title: "Couldn't close project",
         })
       );
     });

--- a/src/hooks/useGlobalEscapeDispatcher.ts
+++ b/src/hooks/useGlobalEscapeDispatcher.ts
@@ -6,6 +6,12 @@ export function useGlobalEscapeDispatcher(): void {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Escape" || e.defaultPrevented || e.isComposing) return;
+      // dnd-kit's pointer sensors cancel an in-flight drag on Escape without
+      // calling preventDefault, so without this guard the same keypress would
+      // also pop the escape stack (dismissing a toast, disarming fleet state,
+      // …). DndProvider maintains the data-dragging flag for every drag;
+      // keyboard drags preventDefault their cancel and never reach here.
+      if (document.documentElement.dataset.dragging === "true") return;
       // The dialog-backstop on document-bubble may have already closed the
       // topmost dialog. With React 18's `useSyncExternalStore` flushing
       // synchronously inside event handlers, that close also unregisters

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -477,16 +477,16 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           } catch (retryError) {
             notify({
               type: "error",
-              title: "Failed to update project",
-              message: formatErrorMessage(retryError, "Failed to update project"),
+              title: "Couldn't update project",
+              message: formatErrorMessage(retryError, "Couldn't update project"),
               actions: [{ label: "Try again", variant: "primary", onClick: retry }],
             });
           }
         };
         notify({
           type: "error",
-          title: "Failed to update project",
-          message: formatErrorMessage(error, "Failed to update project"),
+          title: "Couldn't update project",
+          message: formatErrorMessage(error, "Couldn't update project"),
           actions: [{ label: "Try again", variant: "primary", onClick: retry }],
         });
       }
@@ -518,16 +518,16 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         } catch (retryError) {
           notify({
             type: "error",
-            title: "Failed to stop project",
-            message: formatErrorMessage(retryError, "Failed to stop project"),
+            title: "Couldn't stop project",
+            message: formatErrorMessage(retryError, "Couldn't stop project"),
             actions: [{ label: "Try again", variant: "primary", onClick: retry }],
           });
         }
       };
       notify({
         type: "error",
-        title: "Failed to stop project",
-        message: formatErrorMessage(error, "Failed to stop project"),
+        title: "Couldn't stop project",
+        message: formatErrorMessage(error, "Couldn't stop project"),
         actions: [{ label: "Try again", variant: "primary", onClick: retry }],
       });
     } finally {
@@ -695,10 +695,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
         } catch (retryError) {
           notify({
             type: "error",
-            title: isActive ? "Failed to close project" : "Failed to remove project",
+            title: isActive ? "Couldn't close project" : "Couldn't remove project",
             message: formatErrorMessage(
               retryError,
-              isActive ? "Failed to close project" : "Failed to remove project"
+              isActive ? "Couldn't close project" : "Couldn't remove project"
             ),
             actions: [{ label: "Try again", variant: "primary", onClick: retry }],
           });
@@ -706,12 +706,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       };
       notify({
         type: "error",
-        title: removeConfirmProject.isActive
-          ? "Failed to close project"
-          : "Failed to remove project",
+        title: removeConfirmProject.isActive ? "Couldn't close project" : "Couldn't remove project",
         message: formatErrorMessage(
           error,
-          removeConfirmProject.isActive ? "Failed to close project" : "Failed to remove project"
+          removeConfirmProject.isActive ? "Couldn't close project" : "Couldn't remove project"
         ),
         actions: [{ label: "Try again", variant: "primary", onClick: retry }],
       });

--- a/src/hooks/useUnsavedChanges.ts
+++ b/src/hooks/useUnsavedChanges.ts
@@ -1,18 +1,19 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 export interface UseUnsavedChangesOptions {
   isDirty: boolean;
-  confirmMessage?: string;
 }
 
-export function useUnsavedChanges({
-  isDirty,
-  confirmMessage = "You have unsaved changes. Are you sure you want to close?",
-}: UseUnsavedChangesOptions) {
+export function useUnsavedChanges({ isDirty }: UseUnsavedChangesOptions) {
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
   const onBeforeClose = useCallback(() => {
     if (!isDirty) return true;
-    return window.confirm(confirmMessage);
-  }, [isDirty, confirmMessage]);
+    setIsConfirmOpen(true);
+    return false;
+  }, [isDirty]);
 
-  return { onBeforeClose, isDirty };
+  const closeConfirm = useCallback(() => setIsConfirmOpen(false), []);
+
+  return { onBeforeClose, isConfirmOpen, closeConfirm, isDirty };
 }

--- a/src/lib/projectMruSwitch.ts
+++ b/src/lib/projectMruSwitch.ts
@@ -51,8 +51,8 @@ export async function switchProjectByMruDirection(
   } catch (error) {
     notify({
       type: "error",
-      title: "Failed to switch project",
-      message: formatErrorMessage(error, "Failed to switch project"),
+      title: "Couldn't switch project",
+      message: formatErrorMessage(error, "Couldn't switch project"),
       actions: [
         {
           label: "Try again",

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -596,10 +596,11 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
       "colors",
       "scheme",
       "browse",
+      "change",
     ],
     "kind": "command",
     "requiresArgs": false,
-    "title": "Change Theme...",
+    "title": "Browse Themes…",
   },
   {
     "category": "app",
@@ -616,7 +617,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     ],
     "kind": "command",
     "requiresArgs": false,
-    "title": "Pick Theme...",
+    "title": "Pick Theme…",
   },
   {
     "category": "app",

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -12,7 +12,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "keywords": undefined,
     "kind": "command",
     "requiresArgs": false,
-    "title": "Open Action Palette",
+    "title": "Open Command Palette",
   },
   {
     "category": "app",

--- a/src/services/actions/definitions/__tests__/projectMuteAction.test.ts
+++ b/src/services/actions/definitions/__tests__/projectMuteAction.test.ts
@@ -124,7 +124,7 @@ describe("project.muteNotifications", () => {
     expect(notifyMock).toHaveBeenCalledTimes(1);
     expect(notifyMock.mock.calls[0]![0]).toMatchObject({
       type: "error",
-      title: "Failed to mute notifications",
+      title: "Couldn't mute notifications",
       message: "read failed",
     });
   });

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -147,7 +147,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
 
   actions.set("app.theme.pick", () => ({
     id: "app.theme.pick",
-    title: "Pick Theme...",
+    title: "Pick Theme…",
     description: "Open the theme palette to browse and preview themes",
     category: "app",
     kind: "command",
@@ -162,13 +162,13 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
 
   actions.set("app.theme.browser.open", () => ({
     id: "app.theme.browser.open",
-    title: "Change Theme...",
+    title: "Browse Themes…",
     description: "Open the theme browser to preview and commit a new theme",
     category: "app",
     kind: "command",
     danger: "safe",
     scope: "renderer",
-    keywords: ["appearance", "colors", "scheme", "browse"],
+    keywords: ["appearance", "colors", "scheme", "browse", "change"],
     nonRepeatable: true,
     run: async () => {
       window.dispatchEvent(new CustomEvent("daintree:open-theme-browser"));

--- a/src/services/actions/definitions/navigationActions.ts
+++ b/src/services/actions/definitions/navigationActions.ts
@@ -20,7 +20,7 @@ export function registerNavigationActions(
 
   actions.set("action.palette.open", () => ({
     id: "action.palette.open",
-    title: "Open Action Palette",
+    title: "Open Command Palette",
     description: "Search and execute any action",
     category: "navigation",
     kind: "command",

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -319,8 +319,8 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
           type: "error",
-          title: "Failed to mute notifications",
-          message: formatErrorMessage(error, "Failed to mute project notifications"),
+          title: "Couldn't mute notifications",
+          message: formatErrorMessage(error, "Couldn't mute project notifications"),
           duration: 5000,
         });
         throw error;
@@ -428,8 +428,8 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
           type: "error",
-          title: "Failed to silence notifications",
-          message: formatErrorMessage(error, `Failed to silence ${label}`),
+          title: "Couldn't silence notifications",
+          message: formatErrorMessage(error, `Couldn't silence ${label}`),
           duration: 5000,
         });
         throw error;

--- a/src/store/__tests__/projectStore.addProject.test.ts
+++ b/src/store/__tests__/projectStore.addProject.test.ts
@@ -250,7 +250,7 @@ describe("projectStore addProject", () => {
       await useProjectStore.getState().addProjectByPath("relative/path");
 
       expect(notifyMock).toHaveBeenCalledWith(
-        expect.objectContaining({ title: "Failed to add project" })
+        expect.objectContaining({ title: "Couldn't add project" })
       );
     });
 
@@ -271,7 +271,7 @@ describe("projectStore addProject", () => {
       expect(notifyMock).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "error",
-          title: "Failed to mark as safe",
+          title: "Couldn't mark as safe",
           message: "git binary not on PATH",
         })
       );
@@ -301,7 +301,7 @@ describe("projectStore addProject", () => {
       );
       expect(ownershipToasts).toHaveLength(0);
       const genericToasts = notifyMock.mock.calls.filter(
-        (call) => (call[0] as { title?: string }).title === "Failed to add project"
+        (call) => (call[0] as { title?: string }).title === "Couldn't add project"
       );
       expect(genericToasts.length).toBeGreaterThan(0);
     });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -300,7 +300,7 @@ function getProjectOpenErrorMessage(error: unknown): string {
     return "Permission denied. You don't have access to this directory.";
   }
 
-  return message || "Failed to open project.";
+  return message || "Couldn't open project.";
 }
 
 function isPersistedProject(value: unknown): value is Project {
@@ -346,7 +346,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
         component: "projectStore",
         details: { path: resolvedPath || path },
       });
-      const errorMessage = formatErrorMessage(error, "Failed to add project");
+      const errorMessage = formatErrorMessage(error, "Couldn't add project");
 
       // Absolute-path check: POSIX (/...), Windows drive letter (C:\... / C:/...),
       // and Windows UNC (\\server\share...) are all "absolute" here.
@@ -386,12 +386,12 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
                   } catch (markError) {
                     const markMessage = formatErrorMessage(
                       markError,
-                      "Failed to mark directory as safe"
+                      "Couldn't mark directory as safe"
                     );
                     // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
                     notify({
                       type: "error",
-                      title: "Failed to mark as safe",
+                      title: "Couldn't mark as safe",
                       message: markMessage,
                       duration: 6000,
                     });
@@ -431,7 +431,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       const retryPath = resolvedPath ?? path.trim();
       notify({
         type: "error",
-        title: "Failed to add project",
+        title: "Couldn't add project",
         message,
         actions: [
           {
@@ -540,7 +540,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       const message = getProjectOpenErrorMessage(error);
       notify({
         type: "error",
-        title: "Failed to switch project",
+        title: "Couldn't switch project",
         message,
         actions: [
           {
@@ -727,7 +727,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       const message = getProjectOpenErrorMessage(error);
       notify({
         type: "error",
-        title: "Failed to reopen project",
+        title: "Couldn't reopen project",
         message,
         actions: [
           {


### PR DESCRIPTION
This is a large pass at improving overall UI consistency. There are two parts to it.

## 1. Apply 67 small verified design fixes

A sweep of the renderer UI surfaced a long list of tiny design inconsistencies that accumulated over time. Each fix was independently verified against the actual code before being applied. The highlights:

- Border radius drift from the Tailwind v4 upgrade. Bare `rounded` now resolves to 10px under our theme (it was 4px in v3), so keyboard chips, settings badges, several inputs and a checkbox rendered visibly rounder than their deliberately-authored siblings. The checkbox read as a radio button.
- Dead Tailwind palette color classes (`text-amber-500`, `emerald`, `red`) that silently rendered nothing under our token system. Replaced with the proper `status-*` tokens, so those warning/error accents actually show up now.
- Adopted the `text-placeholder` and `text-link` tokens, which were defined but never used. Placeholders were previously styled five different ways.
- Reconciled the three find bars (terminal, diff viewer, browser) to one recipe: padding, icon sizes, shadows, hover and disabled states.
- Unified the palette dialogs on the shared `AppPaletteDialog` shell. `ProjectSwitcherPalette` was hand-rolling its own modal shell with a different width, surface, radius, shadow and exit motion.
- Aligned dialog chrome with `AppDialog`: header weights, close-button hover, footer gaps, border and shadow tokens.
- Fixed the dialog size scale, where `size="xl"` rendered wider than `size="2xl"`.
- The long tail: icon size drift across identical menus, menu labels misaligned 2px from item text, mixed focus-ring recipes within a single settings tab, and hover/disabled state drift between sibling controls.

## 2. Merge and complete the usability polish branch

This also merges `feature/usability-polish-sweep`, which was interrupted partway through, and finishes the loose ends:

- Regenerates the action manifest snapshot, which was only partially updated.
- Migrates two recipe e2e specs from native `window.confirm` handlers to the new in-app `ConfirmDialog`.
- Finishes the half-done conversion of three-dot ellipsis strings to the `…` character, including the `Saving…` buttons and their e2e selector.

## Tests

Test updates mirror the refactors: the `AppPaletteDialog` and `AppDialog.Footer` mocks now render their children, the palette focus-trap tests moved to `AppPaletteDialog` where the trap actually lives, and `ProjectSwitcherPalette` joins the accent-guard durable allowlist for its selected-row rail. All 33,403 unit tests pass, along with the full check suite.

## Follow-ups

Two things came up during review that I deliberately left out of this PR:

- Preset delete has no confirmation dialog at all, which looks like a gap against the destructive-action tiers.
- `preset-edge-cases.spec.ts` silently stopped testing shell-metacharacter preset names when the prompt flow was removed. It still passes, it just no longer checks anything.
