### PR TITLE
feat(agents): add global skip-permissions toggle for all agents

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -250,6 +250,7 @@ export const CHANNELS = {
   PROJECT_LOCATE: "project:locate",
   AGENT_SETTINGS_GET: "agent-settings:get",
   AGENT_SETTINGS_SET: "agent-settings:set",
+  AGENT_SETTINGS_SET_GLOBAL: "agent-settings:set-global",
   AGENT_SETTINGS_RESET: "agent-settings:reset",
   AGENT_SETTINGS_STAMP_VERSION: "agent-settings:stamp-version",
 

--- a/electron/ipc/handlers/__tests__/ai.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/ai.handlers.test.ts
@@ -205,6 +205,38 @@ describe("ai handler payload validation", () => {
     );
   });
 
+  it("rejects AGENT_SETTINGS_SET_GLOBAL payload that is not a boolean (#10432)", async () => {
+    const handler = getInvokeHandler(CHANNELS.AGENT_SETTINGS_SET_GLOBAL);
+    await expect(handler({} as never, "true" as never)).rejects.toThrow(
+      "Invalid globalSkipPermissions"
+    );
+    await expect(handler({} as never, 1 as never)).rejects.toThrow("Invalid globalSkipPermissions");
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("writes AGENT_SETTINGS_SET_GLOBAL via a dot-path leaf without rewriting the slice (#10432, #6106)", async () => {
+    const handler = getInvokeHandler(CHANNELS.AGENT_SETTINGS_SET_GLOBAL);
+    (storeMock.get as Mock).mockImplementation((key: string, defaultValue?: unknown) => {
+      if (key === "agentSettings") {
+        return { agents: { claude: { dangerousEnabled: true } }, settingsVersion: 1 };
+      }
+      return defaultValue;
+    });
+
+    const result = await handler({} as never, true as never);
+
+    // Dot-path leaf write — never the whole `agentSettings` slice.
+    expect(storeMock.set).toHaveBeenCalledWith("agentSettings.globalSkipPermissions", true);
+    expect(storeMock.set).not.toHaveBeenCalledWith("agentSettings", expect.anything());
+    // Per-agent records are preserved untouched (no dangerousEnabled mutation).
+    expect(result).toEqual(
+      expect.objectContaining({
+        globalSkipPermissions: true,
+        agents: { claude: { dangerousEnabled: true } },
+      })
+    );
+  });
+
   it("normalizes malformed stored agent settings in AGENT_SETTINGS_RESET", async () => {
     const handler = getInvokeHandler(CHANNELS.AGENT_SETTINGS_RESET);
     (storeMock.get as Mock).mockImplementation((key: string, defaultValue?: unknown) => {

--- a/electron/ipc/handlers/ai.ts
+++ b/electron/ipc/handlers/ai.ts
@@ -2,11 +2,16 @@
 import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import type { HandlerDependencies } from "../types.js";
-import { DEFAULT_AGENT_SETTINGS, type UserAgentConfig } from "../../../shared/types/index.js";
+import {
+  DEFAULT_AGENT_SETTINGS,
+  type AgentSettings,
+  type UserAgentConfig,
+} from "../../../shared/types/index.js";
 import { AgentHelpService } from "../../services/AgentHelpService.js";
 import { UserAgentRegistryService } from "../../services/UserAgentRegistryService.js";
 import type { AgentHelpRequest, AgentHelpResult } from "../../../shared/types/ipc/agent.js";
 import { broadcastToRenderer, typedHandle } from "../utils.js";
+import { defineIpcNamespace, op } from "../define.js";
 import { createApplicationMenu } from "../../menu.js";
 
 const RESERVED_AGENT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
@@ -106,25 +111,34 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
   };
   handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_SET, handleAgentSettingsSet));
 
-  // Sets the global skip-permissions override (#10432). Written via dot-path
+  // Sets the global skip-permissions override (#10432). Registered via
+  // defineIpcNamespace so its IpcInvokeMap entry is codegen-generated rather
+  // than hand-written (the hand-written map is ratcheted). Written via dot-path
   // leaf so the rest of the agentSettings slice (per-agent records, version)
-  // isn't rewritten with first-launch defaults (#6106). A bare boolean payload
-  // matches the stampVersion convention.
-  const handleAgentSettingsSetGlobal = async (value: unknown) => {
-    if (typeof value !== "boolean") {
-      throw new Error("Invalid globalSkipPermissions");
-    }
-    const currentSettings = normalizeAgentSettings(
-      store.get("agentSettings", DEFAULT_AGENT_SETTINGS)
-    );
-    store.set("agentSettings.globalSkipPermissions", value);
-    return {
-      ...currentSettings.root,
-      globalSkipPermissions: value,
-      agents: currentSettings.agents,
-    };
-  };
-  handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_SET_GLOBAL, handleAgentSettingsSetGlobal));
+  // isn't rewritten with first-launch defaults (#6106).
+  const agentSettingsGlobalNamespace = defineIpcNamespace({
+    name: "agentSettingsGlobal",
+    ops: {
+      setGlobal: op(
+        CHANNELS.AGENT_SETTINGS_SET_GLOBAL,
+        async (value: boolean): Promise<AgentSettings> => {
+          if (typeof value !== "boolean") {
+            throw new Error("Invalid globalSkipPermissions");
+          }
+          const currentSettings = normalizeAgentSettings(
+            store.get("agentSettings", DEFAULT_AGENT_SETTINGS)
+          );
+          store.set("agentSettings.globalSkipPermissions", value);
+          return {
+            ...currentSettings.root,
+            globalSkipPermissions: value,
+            agents: currentSettings.agents,
+          } as AgentSettings;
+        }
+      ),
+    },
+  });
+  handlers.push(agentSettingsGlobalNamespace.register());
 
   // Stamps `settingsVersion` on the persisted store. The renderer migration
   // (see migrateAgentSettings in agentSettingsStore.ts, #7673) calls this only

--- a/electron/ipc/handlers/ai.ts
+++ b/electron/ipc/handlers/ai.ts
@@ -106,6 +106,26 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
   };
   handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_SET, handleAgentSettingsSet));
 
+  // Sets the global skip-permissions override (#10432). Written via dot-path
+  // leaf so the rest of the agentSettings slice (per-agent records, version)
+  // isn't rewritten with first-launch defaults (#6106). A bare boolean payload
+  // matches the stampVersion convention.
+  const handleAgentSettingsSetGlobal = async (value: unknown) => {
+    if (typeof value !== "boolean") {
+      throw new Error("Invalid globalSkipPermissions");
+    }
+    const currentSettings = normalizeAgentSettings(
+      store.get("agentSettings", DEFAULT_AGENT_SETTINGS)
+    );
+    store.set("agentSettings.globalSkipPermissions", value);
+    return {
+      ...currentSettings.root,
+      globalSkipPermissions: value,
+      agents: currentSettings.agents,
+    };
+  };
+  handlers.push(typedHandle(CHANNELS.AGENT_SETTINGS_SET_GLOBAL, handleAgentSettingsSetGlobal));
+
   // Stamps `settingsVersion` on the persisted store. The renderer migration
   // (see migrateAgentSettings in agentSettingsStore.ts, #7673) calls this only
   // after every per-agent pin clear has succeeded — stamping inside the

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1647,8 +1647,7 @@ function buildElectronApi(): ElectronAPI {
       set: (agentId: string, settings: Partial<AgentSettingsEntry>) =>
         _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_SET, { agentType: agentId, settings }),
 
-      setGlobal: (value: boolean) =>
-        _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_SET_GLOBAL, value),
+      setGlobal: (value: boolean) => _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_SET_GLOBAL, value),
 
       reset: (agentType?: string) => _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_RESET, agentType),
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1647,6 +1647,9 @@ function buildElectronApi(): ElectronAPI {
       set: (agentId: string, settings: Partial<AgentSettingsEntry>) =>
         _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_SET, { agentType: agentId, settings }),
 
+      setGlobal: (value: boolean) =>
+        _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_SET_GLOBAL, value),
+
       reset: (agentType?: string) => _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_RESET, agentType),
 
       stampVersion: (version: number) =>

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -5,6 +5,11 @@ import {
   buildAgentLaunchFlags,
   buildLaunchCommandFromFlags,
   generateAgentCommand,
+  generateAgentFlags,
+  resolveEffectiveBypass,
+  reconcileBypassFlags,
+  isAgentBypassSupported,
+  DEFAULT_DANGEROUS_ARGS,
 } from "../agentSettings.js";
 
 // Force POSIX shell-escape semantics so the hardcoded single-quote assertions
@@ -654,5 +659,132 @@ describe("buildLaunchCommandFromFlags", () => {
       clipboardDirectory: "/tmp/daintree-clipboard",
     });
     expect(flags).toEqual(["--yolo"]);
