### PR TITLE
fix(panel): stop dragging a tab from arming the parent panel drag

### DIFF
--- a/src/components/Panel/PanelTabList.tsx
+++ b/src/components/Panel/PanelTabList.tsx
@@ -32,7 +32,11 @@ export function PanelTabList({
   const performanceMode = document.body.dataset.performanceMode === "true";
 
   return (
-    <div className={cn("relative min-w-0 flex-1 flex", className)}>
+    // [data-no-dnd] opts the whole tab strip out of the outer panel-move drag
+    // sensor (NoDndMouseSensor) so dragging/clicking a tab — or the add/overflow
+    // buttons — never arms the parent panel drag. Inner tab reorder is a separate
+    // DndContext using PointerSensor, which ignores [data-no-dnd], so it still works.
+    <div data-no-dnd className={cn("relative min-w-0 flex-1 flex", className)}>
       <div
         ref={tabListRef}
         className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none relative"

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -142,9 +142,10 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
     [onClose]
   );
 
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
-    // Stop propagation to prevent panel drag handle from capturing tab interactions
-    // This keeps tab clicks/drags separate from panel drags
+  const handleClosePointerDown = useCallback((e: React.PointerEvent) => {
+    // Keep the close button from bubbling into the panel drag handle. The close
+    // button is not a sortable activator, so this stays a pure stopPropagation —
+    // it must NOT route through the tab's sortable pointer listener.
     e.stopPropagation();
   }, []);
 
@@ -262,6 +263,24 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
   const { onKeyDown: sortableKeyDownListener, ...sortablePointerListeners } =
     sortableListeners ?? {};
   const sortableKeyDown = sortableKeyDownListener as ((e: React.KeyboardEvent) => void) | undefined;
+  const sortablePointerDown = sortablePointerListeners.onPointerDown as
+    | ((e: React.PointerEvent) => void)
+    | undefined;
+
+  // Composes the guard with dnd-kit's sortable activator. Spreading
+  // `sortablePointerListeners` would clobber a plain onPointerDown prop, so the
+  // tab div renders this AFTER the spread to win the prop race: stopPropagation
+  // keeps the pointerdown from leaking to ancestors, then we hand off to the
+  // sortable sensor so tab reorder still picks up. (The outer panel-move drag is
+  // already blocked by [data-no-dnd] on the tab strip, which gates its
+  // mousedown-based sensor; this guards the pointer path too.)
+  const handleTabPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.stopPropagation();
+      sortablePointerDown?.(e);
+    },
+    [sortablePointerDown]
+  );
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -290,7 +309,6 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
           tabIndex={isActive ? 0 : -1}
           onClick={handleClick}
           onKeyDown={handleKeyDown}
