### PR TITLE
feat(terminal): track window resizes in backgrounded project terminals

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -192,6 +192,7 @@ export const CHANNELS = {
   PROJECT_OPEN_DIALOG: "project:open-dialog",
   PROJECT_ON_SWITCH: "project:on-switch",
   PROJECT_FOCUS_ON_ACTIVATE: "project:focus-on-activate",
+  PROJECT_BACKGROUND_RESIZE: "project:background-resize",
   PROJECT_GET_SETTINGS: "project:get-settings",
   PROJECT_SAVE_SETTINGS: "project:save-settings",
   PROJECT_DETECT_RUNNERS: "project:detect-runners",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1457,6 +1457,9 @@ function buildElectronApi(): ElectronAPI {
       onFocusOnActivate: (callback: (payload: { intent: "focus-next-waiting" }) => void) =>
         _typedOn(CHANNELS.PROJECT_FOCUS_ON_ACTIVATE, callback),
 
+      onBackgroundResize: (callback: (payload: { width: number; height: number }) => void) =>
+        _typedOn(CHANNELS.PROJECT_BACKGROUND_RESIZE, callback),
+
       onUpdated: (callback: (project: Project) => void) =>
         _typedOn(CHANNELS.PROJECT_UPDATED, callback),
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -69,6 +69,13 @@ const CRASH_LOOP_THRESHOLD = 3;
 // observable benefit. Unfreeze is always immediate — keeping a view frozen
 // after we've decided to leave efficiency is the worst-of-both-worlds.
 const EFFICIENCY_FREEZE_DEBOUNCE_MS = 500;
+// Trailing-edge debounce for forwarding resize-end content bounds to cached
+// project views (#10415). Cached renderers are CPU-throttled (and CDP-frozen
+// under efficiency), so mid-drag spam is pure waste — only the settled size
+// matters. IPC to a frozen renderer queues in Mojo and delivers on unfreeze,
+// so no wake cycle is needed. Single debounce on `resize` rather than the
+// `resized` event because Linux never emits `resized`.
+const BACKGROUND_RESIZE_DEBOUNCE_MS = 300;
 /**
  * Soft paint-gate timeout (ms). At this point the gate logs that the
  * incoming view is taking longer than the typical cold start, but the
@@ -231,6 +238,7 @@ export class ProjectViewManager {
   private evictionTimestamps = new Map<string, number>();
   private efficiencyFreezeEnabled = false;
   private efficiencyFreezeTimer: NodeJS.Timeout | null = null;
+  private backgroundResizeTimer: NodeJS.Timeout | null = null;
   private pendingPaintGate: PaintGate | null = null;
   private paintGateTimeoutMs = DEFAULT_PAINT_GATE_TIMEOUT_MS;
   private paintGateHardTimeoutMs = DEFAULT_PAINT_GATE_HARD_TIMEOUT_MS;
@@ -299,6 +307,7 @@ export class ProjectViewManager {
       if (outgoing && !outgoing.webContents.isDestroyed() && outgoing !== view) {
         outgoing.setBounds({ x: 0, y: 0, width, height });
       }
+      this.scheduleBackgroundResizeNotify();
     };
     win.on("resize", this.resizeHandler);
     win.on("maximize", this.resizeHandler);
@@ -930,6 +939,33 @@ export class ProjectViewManager {
     }
   }
 
+  private scheduleBackgroundResizeNotify(): void {
+    if (this.backgroundResizeTimer) {
+      clearTimeout(this.backgroundResizeTimer);
+    }
+    this.backgroundResizeTimer = setTimeout(() => {
+      this.backgroundResizeTimer = null;
+      this.notifyBackgroundResize();
+    }, BACKGROUND_RESIZE_DEBOUNCE_MS);
+  }
+
+  // Forward the settled content bounds to every cached view so its renderer
+  // can keep PTY geometry tracking the window while detached (#10415). The
+  // detached view's own viewport stays stale until reattach — setBounds()
+  // does not propagate to a detached WebContentsView — so the renderer
+  // derives terminal sizes from these bounds instead of from layout.
+  private notifyBackgroundResize(): void {
+    if (this.disposed || this.win.isDestroyed()) return;
+    const { width, height } = this.win.getContentBounds();
+    for (const [projectId, entry] of this.views) {
+      if (projectId === this.activeProjectId) continue;
+      if (entry.state !== "cached") continue;
+      const wc = entry.view.webContents;
+      if (wc.isDestroyed()) continue;
+      wc.send(CHANNELS.PROJECT_BACKGROUND_RESIZE, { width, height });
+    }
+  }
+
   private unfreezeAllCached(): void {
     for (const [projectId, entry] of this.views) {
       if (projectId === this.activeProjectId) continue;
@@ -978,6 +1014,11 @@ export class ProjectViewManager {
       this.efficiencyFreezeTimer = null;
     }
     this.efficiencyFreezeEnabled = false;
+
+    if (this.backgroundResizeTimer) {
+      clearTimeout(this.backgroundResizeTimer);
+      this.backgroundResizeTimer = null;
+    }
 
     this.clearPaintGate();
     for (const projectId of Array.from(this.views.keys())) {

--- a/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
@@ -53,6 +53,15 @@ vi.mock("../webContentsRegistry.js", () => ({
   unregisterWebContents: vi.fn(),
   registerProjectView: vi.fn(),
   unregisterProjectView: vi.fn(),
+  registerCachedViewWebContents: vi.fn(),
+  unregisterCachedViewWebContents: vi.fn(),
+  isCachedViewWebContents: vi.fn(),
+  getWindowForWebContents: vi.fn(),
+  getAppWebContents: vi.fn(),
+  getAppView: vi.fn(),
+  getAllAppWebContents: vi.fn(() => []),
+  getProjectForWebContents: vi.fn(),
+  getWebContentsForProject: vi.fn(),
 }));
 
 vi.mock("../../setup/protocols.js", () => ({

--- a/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
@@ -247,6 +247,39 @@ describe("ProjectViewManager — background resize forwarding", () => {
     expect(backgroundResizeSends(initialWc)).toHaveLength(0);
   });
 
+  it("sends to every cached view, not just the most recent", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    const projBWc = manager.getActiveView()!.webContents as unknown as ReturnType<
+      typeof createMockWebContents
+    >;
+    await manager.switchTo("proj-c", "/path/c");
+    const projCWc = manager.getActiveView()!.webContents as unknown as ReturnType<
+      typeof createMockWebContents
+    >;
+
+    fireResize();
+    vi.advanceTimersByTime(300);
+
+    expect(backgroundResizeSends(initialWc)).toHaveLength(1);
+    expect(backgroundResizeSends(projBWc)).toHaveLength(1);
+    expect(backgroundResizeSends(projCWc)).toHaveLength(0);
+  });
+
+  it("a view cached mid-debounce receives the send; the newly active view does not", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    const projBWc = manager.getActiveView()!.webContents as unknown as ReturnType<
+      typeof createMockWebContents
+    >;
+
+    fireResize();
+    // proj-b backgrounds inside the debounce window; proj-a reactivates.
+    await manager.switchTo("proj-a", "/path/a");
+    vi.advanceTimersByTime(300);
+
+    expect(backgroundResizeSends(projBWc)).toHaveLength(1);
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+  });
+
   it("dispose() cancels a pending notification", async () => {
     await manager.switchTo("proj-b", "/path/b");
 

--- a/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let nextWebContentsId = 100;
+
+function createMockWebContents() {
+  const id = nextWebContentsId++;
+  return {
+    id,
+    isDestroyed: vi.fn(() => false),
+    executeJavaScript: vi.fn(() => Promise.resolve()),
+    loadURL: vi.fn(() => Promise.resolve()),
+    focus: vi.fn(),
+    close: vi.fn(),
+    reload: vi.fn(),
+    send: vi.fn(),
+    session: { flushStorageData: vi.fn() },
+    navigationHistory: { clear: vi.fn() },
+    on: vi.fn(() => {}),
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === "did-finish-load") {
+        Promise.resolve().then(() => handler());
+      }
+    }),
+    removeListener: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    setIgnoreMenuShortcuts: vi.fn(),
+  };
+}
+
+vi.mock("electron", () => {
+  function MockWebContentsView() {
+    const wc = createMockWebContents();
+    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+  }
+  return {
+    app: {
+      isPackaged: false,
+      commandLine: { appendSwitch: vi.fn() },
+      getPath: vi.fn(() => "/tmp/daintree-test-appdata"),
+      setPath: vi.fn(),
+    },
+    BrowserWindow: vi.fn(),
+    WebContentsView: MockWebContentsView,
+    session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },
+    ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+    nativeTheme: { shouldUseDarkColors: true },
+  };
+});
+
+vi.mock("../webContentsRegistry.js", () => ({
+  registerWebContents: vi.fn(),
+  registerAppView: vi.fn(),
+  unregisterWebContents: vi.fn(),
+  registerProjectView: vi.fn(),
+  unregisterProjectView: vi.fn(),
+}));
+
+vi.mock("../../setup/protocols.js", () => ({
+  registerProtocolsForSession: vi.fn(),
+  getDistPath: vi.fn(() => "/dist"),
+}));
+
+vi.mock("../../../shared/config/devServer.js", () => ({
+  getDevServerUrl: vi.fn(() => "http://localhost:5173"),
+}));
+
+vi.mock("../../../shared/utils/trustedRenderer.js", () => ({
+  isTrustedRendererUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../../shared/utils/urlUtils.js", () => ({
+  isLocalhostUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../utils/openExternal.js", () => ({
+  canOpenExternalUrl: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("../../services/CrashRecoveryService.js", () => ({
+  getCrashRecoveryService: vi.fn(() => ({ recordCrash: vi.fn() })),
+}));
+
+vi.mock("../../ipc/errorHandlers.js", () => ({
+  notifyError: vi.fn(),
+}));
+
+vi.mock("../skeletonCss.js", () => ({
+  injectSkeletonCss: vi.fn(),
+  injectSkeletonProjectIdentity: vi.fn(),
+  INITIAL_COLOR_SCHEME_ARG: "--daintree-initial-color-scheme-id",
+  INITIAL_PROJECT_ID_ARG: "--daintree-initial-project-id",
+  INSTANCE_ROLE_ARG: "--daintree-instance-role",
+  resolveInstanceRole: vi.fn(() => "attended"),
+  resolveInitialColorSchemeId: vi.fn(() => "daintree"),
+  resolveInitialCanvasBackgroundColor: vi.fn(() => "#1f1b16"),
+}));
+
+vi.mock("../../setup/environment.js", () => ({
+  isDemoMode: false,
+  isSmokeTest: false,
+}));
+
+vi.mock("../../services/ProjectStore.js", () => ({
+  projectStore: { getProjectById: vi.fn(() => null) },
+}));
+
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+  throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+  unthrottleCpuWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ProjectViewManager } from "../ProjectViewManager.js";
+import { CHANNELS } from "../../ipc/channels.js";
+
+function createMockWindow() {
+  return {
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    getContentBounds: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
+    contentView: {
+      children: [] as unknown[],
+      addChildView: vi.fn(),
+      removeChildView: vi.fn(),
+    },
+    webContents: createMockWebContents(),
+  };
+}
+
+function backgroundResizeSends(wc: ReturnType<typeof createMockWebContents>) {
+  return wc.send.mock.calls.filter(([channel]) => channel === CHANNELS.PROJECT_BACKGROUND_RESIZE);
+}
+
+describe("ProjectViewManager — background resize forwarding", () => {
+  let manager: ProjectViewManager;
+  let win: ReturnType<typeof createMockWindow>;
+  let initialWc: ReturnType<typeof createMockWebContents>;
+  let fireResize: () => void;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    nextWebContentsId = 100;
+    win = createMockWindow();
+    manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+    });
+    (manager as unknown as { waitForPaint: () => Promise<string> }).waitForPaint = () =>
+      Promise.resolve("signal");
+    initialWc = createMockWebContents();
+    const initialView = { webContents: initialWc, setBounds: vi.fn() };
+    manager.registerInitialView(initialView as never, "proj-a", "/path/a");
+
+    const resizeCall = win.on.mock.calls.find(([event]) => event === "resize");
+    if (!resizeCall) throw new Error("resize handler not registered");
+    const handler = resizeCall[1] as () => void;
+    fireResize = () => handler();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends settled content bounds to cached views after the debounce", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    win.getContentBounds.mockReturnValue({ x: 0, y: 0, width: 1440, height: 900 });
+
+    fireResize();
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+
+    vi.advanceTimersByTime(300);
+    const sends = backgroundResizeSends(initialWc);
+    expect(sends).toHaveLength(1);
+    expect(sends[0][1]).toEqual({ width: 1440, height: 900 });
+  });
+
+  it("never sends to the active view", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    const activeWc = manager.getActiveView()!.webContents as unknown as ReturnType<
+      typeof createMockWebContents
+    >;
+
+    fireResize();
+    vi.advanceTimersByTime(300);
+
+    expect(backgroundResizeSends(activeWc)).toHaveLength(0);
+    expect(backgroundResizeSends(initialWc)).toHaveLength(1);
+  });
+
+  it("coalesces a resize burst into a single send", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    fireResize();
+    vi.advanceTimersByTime(100);
+    fireResize();
+    vi.advanceTimersByTime(100);
+    fireResize();
+    vi.advanceTimersByTime(300);
+
+    expect(backgroundResizeSends(initialWc)).toHaveLength(1);
+  });
+
+  it("re-arms the debounce window on each resize event", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    fireResize();
+    vi.advanceTimersByTime(200);
+    fireResize();
+    vi.advanceTimersByTime(200);
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+
+    vi.advanceTimersByTime(100);
+    expect(backgroundResizeSends(initialWc)).toHaveLength(1);
+  });
+
+  it("sends the bounds read at fire time, not at schedule time", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    win.getContentBounds.mockReturnValue({ x: 0, y: 0, width: 1000, height: 700 });
+    fireResize();
+    win.getContentBounds.mockReturnValue({ x: 0, y: 0, width: 1280, height: 800 });
+    vi.advanceTimersByTime(300);
+
+    const sends = backgroundResizeSends(initialWc);
+    expect(sends).toHaveLength(1);
+    expect(sends[0][1]).toEqual({ width: 1280, height: 800 });
+  });
+
+  it("skips destroyed webContents without throwing", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    initialWc.isDestroyed.mockReturnValue(true);
+
+    fireResize();
+    expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+  });
+
+  it("does not send when there are no cached views", () => {
+    fireResize();
+    vi.advanceTimersByTime(300);
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+  });
+
+  it("dispose() cancels a pending notification", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    fireResize();
+    manager.dispose();
+    vi.advanceTimersByTime(300);
+
+    expect(backgroundResizeSends(initialWc)).toHaveLength(0);
+  });
+});

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -497,6 +497,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       callback: (payload: { projectId: string; worktreeLoadError: string | null }) => void
     ): () => void;
     onFocusOnActivate(callback: (payload: { intent: "focus-next-waiting" }) => void): () => void;
+    onBackgroundResize(callback: (payload: { width: number; height: number }) => void): () => void;
     onUpdated(callback: (project: Project) => void): () => void;
     onRemoved(callback: (projectId: string) => void): () => void;
     getSettings(projectId: string): Promise<ProjectSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1584,6 +1584,7 @@ export interface IpcEventMap {
   "project:on-switch": ProjectSwitchPayload;
   "project:worktree-load-status": ProjectWorktreeLoadStatusPayload;
   "project:focus-on-activate": { intent: "focus-next-waiting" };
+  "project:background-resize": { width: number; height: number };
   "project:stats-updated": ProjectStatusMap;
   "project:updated": Project;
   "project:removed": string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import {
   useAgentWaitingNudge,
   useForgeEnableRecommendation,
   useFocusOnActivateIntent,
+  useBackgroundWindowResize,
   usePluginDeepLink,
   useNotificationHistoryPruning,
   useUnloadCleanup,
@@ -664,6 +665,9 @@ function AppInner() {
   // paint signal arrives before panel state is loaded — a direct dispatch
   // would silently no-op against an empty panelStore).
   useFocusOnActivateIntent(isStateLoaded);
+  // Background window-resize receiver — keeps PTY geometry tracking the
+  // window while this project view is detached (#10415).
+  useBackgroundWindowResize();
   // `daintree://` deep-link receiver (#9559). Surfaces the intent once hydration
   // settles; the effect below opens the Plugin Manager, which consumes it.
   const pluginDeepLink = usePluginDeepLink(isStateLoaded);

--- a/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
+++ b/src/hooks/app/__tests__/useBackgroundWindowResize.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+type ResizePayload = { width: number; height: number };
+
+const onBackgroundResizeMock = vi.hoisted(() =>
+  vi.fn<(cb: (payload: ResizePayload) => void) => () => void>()
+);
+
+const applyBackgroundWindowResizeMock = vi.hoisted(() => vi.fn());
+const resetBackgroundResizeBasisMock = vi.hoisted(() => vi.fn());
+
+vi.stubGlobal("window", {
+  ...globalThis.window,
+  electron: {
+    project: {
+      onBackgroundResize: onBackgroundResizeMock,
+    },
+  },
+});
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    applyBackgroundWindowResize: applyBackgroundWindowResizeMock,
+    resetBackgroundResizeBasis: resetBackgroundResizeBasisMock,
+  },
+}));
+
+import { useBackgroundWindowResize } from "../useBackgroundWindowResize";
+
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+}
+
+describe("useBackgroundWindowResize", () => {
+  let lastCallback: ((payload: ResizePayload) => void) | null = null;
+  let unsubscribe: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unsubscribe = vi.fn();
+    lastCallback = null;
+    onBackgroundResizeMock.mockImplementation((cb) => {
+      lastCallback = cb;
+      return unsubscribe as () => void;
+    });
+    setVisibility("hidden");
+  });
+
+  it("subscribes on mount", () => {
+    renderHook(() => useBackgroundWindowResize());
+    expect(onBackgroundResizeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards bounds to terminalInstanceService", () => {
+    renderHook(() => useBackgroundWindowResize());
+
+    act(() => {
+      lastCallback?.({ width: 1280, height: 800 });
+    });
+
+    expect(applyBackgroundWindowResizeMock).toHaveBeenCalledWith(1280, 800);
+  });
+
+  it("ignores a missing payload", () => {
+    renderHook(() => useBackgroundWindowResize());
+
+    act(() => {
+      lastCallback?.(null as unknown as ResizePayload);
+    });
+
+    expect(applyBackgroundWindowResizeMock).not.toHaveBeenCalled();
+  });
+
+  it("resets the scaling basis when the view returns to the foreground", () => {
+    renderHook(() => useBackgroundWindowResize());
+
+    setVisibility("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(resetBackgroundResizeBasisMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reset the basis on a hidden visibilitychange", () => {
+    renderHook(() => useBackgroundWindowResize());
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(resetBackgroundResizeBasisMock).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes and removes the visibility listener on unmount", () => {
+    const { unmount } = renderHook(() => useBackgroundWindowResize());
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalled();
+
+    setVisibility("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(resetBackgroundResizeBasisMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -21,6 +21,7 @@ export { useOrchestrationMilestones } from "./useOrchestrationMilestones";
 export { useAgentWaitingNudge } from "./useAgentWaitingNudge";
 export { useForgeEnableRecommendation } from "./useForgeEnableRecommendation";
 export { useFocusOnActivateIntent } from "./useFocusOnActivateIntent";
+export { useBackgroundWindowResize } from "./useBackgroundWindowResize";
 export { usePluginDeepLink } from "./usePluginDeepLink";
 export type { PluginDeepLinkState } from "./usePluginDeepLink";
 export { useNotificationHistoryPruning } from "./useNotificationHistoryPruning";

--- a/src/hooks/app/useBackgroundWindowResize.ts
+++ b/src/hooks/app/useBackgroundWindowResize.ts
@@ -1,0 +1,32 @@
+import { useEffect } from "react";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+
+/**
+ * Background window-resize receiver (#10415).
+ *
+ * Main forwards debounced resize-end content bounds over
+ * `project:background-resize` to cached (backgrounded) project views, whose
+ * detached WebContentsViews otherwise never learn the window size changed.
+ * The geometry math lives in `terminalInstanceService.applyBackgroundWindowResize`.
+ * Subscribes unconditionally on mount — PTY resize is idempotent and needs no
+ * hydration gate. The visibilitychange listener resets the scaling basis when
+ * the view returns to the foreground, where real layout owns geometry again.
+ */
+export function useBackgroundWindowResize(): void {
+  useEffect(() => {
+    const unsubscribe = window.electron.project.onBackgroundResize((payload) => {
+      if (!payload) return;
+      terminalInstanceService.applyBackgroundWindowResize(payload.width, payload.height);
+    });
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        terminalInstanceService.resetBackgroundResizeBasis();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      unsubscribe();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+}

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1966,56 +1966,65 @@ class TerminalInstanceService {
     return this.resizeController.resize(id, width, height, options);
   }
 
-  private backgroundResizeBasis: { width: number; height: number } | null = null;
+  private backgroundResizeSession: {
+    basis: { width: number; height: number };
+    origin: Map<string, { width: number; height: number }>;
+  } | null = null;
 
   /**
    * PTY-tracking resize for a backgrounded project view (#10415). A detached
    * WebContentsView keeps its stale viewport until reattach — setBounds()
    * does not propagate while detached and ResizeObservers never fire in a
    * hidden page — so per-panel pixel sizes cannot be re-measured here.
-   * Instead each terminal's last measured host size is scaled by the
-   * window-bounds ratio, which is exact for 1fr grid tracks and at worst off
-   * by ~1 col where fixed chrome doesn't scale. The PTY-only resize keeps
-   * agents wrapping at the right width the whole time; the wake path
+   * Instead each terminal's host size is scaled by the window-bounds ratio,
+   * which is exact for 1fr grid tracks and at worst off by ~1 col where
+   * fixed chrome doesn't scale. The PTY-only resize keeps agents wrapping
+   * at the right width the whole time; the wake path
    * (`fullWakeForVisibilityRestore` → `applyDeferredResize`) reconciles
    * xterm and corrects any residual error from real layout on reattach.
    *
-   * The basis is the bounds the current `lastWidth`/`lastHeight` values were
-   * derived from: the live viewport for the first event of a background
-   * session, then the previously applied bounds — so repeated resizes scale
-   * incrementally instead of compounding against the stale viewport.
+   * Scaling is anchored to a per-background-session snapshot: the basis is
+   * the stale viewport (which all `lastWidth`/`lastHeight` measurements were
+   * laid out against) and each terminal's origin size is captured the first
+   * time it's seen. Every event computes absolute targets from that anchor,
+   * so repeated resizes never compound and a terminal skipped in one pass
+   * (resize-locked) still lands on the correct size in the next.
    */
   applyBackgroundWindowResize(width: number, height: number): void {
     if (document.visibilityState === "visible") {
       // Queued delivery after reactivation — real layout owns geometry again.
-      this.backgroundResizeBasis = null;
+      this.backgroundResizeSession = null;
       return;
     }
     if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
       return;
     }
-    const basis = this.backgroundResizeBasis ?? {
-      width: window.innerWidth,
-      height: window.innerHeight,
-    };
-    if (basis.width <= 0 || basis.height <= 0) return;
-    const widthRatio = width / basis.width;
-    const heightRatio = height / basis.height;
+    const session = (this.backgroundResizeSession ??= {
+      basis: { width: window.innerWidth, height: window.innerHeight },
+      origin: new Map(),
+    });
+    if (session.basis.width <= 0 || session.basis.height <= 0) return;
+    const widthRatio = width / session.basis.width;
+    const heightRatio = height / session.basis.height;
     for (const [id, managed] of this.instances) {
       if (managed.isHibernated) continue;
       if (!managed.isOpened) continue;
-      if (managed.lastWidth <= 0 || managed.lastHeight <= 0) continue;
+      let origin = session.origin.get(id);
+      if (!origin) {
+        if (managed.lastWidth <= 0 || managed.lastHeight <= 0) continue;
+        origin = { width: managed.lastWidth, height: managed.lastHeight };
+        session.origin.set(id, origin);
+      }
       this.resizeController.resizePtyOnly(
         id,
-        managed.lastWidth * widthRatio,
-        managed.lastHeight * heightRatio
+        origin.width * widthRatio,
+        origin.height * heightRatio
       );
     }
-    this.backgroundResizeBasis = { width, height };
   }
 
   resetBackgroundResizeBasis(): void {
-    this.backgroundResizeBasis = null;
+    this.backgroundResizeSession = null;
   }
 
   /**

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1966,6 +1966,58 @@ class TerminalInstanceService {
     return this.resizeController.resize(id, width, height, options);
   }
 
+  private backgroundResizeBasis: { width: number; height: number } | null = null;
+
+  /**
+   * PTY-tracking resize for a backgrounded project view (#10415). A detached
+   * WebContentsView keeps its stale viewport until reattach — setBounds()
+   * does not propagate while detached and ResizeObservers never fire in a
+   * hidden page — so per-panel pixel sizes cannot be re-measured here.
+   * Instead each terminal's last measured host size is scaled by the
+   * window-bounds ratio, which is exact for 1fr grid tracks and at worst off
+   * by ~1 col where fixed chrome doesn't scale. The PTY-only resize keeps
+   * agents wrapping at the right width the whole time; the wake path
+   * (`fullWakeForVisibilityRestore` → `applyDeferredResize`) reconciles
+   * xterm and corrects any residual error from real layout on reattach.
+   *
+   * The basis is the bounds the current `lastWidth`/`lastHeight` values were
+   * derived from: the live viewport for the first event of a background
+   * session, then the previously applied bounds — so repeated resizes scale
+   * incrementally instead of compounding against the stale viewport.
+   */
+  applyBackgroundWindowResize(width: number, height: number): void {
+    if (document.visibilityState === "visible") {
+      // Queued delivery after reactivation — real layout owns geometry again.
+      this.backgroundResizeBasis = null;
+      return;
+    }
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      return;
+    }
+    const basis = this.backgroundResizeBasis ?? {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+    if (basis.width <= 0 || basis.height <= 0) return;
+    const widthRatio = width / basis.width;
+    const heightRatio = height / basis.height;
+    for (const [id, managed] of this.instances) {
+      if (managed.isHibernated) continue;
+      if (!managed.isOpened) continue;
+      if (managed.lastWidth <= 0 || managed.lastHeight <= 0) continue;
+      this.resizeController.resizePtyOnly(
+        id,
+        managed.lastWidth * widthRatio,
+        managed.lastHeight * heightRatio
+      );
+    }
+    this.backgroundResizeBasis = { width, height };
+  }
+
+  resetBackgroundResizeBasis(): void {
+    this.backgroundResizeBasis = null;
+  }
+
   /**
    * Resize a set of panels in a single read-all / write-all pass (#8597).
    *

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -169,29 +169,8 @@ export class TerminalResizeController {
       // Background-tier path: a ResizeObserver fired while the host element
       // is inside a content-visibility:hidden container. fitAddon.fit() would
       // read 0x0 from the DOM, so we compute cols/rows from cached cell
-      // metrics instead. We deliberately skip terminal.resize() here — paint
-      // is paused, deferring the buffer reflow to wake time avoids work the
-      // user never sees. sendPtyResize() keeps the PTY in lockstep with the
-      // visible container size so agent output is wrapped correctly when the
-      // pane is revealed, and the settled-strategy timer is preserved.
-      const cellDims = getXtermCellDimensions(managed.terminal);
-      if (!cellDims) {
-        return null;
-      }
-      const cols = Math.max(2, Math.floor(width / cellDims.width));
-      const rows = Math.max(1, Math.floor(height / cellDims.height));
-      if (managed.latestCols === cols && managed.latestRows === rows) {
-        managed.lastWidth = width;
-        managed.lastHeight = height;
-        return null;
-      }
-      managed.lastWidth = width;
-      managed.lastHeight = height;
-      managed.latestCols = cols;
-      managed.latestRows = rows;
-      managed.latestWasAtBottom = wasAtBottom;
-      this.sendPtyResize(id, cols, rows);
-      return { cols, rows };
+      // metrics instead.
+      return this.resizePtyFromCachedCellMetrics(managed, id, width, height, wasAtBottom);
     }
 
     try {
@@ -260,6 +239,58 @@ export class TerminalResizeController {
       console.warn(`[TerminalResizeController] Resize failed for ${id}:`, error);
       return null;
     }
+  }
+
+  /**
+   * PTY-only resize from explicit pixel dimensions — never reflows xterm.
+   * Entry point for backgrounded project views (#10415), whose terminals may
+   * still carry `isVisible === true` from before the view was detached and
+   * would otherwise take the foreground path's xterm reflow while hidden.
+   * The deferred reflow is reconciled at wake via `applyDeferredResize`.
+   */
+  resizePtyOnly(id: string, width: number, height: number): { cols: number; rows: number } | null {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return null;
+    if (this.isResizeLocked(id)) return null;
+    if (Math.abs(managed.lastWidth - width) < 1 && Math.abs(managed.lastHeight - height) < 1) {
+      return null;
+    }
+    const buffer = managed.terminal.buffer.active;
+    const wasAtBottom = buffer.viewportY >= buffer.baseY;
+    return this.resizePtyFromCachedCellMetrics(managed, id, width, height, wasAtBottom);
+  }
+
+  // Computes cols/rows from cached cell metrics with no DOM reads and
+  // deliberately skips terminal.resize() — paint is paused for these
+  // terminals, so deferring the buffer reflow to wake time avoids work the
+  // user never sees. sendPtyResize() keeps the PTY in lockstep with the
+  // target size so agent output is wrapped correctly when the pane is
+  // revealed, and the settled-strategy timer is preserved.
+  private resizePtyFromCachedCellMetrics(
+    managed: ManagedTerminal,
+    id: string,
+    width: number,
+    height: number,
+    wasAtBottom: boolean
+  ): { cols: number; rows: number } | null {
+    const cellDims = getXtermCellDimensions(managed.terminal);
+    if (!cellDims) {
+      return null;
+    }
+    const cols = Math.max(2, Math.floor(width / cellDims.width));
+    const rows = Math.max(1, Math.floor(height / cellDims.height));
+    if (managed.latestCols === cols && managed.latestRows === rows) {
+      managed.lastWidth = width;
+      managed.lastHeight = height;
+      return null;
+    }
+    managed.lastWidth = width;
+    managed.lastHeight = height;
+    managed.latestCols = cols;
+    managed.latestRows = rows;
+    managed.latestWasAtBottom = wasAtBottom;
+    this.sendPtyResize(id, cols, rows);
+    return { cols, rows };
   }
 
   resizeTerminal(managed: ManagedTerminal, cols: number, rows: number): void {

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -169,8 +169,13 @@ export class TerminalResizeController {
       // Background-tier path: a ResizeObserver fired while the host element
       // is inside a content-visibility:hidden container. fitAddon.fit() would
       // read 0x0 from the DOM, so we compute cols/rows from cached cell
-      // metrics instead.
-      return this.resizePtyFromCachedCellMetrics(managed, id, width, height, wasAtBottom);
+      // metrics instead. sendPtyResize() keeps the settled-strategy timer —
+      // the renderer is live here, so coalescing drag bursts still applies.
+      const dims = this.resizePtyFromCachedCellMetrics(managed, width, height, wasAtBottom);
+      if (dims) {
+        this.sendPtyResize(id, dims.cols, dims.rows);
+      }
+      return dims;
     }
 
     try {
@@ -246,9 +251,17 @@ export class TerminalResizeController {
    * Entry point for backgrounded project views (#10415), whose terminals may
    * still carry `isVisible === true` from before the view was detached and
    * would otherwise take the foreground path's xterm reflow while hidden.
-   * The deferred reflow is reconciled at wake via `applyDeferredResize`.
+   * Delivers the PTY resize directly instead of through `sendPtyResize` —
+   * the settled-strategy timer would schedule a `terminal.resize()` in a
+   * hidden (possibly frozen) renderer, and the burst it coalesces was
+   * already debounced in Main. A pending settled timer is cleared since its
+   * stale geometry is superseded. The deferred xterm reflow is reconciled
+   * at wake via `applyDeferredResize`.
    */
   resizePtyOnly(id: string, width: number, height: number): { cols: number; rows: number } | null {
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      return null;
+    }
     const managed = this.deps.getInstance(id);
     if (!managed) return null;
     if (this.isResizeLocked(id)) return null;
@@ -257,18 +270,21 @@ export class TerminalResizeController {
     }
     const buffer = managed.terminal.buffer.active;
     const wasAtBottom = buffer.viewportY >= buffer.baseY;
-    return this.resizePtyFromCachedCellMetrics(managed, id, width, height, wasAtBottom);
+    const dims = this.resizePtyFromCachedCellMetrics(managed, width, height, wasAtBottom);
+    if (dims) {
+      this.clearSettledTimer(id);
+      terminalClient.resize(id, dims.cols, dims.rows);
+    }
+    return dims;
   }
 
   // Computes cols/rows from cached cell metrics with no DOM reads and
   // deliberately skips terminal.resize() — paint is paused for these
   // terminals, so deferring the buffer reflow to wake time avoids work the
-  // user never sees. sendPtyResize() keeps the PTY in lockstep with the
-  // target size so agent output is wrapped correctly when the pane is
-  // revealed, and the settled-strategy timer is preserved.
+  // user never sees. Pure computation + state update; the caller delivers
+  // the PTY resize so each path picks its own strategy handling.
   private resizePtyFromCachedCellMetrics(
     managed: ManagedTerminal,
-    id: string,
     width: number,
     height: number,
     wasAtBottom: boolean
@@ -289,7 +305,6 @@ export class TerminalResizeController {
     managed.latestCols = cols;
     managed.latestRows = rows;
     managed.latestWasAtBottom = wasAtBottom;
-    this.sendPtyResize(id, cols, rows);
     return { cols, rows };
   }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManagedTerminal } from "../types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({
+      visualBuffers: [],
+      signalBuffer: null,
+    })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+type BackgroundResizeTestService = {
+  instances: Map<string, ManagedTerminal>;
+  applyBackgroundWindowResize: (width: number, height: number) => void;
+  resetBackgroundResizeBasis: () => void;
+  resizeController: {
+    resizePtyOnly: (
+      id: string,
+      width: number,
+      height: number
+    ) => { cols: number; rows: number } | null;
+  };
+};
+
+function makeManaged(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
+  return {
+    isOpened: true,
+    isHibernated: false,
+    lastWidth: 800,
+    lastHeight: 600,
+    ...overrides,
+  } as ManagedTerminal;
+}
+
+function setViewport(width: number, height: number, visibility: "visible" | "hidden") {
+  Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
+  Object.defineProperty(window, "innerHeight", { value: height, configurable: true });
+  Object.defineProperty(document, "visibilityState", { value: visibility, configurable: true });
+}
+
+describe("TerminalInstanceService applyBackgroundWindowResize", () => {
+  let service: BackgroundResizeTestService;
+  let resizePtyOnlySpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: BackgroundResizeTestService;
+      });
+    service.instances.clear();
+    service.resetBackgroundResizeBasis();
+    resizePtyOnlySpy = vi
+      .spyOn(service.resizeController, "resizePtyOnly")
+      .mockReturnValue(null) as ReturnType<typeof vi.spyOn>;
+    setViewport(1000, 700, "hidden");
+  });
+
+  afterEach(() => {
+    service.instances.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("scales each terminal's last measured size by the window-bounds ratio", () => {
+    service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
+    service.instances.set("b", makeManaged({ lastWidth: 400, lastHeight: 300 }));
+
+    service.applyBackgroundWindowResize(1200, 840);
+
+    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(2);
+    expect(resizePtyOnlySpy).toHaveBeenCalledWith("a", 800 * 1.2, 600 * 1.2);
+    expect(resizePtyOnlySpy).toHaveBeenCalledWith("b", 400 * 1.2, 300 * 1.2);
+  });
+
+  it("no-ops when the document is visible — real layout owns geometry", () => {
+    setViewport(1000, 700, "visible");
+    service.instances.set("a", makeManaged());
+
+    service.applyBackgroundWindowResize(1200, 840);
+
+    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+  });
+
+  it("scales repeated resizes incrementally against the previously applied bounds", () => {
+    service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
+
+    service.applyBackgroundWindowResize(1200, 840);
+    service.applyBackgroundWindowResize(1500, 700);
+
+    // Second event scales against the 1200x840 basis, not the stale viewport.
+    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * (1500 / 1200), 600 * (700 / 840));
+  });
+
+  it("resetBackgroundResizeBasis restores the live viewport as the basis", () => {
+    service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
+
+    service.applyBackgroundWindowResize(1200, 840);
+    service.resetBackgroundResizeBasis();
+    service.applyBackgroundWindowResize(1300, 770);
+
+    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.3, 600 * 1.1);
+  });
+
+  it("a visible-state delivery resets the basis for the next background session", () => {
+    service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
+
+    service.applyBackgroundWindowResize(1200, 840);
+    setViewport(1000, 700, "visible");
+    service.applyBackgroundWindowResize(1200, 840);
+    setViewport(1000, 700, "hidden");
+    service.applyBackgroundWindowResize(1300, 770);
+
+    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.3, 600 * 1.1);
+  });
+
+  it("skips hibernated, unopened, and never-measured terminals", () => {
+    service.instances.set("hibernated", makeManaged({ isHibernated: true }));
+    service.instances.set("unopened", makeManaged({ isOpened: false }));
+    service.instances.set("unmeasured", makeManaged({ lastWidth: 0, lastHeight: 0 }));
+    service.instances.set("eligible", makeManaged());
+
+    service.applyBackgroundWindowResize(1200, 840);
+
+    expect(resizePtyOnlySpy).toHaveBeenCalledTimes(1);
+    expect(resizePtyOnlySpy).toHaveBeenCalledWith(
+      "eligible",
+      expect.any(Number),
+      expect.any(Number)
+    );
+  });
+
+  it("ignores non-finite and non-positive bounds", () => {
+    service.instances.set("a", makeManaged());
+
+    service.applyBackgroundWindowResize(Number.NaN, 840);
+    service.applyBackgroundWindowResize(1200, Number.POSITIVE_INFINITY);
+    service.applyBackgroundWindowResize(0, 840);
+    service.applyBackgroundWindowResize(-100, 840);
+
+    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+  });
+
+  it("invalid bounds do not corrupt the basis for a following valid event", () => {
+    service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
+
+    service.applyBackgroundWindowResize(0, 0);
+    service.applyBackgroundWindowResize(1200, 840);
+
+    expect(resizePtyOnlySpy).toHaveBeenCalledWith("a", 800 * 1.2, 600 * 1.2);
+  });
+
+  it("no-ops when the stale viewport reports zero dimensions", () => {
+    setViewport(0, 0, "hidden");
+    service.instances.set("a", makeManaged());
+
+    service.applyBackgroundWindowResize(1200, 840);
+
+    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.backgroundResize.test.ts
@@ -121,14 +121,29 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     expect(resizePtyOnlySpy).not.toHaveBeenCalled();
   });
 
-  it("scales repeated resizes incrementally against the previously applied bounds", () => {
+  it("anchors repeated resizes to the session origin — targets are absolute, never compounded", () => {
     service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
 
     service.applyBackgroundWindowResize(1200, 840);
     service.applyBackgroundWindowResize(1500, 700);
 
-    // Second event scales against the 1200x840 basis, not the stale viewport.
-    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * (1500 / 1200), 600 * (700 / 840));
+    // Both events scale the captured 800x600 origin against the 1000x700
+    // viewport snapshot, regardless of what earlier events applied.
+    expect(resizePtyOnlySpy).toHaveBeenNthCalledWith(1, "a", 800 * 1.2, 600 * 1.2);
+    expect(resizePtyOnlySpy).toHaveBeenNthCalledWith(2, "a", 800 * 1.5, 600 * 1.0);
+  });
+
+  it("a terminal skipped in one pass still lands on the correct absolute size in the next", () => {
+    const managed = makeManaged({ lastWidth: 800, lastHeight: 600 });
+    service.instances.set("a", managed);
+
+    // First pass skipped (e.g. resize-locked) — resizePtyOnly returns null
+    // and lastWidth is untouched. The origin snapshot must keep the second
+    // pass anchored to the original viewport, not an advanced basis.
+    service.applyBackgroundWindowResize(1200, 840);
+    service.applyBackgroundWindowResize(1500, 1400);
+
+    expect(resizePtyOnlySpy).toHaveBeenLastCalledWith("a", 800 * 1.5, 600 * 2.0);
   });
 
   it("resetBackgroundResizeBasis restores the live viewport as the basis", () => {
@@ -180,13 +195,27 @@ describe("TerminalInstanceService applyBackgroundWindowResize", () => {
     expect(resizePtyOnlySpy).not.toHaveBeenCalled();
   });
 
-  it("invalid bounds do not corrupt the basis for a following valid event", () => {
+  it("invalid bounds do not corrupt the session for a following valid event", () => {
     service.instances.set("a", makeManaged({ lastWidth: 800, lastHeight: 600 }));
 
     service.applyBackgroundWindowResize(0, 0);
     service.applyBackgroundWindowResize(1200, 840);
 
     expect(resizePtyOnlySpy).toHaveBeenCalledWith("a", 800 * 1.2, 600 * 1.2);
+  });
+
+  it("captures the origin for a terminal measured only after the session started", () => {
+    const managed = makeManaged({ lastWidth: 0, lastHeight: 0 });
+    service.instances.set("late", managed);
+
+    service.applyBackgroundWindowResize(1200, 840);
+    expect(resizePtyOnlySpy).not.toHaveBeenCalled();
+
+    managed.lastWidth = 500;
+    managed.lastHeight = 400;
+    service.applyBackgroundWindowResize(1500, 700);
+
+    expect(resizePtyOnlySpy).toHaveBeenCalledWith("late", 500 * 1.5, 400 * 1.0);
   });
 
   it("no-ops when the stale viewport reports zero dimensions", () => {

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1180,5 +1180,70 @@ describe("TerminalResizeController", () => {
       expect(managed.lastWidth).toBe(800);
       expect(managed.lastHeight).toBe(600);
     });
+
+    it("rejects degenerate pixel dimensions without touching state", () => {
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      const controller = makeController(managed);
+
+      expect(controller.resizePtyOnly("term-1", Number.NaN, 800)).toBeNull();
+      expect(controller.resizePtyOnly("term-1", 1600, Number.POSITIVE_INFINITY)).toBeNull();
+      expect(controller.resizePtyOnly("term-1", 0, 800)).toBeNull();
+      expect(controller.resizePtyOnly("term-1", -100, 800)).toBeNull();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.lastWidth).toBe(800);
+      expect(managed.latestCols).toBe(80);
+    });
+
+    it("delivers the PTY resize immediately for settled-strategy agents, with no xterm reflow", () => {
+      const managed = createManagedTerminal();
+      managed.launchAgentId = "codex";
+      managed.runtimeAgentId = "codex";
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+
+      const controller = makeController(managed);
+      const result = controller.resizePtyOnly("term-1", 1600, 800);
+
+      expect(result).toEqual({ cols: 160, rows: 40 });
+      // Direct delivery — not deferred behind the settled 500ms timer, which
+      // would also reflow xterm in a hidden (possibly frozen) renderer.
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+
+      vi.advanceTimersByTime(500);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("supersedes a pending settled timer scheduled before backgrounding", () => {
+      const managed = createManagedTerminal();
+      managed.launchAgentId = "codex";
+      managed.runtimeAgentId = "codex";
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+
+      const controller = makeController(managed);
+      // A pre-background resize armed the settled timer with stale geometry.
+      controller.sendPtyResize("term-1", 120, 30);
+      expect(resizeMock).not.toHaveBeenCalled();
+
+      controller.resizePtyOnly("term-1", 1600, 800);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+
+      vi.advanceTimersByTime(500);
+      // The stale timer must not fire its 120x30 resize or reflow xterm.
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1087,4 +1087,98 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).not.toHaveBeenCalled();
     });
   });
+
+  describe("resizePtyOnly", () => {
+    function makeController(managed: ReturnType<typeof createManagedTerminal> | undefined) {
+      return new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: {
+          flushForTerminal: vi.fn(),
+          resetForTerminal: vi.fn(),
+        } as any,
+      });
+    }
+
+    it("resizes the PTY without reflowing xterm, even for a visible focused terminal", () => {
+      const managed = createManagedTerminal();
+      managed.isFocused = true;
+      managed.isVisible = true;
+      managed.lastAppliedTier = TerminalRefreshTier.FOCUSED;
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+
+      const controller = makeController(managed);
+      const result = controller.resizePtyOnly("term-1", 1600, 800);
+
+      expect(result).toEqual({ cols: 160, rows: 40 });
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+      expect(managed.latestCols).toBe(160);
+      expect(managed.latestRows).toBe(40);
+      expect(managed.lastWidth).toBe(1600);
+      expect(managed.lastHeight).toBe(800);
+    });
+
+    it("returns null for a missing instance", () => {
+      const controller = makeController(undefined);
+      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
+    it("respects an active resize lock", () => {
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      const controller = makeController(managed);
+      controller.lockResize("term-1", true);
+
+      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
+    it("dedups when pixel dimensions are unchanged", () => {
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      const controller = makeController(managed);
+
+      controller.resizePtyOnly("term-1", 1600, 800);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+
+      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("updates pixel cache without re-notifying the PTY when cols/rows are unchanged", () => {
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      const controller = makeController(managed);
+
+      controller.resizePtyOnly("term-1", 1600, 800);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+
+      // +5px is under one 10px cell — same cols/rows, but the cache must
+      // track the new pixels so the next delta computes against them.
+      const second = controller.resizePtyOnly("term-1", 1605, 800);
+      expect(second).toBeNull();
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(managed.lastWidth).toBe(1605);
+    });
+
+    it("returns null without poisoning the dedup cache when cell dims are unavailable", () => {
+      const managed = createManagedTerminal();
+      const controller = makeController(managed);
+
+      expect(controller.resizePtyOnly("term-1", 1600, 800)).toBeNull();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.lastWidth).toBe(800);
+      expect(managed.lastHeight).toBe(600);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Backgrounded `WebContentsView`s stop receiving resize events when detached from the window, leaving every terminal in the project with stale PTY dimensions while agents wrap output at the wrong width
- `ProjectViewManager` now debounces resize-end (300ms trailing, covering resize/maximize/unmaximize/fullscreen) and forwards the settled `getContentBounds()` to every cached view over a new `project:background-resize` IPC channel — queued Mojo delivery means no unfreeze/refreeze cycle needed
- The renderer scales each terminal's host size using a session-anchored snapshot (stale viewport basis + per-terminal origin sizes), so repeated resizes compute absolute targets and never compound; per-terminal delivery goes through a new `TerminalResizeController.resizePtyOnly` that bypasses the settled-strategy timer — at wake, the existing `fullWakeForVisibilityRestore → applyDeferredResize` path reconciles xterm to the PTY geometry

Resolves #10415.

## Changes

- `electron/window/ProjectViewManager.ts` — debounced `backgroundResize` handler; broadcasts `project:background-resize` to all cached (non-active) views
- `electron/ipc/channels.ts`, `electron/preload.cts`, `shared/types/ipc/` — new `project:background-resize` channel wired end-to-end
- `src/services/terminal/TerminalResizeController.ts` — `resizePtyOnly` method; PTY-only resize bypasses settled-strategy timer, supersedes any in-flight settled timer
- `src/services/terminal/TerminalInstanceService.ts` — `applyBackgroundWindowResize` with session-anchored scaling snapshot; respects per-terminal resize-lock and degenerate-input guards
- `src/hooks/app/useBackgroundWindowResize.ts` + registration in `src/App.tsx` — renderer-side listener that routes the IPC event into `terminalInstanceService`

## Testing

29 new/extended unit tests across:

- `ProjectViewManager.backgroundResize.test.ts` — debounce coalescing, cached-only targeting, mid-switch races, dispose cleanup
- `TerminalResizeController.test.ts` — `resizePtyOnly` contract, settled-strategy bypass, stale-timer supersede
- `TerminalInstanceService.backgroundResize.test.ts` — session-anchored scaling, skip rules (resize-locked terminals, degenerate input), repeated-resize idempotence
- `useBackgroundWindowResize.test.tsx` — renderer hook registration and routing

Full typecheck, lint ratchet, and channel/IPC drift guards pass locally.