### PR TITLE
fix(lifecycle): ignore activate events fired before the app is ready

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const appMock = vi.hoisted(() => ({
   isPackaged: false as boolean,
+  isReady: vi.fn(() => true),
   on: vi.fn(),
   quit: vi.fn(),
   exit: vi.fn(),
@@ -439,6 +440,72 @@ describe("registerAppLifecycleHandlers – window-all-closed", () => {
     isWindowRecreatingMock.mockReturnValue(false);
     handler();
     expect(appMock.quit).toHaveBeenCalledOnce();
+  });
+});
+
+describe("registerAppLifecycleHandlers – activate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks resets call history but not mockReturnValue overrides;
+    // restore the ready-by-default baseline so per-test overrides can't leak.
+    appMock.isReady.mockReturnValue(true);
+    browserWindowMock.getAllWindows.mockReturnValue([]);
+    vi.spyOn(process, "on").mockImplementation(() => process);
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  function getActivateHandler(): () => void {
+    const call = appMock.on.mock.calls.find(([event]: string[]) => event === "activate");
+    return call![1] as () => void;
+  }
+
+  function makeRegistry(size: number): AppLifecycleOptions["windowRegistry"] {
+    return { size } as AppLifecycleOptions["windowRegistry"];
+  }
+
+  it("does not create a window or enumerate windows before the app is ready", async () => {
+    appMock.isReady.mockReturnValue(false);
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const opts = makeOpts();
+    registerAppLifecycleHandlers(opts);
+
+    getActivateHandler()();
+
+    expect(opts.onCreateWindow).not.toHaveBeenCalled();
+    // The guard must sit before the window check — enumerating windows
+    // pre-ready would also be unsafe.
+    expect(browserWindowMock.getAllWindows).not.toHaveBeenCalled();
+  });
+
+  it("creates a window when ready and the registry is empty", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const opts = makeOpts({ windowRegistry: makeRegistry(0) });
+    registerAppLifecycleHandlers(opts);
+
+    getActivateHandler()();
+
+    expect(opts.onCreateWindow).toHaveBeenCalledOnce();
+  });
+
+  it("does not create a window when ready and the registry has windows", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const opts = makeOpts({ windowRegistry: makeRegistry(1) });
+    registerAppLifecycleHandlers(opts);
+
+    getActivateHandler()();
+
+    expect(opts.onCreateWindow).not.toHaveBeenCalled();
+  });
+
+  it("falls back to BrowserWindow.getAllWindows without a registry", async () => {
+    browserWindowMock.getAllWindows.mockReturnValue([{} as never]);
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const opts = makeOpts();
+    registerAppLifecycleHandlers(opts);
+
+    getActivateHandler()();
+
+    expect(opts.onCreateWindow).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -507,6 +507,46 @@ describe("registerAppLifecycleHandlers – activate", () => {
 
     expect(opts.onCreateWindow).not.toHaveBeenCalled();
   });
+
+  it("creates a window when ready with no registry and no open windows", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const opts = makeOpts();
+    registerAppLifecycleHandlers(opts);
+
+    getActivateHandler()();
+
+    expect(opts.onCreateWindow).toHaveBeenCalledOnce();
+  });
+
+  it("does not touch the registry before the app is ready", async () => {
+    appMock.isReady.mockReturnValue(false);
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const registry = {
+      get size(): number {
+        throw new Error("registry accessed pre-ready");
+      },
+    } as AppLifecycleOptions["windowRegistry"];
+    const opts = makeOpts({ windowRegistry: registry });
+    registerAppLifecycleHandlers(opts);
+
+    expect(() => getActivateHandler()()).not.toThrow();
+    expect(opts.onCreateWindow).not.toHaveBeenCalled();
+  });
+
+  it("re-evaluates readiness on every activation", async () => {
+    appMock.isReady.mockReturnValue(false);
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    const opts = makeOpts({ windowRegistry: makeRegistry(0) });
+    registerAppLifecycleHandlers(opts);
+    const handler = getActivateHandler();
+
+    handler();
+    expect(opts.onCreateWindow).not.toHaveBeenCalled();
+
+    appMock.isReady.mockReturnValue(true);
+    handler();
+    expect(opts.onCreateWindow).toHaveBeenCalledOnce();
+  });
 });
 
 describe("registerWindowSessionEndHandler – Windows planned-shutdown wiring", () => {

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -283,6 +283,11 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
   });
 
   app.on("activate", () => {
+    // A Dock click during a slow startup fires `activate` before
+    // `app.whenReady()` resolves; creating a BrowserWindow then throws. The
+    // startup path in main.ts always creates the initial window once ready,
+    // so dropping a pre-ready activation loses nothing.
+    if (!app.isReady()) return;
     const hasWindows = opts.windowRegistry
       ? opts.windowRegistry.size > 0
       : BrowserWindow.getAllWindows().length > 0;


### PR DESCRIPTION
## Summary

- On macOS, clicking the Dock icon during a slow startup fires the `activate` event before `app.whenReady()` resolves, causing an unhandled rejection: `Cannot create BrowserWindow before app is ready`
- Fixed with a synchronous `app.isReady()` guard as the first statement in the `activate` handler in `appLifecycle.ts` — dropping a pre-ready Dock click is safe because `main.ts` unconditionally creates the initial window in its own `whenReady` callback
- Rejected a deferred `app.whenReady().then()` approach: both the deferred callback and the existing `whenReady` callback observe zero windows simultaneously, causing a double-creation race

Resolves #10381

## Changes

- `electron/lifecycle/appLifecycle.ts`: `if (!app.isReady()) return;` guard at the top of the `activate` handler
- `electron/lifecycle/__tests__/appLifecycle.test.ts`: added `isReady` to the hoisted `appMock` (defaults `true`, transparent to existing suites) and a new `registerAppLifecycleHandlers – activate` describe block with 7 tests covering pre-ready drop, ready+empty registry creates, ready+populated registry skips, `getAllWindows` fallback paths, guard-precedes-registry-access (throwing `size` getter), and per-activation readiness re-evaluation

## Testing

- New `activate` suite: 7 tests, all pass
- Full `appLifecycle` suite: 49 passed / 1 skipped
- Static checks (typecheck, lint, format) pass
- Build passes