-          onPointerDown={handlePointerDown}
           className={cn(
             "relative flex items-center gap-1.5 px-2 py-1 text-xs font-medium select-none cursor-pointer group/tab",
             "border-r border-divider transition-colors",
@@ -302,6 +320,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
           data-tab-id={id}
           {...mergedAttributes}
           {...sortablePointerListeners}
+          onPointerDown={handleTabPointerDown}
         >
           {isActive && (
             <m.div
@@ -435,7 +454,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               <button
                 onClick={handleClose}
                 onKeyDown={handleCloseKeyDown}
-                onPointerDown={handlePointerDown}
+                onPointerDown={handleClosePointerDown}
                 className={cn(
                   "shrink-0 p-0.5 -mr-1 rounded transition-[opacity,color,background-color,border-color]",
                   "opacity-0 group-hover/tab:opacity-100 group-focus-visible/tab:opacity-100 focus-visible:opacity-100",

--- a/src/components/Panel/__tests__/PanelTabList.test.tsx
+++ b/src/components/Panel/__tests__/PanelTabList.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PanelTabList } from "../PanelTabList";
+import type { TabInfo } from "../TabButton";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+
+vi.mock("framer-motion", () => ({
+  LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  m: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+const tabs: TabInfo[] = [
+  {
+    id: "tab-1",
+    title: "Tab one",
+    chrome: deriveTerminalChrome(),
+    kind: "terminal",
+    isActive: true,
+  },
+];
+
+const baseProps = {
+  layoutGroupId: "group-1",
+  tabs,
+  tabListRef: () => {},
+  onKeyDown: () => {},
+  addTabTooltipContent: "Add",
+  overflowTrigger: null,
+  renderTab: (tab: TabInfo) => <span data-testid={`tab-${tab.id}`}>{tab.title}</span>,
+};
+
+describe("PanelTabList", () => {
+  it("marks the tab strip container with [data-no-dnd] so it opts out of the panel-move drag (issue #10443)", () => {
+    const { container } = render(<PanelTabList {...baseProps} />);
+    const noDnd = container.querySelector("[data-no-dnd]");
+    expect(noDnd).not.toBeNull();
+    // The tablist (and therefore the rendered tabs) must live inside the opt-out
+    // boundary, so a mousedown anywhere in the strip never arms the parent panel.
+    const tablist = screen.getByRole("tablist");
+    expect(noDnd?.contains(tablist)).toBe(true);
+    expect(noDnd?.contains(screen.getByTestId("tab-tab-1"))).toBe(true);
+  });
+
+  it("keeps the add-tab button inside the [data-no-dnd] boundary", () => {
+    const { container } = render(<PanelTabList {...baseProps} onAddTab={vi.fn()} />);
+    const noDnd = container.querySelector("[data-no-dnd]");
+    const addButton = screen.getByLabelText("Duplicate panel as new tab");
+    expect(noDnd?.contains(addButton)).toBe(true);
+  });
+});

--- a/src/components/Panel/__tests__/PanelTabList.test.tsx
+++ b/src/components/Panel/__tests__/PanelTabList.test.tsx
@@ -60,4 +60,16 @@ describe("PanelTabList", () => {
     const addButton = screen.getByLabelText("Duplicate panel as new tab");
     expect(noDnd?.contains(addButton)).toBe(true);
   });
+
+  it("keeps the overflow trigger inside the [data-no-dnd] boundary", () => {
+    // The overflow trigger renders as a sibling of the tablist (outside the inner
+    // tab-wrapping div), so it only stays protected as long as the boundary sits
+    // on the outer container. This guards against narrowing it and re-exposing
+    // the bug for that button.
+    const { container } = render(
+      <PanelTabList {...baseProps} overflowTrigger={<button data-testid="overflow">More</button>} />
+    );
+    const noDnd = container.querySelector("[data-no-dnd]");
+    expect(noDnd?.contains(screen.getByTestId("overflow"))).toBe(true);
+  });
 });

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -666,4 +666,52 @@ describe("TabButton", () => {
       expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("pointer drag composition (issue #10443)", () => {
+    it("stops the tab pointerdown from bubbling to the parent panel drag surface", () => {
+      const parentPointerDown = vi.fn();
+      const sensorPointerDown = vi.fn();
+      render(
+        <div onPointerDown={parentPointerDown}>
+          <TabButton {...defaultProps} sortableListeners={{ onPointerDown: sensorPointerDown }} />
+        </div>
+      );
+      fireEvent.pointerDown(screen.getByRole("tab"));
+      // Guard stops propagation so the parent panel-move drag is never armed...
+      expect(parentPointerDown).not.toHaveBeenCalled();
+      // ...but the inner tab sortable sensor still receives the pointerdown so
+      // tab reorder can pick up. This proves the spread no longer clobbers it.
+      expect(sensorPointerDown).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not route the close button pointerdown through the sortable sensor", () => {
+      const parentPointerDown = vi.fn();
+      const sensorPointerDown = vi.fn();
+      render(
+        <div onPointerDown={parentPointerDown}>
+          <TabButton
+            {...defaultProps}
+            onClose={vi.fn()}
+            sortableListeners={{ onPointerDown: sensorPointerDown }}
+          />
+        </div>
+      );
+      fireEvent.pointerDown(screen.getByLabelText("Close Test Agent"));
+      // Close button is not a drag activator: it stops propagation outright and
+      // must NOT pick up a tab drag, so neither the parent nor the sortable fire.
+      expect(parentPointerDown).not.toHaveBeenCalled();
+      expect(sensorPointerDown).not.toHaveBeenCalled();
+    });
+
+    it("still stops propagation when no sortable listeners are wired", () => {
+      const parentPointerDown = vi.fn();
+      render(
+        <div onPointerDown={parentPointerDown}>
+          <TabButton {...defaultProps} />
+        </div>
+      );
+      fireEvent.pointerDown(screen.getByRole("tab"));
+      expect(parentPointerDown).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Dragging or clicking a tab in the panel header tab strip was also arming the outer panel move-drag — the panel header uses a mousedown-based `NoDndMouseSensor` as its drag surface, and tab pointer events bubbled up to it
- `TabButton`'s `pointerdown` guard was being clobbered by the `sortable-listeners` prop spread that came after it, and stopping `pointerdown` doesn't block a `mousedown`-based sensor anyway
- Fix is two layers: `[data-no-dnd]` on the `PanelTabList` container so `NoDndMouseSensor` refuses to arm for any tab-strip interaction; composed `onPointerDown` rendered after the sortable-listeners spread so the guard wins — tab reorder is unaffected (separate `PointerSensor` context that ignores `[data-no-dnd]`)

Resolves #10443

## Changes

- `PanelTabList.tsx` — add `data-no-dnd` to the tab strip container
- `TabButton.tsx` — render composed `onPointerDown` after the sortable-listeners spread so it isn't clobbered; close button keeps a pure `stopPropagation` handler
- `PanelTabList.test.tsx` (new) — asserts that tabs, the add-tab button, and overflow trigger all live inside the `[data-no-dnd]` boundary
- `TabButton.test.tsx` — new pointer-composition tests covering the guard / sortable handoff

## Testing

123 tests pass across the `TabButton`, `PanelTabList`, `PanelHeader`, and `noDndSensor` suites. Manually verified: dragging a tab reorders without co-arming the panel move-drag; keyboard panel-drag still works (`[data-no-dnd]` only gates mouse/touch activators).