### PR TITLE
perf(main): trim main and host bundle eager closures (#10395)

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -1,4 +1,63 @@
 const PACKAGE_VERSION = require("./package.json").version;
+const path = require("path");
+const fs = require("fs");
+
+// Packages require()d from node_modules at runtime — the esbuild `external`
+// list in scripts/build-main.mjs (minus "electron"). Everything else under
+// node_modules is already bundled into dist/dist-electron by Vite/esbuild and
+// is dead weight in the ASAR (~10k files, issue #10395).
+const RUNTIME_NODE_MODULE_ROOTS = [
+  "@parcel/watcher",
+  "node-pty",
+  "better-sqlite3",
+  "win-job-object",
+  "posix-pty-reaper",
+  "copytree",
+  "onnxruntime-node",
+  "avr-vad",
+];
+
+/**
+ * Walk the production dependency closure (dependencies + optional + peer,
+ * skipping packages not installed) of the given root package names, resolving
+ * against the top-level node_modules.
+ */
+function collectDependencyClosure(rootNames) {
+  const closure = new Set();
+  const queue = [...rootNames];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (closure.has(name)) continue;
+    const manifestPath = path.join(__dirname, "node_modules", name, "package.json");
+    if (!fs.existsSync(manifestPath)) continue; // e.g. other-platform optional deps
+    closure.add(name);
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    queue.push(
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.optionalDependencies ?? {}),
+      ...Object.keys(manifest.peerDependencies ?? {})
+    );
+  }
+  return closure;
+}
+
+/**
+ * `!node_modules/<pkg>/**` exclusion patterns for every package in the
+ * production tree that no runtime-required (esbuild-external) package needs.
+ * Computed per build machine so platform-specific optional deps (e.g.
+ * `@parcel/watcher-darwin-arm64`) resolve naturally. Exclusion-only patterns
+ * sidestep electron-builder's unreliable re-include-after-`!node_modules/**`
+ * matching; nested `node_modules` copies under kept packages are untouched.
+ */
+function buildBundledNodeModuleExcludes() {
+  const appDependencies = Object.keys(require("./package.json").dependencies ?? {});
+  const keep = collectDependencyClosure(RUNTIME_NODE_MODULE_ROOTS);
+  const all = collectDependencyClosure(appDependencies);
+  return [...all]
+    .filter((name) => !keep.has(name))
+    .sort()
+    .map((name) => `!node_modules/${name}/**/*`);
+}
 
 // electron-builder 26.x enforces the channel enum: "alpha" | "beta" | "dev"
 // | "rc" | "stable" | null. Anything else fails schema validation. We return
@@ -60,6 +119,9 @@ module.exports = async function () {
       // folded to "" in production builds. Excluding the dir keeps shipped
       // binaries from carrying dead test fixtures.
       "!dist-electron/plugins/sample/**",
+      // Drop node_modules packages that are already bundled into dist/
+      // dist-electron and never require()d at runtime (#10395).
+      ...buildBundledNodeModuleExcludes(),
     ],
     extraResources: [
       { from: "help", to: "help" },
@@ -82,6 +144,12 @@ module.exports = async function () {
       // avr-vad reads its bundled silero_vad_v5.onnx via `fs` relative to its
       // own dist dir; unpack so that path resolves outside the ASAR too.
       "node_modules/avr-vad/**/*",
+      // @parcel/watcher loads per-platform `watcher.node` binaries; the mac
+      // x64ArchFiles signing glob below already assumes they live under
+      // app.asar.unpacked — make that explicit instead of relying on
+      // electron-builder's smart-unpack detection.
+      "node_modules/@parcel/watcher/**/*",
+      "node_modules/@parcel/watcher-*/**/*",
     ],
     electronFuses: {
       runAsNode: false,

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -66,7 +66,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       throw new Error("Invalid file path");
     }
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
     await git.add(["--", payload.filePath]);
     invalidateStagingDiffStatCache(payload.cwd);
   };
@@ -79,7 +79,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       throw new Error("Invalid file path");
     }
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
 
     let hasHead = true;
     try {
@@ -114,7 +114,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     validateCwd(payload?.cwd);
     const paths = validateFilePaths(payload?.filePaths);
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
     await git.add(["--", ...paths]);
     invalidateStagingDiffStatCache(payload.cwd);
   };
@@ -128,7 +128,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     validateCwd(payload?.cwd);
     const paths = validateFilePaths(payload?.filePaths);
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
 
     let hasHead = true;
     try {
@@ -150,7 +150,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     checkRateLimit(CHANNELS.GIT_STAGE_ALL, 10, 10_000);
     validateCwd(cwd);
 
-    const git = createHardenedGit(cwd);
+    const git = await createHardenedGit(cwd);
     await git.add("-A");
     invalidateStagingDiffStatCache(cwd);
   };
@@ -160,7 +160,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     checkRateLimit(CHANNELS.GIT_UNSTAGE_ALL, 10, 10_000);
     validateCwd(cwd);
 
-    const git = createHardenedGit(cwd);
+    const git = await createHardenedGit(cwd);
 
     let hasHead = true;
     try {
@@ -188,7 +188,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       throw new Error("Commit message is required");
     }
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
     await scanStagedFilesForConflictMarkers(git);
     const result = await git.commit(payload.message.trim());
     if (store.get("notificationSettings").uiFeedbackSoundEnabled) {
@@ -213,7 +213,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     validateCwd(payload?.cwd);
 
     pushingCwds.add(payload.cwd);
-    const git = createAuthenticatedGit(payload.cwd);
+    const git = await createAuthenticatedGit(payload.cwd);
     let branchName: string | undefined;
     const senderWindow = ctx.senderWindow;
 
@@ -243,7 +243,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
         targetBranch: targetBranch ?? undefined,
       });
 
