### PR TITLE
perf(pty): snapshot and dispose preserved exited terminals

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -53,6 +53,8 @@ import {
 import type { IBufferCell, IMarker } from "@xterm/headless";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
+  isSessionPersistSuppressed,
+  persistSessionSnapshotSync,
   restoreSessionFromFile,
 } from "./terminalSessionPersistence.js";
 import { SessionSnapshotter, type SessionSnapshotterHost } from "./SessionSnapshotter.js";
@@ -560,6 +562,56 @@ export class TerminalProcess {
     }
     terminal.headlessTerminal = undefined;
     terminal.serializeAddon = undefined;
+  }
+
+  /**
+   * Preserved exited terminals don't need a live headless xterm — the buffer
+   * is final. Serialize it once, cache the string on `terminalInfo`, and
+   * dispose the headless instance (Unicode11 + SerializeAddon + scrollback
+   * CircularList, ~15-30 MB per exited terminal). Serialization runs inside a
+   * sentinel `write("")` callback so xterm's async parser queue is fully
+   * drained first — the tail of the output must land in the buffer, and
+   * disposing with queued writes throws against the torn-down core.
+   *
+   * On serialize failure the live headless instance is kept: serving the
+   * existing buffer beats serving nothing, at the cost of the memory.
+   */
+  private snapshotAndDisposePreserved(): void {
+    const terminal = this.terminalInfo;
+    const headless = terminal.headlessTerminal;
+    if (!headless || !terminal.serializeAddon) {
+      return;
+    }
+    headless.write("", () => {
+      if (terminal.headlessTerminal !== headless || !terminal.serializeAddon) {
+        return;
+      }
+      let snapshot: string;
+      try {
+        snapshot = terminal.serializeAddon.serialize();
+      } catch (error) {
+        console.error(`[TerminalProcess] Failed to snapshot preserved terminal ${this.id}:`, error);
+        return;
+      }
+      // sessionSnapshotter.dispose() already ran in the onExit handler,
+      // cancelling any debounced write — flush the final state to disk
+      // directly so crash recovery sees the post-exit buffer (#3177).
+      // Banner-aware like flushSyncOnKill; same gates (agent sessions are
+      // never replayed by crash recovery).
+      if (
+        TERMINAL_SESSION_PERSISTENCE_ENABLED &&
+        !isSessionPersistSuppressed() &&
+        !terminal.launchAgentId
+      ) {
+        try {
+          persistSessionSnapshotSync(this.id, this.serializeForPersistence() ?? snapshot);
+        } catch {
+          // best-effort only
+        }
+      }
+      terminal.preservedSnapshot = snapshot;
+      this.disposeHeadless();
+    });
   }
 
   /**
@@ -1812,6 +1864,7 @@ export class TerminalProcess {
         terminal.exitCode = exitCode ?? 0;
         terminal.isExited = true;
         this.lifecycle.setExited({ code: exitCode ?? 0, signal, reason: reasonForEvent });
+        this.snapshotAndDisposePreserved();
         return;
       }
 

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -36,6 +36,42 @@ function createMockPty(): IPty {
   return pty as IPty;
 }
 
+type ControllablePty = IPty & {
+  emitData: (d: string) => void;
+  emitExit: (code: number, signal?: number) => void;
+};
+
+function createControllablePty(): ControllablePty {
+  let dataCb: ((data: string) => void) | null = null;
+  let exitCb: ((e: { exitCode: number; signal?: number }) => void) | null = null;
+
+  const pty: Partial<IPty> & Pick<ControllablePty, "emitData" | "emitExit"> = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: () => {},
+    pause: () => {},
+    resume: () => {},
+    onData: (cb: (data: string) => void) => {
+      dataCb = cb;
+      return { dispose: () => {} };
+    },
+    onExit: (cb: (e: { exitCode: number; signal?: number }) => void) => {
+      exitCb = cb;
+      return { dispose: () => {} };
+    },
+    emitData: (d: string) => {
+      dataCb?.(d);
+    },
+    emitExit: (code: number, signal?: number) => {
+      exitCb?.({ exitCode: code, signal });
+    },
+  };
+  return pty as ControllablePty;
+}
+
 function defaultSpawnContext(overrides?: Partial<SpawnContext>): SpawnContext {
   return {
     shell: "/bin/zsh",
@@ -47,7 +83,10 @@ function defaultSpawnContext(overrides?: Partial<SpawnContext>): SpawnContext {
 
 type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
 
-function createTerminal(options?: Partial<TerminalProcessOptions>): TerminalProcess {
+function createTerminal(
+  options?: Partial<TerminalProcessOptions>,
+  pty: IPty = createMockPty()
+): TerminalProcess {
   const merged = {
     cwd: process.cwd(),
     cols: 80,
@@ -66,12 +105,13 @@ function createTerminal(options?: Partial<TerminalProcessOptions>): TerminalProc
         handleActivityState: () => {},
         updateAgentState: () => {},
         emitAgentKilled: () => {},
+        emitAgentCompleted: () => {},
       } as unknown as ConstructorParameters<typeof TerminalProcess>[3]["agentStateService"],
       ptyPool: null,
       processTreeCache: null,
     },
     ctx,
-    createMockPty()
+    pty
   );
 }
 
@@ -122,5 +162,109 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
     terminal.flushEventDrivenSnapshot();
 
     expect(persistAsyncMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalProcess — snapshot and dispose preserved exited terminals", () => {
+  beforeEach(() => {
+    persistAsyncMock.mockReset();
+    persistAsyncMock.mockReturnValue(Promise.resolve());
+    persistSyncMock.mockReset();
+  });
+
+  async function exitAndAwaitDispose(
+    terminal: TerminalProcess,
+    pty: ControllablePty,
+    code = 0
+  ): Promise<void> {
+    pty.emitExit(code);
+    await vi.waitFor(() => {
+      expect(terminal.getInfo().headlessTerminal).toBeUndefined();
+    });
+  }
+
+  it("serializes the full buffer, then disposes the headless terminal on preserved exit", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("hello from agent\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+
+    const info = terminal.getInfo();
+    expect(info.isExited).toBe(true);
+    expect(info.serializeAddon).toBeUndefined();
+    expect(info.preservedSnapshot).toContain("hello from agent");
+
+    expect(terminal.getSerializedState()).toContain("hello from agent");
+    await expect(terminal.getSerializedStateAsync()).resolves.toContain("hello from agent");
+  });
+
+  it("drains pending headless writes before snapshotting (tail of output is captured)", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("early output\r\n");
+    // Exit immediately after the final chunk — the write is still queued in
+    // xterm's async parser when onExit fires.
+    pty.emitData("final tail line\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+
+    const snapshot = terminal.getSerializedState();
+    expect(snapshot).toContain("early output");
+    expect(snapshot).toContain("final tail line");
+  });
+
+  it("keeps serving the snapshot after a post-exit resize (exit→resize→reattach)", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("resize survivor\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+    const before = terminal.getSerializedState();
+
+    expect(() => terminal.resize(120, 30)).not.toThrow();
+
+    expect(terminal.getSerializedState()).toBe(before);
+    await expect(terminal.getSerializedStateAsync()).resolves.toBe(before);
+  });
+
+  it("flushes a final on-disk snapshot for crash recovery on non-agent preserved exit", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal({ launchAgentId: undefined }, pty);
+    // Runtime-promoted terminal: preserved on exit, but not gated out of
+    // persistence by launchAgentId.
+    terminal.getInfo().everDetectedAgent = true;
+
+    pty.emitData("promoted terminal output\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+
+    expect(persistSyncMock).toHaveBeenCalledTimes(1);
+    const [persistedId, persistedState] = persistSyncMock.mock.calls[0]!;
+    expect(persistedId).toBe("t1");
+    expect(persistedState).toContain("promoted terminal output");
+  });
+
+  it("does not write a crash-recovery snapshot for agent terminals", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("agent output\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+
+    expect(persistSyncMock).not.toHaveBeenCalled();
+    expect(terminal.getSerializedState()).toContain("agent output");
+  });
+
+  it("disposes headless without caching a snapshot on non-preserved (non-zero) exit", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("crash output\r\n");
+    pty.emitExit(1);
+
+    await vi.waitFor(() => {
+      expect(terminal.getInfo().headlessTerminal).toBeUndefined();
+    });
+    expect(terminal.getInfo().preservedSnapshot).toBeUndefined();
   });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -266,5 +266,72 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
       expect(terminal.getInfo().headlessTerminal).toBeUndefined();
     });
     expect(terminal.getInfo().preservedSnapshot).toBeUndefined();
+    expect(terminal.getSerializedState()).toBeNull();
+    await expect(terminal.getSerializedStateAsync()).resolves.toBeNull();
+  });
+
+  it("keeps the live headless terminal when serialization fails", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+    const addon = terminal.getInfo().serializeAddon!;
+    const spy = vi.spyOn(addon, "serialize").mockImplementationOnce(() => {
+      throw new Error("serialize boom");
+    });
+
+    pty.emitData("still readable\r\n");
+    pty.emitExit(0);
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalled();
+    });
+
+    const info = terminal.getInfo();
+    expect(info.preservedSnapshot).toBeUndefined();
+    expect(info.headlessTerminal).toBeDefined();
+    expect(info.serializeAddon).toBeDefined();
+    // Subsequent reads serve the live buffer.
+    expect(terminal.getSerializedState()).toContain("still readable");
+  });
+
+  it("serves the cached snapshot without re-serializing", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+    const spy = vi.spyOn(terminal.getInfo().serializeAddon!, "serialize");
+
+    pty.emitData("cache me\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+
+    const callsAfterExit = spy.mock.calls.length;
+    terminal.getSerializedState();
+    terminal.getSerializedState();
+    await terminal.getSerializedStateAsync();
+    expect(spy.mock.calls.length).toBe(callsAfterExit);
+  });
+
+  it("caches and serves an empty-buffer snapshot", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    await exitAndAwaitDispose(terminal, pty);
+
+    const info = terminal.getInfo();
+    expect(info.preservedSnapshot).toBeDefined();
+    expect(terminal.getSerializedState()).toBe(info.preservedSnapshot);
+    await expect(terminal.getSerializedStateAsync()).resolves.toBe(info.preservedSnapshot);
+  });
+
+  it("bails safely when dispose() lands before the drain callback fires", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("racing output\r\n");
+    pty.emitExit(0);
+    // dispose() tears down headless synchronously, before xterm's async
+    // parser queue delivers the sentinel drain callback.
+    terminal.dispose();
+
+    expect(terminal.getInfo().headlessTerminal).toBeUndefined();
+    // Let any queued drain callback fire and hit the bail guard.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(terminal.getInfo().preservedSnapshot).toBeUndefined();
   });
 });

--- a/electron/services/pty/terminalSerialization.ts
+++ b/electron/services/pty/terminalSerialization.ts
@@ -3,6 +3,11 @@ import type { TerminalInfo } from "./types.js";
 import { getTerminalSerializerService } from "./TerminalSerializerService.js";
 
 export function serializeTerminal(id: string, terminalInfo: TerminalInfo): string | null {
+  // Preserved exited terminal — the headless xterm is disposed and the final
+  // buffer lives as a cached string. Empty string is a valid snapshot.
+  if (terminalInfo.preservedSnapshot !== undefined) {
+    return terminalInfo.preservedSnapshot;
+  }
   try {
     return terminalInfo.serializeAddon!.serialize();
   } catch (error) {
@@ -15,6 +20,9 @@ export async function serializeTerminalAsync(
   id: string,
   terminalInfo: TerminalInfo
 ): Promise<string | null> {
+  if (terminalInfo.preservedSnapshot !== undefined) {
+    return terminalInfo.preservedSnapshot;
+  }
   try {
     const lineCount = terminalInfo.headlessTerminal!.buffer.active.length;
     const serializerService = getTerminalSerializerService();

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -138,6 +138,13 @@ export interface TerminalInfo extends TerminalPublicState {
    * See `AgentStateService` for the suppression policy.
    */
   hysteresisLockedUntil?: number;
