### PR TITLE
fix(help): narrow pinned-terminal danger to live grid reachability (#10431)

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -240,6 +240,10 @@ export function HelpPanel({
         p != null &&
         isPtyPanel(p) &&
         isGridPanelLocation(p.location) &&
+        // `missing-cli`/`failed` gate panels are UI placeholders with no backing
+        // PTY — they can't receive a dispatched command.
+        p.spawnStatus !== "missing-cli" &&
+        p.spawnStatus !== "failed" &&
         p.hasPty !== false &&
         p.exitCode === undefined &&
         p.runtimeStatus !== "exited" &&

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -49,7 +49,7 @@ import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { TerminalRefreshTier } from "@/types";
 import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
-import { isPtyPanel } from "@shared/types/panel";
+import { isGridPanelLocation, isPtyPanel } from "@shared/types/panel";
 import type { PinnedActionContextSnapshot } from "@shared/types/ipc/help";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
@@ -226,18 +226,28 @@ export function HelpPanel({
 
   const focusedWorktreeId = useWorktreeSelectionStore((s) => s.focusedWorktreeId);
   const selectWorktree = useWorktreeSelectionStore((s) => s.selectWorktree);
-  const pinnedTerminalPanel = usePanelStore((s) =>
-    pinnedContext?.terminalId ? s.panelsById[pinnedContext.terminalId] : undefined
+  // Tool calls re-resolve their target terminal live at dispatch time, so the
+  // frozen provision-time `pinnedContext.terminalId` going stale doesn't mean
+  // they can't reach anything. Danger only when a pinned session has no live
+  // grid terminal left to dispatch into; warning when the user has since
+  // focused a different worktree than the one the session is bound to. Danger
+  // wins — nowhere to reach is the more urgent mismatch. The dock-hosted
+  // assistant terminal is excluded — it's never a tool-call target.
+  const hasAnyLiveGridPty = usePanelStore((s) =>
+    s.panelIds.some((id) => {
+      const p = s.panelsById[id];
+      return (
+        p != null &&
+        isPtyPanel(p) &&
+        isGridPanelLocation(p.location) &&
+        p.hasPty !== false &&
+        p.exitCode === undefined &&
+        p.runtimeStatus !== "exited" &&
+        p.runtimeStatus !== "error"
+      );
+    })
   );
-  // Escalation: danger when the pinned terminal is gone or has exited (its
-  // PTY can no longer receive dispatched commands), warning when the user has
-  // since focused a different worktree than the one the session is bound to.
-  // Danger wins — a dead target is the more urgent mismatch.
-  const pinnedTerminalPanelPty =
-    pinnedTerminalPanel && isPtyPanel(pinnedTerminalPanel) ? pinnedTerminalPanel : undefined;
-  const isPinnedTerminalDead =
-    pinnedContext?.terminalId != null &&
-    (!pinnedTerminalPanel || pinnedTerminalPanelPty?.exitCode !== undefined);
+  const isPinnedTerminalDead = pinnedContext?.terminalId != null && !hasAnyLiveGridPty;
   const isPinnedWorktreeDiverged =
     pinnedContext?.worktreeId != null &&
     focusedWorktreeId !== null &&
@@ -969,7 +979,7 @@ export function HelpPanel({
                   )}
                   title={
                     isPinnedTerminalDead
-                      ? "The terminal this assistant was pinned to has closed — its tool calls can't reach it."
+                      ? "No open terminal can receive this assistant's tool calls."
                       : "Assistant tool calls are pinned to this worktree and terminal."
                   }
                 >
@@ -996,7 +1006,7 @@ export function HelpPanel({
                   "bg-status-danger/10 text-status-danger hover:bg-status-danger/15 transition-colors duration-150",
                   "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 )}
-                title="The pinned terminal has closed — start a new session"
+                title="No open terminal to receive tool calls — start a new session"
               >
                 Start new session
               </button>

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2220,7 +2220,7 @@ describe("HelpPanel — pinned-terminal danger tracks live grid reachability (#1
     expect(container.querySelector(".text-status-danger")).not.toBeNull();
   });
 
-  it("does not flag danger when a grid terminal exists but has exited", async () => {
+  it("does not flag danger when a dead and a live grid terminal both exist", async () => {
     setupPinnedSession({
       "assistant-term": dockAssistantTerminal(),
       // A grid terminal that has exited is not a live dispatch target...
@@ -2266,6 +2266,41 @@ describe("HelpPanel — pinned-terminal danger tracks live grid reachability (#1
     const { container } = await renderResolved();
 
     expect(container.querySelector(`button[title="${DANGER_BUTTON_TITLE}"]`)).not.toBeNull();
+  });
+
+  it("flags danger when the only grid terminal is a missing-cli gate (no backing PTY)", async () => {
+    setupPinnedSession({
+      "assistant-term": dockAssistantTerminal(),
+      // A `missing-cli` gate panel looks otherwise live (no exitCode/runtimeStatus)
+      // but has no PTY behind it, so it can't receive a dispatched command.
+      "gate-grid": {
+        id: "gate-grid",
+        kind: "terminal",
+        spawnStatus: "missing-cli",
+        cwd: "/repo",
+        location: "grid",
+      },
+    });
+
+    const { container } = await renderResolved();
+
+    expect(container.querySelector(`button[title="${DANGER_BUTTON_TITLE}"]`)).not.toBeNull();
+  });
+
+  it("does not flag danger when pinnedContext has no terminal id", async () => {
+    // No terminal was pinned at provision time — the danger guard must stay off
+    // regardless of grid reachability.
+    setupPinnedSession({ "assistant-term": dockAssistantTerminal() });
+    window.electron.help.getPinnedActionContext = vi.fn().mockResolvedValue({
+      terminalId: null,
+      worktreeId: "wt-1",
+      worktreeName: "main",
+      worktreeBranch: "main",
+    });
+
+    const { container } = await renderResolved();
+
+    expect(container.querySelector(`button[title="${DANGER_BUTTON_TITLE}"]`)).toBeNull();
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2138,6 +2138,137 @@ describe("HelpPanel — + New session destructive reset", () => {
   });
 });
 
+// The footer "pinned terminal dead" danger indicator must track real tool-call
+// reachability — a live grid terminal to dispatch into — not whether the
+// frozen provision-time pinned terminal id still exists (#10431). Tool calls
+// re-resolve their target at dispatch time, so the pinned id going stale is not
+// a failure; only the absence of any live grid terminal is.
+describe("HelpPanel — pinned-terminal danger tracks live grid reachability (#10431)", () => {
+  const DANGER_BUTTON_TITLE = "No open terminal to receive tool calls — start a new session";
+
+  function dockAssistantTerminal() {
+    // The assistant runs in the dock; it is never a tool-call target, so it must
+    // not count toward "a live terminal exists to reach".
+    return {
+      id: "assistant-term",
+      kind: "terminal",
+      spawnStatus: "ready",
+      cwd: "/help",
+      command: "claude",
+      location: "dock",
+      agentState: "idle",
+    };
+  }
+
+  function setupPinnedSession(panels: Record<string, unknown>) {
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    helpPanelState.terminalId = "assistant-term";
+    helpPanelState.agentId = "claude";
+    helpPanelState.sessionId = "sess-pinned";
+    panelStoreState.panelIds = Object.keys(panels);
+    panelStoreState.panelsById = panels;
+    window.electron.help.getPinnedActionContext = vi.fn().mockResolvedValue({
+      terminalId: "pinned-grid-term",
+      worktreeId: "wt-1",
+      worktreeName: "main",
+      worktreeBranch: "main",
+    });
+  }
+
+  async function renderResolved() {
+    let result!: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(<HelpPanel width={380} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    return result;
+  }
+
+  it("does not flag danger when the pinned terminal is gone but another live grid terminal exists", async () => {
+    setupPinnedSession({
+      "assistant-term": dockAssistantTerminal(),
+      // A different, live grid terminal — the pinned id ("pinned-grid-term") is
+      // absent, but this one is a valid dispatch target.
+      "grid-term": {
+        id: "grid-term",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/repo",
+        location: "grid",
+        agentState: "idle",
+      },
+    });
+
+    const { container } = await renderResolved();
+
+    expect(container.querySelector(`button[title="${DANGER_BUTTON_TITLE}"]`)).toBeNull();
+    expect(container.querySelector(".text-status-danger")).toBeNull();
+  });
+
+  it("flags danger and offers a new session when no live grid terminal remains", async () => {
+    setupPinnedSession({
+      // Only the dock assistant terminal exists — no grid target to reach.
+      "assistant-term": dockAssistantTerminal(),
+    });
+
+    const { container } = await renderResolved();
+
+    const button = container.querySelector(`button[title="${DANGER_BUTTON_TITLE}"]`);
+    expect(button).not.toBeNull();
+    expect(button!.textContent).toContain("Start new session");
+    expect(container.querySelector(".text-status-danger")).not.toBeNull();
+  });
+
+  it("does not flag danger when a grid terminal exists but has exited", async () => {
+    setupPinnedSession({
+      "assistant-term": dockAssistantTerminal(),
+      // A grid terminal that has exited is not a live dispatch target...
+      "dead-grid": {
+        id: "dead-grid",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/repo",
+        location: "grid",
+        runtimeStatus: "exited",
+        exitCode: 0,
+      },
+      // ...but this live one is, so danger must not fire.
+      "live-grid": {
+        id: "live-grid",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/repo",
+        location: "grid",
+        agentState: "idle",
+      },
+    });
+
+    const { container } = await renderResolved();
+
+    expect(container.querySelector(`button[title="${DANGER_BUTTON_TITLE}"]`)).toBeNull();
+  });
+
+  it("flags danger when the only grid terminal has exited", async () => {
+    setupPinnedSession({
+      "assistant-term": dockAssistantTerminal(),
+      "dead-grid": {
+        id: "dead-grid",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/repo",
+        location: "grid",
+        runtimeStatus: "exited",
+        exitCode: 137,
+      },
+    });
+
+    const { container } = await renderResolved();
+
+    expect(container.querySelector(`button[title="${DANGER_BUTTON_TITLE}"]`)).not.toBeNull();
+  });
+});
+
 // The renderer no longer tears down the assistant on visibility-hidden.
 // PTY/MCP lifecycle is owned by main; hibernation capture for true LRU
 // eviction happens in `HelpSessionService.revokeByWebContentsId`. These


### PR DESCRIPTION
## Summary

- The assistant footer in `HelpPanel` was showing a red danger indicator and "Start new session" prompt whenever the frozen provision-time terminal id in `pinnedContext` no longer existed in `panelsById` — but tools re-resolve their target terminal live at dispatch time, so a stale pinned id isn't a real failure.
- Replaced the frozen pinned-terminal panel lookup with a live grid-PTY reachability selector (`hasAnyLiveGridPty`). `isPinnedTerminalDead` now only fires when a pinned session has no live grid terminal to dispatch into.
- Excludes the dock-hosted assistant terminal (never a tool-call target) and `missing-cli`/`failed` gate panels (UI placeholders with no backing PTY). Updated two inaccurate footer tooltip strings.

Resolves #10431

## Changes

- `src/components/HelpPanel/HelpPanel.tsx` — live reachability selector replaces frozen id lookup; updated tooltip strings
- `src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx` — 6 behavioral regression tests: stale-pin-with-live-grid (no danger), no-grid-target (danger), dead+live grid (no danger), only-exited-grid (danger), missing-cli gate (danger), empty-pinned-context guard (no danger)

## Testing

111 tests pass in the changed test file. `prettier` and `eslint` clean on both changed files.