### PR TITLE
feat(gpu): make the GPU-disabled flag recoverable and reason-aware

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -580,6 +580,7 @@ describe("app:boot handler", () => {
       agentSettings: { agents: {} },
       gpuWebGLHardware: true,
       gpuHardwareAccelerationDisabled: false,
+      gpuDisabledReason: null,
       gpuAngleFallbackActive: false,
       safeMode: false,
       isWindowsStore: false,

--- a/electron/ipc/handlers/app/gpu.ts
+++ b/electron/ipc/handlers/app/gpu.ts
@@ -30,7 +30,7 @@ export function registerGpuHandlers(): () => void {
       clearGpuAngleFallbackFlag(userDataPath);
       store.set("gpu", { hardwareAccelerationDisabled: false });
     } else {
-      writeGpuDisabledFlag(userDataPath);
+      writeGpuDisabledFlag(userDataPath, "user");
       store.set("gpu", { hardwareAccelerationDisabled: true });
     }
     app.relaunch();

--- a/electron/ipc/handlers/app/gpu.ts
+++ b/electron/ipc/handlers/app/gpu.ts
@@ -27,7 +27,14 @@ export function registerGpuHandlers(): () => void {
     const userDataPath = app.getPath("userData");
     if (enabled) {
       clearGpuDisabledFlag(userDataPath);
-      clearGpuAngleFallbackFlag(userDataPath);
+      try {
+        clearGpuAngleFallbackFlag(userDataPath);
+      } catch (err) {
+        // The disabled flag is already gone — proceed with the relaunch so the
+        // user's re-enable still lands; a stale ANGLE flag only re-applies the
+        // soft fallback switches and clears on the next successful toggle.
+        console.warn("[GPU] Failed to clear ANGLE fallback flag on re-enable:", err);
+      }
       store.set("gpu", { hardwareAccelerationDisabled: false });
     } else {
       writeGpuDisabledFlag(userDataPath, "user");

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -32,6 +32,7 @@ import {
   isGpuDisabledByFlag,
   isGpuAngleFallbackApplied,
 } from "../../../services/GpuCrashMonitorService.js";
+import { readGpuDisabledFlagData } from "../../../services/gpuDisabledFlag.js";
 import { getCrashLoopGuard } from "../../../services/CrashLoopGuardService.js";
 import { getPanelSuspectLedger } from "../../../services/PanelSuspectLedgerService.js";
 import { closeTelemetry } from "../../../services/TelemetryService.js";
@@ -426,6 +427,7 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       agentSettings: store.get("agentSettings"),
       gpuWebGLHardware,
       gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
+      gpuDisabledReason: readGpuDisabledFlagData(app.getPath("userData"))?.reason ?? null,
       gpuAngleFallbackActive: isGpuAngleFallbackApplied(app.getPath("userData")),
       safeMode: inSafeMode,
       isWindowsStore:

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -7,6 +7,7 @@ import { TerminalSnapshotSchema, filterValidTerminalEntries } from "../schemas/i
 import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../utils/gpuDetection.js";
 import { isRunningUnderRosetta } from "../utils/rosettaDetection.js";
 import { isGpuDisabledByFlag, isGpuAngleFallbackApplied } from "./GpuCrashMonitorService.js";
+import { readGpuDisabledFlagData } from "./gpuDisabledFlag.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
 import type { HydrateResult } from "../../shared/types/ipc/app.js";
 import { inferKind } from "../../shared/utils/inferPanelKind.js";
@@ -104,6 +105,7 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     agentSettings: store.get("agentSettings"),
     gpuWebGLHardware,
     gpuHardwareAccelerationDisabled: isGpuDisabledByFlag(app.getPath("userData")),
+    gpuDisabledReason: readGpuDisabledFlagData(app.getPath("userData"))?.reason ?? null,
     gpuAngleFallbackActive: isGpuAngleFallbackApplied(app.getPath("userData")),
     safeMode: inSafeMode,
     isWindowsStore: (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true,

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -231,8 +231,15 @@ async function collectGpu() {
   try {
     const { isGpuDisabledByFlag, isGpuAngleFallbackByFlag, isGpuAngleFallbackApplied } =
       await import("./GpuCrashMonitorService.js");
+    const { readGpuDisabledFlagData } = await import("./gpuDisabledFlag.js");
     const userDataPath = app.getPath("userData");
     result.hardwareAccelerationDisabled = isGpuDisabledByFlag(userDataPath);
+    // Reason/version/timestamp distinguish a crash-fallback victim from a
+    // deliberate Settings toggle in support exports (#10379).
+    const disabledFlagData = readGpuDisabledFlagData(userDataPath);
+    result.gpuDisabledReason = disabledFlagData?.reason ?? null;
+    result.gpuDisabledFlagVersion = disabledFlagData?.version ?? null;
+    result.gpuDisabledFlagTimestamp = disabledFlagData?.timestamp ?? null;
     // Both surfaced: `angleFallbackActive` reflects what the app is actually
     // running with (platform-gated, matches the renderer signal). The raw
     // flag is also reported so support can tell when a non-Linux-Wayland
@@ -243,6 +250,9 @@ async function collectGpu() {
     result.hardwareAccelerationDisabled = "unknown";
     result.angleFallbackActive = "unknown";
     result.angleFallbackFlag = "unknown";
+    result.gpuDisabledReason = "unknown";
+    result.gpuDisabledFlagVersion = "unknown";
+    result.gpuDisabledFlagTimestamp = "unknown";
   }
 
   try {

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -9,8 +9,10 @@ import { closeTelemetry } from "./TelemetryService.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
 import { getCrashRecoveryService } from "./CrashRecoveryService.js";
 import { getPanelSuspectLedger } from "./PanelSuspectLedgerService.js";
+import { GPU_DISABLED_FLAG_FILENAME, writeGpuDisabledFlagFile } from "./gpuDisabledFlag.js";
+import type { GpuDisabledReason } from "../../shared/types/ipc/app.js";
 
-const GPU_DISABLED_FLAG = "gpu-disabled.flag";
+const GPU_DISABLED_FLAG = GPU_DISABLED_FLAG_FILENAME;
 const GPU_ANGLE_FALLBACK_FLAG = "gpu-angle-fallback.flag";
 const GPU_CRASH_THRESHOLD = 3;
 export const GPU_CRASH_WINDOW_MS = 5 * 60 * 1000;
@@ -29,12 +31,12 @@ export function isGpuDisabledByFlag(userDataPath: string): boolean {
   return cachedGpuDisabledByFlag;
 }
 
-export function writeGpuDisabledFlag(userDataPath: string): void {
-  resilientAtomicWriteFileSync(
-    path.join(userDataPath, GPU_DISABLED_FLAG),
-    String(Date.now()),
-    "utf8"
-  );
+export function writeGpuDisabledFlag(userDataPath: string, reason: GpuDisabledReason): void {
+  writeGpuDisabledFlagFile(userDataPath, {
+    reason,
+    version: app.getVersion(),
+    timestamp: Date.now(),
+  });
 }
 
 export function clearGpuDisabledFlag(userDataPath: string): void {
@@ -155,7 +157,22 @@ class GpuCrashMonitorService {
         exitCode: details.exitCode,
       });
 
-      if (this.relaunching || alreadyDisabled) return;
+      if (this.relaunching) return;
+
+      // Acceleration already off: there is no further mitigation tier to
+      // escalate to, but keep the sliding-window count above running so a GPU
+      // process that crash-loops in software mode stays visible in logs
+      // instead of vanishing behind an early return (#10379).
+      if (alreadyDisabled) {
+        if (effectiveCount >= GPU_CRASH_THRESHOLD) {
+          logger.warn("gpu-crash-loop-while-disabled", {
+            crashCount: effectiveCount,
+            reason: details.reason,
+            exitCode: details.exitCode,
+          });
+        }
+        return;
+      }
 
       // First-strike soft fallback: when the system has not yet been moved to
       // ANGLE/Vulkan, the first crash relaunches with the fallback flags. The
@@ -224,7 +241,7 @@ class GpuCrashMonitorService {
 
       if (effectiveCount >= GPU_CRASH_THRESHOLD) {
         try {
-          writeGpuDisabledFlag(userDataPath);
+          writeGpuDisabledFlag(userDataPath, "crash");
           clearGpuAngleFallbackFlag(userDataPath);
           store.set("gpu", { hardwareAccelerationDisabled: true });
         } catch (err) {

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -37,6 +37,7 @@ export function writeGpuDisabledFlag(userDataPath: string, reason: GpuDisabledRe
     version: app.getVersion(),
     timestamp: Date.now(),
   });
+  cachedGpuDisabledByFlag = null;
 }
 
 export function clearGpuDisabledFlag(userDataPath: string): void {
@@ -44,6 +45,7 @@ export function clearGpuDisabledFlag(userDataPath: string): void {
   if (fs.existsSync(flagPath)) {
     fs.unlinkSync(flagPath);
   }
+  cachedGpuDisabledByFlag = null;
 }
 
 export function isGpuAngleFallbackByFlag(userDataPath: string): boolean {

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -82,6 +82,7 @@ import {
   clearGpuAngleFallbackFlag,
   GPU_CRASH_WINDOW_MS,
 } from "../GpuCrashMonitorService.js";
+import { readGpuDisabledFlagData } from "../gpuDisabledFlag.js";
 
 describe("GpuCrashMonitorService", () => {
   let tmpDir: string;
@@ -115,17 +116,25 @@ describe("GpuCrashMonitorService", () => {
     });
 
     it("writeGpuDisabledFlag creates the flag file", () => {
-      writeGpuDisabledFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir, "crash");
       expect(fs.existsSync(path.join(tmpDir, "gpu-disabled.flag"))).toBe(true);
     });
 
+    it("writeGpuDisabledFlag persists the reason and writing app version", () => {
+      appMock.getVersion.mockReturnValue("2.3.4");
+      writeGpuDisabledFlag(tmpDir, "user");
+      const data = readGpuDisabledFlagData(tmpDir);
+      expect(data).toMatchObject({ reason: "user", version: "2.3.4" });
+      expect(data!.timestamp).toBeGreaterThan(0);
+    });
+
     it("isGpuDisabledByFlag returns true after writing flag", () => {
-      writeGpuDisabledFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir, "crash");
       expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
     });
 
     it("clearGpuDisabledFlag removes the flag file", () => {
-      writeGpuDisabledFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir, "crash");
       clearGpuDisabledFlag(tmpDir);
       expect(isGpuDisabledByFlag(tmpDir)).toBe(false);
     });
@@ -155,7 +164,7 @@ describe("GpuCrashMonitorService", () => {
     });
 
     it("disable and angle fallback flags coexist independently", () => {
-      writeGpuDisabledFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir, "crash");
       writeGpuAngleFallbackFlag(tmpDir);
       expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
       expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(true);
@@ -201,7 +210,7 @@ describe("GpuCrashMonitorService", () => {
       Object.defineProperty(process, "platform", { value: "linux" });
       process.env.XDG_SESSION_TYPE = "wayland";
       writeGpuAngleFallbackFlag(tmpDir);
-      writeGpuDisabledFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir, "crash");
       expect(isGpuAngleFallbackApplied(tmpDir)).toBe(false);
     });
 
@@ -343,7 +352,7 @@ describe("GpuCrashMonitorService", () => {
     });
 
     it("does not relaunch if disable flag already exists (already disabled)", async () => {
-      writeGpuDisabledFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir, "crash");
       await loadAndInit();
       emitGpuCrash();
       emitGpuCrash();
@@ -351,6 +360,36 @@ describe("GpuCrashMonitorService", () => {
       expect(appMock.relaunch).not.toHaveBeenCalled();
       expect(appMock.exit).not.toHaveBeenCalled();
       expect(storeMock.set).not.toHaveBeenCalled();
+    });
+
+    it("keeps counting crashes while disabled and logs the software-mode crash loop at threshold", async () => {
+      writeGpuDisabledFlag(tmpDir, "crash");
+      await loadAndInit();
+      emitGpuCrash();
+      emitGpuCrash();
+      expect(loggerMethods.warn).not.toHaveBeenCalledWith(
+        "gpu-crash-loop-while-disabled",
+        expect.anything()
+      );
+      emitGpuCrash();
+      expect(loggerMethods.warn).toHaveBeenCalledWith(
+        "gpu-crash-loop-while-disabled",
+        expect.objectContaining({ crashCount: 3 })
+      );
+      expect(appMock.relaunch).not.toHaveBeenCalled();
+      expect(appMock.exit).not.toHaveBeenCalled();
+    });
+
+    it("nuclear disable records the crash reason in the flag file", async () => {
+      writeGpuAngleFallbackFlag(tmpDir);
+      await loadAndInit();
+      emitGpuCrash();
+      emitGpuCrash();
+      emitGpuCrash();
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+      expect(readGpuDisabledFlagData(tmpDir)).toMatchObject({ reason: "crash" });
     });
 
     it("counts oom, launch-failed, and abnormal-exit as crashes (first crash → soft fallback)", async () => {
@@ -950,7 +989,7 @@ describe("GpuCrashMonitorService", () => {
       });
 
       it("already-disabled path does not call the cleanup helper", async () => {
-        writeGpuDisabledFlag(tmpDir);
+        writeGpuDisabledFlag(tmpDir, "crash");
         await loadAndInit();
         emitGpuCrash();
         emitGpuCrash();
@@ -1099,7 +1138,7 @@ describe("GpuCrashMonitorService", () => {
     });
 
     it("logs disable-flag-active at init when flag exists", async () => {
-      writeGpuDisabledFlag(tmpDir);
+      writeGpuDisabledFlag(tmpDir, "crash");
       await loadAndInit();
       expect(loggerMethods.info).toHaveBeenCalledWith("gpu-crash-disable-flag-active");
     });

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -120,6 +120,19 @@ describe("GpuCrashMonitorService", () => {
       expect(fs.existsSync(path.join(tmpDir, "gpu-disabled.flag"))).toBe(true);
     });
 
+    it("isGpuDisabledByFlag reflects a write that happens after a cached read", () => {
+      expect(isGpuDisabledByFlag(tmpDir)).toBe(false);
+      writeGpuDisabledFlag(tmpDir, "crash");
+      expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
+    });
+
+    it("isGpuDisabledByFlag reflects a clear that happens after a cached read", () => {
+      writeGpuDisabledFlag(tmpDir, "crash");
+      expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
+      clearGpuDisabledFlag(tmpDir);
+      expect(isGpuDisabledByFlag(tmpDir)).toBe(false);
+    });
+
     it("writeGpuDisabledFlag persists the reason and writing app version", () => {
       appMock.getVersion.mockReturnValue("2.3.4");
       writeGpuDisabledFlag(tmpDir, "user");

--- a/electron/services/__tests__/gpuDisabledFlag.test.ts
+++ b/electron/services/__tests__/gpuDisabledFlag.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  GPU_DISABLED_FLAG_FILENAME,
+  LEGACY_GPU_FLAG_VERSION,
+  parseGpuDisabledFlag,
+  readGpuDisabledFlagData,
+  shouldRetryGpuAfterUpdate,
+  writeGpuDisabledFlagFile,
+} from "../gpuDisabledFlag.js";
+
+describe("gpuDisabledFlag", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gpu-flag-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("parseGpuDisabledFlag", () => {
+    it("parses structured JSON content", () => {
+      expect(
+        parseGpuDisabledFlag('{"reason":"user","version":"1.2.3","timestamp":1718105000000}')
+      ).toEqual({ reason: "user", version: "1.2.3", timestamp: 1718105000000 });
+    });
+
+    it("treats a legacy bare timestamp as a crash flag with the legacy version", () => {
+      const data = parseGpuDisabledFlag("1718105000000");
+      expect(data).toEqual({
+        reason: "crash",
+        version: LEGACY_GPU_FLAG_VERSION,
+        timestamp: 1718105000000,
+      });
+    });
+
+    it("treats unparseable content as a crash flag with zeroed timestamp", () => {
+      const data = parseGpuDisabledFlag("not a flag {{{");
+      expect(data.reason).toBe("crash");
+      expect(data.version).toBe(LEGACY_GPU_FLAG_VERSION);
+      expect(data.timestamp).toBe(0);
+    });
+
+    it("coerces unknown reason values to crash", () => {
+      const data = parseGpuDisabledFlag('{"reason":"gremlins","version":"1.0.0","timestamp":5}');
+      expect(data.reason).toBe("crash");
+      expect(data.version).toBe("1.0.0");
+    });
+
+    it("fills missing version/timestamp fields with safe fallbacks", () => {
+      const data = parseGpuDisabledFlag('{"reason":"user"}');
+      expect(data).toEqual({ reason: "user", version: LEGACY_GPU_FLAG_VERSION, timestamp: 0 });
+    });
+
+    it("ignores surrounding whitespace", () => {
+      expect(parseGpuDisabledFlag("  1718105000000\n").timestamp).toBe(1718105000000);
+    });
+  });
+
+  describe("readGpuDisabledFlagData", () => {
+    it("returns null when the flag file is absent", () => {
+      expect(readGpuDisabledFlagData(tmpDir)).toBeNull();
+    });
+
+    it("round-trips data written by writeGpuDisabledFlagFile", () => {
+      const data = { reason: "user" as const, version: "3.1.4", timestamp: 1718105000000 };
+      writeGpuDisabledFlagFile(tmpDir, data);
+      expect(readGpuDisabledFlagData(tmpDir)).toEqual(data);
+    });
+
+    it("reads a legacy timestamp-only flag file", () => {
+      fs.writeFileSync(path.join(tmpDir, GPU_DISABLED_FLAG_FILENAME), "1718105000000", "utf8");
+      expect(readGpuDisabledFlagData(tmpDir)).toEqual({
+        reason: "crash",
+        version: LEGACY_GPU_FLAG_VERSION,
+        timestamp: 1718105000000,
+      });
+    });
+  });
+
+  describe("shouldRetryGpuAfterUpdate", () => {
+    it("returns false when no flag exists", () => {
+      expect(shouldRetryGpuAfterUpdate(null, "2.0.0")).toBe(false);
+    });
+
+    it("retries a crash flag written by a different app version", () => {
+      expect(
+        shouldRetryGpuAfterUpdate({ reason: "crash", version: "1.0.0", timestamp: 1 }, "2.0.0")
+      ).toBe(true);
+    });
+
+    it("does not retry a crash flag written by the current version", () => {
+      expect(
+        shouldRetryGpuAfterUpdate({ reason: "crash", version: "2.0.0", timestamp: 1 }, "2.0.0")
+      ).toBe(false);
+    });
+
+    it("never retries a user-written flag, even across versions", () => {
+      expect(
+        shouldRetryGpuAfterUpdate({ reason: "user", version: "1.0.0", timestamp: 1 }, "2.0.0")
+      ).toBe(false);
+    });
+
+    it("retries legacy flags after any update (legacy version never matches)", () => {
+      const legacy = parseGpuDisabledFlag("1718105000000");
+      expect(shouldRetryGpuAfterUpdate(legacy, "2.0.0")).toBe(true);
+    });
+  });
+});

--- a/electron/services/__tests__/gpuDisabledFlag.test.ts
+++ b/electron/services/__tests__/gpuDisabledFlag.test.ts
@@ -60,6 +60,19 @@ describe("gpuDisabledFlag", () => {
     it("ignores surrounding whitespace", () => {
       expect(parseGpuDisabledFlag("  1718105000000\n").timestamp).toBe(1718105000000);
     });
+
+    it("treats valid JSON without a reason field as a legacy crash flag", () => {
+      for (const raw of ["{}", "[]", "null", "true"]) {
+        const data = parseGpuDisabledFlag(raw);
+        expect(data.reason).toBe("crash");
+        expect(data.version).toBe(LEGACY_GPU_FLAG_VERSION);
+      }
+    });
+
+    it("zeroes a non-numeric timestamp field", () => {
+      const data = parseGpuDisabledFlag('{"reason":"user","version":"1.0.0","timestamp":"soon"}');
+      expect(data.timestamp).toBe(0);
+    });
   });
 
   describe("readGpuDisabledFlagData", () => {

--- a/electron/services/__tests__/prefetchHydrateCache.test.ts
+++ b/electron/services/__tests__/prefetchHydrateCache.test.ts
@@ -25,6 +25,7 @@ function makeHydrate(projectId: string): HydrateResult {
     agentSettings: {} as HydrateResult["agentSettings"],
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuDisabledReason: null,
     gpuAngleFallbackActive: false,
     safeMode: false,
     isWindowsStore: false,

--- a/electron/services/gpuDisabledFlag.ts
+++ b/electron/services/gpuDisabledFlag.ts
@@ -1,0 +1,89 @@
+// eager-import-allow: stateless sync-fs reader/writer for the GPU-disabled sentinel
+// Kept free of service imports so `electron/setup/environment.ts` can use it
+// before its module body runs (userData re-pathing, stdio guards) — importing
+// GpuCrashMonitorService there would hoist logger/telemetry/store evaluation
+// ahead of `app.setPath("userData", ...)`.
+import fs from "node:fs";
+import path from "node:path";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
+import type { GpuDisabledReason } from "../../shared/types/ipc/app.js";
+
+export const GPU_DISABLED_FLAG_FILENAME = "gpu-disabled.flag";
+
+/**
+ * Sentinel version recorded for legacy timestamp-only flag files. Never equals
+ * a real app version, so crash-reason legacy flags always qualify for the
+ * version-change auto-retry.
+ */
+export const LEGACY_GPU_FLAG_VERSION = "0.0.0";
+
+export interface GpuDisabledFlagData {
+  reason: GpuDisabledReason;
+  /** App version that wrote the flag (`LEGACY_GPU_FLAG_VERSION` for legacy files). */
+  version: string;
+  /** Epoch ms when the flag was written; 0 when unrecoverable from a legacy file. */
+  timestamp: number;
+}
+
+/**
+ * Parses flag-file content. Structured JSON (`{reason, version, timestamp}`)
+ * is read field-by-field with safe fallbacks; anything else — including the
+ * legacy bare-timestamp format — maps to a crash-reason legacy record, since
+ * pre-reason flags were predominantly crash-written and treating them as
+ * crash lets the auto-retry recover those users after the next update.
+ */
+export function parseGpuDisabledFlag(raw: string): GpuDisabledFlagData {
+  const trimmed = raw.trim();
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && "reason" in parsed) {
+      const candidate = parsed as { reason?: unknown; version?: unknown; timestamp?: unknown };
+      return {
+        reason: candidate.reason === "user" ? "user" : "crash",
+        version:
+          typeof candidate.version === "string" ? candidate.version : LEGACY_GPU_FLAG_VERSION,
+        timestamp: typeof candidate.timestamp === "number" ? candidate.timestamp : 0,
+      };
+    }
+  } catch {
+    // Not JSON — fall through to the legacy bare-timestamp path.
+  }
+  const timestamp = Number.parseInt(trimmed, 10);
+  return {
+    reason: "crash",
+    version: LEGACY_GPU_FLAG_VERSION,
+    timestamp: Number.isFinite(timestamp) ? timestamp : 0,
+  };
+}
+
+/** Stateless read of the flag file; null when absent or unreadable. */
+export function readGpuDisabledFlagData(userDataPath: string): GpuDisabledFlagData | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(path.join(userDataPath, GPU_DISABLED_FLAG_FILENAME), "utf8");
+  } catch {
+    return null;
+  }
+  return parseGpuDisabledFlag(raw);
+}
+
+export function writeGpuDisabledFlagFile(userDataPath: string, data: GpuDisabledFlagData): void {
+  resilientAtomicWriteFileSync(
+    path.join(userDataPath, GPU_DISABLED_FLAG_FILENAME),
+    JSON.stringify(data),
+    "utf8"
+  );
+}
+
+/**
+ * Crash-written flags are retried once per app version: if the GPU crashes
+ * were caused by an Electron or driver bug, the fix would otherwise never
+ * reach affected users because the flag outlives the update. User-written
+ * flags are a deliberate choice and never auto-retried.
+ */
+export function shouldRetryGpuAfterUpdate(
+  data: GpuDisabledFlagData | null,
+  currentVersion: string
+): boolean {
+  return data !== null && data.reason === "crash" && data.version !== currentVersion;
+}

--- a/electron/services/gpuDisabledFlag.ts
+++ b/electron/services/gpuDisabledFlag.ts
@@ -58,12 +58,16 @@ export function parseGpuDisabledFlag(raw: string): GpuDisabledFlagData {
 
 /** Stateless read of the flag file; null when absent or unreadable. */
 export function readGpuDisabledFlagData(userDataPath: string): GpuDisabledFlagData | null {
-  let raw: string;
+  let raw: unknown;
   try {
     raw = fs.readFileSync(path.join(userDataPath, GPU_DISABLED_FLAG_FILENAME), "utf8");
   } catch {
     return null;
   }
+  // Real fs with an encoding always returns a string; partially-mocked fs in
+  // tests can return undefined. Treat any non-string result as an absent flag
+  // — matching how the pre-reason `existsSync` check tolerated those mocks.
+  if (typeof raw !== "string") return null;
   return parseGpuDisabledFlag(raw);
 }
 

--- a/electron/setup/__tests__/environment.test.ts
+++ b/electron/setup/__tests__/environment.test.ts
@@ -9,6 +9,7 @@ const fsMock = vi.hoisted(() => ({
   renameSync: vi.fn(),
   writeFileSync: vi.fn(),
   readFileSync: vi.fn<(p: string, enc: string) => string>(),
+  unlinkSync: vi.fn(),
 }));
 
 const electronMock = vi.hoisted(() => ({
@@ -16,6 +17,7 @@ const electronMock = vi.hoisted(() => ({
     isPackaged: false,
     getPath: vi.fn<(key?: string) => string>(() => "/tmp/test-appdata"),
     setPath: vi.fn(),
+    getVersion: vi.fn<() => string>(() => "9.9.9"),
     commandLine: { appendSwitch: vi.fn() },
     enableSandbox: vi.fn(),
     disableHardwareAcceleration: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock("fs", () => ({
     renameSync: fsMock.renameSync,
     writeFileSync: fsMock.writeFileSync,
     readFileSync: fsMock.readFileSync,
+    unlinkSync: fsMock.unlinkSync,
   },
   existsSync: fsMock.existsSync,
   readdirSync: fsMock.readdirSync,
@@ -48,6 +51,7 @@ vi.mock("fs", () => ({
   renameSync: fsMock.renameSync,
   writeFileSync: fsMock.writeFileSync,
   readFileSync: fsMock.readFileSync,
+  unlinkSync: fsMock.unlinkSync,
 }));
 
 vi.mock("electron", () => electronMock);
@@ -666,6 +670,19 @@ describe("Chromium feature flags", () => {
   });
 });
 
+// The disabled flag is read via readFileSync (reason-aware since #10379);
+// route its content through the fs mock, ENOENT when absent, and leave every
+// other path on the unconfigured-mock default.
+function mockDisabledFlagContent(content: string | null) {
+  fsMock.readFileSync.mockImplementation(((p: string) => {
+    if (String(p).includes("gpu-disabled.flag")) {
+      if (content !== null) return content;
+      throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+    }
+    return undefined as unknown as string;
+  }) as (p: string, enc: string) => string);
+}
+
 describe("Linux Wayland multi-GPU fallback", () => {
   function flagAwareExists(flags: { disabled?: boolean; angle?: boolean }) {
     return (p: string) => {
@@ -755,6 +772,8 @@ describe("Linux Wayland multi-GPU fallback", () => {
 
   it("does NOT append ANGLE switches when hardware acceleration is already disabled", async () => {
     fsMock.existsSync.mockImplementation(flagAwareExists({ disabled: true, angle: true }));
+    // Same-version crash flag: no version-change retry, acceleration stays off.
+    mockDisabledFlagContent(JSON.stringify({ reason: "crash", version: "9.9.9", timestamp: 1 }));
     gpuDetectionMock.isLinuxWaylandHybridGpu.mockReturnValue(true);
 
     await import("../environment.js");
@@ -793,6 +812,74 @@ describe("Linux Wayland multi-GPU fallback", () => {
 
     const mod = await import("../environment.js");
     expect(mod.gpuAngleFallbackActive).toBe(false);
+  });
+});
+
+describe("GPU disabled flag version-change retry", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+    process.argv = ["electron", "main.js"];
+    fsMock.existsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+    process.argv = originalArgv;
+  });
+
+  it("clears a crash flag written by an older version and keeps acceleration on", async () => {
+    mockDisabledFlagContent(JSON.stringify({ reason: "crash", version: "1.0.0", timestamp: 1 }));
+
+    const mod = await import("../environment.js");
+
+    expect(mod.gpuHardwareAccelerationDisabled).toBe(false);
+    expect(electronMock.app.disableHardwareAcceleration).not.toHaveBeenCalled();
+    const unlinked = fsMock.unlinkSync.mock.calls.map(([p]) => String(p));
+    expect(unlinked.some((p) => p.includes("gpu-disabled.flag"))).toBe(true);
+    expect(unlinked.some((p) => p.includes("gpu-angle-fallback.flag"))).toBe(true);
+  });
+
+  it("keeps acceleration off for a crash flag written by the current version", async () => {
+    mockDisabledFlagContent(JSON.stringify({ reason: "crash", version: "9.9.9", timestamp: 1 }));
+
+    const mod = await import("../environment.js");
+
+    expect(mod.gpuHardwareAccelerationDisabled).toBe(true);
+    expect(electronMock.app.disableHardwareAcceleration).toHaveBeenCalled();
+    expect(fsMock.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("never retries a user-written flag, even across versions", async () => {
+    mockDisabledFlagContent(JSON.stringify({ reason: "user", version: "1.0.0", timestamp: 1 }));
+
+    const mod = await import("../environment.js");
+
+    expect(mod.gpuHardwareAccelerationDisabled).toBe(true);
+    expect(electronMock.app.disableHardwareAcceleration).toHaveBeenCalled();
+    expect(fsMock.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("treats a legacy timestamp-only flag as crash and retries it after an update", async () => {
+    mockDisabledFlagContent("1718105000000");
+
+    const mod = await import("../environment.js");
+
+    expect(mod.gpuHardwareAccelerationDisabled).toBe(false);
+    expect(electronMock.app.disableHardwareAcceleration).not.toHaveBeenCalled();
+  });
+
+  it("keeps acceleration off this session when clearing the flag fails", async () => {
+    mockDisabledFlagContent(JSON.stringify({ reason: "crash", version: "1.0.0", timestamp: 1 }));
+    fsMock.unlinkSync.mockImplementation(() => {
+      throw Object.assign(new Error("EROFS: read-only file system"), { code: "EROFS" });
+    });
+
+    const mod = await import("../environment.js");
+
+    expect(mod.gpuHardwareAccelerationDisabled).toBe(true);
+    expect(electronMock.app.disableHardwareAcceleration).toHaveBeenCalled();
   });
 });
 

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -102,7 +102,12 @@ if (shouldResetData) {
 const gpuFlagPath = path.join(app.getPath("userData"), GPU_DISABLED_FLAG_FILENAME);
 const gpuDisabledFlagData = readGpuDisabledFlagData(app.getPath("userData"));
 let gpuFlagClearedForRetry = false;
-if (shouldRetryGpuAfterUpdate(gpuDisabledFlagData, app.getVersion())) {
+// The null check short-circuits before app.getVersion() — the common no-flag
+// boot skips the call entirely.
+if (
+  gpuDisabledFlagData !== null &&
+  shouldRetryGpuAfterUpdate(gpuDisabledFlagData, app.getVersion())
+) {
   try {
     fs.unlinkSync(gpuFlagPath);
     gpuFlagClearedForRetry = true;

--- a/electron/setup/environment.ts
+++ b/electron/setup/environment.ts
@@ -25,6 +25,14 @@ import fs from "fs";
 import { existsSync } from "fs";
 import os from "os";
 import { isLinuxWaylandHybridGpu } from "../utils/gpuDetection.js";
+// Deliberately the tiny pure-fs module, NOT GpuCrashMonitorService — importing
+// the service here would evaluate its logger/telemetry/store import chain at
+// module load, before this file's body re-paths userData for dev instances.
+import {
+  GPU_DISABLED_FLAG_FILENAME,
+  readGpuDisabledFlagData,
+  shouldRetryGpuAfterUpdate,
+} from "../services/gpuDisabledFlag.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { isDemoMode, isSmokeTest, smokeTestStart } from "./runtimeFlags.js";
 // Side-effect import: registers the macOS `daintree://` `open-url` listener on
@@ -85,10 +93,39 @@ if (shouldResetData) {
   }
 }
 
-// GPU crash fallback: disable hardware acceleration before app.whenReady()
-// This flag is written by GpuCrashMonitorService after repeated GPU crashes.
-const gpuFlagPath = path.join(app.getPath("userData"), "gpu-disabled.flag");
-export const gpuHardwareAccelerationDisabled = fs.existsSync(gpuFlagPath);
+// GPU crash fallback: disable hardware acceleration before app.whenReady().
+// The flag is written by GpuCrashMonitorService after repeated GPU crashes or
+// by the Settings > Troubleshooting toggle (reason "user"). Crash-written
+// flags are retried once per app version — if the crashes came from an
+// Electron or driver bug, the fix would otherwise never reach affected users
+// because the flag outlives the update. User-written flags never auto-retry.
+const gpuFlagPath = path.join(app.getPath("userData"), GPU_DISABLED_FLAG_FILENAME);
+const gpuDisabledFlagData = readGpuDisabledFlagData(app.getPath("userData"));
+let gpuFlagClearedForRetry = false;
+if (shouldRetryGpuAfterUpdate(gpuDisabledFlagData, app.getVersion())) {
+  try {
+    fs.unlinkSync(gpuFlagPath);
+    gpuFlagClearedForRetry = true;
+    console.log(
+      `[GPU] Retrying hardware acceleration after update (flag written by version ${gpuDisabledFlagData!.version}, now ${app.getVersion()})`
+    );
+    // Retry from a clean slate: drop the ANGLE/Vulkan fallback flag too so the
+    // post-update session starts on the default GPU path. Best-effort — the
+    // crash monitor rewrites it if the first post-update crash recurs.
+    try {
+      fs.unlinkSync(path.join(app.getPath("userData"), "gpu-angle-fallback.flag"));
+    } catch {
+      // Usually ENOENT — the nuclear-disable path already cleared it.
+    }
+  } catch (err) {
+    // Couldn't clear the flag (read-only fs, permissions). Keep acceleration
+    // off for this session — never let a failed cleanup write flip behavior
+    // the persisted state can't back up (lesson #6350).
+    console.warn("[GPU] Failed to clear gpu-disabled flag for version retry:", err);
+  }
+}
+export const gpuHardwareAccelerationDisabled =
+  gpuDisabledFlagData !== null && !gpuFlagClearedForRetry;
 if (gpuHardwareAccelerationDisabled) {
   app.disableHardwareAcceleration();
   console.log("[GPU] Hardware acceleration disabled by crash fallback flag");

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -104,6 +104,14 @@ export interface AppVersionInfo {
   os: string;
 }
 
+/**
+ * Why hardware acceleration is disabled: "crash" is the automatic fallback
+ * after repeated GPU crashes; "user" is the Settings > Troubleshooting toggle.
+ * Legacy timestamp-only flag files (written before reason tracking) report
+ * "crash" so the version-change auto-retry can recover them.
+ */
+export type GpuDisabledReason = "crash" | "user";
+
 /** Describes how the settings store recovered from corruption at startup */
 export type SettingsRecovery =
   | { kind: "restored-from-backup"; quarantinedPath?: string }
@@ -149,6 +157,12 @@ export interface HydrateResult {
   agentSettings: import("../agentSettings.js").AgentSettings;
   gpuWebGLHardware: boolean;
   gpuHardwareAccelerationDisabled: boolean;
+  /**
+   * Why hardware acceleration is disabled, or null when it is enabled. Lets
+   * the renderer suppress the "disabled after repeated GPU crashes" boot
+   * notification when the user disabled acceleration deliberately.
+   */
+  gpuDisabledReason: GpuDisabledReason | null;
   /**
    * True when the app is running with ANGLE/Vulkan fallback rendering after a
    * prior GPU crash (the `gpu-angle-fallback.flag` file exists in userData).

--- a/src/hooks/__tests__/useAppBoot.test.tsx
+++ b/src/hooks/__tests__/useAppBoot.test.tsx
@@ -14,6 +14,7 @@ function makeBootResult(): BootResult {
     agentSettings: {} as BootResult["agentSettings"],
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuDisabledReason: null,
     gpuAngleFallbackActive: false,
     safeMode: false,
     isWindowsStore: false,

--- a/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
+++ b/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
@@ -39,6 +39,7 @@ function makeBootResult(overrides?: Partial<BootResult>): BootResult {
     agentSettings: {} as BootResult["agentSettings"],
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuDisabledReason: null,
     gpuAngleFallbackActive: false,
     safeMode: false,
     isWindowsStore: false,

--- a/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
+++ b/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
@@ -12,13 +12,14 @@ const { dispatchRecoveryNotifications, __resetGpuAccelNotifiedForTests } =
 
 function makeHydrateResult(overrides: Partial<HydrateResult>): HydrateResult {
   // dispatchRecoveryNotifications only reads gpuHardwareAccelerationDisabled,
-  // settingsRecovery, and projectStateRecovery — the rest is fixture noise
-  // satisfied via a single boundary cast.
+  // gpuDisabledReason, settingsRecovery, and projectStateRecovery — the rest
+  // is fixture noise satisfied via a single boundary cast.
   const base: Partial<HydrateResult> = {
     appState: { terminals: [], sidebarWidth: 240 },
     project: null,
     gpuWebGLHardware: true,
     gpuHardwareAccelerationDisabled: false,
+    gpuDisabledReason: null,
     gpuAngleFallbackActive: false,
     safeMode: false,
     settingsRecovery: null,
@@ -41,7 +42,10 @@ describe("dispatchRecoveryNotifications", () => {
 
   describe("GPU hardware acceleration", () => {
     it("fires the GPU disabled toast once per renderer lifecycle", () => {
-      const result = makeHydrateResult({ gpuHardwareAccelerationDisabled: true });
+      const result = makeHydrateResult({
+        gpuHardwareAccelerationDisabled: true,
+        gpuDisabledReason: "crash",
+      });
 
       dispatchRecoveryNotifications(result);
       dispatchRecoveryNotifications(result);
@@ -61,6 +65,47 @@ describe("dispatchRecoveryNotifications", () => {
     it("does not fire when the flag is false", () => {
       dispatchRecoveryNotifications(makeHydrateResult({ gpuHardwareAccelerationDisabled: false }));
       expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("stays silent when the user disabled acceleration manually", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          gpuHardwareAccelerationDisabled: true,
+          gpuDisabledReason: "user",
+        })
+      );
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("stays silent when disabled with no recorded reason", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          gpuHardwareAccelerationDisabled: true,
+          gpuDisabledReason: null,
+        })
+      );
+      expect(notifyMock).not.toHaveBeenCalled();
+    });
+
+    it("offers a re-enable action that calls the GPU IPC bridge", () => {
+      const setHardwareAcceleration = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal("window", {
+        electron: { gpu: { setHardwareAcceleration } },
+      });
+      try {
+        dispatchRecoveryNotifications(
+          makeHydrateResult({
+            gpuHardwareAccelerationDisabled: true,
+            gpuDisabledReason: "crash",
+          })
+        );
+        const arg = notifyMock.mock.calls[0]![0];
+        expect(arg.action.label).toBe("Re-enable");
+        arg.action.onClick();
+        expect(setHardwareAcceleration).toHaveBeenCalledWith(true);
+      } finally {
+        vi.unstubAllGlobals();
+      }
     });
   });
 
@@ -154,6 +199,7 @@ describe("dispatchRecoveryNotifications", () => {
     dispatchRecoveryNotifications(
       makeHydrateResult({
         gpuHardwareAccelerationDisabled: true,
+        gpuDisabledReason: "crash",
         settingsRecovery: { kind: "restored-from-backup" },
         projectStateRecovery: { quarantinedPath: "/tmp/p" },
         crashLoopStateRecovery: { quarantinedPath: "/tmp/c" },

--- a/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
+++ b/src/utils/stateHydration/__tests__/recoveryNotifications.test.ts
@@ -87,6 +87,25 @@ describe("dispatchRecoveryNotifications", () => {
       expect(notifyMock).not.toHaveBeenCalled();
     });
 
+    it("a user-disabled hydrate does not consume the one-shot crash toast guard", () => {
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          gpuHardwareAccelerationDisabled: true,
+          gpuDisabledReason: "user",
+        })
+      );
+      expect(notifyMock).not.toHaveBeenCalled();
+
+      dispatchRecoveryNotifications(
+        makeHydrateResult({
+          gpuHardwareAccelerationDisabled: true,
+          gpuDisabledReason: "crash",
+        })
+      );
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      expect(notifyMock.mock.calls[0]![0].title).toBe("Hardware acceleration disabled");
+    });
+
     it("offers a re-enable action that calls the GPU IPC bridge", () => {
       const setHardwareAcceleration = vi.fn().mockResolvedValue(undefined);
       vi.stubGlobal("window", {

--- a/src/utils/stateHydration/recoveryNotifications.ts
+++ b/src/utils/stateHydration/recoveryNotifications.ts
@@ -10,16 +10,26 @@ export function __resetGpuAccelNotifiedForTests(): void {
 }
 
 export function dispatchRecoveryNotifications(hydrateResult: HydrateResult): void {
-  if (hydrateResult.gpuHardwareAccelerationDisabled && !gpuAccelNotifiedRef.current) {
+  // Only the crash-fallback disable warrants a boot notification — a user who
+  // toggled acceleration off in Settings > Troubleshooting already knows.
+  if (
+    hydrateResult.gpuHardwareAccelerationDisabled &&
+    hydrateResult.gpuDisabledReason === "crash" &&
+    !gpuAccelNotifiedRef.current
+  ) {
     gpuAccelNotifiedRef.current = true;
     notify({
       type: "warning",
       title: "Hardware acceleration disabled",
       message:
-        "Daintree disabled GPU acceleration after repeated GPU crashes. Performance may be reduced — re-enable it in Settings > Troubleshooting.",
+        "Daintree disabled GPU acceleration after repeated GPU crashes. Performance may be reduced. Re-enabling restarts the app.",
       priority: "watch",
       duration: 0,
       context: { eventKind: "recovery" },
+      action: {
+        label: "Re-enable",
+        onClick: () => window.electron.gpu.setHardwareAcceleration(true),
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

- `gpu-disabled.flag` now stores structured JSON with `reason` (`"crash"` | `"user"`), `version`, and `timestamp`. Crash-written flags auto-retry hardware acceleration on the next version change; user-written flags never auto-retry. Legacy timestamp-only flags parse as crash-reason with a sentinel version so they qualify for retry.
- The boot notification for repeated GPU crashes now fires only for crash-reason disables and includes a "Re-enable" action button that calls `window.electron.gpu.setHardwareAcceleration(true)`.
- GPU crashes keep being counted after the flag is set. A software-mode crash loop at threshold logs a distinct `gpu-crash-loop-while-disabled` event instead of silently returning early.

Resolves #10379

## Changes

- New pure module `electron/services/gpuDisabledFlag.ts` — service-import-free so `environment.ts` can consume it pre-ready without hoisting the logger/telemetry/store chain.
- `environment.ts` version-change retry: clears the flag and ANGLE fallback flag, then retries acceleration; if the unlink fails, acceleration stays off for the session.
- `HydrateResult` gains `gpuDisabledReason` field; populated at both assembly sites so the renderer can gate the boot notification correctly.
- Diagnostics export gains `gpuDisabledReason`, `gpuDisabledFlagVersion`, and `gpuDisabledFlagTimestamp`.
- Review fixes: `isGpuDisabledByFlag` cache invalidation on write/clear; re-enable path proceeds past a failed ANGLE-flag clear.

## Testing

- New `gpuDisabledFlag.test.ts` covering parser, reader, writer, and retry decision logic.
- `GpuCrashMonitorService` tests extended for reason persistence, cache invalidation, and software-mode crash-loop logging.
- `recoveryNotifications` tests covering reason gating, one-shot guard, and the Re-enable action.
- `environment.test.ts` version-change retry suite.
- `HydrateResult` fixtures updated across 6 test files.
- Static checks, full unit suite, build, and preload-backdoors all pass locally.