### PR TITLE
perf(boot): batch of boot-path micro-optimizations (#10393)

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -129,6 +129,10 @@ const terminalResourceMonitor = new TerminalResourceMonitor(
   sendEvent
 );
 let ptyPool: PtyPool | null = null;
+// True when the boot-time homedir pool warm was deferred because main
+// signalled an imminent project restore (DAINTREE_PTY_DEFER_POOL_WARM).
+// Consumed by the first set-active-project / project-switch handler.
+let initialPoolWarmDeferred = false;
 
 // Zero-copy ring buffers for terminal I/O (set via init-buffers message)
 // Visual buffers: consumed by renderer (xterm.js) - critical path, sharded for isolation
@@ -1286,6 +1290,12 @@ const hostContext: HostContext = {
   set ptyPool(value: PtyPool | null) {
     ptyPool = value;
   },
+  get initialPoolWarmDeferred() {
+    return initialPoolWarmDeferred;
+  },
+  set initialPoolWarmDeferred(value: boolean) {
+    initialPoolWarmDeferred = value;
+  },
   sendEvent,
   getPauseCoordinator,
   getOrCreatePauseCoordinator,
@@ -1380,17 +1390,26 @@ async function initialize(): Promise<void> {
 
     if (shouldEnablePtyPool()) {
       ptyPool = getPtyPool({ poolSize: 2, maxEntries: 8 });
-      const homedir = os.homedir();
 
-      // Warm pool in background
-      ptyPool
-        .warmPool(homedir)
-        .then(() => {
-          console.log("[PtyHost] PTY pool warmed in background");
-        })
-        .catch((err) => {
-          console.error("[PtyHost] Failed to warm pool:", err);
-        });
+      if (process.env.DAINTREE_PTY_DEFER_POOL_WARM === "1") {
+        // Project-restoring boot: the set-active-project that follows ready
+        // drains the pool to the project path, so a homedir warm here would
+        // only spawn shells for the drain to kill. The set-active-project
+        // handler performs the warm instead — project drain, or a homedir
+        // fallback when the restore fell through (#10393).
+        initialPoolWarmDeferred = true;
+        console.log("[PtyHost] Initial pool warm deferred to set-active-project");
+      } else {
+        // Warm pool in background
+        ptyPool
+          .warmPool(os.homedir())
+          .then(() => {
+            console.log("[PtyHost] PTY pool warmed in background");
+          })
+          .catch((err) => {
+            console.error("[PtyHost] Failed to warm pool:", err);
+          });
+      }
 
       ptyManager.setPtyPool(ptyPool);
     } else {

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -67,6 +67,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     visualSignalView: null,
     analysisBuffer: null,
     ptyPool: null,
+    initialPoolWarmDeferred: false,
     sendEvent: vi.fn(),
     getPauseCoordinator: vi.fn(),
     getOrCreatePauseCoordinator: vi.fn(),

--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -326,6 +326,17 @@ describe("deferred boot pool warm (#10393)", () => {
     expect(pool.drainAndRefill).toHaveBeenCalledWith("/repo");
     expect(ctx.initialPoolWarmDeferred).toBe(false);
   });
+
+  it("fallback-warms on a project-switch with no recorded path (restart replay)", () => {
+    const { ctx, pool } = makeDeferredCtx(true);
+    const handlers = createConnectionHandlers(ctx);
+
+    handlers["project-switch"]({ windowId: 1, projectId: "proj-a" });
+
+    expect(pool.warmPool).toHaveBeenCalledTimes(1);
+    expect(pool.drainAndRefill).not.toHaveBeenCalled();
+    expect(ctx.initialPoolWarmDeferred).toBe(false);
+  });
 });
 
 describe("set-active-project non-empty envHash warming (#9810)", () => {

--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -48,6 +48,7 @@ function makeCtx(stateRef: {
       stateRef.analysisBuffer = value;
     },
     ptyPool: null,
+    initialPoolWarmDeferred: false,
     sendEvent: vi.fn(),
     getPauseCoordinator: vi.fn(),
     getOrCreatePauseCoordinator: vi.fn(),
@@ -254,6 +255,76 @@ describe("set-active-project pool warming (#9774)", () => {
       })
     ).not.toThrow();
     expect(ctx.windowProjectMap.get(1)).toBe("proj-a");
+  });
+});
+
+describe("deferred boot pool warm (#10393)", () => {
+  interface FakePool {
+    drainAndRefill: ReturnType<typeof vi.fn>;
+    warmPool: ReturnType<typeof vi.fn>;
+    warmForKey: ReturnType<typeof vi.fn>;
+    getMaxEntries: () => number;
+    getMaxPoolSize: () => number;
+  }
+
+  function makeDeferredCtx(deferred: boolean) {
+    const stateRef = {
+      visualBuffers: [] as SharedRingBuffer[],
+      visualSignalView: null as Int32Array | null,
+      analysisBuffer: null as SharedRingBuffer | null,
+    };
+    const pool: FakePool = {
+      drainAndRefill: vi.fn(() => Promise.resolve()),
+      warmPool: vi.fn(() => Promise.resolve()),
+      warmForKey: vi.fn(),
+      getMaxEntries: () => 8,
+      getMaxPoolSize: () => 2,
+    };
+    const ctx = makeCtx(stateRef);
+    ctx.ptyPool = pool as unknown as HostContext["ptyPool"];
+    ctx.initialPoolWarmDeferred = deferred;
+    return { ctx, pool };
+  }
+
+  it("runs the fallback warm when the restore fell through (no projectPath)", () => {
+    const { ctx, pool } = makeDeferredCtx(true);
+    const handlers = createConnectionHandlers(ctx);
+
+    handlers["set-active-project"]({ windowId: 1, projectId: null });
+
+    expect(pool.warmPool).toHaveBeenCalledTimes(1);
+    expect(pool.drainAndRefill).not.toHaveBeenCalled();
+    expect(ctx.initialPoolWarmDeferred).toBe(false);
+  });
+
+  it("does not fallback-warm when the boot warm was not deferred", () => {
+    const { ctx, pool } = makeDeferredCtx(false);
+    const handlers = createConnectionHandlers(ctx);
+
+    handlers["set-active-project"]({ windowId: 1, projectId: null });
+
+    expect(pool.warmPool).not.toHaveBeenCalled();
+  });
+
+  it("consumes the deferral via the project drain when a projectPath arrives", () => {
+    const { ctx, pool } = makeDeferredCtx(true);
+    const handlers = createConnectionHandlers(ctx);
+
+    handlers["set-active-project"]({ windowId: 1, projectId: "proj-a", projectPath: "/repo" });
+
+    expect(pool.drainAndRefill).toHaveBeenCalledWith("/repo");
+    expect(pool.warmPool).not.toHaveBeenCalled();
+    expect(ctx.initialPoolWarmDeferred).toBe(false);
+  });
+
+  it("consumes the deferral on project-switch", () => {
+    const { ctx, pool } = makeDeferredCtx(true);
+    const handlers = createConnectionHandlers(ctx);
+
+    handlers["project-switch"]({ windowId: 1, projectId: "proj-a", projectPath: "/repo" });
+
+    expect(pool.drainAndRefill).toHaveBeenCalledWith("/repo");
+    expect(ctx.initialPoolWarmDeferred).toBe(false);
   });
 });
 

