### PR TITLE
perf(boot): move the MCP server stack off the first-paint path

### DIFF
--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -9,7 +9,7 @@ import { CHANNELS } from "../../channels.js";
 import { waitForRateLimitSlot, consumeRestoreQuota } from "../../utils.js";
 import { defineIpcNamespace, op, opValidated } from "../../define.js";
 import { projectStore } from "../../../services/ProjectStore.js";
-import { mcpServerService } from "../../../services/McpServerService.js";
+import type * as McpServerServiceModule from "../../../services/McpServerService.js";
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
 import { helpSessionService } from "../../../services/HelpSessionService.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -22,6 +22,21 @@ import {
 } from "../../../../shared/config/agentRegistry.js";
 
 type ValidatedTerminalSpawnOptions = z.output<typeof TerminalSpawnOptionsSchema>;
+
+// Lazy cached accessor (same pattern as `helpAssistant.ts`) — the MCP server
+// stack is ~637KB and only needed for Claude launches with a non-"off" MCP
+// tier, so keep it out of this module's static import set (it loads eagerly
+// at boot).
+type McpServerSingleton = typeof McpServerServiceModule.mcpServerService;
+
+let cachedMcpServerService: McpServerSingleton | null = null;
+async function getMcpServerService(): Promise<McpServerSingleton> {
+  if (!cachedMcpServerService) {
+    const mod = await import("../../../services/McpServerService.js");
+    cachedMcpServerService = mod.mcpServerService;
+  }
+  return cachedMcpServerService;
+}
 import {
   listAgentSessions,
   clearAgentSessions,
@@ -350,6 +365,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         const projSettings = await projectStore.getProjectSettings(projectId);
         const tier = resolveDaintreeMcpTier(projSettings);
         if (tier !== "off") {
+          const mcpServerService = await getMcpServerService();
           const ready = mcpServerService.isRunning || (await mcpServerService.ensureReady());
           if (!ready) {
             console.warn(

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -39,6 +39,7 @@ import type {
 } from "./mcp-server/shared.js";
 import type { ActionManifestEntry } from "../../shared/types/actions.js";
 import { events } from "./events.js";
+import { wireMcpServerToConnectivityRegistry } from "./connectivity/index.js";
 
 // Re-export types for backward compatibility with existing importers.
 export type { HelpTokenValidator } from "./mcp-server/shared.js";
@@ -686,3 +687,11 @@ export class McpServerService {
 }
 
 export const mcpServerService = new McpServerService();
+
+// The connectivity registry deliberately never imports this module (it sits on
+// the eager boot path; this stack does not). Wiring here, at module scope,
+// covers every load path — deferred boot task, help-session provision,
+// agent-spawn `ensureReady`, settings IPC — before any caller can `start()`
+// the server, so the registry's onStatusChange subscription always lands
+// before the first status event.
+wireMcpServerToConnectivityRegistry(mcpServerService);

--- a/electron/services/connectivity/__tests__/connectivityIndex.test.ts
+++ b/electron/services/connectivity/__tests__/connectivityIndex.test.ts
@@ -64,6 +64,34 @@ describe("connectivity lazy MCP proxy", () => {
     expect(fake.listeners.size).toBe(1);
   });
 
+  it("leaves the seed at unknown when wired after start, even if already running", () => {
+    const registry = getServiceConnectivityRegistry();
+    registry.start();
+
+    const fake = createFakeMcpServer(true);
+    wireMcpServerToConnectivityRegistry(fake);
+
+    // Deliberate per the registry's seeding contract: a server that was
+    // already running when wiring lands waits for its first live status
+    // event rather than back-filling the snapshot, avoiding a spurious
+    // unreachable→reachable recovery toast.
+    expect(registry.getSnapshot().mcp.status).toBe("unknown");
+
+    fake.setRunning(true);
+    expect(registry.getSnapshot().mcp.status).toBe("reachable");
+  });
+
+  it("tolerates repeated dispose before wiring", () => {
+    const registry = getServiceConnectivityRegistry();
+    registry.start();
+    registry.dispose();
+    registry.dispose();
+
+    const fake = createFakeMcpServer(false);
+    wireMcpServerToConnectivityRegistry(fake);
+    expect(fake.listeners.size).toBe(0);
+  });
+
   it("drops a subscription unsubscribed before wiring", () => {
     const registry = getServiceConnectivityRegistry();
     registry.start();

--- a/electron/services/connectivity/__tests__/connectivityIndex.test.ts
+++ b/electron/services/connectivity/__tests__/connectivityIndex.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../ipc/utils.js", () => ({ broadcastToRenderer: vi.fn() }));
+
+import {
+  getServiceConnectivityRegistry,
+  wireMcpServerToConnectivityRegistry,
+  _resetServiceConnectivityRegistryForTests,
+} from "../index.js";
+
+interface FakeMcpServer {
+  isRunning: boolean;
+  listeners: Set<(running: boolean) => void>;
+  onStatusChange(listener: (running: boolean) => void): () => void;
+  setRunning(running: boolean): void;
+}
+
+function createFakeMcpServer(initialRunning: boolean): FakeMcpServer {
+  const fake: FakeMcpServer = {
+    isRunning: initialRunning,
+    listeners: new Set(),
+    onStatusChange: (listener) => {
+      fake.listeners.add(listener);
+      return () => {
+        fake.listeners.delete(listener);
+      };
+    },
+    setRunning: (running) => {
+      fake.isRunning = running;
+      for (const listener of fake.listeners) listener(running);
+    },
+  };
+  return fake;
+}
+
+describe("connectivity lazy MCP proxy", () => {
+  afterEach(() => {
+    _resetServiceConnectivityRegistryForTests();
+  });
+
+  it("buffers a subscription made before wiring and forwards events after", () => {
+    const registry = getServiceConnectivityRegistry();
+    registry.start();
+    expect(registry.getSnapshot().mcp.status).toBe("unknown");
+
+    const fake = createFakeMcpServer(false);
+    wireMcpServerToConnectivityRegistry(fake);
+    expect(fake.listeners.size).toBe(1);
+
+    fake.setRunning(true);
+    expect(registry.getSnapshot().mcp.status).toBe("reachable");
+
+    fake.setRunning(false);
+    expect(registry.getSnapshot().mcp.status).toBe("unreachable");
+  });
+
+  it("delegates isRunning and subscriptions directly once wired before start", () => {
+    const registry = getServiceConnectivityRegistry();
+    const fake = createFakeMcpServer(true);
+    wireMcpServerToConnectivityRegistry(fake);
+
+    registry.start();
+    expect(registry.getSnapshot().mcp.status).toBe("reachable");
+    expect(fake.listeners.size).toBe(1);
+  });
+
+  it("drops a subscription unsubscribed before wiring", () => {
+    const registry = getServiceConnectivityRegistry();
+    registry.start();
+    registry.dispose();
+
+    const fake = createFakeMcpServer(false);
+    wireMcpServerToConnectivityRegistry(fake);
+    expect(fake.listeners.size).toBe(0);
+  });
+
+  it("ignores a second wire call", () => {
+    const registry = getServiceConnectivityRegistry();
+    registry.start();
+
+    const first = createFakeMcpServer(false);
+    const second = createFakeMcpServer(false);
+    wireMcpServerToConnectivityRegistry(first);
+    wireMcpServerToConnectivityRegistry(second);
+
+    expect(first.listeners.size).toBe(1);
+    expect(second.listeners.size).toBe(0);
+
+    second.setRunning(true);
+    expect(getServiceConnectivityRegistry().getSnapshot().mcp.status).toBe("unknown");
+
+    first.setRunning(true);
+    expect(getServiceConnectivityRegistry().getSnapshot().mcp.status).toBe("reachable");
+  });
+
+  it("unsubscribes from the real service when disposed after wiring", () => {
+    const registry = getServiceConnectivityRegistry();
+    registry.start();
+
+    const fake = createFakeMcpServer(false);
+    wireMcpServerToConnectivityRegistry(fake);
+    expect(fake.listeners.size).toBe(1);
+
+    registry.dispose();
+    expect(fake.listeners.size).toBe(0);
+  });
+});

--- a/electron/services/connectivity/index.ts
+++ b/electron/services/connectivity/index.ts
@@ -3,9 +3,11 @@ import { broadcastToRenderer } from "../../ipc/utils.js";
 import { getForgeProviderImpl, onForgeProviderRegistryChanged } from "../forgeProviderRegistry.js";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "../../../shared/utils/forgeProviderIds.js";
 import type { ForgeTokenHealthState, HealthEventsCapability } from "../../../shared/types/forge.js";
-import { mcpServerService } from "../McpServerService.js";
 import { agentConnectivityService } from "./AgentConnectivityService.js";
-import { ServiceConnectivityRegistry } from "./ServiceConnectivityRegistry.js";
+import {
+  ServiceConnectivityRegistry,
+  type ServiceConnectivityRegistryOptions,
+} from "./ServiceConnectivityRegistry.js";
 import type { MainProcessToastPayload } from "../../../shared/types/ipc/maps.js";
 
 export {
@@ -24,6 +26,61 @@ export { ServiceConnectivityRegistry } from "./ServiceConnectivityRegistry.js";
 export type { ServiceConnectivityRegistryOptions } from "./ServiceConnectivityRegistry.js";
 
 let registryInstance: ServiceConnectivityRegistry | null = null;
+
+type McpServerLike = ServiceConnectivityRegistryOptions["mcpServer"];
+type McpStatusListener = (running: boolean) => void;
+
+/**
+ * Lazy stand-in for `mcpServerService` so this module — on the boot path via
+ * `getServiceConnectivityRegistry()` — never imports the ~637KB MCP server
+ * stack. `ServiceConnectivityRegistry.start()` subscribes synchronously during
+ * boot, before the MCP module can have loaded, so the proxy buffers those
+ * subscriptions and forwards them when `wireMcpServerToConnectivityRegistry()`
+ * installs the real service. `McpServerService.ts` calls the wire function at
+ * module scope, which preserves the documented onStatusChange-before-first-event
+ * ordering: every subscription is forwarded before any caller can obtain the
+ * service and call `start()` on it.
+ */
+class LazyMcpServerProxy {
+  private real: McpServerLike | null = null;
+  private readonly pending = new Map<McpStatusListener, { unsubscribe: (() => void) | null }>();
+
+  get isRunning(): boolean {
+    return this.real?.isRunning ?? false;
+  }
+
+  onStatusChange(listener: McpStatusListener): () => void {
+    if (this.real) return this.real.onStatusChange(listener);
+    const entry: { unsubscribe: (() => void) | null } = { unsubscribe: null };
+    this.pending.set(listener, entry);
+    return () => {
+      entry.unsubscribe?.();
+      entry.unsubscribe = null;
+      this.pending.delete(listener);
+    };
+  }
+
+  setReal(service: McpServerLike): void {
+    if (this.real) return;
+    this.real = service;
+    for (const [listener, entry] of this.pending) {
+      entry.unsubscribe = service.onStatusChange(listener);
+    }
+  }
+}
+
+let mcpServerProxy = new LazyMcpServerProxy();
+
+/**
+ * Install the real `mcpServerService` behind the connectivity registry's lazy
+ * MCP slot. Idempotent — only the first call wires. Called from
+ * `McpServerService.ts` at module scope so every load path (deferred boot
+ * task, help-session provision, agent-spawn `ensureReady`, settings IPC) wires
+ * exactly once.
+ */
+export function wireMcpServerToConnectivityRegistry(service: McpServerLike): void {
+  mcpServerProxy.setReal(service);
+}
 
 const UNKNOWN_TOKEN_HEALTH: ForgeTokenHealthState = {
   status: "unknown",
@@ -81,7 +138,7 @@ export function getServiceConnectivityRegistry(): ServiceConnectivityRegistry {
   if (!registryInstance) {
     registryInstance = new ServiceConnectivityRegistry({
       gitHubHealth: createForgeTokenHealthSource(BUILTIN_GITHUB_PROVIDER_ID),
-      mcpServer: mcpServerService,
+      mcpServer: mcpServerProxy,
       agentConnectivity: agentConnectivityService,
       onRecovery: (_serviceKey, label) => {
         const payload: MainProcessToastPayload = {
@@ -102,4 +159,5 @@ export function _resetServiceConnectivityRegistryForTests(): void {
     registryInstance.dispose();
     registryInstance = null;
   }
+  mcpServerProxy = new LazyMcpServerProxy();
 }

--- a/electron/services/connectivity/index.ts
+++ b/electron/services/connectivity/index.ts
@@ -153,7 +153,14 @@ export function getServiceConnectivityRegistry(): ServiceConnectivityRegistry {
   return registryInstance;
 }
 
-/** Test-only helper to reset the singleton between cases. */
+/**
+ * Test-only helper to reset the singleton between cases. Also replaces the
+ * lazy MCP proxy — note that `McpServerService.ts` wires its singleton at
+ * module scope, so a test that imports that module (directly or transitively)
+ * has already wired the OLD proxy; the fresh one stays unwired until the test
+ * calls `wireMcpServerToConnectivityRegistry` itself. Use fakes, not the real
+ * singleton, in tests that rely on this reset.
+ */
 export function _resetServiceConnectivityRegistryForTests(): void {
   if (registryInstance) {
     registryInstance.dispose();

--- a/electron/services/mcp-server/readinessProbe.ts
+++ b/electron/services/mcp-server/readinessProbe.ts
@@ -1,5 +1,8 @@
 import http from "node:http";
-import { ACTIONS_LIST_TOOL } from "./shared.js";
+// From the allowlists config, not `./shared.js` — this module is on the eager
+// boot path (HelpSessionService value-imports it) and `shared.js` value-imports
+// the MCP SDK's `types.js`, which builds the full zod protocol schemas.
+import { ACTIONS_LIST_TOOL } from "../../../shared/config/helpAssistantTierAllowlists.js";
 
 export const PROBE_MAX_ATTEMPTS = 3;
 export const PROBE_BASE_DELAY_MS = 50;

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -24,9 +24,17 @@ import {
 } from "../../../shared/types/terminalWaitUntilIdle.js";
 import {
   ACTION_TIER_ADDONS as ACTION_TIER_ADDONS_LIST,
+  ACTIONS_LIST_TOOL,
   SYSTEM_TIER_ADDONS as SYSTEM_TIER_ADDONS_LIST,
   WORKBENCH_TIER_TOOLS as WORKBENCH_TIER_TOOLS_LIST,
 } from "../../../shared/config/helpAssistantTierAllowlists.js";
+import { safeSerializeToolResult } from "../../utils/safeSerializeToolResult.js";
+
+// Re-exported for SDK-free consumers that historically imported from here.
+// `readinessProbe.ts` and `pluginMcpHash.ts` import from the standalone homes
+// directly — this module value-imports the MCP SDK's `types.js` above, so an
+// eager import edge into it drags zod schema construction onto the boot path.
+export { ACTIONS_LIST_TOOL, safeSerializeToolResult };
 
 export {
   type WaitUntilIdleResult,
@@ -130,8 +138,6 @@ export const MCP_DENIAL_SILENCE_THRESHOLD = 2;
 
 export const MCP_MANIFEST_REQUEST_TIMEOUT_MS = 5_000;
 export const MCP_DISPATCH_TIMEOUT_MS = 30_000;
-
-export const ACTIONS_LIST_TOOL = "actions.list";
 
 export const MAX_RESTART_ATTEMPTS = 5;
 export const RESTART_BASE_DELAY_MS = 500;
@@ -834,54 +840,6 @@ export function readStringField(value: unknown, keys: readonly string[]): string
     if (typeof v === "string" && v.length > 0) return v;
   }
   return undefined;
-}
-
-export function safeSerializeToolResult(value: unknown): string {
-  const seen = new WeakSet<object>();
-
-  try {
-    const serialized = JSON.stringify(
-      value,
-      (_key, currentValue) => {
-        if (typeof currentValue === "bigint") {
-          return currentValue.toString();
-        }
-        if (typeof currentValue === "symbol") {
-          return currentValue.toString();
-        }
-        if (typeof currentValue === "function") {
-          return `[Function: ${currentValue.name || "anonymous"}]`;
-        }
-        if (currentValue instanceof Error) {
-          return {
-            name: currentValue.name,
-            message: currentValue.message,
-            stack: currentValue.stack,
-          };
-        }
-        if (currentValue !== null && typeof currentValue === "object") {
-          if (seen.has(currentValue)) {
-            return "[Circular]";
-          }
-          seen.add(currentValue);
-        }
-        return currentValue;
-      },
-      2
-    );
-
-    if (serialized !== undefined) {
-      return serialized;
-    }
-  } catch {
-    // Fall through to string coercion.
-  }
-
-  try {
-    return String(value);
-  } catch {
-    return Object.prototype.toString.call(value);
-  }
 }
 
 export type {

--- a/electron/utils/__tests__/safeSerializeToolResult.test.ts
+++ b/electron/utils/__tests__/safeSerializeToolResult.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { safeSerializeToolResult } from "../safeSerializeToolResult.js";
+
+describe("safeSerializeToolResult", () => {
+  it("serializes plain JSON values losslessly", () => {
+    const value = { a: 1, b: "two", c: [true, null], d: { nested: "yes" } };
+    expect(JSON.parse(safeSerializeToolResult(value))).toEqual(value);
+  });
+
+  it("coerces BigInt and Symbol to strings instead of throwing", () => {
+    const result = JSON.parse(safeSerializeToolResult({ big: 10n, sym: Symbol("tag") }));
+    expect(result.big).toBe("10");
+    expect(result.sym).toBe("Symbol(tag)");
+  });
+
+  it("replaces functions with a named placeholder", () => {
+    const result = JSON.parse(safeSerializeToolResult({ fn: function namedFn() {} }));
+    expect(result.fn).toBe("[Function: namedFn]");
+  });
+
+  it("expands Error instances into name, message, and stack", () => {
+    const result = JSON.parse(safeSerializeToolResult({ err: new TypeError("boom") }));
+    expect(result.err.name).toBe("TypeError");
+    expect(result.err.message).toBe("boom");
+    expect(typeof result.err.stack).toBe("string");
+  });
+
+  it("marks circular references instead of throwing", () => {
+    const value: Record<string, unknown> = { name: "root" };
+    value.self = value;
+    const result = JSON.parse(safeSerializeToolResult(value));
+    expect(result.name).toBe("root");
+    expect(result.self).toBe("[Circular]");
+  });
+
+  it("falls back to string coercion when JSON.stringify yields undefined", () => {
+    expect(safeSerializeToolResult(undefined)).toBe("undefined");
+  });
+});

--- a/electron/utils/__tests__/safeSerializeToolResult.test.ts
+++ b/electron/utils/__tests__/safeSerializeToolResult.test.ts
@@ -36,4 +36,16 @@ describe("safeSerializeToolResult", () => {
   it("falls back to string coercion when JSON.stringify yields undefined", () => {
     expect(safeSerializeToolResult(undefined)).toBe("undefined");
   });
+
+  it("falls back to string coercion when a toJSON implementation throws", () => {
+    // JSON.stringify invokes toJSON before the replacer can intercept, so the
+    // throw escapes to the outer catch and string coercion takes over.
+    const hostile = {
+      ok: true,
+      toJSON() {
+        throw new Error("boom");
+      },
+    };
+    expect(safeSerializeToolResult(hostile)).toBe("[object Object]");
+  });
 });

--- a/electron/utils/pluginMcpHash.ts
+++ b/electron/utils/pluginMcpHash.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { safeSerializeToolResult } from "../services/mcp-server/shared.js";
+import { safeSerializeToolResult } from "./safeSerializeToolResult.js";
 
 /**
  * SHA-256 of a UTF-8 string, hex-encoded. Used by the plugin-MCP TOFU pin

--- a/electron/utils/safeSerializeToolResult.ts
+++ b/electron/utils/safeSerializeToolResult.ts
@@ -1,0 +1,58 @@
+/**
+ * Serialize an arbitrary tool result to JSON without throwing: BigInt and
+ * Symbol coerce to strings, functions to a placeholder, Errors to a plain
+ * object, and circular references to "[Circular]". Falls back to string
+ * coercion when JSON.stringify still can't produce output.
+ *
+ * Lives outside `services/mcp-server/` on purpose: `pluginMcpHash.ts` needs it
+ * on the eager boot path, and `mcp-server/shared.ts` value-imports the MCP
+ * SDK's `types.js` (full zod schema construction at module init) — keeping the
+ * serializer standalone keeps that cost off first paint.
+ */
+export function safeSerializeToolResult(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  try {
+    const serialized = JSON.stringify(
+      value,
+      (_key, currentValue) => {
+        if (typeof currentValue === "bigint") {
+          return currentValue.toString();
+        }
+        if (typeof currentValue === "symbol") {
+          return currentValue.toString();
+        }
+        if (typeof currentValue === "function") {
+          return `[Function: ${currentValue.name || "anonymous"}]`;
+        }
+        if (currentValue instanceof Error) {
+          return {
+            name: currentValue.name,
+            message: currentValue.message,
+            stack: currentValue.stack,
+          };
+        }
+        if (currentValue !== null && typeof currentValue === "object") {
+          if (seen.has(currentValue)) {
+            return "[Circular]";
+          }
+          seen.add(currentValue);
+        }
+        return currentValue;
+      },
+      2
+    );
+
+    if (serialized !== undefined) {
+      return serialized;
+    }
+  } catch {
+    // Fall through to string coercion.
+  }
+
+  try {
+    return String(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -778,6 +778,15 @@ export async function initGlobalServices(
       name: "mcp-server",
       run: async () => {
         try {
+          // The server defaults to disabled, and `httpLifecycle.start()` would
+          // just no-op after we paid the ~637KB module load to find that out.
+          // Mirror its enabled check with a synchronous store read and skip
+          // the import entirely. Safe to skip: every mid-session enable path
+          // (settings IPC, help-session provision, agent-spawn `ensureReady`)
+          // dynamically imports the service itself, and
+          // `HelpSessionService.ensureMcpServerReady()` re-wires the help-token
+          // validators this task would have wired.
+          if (!store.get("mcpServer").enabled) return;
           const { mcpServerService } = await import("../services/McpServerService.js");
           const { helpSessionService } = await import("../services/HelpSessionService.js");
           // Register the help-token validator before start() so the very first

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -1,7 +1,7 @@
 import type { HelpAssistantTier } from "../types/ipc/maps.js";
 import type { BuiltInActionId } from "../types/actions.js";
 
-const ACTIONS_LIST_TOOL = "actions.list";
+export const ACTIONS_LIST_TOOL = "actions.list";
 const TERMINAL_WAIT_UNTIL_IDLE_TOOL = "terminal.waitUntilIdle";
 
 export const WORKBENCH_TIER_TOOLS = [


### PR DESCRIPTION
## Summary

- The entire ~637KB MCP server stack (SDK server, transports, `iconv-lite`, zod-v4 schema construction) was being parsed before first paint, statically imported by `main.js`, even though MCP defaults to off and a deferred init task already existed.
- This PR makes the stack fully lazy — it now lives in its own chunk and is only loaded when MCP is actually enabled or an agent spawn triggers `ensureReady`.
- Production build confirms zero `modelcontextprotocol` matches in `main.js` / `bootstrap.js` / `pty-host.js` / `workspace-host.js` / `preload.cjs`.

Resolves #10384

## Changes

- **`terminal/lifecycle.ts`** — static `mcpServerService` import replaced with the lazy cached-accessor pattern already used by `helpAssistant.ts` and `mcpServer.ts`. The only call site is the already-async Claude-spawn MCP-injection branch.
- **`connectivity/index.ts`** — static import removed; new `LazyMcpServerProxy` (`McpServerLike`) buffers the registry's synchronous `onStatusChange` subscription until the real service is wired, preserving the documented ordering guarantee.
- **`McpServerService.ts`** — calls `wireMcpServerToConnectivityRegistry(mcpServerService)` at module scope so every load path (deferred boot task, help-session provision, agent-spawn `ensureReady`, settings IPC) wires the connectivity proxy before any `start()` can emit a status event. No import cycle — `connectivity`'s graph never reaches `McpServerService`.
- **`safeSerializeToolResult`** extracted to `electron/utils/safeSerializeToolResult.ts` and `ACTIONS_LIST_TOOL` lifted to `shared/config/helpAssistantTierAllowlists.ts` — severs both eager chains into `mcp-server/shared.ts` (`pluginMcpHash.ts` and `HelpSessionService` → `readinessProbe.ts`), which value-imports the SDK's `types.js` (zod schema construction at module init). `shared.ts` re-exports both for existing lazy consumers.
- **`globalServicesInit.ts`** — the deferred mcp-server task early-returns on a synchronous `!store.get("mcpServer").enabled` check before the dynamic import. Mid-session enables still work: settings IPC, `ensureMcpServerReady`, and agent-spawn `ensureReady` all dynamically import the service themselves, and `ensureMcpServerReady` re-wires the help-token validators.

**Residual (intentionally untouched):** `registerMcpServerHandlers` still calls `getMcpServerService()` at IPC-registration time to wire the runtime-state push relay — it's the async pattern the issue cites approvingly. The chunk no longer blocks module-graph evaluation but does load shortly after registration to serve that subscription. A follow-up could defer that wiring behind the same enabled flag.

## Testing

- Production build artifact scan: zero `modelcontextprotocol` matches in eager entry points; SDK now lives only in `dist-electron/electron/chunks/McpServerService-*.js`. `iconv-lite` also left the eager entries.
- 7 new behavior tests for `safeSerializeToolResult`.
- 7 new tests for the lazy proxy lifecycle: buffer-then-wire, wired-before-start seeding, unsubscribe-before-wire, wire idempotency, dispose-after-wire, wire-after-start unknown-seed contract, repeated dispose.
- Full local CI pass: `npm run check`, vitest, build, preload-backdoors, debug-artifact scan all clean.