### PR TITLE
perf(store): stop re-reading config.json on every main-process store access

### DIFF
--- a/electron/__tests__/store.proxy.test.ts
+++ b/electron/__tests__/store.proxy.test.ts
@@ -8,7 +8,13 @@ vi.mock("electron-store", async () => {
   return { default: conf.default };
 });
 
-import { store, initializeStore, _resetStoreInstance, _peekStoreInstance } from "../store.js";
+import {
+  store,
+  initializeStore,
+  invalidateStoreValueCache,
+  _resetStoreInstance,
+  _peekStoreInstance,
+} from "../store.js";
 
 describe("store Proxy", () => {
   let tempDir: string;
@@ -66,5 +72,68 @@ describe("store Proxy", () => {
     expect(_peekStoreInstance()).toBeUndefined();
     initializeStore(testOptions(tempDir));
     expect(_peekStoreInstance()).toBeDefined();
+  });
+
+  describe("value cache", () => {
+    it("serves repeat reads from the in-memory snapshot, not the file", () => {
+      initializeStore(testOptions(tempDir));
+      expect(store.get("_schemaVersion" as never)).toBe(0);
+      // Rewrite the file behind electron-store's back; a cached read must
+      // not see it (proving no per-get disk read happens).
+      const configPath = path.join(tempDir, "config.json");
+      fs.writeFileSync(configPath, JSON.stringify({ _schemaVersion: 42 }), "utf8");
+      expect(store.get("_schemaVersion" as never)).toBe(0);
+    });
+
+    it("invalidates on set() so the next read re-snapshots the file", () => {
+      initializeStore(testOptions(tempDir));
+      expect(store.get("_schemaVersion" as never)).toBe(0);
+      const configPath = path.join(tempDir, "config.json");
+      fs.writeFileSync(configPath, JSON.stringify({ _schemaVersion: 42, other: 1 }), "utf8");
+      store.set("other" as never, 2 as never);
+      expect(store.get("_schemaVersion" as never)).toBe(42);
+      expect(store.get("other" as never)).toBe(2);
+    });
+
+    it("invalidates on delete()", () => {
+      initializeStore(testOptions(tempDir));
+      store.set("flag" as never, true as never);
+      expect(store.get("flag" as never)).toBe(true);
+      store.delete("flag" as never);
+      expect(store.get("flag" as never)).toBeUndefined();
+    });
+
+    it("invalidateStoreValueCache() forces a re-read after an external file swap", () => {
+      initializeStore(testOptions(tempDir));
+      expect(store.get("_schemaVersion" as never)).toBe(0);
+      const configPath = path.join(tempDir, "config.json");
+      fs.writeFileSync(configPath, JSON.stringify({ _schemaVersion: 9 }), "utf8");
+      invalidateStoreValueCache();
+      expect(store.get("_schemaVersion" as never)).toBe(9);
+    });
+
+    it("resolves dot-notation paths against the snapshot", () => {
+      initializeStore(testOptions(tempDir));
+      store.set("nested" as never, { inner: { value: 7 } } as never);
+      expect(store.get("nested.inner.value" as never)).toBe(7);
+      expect(store.get("nested.missing.value" as never)).toBeUndefined();
+      expect(store.get("nested.missing" as never, "fallback" as never)).toBe("fallback");
+    });
+
+    it("returns isolated clones — mutating a read result cannot poison later reads", () => {
+      initializeStore(testOptions(tempDir));
+      store.set("obj" as never, { list: [1] } as never);
+      const first = store.get("obj" as never) as { list: number[] };
+      first.list.push(2);
+      const second = store.get("obj" as never) as { list: number[] };
+      expect(second.list).toEqual([1]);
+    });
+
+    it("bypasses the cache for the in-memory fallback store", () => {
+      initializeStore(testOptions("/nonexistent/\0/path"));
+      expect(_peekStoreInstance()?.path).toBe("");
+      store.set("k" as never, "v" as never);
+      expect(store.get("k" as never)).toBe("v");
+    });
   });
 });