-      const authGit = createAuthenticatedGit(payload.cwd, {
+      const authGit = await createAuthenticatedGit(payload.cwd, {
         progress: (data) => {
           sendProgress({
             cwd: payload.cwd,
@@ -318,7 +318,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     checkRateLimit(CHANNELS.GIT_PULL_REBASE, 3, 10_000);
     validateCwd(payload?.cwd);
 
-    const git = createAuthenticatedGit(payload.cwd);
+    const git = await createAuthenticatedGit(payload.cwd);
 
     try {
       const branch = await git.revparse(["--abbrev-ref", "HEAD"]);
@@ -358,7 +358,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       throw new Error("Invalid lease SHA");
     }
 
-    const git = createAuthenticatedGit(payload.cwd);
+    const git = await createAuthenticatedGit(payload.cwd);
     const branchName = payload.branchName.trim();
 
     try {
@@ -397,7 +397,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     const branchName = payload.branchName.trim();
     const limit = Math.max(1, Math.min(100, payload.limit ?? 20));
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
     try {
       // No `--no-merges` — `behindCount` from `git status -b` includes merge
       // commits, and the dialog's "N more" tail relies on the listed rows
@@ -428,7 +428,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
   const handleGetUsername = async (cwd: string): Promise<string | null> => {
     checkRateLimit(CHANNELS.GIT_GET_USERNAME, 20, 10_000);
     validateCwd(cwd);
-    const git = createHardenedGit(cwd);
+    const git = await createHardenedGit(cwd);
     try {
       const { value } = await git.getConfig("user.name");
       return value || null;
@@ -442,7 +442,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     checkRateLimit(CHANNELS.GIT_GET_STAGING_STATUS, 20, 10_000);
     validateCwd(cwd);
 
-    const git = createHardenedGit(cwd);
+    const git = await createHardenedGit(cwd);
     const status = await git.status();
 
     const mapStatus = (s: string): GitStatus => {
@@ -612,7 +612,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     checkRateLimit(CHANNELS.GIT_ABORT_REPOSITORY_OPERATION, 5, 10_000);
     validateCwd(cwd);
 
-    const git = createHardenedGit(cwd);
+    const git = await createHardenedGit(cwd);
     const gitDir = await resolveGitDir(git, cwd);
     const { state } = await detectRepoOperationState(gitDir, false);
 
@@ -641,7 +641,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     checkRateLimit(CHANNELS.GIT_CONTINUE_REPOSITORY_OPERATION, 5, 10_000);
     validateCwd(cwd);
 
-    const git = withNonInteractiveEnv(createHardenedGit(cwd));
+    const git = withNonInteractiveEnv(await createHardenedGit(cwd));
     const gitDir = await resolveGitDir(git, cwd);
     const { state } = await detectRepoOperationState(gitDir, false);
 
@@ -680,7 +680,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       throw new Error("Invalid diff type: must be 'unstaged', 'staged', or 'head'");
     }
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
 
     let raw: string;
     switch (diffType) {
@@ -792,7 +792,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       throw new Error("Invalid side: must be 'ours' or 'theirs'");
     }
 
-    const git = createHardenedGit(payload.cwd);
+    const git = await createHardenedGit(payload.cwd);
     const flag = payload.side === "ours" ? "--ours" : "--theirs";
     // `checkout --ours/--theirs` leaves the file unstaged — the conflict markers
     // are still in the index. Follow with `git add` so the resolution lands in

--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -205,7 +205,7 @@ export function registerGitCloneHandlers(): () => void {
           // omits the URL for the same reason.
           cloneUrl = (await cloneCapability.getAuthenticatedCloneUrl(url).catch(() => null)) ?? url;
         }
-        const git = createAuthenticatedGit(parentPath, {
+        const git = await createAuthenticatedGit(parentPath, {
           signal: localController.signal,
           progress({ stage, progress }) {
             // Sentence-case the display label (git emits lowercase, e.g.

--- a/electron/ipc/handlers/projectCrud/gitInit.ts
+++ b/electron/ipc/handlers/projectCrud/gitInit.ts
@@ -33,7 +33,7 @@ export function registerGitInitHandlers(): () => void {
       throw new Error("Path is not a directory");
     }
 
-    const git = createHardenedGit(directoryPath);
+    const git = await createHardenedGit(directoryPath);
     await git.init();
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_INIT_GIT, handleProjectInitGit));
@@ -92,7 +92,7 @@ export function registerGitInitHandlers(): () => void {
         throw new Error("Path is not a directory");
       }
 
-      const git = createHardenedGit(directoryPath);
+      const git = await createHardenedGit(directoryPath);
 
       emitProgress("init", "start", "Initializing Git repository...");
       await git.init();

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -228,7 +228,7 @@ export function registerScratchHandlers(deps: HandlerDependencies): () => void {
           // If the user already chose a git-tracked destination, `git init` is a
           // no-op — it reports the existing repo and exits 0.
           try {
-            const git = createHardenedGit(destinationPath);
+            const git = await createHardenedGit(destinationPath);
             await git.init();
           } catch (error) {
             logError(

--- a/electron/schemas/__tests__/agent.test.ts
+++ b/electron/schemas/__tests__/agent.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { AgentStateSchema, AgentStateChangedSchema } from "../agent.js";
+import {
+  AgentStateSchema,
+  AgentStateChangedSchema,
+  AgentSpawnedSchema,
+  AgentCompletedSchema,
+} from "../agent.js";
 
 describe("AgentStateSchema (issue #5810 migration)", () => {
   it("preprocesses the retired 'running' value to 'working'", () => {
@@ -42,6 +47,34 @@ describe("AgentStateChangedSchema (zod/mini migration, issue #10395)", () => {
     expect(result.data?.previousState).toBe("idle");
   });
 
+  it("maps retired 'running' in previousState too", () => {
+    const result = AgentStateChangedSchema.safeParse({ ...validPayload, previousState: "running" });
+    expect(result.success).toBe(true);
+    expect(result.data?.previousState).toBe("working");
+  });
+
+  it.each([0, 1])("accepts boundary confidence %s", (confidence) => {
+    expect(AgentStateChangedSchema.safeParse({ ...validPayload, confidence }).success).toBe(true);
+  });
+
+  it("rejects NaN confidence", () => {
+    expect(AgentStateChangedSchema.safeParse({ ...validPayload, confidence: NaN }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects negative sessionCost", () => {
+    expect(
+      AgentStateChangedSchema.safeParse({ ...validPayload, sessionCost: -0.001 }).success
+    ).toBe(false);
+  });
+
+  it("rejects a zero timestamp", () => {
+    expect(AgentStateChangedSchema.safeParse({ ...validPayload, timestamp: 0 }).success).toBe(
+      false
+    );
+  });
+
   it("accepts a minimal payload without optional fields", () => {
     const result = AgentStateChangedSchema.safeParse({
       state: "waiting",
@@ -73,5 +106,19 @@ describe("AgentStateChangedSchema (zod/mini migration, issue #10395)", () => {
     expect(AgentStateChangedSchema.safeParse({ ...validPayload, timestamp: 1.5 }).success).toBe(
       false
     );
+  });
+});
+
+describe("other migrated event schemas (zod/mini)", () => {
+  it("AgentSpawnedSchema accepts a valid payload and rejects an empty terminalId", () => {
+    const payload = { agentId: "claude", terminalId: "term-1", timestamp: 1735000000000 };
+    expect(AgentSpawnedSchema.safeParse(payload).success).toBe(true);
+    expect(AgentSpawnedSchema.safeParse({ ...payload, terminalId: "" }).success).toBe(false);
+  });
+
+  it("AgentCompletedSchema accepts a negative exitCode but rejects negative duration", () => {
+    const payload = { agentId: "claude", exitCode: -1, duration: 10, timestamp: 1735000000000 };
+    expect(AgentCompletedSchema.safeParse(payload).success).toBe(true);
+    expect(AgentCompletedSchema.safeParse({ ...payload, duration: -1 }).success).toBe(false);
   });
 });

--- a/electron/schemas/__tests__/agent.test.ts
+++ b/electron/schemas/__tests__/agent.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { AgentStateSchema } from "../agent.js";
+import { AgentStateSchema, AgentStateChangedSchema } from "../agent.js";
 
 describe("AgentStateSchema (issue #5810 migration)", () => {
   it("preprocesses the retired 'running' value to 'working'", () => {
@@ -15,5 +15,63 @@ describe("AgentStateSchema (issue #5810 migration)", () => {
 
   it("rejects unknown values", () => {
     expect(() => AgentStateSchema.parse("banana")).toThrow();
+  });
+});
+
+describe("AgentStateChangedSchema (zod/mini migration, issue #10395)", () => {
+  const validPayload = {
+    agentId: "claude",
+    terminalId: "term-1",
+    state: "working",
+    previousState: "idle",
+    timestamp: 1735000000000,
+    trigger: "output",
+    confidence: 0.8,
+    cwd: "/tmp/worktree",
+    sessionCost: 0.12,
+    sessionTokens: 1200,
+    temperature: 0.5,
+    heatAdded: 0.1,
+    changedChars: 42,
+  };
+
+  it("accepts a full valid payload and maps retired 'running' state", () => {
+    const result = AgentStateChangedSchema.safeParse({ ...validPayload, state: "running" });
+    expect(result.success).toBe(true);
+    expect(result.data?.state).toBe("working");
+    expect(result.data?.previousState).toBe("idle");
+  });
+
+  it("accepts a minimal payload without optional fields", () => {
+    const result = AgentStateChangedSchema.safeParse({
+      state: "waiting",
+      previousState: "working",
+      timestamp: 1735000000000,
+      trigger: "heuristic",
+      confidence: 1,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects out-of-range confidence", () => {
+    expect(AgentStateChangedSchema.safeParse({ ...validPayload, confidence: 1.5 }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects an empty agentId", () => {
+    expect(AgentStateChangedSchema.safeParse({ ...validPayload, agentId: "" }).success).toBe(false);
+  });
+
+  it("rejects a non-finite temperature", () => {
+    expect(
+      AgentStateChangedSchema.safeParse({ ...validPayload, temperature: Infinity }).success
+    ).toBe(false);
+  });
+
+  it("rejects a non-integer timestamp", () => {
+    expect(AgentStateChangedSchema.safeParse({ ...validPayload, timestamp: 1.5 }).success).toBe(
+      false
+    );
   });
 });

--- a/electron/schemas/agent.ts
+++ b/electron/schemas/agent.ts
@@ -1,22 +1,29 @@
-import { z } from "zod";
+// zod/mini keeps the pty-host and workspace-host bundles free of full zod
+// (~322KB): schemas here use the functional API (z.extend, z.optional,
+// .check(z.*)) instead of chained methods, which mini does not ship.
+import { z } from "zod/mini";
 import { BUILT_IN_AGENT_IDS } from "../../shared/config/agentIds.js";
 
 /** Schema for a built-in agent identity (claude, gemini, codex, opencode, …). */
 export const BuiltInAgentIdSchema = z.enum(BUILT_IN_AGENT_IDS);
 
-export const AgentStateSchema = z.preprocess(
-  (value) => (value === "running" ? "working" : value),
+export const AgentStateSchema = z.pipe(
+  z.transform((value) => (value === "running" ? "working" : value)),
   z.enum(["idle", "working", "waiting", "directing", "completed", "exited"])
 );
 
+const optionalNonEmptyString = z.optional(z.string().check(z.minLength(1)));
+const positiveInt = z.int().check(z.positive());
+const nonNegativeInt = z.int().check(z.nonnegative());
+
 // @see shared/types/events.ts for the TypeScript interface definition.
 export const EventContextSchema = z.object({
-  worktreeId: z.string().optional(),
-  agentId: z.string().optional(),
-  runId: z.string().optional(),
-  terminalId: z.string().optional(),
-  issueNumber: z.number().int().positive().optional(),
-  prNumber: z.number().int().positive().optional(),
+  worktreeId: z.optional(z.string()),
+  agentId: z.optional(z.string()),
+  runId: z.optional(z.string()),
+  terminalId: z.optional(z.string()),
+  issueNumber: z.optional(positiveInt),
+  prNumber: z.optional(positiveInt),
 });
 
 export const AgentStateChangeTriggerSchema = z.enum([
@@ -30,39 +37,40 @@ export const AgentStateChangeTriggerSchema = z.enum([
   "title",
 ]);
 
-export const AgentSpawnedSchema = EventContextSchema.extend({
-  agentId: z.string().min(1),
-  terminalId: z.string().min(1),
-  timestamp: z.number().int().positive(),
-  traceId: z.string().optional(),
+export const AgentSpawnedSchema = z.extend(EventContextSchema, {
+  agentId: z.string().check(z.minLength(1)),
+  terminalId: z.string().check(z.minLength(1)),
+  timestamp: positiveInt,
+  traceId: z.optional(z.string()),
 });
 
-export const AgentStateChangedSchema = EventContextSchema.extend({
+export const AgentStateChangedSchema = z.extend(EventContextSchema, {
   // Optional: runtime-detected-only flows may emit state changes without a
   // persisted launch hint. Consumers should fall back to terminalId.
-  agentId: z.string().min(1).optional(),
+  agentId: optionalNonEmptyString,
   state: AgentStateSchema,
   previousState: AgentStateSchema,
-  timestamp: z.number().int().positive(),
-  traceId: z.string().optional(),
+  timestamp: positiveInt,
+  traceId: z.optional(z.string()),
   trigger: AgentStateChangeTriggerSchema,
   // Confidence in the state detection (0.0 = uncertain, 1.0 = certain)
-  confidence: z.number().min(0).max(1),
+  confidence: z.number().check(z.gte(0), z.lte(1)),
   // Working directory of the spawned terminal (used as the git target for
   // pre-agent snapshots; equal to the worktree path in the typical case).
-  cwd: z.string().optional(),
-  waitingReason: z.enum(["prompt", "question"]).optional(),
-  sessionCost: z.number().nonnegative().optional(),
-  sessionTokens: z.number().int().nonnegative().optional(),
+  cwd: z.optional(z.string()),
+  waitingReason: z.optional(z.enum(["prompt", "question"])),
+  sessionCost: z.optional(z.number().check(z.nonnegative())),
+  sessionTokens: z.optional(nonNegativeInt),
   // Live temperature snapshot from AgentActivityTemperature — present only on
   // accepted transitions that flow through the activity detector. The resize
   // `suppressed` flag is intentionally NOT carried; it is a separate signal
   // (resize-observation suppression) that the event inspector already has
   // visibility into through other channels. Carrying it here would conflate
-  // two distinct decisions in the timeline view.
-  temperature: z.number().finite().optional(),
-  heatAdded: z.number().nonnegative().optional(),
-  changedChars: z.number().int().nonnegative().optional(),
+  // two distinct decisions in the timeline view. zod v4's z.number() already
+  // rejects NaN and ±Infinity, so no explicit finiteness check is needed.
+  temperature: z.optional(z.number()),
+  heatAdded: z.optional(z.number().check(z.nonnegative())),
+  changedChars: z.optional(nonNegativeInt),
 });
 
 /**
@@ -91,56 +99,56 @@ export const AgentStateTransitionDropReasonSchema = z.enum([
  * triaged from the diagnostics event inspector without losing the original
  * intent. Diagnostics tier only — never user-visible UI.
  */
-export const AgentStateTransitionDroppedSchema = EventContextSchema.extend({
+export const AgentStateTransitionDroppedSchema = z.extend(EventContextSchema, {
   /** Terminal ID the drop applies to. */
-  terminalId: z.string().min(1),
+  terminalId: z.string().check(z.minLength(1)),
   /** Optional agent identity for routing/grouping in the inspector. */
-  agentId: z.string().min(1).optional(),
+  agentId: optionalNonEmptyString,
   /** Why the transition was dropped. */
   outcome: AgentStateTransitionDropReasonSchema,
   /** The state the terminal was in when the drop fired. */
   currentState: AgentStateSchema,
   /** The state we attempted to transition to (where known). */
-  attemptedState: AgentStateSchema.optional(),
+  attemptedState: z.optional(AgentStateSchema),
   /** What triggered the attempt (input/output/heuristic/etc.). */
-  trigger: AgentStateChangeTriggerSchema.optional(),
+  trigger: z.optional(AgentStateChangeTriggerSchema),
   /** Confidence the attempt was made with (0.0–1.0). */
-  confidence: z.number().min(0).max(1).optional(),
+  confidence: z.optional(z.number().check(z.gte(0), z.lte(1))),
   /** CWD at the time of the drop, if known — useful for grep in the inspector. */
-  cwd: z.string().optional(),
+  cwd: z.optional(z.string()),
   /** Session token the attempt carried, for stale-session drops. */
-  spawnedAt: z.number().int().positive().optional(),
+  spawnedAt: z.optional(positiveInt),
   /** Live session token, for stale-session drops. */
-  terminalSpawnedAt: z.number().int().positive().optional(),
+  terminalSpawnedAt: z.optional(positiveInt),
   /** Human-readable explanation — typically the validation error text. */
-  reason: z.string().optional(),
+  reason: z.optional(z.string()),
   /** Zod issue messages for `schema-invalid` drops (already flattened to strings). */
-  validationErrors: z.array(z.string()).optional(),
+  validationErrors: z.optional(z.array(z.string())),
   /** Trace ID for correlation with the related (possibly emitted) `agent:state-changed`. */
-  traceId: z.string().optional(),
-  timestamp: z.number().int().positive(),
+  traceId: z.optional(z.string()),
+  timestamp: positiveInt,
 });
 
-export const AgentOutputSchema = EventContextSchema.extend({
-  agentId: z.string().min(1),
-  data: z.string().min(1),
-  timestamp: z.number().int().positive(),
-  traceId: z.string().optional(),
+export const AgentOutputSchema = z.extend(EventContextSchema, {
+  agentId: z.string().check(z.minLength(1)),
+  data: z.string().check(z.minLength(1)),
+  timestamp: positiveInt,
+  traceId: z.optional(z.string()),
 });
 
-export const AgentCompletedSchema = EventContextSchema.extend({
-  agentId: z.string().min(1),
-  exitCode: z.number().int(),
-  duration: z.number().int().nonnegative(),
-  timestamp: z.number().int().positive(),
-  traceId: z.string().optional(),
+export const AgentCompletedSchema = z.extend(EventContextSchema, {
+  agentId: z.string().check(z.minLength(1)),
+  exitCode: z.int(),
+  duration: nonNegativeInt,
+  timestamp: positiveInt,
+  traceId: z.optional(z.string()),
 });
 
-export const AgentKilledSchema = EventContextSchema.extend({
-  agentId: z.string().min(1),
-  reason: z.string().optional(),
-  timestamp: z.number().int().positive(),
-  traceId: z.string().optional(),
+export const AgentKilledSchema = z.extend(EventContextSchema, {
+  agentId: z.string().check(z.minLength(1)),
+  reason: z.optional(z.string()),
+  timestamp: positiveInt,
+  traceId: z.optional(z.string()),
 });
 
 export const AgentEventPayloadSchema = z.union([

--- a/electron/services/FileSearchService.ts
+++ b/electron/services/FileSearchService.ts
@@ -185,7 +185,7 @@ async function loadFilesFromDisk(cwd: string): Promise<string[]> {
 }
 
 async function loadGitFiles(cwd: string): Promise<string[]> {
-  const git = createHardenedGit(cwd);
+  const git = await createHardenedGit(cwd);
   const isRepo = await git.checkIsRepo();
   if (!isRepo) {
     return [];

--- a/electron/services/FileSearchService.ts
+++ b/electron/services/FileSearchService.ts
@@ -210,7 +210,7 @@ async function loadGitFiles(cwd: string): Promise<string[]> {
     args.push("--", pathspec);
   }
 
-  const output = await createHardenedGit(gitRoot).raw(args);
+  const output = await (await createHardenedGit(gitRoot)).raw(args);
   const prefix = pathspec ? `${pathspec.replace(/\/$/, "")}/` : "";
 
   const files = output

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -19,19 +19,25 @@ function escapeRegex(str: string): string {
 }
 
 export class GitService {
-  private git: SimpleGit;
+  private git: Promise<SimpleGit> | null = null;
   private rootPath: string;
 
   constructor(rootPath: string) {
     this.rootPath = rootPath;
-    this.git = createHardenedGit(rootPath);
+  }
+
+  // Lazy so constructing a GitService that is never used cannot leave an
+  // unhandled rejection behind (createHardenedGit is async since #10395).
+  private getGit(): Promise<SimpleGit> {
+    this.git ??= createHardenedGit(this.rootPath);
+    return this.git;
   }
 
   async listBranches(): Promise<BranchInfo[]> {
     try {
       logDebug("Listing branches", { rootPath: this.rootPath });
 
-      const summary: BranchSummary = await this.git.branch(["-a"]);
+      const summary: BranchSummary = await (await this.getGit()).branch(["-a"]);
       const branches: BranchInfo[] = [];
 
       for (const [branchName, branchDetail] of Object.entries(summary.branches)) {
@@ -115,6 +121,7 @@ export class GitService {
     }
 
     try {
+      const git = await this.getGit();
       if (fromRemote) {
         logDebug("Creating worktree from remote branch", {
           path,
@@ -124,7 +131,7 @@ export class GitService {
 
         // `--end-of-options` after the subcommand flags so any leading-dash
         // ref or path that slipped past validation is treated as positional.
-        await this.git.raw([
+        await git.raw([
           "worktree",
           "add",
           "-b",
@@ -141,15 +148,7 @@ export class GitService {
           baseBranch,
         });
 
-        await this.git.raw([
-          "worktree",
-          "add",
-          "-b",
-          newBranch,
-          "--end-of-options",
-          path,
-          baseBranch,
-        ]);
+        await git.raw(["worktree", "add", "-b", newBranch, "--end-of-options", path, baseBranch]);
       }
 
       logDebug("Worktree created successfully", { path, newBranch });
@@ -166,7 +165,7 @@ export class GitService {
     Array<{ path: string; branch: string; bare: boolean; isMainWorktree: boolean }>
   > {
     try {
-      const output = await this.git.raw(["worktree", "list", "--porcelain"]);
+      const output = await (await this.getGit()).raw(["worktree", "list", "--porcelain"]);
       const worktrees: Array<{
         path: string;
         branch: string;
@@ -280,14 +279,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     try {
       // `--no-textconv` blocks user-defined diff drivers that would otherwise
       // execute arbitrary binaries via `.gitattributes` textconv mappings.
-      const diff = await this.git.diff([
-        "HEAD",
-        "--no-ext-diff",
-        "--no-textconv",
-        "--no-color",
-        "--",
-        normalizedPath,
-      ]);
+      const diff = await (
+        await this.getGit()
+      ).diff(["HEAD", "--no-ext-diff", "--no-textconv", "--no-color", "--", normalizedPath]);
 
       if (diff.includes("Binary files")) {
         return "BINARY_FILE";
@@ -347,7 +341,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     if (filePath) {
       // Return the unified diff for a specific file
       try {
-        const diff = await this.git.raw([
+        const diff = await (
+          await this.getGit()
+        ).raw([
           "diff",
           "--no-ext-diff",
           "--no-textconv",
@@ -385,8 +381,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
     // Return the list of changed files with per-file churn (--numstat)
     try {
+      const git = await this.getGit();
       const [nameStatusOutput, numstatOutput, toplevel] = await Promise.all([
-        this.git.raw([
+        git.raw([
           "diff",
           "--no-ext-diff",
           "--no-textconv",
@@ -395,7 +392,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           "--end-of-options",
           range,
         ]),
-        this.git
+        git
           .raw([
             "diff",
             "--no-ext-diff",
@@ -417,7 +414,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
             );
             return "";
           }),
-        this.git.revparse(["--show-toplevel"]),
+        git.revparse(["--show-toplevel"]),
       ]);
 
       const gitRoot = realpathSync(toplevel.trim()).replace(/\\/g, "/");
@@ -506,7 +503,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
   async getRemoteUrl(repoPath: string): Promise<string | null> {
     return this.handleGitOperation(async () => {
-      const git = createHardenedGit(repoPath);
+      const git = await createHardenedGit(repoPath);
       const remotes = await git.getRemotes(true);
       const origin = remotes.find((r) => r.name === "origin");
       return origin?.refs?.fetch || null;
@@ -515,7 +512,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
   async listRemotes(repoPath: string): Promise<Array<{ name: string; fetchUrl: string }>> {
     return this.handleGitOperation(async () => {
-      const git = createHardenedGit(repoPath);
+      const git = await createHardenedGit(repoPath);
       const remotes = await git.getRemotes(true);
       return remotes.map((r) => ({ name: r.name, fetchUrl: r.refs?.fetch || "" }));
     }, "listRemotes");
@@ -531,7 +528,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
   async getRepositoryRoot(repoPath: string): Promise<string> {
     return this.handleGitOperation(async () => {
-      const git = createHardenedGit(repoPath);
+      const git = await createHardenedGit(repoPath);
       const root = await git.revparse(["--show-toplevel"]);
       return root.trim();
     }, "getRepositoryRoot");
@@ -549,7 +546,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     args.push("--end-of-options", worktreePath);
 
     return this.handleGitOperation(async () => {
-      await this.git.raw(args);
+      await (await this.getGit()).raw(args);
     }, "removeWorktree");
   }
 

--- a/electron/services/PreAgentSnapshotService.ts
+++ b/electron/services/PreAgentSnapshotService.ts
@@ -97,7 +97,7 @@ export class PreAgentSnapshotService {
   }
 
   private async createSnapshot(worktreeId: string): Promise<void> {
-    const git = createHardenedGit(worktreeId);
+    const git = await createHardenedGit(worktreeId);
 
     // Check for rebase/merge in progress
     const status = await git.status();
@@ -167,7 +167,7 @@ export class PreAgentSnapshotService {
       };
     }
 
-    const git = createHardenedGit(worktreeId);
+    const git = await createHardenedGit(worktreeId);
 
     // Find the stash entry by message prefix
     const stashIndex = await this.findStashIndex(worktreeId);
@@ -221,7 +221,7 @@ export class PreAgentSnapshotService {
     if (snapshot.hasChanges) {
       const stashIndex = await this.findStashIndex(worktreeId);
       if (stashIndex !== null) {
-        const git = createHardenedGit(worktreeId);
+        const git = await createHardenedGit(worktreeId);
         await git.stash(["drop", `stash@{${stashIndex}}`]);
       }
     }
@@ -238,7 +238,7 @@ export class PreAgentSnapshotService {
   }
 
   private async findStashIndex(worktreeId: string): Promise<number | null> {
-    const git = createHardenedGit(worktreeId);
+    const git = await createHardenedGit(worktreeId);
     const raw = await git.raw(["stash", "list", "--pretty=format:%gd %ct %s"]);
     if (!raw.trim()) return null;
 

--- a/electron/services/ProjectPulseService.ts
+++ b/electron/services/ProjectPulseService.ts
@@ -219,7 +219,7 @@ export class ProjectPulseService {
       return { sha: PROBE_MISSING_PATH_SENTINEL, branch: undefined };
     }
     try {
-      const git = createHardenedGit(worktreePath);
+      const git = await createHardenedGit(worktreePath);
       const shaOut = await git.raw(["rev-parse", "--verify", "HEAD"]);
       const sha = shaOut.trim() || null;
       let branch: string | undefined;
@@ -260,7 +260,7 @@ export class ProjectPulseService {
       throw new Error(`Worktree path does not exist: ${worktreePath}`);
     }
 
-    const git = createHardenedGit(worktreePath, signal);
+    const git = await createHardenedGit(worktreePath, signal);
     const startTime = Date.now();
 
     const isRepo = await git.checkIsRepo();

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -379,7 +379,7 @@ class PullRequestService {
   private async resolveProvider(): Promise<void> {
     if (!this.projectId) return;
     try {
-      const git = createHardenedGit(this.cwd);
+      const git = await createHardenedGit(this.cwd);
       // simple-git's typed `getConfig` returns a `ConfigGetResult` envelope at
       // runtime (`{ key, paths, scopes, value, values }`). Earlier code cast it
       // straight to `string | null` on the assumption that daintree's wiring

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/mini";
 import { events } from "../events.js";
 import { nextAgentState, getStateChangeTimestamp, type AgentEvent } from "../AgentStateMachine.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { z } from "zod";
+import { z } from "zod/mini";
 import type * as pty from "node-pty";
 import type { Terminal as HeadlessTerminalType } from "@xterm/headless";
 import headless from "@xterm/headless";

--- a/electron/services/worktree/mood.ts
+++ b/electron/services/worktree/mood.ts
@@ -9,7 +9,7 @@ const MS_PER_DAY = 1000 * 60 * 60 * 24;
  */
 export async function getLastCommitAgeInDays(worktreePath: string): Promise<number | null> {
   try {
-    const git = createHardenedGit(worktreePath);
+    const git = await createHardenedGit(worktreePath);
     const log = await git.log({ maxCount: 1 });
     const lastDate = log.latest?.date;
     if (!lastDate) return null;

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -72,6 +72,7 @@ vi.mock("../../utils/appProtocol.js", () => ({
   buildHeaders: vi.fn(),
   isImmutableAppAsset: vi.fn(() => false),
   isNotModified: vi.fn(() => false),
+  toHttpDate: vi.fn((date: Date) => date.toUTCString()),
 }));
 
 // Real-ish flag values matter: the protocol handler passes
@@ -1277,6 +1278,7 @@ describe("protocol registration", () => {
     vi.mocked(fs.open).mockResolvedValue({
       readFile: vi.fn().mockResolvedValue(Buffer.from("data")),
       close: vi.fn().mockResolvedValue(undefined),
+      stat: vi.fn().mockResolvedValue({ isFile: () => true, mtime: new Date() }),
     } as unknown as Awaited<ReturnType<typeof fs.open>>);
     vi.mocked(appProtocol.getMimeType).mockReturnValue("text/javascript");
 
@@ -1313,6 +1315,7 @@ describe("protocol registration", () => {
     vi.mocked(fs.open).mockResolvedValue({
       readFile: vi.fn().mockResolvedValue(Buffer.from("data")),
       close: vi.fn().mockResolvedValue(undefined),
+      stat: vi.fn().mockResolvedValue({ isFile: () => true, mtime: new Date() }),
     } as unknown as Awaited<ReturnType<typeof fs.open>>);
     vi.mocked(appProtocol.getMimeType).mockReturnValue("text/javascript");
 
@@ -1719,12 +1722,14 @@ describe("createPluginProtocolHandler", () => {
   type ProtocolHandler = (request: GlobalRequest) => Promise<Response>;
 
   const PLUGIN_ROOT = path.resolve("/plugins/installed/my-plugin");
+  const PLUGIN_MTIME = new Date("2024-01-02T03:04:05.000Z");
 
-  function makeFileHandle(content: string | Buffer = "data") {
+  function makeFileHandle(content: string | Buffer = "data", isFile = true) {
     const buffer = typeof content === "string" ? Buffer.from(content) : content;
     return {
       readFile: vi.fn().mockResolvedValue(buffer),
       close: vi.fn().mockResolvedValue(undefined),
+      stat: vi.fn().mockResolvedValue({ isFile: () => isFile, mtime: PLUGIN_MTIME }),
     };
   }
 
@@ -1780,6 +1785,49 @@ describe("createPluginProtocolHandler", () => {
     expect(response.headers.get("Permissions-Policy")).toBeTruthy();
     // No Cross-Origin-Embedder-Policy header on sub-resources (document sets it).
     expect(response.headers.get("Cross-Origin-Embedder-Policy")).toBeNull();
+  });
+
+  it("emits Last-Modified on 200 responses so the V8 code cache can persist (#10395)", async () => {
+    const handler = buildHandler();
+    const response = await handler(makeRequest("plugin://my-plugin/dist/index.js"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Last-Modified")).toBe(PLUGIN_MTIME.toUTCString());
+  });
+
+  it("returns 304 with validator headers when If-Modified-Since matches (#10395)", async () => {
+    const appProtocol = await import("../../utils/appProtocol.js");
+    vi.mocked(appProtocol.isNotModified).mockReturnValueOnce(true);
+
+    const handler = buildHandler();
+    const response = await handler(
+      makeRequest("plugin://my-plugin/dist/index.js", {
+        headers: { "If-Modified-Since": PLUGIN_MTIME.toUTCString() },
+      })
+    );
+
+    expect(response.status).toBe(304);
+    expect(response.headers.get("Last-Modified")).toBe(PLUGIN_MTIME.toUTCString());
+    expect(vi.mocked(appProtocol.isNotModified)).toHaveBeenCalledWith(
+      PLUGIN_MTIME.toUTCString(),
+      PLUGIN_MTIME
+    );
+  });
+
+  it("returns 404 when the opened path is a directory (no 304 short-circuit)", async () => {
+    const fs = await import("fs/promises");
+    const handle = makeFileHandle("data", false);
+    vi.mocked(fs.open).mockResolvedValue(handle as unknown as Awaited<ReturnType<typeof fs.open>>);
+
+    const handler = buildHandler();
+    const response = await handler(
+      makeRequest("plugin://my-plugin/dist", {
+        headers: { "If-Modified-Since": PLUGIN_MTIME.toUTCString() },
+      })
+    );
+
+    expect(response.status).toBe(404);
+    expect(handle.close).toHaveBeenCalled();
   });
 
   it("returns 404 for an unknown plugin id", async () => {

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -11,6 +11,7 @@ import {
   isImmutableAppAsset,
   isNotModified,
   setAppPermissionsPolicy,
+  toHttpDate,
 } from "../utils/appProtocol.js";
 import {
   DAINTREE_APP_PERMISSIONS_POLICY,
@@ -319,12 +320,17 @@ const PLUGIN_REVALIDATE_DIRECTIVE = "no-cache";
 // same-origin, COEP-enabled embedders silently reject every plugin asset with
 // ERR_BLOCKED_BY_RESPONSE. COEP is not set on individual sub-resources — the
 // plugin view document is responsible for cross-origin isolation policy.
-function buildPluginHeaders(mimeType: string, filePath: string): Record<string, string> {
+function buildPluginHeaders(
+  mimeType: string,
+  filePath: string,
+  stats?: { mtime: Date }
+): Record<string, string> {
   // Vite content-hashed assets (`assets/<name>-<hash>.<ext>`) are immutable;
   // everything else is `no-cache` so plugin reloads pick up fresh bundles.
   // V8 code cache persistence requires a validator header (Last-Modified or
-  // ETag) on top of Cache-Control. We omit both for the MVP — first-load cost
-  // only; revisit if profile data shows a regression.
+  // ETag) on top of Cache-Control, so `Last-Modified` is emitted whenever the
+  // handler has stats — without it Chromium treats the response as
+  // non-cacheable and recompiles plugin scripts on every load (#8652).
   const cacheControl = isImmutableAppAsset(filePath)
     ? PLUGIN_IMMUTABLE_DIRECTIVE
     : PLUGIN_REVALIDATE_DIRECTIVE;
@@ -336,6 +342,7 @@ function buildPluginHeaders(mimeType: string, filePath: string): Record<string, 
     "Permissions-Policy": DAINTREE_APP_PERMISSIONS_POLICY,
     "X-Content-Type-Options": "nosniff",
     "Cache-Control": cacheControl,
+    ...(stats ? { "Last-Modified": toHttpDate(stats.mtime) } : {}),
   };
 }
 
@@ -489,11 +496,32 @@ export function createPluginProtocolHandler(getPluginDir: GetPluginDir) {
     }
 
     try {
-      const buffer = await fileHandle.readFile();
+      // Stat via the open handle (no realpath/stat TOCTOU window) so the 304
+      // shortcut and the Last-Modified validator share one source of truth.
+      const fileStats = await fileHandle.stat();
+      // fs.open succeeds on directories on POSIX; guard before the 304
+      // short-circuit so a directory URL carrying If-Modified-Since falls
+      // through to 404 instead of returning 304. Mirrors app://.
+      if (!fileStats.isFile()) {
+        return new Response("Not Found", {
+          status: 404,
+          headers: buildPluginErrorHeaders(),
+        });
+      }
+
       const mimeType = getMimeType(realFile);
+      const ifModifiedSince = request.headers.get("If-Modified-Since");
+      if (isNotModified(ifModifiedSince, fileStats.mtime)) {
+        return new Response(null, {
+          status: 304,
+          headers: buildPluginHeaders(mimeType, realFile, fileStats),
+        });
+      }
+
+      const buffer = await fileHandle.readFile();
       return new Response(buffer, {
         status: 200,
-        headers: buildPluginHeaders(mimeType, realFile),
+        headers: buildPluginHeaders(mimeType, realFile, fileStats),
       });
     } catch (err) {
       console.error("[MAIN] plugin protocol read failed:", candidatePath, err);

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -28,43 +28,43 @@ import {
 import { simpleGit } from "simple-git";
 
 describe("validateCwd", () => {
-  it("throws for empty string", () => {
+  it("throws for empty string", async () => {
     expect(() => validateCwd("")).toThrow("Invalid working directory");
   });
 
-  it("throws for whitespace-only string", () => {
+  it("throws for whitespace-only string", async () => {
     expect(() => validateCwd("   ")).toThrow("Invalid working directory");
   });
 
-  it("throws for non-string input (number)", () => {
+  it("throws for non-string input (number)", async () => {
     expect(() => validateCwd(123)).toThrow("Invalid working directory");
   });
 
-  it("throws for non-string input (null)", () => {
+  it("throws for non-string input (null)", async () => {
     expect(() => validateCwd(null)).toThrow("Invalid working directory");
   });
 
-  it("throws for non-string input (undefined)", () => {
+  it("throws for non-string input (undefined)", async () => {
     expect(() => validateCwd(undefined)).toThrow("Invalid working directory");
   });
 
-  it("throws for relative path", () => {
+  it("throws for relative path", async () => {
     expect(() => validateCwd("relative/path")).toThrow("absolute path");
   });
 
-  it("throws for parent traversal path", () => {
+  it("throws for parent traversal path", async () => {
     expect(() => validateCwd("../malicious-repo")).toThrow("absolute path");
   });
 
-  it("throws for dot-relative path", () => {
+  it("throws for dot-relative path", async () => {
     expect(() => validateCwd("./something")).toThrow("absolute path");
   });
 
-  it("does not throw for absolute path (unix)", () => {
+  it("does not throw for absolute path (unix)", async () => {
     expect(() => validateCwd("/absolute/path")).not.toThrow();
   });
 
-  it("does not throw for root path", () => {
+  it("does not throw for root path", async () => {
     expect(() => validateCwd("/")).not.toThrow();
   });
 });
@@ -74,8 +74,8 @@ describe("createHardenedGit", () => {
     vi.clearAllMocks();
   });
 
-  it("calls simpleGit with correct baseDir", () => {
-    createHardenedGit("/test/repo");
+  it("calls simpleGit with correct baseDir", async () => {
+    await createHardenedGit("/test/repo");
 
     expect(simpleGit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -84,37 +84,37 @@ describe("createHardenedGit", () => {
     );
   });
 
-  it("disables fsmonitor to prevent cross-worktree contamination", () => {
-    createHardenedGit("/test/repo");
+  it("disables fsmonitor to prevent cross-worktree contamination", async () => {
+    await createHardenedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("core.fsmonitor=false");
     expect(options.config).not.toContain("core.fsmonitor=true");
   });
 
-  it("passes config overrides including protocol.ext.allow=never", () => {
-    createHardenedGit("/test/repo");
+  it("passes config overrides including protocol.ext.allow=never", async () => {
+    await createHardenedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("protocol.ext.allow=never");
   });
 
-  it("disables core.sshCommand via config", () => {
-    createHardenedGit("/test/repo");
+  it("disables core.sshCommand via config", async () => {
+    await createHardenedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("core.sshCommand=");
   });
 
-  it("disables credential.helper via config", () => {
-    createHardenedGit("/test/repo");
+  it("disables credential.helper via config", async () => {
+    await createHardenedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("credential.helper=");
   });
 
-  it("enables allowUnsafe flags for overriding blocked config keys", () => {
-    createHardenedGit("/test/repo");
+  it("enables allowUnsafe flags for overriding blocked config keys", async () => {
+    await createHardenedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.unsafe).toEqual({
@@ -129,8 +129,8 @@ describe("createHardenedGit", () => {
     });
   });
 
-  it("includes all security-critical config overrides", () => {
-    createHardenedGit("/test/repo");
+  it("includes all security-critical config overrides", async () => {
+    await createHardenedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     const expectedKeys = [
@@ -152,23 +152,23 @@ describe("createHardenedGit", () => {
     expect(options.config).toHaveLength(expectedKeys.length);
   });
 
-  it("passes abort signal when provided", () => {
+  it("passes abort signal when provided", async () => {
     const controller = new AbortController();
-    createHardenedGit("/test/repo", controller.signal);
+    await createHardenedGit("/test/repo", controller.signal);
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.abort).toBe(controller.signal);
   });
 
-  it("does not include abort option when no signal provided", () => {
-    createHardenedGit("/test/repo");
+  it("does not include abort option when no signal provided", async () => {
+    await createHardenedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options).not.toHaveProperty("abort");
   });
 
-  it("sets LC_MESSAGES=C, LANGUAGE empty, and GIT_OPTIONAL_LOCKS=0 via .env()", () => {
-    createHardenedGit("/test/repo");
+  it("sets LC_MESSAGES=C, LANGUAGE empty, and GIT_OPTIONAL_LOCKS=0 via .env()", async () => {
+    await createHardenedGit("/test/repo");
 
     expect(mockGitInstance.env).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -179,19 +179,19 @@ describe("createHardenedGit", () => {
     );
   });
 
-  it("sets a platform-appropriate LC_CTYPE so non-ASCII paths survive iconv", () => {
-    createHardenedGit("/test/repo");
+  it("sets a platform-appropriate LC_CTYPE so non-ASCII paths survive iconv", async () => {
+    await createHardenedGit("/test/repo");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(typeof envArg.LC_CTYPE).toBe("string");
     expect(envArg.LC_CTYPE).toMatch(/UTF-8$/);
   });
 
-  it("clears inherited LC_ALL so the more specific LC_CTYPE / LC_MESSAGES win", () => {
+  it("clears inherited LC_ALL so the more specific LC_CTYPE / LC_MESSAGES win", async () => {
     const orig = process.env.LC_ALL;
     process.env.LC_ALL = "C";
     try {
-      createHardenedGit("/test/repo");
+      await createHardenedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.LC_ALL).toBe("");
@@ -201,11 +201,11 @@ describe("createHardenedGit", () => {
     }
   });
 
-  it("does not apply hardened SSH command (blocked via config instead)", () => {
+  it("does not apply hardened SSH command (blocked via config instead)", async () => {
     const origSsh = process.env.GIT_SSH_COMMAND;
     delete process.env.GIT_SSH_COMMAND;
     try {
-      createHardenedGit("/test/repo");
+      await createHardenedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.GIT_SSH_COMMAND).toBeUndefined();
@@ -214,10 +214,10 @@ describe("createHardenedGit", () => {
     }
   });
 
-  it("spreads process.env into hardenedGit .env() call", () => {
+  it("spreads process.env into hardenedGit .env() call", async () => {
     process.env.DAINTREE_TEST_SENTINEL = "sentinel_value";
     try {
-      createHardenedGit("/test/repo");
+      await createHardenedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.PATH).toBe(process.env.PATH);
@@ -227,7 +227,7 @@ describe("createHardenedGit", () => {
     }
   });
 
-  it("strips inherited git execution env before applying hardened overrides", () => {
+  it("strips inherited git execution env before applying hardened overrides", async () => {
     const envKeys = [
       "EDITOR",
       "GIT_CONFIG_COUNT",
@@ -245,7 +245,7 @@ describe("createHardenedGit", () => {
       process.env[key] = "inherited-unsafe-value";
     }
     try {
-      createHardenedGit("/test/repo", undefined, "linux");
+      await createHardenedGit("/test/repo", undefined, "linux");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       for (const key of envKeys) {
@@ -261,13 +261,13 @@ describe("createHardenedGit", () => {
     }
   });
 
-  it("locale env values override conflicting process.env entries", () => {
+  it("locale env values override conflicting process.env entries", async () => {
     const origMessages = process.env.LC_MESSAGES;
     const origLanguage = process.env.LANGUAGE;
     process.env.LC_MESSAGES = "fr_FR.UTF-8";
     process.env.LANGUAGE = "fr_FR";
     try {
-      createHardenedGit("/test/repo");
+      await createHardenedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.LC_MESSAGES).toBe("C");
@@ -280,46 +280,46 @@ describe("createHardenedGit", () => {
     }
   });
 
-  it("suppresses optional .git/index.lock writes via GIT_OPTIONAL_LOCKS=0", () => {
-    createHardenedGit("/test/repo");
+  it("suppresses optional .git/index.lock writes via GIT_OPTIONAL_LOCKS=0", async () => {
+    await createHardenedGit("/test/repo");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");
   });
 
-  it("blocks interactive credential prompts via GIT_TERMINAL_PROMPT=0", () => {
-    createHardenedGit("/test/repo");
+  it("blocks interactive credential prompts via GIT_TERMINAL_PROMPT=0", async () => {
+    await createHardenedGit("/test/repo");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.GIT_TERMINAL_PROMPT).toBe("0");
   });
 
-  it("disables Windows GCM interactive dialogs via GCM_INTERACTIVE=Never", () => {
-    createHardenedGit("/test/repo");
+  it("disables Windows GCM interactive dialogs via GCM_INTERACTIVE=Never", async () => {
+    await createHardenedGit("/test/repo");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.GCM_INTERACTIVE).toBe("Never");
   });
 
-  it("sets GIT_ASKPASS=true on POSIX so credential helpers fail fast", () => {
-    createHardenedGit("/test/repo", undefined, "darwin");
+  it("sets GIT_ASKPASS=true on POSIX so credential helpers fail fast", async () => {
+    await createHardenedGit("/test/repo", undefined, "darwin");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.GIT_ASKPASS).toBe("true");
   });
 
-  it("sets GIT_ASKPASS=true on linux", () => {
-    createHardenedGit("/test/repo", undefined, "linux");
+  it("sets GIT_ASKPASS=true on linux", async () => {
+    await createHardenedGit("/test/repo", undefined, "linux");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.GIT_ASKPASS).toBe("true");
   });
 
-  it("does not set GIT_ASKPASS on Windows (no `true` binary on PATH)", () => {
+  it("does not set GIT_ASKPASS on Windows (no `true` binary on PATH)", async () => {
     const origAskpass = process.env.GIT_ASKPASS;
     delete process.env.GIT_ASKPASS;
     try {
-      createHardenedGit("/test/repo", undefined, "win32");
+      await createHardenedGit("/test/repo", undefined, "win32");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.GIT_ASKPASS).toBeUndefined();
@@ -334,8 +334,8 @@ describe("createAuthenticatedGit", () => {
     vi.clearAllMocks();
   });
 
-  it("calls simpleGit with correct baseDir", () => {
-    createAuthenticatedGit("/test/repo");
+  it("calls simpleGit with correct baseDir", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     expect(simpleGit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -344,8 +344,8 @@ describe("createAuthenticatedGit", () => {
     );
   });
 
-  it("does not include credential-blocking config entries", () => {
-    createAuthenticatedGit("/test/repo");
+  it("does not include credential-blocking config entries", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).not.toContain("credential.helper=");
@@ -353,8 +353,8 @@ describe("createAuthenticatedGit", () => {
     expect(options.config).not.toContain("core.askpass=");
   });
 
-  it("includes all non-credential security config entries", () => {
-    createAuthenticatedGit("/test/repo");
+  it("includes all non-credential security config entries", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("core.fsmonitor=false");
@@ -367,8 +367,8 @@ describe("createAuthenticatedGit", () => {
     expect(options.config).toContain("core.precomposeunicode=true");
   });
 
-  it("sets GIT_TERMINAL_PROMPT, hardened GIT_SSH_COMMAND, and GIT_OPTIONAL_LOCKS=0 via .env()", () => {
-    createAuthenticatedGit("/test/repo");
+  it("sets GIT_TERMINAL_PROMPT, hardened GIT_SSH_COMMAND, and GIT_OPTIONAL_LOCKS=0 via .env()", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     expect(mockGitInstance.env).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -380,25 +380,25 @@ describe("createAuthenticatedGit", () => {
     );
   });
 
-  it("sets GIT_OPTIONAL_LOCKS=0 to suppress incidental lock writes", () => {
-    createAuthenticatedGit("/test/repo");
+  it("sets GIT_OPTIONAL_LOCKS=0 to suppress incidental lock writes", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");
   });
 
-  it("sets GCM_INTERACTIVE=Never to prevent Windows GCM dialogs", () => {
-    createAuthenticatedGit("/test/repo");
+  it("sets GCM_INTERACTIVE=Never to prevent Windows GCM dialogs", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.GCM_INTERACTIVE).toBe("Never");
   });
 
-  it("does NOT set GIT_ASKPASS so legitimate credential helpers can resolve", () => {
+  it("does NOT set GIT_ASKPASS so legitimate credential helpers can resolve", async () => {
     const origAskpass = process.env.GIT_ASKPASS;
     delete process.env.GIT_ASKPASS;
     try {
-      createAuthenticatedGit("/test/repo");
+      await createAuthenticatedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.GIT_ASKPASS).toBeUndefined();
@@ -407,8 +407,8 @@ describe("createAuthenticatedGit", () => {
     }
   });
 
-  it("sets LC_MESSAGES=C, LANGUAGE empty, and GIT_OPTIONAL_LOCKS=0 via .env()", () => {
-    createAuthenticatedGit("/test/repo");
+  it("sets LC_MESSAGES=C, LANGUAGE empty, and GIT_OPTIONAL_LOCKS=0 via .env()", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     expect(mockGitInstance.env).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -419,19 +419,19 @@ describe("createAuthenticatedGit", () => {
     );
   });
 
-  it("sets a platform-appropriate LC_CTYPE so non-ASCII paths survive iconv", () => {
-    createAuthenticatedGit("/test/repo");
+  it("sets a platform-appropriate LC_CTYPE so non-ASCII paths survive iconv", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(typeof envArg.LC_CTYPE).toBe("string");
     expect(envArg.LC_CTYPE).toMatch(/UTF-8$/);
   });
 
-  it("clears inherited LC_ALL so the more specific LC_CTYPE / LC_MESSAGES win", () => {
+  it("clears inherited LC_ALL so the more specific LC_CTYPE / LC_MESSAGES win", async () => {
     const orig = process.env.LC_ALL;
     process.env.LC_ALL = "C";
     try {
-      createAuthenticatedGit("/test/repo");
+      await createAuthenticatedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.LC_ALL).toBe("");
@@ -441,10 +441,10 @@ describe("createAuthenticatedGit", () => {
     }
   });
 
-  it("spreads process.env into the .env() call", () => {
+  it("spreads process.env into the .env() call", async () => {
     process.env.DAINTREE_TEST_SENTINEL = "sentinel_value";
     try {
-      createAuthenticatedGit("/test/repo");
+      await createAuthenticatedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.PATH).toBe(process.env.PATH);
@@ -455,7 +455,7 @@ describe("createAuthenticatedGit", () => {
     }
   });
 
-  it("forced env values override conflicting process.env entries", () => {
+  it("forced env values override conflicting process.env entries", async () => {
     const origPrompt = process.env.GIT_TERMINAL_PROMPT;
     const origSsh = process.env.GIT_SSH_COMMAND;
     const origPager = process.env.GIT_PAGER;
@@ -467,7 +467,7 @@ describe("createAuthenticatedGit", () => {
     process.env.LC_MESSAGES = "fr_FR.UTF-8";
     process.env.LANGUAGE = "fr_FR";
     try {
-      createAuthenticatedGit("/test/repo");
+      await createAuthenticatedGit("/test/repo");
 
       const envArg = mockGitInstance.env.mock.calls[0][0];
       expect(envArg.GIT_TERMINAL_PROMPT).toBe("0");
@@ -491,15 +491,15 @@ describe("createAuthenticatedGit", () => {
     }
   });
 
-  it("sets block timeout to 0 for network operations", () => {
-    createAuthenticatedGit("/test/repo");
+  it("sets block timeout to 0 for network operations", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.timeout).toEqual({ block: 0 });
   });
 
-  it("enables allowUnsafe flags", () => {
-    createAuthenticatedGit("/test/repo");
+  it("enables allowUnsafe flags", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.unsafe).toEqual({
@@ -514,38 +514,38 @@ describe("createAuthenticatedGit", () => {
     });
   });
 
-  it("forwards abort signal when provided", () => {
+  it("forwards abort signal when provided", async () => {
     const controller = new AbortController();
-    createAuthenticatedGit("/test/repo", { signal: controller.signal });
+    await createAuthenticatedGit("/test/repo", { signal: controller.signal });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.abort).toBe(controller.signal);
   });
 
-  it("does not include abort option when no signal provided", () => {
-    createAuthenticatedGit("/test/repo");
+  it("does not include abort option when no signal provided", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options).not.toHaveProperty("abort");
   });
 
-  it("forwards progress callback when provided", () => {
+  it("forwards progress callback when provided", async () => {
     const progressFn = vi.fn();
-    createAuthenticatedGit("/test/repo", { progress: progressFn });
+    await createAuthenticatedGit("/test/repo", { progress: progressFn });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.progress).toBe(progressFn);
   });
 
-  it("does not include progress option when not provided", () => {
-    createAuthenticatedGit("/test/repo");
+  it("does not include progress option when not provided", async () => {
+    await createAuthenticatedGit("/test/repo");
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options).not.toHaveProperty("progress");
   });
 
-  it("appends extraConfig items to config", () => {
-    createAuthenticatedGit("/test/repo", {
+  it("appends extraConfig items to config", async () => {
+    await createAuthenticatedGit("/test/repo", {
       extraConfig: ["transfer.bundleURI=false"],
     });
 
@@ -559,9 +559,9 @@ describe("createBackgroundFetchGit", () => {
     vi.clearAllMocks();
   });
 
-  it("layers background-fetch config on top of authenticated config", () => {
+  it("layers background-fetch config on top of authenticated config", async () => {
     const controller = new AbortController();
-    createBackgroundFetchGit("/test/repo", { signal: controller.signal });
+    await createBackgroundFetchGit("/test/repo", { signal: controller.signal });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.config).toContain("core.packedRefsTimeout=5000");
@@ -573,17 +573,17 @@ describe("createBackgroundFetchGit", () => {
     expect(options.config).not.toContain("core.askpass=");
   });
 
-  it("forwards the abort signal to simple-git", () => {
+  it("forwards the abort signal to simple-git", async () => {
     const controller = new AbortController();
-    createBackgroundFetchGit("/test/repo", { signal: controller.signal });
+    await createBackgroundFetchGit("/test/repo", { signal: controller.signal });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.abort).toBe(controller.signal);
   });
 
-  it("sets GIT_ASKPASS=true on POSIX so credential helpers fail fast", () => {
+  it("sets GIT_ASKPASS=true on POSIX so credential helpers fail fast", async () => {
     const controller = new AbortController();
-    createBackgroundFetchGit("/test/repo", {
+    await createBackgroundFetchGit("/test/repo", {
       signal: controller.signal,
       platform: "darwin",
     });
@@ -595,9 +595,9 @@ describe("createBackgroundFetchGit", () => {
     expect(lastEnv.GIT_OPTIONAL_LOCKS).toBe("0");
   });
 
-  it("re-states GIT_OPTIONAL_LOCKS and GCM_INTERACTIVE in the POSIX second .env() call", () => {
+  it("re-states GIT_OPTIONAL_LOCKS and GCM_INTERACTIVE in the POSIX second .env() call", async () => {
     const controller = new AbortController();
-    createBackgroundFetchGit("/test/repo", {
+    await createBackgroundFetchGit("/test/repo", {
       signal: controller.signal,
       platform: "darwin",
     });
@@ -609,9 +609,9 @@ describe("createBackgroundFetchGit", () => {
     expect(lastEnv.GCM_INTERACTIVE).toBe("Never");
   });
 
-  it("does not set GIT_ASKPASS on Windows (no `true` binary on PATH)", () => {
+  it("does not set GIT_ASKPASS on Windows (no `true` binary on PATH)", async () => {
     const controller = new AbortController();
-    createBackgroundFetchGit("/test/repo", {
+    await createBackgroundFetchGit("/test/repo", {
       signal: controller.signal,
       platform: "win32",
     });
@@ -623,9 +623,9 @@ describe("createBackgroundFetchGit", () => {
     expect(env.GIT_ASKPASS).toBeUndefined();
   });
 
-  it("appends caller-supplied extraConfig after background-fetch config", () => {
+  it("appends caller-supplied extraConfig after background-fetch config", async () => {
     const controller = new AbortController();
-    createBackgroundFetchGit("/test/repo", {
+    await createBackgroundFetchGit("/test/repo", {
       signal: controller.signal,
       extraConfig: ["transfer.bundleURI=false"],
     });
@@ -635,9 +635,9 @@ describe("createBackgroundFetchGit", () => {
     expect(options.config).toContain("core.packedRefsTimeout=5000");
   });
 
-  it("inherits block timeout 0 from authenticated profile", () => {
+  it("inherits block timeout 0 from authenticated profile", async () => {
     const controller = new AbortController();
-    createBackgroundFetchGit("/test/repo", { signal: controller.signal });
+    await createBackgroundFetchGit("/test/repo", { signal: controller.signal });
 
     const options = (simpleGit as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(options.timeout).toEqual({ block: 0 });
@@ -662,101 +662,101 @@ describe("createWslHardenedGit", () => {
     });
   });
 
-  it("throws on non-Windows platforms", () => {
+  it("throws on non-Windows platforms", async () => {
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-    expect(() =>
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
         posixPath: "/home/user/proj",
       })
-    ).toThrow("only available on Windows");
+    ).rejects.toThrow("only available on Windows");
   });
 
-  it("throws when distro is empty", () => {
-    expect(() =>
+  it("throws when distro is empty", async () => {
+    await expect(
       createWslHardenedGit({
         distro: "",
         uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
         posixPath: "/home/user/proj",
       })
-    ).toThrow("WSL distro");
+    ).rejects.toThrow("WSL distro");
   });
 
-  it("throws when posix path does not start with /", () => {
-    expect(() =>
+  it("throws when posix path does not start with /", async () => {
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
         posixPath: "home/user/proj",
       })
-    ).toThrow("posix path");
+    ).rejects.toThrow("posix path");
   });
 
-  it("throws when UNC path is not a WSL UNC", () => {
-    expect(() =>
+  it("throws when UNC path is not a WSL UNC", async () => {
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "C:\\repos\\proj",
         posixPath: "/home/user/proj",
       })
-    ).toThrow("UNC path");
+    ).rejects.toThrow("UNC path");
   });
 
-  it("rejects strings starting with \\\\wsl but missing the WSL UNC shape", () => {
+  it("rejects strings starting with \\\\wsl but missing the WSL UNC shape", async () => {
     // Old `startsWith("\\\\wsl")` gate let this through; tightened check
     // (detectWslPath) fails closed on the malformed shape.
-    expect(() =>
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "\\\\wslfoo\\bar",
         posixPath: "/home/user/proj",
       })
-    ).toThrow("UNC path");
+    ).rejects.toThrow("UNC path");
   });
 
-  it("rejects bare \\\\wsl$\\ with no distro segment", () => {
-    expect(() =>
+  it("rejects bare \\\\wsl$\\ with no distro segment", async () => {
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "\\\\wsl$\\",
         posixPath: "/",
       })
-    ).toThrow("UNC path");
+    ).rejects.toThrow("UNC path");
   });
 
-  it("rejects bare \\\\wsl.localhost\\ with no distro segment", () => {
-    expect(() =>
+  it("rejects bare \\\\wsl.localhost\\ with no distro segment", async () => {
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "\\\\wsl.localhost\\",
         posixPath: "/",
       })
-    ).toThrow("UNC path");
+    ).rejects.toThrow("UNC path");
   });
 
-  it("rejects when supplied distro does not match parsed UNC distro", () => {
-    expect(() =>
+  it("rejects when supplied distro does not match parsed UNC distro", async () => {
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "\\\\wsl$\\Debian\\home\\user\\proj",
         posixPath: "/home/user/proj",
       })
-    ).toThrow("distro does not match");
+    ).rejects.toThrow("distro does not match");
   });
 
-  it("rejects when supplied posixPath does not match parsed UNC remainder", () => {
-    expect(() =>
+  it("rejects when supplied posixPath does not match parsed UNC remainder", async () => {
+    await expect(
       createWslHardenedGit({
         distro: "Ubuntu",
         uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
         posixPath: "/some/other/path",
       })
-    ).toThrow("posix path does not match");
+    ).rejects.toThrow("posix path does not match");
   });
 
-  it("uses the UNC path as baseDir so simple-git's statSync succeeds on Windows", () => {
-    createWslHardenedGit({
+  it("uses the UNC path as baseDir so simple-git's statSync succeeds on Windows", async () => {
+    await createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       posixPath: "/home/user/proj",
@@ -769,8 +769,8 @@ describe("createWslHardenedGit", () => {
     );
   });
 
-  it("sets binary to wsl.exe + git two-tuple", () => {
-    createWslHardenedGit({
+  it("sets binary to wsl.exe + git two-tuple", async () => {
+    await createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       posixPath: "/home/user/proj",
@@ -780,8 +780,8 @@ describe("createWslHardenedGit", () => {
     expect(options.binary).toEqual(["wsl.exe", "git"]);
   });
 
-  it("carries the full HARDENED_GIT_CONFIG", () => {
-    createWslHardenedGit({
+  it("carries the full HARDENED_GIT_CONFIG", async () => {
+    await createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       posixPath: "/home/user/proj",
@@ -794,8 +794,8 @@ describe("createWslHardenedGit", () => {
     expect(options.config).toHaveLength(HARDENED_GIT_CONFIG.length);
   });
 
-  it("sets WSL_DISTRO_NAME, GIT_OPTIONAL_LOCKS=0, and locale in env for diagnostics", () => {
-    createWslHardenedGit({
+  it("sets WSL_DISTRO_NAME, GIT_OPTIONAL_LOCKS=0, and locale in env for diagnostics", async () => {
+    await createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       posixPath: "/home/user/proj",
@@ -810,8 +810,8 @@ describe("createWslHardenedGit", () => {
     expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");
   });
 
-  it("applies the same env hardening as createHardenedGit (Linux git inside WSL)", () => {
-    createWslHardenedGit({
+  it("applies the same env hardening as createHardenedGit (Linux git inside WSL)", async () => {
+    await createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       posixPath: "/home/user/proj",
@@ -824,9 +824,9 @@ describe("createWslHardenedGit", () => {
     expect(envArg.GCM_INTERACTIVE).toBe("Never");
   });
 
-  it("forwards abort signal when provided", () => {
+  it("forwards abort signal when provided", async () => {
     const controller = new AbortController();
-    createWslHardenedGit(
+    await createWslHardenedGit(
       {
         distro: "Ubuntu",
         uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
@@ -839,8 +839,8 @@ describe("createWslHardenedGit", () => {
     expect(options.abort).toBe(controller.signal);
   });
 
-  it("enables allowUnsafe flags matching createHardenedGit", () => {
-    createWslHardenedGit({
+  it("enables allowUnsafe flags matching createHardenedGit", async () => {
+    await createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
       posixPath: "/home/user/proj",
@@ -861,7 +861,7 @@ describe("createWslHardenedGit", () => {
 });
 
 describe("getGitLocaleEnv", () => {
-  it("returns LC_CTYPE=C.UTF-8, LANG=C.UTF-8, and GIT_OPTIONAL_LOCKS=0 on win32", () => {
+  it("returns LC_CTYPE=C.UTF-8, LANG=C.UTF-8, and GIT_OPTIONAL_LOCKS=0 on win32", async () => {
     expect(getGitLocaleEnv("win32")).toEqual({
       LC_CTYPE: "C.UTF-8",
       LANG: "C.UTF-8",
@@ -869,40 +869,40 @@ describe("getGitLocaleEnv", () => {
     });
   });
 
-  it("returns LC_CTYPE=en_US.UTF-8 and GIT_OPTIONAL_LOCKS=0 on darwin (macOS lacks C.UTF-8)", () => {
+  it("returns LC_CTYPE=en_US.UTF-8 and GIT_OPTIONAL_LOCKS=0 on darwin (macOS lacks C.UTF-8)", async () => {
     expect(getGitLocaleEnv("darwin")).toEqual({
       LC_CTYPE: "en_US.UTF-8",
       GIT_OPTIONAL_LOCKS: "0",
     });
   });
 
-  it("returns LC_CTYPE=C.UTF-8 and GIT_OPTIONAL_LOCKS=0 on linux", () => {
+  it("returns LC_CTYPE=C.UTF-8 and GIT_OPTIONAL_LOCKS=0 on linux", async () => {
     expect(getGitLocaleEnv("linux")).toEqual({
       LC_CTYPE: "C.UTF-8",
       GIT_OPTIONAL_LOCKS: "0",
     });
   });
 
-  it("does not set LANG on non-win32 platforms", () => {
+  it("does not set LANG on non-win32 platforms", async () => {
     expect(getGitLocaleEnv("linux")).not.toHaveProperty("LANG");
     expect(getGitLocaleEnv("darwin")).not.toHaveProperty("LANG");
   });
 });
 
 describe("config constants", () => {
-  it("HARDENED_GIT_CONFIG includes credential-blocking entries", () => {
+  it("HARDENED_GIT_CONFIG includes credential-blocking entries", async () => {
     expect(HARDENED_GIT_CONFIG).toContain("credential.helper=");
     expect(HARDENED_GIT_CONFIG).toContain("core.sshCommand=");
     expect(HARDENED_GIT_CONFIG).toContain("core.askpass=");
   });
 
-  it("AUTHENTICATED_GIT_CONFIG excludes credential-blocking entries", () => {
+  it("AUTHENTICATED_GIT_CONFIG excludes credential-blocking entries", async () => {
     expect(AUTHENTICATED_GIT_CONFIG).not.toContain("credential.helper=");
     expect(AUTHENTICATED_GIT_CONFIG).not.toContain("core.sshCommand=");
     expect(AUTHENTICATED_GIT_CONFIG).not.toContain("core.askpass=");
   });
 
-  it("both configs share the same security base entries", () => {
+  it("both configs share the same security base entries", async () => {
     const securityEntries = [
       "core.fsmonitor=false",
       "core.untrackedCache=false",
@@ -921,7 +921,7 @@ describe("config constants", () => {
 });
 
 describe("buildHardenedGitEnv", () => {
-  it("returns the same env shape that createHardenedGit applies via .env()", () => {
+  it("returns the same env shape that createHardenedGit applies via .env()", async () => {
     const env = buildHardenedGitEnv("linux");
     expect(env).toEqual(
       expect.objectContaining({
@@ -937,17 +937,17 @@ describe("buildHardenedGitEnv", () => {
     );
   });
 
-  it("does not set GIT_ASKPASS on win32", () => {
+  it("does not set GIT_ASKPASS on win32", async () => {
     const env = buildHardenedGitEnv("win32");
     expect(env.GIT_ASKPASS).toBeUndefined();
   });
 
-  it("sets GIT_ASKPASS=true on darwin", () => {
+  it("sets GIT_ASKPASS=true on darwin", async () => {
     const env = buildHardenedGitEnv("darwin");
     expect(env.GIT_ASKPASS).toBe("true");
   });
 
-  it("uses the platform arg instead of process.platform when supplied", () => {
+  it("uses the platform arg instead of process.platform when supplied", async () => {
     const env = buildHardenedGitEnv("darwin");
     expect(env.LC_CTYPE).toBe("en_US.UTF-8");
   });

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -188,7 +188,7 @@ export function parseNumstat(diffOutput: string, gitRoot: string): Map<string, D
 
 export async function getCommitCount(cwd: string): Promise<number> {
   try {
-    const git = createHardenedGit(cwd);
+    const git = await createHardenedGit(cwd);
     const count = await git.raw(["rev-list", "--count", "HEAD"]);
     return parseInt(count.trim(), 10);
   } catch (error) {
@@ -224,7 +224,7 @@ export async function listCommits(options: ListCommitsOptions): Promise<ListComm
   const { cwd, search, branch, skip = 0, limit = 30 } = options;
 
   try {
-    const git = createHardenedGit(cwd);
+    const git = await createHardenedGit(cwd);
 
     const totalCountStr = await git.raw(["rev-list", "--count", branch || "HEAD"]);
     const total = parseInt(totalCountStr.trim(), 10);
@@ -278,7 +278,7 @@ export async function listCommits(options: ListCommitsOptions): Promise<ListComm
 
 export async function getLatestTrackedFileMtime(worktreePath: string): Promise<number | null> {
   try {
-    const git = createHardenedGit(worktreePath);
+    const git = await createHardenedGit(worktreePath);
     const unixSeconds = await git.raw(["log", "-1", "--format=%ct"]);
     const parsed = Number.parseInt(unixSeconds.trim(), 10);
     return Number.isFinite(parsed) && parsed > 0 ? parsed * 1000 : null;
@@ -302,10 +302,12 @@ export interface GetWorktreeChangesOptions {
   wsl?: WslGitInvocation;
 }
 
-function gitForChanges(cwd: string, opts: GetWorktreeChangesOptions): SimpleGit {
+async function gitForChanges(cwd: string, opts: GetWorktreeChangesOptions): Promise<SimpleGit> {
   if (opts.wsl) {
     try {
-      return createWslHardenedGit(opts.wsl);
+      // `await` so a rejected factory promise lands in this catch and falls
+      // back, matching the previous synchronous-throw behaviour.
+      return await createWslHardenedGit(opts.wsl);
     } catch {
       // Fall back to native git if the WSL invocation is rejected (e.g. wrong
       // platform, missing distro). Polling continues using the slower path.
@@ -356,7 +358,7 @@ export async function getWorktreeChangesWithStats(
     }
 
     try {
-      const git: SimpleGit = gitForChanges(cwd, options);
+      const git: SimpleGit = await gitForChanges(cwd, options);
       const status: StatusResult = await git.status();
 
       // Consolidate rev-parse into a single spawn; HEAD may not exist in empty

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -1,7 +1,15 @@
 import path from "path";
-import { simpleGit } from "simple-git";
 import type { SimpleGit, SimpleGitProgressEvent } from "simple-git";
 import { detectWslPath } from "./wsl.js";
+
+// Deferred import keeps simple-git out of the eager pre-paint main bundle —
+// esbuild's `splitting: true` emits it as a lazy chunk (issue #10395). Kicked
+// off at module evaluation so the chunk is typically loaded before the first
+// git call; each factory awaits the same promise and surfaces load errors at
+// call time. The no-op catch marks the prefetch handled so a broken install
+// can't fire an unhandled rejection before any factory runs.
+const simpleGitModule = import("simple-git");
+void simpleGitModule.catch(() => {});
 
 const SAFE_GIT_CONFIG = [
   "core.fsmonitor=false",
@@ -146,11 +154,12 @@ export function buildHardenedGitEnv(
   };
 }
 
-export function createHardenedGit(
+export async function createHardenedGit(
   cwd: string,
   signal?: AbortSignal,
   platform: NodeJS.Platform = process.platform
-): SimpleGit {
+): Promise<SimpleGit> {
+  const { simpleGit } = await simpleGitModule;
   return simpleGit({
     baseDir: cwd,
     config: [...HARDENED_GIT_CONFIG],
@@ -202,10 +211,10 @@ export interface WslGitInvocation {
  *
  * Windows-only: throws on other platforms.
  */
-export function createWslHardenedGit(
+export async function createWslHardenedGit(
   invocation: WslGitInvocation,
   signal?: AbortSignal
-): SimpleGit {
+): Promise<SimpleGit> {
   if (process.platform !== "win32") {
     throw new Error("createWslHardenedGit is only available on Windows");
   }
@@ -229,6 +238,7 @@ export function createWslHardenedGit(
     throw new Error("WSL posix path does not match parsed UNC");
   }
 
+  const { simpleGit } = await simpleGitModule;
   return simpleGit({
     baseDir: uncPath,
     binary: ["wsl.exe", "git"],
@@ -265,8 +275,12 @@ export interface AuthenticatedGitOptions {
   extraConfig?: string[];
 }
 
-export function createAuthenticatedGit(cwd: string, opts: AuthenticatedGitOptions = {}): SimpleGit {
+export async function createAuthenticatedGit(
+  cwd: string,
+  opts: AuthenticatedGitOptions = {}
+): Promise<SimpleGit> {
   const { signal, progress, extraConfig } = opts;
+  const { simpleGit } = await simpleGitModule;
   return simpleGit({
     baseDir: cwd,
     config: [...AUTHENTICATED_GIT_CONFIG, ...(extraConfig ?? [])],
@@ -330,9 +344,12 @@ export interface BackgroundFetchGitOptions {
  * The signal is required: every background fetch must carry an
  * AbortController so a stalled connection can be cancelled.
  */
-export function createBackgroundFetchGit(cwd: string, opts: BackgroundFetchGitOptions): SimpleGit {
+export async function createBackgroundFetchGit(
+  cwd: string,
+  opts: BackgroundFetchGitOptions
+): Promise<SimpleGit> {
   const { signal, progress, extraConfig, platform = process.platform } = opts;
-  const git = createAuthenticatedGit(cwd, {
+  const git = await createAuthenticatedGit(cwd, {
     signal,
     progress,
     extraConfig: [...BACKGROUND_FETCH_CONFIG, ...(extraConfig ?? [])],

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -280,7 +280,7 @@ export class RepoFetchCoordinator {
     const timeout = setTimeout(() => controller.abort(), FETCH_ABORT_TIMEOUT_MS);
     let succeeded = false;
     try {
-      const git = createBackgroundFetchGit(opts.worktreePath, {
+      const git = await createBackgroundFetchGit(opts.worktreePath, {
         signal: controller.signal,
       });
       // --no-write-fetch-head: skip writing FETCH_HEAD on background fetches

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -563,7 +563,7 @@ export class WorkspaceService {
       // Merge: global (lowest priority) < project-level < DAINTREE_* (set in buildEnv)
       const projectEnvVars = await this.loadProjectEnvVars(projectRootPath);
       this.projectEnvVars = { ...(globalEnvVars ?? {}), ...projectEnvVars };
-      this.git = createHardenedGit(projectRootPath, this._shutdownController.signal);
+      this.git = await createHardenedGit(projectRootPath, this._shutdownController.signal);
       this.listService.setGit(this.git, projectRootPath);
 
       // #6669: prune at startup so externally-deleted worktrees (kept in
@@ -1434,7 +1434,7 @@ export class WorkspaceService {
    */
   private async probeForgeRemoteAsync(monitor: WorktreeMonitor): Promise<void> {
     try {
-      const git = createHardenedGit(monitor.path);
+      const git = await createHardenedGit(monitor.path);
       const remotes = await git.getRemotes(true);
       const origin = remotes.find((r) => r.name === "origin") ?? remotes[0];
       const fetchUrl = origin?.refs?.fetch;
@@ -2212,7 +2212,7 @@ export class WorkspaceService {
     // absoluteCreatePath is block-scoped to the try.
     let pendingCreateKey: string | null = null;
     try {
-      const git = createHardenedGit(rootPath);
+      const git = await createHardenedGit(rootPath);
       const { baseBranch, path } = options;
       let { newBranch } = options;
       let { fromRemote = false, useExistingBranch = false } = options;
@@ -2833,7 +2833,7 @@ export class WorkspaceService {
 
   async listBranches(requestId: string, rootPath: string): Promise<void> {
     try {
-      const git = createHardenedGit(rootPath);
+      const git = await createHardenedGit(rootPath);
       const summary: BranchSummary = await git.branch(["-a"]);
       const branches: BranchInfo[] = [];
 
@@ -2875,7 +2875,7 @@ export class WorkspaceService {
     headRefName: string
   ): Promise<void> {
     try {
-      const git = createAuthenticatedGit(rootPath);
+      const git = await createAuthenticatedGit(rootPath);
       await git.raw(["fetch", "origin", `pull/${prNumber}/head:${headRefName}`]);
       this.sendEvent({ type: "fetch-pr-branch-result", requestId, success: true });
     } catch (error) {
@@ -2893,7 +2893,7 @@ export class WorkspaceService {
 
   async getRecentBranches(requestId: string, rootPath: string): Promise<void> {
     try {
-      const git = createHardenedGit(rootPath);
+      const git = await createHardenedGit(rootPath);
       const rawReflog = await git.raw(["reflog", "--format=%gs"]);
 
       if (!rawReflog?.trim()) {
@@ -2958,7 +2958,7 @@ export class WorkspaceService {
         // ignore
       }
 
-      const git = createHardenedGit(cwd);
+      const git = await createHardenedGit(cwd);
 
       if (status === "untracked" || status === "added") {
         const { readFile } = await import("fs/promises");

--- a/electron/workspace-host/WorktreeLifecycleService.ts
+++ b/electron/workspace-host/WorktreeLifecycleService.ts
@@ -2,7 +2,8 @@ import { spawn, spawnSync, type ChildProcess } from "child_process";
 import { readFile, access, cp, mkdir, readdir, unlink } from "fs/promises";
 import { join as pathJoin, basename, dirname } from "path";
 import os from "os";
-import { z } from "zod/v4";
+// zod/mini keeps full zod out of the workspace-host bundle (issue #10395).
+import { z } from "zod/mini";
 import { scrubSecrets } from "../../shared/utils/secretScrubber.js";
 import { buildProbeEnv } from "../utils/spawnEnv.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
@@ -18,24 +19,27 @@ const OUTPUT_TAIL_BYTES = 8192;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_TEARDOWN_LOGS_PER_WORKTREE = 10;
 
+const optionalPositiveNumber = z.optional(z.number().check(z.positive()));
+const optionalStringArray = z.optional(z.array(z.string()));
+
 const ResourceTimeoutsSchema = z.object({
-  provision: z.number().positive().optional(),
-  teardown: z.number().positive().optional(),
-  resume: z.number().positive().optional(),
-  pause: z.number().positive().optional(),
-  status: z.number().positive().optional(),
+  provision: optionalPositiveNumber,
+  teardown: optionalPositiveNumber,
+  resume: optionalPositiveNumber,
+  pause: optionalPositiveNumber,
+  status: optionalPositiveNumber,
 });
 
 const ResourceConfigSchema = z.object({
-  provision: z.array(z.string()).optional(),
-  teardown: z.array(z.string()).optional(),
-  resume: z.array(z.string()).optional(),
-  pause: z.array(z.string()).optional(),
-  status: z.string().optional(),
-  connect: z.string().optional(),
-  timeouts: ResourceTimeoutsSchema.optional(),
-  statusInterval: z.number().positive().optional(),
-  provider: z.string().optional(),
+  provision: optionalStringArray,
+  teardown: optionalStringArray,
+  resume: optionalStringArray,
+  pause: optionalStringArray,
+  status: z.optional(z.string()),
+  connect: z.optional(z.string()),
+  timeouts: z.optional(ResourceTimeoutsSchema),
+  statusInterval: optionalPositiveNumber,
+  provider: z.optional(z.string()),
 });
 
 export type ResourceConfig = z.infer<typeof ResourceConfigSchema>;
@@ -43,10 +47,10 @@ export type ResourceConfig = z.infer<typeof ResourceConfigSchema>;
 const ResourcesConfigSchema = z.record(z.string(), ResourceConfigSchema);
 
 const DaintreeLifecycleConfigSchema = z.object({
-  setup: z.array(z.string()).optional(),
-  teardown: z.array(z.string()).optional(),
-  resource: ResourceConfigSchema.optional(),
-  resources: ResourcesConfigSchema.optional(),
+  setup: optionalStringArray,
+  teardown: optionalStringArray,
+  resource: z.optional(ResourceConfigSchema),
+  resources: z.optional(ResourcesConfigSchema),
 });
 
 export type DaintreeLifecycleConfig = z.infer<typeof DaintreeLifecycleConfigSchema>;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1981,8 +1981,8 @@ export class WorktreeMonitor {
 
     const wsl = this.wslInvocation;
     const git = wsl
-      ? createWslHardenedGit(wsl, this._pollAbortController.signal)
-      : createHardenedGit(this.path, this._pollAbortController.signal);
+      ? await createWslHardenedGit(wsl, this._pollAbortController.signal)
+      : await createHardenedGit(this.path, this._pollAbortController.signal);
 
     try {
       // Resolve base ref via the rev-list itself: try origin/<branch> first
@@ -2089,8 +2089,8 @@ export class WorktreeMonitor {
     try {
       const wsl = this.wslInvocation;
       const git = wsl
-        ? createWslHardenedGit(wsl, this._pollAbortController.signal)
-        : createHardenedGit(this.path, this._pollAbortController.signal);
+        ? await createWslHardenedGit(wsl, this._pollAbortController.signal)
+        : await createHardenedGit(this.path, this._pollAbortController.signal);
       const log = await git.log({ maxCount: 1 });
       const lastCommitMsg = log.latest?.message;
 


### PR DESCRIPTION
## Summary

- Trims eager bundle sizes across `main.js`, `workspace-host.js`, and `pty-host.js` via four targeted changes: lazy `simple-git`, `zod/mini` in host bundles, ASAR `node_modules` exclusion list, and `plugin://` caching headers
- Measured deltas (production esbuild, static import closure per entry): `main.js` −55 KB, `workspace-host.js` −95 KB, `pty-host.js` −18 KB
- All call sites verified; targeted test suite passes (115 tests across schemas, git utils, `GitService`, workspace-host, git handlers)

Resolves #10395

## Changes

**Lazy `simple-git`** — `electron/utils/hardenedGit.ts` defers `import("simple-git")` to a module-eval prefetch so esbuild splitting emits it as a lazy chunk. All four git factories are now async (`Promise<SimpleGit>`); `await` propagated to ~50 call sites across 15 files. `GitService` uses a lazy cached getter. Verified absent from the eager static-import closure of `main.js`, `pty-host.js`, and `workspace-host.js`.

**`zod/mini` in host bundles** — `electron/schemas/agent.ts`, `AgentStateService`, `TerminalProcess`, and `WorktreeLifecycleService` migrated to `zod/mini` (functional API: `z.extend`/`z.optional`/`.check(z.minLength(1))`/`z.pipe(z.transform(...))`). `z.number().finite()` dropped — zod v4 rejects ±Infinity/NaN natively. New tests cover the `running→working` mapping (state + `previousState`), confidence boundaries, and `AgentSpawned`/`AgentCompleted` payloads.

**ASAR `node_modules` trim** — `electron-builder.config.cjs` computes a dependency-closure exclusion list at build time: `closure(all package.json deps)` minus `closure(esbuild externals: @parcel/watcher, node-pty, better-sqlite3, win-job-object, posix-pty-reaper, copytree, onnxruntime-node, avr-vad)` → 72 `!node_modules/<pkg>/**/*` exclusion patterns. Exclusion-only approach avoids electron-builder's unreliable re-include-after-blanket-negation. `@parcel/watcher` + `@parcel/watcher-*` added to `asarUnpack` to make the mac `x64ArchFiles` signing-glob assumption explicit. **Note:** natives are verified in the kept set, but a `npm run package` smoke test is still needed before this ships in a release.

**`plugin://` V8 bytecode cache** — `buildPluginHeaders()` now emits `Last-Modified` (stat via the open file handle, no TOCTOU) and the handler answers `If-Modified-Since` with 304, with a `!isFile()` → 404 guard before the 304 short-circuit. Mirrors the `app://` fix from #8652.

**Honest caveat on `pty-host`:** the −18 KB win is limited because esbuild splitting unions shared chunks — main's classic-zod consumers (`ipc.ts`, `plugin.ts`, …) keep the ~295 KB `zod/core` chunk alive and both hosts import it eagerly. Full host-side zod removal would need hand validators in `agent.ts` or a main-process-wide `zod→mini` migration — worth tracking as a follow-up.

## Testing

- `npm run typecheck` passes across all 5 tsconfig projects
- Targeted vitest suites pass: `electron/schemas/__tests__/agent.test.ts`, `electron/utils/__tests__/hardenedGit.test.ts`, git utils/`GitService`/workspace-host/git handlers (115 tests total)
- ESLint and Prettier clean on changed files
- GitHub CI (`ci-ok`) is the authoritative gate