### PR TITLE
fix(terminal): make watchdog BACKGROUND-tier reconciliation converge after warm-swap

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -28,6 +28,7 @@ import { TerminalSearchBar } from "./TerminalSearchBar";
 import { TerminalScrollIndicator } from "./TerminalScrollIndicator";
 import { useGridScrollRoot } from "./GridScrollRootContext";
 import { isStaleHiddenReading } from "./visibilityReadingGuard";
+import { useUnmountVisibilityCleanup } from "./useUnmountVisibilityCleanup";
 import { COMFORTABLE_PANEL_HEIGHT_PX } from "@/lib/terminalLayout";
 import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
@@ -668,6 +669,13 @@ function TerminalPaneComponent({
         )
           return;
 
+        // A callback queued from a previous mount site (warm-swap reattach)
+        // must not write at all. setVisible already drops it via its
+        // generation guard — dropping the store write under the same
+        // condition keeps store and service from diverging permanently
+        // (#10416).
+        if (terminalInstanceService.getAttachGeneration(id) !== gen) return;
+
         updateVisibility(id, entry.isIntersecting);
         terminalInstanceService.setVisible(id, entry.isIntersecting, gen);
       },
@@ -694,11 +702,7 @@ function TerminalPaneComponent({
   // Calling it here too is redundant and breaks in React StrictMode (dev),
   // where the effect's cleanup captures the same generation as the active
   // mount, bypassing the stale-generation guard and hiding the terminal.
-  useEffect(() => {
-    return () => {
-      updateVisibility(id, false);
-    };
-  }, [id, updateVisibility]);
+  useUnmountVisibilityCleanup(id, restartKey, updateVisibility);
 
   const handleReady = useCallback(() => {}, []);
 

--- a/src/components/Terminal/__tests__/useUnmountVisibilityCleanup.test.tsx
+++ b/src/components/Terminal/__tests__/useUnmountVisibilityCleanup.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useUnmountVisibilityCleanup } from "../useUnmountVisibilityCleanup";
+
+const mocks = vi.hoisted(() => ({
+  getAttachGeneration: vi.fn(() => 1),
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: { getAttachGeneration: mocks.getAttachGeneration },
+}));
+
+describe("useUnmountVisibilityCleanup", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    mocks.getAttachGeneration.mockReturnValue(1);
+  });
+
+  it("marks the panel hidden on a real unmount (generation unchanged)", () => {
+    const updateVisibility = vi.fn();
+    const { unmount } = renderHook(() => useUnmountVisibilityCleanup("t1", 0, updateVisibility));
+
+    unmount();
+    expect(updateVisibility).toHaveBeenCalledTimes(1);
+    expect(updateVisibility).toHaveBeenCalledWith("t1", false);
+  });
+
+  it("skips the stale cleanup when the terminal re-attached under a newer generation", () => {
+    const updateVisibility = vi.fn();
+    const { unmount } = renderHook(() => useUnmountVisibilityCleanup("t1", 0, updateVisibility));
+
+    // Warm-swap: the replacement pane attaches before this cleanup fires.
+    mocks.getAttachGeneration.mockReturnValue(2);
+    unmount();
+    expect(updateVisibility).not.toHaveBeenCalled();
+  });
+
+  it("re-captures the generation when restartKey changes", () => {
+    const updateVisibility = vi.fn();
+    const { rerender, unmount } = renderHook(
+      ({ restartKey }) => useUnmountVisibilityCleanup("t1", restartKey, updateVisibility),
+      { initialProps: { restartKey: 0 } }
+    );
+
+    // Restart re-attaches (generation bumps) before the effect re-runs; the
+    // outgoing effect's cleanup must not write false for the still-mounted pane.
+    mocks.getAttachGeneration.mockReturnValue(2);
+    rerender({ restartKey: 1 });
+    expect(updateVisibility).not.toHaveBeenCalled();
+
+    // The re-captured generation makes the final real unmount clean up normally.
+    unmount();
+    expect(updateVisibility).toHaveBeenCalledTimes(1);
+    expect(updateVisibility).toHaveBeenCalledWith("t1", false);
+  });
+
+  it("cleans up the outgoing id when the pane is reused for another terminal", () => {
+    const updateVisibility = vi.fn();
+    const { rerender } = renderHook(
+      ({ id }) => useUnmountVisibilityCleanup(id, 0, updateVisibility),
+      { initialProps: { id: "t1" } }
+    );
+
+    rerender({ id: "t2" });
+    expect(updateVisibility).toHaveBeenCalledTimes(1);
+    expect(updateVisibility).toHaveBeenCalledWith("t1", false);
+  });
+});