--- a/electron/__tests__/storeBackupRestore.test.ts
+++ b/electron/__tests__/storeBackupRestore.test.ts
@@ -15,6 +15,7 @@ import {
   restoreFromBackup,
   refreshBackup,
   initializeStore,
+  runDeferredStoreBackup,
   consumePendingSettingsRecovery,
   _resetPendingSettingsRecovery,
   _resetStoreInstance,
@@ -228,6 +229,10 @@ describe("initializeStore", () => {
     expect(instance.get("_schemaVersion")).toBe(0);
     const configPath = path.join(tempDir, "config.json");
     expect(fs.existsSync(configPath)).toBe(true);
+    // The .bak refresh is deferred off the boot path; it only lands once the
+    // bootstrap-scheduled task runs.
+    expect(fs.existsSync(`${configPath}.bak`)).toBe(false);
+    runDeferredStoreBackup();
     expect(fs.existsSync(`${configPath}.bak`)).toBe(true);
   });
 
@@ -236,6 +241,7 @@ describe("initializeStore", () => {
     fs.writeFileSync(configPath, JSON.stringify({ _schemaVersion: 5 }), "utf8");
     const instance = initializeStore(testOptions(tempDir));
     expect(instance.get("_schemaVersion")).toBe(5);
+    runDeferredStoreBackup();
     expect(fs.existsSync(`${configPath}.bak`)).toBe(true);
   });
 
@@ -248,6 +254,7 @@ describe("initializeStore", () => {
     expect(instance.get("_schemaVersion")).toBe(5);
     // A benign load must not be misreported as a silent reset.
     expect(consumePendingSettingsRecovery()).toBeNull();
+    runDeferredStoreBackup();
     expect(fs.existsSync(`${configPath}.bak`)).toBe(true);
   });
 
@@ -300,7 +307,9 @@ describe("initializeStore", () => {
     expect(instance).toBeDefined();
     // Store has been silently reset to defaults by electron-store
     expect(instance.get("_schemaVersion")).toBe(0);
-    // Backup must remain untouched — recovery is still possible
+    // Even after the deferred backup task runs, the wipe guard must keep the
+    // last-good backup untouched — recovery is still possible.
+    runDeferredStoreBackup();
     expect(fs.readFileSync(`${configPath}.bak`, "utf8")).toBe(lastGood);
     // …and recovery state should reflect the silent reset
     expect(consumePendingSettingsRecovery()).toEqual({ kind: "reset-to-defaults" });
@@ -318,6 +327,7 @@ describe("initializeStore", () => {
     expect(instance.get("_schemaVersion")).toBe(5);
     expect(instance.get("newDefault")).toBe("added");
     // Backup must reflect the merged-on-disk content, not stay frozen
+    runDeferredStoreBackup();
     const backup = JSON.parse(fs.readFileSync(`${configPath}.bak`, "utf8"));
     expect(backup._schemaVersion).toBe(5);
     expect(backup.newDefault).toBe("added");
@@ -426,6 +436,7 @@ describe("initializeStore", () => {
       () => {
         const configPath = path.join(tempDir, "config.json");
         initializeStore(testOptions(tempDir));
+        runDeferredStoreBackup();
         const mode = fs.statSync(`${configPath}.bak`).mode & 0o777;
         expect(mode).toBe(0o600);
       }
@@ -452,6 +463,7 @@ describe("initializeStore", () => {
         fs.writeFileSync(backupPath, JSON.stringify({ _schemaVersion: 5 }), "utf8");
         fs.chmodSync(backupPath, 0o644);
         initializeStore(testOptions(tempDir));
+        runDeferredStoreBackup();
         const mode = fs.statSync(backupPath).mode & 0o777;
         expect(mode).toBe(0o600);
       }

--- a/electron/bootstrap.ts
+++ b/electron/bootstrap.ts
@@ -12,7 +12,7 @@ import { app, dialog } from "electron";
 import { BOOT_MIGRATIONS, runBootMigrations } from "./boot/migrations/index.js";
 import { isSafeModeActive } from "./services/CrashLoopGuardService.js";
 import { setCompileCacheEnableStatus } from "./utils/hostPerformance.js";
-import { initializeStore, _peekStoreInstance } from "./store.js";
+import { initializeStore, _peekStoreInstance, runDeferredStoreBackup } from "./store.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 
 const cacheDir = path.join(app.getPath("userData"), "compile-cache");
@@ -87,6 +87,14 @@ try {
 }
 
 await import("./main.js");
+
+// Refresh the config.json.bak copy (and tighten its permissions) off the
+// boot-critical path. initializeStore() used to do this synchronously before
+// main.js loaded; the previous session's .bak stays valid for corrupt-config
+// recovery until this fires, so deferring loses nothing.
+setImmediate(() => {
+  runDeferredStoreBackup();
+});
 
 // Persist any compile-cache entries written during boot. enableCompileCache()
 // only flushes on a clean process exit, so a crash or SIGKILL before the first

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -1044,7 +1044,10 @@ describe("app:set-state handler", () => {
 
     await invokeSetState({ focusMode: true });
 
-    const [, written] = vi.mocked(storeModule.store.set).mock.calls[0]!;
+    // store.set is called in the (key, value) form; read through an untyped
+    // view since vi.mocked resolves the single-argument set(object) overload.
+    const calls = vi.mocked(storeModule.store.set).mock.calls as unknown as unknown[][];
+    const written = calls[0]![1];
     expect(written).toMatchObject({ sidebarWidth: 350, hasSeenWelcome: true, focusMode: true });
   });
 
@@ -1064,7 +1067,8 @@ describe("app:set-state handler", () => {
 
     const setMock = vi.mocked(storeModule.store.set);
     expect(setMock).toHaveBeenCalledTimes(1);
-    const [, written] = setMock.mock.calls[0]!;
+    const calls = setMock.mock.calls as unknown as unknown[][];
+    const written = calls[0]![1];
     expect(written).not.toHaveProperty("focusPanelState");
     expect(written).toMatchObject({ sidebarWidth: 350 });
     expect(storeModule.store.delete).not.toHaveBeenCalled();

--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -994,3 +994,92 @@ describe("app:boot handler", () => {
     expect(projectStore.getCurrentProject).not.toHaveBeenCalled();
   });
 });
+
+describe("app:set-state handler", () => {
+  async function invokeSetState(payload: unknown) {
+    ipcHandlers.clear();
+    const cleanup = registerAppStateHandlers();
+    const handler = ipcHandlers.get("app:set-state");
+    if (!handler) throw new Error("app:set-state handler not registered");
+    await handler(makeInvokeEvent(), payload);
+    cleanup();
+  }
+
+  let storeModule: typeof import("../../store.js");
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ipcHandlers.clear();
+    storeModule = await import("../../store.js");
+    vi.mocked(storeModule.store.get).mockImplementation(((key: string) => {
+      if (key === "appState") return { terminals: [], sidebarWidth: 350 };
+      if (key === "terminalConfig") return { resourceMonitoringEnabled: false };
+      if (key === "agentSettings") return {};
+      return undefined;
+    }) as never);
+  });
+
+  it("persists a multi-field update as a single merged appState write", async () => {
+    await invokeSetState({ sidebarWidth: 400, focusMode: true, activeWorktreeId: "wt-1" });
+
+    const setMock = vi.mocked(storeModule.store.set);
+    expect(setMock).toHaveBeenCalledTimes(1);
+    expect(setMock).toHaveBeenCalledWith(
+      "appState",
+      expect.objectContaining({
+        terminals: [],
+        sidebarWidth: 400,
+        focusMode: true,
+        activeWorktreeId: "wt-1",
+      })
+    );
+    expect(storeModule.store.delete).not.toHaveBeenCalled();
+  });
+
+  it("preserves unrelated persisted fields in the merged write", async () => {
+    vi.mocked(storeModule.store.get).mockImplementation(((key: string) => {
+      if (key === "appState") return { terminals: [], sidebarWidth: 350, hasSeenWelcome: true };
+      return undefined;
+    }) as never);
+
+    await invokeSetState({ focusMode: true });
+
+    const [, written] = vi.mocked(storeModule.store.set).mock.calls[0]!;
+    expect(written).toMatchObject({ sidebarWidth: 350, hasSeenWelcome: true, focusMode: true });
+  });
+
+  it("drops cleared fields from the merged object instead of writing undefined", async () => {
+    vi.mocked(storeModule.store.get).mockImplementation(((key: string) => {
+      if (key === "appState") {
+        return {
+          terminals: [],
+          sidebarWidth: 350,
+          focusPanelState: { sidebarWidth: 300, diagnosticsOpen: false },
+        };
+      }
+      return undefined;
+    }) as never);
+
+    await invokeSetState({ focusPanelState: null });
+
+    const setMock = vi.mocked(storeModule.store.set);
+    expect(setMock).toHaveBeenCalledTimes(1);
+    const [, written] = setMock.mock.calls[0]!;
+    expect(written).not.toHaveProperty("focusPanelState");
+    expect(written).toMatchObject({ sidebarWidth: 350 });
+    expect(storeModule.store.delete).not.toHaveBeenCalled();
+  });
+
+  it("writes nothing when no field survives validation", async () => {
+    await invokeSetState({ sidebarWidth: 99999 });
+    expect(storeModule.store.set).not.toHaveBeenCalled();
+  });
+
+  it("schedules a crash backup only for crash-critical fields", async () => {
+    await invokeSetState({ sidebarWidth: 400 });
+    expect(crashService.scheduleBackup).not.toHaveBeenCalled();
+
+    await invokeSetState({ focusMode: true });
+    expect(crashService.scheduleBackup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/forge.rateLimit.test.ts
@@ -73,7 +73,10 @@ vi.mock("../forgeResolution.js", () => ({
   getImplForNamespace: () => fakeImpl,
 }));
 
-vi.mock("../../../store.js", () => ({ store: storeMock }));
+vi.mock("../../../store.js", () => ({
+  store: storeMock,
+  auditLogsStore: { get: vi.fn(() => []), set: vi.fn() },
+}));
 
 vi.mock("../../../services/forgeProviderRegistry.js", () => ({
   getForgeProviderImpl: () => fakeImpl,

--- a/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
@@ -47,7 +47,10 @@ const storeMock = vi.hoisted(() => {
   };
 });
 
-vi.mock("../../../store.js", () => ({ store: storeMock }));
+vi.mock("../../../store.js", () => ({
+  store: storeMock,
+  auditLogsStore: { get: vi.fn(() => []), set: vi.fn() },
+}));
 
 import { registerForgeDataHandlers } from "../forgeData.js";
 import { _resetRateLimitQueuesForTest } from "../../utils.js";

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -20,7 +20,10 @@ const storeMock = vi.hoisted(() => {
   };
 });
 
-vi.mock("../../../store.js", () => ({ store: storeMock }));
+vi.mock("../../../store.js", () => ({
+  store: storeMock,
+  auditLogsStore: { get: vi.fn(() => []), set: vi.fn() },
+}));
 
 const registryMock = vi.hoisted(() => ({
   getRegisteredForgeProviders: vi.fn<() => ForgeProviderEntry[]>(() => []),

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -771,13 +771,22 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       const hasCriticalField = Object.keys(updates).some((k) => CRASH_CRITICAL_FIELDS.has(k));
 
       try {
-        for (const [field, value] of Object.entries(updates)) {
-          if (value === undefined) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (store.delete as (k: string) => void)(`appState.${field}` as any);
-          } else {
-            store.set(`appState.${field}`, value);
+        // Batch all fields into one write: every store.set() re-reads and
+        // re-serializes the whole config.json, so a per-field loop costs N×
+        // the file IO of a single merged set.
+        if (Object.keys(updates).length > 0) {
+          const current = (store.get("appState") ?? {}) as Record<string, unknown>;
+          const merged: Record<string, unknown> = { ...current };
+          for (const [field, value] of Object.entries(updates)) {
+            if (value === undefined) {
+              // electron-store v11 throws on `undefined` values — drop the
+              // key from the merged object instead (was store.delete before).
+              delete merged[field];
+            } else {
+              merged[field] = value;
+            }
           }
+          store.set("appState", merged as StoreSchema["appState"]);
         }
       } finally {
         if (hasCriticalField) {

--- a/electron/services/PluginActionAuditService.ts
+++ b/electron/services/PluginActionAuditService.ts
@@ -16,7 +16,7 @@ import {
 import type { ActionSource, ActionDanger } from "../../shared/types/actions.js";
 import { events } from "./events.js";
 import type { TypedEventBus } from "./events.js";
-import { store } from "../store.js";
+import { auditLogsStore, store } from "../store.js";
 
 const FLUSH_DEBOUNCE_MS = 1000;
 const MAX_PLAINTEXT_CHARS = 4096;
@@ -41,6 +41,20 @@ function summarizePlaintext(args: unknown): string | undefined {
     : serialized;
 }
 
+export interface PluginAuditLogStore {
+  read(): unknown;
+  write(records: PluginActionAuditRecord[]): void;
+}
+
+// Persists the ring in the dedicated audit-logs store (migration023) so
+// config.json stays small and audit appends never re-serialize it.
+// `auditEnabled` / `auditMaxRecords` stay in config.json (`plugins`), read via
+// the injected config closures.
+const defaultLogStore: PluginAuditLogStore = {
+  read: () => auditLogsStore.get("pluginAuditLog"),
+  write: (records) => auditLogsStore.set("pluginAuditLog", records),
+};
+
 /**
  * Main-process ring buffer of plugin-action dispatch audit records. Mirrors
  * the MCP `AuditService` storage pattern (hydrate / append / trim / debounced
@@ -48,9 +62,10 @@ function summarizePlaintext(args: unknown): string | undefined {
  * chronological dispatch trail.
  *
  * Records are appended from the `action:dispatched` bus event whenever the
- * dispatched action carries a `pluginId`. Persistence is wired to the
- * `plugins` store slice via the `saveConfig`/`readConfig` callbacks so the
- * service stays decoupled from the concrete store module.
+ * dispatched action carries a `pluginId`. Config flags are wired to the
+ * `plugins` store slice via the `saveConfig`/`readConfig` callbacks and the
+ * ring to the audit-logs store via `logStore`, so the service stays decoupled
+ * from the concrete store module.
  */
 export class PluginActionAuditService {
   private records: PluginActionAuditRecord[] = [];
@@ -60,7 +75,8 @@ export class PluginActionAuditService {
 
   constructor(
     private readonly saveConfig: (patch: Record<string, unknown>) => void,
-    private readonly readConfig: () => Record<string, unknown>
+    private readonly readConfig: () => Record<string, unknown>,
+    private readonly logStore: PluginAuditLogStore = defaultLogStore
   ) {}
 
   /**
@@ -100,9 +116,9 @@ export class PluginActionAuditService {
 
   hydrate(): void {
     if (this.hydrated) return;
-    const config = this.readConfig();
-    const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
-    const cap = this.normalizeMaxRecords(config.auditMaxRecords);
+    const stored = this.logStore.read();
+    const persisted = Array.isArray(stored) ? stored : [];
+    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     const safe = persisted.filter((r: unknown): r is PluginActionAuditRecord => {
       if (r === null || typeof r !== "object") return false;
       const rec = r as { id?: unknown; pluginId?: unknown; actionId?: unknown };
@@ -150,7 +166,10 @@ export class PluginActionAuditService {
     /** Human-readable failure message — `error` records. */
     errorMessage?: string;
   }): void {
-    if (this.readConfig().auditEnabled === false) return;
+    // Single config read per append — the same result gates the kill switch
+    // and supplies the trim cap.
+    const config = this.readConfig();
+    if (config.auditEnabled === false) return;
     this.hydrate();
 
     const record: PluginActionAuditRecord = {
@@ -174,12 +193,11 @@ export class PluginActionAuditService {
     if (input.contributionId !== undefined) record.contributionId = input.contributionId;
     if (input.errorMessage !== undefined) record.errorMessage = input.errorMessage;
 
-    this.enqueueAndTrim(record);
+    this.enqueueAndTrim(record, this.normalizeMaxRecords(config.auditMaxRecords));
   }
 
-  private enqueueAndTrim(record: PluginActionAuditRecord): void {
+  private enqueueAndTrim(record: PluginActionAuditRecord, cap: number): void {
     this.records.push(record);
-    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     if (this.records.length > cap) {
       this.records.splice(0, this.records.length - cap);
     }
@@ -198,7 +216,7 @@ export class PluginActionAuditService {
   private flush(): void {
     if (!this.hydrated) return;
     try {
-      this.saveConfig({ auditLog: [...this.records] });
+      this.logStore.write([...this.records]);
     } catch (err) {
       console.error("[PluginAudit] Failed to flush audit log:", err);
     }
@@ -267,6 +285,8 @@ export function getPluginActionAuditService(): PluginActionAuditService {
   if (!instance) {
     // `store` is the lazy electron-store Proxy — importing it doesn't initialize
     // the backing store, and the singleton is only constructed on first use.
+    // The spread merge keeps a legacy `plugins.auditLog` carryover intact for
+    // installs where migration023 deferred (audit-logs store not durable).
     instance = new PluginActionAuditService(
       (patch) => {
         const current = (store.get("plugins") ?? {}) as Record<string, unknown>;

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -1,13 +1,13 @@
 // eager-import-allow: reads/writes store data via sync fs and store.get while migrating the store
 import Store from "electron-store";
 import type { StoreSchema } from "../store.js";
-import { tightenFilePermissions } from "../store.js";
+import { invalidateStoreValueCache, tightenFilePermissions } from "../store.js";
 import fs from "fs";
 import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { getCurrentDiskSpaceStatus } from "./DiskSpaceMonitor.js";
 
-export const LATEST_SCHEMA_VERSION = 22;
+export const LATEST_SCHEMA_VERSION = 23;
 
 export interface Migration {
   version: number;
@@ -148,6 +148,9 @@ export class MigrationRunner {
 
     try {
       fs.renameSync(backupPath, storePath);
+      // The rename swapped config.json behind electron-store's back — drop
+      // the store proxy's value cache so reads reflect the restored file.
+      invalidateStoreValueCache();
       // Backups created by older builds may carry 0o644; tighten the
       // restored live config so the rollback never relaxes permissions.
       tightenFilePermissions(storePath);

--- a/electron/services/__tests__/PluginActionAuditService.test.ts
+++ b/electron/services/__tests__/PluginActionAuditService.test.ts
@@ -1,16 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// The service module statically imports the electron-store-backed `store` for
-// its singleton factory. These tests exercise the class directly with injected
-// callbacks, so stub `store` to keep the unit test hermetic (no electron).
+// The service module statically imports the electron-store-backed `store` and
+// `auditLogsStore` for its singleton factory / default log store. These tests
+// exercise the class directly with injected callbacks, so stub both to keep
+// the unit test hermetic (no electron).
 vi.mock("../../store.js", () => ({
   store: { get: vi.fn(() => ({})), set: vi.fn() },
+  auditLogsStore: { get: vi.fn(), set: vi.fn() },
 }));
 
 import { events, type DaintreeEventMap } from "../events.js";
 import { PluginActionAuditService } from "../PluginActionAuditService.js";
 
-/** In-memory stand-in for the `plugins` store slice. */
+/**
+ * In-memory stand-in for the `plugins` config slice plus the audit-logs ring.
+ * The ring is kept under the same `auditLog` key so seeding and assertions
+ * read naturally, but it round-trips through the injected `logStore` (the
+ * real ring lives in the audit-logs store since migration023).
+ */
 function makeConfigStore(initial: Record<string, unknown> = {}) {
   let config: Record<string, unknown> = { auditEnabled: true, auditMaxRecords: 500, ...initial };
   return {
@@ -19,6 +26,12 @@ function makeConfigStore(initial: Record<string, unknown> = {}) {
     },
     readConfig: () => config,
     raw: () => config,
+    logStore: {
+      read: () => config.auditLog,
+      write: (records: unknown[]) => {
+        config = { ...config, auditLog: records };
+      },
+    },
   };
 }
 
@@ -41,7 +54,7 @@ describe("PluginActionAuditService", () => {
 
   beforeEach(() => {
     store = makeConfigStore();
-    service = new PluginActionAuditService(store.saveConfig, store.readConfig);
+    service = new PluginActionAuditService(store.saveConfig, store.readConfig, store.logStore);
   });
 
   afterEach(() => {
@@ -165,7 +178,7 @@ describe("PluginActionAuditService", () => {
 
   it("flushes to the store after the debounce window (oldest-first)", () => {
     vi.useFakeTimers();
-    const svc = new PluginActionAuditService(store.saveConfig, store.readConfig);
+    const svc = new PluginActionAuditService(store.saveConfig, store.readConfig, store.logStore);
     svc.append({
       pluginId: "p",
       actionId: "first",
@@ -194,7 +207,7 @@ describe("PluginActionAuditService", () => {
 
   it("dispose() flushes pending records synchronously", () => {
     vi.useFakeTimers();
-    const svc = new PluginActionAuditService(store.saveConfig, store.readConfig);
+    const svc = new PluginActionAuditService(store.saveConfig, store.readConfig, store.logStore);
     svc.append({
       pluginId: "p",
       actionId: "x",
@@ -218,7 +231,7 @@ describe("PluginActionAuditService", () => {
         { pluginId: "p", actionId: "a" }, // missing id
       ],
     });
-    const svc = new PluginActionAuditService(seeded.saveConfig, seeded.readConfig);
+    const svc = new PluginActionAuditService(seeded.saveConfig, seeded.readConfig, seeded.logStore);
     const records = svc.getRecords();
     expect(records).toHaveLength(1);
     expect(records[0]!.id).toBe("ok");
@@ -242,7 +255,7 @@ describe("PluginActionAuditService", () => {
         },
       ],
     });
-    const svc = new PluginActionAuditService(seeded.saveConfig, seeded.readConfig);
+    const svc = new PluginActionAuditService(seeded.saveConfig, seeded.readConfig, seeded.logStore);
     const records = svc.getRecords();
     expect(records).toHaveLength(1);
     expect(records[0]!.actionId).toBe("seeded");

--- a/electron/services/forge/__tests__/auditLog.test.ts
+++ b/electron/services/forge/__tests__/auditLog.test.ts
@@ -11,8 +11,17 @@ function makeFixture(initialConfig: Record<string, unknown> = {}) {
   const saveConfig = vi.fn((patch: Record<string, unknown>) => {
     Object.assign(config, patch);
   });
-  const service = new ForgeAuditService(saveConfig, () => config);
-  return { service, saveConfig, config };
+  // The ring is kept under the same `auditLog` key so seeding reads
+  // naturally, but it round-trips through the injected log store (the real
+  // ring lives in the audit-logs store since migration023).
+  const writeRing = vi.fn((records: unknown[]) => {
+    config.auditLog = records;
+  });
+  const service = new ForgeAuditService(saveConfig, () => config, {
+    read: () => config.auditLog,
+    write: writeRing,
+  });
+  return { service, saveConfig, writeRing, config };
 }
 
 function append(
@@ -118,24 +127,27 @@ describe("ForgeAuditService flush", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => vi.useRealTimers());
 
-  it("debounces flush to a single saveConfig call", () => {
-    const { service, saveConfig } = makeFixture();
+  it("debounces flush to a single ring write and never touches config flags", () => {
+    const { service, saveConfig, writeRing } = makeFixture();
     append(service);
     append(service);
     append(service);
-    expect(saveConfig).not.toHaveBeenCalled();
+    expect(writeRing).not.toHaveBeenCalled();
     vi.advanceTimersByTime(2000);
-    expect(saveConfig).toHaveBeenCalledTimes(1);
-    expect(saveConfig.mock.calls[0]![0]).toHaveProperty("auditLog");
+    expect(writeRing).toHaveBeenCalledTimes(1);
+    expect(writeRing.mock.calls[0]![0]).toHaveLength(3);
+    expect(saveConfig).not.toHaveBeenCalled();
   });
 
   it("swallows flush errors to console.error instead of rethrowing", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const config: Record<string, unknown> = { auditEnabled: true, auditMaxRecords: 500 };
-    const saveConfig = vi.fn(() => {
-      throw new Error("disk full");
+    const service = new ForgeAuditService(vi.fn(), () => config, {
+      read: () => undefined,
+      write: () => {
+        throw new Error("disk full");
+      },
     });
-    const service = new ForgeAuditService(saveConfig, () => config);
     append(service);
     expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
     expect(errSpy).toHaveBeenCalled();

--- a/electron/services/forge/__tests__/forgeAuditService.test.ts
+++ b/electron/services/forge/__tests__/forgeAuditService.test.ts
@@ -15,7 +15,10 @@ const storeMock = vi.hoisted(() => {
   };
 });
 
-vi.mock("../../../store.js", () => ({ store: storeMock }));
+vi.mock("../../../store.js", () => ({
+  store: storeMock,
+  auditLogsStore: { get: vi.fn(), set: vi.fn() },
+}));
 
 import { auditForgeCall, forgeAuditService } from "../forgeAuditService.js";
 

--- a/electron/services/forge/auditLog.ts
+++ b/electron/services/forge/auditLog.ts
@@ -91,6 +91,17 @@ export function summarizeForgeArgs(
   }
 }
 
+/**
+ * Persistence boundary for the ring buffer itself. Config flags stay behind
+ * `saveConfig`/`readConfig` (the `forgeAudit` config.json slice); the ring
+ * lives in the dedicated audit-logs store (migration023). Injected so this
+ * class stays store-free and unit-testable.
+ */
+export interface ForgeAuditLogStore {
+  read(): unknown;
+  write(records: ForgeAuditRecord[]): void;
+}
+
 export class ForgeAuditService {
   private records: ForgeAuditRecord[] = [];
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -105,14 +116,15 @@ export class ForgeAuditService {
 
   constructor(
     private readonly saveConfig: (patch: Record<string, unknown>) => void,
-    private readonly readConfig: () => Record<string, unknown>
+    private readonly readConfig: () => Record<string, unknown>,
+    private readonly logStore: ForgeAuditLogStore
   ) {}
 
   hydrate(): void {
     if (this.hydrated) return;
-    const config = this.readConfig();
-    const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
-    const cap = this.normalizeMaxRecords(config.auditMaxRecords);
+    const stored = this.logStore.read();
+    const persisted = Array.isArray(stored) ? stored : [];
+    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     const safe = persisted.filter(
       (r: unknown): r is Record<string, unknown> => r !== null && typeof r === "object"
     );
@@ -145,7 +157,10 @@ export class ForgeAuditService {
     argsSummary?: string;
     errorMessage?: string;
   }): void {
-    if (this.readConfig().auditEnabled === false) return;
+    // Single config read per append — the same result gates the kill switch
+    // and supplies the trim cap.
+    const config = this.readConfig();
+    if (config.auditEnabled === false) return;
     this.hydrate();
 
     const record: ForgeAuditRecord = {
@@ -163,12 +178,11 @@ export class ForgeAuditService {
     if (input.argsSummary !== undefined) record.argsSummary = input.argsSummary;
     if (input.errorMessage !== undefined) record.errorMessage = input.errorMessage;
 
-    this.enqueueAndTrim(record);
+    this.enqueueAndTrim(record, this.normalizeMaxRecords(config.auditMaxRecords));
   }
 
-  private enqueueAndTrim(record: ForgeAuditRecord): void {
+  private enqueueAndTrim(record: ForgeAuditRecord, cap: number): void {
     this.records.push(record);
-    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     if (this.records.length > cap) {
       this.records.splice(0, this.records.length - cap);
     }
@@ -362,7 +376,7 @@ export class ForgeAuditService {
   private flush(): void {
     if (!this.hydrated) return;
     try {
-      this.saveConfig({ auditLog: [...this.records] });
+      this.logStore.write([...this.records]);
     } catch (err) {
       console.error("[Forge] Failed to flush audit log:", err);
     }

--- a/electron/services/forge/forgeAuditService.ts
+++ b/electron/services/forge/forgeAuditService.ts
@@ -1,13 +1,9 @@
 // eager-import-allow: reads/writes the forgeAudit store key via store.get/set inside the audit callbacks, invoked from forge IPC handlers (not at boot)
-import type {
-  ForgeAuditRecord,
-  ForgeAuditResult,
-  ForgeProviderMethodName,
-} from "../../../shared/types/ipc/forge.js";
+import type { ForgeAuditResult, ForgeProviderMethodName } from "../../../shared/types/ipc/forge.js";
 import { FORGE_AUDIT_DEFAULT_MAX_RECORDS } from "../../../shared/types/ipc/forge.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
-import { store } from "../../store.js";
-import { ForgeAuditService } from "./auditLog.js";
+import { auditLogsStore, store } from "../../store.js";
+import { ForgeAuditService, type ForgeAuditLogStore } from "./auditLog.js";
 
 export { summarizeForgeArgs } from "./auditLog.js";
 
@@ -31,19 +27,26 @@ function getConfig(): Record<string, unknown> {
 }
 
 function persistConfig(patch: Record<string, unknown>): void {
-  // Known-key merge guard mirrors `McpServerService.persistConfig`: a partial
-  // patch (e.g. `{ auditEnabled }`) must never drop the persisted `auditLog`.
+  // Flags only — the ring is persisted via `forgeAuditLogStore` since
+  // migration023. The spread merge keeps a legacy `auditLog` carryover intact
+  // for installs where the migration deferred (audit-logs store not durable).
   const current = store.get("forgeAudit") ?? FORGE_AUDIT_CONFIG_DEFAULTS;
-  store.set("forgeAudit", {
-    ...current,
-    ...patch,
-    auditLog: ("auditLog" in patch ? patch.auditLog : current.auditLog) as
-      | ForgeAuditRecord[]
-      | undefined,
-  });
+  store.set("forgeAudit", { ...current, ...patch });
 }
 
-export const forgeAuditService = new ForgeAuditService(persistConfig, getConfig);
+// Persists the ring in the dedicated audit-logs store so config.json stays
+// small and audit appends never re-serialize it. `auditEnabled` /
+// `auditMaxRecords` stay in config.json (`forgeAudit`).
+const forgeAuditLogStore: ForgeAuditLogStore = {
+  read: () => auditLogsStore.get("forgeAuditLog"),
+  write: (records) => auditLogsStore.set("forgeAuditLog", records),
+};
+
+export const forgeAuditService = new ForgeAuditService(
+  persistConfig,
+  getConfig,
+  forgeAuditLogStore
+);
 
 /**
  * Time and audit a single forge-provider method call. Wraps only the provider

--- a/electron/services/migrations/023-audit-rings-to-audit-logs-store.ts
+++ b/electron/services/migrations/023-audit-rings-to-audit-logs-store.ts
@@ -1,0 +1,63 @@
+import type { Migration } from "../StoreMigrations.js";
+import { auditLogsStore } from "../../store.js";
+
+/**
+ * Move the four remaining ring buffers out of config.json into the dedicated
+ * lazily-constructed audit-logs store, completing what migration022 started
+ * for the MCP rings. The rings dominate config.json size, which bootstrap
+ * reads/parses synchronously and the store cache snapshots whole — boot and
+ * write cost scaled with audit volume. Config flags (`auditEnabled`,
+ * `auditMaxRecords`) intentionally stay in config.json.
+ */
+const RING_MOVES = [
+  { sourceKey: "plugins", ringKey: "auditLog", targetKey: "pluginAuditLog" },
+  { sourceKey: "forgeAudit", ringKey: "auditLog", targetKey: "forgeAuditLog" },
+  { sourceKey: "runHistory", ringKey: "records", targetKey: "runHistoryRecords" },
+  { sourceKey: "pluginMcpAudit", ringKey: "auditLog", targetKey: "pluginMcpAuditLog" },
+] as const;
+
+export const migration023: Migration = {
+  version: 23,
+  description: "Move plugin, forge, run-history, and plugin-MCP rings to the audit-logs store",
+  up: (store) => {
+    const get = store.get.bind(store) as (key: string) => unknown;
+    const set = store.set.bind(store) as (key: string, value: unknown) => void;
+
+    const pending = RING_MOVES.filter((move) => {
+      const slice = get(move.sourceKey);
+      return slice !== null && typeof slice === "object" && move.ringKey in slice;
+    });
+    if (pending.length === 0) return;
+
+    // path === "" means the audit-logs store fell back to in-memory — moving
+    // the rings there and stripping the config.json keys would silently lose
+    // them on the next restart. Leave the data in place instead; throwing here
+    // would trip StoreMigrations' restore-from-backup path, which is worse
+    // than deferring the move for diagnostics data.
+    if (auditLogsStore.path === "") {
+      console.warn(
+        "[Migrations] audit-logs store is not durable; leaving audit rings in config.json"
+      );
+      return;
+    }
+
+    for (const move of pending) {
+      const slice = get(move.sourceKey) as Record<string, unknown>;
+      const { [move.ringKey]: ring, ...rest } = slice;
+
+      if (Array.isArray(ring) && ring.length > 0) {
+        const existing = auditLogsStore.get(move.targetKey);
+        // Rings are oldest-first; migrated config.json records predate anything
+        // already in the audit-logs store, so they go first.
+        auditLogsStore.set(move.targetKey, [
+          ...ring,
+          ...(Array.isArray(existing) ? existing : []),
+        ] as never);
+      }
+
+      // Rebuild without the moved key so it's dropped from the persisted
+      // object (electron-store delete only handles top-level keys).
+      set(move.sourceKey, rest);
+    }
+  },
+};

--- a/electron/services/migrations/023-audit-rings-to-audit-logs-store.ts
+++ b/electron/services/migrations/023-audit-rings-to-audit-logs-store.ts
@@ -47,12 +47,27 @@ export const migration023: Migration = {
 
       if (Array.isArray(ring) && ring.length > 0) {
         const existing = auditLogsStore.get(move.targetKey);
-        // Rings are oldest-first; migrated config.json records predate anything
-        // already in the audit-logs store, so they go first.
-        auditLogsStore.set(move.targetKey, [
-          ...ring,
-          ...(Array.isArray(existing) ? existing : []),
-        ] as never);
+        const existingRecords = Array.isArray(existing) ? existing : [];
+        // Idempotency guard for partial-failure retries: if a previous run
+        // copied this ring but failed before stripping the source key (or a
+        // later migration failed and config.json was restored from backup),
+        // the records are already in the audit-logs store — prepending again
+        // would duplicate them. Every ring record carries a unique `id`.
+        const firstId = (ring[0] as { id?: unknown }).id;
+        const alreadyMigrated =
+          typeof firstId === "string" &&
+          existingRecords.some((record) => (record as { id?: unknown })?.id === firstId);
+        if (!alreadyMigrated) {
+          // Rings are oldest-first; migrated config.json records predate
+          // anything already in the audit-logs store, so they go first.
+          auditLogsStore.set(move.targetKey, [...ring, ...existingRecords] as never);
+        }
+      } else if (ring !== undefined && !Array.isArray(ring)) {
+        // Corrupt (non-array) ring value — it is about to be stripped without
+        // a copy; leave a trace so the discard isn't silent.
+        console.warn(
+          `[Migrations] Dropping corrupt non-array ring at ${move.sourceKey}.${move.ringKey}`
+        );
       }
 
       // Rebuild without the moved key so it's dropped from the persisted

--- a/electron/services/migrations/__tests__/023-audit-rings-to-audit-logs-store.test.ts
+++ b/electron/services/migrations/__tests__/023-audit-rings-to-audit-logs-store.test.ts
@@ -173,9 +173,7 @@ describe("migration023 — audit rings to audit-logs store", () => {
 
     expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
     expect("records" in (data.runHistory as object)).toBe(false);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("runHistory.records")
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("runHistory.records"));
     warnSpy.mockRestore();
   });
 

--- a/electron/services/migrations/__tests__/023-audit-rings-to-audit-logs-store.test.ts
+++ b/electron/services/migrations/__tests__/023-audit-rings-to-audit-logs-store.test.ts
@@ -143,6 +143,42 @@ describe("migration023 — audit rings to audit-logs store", () => {
     warnSpy.mockRestore();
   });
 
+  it("does not duplicate records when retried after a partial failure", () => {
+    // Simulates a prior run that copied the ring to the audit-logs store but
+    // failed before stripping the source key (or config.json was restored
+    // from backup after a later migration failed).
+    auditLogsStoreMock.get.mockImplementation((key: string) =>
+      key === "pluginAuditLog" ? [pluginRecord] : []
+    );
+    const data: Record<string, unknown> = {
+      plugins: { auditEnabled: true, auditLog: [pluginRecord] },
+    };
+    const store = makeStoreMock(data);
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    // The source key is still stripped so the retry completes the move.
+    expect("auditLog" in (data.plugins as object)).toBe(false);
+  });
+
+  it("warns and strips a corrupt non-array ring without writing to the audit-logs store", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const data: Record<string, unknown> = {
+      runHistory: { records: "corrupt-string" },
+    };
+    const store = makeStoreMock(data);
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    expect("records" in (data.runHistory as object)).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("runHistory.records")
+    );
+    warnSpy.mockRestore();
+  });
+
   it("tolerates a corrupt audit-logs store value when merging", () => {
     auditLogsStoreMock.get.mockReturnValue("not-an-array");
     const store = makeStoreMock({ runHistory: { records: [runRecord] } });

--- a/electron/services/migrations/__tests__/023-audit-rings-to-audit-logs-store.test.ts
+++ b/electron/services/migrations/__tests__/023-audit-rings-to-audit-logs-store.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { migration023 } from "../023-audit-rings-to-audit-logs-store.js";
+
+const auditLogsStoreMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  path: "/tmp/audit-logs.json",
+}));
+
+vi.mock("../../../store.js", () => ({
+  auditLogsStore: auditLogsStoreMock,
+}));
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    delete: vi.fn((key: string) => {
+      delete data[key];
+    }),
+  } as unknown as Parameters<typeof migration023.up>[0];
+}
+
+const pluginRecord = { id: "plugin-1", ts: 1000, pluginId: "acme", actionId: "acme.go" };
+const forgeRecord = { id: "forge-1", timestamp: 2000, providerId: "builtin.github" };
+const runRecord = { id: "run-1", kind: "recipe", timestamp: 3000 };
+const mcpRecord = { id: "mcp-1", ts: 4000, pluginId: "acme", serverId: "main" };
+
+describe("migration023 — audit rings to audit-logs store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auditLogsStoreMock.path = "/tmp/audit-logs.json";
+    auditLogsStoreMock.get.mockReturnValue([]);
+  });
+
+  it("moves all four rings to the audit-logs store and strips the old keys", () => {
+    const data: Record<string, unknown> = {
+      plugins: {
+        disabled: [],
+        auditEnabled: true,
+        auditMaxRecords: 500,
+        auditLog: [pluginRecord],
+        installed: {},
+      },
+      forgeAudit: { auditEnabled: true, auditMaxRecords: 500, auditLog: [forgeRecord] },
+      runHistory: { records: [runRecord] },
+      pluginMcpAudit: { auditEnabled: true, auditMaxRecords: 500, auditLog: [mcpRecord] },
+    };
+    const store = makeStoreMock(data);
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("pluginAuditLog", [pluginRecord]);
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("forgeAuditLog", [forgeRecord]);
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("runHistoryRecords", [runRecord]);
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("pluginMcpAuditLog", [mcpRecord]);
+
+    expect("auditLog" in (data.plugins as object)).toBe(false);
+    expect("auditLog" in (data.forgeAudit as object)).toBe(false);
+    expect("records" in (data.runHistory as object)).toBe(false);
+    expect("auditLog" in (data.pluginMcpAudit as object)).toBe(false);
+
+    // Config flags stay in config.json.
+    expect(data.plugins).toMatchObject({ disabled: [], auditEnabled: true, auditMaxRecords: 500 });
+    expect(data.forgeAudit).toMatchObject({ auditEnabled: true, auditMaxRecords: 500 });
+    expect(data.pluginMcpAudit).toMatchObject({ auditEnabled: true, auditMaxRecords: 500 });
+  });
+
+  it("prepends migrated records before any already in the audit-logs store", () => {
+    const existing = [{ ...pluginRecord, id: "newer-1", ts: 9000 }];
+    auditLogsStoreMock.get.mockImplementation((key: string) =>
+      key === "pluginAuditLog" ? [...existing] : []
+    );
+    const store = makeStoreMock({ plugins: { auditLog: [pluginRecord] } });
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("pluginAuditLog", [
+      pluginRecord,
+      ...existing,
+    ]);
+  });
+
+  it("strips empty-array rings without writing to the audit-logs store", () => {
+    const data: Record<string, unknown> = {
+      plugins: { auditEnabled: true, auditLog: [] },
+      runHistory: { records: [] },
+    };
+    const store = makeStoreMock(data);
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    expect("auditLog" in (data.plugins as object)).toBe(false);
+    expect("records" in (data.runHistory as object)).toBe(false);
+    expect((data.plugins as Record<string, unknown>).auditEnabled).toBe(true);
+  });
+
+  it("migrates a partial set when only some slices carry a ring", () => {
+    const data: Record<string, unknown> = {
+      plugins: { auditEnabled: true },
+      forgeAudit: { auditEnabled: true, auditLog: [forgeRecord] },
+    };
+    const store = makeStoreMock(data);
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).toHaveBeenCalledTimes(1);
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("forgeAuditLog", [forgeRecord]);
+    // Untouched slices are not rewritten.
+    const setMock = (store as unknown as { set: ReturnType<typeof vi.fn> }).set;
+    expect(setMock).toHaveBeenCalledTimes(1);
+    expect(setMock).toHaveBeenCalledWith("forgeAudit", { auditEnabled: true });
+  });
+
+  it("leaves everything untouched when no ring key is present", () => {
+    const store = makeStoreMock({
+      plugins: { disabled: [], auditEnabled: true },
+      forgeAudit: { auditEnabled: true },
+      runHistory: {},
+      pluginMcpAudit: { auditEnabled: true },
+    });
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    expect((store as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+  });
+
+  it("defers the move when the audit-logs store is not durable", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    auditLogsStoreMock.path = "";
+    const data: Record<string, unknown> = { plugins: { auditLog: [pluginRecord] } };
+    const store = makeStoreMock(data);
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).not.toHaveBeenCalled();
+    expect((store as unknown as { set: ReturnType<typeof vi.fn> }).set).not.toHaveBeenCalled();
+    expect((data.plugins as Record<string, unknown>).auditLog).toEqual([pluginRecord]);
+    warnSpy.mockRestore();
+  });
+
+  it("tolerates a corrupt audit-logs store value when merging", () => {
+    auditLogsStoreMock.get.mockReturnValue("not-an-array");
+    const store = makeStoreMock({ runHistory: { records: [runRecord] } });
+
+    migration023.up(store);
+
+    expect(auditLogsStoreMock.set).toHaveBeenCalledWith("runHistoryRecords", [runRecord]);
+  });
+
+  it("has version 23", () => {
+    expect(migration023.version).toBe(23);
+  });
+});

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -19,6 +19,7 @@ import { migration019 } from "./019-remove-fleet-deck-open.js";
 import { migration020 } from "./020-window-states-store.js";
 import { migration021 } from "./021-merge-disabled-plugins.js";
 import { migration022 } from "./022-audit-logs-store.js";
+import { migration023 } from "./023-audit-rings-to-audit-logs-store.js";
 
 export const migrations: Migration[] = [
   migration002,
@@ -42,4 +43,5 @@ export const migrations: Migration[] = [
   migration020,
   migration021,
   migration022,
+  migration023,
 ];

--- a/electron/services/plugin-mcp/PluginMcpAuditService.ts
+++ b/electron/services/plugin-mcp/PluginMcpAuditService.ts
@@ -62,6 +62,17 @@ export interface PluginMcpAuditInput {
  *   over the raw bytes (no ANSI/Markdown stripping) so a rug-pull payload
  *   hidden in invisible Unicode still flips the digest.
  */
+/**
+ * Persistence boundary for the ring buffer itself. Config flags stay behind
+ * `saveConfig`/`readConfig` (the `pluginMcpAudit` config.json slice); the ring
+ * lives in the dedicated audit-logs store (migration023). Injected so this
+ * class stays store-free and unit-testable.
+ */
+export interface PluginMcpAuditLogStore {
+  read(): unknown;
+  write(records: PluginMcpAuditRecord[]): void;
+}
+
 export class PluginMcpAuditService {
   private records: PluginMcpAuditRecord[] = [];
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -69,11 +80,15 @@ export class PluginMcpAuditService {
 
   constructor(
     private readonly saveConfig: (patch: Record<string, unknown>) => void,
-    private readonly readConfig: () => Record<string, unknown>
+    private readonly readConfig: () => Record<string, unknown>,
+    private readonly logStore: PluginMcpAuditLogStore
   ) {}
 
   append(input: PluginMcpAuditInput): void {
-    if (this.readConfig().auditEnabled === false) return;
+    // Single config read per append — the same result gates the kill switch
+    // and supplies the trim cap.
+    const config = this.readConfig();
+    if (config.auditEnabled === false) return;
     this.hydrate();
 
     const tool_description_sha = sha256Hex(input.descriptionRaw);
@@ -102,14 +117,14 @@ export class PluginMcpAuditService {
     if (input.consentDecision !== undefined) record.consentDecision = input.consentDecision;
     if (input.errorCode !== undefined) record.errorCode = input.errorCode;
 
-    this.enqueueAndTrim(record);
+    this.enqueueAndTrim(record, this.normalizeMaxRecords(config.auditMaxRecords));
   }
 
   hydrate(): void {
     if (this.hydrated) return;
-    const config = this.readConfig();
-    const persisted = Array.isArray(config.auditLog) ? config.auditLog : [];
-    const cap = this.normalizeMaxRecords(config.auditMaxRecords);
+    const stored = this.logStore.read();
+    const persisted = Array.isArray(stored) ? stored : [];
+    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     const safe: PluginMcpAuditRecord[] = [];
     for (const raw of persisted) {
       const record = pickKnownAuditFields(raw);
@@ -127,9 +142,8 @@ export class PluginMcpAuditService {
     return n;
   }
 
-  private enqueueAndTrim(record: PluginMcpAuditRecord): void {
+  private enqueueAndTrim(record: PluginMcpAuditRecord, cap: number): void {
     this.records.push(record);
-    const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
     if (this.records.length > cap) {
       this.records.splice(0, this.records.length - cap);
     }
@@ -148,7 +162,7 @@ export class PluginMcpAuditService {
   private flush(): void {
     if (!this.hydrated) return;
     try {
-      this.saveConfig({ auditLog: [...this.records] });
+      this.logStore.write([...this.records]);
     } catch (err) {
       console.error("[PluginMcpAudit] Failed to flush audit log:", err);
     }

--- a/electron/services/plugin-mcp/__tests__/PluginMcpAuditService.test.ts
+++ b/electron/services/plugin-mcp/__tests__/PluginMcpAuditService.test.ts
@@ -9,6 +9,16 @@ function makeConfig(initial: Record<string, unknown> = {}) {
     },
     read: () => config,
     raw: () => config,
+    // The ring is kept under the same `auditLog` key so seeding and
+    // assertions read naturally, but it round-trips through the injected
+    // log store (the real ring lives in the audit-logs store since
+    // migration023).
+    logStore: {
+      read: () => config.auditLog,
+      write: (records: unknown[]) => {
+        config = { ...config, auditLog: records };
+      },
+    },
   };
 }
 
@@ -18,7 +28,7 @@ describe("PluginMcpAuditService", () => {
 
   beforeEach(() => {
     cfg = makeConfig();
-    service = new PluginMcpAuditService(cfg.save, cfg.read);
+    service = new PluginMcpAuditService(cfg.save, cfg.read, cfg.logStore);
   });
 
   afterEach(() => {
@@ -171,7 +181,7 @@ describe("PluginMcpAuditService", () => {
       descriptionRaw: "SHOULD_BE_DROPPED",
     };
     const cfgTampered = makeConfig({ auditLog: [tampered] });
-    const rebuilt = new PluginMcpAuditService(cfgTampered.save, cfgTampered.read);
+    const rebuilt = new PluginMcpAuditService(cfgTampered.save, cfgTampered.read, cfgTampered.logStore);
     rebuilt.hydrate();
     // Append a record to trigger a flush, then check the persisted JSON.
     rebuilt.append({

--- a/electron/services/plugin-mcp/__tests__/PluginMcpAuditService.test.ts
+++ b/electron/services/plugin-mcp/__tests__/PluginMcpAuditService.test.ts
@@ -181,7 +181,11 @@ describe("PluginMcpAuditService", () => {
       descriptionRaw: "SHOULD_BE_DROPPED",
     };
     const cfgTampered = makeConfig({ auditLog: [tampered] });
-    const rebuilt = new PluginMcpAuditService(cfgTampered.save, cfgTampered.read, cfgTampered.logStore);
+    const rebuilt = new PluginMcpAuditService(
+      cfgTampered.save,
+      cfgTampered.read,
+      cfgTampered.logStore
+    );
     rebuilt.hydrate();
     // Append a record to trigger a flush, then check the persisted JSON.
     rebuilt.append({

--- a/electron/services/plugin-mcp/instances.ts
+++ b/electron/services/plugin-mcp/instances.ts
@@ -1,5 +1,5 @@
 // eager-import-allow: lazily wires the plugin-MCP consent + audit services to the synchronous electron-store slices on first use (mirrors PluginActionAuditService)
-import { store } from "../../store.js";
+import { auditLogsStore, store } from "../../store.js";
 import { PluginMcpAuditService } from "./PluginMcpAuditService.js";
 import { PluginMcpConsentService } from "./PluginMcpConsentService.js";
 import { PluginMcpConsentStore } from "./PluginMcpConsentStore.js";
@@ -9,10 +9,12 @@ let consentStoreInstance: PluginMcpConsentStore | null = null;
 let consentServiceInstance: PluginMcpConsentService | null = null;
 
 /**
- * Plugin-MCP inbound audit log singleton. Wired to the `pluginMcpAudit`
- * electron-store slice. The store key was added in #9234 alongside this
- * service; reading via `?? {}` defends against forward-compat replays where
- * an older schema version omits the slice.
+ * Plugin-MCP inbound audit log singleton. Config flags are wired to the
+ * `pluginMcpAudit` electron-store slice (reading via `?? {}` defends against
+ * forward-compat replays where an older schema version omits the slice); the
+ * ring itself lives in the audit-logs store since migration023. The spread
+ * merge keeps a legacy `pluginMcpAudit.auditLog` carryover intact for
+ * installs where the migration deferred (audit-logs store not durable).
  */
 export function getPluginMcpAuditService(): PluginMcpAuditService {
   if (!auditInstance) {
@@ -21,7 +23,11 @@ export function getPluginMcpAuditService(): PluginMcpAuditService {
         const current = (store.get("pluginMcpAudit") ?? {}) as Record<string, unknown>;
         store.set("pluginMcpAudit", { ...current, ...patch });
       },
-      () => (store.get("pluginMcpAudit") ?? {}) as Record<string, unknown>
+      () => (store.get("pluginMcpAudit") ?? {}) as Record<string, unknown>,
+      {
+        read: () => auditLogsStore.get("pluginMcpAuditLog"),
+        write: (records) => auditLogsStore.set("pluginMcpAuditLog", records),
+      }
     );
   }
   return auditInstance;

--- a/electron/services/runHistory/runHistoryService.ts
+++ b/electron/services/runHistory/runHistoryService.ts
@@ -1,8 +1,8 @@
-// eager-import-allow: reads/writes the runHistory store key via store.get/set inside the persistence callbacks, invoked from runHistory IPC handlers (not at boot)
+// eager-import-allow: reads/writes the run-history ring via the lazy audit-logs store inside the persistence callbacks, invoked from runHistory IPC handlers (not at boot)
 import type { RunHistoryRecord } from "../../../shared/types/ipc/runHistory.js";
 import { CHANNELS } from "../../ipc/channels.js";
 import { broadcastToRenderer } from "../../ipc/utils.js";
-import { store } from "../../store.js";
+import { auditLogsStore } from "../../store.js";
 import { RunHistoryLog } from "./runHistoryLog.js";
 
 /**
@@ -10,17 +10,15 @@ import { RunHistoryLog } from "./runHistoryLog.js";
  * window's renderer, so the ring accumulates cross-window — a module-level
  * singleton, never per-window. The pure {@link RunHistoryLog} class lives in
  * `runHistoryLog.ts` (store-free, unit-testable); this thin wrapper wires it to
- * the `runHistory` store key, mirroring `forgeAuditService`.
+ * the audit-logs store (migration023 moved the ring out of config.json),
+ * mirroring `forgeAuditService`.
  */
 function readRecords(): unknown {
-  // Defensive `?? {}`: the store default always supplies `runHistory`, but a
-  // test harness mocking the store may not — readRecords must never throw.
-  const config = (store.get("runHistory") as { records?: unknown } | undefined) ?? {};
-  return config.records;
+  return auditLogsStore.get("runHistoryRecords");
 }
 
 function saveRecords(records: RunHistoryRecord[]): void {
-  store.set("runHistory", { records });
+  auditLogsStore.set("runHistoryRecords", records);
 }
 
 export const runHistoryLog = new RunHistoryLog(saveRecords, readRecords);

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -52,6 +52,10 @@ interface WindowStatesStoreSchema {
 interface AuditLogsStoreSchema {
   mcpAuditLog: McpLogRecord[];
   mcpTurnOutcomeLog: AssistantTurnRecord[];
+  pluginAuditLog: PluginActionAuditRecord[];
+  forgeAuditLog: ForgeAuditRecord[];
+  runHistoryRecords: RunHistoryRecord[];
+  pluginMcpAuditLog: PluginMcpAuditRecord[];
 }
 
 export interface StoreSchema {
@@ -358,7 +362,7 @@ export interface StoreSchema {
     auditEnabled: boolean;
     /** Ring-buffer cap for persisted plugin-action audit records. */
     auditMaxRecords: number;
-    /** Persisted plugin-action audit ring buffer (oldest-first). */
+    /** @deprecated Moved to the audit-logs store by migration023. Read-only carryover. */
     auditLog?: PluginActionAuditRecord[];
     installed: Record<string, InstalledPluginRecord>;
   };
@@ -393,6 +397,7 @@ export interface StoreSchema {
   forgeAudit: {
     auditEnabled: boolean;
     auditMaxRecords: number;
+    /** @deprecated Moved to the audit-logs store by migration023. Read-only carryover. */
     auditLog?: ForgeAuditRecord[];
   };
   /**
@@ -404,6 +409,7 @@ export interface StoreSchema {
    * electron-store) — the on-disk shape is owned by `RunHistoryLog`.
    */
   runHistory: {
+    /** @deprecated Moved to the audit-logs store by migration023. Read-only carryover. */
     records?: RunHistoryRecord[];
   };
   /**
@@ -417,6 +423,7 @@ export interface StoreSchema {
   pluginMcpAudit: {
     auditEnabled: boolean;
     auditMaxRecords: number;
+    /** @deprecated Moved to the audit-logs store by migration023. Read-only carryover. */
     auditLog?: PluginMcpAuditRecord[];
   };
   /**
@@ -605,9 +612,7 @@ const storeOptions = {
       auditEnabled: true,
       auditMaxRecords: FORGE_AUDIT_DEFAULT_MAX_RECORDS,
     },
-    runHistory: {
-      records: [],
-    },
+    runHistory: {},
     pluginMcpAudit: {
       auditEnabled: true,
       auditMaxRecords: PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS,
@@ -804,6 +809,57 @@ export function _resetPendingSettingsRecovery(): void {
 
 let storeInstance: Store<StoreSchema> | undefined;
 
+/**
+ * In-memory snapshot of the on-disk store. electron-store v11 (conf) has no
+ * cache of its own — every `get()` re-reads and re-parses config.json from
+ * disk. The proxy below populates this snapshot lazily on the first read and
+ * serves all subsequent reads from memory, invalidating synchronously BEFORE
+ * any mutation is delegated (main is single-threaded, so a pre-write snapshot
+ * can never be served after the write — cf. the agentSettingsClient
+ * write-window precedent). Only the main process writes config.json (the
+ * pty-host and workspace-host subprocesses never import this module), so no
+ * cross-process invalidation channel is needed.
+ */
+let storeValueCache: Record<string, unknown> | null = null;
+
+/**
+ * Drop the cached store snapshot. The proxy invalidates automatically for all
+ * mutations routed through it; this export exists for the rare paths that
+ * replace config.json behind electron-store's back (MigrationRunner's
+ * restore-from-backup file swap) and for tests.
+ */
+export function invalidateStoreValueCache(): void {
+  storeValueCache = null;
+}
+
+/** Dot-path lookup mirroring conf's `accessPropertiesByDotNotation` reads. */
+function getCachedValue(snapshot: Record<string, unknown>, key: string): unknown {
+  let node: unknown = snapshot;
+  for (const part of key.split(".")) {
+    if (node === null || typeof node !== "object" || !Object.hasOwn(node, part)) {
+      return undefined;
+    }
+    node = (node as Record<string, unknown>)[part];
+  }
+  return node;
+}
+
+/**
+ * Refreshing the `.bak` copy (and tightening its permissions) is recovery
+ * housekeeping, not boot-critical work — but it ran synchronously inside
+ * `initializeStore()` on the bootstrap critical path. `initializeStore()` now
+ * stashes the work here and `bootstrap.ts` schedules it after main.js has
+ * loaded. Until it runs, the previous session's `.bak` remains valid for
+ * corrupt-config recovery, so the deferral window loses nothing.
+ */
+let deferredBackupTask: (() => void) | null = null;
+
+export function runDeferredStoreBackup(): void {
+  const task = deferredBackupTask;
+  deferredBackupTask = null;
+  task?.();
+}
+
 export function initializeStore(options: typeof storeOptions = storeOptions): Store<StoreSchema> {
   if (storeInstance) return storeInstance;
 
@@ -845,13 +901,21 @@ export function initializeStore(options: typeof storeOptions = storeOptions): St
       if (pendingSettingsRecovery === null) {
         pendingSettingsRecovery = { kind: "reset-to-defaults" };
       }
-    } else {
-      refreshBackup(created.path);
     }
     // Migrate existing 0o644 files (created before configFileMode landed) to
-    // 0o600 even when the user never triggers a write this session.
+    // 0o600 even when the user never triggers a write this session. The live
+    // config carries secrets, so this stays synchronous; the .bak refresh and
+    // its chmod are deferred off the boot path (see runDeferredStoreBackup).
     tightenFilePermissions(created.path);
-    tightenFilePermissions(`${created.path}.bak`);
+    const configFilePath = created.path;
+    deferredBackupTask = () => {
+      // Wipe detection above means the on-disk config no longer reflects the
+      // user's data — never overwrite the last-good .bak with it.
+      if (!wipedDuringConstruction) {
+        refreshBackup(configFilePath);
+      }
+      tightenFilePermissions(`${configFilePath}.bak`);
+    };
     storeInstance = created;
     return created;
   } catch (error) {
@@ -865,6 +929,8 @@ export function initializeStore(options: typeof storeOptions = storeOptions): St
 
 export function _resetStoreInstance(): void {
   storeInstance = undefined;
+  storeValueCache = null;
+  deferredBackupTask = null;
 }
 
 export function _peekStoreInstance(): Store<StoreSchema> | undefined {
@@ -926,15 +992,49 @@ export function writeWslGitMap(
   store.set("wslGitByWorktree", safe);
 }
 
+/**
+ * Methods that mutate the backing file. The proxy nulls the value cache
+ * before delegating so a same-tick read after a write always re-snapshots.
+ * Every production write goes through this proxy — it is the module's only
+ * exported handle — so proxy-level invalidation is the primary (and
+ * sufficient) path; `invalidateStoreValueCache()` covers the lone file-swap
+ * bypass in MigrationRunner.
+ */
+const STORE_MUTATING_METHODS = new Set(["set", "delete", "clear", "reset"]);
+
 export const store = new Proxy({} as Store<StoreSchema>, {
   get(_target, prop) {
     const instance = getOrLazyInitInstance();
     const value = Reflect.get(instance as object, prop, instance);
-    return typeof value === "function"
-      ? (value as (...args: unknown[]) => unknown).bind(instance)
-      : value;
+    if (typeof value !== "function") return value;
+    const bound = (value as (...args: unknown[]) => unknown).bind(instance);
+    // Cached read path. Skipped for the in-memory fallback (path === ""),
+    // whose Map-backed `store` property is always empty.
+    if (prop === "get" && instance.path !== "") {
+      return (key: string, defaultValue?: unknown) => {
+        if (storeValueCache === null) {
+          // One disk read + parse; every get until the next write is a memory hit.
+          storeValueCache = instance.store as unknown as Record<string, unknown>;
+        }
+        const resolved = getCachedValue(storeValueCache, key);
+        if (resolved === undefined) return defaultValue;
+        // conf returns a freshly-parsed object per get; clone so a caller
+        // mutating the returned value can't corrupt the shared snapshot.
+        return typeof resolved === "object" && resolved !== null
+          ? structuredClone(resolved)
+          : resolved;
+      };
+    }
+    if (STORE_MUTATING_METHODS.has(prop as string)) {
+      return (...args: unknown[]) => {
+        storeValueCache = null;
+        return bound(...args);
+      };
+    }
+    return bound;
   },
   set(_target, prop, value) {
+    storeValueCache = null;
     const instance = getOrLazyInitInstance();
     return Reflect.set(instance as object, prop, value, instance);
   },
@@ -1008,7 +1108,14 @@ function initializeAuditLogsStore(): Store<AuditLogsStoreSchema> {
     const created = new Store<AuditLogsStoreSchema>({
       name: "audit-logs",
       cwd: storeOptions.cwd,
-      defaults: { mcpAuditLog: [], mcpTurnOutcomeLog: [] },
+      defaults: {
+        mcpAuditLog: [],
+        mcpTurnOutcomeLog: [],
+        pluginAuditLog: [],
+        forgeAuditLog: [],
+        runHistoryRecords: [],
+        pluginMcpAuditLog: [],
+      },
       clearInvalidConfig: true,
       configFileMode: 0o600,
     });


### PR DESCRIPTION
## Summary

- `electron-store` v11 (conf) has no in-memory cache — every `store.get()` re-read and re-parsed the ~35 KB `config.json` from disk, and every write cost 2 reads + 1 write on top of that.
- This adds a lazy whole-store snapshot to the main process store proxy in `electron/store.ts`, batches per-field `set` calls in `handleAppSetState` into a single merged write, reduces redundant config reads in the three audit services, moves the four remaining ring buffer keys to the lazy audit-logs store (migration 023), and shifts the `config.json.bak` refresh off the bootstrap critical path.

Resolves #10386

## Changes

- **`electron/store.ts`**: in-memory value cache on the store `Proxy`. Lazy whole-store snapshot on first `get`, dot-path reads from memory, `structuredClone` on object returns to preserve conf's fresh-object-per-get semantics, synchronous cache invalidation before `set`/`delete`/`clear`/`reset` delegates, bypassed for the in-memory fallback. `invalidateStoreValueCache()` exported and called from `MigrationRunner.restoreFromBackup` (the one path that swaps `config.json` behind electron-store's back).
- **`electron/ipc/handlers/app/state.ts`**: `handleAppSetState` batches N per-field `store.set` calls into one merged `appState` write; `undefined` values drop keys (electron-store throws on `undefined`).
- **`PluginActionAuditService` / `ForgeAuditService` / `PluginMcpAuditService`**: audit config read once per append rather than twice (kill-switch check + trim cap were separate reads).
- **Migration 023**: moves `plugins.auditLog`, `forgeAudit.auditLog`, `runHistory.records`, and `pluginMcpAudit.auditLog` to the lazy audit-logs store, mirroring migration 022. Services persist rings via injected `logStore` `{read, write}` (the MCP AuditService pattern). Config flags stay in `config.json`. Not-durable audit store defers the move. ID-based idempotency guard prevents double-prepend on partial-failure retry.
- **`electron/bootstrap.ts`**: `initializeStore` stashes `runDeferredStoreBackup()`; bootstrap schedules it via `setImmediate` after `main.js` loads. Previous session's `.bak` stays valid for recovery in the window; wipe-detection still suppresses the refresh.

## Testing

369 unit tests across 17 affected files pass. Scoped eslint clean; electron tsconfig and app.state-scoped root tsc clean; prettier normalized. Local CI gate skipped per request — GitHub CI validates.