### PR TITLE
fix(quick-run): drop /50 border modifier so atacama quick-run border stays visible

### DIFF
--- a/src/components/Project/QuickRun.tsx
+++ b/src/components/Project/QuickRun.tsx
@@ -394,7 +394,7 @@ export function QuickRun({ projectId }: QuickRunProps) {
               <div
                 className={cn(
                   // Fallback keeps themes without --dock-input-bg byte-identical.
-                  "relative flex items-center rounded-[var(--radius-md)] border border-border-subtle/50 bg-[var(--dock-input-bg,var(--color-overlay-soft))]",
+                  "relative flex items-center rounded-[var(--radius-md)] border border-border-subtle bg-[var(--dock-input-bg,var(--color-overlay-soft))]",
                   "transition focus-within:border-daintree-accent/35 focus-within:ring-1 focus-within:ring-daintree-accent/12"
                 )}
               >


### PR DESCRIPTION
## Summary

The quick-run input border was invisible in the light-theme E2E tests for the atacama theme. The wrapper used `border-border-subtle/50`, which Tailwind v4 compiles to `color-mix(in oklab, var(--color-border-subtle) 50%, transparent)`. Atacama's `border-subtle` token is already a low-alpha value (`rgba(39,33,25,0.09)`), so the oklab mix collapsed it to fully transparent in Chromium. The border was gone.

Fix is one line in `src/components/Project/QuickRun.tsx` — drop the `/50` modifier and use the pre-baked `border-subtle` token directly. Contrast lands at ~1.19 for atacama and ~1.20 for the other light themes. Dark themes move from an accidental ~4.5% effective alpha to the designed 9% token value, still well within "subtle".

Resolves #10427

## Changes

- `src/components/Project/QuickRun.tsx`: replace `border-border-subtle/50` with `border-border-subtle` on the input wrapper

## Testing

- `npm run build:e2e` + `npx playwright test e2e/full/panels/core-light-theme-smoke.spec.ts` — passes locally across all light schemes
- Prettier clean on the changed file
- ESLint flags three pre-existing `no-floating-promises` errors on untouched lines — present on develop, covered by the lint ratchet baseline, not addressed here

## Notes (pre-existing, out of scope)

- `e2e/helpers/theme.ts` `parseColor()` silently falls back to opaque black on unrecognised color strings — can mask regressions as false passes
- `src/index.css` `panel-state-compiling` rings use `color-mix(in oklab, var(--color-border-subtle) 8%, transparent)` — same underflow risk on low-alpha light tokens