### PR TITLE
feat(release): add explicit x64 suffix to macOS release artifacts

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -204,8 +204,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # x64 has no arch suffix because electron-builder treats it as the default arch
-          # (builder-util getArchSuffix returns "" for the default); arm64 and universal do.
+          # Unpacked dir names come from electron-builder's getArchSuffix, which
+          # returns "" for the default arch (x64) — so release/mac/ is the x64
+          # bundle. Compressed artifacts carry an explicit -x64 suffix instead,
+          # via the artifactName overrides in electron-builder.config.cjs (#10380).
           apps=(
             "release/mac-arm64/Daintree.app"
             "release/mac/Daintree.app"

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -203,16 +203,21 @@ module.exports = async function () {
         { target: "dmg", arch: ["arm64", "x64", "universal"] },
         { target: "zip", arch: ["arm64", "x64", "universal"] },
       ],
+      // A user-specified artifactName forces ${arch} to render for x64 too
+      // (bypassing electron-builder's default-arch suffix stripping), so no
+      // macOS artifact looks like "the" Mac download (#10380). This pattern
+      // covers the zip target — a root-level `zip` block is rejected by the
+      // config schema — while the dmg block's artifactName takes precedence
+      // for DMGs.
+      artifactName: "${productName}-${version}-${arch}-${os}.${ext}",
       hardenedRuntime: true,
       gatekeeperAssess: false,
       entitlements: "build/entitlements.mac.plist",
       entitlementsInherit: "build/entitlements.mac.plist",
     },
-    // Explicit artifactName on the dmg/zip target blocks forces ${arch} to
-    // render for x64 too (a user-specified pattern bypasses electron-builder's
-    // default-arch suffix stripping), so no macOS artifact looks like "the"
-    // Mac download (#10380). Unpacked dirs (release/mac/, release/mac-arm64/,
-    // release/mac-universal/) are unaffected by artifactName.
+    // Explicit dmg block override; the dmg pattern drops the ${os} token.
+    // Unpacked dirs (release/mac/, release/mac-arm64/, release/mac-universal/)
+    // are unaffected by artifactName.
     dmg: {
       icon: "build/icon.icns",
       artifactName: "${productName}-${version}-${arch}.${ext}",
@@ -220,9 +225,6 @@ module.exports = async function () {
         { x: 130, y: 220 },
         { x: 410, y: 220, type: "link", path: "/Applications" },
       ],
-    },
-    zip: {
-      artifactName: "${productName}-${version}-${arch}-${os}.${ext}",
     },
     win: {
       icon: "build/icon.ico",

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -208,12 +208,21 @@ module.exports = async function () {
       entitlements: "build/entitlements.mac.plist",
       entitlementsInherit: "build/entitlements.mac.plist",
     },
+    // Explicit artifactName on the dmg/zip target blocks forces ${arch} to
+    // render for x64 too (a user-specified pattern bypasses electron-builder's
+    // default-arch suffix stripping), so no macOS artifact looks like "the"
+    // Mac download (#10380). Unpacked dirs (release/mac/, release/mac-arm64/,
+    // release/mac-universal/) are unaffected by artifactName.
     dmg: {
       icon: "build/icon.icns",
+      artifactName: "${productName}-${version}-${arch}.${ext}",
       contents: [
         { x: 130, y: 220 },
         { x: 410, y: 220, type: "link", path: "/Applications" },
       ],
+    },
+    zip: {
+      artifactName: "${productName}-${version}-${arch}-${os}.${ext}",
     },
     win: {
       icon: "build/icon.ico",

--- a/scripts/ci/electron-builder-config.test.mjs
+++ b/scripts/ci/electron-builder-config.test.mjs
@@ -35,11 +35,17 @@ describe("electron-builder config — macOS artifact naming (#10380)", () => {
     // key (e.g. a root-level `zip` block) fails validateConfiguration() at
     // packaging time and breaks the release build before any artifact exists.
     const scheme = JSON.parse(
-      await readFile(new URL("../../node_modules/app-builder-lib/scheme.json", import.meta.url), "utf8")
+      await readFile(
+        new URL("../../node_modules/app-builder-lib/scheme.json", import.meta.url),
+        "utf8"
+      )
     );
     const allowedKeys = new Set(Object.keys(scheme.properties));
     for (const key of Object.keys(config)) {
-      expect(allowedKeys, `root config key "${key}" is not in the electron-builder schema`).toContain(key);
+      expect(
+        allowedKeys,
+        `root config key "${key}" is not in the electron-builder schema`
+      ).toContain(key);
     }
   });
 });

