### PR TITLE
fix(hydration): preserve tab-group membership when a panel respawns with a new id

### DIFF
--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -1120,7 +1120,13 @@ describe("hydrateAppState", () => {
     ];
     projectClientMock.getTabGroups.mockResolvedValue(persistedTabGroups);
 
-    const addPanel = vi.fn().mockResolvedValue("terminal-id");
+    // Echo the requested id so each panel restores under its saved id (the
+    // clean cold-restart path). This keeps the saved→restored remap empty, so
+    // tab groups hydrate unchanged (#10440).
+    const addPanel = vi.fn(
+      async (args: { requestedId?: string; existingId?: string }) =>
+        args.requestedId ?? args.existingId ?? "terminal-id"
+    );
     const setActiveWorktree = vi.fn();
     const loadRecipes = vi.fn().mockResolvedValue(undefined);
     const openDiagnosticsDock = vi.fn();
@@ -1140,6 +1146,84 @@ describe("hydrateAppState", () => {
     // Verify hydrateTabGroups was called with the persisted groups
     expect(hydrateTabGroups).toHaveBeenCalledTimes(1);
     expect(hydrateTabGroups).toHaveBeenCalledWith(persistedTabGroups);
+  });
+
+  it("remaps tab-group panel ids when a panel respawns with a generated id (#10440)", async () => {
+    // A persisted PTY panel whose reconnect times out respawns under a fresh
+    // generated id. The saved tab group still references the old id; without the
+    // remap, hydrateTabGroups would filter it out, shrink the group to one
+    // member, and discard it — permanently destroying the grouping.
+    appClientMock.hydrate.mockResolvedValue({
+      appState: {
+        terminals: [
+          {
+            id: "old-panel-id",
+            kind: "terminal",
+            title: "Terminal 1",
+            cwd: "/project",
+            location: "grid",
+          },
+          {
+            id: "stable-panel-id",
+            kind: "terminal",
+            title: "Terminal 2",
+            cwd: "/project",
+            location: "grid",
+          },
+        ],
+        sidebarWidth: 350,
+      },
+      terminalConfig,
+      project,
+      agentSettings,
+    });
+
+    // Persisted group references the pre-restart saved ids.
+    const persistedTabGroups = [
+      {
+        id: "group-1",
+        location: "grid",
+        worktreeId: undefined,
+        activeTabId: "old-panel-id",
+        panelIds: ["old-panel-id", "stable-panel-id"],
+      },
+    ];
+    projectClientMock.getTabGroups.mockResolvedValue(persistedTabGroups);
+
+    // The first panel's reconnect times out (reconnectManager surfaces the
+    // 2000ms rejection as status "timeout"), so it respawns with requestedId
+    // undefined and the store assigns "new-panel-id". The second misses (not
+    // found) and respawns under its saved id.
+    terminalClientMock.reconnect.mockImplementation(async (id: string) => {
+      if (id === "old-panel-id") throw new Error("Reconnection timeout");
+      return { exists: false };
+    });
+    const addPanel = vi.fn(async (args: { requestedId?: string; existingId?: string }) =>
+      args.requestedId === undefined ? "new-panel-id" : args.requestedId
+    );
+    const setActiveWorktree = vi.fn();
+    const loadRecipes = vi.fn().mockResolvedValue(undefined);
+    const openDiagnosticsDock = vi.fn();
+    const hydrateTabGroups = vi.fn();
+
+    await hydrateAppState({
+      addPanel,
+      setActiveWorktree,
+      loadRecipes,
+      openDiagnosticsDock,
+      hydrateTabGroups,
+    });
+
+    // hydrateTabGroups receives the group with the old id remapped to the new
+    // runtime id (both panelIds membership and the activeTabId pointer).
+    expect(hydrateTabGroups).toHaveBeenCalledTimes(1);
+    expect(hydrateTabGroups).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: "group-1",
+        activeTabId: "new-panel-id",
+        panelIds: ["new-panel-id", "stable-panel-id"],
+      }),
+    ]);
   });
 
   it("clears tab groups when no persisted groups exist", async () => {

--- a/src/utils/__tests__/stateHydration.test.ts
+++ b/src/utils/__tests__/stateHydration.test.ts
@@ -1226,6 +1226,82 @@ describe("hydrateAppState", () => {
     ]);
   });
 
