### PR TITLE
fix(onboarding): checklist 'Open your project' now adds the project

### DIFF
--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -111,12 +111,12 @@ describe("GettingStartedChecklist", () => {
     expect(completedButton).toBeNull();
   });
 
-  it("dispatches project.openDialog when 'Open your project' is clicked", () => {
+  it("dispatches project.add when 'Open your project' is clicked", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
 
     fireEvent.click(screen.getByRole("button", { name: /open your project/i }));
     expect(dispatchMock).toHaveBeenCalledTimes(1);
-    expect(dispatchMock).toHaveBeenCalledWith("project.openDialog", undefined, { source: "user" });
+    expect(dispatchMock).toHaveBeenCalledWith("project.add", undefined, { source: "user" });
   });
 
   it("dispatches panel.palette when 'Ask AI to help with your code' is clicked", () => {

--- a/src/components/Onboarding/checklistItems.ts
+++ b/src/components/Onboarding/checklistItems.ts
@@ -20,7 +20,7 @@ export const CHECKLIST_ITEMS: ChecklistItemDef[] = [
     label: "Open your project",
     description: "Connect a local folder — everything else flows from here",
     icon: FolderOpen,
-    actionId: "project.openDialog",
+    actionId: "project.add",
   },
   {
     id: "launchedAgent",

--- a/src/components/Project/__tests__/WelcomeScreen.test.tsx
+++ b/src/components/Project/__tests__/WelcomeScreen.test.tsx
@@ -383,11 +383,11 @@ describe("WelcomeScreen", () => {
     expect(buttons).toHaveLength(3);
   });
 
-  it("dispatches project.openDialog when Open your project is clicked", () => {
+  it("dispatches project.add when Open your project is clicked", () => {
     render(<WelcomeScreen gettingStarted={makeGettingStarted(allIncomplete)} />);
 
     fireEvent.click(screen.getByRole("button", { name: /open your project/i }));
-    expect(dispatchMock).toHaveBeenCalledWith("project.openDialog", undefined, {
+    expect(dispatchMock).toHaveBeenCalledWith("project.add", undefined, {
       source: "user",
     });
   });


### PR DESCRIPTION
## Summary

- The checklist item dispatched `project.openDialog`, which opens the native picker but discards the result — so clicking it and selecting a folder did nothing
- Swapped to `project.add`, which runs the full add flow: picker, registration via `projectClient.add()`, project list reload, and project switch — identical to the WelcomeScreen "Open folder" quick-action
- One constant change in `checklistItems.ts` fixes both the `GettingStartedChecklist` and the `WelcomeScreen` NudgeSequencer; `project.openDialog` is left intact (legitimately used in `NewWorktreeDialog`)

Resolves #10383

## Changes

- `src/components/Onboarding/checklistItems.ts` — swap `actionId` from `project.openDialog` to `project.add`
- `src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx` — assert new action ID
- `src/components/Project/__tests__/WelcomeScreen.test.tsx` — assert new action ID

## Testing

- Full local CI suite passed (12 checks, 33517 tests) on the gated SHA `14df1a1`
- Completion marking unaffected: `useGettingStartedChecklist` auto-marks `openedProject` via a Zustand subscription on `currentProject`, independent of which action triggers the flow