--- a/src/components/Terminal/useUnmountVisibilityCleanup.ts
+++ b/src/components/Terminal/useUnmountVisibilityCleanup.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+
+/**
+ * Marks the panel hidden in the store when the pane unmounts — guarded by the
+ * attach generation captured at mount. During a warm-swap the old pane's
+ * cleanup can fire after the replacement pane has already re-attached (the
+ * generation advanced); writing false then would poison store visibility
+ * while the service stays visible, pinning the computed refresh tier at
+ * BACKGROUND and trapping the reconciliation watchdog in a repair loop
+ * (#10416). restartKey is in the deps because a restart re-attaches under a
+ * new generation — without re-capturing, the final real unmount would be
+ * mistaken for a stale cleanup and skipped.
+ */
+export function useUnmountVisibilityCleanup(
+  id: string,
+  restartKey: number,
+  updateVisibility: (id: string, isVisible: boolean) => void
+): void {
+  useEffect(() => {
+    const gen = terminalInstanceService.getAttachGeneration(id);
+    return () => {
+      if (terminalInstanceService.getAttachGeneration(id) === gen) {
+        updateVisibility(id, false);
+      }
+    };
+  }, [id, restartKey, updateVisibility]);
+}

--- a/src/components/Terminal/useUnmountVisibilityCleanup.ts
+++ b/src/components/Terminal/useUnmountVisibilityCleanup.ts
@@ -11,6 +11,12 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
  * (#10416). restartKey is in the deps because a restart re-attaches under a
  * new generation — without re-capturing, the final real unmount would be
  * mistaken for a stale cleanup and skipped.
+ *
+ * StrictMode double-invoke is safe: XtermAdapter's attach (useLayoutEffect,
+ * generation bump) replays before this passive effect first runs, so the
+ * captured generation matches the live mount and the replayed cleanup writes
+ * false at worst transiently — the IntersectionObserver's first real reading
+ * restores it, same as the unguarded cleanup this hook replaced.
  */
 export function useUnmountVisibilityCleanup(
   id: string,

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -337,6 +337,8 @@ class TerminalInstanceService {
       unhibernate: (id) => this.unhibernate(id),
       forceReflow: (element) => forceXtermReflow(element),
       isStoreBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
+      isStoreHidden: (id) => usePanelStore.getState().panelsById[id]?.isVisible === false,
+      repairStoreVisibility: (id) => usePanelStore.getState().updateVisibility(id, true),
     });
 
     // If JetBrains Mono loads after the startup timeout already opened terminals

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -229,7 +229,10 @@ export class TerminalReconciliationWatchdog {
       // A BACKGROUND computed tier with store visibility intact is store
       // policy (completed/exited agent, exited process, PTY-less panel) —
       // hibernation eligibility, not divergence. Repairing it would fight
-      // the policy on every tick, forever (#10416).
+      // the policy on every tick, forever (#10416). Applies regardless of
+      // appliedTier: when both tiers sit at BACKGROUND the applied state
+      // already matches policy, and an applied-only BACKGROUND divergence
+      // (computed tier active) skips this guard and repairs below.
       if (computedTier === TerminalRefreshTier.BACKGROUND && !storeHidden) return 0;
       if (heavyBudget <= 0) return 0;
       managed.lastWatchdogRepairAt = now;

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -65,6 +65,10 @@ export interface ReconciliationWatchdogDeps {
   unhibernate: (id: string) => void;
   forceReflow: (element: HTMLElement) => void;
   isStoreBackgrounded: (id: string) => boolean;
+  /** Store-side panel.isVisible === false — the one store state DOM geometry can prove wrong. */
+  isStoreHidden: (id: string) => boolean;
+  /** Repair: store visibility poisoned to false for a genuinely on-screen terminal. */
+  repairStoreVisibility: (id: string) => void;
 }
 
 /**
@@ -221,15 +225,25 @@ export class TerminalReconciliationWatchdog {
       computedTier === TerminalRefreshTier.BACKGROUND ||
       appliedTier === TerminalRefreshTier.BACKGROUND
     ) {
+      const storeHidden = this.deps.isStoreHidden(id);
+      // A BACKGROUND computed tier with store visibility intact is store
+      // policy (completed/exited agent, exited process, PTY-less panel) —
+      // hibernation eligibility, not divergence. Repairing it would fight
+      // the policy on every tick, forever (#10416).
+      if (computedTier === TerminalRefreshTier.BACKGROUND && !storeHidden) return 0;
       if (heavyBudget <= 0) return 0;
-      // A misclassified computed tier can't be corrected here (it lives in
-      // the panel store) — floor the repair to VISIBLE and log loudly so the
-      // store-side root cause surfaces.
-      const repairTier =
-        computedTier !== undefined && computedTier !== TerminalRefreshTier.BACKGROUND
-          ? computedTier
-          : TerminalRefreshTier.VISIBLE;
       managed.lastWatchdogRepairAt = now;
+      // DOM geometry and service state prove the terminal on-screen, so a
+      // store-side isVisible=false is a stale write (e.g. an unguarded
+      // cleanup racing a warm-swap reattach) — repair it at the source so
+      // the computed tier re-derives and reconciliation converges instead
+      // of re-detecting the same divergence every tick (#10416).
+      if (storeHidden) this.deps.repairStoreVisibility(id);
+      const refreshedTier = storeHidden ? managed.getRefreshTier?.() : computedTier;
+      const repairTier =
+        refreshedTier !== undefined && refreshedTier !== TerminalRefreshTier.BACKGROUND
+          ? refreshedTier
+          : TerminalRefreshTier.VISIBLE;
       logWarn(
         "[TerminalReconciliationWatchdog] on-screen terminal at BACKGROUND tier — repairing",
         {
@@ -237,6 +251,7 @@ export class TerminalReconciliationWatchdog {
           computedTier,
           appliedTier,
           repairTier,
+          storeHidden,
         }
       );
       this.deps.applyRendererPolicy(id, repairTier);
@@ -324,6 +339,7 @@ export class TerminalReconciliationWatchdog {
       id,
       serviceVisible: managed.isVisible,
       storeBackgrounded: this.deps.isStoreBackgrounded(id),
+      storeHidden: this.deps.isStoreHidden(id),
       computedTier: managed.getRefreshTier?.(),
       appliedTier: managed.lastAppliedTier,
       pendingTier: managed.pendingTier,

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -316,6 +316,46 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(managed.lastWatchdogRepairAt).toBeUndefined();
     });
 
+    it("leaves a policy BACKGROUND tier alone even when the applied tier is also BACKGROUND", () => {
+      const managed = makeManaged({
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+      });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 3);
+      expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
+      expect(deps.repairStoreVisibility).not.toHaveBeenCalled();
+      expect(managed.lastWatchdogRepairAt).toBeUndefined();
+    });
+
+    it("rate-limits via cooldown when the store repair fails to converge", () => {
+      // If repairStoreVisibility doesn't take (store keeps reporting hidden),
+      // the watchdog must degrade to periodic cooldown-spaced retries — the
+      // pre-#10416 behavior — not a per-tick repair loop.
+      const managed = makeManaged({
+        lastAppliedTier: TerminalRefreshTier.VISIBLE,
+        getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+      });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, { isStoreHidden: vi.fn(() => true) });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.repairStoreVisibility).toHaveBeenCalledTimes(1);
+      expect(managed.lastWatchdogRepairAt).toBeGreaterThan(0);
+
+      // Inside the cooldown window — no retry.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.repairStoreVisibility).toHaveBeenCalledTimes(1);
+
+      // Past the cooldown — the still-diverged store retries.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.repairStoreVisibility).toHaveBeenCalledTimes(2);
+    });
+
     it("repairs poisoned store visibility and applies the re-derived tier", () => {
       // The warm-swap split from #10416: store isVisible=false while service
       // and DOM agree the terminal is on-screen.

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -116,6 +116,8 @@ function makeDeps(
     unhibernate: vi.fn(),
     forceReflow: vi.fn(),
     isStoreBackgrounded: vi.fn(() => false),
+    isStoreHidden: vi.fn(() => false),
+    repairStoreVisibility: vi.fn(),
     ...overrides,
   };
 }
@@ -296,7 +298,62 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.applyRendererPolicy).toHaveBeenCalledWith("t1", TerminalRefreshTier.FOCUSED);
     });
 
-    it("floors the repair tier to VISIBLE when the computed tier itself is BACKGROUND", () => {
+    it("leaves a computed BACKGROUND tier alone when store visibility is intact (policy)", () => {
+      // Completed/exited agents and exited processes compute BACKGROUND by
+      // design (hibernation eligibility) — repairing would loop forever (#10416).
+      const managed = makeManaged({
+        lastAppliedTier: TerminalRefreshTier.VISIBLE,
+        getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+      });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS * 3);
+      expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
+      expect(deps.repairStoreVisibility).not.toHaveBeenCalled();
+      expect(logWarn).not.toHaveBeenCalled();
+      expect(managed.lastWatchdogRepairAt).toBeUndefined();
+    });
+
+    it("repairs poisoned store visibility and applies the re-derived tier", () => {
+      // The warm-swap split from #10416: store isVisible=false while service
+      // and DOM agree the terminal is on-screen.
+      let storeHidden = true;
+      const managed = makeManaged({
+        lastAppliedTier: TerminalRefreshTier.VISIBLE,
+        getRefreshTier: () =>
+          storeHidden ? TerminalRefreshTier.BACKGROUND : TerminalRefreshTier.FOCUSED,
+      });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances, {
+        isStoreHidden: vi.fn(() => storeHidden),
+        repairStoreVisibility: vi.fn(() => {
+          storeHidden = false;
+        }),
+      });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.repairStoreVisibility).toHaveBeenCalledWith("t1");
+      expect(deps.applyRendererPolicy).toHaveBeenCalledWith("t1", TerminalRefreshTier.FOCUSED);
+      expect(logWarn).toHaveBeenCalledWith(
+        expect.stringContaining("BACKGROUND tier"),
+        expect.objectContaining({ id: "t1", storeHidden: true })
+      );
+
+      // Converges: once the store is repaired the divergence is gone — no
+      // further repairs after the cooldown elapses.
+      vi.clearAllMocks();
+      vi.advanceTimersByTime(WATCHDOG_REPAIR_COOLDOWN_MS + WATCHDOG_INTERVAL_MS * 2);
+      expect(deps.repairStoreVisibility).not.toHaveBeenCalled();
+      expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
+    });
+
+    it("floors to VISIBLE when the tier still computes BACKGROUND after the store repair", () => {
+      // Store-hidden completed agent: the store repair lands but policy keeps
+      // the computed tier at BACKGROUND — next tick treats it as intentional.
+      let storeHidden = true;
       instances.set(
         "t1",
         makeManaged({
@@ -304,11 +361,22 @@ describe("TerminalReconciliationWatchdog", () => {
           getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
         })
       );
-      const deps = makeDeps(instances);
+      const deps = makeDeps(instances, {
+        isStoreHidden: vi.fn(() => storeHidden),
+        repairStoreVisibility: vi.fn(() => {
+          storeHidden = false;
+        }),
+      });
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.repairStoreVisibility).toHaveBeenCalledWith("t1");
       expect(deps.applyRendererPolicy).toHaveBeenCalledWith("t1", TerminalRefreshTier.VISIBLE);
+
+      vi.clearAllMocks();
+      vi.advanceTimersByTime(WATCHDOG_REPAIR_COOLDOWN_MS + WATCHDOG_INTERVAL_MS * 2);
+      expect(deps.repairStoreVisibility).not.toHaveBeenCalled();
+      expect(deps.applyRendererPolicy).not.toHaveBeenCalled();
     });
 
     it("reasserts the backend tier when it diverged to background", () => {


### PR DESCRIPTION
## Summary

- After a `projectview.warm-swap`, `TerminalPane`'s store visibility writes lacked the attach-generation guard that the service already has. A stale unmount cleanup from a previous mount poisoned `panelStore.isVisible`, causing `TerminalReconciliationWatchdog` to re-detect the same divergence every ~6 s indefinitely (296 log entries over 35 min in the issue trace).
- The watchdog's repair only re-applied the renderer tier and had no path to fix the store, so divergence was permanent. It also fought intentional policy BACKGROUND (completed/exited agents, PTY-less panels) every tick.
- This PR fixes both root causes so reconciliation converges rather than loops.

Resolves #10416

## Changes

- **`useUnmountVisibilityCleanup` hook** (`src/components/Terminal/useUnmountVisibilityCleanup.ts`): new hook that captures the attach generation at mount (re-captured on `restartKey` so restarts don't strand the final cleanup) and skips stale warm-swap cleanups on unmount.
- **`TerminalPane` IO callback** (`src/components/Terminal/TerminalPane.tsx`): early-returns before both store and service writes when the attach generation has advanced, closing the asymmetry named in the issue.
- **`TerminalReconciliationWatchdog`** (`src/services/terminal/TerminalReconciliationWatchdog.ts`): two new deps `isStoreHidden`/`repairStoreVisibility`. A computed BACKGROUND with store visibility intact is treated as intentional policy and skipped silently. A store reporting hidden for a geometrically on-screen terminal is repaired at the source via `updateVisibility(id, true)`, the tier re-derived and applied. Failed repairs degrade to cooldown-spaced retries.
- **`TerminalInstanceService`** (`src/services/terminal/TerminalInstanceService.ts`): wires the two new watchdog deps reading/writing `usePanelStore`.

## Testing

- 7 new/updated `TerminalReconciliationWatchdog` test cases: policy skip (incl. dual-BACKGROUND), poisoned-store repair and convergence, floor-to-VISIBLE once for store-hidden completed agents, failed-repair cooldown.
- New `useUnmountVisibilityCleanup.test.tsx`: real unmount cleans up, stale warm-swap cleanup skipped, `restartKey` re-capture, id-change cleanup.
- 195 targeted tests pass post-rebase (watchdog, hook, TIS attach/tier/bootstrap/detach/hibernation, `panelStore.refreshTier`, `XtermAdapter.lifecycle`, `visibilityReadingGuard`). Prettier/ESLint clean on changed files (pre-existing warnings only).