### PR TITLE
perf(boot): consolidate renderer boot IPC round-trips

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../services/CrashRecoveryService.js", () => ({
 vi.mock("../../services/ProjectStore.js", () => ({
   projectStore: {
     getCurrentProject: vi.fn(() => null),
+    getAllProjects: vi.fn(() => []),
     getProjectById: vi.fn(() => null),
     getProjectStateWithRecovery: vi.fn(),
     saveProjectState: vi.fn(),

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -41,6 +41,7 @@ export const CHANNELS = {
   TERMINAL_GET_ALL: "terminal:get-all",
   TERMINAL_SEARCH_SEMANTIC_BUFFERS: "terminal:search-semantic-buffers",
   TERMINAL_RECONNECT: "terminal:reconnect",
+  TERMINAL_RECONNECT_BULK: "terminal:reconnect-bulk",
   TERMINAL_REPLAY_HISTORY: "terminal:replay-history",
   TERMINAL_GET_SERIALIZED_STATE: "terminal:get-serialized-state",
   TERMINAL_GET_SERIALIZED_STATES: "terminal:get-serialized-states",

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -44,6 +44,8 @@ import { consumePrefetchedHydrateResult } from "../../../services/prefetchHydrat
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { notifyAppViewPainted } from "../../../setup/deepLinkInstall.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
+import { getValidatedOverrides } from "../keybinding.js";
+import { loadSanitizedUserAgentRegistry } from "../../../services/UserAgentRegistryService.js";
 import type { HandlerDependencies, IpcContext } from "../../types.js";
 
 export function registerAppStateHandlers(deps?: HandlerDependencies): () => void {
@@ -98,6 +100,12 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
         // Crash-loop quarantine notifications are gated on safe mode; the
         // fast path runs only when safe mode is inactive, so clear the field.
         crashLoopStateRecovery: null,
+        // Ride-along synchronous reads not covered by the prefetch cache —
+        // always read fresh so the toolbar/bootstrap dedup never sees a stale
+        // snapshot from the hover-prefetch window.
+        projects: projectStore.getAllProjects(),
+        keybindingOverrides: getValidatedOverrides(),
+        userAgentRegistry: loadSanitizedUserAgentRegistry(),
       };
     }
 
@@ -445,6 +453,13 @@ export function registerAppStateHandlers(deps?: HandlerDependencies): () => void
       terminalSizes: terminalSizesToUse,
       draftInputs: draftInputsToUse,
       projectPresets: projectPresetsPromise ? await projectPresetsPromise : undefined,
+      // Folded into the payload so the Toolbar mount and the hydration
+      // bootstrap skip their standalone round-trips during the boot window
+      // (project:get-all / project:get-current, keybinding:get-overrides,
+      // user-agent-registry:get). All three are synchronous reads.
+      projects: projectStore.getAllProjects(),
+      keybindingOverrides: getValidatedOverrides(),
+      userAgentRegistry: loadSanitizedUserAgentRegistry(),
     };
   };
   handlers.push(typedHandleWithContext(CHANNELS.APP_HYDRATE, handleAppHydrate));

--- a/electron/ipc/handlers/keybinding.ts
+++ b/electron/ipc/handlers/keybinding.ts
@@ -9,7 +9,7 @@ import { exportProfile, importProfile } from "../../utils/keybindingProfileIO.js
 import type { ImportResult } from "../../utils/keybindingProfileIO.js";
 import { typedHandle, typedHandleWithContext } from "../utils.js";
 
-function getValidatedOverrides(): Record<string, string[]> {
+export function getValidatedOverrides(): Record<string, string[]> {
   const raw = store.get("keybindingOverrides.overrides");
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return {};

--- a/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.reconnectBulk.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+}));
+
+const mockIsHelpTerminal = vi.fn((_id: string) => false);
+
+vi.mock("../../../../services/AgentAvailabilityStore.js", () => ({
+  getAgentAvailabilityStore: () => ({
+    isHelpTerminal: mockIsHelpTerminal,
+  }),
+}));
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../../../channels.js";
+import { registerTerminalSnapshotHandlers } from "../snapshots.js";
+import type { HandlerDependencies } from "../../../types.js";
+
+type ReconnectBulkHandler = (
+  event: unknown,
+  terminalIds: string[]
+) => Promise<Record<string, { exists: boolean; id?: string; hasPty?: boolean }>>;
+
+function makeTerminal(id: string) {
+  return {
+    id,
+    projectId: "project-1",
+    kind: "terminal",
+    cwd: "/tmp",
+    spawnedAt: 1,
+    hasPty: true,
+  };
+}
+
+describe("terminal:reconnect-bulk handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsHelpTerminal.mockReturnValue(false);
+  });
+
+  function getHandler(): ReconnectBulkHandler {
+    const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+      .calls;
+    const handlerCall = calls.find((call) => call[0] === CHANNELS.TERMINAL_RECONNECT_BULK);
+    expect(handlerCall).toBeTruthy();
+    return handlerCall?.[1] as ReconnectBulkHandler;
+  }
+
+  it("returns a per-id map matching the single reconnect contract", async () => {
+    const ptyClient = {
+      getTerminalAsync: vi.fn(async (id: string) => (id === "t-live" ? makeTerminal(id) : null)),
+    };
+
+    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
+    const handler = getHandler();
+
+    const result = await handler({}, ["t-live", "t-dead"]);
+
+    expect(result["t-live"]).toMatchObject({ exists: true, id: "t-live", hasPty: true });
+    expect(result["t-dead"]).toEqual({ exists: false });
+  });
+
+  it("deduplicates ids before probing", async () => {
+    const ptyClient = {
+      getTerminalAsync: vi.fn(async (id: string) => makeTerminal(id)),
+    };
+
+    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
+    const handler = getHandler();
+
+    const result = await handler({}, ["t-1", "t-1", "t-2"]);
+
+    expect(Object.keys(result).sort()).toEqual(["t-1", "t-2"]);
+    expect(ptyClient.getTerminalAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it("degrades a failing id to { exists: false } without failing the batch", async () => {
+    const ptyClient = {
+      getTerminalAsync: vi.fn(async (id: string) => {
+        if (id === "t-fail") throw new Error("boom");
+        return makeTerminal(id);
+      }),
+    };
+
+    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
+    const handler = getHandler();
+
+    const result = await handler({}, ["t-ok", "t-fail"]);
+
+    expect(result["t-ok"]).toMatchObject({ exists: true });
+    expect(result["t-fail"]).toEqual({ exists: false });
+  });
+
+  it("reports help terminals as { exists: false }, mirroring single reconnect", async () => {
+    mockIsHelpTerminal.mockImplementation((id: string) => id === "t-help");
+    const ptyClient = {
+      getTerminalAsync: vi.fn(async (id: string) => makeTerminal(id)),
+    };
+
+    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
+    const handler = getHandler();
+
+    const result = await handler({}, ["t-help", "t-normal"]);
+
+    expect(result["t-help"]).toEqual({ exists: false });
+    expect(result["t-normal"]).toMatchObject({ exists: true });
+  });
+
+  it("rejects invalid payloads", async () => {
+    const ptyClient = {
+      getTerminalAsync: vi.fn(async () => null),
+    };
+
+    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
+    const handler = getHandler();
+
+    await expect(handler({}, null as unknown as string[])).rejects.toThrow(
+      "Invalid terminal IDs: must be an array"
+    );
+    await expect(handler({}, ["" as unknown as string])).rejects.toThrow(
+      "Invalid terminal ID in batch payload"
+    );
+    await expect(handler({}, new Array(257).fill("id"))).rejects.toThrow(
+      "Invalid terminal IDs: maximum 256 IDs allowed"
+    );
+  });
+
+  it("returns an empty map for an empty id list", async () => {
+    const ptyClient = {
+      getTerminalAsync: vi.fn(async () => null),
+    };
+
+    registerTerminalSnapshotHandlers({ ptyClient } as unknown as HandlerDependencies);
+    const handler = getHandler();
+
+    await expect(handler({}, [])).resolves.toEqual({});
+    expect(ptyClient.getTerminalAsync).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -428,6 +428,46 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
     }
   };
 
+  // Bulk variant for the cold-boot panel-restore prefetch (#10390): one IPC
+  // round-trip probes every saved panel id instead of N serialized probes
+  // inside the spawn queue. Mirrors getSerializedStates' batch contract —
+  // per-id failures degrade to { exists: false } rather than failing the batch.
+  const handleTerminalReconnectBulk = async (
+    terminalIds: string[]
+  ): Promise<Record<string, import("../../../../shared/types/ipc.js").TerminalReconnectResult>> => {
+    if (!Array.isArray(terminalIds)) {
+      throw new Error("Invalid terminal IDs: must be an array");
+    }
+
+    if (terminalIds.length > 256) {
+      throw new Error("Invalid terminal IDs: maximum 256 IDs allowed");
+    }
+
+    const normalizedIds = Array.from(
+      new Set(
+        terminalIds.map((id) => {
+          if (typeof id !== "string" || !id.trim()) {
+            throw new Error("Invalid terminal ID in batch payload");
+          }
+          return id;
+        })
+      )
+    );
+
+    const results = await Promise.all(
+      normalizedIds.map(async (terminalId) => {
+        try {
+          return [terminalId, await handleTerminalReconnect(terminalId)] as const;
+        } catch (error) {
+          logWarn(`terminal:reconnect-bulk(${terminalId}) failed`, { error });
+          return [terminalId, { exists: false as const }] as const;
+        }
+      })
+    );
+
+    return Object.fromEntries(results);
+  };
+
   const namespace = defineIpcNamespace({
     name: "terminalSnapshots",
     ops: {
@@ -457,6 +497,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         handleTerminalSearchSemanticBuffers
       ),
       reconnect: op(CHANNELS.TERMINAL_RECONNECT, handleTerminalReconnect),
+      reconnectBulk: op(CHANNELS.TERMINAL_RECONNECT_BULK, handleTerminalReconnectBulk),
     },
   });
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -988,6 +988,9 @@ const api: ElectronAPI = {
 
     reconnect: (terminalId: string) => _unwrappingInvoke(CHANNELS.TERMINAL_RECONNECT, terminalId),
 
+    reconnectBulk: (terminalIds: string[]) =>
+      _unwrappingInvoke(CHANNELS.TERMINAL_RECONNECT_BULK, terminalIds),
+
     replayHistory: (terminalId: string, maxLines?: number) =>
       _unwrappingInvoke(CHANNELS.TERMINAL_REPLAY_HISTORY, { terminalId, maxLines }),
 

--- a/electron/services/UserAgentRegistryService.ts
+++ b/electron/services/UserAgentRegistryService.ts
@@ -15,6 +15,63 @@ function cloneConfig(config: UserAgentConfig): UserAgentConfig {
   return structuredClone(config);
 }
 
+/**
+ * Read + sanitize the persisted user-agent registry from the store. Shared by
+ * the service's own load path and the batched `app:boot` hydrate payload so
+ * both surfaces apply identical validation to the raw store bytes.
+ */
+export function loadSanitizedUserAgentRegistry(): UserAgentRegistry {
+  try {
+    const stored = store.get("userAgentRegistry", {});
+    if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
+      console.warn("[UserAgentRegistryService] Stored registry is not an object, resetting");
+      return {};
+    }
+
+    const sanitized: UserAgentRegistry = {};
+    for (const [id, config] of Object.entries(stored)) {
+      if (RESERVED_REGISTRY_KEYS.has(id)) {
+        console.warn(`[UserAgentRegistryService] Skipping reserved registry key: ${id}`);
+        continue;
+      }
+      if (!SAFE_AGENT_ID_PATTERN.test(id)) {
+        console.warn(`[UserAgentRegistryService] Skipping registry entry with invalid id: ${id}`);
+        continue;
+      }
+      if (isBuiltInAgent(id)) {
+        console.warn(
+          `[UserAgentRegistryService] Skipping built-in agent ID in user registry: ${id}`
+        );
+        continue;
+      }
+
+      const entryValidation = UserAgentConfigSchema.safeParse(config);
+      if (!entryValidation.success) {
+        console.warn(
+          `[UserAgentRegistryService] Skipping invalid registry entry "${id}":`,
+          entryValidation.error.message
+        );
+        continue;
+      }
+
+      const validated = entryValidation.data;
+      if (validated.id !== id) {
+        console.warn(
+          `[UserAgentRegistryService] Skipping registry entry with mismatched id: key=${id}, config.id=${validated.id}`
+        );
+        continue;
+      }
+
+      sanitized[id] = cloneConfig(validated);
+    }
+
+    return sanitized;
+  } catch (error) {
+    console.error("[UserAgentRegistryService] Failed to load registry:", error);
+    return {};
+  }
+}
+
 export class UserAgentRegistryService {
   private registry: UserAgentRegistry = {};
 
@@ -24,56 +81,7 @@ export class UserAgentRegistryService {
   }
 
   private loadRegistry(): void {
-    try {
-      const stored = store.get("userAgentRegistry", {});
-      if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
-        console.warn("[UserAgentRegistryService] Stored registry is not an object, resetting");
-        this.registry = {};
-        return;
-      }
-
-      const sanitized: UserAgentRegistry = {};
-      for (const [id, config] of Object.entries(stored)) {
-        if (RESERVED_REGISTRY_KEYS.has(id)) {
-          console.warn(`[UserAgentRegistryService] Skipping reserved registry key: ${id}`);
-          continue;
-        }
-        if (!SAFE_AGENT_ID_PATTERN.test(id)) {
-          console.warn(`[UserAgentRegistryService] Skipping registry entry with invalid id: ${id}`);
-          continue;
-        }
-        if (isBuiltInAgent(id)) {
-          console.warn(
-            `[UserAgentRegistryService] Skipping built-in agent ID in user registry: ${id}`
-          );
-          continue;
-        }
-
-        const entryValidation = UserAgentConfigSchema.safeParse(config);
-        if (!entryValidation.success) {
-          console.warn(
-            `[UserAgentRegistryService] Skipping invalid registry entry "${id}":`,
-            entryValidation.error.message
-          );
-          continue;
-        }
-
-        const validated = entryValidation.data;
-        if (validated.id !== id) {
-          console.warn(
-            `[UserAgentRegistryService] Skipping registry entry with mismatched id: key=${id}, config.id=${validated.id}`
-          );
-          continue;
-        }
-
-        sanitized[id] = cloneConfig(validated);
-      }
-
-      this.registry = sanitized;
-    } catch (error) {
-      console.error("[UserAgentRegistryService] Failed to load registry:", error);
-      this.registry = {};
-    }
+    this.registry = loadSanitizedUserAgentRegistry();
   }
 
   private saveRegistry(nextRegistry: UserAgentRegistry): { success: boolean; error?: string } {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -248,6 +248,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     getAllTerminals(): Promise<BackendTerminalInfo[]>;
     searchSemanticBuffers(query: string, isRegex: boolean): Promise<SemanticSearchMatch[]>;
     reconnect(terminalId: string): Promise<TerminalReconnectResult>;
+    reconnectBulk(terminalIds: string[]): Promise<Record<string, TerminalReconnectResult>>;
     replayHistory(terminalId: string, maxLines?: number): Promise<{ replayed: number }>;
     getSerializedState(terminalId: string): Promise<string | null>;
     getSerializedStates(terminalIds: string[]): Promise<Record<string, string | null>>;

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -224,4 +224,27 @@ export interface HydrateResult {
    * standalone IPC call.
    */
   projectPresets?: Record<string, import("../../config/agentRegistry.js").AgentPreset[]>;
+  /**
+   * Full project list folded into the hydrate payload so the Toolbar's mount
+   * effect skips its `project:get-all` + `project:get-current` round-trips
+   * during the boot window. Optional for backward compatibility: when absent
+   * (older main process, or the safe-boot fallback), the renderer falls back
+   * to the standalone IPC calls.
+   */
+  projects?: import("../project.js").Project[];
+  /**
+   * Persisted keybinding overrides folded into the hydrate payload so the
+   * hydration bootstrap skips the standalone `keybinding:get-overrides`
+   * round-trip. Same validation as the standalone handler. Undefined on older
+   * payloads and the safe-boot fallback, where the renderer falls back to IPC.
+   */
+  keybindingOverrides?: Record<string, string[]>;
+  /**
+   * Sanitized user-agent registry folded into the hydrate payload so the
+   * hydration bootstrap skips the standalone `user-agent-registry:get`
+   * round-trip. Same sanitization as the standalone handler. Undefined on
+   * older payloads and the safe-boot fallback, where the renderer falls back
+   * to IPC.
+   */
+  userAgentRegistry?: import("../userAgentRegistry.js").UserAgentRegistry;
 }

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1165,6 +1165,10 @@ export interface GeneratedIpcInvokeMap {
     args: [terminalId: string];
     result: import("./terminal.js").TerminalReconnectResult;
   };
+  "terminal:reconnect-bulk": {
+    args: [terminalIds: string[]];
+    result: Record<string, import("./terminal.js").TerminalReconnectResult>;
+  };
   "terminal:replay-history": {
     args: [__0: { terminalId: string; maxLines: number }];
     result: { replayed: number };

--- a/src/clients/__tests__/projectClient.test.ts
+++ b/src/clients/__tests__/projectClient.test.ts
@@ -279,20 +279,20 @@ describe("projectClient getSettings caching", () => {
     expect(r2).toBe(settingsB);
   });
 
-  it("re-fetches after the 150ms TTL expires", async () => {
+  it("re-fetches after the TTL expires", async () => {
     vi.setSystemTime(new Date(0));
     getSettingsMock.mockResolvedValue(settingsA);
 
     await projectClient.getSettings("proj-1");
     expect(getSettingsMock).toHaveBeenCalledTimes(1);
 
-    // Within TTL: cached
-    vi.setSystemTime(new Date(149));
+    // Within TTL: cached (wide enough to outlive the serialized startup queue, #10390)
+    vi.setSystemTime(new Date(499));
     await projectClient.getSettings("proj-1");
     expect(getSettingsMock).toHaveBeenCalledTimes(1);
 
     // After TTL: fresh fetch
-    vi.setSystemTime(new Date(200));
+    vi.setSystemTime(new Date(600));
     getSettingsMock.mockResolvedValue(settingsB);
     const r3 = await projectClient.getSettings("proj-1");
     expect(getSettingsMock).toHaveBeenCalledTimes(2);

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -35,7 +35,12 @@ let subscribed = false;
 // dedup the IPC and let the cached result satisfy follow-on calls within
 // SETTINGS_TTL_MS. Invalidated synchronously by saveSettings() and by
 // project switch (so a stale cache cannot bleed across project boundaries).
-const SETTINGS_TTL_MS = 150;
+// 500ms (up from 150ms) so the cache survives the gaps between attach-gated
+// spawn tasks in the serialized startup queue (#10390) — at 150ms every spawn
+// after the first refetched identical bytes. Stale reads stay impossible for
+// the cases that matter: saveSettings() and project switch both invalidate
+// synchronously.
+const SETTINGS_TTL_MS = 500;
 const settingsInflight: Map<string, Promise<ProjectSettings>> = new Map();
 const settingsCache: Map<string, { value: ProjectSettings; expiresAt: number }> = new Map();
 

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -455,6 +455,15 @@ export const terminalClient = {
   },
 
   /**
+   * Probe reconnect state for many terminals in a single round-trip.
+   * Returns a map keyed by terminal ID; missing/failed IDs report
+   * `{ exists: false }`. Used by the cold-boot panel-restore prefetch.
+   */
+  reconnectBulk: (terminalIds: string[]): Promise<Record<string, TerminalReconnectResult>> => {
+    return window.electron.terminal.reconnectBulk(terminalIds);
+  },
+
+  /**
    * Replay terminal history from backend semantic buffer.
    * Used after reconnecting to restore terminal output.
    */

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -506,8 +506,25 @@ export function Toolbar({
   );
 
   useEffect(() => {
-    loadProjects();
-    getCurrentProject();
+    // When the boot payload already seeded the store (#10390), skip the
+    // redundant initial getAll/getCurrent pair and only run the background
+    // missing-directory validation that boot data can't replace. The
+    // getCurrentProject() escape hatch covers project-scoped views that boot
+    // before main binds them to a project (retry loop in projectStore).
+    const {
+      isBootstrapped,
+      currentProject: seededProject,
+      checkMissingProjects,
+    } = useProjectStore.getState();
+    if (isBootstrapped) {
+      if (!seededProject) {
+        getCurrentProject();
+      }
+      void checkMissingProjects();
+    } else {
+      loadProjects();
+      getCurrentProject();
+    }
 
     const cleanup = projectClient.onSwitch(() => {
       getCurrentProject();

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -518,7 +518,7 @@ export function Toolbar({
     } = useProjectStore.getState();
     if (isBootstrapped) {
       if (!seededProject) {
-        getCurrentProject();
+        void getCurrentProject();
       }
       void checkMissingProjects();
     } else {

--- a/src/lib/bootPromise.ts
+++ b/src/lib/bootPromise.ts
@@ -122,6 +122,9 @@ export function releaseBootPayload(): void {
     result.draftInputs = undefined;
     result.projectPresets = undefined;
     result.appTheme = undefined;
+    result.projects = undefined;
+    result.keybindingOverrides = undefined;
+    result.userAgentRegistry = undefined;
   };
 
   releaseFrom((bootPromise as ReactThenable<BootResult> | null)?.value);

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -68,24 +68,33 @@ class KeybindingService {
     });
   }
 
+  /**
+   * Replace the in-memory overrides with an already-fetched payload — same
+   * validation as `loadOverrides()` minus the IPC round-trip. Used by the
+   * hydration bootstrap to seed overrides from the batched `app:boot` payload.
+   */
+  applyOverrides(overrides: Record<string, string[]> | undefined): void {
+    this.overrides.clear();
+    if (overrides && typeof overrides === "object") {
+      for (const [actionId, combos] of Object.entries(overrides)) {
+        if (!Array.isArray(combos)) continue;
+        if (!builtInActionIdSet.has(actionId) && !this.bindings.has(actionId)) {
+          console.warn(
+            `[KeybindingService] Dropping override for unknown action "${actionId}" — not a built-in or registered binding.`
+          );
+          continue;
+        }
+        this.overrides.set(actionId, combos as string[]);
+      }
+    }
+    this.notifyListeners();
+  }
+
   async loadOverrides(): Promise<void> {
     if (typeof window !== "undefined" && window.electron?.keybinding) {
       try {
         const overrides = await window.electron.keybinding.getOverrides();
-        this.overrides.clear();
-        if (overrides && typeof overrides === "object") {
-          for (const [actionId, combos] of Object.entries(overrides)) {
-            if (!Array.isArray(combos)) continue;
-            if (!builtInActionIdSet.has(actionId) && !this.bindings.has(actionId)) {
-              console.warn(
-                `[KeybindingService] Dropping override for unknown action "${actionId}" — not a built-in or registered binding.`
-              );
-              continue;
-            }
-            this.overrides.set(actionId, combos as string[]);
-          }
-        }
-        this.notifyListeners();
+        this.applyOverrides(overrides);
       } catch (error) {
         // Mirrors useUserAgentRegistryStore.initialize() — non-fatal degradation.
         // `this.bindings` retains DEFAULT_KEYBINDINGS (seeded in constructor).

--- a/src/store/__tests__/userAgentRegistryStore.test.ts
+++ b/src/store/__tests__/userAgentRegistryStore.test.ts
@@ -77,6 +77,45 @@ describe("userAgentRegistryStore", () => {
     expect(singleton).toHaveProperty("newAgent");
   });
 
+  it("seeds the registry from a boot payload without IPC and syncs the singleton", () => {
+    useUserAgentRegistryStore
+      .getState()
+      .seedRegistry({ bootAgent: { id: "bootAgent", name: "Boot Agent" } as never });
+
+    const state = useUserAgentRegistryStore.getState();
+    expect(state.isInitialized).toBe(true);
+    expect(state.isLoading).toBe(false);
+    expect(state.registry).toEqual({ bootAgent: { id: "bootAgent", name: "Boot Agent" } });
+    expect(getMock).not.toHaveBeenCalled();
+    expect(getUserRegistry()).toEqual({ bootAgent: { id: "bootAgent", name: "Boot Agent" } });
+  });
+
+  it("seedRegistry no-ops once the store is already initialized", async () => {
+    getMock.mockResolvedValue({ myAgent: { id: "myAgent", name: "My Agent" } });
+    await useUserAgentRegistryStore.getState().initialize();
+
+    useUserAgentRegistryStore
+      .getState()
+      .seedRegistry({ lateAgent: { id: "lateAgent", name: "Too Late" } as never });
+
+    expect(useUserAgentRegistryStore.getState().registry).toEqual({
+      myAgent: { id: "myAgent", name: "My Agent" },
+    });
+  });
+
+  it("initialize no-ops after seedRegistry has already seeded the store", async () => {
+    useUserAgentRegistryStore
+      .getState()
+      .seedRegistry({ bootAgent: { id: "bootAgent", name: "Boot Agent" } as never });
+
+    await useUserAgentRegistryStore.getState().initialize();
+
+    expect(getMock).not.toHaveBeenCalled();
+    expect(useUserAgentRegistryStore.getState().registry).toEqual({
+      bootAgent: { id: "bootAgent", name: "Boot Agent" },
+    });
+  });
+
   it("clears the userRegistry singleton on cleanup", () => {
     useUserAgentRegistryStore.setState({
       registry: { test: { id: "test", name: "Test Agent" } as never },

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -95,6 +95,14 @@ interface ProjectState {
   isLoading: boolean;
   error: string | null;
   /**
+   * True once the batched boot payload has seeded `projects` + `currentProject`
+   * (#10390). The Toolbar's mount effect uses this to skip its redundant
+   * initial `loadProjects()` + `getCurrentProject()` IPC pair during the boot
+   * window; post-switch refetches are unaffected. Never reset — boot seeding
+   * happens once per renderer context.
+   */
+  isBootstrapped: boolean;
+  /**
    * Set when a project switch committed to the new project but its worktree
    * load threw (#8400). Surfaced as a Tier 3 inline recovery banner. Transient
    * — never persisted, cleared on the next switch start or a successful retry.
@@ -319,6 +327,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   projects: [],
   currentProject: null,
   isLoading: false,
+  isBootstrapped: false,
   gitInitDialogOpen: false,
   gitInitDirectoryPath: null,
   createFolderDialogOpen: false,

--- a/src/store/userAgentRegistryStore.ts
+++ b/src/store/userAgentRegistryStore.ts
@@ -14,6 +14,12 @@ interface UserAgentRegistryState {
 
 interface UserAgentRegistryActions {
   initialize: () => Promise<void>;
+  /**
+   * Seed the registry from an already-fetched payload (the batched `app:boot`
+   * hydrate result) without an IPC round-trip. No-ops when the store is
+   * already initialized so a late seed can't clobber fresher data.
+   */
+  seedRegistry: (registry: UserAgentRegistry) => void;
   addAgent: (config: UserAgentConfig) => Promise<{ success: boolean; error?: string }>;
   updateAgent: (
     id: string,
@@ -56,6 +62,11 @@ export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()(
       })();
 
       return initPromise;
+    },
+
+    seedRegistry: (registry: UserAgentRegistry) => {
+      if (get().isInitialized) return;
+      set({ registry, isLoading: false, error: null, isInitialized: true });
     },
 
     addAgent: async (config: UserAgentConfig) => {

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -277,16 +277,61 @@ describe("hydrateAppState", () => {
     });
 
     const updater = projectStoreSetStateMock.mock.calls[0]?.[0] as
-      | ((state: { projects: (typeof project)[]; currentProject: typeof project | null }) => {
+      | ((state: {
           projects: (typeof project)[];
           currentProject: typeof project | null;
+          isBootstrapped: boolean;
+        }) => {
+          projects: (typeof project)[];
+          currentProject: typeof project | null;
+          isBootstrapped: boolean;
         })
       | undefined;
 
     expect(updater).toBeTypeOf("function");
-    expect(updater?.({ projects: [], currentProject: null })).toEqual({
+    expect(updater?.({ projects: [], currentProject: null, isBootstrapped: false })).toEqual({
       projects: [project],
       currentProject: project,
+      // The payload carried no `projects` list (older main process), so the
+      // bootstrap flag stays down and the Toolbar's IPC fallback still fires.
+      isBootstrapped: false,
+    });
+  });
+
+  it("seeds the full project list and bootstrap flag when the payload carries projects (#10390)", async () => {
+    const otherProject = { id: "project-2", path: "/other" };
+    appClientMock.hydrate.mockResolvedValue({
+      appState: {
+        terminals: [],
+      },
+      terminalConfig,
+      project,
+      projects: [project, otherProject],
+      agentSettings,
+      gpuWebGLHardware: true,
+    });
+
+    await hydrateAppState({
+      addPanel: vi.fn().mockResolvedValue("panel-1"),
+      setActiveWorktree: vi.fn(),
+      loadRecipes: vi.fn().mockResolvedValue(undefined),
+      openDiagnosticsDock: vi.fn(),
+    });
+
+    const updater = projectStoreSetStateMock.mock.calls[0]?.[0] as (state: {
+      projects: (typeof project)[];
+      currentProject: typeof project | null;
+      isBootstrapped: boolean;
+    }) => {
+      projects: (typeof project)[];
+      currentProject: typeof project | null;
+      isBootstrapped: boolean;
+    };
+
+    expect(updater({ projects: [], currentProject: null, isBootstrapped: false })).toEqual({
+      projects: [project, otherProject],
+      currentProject: project,
+      isBootstrapped: true,
     });
   });
 

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -10,6 +10,7 @@ const getTmpDirMock = vi.fn().mockResolvedValue("/tmp");
 const terminalClientMock = {
   getForProject: vi.fn(),
   reconnect: vi.fn(),
+  reconnectBulk: vi.fn(),
   getSerializedStates: vi.fn(),
 };
 
@@ -178,6 +179,7 @@ describe("hydrateAppState", () => {
     });
     terminalClientMock.getForProject.mockResolvedValue([]);
     terminalClientMock.reconnect.mockResolvedValue({ exists: false });
+    terminalClientMock.reconnectBulk.mockResolvedValue({});
     terminalClientMock.getSerializedStates.mockRejectedValue(
       new Error("Batch serialized state endpoint unavailable")
     );
@@ -296,6 +298,46 @@ describe("hydrateAppState", () => {
       // bootstrap flag stays down and the Toolbar's IPC fallback still fires.
       isBootstrapped: false,
     });
+  });
+
+  it("prefetches reconnect probes in one bulk IPC for saved PTY panels missing from the backend (#10390)", async () => {
+    appClientMock.hydrate.mockResolvedValue({
+      appState: {
+        terminals: [
+          { id: "term-1", kind: "terminal", title: "T1", cwd: "/project", location: "grid" },
+          {
+            id: "browser-1",
+            kind: "browser",
+            title: "Browser",
+            cwd: "/project",
+            location: "grid",
+            browserUrl: "http://localhost:5173",
+          },
+        ],
+        sidebarWidth: 350,
+      },
+      terminalConfig,
+      project,
+      agentSettings,
+      gpuWebGLHardware: true,
+    });
+    terminalClientMock.reconnectBulk.mockResolvedValue({
+      "term-1": { exists: false },
+    });
+
+    await hydrateAppState({
+      addPanel: vi.fn().mockResolvedValue("term-1"),
+      setActiveWorktree: vi.fn(),
+      loadRecipes: vi.fn().mockResolvedValue(undefined),
+      openDiagnosticsDock: vi.fn(),
+    });
+
+    // Only the PTY-kind panel missing from the backend is probed; the
+    // non-PTY browser panel is excluded from the bulk payload.
+    expect(terminalClientMock.reconnectBulk).toHaveBeenCalledTimes(1);
+    expect(terminalClientMock.reconnectBulk).toHaveBeenCalledWith(["term-1"]);
+    // The prefetched result satisfies the probe — no per-panel reconnect IPC.
+    expect(terminalClientMock.reconnect).not.toHaveBeenCalled();
   });
 
   it("seeds the full project list and bootstrap flag when the payload carries projects (#10390)", async () => {

--- a/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
+++ b/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
@@ -2,27 +2,48 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const loadOverridesMock = vi.hoisted(() => vi.fn());
+const applyOverridesMock = vi.hoisted(() => vi.fn());
 const initializeMock = vi.hoisted(() => vi.fn());
+const seedRegistryMock = vi.hoisted(() => vi.fn());
+const projectSetStateMock = vi.hoisted(() => vi.fn());
+const getSafeBootPromiseMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/services/KeybindingService", () => ({
   keybindingService: {
     loadOverrides: () => loadOverridesMock(),
+    applyOverrides: (overrides: unknown) => applyOverridesMock(overrides),
   },
 }));
 
 vi.mock("@/store/userAgentRegistryStore", () => ({
   useUserAgentRegistryStore: {
-    getState: () => ({ initialize: initializeMock }),
+    getState: () => ({ initialize: initializeMock, seedRegistry: seedRegistryMock }),
   },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: {
+    setState: projectSetStateMock,
+  },
+}));
+
+vi.mock("@/lib/bootPromise", () => ({
+  getSafeBootPromise: () => getSafeBootPromiseMock(),
 }));
 
 const { ensureHydrationBootstrap, __resetBootstrapForTests } = await import("../bootstrapGuard");
 
 beforeEach(() => {
   loadOverridesMock.mockReset();
+  applyOverridesMock.mockReset();
   initializeMock.mockReset();
+  seedRegistryMock.mockReset();
+  projectSetStateMock.mockReset();
+  getSafeBootPromiseMock.mockReset();
   loadOverridesMock.mockResolvedValue(undefined);
   initializeMock.mockResolvedValue(undefined);
+  // Default: boot payload unavailable — exercises the original IPC pull path.
+  getSafeBootPromiseMock.mockResolvedValue({ ok: false, error: new Error("no boot") });
   __resetBootstrapForTests();
 });
 
@@ -77,6 +98,98 @@ describe("ensureHydrationBootstrap", () => {
 
     expect(loadOverridesMock).toHaveBeenCalledTimes(2);
     expect(initializeMock).toHaveBeenCalledTimes(2);
+  });
+
+  describe("boot payload seeding (#10390)", () => {
+    const bootProjects = [
+      { id: "p-1", name: "One", path: "/one", emoji: "1", lastOpened: 1 },
+      { id: "p-2", name: "Two", path: "/two", emoji: "2", lastOpened: 2 },
+    ];
+
+    it("seeds all three stores from the payload without firing the IPC pair", async () => {
+      const overrides = { "action.copy": ["mod+c"] };
+      const registry = { "agent-x": { id: "agent-x" } };
+      getSafeBootPromiseMock.mockResolvedValue({
+        ok: true,
+        result: {
+          keybindingOverrides: overrides,
+          userAgentRegistry: registry,
+          projects: bootProjects,
+          project: bootProjects[0],
+        },
+      });
+
+      await ensureHydrationBootstrap();
+
+      expect(applyOverridesMock).toHaveBeenCalledTimes(1);
+      expect(applyOverridesMock).toHaveBeenCalledWith(overrides);
+      expect(seedRegistryMock).toHaveBeenCalledTimes(1);
+      expect(seedRegistryMock).toHaveBeenCalledWith(registry);
+      expect(loadOverridesMock).not.toHaveBeenCalled();
+      expect(initializeMock).not.toHaveBeenCalled();
+
+      expect(projectSetStateMock).toHaveBeenCalledTimes(1);
+      const updater = projectSetStateMock.mock.calls[0]?.[0] as (state: {
+        projects: unknown[];
+        currentProject: unknown;
+        isBootstrapped: boolean;
+      }) => Record<string, unknown>;
+      const next = updater({ projects: [], currentProject: null, isBootstrapped: false });
+      expect(next).toEqual({
+        projects: bootProjects,
+        currentProject: bootProjects[0],
+        isBootstrapped: true,
+      });
+    });
+
+    it("keeps the store's currentProject when the payload has no current project", async () => {
+      getSafeBootPromiseMock.mockResolvedValue({
+        ok: true,
+        result: {
+          projects: bootProjects,
+          project: null,
+        },
+      });
+
+      await ensureHydrationBootstrap();
+
+      const updater = projectSetStateMock.mock.calls[0]?.[0] as (state: {
+        projects: unknown[];
+        currentProject: unknown;
+        isBootstrapped: boolean;
+      }) => Record<string, unknown>;
+      const existing = { id: "p-existing" };
+      const next = updater({ projects: [], currentProject: existing, isBootstrapped: false });
+      expect(next.currentProject).toBe(existing);
+      expect(next.isBootstrapped).toBe(true);
+    });
+
+    it("falls back per-field when the payload is partial", async () => {
+      getSafeBootPromiseMock.mockResolvedValue({
+        ok: true,
+        result: {
+          keybindingOverrides: { "action.paste": ["mod+v"] },
+          // userAgentRegistry and projects absent (older main process)
+        },
+      });
+
+      await ensureHydrationBootstrap();
+
+      expect(applyOverridesMock).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(seedRegistryMock).not.toHaveBeenCalled();
+      expect(projectSetStateMock).not.toHaveBeenCalled();
+    });
+
+    it("runs the full IPC pull path on the safe-boot { ok: false } fallback", async () => {
+      await ensureHydrationBootstrap();
+
+      expect(loadOverridesMock).toHaveBeenCalledTimes(1);
+      expect(initializeMock).toHaveBeenCalledTimes(1);
+      expect(applyOverridesMock).not.toHaveBeenCalled();
+      expect(seedRegistryMock).not.toHaveBeenCalled();
+      expect(projectSetStateMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("perf instrumentation", () => {

--- a/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
+++ b/src/utils/stateHydration/__tests__/bootstrapGuard.test.ts
@@ -164,6 +164,27 @@ describe("ensureHydrationBootstrap", () => {
       expect(next.isBootstrapped).toBe(true);
     });
 
+    it("sets the bootstrap flag for an empty project list (fresh install)", async () => {
+      getSafeBootPromiseMock.mockResolvedValue({
+        ok: true,
+        result: {
+          projects: [],
+          project: null,
+        },
+      });
+
+      await ensureHydrationBootstrap();
+
+      const updater = projectSetStateMock.mock.calls[0]?.[0] as (state: {
+        projects: unknown[];
+        currentProject: unknown;
+        isBootstrapped: boolean;
+      }) => Record<string, unknown>;
+      const next = updater({ projects: [], currentProject: null, isBootstrapped: false });
+      expect(next.projects).toEqual([]);
+      expect(next.isBootstrapped).toBe(true);
+    });
+
     it("falls back per-field when the payload is partial", async () => {
       getSafeBootPromiseMock.mockResolvedValue({
         ok: true,

--- a/src/utils/stateHydration/__tests__/reconnectManager.test.ts
+++ b/src/utils/stateHydration/__tests__/reconnectManager.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TerminalReconnectResult } from "@shared/types/ipc/terminal";
+
+const reconnectMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    reconnect: (terminalId: string) => reconnectMock(terminalId),
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logWarn: vi.fn(),
+}));
+
+const { reconnectWithTimeout } = await import("../reconnectManager");
+
+const noopLog = () => {};
+
+beforeEach(() => {
+  reconnectMock.mockReset();
+});
+
+describe("reconnectWithTimeout", () => {
+  it("consumes a prefetched live result without firing the per-panel IPC", async () => {
+    const prefetched: TerminalReconnectResult = {
+      exists: true,
+      id: "t-1",
+      hasPty: true,
+    } as TerminalReconnectResult;
+
+    const outcome = await reconnectWithTimeout("t-1", noopLog, prefetched);
+
+    expect(outcome).toEqual({ status: "found", terminal: prefetched });
+    expect(reconnectMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a prefetched { exists: false } to not_found without IPC", async () => {
+    const outcome = await reconnectWithTimeout("t-gone", noopLog, {
+      exists: false,
+    } as TerminalReconnectResult);
+
+    expect(outcome).toEqual({ status: "not_found" });
+    expect(reconnectMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a prefetched ptyless terminal to not_found, mirroring the IPC path", async () => {
+    const outcome = await reconnectWithTimeout("t-noPty", noopLog, {
+      exists: true,
+      id: "t-noPty",
+      hasPty: false,
+    } as TerminalReconnectResult);
+
+    expect(outcome).toEqual({ status: "not_found" });
+    expect(reconnectMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the per-panel IPC when no prefetched result is supplied", async () => {
+    reconnectMock.mockResolvedValueOnce({ exists: true, id: "t-2", hasPty: true });
+
+    const outcome = await reconnectWithTimeout("t-2", noopLog);
+
+    expect(outcome.status).toBe("found");
+    expect(reconnectMock).toHaveBeenCalledTimes(1);
+    expect(reconnectMock).toHaveBeenCalledWith("t-2");
+  });
+
+  it("reports IPC errors as error outcomes on the fallback path", async () => {
+    const failure = new Error("ipc down");
+    reconnectMock.mockRejectedValueOnce(failure);
+
+    const outcome = await reconnectWithTimeout("t-3", noopLog);
+
+    expect(outcome).toEqual({ status: "error", error: failure });
+  });
+});

--- a/src/utils/stateHydration/__tests__/reconnectManager.test.ts
+++ b/src/utils/stateHydration/__tests__/reconnectManager.test.ts
@@ -73,4 +73,18 @@ describe("reconnectWithTimeout", () => {
 
     expect(outcome).toEqual({ status: "error", error: failure });
   });
+
+  it("times out a hung IPC probe on the fallback path", async () => {
+    vi.useFakeTimers();
+    try {
+      reconnectMock.mockReturnValueOnce(new Promise(() => {}));
+
+      const outcomePromise = reconnectWithTimeout("t-hung", noopLog);
+      await vi.advanceTimersByTimeAsync(2001);
+
+      await expect(outcomePromise).resolves.toEqual({ status: "timeout" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/utils/stateHydration/bootstrapGuard.ts
+++ b/src/utils/stateHydration/bootstrapGuard.ts
@@ -1,5 +1,7 @@
 import { keybindingService } from "@/services/KeybindingService";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
+import { useProjectStore } from "@/store/projectStore";
+import { getSafeBootPromise } from "@/lib/bootPromise";
 import { withRendererSpan } from "@/utils/performance";
 import { PERF_MARKS } from "@shared/perf/marks";
 
@@ -7,19 +9,44 @@ let hydrationBootstrapPromise: Promise<void> | null = null;
 
 export async function ensureHydrationBootstrap(): Promise<void> {
   if (!hydrationBootstrapPromise) {
-    hydrationBootstrapPromise = Promise.all([
-      withRendererSpan(PERF_MARKS.HYDRATE_BOOTSTRAP_LOAD_OVERRIDES, () =>
-        keybindingService.loadOverrides()
-      ),
-      withRendererSpan(PERF_MARKS.HYDRATE_BOOTSTRAP_INIT_USER_AGENTS, () =>
-        useUserAgentRegistryStore.getState().initialize()
-      ),
-    ])
-      .then(() => undefined)
-      .catch((error) => {
-        hydrationBootstrapPromise = null;
-        throw error;
-      });
+    hydrationBootstrapPromise = (async () => {
+      // The batched app:boot payload carries keybinding overrides, the
+      // user-agent registry, and the full project list as ride-along fields
+      // (#10390). When present, seed the renderer stores directly instead of
+      // firing the standalone IPC pair. The fields are undefined on older
+      // main processes and the safe-boot { ok: false } fallback, where the
+      // original IPC pull path runs unchanged.
+      const safeBoot = await getSafeBootPromise();
+      const boot = safeBoot.ok ? safeBoot.result : null;
+
+      if (boot?.projects !== undefined) {
+        const bootProjects = boot.projects;
+        const bootCurrentProject = boot.project ?? null;
+        useProjectStore.setState((state) => ({
+          projects: bootProjects,
+          currentProject: bootCurrentProject ?? state.currentProject,
+          isBootstrapped: true,
+        }));
+      }
+
+      await Promise.all([
+        withRendererSpan(PERF_MARKS.HYDRATE_BOOTSTRAP_LOAD_OVERRIDES, () =>
+          boot?.keybindingOverrides !== undefined
+            ? Promise.resolve(keybindingService.applyOverrides(boot.keybindingOverrides))
+            : keybindingService.loadOverrides()
+        ),
+        withRendererSpan(PERF_MARKS.HYDRATE_BOOTSTRAP_INIT_USER_AGENTS, () => {
+          if (boot?.userAgentRegistry !== undefined) {
+            useUserAgentRegistryStore.getState().seedRegistry(boot.userAgentRegistry);
+            return Promise.resolve();
+          }
+          return useUserAgentRegistryStore.getState().initialize();
+        }),
+      ]);
+    })().catch((error) => {
+      hydrationBootstrapPromise = null;
+      throw error;
+    });
   }
 
   await hydrationBootstrapPromise;

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -10,7 +10,11 @@ import type {
   TerminalReconnectError,
   TabGroup,
 } from "@/types";
-import type { BackendTerminalInfo } from "@shared/types/ipc/terminal";
+import type { BackendTerminalInfo, TerminalReconnectResult } from "@shared/types/ipc/terminal";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
+import { inferKind } from "./statePatcher";
+import { RECONNECT_TIMEOUT_MS } from "./reconnectManager";
 import type { ActionFrecencyEntry } from "@shared/types/actions";
 import { panelPersistence } from "@/store/persistence/panelPersistence";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -190,13 +194,21 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     const clipboardDirectory = tmpDir ? `${tmpDir}/${CLIPBOARD_DIR_NAME}` : undefined;
 
     useProjectStore.setState((state) => {
-      if (!currentProject) return { currentProject: null };
-      const projects = state.projects.some((project) => project.id === currentProject.id)
-        ? state.projects.map((project) =>
+      // The full project list rides along in newer hydrate payloads (#10390).
+      // Seed it (plus the bootstrap flag the Toolbar mount effect checks) so
+      // the IPC-pull fallback path gets the same dedup as the boot path,
+      // which seeds earlier via ensureHydrationBootstrap.
+      const baseProjects = hydrateResult.projects ?? state.projects;
+      const bootstrapped = state.isBootstrapped || hydrateResult.projects !== undefined;
+      if (!currentProject) {
+        return { projects: baseProjects, currentProject: null, isBootstrapped: bootstrapped };
+      }
+      const projects = baseProjects.some((project) => project.id === currentProject.id)
+        ? baseProjects.map((project) =>
             project.id === currentProject.id ? currentProject : project
           )
-        : [...state.projects, currentProject];
-      return { projects, currentProject };
+        : [...baseProjects, currentProject];
+      return { projects, currentProject, isBootstrapped: bootstrapped };
     });
 
     terminalInstanceService.setGPUHardwareAvailable(gpuWebGLHardware ?? true);
@@ -357,6 +369,38 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         // Build a map of backend terminals by ID for quick lookup
         const backendTerminalMap = new Map(backendTerminals.map((t) => [t.id, t]));
 
+        // Prefetch reconnect probes for saved PTY panels that getForProject
+        // missed, in one bulk IPC, before the serialized spawn queue would
+        // otherwise fire them one-by-one (#10390). Spawn realization stays
+        // serialized inside restorePanelsPhase — only the probe lookup moves
+        // from "fire IPC inside the queue" to "read from this prefetch map".
+        // Timeout/failure resolves to undefined so panel restore falls back to
+        // the original per-panel probe path.
+        const reconnectPrefetchIds = (appState.terminals ?? [])
+          .filter((saved) => {
+            if (!saved || isSmokeTestTerminalId(saved.id)) return false;
+            if (backendTerminalMap.has(saved.id)) return false;
+            const kind = inferKind(saved);
+            return kind !== "assistant" && panelKindHasPty(kind);
+          })
+          .map((saved) => saved.id);
+        const reconnectPrefetchPromise: Promise<
+          Record<string, TerminalReconnectResult> | undefined
+        > =
+          reconnectPrefetchIds.length > 0 && typeof terminalClient.reconnectBulk === "function"
+            ? Promise.race([
+                terminalClient.reconnectBulk(reconnectPrefetchIds),
+                new Promise<undefined>((resolve) =>
+                  setTimeout(() => resolve(undefined), RECONNECT_TIMEOUT_MS)
+                ),
+              ]).catch((error: unknown) => {
+                logWarn("Bulk reconnect prefetch failed; falling back to per-panel probes", {
+                  error,
+                });
+                return undefined;
+              })
+            : Promise.resolve(undefined);
+
         // Fetch terminal sizes for restoration
         const terminalSizes = await terminalSizesPromise;
 
@@ -386,10 +430,13 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
           logHydrationInfo(`Restoring ${appState.terminals.length} saved panel(s)`);
         }
 
+        const prefetchedReconnectResults = await reconnectPrefetchPromise;
+
         const { restoreTasks } = await restorePanelsPhase(appState.terminals, {
           addPanel,
           withHydrationBatch,
           backendTerminalMap,
+          prefetchedReconnectResults,
           terminalSizes,
           activeWorktreeId,
           projectRoot: projectRoot || "",

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -378,7 +378,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         // the original per-panel probe path.
         const reconnectPrefetchIds = (appState.terminals ?? [])
           .filter((saved) => {
-            if (!saved || isSmokeTestTerminalId(saved.id)) return false;
+            // A corrupt saved id would make the strict bulk handler reject the
+            // whole batch; keep it out so one bad panel can't disable the
+            // prefetch for the rest (it still gets its per-panel fallback).
+            if (!saved || typeof saved.id !== "string" || !saved.id.trim()) return false;
+            if (isSmokeTestTerminalId(saved.id)) return false;
             if (backendTerminalMap.has(saved.id)) return false;
             const kind = inferKind(saved);
             return kind !== "assistant" && panelKindHasPty(kind);

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -2,7 +2,11 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { getPanelKindConfig, panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { logWarn } from "@/utils/logger";
-import type { TerminalState, BackendTerminalInfo } from "@shared/types/ipc/terminal";
+import type {
+  TerminalState,
+  BackendTerminalInfo,
+  TerminalReconnectResult,
+} from "@shared/types/ipc/terminal";
 import type { AgentSettings } from "@shared/types/agentSettings";
 import type { WorktreeState } from "@shared/types";
 import type { AgentPreset } from "@/config/agents";
@@ -32,6 +36,13 @@ export interface PanelRestoreContext {
   addPanel: AddPanelFn;
   withHydrationBatch: (run: () => Promise<void>) => Promise<void>;
   backendTerminalMap: Map<string, BackendTerminalInfo>;
+  /**
+   * Bulk-prefetched `terminal:reconnect` probe results keyed by saved panel id
+   * (#10390). When a saved id is present here, `reconnectWithTimeout` consumes
+   * the prefetched result instead of firing a per-panel IPC inside the
+   * serialized spawn queue. Absent ids fall back to the individual probe.
+   */
+  prefetchedReconnectResults?: Record<string, TerminalReconnectResult>;
   terminalSizes: Record<string, { cols: number; rows: number }>;
   activeWorktreeId: string | null;
   projectRoot: string;
@@ -70,6 +81,7 @@ export async function restorePanelsPhase(
     addPanel,
     withHydrationBatch,
     backendTerminalMap,
+    prefetchedReconnectResults,
     terminalSizes,
     activeWorktreeId,
     projectRoot,
@@ -220,7 +232,11 @@ export async function restorePanelsPhase(
             const location = (saved.location === "dock" ? "dock" : "grid") as "grid" | "dock";
 
             if (panelKindHasPty(kind)) {
-              const reconnectOutcome = await reconnectWithTimeout(saved.id, logHydrationInfo);
+              const reconnectOutcome = await reconnectWithTimeout(
+                saved.id,
+                logHydrationInfo,
+                prefetchedReconnectResults?.[saved.id]
+              );
               const reconnectTimedOut = reconnectOutcome.status === "timeout";
               const reconnectedTerminal =
                 reconnectOutcome.status === "found" ? reconnectOutcome.terminal : null;

--- a/src/utils/stateHydration/reconnectManager.ts
+++ b/src/utils/stateHydration/reconnectManager.ts
@@ -1,7 +1,8 @@
 import { terminalClient } from "@/clients";
+import type { TerminalReconnectResult } from "@shared/types/ipc/terminal";
 import { logWarn } from "@/utils/logger";
 
-const RECONNECT_TIMEOUT_MS = 2000;
+export const RECONNECT_TIMEOUT_MS = 2000;
 
 export type ReconnectOutcome =
   | { status: "found"; terminal: NonNullable<Awaited<ReturnType<typeof terminalClient.reconnect>>> }
@@ -11,8 +12,22 @@ export type ReconnectOutcome =
 
 export async function reconnectWithTimeout(
   terminalId: string,
-  logHydrationInfo: (message: string, context?: Record<string, unknown>) => void
+  logHydrationInfo: (message: string, context?: Record<string, unknown>) => void,
+  prefetchedResult?: TerminalReconnectResult
 ): Promise<ReconnectOutcome> {
+  // A bulk-prefetched probe result (#10390) replaces the per-panel IPC: same
+  // decision logic, no round-trip inside the serialized spawn queue.
+  if (prefetchedResult !== undefined) {
+    if (prefetchedResult.exists && prefetchedResult.hasPty) {
+      logHydrationInfo(`Reconnect prefetch hit for ${terminalId} - terminal exists in backend`);
+      return { status: "found", terminal: prefetchedResult };
+    }
+    logHydrationInfo(
+      `Reconnect prefetch: terminal ${terminalId} not found (exists=${prefetchedResult.exists}, hasPty=${prefetchedResult.hasPty})`
+    );
+    return { status: "not_found" };
+  }
+
   try {
     logHydrationInfo(`Trying reconnect fallback for ${terminalId}`);
 


### PR DESCRIPTION
## Summary

- Reduces IPC round-trips during renderer boot across four areas: bulk terminal reconnect probing, toolbar project call dedup, keybinding/user-agent registry folded into the boot payload, and a wider settings cache TTL
- No behavior changes -- every new `HydrateResult` field is optional with graceful per-field IPC fallback on older main processes and safe-boot `{ok:false}`
- Typecheck (all 5 tsconfigs) and targeted vitest suites passed locally; full CI runs on GitHub per maintainer instruction

Resolves #10390

## Changes

**1. Bulk reconnect prefetch (`terminal:reconnect-bulk`)**

New IPC channel that mirrors the `getSerializedStates` batch contract -- max 256 IDs, deduped, per-ID failure returns `{exists:false}`. `hydrateAppState` derives saved PTY panel IDs missing from `backendTerminalMap` and probes them in one IPC call raced against the existing 2s reconnect timeout. `reconnectWithTimeout` consumes the prefetched result inside the spawn queue, falling back to per-panel IPC when absent. `terminalStartupQueue` is untouched -- spawn realization stays serialized.

**2. Toolbar project IPC dedup**

`HydrateResult` now carries the full projects list. `ensureHydrationBootstrap` seeds `projectStore` (`projects` + `currentProject` + `isBootstrapped`) from the boot payload at App module-eval time. Toolbar's mount effect skips `loadProjects()` + `getCurrentProject()` when `isBootstrapped`, still fires background `checkMissingProjects()` (fs validation the boot data can't replace) and `getCurrentProject()` only when `currentProject` is null (unbound project-view retry). `onSwitch` refetch is unchanged.

**3. Keybinding overrides + user-agent registry in `app:boot`**

Two new optional `HydrateResult` fields populated synchronously in `handleAppHydrate` (both fast and normal path) via exported `getValidatedOverrides()` and extracted `loadSanitizedUserAgentRegistry()`. Renderer seeds via `keybindingService.applyOverrides()` and `userAgentRegistryStore.seedRegistry()` (both idempotent), falling back per-field to the original IPC pair. `releaseBootPayload` nulls both fields after hydration.

**4. `SETTINGS_TTL_MS` 150ms → 500ms**

Ensures the per-project settings cache survives the serialized startup queue so spawn tasks don't each refetch. `saveSettings` and project switch still invalidate synchronously, so there's no stale-read window that matters.

## Testing

- `npm run typecheck` clean across all 5 tsconfigs
- 104 targeted vitest tests across `bootstrapGuard`, `reconnectManager`, `stateHydration`, `userAgentRegistryStore`, and `snapshots.reconnectBulk`
- 262 tests in the broader batch including `KeybindingService` and `panelRestorePhase`
- Full CI suite runs on GitHub (skipped local per maintainer instruction)