--- a/electron/pty-host/handlers/__tests__/diagnostics.test.ts
+++ b/electron/pty-host/handlers/__tests__/diagnostics.test.ts
@@ -57,6 +57,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     visualSignalView: null,
     analysisBuffer: null,
     ptyPool: null,
+    initialPoolWarmDeferred: false,
     sendEvent: vi.fn(),
     getPauseCoordinator: vi.fn(() => undefined),
     getOrCreatePauseCoordinator: vi.fn(),

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -80,6 +80,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     visualSignalView: null,
     analysisBuffer: null,
     ptyPool: null,
+    initialPoolWarmDeferred: false,
     sendEvent: vi.fn(),
     getPauseCoordinator: vi.fn(),
     getOrCreatePauseCoordinator: vi.fn(),

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -84,6 +84,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     visualSignalView: null,
     analysisBuffer: null,
     ptyPool: null,
+    initialPoolWarmDeferred: false,
     sendEvent: vi.fn(),
     getPauseCoordinator: vi.fn(),
     getOrCreatePauseCoordinator: vi.fn(),

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -26,6 +26,7 @@ function createCtx(overrides: Partial<HostContext> = {}): HostContext {
     visualSignalView: null,
     analysisBuffer: null,
     ptyPool: null,
+    initialPoolWarmDeferred: false,
     sendEvent: vi.fn(),
     getPauseCoordinator: vi.fn(),
     getOrCreatePauseCoordinator: vi.fn(),

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -234,6 +234,14 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
       windowProjectMap.set(msg.windowId, msg.projectId);
       recomputeActivityTiers();
       const pool = ctx.ptyPool;
+      if (!msg.projectPath && pool && ctx.initialPoolWarmDeferred) {
+        // Restart replay can carry a switch context with no recorded path —
+        // consume the deferral so the pool doesn't stay cold indefinitely.
+        ctx.initialPoolWarmDeferred = false;
+        pool.warmPool().catch((err) => {
+          console.error("[PtyHost] Deferred pool warm failed:", err);
+        });
+      }
       if (msg.projectPath && pool) {
         ctx.initialPoolWarmDeferred = false;
         pool.drainAndRefill(msg.projectPath).catch((err) => {

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -180,7 +180,17 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
       windowProjectMap.set(msg.windowId, msg.projectId);
       recomputeActivityTiers();
       const pool = ctx.ptyPool;
+      if (!msg.projectPath && pool && ctx.initialPoolWarmDeferred) {
+        // The boot-time homedir warm was deferred for a project restore that
+        // fell through (e.g. the saved project no longer exists) — run it now
+        // at the pool's default cwd (still homedir).
+        ctx.initialPoolWarmDeferred = false;
+        pool.warmPool().catch((err) => {
+          console.error("[PtyHost] Deferred pool warm failed:", err);
+        });
+      }
       if (msg.projectPath && pool) {
+        ctx.initialPoolWarmDeferred = false;
         // Bound the warm set to what the pool can hold alongside the root entry
         // without LRU-evicting the entries we just warmed. The root drain/refill
         // takes poolSize slots; each panel cwd takes up to poolSize more. Cap
@@ -225,6 +235,7 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
       recomputeActivityTiers();
       const pool = ctx.ptyPool;
       if (msg.projectPath && pool) {
+        ctx.initialPoolWarmDeferred = false;
         pool.drainAndRefill(msg.projectPath).catch((err) => {
           console.error("[PtyHost] drainAndRefill failed:", err);
         });

--- a/electron/pty-host/handlers/types.ts
+++ b/electron/pty-host/handlers/types.ts
@@ -43,6 +43,12 @@ export interface HostContext {
   visualSignalView: Int32Array | null;
   analysisBuffer: SharedRingBuffer | null;
   ptyPool: PtyPool | null;
+  /**
+   * True when the boot-time homedir pool warm was deferred because main
+   * signalled an imminent project restore (DAINTREE_PTY_DEFER_POOL_WARM).
+   * Consumed (set false) by the first set-active-project / project-switch.
+   */
+  initialPoolWarmDeferred: boolean;
 
   // Stable function references
   sendEvent: (event: PtyHostEvent) => void;

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -196,6 +196,7 @@ export class PtyClient extends EventEmitter {
     { projectId: string | null; projectPath?: string; mode: "active" | "switch" }
   >();
   private shouldResyncProjectContext = false;
+  private deferInitialPoolWarm = false;
   private hostStartRequested = false;
   private pendingMessagePorts = new Map<number, MessagePortMain>();
   private terminalPids: Map<string, number> = new Map();
@@ -263,6 +264,7 @@ export class PtyClient extends EventEmitter {
       {
         memoryLimitMb: this.config.memoryLimitMb,
         electronDir,
+        deferInitialPoolWarm: () => this.deferInitialPoolWarm,
       },
       {
         onMessage: (event) => this.handleHostEvent(event),
@@ -347,6 +349,18 @@ export class PtyClient extends EventEmitter {
   /** Whether {@link PtyClient.start} has forked (or requested) the host yet. */
   isHostStarted(): boolean {
     return this.hostStartRequested;
+  }
+
+  /**
+   * Mark the host fork as a project-restoring boot: the host skips its
+   * boot-time homedir pool warm because the set-active-project sent right
+   * after ready drains the pool to the project path anyway (#10393). The
+   * host falls back to a homedir warm if the restore falls through, and the
+   * flag is re-read on every restart fork — context replay re-warms the pool
+   * either way. Call before {@link start}.
+   */
+  setDeferInitialPoolWarm(defer: boolean): void {
+    this.deferInitialPoolWarm = defer;
   }
 
   /** Wait for the host to be ready */

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -119,6 +119,13 @@ export const CRASH_WINDOW_MS = 30 * 60 * 1000;
 export interface PtyHostLifecycleConfig {
   memoryLimitMb: number;
   electronDir: string;
+  /**
+   * Read at each fork. When true the host defers its boot-time homedir pool
+   * warm — used on project-restoring boots where the set-active-project that
+   * follows ready immediately drains the pool to the project path, so the
+   * homedir warm would only spawn shells for the drain to kill (#10393).
+   */
+  deferInitialPoolWarm?: () => boolean;
 }
 
 export interface PtyHostLifecycleCallbacks {
@@ -321,6 +328,7 @@ export class PtyHostLifecycle {
           DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
           DAINTREE_PERF_FORK_ABS_MS: String(forkAbsMs),
           DAINTREE_PERF_MAIN_BOOT_ABS_MS: String(mainBootAbsMs),
+          ...(this.config.deferInitialPoolWarm?.() ? { DAINTREE_PTY_DEFER_POOL_WARM: "1" } : {}),
           // node-pty 1.x hangs intermittently on Linux kernels with io_uring
           // enabled (microsoft/node-pty#630, closed as not planned). The fix
           // is permanent and must be set inside the explicit env object — a

--- a/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
+++ b/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
@@ -225,6 +225,30 @@ describe("PtyHostLifecycle", () => {
     expect(lifecycle.child).toBe(mockChild);
   });
 
+  it("injects DAINTREE_PTY_DEFER_POOL_WARM into the fork env per the config getter (#10393)", () => {
+    let defer = true;
+    const callbacks = createCallbacks();
+    const lifecycle = new PtyHostLifecycle(
+      { memoryLimitMb: 256, electronDir: "/tmp/electron", deferInitialPoolWarm: () => defer },
+      callbacks.callbacks
+    );
+    lifecycle.start();
+    expect(shared.forkMock.mock.calls[0][2].env.DAINTREE_PTY_DEFER_POOL_WARM).toBe("1");
+
+    // The getter is re-read on each fork, not captured at construction.
+    defer = false;
+    lifecycle.child = null;
+    lifecycle.manualRestart();
+    expect(shared.forkMock).toHaveBeenCalledTimes(2);
+    expect(shared.forkMock.mock.calls[1][2].env).not.toHaveProperty("DAINTREE_PTY_DEFER_POOL_WARM");
+  });
+
+  it("omits DAINTREE_PTY_DEFER_POOL_WARM when the config getter is absent", () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    expect(shared.forkMock.mock.calls[0][2].env).not.toHaveProperty("DAINTREE_PTY_DEFER_POOL_WARM");
+  });
+
   it("calls onForkFailed when utilityProcess.fork throws", async () => {
     const error = new Error("fork failed");
     shared.forkMock.mockImplementationOnce(() => {

--- a/electron/window/__tests__/skeletonCss.test.ts
+++ b/electron/window/__tests__/skeletonCss.test.ts
@@ -17,6 +17,7 @@ vi.mock("electron", () => ({
 }));
 
 import {
+  buildSkeletonCss,
   injectSkeletonCss,
   injectSkeletonProjectIdentity,
   resolveInitialCanvasBackgroundColor,
@@ -137,6 +138,35 @@ describe("injectSkeletonCss var scoping (#9716)", () => {
     const selectors = css.match(/[^\s][^{]*\{/g) ?? [];
     expect(selectors.some((s) => s.trim().startsWith("#startup-skeleton"))).toBe(true);
     expect(selectors.some((s) => s.trim().startsWith(":root"))).toBe(false);
+  });
+});
+
+describe("buildSkeletonCss pre-read theme config (#10393)", () => {
+  beforeEach(() => {
+    storeMock.get.mockReset();
+    storeMock.get.mockImplementation((key: string) => {
+      if (key === "appState") return { sidebarWidth: 350, focusMode: false };
+      if (key === "appTheme") return { colorSchemeId: "daintree" };
+      return undefined;
+    });
+  });
+
+  it("uses the passed config instead of re-reading appTheme from the store", () => {
+    const css = buildSkeletonCss(undefined, { colorSchemeId: "bondi" });
+    // The store still says "daintree" — the bondi token proves the pre-read
+    // config won, and the call log proves the disk read was skipped.
+    expect(css).toContain(
+      `--theme-surface-canvas: ${resolveAppTheme("bondi", []).tokens["surface-canvas"]};`
+    );
+    expect(storeMock.get).not.toHaveBeenCalledWith("appTheme");
+  });
+
+  it("falls back to the store read when no config is passed", () => {
+    const css = buildSkeletonCss();
+    expect(css).toContain(
+      `--theme-surface-canvas: ${resolveAppTheme("daintree", []).tokens["surface-canvas"]};`
+    );
+    expect(storeMock.get).toHaveBeenCalledWith("appTheme");
   });
 });
 

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -367,7 +367,7 @@ export function setupBrowserWindow(
     // skips the synchronous config.json re-reads; later dom-ready events
     // (crash auto-reloads) rebuild it so the skeleton reflects current
     // theme/sidebar/focus state.
-    const precomputedSkeletonCss = buildSkeletonCss();
+    const precomputedSkeletonCss = buildSkeletonCss(undefined, themeConfig);
     let firstDomReady = true;
     appWebContents.on("dom-ready", () => {
       if (firstDomReady) {

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -121,14 +121,20 @@ export function resolveInitialCanvasBackgroundColor(): string {
  * persisted app state and theme config synchronously, so callers on the boot
  * critical path can precompute the string once (before loadURL) instead of
  * re-reading config.json inside the dom-ready handler that gates win.show().
+ * Accepts a pre-read theme config so callers that already hold one avoid a
+ * redundant full-store read (every `store.get()` re-reads the config file
+ * from disk).
  */
-export function buildSkeletonCss(project?: Pick<Project, "color"> | null): string {
+export function buildSkeletonCss(
+  project?: Pick<Project, "color"> | null,
+  preReadThemeConfig?: Partial<AppThemeConfig>
+): string {
   const appState = store.get("appState");
   const sidebarWidth = appState?.sidebarWidth ?? 350;
   const focusMode = appState?.focusMode ?? false;
 
   // Resolve theme
-  const themeConfig = store.get("appTheme") ?? {};
+  const themeConfig = preReadThemeConfig ?? store.get("appTheme") ?? {};
   const colorSchemeId =
     typeof themeConfig.colorSchemeId === "string" ? themeConfig.colorSchemeId : "daintree";
   // Apply lazy migration for legacy string-encoded customSchemes

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -150,6 +150,12 @@ export async function setupWindowServices(
   const deferRendererLoadForE2E = shouldDeferRendererLoadForE2E();
 
   let rendererLoadStarted = false;
+  // True once a port pair has been distributed with a live PtyClient (the
+  // client queues ports internally until the host is running, so "client
+  // exists" is sufficient). Lets the post-services block below skip its
+  // redundant re-distribution, which would discard the pair the renderer is
+  // already holding.
+  let ptyPortsWired = false;
   const startRendererLoad = (reason: string): void => {
     if (rendererLoadStarted) return;
     rendererLoadStarted = true;
@@ -167,6 +173,9 @@ export async function setupWindowServices(
       if (isSmokeTest) console.error("[SMOKE] CHECK: Renderer did-finish-load — OK");
       markPerformance(PERF_MARKS.RENDERER_READY);
       createAndDistributePorts(win, ctx);
+      if (getPtyClient()) {
+        ptyPortsWired = true;
+      }
       // Re-register the renderer in directPortViews on reload so
       // sendToEntryWindows continues routing host events to it. With
       // early-renderer mode (default), workspaceClient may still be null on
@@ -253,6 +262,11 @@ export async function setupWindowServices(
     // this never double-runs the probe and guarantees the #8625 invariant holds
     // before the fork rather than silently skipping it on a null promise.
     await (getEarlyPathRefreshPromise() ?? kickOffEarlyPathRefresh());
+    // Project-restoring boots send set-active-project with a project path
+    // right after the host is ready, draining the pool — tell the host to
+    // skip the homedir warm those drains would immediately kill (#10393).
+    // The host falls back to a homedir warm if the restore falls through.
+    ptyClient.setDeferInitialPoolWarm(Boolean(opts.initialProjectPath || opts.initialProjectId));
     ptyClient.start();
   }
 
@@ -306,20 +320,36 @@ export async function setupWindowServices(
 
     // Give PluginService the WorkspaceClient reference now that it's ready.
     // initialize() is deferred and may run before or after this point — the
-    // service's pendingWorktreeSubs replay handles either ordering.
-    try {
-      const { pluginService } = await import("../services/PluginService.js");
-      pluginService.setWorkspaceClient(workspaceClient);
-    } catch (err) {
-      console.error("[MAIN] Failed to wire WorkspaceClient into PluginService:", err);
+    // service's pendingWorktreeSubs replay handles either ordering. The two
+    // imports are independent; load them concurrently with per-module error
+    // isolation.
+    const [pluginServiceResult, portBrokerResult] = await Promise.allSettled([
+      import("../services/PluginService.js"),
+      import("../services/WorktreePortBroker.js"),
+    ]);
+
+    if (pluginServiceResult.status === "fulfilled") {
+      try {
+        pluginServiceResult.value.pluginService.setWorkspaceClient(workspaceClient);
+      } catch (err) {
+        console.error("[MAIN] Failed to wire WorkspaceClient into PluginService:", err);
+      }
+    } else {
+      console.error(
+        "[MAIN] Failed to wire WorkspaceClient into PluginService:",
+        pluginServiceResult.reason
+      );
     }
 
     markPerformance(PERF_MARKS.SERVICE_INIT_WORKSPACE_READY);
 
     // Create WorktreePortBroker alongside WorkspaceClient
     if (!getWorktreePortBrokerRef()) {
-      const { WorktreePortBroker } = await import("../services/WorktreePortBroker.js");
-      setWorktreePortBrokerRef(new WorktreePortBroker());
+      if (portBrokerResult.status === "fulfilled") {
+        setWorktreePortBrokerRef(new portBrokerResult.value.WorktreePortBroker());
+      } else {
+        throw portBrokerResult.reason;
+      }
     }
 
     handlerDeps.worktreeService = workspaceClient;
@@ -471,7 +501,11 @@ export async function setupWindowServices(
   // PTY-related features
   if (ptyReady) {
     const pty = getPtyClient()!;
-    createAndDistributePorts(win, ctx);
+    // Skip when the did-finish-load handler already distributed a pair with a
+    // live PtyClient — re-distributing here would close the renderer's ports.
+    if (!ptyPortsWired) {
+      createAndDistributePorts(win, ctx);
+    }
 
     if (restoreProject) {
       pty.setActiveProject(

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -266,7 +266,10 @@ export async function setupWindowServices(
     // right after the host is ready, draining the pool — tell the host to
     // skip the homedir warm those drains would immediately kill (#10393).
     // The host falls back to a homedir warm if the restore falls through.
-    ptyClient.setDeferInitialPoolWarm(Boolean(opts.initialProjectPath || opts.initialProjectId));
+    // Keyed on initialProjectId only: path-only boots (CLI open) send
+    // set-active-project(null) before the project-switch, which would fire
+    // the fallback homedir warm and waste the deferral anyway.
+    ptyClient.setDeferInitialPoolWarm(Boolean(opts.initialProjectId));
     ptyClient.start();
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -43,7 +43,6 @@ import { RepoFetchCoordinator } from "./RepoFetchCoordinator.js";
 import { waitForPathExists } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import {
-  probeGitLfsAvailable,
   parseCheckedOutBranches,
   nextAvailableBranchName,
   ensureNoteFile,
@@ -581,14 +580,7 @@ export class WorkspaceService {
       const rawWorktrees = await this.listService.list();
       const worktrees = this.listService.mapToWorktrees(rawWorktrees);
 
-      // Run the LFS probe concurrently with monitor sync so we don't add its
-      // 3s worst case on top of sync latency. The probe is a read-only CLI
-      // check (no PATH side-effects); its result travels on the load-project
-      // event so the renderer can warn proactively when a repo uses LFS.
-      const [, lfsAvailable] = await Promise.all([
-        this.syncMonitors(worktrees, this.activeWorktreeId, this.mainBranch, undefined, true),
-        probeGitLfsAvailable(),
-      ]);
+      await this.syncMonitors(worktrees, this.activeWorktreeId, this.mainBranch, undefined, true);
 
       this.startTopologyWatcher();
       // Started independently of startTopologyWatcher() — that method no-ops
@@ -612,7 +604,7 @@ export class WorkspaceService {
       // owning project picks them up.
       this.pruneStaleWslGitEntries(worktrees);
 
-      this.sendEvent({ type: "load-project-result", requestId, success: true, lfsAvailable });
+      this.sendEvent({ type: "load-project-result", requestId, success: true });
 
       void Promise.allSettled([this.initializePRService(), this.refreshAll()]).then((results) => {
         const [prResult, refreshResult] = results;

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -522,19 +522,7 @@ export type WorkspaceHostEvent =
   | { type: "pong" }
   | { type: "error"; error: string; requestId?: string }
   // Project lifecycle responses
-  | {
-      type: "load-project-result";
-      requestId: string;
-      success: boolean;
-      error?: string;
-      /**
-       * Whether `git lfs` is available on PATH for this machine. Probed during
-       * load-project via `git lfs version`. `undefined` means the probe did not
-       * run (e.g. project load failed before the probe) and the renderer should
-       * treat it as unknown rather than unavailable.
-       */
-      lfsAvailable?: boolean;
-    }
+  | { type: "load-project-result"; requestId: string; success: boolean; error?: string }
   | { type: "sync-result"; requestId: string; success: boolean; error?: string }
   | { type: "update-monitor-config-result"; requestId: string; success: boolean; error?: string }
   | { type: "project-switch-result"; requestId: string; success: boolean }


### PR DESCRIPTION
## Summary

- Removes the blocking git-lfs probe from the load-project critical path (15-80ms saved); `lfsAvailable` is dropped from `LoadProjectResultEvent` — zero consumers, and `probeGitLfsAvailable` is kept for tests
- Parallelizes the `PluginService` + `WorktreePortBroker` dynamic imports via `Promise.allSettled`, preserving original error semantics (plugin failure logged, broker failure throws)
- Theme resolved once per window creation: `createWindow` passes its pre-read `appTheme` config into `buildSkeletonCss` via a new optional `preReadThemeConfig` param, skipping the redundant synchronous `config.json` read; crash-reload path still re-reads fresh
- PTY `MessagePort` pair no longer created twice per boot: a `ptyPortsWired` flag skips the post-services re-distribution when the `did-finish-load` handler already wired a pair with a live `PtyClient`
- `PtyPool` homedir warm deferred on project-restoring boots via `DAINTREE_PTY_DEFER_POOL_WARM` fork-env flag (keyed on `initialProjectId`); `set-active-project`'s `drainAndRefill` warms at the project path instead; deterministic homedir fallback covers deleted-project restores and restart replays

Item 6 from the checklist (folding the last-project-id read into the integrity probe's DB connection) is intentionally skipped. `getSharedDb()` is still unopened at that point — using it would pull migrations earlier in boot, which Codex flagged as a behaviour change. Threading the read through `DatabaseMaintenanceService` couples app-state reads to that service for a sub-millisecond win on a page-cache-hot file. Worth either closing as won't-do or splitting into its own PR.

One note on item 5: a plain `warmPool`→`drainAndRefill` swap would be a no-op, since the warm always starts before `set-active-project` arrives. The fork-time env signal is what actually skips the wasted spawns.

Resolves #10393

## Changes

- `electron/services/workspace/WorkspaceService.ts` — remove `lfsAvailable` probe from `loadProject`
- `electron/pty-host/PtyHostLifecycle.ts` — `DAINTREE_PTY_DEFER_POOL_WARM` fork-env flag + handler
- `electron/pty-host/PtyPool.ts` — deferred warm path
- `electron/window/windowManager.ts` — `ptyPortsWired` flag, parallelized dynamic imports
- `electron/window/skeletonCss.ts` — `preReadThemeConfig` optional param
- `electron/window/windowUtils.ts` / `createWindow` — pass pre-read theme config

## Testing

Targeted vitest suites: pty-host handler tests, `PtyHostLifecycle` fork-env tests, `buildSkeletonCss` pre-read tests, `WorkspaceService` LFS test, `PtyPool`. All 165+76 tests green. Typecheck and prettier clean on changed files.

New tests: 4 deferred-warm handler tests + no-path project-switch fallback, 2 fork-env injection tests, 2 `buildSkeletonCss` pre-read tests.