### PR TITLE
perf(core): last-mile micro-optimizations across main and renderer

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -56,6 +56,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
     getProjectStateWithRecovery: vi.fn(),
     saveProjectState: vi.fn(),
     enqueueProjectStateUpdate: vi.fn(async () => undefined),
+    readInRepoPresets: vi.fn(async () => ({})),
   },
 }));
 
@@ -788,6 +789,83 @@ describe("app:boot handler", () => {
     expect(result.tabGroups).toBeUndefined();
     expect(result.terminalSizes).toBeUndefined();
     expect(result.draftInputs).toBeUndefined();
+  });
+
+  it("folds in-repo project presets into the payload when a project is resolved", async () => {
+    vi.mocked(projectStore.getCurrentProject).mockReturnValue({
+      id: "p1",
+      name: "P",
+      path: "/p",
+    } as unknown as ReturnType<typeof projectStore.getCurrentProject>);
+    const presets = { claude: [{ id: "team-preset", name: "Team" }] };
+    vi.mocked(projectStore.readInRepoPresets).mockResolvedValue(
+      presets as unknown as Awaited<ReturnType<typeof projectStore.readInRepoPresets>>
+    );
+
+    const result = await invokeBoot();
+    expect(projectStore.readInRepoPresets).toHaveBeenCalledWith("/p");
+    expect(result.projectPresets).toEqual(presets);
+  });
+
+  it("degrades projectPresets to empty when the in-repo read fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(projectStore.getCurrentProject).mockReturnValue({
+      id: "p1",
+      name: "P",
+      path: "/p",
+    } as unknown as ReturnType<typeof projectStore.getCurrentProject>);
+    vi.mocked(projectStore.readInRepoPresets).mockRejectedValueOnce(new Error("EACCES"));
+
+    const result = await invokeBoot();
+    expect(result.projectPresets).toEqual({});
+    warnSpy.mockRestore();
+  });
+
+  it("leaves projectPresets undefined on the no-project fallback branch", async () => {
+    const result = await invokeBoot();
+    expect(projectStore.readInRepoPresets).not.toHaveBeenCalled();
+    expect(result.projectPresets).toBeUndefined();
+  });
+
+  it("folds a fully-migrated appTheme config into the boot payload", async () => {
+    const appTheme = {
+      colorSchemeId: "daintree",
+      customSchemes: [{ id: "custom-1", name: "Custom", type: "dark", tokens: {} }],
+      accentColorOverride: "#ff0000",
+      colorVisionMode: "red-green",
+    };
+    const storeModule = await import("../../store.js");
+    vi.mocked(storeModule.store.get).mockImplementation((key: string) => {
+      if (key === "appState") return { terminals: [], sidebarWidth: 350 };
+      if (key === "terminalConfig") return { resourceMonitoringEnabled: false };
+      if (key === "agentSettings") return {};
+      if (key === "appTheme") return appTheme;
+      return undefined;
+    });
+
+    const result = await invokeBoot();
+    expect(result.appTheme).toEqual(appTheme);
+  });
+
+  it("leaves appTheme off the payload when the stored config still needs migration or defaulting", async () => {
+    const storeModule = await import("../../store.js");
+    for (const stored of [
+      undefined,
+      {},
+      { colorSchemeId: "" },
+      { colorSchemeId: "daintree", customSchemes: '[{"id":"legacy"}]' },
+    ]) {
+      vi.mocked(storeModule.store.get).mockImplementation((key: string) => {
+        if (key === "appState") return { terminals: [], sidebarWidth: 350 };
+        if (key === "terminalConfig") return { resourceMonitoringEnabled: false };
+        if (key === "agentSettings") return {};
+        if (key === "appTheme") return stored;
+        return undefined;
+      });
+
+      const result = await invokeBoot();
+      expect(result.appTheme).toBeUndefined();
+    }
   });
 
   describe("APP_HYDRATE_PREFETCH perf mark", () => {

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -22,17 +22,34 @@ vi.mock("electron", () => ({
   },
 }));
 
-const projectStoreMock = vi.hoisted(() => ({
-  getCurrentProjectId: vi.fn<() => string | null>(),
-  getProjectById:
-    vi.fn<(id: string) => { id: string; name: string; path: string; status?: string } | null>(),
-  setCurrentProject: vi.fn<(id: string) => Promise<void>>(),
-  getProjectState: vi.fn<(id: string) => Promise<Record<string, unknown> | null>>(),
-  saveProjectState: vi.fn<(id: string, state: unknown) => Promise<void>>(),
-  getAllProjects: vi.fn(() => []),
-  getCurrentProject: vi.fn(() => null),
-  updateProjectStatus: vi.fn(),
-}));
+const projectStoreMock = vi.hoisted(() => {
+  const getProjectState = vi.fn<(id: string) => Promise<Record<string, unknown> | null>>();
+  const saveProjectState = vi.fn<(id: string, state: unknown) => Promise<void>>();
+  return {
+    getCurrentProjectId: vi.fn<() => string | null>(),
+    getProjectById:
+      vi.fn<(id: string) => { id: string; name: string; path: string; status?: string } | null>(),
+    setCurrentProject: vi.fn<(id: string) => Promise<void>>(),
+    getProjectState,
+    saveProjectState,
+    // Mirrors the real queue contract: read, apply updater, save unless null.
+    enqueueProjectStateUpdate: vi.fn(
+      async (
+        id: string,
+        updater: (existing: Record<string, unknown> | null) => Record<string, unknown> | null
+      ) => {
+        const existing = await getProjectState(id);
+        const updated = await updater(existing);
+        if (updated !== null) {
+          await saveProjectState(id, updated);
+        }
+      }
+    ),
+    getAllProjects: vi.fn(() => []),
+    getCurrentProject: vi.fn(() => null),
+    updateProjectStatus: vi.fn(),
+  };
+});
 
 vi.mock("../../../services/ProjectStore.js", () => ({
   projectStore: projectStoreMock,

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -100,6 +100,16 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       };
     }
 
+    // In-repo presets ride along in the payload; kicked off after the fast
+    // path (the cached result already carries them) so the disk read overlaps
+    // the rest of the hydrate work.
+    const projectPresetsPromise = currentProject
+      ? projectStore.readInRepoPresets(currentProject.path).catch((error) => {
+          console.warn("[AppHydrate] Failed to read in-repo presets:", error);
+          return {};
+        })
+      : undefined;
+
     // Read the global app state only after the fast path — the cached
     // HydrateResult already carries appState, so reading it earlier would pay
     // a redundant full config.json parse on every cache hit.
@@ -431,6 +441,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       tabGroups: tabGroupsToUse,
       terminalSizes: terminalSizesToUse,
       draftInputs: draftInputsToUse,
+      projectPresets: projectPresetsPromise ? await projectPresetsPromise : undefined,
     };
   };
   handlers.push(typedHandleWithContext(CHANNELS.APP_HYDRATE, handleAppHydrate));
@@ -455,10 +466,25 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       const pending = crashService.getPendingCrash();
       crashPending = pending ? { ...pending, crashCount: guard.getCrashCount() } : null;
     }
+    // Ride-along app theme: only when the stored config is already in its
+    // fully-migrated shape. First-run defaulting and legacy customSchemes
+    // migration stay in the `app-theme:get` handler, which the renderer falls
+    // back to whenever this field is undefined.
+    const rawAppTheme = store.get("appTheme");
+    const appTheme =
+      rawAppTheme &&
+      typeof rawAppTheme === "object" &&
+      !Array.isArray(rawAppTheme) &&
+      typeof rawAppTheme.colorSchemeId === "string" &&
+      rawAppTheme.colorSchemeId &&
+      typeof (rawAppTheme.customSchemes as unknown) !== "string"
+        ? (rawAppTheme as import("../../../../shared/types/appTheme.js").AppThemeConfig)
+        : undefined;
     return {
       ...hydrate,
       crashPending,
       crashConfig: crashService.getConfig(),
+      appTheme,
     };
   };
   handlers.push(typedHandleWithContext(CHANNELS.APP_BOOT, handleAppBoot));

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -116,6 +116,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
 
     const git = createHardenedGit(payload.cwd);
     await git.add(["--", ...paths]);
+    invalidateStagingDiffStatCache(payload.cwd);
   };
   handlers.push(typedHandle(CHANNELS.GIT_STAGE_FILES, handleStageFiles));
 
@@ -141,6 +142,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     } else {
       await git.raw(["rm", "--cached", "--", ...paths]);
     }
+    invalidateStagingDiffStatCache(payload.cwd);
   };
   handlers.push(typedHandle(CHANNELS.GIT_UNSTAGE_FILES, handleUnstageFiles));
 

--- a/electron/ipc/handlers/projectCrud/index.ts
+++ b/electron/ipc/handlers/projectCrud/index.ts
@@ -29,7 +29,7 @@ export function registerProjectCrudHandlers(deps: HandlerDependencies): () => vo
     registerProjectSettingsHandlers(deps),
     registerGitInitHandlers(),
     registerGitCloneHandlers(),
-    registerProjectPrefetchHandlers(),
+    registerProjectPrefetchHandlers(deps),
   ];
 
   return () => cleanups.forEach((cleanup) => cleanup());

--- a/electron/ipc/handlers/projectCrud/prefetch.ts
+++ b/electron/ipc/handlers/projectCrud/prefetch.ts
@@ -3,24 +3,30 @@ import { typedHandle } from "../../utils.js";
 import { buildSwitchHydrateResult } from "../../../services/AppHydrationService.js";
 import { prefetchHydrateResult } from "../../../services/prefetchHydrateCache.js";
 import { projectStore } from "../../../services/ProjectStore.js";
+import type { HandlerDependencies } from "../../types.js";
 
 /**
  * Hover-prefetch entry point for the project switcher palette. The renderer
  * fires this as a debounced, fire-and-forget call when the mouse settles on a
  * project row for 150ms; the main process builds the `HydrateResult` payload
  * and caches it so the subsequent `app:hydrate` call from the new project view
- * resolves as a cache hit (no second disk read).
+ * resolves as a cache hit (no second disk read). The workspace host is
+ * prewarmed in the same pass so the post-swap worktree load skips the cold
+ * fork — `prewarmProject` is idempotent and self-reclaims if the hover never
+ * becomes a click.
  *
  * Errors are swallowed inside the cache layer — a failed prefetch must never
  * surface to the user, since the click-time hydrate will simply fall through
  * to the normal read path.
  */
-export function registerProjectPrefetchHandlers(): () => void {
+export function registerProjectPrefetchHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
   const handleProjectPrefetchHydrate = async (projectId: string): Promise<void> => {
     if (typeof projectId !== "string" || !projectId) return;
-    if (!projectStore.getProjectById(projectId)) return;
+    const project = projectStore.getProjectById(projectId);
+    if (!project) return;
+    deps.worktreeService?.prewarmProject(project.path);
     await prefetchHydrateResult(projectId, buildSwitchHydrateResult);
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_PREFETCH_HYDRATE, handleProjectPrefetchHydrate));

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -40,7 +40,15 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     }
 
     const previousProjectId = projectStore.getCurrentProjectId();
-    await persistOutgoingProjectState(outgoingState, previousProjectId, "project:switch");
+    // Started concurrently with the view swap — the incoming view never reads
+    // the outgoing project's state file — and awaited before returning so the
+    // IPC contract (state persisted before resolve) is preserved.
+    const persistOutgoing = persistOutgoingProjectState(
+      outgoingState,
+      previousProjectId,
+      "project:switch"
+    );
+    trackOutgoingPersist(previousProjectId, persistOutgoing);
 
     const pvm = resolveProjectViewManager(deps, ctx.event);
     if (pvm) {
@@ -51,12 +59,17 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       if (options?.focusIntent) {
         pvm.setPendingFocusIntent(projectId, options.focusIntent);
       }
+      // Rapid switch-back: a cold-start hydrate of the target must not read
+      // its state file while a previous switch's persist is still writing it.
+      await awaitPendingOutgoingPersist(projectId);
       await activateProjectView(deps, ctx.event, pvm, projectId, project, {
         logPrefix: "[ProjectSwitch]",
       });
+      await persistOutgoing;
       return project;
     }
 
+    await persistOutgoing;
     return await projectSwitchService.switchProject(projectId);
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_SWITCH, handleProjectSwitch));
@@ -84,20 +97,29 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
     }
 
     const previousProjectId = projectStore.getCurrentProjectId();
+    let persistOutgoing: Promise<void> = Promise.resolve();
     if (previousProjectId !== projectId) {
-      await persistOutgoingProjectState(outgoingState, previousProjectId, "project:reopen");
+      persistOutgoing = persistOutgoingProjectState(
+        outgoingState,
+        previousProjectId,
+        "project:reopen"
+      );
+      trackOutgoingPersist(previousProjectId, persistOutgoing);
     }
 
     const pvm = resolveProjectViewManager(deps, ctx.event);
     if (pvm) {
+      await awaitPendingOutgoingPersist(projectId);
       await activateProjectView(deps, ctx.event, pvm, projectId, project, {
         logPrefix: "[ProjectReopen]",
         markActive: true,
         resumeWorkspace: true,
       });
+      await persistOutgoing;
       return project;
     }
 
+    await persistOutgoing;
     if (deps.worktreeService) {
       deps.worktreeService.resumeProject(project.path);
     }
@@ -106,6 +128,27 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_REOPEN, handleProjectReopen));
 
   return () => handlers.forEach((cleanup) => cleanup());
+}
+
+const pendingOutgoingPersists = new Map<string, Promise<void>>();
+
+function trackOutgoingPersist(projectId: string | null, persist: Promise<void>): void {
+  if (!projectId) return;
+  pendingOutgoingPersists.set(projectId, persist);
+  const cleanup = () => {
+    if (pendingOutgoingPersists.get(projectId) === persist) {
+      pendingOutgoingPersists.delete(projectId);
+    }
+  };
+  persist.then(cleanup, cleanup);
+}
+
+async function awaitPendingOutgoingPersist(projectId: string): Promise<void> {
+  const pending = pendingOutgoingPersists.get(projectId);
+  if (pending) {
+    // Failures surface on the originating switch's own await, not here.
+    await pending.catch(() => {});
+  }
 }
 
 function resolveProjectViewManager(deps: HandlerDependencies, event: Electron.IpcMainInvokeEvent) {
@@ -137,8 +180,9 @@ async function persistOutgoingProjectState(
           `${logLabel}/pre-apply(${previousProjectId})`
         ) as TabGroup[])
       : undefined;
