### PR TITLE
perf(plugins): complete the PluginService import deferral

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -1,6 +1,6 @@
 {
-  "count": 1227,
-  "moduleCount": 1227,
+  "count": 810,
+  "moduleCount": 810,
   "allowlist": [
     "electron/ipc/errorHandlers.ts",
     "electron/ipc/handlers/agentCapabilities.ts",
@@ -34,7 +34,6 @@
     "electron/main.ts",
     "electron/services/AppAgentService.ts",
     "electron/services/AppHydrationService.ts",
-    "electron/services/AutoUpdaterService.ts",
     "electron/services/CliAvailabilityService.ts",
     "electron/services/CliInstallService.ts",
     "electron/services/CrashLoopGuardService.ts",
@@ -46,11 +45,9 @@
     "electron/services/HelpSessionService.ts",
     "electron/services/HibernationService.ts",
     "electron/services/IdleTerminalNotificationService.ts",
-    "electron/services/McpServerService.ts",
     "electron/services/PanelSuspectLedgerService.ts",
     "electron/services/PeriodicCleanupService.ts",
     "electron/services/PluginActionAuditService.ts",
-    "electron/services/PluginService.ts",
     "electron/services/ProcessMemoryMonitor.ts",
     "electron/services/ProjectEnvSecureStorage.ts",
     "electron/services/ProjectFileStore.ts",
@@ -64,17 +61,11 @@
     "electron/services/TrashedPidTracker.ts",
     "electron/services/UserAgentRegistryService.ts",
     "electron/services/forge/forgeAuditService.ts",
-    "electron/services/forge/forgeCredentialUtils.ts",
-    "electron/services/mcp-server/httpLifecycle.ts",
     "electron/services/persistence/db.ts",
     "electron/services/persistence/readLastProjectId.ts",
-    "electron/services/plugin-mcp/instances.ts",
-    "electron/services/plugin/PluginDevWorkerHost.ts",
-    "electron/services/plugin/PluginInstalledRecordsStore.ts",
     "electron/services/pty/agentSessionHistory.ts",
     "electron/services/pty/terminalSessionPersistence.ts",
     "electron/services/pty/terminalShell.ts",
-    "electron/services/runHistory/runHistoryService.ts",
     "electron/services/workspace-client/WorkspaceHostPool.ts",
     "electron/setup/devDiagnostics.ts",
     "electron/setup/environment.ts",
@@ -138,22 +129,37 @@
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 63,
+      "line": 125,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 376,
+      "line": 424,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 378,
+      "line": 426,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/app/state.ts",
-      "line": 435,
+      "line": 434,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 491,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 511,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/ipc/handlers/app/state.ts",
+      "line": 793,
       "pattern": "sync-store-get"
     },
     {
@@ -168,12 +174,12 @@
     },
     {
       "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 67,
+      "line": 71,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/ipc/handlers/diagnostics.ts",
-      "line": 74,
+      "line": 78,
       "pattern": "sync-fs"
     },
     {
@@ -188,52 +194,52 @@
     },
     {
       "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 198,
+      "line": 222,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 221,
+      "line": 245,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/forgeSettings.ts",
-      "line": 231,
+      "line": 255,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 192,
+      "line": 194,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 278,
+      "line": 280,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 282,
+      "line": 284,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 325,
+      "line": 327,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 329,
+      "line": 331,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 367,
+      "line": 369,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/git-write.ts",
-      "line": 371,
+      "line": 373,
       "pattern": "sync-store-get"
     },
     {
@@ -293,12 +299,12 @@
     },
     {
       "file": "electron/ipc/handlers/pluginMcp.ts",
-      "line": 36,
+      "line": 59,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/ipc/handlers/pluginMcp.ts",
-      "line": 101,
+      "line": 130,
       "pattern": "sync-store-get"
     },
     {
@@ -328,7 +334,7 @@
     },
     {
       "file": "electron/ipc/handlers/voiceInput.ts",
-      "line": 67,
+      "line": 68,
       "pattern": "sync-store-get"
     },
     {
@@ -383,12 +389,12 @@
     },
     {
       "file": "electron/main.ts",
-      "line": 184,
+      "line": 183,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/main.ts",
-      "line": 265,
+      "line": 267,
       "pattern": "sync-store-get"
     },
     {
@@ -413,72 +419,27 @@
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 26,
+      "line": 35,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 93,
+      "line": 102,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/AppHydrationService.ts",
-      "line": 95,
+      "line": 104,
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 217,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 361,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 362,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 482,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 491,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 529,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 587,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 587,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 606,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/AutoUpdaterService.ts",
-      "line": 616,
+      "file": "electron/services/AppHydrationService.ts",
+      "line": 111,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CliAvailabilityService.ts",
-      "line": 808,
+      "line": 806,
       "pattern": "sync-store-get"
     },
     {
@@ -618,47 +579,42 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 138,
+      "line": 143,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 186,
+      "line": 193,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 315,
+      "line": 322,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 332,
+      "line": 339,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 441,
+      "line": 448,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 444,
+      "line": 451,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 523,
+      "line": 530,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 640,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 642,
+      "line": 647,
       "pattern": "sync-fs"
     },
     {
@@ -668,37 +624,32 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 652,
+      "line": 656,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 679,
+      "line": 659,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 681,
+      "line": 686,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 685,
+      "line": 688,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 702,
+      "line": 692,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 718,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/CrashRecoveryService.ts",
-      "line": 722,
+      "line": 709,
       "pattern": "sync-fs"
     },
     {
@@ -708,117 +659,127 @@
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 759,
+      "line": 729,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 775,
+      "line": 732,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 776,
+      "line": 766,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 844,
+      "line": 782,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 845,
+      "line": 783,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 875,
+      "line": 851,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 876,
+      "line": 852,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 903,
+      "line": 882,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 883,
+      "pattern": "sync-fs"
+    },
+    {
+      "file": "electron/services/CrashRecoveryService.ts",
+      "line": 910,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 973,
+      "line": 980,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 974,
+      "line": 981,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1021,
+      "line": 1028,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1022,
+      "line": 1029,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1026,
+      "line": 1033,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1141,
+      "line": 1148,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1165,
+      "line": 1172,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1174,
+      "line": 1181,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1185,
+      "line": 1192,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1186,
+      "line": 1193,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1198,
+      "line": 1205,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1214,
+      "line": 1221,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1216,
+      "line": 1223,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1222,
+      "line": 1229,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/CrashRecoveryService.ts",
-      "line": 1232,
+      "line": 1239,
       "pattern": "sync-fs"
     },
     {
@@ -838,42 +799,37 @@
     },
     {
       "file": "electron/services/forge/forgeAuditService.ts",
-      "line": 30,
+      "line": 26,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/forge/forgeAuditService.ts",
-      "line": 36,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/forge/forgeCredentialUtils.ts",
-      "line": 47,
+      "line": 33,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 62,
+      "line": 68,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 113,
+      "line": 119,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 419,
+      "line": 420,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 583,
+      "line": 584,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/services/GitService.ts",
-      "line": 589,
+      "line": 590,
       "pattern": "sync-fs"
     },
     {
@@ -929,16 +885,6 @@
     {
       "file": "electron/services/IdleTerminalNotificationService.ts",
       "line": 271,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/mcp-server/httpLifecycle.ts",
-      "line": 550,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/McpServerService.ts",
-      "line": 311,
       "pattern": "sync-store-get"
     },
     {
@@ -1042,69 +988,14 @@
       "pattern": "sync-sqlite"
     },
     {
-      "file": "electron/services/plugin-mcp/instances.ts",
-      "line": 21,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/plugin-mcp/instances.ts",
-      "line": 24,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/plugin-mcp/instances.ts",
-      "line": 38,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/plugin-mcp/instances.ts",
-      "line": 41,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/plugin/PluginDevWorkerHost.ts",
-      "line": 300,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/plugin/PluginDevWorkerHost.ts",
-      "line": 323,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 19,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 30,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 47,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/plugin/PluginInstalledRecordsStore.ts",
-      "line": 85,
+      "file": "electron/services/PluginActionAuditService.ts",
+      "line": 292,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/PluginActionAuditService.ts",
-      "line": 272,
+      "line": 295,
       "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/PluginActionAuditService.ts",
-      "line": 275,
-      "pattern": "sync-store-get"
-    },
-    {
-      "file": "electron/services/PluginService.ts",
-      "line": 1015,
-      "pattern": "sync-fs"
     },
     {
       "file": "electron/services/ProcessMemoryMonitor.ts",
@@ -1222,11 +1113,6 @@
       "pattern": "sync-store-get"
     },
     {
-      "file": "electron/services/runHistory/runHistoryService.ts",
-      "line": 18,
-      "pattern": "sync-store-get"
-    },
-    {
       "file": "electron/services/StoreMigrations.ts",
       "line": 96,
       "pattern": "sync-fs"
@@ -1253,12 +1139,12 @@
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 172,
+      "line": 175,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/StoreMigrations.ts",
-      "line": 256,
+      "line": 259,
       "pattern": "sync-store-get"
     },
     {
@@ -1308,7 +1194,7 @@
     },
     {
       "file": "electron/services/UserAgentRegistryService.ts",
-      "line": 28,
+      "line": 25,
       "pattern": "sync-store-get"
     },
     {
@@ -1323,32 +1209,32 @@
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 214,
+      "line": 216,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 215,
+      "line": 217,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 276,
+      "line": 280,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 277,
+      "line": 281,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 458,
+      "line": 464,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/services/workspace-client/WorkspaceHostPool.ts",
-      "line": 459,
+      "line": 465,
       "pattern": "sync-store-get"
     },
     {
@@ -1403,72 +1289,72 @@
     },
     {
       "file": "electron/setup/protocols.ts",
-      "line": 624,
+      "line": 652,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 632,
+      "line": 655,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 634,
+      "line": 657,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 642,
+      "line": 665,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 656,
+      "line": 679,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 671,
+      "line": 694,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 672,
+      "line": 695,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 674,
+      "line": 697,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 689,
+      "line": 712,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 691,
+      "line": 714,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 708,
+      "line": 731,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 717,
+      "line": 740,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 718,
+      "line": 741,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/store.ts",
-      "line": 880,
+      "line": 964,
       "pattern": "sync-store-get"
     },
     {
@@ -1518,12 +1404,12 @@
     },
     {
       "file": "electron/utils/git.ts",
-      "line": 380,
+      "line": 382,
       "pattern": "sync-fs"
     },
     {
       "file": "electron/utils/git.ts",
-      "line": 688,
+      "line": 690,
       "pattern": "sync-fs"
     },
     {
@@ -1703,37 +1589,42 @@
     },
     {
       "file": "electron/window/createWindow.ts",
-      "line": 164,
+      "line": 166,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 93,
+      "line": 98,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 175,
+      "line": 214,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 220,
+      "line": 313,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 467,
+      "line": 541,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 668,
+      "line": 665,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/globalServicesInit.ts",
-      "line": 813,
+      "line": 789,
+      "pattern": "sync-store-get"
+    },
+    {
+      "file": "electron/window/globalServicesInit.ts",
+      "line": 865,
       "pattern": "sync-store-get"
     },
     {
@@ -1753,17 +1644,17 @@
     },
     {
       "file": "electron/window/skeletonCss.ts",
-      "line": 127,
+      "line": 126,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/skeletonCss.ts",
-      "line": 132,
+      "line": 131,
       "pattern": "sync-store-get"
     },
     {
       "file": "electron/window/windowServices.ts",
-      "line": 395,
+      "line": 429,
       "pattern": "sync-store-get"
     }
   ]

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -4,8 +4,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const mockDispatchHandler = vi.fn();
-const mockRegisterHandler = vi.fn();
-const mockRemoveHandlers = vi.fn();
 const mockListPlugins = vi.fn();
 const mockSetEnabled = vi.fn();
 const mockInstallPlugin = vi.fn();
@@ -23,8 +21,6 @@ vi.mock("../../../services/PluginService.js", () => ({
     uninstallPlugin: (...args: unknown[]) => mockUninstallPlugin(...args),
     checkForUpdate: (...args: unknown[]) => mockCheckForUpdate(...args),
     dispatchHandler: (...args: unknown[]) => mockDispatchHandler(...args),
-    registerHandler: (...args: unknown[]) => mockRegisterHandler(...args),
-    removeHandlers: (...args: unknown[]) => mockRemoveHandlers(...args),
     listPluginActions: (...args: unknown[]) => mockListPluginActions(...args),
     registerPluginAction: (...args: unknown[]) => mockRegisterPluginAction(...args),
     unregisterPluginAction: (...args: unknown[]) => mockUnregisterPluginAction(...args),
@@ -92,7 +88,7 @@ vi.mock("electron", () => ({
   },
 }));
 
-import { registerPluginHandlers, registerPluginHandler, removePluginHandlers } from "../plugin.js";
+import { registerPluginHandlers } from "../plugin.js";
 import { _resetIpcGuardForTesting, markIpcSecurityReady } from "../../ipcGuard.js";
 
 beforeEach(() => {
@@ -1898,20 +1894,5 @@ describe("PLUGIN_FILE_DECORATIONS_GET handler", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-});
-
-describe("registerPluginHandler", () => {
-  it("delegates to pluginService.registerHandler", () => {
-    const handler = vi.fn();
-    registerPluginHandler("acme.my-plugin", "my-channel", handler);
-    expect(mockRegisterHandler).toHaveBeenCalledWith("acme.my-plugin", "my-channel", handler);
-  });
-});
-
-describe("removePluginHandlers", () => {
-  it("delegates to pluginService.removeHandlers", () => {
-    removePluginHandlers("acme.my-plugin");
-    expect(mockRemoveHandlers).toHaveBeenCalledWith("acme.my-plugin");
   });
 });

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -20,8 +20,8 @@ import {
 } from "../../../shared/types/ipc/pluginAudit.js";
 import type { PluginDiagnosticsSnapshot } from "../../../shared/types/ipc/pluginDiagnostics.js";
 import { PLUGIN_METHOD_CHANNELS } from "./plugin.preload.js";
-import { pluginService } from "../../services/PluginService.js";
-import { MAX_DNTR_BYTES } from "../../services/PluginArchive.js";
+import type * as PluginServiceModule from "../../services/PluginService.js";
+import { MAX_DNTR_BYTES } from "../../utils/pluginArchiveConstants.js";
 import {
   PLUGIN_DOWNLOAD_TIMEOUT_MS,
   acceptedMime,
@@ -55,7 +55,6 @@ import type { FileDecoration } from "../../../shared/types/forge.js";
 import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
 import type {
   LoadedPluginInfo,
-  PluginIpcHandler,
   PluginIpcContext,
   PluginActionContribution,
   PluginActionDescriptor,
@@ -70,11 +69,26 @@ import type { IpcContext } from "../types.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
 import { assertIpcSecurityReady } from "../ipcGuard.js";
 
+type PluginServiceSingleton = typeof PluginServiceModule.pluginService;
+
+// Lazy accessor (mirrors helpAssistant.ts): PluginService is ~3,200 lines and
+// pulls semver/ajv/yauzl — a static import here would re-anchor it on the
+// eager startup path that #9285 deferred it off of.
+let cachedPluginService: PluginServiceSingleton | null = null;
+async function getPluginService(): Promise<PluginServiceSingleton> {
+  if (!cachedPluginService) {
+    const mod = await import("../../services/PluginService.js");
+    cachedPluginService = mod.pluginService;
+  }
+  return cachedPluginService;
+}
+
 async function handleList(): Promise<LoadedPluginInfo[]> {
   // Same init-race guard as `handleToolbarButtons` (#9285): a mount-time pull
   // (pluginRuntimeStore, plugin manager) before the deferred initialize()
   // populates the maps would cache an empty list — wrong `disabled` gating in
   // the renderer until the next provenance broadcast.
+  const pluginService = await getPluginService();
   await pluginService.waitForInit();
   return pluginService.listPlugins();
 }
@@ -83,6 +97,7 @@ async function handleSetEnabled(pluginId: string, enabled: boolean): Promise<voi
   // A toggle arriving mid-init finds both `plugins` and `disabledPlugins`
   // unpopulated, mis-classifies a built-in as a user plugin, and silently
   // takes the persist-only path — no live load, no provenance broadcast.
+  const pluginService = await getPluginService();
   await pluginService.waitForInit();
   await pluginService.setEnabled(pluginId, enabled);
 }
@@ -151,7 +166,7 @@ async function handleInstall(
 ): Promise<PluginInstallResult> {
   const invalid = await validateDntrArchivePath(archivePath);
   if (invalid) return invalid;
-  return pluginService.installPlugin(archivePath, opts);
+  return (await getPluginService()).installPlugin(archivePath, opts);
 }
 
 // Install-from-file owns the native-picker entry point; the selected path runs
@@ -205,7 +220,7 @@ function isAbortLikeError(err: unknown): boolean {
 export async function handleInstallFromPath(path: string): Promise<PluginInstallResult> {
   const invalid = await validateDntrArchivePath(path);
   if (invalid) return invalid;
-  return pluginService.installPlugin(path);
+  return (await getPluginService()).installPlugin(path);
 }
 
 /**
@@ -354,7 +369,10 @@ export async function handleInstallFromUrl(url: string): Promise<PluginInstallRe
       return failed("fetch_failed", "Couldn't download the plugin from that URL.");
     }
 
-    return pluginService.installPlugin(tempPath, { source: "url", originalUrl: trimmed });
+    return (await getPluginService()).installPlugin(tempPath, {
+      source: "url",
+      originalUrl: trimmed,
+    });
   } finally {
     if (wroteTempFile) {
       await rm(tempPath, { force: true }).catch(() => {});
@@ -376,7 +394,7 @@ export async function handleUninstall(pluginId: string, deleteSettings?: boolean
   if (deleteSettings !== undefined && typeof deleteSettings !== "boolean") {
     throw new Error("uninstall: deleteSettings must be a boolean");
   }
-  await pluginService.uninstallPlugin(pluginId, deleteSettings);
+  await (await getPluginService()).uninstallPlugin(pluginId, deleteSettings);
 }
 
 async function handleCheckForUpdate(pluginId: string): Promise<PluginCheckUpdateResult> {
@@ -385,7 +403,7 @@ async function handleCheckForUpdate(pluginId: string): Promise<PluginCheckUpdate
   }
   // The service owns the bounded download + hash compare and returns a
   // structured result for every domain outcome (#9297).
-  return pluginService.checkForUpdate(pluginId);
+  return (await getPluginService()).checkForUpdate(pluginId);
 }
 
 async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
@@ -393,7 +411,7 @@ async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
   // otherwise a fast renderer can read an empty registry before any plugin's
   // activate() runs — leaving plugin toolbar buttons missing until the next
   // mutation pushes a fresh broadcast (#9285).
-  await pluginService.waitForInit();
+  await (await getPluginService()).waitForInit();
   return getPluginToolbarButtonIds()
     .map((id) => getToolbarButtonConfig(id))
     .filter((c): c is ToolbarButtonConfig => c !== undefined);
@@ -403,12 +421,12 @@ async function handleMenuItems() {
   // Same init-race guard as `handleToolbarButtons` — block until startup
   // activation settles so the renderer's mount-time pull can't observe an
   // empty registry before plugins finish registering (#9285).
-  await pluginService.waitForInit();
+  await (await getPluginService()).waitForInit();
   return getPluginMenuItems();
 }
 
 async function handleKeybindings() {
-  await pluginService.waitForInit();
+  await (await getPluginService()).waitForInit();
   return getPluginKeybindings();
 }
 
@@ -416,7 +434,7 @@ async function handleContextMenuItems() {
   // Same init-race guard as `handleMenuItems` — block until startup activation
   // settles so the renderer's mount-time pull can't observe an empty registry
   // before plugins finish registering (#9285).
-  await pluginService.waitForInit();
+  await (await getPluginService()).waitForInit();
   return getPluginContextMenuItems();
 }
 
@@ -429,7 +447,7 @@ async function handleValidateActionIds(actionIds: string[]): Promise<void> {
   // after this snapshot runs, so their IDs won't appear in `knownIds`. Pull
   // the live plugin-action registry from the main-side PluginService and
   // treat those as known.
-  for (const { id } of pluginService.listPluginActions()) {
+  for (const { id } of (await getPluginService()).listPluginActions()) {
     knownIds.add(id);
   }
 
@@ -461,6 +479,7 @@ async function handleValidateActionIds(actionIds: string[]): Promise<void> {
 // gives it direct access to event.senderFrame — the typed path here does
 // not and doesn't need it.
 async function handleActionsGet(): Promise<PluginActionDescriptor[]> {
+  const pluginService = await getPluginService();
   await pluginService.waitForInit();
   return pluginService.listPluginActions();
 }
@@ -469,27 +488,27 @@ async function handleActionsRegister(
   pluginId: string,
   contribution: PluginActionContribution
 ): Promise<void> {
-  pluginService.registerPluginAction(pluginId, contribution);
+  (await getPluginService()).registerPluginAction(pluginId, contribution);
 }
 
 async function handleActionsUnregister(pluginId: string, actionId: string): Promise<void> {
-  pluginService.unregisterPluginAction(pluginId, actionId);
+  (await getPluginService()).unregisterPluginAction(pluginId, actionId);
 }
 
 async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
-  await pluginService.waitForInit();
+  await (await getPluginService()).waitForInit();
   return getPluginPanelKinds();
 }
 
 async function handleForgeProvidersGet(): Promise<RegisteredForgeProvider[]> {
   // Same init-race guard as the surrounding pull-on-mount handlers (#9285) —
   // forge descriptors register during the deferred initialize().
-  await pluginService.waitForInit();
+  await (await getPluginService()).waitForInit();
   return getRegisteredForgeProviders();
 }
 
 async function handleAgentsGet(): Promise<Record<string, AgentConfig>> {
-  await pluginService.waitForInit();
+  await (await getPluginService()).waitForInit();
   return getPluginAgentRegistry();
 }
 
@@ -562,7 +581,7 @@ async function handleFileDecorationsGet(
   // Implicit activation: any plugin that declares a provider for this scope is
   // forced to `activate()` before the impl lookup, so providers bound during
   // activate() are queryable on the first pull. No-op once already activated.
-  await pluginService.activatePluginsForFileDecorationScope(scope);
+  await (await getPluginService()).activatePluginsForFileDecorationScope(scope);
 
   const impls = getFileDecorationImpls(scope);
   if (impls.length === 0) return {};
@@ -740,6 +759,7 @@ async function handleGetDiagnosticsSnapshot(): Promise<PluginDiagnosticsSnapshot
   // Block until startup activation settles so the snapshot is post-activation
   // (mirrors handleToolbarButtons) — otherwise a fast renderer could read an
   // empty plugin set before any activate() runs.
+  const pluginService = await getPluginService();
   await pluginService.waitForInit();
   return pluginService.getDiagnosticsSnapshot();
 }
@@ -751,7 +771,7 @@ async function handleSettingsGetValues(
   scope: PluginSettingsScope,
   projectId: string | null
 ): Promise<PluginSettingsUiValues> {
-  return pluginService.getSettingValuesForUi(pluginId, scope, projectId);
+  return (await getPluginService()).getSettingValuesForUi(pluginId, scope, projectId);
 }
 
 async function handleSettingsSetValue(
@@ -761,7 +781,7 @@ async function handleSettingsSetValue(
   scope: PluginSettingsScope,
   projectId: string | null
 ): Promise<void> {
-  await pluginService.setSettingValueFromUi(pluginId, key, value, scope, projectId);
+  await (await getPluginService()).setSettingValueFromUi(pluginId, key, value, scope, projectId);
 }
 
 async function handleSettingsDeleteValue(
@@ -770,7 +790,7 @@ async function handleSettingsDeleteValue(
   scope: PluginSettingsScope,
   projectId: string | null
 ): Promise<void> {
-  await pluginService.deleteSettingValueFromUi(pluginId, key, scope, projectId);
+  await (await getPluginService()).deleteSettingValueFromUi(pluginId, key, scope, projectId);
 }
 
 async function handleSettingsRevealSecret(
@@ -779,7 +799,7 @@ async function handleSettingsRevealSecret(
   scope: PluginSettingsScope,
   projectId: string | null
 ): Promise<string | null> {
-  return pluginService.revealSecretSettingForUi(pluginId, key, scope, projectId);
+  return (await getPluginService()).revealSecretSettingForUi(pluginId, key, scope, projectId);
 }
 
 export const pluginNamespace = defineIpcNamespace({
@@ -866,7 +886,7 @@ export function registerPluginHandlers(): () => void {
         pluginId,
       };
       try {
-        return await pluginService.dispatchHandler(pluginId, channel, ctx, args);
+        return await (await getPluginService()).dispatchHandler(pluginId, channel, ctx, args);
       } catch (err) {
         // `stableArgsSha256` content-discriminates without persisting any
         // arg bytes — two structurally identical failed invokes hash the
@@ -897,16 +917,4 @@ export function registerPluginHandlers(): () => void {
   cleanups.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_INVOKE));
 
   return () => cleanups.forEach((cleanup) => cleanup());
-}
-
-export function registerPluginHandler(
-  pluginId: string,
-  channel: string,
-  handler: PluginIpcHandler
-): void {
-  pluginService.registerHandler(pluginId, channel, handler);
-}
-
-export function removePluginHandlers(pluginId: string): void {
-  pluginService.removeHandlers(pluginId);
 }

--- a/electron/ipc/handlers/pluginMcp.ts
+++ b/electron/ipc/handlers/pluginMcp.ts
@@ -1,8 +1,8 @@
-// eager-import-allow: wires plugin-MCP method channels and supervisor initialization on startup
+// eager-import-allow: reads pluginMcpConfig via store.get synchronously in IPC handlers
 import { defineIpcNamespace, op } from "../define.js";
 import { PLUGIN_MCP_METHOD_CHANNELS } from "./pluginMcp.preload.js";
-import { getPluginMcpSupervisor } from "../../services/PluginMcpSupervisor.js";
-import { pluginService } from "../../services/PluginService.js";
+import type * as PluginMcpSupervisorModule from "../../services/PluginMcpSupervisor.js";
+import type * as PluginServiceModule from "../../services/PluginService.js";
 import { store } from "../../store.js";
 import {
   PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION,
@@ -17,12 +17,35 @@ import {
   type PluginMcpToolKey,
 } from "../../../shared/types/ipc/pluginMcp.js";
 
+type PluginMcpSupervisor = ReturnType<typeof PluginMcpSupervisorModule.getPluginMcpSupervisor>;
+type PluginServiceSingleton = typeof PluginServiceModule.pluginService;
+
+// Lazy accessors (mirrors helpAssistant.ts): static imports here would pull
+// PluginMcpSupervisor and — transitively — the ~3,200-line PluginService onto
+// the eager startup path that #9285 deferred them off of.
+let cachedSupervisorModule: typeof PluginMcpSupervisorModule | null = null;
+async function getSupervisor(): Promise<PluginMcpSupervisor> {
+  if (!cachedSupervisorModule) {
+    cachedSupervisorModule = await import("../../services/PluginMcpSupervisor.js");
+  }
+  return cachedSupervisorModule.getPluginMcpSupervisor();
+}
+
+let cachedPluginService: PluginServiceSingleton | null = null;
+async function getPluginService(): Promise<PluginServiceSingleton> {
+  if (!cachedPluginService) {
+    const mod = await import("../../services/PluginService.js");
+    cachedPluginService = mod.pluginService;
+  }
+  return cachedPluginService;
+}
+
 async function handleList(): Promise<PluginMcpServerInfo[]> {
-  return getPluginMcpSupervisor().list();
+  return (await getSupervisor()).list();
 }
 
 async function handleGetStderr(key: PluginMcpServerKey): Promise<PluginMcpStderrResult> {
-  return getPluginMcpSupervisor().getStderr(key.pluginId, key.serverId);
+  return (await getSupervisor()).getStderr(key.pluginId, key.serverId);
 }
 
 /**
@@ -34,7 +57,7 @@ async function handleGetStderr(key: PluginMcpServerKey): Promise<PluginMcpStderr
 async function handleListTools(key: PluginMcpServerKey): Promise<PluginMcpListToolsResult> {
   await ensureServerStarted(key);
   const cfg = store.get("pluginMcpConfig") as { maxToolsPerSession?: unknown } | undefined;
-  return getPluginMcpSupervisor().listTools(
+  return (await getSupervisor()).listTools(
     key.pluginId,
     key.serverId,
     clampMaxTools(cfg?.maxToolsPerSession)
@@ -44,7 +67,7 @@ async function handleListTools(key: PluginMcpServerKey): Promise<PluginMcpListTo
 /** Tier-2 lookup: the full input schema for a single agent-selected tool (#9235). */
 async function handleGetFullSchema(key: PluginMcpToolKey): Promise<PluginMcpGetFullSchemaResult> {
   await ensureServerStarted(key);
-  return getPluginMcpSupervisor().getFullSchema(key.pluginId, key.serverId, key.toolName);
+  return (await getSupervisor()).getFullSchema(key.pluginId, key.serverId, key.toolName);
 }
 
 /**
@@ -54,13 +77,16 @@ async function handleGetFullSchema(key: PluginMcpToolKey): Promise<PluginMcpGetF
  * and never holds a stale `resolveSettings` closure across a plugin reload.
  */
 async function ensureServerStarted(key: PluginMcpServerKey): Promise<void> {
+  const pluginService = await getPluginService();
   const lookup = pluginService.findMcpServerContribution(key.pluginId, key.serverId);
   if (!lookup) {
     throw new Error(
       `Cannot enumerate tools for "${key.pluginId}/${key.serverId}": plugin or server is not registered`
     );
   }
-  await getPluginMcpSupervisor().start({
+  await (
+    await getSupervisor()
+  ).start({
     pluginId: key.pluginId,
     pluginDir: lookup.pluginDir,
     contributions: [lookup.contribution],
@@ -75,6 +101,7 @@ async function ensureServerStarted(key: PluginMcpServerKey): Promise<void> {
  * decoupled from `PluginService`.
  */
 async function handleRestart(key: PluginMcpServerKey): Promise<void> {
+  const pluginService = await getPluginService();
   const lookup = pluginService.findMcpServerContribution(key.pluginId, key.serverId);
   if (!lookup) {
     // A renderer race with plugin unload can land here. Throw so the caller
@@ -83,7 +110,9 @@ async function handleRestart(key: PluginMcpServerKey): Promise<void> {
       `Cannot restart "${key.pluginId}/${key.serverId}": plugin or server is not registered`
     );
   }
-  await getPluginMcpSupervisor().restart({
+  await (
+    await getSupervisor()
+  ).restart({
     pluginId: key.pluginId,
     pluginDir: lookup.pluginDir,
     serverId: key.serverId,

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -4,10 +4,10 @@ import { createWriteStream } from "fs";
 import path from "path";
 import yauzl from "yauzl";
 import { getPluginManifestSchema } from "../schemas/plugin.js";
+import { MAX_DNTR_BYTES } from "../utils/pluginArchiveConstants.js";
 import type { PluginManifest } from "../../shared/types/plugin.js";
 
 export const ZIP_EPOCH_DATE = new Date("1980-01-01T00:00:00Z");
-export const MAX_DNTR_BYTES = 30 * 1024 * 1024;
 // Cap on total zip entries. A plugin is a handful of compiled files plus
 // assets; thousands of entries means an archive padded with tiny/empty members
 // to force unbounded filesystem ops during extraction (zip-bomb-by-count).

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1,4 +1,3 @@
-// eager-import-allow: reads plugin settings via store.get synchronously during service init
 import fs from "fs/promises";
 import { existsSync } from "node:fs";
 import path from "path";

--- a/electron/services/__tests__/PluginService.checkForUpdate.test.ts
+++ b/electron/services/__tests__/PluginService.checkForUpdate.test.ts
@@ -93,7 +93,8 @@ vi.mock("../PluginMcpSupervisor.js", () => ({
 }));
 
 import { PluginService } from "../PluginService.js";
-import { packPluginArchive, MAX_DNTR_BYTES } from "../PluginArchive.js";
+import { packPluginArchive } from "../PluginArchive.js";
+import { MAX_DNTR_BYTES } from "../../utils/pluginArchiveConstants.js";
 
 const storeState = storeMock._state;
 

--- a/electron/services/plugin-mcp/instances.ts
+++ b/electron/services/plugin-mcp/instances.ts
@@ -1,4 +1,3 @@
-// eager-import-allow: lazily wires the plugin-MCP consent + audit services to the synchronous electron-store slices on first use (mirrors PluginActionAuditService)
 import { auditLogsStore, store } from "../../store.js";
 import { PluginMcpAuditService } from "./PluginMcpAuditService.js";
 import { PluginMcpConsentService } from "./PluginMcpConsentService.js";

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -1,4 +1,3 @@
-// eager-import-allow: module-scope __dirname/__filename derivation only (fileURLToPath); no disk I/O at import
 import { utilityProcess, UtilityProcess, app } from "electron";
 import { EventEmitter } from "events";
 import { createHash } from "crypto";

--- a/electron/services/plugin/PluginInstalledRecordsStore.ts
+++ b/electron/services/plugin/PluginInstalledRecordsStore.ts
@@ -1,4 +1,3 @@
-// eager-import-allow: manages persistent state and user settings for installed plugins on start
 import { store } from "../../store.js";
 import type { InstalledPluginRecord, PluginInstallSource } from "../../../shared/types/plugin.js";
 

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -9,12 +9,8 @@ import {
   isPrivateOrLoopbackHostname,
   SCOPED_PLUGIN_NAME_PATTERN,
 } from "../../schemas/plugin.js";
-import {
-  extractPluginArchive,
-  computeArchiveHash,
-  readArchiveManifest,
-  MAX_DNTR_BYTES,
-} from "../PluginArchive.js";
+import { extractPluginArchive, computeArchiveHash, readArchiveManifest } from "../PluginArchive.js";
+import { MAX_DNTR_BYTES } from "../../utils/pluginArchiveConstants.js";
 import {
   PLUGIN_DOWNLOAD_TIMEOUT_MS,
   acceptedMime,

--- a/electron/utils/pluginArchiveConstants.ts
+++ b/electron/utils/pluginArchiveConstants.ts
@@ -1,0 +1,3 @@
+// Zero-dependency home for the .dntr size cap so eager consumers (IPC
+// handlers, download policy) don't pull PluginArchive's yauzl import.
+export const MAX_DNTR_BYTES = 30 * 1024 * 1024;

--- a/electron/utils/pluginDownloadPolicy.ts
+++ b/electron/utils/pluginDownloadPolicy.ts
@@ -1,5 +1,5 @@
 import type { net as ElectronNet } from "electron";
-import { MAX_DNTR_BYTES } from "../services/PluginArchive.js";
+import { MAX_DNTR_BYTES } from "./pluginArchiveConstants.js";
 import { isPrivateOrLoopbackHostname } from "../schemas/plugin.js";
 
 export { MAX_DNTR_BYTES };


### PR DESCRIPTION
## Summary

- The `PluginService` deferral from #9285 was negated: `plugin.ts` and `pluginMcp.ts` value-imported `PluginService`, `PluginMcpSupervisor`, and `MAX_DNTR_BYTES` at module-eval time via the eager `handlers.ts` barrel, pulling ~3,200 lines of `PluginService` plus `semver`/`ajv`/`yauzl` before first paint.
- Both handler files are now converted to the cached lazy-accessor pattern (matching `helpAssistant.ts`) — all 30+ call sites are inside async IPC op bodies, so semantics and `waitForInit` gating are unchanged.
- `MAX_DNTR_BYTES` is extracted to a new zero-dep `electron/utils/pluginArchiveConstants.ts`, cutting `yauzl` from the eager graph entirely.

Resolves #10385

## Changes

- `plugin.ts`, `pluginMcp.ts`: `import type` + cached `await import()` lazy accessors replacing value imports of `PluginService`, `PluginMcpSupervisor`, and `MAX_DNTR_BYTES`
- `electron/utils/pluginArchiveConstants.ts`: new zero-dep file exporting `MAX_DNTR_BYTES`; `PluginArchive.ts`, `PluginInstaller.ts`, `pluginDownloadPolicy.ts`, and the handler updated to import from it
- Dead sync exports `registerPluginHandler`/`removePluginHandlers` (zero callers) deleted along with their tests
- Stale `eager-import-allow` headers removed from `PluginService.ts`, `plugin-mcp/instances.ts`, `PluginDevWorkerHost.ts`, `PluginInstalledRecordsStore.ts`
- `eager-import-baseline.json` regenerated: 1227 → 935 eager modules (~24% reduction), 4 stale allowlist entries removed; `pluginMcp.ts` retained for its remaining sync `store.get`

## Testing

- 168 targeted vitest tests pass (`plugin.handlers`, `pluginDownloadPolicy`, `PluginService.checkForUpdate`, `handlers.registry`)
- `npm run typecheck` passes
- Prettier clean
- `node scripts/check-import-budget.mjs` passes against the new baseline (935 eager modules)