+  /**
+   * Final serialized buffer captured when a preserved terminal exits and its
+   * headless xterm is disposed to reclaim memory. Served by
+   * `serializeTerminal`/`serializeTerminalAsync` in place of the live buffer.
+   * Runtime-only; not persisted, not crossed over IPC.
+   */
+  preservedSnapshot?: string;
 }
 
 export interface PtyManagerEvents {


### PR DESCRIPTION
## Summary

- When a terminal exits cleanly and is preserved, the headless xterm instance (Unicode11 addon + SerializeAddon + up to 10k-line scrollback) was kept alive until the panel closed — roughly 15-30 MB per exited terminal.
- The fix serializes the buffer once at exit, disposes the headless instance, then serves the cached snapshot string for all subsequent reads (get-serialized-state IPC, backpressure reattach).
- Drain/flush edge case handled via a sentinel `headless.write("", callback)` so tail output lands before disposal; serialize failure falls back to keeping the live instance (serving a live buffer beats serving nothing).

Resolves #10388

## Changes

- `electron/services/pty/TerminalProcess.ts` — new `snapshotAndDisposePreserved()`, called from the preserve branch of `onExit` after `lifecycle.setExited`. Drains the async parser queue, serializes via `SerializeAddon`, writes a final crash-recovery snapshot for non-agent terminals (mirrors `flushSyncOnKill` — `sessionSnapshotter.dispose()` cancels the debounced write so we need an explicit sync flush here), caches to `terminalInfo.preservedSnapshot`, then disposes.
- `electron/services/pty/terminalSerialization.ts` — `serializeTerminal` and `serializeTerminalAsync` early-return `preservedSnapshot` when set, so the cache is served without re-serializing after disposal.
- `electron/services/pty/types.ts` — `TerminalInfo.preservedSnapshot?: string` (runtime-only, not in `TerminalPublicState`, not over IPC).

## Testing

10 new tests in `electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts`:

- Preserved exit serializes and disposes
- Drain captures tail output emitted right before exit
- Exit→resize→reattach serves unchanged snapshot (post-dispose resize no-ops)
- Crash-recovery persist fires once for runtime-promoted non-agent terminals
- No persist for `launchAgentId` terminals
- Non-preserved exit disposes without caching; both serialize paths return `null`
- Serialize failure keeps live headless serving reads
- Cached snapshot served without re-serializing
- Empty-buffer snapshot valid
- `dispose()` racing the drain callback bails safely

Local CI (typecheck, eslint, prettier, all guard scripts, production build) green at `4032336`. Targeted suites 14/14 green.