--- a/scripts/ci/electron-builder-config.test.mjs
+++ b/scripts/ci/electron-builder-config.test.mjs
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import buildConfig from "../../electron-builder.config.cjs";
+
+describe("electron-builder config — macOS artifact naming (#10380)", () => {
+  it("forces an explicit arch token into every macOS artifact name", async () => {
+    const config = await buildConfig();
+    // A user-specified artifactName bypasses electron-builder's default-arch
+    // suffix stripping, so ${arch} renders "x64" instead of "" and no artifact
+    // looks like "the" Mac download.
+    expect(config.dmg.artifactName).toContain("${arch}");
+    expect(config.zip.artifactName).toContain("${arch}");
+  });
+
+  it("keeps the -mac suffix on zip artifacts for update-metadata ranking", async () => {
+    const config = await buildConfig();
+    // macZipPriority() in generate-update-metadata.mjs matches *-mac.zip names;
+    // dropping the os token from the zip pattern would break latest-mac.yml
+    // file ordering and electron-updater arch routing.
+    expect(config.zip.artifactName.endsWith("-${os}.${ext}")).toBe(true);
+  });
+
+  it("does not override mac defaultArch", async () => {
+    const config = await buildConfig();
+    // defaultArch changes computeAppOutDir, renaming release/mac/ to
+    // release/mac-x64/ and breaking the hardcoded app-bundle paths in
+    // release-macos.yml. The arch suffix belongs on artifactName only.
+    expect(config.mac.defaultArch).toBeUndefined();
+  });
+});

--- a/scripts/ci/electron-builder-config.test.mjs
+++ b/scripts/ci/electron-builder-config.test.mjs
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import buildConfig from "../../electron-builder.config.cjs";
 
