### PR TITLE
fix(dev-preview): make the auto-detected run button actually start the preview

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -437,6 +437,7 @@ export function DevPreviewPane({
   // Store the original guest UA so we can restore it when clearing a preset
   const originalUaRef = useRef<string | null>(null);
   const [isAutoDetecting, setIsAutoDetecting] = useState(false);
+  const [autoDetectFailed, setAutoDetectFailed] = useState(false);
   const autoDetectRef = useRef(false);
   const { saveSettings } = useProjectSettings();
   const allDetectedRunners = useProjectSettingsStore((state) => state.allDetectedRunners);
@@ -1044,9 +1045,13 @@ export function DevPreviewPane({
 
       autoDetectRef.current = true;
       setIsAutoDetecting(true);
+      setAutoDetectFailed(false);
       try {
         const latestSettings = await projectClient.getSettings(currentProjectId);
-        if (!latestSettings) return false;
+        if (!latestSettings) {
+          if (isMountedRef.current) setAutoDetectFailed(true);
+          return false;
+        }
 
         let command = candidateCommand;
         if (!command) {
@@ -1057,7 +1062,10 @@ export function DevPreviewPane({
           )?.command;
         }
 
-        if (!command) return false;
+        if (!command) {
+          if (isMountedRef.current) setAutoDetectFailed(true);
+          return false;
+        }
 
         await saveSettings({
           ...latestSettings,
@@ -1069,6 +1077,7 @@ export function DevPreviewPane({
         return true;
       } catch (err) {
         logError("Failed to auto-detect dev server", err);
+        if (isMountedRef.current) setAutoDetectFailed(true);
         return false;
       } finally {
         autoDetectRef.current = false;
@@ -1651,7 +1660,7 @@ export function DevPreviewPane({
                       </div>
                       <div className="flex flex-col items-center gap-2">
                         <Button
-                          onClick={() => void handleAutoDetect()}
+                          onClick={() => void handleAutoDetect(primaryCandidate.command)}
                           disabled={isAutoDetecting || isSettingsLoading}
                           variant="ghost"
                           size="sm"
@@ -1664,6 +1673,22 @@ export function DevPreviewPane({
                               : `Run \`${primaryCandidate.command}\``}
                           </span>
                         </Button>
+                        {autoDetectFailed && (
+                          <InlineStatusBanner
+                            icon={XCircle}
+                            severity="error"
+                            title="Couldn't start preview"
+                            description="The detected command couldn't be saved to project settings."
+                            className="w-full rounded text-left"
+                            action={{
+                              id: "dev-preview-auto-detect-retry",
+                              label: "Retry",
+                              icon: RotateCw,
+                              variant: "dangerFilled",
+                              onClick: () => void handleAutoDetect(primaryCandidate.command),
+                            }}
+                          />
+                        )}
                         {candidates.length > 1 && (
                           <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
                             <PopoverTrigger asChild>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -437,8 +437,15 @@ export function DevPreviewPane({
   // Store the original guest UA so we can restore it when clearing a preset
   const originalUaRef = useRef<string | null>(null);
   const [isAutoDetecting, setIsAutoDetecting] = useState(false);
-  const [autoDetectFailed, setAutoDetectFailed] = useState(false);
+  // The command whose auto-detect/save attempt failed; null = no failure shown.
+  // Empty string means the attempt never resolved a command (re-detection found
+  // nothing), so retry falls back to the currently displayed candidate.
+  const [autoDetectFailedCommand, setAutoDetectFailedCommand] = useState<string | null>(null);
   const autoDetectRef = useRef(false);
+
+  useEffect(() => {
+    if (devCommand) setAutoDetectFailedCommand(null);
+  }, [devCommand]);
   const { saveSettings } = useProjectSettings();
   const allDetectedRunners = useProjectSettingsStore((state) => state.allDetectedRunners);
   const isSettingsLoading = useProjectSettingsStore((state) => state.isLoading);
@@ -1045,11 +1052,12 @@ export function DevPreviewPane({
 
       autoDetectRef.current = true;
       setIsAutoDetecting(true);
-      setAutoDetectFailed(false);
+      setAutoDetectFailedCommand(null);
+      let attemptedCommand = candidateCommand ?? "";
       try {
         const latestSettings = await projectClient.getSettings(currentProjectId);
         if (!latestSettings) {
-          if (isMountedRef.current) setAutoDetectFailed(true);
+          if (isMountedRef.current) setAutoDetectFailedCommand(attemptedCommand);
           return false;
         }
 
@@ -1063,9 +1071,10 @@ export function DevPreviewPane({
         }
 
         if (!command) {
-          if (isMountedRef.current) setAutoDetectFailed(true);
+          if (isMountedRef.current) setAutoDetectFailedCommand("");
           return false;
         }
+        attemptedCommand = command;
 
         await saveSettings({
           ...latestSettings,
@@ -1077,7 +1086,7 @@ export function DevPreviewPane({
         return true;
       } catch (err) {
         logError("Failed to auto-detect dev server", err);
-        if (isMountedRef.current) setAutoDetectFailed(true);
+        if (isMountedRef.current) setAutoDetectFailedCommand(attemptedCommand);
         return false;
       } finally {
         autoDetectRef.current = false;
@@ -1673,7 +1682,7 @@ export function DevPreviewPane({
                               : `Run \`${primaryCandidate.command}\``}
                           </span>
                         </Button>
-                        {autoDetectFailed && (
+                        {autoDetectFailedCommand !== null && (
                           <InlineStatusBanner
                             icon={XCircle}
                             severity="error"
@@ -1685,7 +1694,10 @@ export function DevPreviewPane({
                               label: "Retry",
                               icon: RotateCw,
                               variant: "dangerFilled",
-                              onClick: () => void handleAutoDetect(primaryCandidate.command),
+                              onClick: () =>
+                                void handleAutoDetect(
+                                  autoDetectFailedCommand || primaryCandidate.command
+                                ),
                             }}
                           />
                         )}

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DevPreviewPaneProps } from "../DevPreviewPane";
 import { DevPreviewPane } from "../DevPreviewPane";
+import { projectClient } from "@/clients";
 
 const notifyMock = vi.hoisted(() => vi.fn());
 
@@ -2346,6 +2347,116 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       expect(screen.getByTestId("panel-header-content")).toBeTruthy();
       expect(container.textContent).toContain("npm run custom");
+    });
+  });
+
+  describe("auto-detected run button (#10419)", () => {
+    const flushAutoDetect = async () => {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    };
+
+    beforeEach(() => {
+      terminalStoreState.getTerminal.mockImplementation(() => ({
+        kind: "dev-preview",
+        id: "dev-preview-panel-1",
+        browserHistory: { past: [], present: "", future: [] },
+        browserZoom: 1.0,
+        devPreviewConsoleOpen: false,
+        devCommand: "",
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useProjectSettingsStoreMock.mockImplementation((selector: (state: any) => unknown) =>
+        selector({
+          projectId: "project-1",
+          settings: {
+            devServerCommand: "",
+            environmentVariables: {},
+            runCommands: [],
+          },
+          detectedRunners: [],
+          allDetectedRunners: [
+            { id: "r1", name: "dev", command: "npm run dev", source: "package.json" as const },
+          ],
+          isLoading: false,
+          error: null,
+          loadSettings: vi.fn(),
+          setSettings: vi.fn(),
+        })
+      );
+      devServerStateRef.current = {
+        ...devServerStateRef.current,
+        status: "stopped",
+        url: null,
+      };
+      projectClientGetSettingsMock.mockResolvedValue({
+        devServerCommand: "",
+        devServerAutoDetected: false,
+        devServerDismissed: false,
+        turbopackEnabled: true,
+      });
+      saveSettingsMock.mockResolvedValue(undefined);
+    });
+
+    const getRunButton = () => screen.getByRole("button", { name: "Run `npm run dev`" });
+
+    it("saves the displayed candidate command without re-running detection", async () => {
+      render(<DevPreviewPane {...baseProps} />);
+
+      fireEvent.click(getRunButton());
+      await flushAutoDetect();
+
+      expect(saveSettingsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          devServerCommand: "npm run dev",
+          devServerAutoDetected: true,
+          devServerDismissed: false,
+        })
+      );
+      expect(vi.mocked(projectClient.detectRunners)).not.toHaveBeenCalled();
+    });
+
+    it("shows an inline error banner with a retry action when saving fails", async () => {
+      saveSettingsMock.mockRejectedValueOnce(new Error("save failed"));
+      render(<DevPreviewPane {...baseProps} />);
+
+      fireEvent.click(getRunButton());
+      await flushAutoDetect();
+
+      expect(screen.getByText("Couldn't start preview")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    });
+
+    it("shows the error banner when project settings cannot be loaded", async () => {
+      projectClientGetSettingsMock.mockResolvedValueOnce(null);
+      render(<DevPreviewPane {...baseProps} />);
+
+      fireEvent.click(getRunButton());
+      await flushAutoDetect();
+
+      expect(saveSettingsMock).not.toHaveBeenCalled();
+      expect(screen.getByText("Couldn't start preview")).toBeTruthy();
+    });
+
+    it("clears the banner on retry and saves the same command", async () => {
+      saveSettingsMock.mockRejectedValueOnce(new Error("save failed"));
+      render(<DevPreviewPane {...baseProps} />);
+
+      fireEvent.click(getRunButton());
+      await flushAutoDetect();
+      expect(screen.getByText("Couldn't start preview")).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      await flushAutoDetect();
+
+      expect(screen.queryByText("Couldn't start preview")).toBeNull();
+      expect(saveSettingsMock).toHaveBeenCalledTimes(2);
+      expect(saveSettingsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ devServerCommand: "npm run dev" })
+      );
     });
   });
 

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -298,6 +298,12 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
   ConfirmDialog: () => null,
 }));
 
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 vi.mock("@/components/DevPreview/ConsoleDrawer", () => ({
   ConsoleDrawer: ({ onRestartDevServer }: { onRestartDevServer?: () => void }) => (
     <button
@@ -2359,6 +2365,32 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       });
     };
 
+    type RunnerFixture = { id: string; name: string; command: string; source: "package.json" };
+
+    const defaultRunners: RunnerFixture[] = [
+      { id: "r1", name: "dev", command: "pnpm dev", source: "package.json" },
+    ];
+
+    const setSettingsStoreState = (devServerCommand: string, runners = defaultRunners) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useProjectSettingsStoreMock.mockImplementation((selector: (state: any) => unknown) =>
+        selector({
+          projectId: "project-1",
+          settings: {
+            devServerCommand,
+            environmentVariables: {},
+            runCommands: [],
+          },
+          detectedRunners: [],
+          allDetectedRunners: runners,
+          isLoading: false,
+          error: null,
+          loadSettings: vi.fn(),
+          setSettings: vi.fn(),
+        })
+      );
+    };
+
     beforeEach(() => {
       terminalStoreState.getTerminal.mockImplementation(() => ({
         kind: "dev-preview",
@@ -2368,25 +2400,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         devPreviewConsoleOpen: false,
         devCommand: "",
       }));
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      useProjectSettingsStoreMock.mockImplementation((selector: (state: any) => unknown) =>
-        selector({
-          projectId: "project-1",
-          settings: {
-            devServerCommand: "",
-            environmentVariables: {},
-            runCommands: [],
-          },
-          detectedRunners: [],
-          allDetectedRunners: [
-            { id: "r1", name: "dev", command: "npm run dev", source: "package.json" as const },
-          ],
-          isLoading: false,
-          error: null,
-          loadSettings: vi.fn(),
-          setSettings: vi.fn(),
-        })
-      );
+      setSettingsStoreState("");
       devServerStateRef.current = {
         ...devServerStateRef.current,
         status: "stopped",
@@ -2401,7 +2415,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       saveSettingsMock.mockResolvedValue(undefined);
     });
 
-    const getRunButton = () => screen.getByRole("button", { name: "Run `npm run dev`" });
+    const getRunButton = () => screen.getByRole("button", { name: "Run `pnpm dev`" });
 
     it("saves the displayed candidate command without re-running detection", async () => {
       render(<DevPreviewPane {...baseProps} />);
@@ -2411,7 +2425,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
       expect(saveSettingsMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          devServerCommand: "npm run dev",
+          devServerCommand: "pnpm dev",
           devServerAutoDetected: true,
           devServerDismissed: false,
         })
@@ -2441,6 +2455,17 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(screen.getByText("Couldn't start preview")).toBeTruthy();
     });
 
+    it("shows the error banner when loading settings rejects", async () => {
+      projectClientGetSettingsMock.mockRejectedValueOnce(new Error("IPC failure"));
+      render(<DevPreviewPane {...baseProps} />);
+
+      fireEvent.click(getRunButton());
+      await flushAutoDetect();
+
+      expect(saveSettingsMock).not.toHaveBeenCalled();
+      expect(screen.getByText("Couldn't start preview")).toBeTruthy();
+    });
+
     it("clears the banner on retry and saves the same command", async () => {
       saveSettingsMock.mockRejectedValueOnce(new Error("save failed"));
       render(<DevPreviewPane {...baseProps} />);
@@ -2455,8 +2480,48 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       expect(screen.queryByText("Couldn't start preview")).toBeNull();
       expect(saveSettingsMock).toHaveBeenCalledTimes(2);
       expect(saveSettingsMock).toHaveBeenLastCalledWith(
-        expect.objectContaining({ devServerCommand: "npm run dev" })
+        expect.objectContaining({ devServerCommand: "pnpm dev" })
       );
+    });
+
+    it("retries the alternate command that failed, not the primary candidate", async () => {
+      setSettingsStoreState("", [
+        { id: "r1", name: "dev", command: "pnpm dev", source: "package.json" },
+        { id: "r2", name: "start", command: "npm start", source: "package.json" },
+      ]);
+      saveSettingsMock.mockRejectedValueOnce(new Error("save failed"));
+      render(<DevPreviewPane {...baseProps} />);
+
+      // The popover mock renders the picker entries inline; pick the alternate.
+      fireEvent.click(screen.getByText("npm start"));
+      await flushAutoDetect();
+      expect(screen.getByText("Couldn't start preview")).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+      await flushAutoDetect();
+
+      expect(saveSettingsMock).toHaveBeenCalledTimes(2);
+      expect(saveSettingsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ devServerCommand: "npm start" })
+      );
+    });
+
+    it("does not resurface a stale failure after the pane is reconfigured", async () => {
+      saveSettingsMock.mockRejectedValueOnce(new Error("save failed"));
+      const { rerender } = render(<DevPreviewPane {...baseProps} />);
+
+      fireEvent.click(getRunButton());
+      await flushAutoDetect();
+      expect(screen.getByText("Couldn't start preview")).toBeTruthy();
+
+      setSettingsStoreState("pnpm dev");
+      rerender(<DevPreviewPane {...baseProps} />);
+      await flushAutoDetect();
+
+      setSettingsStoreState("");
+      rerender(<DevPreviewPane {...baseProps} />);
+
+      expect(screen.queryByText("Couldn't start preview")).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- The "Run \`<cmd>\`" button in the unconfigured dev-preview empty state was calling `handleAutoDetect()` with no argument, so it discarded the displayed `primaryCandidate.command` and re-ran detection from scratch — if detection disagreed or returned nothing, the click silently did something other than what the button showed.
- Every failure path in `handleAutoDetect` (`getSettings` returning null, no candidate found, save error) returned silently with no user feedback, making the button appear completely broken.
- Fix passes the displayed candidate command directly to `handleAutoDetect`, adds `autoDetectFailedCommand` state (cleared on each attempt and on reconfigure), and renders a pane-local `InlineStatusBanner` with a Retry action on failure — the Retry re-attempts the exact command that failed, not the current primary candidate.

Resolves #10419

## Changes

- `src/components/DevPreview/DevPreviewPane.tsx` — empty-state run button and picker retry now pass the candidate command to `handleAutoDetect`; `autoDetectFailedCommand` state drives an `InlineStatusBanner` on all failure exits; banner is cleared when the pane becomes configured. No `notify()` toast — the empty state is itself the recovery surface.
- `src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx` — 7 new tests: candidate pass-through without re-detection, save-failure banner + Retry, `getSettings` null and rejection paths, retry clears banner and re-saves the same command, alternate-script failure retries the alternate (not primary), stale banner does not resurface after reconfigure.

## Testing

161 tests pass across `DevPreviewPane.webview.test.tsx` and `DevPreviewPane.test.tsx` post-rebase. Prettier and ESLint clean on changed files.