### PR TITLE
fix(panels): keep grid position when a panel gains a second tab

### DIFF
--- a/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
@@ -139,6 +139,61 @@ describe("panelIdsByWorktreeId invariant across mutations", () => {
       ).toEqual([["t1"], ["t2", "t3"], ["t4"]]);
     });
 
+    it("getTabGroups keeps group position when a panel gains a second tab via addPanelToGroup", () => {
+      // The real #10435 trigger path: an existing panel gains a second tab
+      // through addPanelToGroup. The group must stay at its earliest member's
+      // position rather than jumping to grid position 0.
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+
+      const groupId = usePanelStore.getState().createTabGroup("grid", "wt-A", ["t2"]);
+      usePanelStore.getState().addPanelToGroup(groupId, "t3");
+
+      expect(
+        usePanelStore
+          .getState()
+          .getTabGroups("grid", "wt-A")
+          .map((g) => g.panelIds)
+      ).toEqual([["t1"], ["t2", "t3"]]);
+    });
+
+    it("getTabGroups interleaves multiple explicit groups by panelIds order", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+      seedTerminal("t4", "wt-A");
+      seedTerminal("t5", "wt-A");
+
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["t2", "t3"]);
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["t4", "t5"]);
+
+      expect(
+        usePanelStore
+          .getState()
+          .getTabGroups("grid", "wt-A")
+          .map((g) => g.panelIds)
+      ).toEqual([["t1"], ["t2", "t3"], ["t4", "t5"]]);
+    });
+
+    it("getTabGroups places a non-contiguous group at its earliest member's position", () => {
+      // A group owning t2 and t4 lands at t2's position; t3 stays a virtual
+      // group emitted after the group it sits between in panelIds.
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+      seedTerminal("t4", "wt-A");
+
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["t2", "t4"]);
+
+      expect(
+        usePanelStore
+          .getState()
+          .getTabGroups("grid", "wt-A")
+          .map((g) => g.panelIds)
+      ).toEqual([["t1"], ["t2", "t4"], ["t3"]]);
+    });
+
     it("moveTerminalToPosition reorders the affected bucket", () => {
       seedTerminal("t1", "wt-A");
       seedTerminal("t2", "wt-A");

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
@@ -93,14 +93,50 @@ describe("panelIdsByWorktreeId invariant across mutations", () => {
       seedTerminal("t2", "wt-A");
       seedTerminal("t3", "wt-A");
 
-      // Explicit groups sort to the front of getTabGroups; the explicit
-      // [t1, t2] tab group lands at index 0, virtual t3 lands at index 1.
+      // getTabGroups interleaves explicit and virtual groups by earliest
+      // panelIds position; the explicit [t1, t2] group lands at index 0 and
+      // virtual t3 at index 1.
       usePanelStore.getState().createTabGroup("grid", "wt-A", ["t1", "t2"]);
 
       // Move the virtual t3 group (index 1) to the front of the grid scope.
       usePanelStore.getState().reorderTabGroups(1, 0, "grid", "wt-A");
 
       expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["t3", "t1", "t2"]);
+    });
+
+    it("getTabGroups interleaves explicit and virtual groups by panelIds order", () => {
+      // A panel gaining a second tab (becoming an explicit group) must keep its
+      // grid position rather than jumping to the front (#10435).
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["t2", "t3"]);
+
+      // Leading virtual group (t1) must precede the explicit [t2, t3] group.
+      expect(
+        usePanelStore
+          .getState()
+          .getTabGroups("grid", "wt-A")
+          .map((g) => g.panelIds)
+      ).toEqual([["t1"], ["t2", "t3"]]);
+    });
+
+    it("getTabGroups interleaves a virtual group on each side of an explicit group", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+      seedTerminal("t4", "wt-A");
+
+      usePanelStore.getState().createTabGroup("grid", "wt-A", ["t2", "t3"]);
+
+      // Virtual groups must surround the explicit group in panelIds order.
+      expect(
+        usePanelStore
+          .getState()
+          .getTabGroups("grid", "wt-A")
+          .map((g) => g.panelIds)
+      ).toEqual([["t1"], ["t2", "t3"], ["t4"]]);
     });
 
     it("moveTerminalToPosition reorders the affected bucket", () => {

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -330,15 +330,39 @@ export const createTabGroupActions = (
       }
     }
 
-    // Find ungrouped panels. Source from the eagerly-committed worktree index
-    // (not `panelIds`, which lags during a spawn batch) so freshly-batched
-    // panels paint immediately rather than after a worktree switch (#9649).
-    const ungroupedPanels: CarrierPanel[] = [];
+    // Map each valid explicit-group member to its sanitized group so the
+    // interleave pass below can slot the group in at its earliest member's
+    // position instead of forcing every explicit group ahead of the virtual
+    // ones — the latter made a panel jump to grid position 0 the moment it
+    // gained a second tab (#10435).
+    const memberToGroup = new Map<string, TabGroup>();
+    for (const group of explicitGroups) {
+      for (const id of group.panelIds) memberToGroup.set(id, group);
+    }
+    const emittedGroupIds = new Set<string>();
+
+    // Interleave explicit and virtual (single-panel) groups in one ordered pass.
+    // Source from the eagerly-committed worktree index (not `panelIds`, which
+    // lags during a spawn batch) so freshly-batched panels paint immediately
+    // rather than after a worktree switch (#9649). Each explicit group is
+    // emitted once, when its earliest member is first encountered; every other
+    // panel becomes a virtual single-panel group in place — preserving the
+    // panelIds grid order across both kinds (#10435).
+    const result: TabGroup[] = [];
     for (const tid of collectUngroupedCandidateIds(
       state.panelIds,
       state.panelIdsByWorktreeId,
       worktreeId
     )) {
+      const explicit = memberToGroup.get(tid);
+      if (explicit) {
+        if (!emittedGroupIds.has(explicit.id)) {
+          emittedGroupIds.add(explicit.id);
+          result.push(explicit);
+        }
+        continue;
+      }
+
       const t = state.panelsById[tid];
       if (!t) continue;
       if (t.location === "trash" || trashedTerminals.has(t.id)) continue;
@@ -346,27 +370,27 @@ export const createTabGroupActions = (
       if (effectiveLocation === null) continue;
       if (effectiveLocation !== location) continue;
       if (!panelMatchesWorktreeScope(t.worktreeId, worktreeId, location)) continue;
-      if (panelsInExplicitGroups.has(t.id)) continue;
-      ungroupedPanels.push(t);
+
+      result.push({
+        id: t.id,
+        location,
+        worktreeId,
+        activeTabId: t.id,
+        panelIds: [t.id],
+      });
     }
 
-    const virtualGroups: TabGroup[] = ungroupedPanels.map((panel) => ({
-      id: panel.id,
-      location,
-      worktreeId,
-      activeTabId: panel.id,
-      panelIds: [panel.id],
-    }));
+    // Defensive tail: emit any explicit group whose members never surfaced in
+    // the candidate iteration, preserving the prior guarantee that an explicit
+    // group is never silently dropped from the returned list.
+    for (const group of explicitGroups) {
+      if (!emittedGroupIds.has(group.id)) {
+        emittedGroupIds.add(group.id);
+        result.push(group);
+      }
+    }
 
-    // Sort explicit groups by their earliest terminal index in panelIds
-    const idIndexMap = new Map(state.panelIds.map((id, i) => [id, i]));
-    explicitGroups.sort((a, b) => {
-      const aFirstIndex = Math.min(...a.panelIds.map((id) => idIndexMap.get(id) ?? Infinity));
-      const bFirstIndex = Math.min(...b.panelIds.map((id) => idIndexMap.get(id) ?? Infinity));
-      return aFirstIndex - bFirstIndex;
-    });
-
-    return [...explicitGroups, ...virtualGroups];
+    return result;
   },
 
   moveTabGroupToLocation: (groupId, location) => {

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -301,7 +301,6 @@ export const createTabGroupActions = (
     const tabGroups = state.tabGroups;
 
     const explicitGroups: TabGroup[] = [];
-    const panelsInExplicitGroups = new Set<string>();
 
     for (const group of tabGroups.values()) {
       if (
@@ -325,7 +324,6 @@ export const createTabGroupActions = (
               ? group.activeTabId
               : (validPanelIds[0] ?? ""),
           });
-          validPanelIds.forEach((id) => panelsInExplicitGroups.add(id));
         }
       }
     }


### PR DESCRIPTION
## Summary

- `getTabGroups` in `tabGroups.ts` always returned explicit tab groups before virtual single-panel groups, so a panel jumped to grid position 0 the moment it gained a second tab
- Fix interleaves both group types sorted by earliest `panelIds` position, preserving the panel's original grid order
- Removes a now-dead `set` and adds regression tests covering the interleave behaviour

Resolves #10435

## Changes

- `src/store/slices/panelRegistry/tabGroups.ts` — interleave explicit and virtual tab groups by earliest `panelIds` index; drop dead set
- `src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts` — regression tests for the ordering invariant

## Testing

81 targeted unit tests pass. Regression tests added directly in the affected test file to catch the ordering bug and confirm the fix holds.