@@ -6,9 +7,10 @@ describe("electron-builder config — macOS artifact naming (#10380)", () => {
     const config = await buildConfig();
     // A user-specified artifactName bypasses electron-builder's default-arch
     // suffix stripping, so ${arch} renders "x64" instead of "" and no artifact
-    // looks like "the" Mac download.
+    // looks like "the" Mac download. mac.artifactName covers the zip target;
+    // the dmg block overrides it for DMGs.
     expect(config.dmg.artifactName).toContain("${arch}");
-    expect(config.zip.artifactName).toContain("${arch}");
+    expect(config.mac.artifactName).toContain("${arch}");
   });
 
   it("keeps the -mac suffix on zip artifacts for update-metadata ranking", async () => {
@@ -16,7 +18,7 @@ describe("electron-builder config — macOS artifact naming (#10380)", () => {
     // macZipPriority() in generate-update-metadata.mjs matches *-mac.zip names;
     // dropping the os token from the zip pattern would break latest-mac.yml
     // file ordering and electron-updater arch routing.
-    expect(config.zip.artifactName.endsWith("-${os}.${ext}")).toBe(true);
+    expect(config.mac.artifactName.endsWith("-${os}.${ext}")).toBe(true);
   });
 
   it("does not override mac defaultArch", async () => {
@@ -25,5 +27,19 @@ describe("electron-builder config — macOS artifact naming (#10380)", () => {
     // release/mac-x64/ and breaking the hardcoded app-bundle paths in
     // release-macos.yml. The arch suffix belongs on artifactName only.
     expect(config.mac.defaultArch).toBeUndefined();
+  });
+
+  it("only uses root config keys the electron-builder schema accepts", async () => {
+    const config = await buildConfig();
+    // The schema has additionalProperties: false at the root, so an unknown
+    // key (e.g. a root-level `zip` block) fails validateConfiguration() at
+    // packaging time and breaks the release build before any artifact exists.
+    const scheme = JSON.parse(
+      await readFile(new URL("../../node_modules/app-builder-lib/scheme.json", import.meta.url), "utf8")
+    );
+    const allowedKeys = new Set(Object.keys(scheme.properties));
+    for (const key of Object.keys(config)) {
+      expect(allowedKeys, `root config key "${key}" is not in the electron-builder schema`).toContain(key);
+    }
   });
 });

--- a/scripts/ci/generate-update-metadata.mjs
+++ b/scripts/ci/generate-update-metadata.mjs
@@ -54,12 +54,14 @@ async function artifactEntry(releaseDir, fileName) {
 // a native build exists.
 function macZipPriority(fileName) {
   if (fileName.includes("-x64-mac.zip")) return 0;
-  if (fileName.includes("-arm64-mac.zip")) return 1;
-  if (fileName.includes("universal-mac.zip")) return 2;
-  // Bare -mac.zip (no arch suffix) is the x64 build from electron-builder.
-  // Check after arm64 so arm64-mac.zip doesn't match this branch.
-  if (fileName.endsWith("-mac.zip")) return 0;
-  return 3;
+  if (fileName.includes("-arm64-mac.zip")) return 2;
+  if (fileName.includes("universal-mac.zip")) return 3;
+  // Bare -mac.zip (no arch suffix) was the x64 name before the explicit -x64
+  // rename (#10380). Checked after arm64/universal so those never match this
+  // branch; ranked after the explicit x64 name so a stale bare artifact in a
+  // dirty release dir never outranks the current build.
+  if (fileName.endsWith("-mac.zip")) return 1;
+  return 4;
 }
 
 function selectArtifacts(platform, fileNames) {

--- a/scripts/ci/generate-update-metadata.test.mjs
+++ b/scripts/ci/generate-update-metadata.test.mjs
@@ -66,34 +66,9 @@ describe("generate-update-metadata", () => {
     await mkdir(releaseDir);
     const packagePath = await writePackageJson(dir);
     await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-mac.zip", "arm64");
-    await writeArtifact(releaseDir, "Daintree-1.2.3-mac.zip", "x64");
-    await writeArtifact(releaseDir, "Daintree-1.2.3-universal-mac.zip", "universal");
-    await writeArtifact(releaseDir, "Daintree-1.2.3-universal.dmg", "dmg");
-
-    const metadata = await generateUpdateMetadata({
-      platform: "mac",
-      releaseDir,
-      metadataPath: path.join(releaseDir, "latest-mac.yml"),
-      packagePath,
-      releaseDate: "2026-01-02T03:04:05.000Z",
-    });
-
-    expect(metadata.path).toBe("Daintree-1.2.3-mac.zip");
-    expect(metadata.files.map((file) => file.url)).toEqual([
-      "Daintree-1.2.3-mac.zip",
-      "Daintree-1.2.3-arm64-mac.zip",
-      "Daintree-1.2.3-universal-mac.zip",
-    ]);
-  });
-
-  it("ranks explicit -x64-mac.zip before universal when no bare -mac.zip is present", async () => {
-    const dir = await tempDir();
-    const releaseDir = path.join(dir, "release");
-    await mkdir(releaseDir);
-    const packagePath = await writePackageJson(dir);
-    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-mac.zip", "arm64");
     await writeArtifact(releaseDir, "Daintree-1.2.3-x64-mac.zip", "x64");
     await writeArtifact(releaseDir, "Daintree-1.2.3-universal-mac.zip", "universal");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-universal.dmg", "dmg");
 
     const metadata = await generateUpdateMetadata({
       platform: "mac",
@@ -106,6 +81,33 @@ describe("generate-update-metadata", () => {
     expect(metadata.path).toBe("Daintree-1.2.3-x64-mac.zip");
     expect(metadata.files.map((file) => file.url)).toEqual([
       "Daintree-1.2.3-x64-mac.zip",
+      "Daintree-1.2.3-arm64-mac.zip",
+      "Daintree-1.2.3-universal-mac.zip",
+    ]);
+  });
+
+  // Back-compat: builds published before the explicit -x64 rename (#10380)
+  // produced a bare -mac.zip for x64; macZipPriority keeps ranking it first.
+  it("ranks a legacy bare -mac.zip before universal when no -x64-mac.zip is present", async () => {
+    const dir = await tempDir();
+    const releaseDir = path.join(dir, "release");
+    await mkdir(releaseDir);
+    const packagePath = await writePackageJson(dir);
+    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-mac.zip", "arm64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-mac.zip", "x64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-universal-mac.zip", "universal");
+
+    const metadata = await generateUpdateMetadata({
+      platform: "mac",
+      releaseDir,
+      metadataPath: path.join(releaseDir, "latest-mac.yml"),
+      packagePath,
+      releaseDate: "2026-01-02T03:04:05.000Z",
+    });
+
+    expect(metadata.path).toBe("Daintree-1.2.3-mac.zip");
+    expect(metadata.files.map((file) => file.url)).toEqual([
+      "Daintree-1.2.3-mac.zip",
       "Daintree-1.2.3-arm64-mac.zip",
       "Daintree-1.2.3-universal-mac.zip",
     ]);

--- a/scripts/ci/generate-update-metadata.test.mjs
+++ b/scripts/ci/generate-update-metadata.test.mjs
@@ -113,6 +113,31 @@ describe("generate-update-metadata", () => {
     ]);
   });
 
+  it("prefers the explicit -x64-mac.zip over a stale legacy bare -mac.zip", async () => {
+    const dir = await tempDir();
+    const releaseDir = path.join(dir, "release");
+    await mkdir(releaseDir);
+    const packagePath = await writePackageJson(dir);
+    await writeArtifact(releaseDir, "Daintree-1.2.3-mac.zip", "stale-x64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-x64-mac.zip", "x64");
+    await writeArtifact(releaseDir, "Daintree-1.2.3-arm64-mac.zip", "arm64");
+
+    const metadata = await generateUpdateMetadata({
+      platform: "mac",
+      releaseDir,
+      metadataPath: path.join(releaseDir, "latest-mac.yml"),
+      packagePath,
+      releaseDate: "2026-01-02T03:04:05.000Z",
+    });
+
+    expect(metadata.path).toBe("Daintree-1.2.3-x64-mac.zip");
+    expect(metadata.files.map((file) => file.url)).toEqual([
+      "Daintree-1.2.3-x64-mac.zip",
+      "Daintree-1.2.3-mac.zip",
+      "Daintree-1.2.3-arm64-mac.zip",
+    ]);
+  });
+
   it("ranks arm64 before universal when no x64 ZIP is present", async () => {
     const dir = await tempDir();
     const releaseDir = path.join(dir, "release");


### PR DESCRIPTION
## Summary

- macOS x64 artifacts had no architecture suffix (`Daintree-X.Y.Z.dmg`) because `${arch}` renders empty for electron-builder's default arch — so the Intel build looked like *the* Mac download, and Apple Silicon users grabbed it and ran under Rosetta
- Adds explicit `x64` to both the `.dmg` and `-mac.zip` artifact names via `artifactName` on the `dmg` and `mac` blocks in `electron-builder.config.cjs`; unpacked dirs and `release-macos.yml` hardcoded bundle paths are unaffected
- Updates `generate-update-metadata.mjs` to rank the new `-x64-mac.zip` above the legacy bare `-mac.zip`, while keeping the bare-name branch for back-compat with already-published builds

Resolves #10380

## Changes

- **`electron-builder.config.cjs`** — explicit `artifactName` on `dmg` (`${productName}-${version}-${arch}.${ext}`) and `mac` (`${productName}-${version}-${arch}-${os}.${ext}`); `isUserForced` bypasses electron-builder's default-arch suffix stripping, so x64 now produces `Daintree-X.Y.Z-x64.dmg` and `Daintree-X.Y.Z-x64-mac.zip`
- **`scripts/ci/generate-update-metadata.mjs`** — `macZipPriority` ranks explicit `-x64-mac.zip` (0) above legacy bare `-mac.zip` (1), then `arm64` (2), `universal` (3)
- **`scripts/ci/generate-update-metadata.test.mjs`** — primary ranking test updated to the new x64 name; legacy bare-name back-compat test retained; new tie-preference test added
- **`scripts/ci/electron-builder-config.test.mjs`** (new) — guards the `${arch}` token in both artifact name patterns, the `-mac` zip suffix `macZipPriority` depends on, absence of `mac.defaultArch`, and that all root config keys are valid under electron-builder's schema (`additionalProperties: false`)
- **`.github/workflows/release-macos.yml`** — comment-only update clarifying that unpacked-dir naming and artifact naming are controlled separately

## Testing

- All 15 existing `generate-update-metadata` tests pass, plus 4 new config regression tests
- electron-updater routing unchanged: `MacUpdater` filters on the `arm64` substring, and `-x64-mac.zip` contains neither `arm64` nor `universal`, so Intel and Apple Silicon update routing stays correct
- Build, preload-backdoor check, and prettier all pass locally