+  it("does not throw on a malformed group during remap, preserving valid groups (#10440)", async () => {
+    // A malformed persisted group (panelIds not an array) must pass through the
+    // remap untouched rather than throwing — otherwise the catch path would wipe
+    // every group for the session. Requires the remap to be active (size > 0).
+    appClientMock.hydrate.mockResolvedValue({
+      appState: {
+        terminals: [
+          {
+            id: "old-panel-id",
+            kind: "terminal",
+            title: "Terminal 1",
+            cwd: "/project",
+            location: "grid",
+          },
+          {
+            id: "stable-panel-id",
+            kind: "terminal",
+            title: "Terminal 2",
+            cwd: "/project",
+            location: "grid",
+          },
+        ],
+        sidebarWidth: 350,
+      },
+      terminalConfig,
+      project,
+      agentSettings,
+    });
+
+    const persistedTabGroups = [
+      // Malformed — panelIds is not an array. Must survive the remap untouched.
+      { id: "bad", location: "grid", worktreeId: undefined, activeTabId: "x", panelIds: null },
+      {
+        id: "group-1",
+        location: "grid",
+        worktreeId: undefined,
+        activeTabId: "old-panel-id",
+        panelIds: ["old-panel-id", "stable-panel-id"],
+      },
+    ];
+    projectClientMock.getTabGroups.mockResolvedValue(persistedTabGroups);
+
+    terminalClientMock.reconnect.mockImplementation(async (id: string) => {
+      if (id === "old-panel-id") throw new Error("Reconnection timeout");
+      return { exists: false };
+    });
+    const addPanel = vi.fn(async (args: { requestedId?: string; existingId?: string }) =>
+      args.requestedId === undefined ? "new-panel-id" : args.requestedId
+    );
+    const setActiveWorktree = vi.fn();
+    const loadRecipes = vi.fn().mockResolvedValue(undefined);
+    const openDiagnosticsDock = vi.fn();
+    const hydrateTabGroups = vi.fn();
+
+    await hydrateAppState({
+      addPanel,
+      setActiveWorktree,
+      loadRecipes,
+      openDiagnosticsDock,
+      hydrateTabGroups,
+    });
+
+    // The remap ran (no throw), the malformed group passed through unchanged,
+    // and the valid group was remapped. The catch path (which would call with
+    // [] + skipPersist) never fired.
+    expect(hydrateTabGroups).toHaveBeenCalledTimes(1);
+    expect(hydrateTabGroups).toHaveBeenCalledWith([
+      expect.objectContaining({ id: "bad", panelIds: null }),
+      expect.objectContaining({
+        id: "group-1",
+        activeTabId: "new-panel-id",
+        panelIds: ["new-panel-id", "stable-panel-id"],
+      }),
+    ]);
+  });
+
   it("clears tab groups when no persisted groups exist", async () => {
     // When there are no persisted tab groups, hydrateTabGroups should be
     // called with an empty array to clear any stale state.

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -56,12 +56,20 @@ vi.mock("../statePatcher", () => ({
     worktreeId: s.worktreeId,
     existingId: rt.id,
   }),
-  buildArgsForRespawn: (s: TerminalState, kind: string) => ({
+  buildArgsForRespawn: (
+    s: TerminalState,
+    kind: string,
+    _projectRoot?: string,
+    _agentSettings?: unknown,
+    reconnectTimedOut?: boolean
+  ) => ({
     cwd: s.cwd ?? "/cwd",
     kind,
     location: s.location === "dock" ? "dock" : "grid",
     worktreeId: s.worktreeId,
-    requestedId: s.id,
+    // Mirror the real buildArgsForRespawn: a timed-out reconnect drops the
+    // requested id so the store generates a fresh one (#10440).
+    requestedId: reconnectTimedOut ? undefined : s.id,
     launchAgentId: s.launchAgentId,
   }),
   buildArgsForNonPtyRecreation: (s: TerminalState, kind: string) => ({
@@ -503,5 +511,72 @@ describe("restorePanelsPhase — matched backend not re-appended as orphan", () 
       (call) => (call[0] as { existingId?: string }).existingId
     );
     expect(ids.sort()).toEqual(["matched", "orphan"]);
+  });
+});
+
+describe("restorePanelsPhase — savedIdToRestoredId remap (issue #10440)", () => {
+  it("maps the saved id to the freshly generated id when a PTY reconnect times out", async () => {
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "timeout" });
+    const ctx = makeContext();
+    // A timed-out respawn passes requestedId: undefined, so the store assigns a
+    // new id — model that here and assert the map captures saved → new.
+    ctx.addPanel.mockImplementation(
+      async (args: { requestedId?: string; existingId?: string }) =>
+        args.requestedId ?? args.existingId ?? "regenerated-id"
+    );
+    const { savedIdToRestoredId } = await restorePanelsPhase(
+      [panel("p1", { kind: "agent", launchAgentId: "claude" })],
+      ctx
+    );
+    expect(savedIdToRestoredId.get("p1")).toBe("regenerated-id");
+    expect(savedIdToRestoredId.size).toBe(1);
+  });
+
+  it("leaves the map empty when a respawn keeps the saved id (not_found, no timeout)", async () => {
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "not_found" });
+    const ctx = makeContext();
+    // not_found respawn keeps requestedId: "p1", so addPanel returns "p1" — the
+    // restored id equals the saved id, an identity mapping that is excluded.
+    const { savedIdToRestoredId } = await restorePanelsPhase(
+      [panel("p1", { kind: "agent", launchAgentId: "claude" })],
+      ctx
+    );
+    expect(savedIdToRestoredId.size).toBe(0);
+  });
+
+  it("excludes identity mappings for cleanly reconnected backend terminals", async () => {
+    const ctx = makeContext();
+    ctx.backendTerminalMap.set("t1", backend("t1"));
+    const { savedIdToRestoredId } = await restorePanelsPhase([panel("t1")], ctx);
+    // Backend reconnect restores under existingId "t1" — same as saved, skipped.
+    expect(savedIdToRestoredId.size).toBe(0);
+  });
+
+  it("maps only the timed-out panel, leaving cleanly restored siblings out", async () => {
+    // p1 times out (new id); p2 reconnects cleanly under its saved id.
+    reconnectWithTimeoutMock.mockImplementation(async (id: string) =>
+      id === "p1" ? { status: "timeout" } : { status: "not_found" }
+    );
+    const ctx = makeContext();
+    ctx.addPanel.mockImplementation(
+      async (args: { requestedId?: string; existingId?: string }) =>
+        args.requestedId ?? args.existingId ?? "new-p1"
+    );
+    const { savedIdToRestoredId } = await restorePanelsPhase(
+      [
+        panel("p1", { kind: "agent", launchAgentId: "claude" }),
+        panel("p2", { kind: "agent", launchAgentId: "claude" }),
+      ],
+      ctx
+    );
+    expect(savedIdToRestoredId.size).toBe(1);
+    expect(savedIdToRestoredId.get("p1")).toBe("new-p1");
+    expect(savedIdToRestoredId.has("p2")).toBe(false);
+  });
+
+  it("returns an empty map when there are no saved panels", async () => {
+    const ctx = makeContext();
+    const { savedIdToRestoredId } = await restorePanelsPhase(undefined, ctx);
+    expect(savedIdToRestoredId.size).toBe(0);
   });
 });

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -579,4 +579,37 @@ describe("restorePanelsPhase — savedIdToRestoredId remap (issue #10440)", () =
     const { savedIdToRestoredId } = await restorePanelsPhase(undefined, ctx);
     expect(savedIdToRestoredId.size).toBe(0);
   });
