### PR TITLE
feat(assistant): expose terminal.rename to in-app assistant and MCP

### DIFF
--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2666,6 +2666,12 @@ describe("McpServerService", () => {
         description:
           "Toggle the focused terminal between the dock and the grid. Pushes a layout undo snapshot so the move can be reversed.",
       }),
+      createManifestEntry({
+        id: "terminal.rename" as ActionId,
+        title: "Rename Terminal",
+        description:
+          "Rename a terminal. Accepts an optional terminalId (defaults to the focused terminal) and a name; omitting the name opens the rename dialog.",
+      }),
       waitUntilIdleManifestEntry(),
       createManifestEntry({
         id: "recipe.list" as ActionId,

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -328,6 +328,7 @@ const MCP_TOOL_ALLOWLIST_ENTRIES = [
   "terminal.sendCommand",
   "terminal.inject",
   "terminal.new",
+  "terminal.rename",
   "terminal.waitUntilIdle",
 
   "worktree.list",

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -77,6 +77,7 @@ export const ACTION_TIER_ADDONS = [
   "terminal.moveToDock",
   "terminal.moveToGrid",
   "terminal.toggleDock",
+  "terminal.rename",
   TERMINAL_WAIT_UNTIL_IDLE_TOOL,
 
   "recipe.list",


### PR DESCRIPTION
## Summary

- `terminal.rename` was missing from both the in-app assistant tier allowlist and the external MCP tool allowlist, so it never appeared in `tools/list` despite the action already existing and being marked `danger: "safe"`
- Adds `terminal.rename` to `ACTION_TIER_ADDONS` in `shared/config/helpAssistantTierAllowlists.ts` and to `MCP_TOOL_ALLOWLIST_ENTRIES` in `electron/services/mcp-server/shared.ts`
- Kept out of `SYSTEM_TIER_ADDONS` — this is a non-destructive mutation, not a system-level operation

Resolves #10436

## Changes

- `shared/config/helpAssistantTierAllowlists.ts` — added `"terminal.rename"` to `ACTION_TIER_ADDONS` alongside the other terminal mutation tools
- `electron/services/mcp-server/shared.ts` — added `"terminal.rename"` to `MCP_TOOL_ALLOWLIST_ENTRIES`

## Testing

- `tsc` clean
- 413 unit tests pass
- Own-file lint/format clean