### PR TITLE
feat(rosetta): show prominent warning when running under Rosetta on Apple Silicon

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -142,6 +142,7 @@ export const CHANNELS = {
   APP_FIRST_INTERACTIVE: "app:first-interactive",
   APP_VIEW_PAINTED: "app:view-painted",
   APP_VIEW_WARM_PAINTED: "app:view-warm-painted",
+  APP_DISMISS_ROSETTA_WARNING: "app:dismiss-rosetta-warning",
   MENU_ACTION: "menu:action",
   MENU_SHOW_CONTEXT: "menu:show-context",
 

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -60,6 +60,7 @@ import { registerPerfHandlers } from "./handlers/perf.js";
 import { registerAccessibilityHandlers } from "./handlers/accessibility.js";
 import { registerDemoHandlers } from "./handlers/demo.js";
 import { registerRecoveryHandlers } from "./handlers/recovery.js";
+import { registerRosettaHandlers } from "./handlers/rosetta.js";
 import { registerSafeModeHandlers } from "./handlers/safeMode.js";
 import { registerWatchdogHandlers } from "./handlers/watchdog.js";
 import { registerPluginHandlers } from "./handlers/plugin.js";
@@ -172,6 +173,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerAccessibilityHandlers());
     register(() => registerDemoHandlers(deps));
     register(() => registerRecoveryHandlers(deps));
+    register(() => registerRosettaHandlers());
     register(() => registerSafeModeHandlers());
     register(() => registerWatchdogHandlers(deps));
     register(() => registerPluginHandlers());

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -808,11 +808,6 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
   };
   handlers.push(typedHandle(CHANNELS.APP_FORCE_QUIT, handleAppForceQuit));
 