-  const existing = await projectStore.getProjectState(previousProjectId);
-  await projectStore.saveProjectState(previousProjectId, {
+  // Queued so the read-merge-write can't clobber concurrent queued writers
+  // (terminalLayout handlers) now that the persist runs alongside the swap.
+  await projectStore.enqueueProjectStateUpdate(previousProjectId, (existing) => ({
     ...(existing ?? { projectId: previousProjectId, sidebarWidth: 350, terminals: [] }),
     projectId: previousProjectId,
     ...(validTerminals !== undefined && { terminals: validTerminals }),
@@ -146,7 +190,7 @@ async function persistOutgoingProjectState(
     ...(validDrafts !== undefined && { draftInputs: validDrafts }),
     ...(validTabGroups !== undefined && { tabGroups: validTabGroups }),
     activeWorktreeId: outgoingState.activeWorktreeId,
-  });
+  }));
 }
 
 type ActivateOptions = {

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -234,9 +234,10 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
     }
 
     try {
-      const { execFileSync } = await import("child_process");
+      const { execFile } = await import("child_process");
+      const { promisify } = await import("util");
       const checkCmd = process.platform === "win32" ? "where" : "which";
-      execFileSync(checkCmd, [command], { stdio: "ignore" });
+      await promisify(execFile)(checkCmd, [command], { timeout: 5_000, windowsHide: true });
       return true;
     } catch {
       return false;

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -58,6 +58,11 @@ const SIMPLE_SNAPSHOT_SETTLE_MS = 1000;
 const WORKING_INDICATOR_TTL_MS = 5000;
 const CPU_HIGH_THRESHOLD = 10;
 const CPU_LOW_THRESHOLD = 3;
+// Full-buffer strip+detect cadence cap. The rolling pattern buffer keeps
+// accumulating per chunk; only the stripAnsi + pattern-bank scan is
+// throttled, with a trailing-edge run so the final chunk before quiet is
+// still scanned. Downstream consumers debounce at 100ms+ scales.
+const PATTERN_SCAN_THROTTLE_MS = 30;
 
 export interface ProcessStateValidator {
   hasActiveChildren(): boolean;
@@ -155,6 +160,8 @@ export class ActivityMonitor {
   private idleSince = 0;
   private lastPatternResultAt = 0;
   private workingHoldUntil = 0;
+  private lastPatternScanAt = 0;
+  private patternScanTimer: NodeJS.Timeout | null = null;
 
   // Subsystem instances
   private readonly inputTracker: InputTracker;
@@ -419,6 +426,23 @@ export class ActivityMonitor {
   // busy on working-pattern matches.
   private detectPatternsFromData(data: string, now: number): void {
     this.patternBuf.update(data);
+
+    const elapsed = now - this.lastPatternScanAt;
+    if (elapsed < PATTERN_SCAN_THROTTLE_MS) {
+      if (!this.patternScanTimer) {
+        this.patternScanTimer = setTimeout(() => {
+          this.patternScanTimer = null;
+          if (this.isDisposed) return;
+          this.scanPatternBuffer(Date.now());
+        }, PATTERN_SCAN_THROTTLE_MS - elapsed);
+      }
+      return;
+    }
+    this.scanPatternBuffer(now);
+  }
+
+  private scanPatternBuffer(now: number): void {
+    this.lastPatternScanAt = now;
     const bufferText = stripAnsi(this.patternBuf.getText());
 
     // Check for boot-complete patterns in the rolling buffer
@@ -853,6 +877,11 @@ export class ActivityMonitor {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
+    if (this.patternScanTimer) {
+      clearTimeout(this.patternScanTimer);
+      this.patternScanTimer = null;
+    }
+    this.lastPatternScanAt = 0;
     this.completionTimer.dispose();
     this.inputTracker.reset();
     this.outputVolumeDetector.reset();

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -23,6 +23,14 @@ import { inferKind } from "../../shared/utils/inferPanelKind.js";
  */
 export async function buildSwitchHydrateResult(projectId: string): Promise<HydrateResult> {
   const currentProject = projectStore.getProjectById(projectId);
+  // In-repo presets ride along in the payload; kicked off first so the disk
+  // read overlaps the rest of the hydrate work.
+  const projectPresetsPromise = currentProject
+    ? projectStore.readInRepoPresets(currentProject.path).catch((error) => {
+        console.warn("[SwitchHydrate] Failed to read in-repo presets:", error);
+        return {};
+      })
+    : undefined;
   const globalAppState = store.get("appState");
 
   let terminalsToUse: typeof globalAppState.terminals = [];
@@ -111,5 +119,6 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     tabGroups: projectState?.tabGroups ?? [],
     terminalSizes: projectState?.terminalSizes ?? {},
     draftInputs: projectState?.draftInputs ?? {},
+    projectPresets: projectPresetsPromise ? await projectPresetsPromise : undefined,
   };
 }

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -1,5 +1,5 @@
 // eager-import-allow: reads the CLI-availability cache via store.get synchronously
-import { execFile, execFileSync } from "child_process";
+import { execFile } from "child_process";
 import { access, constants } from "fs/promises";
 import { delimiter, dirname, join, win32 as pathWin32 } from "path";
 import { homedir } from "os";
@@ -535,91 +535,89 @@ export class CliAvailabilityService {
     return { status: "missing" };
   }
 
-  private probeViaShell(command: string): Promise<ProbeResult> {
-    return new Promise((resolve) => {
-      setImmediate(() => {
-        const isWindows = process.platform === "win32";
-        const checkCmd = isWindows ? "where" : "which";
-        // `where.exe` already prints every PATH match. On Unix, request all
-        // matches via `which -a` to drive duplicate detection (#6054). When
-        // `-a` is rejected by a minimal `which` (e.g. older BusyBox), retry
-        // without the flag so duplicate detection degrades to a single-path
-        // lookup rather than reporting the agent as missing.
-        const runWhich = (
-          extraArgs: string[]
-        ): { ok: true; lines: string[] } | { ok: false; err: unknown } => {
-          try {
-            const buffer = execFileSync(checkCmd, [...extraArgs, command], {
-              stdio: ["ignore", "pipe", "ignore"],
-              timeout: CliAvailabilityService.WHICH_TIMEOUT_MS,
-            });
-            const output = buffer.toString("utf8").trim();
-            const lines = output
+  private async probeViaShell(command: string): Promise<ProbeResult> {
+    const isWindows = process.platform === "win32";
+    const checkCmd = isWindows ? "where" : "which";
+    // `where.exe` already prints every PATH match. On Unix, request all
+    // matches via `which -a` to drive duplicate detection (#6054). When
+    // `-a` is rejected by a minimal `which` (e.g. older BusyBox), retry
+    // without the flag so duplicate detection degrades to a single-path
+    // lookup rather than reporting the agent as missing.
+    const runWhich = (
+      extraArgs: string[]
+    ): Promise<{ ok: true; lines: string[] } | { ok: false; err: unknown }> =>
+      new Promise((resolve) => {
+        execFile(
+          checkCmd,
+          [...extraArgs, command],
+          {
+            timeout: CliAvailabilityService.WHICH_TIMEOUT_MS,
+            windowsHide: true,
+          },
+          (err, stdout) => {
+            if (err) {
+              resolve({ ok: false, err });
+              return;
+            }
+            const lines = String(stdout ?? "")
+              .trim()
               .split(/\r?\n/)
               .map((line) => line.trim())
               .filter(Boolean);
-            return { ok: true, lines };
-          } catch (err) {
-            return { ok: false, err };
+            resolve({ ok: true, lines });
           }
-        };
-
-        const classifyError = (err: unknown): ProbeResult | null => {
-          const code = (err as NodeJS.ErrnoException | undefined)?.code;
-          // EACCES / EPERM from which/where itself is rare — most endpoint
-          // security blocks surface on the spawn attempt. Still, when they
-          // do, the binary clearly exists on disk (otherwise we'd have
-          // ENOENT) so "blocked" is the correct classification.
-          if (typeof code === "string" && SECURITY_ERROR_CODES.has(code)) {
-            return {
-              status: "blocked",
-              reason: "security",
-              via: "which",
-              message: `${checkCmd} "${command}" failed with ${code} — likely blocked by security software or missing execute permission`,
-            };
-          }
-          return null;
-        };
-
-        const primary = runWhich(isWindows ? [] : ["-a"]);
-        if (primary.ok) {
-          if (primary.lines.length === 0) {
-            // Some shells exit 0 with empty stdout. Preserve the historical
-            // contract: fall back to the bare command so the binary is still
-            // launchable via PATH lookup at spawn time.
-            resolve({ status: "found", path: command, via: "which" });
-            return;
-          }
-          const allPaths = dedupePathsByDirectory(primary.lines, isWindows);
-          resolve({ status: "found", path: allPaths[0], via: "which", allPaths });
-          return;
-        }
-
-        // Non-zero exit. On Unix this can be BusyBox/minimal `which`
-        // rejecting `-a`; retry without the flag so a real install isn't
-        // misreported as missing. Skip for security errors so the blocked
-        // verdict surfaces directly.
-        const primaryBlocked = classifyError(primary.err);
-        if (primaryBlocked) {
-          resolve(primaryBlocked);
-          return;
-        }
-        if (!isWindows) {
-          const fallback = runWhich([]);
-          if (fallback.ok) {
-            const path = fallback.lines[0] ?? command;
-            resolve({ status: "found", path, via: "which" });
-            return;
-          }
-          const fallbackBlocked = classifyError(fallback.err);
-          if (fallbackBlocked) {
-            resolve(fallbackBlocked);
-            return;
-          }
-        }
-        resolve({ status: "missing" });
+        );
       });
-    });
+
+    const classifyError = (err: unknown): ProbeResult | null => {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      // EACCES / EPERM from which/where itself is rare — most endpoint
+      // security blocks surface on the spawn attempt. Still, when they
+      // do, the binary clearly exists on disk (otherwise we'd have
+      // ENOENT) so "blocked" is the correct classification.
+      if (typeof code === "string" && SECURITY_ERROR_CODES.has(code)) {
+        return {
+          status: "blocked",
+          reason: "security",
+          via: "which",
+          message: `${checkCmd} "${command}" failed with ${code} — likely blocked by security software or missing execute permission`,
+        };
+      }
+      return null;
+    };
+
+    const primary = await runWhich(isWindows ? [] : ["-a"]);
+    if (primary.ok) {
+      if (primary.lines.length === 0) {
+        // Some shells exit 0 with empty stdout. Preserve the historical
+        // contract: fall back to the bare command so the binary is still
+        // launchable via PATH lookup at spawn time.
+        return { status: "found", path: command, via: "which" };
+      }
+      const allPaths = dedupePathsByDirectory(primary.lines, isWindows);
+      return { status: "found", path: allPaths[0], via: "which", allPaths };
+    }
+
+    // Non-zero exit. On Unix this can be BusyBox/minimal `which`
+    // rejecting `-a`; retry without the flag so a real install isn't
+    // misreported as missing. Skip for security errors so the blocked
+    // verdict surfaces directly.
+    const primaryBlocked = classifyError(primary.err);
+    if (primaryBlocked) {
+      return primaryBlocked;
+    }
+    if (!isWindows) {
+      const fallback = await runWhich([]);
+      if (fallback.ok) {
+        const path = fallback.lines[0] ?? command;
+        return { status: "found", path, via: "which" };
+      }
+      const fallbackBlocked = classifyError(fallback.err);
+      if (fallbackBlocked) {
+        return fallbackBlocked;
+      }
+    }
+    return { status: "missing" };
   }
 
   private async probeNativePaths(paths: string[]): Promise<ProbeResult> {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5608,16 +5608,19 @@ describe("ActivityMonitor", () => {
 
       monitor.startPolling();
       // The data path runs through onData() and triggers bootDetector.check
-      // against the rolling pattern buffer.
+      // against the rolling pattern buffer. Back-to-back chunks inside the
+      // pattern-scan throttle window are scanned by the trailing-edge timer.
       monitor.onData("starting up\nstill working\n");
       expect(onBootComplete).not.toHaveBeenCalled();
 
       monitor.onData("system ready\n");
+      vi.advanceTimersByTime(30);
       expect(onBootComplete).toHaveBeenCalledTimes(1);
       expect(onBootComplete).toHaveBeenCalledWith(expect.any(Number));
 
       // Subsequent matching data must not re-fire.
       monitor.onData("ready again ready\n");
+      vi.advanceTimersByTime(30);
       expect(onBootComplete).toHaveBeenCalledTimes(1);
 
       monitor.dispose();
@@ -5754,6 +5757,51 @@ describe("ActivityMonitor", () => {
       expect(onBootComplete).toHaveBeenCalledTimes(1);
 
       monitor.dispose();
+    });
+  });
+
+  describe("Pattern-scan throttle", () => {
+    it("scans a chunk arriving inside the throttle window via the trailing-edge timer", () => {
+      vi.setSystemTime(10000);
+      const onBootComplete = vi.fn();
+      const monitor = new ActivityMonitor("scan-trailing", 1000, vi.fn(), {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        bootCompletePatterns: [/ready/i],
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      monitor.startPolling();
+      monitor.onData("starting up\n");
+      monitor.onData("system ready\n");
+      expect(onBootComplete).not.toHaveBeenCalled();
+
+      // No further data: the deferred run must still scan the final chunk.
+      vi.advanceTimersByTime(30);
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      monitor.dispose();
+    });
+
+    it("dispose cancels a pending trailing-edge scan", () => {
+      vi.setSystemTime(10000);
+      const onBootComplete = vi.fn();
+      const monitor = new ActivityMonitor("scan-dispose", 1000, vi.fn(), {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        bootCompletePatterns: [/ready/i],
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      monitor.startPolling();
+      monitor.onData("starting up\n");
+      monitor.onData("system ready\n");
+      monitor.dispose();
+
+      vi.advanceTimersByTime(100);
+      expect(onBootComplete).not.toHaveBeenCalled();
     });
   });
 

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -35,6 +35,7 @@ const mockState = vi.hoisted(() => ({
         draftInputs?: Record<string, string>;
       }
     | undefined,
+  projectPresets: {} as Record<string, unknown[]>,
   projectStateQuarantinedPath: undefined as string | undefined,
   safeMode: false,
   gpuStatus: { webgl2: "enabled" },
@@ -46,6 +47,7 @@ const getProjectByIdMock = vi.hoisted(() =>
   vi.fn((projectId: string) => (projectId === mockState.project?.id ? mockState.project : null))
 );
 const getProjectStateMock = vi.hoisted(() => vi.fn(async () => mockState.projectState));
+const readInRepoPresetsMock = vi.hoisted(() => vi.fn(async () => mockState.projectPresets));
 const getProjectStateWithRecoveryMock = vi.hoisted(() =>
   vi.fn(async () => ({
     state: mockState.projectState,
@@ -83,6 +85,7 @@ vi.mock("../ProjectStore.js", () => ({
     getProjectById: getProjectByIdMock,
     getProjectState: getProjectStateMock,
     getProjectStateWithRecovery: getProjectStateWithRecoveryMock,
+    readInRepoPresets: readInRepoPresetsMock,
   },
 }));
 
@@ -131,6 +134,7 @@ describe("AppHydrationService adversarial", () => {
     mockState.agentSettings = { defaultAgent: "codex" };
     mockState.project = { id: "project-1", name: "Project One", path: "/project/one" };
     mockState.projectState = undefined;
+    mockState.projectPresets = {};
     mockState.projectStateQuarantinedPath = undefined;
     mockState.safeMode = false;
     mockState.gpuStatus = { webgl2: "enabled" };
@@ -323,6 +327,37 @@ describe("AppHydrationService adversarial", () => {
     expect(result.tabGroups).toEqual(tabGroups);
     expect(result.terminalSizes).toEqual(terminalSizes);
     expect(result.draftInputs).toEqual(draftInputs);
+  });
+
+  it("folds in-repo project presets into the payload", async () => {
+    const presets = { claude: [{ id: "team-preset", name: "Team" }] };
+    mockState.projectPresets = presets as Record<string, unknown[]>;
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(readInRepoPresetsMock).toHaveBeenCalledWith("/project/one");
+    expect(result.projectPresets).toEqual(presets);
+  });
+
+  it("degrades projectPresets to empty when the in-repo read fails", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    readInRepoPresetsMock.mockRejectedValueOnce(new Error("EACCES"));
+
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("project-1");
+
+    expect(result.projectPresets).toEqual({});
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("leaves projectPresets undefined when the project is unknown", async () => {
+    const { buildSwitchHydrateResult } = await import("../AppHydrationService.js");
+    const result = await buildSwitchHydrateResult("missing-project");
+
+    expect(readInRepoPresetsMock).not.toHaveBeenCalled();
+    expect(result.projectPresets).toBeUndefined();
   });
 
   it("defaults tabGroups/terminalSizes/draftInputs to empty when project state is missing", async () => {

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -11,19 +11,40 @@ import { refreshPath } from "../../setup/environment.js";
 import { broadcastToRenderer } from "../../ipc/utils.js";
 import { CHANNELS } from "../../ipc/channels.js";
 
-// Mock child_process. Both `execFileSync` (sync shell probe) and `execFile`
-// (async npm-global / WSL probes) are used by the service — mock both or
-// the async probes will call `undefined(...)` and throw TypeErrors at runtime.
+// Mock child_process. The service's probes (shell which/where, npm-global,
+// WSL) all run through async `execFile` — mock it or the probes will call
+// `undefined(...)` and throw TypeErrors at runtime. `execFileSync` is mocked
+// too: the tests in this file drive shell-probe behavior through
+// `mockedExecFileSync` implementations, and the default `execFile` impl
+// DELEGATES `which`/`where` spawns to it — calling the sync mock and
+// translating its return/throw into the async callback contract (string
+// stdout on success, error on throw). All other files (npm, wsl.exe, npx)
+// get an ENOENT callback so unmocked tests see the probe as "binary not
+// found" rather than hanging on an un-invoked callback.
 //
 // `execFile` has an overloaded signature: (file, args, callback) or
-// (file, args, options, callback). The default mock invokes whichever
-// callback was passed with an ENOENT error so unmocked tests see the probe
-// as "binary not found" rather than hanging on an un-invoked callback.
-// `vi.hoisted` guarantees this runs before `vi.mock` factories despite the
-// auto-hoisting that normally blocks reference to local bindings.
+// (file, args, options, callback). `vi.hoisted` guarantees this runs before
+// `vi.mock` factories despite the auto-hoisting that normally blocks
+// reference to local bindings.
 const { defaultExecFileImpl } = vi.hoisted(() => ({
   defaultExecFileImpl: (...args: unknown[]) => {
-    const callback = args.find((a): a is (err: unknown) => void => typeof a === "function");
+    const callback = args.find(
+      (a): a is (err: unknown, stdout?: string) => void => typeof a === "function"
+    );
+    const [file, fileArgs, options] = args;
+    if (file === "which" || file === "where") {
+      queueMicrotask(() => {
+        try {
+          const out = execFileSync(file, fileArgs as readonly string[], options as never) as
+            | string
+            | Buffer;
+          callback?.(null, typeof out === "string" ? out : out.toString("utf8"));
+        } catch (err) {
+          callback?.(err);
+        }
+      });
+      return {} as never;
+    }
     const err = Object.assign(new Error("not found"), { code: "ENOENT" });
     queueMicrotask(() => callback?.(err));
     return {} as never;
@@ -195,12 +216,13 @@ describe("CliAvailabilityService", () => {
       // matches the registry size exactly.
       expect(mockedExecFileSync).toHaveBeenCalledTimes(16);
 
-      // stdio is now [ignore, pipe, ignore] so we can capture the resolved
-      // path from stdout while still suppressing any TTY output on stderr.
-      expect(mockedExecFileSync).toHaveBeenCalledWith(
-        expect.any(String),
+      // The shell probe runs through async execFile — assert the option
+      // shape (timeout + windowsHide) on the mock that observes it directly.
+      expect(mockedExecFile).toHaveBeenCalledWith(
+        "which",
         expect.any(Array),
-        expect.objectContaining({ stdio: ["ignore", "pipe", "ignore"] })
+        expect.objectContaining({ timeout: expect.any(Number), windowsHide: true }),
+        expect.any(Function)
       );
     });
 

--- a/electron/services/pty/SemanticBufferManager.ts
+++ b/electron/services/pty/SemanticBufferManager.ts
@@ -5,6 +5,8 @@ import {
   SEMANTIC_FLUSH_INTERVAL_MS,
 } from "./types.js";
 
+const PENDING_SEMANTIC_DATA_MAX_CHARS = 64 * 1024;
+
 export class SemanticBufferManager {
   private pendingSemanticData = "";
   private semanticFlushTimer: NodeJS.Timeout | null = null;
@@ -13,6 +15,9 @@ export class SemanticBufferManager {
 
   onData(data: string): void {
     this.pendingSemanticData += data;
+    if (this.pendingSemanticData.length > PENDING_SEMANTIC_DATA_MAX_CHARS) {
+      this.pendingSemanticData = this.pendingSemanticData.slice(-PENDING_SEMANTIC_DATA_MAX_CHARS);
+    }
 
     if (this.semanticFlushTimer) {
       return;
@@ -84,7 +89,7 @@ export class SemanticBufferManager {
         return line;
       });
 
-    terminal.semanticBuffer.push(...processedLines);
+    terminal.semanticBuffer.push(...processedLines.slice(-SEMANTIC_BUFFER_MAX_LINES));
 
     if (terminal.semanticBuffer.length > SEMANTIC_BUFFER_MAX_LINES) {
       terminal.semanticBuffer = terminal.semanticBuffer.slice(-SEMANTIC_BUFFER_MAX_LINES);

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -93,6 +93,11 @@ import {
   AgentActivityTemperature,
 } from "./AgentActivityTemperature.js";
 
+// Coalescing window for host→main agent:output forwarding. Pending output is
+// flushed synchronously before any agent state transition (and on exit) so
+// turn-outcome classification still sees the tail in order.
+const AGENT_OUTPUT_FLUSH_INTERVAL_MS = 50;
+
 type CursorBufferLine = {
   translateToString: (trimRight?: boolean) => string;
   getCell?: (index: number, cell?: IBufferCell) => IBufferCell | undefined;
@@ -155,6 +160,10 @@ export class TerminalProcess {
   private sessionSnapshotter!: SessionSnapshotter;
   private readonly agentOutputTemperature = new AgentActivityTemperature();
   private agentOutputContentSnapshot: VisibleContentSnapshot | undefined;
+
+  private pendingAgentOutput = "";
+  private pendingAgentOutputAgentId: string | null = null;
+  private agentOutputFlushTimer: NodeJS.Timeout | null = null;
 
   private readonly terminalInfo: TerminalInfo;
 
@@ -463,6 +472,7 @@ export class TerminalProcess {
             );
             return;
           }
+          this.flushAgentOutput();
           deps.agentStateService.handleActivityState(this.terminalInfo, state, metadata);
         },
         {
@@ -473,6 +483,7 @@ export class TerminalProcess {
           }),
           processStateValidator,
           onWaitingTimeout: (_id, _spawnedAt) => {
+            this.flushAgentOutput();
             deps.agentStateService.updateAgentState(
               this.terminalInfo,
               { type: "watchdog-timeout" },
@@ -579,6 +590,7 @@ export class TerminalProcess {
     this.stopActivityMonitor();
     this.identityWatcher.stop();
     this.semanticBufferManager.flush();
+    this.flushAgentOutput();
 
     if (this.ptyDataDisposable) {
       try {
@@ -625,6 +637,7 @@ export class TerminalProcess {
    * forensics buffer, since fallback classification scans the tail.
    */
   private emitTerminalExited(args: TerminalExitArgs): void {
+    this.flushAgentOutput();
     this.exitObservers.emit(args);
   }
 
@@ -1347,6 +1360,7 @@ export class TerminalProcess {
             );
             return;
           }
+          this.flushAgentOutput();
           this.deps.agentStateService.handleActivityState(this.terminalInfo, state, metadata);
         },
         {
@@ -1359,6 +1373,7 @@ export class TerminalProcess {
           initialState,
           skipInitialStateEmit: preserveState,
           onWaitingTimeout: (_id, _spawnedAt) => {
+            this.flushAgentOutput();
             this.deps.agentStateService.updateAgentState(
               this.terminalInfo,
               { type: "watchdog-timeout" },
@@ -1504,6 +1519,7 @@ export class TerminalProcess {
       return;
     }
     if (result.stateHint === "busy" && this.terminalInfo.agentState === state) {
+      this.flushAgentOutput();
       this.deps.agentStateService.handleActivityState(this.terminalInfo, "busy", {
         trigger: "output",
       });
@@ -1676,15 +1692,50 @@ export class TerminalProcess {
 
       const liveId = getLiveAgentId(terminal);
       if (liveId) {
-        events.emit("agent:output", {
-          agentId: liveId,
-          data,
-          timestamp: Date.now(),
-          traceId: terminal.traceId,
-          terminalId: this.id,
-        });
+        this.queueAgentOutput(liveId, data);
       }
     }
+  }
+
+  private queueAgentOutput(agentId: string, data: string): void {
+    if (this.pendingAgentOutputAgentId !== null && this.pendingAgentOutputAgentId !== agentId) {
+      this.flushAgentOutput();
+    }
+    this.pendingAgentOutputAgentId = agentId;
+    this.pendingAgentOutput += data;
+
+    if (this.pendingAgentOutput.length >= OUTPUT_BUFFER_SIZE) {
+      this.flushAgentOutput();
+      return;
+    }
+    if (this.agentOutputFlushTimer) {
+      return;
+    }
+    this.agentOutputFlushTimer = setTimeout(() => {
+      this.agentOutputFlushTimer = null;
+      this.flushAgentOutput();
+    }, AGENT_OUTPUT_FLUSH_INTERVAL_MS);
+  }
+
+  private flushAgentOutput(): void {
+    if (this.agentOutputFlushTimer) {
+      clearTimeout(this.agentOutputFlushTimer);
+      this.agentOutputFlushTimer = null;
+    }
+    if (!this.pendingAgentOutput || this.pendingAgentOutputAgentId === null) {
+      return;
+    }
+    const agentId = this.pendingAgentOutputAgentId;
+    const data = this.pendingAgentOutput;
+    this.pendingAgentOutput = "";
+    this.pendingAgentOutputAgentId = null;
+    events.emit("agent:output", {
+      agentId,
+      data,
+      timestamp: Date.now(),
+      traceId: this.terminalInfo.traceId,
+      terminalId: this.id,
+    });
   }
 
   private setupPtyHandlers(ptyProcess: pty.IPty, dataHandoff?: PooledPtyDataHandoff): void {
@@ -1779,6 +1830,7 @@ export class TerminalProcess {
   }
 
   handleAgentDetection(result: DetectionResult, spawnedAt: number): void {
+    this.flushAgentOutput();
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     runHandleAgentDetection(

--- a/electron/services/pty/__tests__/SemanticBufferManager.test.ts
+++ b/electron/services/pty/__tests__/SemanticBufferManager.test.ts
@@ -124,6 +124,33 @@ describe("SemanticBufferManager", () => {
     manager.dispose();
   });
 
+  it("caps pending data at accumulation time under a flood", () => {
+    const info = createTerminalInfo();
+    const manager = new SemanticBufferManager(info);
+
+    for (let i = 0; i < 50; i++) {
+      manager.onData(`${"x".repeat(100)} chunk${i}\n`.repeat(100));
+    }
+    manager.onData("final line\n");
+    vi.advanceTimersByTime(100);
+
+    expect(info.semanticBuffer.length).toBeLessThanOrEqual(50);
+    expect(info.semanticBuffer[info.semanticBuffer.length - 1]).toBe("final line");
+
+    manager.dispose();
+  });
+
+  it("survives a short-line flood without overflowing the push spread", () => {
+    const info = createTerminalInfo();
+    const manager = new SemanticBufferManager(info);
+
+    manager.onData("y\n".repeat(500_000));
+    expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+    expect(info.semanticBuffer.length).toBeLessThanOrEqual(50);
+
+    manager.dispose();
+  });
+
   it("getLastCommand() returns undefined on empty buffer", () => {
     const info = createTerminalInfo();
     const manager = new SemanticBufferManager(info);

--- a/electron/services/pty/__tests__/TerminalProcess.agentOutput.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentOutput.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+import { events } from "../../events.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+let ptyOnDataCallback: ((data: string) => void) | null = null;
+
+function createMockPty(): IPty {
+  const pty: Partial<IPty> = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: (cb: (data: string) => void) => {
+      ptyOnDataCallback = cb;
+      return { dispose: () => {} };
+    },
+    onExit: () => ({ dispose: () => {} }),
+  };
+  const withDestroy = pty as Partial<IPty> & { destroy: () => void };
+  withDestroy.destroy = vi.fn();
+  return pty as IPty;
+}
+
+function defaultSpawnContext(): SpawnContext {
+  return {
+    shell: "/bin/zsh",
+    args: ["-l"],
+    env: {},
+  };
+}
+
+type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
+type TerminalProcessDeps = ConstructorParameters<typeof TerminalProcess>[3];
+
+function createTerminal(
+  options?: Partial<TerminalProcessOptions>,
+  deps?: Partial<TerminalProcessDeps>
+): TerminalProcess {
+  return new TerminalProcess(
+    "t1",
+    {
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      kind: "terminal" as const,
+      ...options,
+    },
+    { emitData: () => {}, onExit: () => {} },
+    {
+      agentStateService: {
+        handleActivityState: () => {},
+        updateAgentState: () => {},
+        emitAgentKilled: () => {},
+      } as unknown as TerminalProcessDeps["agentStateService"],
+      ptyPool: null,
+      processTreeCache: null,
+      ...deps,
+    },
+    defaultSpawnContext(),
+    createMockPty()
+  );
+}
+
+describe("TerminalProcess agent:output coalescing", () => {
+  let received: Array<{ agentId: string; data: string; terminalId?: string }>;
+  let unsubscribe: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ptyOnDataCallback = null;
+    received = [];
+    unsubscribe = events.on("agent:output", (payload) => {
+      received.push(payload);
+    });
+  });
+
+  afterEach(() => {
+    unsubscribe();
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  it("coalesces multiple chunks into one emit on the flush timer", () => {
+    const terminal = createTerminal({ launchAgentId: "claude" });
+    expect(ptyOnDataCallback).not.toBeNull();
+
+    ptyOnDataCallback!("chunk-a");
+    ptyOnDataCallback!("chunk-b");
+    expect(received).toHaveLength(0);
+
+    vi.advanceTimersByTime(50);
+    expect(received).toHaveLength(1);
+    expect(received[0].agentId).toBe("claude");
+    expect(received[0].data).toBe("chunk-achunk-b");
+    expect(received[0].terminalId).toBe("t1");
+
+    terminal.dispose();
+  });
+
+  it("flushes immediately when pending output reaches the size cap", () => {
+    const terminal = createTerminal({ launchAgentId: "claude" });
+    const big = "x".repeat(2500);
+
+    ptyOnDataCallback!(big);
+    expect(received).toHaveLength(1);
+    expect(received[0].data).toBe(big);
+
+    terminal.dispose();
+  });
+
+  it("emits nothing for plain terminals", () => {
+    const terminal = createTerminal();
+
+    ptyOnDataCallback!("plain shell output");
+    vi.advanceTimersByTime(100);
+    expect(received).toHaveLength(0);
+
+    terminal.dispose();
+  });
+
+  it("flushes pending output before the kill transition", () => {
+    const order: string[] = [];
+    const offOrder = events.on("agent:output", () => {
+      order.push("output");
+    });
+    const terminal = createTerminal(
+      { launchAgentId: "claude" },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {
+            order.push("state");
+          },
+          emitAgentKilled: () => {},
+        } as unknown as TerminalProcessDeps["agentStateService"],
+      }
+    );
+
+    ptyOnDataCallback!("tail-data");
+    expect(received).toHaveLength(0);
+
+    terminal.kill("user requested");
+
+    expect(received).toHaveLength(1);
+    expect(received[0].data).toBe("tail-data");
+    expect(order).toEqual(["output", "state"]);
+
+    offOrder();
+    terminal.dispose();
+  });
+
+  it("flushes pending output on dispose without waiting for the timer", () => {
+    const terminal = createTerminal({ launchAgentId: "claude" });
+
+    ptyOnDataCallback!("last-words");
+    expect(received).toHaveLength(0);
+
+    terminal.dispose();
+    expect(received).toHaveLength(1);
+    expect(received[0].data).toBe("last-words");
+  });
+});

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -1040,8 +1040,10 @@ describe("setupWebviewCSP — partition CSP wiring", () => {
       string,
       (details: unknown, callback: (response: unknown) => void) => void
     >();
+    const filtersByPartition = new Map<string, Electron.WebRequestFilter>();
     fromPartition.mockImplementation((partition: string) => {
-      const onHeadersReceived = vi.fn((listener) => {
+      const onHeadersReceived = vi.fn((filter, listener) => {
+        filtersByPartition.set(partition, filter);
         callbacksByPartition.set(partition, listener);
       });
       return {
@@ -1054,6 +1056,13 @@ describe("setupWebviewCSP — partition CSP wiring", () => {
     const daintreeListener = callbacksByPartition.get("persist:daintree");
     expect(daintreeListener).toBeDefined();
     expect(callbacksByPartition.has("persist:browser")).toBe(false);
+
+    // Electron 41+ treats an empty `urls` array as matching nothing, so an
+    // empty registration would silently strip header-only CSP directives.
+    const daintreeFilter = filtersByPartition.get("persist:daintree");
+    expect(daintreeFilter?.urls.length).toBeGreaterThan(0);
+    expect(daintreeFilter?.types).toContain("mainFrame");
+    expect(daintreeFilter?.types).toContain("script");
 
     let daintreeResponse: { responseHeaders?: Record<string, string[]> } | undefined;
     daintreeListener!({ responseHeaders: {} }, (response: unknown) => {

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -668,11 +668,20 @@ export function setupWebviewCSP(): void {
           : getDaintreeAppCSP(isDev)
         : getLocalhostDevCSP();
 
-    ses.webRequest.onHeadersReceived((details, callback) => {
-      callback({
-        responseHeaders: mergeCspHeaders(details, cspPolicy),
-      });
-    });
+    // CSP response headers are only enforced on document and worker
+    // main-script responses (workers map to "script" in the webRequest
+    // resource-type model), so stylesheet/image/font/xhr/media/ping traffic
+    // skips the network-service→main-process detour entirely. `urls` must be
+    // explicit: since Electron 41 an empty array matches nothing, and
+    // Electron 42 rejects "other" in `types` at registration.
+    ses.webRequest.onHeadersReceived(
+      { urls: ["<all_urls>"], types: ["mainFrame", "subFrame", "script"] },
+      (details, callback) => {
+        callback({
+          responseHeaders: mergeCspHeaders(details, cspPolicy),
+        });
+      }
+    );
 
     configuredPartitions.add(partition);
   };

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -655,8 +655,13 @@ export class ProjectViewManager {
       view.webContents.focus();
     }
 
-    // Evict LRU views if over limit
-    this.evictStaleViews("lru");
+    // Evict LRU views if over limit — deferred off the switch promise;
+    // evictStaleViews re-checks all state at run time.
+    setImmediate(() => {
+      if (!this.disposed && !this.win.isDestroyed()) {
+        this.evictStaleViews("lru");
+      }
+    });
 
     return { view, isNew: true };
   }

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -162,6 +162,8 @@ vi.mock("../../utils/webContentsLifecycle.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 
+const flushImmediates = () => new Promise<void>((resolve) => setImmediate(resolve));
+
 function createMockWindow() {
   return {
     id: 1,
@@ -253,6 +255,7 @@ describe("ProjectViewManager adversarial", () => {
 
     // Switch to C — evicts A (LRU, cache limit 2)
     await manager.switchTo("proj-c", "/c");
+    await flushImmediates();
 
     expect(initialWc.close).toHaveBeenCalledTimes(1);
     // executeJavaScript was already called during deactivation — not called again on eviction

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -187,6 +187,8 @@ import { forgetBlinkSample, forgetEluSample } from "../../services/ProcessMemory
 import { detachRendererConsoleCapture } from "../rendererConsoleCapture.js";
 import { throttleCpuWebContents } from "../../utils/webContentsLifecycle.js";
 
+const flushImmediates = () => new Promise<void>((resolve) => setImmediate(resolve));
+
 function createMockWindow() {
   return {
     isDestroyed: vi.fn(() => false),
@@ -233,6 +235,7 @@ describe("ProjectViewManager — eviction safety", () => {
 
     // Switch to proj-b (now have 2 views, proj-b is active)
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // Destroy proj-b which sets activeProjectId to null
     manager.destroyView("proj-b");
@@ -278,9 +281,11 @@ describe("ProjectViewManager — eviction safety", () => {
 
     // Switch to proj-b (2 views, within limit)
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // Switch to proj-c (3 views, over limit)
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // proj-a should have been evicted (getAllViews has 2 entries for proj-b and proj-c)
     const views = managerWithLimit.getAllViews();
@@ -312,6 +317,7 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // proj-a (oldest) has an active agent. Eviction must skip it and evict proj-b instead
     // once we go over the limit with proj-c.
@@ -325,6 +331,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const wcB = wcBEntry?.view.webContents as ReturnType<typeof createMockWebContents> | undefined;
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).toContain("proj-a");
@@ -349,6 +356,7 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // Seed proj-a's terminal as idle (so projectByTerminal knows t-a → proj-a),
     // then flip it to "working" purely via the event bus — the path the cache
@@ -371,6 +379,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const wcB = wcBEntry?.view.webContents as ReturnType<typeof createMockWebContents> | undefined;
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).toContain("proj-a");
@@ -393,6 +402,7 @@ describe("ProjectViewManager — eviction safety", () => {
     const viewA = { webContents: wcA, setBounds: vi.fn() };
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // Seed proj-a as working, then simulate a host crash that comes back with an
     // empty registry — the reseed must drop the stale "working" entry so proj-a
@@ -406,6 +416,7 @@ describe("ProjectViewManager — eviction safety", () => {
     await ptyClientHandlers.get("host-crash")?.();
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // proj-a is the LRU and no longer protected, so it is evicted.
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
@@ -448,6 +459,7 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // Both background candidates have active agents — fallback must evict the LRU
     // (proj-a) and emit a telemetry event rather than let the pool grow unbounded.
@@ -458,6 +470,7 @@ describe("ProjectViewManager — eviction safety", () => {
     await managerWithLimit.initAgentStateCache(mockPtyClient as never);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).not.toContain("proj-a");
@@ -485,7 +498,9 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // All three cached projects have active agents.
     mockGetAllTerminals.mockResolvedValue([
@@ -529,6 +544,7 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // proj-a is the LRU view but small; proj-b is the heaviest cached renderer
     // and more recent. Under #8602, size must not promote proj-b ahead of the
@@ -541,6 +557,7 @@ describe("ProjectViewManager — eviction safety", () => {
     ] as unknown as Electron.ProcessMetric[]);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).not.toContain("proj-a");
@@ -568,14 +585,18 @@ describe("ProjectViewManager — eviction safety", () => {
       managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
       await managerWithLimit.switchTo("proj-b", "/path/b");
+      await flushImmediates();
       await managerWithLimit.switchTo("proj-c", "/path/c");
+      await flushImmediates();
 
       // Re-visit proj-a from cache — its lastUsed must be refreshed so it is
       // no longer the oldest candidate. Without this, the next overflow would
       // wrongly target proj-a.
       await managerWithLimit.switchTo("proj-a", "/path/a");
+      await flushImmediates();
 
       await managerWithLimit.switchTo("proj-d", "/path/d");
+      await flushImmediates();
 
       const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
       expect(remaining).not.toContain("proj-b");
@@ -602,11 +623,13 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // No metrics returned — LRU should still drive eviction (proj-a evicted).
     mockGetAppMetrics.mockReturnValue([]);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).not.toContain("proj-a");
@@ -630,6 +653,7 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // Only proj-a has a measured pid; proj-b is unmeasured. Memory data does
     // not influence the sort — proj-a is the LRU pick and wins eviction
@@ -639,6 +663,7 @@ describe("ProjectViewManager — eviction safety", () => {
     ] as unknown as Electron.ProcessMetric[]);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).not.toContain("proj-a");
@@ -661,6 +686,7 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // proj-a is huge but has an active agent — must not be evicted.
     // proj-b is smaller but evictable.
@@ -680,6 +706,7 @@ describe("ProjectViewManager — eviction safety", () => {
     await managerWithLimit.initAgentStateCache(mockPtyClient as never);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).toContain("proj-a");
@@ -703,12 +730,14 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     mockGetAppMetrics.mockReturnValue([
       { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
       "projectview.eviction",
@@ -731,6 +760,7 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     mockGetAppMetrics.mockImplementation(() => {
       throw new Error("metrics unavailable");
@@ -738,6 +768,7 @@ describe("ProjectViewManager — eviction safety", () => {
 
     // Eviction must still complete without throwing — LRU drives the choice.
     await expect(managerWithLimit.switchTo("proj-c", "/path/c")).resolves.toBeDefined();
+    await flushImmediates();
 
     const remaining = managerWithLimit.getAllViews().map((v) => v.projectId);
     expect(remaining).not.toContain("proj-a");
@@ -760,8 +791,11 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     await managerWithLimit.switchTo("proj-d", "/path/d");
+    await flushImmediates();
 
     const wcB = managerWithLimit.getAllViews().find((v) => v.projectId === "proj-b")?.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
@@ -811,7 +845,9 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(vi.mocked(forgetBlinkSample)).toHaveBeenCalledWith(wcA.id);
   });
@@ -831,7 +867,9 @@ describe("ProjectViewManager — eviction safety", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(vi.mocked(forgetEluSample)).toHaveBeenCalledWith(wcA.id);
   });
@@ -866,7 +904,9 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(vi.mocked(logInfo)).toHaveBeenCalledWith("projectview.eviction", {
       projectId: "proj-a",
@@ -901,7 +941,9 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     vi.mocked(logInfo).mockClear();
 
@@ -946,13 +988,18 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     await manager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     vi.mocked(logInfo).mockClear();
 
     await manager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
 
     const revivalCalls = vi
       .mocked(logInfo)
@@ -985,20 +1032,27 @@ describe("ProjectViewManager — telemetry", () => {
 
     // Set up a revival for proj-a (same trace as the previous test)
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     await manager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-a", "/path/a"); // revival fires for proj-a — timestamp consumed
+    await flushImmediates();
 
     // Switch away to a fresh cold-started project so the next return to proj-a
     // exercises the cache-hit path without touching any other stale timestamps.
     // proj-d is new; cold-starting it evicts proj-b (LRU), leaving {a, d} cached.
     await manager.switchTo("proj-d", "/path/d");
+    await flushImmediates();
 
     vi.mocked(logInfo).mockClear();
 
     // Return to proj-a — cache hit, but evictionTimestamps has no entry for proj-a.
     await manager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
 
     const revivalCalls = vi
       .mocked(logInfo)
@@ -1023,6 +1077,7 @@ describe("ProjectViewManager — telemetry", () => {
     vi.mocked(logInfo).mockClear();
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     const coldStartCall = vi
       .mocked(logInfo)
@@ -1050,7 +1105,9 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c"); // evicts proj-a
+    await flushImmediates();
 
     // dispose should not throw and should clear internal state
     expect(() => manager.dispose()).not.toThrow();
@@ -1075,6 +1132,7 @@ describe("ProjectViewManager — telemetry", () => {
 
     // Cold start to proj-b — no cached view exists, so warm-swap must not fire.
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     const warmSwapCalls = vi
       .mocked(logInfo)
@@ -1097,12 +1155,14 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     vi.mocked(logInfo).mockClear();
 
     // Cache hit on proj-a — no prior eviction, so revival does NOT fire,
     // but warm-swap MUST fire with the activation latency.
     await manager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
 
     const warmSwapCalls = vi
       .mocked(logInfo)
@@ -1134,6 +1194,7 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")?.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
@@ -1201,6 +1262,7 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     // Metrics return nothing for proj-a's pid — sampler must skip silently.
     mockGetAppMetrics.mockReturnValue([]);
@@ -1230,7 +1292,9 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     // proj-c is now active; proj-a and proj-b are cached.
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")?.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
@@ -1276,6 +1340,7 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     mockGetAppMetrics.mockImplementation(() => {
       throw new Error("metrics unavailable");
@@ -1306,6 +1371,7 @@ describe("ProjectViewManager — telemetry", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     mockGetAppMetrics.mockReturnValue([
       { pid: wcA.osPid, memory: { privateBytes: 250 * 1024 } },
@@ -1356,6 +1422,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     expect(onViewCached).not.toHaveBeenCalled();
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     expect(onViewCached).toHaveBeenCalledTimes(1);
     expect(onViewCached).toHaveBeenCalledWith(wcA.id);
@@ -1385,6 +1452,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     throttleMock.mockClear();
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     const cachedOrder = onViewCached.mock.invocationCallOrder[0];
     const throttleCall = throttleMock.mock.calls.findIndex((args) => {
@@ -1415,10 +1483,12 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
     const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     const cEntry = manager.getAllViews().find((v) => v.projectId === "proj-c");
     const wcC = cEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
@@ -1464,6 +1534,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
 
     expect(onViewCached).not.toHaveBeenCalled();
   });
@@ -1490,6 +1561,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     wcA.isDestroyed.mockReturnValue(true);
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
 
     expect(onViewCached).not.toHaveBeenCalled();
   });
@@ -1513,6 +1585,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await expect(manager.switchTo("proj-b", "/path/b")).resolves.toMatchObject({ isNew: true });
+    await flushImmediates();
     expect(manager.getActiveProjectId()).toBe("proj-b");
     expect(onViewCached).toHaveBeenCalledWith(wcA.id);
     // CPU throttle must still happen even if the callback throws — the catch
@@ -1535,6 +1608,7 @@ describe("ProjectViewManager — onViewCached (freeze risk mitigation)", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await expect(manager.switchTo("proj-b", "/path/b")).resolves.toMatchObject({ isNew: true });
+    await flushImmediates();
     expect(vi.mocked(throttleCpuWebContents)).toHaveBeenCalledWith(wcA);
   });
 });
@@ -1578,6 +1652,7 @@ describe("ProjectViewManager — listener cleanup", () => {
 
     // Cold-start proj-b — setupViewHandlers attaches the 6 persistent listeners.
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
     expect(bEntry).toBeDefined();
     const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
@@ -1634,6 +1709,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
     const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
@@ -1673,6 +1749,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     const bEntry = manager.getAllViews().find((v) => v.projectId === "proj-b");
     const wcB = bEntry!.view.webContents as unknown as ReturnType<typeof createMockWebContents>;
 
@@ -1712,6 +1789,7 @@ describe("ProjectViewManager — listener cleanup", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")!.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
 
@@ -1739,7 +1817,9 @@ describe("ProjectViewManager — listener cleanup", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")!.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
@@ -1827,7 +1907,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // cachedProjectViews=3, so 3 views fit — no eviction.
     expect(manager.getAllViews().length).toBe(3);
@@ -1844,7 +1926,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(manager.getAllViews().length).toBe(3);
     expect(wcA.close).not.toHaveBeenCalled();
@@ -1860,7 +1944,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // Override clamped effectiveMax to 1 — only the active proj-c remains.
     const remaining = manager.getAllViews().map((v) => v.projectId);
@@ -1883,7 +1969,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // 50 + 2*1024*1024 KB ≈ 2050 MB > 768 → no override.
     expect(manager.getAllViews().length).toBe(3);
@@ -1899,7 +1987,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     expect(manager.getAllViews().length).toBe(1);
 
     // Pressure subsides
@@ -1907,8 +1997,11 @@ describe("ProjectViewManager — low-memory eviction", () => {
 
     // Subsequent switches should now respect the original cap of 3
     await manager.switchTo("proj-d", "/path/d");
+    await flushImmediates();
     await manager.switchTo("proj-e", "/path/e");
+    await flushImmediates();
     await manager.switchTo("proj-f", "/path/f");
+    await flushImmediates();
     expect(manager.getAllViews().length).toBe(3);
   });
 
@@ -1921,7 +2014,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
       "projectview.pressure-override",
@@ -1951,7 +2046,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // Threshold set but API missing → no override, normal LRU keeps 3 views.
     expect(manager.getAllViews().length).toBe(3);
@@ -1975,7 +2072,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await managerWithLimit.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await managerWithLimit.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // 3 views, cap 2, API missing → normal LRU evicts proj-a with reason "lru".
     expect(managerWithLimit.getAllViews().length).toBe(2);
@@ -1995,7 +2094,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(manager.getAllViews().length).toBe(3);
     expect(wcA.close).not.toHaveBeenCalled();
@@ -2011,7 +2112,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(manager.getAllViews().length).toBe(3);
     expect(wcA.close).not.toHaveBeenCalled();
@@ -2028,7 +2131,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(manager.getAllViews().length).toBe(1);
     expect(wcA.close).toHaveBeenCalled();
@@ -2043,7 +2148,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // Active view (proj-c) survives even under severe pressure.
     const remaining = manager.getAllViews().map((v) => v.projectId);
@@ -2070,8 +2177,11 @@ describe("ProjectViewManager — low-memory eviction", () => {
     pressureManager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await pressureManager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await pressureManager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     await pressureManager.switchTo("proj-d", "/path/d");
+    await flushImmediates();
 
     // 4 views, override clamps to 1 → 3 evictions, callback fires for each.
     expect(pressureManager.getAllViews().length).toBe(1);
@@ -2088,7 +2198,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // Threshold cleared — normal LRU applies, all 3 views fit.
     expect(manager.getAllViews().length).toBe(3);
@@ -2107,7 +2219,9 @@ describe("ProjectViewManager — low-memory eviction", () => {
     manager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await manager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await manager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     // All bad values normalize to null, so override is disabled.
     expect(manager.getAllViews().length).toBe(3);

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -159,6 +159,8 @@ vi.mock("../../utils/logger.js", () => ({
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo } from "../../utils/logger.js";
 
+const flushImmediates = () => new Promise<void>((resolve) => setImmediate(resolve));
+
 function createMockWindow() {
   return {
     isDestroyed: vi.fn(() => false),
@@ -248,7 +250,9 @@ describe("ProjectViewManager — preload eval cost (#9770)", () => {
 
     // Evict proj-a (its webContents → project mapping is torn down).
     await evictingManager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await evictingManager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
 
     expect(() => evictingManager.recordPreloadDuration(staleWcId, 42)).not.toThrow();
     expect(evictingManager.getProjectIdForWebContents(staleWcId)).toBeNull();
@@ -273,14 +277,19 @@ describe("ProjectViewManager — preload eval cost (#9770)", () => {
     revivalManager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await revivalManager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await revivalManager.switchTo("proj-c", "/path/c"); // evicts proj-a (ET set)
+    await flushImmediates();
     await revivalManager.switchTo("proj-a", "/path/a"); // cold start — proj-a re-created
+    await flushImmediates();
 
     revivalManager.recordPreloadDuration(webContentsIdFor(revivalManager, "proj-a"), 27.5);
 
     // A cache hit on proj-a (still carrying its eviction timestamp) fires revival.
     await revivalManager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     await revivalManager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
 
     const revivals = (logInfo as ReturnType<typeof vi.fn>).mock.calls.filter(
       ([event, ctx]) =>
@@ -296,10 +305,15 @@ describe("ProjectViewManager — preload eval cost (#9770)", () => {
     revivalManager.registerInitialView(viewA as never, "proj-a", "/path/a");
 
     await revivalManager.switchTo("proj-b", "/path/b");
+    await flushImmediates();
     await revivalManager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     await revivalManager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
     await revivalManager.switchTo("proj-c", "/path/c");
+    await flushImmediates();
     await revivalManager.switchTo("proj-a", "/path/a");
+    await flushImmediates();
 
     const revival = (logInfo as ReturnType<typeof vi.fn>).mock.calls.find(
       ([event, ctx]) =>

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -5,6 +5,9 @@ import type { GitOperationReason } from "../../shared/types/ipc/errors.js";
 
 const FETCH_ABORT_TIMEOUT_MS = 60_000;
 
+const FETCH_RECENCY_WINDOW_MS = 15_000;
+const FORCE_FETCH_RECENCY_WINDOW_MS = 5_000;
+
 const NETWORK_FAILURE_TTL_MS = 60_000;
 const NETWORK_FAILURE_JITTER_MS = 30_000;
 const REPO_NOT_FOUND_FIRST_FETCH_TTL_MS = 5 * 60_000;
@@ -90,6 +93,11 @@ export interface FetchResult {
  *     after a short window. After at least one prior success, a 404 is more
  *     likely a permission revocation masked as 404 (GitHub does this) — treat
  *     it as auth-failed.
+ *   - Sibling worktrees schedule independent cadence fetches against the same
+ *     origin (and wake/auth-retry paths force one per monitor). A short
+ *     recency window dedups them: when the repo fetched successfully moments
+ *     ago, return that success without spawning git. Refs are shared via the
+ *     commondir, so they are genuinely fresh for every sibling.
  */
 export class RepoFetchCoordinator {
   private readonly states = new Map<string, RepoState>();
@@ -142,6 +150,11 @@ export class RepoFetchCoordinator {
           networkFailed: true,
         };
       }
+    }
+
+    const recent = this.recentSuccessResult(state, opts.force === true);
+    if (recent) {
+      return recent;
     }
 
     const generationAtStart = state.generation;
@@ -213,6 +226,25 @@ export class RepoFetchCoordinator {
     return this.states.get(commonDir)?.lastSuccessfulFetch ?? null;
   }
 
+  /**
+   * Success result reusing the last fetch when it landed within the recency
+   * window — `null` when a real fetch is needed. Never applies over a cached
+   * failure so failure surfacing keeps today's semantics. A negative elapsed
+   * (clock moved backwards) also forces a real fetch.
+   */
+  private recentSuccessResult(state: RepoState, force: boolean): FetchResult | null {
+    if (state.failure || state.lastSuccessfulFetch === null) return null;
+    const window = force ? FORCE_FETCH_RECENCY_WINDOW_MS : FETCH_RECENCY_WINDOW_MS;
+    const elapsed = Date.now() - state.lastSuccessfulFetch;
+    if (elapsed < 0 || elapsed >= window) return null;
+    return {
+      status: "success",
+      lastFetchedAt: state.lastSuccessfulFetch,
+      authFailed: false,
+      networkFailed: false,
+    };
+  }
+
   private getOrCreateState(commonDir: string): RepoState {
     let state = this.states.get(commonDir);
     if (!state) {
@@ -232,6 +264,18 @@ export class RepoFetchCoordinator {
     generationAtStart: number,
     opts: FetchOptions
   ): Promise<FetchResult> {
+    const stateAtStart = this.states.get(commonDir);
+    if (!stateAtStart || stateAtStart.generation !== generationAtStart) {
+      return { status: "skipped", skipReason: "stale-generation" };
+    }
+    // Re-check recency after waiting on the chain — back-to-back sibling
+    // fetches (wake storm, auth retry) all queue before the first completes,
+    // so the dedup has to look at the timestamp the prior link just wrote.
+    const recent = this.recentSuccessResult(stateAtStart, opts.force === true);
+    if (recent) {
+      return recent;
+    }
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), FETCH_ABORT_TIMEOUT_MS);
     let succeeded = false;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -78,6 +78,13 @@ interface GitFileStatBaseline {
   packedRefs: number;
 }
 
+interface BaseDivergence {
+  baseBranchName: string | null;
+  aheadCount: number | null;
+  behindCount: number | null;
+  matchesUpstream: boolean;
+}
+
 export interface WorktreeMonitorConfig {
   basePollingInterval: number;
   adaptiveBackoff: boolean;
@@ -202,6 +209,8 @@ export class WorktreeMonitor {
   // simple-git fork-exec. null = no baseline yet (first poll, or post-error).
   private lastStatBaseline: GitFileStatBaseline | null = null;
   private lastStatBaselineAt: number = 0;
+  private lastBaseDivergenceKey: string | null = null;
+  private lastBaseDivergenceResult: BaseDivergence | null = null;
   private cachedCommonDir: string | null = null;
   // Timer used to defer the initial `updateGitStatus` call for background
   // monitors so N monitors starting together don't fork git simultaneously.
@@ -1952,50 +1961,49 @@ export class WorktreeMonitor {
     }
   }
 
-  private async computeBaseDivergence(hasUpstream: boolean): Promise<{
-    baseBranchName: string | null;
-    aheadCount: number | null;
-    behindCount: number | null;
-    matchesUpstream: boolean;
-  } | null> {
+  private async computeBaseDivergence(hasUpstream: boolean): Promise<BaseDivergence | null> {
     if (!this._branch || this._isMainWorktree) return null;
+
+    // Pick the branch to diff against. A linked PR's base branch is
+    // authoritative — it's exactly where this worktree's work will merge,
+    // which may differ from the repo's integration branch (e.g. a hotfix
+    // PR targeting `main` in a gitflow repo). Without a PR, fall back to
+    // the repository's main/integration branch.
+    const baseBranch = this._linked?.pr?.baseRef?.trim() || this.mainBranch;
+
+    // Divergence only moves when refs move, never on working-tree edits, so
+    // a stat key over the involved refs lets forced passes (watcher-driven
+    // edit storms) reuse the last result without any git spawns.
+    const key = await this.buildBaseDivergenceKey(baseBranch, hasUpstream);
+    if (key !== null && key === this.lastBaseDivergenceKey) {
+      return this.lastBaseDivergenceResult;
+    }
+
     const wsl = this.wslInvocation;
     const git = wsl
       ? createWslHardenedGit(wsl, this._pollAbortController.signal)
       : createHardenedGit(this.path, this._pollAbortController.signal);
 
     try {
-      // Pick the branch to diff against. A linked PR's base branch is
-      // authoritative — it's exactly where this worktree's work will merge,
-      // which may differ from the repo's integration branch (e.g. a hotfix
-      // PR targeting `main` in a gitflow repo). Without a PR, fall back to
-      // the repository's main/integration branch.
-      const baseBranch = this._linked?.pr?.baseRef?.trim() || this.mainBranch;
-
-      // Resolve base ref: try origin/<branch> first (remote ref stays fresh
-      // after fetch), fall back to local branch for repos without a remote.
+      // Resolve base ref via the rev-list itself: try origin/<branch> first
+      // (remote ref stays fresh after fetch), fall back to the local branch
+      // for repos without a remote.
       const remoteRef = `origin/${baseBranch}`;
       const localRef = baseBranch;
-      let resolvedRef: string;
+      const baseBranchName = baseBranch;
+      let resolvedRef = remoteRef;
+      let result: string;
       try {
-        await git.raw(["rev-parse", "--verify", remoteRef]);
-        resolvedRef = remoteRef;
+        result = await git.raw(["rev-list", "--count", "--left-right", `${remoteRef}...HEAD`]);
       } catch {
         try {
-          await git.raw(["rev-parse", "--verify", localRef]);
+          result = await git.raw(["rev-list", "--count", "--left-right", `${localRef}...HEAD`]);
           resolvedRef = localRef;
         } catch {
+          this.lastBaseDivergenceKey = null;
           return null;
         }
       }
-
-      const baseBranchName = baseBranch;
-      const result = await git.raw([
-        "rev-list",
-        "--count",
-        "--left-right",
-        `${resolvedRef}...HEAD`,
-      ]);
       const trimmed = result.trim();
       const parts = trimmed.split("\t");
       const behindCount = parts[0] != null && parts[0] !== "" ? parseInt(parts[0], 10) : 0;
@@ -2015,12 +2023,50 @@ export class WorktreeMonitor {
         }
       }
 
-      return {
+      const divergence: BaseDivergence = {
         baseBranchName,
         aheadCount: Number.isFinite(aheadCount) ? aheadCount : null,
         behindCount: Number.isFinite(behindCount) ? behindCount : null,
         matchesUpstream,
       };
+      this.lastBaseDivergenceKey = key;
+      this.lastBaseDivergenceResult = divergence;
+      return divergence;
+    } catch {
+      this.lastBaseDivergenceKey = null;
+      return null;
+    }
+  }
+
+  /**
+   * Stat-derived cache key for `computeBaseDivergence`. Covers every ref the
+   * computation reads: HEAD, this branch's local ref, the base branch's local
+   * and remote refs, the upstream remote ref (the `@{u}` proxy for
+   * `matchesUpstream`), and packed-refs. The remote-ref stats are essential —
+   * `git fetch` writes loose refs under refs/remotes/ without touching
+   * packed-refs, so the stat-baseline fields alone would serve stale
+   * behind-of-base counts after background fetches. Returns `null` (compute,
+   * don't cache) on any stat failure beyond ENOENT.
+   */
+  private async buildBaseDivergenceKey(
+    baseBranch: string,
+    hasUpstream: boolean
+  ): Promise<string | null> {
+    const branch = this._branch;
+    if (!branch) return null;
+    const gitDir = getGitDir(this.path, { cache: true, logErrors: false });
+    if (!gitDir) return null;
+    try {
+      const commonDir = await this.resolveCommonDirAsync(gitDir);
+      const stats = await Promise.all([
+        this.statMtime(pathJoin(gitDir, "HEAD")),
+        this.statMtime(pathJoin(commonDir, "refs", "heads", branch)),
+        this.statMtime(pathJoin(commonDir, "packed-refs")),
+        this.statMtime(pathJoin(commonDir, "refs", "heads", baseBranch)),
+        this.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", baseBranch)),
+        this.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", branch)),
+      ]);
+      return [branch, baseBranch, hasUpstream, ...stats].join(" ");
     } catch {
       return null;
     }

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -106,7 +106,9 @@ describe("RepoFetchCoordinator", () => {
     const firstTs = ok.lastFetchedAt;
     expect(firstTs).not.toBeNull();
 
-    // Second call: transient fetch error.
+    // Second call: transient fetch error. Advance past the recency window so
+    // the call actually fetches instead of reusing the first success.
+    vi.advanceTimersByTime(30_000);
     mockCreateBackgroundFetchGit.mockReturnValueOnce(
       makeMockGit(() => Promise.reject(new Error("the remote end hung up unexpectedly")))
     );
@@ -133,6 +135,8 @@ describe("RepoFetchCoordinator", () => {
   it("serializes fetches for sibling worktrees sharing a commondir", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
 
+    // Failing fetches never record a success, so each queued sibling still
+    // runs a real fetch — exercising the per-commondir chain itself.
     let inFlight = 0;
     let maxInFlight = 0;
     mockCreateBackgroundFetchGit.mockReturnValue(
@@ -142,6 +146,7 @@ describe("RepoFetchCoordinator", () => {
         await Promise.resolve();
         await Promise.resolve();
         inFlight--;
+        throw new Error("the remote end hung up unexpectedly");
       })
     );
 
@@ -154,6 +159,105 @@ describe("RepoFetchCoordinator", () => {
 
     expect(maxInFlight).toBe(1);
     expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(3);
+  });
+
+  it("dedups queued sibling fetches once the first one in the chain succeeds", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(makeMockGit(() => Promise.resolve()));
+
+    const onFetchSuccess = vi.fn();
+    const coord = new RepoFetchCoordinator({ onFetchSuccess });
+    const results = await Promise.all([
+      coord.fetchForWorktree({ worktreeId: "wtA", worktreePath: "/repo/a" }),
+      coord.fetchForWorktree({ worktreeId: "wtB", worktreePath: "/repo/b" }),
+      coord.fetchForWorktree({ worktreeId: "wtC", worktreePath: "/repo/c" }),
+    ]);
+
+    expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(1);
+    expect(results.map((r) => r.status)).toEqual(["success", "success", "success"]);
+    const stamps = new Set(results.map((r) => r.lastFetchedAt));
+    expect(stamps.size).toBe(1);
+    expect(onFetchSuccess).toHaveBeenCalledTimes(1);
+    expect(onFetchSuccess).toHaveBeenCalledWith("wtA");
+  });
+
+  it("skips a fetch inside the recency window and runs a real one after it elapses", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(makeMockGit(() => Promise.resolve()));
+
+    const coord = new RepoFetchCoordinator();
+    const first = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(first.status).toBe("success");
+
+    mockCreateBackgroundFetchGit.mockClear();
+    const within = await coord.fetchForWorktree({ worktreeId: "wt2", worktreePath: "/repo" });
+    expect(within.status).toBe("success");
+    expect(within.lastFetchedAt).toBe(first.lastFetchedAt);
+    expect(mockCreateBackgroundFetchGit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(16_000);
+    const after = await coord.fetchForWorktree({ worktreeId: "wt2", worktreePath: "/repo" });
+    expect(after.status).toBe("success");
+    expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies a short recency window to force fetches (wake storm)", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(makeMockGit(() => Promise.resolve()));
+
+    const coord = new RepoFetchCoordinator();
+    const first = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+      force: true,
+    });
+    expect(first.status).toBe("success");
+
+    mockCreateBackgroundFetchGit.mockClear();
+    const within = await coord.fetchForWorktree({
+      worktreeId: "wt2",
+      worktreePath: "/repo",
+      force: true,
+    });
+    expect(within.status).toBe("success");
+    expect(within.lastFetchedAt).toBe(first.lastFetchedAt);
+    expect(mockCreateBackgroundFetchGit).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(6_000);
+    const after = await coord.fetchForWorktree({
+      worktreeId: "wt2",
+      worktreePath: "/repo",
+      force: true,
+    });
+    expect(after.status).toBe("success");
+    expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(1);
+  });
+
+  it("never serves the recency skip over a cached failure", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    let attempt = 0;
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => {
+        attempt++;
+        if (attempt === 1) return Promise.resolve();
+        return Promise.reject(new Error("Could not resolve host: github.com"));
+      })
+    );
+
+    const coord = new RepoFetchCoordinator();
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    vi.advanceTimersByTime(6_000);
+    const failed = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+      force: true,
+    });
+    expect(failed.status).toBe("failed");
+
+    const blocked = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(blocked.status).toBe("skipped");
+    expect(blocked.skipReason).toBe("in-failure-window");
+    expect(blocked.networkFailed).toBe(true);
   });
 
   it("allows concurrent fetches for distinct commondirs", async () => {
@@ -283,7 +387,9 @@ describe("RepoFetchCoordinator", () => {
     await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
     expect(coord.getLastSuccessfulFetch("/repo/.git")).not.toBeNull();
 
-    // Second fetch fails with 404 — now treated as auth-failed.
+    // Second fetch (past the recency window) fails with 404 — now treated as
+    // auth-failed.
+    vi.advanceTimersByTime(30_000);
     const second = await coord.fetchForWorktree({
       worktreeId: "wt1",
       worktreePath: "/repo",

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -859,6 +859,76 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
+    it("falls back to the local base ref when origin/<base> can't be resolved", async () => {
+      mockGetWorktreeChangesWithStats.mockResolvedValue(
+        cleanChangesWith({ tracking: "origin/test-branch", ahead: 1, behind: 0 })
+      );
+      mockGitRaw.mockImplementation((args: string[]) => {
+        if (args[0] === "rev-parse") return Promise.resolve("abc\nabc\n");
+        if (args.includes("origin/main...HEAD")) {
+          return Promise.reject(new Error("unknown revision"));
+        }
+        return Promise.resolve("1\t4\n");
+      });
+
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+      await flushInitialStatus();
+
+      expect(mockGitRaw).toHaveBeenCalledWith([
+        "rev-list",
+        "--count",
+        "--left-right",
+        "main...HEAD",
+      ]);
+      const snapshot = monitor.getSnapshot();
+      expect(snapshot.baseBranchName).toBe("main");
+      expect(snapshot.baseBehindCount).toBe(1);
+      expect(snapshot.baseAheadCount).toBe(4);
+      expect(snapshot.baseMatchesUpstream).toBe(true);
+      expect(mockGitRaw).toHaveBeenCalledWith(["rev-parse", "@{u}", "main"]);
+
+      monitor.stop();
+    });
+
+    it("reuses cached divergence on forced passes until a tracked ref's stat changes", async () => {
+      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(readFile).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      vi.mocked(stat).mockResolvedValue({ mtimeMs: 1_000 } as unknown as Awaited<
+        ReturnType<typeof stat>
+      >);
+      mockGetWorktreeChangesWithStats.mockResolvedValue(cleanChangesWith({ tracking: null }));
+      mockGitRaw.mockResolvedValue("2\t5\n");
+
+      const revListCalls = () =>
+        mockGitRaw.mock.calls.filter((c) => Array.isArray(c[0]) && c[0][0] === "rev-list").length;
+
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
+      await monitor.start();
+      await flushInitialStatus();
+      expect(revListCalls()).toBe(1);
+      expect(monitor.getSnapshot().baseAheadCount).toBe(5);
+      expect(monitor.getSnapshot().baseBehindCount).toBe(2);
+
+      // Forced pass with unchanged refs: divergence comes from the cache.
+      await monitor.updateGitStatus(true);
+      expect(revListCalls()).toBe(1);
+      expect(monitor.getSnapshot().baseAheadCount).toBe(5);
+
+      // A background fetch writes the loose remote base ref without touching
+      // packed-refs — the cache key must notice and recompute.
+      vi.mocked(stat).mockImplementation(async (p) => {
+        const mtimeMs = String(p).endsWith("origin/main") ? 2_000 : 1_000;
+        return { mtimeMs } as unknown as Awaited<ReturnType<typeof stat>>;
+      });
+      mockGitRaw.mockResolvedValue("0\t5\n");
+      await monitor.updateGitStatus(true);
+      expect(revListCalls()).toBe(2);
+      expect(monitor.getSnapshot().baseBehindCount).toBe(0);
+
+      monitor.stop();
+    });
+
     it("reports zero counts when branch is in sync with upstream", async () => {
       mockGetWorktreeChangesWithStats.mockResolvedValue(
         cleanChangesWith({ tracking: "origin/main", ahead: 0, behind: 0 })

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -131,6 +131,14 @@ export interface BootResult extends HydrateResult {
   crashPending: import("./crashRecovery.js").PendingCrash | null;
   /** Live crash recovery configuration (auto-restore toggle, thresholds). */
   crashConfig: import("./crashRecovery.js").CrashRecoveryConfig;
+  /**
+   * Persisted app theme config folded into the boot payload so the renderer
+   * seeds custom schemes, accent override, and color-vision mode without a
+   * post-mount `app-theme:get` round-trip. Undefined when the stored config
+   * still needs first-run defaulting or legacy customSchemes migration — the
+   * renderer falls back to the live IPC call, which performs both.
+   */
+  appTheme?: import("../appTheme.js").AppThemeConfig;
 }
 
 /** Result from app hydration */
@@ -197,4 +205,13 @@ export interface HydrateResult {
   tabGroups?: import("../panel.js").TabGroup[];
   terminalSizes?: Record<string, { cols: number; rows: number }>;
   draftInputs?: Record<string, string>;
+  /**
+   * In-repo agent presets (`.daintree/presets/`) folded into the hydrate
+   * payload so the renderer skips the standalone `project:get-inrepo-presets`
+   * round-trip + repo disk read on the panel-restore critical path. Populated
+   * whenever a project is resolved; undefined on the no-project fallback
+   * branch and older payloads, where the renderer falls back to the
+   * standalone IPC call.
+   */
+  projectPresets?: Record<string, import("../../config/agentRegistry.js").AgentPreset[]>;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -719,6 +719,9 @@ function AppInner() {
       void preloadQuickCreatePalette();
       void preloadLogLevelPalette();
       void preloadPluginManagerView();
+      void preloadWorktreeOverviewModal();
+      void preloadShortcutReferenceDialog();
+      void preloadCrossWorktreeDiff();
       import("@fontsource/jetbrains-mono/latin-500.css").catch(() => {});
       import("@fontsource/jetbrains-mono/latin-600.css").catch(() => {});
       // Warm the FileViewerModal/DiffViewer chunk split out of the eager

--- a/src/clients/__tests__/agentSettingsClient.test.ts
+++ b/src/clients/__tests__/agentSettingsClient.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const typedGlobal = globalThis as unknown as Record<string, unknown>;
+
+let agentSettingsClient: typeof import("../agentSettingsClient").agentSettingsClient;
+
+let getMock: ReturnType<typeof vi.fn>;
+let setMock: ReturnType<typeof vi.fn>;
+let resetMock: ReturnType<typeof vi.fn>;
+let stampVersionMock: ReturnType<typeof vi.fn>;
+
+describe("agentSettingsClient", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    getMock = vi.fn();
+    setMock = vi.fn().mockResolvedValue({});
+    resetMock = vi.fn().mockResolvedValue({});
+    stampVersionMock = vi.fn().mockResolvedValue({});
+
+    typedGlobal.window = {
+      electron: {
+        agentSettings: {
+          get: getMock,
+          set: setMock,
+          reset: resetMock,
+          stampVersion: stampVersionMock,
+        },
+      },
+    };
+
+    const mod = await import("../agentSettingsClient");
+    agentSettingsClient = mod.agentSettingsClient;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  it("coalesces concurrent get() calls into a single IPC call", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getMock.mockReturnValue(deferred);
+
+    const p1 = agentSettingsClient.get();
+    const p2 = agentSettingsClient.get();
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(p1).toBe(p2);
+
+    resolve({ claude: { pinned: true } });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual({ claude: { pinned: true } });
+    expect(r2).toEqual({ claude: { pinned: true } });
+  });
+
+  it("does not cache resolved values — sequential get() calls re-fetch", async () => {
+    getMock.mockResolvedValue({ claude: {} });
+
+    await agentSettingsClient.get();
+    await agentSettingsClient.get();
+
+    expect(getMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers from a rejected get() on the next call", async () => {
+    getMock.mockRejectedValueOnce(new Error("IPC error"));
+
+    await expect(agentSettingsClient.get()).rejects.toThrow("IPC error");
+
+    getMock.mockResolvedValue({ claude: {} });
+    const result = await agentSettingsClient.get();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ claude: {} });
+  });
+
+  it("set() clears the inflight get() so post-write reads start fresh", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getMock.mockReturnValueOnce(deferred);
+
+    const stale = agentSettingsClient.get();
+    void agentSettingsClient.set("claude", { pinned: true });
+
+    getMock.mockResolvedValue({ claude: { pinned: true } });
+    const fresh = agentSettingsClient.get();
+    expect(fresh).not.toBe(stale);
+    expect(getMock).toHaveBeenCalledTimes(2);
+
+    resolve({ claude: {} });
+    await expect(fresh).resolves.toEqual({ claude: { pinned: true } });
+  });
+
+  it("reset() and stampVersion() also clear the inflight get()", async () => {
+    let resolveFirst!: (v: unknown) => void;
+    getMock.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveFirst = r;
+      })
+    );
+    const stale = agentSettingsClient.get();
+    void agentSettingsClient.reset();
+    getMock.mockResolvedValueOnce({});
+    const fresh = agentSettingsClient.get();
+    expect(fresh).not.toBe(stale);
+    resolveFirst({});
+    await Promise.all([stale, fresh]);
+
+    let resolveSecond!: (v: unknown) => void;
+    getMock.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveSecond = r;
+      })
+    );
+    const stale2 = agentSettingsClient.get();
+    void agentSettingsClient.stampVersion(2);
+    getMock.mockResolvedValueOnce({});
+    const fresh2 = agentSettingsClient.get();
+    expect(fresh2).not.toBe(stale2);
+    expect(getMock).toHaveBeenCalledTimes(4);
+    resolveSecond({});
+    await Promise.all([stale2, fresh2]);
+  });
+});

--- a/src/clients/__tests__/agentSettingsClient.test.ts
+++ b/src/clients/__tests__/agentSettingsClient.test.ts
@@ -56,13 +56,45 @@ describe("agentSettingsClient", () => {
     expect(r2).toEqual({ claude: { pinned: true } });
   });
 
-  it("does not cache resolved values — sequential get() calls re-fetch", async () => {
+  it("caches the resolved value — sequential get() calls skip the IPC", async () => {
     getMock.mockResolvedValue({ claude: {} });
 
-    await agentSettingsClient.get();
+    const first = await agentSettingsClient.get();
+    const second = await agentSettingsClient.get();
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it("invalidate() drops the cache so the next get() hits main", async () => {
+    getMock.mockResolvedValueOnce({ claude: {} });
     await agentSettingsClient.get();
 
+    agentSettingsClient.invalidate();
+
+    getMock.mockResolvedValueOnce({ claude: { pinned: true } });
+    const fresh = await agentSettingsClient.get();
     expect(getMock).toHaveBeenCalledTimes(2);
+    expect(fresh).toEqual({ claude: { pinned: true } });
+  });
+
+  it("does not cache a snapshot fetched across a write window", async () => {
+    let resolve!: (v: unknown) => void;
+    getMock.mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r;
+      })
+    );
+
+    const racing = agentSettingsClient.get();
+    await agentSettingsClient.set("claude", { pinned: true });
+    resolve({ claude: {} });
+    await racing;
+
+    getMock.mockResolvedValueOnce({ claude: { pinned: true } });
+    const fresh = await agentSettingsClient.get();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(fresh).toEqual({ claude: { pinned: true } });
   });
 
   it("recovers from a rejected get() on the next call", async () => {

--- a/src/clients/__tests__/systemClient.test.ts
+++ b/src/clients/__tests__/systemClient.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const typedGlobal = globalThis as unknown as Record<string, unknown>;
+
+let systemClient: typeof import("../systemClient").systemClient;
+
+let getTmpDirMock: ReturnType<typeof vi.fn>;
+
+describe("systemClient.getTmpDir", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    getTmpDirMock = vi.fn();
+
+    typedGlobal.window = {
+      electron: {
+        system: {
+          getTmpDir: getTmpDirMock,
+        },
+      },
+    };
+
+    const mod = await import("../systemClient");
+    systemClient = mod.systemClient;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  it("coalesces concurrent calls into a single IPC call", async () => {
+    let resolve!: (v: string) => void;
+    const deferred = new Promise<string>((r) => {
+      resolve = r;
+    });
+    getTmpDirMock.mockReturnValue(deferred);
+
+    const p1 = systemClient.getTmpDir();
+    const p2 = systemClient.getTmpDir();
+
+    expect(getTmpDirMock).toHaveBeenCalledTimes(1);
+    expect(p1).toBe(p2);
+
+    resolve("/tmp");
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe("/tmp");
+    expect(r2).toBe("/tmp");
+  });
+
+  it("returns the cached value on subsequent calls after resolution", async () => {
+    getTmpDirMock.mockResolvedValue("/tmp");
+
+    const r1 = await systemClient.getTmpDir();
+    const r2 = await systemClient.getTmpDir();
+    const r3 = await systemClient.getTmpDir();
+
+    expect(getTmpDirMock).toHaveBeenCalledTimes(1);
+    expect(r1).toBe("/tmp");
+    expect(r2).toBe("/tmp");
+    expect(r3).toBe("/tmp");
+  });
+
+  it("does not poison the cache on IPC rejection", async () => {
+    getTmpDirMock.mockRejectedValueOnce(new Error("IPC error"));
+
+    await expect(systemClient.getTmpDir()).rejects.toThrow("IPC error");
+
+    getTmpDirMock.mockResolvedValue("/tmp");
+    const result = await systemClient.getTmpDir();
+    expect(getTmpDirMock).toHaveBeenCalledTimes(2);
+    expect(result).toBe("/tmp");
+  });
+});

--- a/src/clients/agentSettingsClient.ts
+++ b/src/clients/agentSettingsClient.ts
@@ -1,42 +1,62 @@
 import type { AgentSettings, AgentSettingsEntry } from "@shared/types";
 
-// Singleflight on get(): burst paths (bulk restart, duplicate, recipe spawns)
-// coalesce concurrent reads into one IPC round-trip. Deliberately no resolved-
-// value cache — agentSettingsStore.refresh() exists to re-pull external
-// changes (cross-window writes, config reloads) and must always hit main.
-// Writes clear the inflight read so post-write get() calls never coalesce
-// onto a pre-write fetch.
+// Value cache + singleflight on get(): burst paths (bulk restart, duplicate,
+// recipe spawns) coalesce concurrent reads into one IPC round-trip, and later
+// reads are served from the cached snapshot without touching main. Freshness
+// contract: writes through this client invalidate (at call time AND on
+// settle, so a read that raced the write window can't leave a pre-write
+// snapshot cached); external changes (cross-window writes, config reloads)
+// are re-pulled by agentSettingsStore.refresh(), which calls invalidate()
+// first so its get() always hits main.
+let cachedSettings: AgentSettings | null = null;
 let inflightGet: Promise<AgentSettings> | null = null;
 
-function clearInflightGet(): void {
+function invalidate(): void {
+  cachedSettings = null;
   inflightGet = null;
 }
 
 export const agentSettingsClient = {
   get: (): Promise<AgentSettings> => {
+    if (cachedSettings) return Promise.resolve(cachedSettings);
     if (inflightGet) return inflightGet;
 
-    const promise = window.electron.agentSettings.get().finally(() => {
-      if (inflightGet === promise) {
-        inflightGet = null;
+    const promise = window.electron.agentSettings.get().then(
+      (settings) => {
+        // Only cache if no invalidation superseded this fetch mid-flight —
+        // a write that landed while we were reading makes this snapshot stale.
+        if (inflightGet === promise) {
+          cachedSettings = settings;
+          inflightGet = null;
+        }
+        return settings;
+      },
+      (error: unknown) => {
+        if (inflightGet === promise) {
+          inflightGet = null;
+        }
+        throw error;
       }
-    });
+    );
     inflightGet = promise;
     return promise;
   },
 
+  /** Drop the cached snapshot so the next get() hits main. */
+  invalidate,
+
   set: (agentId: string, settings: Partial<AgentSettingsEntry>): Promise<AgentSettings> => {
-    clearInflightGet();
-    return window.electron.agentSettings.set(agentId, settings);
+    invalidate();
+    return window.electron.agentSettings.set(agentId, settings).finally(invalidate);
   },
 
   reset: (agentType?: string): Promise<AgentSettings> => {
-    clearInflightGet();
-    return window.electron.agentSettings.reset(agentType);
+    invalidate();
+    return window.electron.agentSettings.reset(agentType).finally(invalidate);
   },
 
   stampVersion: (version: number): Promise<Record<string, unknown>> => {
-    clearInflightGet();
-    return window.electron.agentSettings.stampVersion(version);
+    invalidate();
+    return window.electron.agentSettings.stampVersion(version).finally(invalidate);
   },
 } as const;

--- a/src/clients/agentSettingsClient.ts
+++ b/src/clients/agentSettingsClient.ts
@@ -1,19 +1,42 @@
 import type { AgentSettings, AgentSettingsEntry } from "@shared/types";
 
+// Singleflight on get(): burst paths (bulk restart, duplicate, recipe spawns)
+// coalesce concurrent reads into one IPC round-trip. Deliberately no resolved-
+// value cache — agentSettingsStore.refresh() exists to re-pull external
+// changes (cross-window writes, config reloads) and must always hit main.
+// Writes clear the inflight read so post-write get() calls never coalesce
+// onto a pre-write fetch.
+let inflightGet: Promise<AgentSettings> | null = null;
+
+function clearInflightGet(): void {
+  inflightGet = null;
+}
+
 export const agentSettingsClient = {
   get: (): Promise<AgentSettings> => {
-    return window.electron.agentSettings.get();
+    if (inflightGet) return inflightGet;
+
+    const promise = window.electron.agentSettings.get().finally(() => {
+      if (inflightGet === promise) {
+        inflightGet = null;
+      }
+    });
+    inflightGet = promise;
+    return promise;
   },
 
   set: (agentId: string, settings: Partial<AgentSettingsEntry>): Promise<AgentSettings> => {
+    clearInflightGet();
     return window.electron.agentSettings.set(agentId, settings);
   },
 
   reset: (agentType?: string): Promise<AgentSettings> => {
+    clearInflightGet();
     return window.electron.agentSettings.reset(agentType);
   },
 
   stampVersion: (version: number): Promise<Record<string, unknown>> => {
+    clearInflightGet();
     return window.electron.agentSettings.stampVersion(version);
   },
 } as const;

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -7,6 +7,12 @@
  * const hasGit = await systemClient.checkCommand("git");
  * ```
  */
+// os.tmpdir() is session-constant, so the first resolved value is cached for
+// the app lifetime; concurrent first calls share one IPC round-trip. Pattern
+// mirrors globalEnvClient.ts (minus invalidation — the value cannot change).
+let tmpDirInflight: Promise<string> | null = null;
+let cachedTmpDir: string | null = null;
+
 export const systemClient = {
   openExternal: (url: string): Promise<void> => {
     return window.electron.system.openExternal(url);
@@ -38,7 +44,22 @@ export const systemClient = {
   },
 
   getTmpDir: (): Promise<string> => {
-    return window.electron.system.getTmpDir();
+    if (cachedTmpDir !== null) return Promise.resolve(cachedTmpDir);
+    if (tmpDirInflight) return tmpDirInflight;
+
+    const promise = window.electron.system
+      .getTmpDir()
+      .then((result) => {
+        cachedTmpDir = result;
+        return result;
+      })
+      .finally(() => {
+        if (tmpDirInflight === promise) {
+          tmpDirInflight = null;
+        }
+      });
+    tmpDirInflight = promise;
+    return promise;
   },
 
   healthCheck: (agentIds?: string[]): ReturnType<typeof window.electron.system.healthCheck> => {

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -49,6 +49,7 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
 
 import { resolveEffectivePresetId } from "@shared/types";
@@ -102,7 +103,6 @@ function AgentExternalLinkItems({ links }: { links?: AgentExternalLink[] }) {
 
 interface WorktreeMenuItemsProps {
   agentType: AgentType;
-  worktrees: ReturnType<typeof useWorktrees>["worktrees"];
 }
 
 // Flattens the worktree picker from a nested 3-deep submenu (worktree →
@@ -120,7 +120,8 @@ interface WorktreeMenuItemsProps {
 // row's onSelect honors the ref and skips the grid dispatch when set.
 // pointerDown/pointerUp still stopPropagation to keep Radix from
 // treating the icon press as the row's primary selection event.
-function WorktreeMenuItems({ agentType, worktrees }: WorktreeMenuItemsProps) {
+function WorktreeMenuItems({ agentType }: WorktreeMenuItemsProps) {
+  const { worktrees } = useWorktrees();
   const dockClickedRef = useRef(false);
   const source = useMenuActionSource();
   return (
@@ -176,7 +177,7 @@ export function AgentButton({
   availability,
   "data-toolbar-item": dataToolbarItem,
 }: AgentButtonProps) {
-  const { worktrees } = useWorktrees();
+  const hasWorktrees = useWorktreeStore((s) => s.worktrees.size > 0);
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const ariaShortcut = useAriaKeyshortcuts(`agent.${type}`);
   const hover = useShortcutHintHover(`agent.${type}`);
@@ -445,13 +446,13 @@ export function AgentButton({
           >
             Launch {config.name} in Dock
           </ContextMenuActionItem>
-          {worktrees.length > 0 && (
+          {hasWorktrees && (
             <ContextMenuSub>
               <ContextMenuSubTrigger disabled={!isLaunchable}>
                 Launch in Worktree
               </ContextMenuSubTrigger>
               <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-                <WorktreeMenuItems agentType={type} worktrees={worktrees} />
+                <WorktreeMenuItems agentType={type} />
               </ContextMenuSubContent>
             </ContextMenuSub>
           )}
@@ -742,13 +743,13 @@ export function AgentButton({
             </ContextMenuSubContent>
           </ContextMenuSub>
         )}
-        {worktrees.length > 0 && (
+        {hasWorktrees && (
           <ContextMenuSub>
             <ContextMenuSubTrigger disabled={!isLaunchable}>
               Launch in Worktree
             </ContextMenuSubTrigger>
             <ContextMenuSubContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-              <WorktreeMenuItems agentType={type} worktrees={worktrees} />
+              <WorktreeMenuItems agentType={type} />
             </ContextMenuSubContent>
           </ContextMenuSub>
         )}

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -109,6 +109,11 @@ vi.mock("@/hooks/useWorktrees", () => ({
   useWorktrees: () => ({ worktrees: mockWorktrees }),
 }));
 
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (s: { worktrees: Map<string, unknown> }) => unknown) =>
+    selector({ worktrees: new Map(mockWorktrees.map((wt) => [wt.id, wt])) }),
+}));
+
 vi.mock("@/hooks", () => ({
   useKeybindingDisplay: () => null,
   useAriaKeyshortcuts: () => undefined,

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -37,6 +37,7 @@ import { usePreferencesStore } from "@/store";
 import { keybindingService } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 import { formatTimeAgo } from "@/utils/timeAgo";
 import { useDistributionStore } from "@/store/distributionStore";
@@ -219,13 +220,29 @@ export function GeneralTab({
   const handleStoreUpdateNotificationsToggle = async () => {
     if (storeUpdateSettingsSaving || storeUpdateNotificationsEnabled === null) return;
     if (!window.electron?.storeUpdate?.setSettings) return;
-    const next = !storeUpdateNotificationsEnabled;
+    const prev = storeUpdateNotificationsEnabled;
+    const next = !prev;
+    setStoreUpdateNotificationsEnabled(next);
     setStoreUpdateSettingsSaving(true);
     try {
       const result = await window.electron.storeUpdate.setSettings(next);
       if (isMountedRef.current) setStoreUpdateNotificationsEnabled(result.enabled);
     } catch (error) {
       logError("Failed to set store update notification settings", error);
+      if (isMountedRef.current) setStoreUpdateNotificationsEnabled(prev);
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Update notification preference couldn't be saved.",
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => void handleStoreUpdateNotificationsToggle(),
+          },
+        ],
+        context: { eventKind: "uiFeedback" },
+      });
     } finally {
       if (isMountedRef.current) setStoreUpdateSettingsSaving(false);
     }
@@ -234,12 +251,28 @@ export function GeneralTab({
   const handleChannelChange = async (channel: "stable" | "nightly") => {
     if (updatesManagedByStore) return;
     if (channelSaving || channel === updateChannel) return;
+    const prev = updateChannel;
+    setUpdateChannel(channel);
     setChannelSaving(true);
     try {
       const result = await window.electron.update.setChannel(channel);
       if (isMountedRef.current) setUpdateChannel(result);
     } catch (error) {
       logError("Failed to set update channel", error);
+      if (isMountedRef.current) setUpdateChannel(prev);
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Update channel couldn't be changed.",
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => void handleChannelChange(channel),
+          },
+        ],
+        context: { eventKind: "uiFeedback" },
+      });
     } finally {
       if (isMountedRef.current) setChannelSaving(false);
     }
@@ -383,11 +416,13 @@ export function GeneralTab({
   }, []);
   const handleHibernationToggle = async () => {
     if (!hibernationConfig || isSaving) return;
+    const prev = hibernationConfig;
+    setHibernationConfig({ ...prev, enabled: !prev.enabled });
     setIsSaving(true);
     try {
       const result = await actionService.dispatch(
         "hibernation.updateConfig",
-        { enabled: !hibernationConfig.enabled },
+        { enabled: !prev.enabled },
         { source: "user" }
       );
       if (!isMountedRef.current) return;
@@ -397,7 +432,17 @@ export function GeneralTab({
       setHibernationConfig(result.result as HibernationConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
+      setHibernationConfig(prev);
       logError("Failed to update hibernation config", error);
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Auto-hibernation couldn't be updated.",
+        actions: [
+          { label: "Try again", variant: "primary", onClick: () => void handleHibernationToggle() },
+        ],
+        context: { eventKind: "uiFeedback" },
+      });
     } finally {
       if (isMountedRef.current) {
         setIsSaving(false);
@@ -407,11 +452,13 @@ export function GeneralTab({
 
   const handleIdleNotifyToggle = async () => {
     if (!idleNotifyConfig || isIdleNotifySaving) return;
+    const prev = idleNotifyConfig;
+    setIdleNotifyConfig({ ...prev, enabled: !prev.enabled });
     setIsIdleNotifySaving(true);
     try {
       const result = await actionService.dispatch(
         "idleTerminalNotify.updateConfig",
-        { enabled: !idleNotifyConfig.enabled },
+        { enabled: !prev.enabled },
         { source: "user" }
       );
       if (!isMountedRef.current) return;
@@ -421,7 +468,17 @@ export function GeneralTab({
       setIdleNotifyConfig(result.result as IdleTerminalNotifyConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
+      setIdleNotifyConfig(prev);
       logError("Failed to update idle terminal notify config", error);
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Idle terminal notifications couldn't be updated.",
+        actions: [
+          { label: "Try again", variant: "primary", onClick: () => void handleIdleNotifyToggle() },
+        ],
+        context: { eventKind: "uiFeedback" },
+      });
     } finally {
       if (isMountedRef.current) {
         setIsIdleNotifySaving(false);
@@ -431,6 +488,8 @@ export function GeneralTab({
 
   const handleIdleNotifyThresholdChange = async (value: number) => {
     if (!idleNotifyConfig || isIdleNotifySaving) return;
+    const prev = idleNotifyConfig;
+    setIdleNotifyConfig({ ...prev, thresholdMinutes: value });
     setIsIdleNotifySaving(true);
     try {
       const result = await actionService.dispatch(
@@ -445,7 +504,21 @@ export function GeneralTab({
       setIdleNotifyConfig(result.result as IdleTerminalNotifyConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
+      setIdleNotifyConfig(prev);
       logError("Failed to update idle terminal notify threshold", error);
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Idle threshold couldn't be updated.",
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => void handleIdleNotifyThresholdChange(value),
+          },
+        ],
+        context: { eventKind: "uiFeedback" },
+      });
     } finally {
       if (isMountedRef.current) {
         setIsIdleNotifySaving(false);
@@ -455,6 +528,8 @@ export function GeneralTab({
 
   const handleThresholdChange = async (value: number) => {
     if (!hibernationConfig || isSaving) return;
+    const prev = hibernationConfig;
+    setHibernationConfig({ ...prev, inactiveThresholdHours: value });
     setIsSaving(true);
     try {
       const result = await actionService.dispatch(
@@ -469,7 +544,21 @@ export function GeneralTab({
       setHibernationConfig(result.result as HibernationConfig);
     } catch (error) {
       if (!isMountedRef.current) return;
+      setHibernationConfig(prev);
       logError("Failed to update hibernation threshold", error);
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Inactivity threshold couldn't be updated.",
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => void handleThresholdChange(value),
+          },
+        ],
+        context: { eventKind: "uiFeedback" },
+      });
     } finally {
       if (isMountedRef.current) {
         setIsSaving(false);
@@ -643,7 +732,7 @@ export function GeneralTab({
                 isEnabled={storeUpdateNotificationsEnabled ?? true}
                 onChange={() => void handleStoreUpdateNotificationsToggle()}
                 ariaLabel="Toggle Microsoft Store update notifications"
-                disabled={storeUpdateNotificationsEnabled === null || storeUpdateSettingsSaving}
+                disabled={storeUpdateNotificationsEnabled === null}
               />
             </SettingsSection>
           ) : (
@@ -657,7 +746,7 @@ export function GeneralTab({
                 {(["stable", "nightly"] as const).map((ch) => (
                   <button
                     key={ch}
-                    disabled={channelSaving || updateChannel === null}
+                    disabled={updateChannel === null}
                     onClick={() => void handleChannelChange(ch)}
                     className={cn(
                       "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors capitalize",
@@ -752,7 +841,6 @@ export function GeneralTab({
                 isEnabled={idleNotifyConfig.enabled}
                 onChange={handleIdleNotifyToggle}
                 ariaLabel="Idle Terminal Notifications Toggle"
-                disabled={isIdleNotifySaving}
               />
 
               {idleNotifyConfig.enabled && (
@@ -762,7 +850,6 @@ export function GeneralTab({
                     {IDLE_TERMINAL_THRESHOLD_PRESETS.map(({ value, label }) => (
                       <button
                         key={value}
-                        disabled={isIdleNotifySaving}
                         onClick={() => handleIdleNotifyThresholdChange(value)}
                         className={cn(
                           "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",
@@ -803,7 +890,6 @@ export function GeneralTab({
                 isEnabled={hibernationConfig.enabled}
                 onChange={handleHibernationToggle}
                 ariaLabel="Auto-Hibernation Toggle"
-                disabled={isSaving}
               />
 
               {hibernationConfig.enabled && (
@@ -813,7 +899,6 @@ export function GeneralTab({
                     {THRESHOLD_PRESETS.map(({ value, label }) => (
                       <button
                         key={value}
-                        disabled={isSaving}
                         onClick={() => handleThresholdChange(value)}
                         className={cn(
                           "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors",

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { FileChangeDetail, GitStatus } from "../../types";
 import { cn } from "../../lib/utils";
 import { FileDiffModal } from "./FileDiffModal";
@@ -157,6 +157,15 @@ export function FileChangeList({
   const remainingFiles = useMemo(
     () => sortedChanges.slice(maxVisible, maxVisible + 2),
     [sortedChanges, maxVisible]
+  );
+
+  const getAdjacentFile = useCallback(
+    (delta: -1 | 1) => {
+      if (selectedIndex === null) return null;
+      const change = sortedChanges[selectedIndex + delta];
+      return change ? { path: change.relativePath, status: change.status } : null;
+    },
+    [selectedIndex, sortedChanges]
   );
 
   const groupedChanges = useMemo((): FolderGroup[] => {
@@ -320,6 +329,7 @@ export function FileChangeList({
           currentFileIndex={selectedIndex ?? undefined}
           totalFileCount={sortedChanges.length}
           onNavigateFile={navigateFile}
+          getAdjacentFile={getAdjacentFile}
         />
       </>
     );
@@ -359,6 +369,7 @@ export function FileChangeList({
         currentFileIndex={selectedIndex ?? undefined}
         totalFileCount={sortedChanges.length}
         onNavigateFile={navigateFile}
+        getAdjacentFile={getAdjacentFile}
       />
     </>
   );

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -11,10 +11,24 @@ import { usePreferencesStore } from "@/store/preferencesStore";
 // the shared gitOps rate-limit budget). Cleared whenever a diff modal closes,
 // which bounds staleness to a single review session.
 const DIFF_CACHE_MAX = 20;
+const PREFETCH_DWELL_MS = 500;
 const diffCache = new Map<string, string>();
+const inflightDiffRequests = new Map<string, Promise<string | null>>();
+let diffCacheGeneration = 0;
 
 export function _resetDiffCacheForTests(): void {
   diffCache.clear();
+  inflightDiffRequests.clear();
+  diffCacheGeneration++;
+}
+
+function diffCacheKey(
+  worktreePath: string,
+  filePath: string,
+  status: GitStatus,
+  ignoreWhitespace: boolean
+): string {
+  return `${worktreePath}\u0000${filePath}\u0000${status}\u0000${ignoreWhitespace}`;
 }
 
 function cacheDiff(key: string, value: string): void {
@@ -24,6 +38,45 @@ function cacheDiff(key: string, value: string): void {
     const oldest = diffCache.keys().next().value;
     if (oldest !== undefined) diffCache.delete(oldest);
   }
+}
+
+// Single fetch path shared by the foreground load and the next-file prefetch:
+// cache hits resolve without dispatching and in-flight requests are deduped so
+// the two never double-spend the shared gitOps rate-limit budget on one key.
+// The generation guard keeps a request resolving after the modal closed (and
+// cleared the cache) from seeding the next session with a stale entry.
+function requestDiff(
+  worktreePath: string,
+  filePath: string,
+  status: GitStatus,
+  ignoreWhitespace: boolean,
+  bypassCache = false
+): Promise<string | null> {
+  const key = diffCacheKey(worktreePath, filePath, status, ignoreWhitespace);
+  if (!bypassCache) {
+    const cached = diffCache.get(key);
+    if (cached !== undefined) return Promise.resolve(cached);
+    const inflight = inflightDiffRequests.get(key);
+    if (inflight) return inflight;
+  }
+  const generation = diffCacheGeneration;
+  const request = actionService
+    .dispatch<{ content: string }>(
+      "git.getFileDiff",
+      { cwd: worktreePath, filePath, status, ignoreWhitespace },
+      { source: "user" }
+    )
+    .then((result) => {
+      if (!result.ok) return null;
+      const content = result.result.content || "NO_CHANGES";
+      if (generation === diffCacheGeneration) cacheDiff(key, content);
+      return content;
+    })
+    .finally(() => {
+      if (inflightDiffRequests.get(key) === request) inflightDiffRequests.delete(key);
+    });
+  inflightDiffRequests.set(key, request);
+  return request;
 }
 
 // Lazy boundary cutting the static edge to `react-diff-view` + `refractor`
@@ -66,6 +119,8 @@ export interface FileDiffModalProps {
   totalFileCount?: number;
   /** Step to the previous (-1) or next (1) file in the set. */
   onNavigateFile?: (delta: -1 | 1) => void;
+  /** Resolve the neighboring file in the set, for prefetching its diff. */
+  getAdjacentFile?: (delta: -1 | 1) => { path: string; status: GitStatus } | null;
 }
 
 export function FileDiffModal({
@@ -78,6 +133,7 @@ export function FileDiffModal({
   currentFileIndex,
   totalFileCount,
   onNavigateFile,
+  getAdjacentFile,
 }: FileDiffModalProps) {
   const [diff, setDiff] = useState<string | undefined>(undefined);
   const requestRef = useRef(0);
@@ -99,7 +155,7 @@ export function FileDiffModal({
 
   const fetchDiff = useCallback(
     async (bypassCache = false) => {
-      const cacheKey = `${worktreePath}\u0000${filePath}\u0000${status}\u0000${ignoreWhitespace}`;
+      const cacheKey = diffCacheKey(worktreePath, filePath, status, ignoreWhitespace);
       const requestId = ++requestRef.current;
       if (!bypassCache) {
         const cached = diffCache.get(cacheKey);
@@ -110,19 +166,15 @@ export function FileDiffModal({
       }
       setDiff(undefined);
       try {
-        const result = await actionService.dispatch<{ content: string }>(
-          "git.getFileDiff",
-          { cwd: worktreePath, filePath, status, ignoreWhitespace },
-          { source: "user" }
+        const content = await requestDiff(
+          worktreePath,
+          filePath,
+          status,
+          ignoreWhitespace,
+          bypassCache
         );
         if (requestRef.current !== requestId) return;
-        if (!result.ok) {
-          setDiff("ERROR");
-          return;
-        }
-        const content = result.result.content || "NO_CHANGES";
-        cacheDiff(cacheKey, content);
-        setDiff(content);
+        setDiff(content ?? "ERROR");
       } catch {
         if (requestRef.current !== requestId) return;
         setDiff("ERROR");
@@ -140,11 +192,29 @@ export function FileDiffModal({
       setDiff(undefined);
       requestRef.current++;
       diffCache.clear();
+      diffCacheGeneration++;
       return;
     }
 
     void fetchDiff();
   }, [isOpen, fetchDiff]);
+
+  // Once the current diff has landed and the user has dwelled on it, warm the
+  // next file's diff so forward stepping renders from cache instead of a
+  // skeleton. The dwell timer keeps rapid scrubbing from bursting requests
+  // against the shared gitOps rate limit; failures are silently dropped — the
+  // foreground fetch will retry and surface its own error.
+  useEffect(() => {
+    if (!isOpen || !getAdjacentFile || diff === undefined || diff === "ERROR") return;
+    const timer = window.setTimeout(() => {
+      const next = getAdjacentFile(1);
+      if (!next) return;
+      void requestDiff(worktreePath, next.path, next.status, ignoreWhitespace).catch(
+        () => undefined
+      );
+    }, PREFETCH_DWELL_MS);
+    return () => window.clearTimeout(timer);
+  }, [isOpen, diff, getAdjacentFile, worktreePath, ignoreWhitespace]);
 
   return (
     <Suspense fallback={<FileViewerModalFallback isOpen={isOpen} />}>

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { FolderGit2, Check, AlertCircle } from "lucide-react";
@@ -46,6 +47,24 @@ import {
 
 type BranchMode = "new" | "existing";
 
+const branchListCache = new Map<string, BranchInfo[]>();
+
+export function clearBranchListCache(): void {
+  branchListCache.clear();
+}
+
+function deriveDefaultBaseBranch(branchList: BranchInfo[]): {
+  name: string;
+  fromRemote: boolean;
+} {
+  const currentBranch = branchList.find((b) => b.current);
+  const mainBranch =
+    branchList.find((b) => b.name === "main") || branchList.find((b) => b.name === "master");
+  const name = currentBranch?.name || mainBranch?.name || branchList[0]?.name || "";
+  const info = branchList.find((b) => b.name === name);
+  return { name, fromRemote: !!info?.remote };
+}
+
 /** Collapse the normalized forge PR state to the workspace-host form (declined folds into closed). */
 function normalizeSourcePrState(state: PR["state"]): "open" | "closed" | "merged" {
   switch (state) {
@@ -92,6 +111,7 @@ export function NewWorktreeDialog({
   const [worktreeMode, setWorktreeMode] = useState<string>("local");
   const keepEditingButtonRef = useRef<HTMLButtonElement>(null);
   const isCreatingRef = useRef(false);
+  const baseBranchTouchedRef = useRef(false);
 
   const { errors, setValidationError, clearErrors, markTouched, resetErrors } =
     useWorktreeFormErrors();
@@ -104,8 +124,17 @@ export function NewWorktreeDialog({
   const setLastSelectedWorktreeRecipeIdByProject = usePreferencesStore(
     (s) => s.setLastSelectedWorktreeRecipeIdByProject
   );
-  const worktreeMap = useWorktreeStore((s) => s.worktrees);
-  const { recipes, runRecipeWithResults } = useRecipeStore();
+  const inUseBranches = useWorktreeStore(
+    useShallow((s) => {
+      const names: string[] = [];
+      for (const wt of s.worktrees.values()) {
+        if (wt.branch) names.push(wt.branch);
+      }
+      return names.sort();
+    })
+  );
+  const recipes = useRecipeStore((s) => s.recipes);
+  const runRecipeWithResults = useRecipeStore((s) => s.runRecipeWithResults);
   const currentProject = useProjectStore((s) => s.currentProject);
   const projectId = currentProject?.id ?? "";
   const lastSelectedWorktreeRecipeId = lastSelectedWorktreeRecipeIdByProject[projectId];
@@ -192,6 +221,7 @@ export function NewWorktreeDialog({
 
   const onSelectBranch = useCallback(
     (name: string, isRemote: boolean) => {
+      baseBranchTouchedRef.current = true;
       setBaseBranch(name);
       setFromRemote(isRemote);
     },
@@ -221,12 +251,9 @@ export function NewWorktreeDialog({
   });
 
   const existingBranchCandidates = useMemo(() => {
-    const inUseSet = new Set<string>();
-    for (const wt of worktreeMap.values()) {
-      if (wt.branch) inUseSet.add(wt.branch);
-    }
+    const inUseSet = new Set(inUseBranches);
     return branches.filter((b) => !b.remote && !inUseSet.has(b.name));
-  }, [branches, worktreeMap]);
+  }, [branches, inUseBranches]);
 
   const filteredExistingBranches = useMemo(() => {
     const q = existingBranchQuery.trim().toLowerCase();
@@ -313,10 +340,14 @@ export function NewWorktreeDialog({
   useEffect(() => {
     if (!isOpen) return;
 
-    setLoading(true);
+    // PR opens bypass the cache: PR-branch resolution may fetch from the
+    // remote and must run against a fresh branch list.
+    const cached = initialPR ? undefined : branchListCache.get(rootPath);
+
+    setLoading(!cached);
     resetErrors();
     setPrBranchResolved(null);
-    setBranches([]);
+    setBranches(cached ?? []);
     setBaseBranch("");
     setIsDismissing(false);
     setBranchMode("new");
@@ -324,7 +355,14 @@ export function NewWorktreeDialog({
     setExistingBranchQuery("");
     setWorktreeMode("local");
     isCreatingRef.current = false;
+    baseBranchTouchedRef.current = false;
     // resetErrors() is NOT called here — touched refs are managed by individual hooks
+
+    if (cached) {
+      const seed = deriveDefaultBaseBranch(cached);
+      setBaseBranch(seed.name);
+      setFromRemote(seed.fromRemote);
+    }
 
     let isCurrent = true;
 
@@ -342,6 +380,7 @@ export function NewWorktreeDialog({
       .then(async (branchList) => {
         if (!isCurrent) return;
 
+        branchListCache.set(rootPath, branchList);
         setBranches(branchList);
 
         if (initialPR?.headRef) {
@@ -362,6 +401,7 @@ export function NewWorktreeDialog({
               if (!isCurrent) return;
               const updatedBranches = await worktreeClient.listBranches(rootPath);
               if (!isCurrent) return;
+              branchListCache.set(rootPath, updatedBranches);
               setBranches(updatedBranches);
               const fetchedLocal = updatedBranches.find(
                 (b) => b.name === initialPR.headRef && !b.remote
@@ -389,22 +429,18 @@ export function NewWorktreeDialog({
               setFromRemote(false);
             }
           }
-        } else {
-          const currentBranch = branchList.find((b) => b.current);
-          const mainBranch =
-            branchList.find((b) => b.name === "main") ||
-            branchList.find((b) => b.name === "master");
-
-          const initialBranch =
-            currentBranch?.name || mainBranch?.name || branchList[0]?.name || "";
-          setBaseBranch(initialBranch);
-
-          const initialBranchInfo = branchList.find((b) => b.name === initialBranch);
-          setFromRemote(!!initialBranchInfo?.remote);
+        } else if (!baseBranchTouchedRef.current) {
+          const next = deriveDefaultBaseBranch(branchList);
+          setBaseBranch(next.name);
+          setFromRemote(next.fromRemote);
         }
       })
       .catch((err) => {
         if (!isCurrent) return;
+        if (cached) {
+          logError("Failed to refresh branches", err);
+          return;
+        }
         setValidationError(`Failed to load branches: ${err.message}`, null);
         setBranches([]);
         setBaseBranch("");
@@ -929,7 +965,10 @@ export function NewWorktreeDialog({
                   id="from-remote"
                   type="checkbox"
                   checked={fromRemote}
-                  onChange={(e) => setFromRemote(e.target.checked)}
+                  onChange={(e) => {
+                    baseBranchTouchedRef.current = true;
+                    setFromRemote(e.target.checked);
+                  }}
                   className="rounded border-daintree-border text-daintree-accent focus:ring-daintree-accent"
                 />
                 <label htmlFor="from-remote" className="text-sm text-daintree-text select-none">

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1,5 +1,6 @@
 import {
   useCallback,
+  useDeferredValue,
   useEffect,
   useEffectEvent,
   useLayoutEffect,
@@ -69,7 +70,6 @@ import {
   type PushErrorState,
   type SectionViewState,
   DEFAULT_SECTION_STATE,
-  FILTER_DEBOUNCE_MS,
   getPushBannerConfig,
   isDensity,
   isSortKey,
@@ -320,59 +320,44 @@ export function ReviewHubContent({
   const [changesView, setChangesView] = useState<SectionViewState>(DEFAULT_SECTION_STATE);
   const stagedInputRef = useRef<HTMLInputElement | null>(null);
   const changesInputRef = useRef<HTMLInputElement | null>(null);
-  const stagedDebounceRef = useRef<{
-    (v: string): void;
-    cancel: () => void;
-    flush: () => Promise<void>;
-  } | null>(null);
-  const changesDebounceRef = useRef<{
-    (v: string): void;
-    cancel: () => void;
-    flush: () => Promise<void>;
-  } | null>(null);
 
-  useEffect(() => {
-    stagedDebounceRef.current = debounce((q: string) => {
-      setStagedView((prev) => ({ ...prev, filterQuery: q }));
-    }, FILTER_DEBOUNCE_MS);
-    changesDebounceRef.current = debounce((q: string) => {
-      setChangesView((prev) => ({ ...prev, filterQuery: q }));
-    }, FILTER_DEBOUNCE_MS);
-    return () => {
-      stagedDebounceRef.current?.cancel();
-      changesDebounceRef.current?.cancel();
-    };
+  const setStagedFilterQuery = useCallback((q: string) => {
+    setStagedView((prev) => ({ ...prev, filterQuery: q }));
+  }, []);
+
+  const setChangesFilterQuery = useCallback((q: string) => {
+    setChangesView((prev) => ({ ...prev, filterQuery: q }));
   }, []);
 
   const clearStagedFilter = useCallback(() => {
-    stagedDebounceRef.current?.cancel();
     if (stagedInputRef.current) stagedInputRef.current.value = "";
     setStagedView((prev) => ({ ...prev, filterQuery: "" }));
   }, []);
 
   const clearChangesFilter = useCallback(() => {
-    changesDebounceRef.current?.cancel();
     if (changesInputRef.current) changesInputRef.current.value = "";
     setChangesView((prev) => ({ ...prev, filterQuery: "" }));
   }, []);
+
+  const deferredStagedQuery = useDeferredValue(stagedView.filterQuery);
+  const deferredChangesQuery = useDeferredValue(changesView.filterQuery);
 
   const derivedStaged = useMemo(() => {
     if (!status) return [];
     let rows = status.staged;
     if (!stagedView.showGenerated) rows = rows.filter((f) => !isGeneratedFile(f.path));
-    if (stagedView.filterQuery)
-      rows = rows.filter((f) => matchesFilter(f.path, stagedView.filterQuery));
+    if (deferredStagedQuery) rows = rows.filter((f) => matchesFilter(f.path, deferredStagedQuery));
     return sortFiles(rows, stagedView.sortKey, stagedView.sortDir);
-  }, [status, stagedView]);
+  }, [status, stagedView, deferredStagedQuery]);
 
   const derivedUnstaged = useMemo(() => {
     if (!status) return [];
     let rows = status.unstaged;
     if (!changesView.showGenerated) rows = rows.filter((f) => !isGeneratedFile(f.path));
-    if (changesView.filterQuery)
-      rows = rows.filter((f) => matchesFilter(f.path, changesView.filterQuery));
+    if (deferredChangesQuery)
+      rows = rows.filter((f) => matchesFilter(f.path, deferredChangesQuery));
     return sortFiles(rows, changesView.sortKey, changesView.sortDir);
-  }, [status, changesView]);
+  }, [status, changesView, deferredChangesQuery]);
 
   // Flat keyboard-navigation list: staged rows first, then unstaged, matching
   // render order. Each entry carries its section so action keys (stage/unstage,
@@ -502,6 +487,15 @@ export function ReviewHubContent({
     [navigableItems, selectedFileIndex]
   );
 
+  const getAdjacentWorkingTreeFile = useCallback(
+    (delta: -1 | 1) => {
+      if (selectedFileIndex === null) return null;
+      const item = navigableItems[selectedFileIndex + delta];
+      return item ? { path: item.file.path, status: item.file.status } : null;
+    },
+    [navigableItems, selectedFileIndex]
+  );
+
   const selectedBaseBranchIndex = useMemo(() => {
     if (!selectedBaseBranchFile || !sortedBaseBranchFiles) return null;
     const idx = sortedBaseBranchFiles.findIndex((f) => f.path === selectedBaseBranchFile.path);
@@ -605,13 +599,12 @@ export function ReviewHubContent({
   }, [worktreePath]);
 
   const handleStageFiltered = useCallback(async () => {
+    const paths = derivedUnstaged.map((f) => f.path);
+    if (paths.length === 0) return;
     setActionError(null);
     debouncedBgRefreshRef.current?.cancel();
-    const paths = derivedUnstaged.map((f) => f.path);
     try {
-      for (const path of paths) {
-        await window.electron.git.stageFile(worktreePath, path);
-      }
+      await window.electron.git.stageFiles(worktreePath, paths);
     } catch (err) {
       setActionError(formatErrorMessage(err, "Failed to stage files"));
     } finally {
@@ -620,13 +613,12 @@ export function ReviewHubContent({
   }, [worktreePath, refresh, derivedUnstaged]);
 
   const handleUnstageFiltered = useCallback(async () => {
+    const paths = derivedStaged.map((f) => f.path);
+    if (paths.length === 0) return;
     setActionError(null);
     debouncedBgRefreshRef.current?.cancel();
-    const paths = derivedStaged.map((f) => f.path);
     try {
-      for (const path of paths) {
-        await window.electron.git.unstageFile(worktreePath, path);
-      }
+      await window.electron.git.unstageFiles(worktreePath, paths);
     } catch (err) {
       setActionError(formatErrorMessage(err, "Failed to unstage files"));
     } finally {
@@ -736,10 +728,8 @@ export function ReviewHubContent({
       // Filter state lives in `stagedView`/`changesView` rather than refs, so the
       // modal-shell path (which unmounts on close) never noticed leftover
       // filters. Once mounted as a non-modal panel, the same component instance
-      // survives close→reopen — reset the filter, sort, density, and the
-      // pending debounced writes so the next open starts from defaults.
-      stagedDebounceRef.current?.cancel();
-      changesDebounceRef.current?.cancel();
+      // survives close→reopen — reset the filter, sort, and density so the
+      // next open starts from defaults.
       if (stagedInputRef.current) stagedInputRef.current.value = "";
       if (changesInputRef.current) changesInputRef.current.value = "";
       setStagedView(DEFAULT_SECTION_STATE);
@@ -1975,7 +1965,7 @@ export function ReviewHubContent({
                                 type="text"
                                 placeholder="Filter…"
                                 defaultValue={stagedView.filterQuery}
-                                onChange={(e) => stagedDebounceRef.current?.(e.target.value)}
+                                onChange={(e) => setStagedFilterQuery(e.target.value)}
                                 className={cn(
                                   "w-[120px] h-5 pl-6 pr-1.5 rounded text-[11px]",
                                   "bg-tint/[0.04] border border-tint/[0.08]",
@@ -2213,7 +2203,7 @@ export function ReviewHubContent({
                                 type="text"
                                 placeholder="Filter…"
                                 defaultValue={changesView.filterQuery}
-                                onChange={(e) => changesDebounceRef.current?.(e.target.value)}
+                                onChange={(e) => setChangesFilterQuery(e.target.value)}
                                 className={cn(
                                   "w-[120px] h-5 pl-6 pr-1.5 rounded text-[11px]",
                                   "bg-tint/[0.04] border border-tint/[0.08]",
@@ -2479,6 +2469,7 @@ export function ReviewHubContent({
         currentFileIndex={selectedFileIndex ?? undefined}
         totalFileCount={navigableItems.length}
         onNavigateFile={navigateWorkingTreeFile}
+        getAdjacentFile={getAdjacentWorkingTreeFile}
       />
 
       {/* File diff modal — base-branch mode */}

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -3130,7 +3130,7 @@ describe("ReviewHub", () => {
       });
     });
 
-    it("uses per-file stageFile when filter is active", async () => {
+    it("uses batched stageFiles when filter is active", async () => {
       getStagingStatusMock.mockResolvedValue(multiFileStatus());
 
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
@@ -3146,7 +3146,7 @@ describe("ReviewHub", () => {
       fireEvent.click(stageBtn);
 
       await waitFor(() => {
-        expect(stageFileMock).toHaveBeenCalledWith(WORKTREE_PATH, "src/legacy.ts");
+        expect(stageFilesMock).toHaveBeenCalledWith(WORKTREE_PATH, ["src/legacy.ts"]);
         expect(window.electron.git.stageAll).not.toHaveBeenCalled();
       });
     });

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -342,8 +342,6 @@ export function sortFiles(
   return sorted;
 }
 
-export const FILTER_DEBOUNCE_MS = 200;
-
 export function isSortKey(v: string): v is SortKey {
   return v === "path" || v === "status" || v === "churn";
 }

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -13,6 +13,8 @@ import { actionService } from "@/services/ActionService";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
+const MAX_VISIBLE_FILES = 100;
+
 export interface WorktreeDetailsProps {
   worktree: WorktreeState;
   homeDir?: string;
@@ -186,7 +188,7 @@ export function WorktreeDetails({
               <FileChangeList
                 changes={worktree.worktreeChanges.changes}
                 rootPath={worktree.worktreeChanges.rootPath}
-                maxVisible={worktree.worktreeChanges.changes.length}
+                maxVisible={MAX_VISIBLE_FILES}
                 groupByFolder={worktree.worktreeChanges.changedFileCount > 5}
                 isStale={isStale}
               />

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -71,15 +71,22 @@ vi.mock("@/store/panelStore", () => ({
 }));
 
 const mockGenerateRecipeFromActiveTerminals = vi.fn().mockReturnValue([]);
-vi.mock("@/store/recipeStore", () => ({
-  useRecipeStore: Object.assign(() => ({ recipes: [], runRecipeWithResults: vi.fn() }), {
-    getState: () => ({
-      runRecipeWithResults: vi.fn(),
-      getRecipeById: () => null,
-      generateRecipeFromActiveTerminals: mockGenerateRecipeFromActiveTerminals,
-    }),
-  }),
-}));
+vi.mock("@/store/recipeStore", () => {
+  const recipeState = { recipes: [], runRecipeWithResults: vi.fn() };
+  return {
+    useRecipeStore: Object.assign(
+      (selector?: (s: typeof recipeState) => unknown) =>
+        selector ? selector(recipeState) : recipeState,
+      {
+        getState: () => ({
+          runRecipeWithResults: vi.fn(),
+          getRecipeById: () => null,
+          generateRecipeFromActiveTerminals: mockGenerateRecipeFromActiveTerminals,
+        }),
+      }
+    ),
+  };
+});
 
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (s: Record<string, unknown>) => unknown) =>
@@ -98,7 +105,9 @@ vi.mock("@/store/projectStore", () => ({
 
 const mockWorktreeDataMap = new Map();
 mockWorktreeDataMap.set("main-wt", {
+  id: "main-wt",
   worktreeId: "main-wt",
+  name: "main",
   branch: "main",
   path: "/test/root",
   isMainWorktree: true,
@@ -251,7 +260,11 @@ vi.mock("@/components/Worktree/worktreeCreationErrors", () => ({
 // jsdom doesn't support scrollIntoView
 Element.prototype.scrollIntoView = vi.fn();
 
-import { NewWorktreeDialog } from "../NewWorktreeDialog";
+import { NewWorktreeDialog, clearBranchListCache } from "../NewWorktreeDialog";
+
+beforeEach(() => {
+  clearBranchListCache();
+});
 
 const TEST_BRANCHES: BranchInfo[] = [
   { name: "main", current: true, commit: "abc123" },
@@ -566,6 +579,91 @@ describe("NewWorktreeDialog — pending creation wiring", () => {
       "/test/root-worktrees/feature/test",
       expect.stringContaining("permission denied")
     );
+  });
+});
+
+describe("NewWorktreeDialog — branch list cache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockListBranches.mockResolvedValue(TEST_BRANCHES);
+    mockGetRecentBranches.mockResolvedValue([]);
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/test/root-worktrees/${branch}`)
+    );
+    mockDispatch.mockResolvedValue({ ok: true, result: "new-wt-id" });
+    mockGetCurrentUser.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows the skeleton on first-ever open while branches load", async () => {
+    mockListBranches.mockReturnValue(new Promise(() => {}));
+    renderDialog();
+
+    expect(screen.getByRole("status")).toBeDefined();
+    expect(screen.queryByTestId("branch-name-input")).toBeNull();
+  });
+
+  it("renders the form immediately on reopen from the cached branch list", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+    cleanup();
+
+    mockListBranches.mockReturnValue(new Promise(() => {}));
+    renderDialog();
+
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.getByTestId("branch-name-input")).toBeDefined();
+    expect(document.getElementById("base-branch")?.textContent).toContain("main");
+  });
+
+  it("keeps the cached form when the background refresh fails", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+    cleanup();
+
+    mockListBranches.mockRejectedValueOnce(new Error("refresh failed"));
+    renderDialog();
+    await advanceTimersGradually(500);
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByTestId("branch-name-input")).toBeDefined();
+    expect(document.getElementById("base-branch")?.textContent).toContain("main");
+  });
+
+  it("bypasses the cache and keeps the skeleton for PR checkout opens", async () => {
+    renderDialog();
+    await advanceTimersGradually(500);
+    cleanup();
+
+    mockListBranches.mockReturnValue(new Promise(() => {}));
+    renderDialog({
+      initialPR: {
+        number: 42,
+        title: "Test PR",
+        body: "",
+        headRef: "feature/test",
+        baseRef: "main",
+        state: "open",
+        rawState: "OPEN",
+        url: "https://github.com/test/repo/pull/42",
+        author: { login: "user", avatarUrl: "", rawData: null },
+        isDraft: false,
+        merged: false,
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      },
+    });
+
+    expect(screen.getByRole("status")).toBeDefined();
   });
 });
 

--- a/src/components/Worktree/branchPickerUtils.ts
+++ b/src/components/Worktree/branchPickerUtils.ts
@@ -2,6 +2,8 @@ import Fuse, { type IFuseOptions } from "fuse.js";
 import type { BranchInfo } from "@/types/electron";
 import type { WorktreeSnapshot } from "@shared/types";
 
+export type BranchWorktreeRef = Pick<WorktreeSnapshot, "id" | "name">;
+
 export interface BranchOption {
   name: string;
   isCurrent: boolean;
@@ -21,7 +23,7 @@ export interface BranchSearchResult extends BranchOption {
   matchRanges: BranchMatchRange[];
   isRecent: boolean;
   recentRank: number;
-  inUseWorktree: WorktreeSnapshot | null;
+  inUseWorktree: BranchWorktreeRef | null;
 }
 
 export type BranchPickerRow =
@@ -31,7 +33,7 @@ export type BranchPickerRow =
 export interface FilterBranchesOptions {
   query: string;
   recentBranchNames: string[];
-  worktreeByBranch: Map<string, WorktreeSnapshot>;
+  worktreeByBranch: Map<string, BranchWorktreeRef>;
   emptyQueryLimit?: number;
 }
 
@@ -117,7 +119,7 @@ function buildEmptyQueryRows(
   branches: readonly BranchOption[],
   recentSet: Set<string>,
   recentRankMap: Map<string, number>,
-  worktreeByBranch: Map<string, WorktreeSnapshot>,
+  worktreeByBranch: Map<string, BranchWorktreeRef>,
   limit: number
 ): BranchPickerRow[] {
   const rows: BranchPickerRow[] = [];
@@ -165,7 +167,7 @@ function buildFuzzyQueryRows(
   query: string,
   recentSet: Set<string>,
   recentRankMap: Map<string, number>,
-  worktreeByBranch: Map<string, WorktreeSnapshot>
+  worktreeByBranch: Map<string, BranchWorktreeRef>
 ): BranchPickerRow[] {
   const fuse = getFuse(branches);
   const results = fuse.search(query, { limit: 200 });

--- a/src/components/Worktree/hooks/useBranchPicker.ts
+++ b/src/components/Worktree/hooks/useBranchPicker.ts
@@ -1,13 +1,14 @@
 import { useState, useEffect, useRef, useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import {
   toBranchOption,
   buildBranchRows,
   type BranchOption,
   type BranchPickerRow,
+  type BranchWorktreeRef,
 } from "../branchPickerUtils";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import type { BranchInfo } from "@/types/electron";
-import type { WorktreeSnapshot } from "@shared/types";
 
 export interface UseBranchPickerResult {
   branchPickerOpen: boolean;
@@ -46,15 +47,26 @@ export function useBranchPicker({
 
   const branchOptions = useMemo(() => branches.map(toBranchOption), [branches]);
 
-  const worktreeMap = useWorktreeStore((s) => s.worktrees);
+  const worktreeBranchEntries = useWorktreeStore(
+    useShallow((s) => {
+      const entries: string[] = [];
+      for (const wt of s.worktrees.values()) {
+        if (wt.branch) entries.push(wt.branch, wt.id, wt.name);
+      }
+      return entries;
+    })
+  );
 
   const worktreeByBranch = useMemo(() => {
-    const map = new Map<string, WorktreeSnapshot>();
-    for (const wt of worktreeMap.values()) {
-      if (wt.branch) map.set(wt.branch, wt);
+    const map = new Map<string, BranchWorktreeRef>();
+    for (let i = 0; i < worktreeBranchEntries.length; i += 3) {
+      map.set(worktreeBranchEntries[i]!, {
+        id: worktreeBranchEntries[i + 1]!,
+        name: worktreeBranchEntries[i + 2]!,
+      });
     }
     return map;
-  }, [worktreeMap]);
+  }, [worktreeBranchEntries]);
 
   const branchRows = useMemo(
     () =>

--- a/src/hooks/__tests__/useAudioDevices.test.ts
+++ b/src/hooks/__tests__/useAudioDevices.test.ts
@@ -133,6 +133,27 @@ describe("useAudioDevices", () => {
     await waitFor(() => expect(enumerateSpy).toHaveBeenCalledTimes(1));
   });
 
+  it("does not accumulate devicechange listeners across remount cycles", async () => {
+    enumerateSpy.mockResolvedValue([]);
+
+    const first = renderHook(() => useAudioDevices());
+    await waitFor(() => expect(enumerateSpy).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    const second = renderHook(() => useAudioDevices());
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    const deviceChangeHandler = addEventListenerSpy.mock.calls[0]?.[1] as () => void;
+    enumerateSpy.mockClear();
+    act(() => {
+      deviceChangeHandler();
+    });
+
+    await waitFor(() => expect(enumerateSpy).toHaveBeenCalledTimes(1));
+    expect(enumerateSpy).toHaveBeenCalledTimes(1);
+    second.unmount();
+  });
+
   it("re-enumerates on manual refresh() call", async () => {
     enumerateSpy.mockResolvedValue([{ deviceId: "mic1", kind: "audioinput", label: "Mic 1" }]);
 

--- a/src/hooks/app/useCloudSyncWarning.tsx
+++ b/src/hooks/app/useCloudSyncWarning.tsx
@@ -14,18 +14,27 @@ function getPlatform(): Platform {
 
 export function useCloudSyncWarning(homeDir?: string) {
   const currentProject = useProjectStore((state) => state.currentProject);
-  const { settings, projectId: settingsProjectId } = useProjectSettingsStore();
+  const settingsProjectId = useProjectSettingsStore((s) => s.projectId);
+  const hasSettings = useProjectSettingsStore((s) => s.settings !== null);
+  const cloudSyncWarningDismissed = useProjectSettingsStore(
+    (s) => s.settings?.cloudSyncWarningDismissed === true
+  );
   const lastInboxedProjectRef = useRef<string | null>(null);
 
   useEffect(() => {
     const setBanner = useCloudSyncBannerStore.getState().setBanner;
 
-    if (!currentProject?.id || settingsProjectId !== currentProject.id || !settings || !homeDir) {
+    if (
+      !currentProject?.id ||
+      settingsProjectId !== currentProject.id ||
+      !hasSettings ||
+      !homeDir
+    ) {
       setBanner({ service: null, projectId: null });
       return;
     }
 
-    if (settings.cloudSyncWarningDismissed) {
+    if (cloudSyncWarningDismissed) {
       setBanner({ service: null, projectId: null });
       return;
     }
@@ -57,5 +66,12 @@ export function useCloudSyncWarning(homeDir?: string) {
         context: { eventKind: "host" },
       });
     }
-  }, [currentProject?.id, currentProject?.path, settingsProjectId, settings, homeDir]);
+  }, [
+    currentProject?.id,
+    currentProject?.path,
+    settingsProjectId,
+    hasSettings,
+    cloudSyncWarningDismissed,
+    homeDir,
+  ]);
 }

--- a/src/hooks/useAppThemeConfig.ts
+++ b/src/hooks/useAppThemeConfig.ts
@@ -1,9 +1,10 @@
 import { useEffect } from "react";
 import { useAppThemeStore } from "@/store/appThemeStore";
 import { appThemeClient } from "@/clients/appThemeClient";
+import { getSafeBootPromise } from "@/lib/bootPromise";
 import { logError } from "@/utils/logger";
 import { normalizeAccentHex, normalizeAppColorScheme } from "@shared/theme";
-import type { AppColorScheme } from "@shared/types/appTheme";
+import type { AppColorScheme, AppThemeConfig } from "@shared/types/appTheme";
 import type { ColorVisionMode } from "@shared/types";
 
 const VALID_COLOR_VISION_MODES: ColorVisionMode[] = ["default", "red-green", "blue-yellow"];
@@ -20,64 +21,71 @@ export function useAppThemeConfig() {
   useEffect(() => {
     let cancelled = false;
 
-    appThemeClient
-      .get()
-      .then((config) => {
+    const applyConfig = (config: AppThemeConfig) => {
+      if (Array.isArray(config.customSchemes)) {
+        for (const scheme of config.customSchemes) {
+          addCustomScheme(normalizeAppColorScheme(scheme as AppColorScheme));
+        }
+      }
+
+      // Seed accent override before scheme injection so the first injection
+      // already reflects the persisted override. Use the raw Zustand setter
+      // (not setAccentColorOverride) to avoid a redundant DOM inject — the
+      // subsequent setSelectedSchemeIdSilent call below performs it once.
+      const normalizedAccent = normalizeAccentHex(config.accentColorOverride);
+      if (normalizedAccent || config.accentColorOverride === null) {
+        useAppThemeStore.setState({ accentColorOverride: normalizedAccent });
+      }
+
+      if (typeof config.colorSchemeId === "string" && config.colorSchemeId.trim()) {
+        setSelectedSchemeIdSilent(config.colorSchemeId.trim());
+      }
+
+      if (Array.isArray(config.recentSchemeIds)) {
+        const sanitized = config.recentSchemeIds
+          .filter((id: unknown): id is string => typeof id === "string" && id.trim().length > 0)
+          .map((id) => id.trim())
+          .slice(0, 5);
+        setRecentSchemeIds(sanitized);
+      }
+
+      if (
+        typeof config.colorVisionMode === "string" &&
+        VALID_COLOR_VISION_MODES.includes(config.colorVisionMode as ColorVisionMode)
+      ) {
+        setColorVisionMode(config.colorVisionMode as ColorVisionMode);
+      }
+
+      if (typeof config.followSystem === "boolean") {
+        setFollowSystem(config.followSystem);
+      }
+      if (typeof config.preferredDarkSchemeId === "string" && config.preferredDarkSchemeId.trim()) {
+        setPreferredDarkSchemeId(config.preferredDarkSchemeId.trim());
+      }
+      if (
+        typeof config.preferredLightSchemeId === "string" &&
+        config.preferredLightSchemeId.trim()
+      ) {
+        setPreferredLightSchemeId(config.preferredLightSchemeId.trim());
+      }
+    };
+
+    // Seed from the in-flight `app:boot` payload instead of firing a duplicate
+    // `app-theme:get` round-trip. The live IPC remains the fallback for the
+    // safe-boot {ok:false} path and for configs the main process leaves off
+    // the payload (first-run defaulting, legacy customSchemes migration).
+    void (async () => {
+      try {
+        const boot = await getSafeBootPromise();
         if (cancelled) return;
-
-        if (Array.isArray(config.customSchemes)) {
-          for (const scheme of config.customSchemes) {
-            addCustomScheme(normalizeAppColorScheme(scheme as AppColorScheme));
-          }
-        }
-
-        // Seed accent override before scheme injection so the first injection
-        // already reflects the persisted override. Use the raw Zustand setter
-        // (not setAccentColorOverride) to avoid a redundant DOM inject — the
-        // subsequent setSelectedSchemeIdSilent call below performs it once.
-        const normalizedAccent = normalizeAccentHex(config.accentColorOverride);
-        if (normalizedAccent || config.accentColorOverride === null) {
-          useAppThemeStore.setState({ accentColorOverride: normalizedAccent });
-        }
-
-        if (typeof config.colorSchemeId === "string" && config.colorSchemeId.trim()) {
-          setSelectedSchemeIdSilent(config.colorSchemeId.trim());
-        }
-
-        if (Array.isArray(config.recentSchemeIds)) {
-          const sanitized = config.recentSchemeIds
-            .filter((id: unknown): id is string => typeof id === "string" && id.trim().length > 0)
-            .map((id) => id.trim())
-            .slice(0, 5);
-          setRecentSchemeIds(sanitized);
-        }
-
-        if (
-          typeof config.colorVisionMode === "string" &&
-          VALID_COLOR_VISION_MODES.includes(config.colorVisionMode as ColorVisionMode)
-        ) {
-          setColorVisionMode(config.colorVisionMode as ColorVisionMode);
-        }
-
-        if (typeof config.followSystem === "boolean") {
-          setFollowSystem(config.followSystem);
-        }
-        if (
-          typeof config.preferredDarkSchemeId === "string" &&
-          config.preferredDarkSchemeId.trim()
-        ) {
-          setPreferredDarkSchemeId(config.preferredDarkSchemeId.trim());
-        }
-        if (
-          typeof config.preferredLightSchemeId === "string" &&
-          config.preferredLightSchemeId.trim()
-        ) {
-          setPreferredLightSchemeId(config.preferredLightSchemeId.trim());
-        }
-      })
-      .catch((error) => {
+        const fromBoot = boot.ok ? (boot.result.appTheme as AppThemeConfig | undefined) : undefined;
+        const config = fromBoot ?? (await appThemeClient.get());
+        if (cancelled) return;
+        applyConfig(config);
+      } catch (error) {
         logError("Failed to load app theme config", error);
-      });
+      }
+    })();
 
     return () => {
       cancelled = true;

--- a/src/hooks/useAudioDevices.ts
+++ b/src/hooks/useAudioDevices.ts
@@ -20,7 +20,6 @@ let cachedDevices: AudioDevice[] | null = null;
 let cachedError: string | null = null;
 let cachedLoading = true;
 let listeners: Array<() => void> = [];
-let listenerCount = 0;
 let subscribedToDeviceChange = false;
 let enumerationGen = 0;
 let stableSnapshot: Snapshot = {
@@ -81,8 +80,9 @@ function getSnapshot(): Snapshot {
 
 function subscribe(callback: () => void): () => void {
   listeners = [...listeners, callback];
-  listenerCount++;
 
+  // App-lifetime listener: never detached, so remount cycles reuse the single
+  // subscription instead of stacking unremovable anonymous handlers.
   if (!subscribedToDeviceChange && navigator?.mediaDevices?.addEventListener) {
     subscribedToDeviceChange = true;
     navigator.mediaDevices.addEventListener("devicechange", () => {
@@ -98,10 +98,6 @@ function subscribe(callback: () => void): () => void {
 
   return () => {
     listeners = listeners.filter((l) => l !== callback);
-    listenerCount--;
-    if (listenerCount === 0 && subscribedToDeviceChange) {
-      subscribedToDeviceChange = false;
-    }
   };
 }
 
@@ -124,7 +120,6 @@ export function __resetForTesting(): void {
   cachedError = null;
   cachedLoading = true;
   listeners = [];
-  listenerCount = 0;
   subscribedToDeviceChange = false;
   enumerationGen = 0;
   stableSnapshot = {

--- a/src/lib/__tests__/bootPromise.test.ts
+++ b/src/lib/__tests__/bootPromise.test.ts
@@ -29,6 +29,8 @@ function makeBootResult(): BootResult {
     tabGroups: [{ id: "g1", location: "grid", activeTabId: "t1", panelIds: ["t1"] }],
     terminalSizes: { t1: { cols: 80, rows: 24 } },
     draftInputs: { t1: "secret half-typed draft" },
+    projectPresets: { claude: [{ id: "p1", name: "Preset" }] },
+    appTheme: { schemeId: "dark", customSchemes: [] },
   } as unknown as BootResult;
 }
 
@@ -59,6 +61,8 @@ describe("releaseBootPayload", () => {
     expect(result.draftInputs).toBeUndefined();
     expect(result.tabGroups).toBeUndefined();
     expect(result.terminalSizes).toBeUndefined();
+    expect(result.projectPresets).toBeUndefined();
+    expect(result.appTheme).toBeUndefined();
     // Crash fields are still read from the cached payload after hydration.
     expect(result.crashPending).toBeNull();
     expect(result.crashConfig).toEqual({ autoRestoreOnCrash: true });

--- a/src/lib/bootPromise.ts
+++ b/src/lib/bootPromise.ts
@@ -103,9 +103,9 @@ export function getSafeBootPromise(): Promise<SafeBootResult> {
  * Free the heavy boot payload once hydration has copied it into Zustand. The
  * resolved `BootResult` is reachable for the renderer's life via the cached
  * thenables' `value` fields (React `use()` reads them synchronously), so its
- * large sub-objects (`appState`, `terminalConfig`, `agentSettings`, and the
- * per-project `tabGroups`/`terminalSizes`/`draftInputs` — the latter holding
- * user-typed draft text) would otherwise leak forever. The promise references
+ * large sub-objects (`appState`, `terminalConfig`, `agentSettings`, `appTheme`,
+ * and the per-project `tabGroups`/`terminalSizes`/`draftInputs`/`projectPresets`
+ * — `draftInputs` holding user-typed draft text) would otherwise leak forever. The promise references
  * themselves stay stable — only the consumed sub-fields are nulled. The crash
  * fields (`crashPending`, `crashConfig`) are intentionally left intact: they
  * are still read from the cached payload after hydration. Call exactly once,
@@ -120,6 +120,8 @@ export function releaseBootPayload(): void {
     result.tabGroups = undefined;
     result.terminalSizes = undefined;
     result.draftInputs = undefined;
+    result.projectPresets = undefined;
+    result.appTheme = undefined;
   };
 
   releaseFrom((bootPromise as ReactThenable<BootResult> | null)?.value);

--- a/src/services/terminal/TerminalReflowController.ts
+++ b/src/services/terminal/TerminalReflowController.ts
@@ -1,5 +1,29 @@
+import type { Terminal } from "@xterm/xterm";
 import type { ManagedTerminal } from "./types";
 import { logWarn } from "@/utils/logger";
+
+type XtermCoreRenderPause = {
+  _renderService?: {
+    _isPaused?: boolean;
+  };
+};
+
+/**
+ * Three-state read of xterm's private IntersectionObserver pause flag (same
+ * `_core` escape hatch as `getXtermCellDimensions` / `isXtermRenderPaused`).
+ * Returns `undefined` when the field is missing (API drift) so callers can
+ * fall back to the unconditional reflow path — unlike the watchdog's
+ * boolean read, which treats drift as not-paused.
+ */
+function readXtermRenderPaused(terminal: Terminal): boolean | undefined {
+  try {
+    const isPaused = (terminal as Terminal & { _core?: XtermCoreRenderPause })._core?._renderService
+      ?._isPaused;
+    return typeof isPaused === "boolean" ? isPaused : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Force a synchronous reflow that triggers xterm.js's IntersectionObserver
@@ -113,6 +137,11 @@ export class TerminalReflowController {
     // the buffered range. Skip without stamping the throttle so we reflow
     // on the next tick after ESU.
     if (managed.terminal.modes?.synchronizedOutputMode === true) return;
+    // Renderer is provably unpaused — the jitter would be a wasted forced
+    // layout. Skip without stamping lastReflowAt so a pause detected on the
+    // next write reflows immediately. `true` or `undefined` (API drift)
+    // falls through to keep all three #5092 recovery layers working.
+    if (readXtermRenderPaused(managed.terminal) === false) return;
 
     const now = typeof performance !== "undefined" ? performance.now() : Date.now();
     if (now - (managed.lastReflowAt ?? 0) < REFLOW_THROTTLE_MS) return;

--- a/src/services/terminal/__tests__/TerminalReflowController.test.ts
+++ b/src/services/terminal/__tests__/TerminalReflowController.test.ts
@@ -191,6 +191,39 @@ describe("TerminalReflowController.maybeReflow", () => {
     expect(paddingHistory(managed).length).toBe(0);
   });
 
+  it("skips without stamping the throttle when the renderer is provably unpaused", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { _core: object })._core = {
+      _renderService: { _isPaused: false },
+    };
+
+    controller.maybeReflow(managed);
+    expect(managed.lastReflowAt).toBe(0);
+    expect(paddingHistory(managed).length).toBe(0);
+  });
+
+  it("reflows when the renderer is paused", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { _core: object })._core = {
+      _renderService: { _isPaused: true },
+    };
+
+    controller.maybeReflow(managed);
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
+  });
+
+  it("reflows when the pause flag is missing (API drift)", () => {
+    const managed = makeManaged();
+    (managed.terminal as unknown as { _core: object })._core = {
+      _renderService: {},
+    };
+
+    controller.maybeReflow(managed);
+    expect(paddingHistory(managed)).toContain("0.01px");
+    expect(managed.lastReflowAt).toBeGreaterThan(0);
+  });
+
   it("does not stamp the throttle while synchronized output mode is active", () => {
     const managed = makeManaged();
     (

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const clientMock = vi.hoisted(() => ({
   get: vi.fn(),
+  invalidate: vi.fn(),
   set: vi.fn(),
   reset: vi.fn(),
   stampVersion: vi.fn(),

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/clients", () => ({
   },
   agentSettingsClient: {
     get: vi.fn().mockResolvedValue({ agents: {} }),
+    invalidate: vi.fn(),
     set: vi.fn(),
     reset: vi.fn(),
     stampVersion: vi.fn(),

--- a/src/store/__tests__/urlHistoryStore.test.ts
+++ b/src/store/__tests__/urlHistoryStore.test.ts
@@ -617,7 +617,13 @@ describe("urlHistoryStore persistence migration", () => {
     const backing = installLocalStorage({ [STORAGE_KEY]: legacyBlob });
 
     const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
-    store.getState().recordVisit("proj1", "http://b.test/", "B");
+    vi.useFakeTimers();
+    try {
+      store.getState().recordVisit("proj1", "http://b.test/", "B");
+      vi.advanceTimersByTime(300);
+    } finally {
+      vi.useRealTimers();
+    }
 
     const written = backing.get(STORAGE_KEY);
     expect(written).toBeDefined();

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -333,6 +333,10 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
     const myEpoch = ++normalizeEpoch;
     set({ error: null });
     try {
+      // refresh() exists to re-pull external changes (cross-window writes,
+      // config reloads) — drop the client's value cache so this read and
+      // every later get() see post-change data, not a pre-change snapshot.
+      agentSettingsClient.invalidate();
       const raw = (await agentSettingsClient.get()) ?? DEFAULT_AGENT_SETTINGS;
       if (myEpoch !== normalizeEpoch) return;
       const { availability, hasRealData } = readAvailabilitySnapshot();
@@ -469,6 +473,7 @@ export function getPinnedAgents(): string[] {
 export function cleanupAgentSettingsStore() {
   normalizeEpoch++;
   initPromise = null;
+  agentSettingsClient.invalidate();
   useAgentSettingsStore.setState({
     settings: DEFAULT_AGENT_SETTINGS,
     isLoading: true,

--- a/src/store/eventStore.ts
+++ b/src/store/eventStore.ts
@@ -27,6 +27,31 @@ interface EventsState {
 
 const MAX_EVENTS = 1000;
 
+// Payloads are immutable once recorded, so the lowercase serialization used by
+// the search filter is computed once per payload instead of once per recompute.
+const payloadSearchTextCache = new WeakMap<object, string>();
+
+function safeStringifyLower(value: unknown): string {
+  try {
+    const str = JSON.stringify(value);
+    return typeof str === "string" ? str.toLowerCase() : "";
+  } catch {
+    return "";
+  }
+}
+
+function getPayloadSearchText(payload: unknown): string {
+  if (payload === null || typeof payload !== "object") {
+    return safeStringifyLower(payload);
+  }
+  let text = payloadSearchTextCache.get(payload);
+  if (text === undefined) {
+    text = safeStringifyLower(payload);
+    payloadSearchTextCache.set(payload, text);
+  }
+  return text;
+}
+
 const createEventsStore: StateCreator<EventsState> = (set, get) => ({
   events: [],
   isOpen: false,
@@ -177,12 +202,7 @@ const createEventsStore: StateCreator<EventsState> = (set, get) => ({
         if (event.type.toLowerCase().includes(searchLower)) {
           return true;
         }
-        try {
-          const payloadStr = JSON.stringify(event.payload).toLowerCase();
-          return payloadStr.includes(searchLower);
-        } catch {
-          return false;
-        }
+        return getPayloadSearchText(event.payload).includes(searchLower);
       });
     }
 

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -125,15 +125,10 @@ export const createAddPanelActions = (
       }
 
       if (tier === "confirm" && !warningsDisabled) {
-        let memoryMB: number | null = null;
-        try {
-          const metrics = await import("@/clients").then((m) => m.systemClient.getAppMetrics());
-          memoryMB = metrics.totalMemoryMB;
-        } catch {
-          // Memory info unavailable
-        }
-
-        const confirmed = await requestConfirmation(globalCount, memoryMB);
+        // Pass `null` for memory rather than blocking the dialog on a metrics
+        // IPC — same call `preflightSpawnBatchLimit` makes; the dialog renders
+        // without the memory hint, never waits on it.
+        const confirmed = await requestConfirmation(globalCount, null);
         if (!confirmed) return null;
 
         // Re-check count after confirmation in case panels were closed during the dialog

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { UrlHistoryEntry } from "@shared/types/browser";
 import { sanitizeUrlForHistory } from "@shared/utils/urlHistory";
-import { createSafeJSONStorage } from "./persistence/safeStorage";
+import { createDebouncedSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 const MAX_ENTRIES_PER_PROJECT = 500;
@@ -183,7 +183,7 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
     }),
     {
       name: "daintree-url-history",
-      storage: createSafeJSONStorage(),
+      storage: createDebouncedSafeJSONStorage(300),
       version: 1,
       migrate: (persistedState) => persistedState as UrlHistoryState,
       merge: (persistedState, currentState) => {

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -22,6 +22,7 @@ const projectClientMock = {
   getTerminalSizes: vi.fn(),
   getDraftInputs: vi.fn(),
   setDraftInputs: vi.fn(),
+  getInRepoPresets: vi.fn(),
 };
 
 const terminalConfigClientMock = {
@@ -184,6 +185,7 @@ describe("hydrateAppState", () => {
     projectClientMock.getTabGroups.mockResolvedValue([]);
     projectClientMock.getTerminalSizes.mockResolvedValue({});
     projectClientMock.getDraftInputs.mockResolvedValue({});
+    projectClientMock.getInRepoPresets.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -3138,6 +3140,52 @@ describe("hydrateAppState", () => {
       expect(projectClientMock.getDraftInputs).not.toHaveBeenCalled();
       // Empty array still clears stale groups (mirrors the IPC path).
       expect(hydrateTabGroups).toHaveBeenCalledWith([]);
+    });
+
+    it("uses projectPresets from the hydrate payload and skips the standalone IPC call", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        projectPresets: { claude: [{ id: "team-preset", name: "Team" }] },
+      });
+
+      await hydrateAppState(baseOptions());
+
+      expect(projectClientMock.getInRepoPresets).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the standalone getInRepoPresets call when projectPresets is absent", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        // projectPresets intentionally omitted (older main process, or the
+        // safe-boot {ok:false} payload).
+      });
+
+      await hydrateAppState(baseOptions());
+
+      expect(projectClientMock.getInRepoPresets).toHaveBeenCalledWith("project-1");
+    });
+
+    it("treats an empty projectPresets payload as authoritative (no IPC fallback)", async () => {
+      appClientMock.hydrate.mockResolvedValue({
+        appState: { terminals: [], sidebarWidth: 350 },
+        terminalConfig,
+        project,
+        agentSettings,
+        gpuWebGLHardware: true,
+        projectPresets: {},
+      });
+
+      await hydrateAppState(baseOptions());
+
+      expect(projectClientMock.getInRepoPresets).not.toHaveBeenCalled();
     });
   });
 

--- a/src/utils/__tests__/terminalValidation.test.ts
+++ b/src/utils/__tests__/terminalValidation.test.ts
@@ -172,4 +172,16 @@ describe("terminalValidation", () => {
     expect(results.get("bad-cwd")?.valid).toBe(false);
     expect(results.get("bad-cli")?.valid).toBe(false);
   });
+
+  it("validateTerminals probes each unique cwd and CLI once across the batch", async () => {
+    const results = await validateTerminals([
+      makeTerminal({ id: "a", cwd: "/repo", launchAgentId: "claude" }) as never,
+      makeTerminal({ id: "b", cwd: "/repo", launchAgentId: "claude" }) as never,
+      makeTerminal({ id: "c", cwd: "/other", launchAgentId: "claude" }) as never,
+    ]);
+
+    expect(results.size).toBe(0);
+    expect(checkDirectoryMock).toHaveBeenCalledTimes(2);
+    expect(checkCommandMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -280,13 +280,16 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
       : Promise.resolve(emptyDraftInputs);
 
     const emptyProjectPresets: Record<string, AgentPreset[]> = {};
-    const projectPresetsPromise: Promise<Record<string, AgentPreset[]>> =
-      currentProjectId && typeof projectClient.getInRepoPresets === "function"
-        ? projectClient.getInRepoPresets(currentProjectId).catch((error) => {
-            logWarn("Failed to prefetch project presets during hydration", { error });
-            return emptyProjectPresets;
-          })
-        : Promise.resolve(emptyProjectPresets);
+    const projectPresetsPromise: Promise<Record<string, AgentPreset[]>> = currentProjectId
+      ? hydrateResult.projectPresets !== undefined
+        ? Promise.resolve(hydrateResult.projectPresets)
+        : typeof projectClient.getInRepoPresets === "function"
+          ? projectClient.getInRepoPresets(currentProjectId).catch((error) => {
+              logWarn("Failed to prefetch project presets during hydration", { error });
+              return emptyProjectPresets;
+            })
+          : Promise.resolve(emptyProjectPresets)
+      : Promise.resolve(emptyProjectPresets);
 
     const recipeLoadPromise = currentProjectId
       ? loadRecipes(currentProjectId).catch((error) => {

--- a/src/utils/terminalValidation.ts
+++ b/src/utils/terminalValidation.ts
@@ -23,32 +23,70 @@ export interface ValidationResult {
   errors: ValidationError[];
 }
 
-export async function validateTerminalConfig(terminal: CarrierPanel): Promise<ValidationResult> {
-  const errors: ValidationError[] = [];
+interface ValidationProbes {
+  checkDirectory: (path: string) => Promise<boolean>;
+  checkCommand: (command: string) => Promise<boolean>;
+}
 
+const directProbes: ValidationProbes = {
+  checkDirectory: (path) => systemClient.checkDirectory(path),
+  checkCommand: (command) => systemClient.checkCommand(command),
+};
+
+// Bulk operations validate many terminals that share a cwd and CLI; memoizing
+// the probe promises per call dedupes identical IPC checks across the batch.
+function createMemoizedProbes(): ValidationProbes {
+  const directoryProbes = new Map<string, Promise<boolean>>();
+  const commandProbes = new Map<string, Promise<boolean>>();
+  return {
+    checkDirectory: (path) => {
+      let probe = directoryProbes.get(path);
+      if (!probe) {
+        probe = systemClient.checkDirectory(path);
+        directoryProbes.set(path, probe);
+      }
+      return probe;
+    },
+    checkCommand: (command) => {
+      let probe = commandProbes.get(command);
+      if (!probe) {
+        probe = systemClient.checkCommand(command);
+        commandProbes.set(command, probe);
+      }
+      return probe;
+    },
+  };
+}
+
+async function validateTerminalConfigWith(
+  terminal: CarrierPanel,
+  probes: ValidationProbes
+): Promise<ValidationResult> {
   const pty = isPtyPanel(terminal) ? terminal : undefined;
 
   // Only validate cwd for PTY panels that have it
-  if (pty?.cwd) {
-    try {
-      const cwdExists = await systemClient.checkDirectory(pty.cwd);
-      if (!cwdExists) {
-        errors.push({
-          type: "cwd",
-          message: `Working directory does not exist: ${pty.cwd}`,
-          code: "ENOENT",
-          recoverable: true,
-        });
-      }
-    } catch (error) {
-      const message = formatErrorMessage(error, "Failed to check directory");
-      errors.push({
-        type: "config",
-        message: `Failed to validate working directory "${pty.cwd}": ${message}`,
-        recoverable: true,
-      });
-    }
-  }
+  const cwd = pty?.cwd;
+  const cwdCheck: Promise<ValidationError | null> = cwd
+    ? probes.checkDirectory(cwd).then(
+        (cwdExists): ValidationError | null =>
+          cwdExists
+            ? null
+            : {
+                type: "cwd",
+                message: `Working directory does not exist: ${cwd}`,
+                code: "ENOENT",
+                recoverable: true,
+              },
+        (error): ValidationError => {
+          const message = formatErrorMessage(error, "Failed to check directory");
+          return {
+            type: "config",
+            message: `Failed to validate working directory "${cwd}": ${message}`,
+            recoverable: true,
+          };
+        }
+      )
+    : Promise.resolve(null);
 
   // Check agent CLI availability.
   // Launch-intent only: this runs before (or just after) launch to verify the CLI
@@ -56,21 +94,32 @@ export async function validateTerminalConfig(terminal: CarrierPanel): Promise<Va
   // point, and using it later would validate the wrong binary for runtime-morphed
   // sessions (e.g., a plain shell that started a different agent).
   const agentId = pty?.launchAgentId;
+  let cliCheck: Promise<ValidationError | null> = Promise.resolve(null);
   if (agentId && agentId !== "terminal") {
     try {
       const agentConfig = getAgentConfig(agentId);
       const cliCommand = agentConfig?.command ?? agentId;
-      const cliAvailable = await systemClient.checkCommand(cliCommand);
-      if (!cliAvailable) {
-        errors.push({
-          type: "cli",
-          message: `${agentId} CLI not found in PATH`,
-          recoverable: false,
-        });
-      }
+      cliCheck = probes.checkCommand(cliCommand).then(
+        (cliAvailable): ValidationError | null =>
+          cliAvailable
+            ? null
+            : {
+                type: "cli",
+                message: `${agentId} CLI not found in PATH`,
+                recoverable: false,
+              },
+        (error): ValidationError => {
+          const message = formatErrorMessage(error, "Failed to check CLI");
+          return {
+            type: "config",
+            message: `Failed to validate CLI "${agentId}": ${message}`,
+            recoverable: true,
+          };
+        }
+      );
     } catch (error) {
       const message = formatErrorMessage(error, "Failed to check CLI");
-      errors.push({
+      cliCheck = Promise.resolve({
         type: "config",
         message: `Failed to validate CLI "${agentId}": ${message}`,
         recoverable: true,
@@ -78,21 +127,29 @@ export async function validateTerminalConfig(terminal: CarrierPanel): Promise<Va
     }
   }
 
+  const [cwdError, cliError] = await Promise.all([cwdCheck, cliCheck]);
+  const errors = [cwdError, cliError].filter((e): e is ValidationError => e !== null);
+
   return {
     valid: errors.length === 0,
     errors,
   };
 }
 
+export async function validateTerminalConfig(terminal: CarrierPanel): Promise<ValidationResult> {
+  return validateTerminalConfigWith(terminal, directProbes);
+}
+
 export async function validateTerminals(
   terminals: CarrierPanel[]
 ): Promise<Map<string, ValidationResult>> {
   const results = new Map<string, ValidationResult>();
+  const probes = createMemoizedProbes();
 
   await Promise.all(
     terminals.map(async (terminal) => {
       try {
-        const result = await validateTerminalConfig(terminal);
+        const result = await validateTerminalConfigWith(terminal, probes);
         if (!result.valid) {
           results.set(terminal.id, result);
         }


### PR DESCRIPTION
This is a batch of last-mile performance work across the app, both real speedups and changes that just make it feel faster. It came out of a wide multi-agent audit of the codebase looking for small wins, and this covers the ones worth shipping now.

The terminal-data hot paths are in here too. Those changes feed agent-state detection and the highest-throughput code in the app, so they got a careful pass: pending output always flushes before any agent state transition, and each change carries its own tests.

### What's in this PR

- **Cool the terminal-data hot paths.** A 64KB cap on `SemanticBufferManager`'s pending-data accumulation, throttling `ActivityMonitor`'s full-buffer ANSI strip and pattern scan to a 30ms cadence with a trailing-edge run so the last chunk before quiet still gets scanned, coalescing the per-chunk `agent:output` IPC into 50ms batches that flush synchronously before any agent state transition (and on exit), and skipping the reflow keep-alive jitter when xterm's renderer is provably unpaused.
- **Batch the stage/unstage IPC in ReviewHub.** `handleStageFiltered`/`handleUnstageFiltered` were firing one IPC call and one git spawn per file, which also tripped the 30-call rate limiter on large changesets. They now use the existing `git.stageFiles`/`unstageFiles` batch channels, so N spawns collapse to one. Also added the missing `invalidateStagingDiffStatCache` to the batch handlers so the follow-up refresh doesn't serve stale stats.
- **Cache the branch list per repo.** The New Worktree dialog showed a full-body skeleton on every open while `listBranches` resolved. There's now a per-repo cache that seeds the form synchronously and revalidates in the background, so the dialog opens instantly after the first time.
- **Deduplicate git spawns in the workspace host.** Sibling worktrees of the same repo were each running their own `git fetch origin`. Added a recency window so they share a recent fetch instead. Dropped the redundant `rev-parse --verify` on every status pass and cached the divergence result so working-tree-only changes don't recompute it.
- **Get disk writes and eviction off the project-switch path.** Outgoing-state persistence and LRU eviction were running inline on every switch. Both are deferred now, with the persist still awaited before the IPC resolves so the contract holds.
- **Pre-warm the workspace host on hover.** Hover prefetch was priming hydrate data but not the host, so the click still paid the cold fork. It now pre-warms the host during the hover dwell, so the switch lands as a near-hit.
- **Fold presets and theme config into the boot payload.** Agent presets and theme config were each a separate post-mount IPC plus a disk read. They ride along the existing hydrate/boot payload now, the same way `tabGroups` and `terminalSizes` already do — and `releaseBootPayload` nulls both fields after hydration, so the cached payload doesn't retain them for the renderer's lifetime.
- **Full value cache on `agentSettingsClient`.** Burst paths (bulk restart, duplicate, recipe spawns) now read a cached snapshot instead of refetching. Writes invalidate it at call time and on settle, and `agentSettingsStore.refresh()` drops it first so external changes (cross-window writes, config reloads) always hit main.
- **Narrow Zustand subscriptions.** `useCloudSyncWarning`, the toolbar `AgentButton`, and `NewWorktreeDialog` were subscribed broadly enough to re-render on unrelated store ticks. Narrowed to primitive/`useShallow` selectors so worktree status churn stops touching them.
- **Optimistic settings toggles.** The GeneralTab toggles were visually frozen during the IPC round-trip. They flip immediately now and revert on failure, matching what PrivacyDataTab already does.
- **Unblock the main process.** Converted the `execFileSync` calls in `system:check-command` and the CLI availability probe to async, and parallelized the per-terminal validation probes with per-command dedup.

Plus a handful of smaller ones: debounced URL-history persistence, cached `getTmpDir`, an event-inspector serialization cache, an audio-device listener leak fix, idle-time chunk preloads, and a non-blocking panel-limit dialog.

Tests were updated alongside each change. CI is the gate.
