### PR TITLE
fix(dev-preview): align command dropdown with header icon controls

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1147,7 +1147,8 @@ export function DevPreviewPane({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className="flex items-center gap-1 p-1.5 hover:bg-daintree-text/10 text-daintree-text/60 hover:text-daintree-text transition-colors max-w-[180px]"
+                onPointerDown={(e) => e.stopPropagation()}
+                className="flex h-6 items-center gap-1 px-1.5 rounded-sm hover:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors max-w-[180px]"
                 aria-label="Switch dev script"
               >
                 <span className="text-xs truncate">{headerLabel}</span>

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1151,7 +1151,7 @@ export function DevPreviewPane({
                 className="flex h-6 items-center gap-1 px-1.5 rounded-sm hover:bg-daintree-text/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 text-daintree-text/60 hover:text-daintree-text transition-colors max-w-[180px]"
                 aria-label="Switch dev script"
               >
-                <span className="text-xs truncate">{headerLabel}</span>
+                <span className="min-w-0 text-xs truncate">{headerLabel}</span>
                 <ChevronDown className="h-3 w-3 shrink-0" />
               </button>
             </DropdownMenuTrigger>

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -264,6 +264,8 @@ vi.mock("@/components/Browser/BrowserToolbar", () => ({
   },
 }));
 
+const headerContentPointerDownSpy = vi.hoisted(() => vi.fn());
+
 vi.mock("@/components/Panel", () => ({
   ContentPanel: ({
     children,
@@ -273,7 +275,11 @@ vi.mock("@/components/Panel", () => ({
     headerContent?: React.ReactNode;
   }) => (
     <div data-testid="content-panel">
-      {headerContent && <div data-testid="panel-header-content">{headerContent}</div>}
+      {headerContent && (
+        <div data-testid="panel-header-content" onPointerDown={headerContentPointerDownSpy}>
+          {headerContent}
+        </div>
+      )}
       {children}
     </div>
   ),
@@ -2353,6 +2359,35 @@ describe("DevPreviewPane webview lifecycle regression", () => {
       const { container } = render(<DevPreviewPane {...baseProps} />);
       expect(screen.getByTestId("panel-header-content")).toBeTruthy();
       expect(container.textContent).toContain("npm run custom");
+    });
+
+    it("does not propagate pointerdown from the trigger to header ancestors", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      useProjectSettingsStoreMock.mockImplementation((selector: (state: any) => unknown) => {
+        const state = {
+          projectId: "project-1",
+          settings: {
+            devServerCommand: "npm run dev",
+            environmentVariables: {},
+            runCommands: [],
+          },
+          detectedRunners: [],
+          allDetectedRunners: [
+            { id: "r1", name: "Dev", command: "npm run dev", source: "package.json" as const },
+          ],
+          isLoading: false,
+          error: null,
+          loadSettings: vi.fn(),
+          setSettings: vi.fn(),
+        };
+        return selector(state);
+      });
+
+      render(<DevPreviewPane {...baseProps} />);
+      headerContentPointerDownSpy.mockClear();
+      const trigger = screen.getByLabelText("Switch dev script");
+      fireEvent.pointerDown(trigger);
+      expect(headerContentPointerDownSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -913,6 +913,9 @@ function PanelHeaderComponent({
       )}
 
       <div className="flex items-center gap-1.5">
+        {/* Kind-specific header content slot */}
+        {headerContent}
+
         {/* Overflow menu — panel management actions */}
         {hasOverflowItems && (
           <DropdownMenu
@@ -1205,9 +1208,6 @@ function PanelHeaderComponent({
             </div>
           </TooltipContent>
         </Tooltip>
-
-        {/* Kind-specific header content slot */}
-        {headerContent}
       </div>
       {isFleetPreviewed ? (
         <span

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -218,8 +218,12 @@ describe("PanelHeader", () => {
       );
       const content = screen.getByTestId("custom-header-content");
       const overflowButton = screen.getByLabelText("More panel actions");
+      const closeButton = screen.getByTestId("panel-close");
       expect(
         content.compareDocumentPosition(overflowButton) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+      expect(
+        content.compareDocumentPosition(closeButton) & Node.DOCUMENT_POSITION_FOLLOWING
       ).toBeTruthy();
     });
   });

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -209,6 +209,21 @@ describe("PanelHeader", () => {
     });
   });
 
+  describe("headerContent slot", () => {
+    it("renders headerContent before the overflow menu button", () => {
+      render(
+        <PanelHeader
+          {...makeProps({ headerContent: <div data-testid="custom-header-content" /> })}
+        />
+      );
+      const content = screen.getByTestId("custom-header-content");
+      const overflowButton = screen.getByLabelText("More panel actions");
+      expect(
+        content.compareDocumentPosition(overflowButton) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+  });
+
   describe("overflow menu items", () => {
     const findMenuButton = (menu: HTMLElement, label: string) =>
       Array.from(menu.querySelectorAll("button")).find((btn) => btn.textContent?.trim() === label);


### PR DESCRIPTION
## Summary

- The dev-preview command dropdown was rendering after the close button instead of with the other icon controls. Moved the `{headerContent}` slot in `PanelHeader.tsx` to be the first child of the right-side controls group, so it sits immediately left of the ellipsis button. `DevPreviewPane` is the only `headerContent` consumer, so no other panel kinds are affected.
- Restyled the dropdown trigger to match sibling icon buttons: explicit `h-6` (the `text-xs` line-height was pushing it to 28px), `px-1.5`, `rounded-sm`, standard `focus-visible` outline classes, `onPointerDown` stop-propagation to prevent panel-drag initiation, and `min-w-0` on the truncate span for reliable flex truncation.

Resolves #10424

## Changes

- `src/components/Panel/PanelHeader.tsx` — move `{headerContent}` slot to first child of right-side controls group
- `src/components/DevPreview/DevPreviewPane.tsx` — restyle dropdown trigger to match icon button siblings
- `src/components/Panel/__tests__/PanelHeader.test.tsx` — DOM-order regression test (`headerContent` renders before both the overflow and close buttons, verified via `compareDocumentPosition`)
- `src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx` — pointer-down propagation test using a synthetic-handler spy on the `ContentPanel` mock wrapper

## Testing

160 tests pass (`npx vitest run` on both test files). Prettier and ESLint clean on all 4 changed files.