### PR TITLE
fix(diff-viewer): keep gutter +/- marker on the line-number's line

### DIFF
--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -61,6 +61,11 @@
   cursor: default;
   user-select: none;
   border-right: 1px solid var(--color-daintree-border);
+  /* Keep the +/- marker on the line number's line: the column width is an
+     exact-fit calc(ch + 21px), so a subpixel deficit (fractional zoom,
+     proportional monospace fallback, high-DPI) lets the line-breaking
+     engine drop the trailing inline-block marker onto its own row. */
+  white-space: nowrap;
 }
 
 /* Unified second gutter column docks beside the first. (Split tables don't
@@ -77,6 +82,12 @@
   width: 1ch;
   margin-left: 4px;
   text-align: center;
+}
+
+/* Per-element nowrap on the line number itself: belt-and-braces with the
+   .diff-gutter rule, and a stable test/class hook. */
+.diff-viewer .diff-line-number {
+  white-space: nowrap;
 }
 
 /* Code content styling */

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -172,7 +172,7 @@ export interface DiffViewerProps {
  */
 const renderGutterWithMarker: RenderGutter = ({ change, renderDefault, wrapInAnchor }) => (
   <>
-    {wrapInAnchor(renderDefault())}
+    <span className="diff-line-number">{wrapInAnchor(renderDefault())}</span>
     <span className="diff-line-marker">
       {change.type === "insert" ? "+" : change.type === "delete" ? "-" : ""}
     </span>
@@ -184,7 +184,7 @@ function makeGutterRenderer(movedKeys: ReadonlySet<string>): RenderGutter {
   if (movedKeys.size === 0) return renderGutterWithMarker;
   const render: RenderGutter = ({ change, renderDefault, wrapInAnchor }) => (
     <>
-      {wrapInAnchor(renderDefault())}
+      <span className="diff-line-number">{wrapInAnchor(renderDefault())}</span>
       <span className="diff-line-marker">
         {change.type === "insert" ? "+" : change.type === "delete" ? "-" : ""}
       </span>

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { ChangeData, HunkData, RenderToken } from "react-diff-view";
+import type { InsertChange, DeleteChange } from "gitdiff-parser";
 import { DiffViewer, _resetLangStateForTests } from "../DiffViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -530,8 +531,14 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
 
   it("wraps the line number in a .diff-line-number span for insert rows", () => {
     const renderGutter = getRenderGutter();
+    const change: InsertChange = {
+      type: "insert",
+      content: "added",
+      lineNumber: 2,
+      isInsert: true,
+    };
     const result = renderGutter({
-      change: { type: "insert", content: "added", lineNumber: 2, isInsert: true },
+      change,
       renderDefault: () => "2",
       wrapInAnchor: (n) => <a href="#L2">{n}</a>,
     });
@@ -548,8 +555,14 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
 
   it("wraps the line number in a .diff-line-number span for delete rows", () => {
     const renderGutter = getRenderGutter();
+    const change: DeleteChange = {
+      type: "delete",
+      content: "old",
+      lineNumber: 1,
+      isDelete: true,
+    };
     const result = renderGutter({
-      change: { type: "delete", content: "old", lineNumber: 1, isDelete: true },
+      change,
       renderDefault: () => "1",
       wrapInAnchor: (n) => <a href="#L1">{n}</a>,
     });
@@ -566,8 +579,14 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
 
   it("emits a sibling .diff-line-marker after the .diff-line-number, never inside it", () => {
     const renderGutter = getRenderGutter();
+    const change: InsertChange = {
+      type: "insert",
+      content: "added",
+      lineNumber: 2,
+      isInsert: true,
+    };
     const result = renderGutter({
-      change: { type: "insert", content: "added", lineNumber: 2, isInsert: true },
+      change,
       renderDefault: () => "2",
       wrapInAnchor: (n) => <a href="#L2">{n}</a>,
     });

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import React from "react";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { ChangeData, HunkData, RenderToken } from "react-diff-view";
@@ -499,5 +500,121 @@ describe("DiffViewer hunk copy", () => {
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith("line1\nadded\nline2");
     });
+  });
+});
+
+// #10422: the +/- marker in the gutter must stay on the same line as the
+// line number regardless of line-number width, zoom, or font. The fix lives
+// in CSS (white-space: nowrap on the gutter cell + a per-element nowrap on
+// .diff-line-number), so the test asserts the static DOM/CSS contract:
+// renderGutter always wraps the line number in a .diff-line-number span and
+// always emits a sibling .diff-line-marker span carrying the +/- glyph.
+describe("DiffViewer gutter marker never wraps (#10422)", () => {
+  beforeEach(() => {
+    _resetLangStateForTests();
+    clearCapturedDiffProps();
+  });
+
+  type RenderGutterParams = {
+    change: ChangeData;
+    renderDefault: () => React.ReactNode;
+    wrapInAnchor: (node: React.ReactNode) => React.ReactNode;
+  };
+  type RenderGutterFn = (params: RenderGutterParams) => React.ReactNode;
+  function getRenderGutter(): RenderGutterFn {
+    render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="split" />));
+    return capturedDiffProps.renderGutter as RenderGutterFn;
+  }
+
+  function findChildren(node: React.ReactNode, className: string): React.ReactElement[] {
+    const out: React.ReactElement[] = [];
+    const visit = (n: React.ReactNode) => {
+      if (!React.isValidElement(n)) return;
+      const props = n.props as { className?: string; children?: React.ReactNode };
+      if (props.className === className) out.push(n);
+      if (props.children) React.Children.forEach(props.children, visit);
+    };
+    React.Children.forEach(node, visit);
+    return out;
+  }
+
+  it("wraps the line number in a .diff-line-number span for insert rows", () => {
+    const renderGutter = getRenderGutter();
+    const result = renderGutter({
+      change: {
+        type: "insert",
+        content: "added",
+        isInsert: true,
+        isDelete: false,
+        isNormal: false,
+        oldLineNumber: undefined,
+        newLineNumber: 2,
+      },
+      renderDefault: () => "2",
+      wrapInAnchor: (n) => <a href="#L2">{n}</a>,
+    });
+    const { container } = render(<>{result}</>);
+
+    const lineNumberSpans = container.querySelectorAll(".diff-line-number");
+    const markerSpans = container.querySelectorAll(".diff-line-marker");
+
+    expect(lineNumberSpans).toHaveLength(1);
+    expect(lineNumberSpans[0]!.querySelector("a")).not.toBeNull();
+    expect(markerSpans).toHaveLength(1);
+    expect(markerSpans[0]!.textContent).toBe("+");
+  });
+
+  it("wraps the line number in a .diff-line-number span for delete rows", () => {
+    const renderGutter = getRenderGutter();
+    const result = renderGutter({
+      change: {
+        type: "delete",
+        content: "old",
+        isInsert: false,
+        isDelete: true,
+        isNormal: false,
+        oldLineNumber: 1,
+        newLineNumber: undefined,
+      },
+      renderDefault: () => "1",
+      wrapInAnchor: (n) => <a href="#L1">{n}</a>,
+    });
+    const { container } = render(<>{result}</>);
+
+    const lineNumberSpans = container.querySelectorAll(".diff-line-number");
+    const markerSpans = container.querySelectorAll(".diff-line-marker");
+
+    expect(lineNumberSpans).toHaveLength(1);
+    expect(lineNumberSpans[0]!.querySelector("a")).not.toBeNull();
+    expect(markerSpans).toHaveLength(1);
+    expect(markerSpans[0]!.textContent).toBe("-");
+  });
+
+  it("emits a sibling .diff-line-marker after the .diff-line-number, never inside it", () => {
+    const renderGutter = getRenderGutter();
+    const result = renderGutter({
+      change: {
+        type: "insert",
+        content: "added",
+        isInsert: true,
+        isDelete: false,
+        isNormal: false,
+        oldLineNumber: undefined,
+        newLineNumber: 2,
+      },
+      renderDefault: () => "2",
+      wrapInAnchor: (n) => <a href="#L2">{n}</a>,
+    });
+    const { container } = render(<>{result}</>);
+
+    const lineNumberSpans = container.querySelectorAll(".diff-line-number");
+    const markerSpans = container.querySelectorAll(".diff-line-marker");
+
+    expect(lineNumberSpans).toHaveLength(1);
+    expect(markerSpans).toHaveLength(1);
+    // The marker is a sibling of the line number, not nested inside it — the
+    // gutter cell is what enforces nowrap; the marker span itself is the
+    // element that would wrap if the cell allowed it.
+    expect(lineNumberSpans[0]!.querySelector(".diff-line-marker")).toBeNull();
   });
 });

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { ChangeData, HunkData, RenderToken } from "react-diff-view";
@@ -526,30 +528,10 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
     return capturedDiffProps.renderGutter as RenderGutterFn;
   }
 
-  function findChildren(node: React.ReactNode, className: string): React.ReactElement[] {
-    const out: React.ReactElement[] = [];
-    const visit = (n: React.ReactNode) => {
-      if (!React.isValidElement(n)) return;
-      const props = n.props as { className?: string; children?: React.ReactNode };
-      if (props.className === className) out.push(n);
-      if (props.children) React.Children.forEach(props.children, visit);
-    };
-    React.Children.forEach(node, visit);
-    return out;
-  }
-
   it("wraps the line number in a .diff-line-number span for insert rows", () => {
     const renderGutter = getRenderGutter();
     const result = renderGutter({
-      change: {
-        type: "insert",
-        content: "added",
-        isInsert: true,
-        isDelete: false,
-        isNormal: false,
-        oldLineNumber: undefined,
-        newLineNumber: 2,
-      },
+      change: { type: "insert", content: "added", lineNumber: 2, isInsert: true },
       renderDefault: () => "2",
       wrapInAnchor: (n) => <a href="#L2">{n}</a>,
     });
@@ -567,15 +549,7 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
   it("wraps the line number in a .diff-line-number span for delete rows", () => {
     const renderGutter = getRenderGutter();
     const result = renderGutter({
-      change: {
-        type: "delete",
-        content: "old",
-        isInsert: false,
-        isDelete: true,
-        isNormal: false,
-        oldLineNumber: 1,
-        newLineNumber: undefined,
-      },
+      change: { type: "delete", content: "old", lineNumber: 1, isDelete: true },
       renderDefault: () => "1",
       wrapInAnchor: (n) => <a href="#L1">{n}</a>,
     });
@@ -593,15 +567,7 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
   it("emits a sibling .diff-line-marker after the .diff-line-number, never inside it", () => {
     const renderGutter = getRenderGutter();
     const result = renderGutter({
-      change: {
-        type: "insert",
-        content: "added",
-        isInsert: true,
-        isDelete: false,
-        isNormal: false,
-        oldLineNumber: undefined,
-        newLineNumber: 2,
-      },
+      change: { type: "insert", content: "added", lineNumber: 2, isInsert: true },
       renderDefault: () => "2",
       wrapInAnchor: (n) => <a href="#L2">{n}</a>,
     });
@@ -616,5 +582,17 @@ describe("DiffViewer gutter marker never wraps (#10422)", () => {
     // gutter cell is what enforces nowrap; the marker span itself is the
     // element that would wrap if the cell allowed it.
     expect(lineNumberSpans[0]!.querySelector(".diff-line-marker")).toBeNull();
+  });
+});
+
+// Load the actual stylesheet at test time so a deleted/regressed rule breaks
+// the build, not just a hand-typed assumption. The load is async-free and
+// the file is small — the assertion guards both the gutter-level fix and the
+// per-element fallback against accidental removal.
+describe("DiffViewer gutter CSS contract (#10422)", () => {
+  it("declares white-space: nowrap on the gutter cell and on .diff-line-number", () => {
+    const cssText = readFileSync(join(__dirname, "..", "DiffViewer.css"), "utf8");
+    expect(cssText).toMatch(/\.diff-viewer\s+\.diff-gutter\s*\{[^}]*white-space:\s*nowrap/);
+    expect(cssText).toMatch(/\.diff-viewer\s+\.diff-line-number\s*\{[^}]*white-space:\s*nowrap/);
   });
 });


### PR DESCRIPTION
## Summary
- Stop the `+` marker on inserted lines from wrapping onto its own row beneath the line number once the gutter widens past 2 digits.
- The gutter column is sized as an exact-fit `calc(${digits + 1}ch + 21px)`, so any subpixel shortfall (fractional zoom, proportional monospace fallback, high-DPI) was letting the inline-block `.diff-line-marker` break onto a second line. `.diff-gutter` now pins the line number and marker together with `white-space: nowrap`, and the line number gets its own `diff-line-number` span as a stable test hook.
- Covers any font and any zoom level.

Resolves #10422

## Changes
- `src/components/Worktree/DiffViewer.css` — `white-space: nowrap` on `.diff-gutter` and `.diff-line-number` so the line-breaking engine can't split the marker off.
- `src/components/Worktree/DiffViewer.tsx` — wrap the rendered line number in a `<span class="diff-line-number">` in both gutter renderers, giving the per-element rule a real target and tests a stable hook.
- `src/components/Worktree/__tests__/DiffViewer.test.tsx` — `ChangeData` shape fix-up, CSS contract test asserting `nowrap` on both `.diff-gutter` and `.diff-line-number`, and direct `InsertChange`/`DeleteChange` typing instead of the loose union.

## Testing
- Updated `DiffViewer.test.tsx` to use the strict `InsertChange`/`DeleteChange` types and added a CSS contract test pinning `white-space: nowrap` on both the gutter and the line-number span.
- Existing `DiffViewer` tests still pass against the new markup.