### PR TITLE
fix(diff-viewer): fix double scrollbar and force persistent always-visible bars

### DIFF
--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -897,7 +897,7 @@ export function FileViewerModal({
       </AppDialog.Header>
 
       <div className="relative flex-1 min-h-0 flex flex-col">
-        <AppDialog.BodyScroll className="p-0">
+        <AppDialog.BodyScroll className="p-0 diff-scroll-root">
           {isImageMode && (
             <div className="flex items-center justify-center p-6 min-h-[300px]">
               {loadState === "image" && (

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -396,7 +396,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
               </button>
             </div>
           )}
-          <div className="flex-1 overflow-auto">
+          <div className="flex-1 overflow-auto diff-scroll-root">
             {!selectedFile && (
               <div className="flex items-center justify-center h-full text-text-muted text-sm">
                 {result ? "Select a file to view its diff" : ""}

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -503,6 +503,12 @@
    split tables use the centered-split system below instead. */
 .diff-viewer .diff-file-scroll {
   overflow-x: auto;
+  /* Re-enable the ::-webkit-scrollbar styling below for a classic always-visible
+     bar; the global `* { scrollbar-width: thin }` otherwise renders this as a
+     macOS overlay that auto-hides (Chromium 121+). Same reset as .diff-hscrollbar
+     and .diff-scroll-root. */
+  scrollbar-width: auto;
+  scrollbar-color: auto;
 }
 
 /* Centered split view: each pane gets a fixed half of the viewport instead of

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -387,37 +387,51 @@
   background: color-mix(in srgb, var(--color-accent-primary) 30%, transparent);
 }
 
-/* Scrollbar styling for diff viewer */
-.diff-viewer::-webkit-scrollbar {
+/* Persistent always-visible scrollbar for the external container that owns
+   DiffViewer's scroll. The .diff-viewer root is content-sized (no overflow) so
+   its host scroll container — AppDialog.BodyScroll in FileViewerModal, the
+   flex-1 wrapper in CrossWorktreeDiff — renders the only vertical scrollbar,
+   avoiding the nested double-scrollbar. The global `* { scrollbar-width: thin }`
+   in index.css opts everything into standard (overlay, auto-hiding on macOS)
+   scrollbars, which also disables ::-webkit-scrollbar in Chromium 121+. Resetting
+   scrollbar-width/color to auto re-enables the webkit pseudo-elements, and a
+   non-zero ::-webkit-scrollbar width forces a classic always-visible bar. Mirrors
+   the .diff-hscrollbar pattern used for the horizontal axis. */
+.diff-scroll-root {
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+}
+
+.diff-scroll-root::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
 
-.diff-viewer::-webkit-scrollbar-track {
+.diff-scroll-root::-webkit-scrollbar-track {
   background: var(--color-daintree-bg);
 }
 
-.diff-viewer::-webkit-scrollbar-thumb {
+.diff-scroll-root::-webkit-scrollbar-thumb {
   background: var(--color-state-idle);
   border-radius: var(--radius-sm);
 }
 
-.diff-viewer::-webkit-scrollbar-thumb:hover {
+.diff-scroll-root::-webkit-scrollbar-thumb:hover {
   background: color-mix(in oklab, var(--color-state-idle) 70%, var(--color-text-primary));
 }
 
 /* D1a (light) — diff scrollbars consume the shared --scrollbar-* tokens so
  * per-theme scrollbar tuning applies. Dark keeps the original hardcoded values
  * above (byte-for-byte unchanged). */
-.light .diff-viewer::-webkit-scrollbar-track {
+.light .diff-scroll-root::-webkit-scrollbar-track {
   background: var(--scrollbar-track);
 }
 
-.light .diff-viewer::-webkit-scrollbar-thumb {
+.light .diff-scroll-root::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb);
 }
 
-.light .diff-viewer::-webkit-scrollbar-thumb:hover {
+.light .diff-scroll-root::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
 }
 

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -536,7 +536,7 @@ export const DiffViewer = forwardRef<HTMLDivElement, DiffViewerProps>(function D
   }
 
   return (
-    <div ref={ref} className="diff-viewer overflow-auto" data-wrap={wrapLines ? "true" : undefined}>
+    <div ref={ref} className="diff-viewer" data-wrap={wrapLines ? "true" : undefined}>
       {files.map((file, index) => (
         <FileDiff
           key={file.newRevision || file.oldRevision || index}


### PR DESCRIPTION
## Summary

- Two nested scroll containers both had `overflow-auto`, causing a doubled vertical scrollbar along the right edge of the diff viewer
- Scrollbars were using macOS overlay style (auto-hide) instead of staying persistently visible
- Cleans up dead CSS rules on `.diff-viewer` that were no longer reachable after the layout fix

Resolves #10429

## Changes

- Removed `overflow-auto` from the `.diff-viewer` root so it's content-sized; the host scroll container owns the only vertical scrollbar
- Added a `.diff-scroll-root` class with `scrollbar-width: auto` and `::-webkit-scrollbar` rules to force classic always-visible bars, applied to the scroll owners in `FileViewerModal` and `CrossWorktreeDiff`
- Activated the existing (but previously suppressed) `::-webkit-scrollbar` styling on `.diff-file-scroll` with the same `scrollbar-width: auto` reset, so the per-file horizontal bar is also always-visible
- Removed dead `.diff-viewer::-webkit-scrollbar` rules (the root no longer scrolls)

## Testing

120 unit tests pass across `DiffViewer`, `FileViewerModal`, `CrossWorktreeDiff`, and `FileDiffModal`. Lint clean on all changed files.