+
+  it("maps every timed-out panel independently with no cross-contamination", async () => {
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "timeout" });
+    const ctx = makeContext();
+    // Each respawn (requestedId undefined) gets a distinct generated id.
+    let next = 0;
+    ctx.addPanel.mockImplementation(
+      async (args: { requestedId?: string; existingId?: string }) =>
+        args.requestedId ?? args.existingId ?? `gen-${++next}`
+    );
+    const { savedIdToRestoredId } = await restorePanelsPhase(
+      [
+        panel("p1", { kind: "agent", launchAgentId: "claude" }),
+        panel("p2", { kind: "agent", launchAgentId: "claude" }),
+      ],
+      ctx
+    );
+    expect(savedIdToRestoredId.size).toBe(2);
+    expect(savedIdToRestoredId.get("p1")).toBe("gen-1");
+    expect(savedIdToRestoredId.get("p2")).toBe("gen-2");
+  });
+
+  it("returns an error-status panel under its saved id with no remap entry", async () => {
+    // status "error" (IPC failure, not timeout) keeps requestedId: saved.id, so
+    // the panel restores under its saved id — an identity mapping, excluded.
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "error", error: new Error("ipc") });
+    const ctx = makeContext();
+    const { savedIdToRestoredId } = await restorePanelsPhase(
+      [panel("p1", { kind: "agent", launchAgentId: "claude" })],
+      ctx
+    );
+    expect(savedIdToRestoredId.size).toBe(0);
+  });
 });

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -346,6 +346,12 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
     }
 
     if (currentProjectId) {
+      // Saved→restored panel id remap produced by restorePanelsPhase; consumed
+      // by the tab-group hydration block below. Declared here (not in the
+      // restore try) so it survives into that block even if panel restore
+      // throws, in which case it stays empty and tab groups hydrate unremapped
+      // exactly as before (#10440).
+      let savedIdToRestoredId = new Map<string, string>();
       try {
         const backendTerminals = await getForProjectPromise;
         finishGetForProjectSpan?.();
@@ -436,7 +442,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
         const prefetchedReconnectResults = await reconnectPrefetchPromise;
 
-        const { restoreTasks } = await restorePanelsPhase(appState.terminals, {
+        const restoreResult = await restorePanelsPhase(appState.terminals, {
           addPanel,
           withHydrationBatch,
           backendTerminalMap,
@@ -452,6 +458,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
           safeMode: hydrateResult.safeMode,
           logHydrationInfo,
         });
+        const { restoreTasks } = restoreResult;
+        // Capture the saved→restored panel id remap so the tab-group block
+        // below (outside this try) can keep group membership intact when a
+        // panel respawned with a fresh id (#10440).
+        savedIdToRestoredId = restoreResult.savedIdToRestoredId;
 
         // Schedule scrollback restores at background priority — no blocking IPC
         // fetch on the critical path. The overlay can dismiss immediately and
@@ -494,7 +505,24 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
               logHydrationInfo("Clearing stale tab groups (no groups for project)");
             }
             tabGroupRestoreCount = tabGroups.length;
-            options.hydrateTabGroups(tabGroups);
+            // Remap persisted panel ids onto the ids panels actually restored
+            // under before handing off to hydrateTabGroups. A panel whose PTY
+            // reconnect timed out respawns with a fresh id, so its persisted
+            // tab-group entry points at a now-dead saved id; without this remap
+            // hydrateTabGroups filters that id out, the group shrinks to one
+            // member, and it is discarded and persisted away — permanently
+            // destroying the grouping (#10440). The map is sparse and empty
+            // whenever every panel kept its saved id, so the fast path leaves
+            // the original array untouched.
+            const remappedTabGroups =
+              savedIdToRestoredId.size > 0
+                ? tabGroups.map((group) => ({
+                    ...group,
+                    activeTabId: savedIdToRestoredId.get(group.activeTabId) ?? group.activeTabId,
+                    panelIds: group.panelIds.map((id) => savedIdToRestoredId.get(id) ?? id),
+                  }))
+                : tabGroups;
+            options.hydrateTabGroups(remappedTabGroups);
             markRendererPerformance(PERF_MARKS.HYDRATE_RESTORE_TAB_GROUPS_END, {
               tabGroupCount: tabGroupRestoreCount,
             });

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -516,11 +516,20 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
             // the original array untouched.
             const remappedTabGroups =
               savedIdToRestoredId.size > 0
-                ? tabGroups.map((group) => ({
-                    ...group,
-                    activeTabId: savedIdToRestoredId.get(group.activeTabId) ?? group.activeTabId,
-                    panelIds: group.panelIds.map((id) => savedIdToRestoredId.get(id) ?? id),
-                  }))
+                ? tabGroups.map((group) =>
+                    // Leave malformed groups untouched so hydrateTabGroups' own
+                    // sanitizer handles them exactly as before — mapping over a
+                    // non-array panelIds here would throw and the catch below
+                    // would wipe every group for the session.
+                    Array.isArray(group.panelIds)
+                      ? {
+                          ...group,
+                          activeTabId:
+                            savedIdToRestoredId.get(group.activeTabId) ?? group.activeTabId,
+                          panelIds: group.panelIds.map((id) => savedIdToRestoredId.get(id) ?? id),
+                        }
+                      : group
+                  )
                 : tabGroups;
             options.hydrateTabGroups(remappedTabGroups);
             markRendererPerformance(PERF_MARKS.HYDRATE_RESTORE_TAB_GROUPS_END, {

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -63,6 +63,16 @@ interface PanelRestoreTaskEntry {
 
 export interface PanelRestorePhaseResult {
   restoreTasks: TerminalRestoreTask[];
+  /**
+   * Sparse map of saved panel id → restored panel id, populated only for
+   * panels whose restored id differs from their saved id (e.g. a PTY panel
+   * whose reconnect timed out and was respawned with a freshly generated id,
+   * see #10440). Consumers that reference saved ids — notably tab-group
+   * hydration — must remap through this before validating against live ids,
+   * or the membership is silently filtered out and the group destroyed.
+   * Empty when every panel restored under its original saved id.
+   */
+  savedIdToRestoredId: Map<string, string>;
 }
 
 /**
@@ -95,6 +105,7 @@ export async function restorePanelsPhase(
   } = ctx;
 
   const restoreTasks: TerminalRestoreTask[] = [];
+  const savedIdToRestoredId = new Map<string, string>();
 
   if (savedPanels && savedPanels.length > 0) {
     // Build a single-pass map of worktreeId → highest lastActiveAt across saved
@@ -442,6 +453,17 @@ export async function restorePanelsPhase(
         .map(([, id]) => id);
       restoreTerminalOrder(orderedIds);
     }
+
+    // Build the saved→restored id remap (#10440). Only panels whose restored
+    // id diverged from the saved id need an entry; identity mappings (the
+    // common clean-reconnect case) are skipped so downstream consumers can
+    // fast-path on an empty map.
+    for (const [index, restoredId] of restoredIdsByIndex.entries()) {
+      const savedId = savedPanels[index]?.id;
+      if (savedId !== undefined && savedId !== restoredId) {
+        savedIdToRestoredId.set(savedId, restoredId);
+      }
+    }
   }
 
   // Restore any orphaned backend terminals not in saved state (append at end).
@@ -527,5 +549,5 @@ export async function restorePanelsPhase(
     }
   }
 
-  return { restoreTasks };
+  return { restoreTasks, savedIdToRestoredId };
 }


### PR DESCRIPTION
## Summary

- When a PTY panel times out on reconnect during restore, it gets a fresh generated id. Tab groups still reference the old saved id, so `hydrateTabGroups` drops the unknown member, shrinks the group to ≤1 panel, discards it, and persists the loss — permanently.
- Fix threads a sparse `savedIdToRestoredId` map out of `restorePanelsPhase` (built from the already-tracked `restoredIdsByIndex`), then remaps each group's `panelIds` and `activeTabId` in the hydration orchestrator before `hydrateTabGroups` runs. Fast-path leaves groups untouched when every panel kept its saved id. Malformed groups (non-array `panelIds`) pass through to `hydrateTabGroups`' own sanitizer unchanged.
- 108 tests pass — unit coverage for the remap map (timeout→remap, `not_found`/error→identity excluded, multi-timeout independence, undefined `savedPanels`) and integration coverage for the remapped `hydrateTabGroups` handoff plus malformed-group passthrough.

Closes #10440

## Changes

- `src/utils/stateHydration/panelRestorePhase.ts` — return `savedIdToRestoredId` alongside existing return values
- `src/utils/stateHydration/index.ts` — consume the map and remap tab-group membership before hydration
- `src/utils/__tests__/panelRestorePhase.test.ts` — unit tests for map construction
- `src/utils/__tests__/stateHydration.test.ts` — integration tests for remapped handoff and malformed-group passthrough

## Testing

Unit and integration tests added; all 108 pass. The core restore-phase logic was verified against the reconnect-timeout path that produces new ids, and the fast-path (no timeouts) leaves tab groups unmodified.