+  });
+});
+
+// #10432 — global skip-permissions override. claude/codex declare
+// supports.permissionBypass === true; gemini declares false but still has a
+// per-agent dangerous flag (--yolo) in DEFAULT_DANGEROUS_ARGS.
+describe("isAgentBypassSupported", () => {
+  it("is true only for agents declaring supports.permissionBypass", () => {
+    expect(isAgentBypassSupported("claude")).toBe(true);
+    expect(isAgentBypassSupported("codex")).toBe(true);
+    expect(isAgentBypassSupported("gemini")).toBe(false);
+    expect(isAgentBypassSupported(undefined)).toBe(false);
+  });
+});
+
+describe("resolveEffectiveBypass", () => {
+  it("forces bypass for a supported agent when the global is on, even with the per-agent toggle off", () => {
+    expect(resolveEffectiveBypass({ dangerousEnabled: false }, "claude", true)).toBe(true);
+    expect(resolveEffectiveBypass({ dangerousEnabled: false }, "codex", true)).toBe(true);
+  });
+
+  it("does not force bypass for an unsupported agent when the global is on", () => {
+    expect(resolveEffectiveBypass({ dangerousEnabled: false }, "gemini", true)).toBe(false);
+  });
+
+  it("keeps the per-agent toggle working regardless of bypass support (unguarded)", () => {
+    // Gemini is not bypass-supported but its per-agent dangerous toggle must
+    // still resolve true — the global guard applies only to the global override.
+    expect(resolveEffectiveBypass({ dangerousEnabled: true }, "gemini", false)).toBe(true);
+  });
+
+  it("resolves false when the global is off and the per-agent toggle is off", () => {
+    expect(resolveEffectiveBypass({ dangerousEnabled: false }, "claude", false)).toBe(false);
+    expect(resolveEffectiveBypass({}, "claude", undefined)).toBe(false);
+  });
+});
+
+describe("reconcileBypassFlags", () => {
+  const claudeFlag = DEFAULT_DANGEROUS_ARGS.claude;
+
+  it("strips the canonical bypass flag when the effective bypass is off, preserving order of other flags", () => {
+    const result = reconcileBypassFlags([claudeFlag, "--model", "opus"], "claude", false);
+    expect(result).toEqual(["--model", "opus"]);
+  });
+
+  it("re-adds the canonical bypass flag when the effective bypass is on", () => {
+    const result = reconcileBypassFlags(["--model", "opus"], "claude", true);
+    expect(result).toContain(claudeFlag);
+    expect(result.filter((f) => f === claudeFlag)).toHaveLength(1);
+  });
+
+  it("is idempotent — a flag already present is not duplicated", () => {
+    const once = reconcileBypassFlags(["--model", "opus"], "claude", true);
+    const twice = reconcileBypassFlags(once, "claude", true);
+    expect(twice).toEqual(once);
+    expect(twice.filter((f) => f === claudeFlag)).toHaveLength(1);
+  });
+
+  it("dedupes multiple stale occurrences when stripping", () => {
+    const result = reconcileBypassFlags([claudeFlag, claudeFlag, "--model"], "claude", false);
+    expect(result).toEqual(["--model"]);
+  });
+
+  it("leaves flags untouched for an agent with no canonical bypass flag", () => {
+    const flags = ["--some-flag", "value"];
+    // opencode is intentionally absent from DEFAULT_DANGEROUS_ARGS.
+    expect(reconcileBypassFlags(flags, "opencode", false)).toEqual(flags);
+    expect(reconcileBypassFlags(flags, "opencode", true)).toEqual(flags);
+  });
+
+  it("honours a custom bypassArgs value for strip-and-re-add", () => {
+    const stripped = reconcileBypassFlags(["--custom-skip", "--model"], "claude", false, "--custom-skip");
+    expect(stripped).toEqual(["--model"]);
+    const readded = reconcileBypassFlags(["--model"], "claude", true, "--custom-skip");
+    expect(readded).toContain("--custom-skip");
+  });
+
+  it("does not mutate the input array", () => {
+    const flags = [claudeFlag, "--model"];
+    reconcileBypassFlags(flags, "claude", false);
+    expect(flags).toEqual([claudeFlag, "--model"]);
+  });
+});
+
+describe("generateAgentFlags with globalSkipPermissions", () => {
+  it("injects the dangerous flag for a supported agent when the global is on", () => {
+    const flags = generateAgentFlags({ dangerousEnabled: false }, "claude", {
+      globalSkipPermissions: true,
+    });
+    expect(flags).toContain(DEFAULT_DANGEROUS_ARGS.claude);
+  });
+
+  it("does not inject the dangerous flag for an unsupported agent when the global is on", () => {
+    const flags = generateAgentFlags({ dangerousEnabled: false }, "gemini", {
+      globalSkipPermissions: true,
+    });
+    expect(flags).not.toContain(DEFAULT_DANGEROUS_ARGS.gemini);
+  });
+
+  it("still honours the per-agent toggle for an unsupported agent when the global is off", () => {
+    const flags = generateAgentFlags({ dangerousEnabled: true }, "gemini", {
+      globalSkipPermissions: false,
+    });
+    expect(flags).toContain(DEFAULT_DANGEROUS_ARGS.gemini);
+  });
+
+  it("omits the dangerous flag when both the global and per-agent toggle are off", () => {
+    const flags = generateAgentFlags({ dangerousEnabled: false }, "claude", {
+      globalSkipPermissions: false,
+    });
+    expect(flags).not.toContain(DEFAULT_DANGEROUS_ARGS.claude);
+  });
+});
+
+describe("buildAgentLaunchFlags with globalSkipPermissions", () => {
+  it("captures the dangerous flag for a supported agent when the global is on", () => {
+    const flags = buildAgentLaunchFlags({ dangerousEnabled: false }, "claude", {
+      globalSkipPermissions: true,
+    });
+    expect(flags).toContain(DEFAULT_DANGEROUS_ARGS.claude);
+  });
+
+  it("does not capture the dangerous flag for an unsupported agent when the global is on", () => {
+    const flags = buildAgentLaunchFlags({ dangerousEnabled: false }, "gemini", {
+      globalSkipPermissions: true,
+    });
+    expect(flags).not.toContain(DEFAULT_DANGEROUS_ARGS.gemini);
   });
 });

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -697,7 +697,8 @@ describe("resolveEffectiveBypass", () => {
 });
 
 describe("reconcileBypassFlags", () => {
-  const claudeFlag = DEFAULT_DANGEROUS_ARGS.claude;
+  // Non-null: "claude" is a known key of DEFAULT_DANGEROUS_ARGS (noUncheckedIndexedAccess).
+  const claudeFlag = DEFAULT_DANGEROUS_ARGS.claude as string;
 
   it("strips the canonical bypass flag when the effective bypass is off, preserving order of other flags", () => {
     const result = reconcileBypassFlags([claudeFlag, "--model", "opus"], "claude", false);

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -731,7 +731,12 @@ describe("reconcileBypassFlags", () => {
   });
 
   it("honours a custom bypassArgs value for strip-and-re-add", () => {
-    const stripped = reconcileBypassFlags(["--custom-skip", "--model"], "claude", false, "--custom-skip");
+    const stripped = reconcileBypassFlags(
+      ["--custom-skip", "--model"],
+      "claude",
+      false,
+      "--custom-skip"
+    );
     expect(stripped).toEqual(["--model"]);
     const readded = reconcileBypassFlags(["--model"], "claude", true, "--custom-skip");
     expect(readded).toContain("--custom-skip");

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -124,7 +124,10 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
  */
 export function isAgentBypassSupported(agentId: string | undefined): boolean {
   if (!agentId) return false;
-  return getEffectiveAgentConfig(agentId)?.supports?.permissionBypass === true;
+  const supports = getEffectiveAgentConfig(agentId)?.supports;
+  // `supports` is `AssistantSupports | false | undefined`; only the structured
+  // form carries `permissionBypass`.
+  return supports !== false && supports?.permissionBypass === true;
 }
 
 /**

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -69,6 +69,19 @@ export interface AgentSettings {
    * main-process IPC handler on the first write after migration.
    */
   settingsVersion?: number;
+  /**
+   * Global "skip permission prompts" override (#10432). When `true`, every
+   * agent whose config declares `supports.permissionBypass === true` launches
+   * in permission-bypass mode regardless of its per-agent/preset
+   * `dangerousEnabled` toggle. Default off — this is a high-blast-radius,
+   * opt-in switch. It is a *live override*, not a default: it is OR-ed into
+   * the effective bypass at flag-generation time (see {@link resolveEffectiveBypass})
+   * and never mutates per-agent `dangerousEnabled`, so toggling it off
+   * immediately stops injecting bypass flags on future spawns/restarts/resumes.
+   * Scoped to normal agent terminals; Daintree Assistant / help sessions keep
+   * their own independent bypass setting.
+   */
+  globalSkipPermissions?: boolean;
 }
 
 export const DEFAULT_DANGEROUS_ARGS: Record<string, string> = {
@@ -100,7 +113,110 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
       },
     ])
   ),
+  globalSkipPermissions: false,
 };
+
+/**
+ * Whether an agent opts into permission-bypass via its config
+ * (`supports.permissionBypass === true`). Strict — agents that omit the field
+ * or set it `false` are NOT bypass-supported, so the global skip-permissions
+ * override must never inject their dangerous flag (#10432).
+ */
+export function isAgentBypassSupported(agentId: string | undefined): boolean {
+  if (!agentId) return false;
+  return getEffectiveAgentConfig(agentId)?.supports?.permissionBypass === true;
+}
+
+/**
+ * Resolves the effective permission-bypass decision for a launch.
+ *
+ * `(perAgent/preset dangerousEnabled) || (globalSkipPermissions && agent
+ * supports bypass)`. The global is OR-ed in only for bypass-supported agents,
+ * so it can't inject a dangerous flag into an agent that rejects it — but it
+ * also can't be defeated by a preset's `dangerousEnabled: false`. The per-agent
+ * `dangerousEnabled` path is unguarded (preserving existing behavior, e.g.
+ * Gemini's `--yolo` per-agent toggle); only the *global* override is gated by
+ * `supports.permissionBypass`.
+ *
+ * @param entry - The effective settings entry (after preset overrides applied).
+ */
+export function resolveEffectiveBypass(
+  entry: AgentSettingsEntry,
+  agentId: string | undefined,
+  globalSkipPermissions?: boolean
+): boolean {
+  if (entry.dangerousEnabled) return true;
+  return !!globalSkipPermissions && isAgentBypassSupported(agentId);
+}
+
+/**
+ * Reconciles a persisted `agentLaunchFlags` snapshot against the current
+ * effective bypass setting (#10432, the "resume trap").
+ *
+ * Strips the agent's canonical bypass flag (the resolved `dangerousArgs`, plus
+ * the registry default as a fallback so a snapshot captured under a different
+ * `dangerousArgs` still gets cleaned) from `flags`, then re-appends it only
+ * when `effectiveBypass` is true. This makes every spawn/restart/restore/resume
+ * idempotent: toggling the global switch off stops carrying a stale bypass flag
+ * forward, and toggling it on re-adds it for supported agents.
+ *
+ * All known bypass flags in {@link DEFAULT_DANGEROUS_ARGS} are single tokens;
+ * the strip matches whole tokens so flag *values* are never collaterally
+ * removed.
+ *
+ * @param bypassArgs - The agent's currently-resolved dangerous args (e.g.
+ *   `entry.dangerousArgs`); falls back to `DEFAULT_DANGEROUS_ARGS[agentId]`.
+ */
+export function reconcileBypassFlags(
+  flags: readonly string[],
+  agentId: string,
+  effectiveBypass: boolean,
+  bypassArgs?: string
+): string[] {
+  // Only bypass-supported agents participate in the resume-trap reconciliation
+  // (#10432). The global override never injects a flag into a non-supported
+  // agent, so a non-supported agent's persisted dangerous flag (e.g. Gemini's
+  // per-agent `--yolo`) must replay verbatim rather than being stripped here.
+  if (!isAgentBypassSupported(agentId)) return [...flags];
+
+  const resolved = (bypassArgs?.trim() || DEFAULT_DANGEROUS_ARGS[agentId] || "").trim();
+  // Strip both the resolved args and the registry default: a snapshot may have
+  // been captured before the user customized `dangerousArgs`, so cleaning only
+  // the current value could leave a stale default token behind.
+  const stripTokens = new Set<string>();
+  for (const source of [resolved, DEFAULT_DANGEROUS_ARGS[agentId]]) {
+    if (!source) continue;
+    for (const token of source.trim().split(/\s+/)) {
+      if (token) stripTokens.add(token);
+    }
+  }
+  if (stripTokens.size === 0) return [...flags];
+
+  if (!effectiveBypass || !resolved) {
+    // Bypass not wanted: drop every occurrence of the canonical token(s).
+    return flags.filter((flag) => !stripTokens.has(flag));
+  }
+
+  // Bypass wanted: replace the first canonical occurrence in place with the
+  // currently-resolved args (preserving flag order so a snapshot that already
+  // carries the right flag is left untouched), drop any duplicates, and append
+  // if the flag was absent.
+  const resolvedTokens = resolved.split(/\s+/).filter(Boolean);
+  const reconciled: string[] = [];
+  let inserted = false;
+  for (const flag of flags) {
+    if (stripTokens.has(flag)) {
+      if (!inserted) {
+        reconciled.push(...resolvedTokens);
+        inserted = true;
+      }
+    } else {
+      reconciled.push(flag);
+    }
+  }
+  if (!inserted) reconciled.push(...resolvedTokens);
+  return reconciled;
+}
 
 export function getAgentSettingsEntry(
   settings: AgentSettings | null | undefined,
@@ -129,6 +245,12 @@ export function resolveEffectivePresetId(
 export interface GenerateAgentFlagsOptions {
   /** Absolute path to the clipboard temp directory (e.g. /tmp/daintree-clipboard) */
   clipboardDirectory?: string;
+  /**
+   * Global skip-permissions override (#10432). When true, OR-ed into the
+   * effective bypass for agents that declare `supports.permissionBypass`, so
+   * the agent's dangerous flag is injected even when its per-agent toggle is off.
+   */
+  globalSkipPermissions?: boolean;
 }
 
 export function generateAgentFlags(
@@ -137,7 +259,7 @@ export function generateAgentFlags(
   options?: GenerateAgentFlagsOptions
 ): string[] {
   const flags: string[] = [];
-  if (entry.dangerousEnabled) {
+  if (resolveEffectiveBypass(entry, agentId, options?.globalSkipPermissions)) {
     // Use entry.dangerousArgs if set, otherwise fall back to default for this agent
     const dangerousArgs =
       entry.dangerousArgs?.trim() || (agentId ? DEFAULT_DANGEROUS_ARGS[agentId] : "");
@@ -184,6 +306,8 @@ export interface GenerateAgentCommandOptions {
   recipeArgs?: string;
   /** Additional CLI arguments from agent preset (whitespace-separated string) */
   presetArgs?: string;
+  /** Global skip-permissions override (#10432); forwarded to {@link generateAgentFlags}. */
+  globalSkipPermissions?: boolean;
 }
 
 /**
@@ -212,6 +336,7 @@ export function generateAgentCommand(
 ): string {
   const flags = generateAgentFlags(entry, agentId, {
     clipboardDirectory: options?.clipboardDirectory,
+    globalSkipPermissions: options?.globalSkipPermissions,
   });
   const parts: string[] = [baseCommand];
 
@@ -433,7 +558,7 @@ export function generateAgentCommand(
 export function buildAgentLaunchFlags(
   entry: AgentSettingsEntry,
   agentId: string,
-  options?: { modelId?: string; presetArgs?: string[] }
+  options?: { modelId?: string; presetArgs?: string[]; globalSkipPermissions?: boolean }
 ): string[] {
   const agentConfig = getEffectiveAgentConfig(agentId);
   const flags: string[] = [];
@@ -461,7 +586,9 @@ export function buildAgentLaunchFlags(
   }
 
   // Dangerous args and custom flags (from generateAgentFlags, excluding clipboard dir)
-  const settingsFlags = generateAgentFlags(entry, agentId);
+  const settingsFlags = generateAgentFlags(entry, agentId, {
+    globalSkipPermissions: options?.globalSkipPermissions,
+  });
   flags.push(...settingsFlags);
 
   return flags;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -312,6 +312,9 @@ export {
   buildResumeCommand,
   buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
+  isAgentBypassSupported,
+  resolveEffectiveBypass,
+  reconcileBypassFlags,
 } from "./agentSettings.js";
 
 // User agent registry types - user-defined agent configuration

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -690,6 +690,11 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   agentSettings: {
     get(): Promise<AgentSettings>;
     set(agentId: AgentId, settings: Partial<AgentSettingsEntry>): Promise<AgentSettings>;
+    /**
+     * Set the global skip-permissions override (#10432). Persisted as a
+     * dot-path leaf so per-agent records aren't rewritten with defaults.
+     */
+    setGlobal(value: boolean): Promise<AgentSettings>;
     reset(agentId?: AgentId): Promise<AgentSettings>;
     /**
      * Mark the persisted store with the given schema version. Only called by

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -40,6 +40,10 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: { worktreeId?: string | undefined }];
     result: import("./agentSessionHistory.js").AgentSessionRecord[];
   };
+  "agent-settings:set-global": {
+    args: [value: boolean];
+    result: import("../agentSettings.js").AgentSettings;
+  };
   "app:clear-quarantined-panel": {
     args: [panelId: string];
     result: { cleared: boolean };

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -709,6 +709,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [payload: { agentType: AgentId; settings: Record<string, unknown> }];
     result: AgentSettings;
   };
+  "agent-settings:set-global": {
+    args: [value: boolean];
+    result: AgentSettings;
+  };
   "agent-settings:reset": {
     args: [agentType?: AgentId];
     result: AgentSettings;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -709,10 +709,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [payload: { agentType: AgentId; settings: Record<string, unknown> }];
     result: AgentSettings;
   };
-  "agent-settings:set-global": {
-    args: [value: boolean];
-    result: AgentSettings;
-  };
   "agent-settings:reset": {
     args: [agentType?: AgentId];
     result: AgentSettings;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,13 +107,13 @@ function reconcileResumeLaunchFlags(session: {
   agentId: string;
   agentLaunchFlags?: string[];
 }): string[] | undefined {
-  const flags = session.agentLaunchFlags;
-  if (!flags || flags.length === 0) return flags;
   const settings = useAgentSettingsStore.getState().settings;
   const entry = settings?.agents?.[session.agentId] ?? {};
   const effectiveBypass = resolveEffectiveBypass(entry, session.agentId, settings?.globalSkipPermissions);
+  // Pass [] when no flags were captured so global-on still injects the bypass
+  // token for a supported agent (reconcileBypassFlags no-ops for others).
   return reconcileBypassFlags(
-    flags,
+    session.agentLaunchFlags ?? [],
     session.agentId,
     effectiveBypass,
     entry.dangerousArgs as string | undefined

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,11 @@ function reconcileResumeLaunchFlags(session: {
 }): string[] | undefined {
   const settings = useAgentSettingsStore.getState().settings;
   const entry = settings?.agents?.[session.agentId] ?? {};
-  const effectiveBypass = resolveEffectiveBypass(entry, session.agentId, settings?.globalSkipPermissions);
+  const effectiveBypass = resolveEffectiveBypass(
+    entry,
+    session.agentId,
+    settings?.globalSkipPermissions
+  );
   // Pass [] when no flags were captured so global-on still injects the bypass
   // token for a supported agent (reconcileBypassFlags no-ops for others).
   return reconcileBypassFlags(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,12 @@ import { PanelTransitionOverlay } from "./components/Panel";
 
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
-import { buildResumeCommand, buildResumeLatestCommand } from "@shared/types/agentSettings";
+import {
+  buildResumeCommand,
+  buildResumeLatestCommand,
+  reconcileBypassFlags,
+  resolveEffectiveBypass,
+} from "@shared/types/agentSettings";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
 import { AccessibilityAnnouncer } from "./components/Accessibility/AccessibilityAnnouncer";
@@ -93,6 +98,27 @@ const loadE2ENotificationBackdoor = () => import("./lib/e2eNotificationBackdoor"
 const loadJetbrainsMono500 = () => import("@fontsource/jetbrains-mono/latin-500.css");
 const loadJetbrainsMono600 = () => import("@fontsource/jetbrains-mono/latin-600.css");
 const preloadFileViewerModal = () => import("@/components/FileViewer/FileViewerModal");
+
+// Reconciles a resumed session's persisted launch flags against the current
+// global skip-permissions setting (#10432, the "resume trap"): the snapshot may
+// have been captured while the global switch was in a different state, so strip
+// the agent's canonical bypass flag and re-add it only if it currently resolves.
+function reconcileResumeLaunchFlags(session: {
+  agentId: string;
+  agentLaunchFlags?: string[];
+}): string[] | undefined {
+  const flags = session.agentLaunchFlags;
+  if (!flags || flags.length === 0) return flags;
+  const settings = useAgentSettingsStore.getState().settings;
+  const entry = settings?.agents?.[session.agentId] ?? {};
+  const effectiveBypass = resolveEffectiveBypass(entry, session.agentId, settings?.globalSkipPermissions);
+  return reconcileBypassFlags(
+    flags,
+    session.agentId,
+    effectiveBypass,
+    entry.dangerousArgs as string | undefined
+  );
+}
 
 // Direct file import (not the Project barrel) so the lazy chunk doesn't pull
 // in barrel siblings. Renders only when no project is open, so it stays off
@@ -349,6 +375,7 @@ import { useMcpConfirmStore } from "./store/mcpConfirmStore";
 import { usePluginConfirmStore } from "./store/pluginConfirmStore";
 import { usePluginMcpConfirmStore } from "./store/pluginMcpConfirmStore";
 import { useDiagnosticsReviewStore } from "./store/diagnosticsReviewStore";
+import { useAgentSettingsStore } from "./store/agentSettingsStore";
 // Eager side-effect import: auto-discovers every built-in plugin renderer and
 // registers its builtin view slots at module-eval time, before first render.
 // Must stay static — a deferred/idle import races the user, so getBuiltinView
@@ -1121,12 +1148,10 @@ function AppInner() {
                       if (result.resumeSession) {
                         const session = result.resumeSession;
                         const agentConfig = getEffectiveAgentConfig(session.agentId);
+                        const resumeFlags = reconcileResumeLaunchFlags(session);
                         const command =
-                          buildResumeCommand(
-                            session.agentId,
-                            session.sessionId,
-                            session.agentLaunchFlags
-                          ) ?? buildResumeLatestCommand(session.agentId, session.agentLaunchFlags);
+                          buildResumeCommand(session.agentId, session.sessionId, resumeFlags) ??
+                          buildResumeLatestCommand(session.agentId, resumeFlags);
                         if (command && agentConfig) {
                           addPanel({
                             kind: "terminal",
@@ -1159,12 +1184,10 @@ function AppInner() {
                       if (selected.resumeSession) {
                         const session = selected.resumeSession;
                         const agentConfig = getEffectiveAgentConfig(session.agentId);
+                        const resumeFlags = reconcileResumeLaunchFlags(session);
                         const command =
-                          buildResumeCommand(
-                            session.agentId,
-                            session.sessionId,
-                            session.agentLaunchFlags
-                          ) ?? buildResumeLatestCommand(session.agentId, session.agentLaunchFlags);
+                          buildResumeCommand(session.agentId, session.sessionId, resumeFlags) ??
+                          buildResumeLatestCommand(session.agentId, resumeFlags);
                         if (command && agentConfig) {
                           addPanel({
                             kind: "terminal",

--- a/src/clients/__tests__/agentSettingsClient.test.ts
+++ b/src/clients/__tests__/agentSettingsClient.test.ts
@@ -6,6 +6,7 @@ let agentSettingsClient: typeof import("../agentSettingsClient").agentSettingsCl
 
 let getMock: ReturnType<typeof vi.fn>;
 let setMock: ReturnType<typeof vi.fn>;
+let setGlobalMock: ReturnType<typeof vi.fn>;
 let resetMock: ReturnType<typeof vi.fn>;
 let stampVersionMock: ReturnType<typeof vi.fn>;
 
@@ -15,6 +16,7 @@ describe("agentSettingsClient", () => {
 
     getMock = vi.fn();
     setMock = vi.fn().mockResolvedValue({});
+    setGlobalMock = vi.fn().mockResolvedValue({});
     resetMock = vi.fn().mockResolvedValue({});
     stampVersionMock = vi.fn().mockResolvedValue({});
 
@@ -23,6 +25,7 @@ describe("agentSettingsClient", () => {
         agentSettings: {
           get: getMock,
           set: setMock,
+          setGlobal: setGlobalMock,
           reset: resetMock,
           stampVersion: stampVersionMock,
         },
@@ -125,6 +128,26 @@ describe("agentSettingsClient", () => {
 
     resolve({ claude: {} });
     await expect(fresh).resolves.toEqual({ claude: { pinned: true } });
+  });
+
+  it("setGlobal() forwards the value and clears the inflight get() so post-write reads start fresh (#10432)", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getMock.mockReturnValueOnce(deferred);
+
+    const stale = agentSettingsClient.get();
+    void agentSettingsClient.setGlobal(true);
+    expect(setGlobalMock).toHaveBeenCalledWith(true);
+
+    getMock.mockResolvedValue({ globalSkipPermissions: true });
+    const fresh = agentSettingsClient.get();
+    expect(fresh).not.toBe(stale);
+    expect(getMock).toHaveBeenCalledTimes(2);
+
+    resolve({});
+    await expect(fresh).resolves.toEqual({ globalSkipPermissions: true });
   });
 
   it("reset() and stampVersion() also clear the inflight get()", async () => {

--- a/src/clients/agentSettingsClient.ts
+++ b/src/clients/agentSettingsClient.ts
@@ -50,6 +50,11 @@ export const agentSettingsClient = {
     return window.electron.agentSettings.set(agentId, settings).finally(invalidate);
   },
 
+  setGlobal: (value: boolean): Promise<AgentSettings> => {
+    invalidate();
+    return window.electron.agentSettings.setGlobal(value).finally(invalidate);
+  },
+
   reset: (agentType?: string): Promise<AgentSettings> => {
     invalidate();
     return window.electron.agentSettings.reset(agentType).finally(invalidate);

--- a/src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx
+++ b/src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx
@@ -112,6 +112,7 @@ export function AgentScopeEditor(props: AgentScopeEditorProps) {
             scopeKind={scope.scopeKind}
             scopeLabel={scope.scopeLabel}
             effectiveSkipPerms={scope.effectiveSkipPerms}
+            globalBypassActive={scope.globalBypassActive}
             effectiveInlineMode={scope.effectiveInlineMode}
             agentDefaultDangerous={scope.agentDefaultDangerous}
             agentDefaultInline={scope.agentDefaultInline}

--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -6,6 +6,8 @@ interface BehavioralControlsProps {
   scopeKind: ScopeKind;
   scopeLabel: string;
   effectiveSkipPerms: boolean;
+  /** Global skip-permissions override is forcing bypass on for this agent (#10432). */
+  globalBypassActive: boolean;
   effectiveInlineMode: boolean;
   agentDefaultDangerous: boolean;
   agentDefaultInline: boolean;
@@ -29,6 +31,7 @@ export function BehavioralControls({
   scopeKind,
   scopeLabel,
   effectiveSkipPerms,
+  globalBypassActive,
   effectiveInlineMode,
   agentDefaultDangerous,
   agentDefaultInline,
@@ -68,11 +71,16 @@ export function BehavioralControls({
             scopeKind === "custom" ? `Reset skip permissions override for ${scopeLabel}` : undefined
           }
         />
-        {effectiveSkipPerms && defaultDangerousArg && (
+        {(effectiveSkipPerms || globalBypassActive) && defaultDangerousArg && (
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] bg-status-error/10 border border-status-error/20">
             <code className="text-xs text-status-error font-mono">{defaultDangerousArg}</code>
             <span className="text-xs text-daintree-text/40">added to command</span>
           </div>
+        )}
+        {globalBypassActive && !effectiveSkipPerms && (
+          <p className="text-xs text-daintree-text/40 select-text">
+            Forced on by the global "Skip permission prompts for agents" setting
+          </p>
         )}
       </div>
 

--- a/src/components/Settings/AgentScopeEditor/useAgentScope.ts
+++ b/src/components/Settings/AgentScopeEditor/useAgentScope.ts
@@ -3,7 +3,8 @@ import { getAgentConfig, getMergedPresets, type AgentPreset } from "@/config/age
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { resolveScopeKind, stripCcrPrefix } from "./scopeUtils";
-import type { AgentSettingsEntry } from "@shared/types";
+import { isAgentBypassSupported, type AgentSettingsEntry } from "@shared/types";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 
 interface UseAgentScopeProps {
   agentId: string;
@@ -69,6 +70,14 @@ export function useAgentScope({
 
   const effectiveSkipPerms =
     scopeKind === "custom" ? (dangerousOverride ?? agentDefaultDangerous) : agentDefaultDangerous;
+
+  // True when the global skip-permissions override (#10432) is forcing bypass
+  // on for this bypass-supporting agent — used to explain the overridden
+  // effective state on the per-agent toggle so it doesn't look contradictory.
+  const globalSkipPermissions = useAgentSettingsStore(
+    (s) => s.settings?.globalSkipPermissions ?? false
+  );
+  const globalBypassActive = globalSkipPermissions && isAgentBypassSupported(agentId);
 
   const effectiveInlineMode =
     scopeKind === "custom" ? (inlineOverride ?? agentDefaultInline) : agentDefaultInline;
@@ -241,6 +250,7 @@ export function useAgentScope({
     isEditableScope,
     supportsInlineMode,
     effectiveSkipPerms,
+    globalBypassActive,
     effectiveInlineMode,
     customArgsValue,
     customArgsPlaceholder,

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -422,6 +422,7 @@ export function AgentSettings({
                 variant="compact"
                 title="Skip permission prompts for agents"
                 subtitle="Agents run commands and edit files without asking — faster, but they act without confirmation. Applies to agent terminals, not Assistant sessions"
+                ariaLabel="Skip permission prompts for agents"
                 isEnabled={settings?.globalSkipPermissions ?? false}
                 onChange={() => {
                   void (async () => {

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -169,6 +169,7 @@ export function AgentSettings({
     refresh,
     updateAgent,
     setAgentPinned,
+    setGlobalSkipPermissions,
     reset,
   } = useAgentSettingsStore();
 
@@ -415,6 +416,20 @@ export function AgentSettings({
                 onboarding, project explanations). Distinct from the Portal "Default New Tab Agent"
                 which controls the browser panel opened by the + button.
               </p>
+            </div>
+            <div id="agents-skip-permissions">
+              <SettingsSwitchCard
+                variant="compact"
+                title="Skip permission prompts for agents"
+                subtitle="Agents run commands and edit files without asking — faster, but they act without confirmation. Applies to agent terminals, not Assistant sessions"
+                isEnabled={settings?.globalSkipPermissions ?? false}
+                onChange={() => {
+                  void (async () => {
+                    await setGlobalSkipPermissions(!(settings?.globalSkipPermissions ?? false));
+                    onSettingsChange?.();
+                  })();
+                }}
+              />
             </div>
           </div>
         )}

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -134,7 +134,11 @@ describe("spawnPanelsFromRecipe", () => {
       "claude",
       { modelId: "sonnet" },
       "claude",
-      { clipboardDirectory: "/tmp/daintree/daintree-clipboard", modelId: "sonnet" }
+      {
+        clipboardDirectory: "/tmp/daintree/daintree-clipboard",
+        modelId: "sonnet",
+        globalSkipPermissions: false,
+      }
     );
     expect(mockAddPanel).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -106,10 +106,12 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
             const agentConfig = getAgentConfig(agentId);
             const baseCommand = agentConfig?.command ?? "";
             const entry = agentSettings?.agents?.[agentId] ?? {};
+            const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
             const command = generateAgentCommand(baseCommand, entry, agentId, {
               clipboardDirectory,
               modelId: t.agentModelId,
               recipeArgs: t.args?.trim() || undefined,
+              globalSkipPermissions,
             });
             // Preserve flags the caller already captured (the clone-layout path
             // projects a live panel's `agentLaunchFlags` onto the recipe). For
@@ -119,7 +121,10 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
             // and recipe args from being dropped on resume (#9650). Recipe args
             // append as raw tokens.
             const agentLaunchFlags = t.agentLaunchFlags ?? [
-              ...buildAgentLaunchFlags(entry, agentId, { modelId: t.agentModelId }),
+              ...buildAgentLaunchFlags(entry, agentId, {
+                modelId: t.agentModelId,
+                globalSkipPermissions,
+              }),
               ...(t.args?.trim().split(/\s+/).filter(Boolean) ?? []),
             ];
 

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -455,12 +455,14 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             agentConfig.command,
             cachedLaunchCliDetail
           );
+          const globalSkipPermissions = launchSettings?.globalSkipPermissions ?? false;
           command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
             initialPrompt: launchOptions?.prompt,
             interactive: launchOptions?.interactive ?? true,
             clipboardDirectory,
             modelId: launchOptions?.modelId,
             presetArgs: preset?.args?.join(" "),
+            globalSkipPermissions,
           });
 
           // Capture process-level flags for session resume persistence
@@ -468,6 +470,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             launchFlags = buildAgentLaunchFlags(effectiveEntry, agentId, {
               modelId: launchOptions?.modelId,
               presetArgs: preset?.args,
+              globalSkipPermissions,
             });
           }
 

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -53,6 +53,7 @@ async function resolveCommandForPanel(panel: PanelInstance): Promise<ResolvedCom
           projectPresets,
         });
         const { preset, presetWasStale, effectiveEntry } = runtimeSettings;
+        const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
         const clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
         const command = generateAgentCommand(
           agentConfig.command,
@@ -63,13 +64,14 @@ async function resolveCommandForPanel(panel: PanelInstance): Promise<ResolvedCom
             clipboardDirectory,
             modelId: panel.agentModelId,
             presetArgs: preset?.args?.join(" "),
+            globalSkipPermissions,
           }
         );
         const agentLaunchFlags = buildAgentLaunchFlagsForRuntimeSettings(
           effectiveEntry,
           panel.launchAgentId,
           preset,
-          { modelId: panel.agentModelId }
+          { modelId: panel.agentModelId, globalSkipPermissions }
         );
         return { command, env: runtimeSettings.env, agentLaunchFlags, preset, presetWasStale };
       } catch (error) {

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -786,9 +786,9 @@ describe("agentSettingsStore adversarial", () => {
     });
     clientMock.setGlobal.mockRejectedValueOnce(new Error("ipc down"));
 
-    await expect(
-      useAgentSettingsStore.getState().setGlobalSkipPermissions(true)
-    ).rejects.toThrow("ipc down");
+    await expect(useAgentSettingsStore.getState().setGlobalSkipPermissions(true)).rejects.toThrow(
+      "ipc down"
+    );
 
     const state = useAgentSettingsStore.getState();
     expect(state.settings?.globalSkipPermissions).toBe(false);

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -5,6 +5,7 @@ const clientMock = vi.hoisted(() => ({
   get: vi.fn(),
   invalidate: vi.fn(),
   set: vi.fn(),
+  setGlobal: vi.fn(),
   reset: vi.fn(),
   stampVersion: vi.fn(),
 }));
@@ -759,5 +760,38 @@ describe("agentSettingsStore adversarial", () => {
     const state = useAgentSettingsStore.getState();
     expect(state.isInitialized).toBe(true);
     expect(state.isLoading).toBe(false);
+  });
+
+  it("setGlobalSkipPermissions optimistically updates the root field without touching per-agent dangerousEnabled (#10432)", async () => {
+    useAgentSettingsStore.setState({
+      settings: {
+        agents: { claude: { dangerousEnabled: true } },
+        globalSkipPermissions: false,
+      },
+    });
+    clientMock.setGlobal.mockResolvedValueOnce({});
+
+    await useAgentSettingsStore.getState().setGlobalSkipPermissions(true);
+
+    expect(clientMock.setGlobal).toHaveBeenCalledWith(true);
+    const settings = useAgentSettingsStore.getState().settings;
+    expect(settings?.globalSkipPermissions).toBe(true);
+    // The per-agent toggle must be left untouched — the global is a live override.
+    expect(settings?.agents.claude.dangerousEnabled).toBe(true);
+  });
+
+  it("setGlobalSkipPermissions rolls back to the prior value when the IPC write rejects (#10432)", async () => {
+    useAgentSettingsStore.setState({
+      settings: { agents: { claude: {} }, globalSkipPermissions: false },
+    });
+    clientMock.setGlobal.mockRejectedValueOnce(new Error("ipc down"));
+
+    await expect(
+      useAgentSettingsStore.getState().setGlobalSkipPermissions(true)
+    ).rejects.toThrow("ipc down");
+
+    const state = useAgentSettingsStore.getState();
+    expect(state.settings?.globalSkipPermissions).toBe(false);
+    expect(state.error).toBeTruthy();
   });
 });

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -777,7 +777,7 @@ describe("agentSettingsStore adversarial", () => {
     const settings = useAgentSettingsStore.getState().settings;
     expect(settings?.globalSkipPermissions).toBe(true);
     // The per-agent toggle must be left untouched — the global is a live override.
-    expect(settings?.agents.claude.dangerousEnabled).toBe(true);
+    expect(settings?.agents.claude?.dangerousEnabled).toBe(true);
   });
 
   it("setGlobalSkipPermissions rolls back to the prior value when the IPC write rejects (#10432)", async () => {

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -223,6 +223,12 @@ interface AgentSettingsActions {
   updateAgent: (agentId: string, updates: Partial<AgentSettingsEntry>) => Promise<void>;
   setAgentPinned: (agentId: string, pinned: boolean) => Promise<void>;
   /**
+   * Set the global skip-permissions override (#10432). Writes the root-level
+   * `globalSkipPermissions` field only — does not mutate any per-agent
+   * `dangerousEnabled`. Optimistic with rollback on IPC failure.
+   */
+  setGlobalSkipPermissions: (value: boolean) => Promise<void>;
+  /**
    * Set or clear the worktree-scoped preset override for an agent. Reads the
    * current `worktreePresets` map, spreads sibling keys, then writes the merged
    * map — bypasses the IPC handler's shallow-merge clobber on the submap.
@@ -411,6 +417,32 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
 
   setAgentPinned: async (agentId: string, pinned: boolean) => {
     return get().updateAgent(agentId, { pinned });
+  },
+
+  setGlobalSkipPermissions: async (value: boolean) => {
+    const myEpoch = ++normalizeEpoch;
+    set({ error: null });
+    const previous = get().settings;
+    // Optimistic top-level spread — never route through updateAgent (which
+    // merges into the agents record and would not touch this root field, #5514).
+    // This must not mutate any per-agent `dangerousEnabled`; it is a live
+    // override OR-ed in at flag-generation time (#10432).
+    if (previous) {
+      set({ settings: { ...previous, globalSkipPermissions: value } });
+    }
+    try {
+      await agentSettingsClient.setGlobal(value);
+      if (myEpoch !== normalizeEpoch) return;
+      // The IPC response echoes the persisted value; the optimistic state
+      // already reflects it, and the renderer-normalized agents record is the
+      // source of truth for per-agent state, so keep it rather than overwriting
+      // from the raw response.
+    } catch (e) {
+      if (myEpoch !== normalizeEpoch) return;
+      if (previous) set({ settings: previous });
+      set({ error: formatErrorMessage(e, "Failed to update global skip-permissions setting") });
+      throw e;
+    }
   },
 
   updateWorktreePreset: async (

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -809,11 +809,13 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               ? replaceRecipeVariables(rawPrompt, resolvedContext)
               : undefined;
             const entry = agentSettings?.agents?.[agentId] ?? {};
+            const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
             const command = generateAgentCommand(baseCommand, entry, agentId, {
               initialPrompt,
               clipboardDirectory,
               modelId: terminal.agentModelId,
               recipeArgs: terminal.args?.trim() || undefined,
+              globalSkipPermissions,
             });
             // Persist the process-level launch flags so restart/resume/continue
             // reproduce the same configuration. Without this the panel arrives
@@ -826,7 +828,10 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             // raw tokens since the restart command builder applies its own
             // escaping.
             const agentLaunchFlags = terminal.agentLaunchFlags ?? [
-              ...buildAgentLaunchFlags(entry, agentId, { modelId: terminal.agentModelId }),
+              ...buildAgentLaunchFlags(entry, agentId, {
+                modelId: terminal.agentModelId,
+                globalSkipPermissions,
+              }),
               ...(terminal.args?.trim().split(/\s+/).filter(Boolean) ?? []),
             ];
             return terminalStore.addPanel({

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -96,6 +96,11 @@ vi.mock("@shared/types", () => ({
   buildResumeCommand: vi.fn().mockReturnValue(null),
   buildResumeLatestCommand: vi.fn().mockReturnValue(null),
   buildLaunchCommandFromFlags: vi.fn().mockReturnValue("claude --flag"),
+  // Identity reconcile keeps persisted flags verbatim so these dispatch-path
+  // tests stay focused on restart wiring rather than bypass reconciliation
+  // (#10432, covered by agentSettings.test.ts and statePatcher.test.ts).
+  reconcileBypassFlags: (flags: readonly string[]) => [...flags],
+  resolveEffectiveBypass: () => false,
 }));
 
 vi.mock("@/store/ccrPresetsStore", () => ({

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -13,6 +13,8 @@ import {
   buildResumeCommand,
   buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
+  reconcileBypassFlags,
+  resolveEffectiveBypass,
 } from "@shared/types";
 import type { AgentSettingsEntry } from "@shared/types/agentSettings";
 import type { AgentState } from "@/types";
@@ -58,6 +60,8 @@ interface LoadedAgentRuntimeSettings {
   entry: AgentSettingsEntry;
   settings: AgentRuntimeSettingsResolution;
   tmpDir: string;
+  /** Global skip-permissions override at restart time (#10432). */
+  globalSkipPermissions: boolean;
 }
 
 function mergeSpawnEnv(
@@ -351,7 +355,12 @@ export const createRestartActions = (
           ccrPresets,
           projectPresets,
         });
-        loadedRuntimeSettings = { entry, settings, tmpDir };
+        loadedRuntimeSettings = {
+          entry,
+          settings,
+          tmpDir,
+          globalSkipPermissions: agentSettings?.globalSkipPermissions ?? false,
+        };
         if (settings.presetWasStale) {
           nextAgentPresetId = undefined;
           nextAgentPresetColor = undefined;
@@ -372,7 +381,10 @@ export const createRestartActions = (
         runtimeForEnv.settings.effectiveEntry,
         effectiveAgentId,
         undefined,
-        { modelId: currentTerminal.agentModelId }
+        {
+          modelId: currentTerminal.agentModelId,
+          globalSkipPermissions: runtimeForEnv.globalSkipPermissions,
+        }
       );
     }
 
@@ -382,6 +394,23 @@ export const createRestartActions = (
         nextAgentLaunchFlags = mergePresetArgsIntoLaunchFlags(
           currentTerminal.agentLaunchFlags,
           presetForLaunchFlags
+        );
+      }
+      // Reconcile the persisted bypass flag against the current effective
+      // setting before any resume/from-flags command is built (#10432, the
+      // "resume trap"): a snapshot captured while the global skip-permissions
+      // switch was on must not survive once it's toggled off, and vice-versa.
+      if (runtimeForEnv && nextAgentLaunchFlags && nextAgentLaunchFlags.length > 0) {
+        const effectiveBypass = resolveEffectiveBypass(
+          runtimeForEnv.settings.effectiveEntry,
+          effectiveAgentId,
+          runtimeForEnv.globalSkipPermissions
+        );
+        nextAgentLaunchFlags = reconcileBypassFlags(
+          nextAgentLaunchFlags,
+          effectiveAgentId,
+          effectiveBypass,
+          runtimeForEnv.settings.effectiveEntry.dangerousArgs
         );
       }
       const sessionId = currentTerminal.agentSessionId;
@@ -415,7 +444,10 @@ export const createRestartActions = (
             runtimeSettings.settings.effectiveEntry,
             effectiveAgentId,
             runtimeSettings.settings.preset,
-            { modelId: currentTerminal.agentModelId }
+            {
+              modelId: currentTerminal.agentModelId,
+              globalSkipPermissions: runtimeSettings.globalSkipPermissions,
+            }
           );
           hasPersistedFlags = nextAgentLaunchFlags.length > 0;
         }
@@ -453,6 +485,7 @@ export const createRestartActions = (
                   clipboardDirectory,
                   modelId: currentTerminal.agentModelId,
                   presetArgs: runtimeSettings.settings.preset?.args?.join(" "),
+                  globalSkipPermissions: runtimeSettings.globalSkipPermissions,
                 }
               );
             }
@@ -975,14 +1008,17 @@ export const createRestartActions = (
 
       const agentConfig = getAgentConfig(effectiveAgentId);
       const baseCommand = agentConfig?.command || effectiveAgentId;
+      const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
       const commandToRun = generateAgentCommand(baseCommand, effectiveEntry, effectiveAgentId, {
         clipboardDirectory,
         modelId: terminal.agentModelId,
         presetArgs: nextPreset.args?.join(" "),
+        globalSkipPermissions,
       });
       const nextLaunchFlags = buildAgentLaunchFlags(effectiveEntry, effectiveAgentId, {
         modelId: terminal.agentModelId,
         presetArgs: nextPreset.args,
+        globalSkipPermissions,
       });
 
       // Capture live terminal dimensions before teardown

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -400,22 +400,32 @@ export const createRestartActions = (
       // setting before any resume/from-flags command is built (#10432, the
       // "resume trap"): a snapshot captured while the global skip-permissions
       // switch was on must not survive once it's toggled off, and vice-versa.
-      if (runtimeForEnv && nextAgentLaunchFlags && nextAgentLaunchFlags.length > 0) {
+      // `nextAgentLaunchFlags` (stored + from-flags rebuild) reconciles only
+      // captured flags; `resumeFlags` additionally injects the bypass token into
+      // an empty snapshot so a session launched before bypass honours global-on.
+      let resumeFlags = nextAgentLaunchFlags;
+      if (runtimeForEnv) {
         const effectiveBypass = resolveEffectiveBypass(
           runtimeForEnv.settings.effectiveEntry,
           effectiveAgentId,
           runtimeForEnv.globalSkipPermissions
         );
-        nextAgentLaunchFlags = reconcileBypassFlags(
-          nextAgentLaunchFlags,
-          effectiveAgentId,
-          effectiveBypass,
-          runtimeForEnv.settings.effectiveEntry.dangerousArgs
-        );
+        const dangerousArgs = runtimeForEnv.settings.effectiveEntry.dangerousArgs;
+        if (nextAgentLaunchFlags && nextAgentLaunchFlags.length > 0) {
+          nextAgentLaunchFlags = reconcileBypassFlags(
+            nextAgentLaunchFlags,
+            effectiveAgentId,
+            effectiveBypass,
+            dangerousArgs
+          );
+          resumeFlags = nextAgentLaunchFlags;
+        } else if (effectiveBypass) {
+          resumeFlags = reconcileBypassFlags([], effectiveAgentId, effectiveBypass, dangerousArgs);
+        }
       }
       const sessionId = currentTerminal.agentSessionId;
       if (sessionId) {
-        const resumeCmd = buildResumeCommand(effectiveAgentId, sessionId, nextAgentLaunchFlags);
+        const resumeCmd = buildResumeCommand(effectiveAgentId, sessionId, resumeFlags);
         if (resumeCmd) {
           commandToRun = resumeCmd;
         }
@@ -426,7 +436,7 @@ export const createRestartActions = (
         // through to a fresh launch so the user keeps their prior CWD-scoped
         // conversation. Suppressed by moveToNewWorktreeAndTransfer because the
         // new CWD would resume a stale or unrelated session.
-        const resumeLatestCmd = buildResumeLatestCommand(effectiveAgentId, nextAgentLaunchFlags);
+        const resumeLatestCmd = buildResumeLatestCommand(effectiveAgentId, resumeFlags);
         if (resumeLatestCmd) {
           commandToRun = resumeLatestCmd;
           usedResumeLatest = true;

--- a/src/utils/agentRuntimeSettings.ts
+++ b/src/utils/agentRuntimeSettings.ts
@@ -82,10 +82,11 @@ export function buildAgentLaunchFlagsForRuntimeSettings(
   entry: AgentSettingsEntry,
   agentId: string,
   preset: AgentPreset | undefined,
-  options?: { modelId?: string }
+  options?: { modelId?: string; globalSkipPermissions?: boolean }
 ): string[] {
   return buildAgentLaunchFlags(entry, agentId, {
     modelId: options?.modelId,
     presetArgs: preset?.args,
+    globalSkipPermissions: options?.globalSkipPermissions,
   });
 }

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -671,7 +671,9 @@ describe("buildArgsForRespawn", () => {
       },
       "agent",
       "/p",
-      { agents: { claude: {} } },
+      // dangerousEnabled keeps the effective bypass on, so the persisted flag
+      // survives bypass reconciliation (#10432) and replays verbatim.
+      { agents: { claude: { dangerousEnabled: true } } },
       false,
       undefined
     );
@@ -695,11 +697,13 @@ describe("buildArgsForRespawn", () => {
       },
       "agent",
       "/p",
-      { agents: { claude: { dangerousEnabled: false } } },
+      { agents: { claude: { dangerousEnabled: true } } },
       false,
       "/tmp/clip"
     );
     // `--...` flags pass through raw; the positional `claude-opus-4-7` is escaped.
+    // dangerousEnabled keeps the effective bypass on, so reconciliation (#10432)
+    // leaves the persisted flag in place.
     expect(result.command).toBe("claude --dangerously-skip-permissions --model 'claude-opus-4-7'");
     expect(generateAgentCommandMock).not.toHaveBeenCalled();
   });
@@ -739,7 +743,7 @@ describe("buildArgsForRespawn", () => {
       },
       "agent",
       "/p",
-      { agents: { claude: {} } },
+      { agents: { claude: { dangerousEnabled: true } } },
       false,
       undefined
     );
@@ -786,7 +790,7 @@ describe("buildArgsForRespawn", () => {
       },
       "agent",
       "/p",
-      { agents: { claude: {} } },
+      { agents: { claude: { dangerousEnabled: true } } },
       false,
       undefined
     );
@@ -808,13 +812,83 @@ describe("buildArgsForRespawn", () => {
       },
       "agent",
       "/p",
-      { agents: { claude: {} } },
+      { agents: { claude: { dangerousEnabled: true } } },
       false,
       undefined
     );
     expect(result.command).toBe("claude --dangerously-skip-permissions");
     expect(buildResumeLatestCommandMock).toHaveBeenCalledOnce();
     expect(generateAgentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("strips a stale bypass flag from persisted flags when the effective setting is off (#10432)", () => {
+    buildResumeCommandMock.mockClear();
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+        agentLaunchFlags: ["--dangerously-skip-permissions", "--model", "opus"],
+      },
+      "agent",
+      "/p",
+      // Per-agent toggle off and global off → effective bypass false → strip the
+      // stale flag the snapshot carried from a prior dangerous launch.
+      { agents: { claude: { dangerousEnabled: false } } },
+      false,
+      undefined
+    );
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("claude", "sess-1", ["--model", "opus"]);
+    expect(result.agentLaunchFlags).toEqual(["--model", "opus"]);
+  });
+
+  it("re-adds the bypass flag for a supported agent when the global override is on (#10432)", () => {
+    buildResumeCommandMock.mockClear();
+    buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+        agentLaunchFlags: ["--model", "opus"],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: { dangerousEnabled: false } }, globalSkipPermissions: true },
+      false,
+      undefined
+    );
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("claude", "sess-1", [
+      "--model",
+      "opus",
+      "--dangerously-skip-permissions",
+    ]);
+  });
+
+  it("does not inject a bypass flag for an unsupported agent even when the global override is on (#10432)", () => {
+    buildResumeCommandMock.mockClear();
+    buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "gemini",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+        agentLaunchFlags: ["--model", "flash"],
+      },
+      "agent",
+      "/p",
+      { agents: { gemini: { dangerousEnabled: false } }, globalSkipPermissions: true },
+      false,
+      undefined
+    );
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("gemini", "sess-1", ["--model", "flash"]);
   });
 
   it("prefers primary buildResumeCommand over resume-latest when session ID is present", () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -891,6 +891,33 @@ describe("buildArgsForRespawn", () => {
     expect(buildResumeCommandMock).toHaveBeenCalledWith("gemini", "sess-1", ["--model", "flash"]);
   });
 
+  it("injects the bypass flag into an empty snapshot at resume when the global override is on (#10432)", () => {
+    buildResumeCommandMock.mockClear();
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal" as const,
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+        // Launched before bypass existed — no flags were captured.
+        agentLaunchFlags: [],
+      },
+      "agent",
+      "/p",
+      { agents: { claude: { dangerousEnabled: false } }, globalSkipPermissions: true },
+      false,
+      undefined
+    );
+    // The resume command gets the injected bypass token...
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("claude", "sess-1", [
+      "--dangerously-skip-permissions",
+    ]);
+    // ...but the stored snapshot is not synthesized from nothing.
+    expect(result.agentLaunchFlags).toEqual([]);
+  });
+
   it("prefers primary buildResumeCommand over resume-latest when session ID is present", () => {
     buildResumeLatestCommandMock.mockReturnValue("claude --continue");
     const result = buildArgsForRespawn(

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -11,6 +11,8 @@ import {
   buildResumeCommand,
   buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
+  reconcileBypassFlags,
+  resolveEffectiveBypass,
 } from "@shared/types";
 import { inferKind as inferKindShared } from "@shared/utils/inferPanelKind";
 import { isAbsolute } from "@shared/utils/path";
@@ -160,6 +162,7 @@ interface ReconnectedTerminalData {
 
 interface AgentSettingsData {
   agents?: Record<string, Record<string, unknown>>;
+  globalSkipPermissions?: boolean;
 }
 
 export function inferAgentIdFromTitle(
@@ -394,6 +397,9 @@ export function buildArgsForRespawn(
   let sessionLostOnRestore = false;
   let presetEnv: Record<string, string> | undefined;
   let preset: AgentPreset | undefined;
+  // Bypass-reconciled launch flags (#10432); falls back to the raw saved flags
+  // for non-agent panels that never enter the reconciliation branch below.
+  let reconciledLaunchFlags: string[] | undefined;
   const savedPresetIdForRespawn = readPresetId(saved);
   const savedPresetColorForRespawn = readPresetColor(saved);
   let presetWasStale = false;
@@ -413,10 +419,28 @@ export function buildArgsForRespawn(
     });
     preset = runtimeSettings.preset;
     presetWasStale = !!savedPresetIdForRespawn && runtimeSettings.presetWasStale;
-    const persistedFlags = presetWasStale ? undefined : saved.agentLaunchFlags;
-    const hasPersistedFlags = Boolean(persistedFlags && persistedFlags.length > 0);
     const effectiveEntry = runtimeSettings.effectiveEntry;
     presetEnv = runtimeSettings.env;
+
+    // Reconcile the persisted bypass flag against the current effective setting
+    // (#10432, the "resume trap"): a snapshot captured while the global
+    // skip-permissions switch was on must not carry the bypass flag forward
+    // once it's toggled off, and vice-versa. Strip-and-re-add against the
+    // current resolution so every restart/restore replays clean flags.
+    const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
+    const effectiveBypass = resolveEffectiveBypass(effectiveEntry, agentId, globalSkipPermissions);
+    const rawPersistedFlags = presetWasStale ? undefined : saved.agentLaunchFlags;
+    const persistedFlags =
+      rawPersistedFlags && rawPersistedFlags.length > 0
+        ? reconcileBypassFlags(
+            rawPersistedFlags,
+            agentId,
+            effectiveBypass,
+            effectiveEntry.dangerousArgs as string | undefined
+          )
+        : rawPersistedFlags;
+    reconciledLaunchFlags = persistedFlags;
+    const hasPersistedFlags = Boolean(persistedFlags && persistedFlags.length > 0);
 
     const buildFromPersistedFlags = () =>
       buildLaunchCommandFromFlags(baseCommand, agentId, persistedFlags as string[], {
@@ -436,6 +460,7 @@ export function buildArgsForRespawn(
           clipboardDirectory,
           modelId: saved.agentModelId,
           presetArgs: preset?.args?.join(" "),
+          globalSkipPermissions,
         });
         sessionLostOnRestore = true;
       }
@@ -454,6 +479,7 @@ export function buildArgsForRespawn(
           clipboardDirectory,
           modelId: saved.agentModelId,
           presetArgs: preset?.args?.join(" "),
+          globalSkipPermissions,
         });
         sessionLostOnRestore = true;
       }
@@ -497,7 +523,7 @@ export function buildArgsForRespawn(
     browserZoom: isDevPreview ? saved.browserZoom : undefined,
     devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
     exitBehavior: isAgentPanel ? undefined : saved.exitBehavior,
-    agentLaunchFlags: presetWasStale ? undefined : saved.agentLaunchFlags,
+    agentLaunchFlags: presetWasStale ? undefined : (reconciledLaunchFlags ?? saved.agentLaunchFlags),
     agentModelId: saved.agentModelId,
     agentPresetId: respawnAgentPresetId,
     agentPresetColor: respawnAgentPresetColor,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -429,18 +429,24 @@ export function buildArgsForRespawn(
     // current resolution so every restart/restore replays clean flags.
     const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
     const effectiveBypass = resolveEffectiveBypass(effectiveEntry, agentId, globalSkipPermissions);
+    const dangerousArgs = effectiveEntry.dangerousArgs as string | undefined;
     const rawPersistedFlags = presetWasStale ? undefined : saved.agentLaunchFlags;
-    const persistedFlags =
-      rawPersistedFlags && rawPersistedFlags.length > 0
-        ? reconcileBypassFlags(
-            rawPersistedFlags,
-            agentId,
-            effectiveBypass,
-            effectiveEntry.dangerousArgs as string | undefined
-          )
-        : rawPersistedFlags;
+    const hasPersistedFlags = Boolean(rawPersistedFlags && rawPersistedFlags.length > 0);
+    // Reconcile only the flags actually captured: this drives the stored
+    // snapshot and the from-flags rebuild, so it must NOT synthesize a flag set
+    // out of nothing (that would mask the fresh-launch fallback).
+    const persistedFlags = hasPersistedFlags
+      ? reconcileBypassFlags(rawPersistedFlags as string[], agentId, effectiveBypass, dangerousArgs)
+      : rawPersistedFlags;
     reconciledLaunchFlags = persistedFlags;
-    const hasPersistedFlags = Boolean(persistedFlags && persistedFlags.length > 0);
+    // Resume commands prepend launch flags, so the bypass token must be injected
+    // even when no flags were captured — a session launched before bypass
+    // existed should honour global-on (#10432). Only diverges from persistedFlags
+    // in that inject-from-empty case.
+    const resumeFlags =
+      effectiveBypass && !hasPersistedFlags
+        ? reconcileBypassFlags([], agentId, effectiveBypass, dangerousArgs)
+        : persistedFlags;
 
     const buildFromPersistedFlags = () =>
       buildLaunchCommandFromFlags(baseCommand, agentId, persistedFlags as string[], {
@@ -449,7 +455,7 @@ export function buildArgsForRespawn(
       });
 
     if (saved.agentSessionId) {
-      const resumeCmd = buildResumeCommand(agentId, saved.agentSessionId, persistedFlags);
+      const resumeCmd = buildResumeCommand(agentId, saved.agentSessionId, resumeFlags);
       if (resumeCmd) {
         command = resumeCmd;
       } else if (hasPersistedFlags) {
@@ -468,7 +474,7 @@ export function buildArgsForRespawn(
       // No session ID was captured (graceful-shutdown pattern match missed or
       // timed out). Try the agent's resume-latest fallback before falling
       // through to a fresh launch so the user keeps their prior conversation.
-      const resumeLatestCmd = buildResumeLatestCommand(agentId, persistedFlags);
+      const resumeLatestCmd = buildResumeLatestCommand(agentId, resumeFlags);
       if (resumeLatestCmd) {
         command = resumeLatestCmd;
       } else if (hasPersistedFlags) {

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -529,7 +529,9 @@ export function buildArgsForRespawn(
     browserZoom: isDevPreview ? saved.browserZoom : undefined,
     devPreviewConsoleOpen: isDevPreview ? saved.devPreviewConsoleOpen : undefined,
     exitBehavior: isAgentPanel ? undefined : saved.exitBehavior,
-    agentLaunchFlags: presetWasStale ? undefined : (reconciledLaunchFlags ?? saved.agentLaunchFlags),
+    agentLaunchFlags: presetWasStale
+      ? undefined
+      : (reconciledLaunchFlags ?? saved.agentLaunchFlags),
     agentModelId: saved.agentModelId,
     agentPresetId: respawnAgentPresetId,
     agentPresetColor: respawnAgentPresetColor,


### PR DESCRIPTION
## Summary

- Adds a global "Skip permission prompts for agents" toggle in Settings → CLI agents → General. When on, every bypass-supported agent skips permission prompts without touching per-agent `dangerousEnabled` settings.
- Effective bypass resolves as `(perAgent dangerousEnabled) || (global && supports.permissionBypass === true)` — the global never injects flags into agents that don't explicitly declare support (only claude and codex today). Per-agent toggles (e.g. Gemini `--yolo`) keep working independently.
- Fixes the resume trap: `reconcileBypassFlags()` strips and re-adds the canonical bypass flag on every restart, restore, and palette resume against the current effective setting, so toggling the global off stops carrying stale bypass into future sessions.

Resolves #10432

## Changes

- `shared/types/agentSettings.ts` — `globalSkipPermissions` setting field, `resolveEffectiveBypass()`, and `reconcileBypassFlags()` (scoped to bypass-supported agents)
- `electron/ipc/channels.ts` + `electron/ipc/handlers/ai.ts` — new `agent-settings:set-global` channel; handler writes via dot-path leaf (`store.set("agentSettings.globalSkipPermissions", value)`, no slice rewrite per #6106)
- `electron/preload.cts` + `src/clients/agentSettingsClient.ts` + `shared/types/ipc/` — IPC surface wired end-to-end
- `src/components/Settings/AgentSettings.tsx` + `src/components/Settings/AgentScopeEditor/BehavioralControls.tsx` — global toggle UI; per-agent control shows a "Forced on by the global setting" hint when the global overrides it
- `src/store/agentSettingsStore.ts` — store action with optimistic update and rollback on IPC failure
- `src/store/slices/panelRegistry/restart.ts` + `src/utils/stateHydration/statePatcher.ts` + `src/hooks/useAgentLauncher.ts` — reconciliation wired into all restart/restore/resume paths; already-running PTYs are untouched
- Tests: `resolveEffectiveBypass`, `reconcileBypassFlags` (strip/re-add/idempotent/dedup/unsupported/custom args), flag generation with global active, respawn/resume reconciliation including empty-snapshot injection, IPC handler boolean guard + dot-path write, client wrapper, store optimistic update + rollback

## Testing

Unit tests cover the full matrix: flag resolution with and without the global, reconciliation edge cases (idempotent runs, deduplication, unsupported agents, custom args), IPC handler validation, client wrapper, and store rollback on failure. Reconciliation paths in `restart.ts` and `statePatcher.ts` tested for both strip-on-disable and inject-on-enable with pre-existing empty snapshots.