-  const handleAppDismissRosettaWarning = async () => {
-    store.set("rosettaWarningDismissed", true);
-  };
-  handlers.push(typedHandle(CHANNELS.APP_DISMISS_ROSETTA_WARNING, handleAppDismissRosettaWarning));
-
   const handleAppResetAndRelaunch = async () => {
     // Clear the crash-loop sentinel before relaunch so the next boot starts
     // fresh. Mirrors the gpu.ts pattern: prepare state -> relaunch -> close

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -27,6 +27,7 @@ export const CRASH_CRITICAL_FIELDS = new Set([
 ]);
 
 import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../../../utils/gpuDetection.js";
+import { isRunningUnderRosetta } from "../../../utils/rosettaDetection.js";
 import {
   isGpuDisabledByFlag,
   isGpuAngleFallbackApplied,
@@ -421,6 +422,8 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       safeMode: inSafeMode,
       isWindowsStore:
         (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true,
+      runningUnderRosetta: isRunningUnderRosetta(),
+      rosettaWarningDismissed: store.get("rosettaWarningDismissed") === true,
       skippedPanelCount,
       quarantinedPanels,
       crashCount: guard.getCrashCount(),
@@ -804,6 +807,11 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
     app.exit(0);
   };
   handlers.push(typedHandle(CHANNELS.APP_FORCE_QUIT, handleAppForceQuit));
+
+  const handleAppDismissRosettaWarning = async () => {
+    store.set("rosettaWarningDismissed", true);
+  };
+  handlers.push(typedHandle(CHANNELS.APP_DISMISS_ROSETTA_WARNING, handleAppDismissRosettaWarning));
 
   const handleAppResetAndRelaunch = async () => {
     // Clear the crash-loop sentinel before relaunch so the next boot starts

--- a/electron/ipc/handlers/rosetta.ts
+++ b/electron/ipc/handlers/rosetta.ts
@@ -1,0 +1,21 @@
+import { defineIpcNamespace, op } from "../define.js";
+import { CHANNELS } from "../channels.js";
+import { store } from "../../store.js";
+
+/**
+ * Persists the permanent dismissal of the Rosetta translation warning banner.
+ * Machine-level and one-way: the installed binary's architecture never changes
+ * via auto-update, so there is no corresponding "undismiss" op.
+ */
+export const rosettaNamespace = defineIpcNamespace({
+  name: "rosetta",
+  ops: {
+    dismissRosettaWarning: op(CHANNELS.APP_DISMISS_ROSETTA_WARNING, async (): Promise<void> => {
+      store.set("rosettaWarningDismissed", true);
+    }),
+  },
+});
+
+export function registerRosettaHandlers(): () => void {
+  return rosettaNamespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1270,6 +1270,8 @@ const api: ElectronAPI = {
 
     forceQuit: () => _unwrappingInvoke(CHANNELS.APP_FORCE_QUIT),
 
+    dismissRosettaWarning: () => _unwrappingInvoke(CHANNELS.APP_DISMISS_ROSETTA_WARNING),
+
     resetAndRelaunch: () => _unwrappingInvoke(CHANNELS.APP_RESET_AND_RELAUNCH),
 
     clearQuarantinedPanel: (panelId: string) =>

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -5,6 +5,7 @@ import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
 import { TerminalSnapshotSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../utils/gpuDetection.js";
+import { isRunningUnderRosetta } from "../utils/rosettaDetection.js";
 import { isGpuDisabledByFlag, isGpuAngleFallbackApplied } from "./GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
 import type { HydrateResult } from "../../shared/types/ipc/app.js";
@@ -106,6 +107,8 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     gpuAngleFallbackActive: isGpuAngleFallbackApplied(app.getPath("userData")),
     safeMode: inSafeMode,
     isWindowsStore: (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true,
+    runningUnderRosetta: isRunningUnderRosetta(),
+    rosettaWarningDismissed: store.get("rosettaWarningDismissed") === true,
     settingsRecovery: null,
     projectStateRecovery: projectStateQuarantinedPath
       ? { quarantinedPath: projectStateQuarantinedPath }

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -7,6 +7,7 @@ import { logBuffer } from "./LogBuffer.js";
 import type { PtyClient } from "./PtyClient.js";
 import { scrubSecrets } from "../../shared/utils/secretScrubber.js";
 import { store, windowStatesStore } from "../store.js";
+import { isRunningUnderRosetta } from "../utils/rosettaDetection.js";
 import type { HandlerDependencies } from "../ipc/types.js";
 
 const execFileAsync = promisify(execFile);
@@ -167,6 +168,7 @@ async function collectRuntime() {
   return {
     platform: process.platform,
     arch: process.arch,
+    runningUnderRosetta: isRunningUnderRosetta(),
     execPath: sanitizePath(app.getPath("exe")),
     appPath: sanitizePath(app.getAppPath()),
     userData: sanitizePath(app.getPath("userData")),

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -202,6 +202,12 @@ export interface StoreSchema {
    * hides the suggestion banner without enabling. Only meaningful on Windows.
    */
   wslGitByWorktree: Record<string, { enabled: boolean; dismissed: boolean }>;
+  /**
+   * Permanent dismissal of the Rosetta translation warning banner. Machine-level
+   * (the installed binary's architecture never changes via auto-update), so a
+   * single global flag rather than per-project state.
+   */
+  rosettaWarningDismissed: boolean;
   appTheme: Partial<AppThemeConfig>;
   privacy: {
     telemetryLevel: "off" | "errors" | "full";
@@ -508,6 +514,7 @@ const storeOptions = {
     windowStates: {},
     worktreeIssueMap: {},
     wslGitByWorktree: {},
+    rosettaWarningDismissed: false,
     appTheme: {},
     privacy: {
       telemetryLevel: "off" as const,

--- a/electron/utils/__tests__/rosettaDetection.test.ts
+++ b/electron/utils/__tests__/rosettaDetection.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronMock = vi.hoisted(() => ({
+  app: { runningUnderARM64Translation: undefined as boolean | undefined },
+}));
+
+vi.mock("electron", () => ({
+  app: electronMock.app,
+}));
+
+import { isRunningUnderRosetta } from "../rosettaDetection.js";
+
+const originalPlatform = process.platform;
+
+function setPlatform(value: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value, writable: true });
+}
+
+describe("isRunningUnderRosetta", () => {
+  beforeEach(() => {
+    electronMock.app.runningUnderARM64Translation = undefined;
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it("returns true on macOS when the translation flag is set", () => {
+    setPlatform("darwin");
+    electronMock.app.runningUnderARM64Translation = true;
+    expect(isRunningUnderRosetta()).toBe(true);
+  });
+
+  it("returns false on macOS when running natively", () => {
+    setPlatform("darwin");
+    electronMock.app.runningUnderARM64Translation = false;
+    expect(isRunningUnderRosetta()).toBe(false);
+  });
+
+  it("returns false on macOS when the flag is unavailable", () => {
+    setPlatform("darwin");
+    expect(isRunningUnderRosetta()).toBe(false);
+  });
+
+  it("excludes Windows ARM x64 translation (WOW64 also sets the flag)", () => {
+    setPlatform("win32");
+    electronMock.app.runningUnderARM64Translation = true;
+    expect(isRunningUnderRosetta()).toBe(false);
+  });
+
+  it("returns false on Linux where the flag is undefined", () => {
+    setPlatform("linux");
+    expect(isRunningUnderRosetta()).toBe(false);
+  });
+});

--- a/electron/utils/rosettaDetection.ts
+++ b/electron/utils/rosettaDetection.ts
@@ -1,0 +1,11 @@
+import { app } from "electron";
+
+/**
+ * True when this x64 build is being translated by Rosetta on an Apple Silicon
+ * Mac. Darwin-gated because `app.runningUnderARM64Translation` also reports
+ * `true` for x64 builds under WOW64 on Windows ARM, where a "download the
+ * Apple Silicon build" prompt would be wrong.
+ */
+export function isRunningUnderRosetta(): boolean {
+  return process.platform === "darwin" && app.runningUnderARM64Translation === true;
+}

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -402,6 +402,8 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     quit(): Promise<void>;
     forceQuit(): Promise<void>;
     resetAndRelaunch(): Promise<void>;
+    /** Persist the permanent dismissal of the Rosetta translation warning banner. */
+    dismissRosettaWarning(): Promise<void>;
     /**
      * Clear a single panel's quarantine entry from the suspect ledger so it
      * hydrates normally on the next launch. Returns `{ cleared: true }` if the

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -163,6 +163,16 @@ export interface HydrateResult {
    * the main process and is `false` for NSIS installs and non-Windows builds.
    */
   isWindowsStore: boolean;
+  /**
+   * True when this is an x64 build translated by Rosetta on an Apple Silicon
+   * Mac. Darwin-only by construction — the equivalent Windows-ARM translation
+   * is deliberately excluded so the renderer's "download the Apple Silicon
+   * build" warning never shows on Windows. Optional for backward compat with
+   * older main processes.
+   */
+  runningUnderRosetta?: boolean;
+  /** True when the user permanently dismissed the Rosetta translation warning. */
+  rosettaWarningDismissed?: boolean;
   /** Number of saved panels skipped due to safe-mode boot (0 when safe mode is inactive). */
   skippedPanelCount?: number;
   /**

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -44,6 +44,10 @@ export interface GeneratedIpcInvokeMap {
     args: [panelId: string];
     result: { cleared: boolean };
   };
+  "app:dismiss-rosetta-warning": {
+    args: [];
+    result: void;
+  };
   "app:get-version-info": {
     args: [];
     result: import("./app.js").AppVersionInfo;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -439,6 +439,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [];
     result: void;
   };
+  "app:dismiss-rosetta-warning": {
+    args: [];
+    result: void;
+  };
   "app:reset-and-relaunch": {
     args: [];
     result: void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -439,10 +439,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [];
     result: void;
   };
-  "app:dismiss-rosetta-warning": {
-    args: [];
-    result: void;
-  };
   "app:reset-and-relaunch": {
     args: [];
     result: void;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import {
   usePanelStoreBootstrap,
   useSemanticWorkerLifecycle,
   useCloudSyncWarning,
+  useRosettaWarning,
   useAccessibilityAnnouncements,
   useGettingStartedChecklist,
   useOrchestrationMilestones,
@@ -837,6 +838,7 @@ function AppInner() {
   usePanelStoreBootstrap(bootResult?.terminalConfig ?? null);
   useSemanticWorkerLifecycle();
   useCloudSyncWarning(homeDir);
+  useRosettaWarning(bootResult);
   useAccessibilityAnnouncements();
 
   useEffect(() => {

--- a/src/components/Recovery/GlobalBannerCoordinator.tsx
+++ b/src/components/Recovery/GlobalBannerCoordinator.tsx
@@ -4,6 +4,7 @@ import { SafeModeBanner } from "./SafeModeBanner";
 import { RestoreConfirmationBanner } from "./RestoreConfirmationBanner";
 import { ForgeTokenBanner } from "./ForgeTokenBanner";
 import { CloudSyncBanner } from "./CloudSyncBanner";
+import { RosettaBanner } from "./RosettaBanner";
 import { useGlobalBannerPriority } from "./useGlobalBannerPriority";
 import { WindowControlsInsetProvider } from "@/components/ui/WindowControlsInset";
 
@@ -21,6 +22,8 @@ function activeBanner(slot: ReturnType<typeof useGlobalBannerPriority>) {
       return <ForgeTokenBanner />;
     case "cloud-sync":
       return <CloudSyncBanner />;
+    case "rosetta":
+      return <RosettaBanner />;
     default:
       return null;
   }

--- a/src/components/Recovery/RosettaBanner.tsx
+++ b/src/components/Recovery/RosettaBanner.tsx
@@ -1,0 +1,59 @@
+import { AlertTriangle } from "lucide-react";
+import { actionService } from "@/services/ActionService";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
+import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+
+const DOWNLOAD_URL = "https://daintree.org/download";
+
+export function RosettaBanner() {
+  const visible = useRosettaBannerStore((s) => s.visible);
+  const setVisible = useRosettaBannerStore((s) => s.setVisible);
+
+  if (!visible) return null;
+
+  const handleDismiss = async () => {
+    // Hide immediately — the dismissal is permanent (the binary's architecture
+    // never changes via auto-update), and a persistence failure shouldn't
+    // resurrect the banner mid-session; it just returns on the next launch.
+    setVisible(false);
+    try {
+      await window.electron.app.dismissRosettaWarning();
+    } catch (err) {
+      logError("Failed to save Rosetta warning preference", err);
+      // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+      notify({
+        type: "error",
+        title: "Couldn't save preference",
+        message: formatErrorMessage(err, "Failed to save Rosetta warning preference"),
+        duration: 6000,
+      });
+    }
+  };
+
+  const handleDownload = () => {
+    void actionService.dispatch("system.openExternal", { url: DOWNLOAD_URL }, { source: "user" });
+  };
+
+  return (
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title="Running under Rosetta"
+      description="This is the Intel build running translated on Apple Silicon, which degrades performance. Install the Apple Silicon build for native speed."
+      severity="warning"
+      role="status"
+      onClose={() => void handleDismiss()}
+      closeAriaLabel="Dismiss Rosetta warning"
+      actions={[
+        {
+          id: "download",
+          label: "Download Apple Silicon build",
+          variant: "primary",
+          onClick: handleDownload,
+        },
+      ]}
+    />
+  );
+}

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -21,6 +21,7 @@ import { useSafeModeStore } from "@/store/safeModeStore";
 import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
 
 const PROVIDER_ID = "daintree.github.github";
 
@@ -63,6 +64,7 @@ function resetStores() {
   useRestoreConfirmationStore.setState({ visible: false, suspectCount: 0, crashCount: 0 });
   useForgeProviderHealthStore.setState({ providers: {} });
   useCloudSyncBannerStore.setState({ service: null, projectId: null });
+  useRosettaBannerStore.setState({ visible: false });
 }
 
 beforeEach(() => {
@@ -345,5 +347,23 @@ describe("GlobalBannerCoordinator", () => {
     expect(screen.getByText("Terminal service crashed")).toBeTruthy();
     expect(screen.queryByText("GitHub token expired")).toBeNull();
     expect(screen.queryByText("Project in a synced folder")).toBeNull();
+  });
+
+  it("renders the Rosetta banner when only the translation warning is active", () => {
+    useRosettaBannerStore.setState({ visible: true });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.getByText("Running under Rosetta")).toBeTruthy();
+  });
+
+  it("prefers cloud sync over the Rosetta warning when both are active", () => {
+    useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
+    useRosettaBannerStore.setState({ visible: true });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.getByText("Project in a synced folder")).toBeTruthy();
+    expect(screen.queryByText("Running under Rosetta")).toBeNull();
   });
 });

--- a/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
+++ b/src/components/Recovery/__tests__/GlobalBannerCoordinator.test.tsx
@@ -357,6 +357,16 @@ describe("GlobalBannerCoordinator", () => {
     expect(screen.getByText("Running under Rosetta")).toBeTruthy();
   });
 
+  it("suppresses the Rosetta warning while the host has crashed", () => {
+    usePanelStore.setState({ backendStatus: "disconnected", lastCrashType: "UNKNOWN_CRASH" });
+    useRosettaBannerStore.setState({ visible: true });
+
+    render(<GlobalBannerCoordinator />);
+
+    expect(screen.getByText("Terminal service crashed")).toBeTruthy();
+    expect(screen.queryByText("Running under Rosetta")).toBeNull();
+  });
+
   it("prefers cloud sync over the Rosetta warning when both are active", () => {
     useCloudSyncBannerStore.setState({ service: "Dropbox", projectId: "p1" });
     useRosettaBannerStore.setState({ visible: true });

--- a/src/components/Recovery/__tests__/RosettaBanner.test.tsx
+++ b/src/components/Recovery/__tests__/RosettaBanner.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+
+const dispatchMock = vi.fn().mockResolvedValue({ ok: true, result: undefined });
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => dispatchMock(...args),
+  },
+}));
+
+const notifyMock = vi.fn();
+vi.mock("@/lib/notify", () => ({
+  notify: (payload: unknown) => notifyMock(payload),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+import { RosettaBanner } from "../RosettaBanner";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
+
+const dismissRosettaWarningMock = vi.fn(() => Promise.resolve());
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  (window as unknown as { electron: unknown }).electron = {
+    app: {
+      dismissRosettaWarning: dismissRosettaWarningMock,
+    },
+  };
+});
+
+describe("RosettaBanner", () => {
+  beforeEach(() => {
+    useRosettaBannerStore.setState({ visible: false });
+    dispatchMock.mockClear();
+    notifyMock.mockClear();
+    dismissRosettaWarningMock.mockReset().mockResolvedValue(undefined);
+    cleanup();
+  });
+
+  it("renders nothing while hidden", () => {
+    const { container } = render(<RosettaBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the warning with a download action when visible", () => {
+    useRosettaBannerStore.setState({ visible: true });
+    render(<RosettaBanner />);
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.getByText("Running under Rosetta")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Download Apple Silicon build" })).toBeTruthy();
+  });
+
+  it("opens the download page via the action service", () => {
+    useRosettaBannerStore.setState({ visible: true });
+    render(<RosettaBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Download Apple Silicon build" }));
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://daintree.org/download" },
+      { source: "user" }
+    );
+  });
+
+  it("hides the banner and persists the dismissal on close", async () => {
+    useRosettaBannerStore.setState({ visible: true });
+    render(<RosettaBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss Rosetta warning" }));
+
+    expect(useRosettaBannerStore.getState().visible).toBe(false);
+    await waitFor(() => {
+      expect(dismissRosettaWarningMock).toHaveBeenCalledOnce();
+    });
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the banner hidden and surfaces a toast when persisting fails", async () => {
+    dismissRosettaWarningMock.mockRejectedValueOnce(new Error("disk full"));
+    useRosettaBannerStore.setState({ visible: true });
+    render(<RosettaBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss Rosetta warning" }));
+
+    await waitFor(() => {
+      expect(notifyMock).toHaveBeenCalled();
+    });
+    expect(useRosettaBannerStore.getState().visible).toBe(false);
+  });
+});

--- a/src/components/Recovery/__tests__/RosettaBanner.test.tsx
+++ b/src/components/Recovery/__tests__/RosettaBanner.test.tsx
@@ -89,6 +89,7 @@ describe("RosettaBanner", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dismiss Rosetta warning" }));
 
     expect(useRosettaBannerStore.getState().visible).toBe(false);
+    expect(screen.queryByRole("status")).toBeNull();
     await waitFor(() => {
       expect(dismissRosettaWarningMock).toHaveBeenCalledOnce();
     });
@@ -103,7 +104,9 @@ describe("RosettaBanner", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dismiss Rosetta warning" }));
 
     await waitFor(() => {
-      expect(notifyMock).toHaveBeenCalled();
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Couldn't save preference" })
+      );
     });
     expect(useRosettaBannerStore.getState().visible).toBe(false);
   });

--- a/src/components/Recovery/__tests__/useShouldSuppressLocalError.test.tsx
+++ b/src/components/Recovery/__tests__/useShouldSuppressLocalError.test.tsx
@@ -9,6 +9,7 @@ import { useSafeModeStore } from "@/store/safeModeStore";
 import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
 
 function resetStores() {
   usePanelStore.setState({
@@ -27,6 +28,7 @@ function resetStores() {
   useRestoreConfirmationStore.setState({ visible: false, suspectCount: 0, crashCount: 0 });
   useForgeProviderHealthStore.setState({ providers: {} });
   useCloudSyncBannerStore.setState({ service: null, projectId: null });
+  useRosettaBannerStore.setState({ visible: false });
 }
 
 beforeEach(() => {
@@ -272,6 +274,16 @@ describe("useShouldSuppressLocalError", () => {
 
       act(() => {
         useCloudSyncBannerStore.setState({ service: "OneDrive", projectId: "p1" });
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("does not suppress backend-dependent banners when the Rosetta warning is active", () => {
+      const { result } = renderHook(() => useShouldSuppressLocalError("backend-dependent"));
+      expect(result.current).toBe(false);
+
+      act(() => {
+        useRosettaBannerStore.setState({ visible: true });
       });
       expect(result.current).toBe(false);
     });

--- a/src/components/Recovery/useGlobalBannerPriority.ts
+++ b/src/components/Recovery/useGlobalBannerPriority.ts
@@ -3,6 +3,7 @@ import { useSafeModeStore } from "@/store/safeModeStore";
 import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
 import { useForgeProviderHealthStore } from "@/store/forgeProviderHealthStore";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
 
 export type GlobalBannerSlot =
   | "host-crash"
@@ -11,6 +12,7 @@ export type GlobalBannerSlot =
   | "restore-confirmation"
   | "forge-token"
   | "cloud-sync"
+  | "rosetta"
   | null;
 
 // Precedence (highest first):
@@ -20,6 +22,7 @@ export type GlobalBannerSlot =
 //   restore-confirmation — informational "session recovered" toast-banner
 //   forge-token        — a forge provider's credentials expired; auth failure, panel data broken
 //   cloud-sync         — project sits in a synced folder; environmental warning
+//   rosetta            — x64 build translated on Apple Silicon; permanent perf warning
 // Watchdog sits below host-crash because a live host failure is more urgent
 // than a downed monitor, and above safe-mode because the watchdog protects
 // against the next crash whereas safe-mode is a consequence of the previous
@@ -35,7 +38,10 @@ export type GlobalBannerSlot =
 // banner is mounted, so it must keep that window when both conditions coexist.
 // forge-token outranks cloud-sync because an expired token is an active
 // failure (forge data is broken now) whereas cloud-sync is a persistent
-// environmental condition with no acute failure.
+// environmental condition with no acute failure. rosetta sits last: like
+// cloud-sync it's environmental with no acute failure, but it's even more
+// static — nothing in the app can change it, only reinstalling the native
+// build — so any more actionable banner deserves the slot first.
 export function useGlobalBannerPriority(): GlobalBannerSlot {
   const backendStatus = usePanelStore((s) => s.backendStatus);
   const watchdogStatus = usePanelStore((s) => s.watchdogStatus);
@@ -46,6 +52,7 @@ export function useGlobalBannerPriority(): GlobalBannerSlot {
     Object.values(s.providers).some((p) => p.tokenUnhealthy)
   );
   const cloudSyncService = useCloudSyncBannerStore((s) => s.service);
+  const rosettaVisible = useRosettaBannerStore((s) => s.visible);
 
   if (backendStatus !== "connected") return "host-crash";
   if (watchdogStatus === "disabled") return "watchdog-disabled";
@@ -53,5 +60,6 @@ export function useGlobalBannerPriority(): GlobalBannerSlot {
   if (restoreVisible) return "restore-confirmation";
   if (tokenUnhealthy) return "forge-token";
   if (cloudSyncService !== null) return "cloud-sync";
+  if (rosettaVisible) return "rosetta";
   return null;
 }

--- a/src/components/Recovery/useShouldSuppressLocalError.ts
+++ b/src/components/Recovery/useShouldSuppressLocalError.ts
@@ -44,6 +44,7 @@ const SLOT_IS_RECOVERY: Record<Exclude<GlobalBannerSlot, null>, boolean> = {
   "restore-confirmation": true,
   "forge-token": false,
   "cloud-sync": false,
+  rosetta: false,
 };
 
 function isSuppressedByGlobalCause(cause: GlobalBannerSlot, category: LocalErrorCategory): boolean {

--- a/src/hooks/app/__tests__/useRosettaWarning.test.tsx
+++ b/src/hooks/app/__tests__/useRosettaWarning.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+const notify = vi.fn();
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => notify(...args),
+}));
+
+import { useRosettaWarning } from "../useRosettaWarning";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
+import type { BootResult } from "@shared/types/ipc/app";
+
+function bootResult(fields: {
+  runningUnderRosetta?: boolean;
+  rosettaWarningDismissed?: boolean;
+}): BootResult {
+  return fields as unknown as BootResult;
+}
+
+describe("useRosettaWarning", () => {
+  beforeEach(() => {
+    notify.mockClear();
+    useRosettaBannerStore.setState({ visible: false });
+  });
+
+  it("does nothing while the boot result is unavailable", () => {
+    useRosettaBannerStore.setState({ visible: true });
+    renderHook(() => useRosettaWarning(null));
+    expect(useRosettaBannerStore.getState().visible).toBe(true);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("shows the banner when running under Rosetta and not dismissed", () => {
+    renderHook(() => useRosettaWarning(bootResult({ runningUnderRosetta: true })));
+    expect(useRosettaBannerStore.getState().visible).toBe(true);
+  });
+
+  it("keeps the banner hidden when the warning was dismissed", () => {
+    renderHook(() =>
+      useRosettaWarning(bootResult({ runningUnderRosetta: true, rosettaWarningDismissed: true }))
+    );
+    expect(useRosettaBannerStore.getState().visible).toBe(false);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("keeps the banner hidden on native builds", () => {
+    useRosettaBannerStore.setState({ visible: true });
+    renderHook(() => useRosettaWarning(bootResult({ runningUnderRosetta: false })));
+    expect(useRosettaBannerStore.getState().visible).toBe(false);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("keeps the banner hidden when the field is absent (older main process)", () => {
+    renderHook(() => useRosettaWarning(bootResult({})));
+    expect(useRosettaBannerStore.getState().visible).toBe(false);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("routes a single low-priority inbox notification per session", () => {
+    const result = bootResult({ runningUnderRosetta: true });
+    const { rerender } = renderHook(({ boot }: { boot: BootResult }) => useRosettaWarning(boot), {
+      initialProps: { boot: result },
+    });
+    rerender({ boot: bootResult({ runningUnderRosetta: true }) });
+    rerender({ boot: bootResult({ runningUnderRosetta: true }) });
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0]?.[0]).toMatchObject({
+      type: "warning",
+      priority: "low",
+      supersedeKey: "rosetta-translation",
+      countable: false,
+      context: { eventKind: "host" },
+    });
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -5,6 +5,7 @@ export { useShortcutHints } from "./useShortcutHints";
 export { usePanelStoreBootstrap } from "./usePanelStoreBootstrap";
 export { useSemanticWorkerLifecycle } from "./useSemanticWorkerLifecycle";
 export { useCloudSyncWarning } from "./useCloudSyncWarning";
+export { useRosettaWarning } from "./useRosettaWarning";
 export { useAccessibilityAnnouncements } from "./useAccessibilityAnnouncements";
 export { useGettingStartedChecklist } from "./useGettingStartedChecklist";
 export { useUnloadCleanup } from "./useUnloadCleanup";

--- a/src/hooks/app/useRosettaWarning.ts
+++ b/src/hooks/app/useRosettaWarning.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import type { BootResult } from "@shared/types/ipc/app";
+import { useRosettaBannerStore } from "@/store/rosettaBannerStore";
+import { notify } from "@/lib/notify";
+
+/**
+ * Surfaces the Rosetta translation warning from the boot payload. The
+ * condition is machine-level and session-stable (the installed binary's
+ * architecture can't change mid-session), so the initial boot result is the
+ * only source of truth — no re-check on project-switch hydrates.
+ */
+export function useRosettaWarning(bootResult: BootResult | null) {
+  const inboxedRef = useRef(false);
+
+  useEffect(() => {
+    if (!bootResult) return;
+
+    const visible =
+      bootResult.runningUnderRosetta === true && bootResult.rosettaWarningDismissed !== true;
+    useRosettaBannerStore.getState().setVisible(visible);
+
+    // Inbox entry once per session — the banner is the live surface; the entry
+    // is an audit trail that survives when a higher-priority global banner
+    // suppresses the live banner. priority:"low" keeps it inbox-only; the
+    // supersedeKey retires the prior row across launches; the ref guards
+    // against re-firing on rerenders.
+    if (visible && !inboxedRef.current) {
+      inboxedRef.current = true;
+      notify({
+        type: "warning",
+        priority: "low",
+        title: "Running under Rosetta",
+        message:
+          "This is the Intel build running translated on Apple Silicon, which degrades performance. Download the Apple Silicon build from daintree.org/download.",
+        supersedeKey: "rosetta-translation",
+        countable: false,
+        context: { eventKind: "host" },
+      });
+    }
+  }, [bootResult]);
+}

--- a/src/hooks/app/useRosettaWarning.ts
+++ b/src/hooks/app/useRosettaWarning.ts
@@ -7,7 +7,10 @@ import { notify } from "@/lib/notify";
  * Surfaces the Rosetta translation warning from the boot payload. The
  * condition is machine-level and session-stable (the installed binary's
  * architecture can't change mid-session), so the initial boot result is the
- * only source of truth — no re-check on project-switch hydrates.
+ * only source of truth — no re-check on project-switch hydrates. Deliberate
+ * tradeoff: when `app:boot` itself fails (`bootResult` stays null) the warning
+ * is skipped for that session even if the app recovers via the live hydrate
+ * fallback — an advisory perf banner isn't worth re-plumbing the fallback path.
  */
 export function useRosettaWarning(bootResult: BootResult | null) {
   const inboxedRef = useRef(false);

--- a/src/store/rosettaBannerStore.ts
+++ b/src/store/rosettaBannerStore.ts
@@ -1,0 +1,11 @@
+import { create } from "zustand";
+
+interface RosettaBannerState {
+  visible: boolean;
+  setVisible: (visible: boolean) => void;
+}
+
+export const useRosettaBannerStore = create<RosettaBannerState>((set) => ({
+  visible: false,
+  setVisible: (visible) => set({ visible }),
+}));


### PR DESCRIPTION
## Summary

- Detects Rosetta translation via `isRunningUnderRosetta()`, a thin wrapper around `app.runningUnderARM64Translation` with a Darwin platform gate — Windows ARM sets the same Electron flag, so the gate prevents a macOS download CTA from appearing there
- Shows a lowest-priority global banner (`InlineStatusBanner` at warning severity) with a "Download Apple Silicon build" action linking to https://daintree.org/download and a permanent dismiss persisted in `electron-store`; when suppressed by a higher-priority banner, a one-shot inbox notification fires as an audit trail
- Includes the Rosetta flag in `DiagnosticsCollector` for support exports

Resolves #10378

## Changes

- `electron/utils/rosettaDetection.ts` — new Darwin-gated detection helper
- `electron/ipc/handlers/rosetta.ts` — `app:dismiss-rosetta-warning` channel via `defineIpcNamespace` codegen
- `electron/store.ts`, `electron/services/AppHydrationService.ts` — `rosettaWarningDismissed` persisted flag rides the existing hydrate payload alongside `runningUnderRosetta`
- `src/components/Recovery/RosettaBanner.tsx` + `src/hooks/app/useRosettaWarning.ts` + `src/store/rosettaBannerStore.ts` — banner component, visibility hook, and store slice
- `src/components/Recovery/GlobalBannerCoordinator.tsx`, `useGlobalBannerPriority.ts` — new `"rosetta"` slot at lowest priority; `SLOT_IS_RECOVERY` flags it advisory so pane-local error banners aren't suppressed by it
- `electron/services/DiagnosticsCollector.ts` — `runningUnderRosetta` added to `collectRuntime()`

## Testing

Unit tests cover: `isRunningUnderRosetta()` platform gating (including win32 exclusion), `useRosettaWarning` visibility matrix and one-shot inbox notify, `RosettaBanner` render / download action / dismiss / persist-failure, `GlobalBannerCoordinator` priority ordering (host-crash and cloud-sync outrank rosetta), and the `useShouldSuppressLocalError` advisory classification. Full local suite green before push.