### PR TITLE
perf(window): memory housekeeping for cached views, portal tabs, and log broadcasts (#10391)

### DIFF
--- a/electron/ipc/__tests__/utils.test.ts
+++ b/electron/ipc/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ const ipcMainMock = vi.hoisted(() => ({
 
 const browserWindowFromWebContentsMock = vi.hoisted(() => vi.fn());
 const browserWindowGetAllWindowsMock = vi.hoisted(() => vi.fn(() => [] as unknown[]));
+const isCachedViewWebContentsMock = vi.hoisted(() => vi.fn((_id: number) => false));
 
 vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
@@ -34,6 +35,7 @@ vi.mock("../../window/webContentsRegistry.js", () => ({
       .filter((w) => !w.isDestroyed() && w.webContents && !w.webContents.isDestroyed())
       .map((w) => w.webContents);
   }),
+  isCachedViewWebContents: isCachedViewWebContentsMock,
 }));
 
 vi.mock("../../window/windowRef.js", () => ({
@@ -43,6 +45,7 @@ vi.mock("../../window/windowRef.js", () => ({
 import {
   sendToRenderer,
   broadcastToRenderer,
+  broadcastToVisibleRenderers,
   sendToRendererContext,
   typedHandle,
   typedHandleWithContext,
@@ -315,6 +318,82 @@ describe("broadcastToRenderer", () => {
 
     expect(() => broadcastToRenderer("channel:test")).not.toThrow();
     expect(send2).toHaveBeenCalledWith("channel:test");
+  });
+});
+
+describe("broadcastToVisibleRenderers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isCachedViewWebContentsMock.mockImplementation(() => false);
+  });
+
+  it("skips cached webContents and sends to visible ones", () => {
+    const sendVisible = vi.fn();
+    const sendCached = vi.fn();
+    const visible = {
+      isDestroyed: () => false,
+      webContents: { id: 1, isDestroyed: () => false, send: sendVisible },
+    };
+    const cached = {
+      isDestroyed: () => false,
+      webContents: { id: 2, isDestroyed: () => false, send: sendCached },
+    };
+    browserWindowGetAllWindowsMock.mockReturnValue([visible, cached]);
+    isCachedViewWebContentsMock.mockImplementation((id: number) => id === 2);
+
+    broadcastToVisibleRenderers("logs:batch", [{ level: "info" }]);
+
+    expect(sendVisible).toHaveBeenCalledWith("logs:batch", [{ level: "info" }]);
+    expect(sendCached).not.toHaveBeenCalled();
+  });
+
+  it("resumes sending once the webContents is no longer cached", () => {
+    const send = vi.fn();
+    const win = {
+      isDestroyed: () => false,
+      webContents: { id: 3, isDestroyed: () => false, send },
+    };
+    browserWindowGetAllWindowsMock.mockReturnValue([win]);
+
+    isCachedViewWebContentsMock.mockImplementation(() => true);
+    broadcastToVisibleRenderers("logs:batch");
+    expect(send).not.toHaveBeenCalled();
+
+    isCachedViewWebContentsMock.mockImplementation(() => false);
+    broadcastToVisibleRenderers("logs:batch");
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it("broadcastToRenderer ignores the cached mark — state broadcasts reach cached views", () => {
+    const send = vi.fn();
+    const win = {
+      isDestroyed: () => false,
+      webContents: { id: 4, isDestroyed: () => false, send },
+    };
+    browserWindowGetAllWindowsMock.mockReturnValue([win]);
+    isCachedViewWebContentsMock.mockImplementation(() => true);
+
+    broadcastToRenderer("project:updated", { id: "p1" });
+    expect(send).toHaveBeenCalledWith("project:updated", { id: "p1" });
+  });
+
+  it("does not throw when webContents.send throws", () => {
+    const send1 = vi.fn(() => {
+      throw new Error("send failed");
+    });
+    const send2 = vi.fn();
+    const win1 = {
+      isDestroyed: () => false,
+      webContents: { id: 6, isDestroyed: () => false, send: send1 },
+    };
+    const win2 = {
+      isDestroyed: () => false,
+      webContents: { id: 7, isDestroyed: () => false, send: send2 },
+    };
+    browserWindowGetAllWindowsMock.mockReturnValue([win1, win2]);
+
+    expect(() => broadcastToVisibleRenderers("logs:batch")).not.toThrow();
+    expect(send2).toHaveBeenCalledWith("logs:batch");
   });
 });
 

--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -4,6 +4,7 @@ import {
   getWindowForWebContents,
   getAppWebContents,
   getAllAppWebContents,
+  isCachedViewWebContents,
 } from "../window/webContentsRegistry.js";
 import { getProjectViewManager } from "../window/windowRef.js";
 import type { IpcInvokeMap, IpcEventMap } from "../types/index.js";
@@ -343,6 +344,27 @@ export function sendToRenderer(
 
 export function broadcastToRenderer(channel: string, ...args: unknown[]): void {
   for (const wc of getAllAppWebContents()) {
+    if (!wc.isDestroyed()) {
+      try {
+        wc.send(channel, ...args);
+      } catch {
+        // Silently ignore send failures during window initialization/disposal.
+      }
+    }
+  }
+}
+
+/**
+ * Broadcast that skips cached (deactivated) project views. Only for
+ * high-frequency streams the renderer can re-fetch on activation (e.g. log
+ * batches via LOGS_GET_ALL) — cached renderers are CPU-throttled or frozen, so
+ * pushed messages would queue unbounded in their task queues. State broadcasts
+ * must keep using broadcastToRenderer: cached views have no replay path on
+ * warm reactivation (#9490).
+ */
+export function broadcastToVisibleRenderers(channel: string, ...args: unknown[]): void {
+  for (const wc of getAllAppWebContents()) {
+    if (isCachedViewWebContents(wc.id)) continue;
     if (!wc.isDestroyed()) {
       try {
         wc.send(channel, ...args);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -78,7 +78,7 @@ import { preAgentSnapshotService } from "./services/PreAgentSnapshotService.js";
 import { isDemoMode, isSmokeTest, kickOffEarlyPathRefresh } from "./setup/environment.js";
 import { store } from "./store.js";
 import { initializeLogger, registerLoggerTransport, setLogLevelOverrides } from "./utils/logger.js";
-import { broadcastToRenderer } from "./ipc/utils.js";
+import { broadcastToVisibleRenderers } from "./ipc/utils.js";
 import {
   initializeCrashRecoveryService,
   getCrashRecoveryService,
@@ -182,7 +182,12 @@ if (!gotTheLock) {
   // receive the same map after their first `ready` event.
   setLogLevelOverrides(store.get("logLevelOverrides") ?? {});
 
-  registerLoggerTransport(broadcastToRenderer, () => BrowserWindow.getAllWindows().length > 0);
+  // Visible-only: log batches are high-frequency and replayable (LOGS_GET_ALL),
+  // so cached/frozen project views skip them instead of queueing every flush.
+  registerLoggerTransport(
+    broadcastToVisibleRenderers,
+    () => BrowserWindow.getAllWindows().length > 0
+  );
 
   crashReporter.start({ uploadToServer: false });
   initializeCrashLoopGuard();

--- a/electron/services/PortalManager.ts
+++ b/electron/services/PortalManager.ts
@@ -4,6 +4,7 @@ import { isSafeNavigationUrl } from "../../shared/utils/urlUtils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { canOpenExternalUrl, openExternalUrl } from "../utils/openExternal.js";
 import { getAppWebContents } from "../window/webContentsRegistry.js";
+import { throttleCpuWebContents, unthrottleCpuWebContents } from "../utils/webContentsLifecycle.js";
 
 export const PORTAL_MAX_LIVE_TABS = 3;
 
@@ -369,8 +370,19 @@ export class PortalManager {
 
     // Park the previously-active view offscreen instead of detaching it —
     // keeps its renderer state (scroll, in-flight requests, sockets) alive.
+    // CPU throttle (not freeze) so its event loop and live SSE/WS streams
+    // keep running while V8/Blink CPU time drops.
     if (this.activeView && this.activeView !== view) {
       this.activeView.setBounds(OFFSCREEN_BOUNDS);
+      if (this.activeView.webContents && !this.activeView.webContents.isDestroyed()) {
+        void throttleCpuWebContents(this.activeView.webContents);
+      }
+    }
+
+    // Restore full CPU rate before making visible — the view may have been
+    // throttled while parked by a previous showTab() or hideAll().
+    if (view.webContents && !view.webContents.isDestroyed()) {
+      void unthrottleCpuWebContents(view.webContents);
     }
 
     // Attach on first show only; subsequent shows just move bounds.
@@ -420,6 +432,12 @@ export class PortalManager {
     if (this.activeView) {
       this.activeView.setBounds(OFFSCREEN_BOUNDS);
       this.hidden = true;
+      // CPU throttle (not freeze) the parked view — keeps SSE/WS streams and
+      // the event loop alive while cutting background CPU. showTab() restores
+      // the full rate on re-show.
+      if (this.activeView.webContents && !this.activeView.webContents.isDestroyed()) {
+        void throttleCpuWebContents(this.activeView.webContents);
+      }
       // Return focus to the main app webContents. The old removeChildView
       // path implicitly blurred the portal view; keep that behavior so
       // keyboard input goes to the overlay's focus-trap (in the renderer's

--- a/electron/services/__tests__/PortalManager.test.ts
+++ b/electron/services/__tests__/PortalManager.test.ts
@@ -70,6 +70,13 @@ vi.mock("../utils/openExternal.js", () => ({
   openExternalUrl: vi.fn().mockResolvedValue(undefined),
 }));
 
+const lifecycleMocks = vi.hoisted(() => ({
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../utils/webContentsLifecycle.js", () => lifecycleMocks);
+
 describe("PortalManager", () => {
   let PortalManagerClass: typeof import("../PortalManager.js").PortalManager;
   let mockWindow: InstanceType<typeof import("electron").BrowserWindow>;
@@ -191,6 +198,48 @@ describe("PortalManager", () => {
       expect(mockWindow.contentView.removeChildView).not.toHaveBeenCalled();
       expect(mockWindow.contentView.addChildView).toHaveBeenCalledTimes(2);
     });
+
+    it("throttles the parked previous tab and unthrottles the shown tab on switch", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.createTab("tab-a", "http://localhost:3000");
+      manager.createTab("tab-b", "http://localhost:4000");
+      const wcA = createdWebContents[0];
+      const wcB = createdWebContents[1];
+
+      manager.showTab("tab-a", { x: 0, y: 0, width: 800, height: 600 });
+      expect(lifecycleMocks.throttleCpuWebContents).not.toHaveBeenCalled();
+      expect(lifecycleMocks.unthrottleCpuWebContents).toHaveBeenCalledWith(wcA);
+
+      manager.showTab("tab-b", { x: 0, y: 0, width: 800, height: 600 });
+      expect(lifecycleMocks.throttleCpuWebContents).toHaveBeenCalledWith(wcA);
+      expect(lifecycleMocks.throttleCpuWebContents).not.toHaveBeenCalledWith(wcB);
+      expect(lifecycleMocks.unthrottleCpuWebContents).toHaveBeenCalledWith(wcB);
+    });
+
+    it("does not throttle when re-showing the already-active tab", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.createTab("tab-a", "http://localhost:3000");
+      manager.showTab("tab-a", { x: 0, y: 0, width: 800, height: 600 });
+      manager.showTab("tab-a", { x: 0, y: 0, width: 900, height: 700 });
+
+      expect(lifecycleMocks.throttleCpuWebContents).not.toHaveBeenCalled();
+    });
+
+    it("skips throttling a destroyed parked webContents", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.createTab("tab-a", "http://localhost:3000");
+      manager.createTab("tab-b", "http://localhost:4000");
+      const wcA = createdWebContents[0];
+
+      manager.showTab("tab-a", { x: 0, y: 0, width: 800, height: 600 });
+      wcA.isDestroyed.mockReturnValue(true);
+
+      manager.showTab("tab-b", { x: 0, y: 0, width: 800, height: 600 });
+      expect(lifecycleMocks.throttleCpuWebContents).not.toHaveBeenCalledWith(wcA);
+    });
   });
 
   describe("bounds validation", () => {
@@ -273,6 +322,36 @@ describe("PortalManager", () => {
       // test name to refer to "view" semantics even though webContents-level
       // assertions aren't needed here.
       expect(view).toBeDefined();
+    });
+
+    it("throttles the parked view's webContents and showTab restores it", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.createTab("tab-hide-throttle", "http://localhost:3000");
+      const wc = createdWebContents[0];
+
+      manager.showTab("tab-hide-throttle", { x: 0, y: 0, width: 800, height: 600 });
+      expect(lifecycleMocks.throttleCpuWebContents).not.toHaveBeenCalled();
+
+      manager.hideAll();
+      expect(lifecycleMocks.throttleCpuWebContents).toHaveBeenCalledWith(wc);
+
+      lifecycleMocks.unthrottleCpuWebContents.mockClear();
+      manager.showTab("tab-hide-throttle", { x: 0, y: 0, width: 800, height: 600 });
+      expect(lifecycleMocks.unthrottleCpuWebContents).toHaveBeenCalledWith(wc);
+    });
+
+    it("does not throttle a destroyed webContents on hideAll", () => {
+      const manager = new PortalManagerClass(mockWindow);
+
+      manager.createTab("tab-hide-destroyed", "http://localhost:3000");
+      const wc = createdWebContents[0];
+
+      manager.showTab("tab-hide-destroyed", { x: 0, y: 0, width: 800, height: 600 });
+      wc.isDestroyed.mockReturnValue(true);
+
+      manager.hideAll();
+      expect(lifecycleMocks.throttleCpuWebContents).not.toHaveBeenCalled();
     });
 
     it("re-showing the same tab after hideAll does not call addChildView again", () => {

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -14,6 +14,8 @@ import {
   unregisterWebContents,
   registerProjectView,
   unregisterProjectView,
+  registerCachedViewWebContents,
+  unregisterCachedViewWebContents,
 } from "./webContentsRegistry.js";
 import { registerProtocolsForSession, getDistPath } from "../setup/protocols.js";
 import { getDevServerUrl } from "../../shared/config/devServer.js";
@@ -52,7 +54,6 @@ import {
   unthrottleCpuWebContents,
 } from "../utils/webContentsLifecycle.js";
 import { ACTIVE_AGENT_STATES, type AgentState } from "../../shared/types/agent.js";
-import { setAlignedInterval } from "../utils/setAlignedInterval.js";
 import {
   beginWindowRecreating,
   endWindowRecreating,
@@ -305,22 +306,35 @@ export class ProjectViewManager {
     win.on("enter-full-screen", this.resizeHandler);
     win.on("leave-full-screen", this.resizeHandler);
 
-    // Outer try/catch is load-bearing: `setAlignedInterval` calls the callback
-    // synchronously on the first aligned tick BEFORE installing the recurring
-    // `setInterval`. If the first tick throws, the recurring interval is never
-    // installed and all subsequent sampling is silently lost. Any uncaught throw
-    // also reaches `uncaughtException`. Sampling failures are pure telemetry
-    // and must never destabilise the manager.
-    this.cachedMemoryTimerCleanup = setAlignedInterval(() => {
-      if (this.disposed) return;
-      try {
-        this.sampleCachedViewMemory();
-      } catch (error) {
-        logWarn("projectview.cached-memory.error", {
-          error: formatErrorMessage(error, "sampleCachedViewMemory threw"),
-        });
+    // Per-instance random phase offset: every window has its own sampler, and
+    // app.getAppMetrics() costs 5–50ms of synchronous main-thread work. A
+    // wall-clock-aligned interval would collapse all windows onto the same
+    // tick and stack those costs; the jittered first delay spreads them across
+    // the sample window. try/catch is load-bearing: an uncaught throw would
+    // stop rescheduling and reach `uncaughtException`. Sampling failures are
+    // pure telemetry and must never destabilise the manager.
+    let sampleTimer: NodeJS.Timeout | null = null;
+    const scheduleSample = (delayMs: number) => {
+      sampleTimer = setTimeout(() => {
+        if (this.disposed) return;
+        try {
+          this.sampleCachedViewMemory();
+        } catch (error) {
+          logWarn("projectview.cached-memory.error", {
+            error: formatErrorMessage(error, "sampleCachedViewMemory threw"),
+          });
+        }
+        scheduleSample(CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS);
+      }, delayMs);
+      sampleTimer.unref?.();
+    };
+    scheduleSample(Math.random() * CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS);
+    this.cachedMemoryTimerCleanup = () => {
+      if (sampleTimer) {
+        clearTimeout(sampleTimer);
+        sampleTimer = null;
       }
-    }, CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS);
+    };
   }
 
   /**
@@ -991,6 +1005,9 @@ export class ProjectViewManager {
     // Throttle background view to reduce CPU and allow Chromium to reclaim memory
     if (!current.view.webContents.isDestroyed()) {
       const cachedWcId = current.view.webContents.id;
+      // Mark cached so visible-only broadcasts (log batches) skip this
+      // renderer — pushed messages have no backpressure once throttled/frozen.
+      registerCachedViewWebContents(current.view.webContents);
       // Close live producer ports BEFORE applying CPU throttle. Once throttled,
       // Chromium can freeze the renderer after ~5 min hidden or under memory
       // pressure; any messages still posted by main/utility processes
@@ -1054,6 +1071,10 @@ export class ProjectViewManager {
 
   private activateView(entry: ViewEntry, insertBehind = false): void {
     registerAppView(this.win, entry.view);
+
+    if (!entry.view.webContents.isDestroyed()) {
+      unregisterCachedViewWebContents(entry.view.webContents.id);
+    }
 
     // Defensive unfreeze BEFORE restoring CPU rate: efficiency transitions and
     // view activations are async, so an activating view may still be frozen

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -98,6 +98,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -77,6 +77,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -90,6 +90,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -326,6 +326,16 @@ describe("ProjectViewManager — efficiency freeze", () => {
     expect(cachedCalls.every((call) => call[0] !== activeWc)).toBe(true);
   });
 
+  it("marks the view cached before applying the CPU throttle", async () => {
+    const { throttleCpuWebContents } = await import("../../utils/webContentsLifecycle.js");
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    const markOrder = vi.mocked(registerCachedViewWebContents).mock.invocationCallOrder[0];
+    const throttleOrder = vi.mocked(throttleCpuWebContents).mock.invocationCallOrder[0];
+    expect(markOrder).toBeLessThan(throttleOrder);
+  });
+
   it("warm reactivation clears the cached mark", async () => {
     await manager.switchTo("proj-b", "/path/b");
     vi.mocked(unregisterCachedViewWebContents).mockClear();

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -53,6 +53,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({
@@ -117,6 +119,10 @@ vi.mock("../../utils/webContentsLifecycle.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { freezeWebContents, unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
+import {
+  registerCachedViewWebContents,
+  unregisterCachedViewWebContents,
+} from "../webContentsRegistry.js";
 
 function createMockWindow() {
   return {
@@ -308,5 +314,117 @@ describe("ProjectViewManager — efficiency freeze", () => {
     // Re-toggle off — no unfreeze call expected (no cached views).
     manager.setEfficiencyFreeze(false);
     expect(vi.mocked(unfreezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("deactivation marks the view cached in the broadcast registry", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(vi.mocked(registerCachedViewWebContents)).toHaveBeenCalledWith(initialWc);
+    // The newly-active view must never be marked cached.
+    const activeWc = manager.getActiveView()!.webContents;
+    const cachedCalls = vi.mocked(registerCachedViewWebContents).mock.calls;
+    expect(cachedCalls.every((call) => call[0] !== activeWc)).toBe(true);
+  });
+
+  it("warm reactivation clears the cached mark", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    vi.mocked(unregisterCachedViewWebContents).mockClear();
+
+    await manager.switchTo("proj-a", "/path/a");
+
+    expect(vi.mocked(unregisterCachedViewWebContents)).toHaveBeenCalledWith(initialWc.id);
+  });
+
+  it("does not mark a destroyed webContents cached on deactivation", async () => {
+    initialWc.isDestroyed.mockReturnValue(true);
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    const cachedCalls = vi.mocked(registerCachedViewWebContents).mock.calls;
+    expect(cachedCalls.every((call) => (call[0] as unknown) !== initialWc)).toBe(true);
+  });
+});
+
+describe("ProjectViewManager — memory sampler jitter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    nextWebContentsId = 100;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function createManagerWithSampleSpy() {
+    const win = createMockWindow();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+    });
+    const sample = vi.fn();
+    (manager as unknown as { sampleCachedViewMemory: () => void }).sampleCachedViewMemory = sample;
+    return { manager, sample };
+  }
+
+  it("first sample fires after a random fraction of the interval, then at the fixed cadence", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const { sample } = createManagerWithSampleSpy();
+
+    // 0.5 × 30s jitter → first tick at 15s.
+    vi.advanceTimersByTime(14_999);
+    expect(sample).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(sample).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    expect(sample).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(30_000);
+    expect(sample).toHaveBeenCalledTimes(3);
+  });
+
+  it("two managers with different jitter do not sample on the same tick", () => {
+    const randomSpy = vi.spyOn(Math, "random");
+    randomSpy.mockReturnValueOnce(0);
+    const first = createManagerWithSampleSpy();
+    randomSpy.mockReturnValueOnce(0.5);
+    const second = createManagerWithSampleSpy();
+
+    vi.advanceTimersByTime(0);
+    expect(first.sample).toHaveBeenCalledTimes(1);
+    expect(second.sample).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(15_000);
+    expect(first.sample).toHaveBeenCalledTimes(1);
+    expect(second.sample).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose stops the sampler", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+    const { manager, sample } = createManagerWithSampleSpy();
+
+    manager.dispose();
+    vi.advanceTimersByTime(120_000);
+
+    expect(sample).not.toHaveBeenCalled();
+  });
+
+  it("a sampler tick that throws does not stop subsequent ticks", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const { sample } = createManagerWithSampleSpy();
+    sample.mockImplementationOnce(() => {
+      throw new Error("metrics unavailable");
+    });
+
+    vi.advanceTimersByTime(0);
+    expect(sample).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(30_000);
+    expect(sample).toHaveBeenCalledTimes(2);
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -49,6 +49,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -96,6 +96,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -77,6 +77,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -88,6 +88,8 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -235,6 +235,24 @@ describe("webContentsRegistry", () => {
     expect(isCachedViewWebContents(wc.id)).toBe(false);
   });
 
+  it("stale-prune in getAllAppWebContents clears the cached mark", async () => {
+    const {
+      getAllAppWebContents,
+      isCachedViewWebContents,
+      registerCachedViewWebContents,
+      registerProjectView,
+    } = await loadRegistry();
+    const wc = createWebContents(204);
+
+    registerProjectView("project-a", wc as unknown as WebContents);
+    registerCachedViewWebContents(wc as unknown as WebContents);
+
+    // fromId returns null (mock default) → the prune branch fires.
+    getAllAppWebContents();
+
+    expect(isCachedViewWebContents(wc.id)).toBe(false);
+  });
+
   it("clears the cached mark on unregisterProjectView so a reused id is never silenced", async () => {
     const {
       isCachedViewWebContents,

--- a/electron/window/__tests__/webContentsRegistry.test.ts
+++ b/electron/window/__tests__/webContentsRegistry.test.ts
@@ -199,6 +199,58 @@ describe("webContentsRegistry", () => {
     expect(getAppWebContents(win)).toBe(win.webContents);
   });
 
+  it("marks a webContents cached and clears the mark on unregister", async () => {
+    const {
+      isCachedViewWebContents,
+      registerCachedViewWebContents,
+      unregisterCachedViewWebContents,
+    } = await loadRegistry();
+    const wc = createWebContents(201);
+
+    expect(isCachedViewWebContents(wc.id)).toBe(false);
+
+    registerCachedViewWebContents(wc as unknown as WebContents);
+    expect(isCachedViewWebContents(wc.id)).toBe(true);
+
+    unregisterCachedViewWebContents(wc.id);
+    expect(isCachedViewWebContents(wc.id)).toBe(false);
+
+    // Idempotent: repeated calls neither throw nor flip state.
+    unregisterCachedViewWebContents(wc.id);
+    registerCachedViewWebContents(wc as unknown as WebContents);
+    registerCachedViewWebContents(wc as unknown as WebContents);
+    expect(isCachedViewWebContents(wc.id)).toBe(true);
+  });
+
+  it("clears the cached mark when the project view's webContents is destroyed", async () => {
+    const { isCachedViewWebContents, registerCachedViewWebContents, registerProjectView } =
+      await loadRegistry();
+    const wc = createWebContents(202);
+
+    registerProjectView("project-a", wc as unknown as WebContents);
+    registerCachedViewWebContents(wc as unknown as WebContents);
+    expect(isCachedViewWebContents(wc.id)).toBe(true);
+
+    wc.emitDestroyed();
+    expect(isCachedViewWebContents(wc.id)).toBe(false);
+  });
+
+  it("clears the cached mark on unregisterProjectView so a reused id is never silenced", async () => {
+    const {
+      isCachedViewWebContents,
+      registerCachedViewWebContents,
+      registerProjectView,
+      unregisterProjectView,
+    } = await loadRegistry();
+    const wc = createWebContents(203);
+
+    registerProjectView("project-a", wc as unknown as WebContents);
+    registerCachedViewWebContents(wc as unknown as WebContents);
+
+    unregisterProjectView(wc.id);
+    expect(isCachedViewWebContents(wc.id)).toBe(false);
+  });
+
   it("allows unregister and later re-register without leaving stale listener state", async () => {
     const { registerWebContents, unregisterWebContents } = await loadRegistry();
     const firstWindow = createWindow(1);

--- a/electron/window/webContentsRegistry.ts
+++ b/electron/window/webContentsRegistry.ts
@@ -238,6 +238,7 @@ export function getAllAppWebContents(): WebContents[] {
       result.push(wc);
     } else {
       viewToProject.delete(wcId);
+      cachedViewWebContents.delete(wcId);
     }
   }
 
@@ -337,6 +338,7 @@ export function getWebContentsForProject(projectId: string): WebContents[] {
       result.push(wc);
     } else {
       viewToProject.delete(wcId);
+      cachedViewWebContents.delete(wcId);
       invalidateAllAppWebContentsCache();
     }
   }

--- a/electron/window/webContentsRegistry.ts
+++ b/electron/window/webContentsRegistry.ts
@@ -43,6 +43,13 @@ const projectViewDestroyListeners = new Map<
   { webContents: WebContents; listener: () => void }
 >();
 
+// Cached (deactivated) project views. High-frequency, replayable streams (log
+// batches) skip these renderers — a CPU-throttled/frozen renderer has no
+// backpressure, so pushed messages pile up in its task queue. State broadcasts
+// (project added/updated/removed, etc.) must NOT consult this set: cached views
+// have no replay path on warm reactivation (#9490).
+const cachedViewWebContents = new Set<number>();
+
 // Memoized getAllAppWebContents() result. broadcastToRenderer() calls it on
 // every relayed event (terminal data/status/activity, events:push), but the
 // recipient set only changes on view register/unregister/destroy — every
@@ -264,6 +271,7 @@ export function registerProjectView(projectId: string, webContents: WebContents)
   if (!projectViewDestroyListeners.has(wcId)) {
     const onDestroyed = () => {
       viewToProject.delete(wcId);
+      cachedViewWebContents.delete(wcId);
       projectViewDestroyListeners.delete(wcId);
       invalidateAllAppWebContentsCache();
     };
@@ -277,6 +285,7 @@ export function registerProjectView(projectId: string, webContents: WebContents)
  */
 export function unregisterProjectView(webContentsId: number): void {
   viewToProject.delete(webContentsId);
+  cachedViewWebContents.delete(webContentsId);
   invalidateAllAppWebContentsCache();
 
   const registration = projectViewDestroyListeners.get(webContentsId);
@@ -284,6 +293,28 @@ export function unregisterProjectView(webContentsId: number): void {
     removeDestroyedListener(registration);
     projectViewDestroyListeners.delete(webContentsId);
   }
+}
+
+/**
+ * Mark a project view's webContents as cached (deactivated). Maintained by
+ * every ProjectViewManager instance, so the set spans all windows.
+ */
+export function registerCachedViewWebContents(webContents: WebContents): void {
+  cachedViewWebContents.add(webContents.id);
+}
+
+/**
+ * Clear the cached mark — call on reactivation. Idempotent.
+ */
+export function unregisterCachedViewWebContents(webContentsId: number): void {
+  cachedViewWebContents.delete(webContentsId);
+}
+
+/**
+ * Whether a webContents is a cached (deactivated) project view.
+ */
+export function isCachedViewWebContents(webContentsId: number): boolean {
+  return cachedViewWebContents.has(webContentsId);
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses five memory housekeeping gaps in the window/project-view layer from #10391. Two were audits that confirmed existing behavior was already correct. Three had real fixes.

Resolves #10391

## Changes

**Cached-view broadcast registry (gap 3)**

`webContentsRegistry` now tracks cached project-view `webContents` ids (`registerCachedViewWebContents` / `unregisterCachedViewWebContents` / `isCachedViewWebContents`). A new `broadcastToVisibleRenderers` helper in `electron/ipc/utils.ts` skips cached views, and only the logger transport in `main.ts` uses it — log batches are high-frequency and replayable via `LOGS_GET_ALL` pull on mount. `broadcastToRenderer` is deliberately unchanged: state broadcasts (project added/updated/removed, etc.) must keep reaching cached views since there's no replay path on warm reactivation (#9490). The cached mark is cleared on activation, on `webContents` destroy, on `unregisterProjectView` (covers `cleanupEntry`/eviction), and in both stale-prune paths.

**Portal tab CPU throttle (gap 2)**

`PortalManager` now applies the per-renderer CDP throttle (`throttleCpuWebContents`, rate 4) when a tab is parked offscreen — both on tab switch in `showTab` and on `hideAll` — and restores full rate before showing a tab. Throttle-only, no `Page.setWebLifecycleState` freeze: portal tabs hold live SSE/WS streams and the throttle leaves the event loop and network intact. Reuses the existing `webContentsLifecycle` helpers, which already honor `DAINTREE_E2E_DISABLE_CACHED_VIEW_CPU_THROTTLE` and avoid `setBackgroundThrottling` (window-wide since Electron 28, #8599).

**Memory sampler jitter (gap 4)**

Each `ProjectViewManager`'s 30s cached-view memory sampler (`app.getAppMetrics()`, 5-50ms sync) previously used `setAlignedInterval`, so every window fired on the same wall-clock tick. Replaced with a recursive `setTimeout` seeded from a random initial offset (`Math.random() × 30s`), fixed cadence afterwards, unref'd, and dispose-safe. `setAlignedInterval` is unchanged for its other four consumers.

**Gap 1 (cache purge on entering cached state)** — audit confirmed `deactivateEntry` is the only transition into "cached" and it already does `flushStorageData` + `navigationHistory.clear` + `requestIdleCallback`/`window.gc` scheduled before the efficiency freeze (#4684 ordering). No code change needed.

**Gap 5 (EventBuffer per-window clones)** — confirmed bounded at 1000 entries per window with single-clone storage; per-window isolation is load-bearing for the event inspector. No change.

Known tradeoff: a Logs panel already open in a cached view misses pushed batches while cached. History is recoverable via the `LOGS_GET_ALL` pull on mount. This is a pre-existing UX gap made slightly more visible — can be addressed separately by re-pulling on view reactivation if it matters in practice.

## Testing

New unit tests covering the cached-set lifecycle (register/unregister/destroy/stale-prune/`unregisterProjectView`), `broadcastToVisibleRenderers` filtering with `broadcastToRenderer` unaffected, portal throttle/unthrottle on switch/hide/show including destroyed-wc guards, sampler jitter timing/stagger/dispose/throw-resilience, and deactivation ordering (cached mark before throttle).

419+ tests across 13 affected files pass locally. `npm run typecheck` and `prettier` clean. Full CI on GitHub.