### PR TITLE
fix(terminal): actually free xterm buffers on hibernation

### DIFF
--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -149,8 +149,11 @@ export class TerminalHibernationManager {
 
     // Dispose terminal instance — this removes xterm's injected DOM elements
     // from the hostElement but leaves the hostElement itself in the DOM
-    // so XtermAdapter's container ref stays valid for reattachment
-    const options = managed.terminal.options;
+    // so XtermAdapter's container ref stays valid for reattachment.
+    // The spread is load-bearing: `terminal.options` is a live getter proxy
+    // backed by rawOptions, and dispose() nulls rawOptions.linkHandler — a
+    // plain snapshot taken pre-dispose keeps the handler for the wake path.
+    const options = { ...managed.terminal.options };
     try {
       managed.terminal.dispose();
     } catch {
@@ -158,9 +161,19 @@ export class TerminalHibernationManager {
     }
     // Swap in a fresh un-opened placeholder so the disposed instance — and
     // with it the whole scrollback buffer graph — becomes GC-eligible for the
-    // duration of hibernation. The placeholder exists only to carry options
-    // for unhibernate(); it must never be open()-ed or given addons/listeners.
+    // duration of hibernation. The placeholder carries the options for
+    // unhibernate(); it must never be open()-ed or given listeners.
     managed.terminal = new Terminal(options);
+    // Re-point the eager addons at the placeholder. loadAddon() left each of
+    // them holding a _terminal reference, so keeping the old instances on
+    // `managed` would retain the disposed terminal's buffer graph anyway.
+    // unhibernate() overwrites all of these from its own setupTerminalAddons
+    // call; the placeholder set exists only to sever that edge while keeping
+    // the fields non-null (fit/search on an un-opened terminal are no-ops).
+    const placeholderAddons = setupTerminalAddons(managed.terminal);
+    managed.fitAddon = placeholderAddons.fitAddon;
+    managed.serializeAddon = placeholderAddons.serializeAddon;
+    managed.searchAddon = placeholderAddons.searchAddon;
 
     managed.isHibernated = true;
     managed.isOpened = false;

--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -107,6 +107,15 @@ export class TerminalHibernationManager {
       /* ignore */
     }
     managed.webLinksAddon = null;
+    try {
+      managed.imageLinksDisposable?.dispose();
+    } catch {
+      /* ignore */
+    }
+    // Null is load-bearing: ensureDeferredAddons() only rebuilds when the
+    // field is null, so a stale reference here would leave the woken terminal
+    // wired to the old disposed instance.
+    managed.imageLinksDisposable = null;
 
     // Dispose terminal-bound listeners (keep IPC listeners at the beginning)
     const terminalBoundListeners = managed.listeners.splice(managed.ipcListenerCount);
@@ -117,6 +126,10 @@ export class TerminalHibernationManager {
         /* ignore — terminal already disposing */
       }
     }
+
+    // The selection listener is gone now, so the cached selection can only go
+    // stale — clear it instead of letting it survive until destroy().
+    this.deps.deleteCachedSelection(id);
 
     // Dispose parser handler
     try {
@@ -137,11 +150,17 @@ export class TerminalHibernationManager {
     // Dispose terminal instance — this removes xterm's injected DOM elements
     // from the hostElement but leaves the hostElement itself in the DOM
     // so XtermAdapter's container ref stays valid for reattachment
+    const options = managed.terminal.options;
     try {
       managed.terminal.dispose();
     } catch {
       /* ignore — terminal already disposing */
     }
+    // Swap in a fresh un-opened placeholder so the disposed instance — and
+    // with it the whole scrollback buffer graph — becomes GC-eligible for the
+    // duration of hibernation. The placeholder exists only to carry options
+    // for unhibernate(); it must never be open()-ed or given addons/listeners.
+    managed.terminal = new Terminal(options);
 
     managed.isHibernated = true;
     managed.isOpened = false;

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -386,9 +386,10 @@ describe("TerminalHibernationManager adversarial", () => {
 
     // With the counter cleared, the terminal is hibernatable again.
     expect(manager.isHibernationEligible(TerminalRefreshTier.BACKGROUND, managed, "t1")).toBe(true);
+    const wokenTerminal = managed.terminal;
     manager.hibernate("t1");
     expect(managed.isHibernated).toBe(true);
-    expect(managed.terminal.dispose).toHaveBeenCalledTimes(1);
+    expect(wokenTerminal.dispose).toHaveBeenCalledTimes(1);
   });
 
   it("BACKGROUNDED_BYPASS_DROPPED_WHEN_RESTORED_BETWEEN_SCHEDULE_AND_FIRE", () => {

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -123,6 +123,7 @@ function makeMockManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTermi
     searchAddon: {} as ManagedTerminal["searchAddon"],
     fileLinksDisposable: { dispose: vi.fn() } as unknown as ManagedTerminal["fileLinksDisposable"],
     webLinksAddon: { dispose: vi.fn() } as unknown as ManagedTerminal["webLinksAddon"],
+    imageLinksDisposable: null,
     hostElement: document.createElement("div"),
     isOpened: true,
     isVisible: true,
@@ -376,12 +377,49 @@ describe("TerminalHibernationManager", () => {
       expect(managed.webLinksAddon).toBeNull();
     });
 
+    it("should dispose imageLinksDisposable and null it so wake rebuilds it (#10387)", () => {
+      const linksDispose = vi.fn();
+      managed.imageLinksDisposable = { dispose: linksDispose };
+
+      manager.hibernate("t1");
+
+      // The null matters as much as the dispose: ensureDeferredAddons() only
+      // rebuilds when the field is null.
+      expect(linksDispose).toHaveBeenCalled();
+      expect(managed.imageLinksDisposable).toBeNull();
+    });
+
     it("should not throw when addons are already null", () => {
       managed.imageAddon = null;
       managed.fileLinksDisposable = null;
       managed.webLinksAddon = null;
+      managed.imageLinksDisposable = null;
 
       expect(() => manager.hibernate("t1")).not.toThrow();
+    });
+
+    it("should replace the disposed terminal with a fresh un-opened placeholder (#10387)", () => {
+      const oldTerminal = managed.terminal;
+
+      manager.hibernate("t1");
+
+      // Keeping the disposed instance referenced would retain its entire
+      // buffer graph for the hibernation window — the placeholder swap is the
+      // actual memory release.
+      expect(oldTerminal.dispose).toHaveBeenCalled();
+      expect(managed.terminal).not.toBe(oldTerminal);
+      expect(freshTerminalOpenMock).not.toHaveBeenCalled();
+    });
+
+    it("should clear the cached selection (#10387)", () => {
+      manager.hibernate("t1");
+      expect(deps.deleteCachedSelection).toHaveBeenCalledWith("t1");
+    });
+
+    it("should not clear the cached selection when the call short-circuits", () => {
+      managed.isHibernated = true;
+      manager.hibernate("t1");
+      expect(deps.deleteCachedSelection).not.toHaveBeenCalled();
     });
 
     it("should clear hibernation timer", () => {

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Terminal } from "@xterm/xterm";
 import { TerminalHibernationManager, HibernationManagerDeps } from "../TerminalHibernationManager";
+import { setupTerminalAddons } from "../TerminalAddonManager";
 import type { ManagedTerminal } from "../types";
 import { AGENT_IDLE_SILENCE_MS } from "../types";
 import { TerminalRefreshTier } from "../../../../shared/types/panel";
@@ -409,6 +411,44 @@ describe("TerminalHibernationManager", () => {
       expect(oldTerminal.dispose).toHaveBeenCalled();
       expect(managed.terminal).not.toBe(oldTerminal);
       expect(freshTerminalOpenMock).not.toHaveBeenCalled();
+    });
+
+    it("should re-point eager addons at the placeholder so the old terminal stays unreachable (#10387)", () => {
+      const oldFit = managed.fitAddon;
+      const oldSerialize = managed.serializeAddon;
+      const oldSearch = managed.searchAddon;
+
+      manager.hibernate("t1");
+
+      // loadAddon() leaves each eager addon holding a _terminal reference, so
+      // stale addon instances on `managed` would keep the disposed terminal's
+      // buffer graph alive even after the placeholder swap.
+      expect(setupTerminalAddons).toHaveBeenCalledWith(managed.terminal);
+      expect(managed.fitAddon).not.toBe(oldFit);
+      expect(managed.serializeAddon).not.toBe(oldSerialize);
+      expect(managed.searchAddon).not.toBe(oldSearch);
+    });
+
+    it("should snapshot options before dispose so dispose-time nulling cannot reach the placeholder (#10387)", () => {
+      // xterm's real `options` is a live getter proxy and dispose() nulls
+      // rawOptions.linkHandler — simulate that with a dispose that mutates the
+      // shared options object.
+      const linkHandler = { activate: vi.fn() };
+      const terminal = managed.terminal as unknown as {
+        options: { scrollback: number; linkHandler: unknown };
+        dispose: ReturnType<typeof vi.fn>;
+      };
+      terminal.options = { scrollback: 5000, linkHandler };
+      terminal.dispose = vi.fn(() => {
+        terminal.options.linkHandler = null;
+      });
+
+      manager.hibernate("t1");
+
+      const ctorArgs = vi.mocked(Terminal).mock.calls.at(-1)?.[0] as
+        | { linkHandler?: unknown }
+        | undefined;
+      expect(ctorArgs?.linkHandler).toBe(linkHandler);
     });
 
     it("should clear the cached selection (#10387)", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -294,22 +294,26 @@ describe("TerminalInstanceService - Hibernation", () => {
       });
       service.instances.set("t1", managed as unknown as Record<string, unknown>);
 
+      const terminalDispose = managed.terminal.dispose;
       service.hibernate("t1");
 
       expect(managed.isHibernated).toBe(true);
-      expect(managed.terminal.dispose).toHaveBeenCalled();
+      expect(terminalDispose).toHaveBeenCalled();
     });
 
     it("should be idempotent — second call is a no-op", () => {
       const managed = makeMockManaged();
       service.instances.set("t1", managed as unknown as Record<string, unknown>);
 
+      const originalDispose = managed.terminal.dispose;
       service.hibernate("t1");
-      const disposeCalls = (managed.terminal.dispose as ReturnType<typeof vi.fn>).mock.calls.length;
+      // hibernate() swaps in a fresh placeholder terminal (#10387) — spy on
+      // it so the no-op second call can be observed on the live reference.
+      const placeholderDispose = vi.spyOn(managed.terminal, "dispose");
 
       service.hibernate("t1");
-      // dispose should not be called again
-      expect(managed.terminal.dispose).toHaveBeenCalledTimes(disposeCalls);
+      expect(originalDispose).toHaveBeenCalledTimes(1);
+      expect(placeholderDispose).not.toHaveBeenCalled();
     });
 
     it("should clear pending hibernation timer", () => {


### PR DESCRIPTION
## Summary

- `hibernate()` in `TerminalHibernationManager` was calling `dispose()` on the xterm `Terminal` but keeping the disposed instance on `managed.terminal`, so the buffer graph (CircularList/BufferSet, 10-50+ MB with full scrollback) stayed reachable and was never GC'd
- The fix snapshots terminal options before `dispose()` (the live getter proxy nulls `linkHandler` post-dispose, so a pre-dispose spread preserves it), swaps in a fresh placeholder `Terminal`, and re-points eager addons (`fitAddon`/`serializeAddon`/`searchAddon`) at the placeholder so their `loadAddon`-time `_terminal` references don't keep the old buffer graph alive
- Two smaller asymmetries fixed in the same pass: `imageLinksDisposable` is now disposed and nulled (parity with `destroy()` and the tier-change path; the null is load-bearing for `ensureDeferredAddons()` rebuild), and cached selections are cleared on hibernate (the selection listener is spliced out, so the entry could only go stale)

Resolves #10387

## Changes

- `src/services/terminal/TerminalHibernationManager.ts` — snapshot options, dispose old terminal, swap in placeholder, re-point eager addons, dispose/null `imageLinksDisposable`, clear cached selection
- `TerminalHibernationManager.test.ts` — 4 new regression tests (placeholder swap, eager addon re-pointing, options snapshot vs dispose-time nulling, `deleteCachedSelection`) + 1 short-circuit test; 3 existing tests updated to capture the pre-hibernate terminal reference
- `TerminalHibernationManager.adversarial.test.ts` — minor fixture update

## Testing

Targeted vitest suites: `TerminalHibernationManager` (including adversarial), `TerminalInstanceService.hibernation/fullWake/postWake/tier/selection`, `TerminalWakeManager`, `TerminalResizeController` — 278 tests, all green. Prettier clean, eslint 0 errors on changed files.