### PR TITLE
fix(dock): background previous tab on docked tab switch

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -134,6 +134,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
 
   const moveToDestination = useDockPanelPortal();
   const portalContainerElementRef = useRef<HTMLDivElement | null>(null);
+  const prevActivePanelIdRef = useRef<string | undefined>(undefined);
   const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
 
   const portalContainerRef = useCallback((node: HTMLDivElement | null) => {
@@ -149,6 +150,13 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   useEffect(() => {
     if (!activePanelId) return;
 
+    // Track the previously-active panel so a tab switch (activePanelId change
+    // while the group stays open) can downgrade the panel that just lost
+    // visibility. Update the ref on every valid-activePanelId path — including
+    // the early returns below — so it never goes stale across close/reopen.
+    const prevId = prevActivePanelIdRef.current;
+    prevActivePanelIdRef.current = activePanelId;
+
     if (!isOpen) {
       try {
         terminalInstanceService.applyRendererPolicy(activePanelId, TerminalRefreshTier.BACKGROUND);
@@ -156,6 +164,17 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         console.warn(`Failed to apply dock state for panel ${activePanelId}:`, error);
       }
       return;
+    }
+
+    // On a tab switch the previous panel is no longer visible behind the new
+    // one — drop it to BACKGROUND so it stops painting at the visible tier.
+    // The policy's downgrade hysteresis absorbs rapid tab-flips (t1→t2→t1).
+    if (prevId && prevId !== activePanelId) {
+      try {
+        terminalInstanceService.applyRendererPolicy(prevId, TerminalRefreshTier.BACKGROUND);
+      } catch (error) {
+        console.warn(`Failed to background previous dock panel ${prevId}:`, error);
+      }
     }
 
     if (!portalContainer) return;

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -653,6 +653,37 @@ describe("DockedTabGroup lifecycle and pop-out (#8160)", () => {
     );
   });
 
+  it("cancels the previous tab's pending VISIBLE RAF when switching before it fires (#10442)", () => {
+    // Switching tabs faster than a frame: the old panel's VISIBLE upgrade is
+    // still queued. The effect cleanup must cancel it so the now-inactive panel
+    // never reaches VISIBLE, while it is still downgraded to BACKGROUND.
+    mockActiveDockTerminalId = "t-1";
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"], "t-1"));
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    const { rerender } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+    // Do NOT flush — t-1's VISIBLE RAF is still pending.
+    expect(rafCallbacks.length).toBe(1);
+
+    mockActiveDockTerminalId = "t-2";
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"], "t-2"));
+    act(() => {
+      rerender(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-2")} panels={panels} />);
+    });
+
+    act(() => {
+      flushRaf();
+    });
+
+    const calls = vi.mocked(terminalInstanceService.applyRendererPolicy).mock.calls;
+    // t-1 was downgraded but never reached VISIBLE (its RAF was cancelled).
+    expect(calls).toContainEqual(["t-1", TerminalRefreshTier.BACKGROUND]);
+    expect(calls).not.toContainEqual(["t-1", TerminalRefreshTier.VISIBLE]);
+    expect(calls).toContainEqual(["t-2", TerminalRefreshTier.VISIBLE]);
+  });
+
   it("double-clicking the chip moves the active panel to the grid and closes the dock", () => {
     mockActiveDockTerminalId = "t-1";
     const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -604,6 +604,55 @@ describe("DockedTabGroup lifecycle and pop-out (#8160)", () => {
     expect(calls.some((c) => c[1] === TerminalRefreshTier.BACKGROUND)).toBe(true);
   });
 
+  it("backgrounds the previous tab and promotes the new one on a tab switch (#10442)", () => {
+    // Group stays open (activeDockTerminalId keeps pointing at a panel in the
+    // group); only the stored active tab changes. The previously-active panel
+    // must drop to BACKGROUND so it stops painting at the visible tier behind
+    // the popover — the new panel goes VISIBLE via the usual RAF.
+    mockActiveDockTerminalId = "t-1";
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"], "t-1"));
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    const { rerender } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    act(() => {
+      flushRaf();
+    });
+    expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
+      "t-1",
+      TerminalRefreshTier.VISIBLE
+    );
+    vi.mocked(terminalInstanceService.applyRendererPolicy).mockClear();
+
+    // Switch to tab t-2 while the group remains open.
+    mockActiveDockTerminalId = "t-2";
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"], "t-2"));
+    act(() => {
+      rerender(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-2")} panels={panels} />);
+    });
+
+    // The previous panel is downgraded synchronously; the new panel's VISIBLE
+    // upgrade is still RAF-gated.
+    expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
+      "t-1",
+      TerminalRefreshTier.BACKGROUND
+    );
+    expect(terminalInstanceService.applyRendererPolicy).not.toHaveBeenCalledWith(
+      "t-2",
+      TerminalRefreshTier.VISIBLE
+    );
+
+    act(() => {
+      flushRaf();
+    });
+    expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
+      "t-2",
+      TerminalRefreshTier.VISIBLE
+    );
+  });
+
   it("double-clicking the chip moves the active panel to the grid and closes the dock", () => {
     mockActiveDockTerminalId = "t-1";
     const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];


### PR DESCRIPTION
## Summary

- Switching tabs in an open docked tab group left the previously-active panel rendering at the `VISIBLE` refresh tier even though it was now hidden behind the popover, inflating the want-count and keeping terminals off the GPU path.
- The renderer-policy effect in `DockedTabGroup.tsx` only backgrounded a panel when the whole group closed. On a tab switch, it upgraded the incoming panel to `VISIBLE` but never downgraded the outgoing one.
- Fix tracks the prior active panel in a ref and explicitly downgrades it to `BACKGROUND` on switch. The policy's downgrade hysteresis absorbs rapid tab-flips cleanly.

Resolves #10442

## Changes

- `DockedTabGroup.tsx` — track previous `activePanelId` via ref; downgrade it to `BACKGROUND` before upgrading the newly active panel to `VISIBLE`
- `DockedTabGroup.mountGuard.test.tsx` — two regression tests: tab-switch policy transition and RAF-cancel on fast switch

## Testing

- Unit tests cover both the policy-transition path and the RAF-cancel path on rapid tab switches
- Same refresh-tier starvation class as #5878 — verified the stale `VISIBLE` panel no longer paints behind the popover after switching tabs