### PR TITLE
fix(project-switcher): stop agents works for non-active projects

### DIFF
--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -469,6 +469,40 @@ describe("useProjectSwitcherPalette", () => {
       expect(result.current.stopConfirmProjectId).toBeNull();
     });
 
+    it("stop confirmation uses closeProject when a different project is active", async () => {
+      projectState.currentProject = { id: "project-2" };
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      await act(async () => {
+        await result.current.stopProject("project-1");
+      });
+
+      await act(async () => {
+        await result.current.confirmStopProject();
+      });
+
+      expect(projectState.closeProject).toHaveBeenCalledWith("project-1", { killTerminals: true });
+      expect(projectState.closeActiveProject).not.toHaveBeenCalled();
+    });
+
+    it("stop confirmation re-evaluates isActive at confirm time, not at stopProject time", async () => {
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      await act(async () => {
+        await result.current.stopProject("project-1");
+      });
+
+      projectState.currentProject = null;
+
+      await act(async () => {
+        await result.current.confirmStopProject();
+      });
+
+      expect(projectState.closeProject).toHaveBeenCalledWith("project-1", { killTerminals: true });
+      expect(projectState.closeActiveProject).not.toHaveBeenCalled();
+    });
+
     it("confirm calls removeProject for non-active project, not closeActiveProject", async () => {
       const { result } = renderHook(() => useProjectSwitcherPalette());
 

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -44,8 +44,9 @@ const {
     locateProject: vi.fn().mockResolvedValue(undefined),
   };
 
-  const useProjectStoreMock = vi.fn((selector: (state: typeof projectState) => unknown) =>
-    selector(projectState)
+  const useProjectStoreMock = Object.assign(
+    vi.fn((selector: (state: typeof projectState) => unknown) => selector(projectState)),
+    { getState: () => projectState }
   );
   const notifyMock = vi.fn().mockReturnValue("");
 
@@ -445,6 +446,26 @@ describe("useProjectSwitcherPalette", () => {
 
       expect(projectState.closeActiveProject).toHaveBeenCalledWith("project-1");
       expect(projectState.closeProject).not.toHaveBeenCalled();
+      expect(result.current.stopConfirmProjectId).toBeNull();
+    });
+
+    it("stop confirmation uses closeProject for a non-active project", async () => {
+      projectState.currentProject = null;
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      await act(async () => {
+        await result.current.stopProject("project-1");
+      });
+
+      expect(result.current.stopConfirmProjectId).toBe("project-1");
+
+      await act(async () => {
+        await result.current.confirmStopProject();
+      });
+
+      expect(projectState.closeProject).toHaveBeenCalledWith("project-1", { killTerminals: true });
+      expect(projectState.closeActiveProject).not.toHaveBeenCalled();
       expect(result.current.stopConfirmProjectId).toBeNull();
     });
 

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -171,6 +171,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const loadProjects = useProjectStore((state) => state.loadProjects);
   const addProjectFn = useProjectStore((state) => state.addProject);
   const closeActiveProject = useProjectStore((state) => state.closeActiveProject);
+  const closeProject = useProjectStore((state) => state.closeProject);
   const removeProject = useProjectStore((state) => state.removeProject);
   const locateProjectFn = useProjectStore((state) => state.locateProject);
   const projectStats = useProjectStatsStore((state) => state.stats);
@@ -509,12 +510,22 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     const capturedId = stopConfirmProjectId;
 
     try {
-      await closeActiveProject(capturedId);
+      const isActive = useProjectStore.getState().currentProject?.id === capturedId;
+      if (isActive) {
+        await closeActiveProject(capturedId);
+      } else {
+        await closeProject(capturedId, { killTerminals: true });
+      }
       setStopConfirmProjectId(null);
     } catch (error) {
       const retry = async () => {
+        const isActive = useProjectStore.getState().currentProject?.id === capturedId;
         try {
-          await closeActiveProject(capturedId);
+          if (isActive) {
+            await closeActiveProject(capturedId);
+          } else {
+            await closeProject(capturedId, { killTerminals: true });
+          }
         } catch (retryError) {
           notify({
             type: "error",
@@ -533,7 +544,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     } finally {
       setIsStoppingProject(false);
     }
-  }, [stopConfirmProjectId, closeActiveProject]);
+  }, [stopConfirmProjectId, closeActiveProject, closeProject]);
 
   const removeProjectFromList = useCallback(
     async (projectId: string) => {


### PR DESCRIPTION
## Summary

- "Stop all agents" on a non-active project always failed with "Project is not currently active" — the handler called `closeActiveProject` regardless of which project was targeted
- `confirmStopProject` now checks whether the target project is active at confirm time: active path calls `closeActiveProject` (full renderer teardown), non-active path calls `closeProject(id, { killTerminals: true })` (IPC-only, no renderer state mutation)
- The retry closure re-evaluates `isActive` at call time too, covering TOCTOU — mirrors the same pattern already used in `confirmRemoveProject`

Resolves #10376

## Changes

- `src/hooks/useProjectSwitcherPalette.ts`: branch on `useProjectStore.getState().currentProject?.id === capturedId` in `confirmStopProject`
- `src/hooks/__tests__/useProjectSwitcherPalette.test.tsx`: wired `getState` on the projectStore mock; added tests for the non-active path (null current project, different project active) and confirm-time TOCTOU re-evaluation

## Testing

30/30 unit tests pass. Full typecheck, lint, format, channel/IPC/confirm-wiring guards, and build clean.