### PR TITLE
feat(agent): let the assistant name agent terminals at spawn time

### DIFF
--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -46,7 +46,7 @@ These cover ~90% of what the assistant is asked to do. They all live in the defa
 
 ### Spawn an agent on a task
 
-1. `agent.launch({ agentId: "claude" | "codex" | "gemini" | …, prompt: <task>, worktreeId: <id> })` — single round-trip per agent. The `prompt` field becomes the agent's first message; you don't need to send it separately. Each call returns a `terminalId` you can map back to the prompt you sent.
+1. `agent.launch({ agentId: "claude" | "codex" | "gemini" | …, prompt: <task>, worktreeId: <id>, name: <short label> })` — single round-trip per agent. The `prompt` field becomes the agent's first message; you don't need to send it separately. **Always pass `name`** — a short task-descriptive label (e.g. `"Claude: auth refactor"`) that becomes the terminal tab title so the user can tell parallel agents apart at a glance. The name is pinned, so agent detection won't overwrite it. Each call returns a `terminalId` you can map back to the prompt you sent.
 2. **Fan out in parallel batches of up to 4.** For N agents, fire up to 4 `agent.launch` calls in parallel within a single message. The Claude Code harness executes multi-tool turns concurrently, so the calls land at the backend together. For N > 4, chunk into multiple messages of ≤ 4 so the user sees natural progress between batches. Do **not** insert `terminal.getStatus` round-trips between launches — that's the slow loop we're avoiding.
 3. Once every batch is dispatched, do **one** `terminal.getStatus({ terminalIds: [<all ids>], includeOutput: { lines: 20 } })` to confirm each terminal picked up its prompt, then report a state summary grouped by `working` / `waiting` / `completed` / `exited`. Sequential one-at-a-time pacing is only appropriate when the user explicitly asks for it.
 
@@ -61,7 +61,7 @@ These cover ~90% of what the assistant is asked to do. They all live in the defa
 
 Action tier exposes several spawn/send tools that look similar. Pick by what you need:
 
-- **Spawn an AI agent with a task** → `agent.launch` (single round-trip, takes `prompt`). Use for "run /research on X", "have Claude work on issue #123", etc.
+- **Spawn an AI agent with a task** → `agent.launch` (single round-trip, takes `prompt` and a `name` for the tab title). Use for "run /research on X", "have Claude work on issue #123", etc. Always set `name` to a short task label so parallel agents are distinguishable.
 - **Spawn a plain shell** → `terminal.new` or `agent.terminal` (aliases — both spawn a non-agent shell). Use only when the user wants a raw terminal, not an agent.
 - **Send a prompt to a running agent** → `terminal.sendCommand` (raw text + Enter). Use for follow-ups.
 - **Inject project context into the focused terminal** → `terminal.inject` (no args; dumps the project's prepared CopyTree context). Use only when the user explicitly asks to inject context — not a general-purpose prompt sender.

--- a/scripts/help-src/CLAUDE.tasks.md
+++ b/scripts/help-src/CLAUDE.tasks.md
@@ -30,7 +30,7 @@ These cover ~90% of what the assistant is asked to do. They all live in the defa
 
 ### Spawn an agent on a task
 
-1. `agent.launch({ agentId: "claude" | "codex" | "gemini" | …, prompt: <task>, worktreeId: <id> })` — single round-trip per agent. The `prompt` field becomes the agent's first message; you don't need to send it separately. Each call returns a `terminalId` you can map back to the prompt you sent.
+1. `agent.launch({ agentId: "claude" | "codex" | "gemini" | …, prompt: <task>, worktreeId: <id>, name: <short label> })` — single round-trip per agent. The `prompt` field becomes the agent's first message; you don't need to send it separately. **Always pass `name`** — a short task-descriptive label (e.g. `"Claude: auth refactor"`) that becomes the terminal tab title so the user can tell parallel agents apart at a glance. The name is pinned, so agent detection won't overwrite it. Each call returns a `terminalId` you can map back to the prompt you sent.
 2. **Fan out in parallel batches of up to 4.** For N agents, fire up to 4 `agent.launch` calls in parallel within a single message. The Claude Code harness executes multi-tool turns concurrently, so the calls land at the backend together. For N > 4, chunk into multiple messages of ≤ 4 so the user sees natural progress between batches. Do **not** insert `terminal.getStatus` round-trips between launches — that's the slow loop we're avoiding.
 3. Once every batch is dispatched, do **one** `terminal.getStatus({ terminalIds: [<all ids>], includeOutput: { lines: 20 } })` to confirm each terminal picked up its prompt, then report a state summary grouped by `working` / `waiting` / `completed` / `exited`. Sequential one-at-a-time pacing is only appropriate when the user explicitly asks for it.
 
@@ -45,7 +45,7 @@ These cover ~90% of what the assistant is asked to do. They all live in the defa
 
 Action tier exposes several spawn/send tools that look similar. Pick by what you need:
 
-- **Spawn an AI agent with a task** → `agent.launch` (single round-trip, takes `prompt`). Use for "run /research on X", "have Claude work on issue #123", etc.
+- **Spawn an AI agent with a task** → `agent.launch` (single round-trip, takes `prompt` and a `name` for the tab title). Use for "run /research on X", "have Claude work on issue #123", etc. Always set `name` to a short task label so parallel agents are distinguishable.
 - **Spawn a plain shell** → `terminal.new` or `agent.terminal` (aliases — both spawn a non-agent shell). Use only when the user wants a raw terminal, not an agent.
 - **Send a prompt to a running agent** → `terminal.sendCommand` (raw text + Enter). Use for follow-ups.
 - **Inject project context into the focused terminal** → `terminal.inject` (no args; dumps the project's prepared CopyTree context). Use only when the user explicitly asks to inject context — not a general-purpose prompt sender.

--- a/src/hooks/__tests__/useAgentLauncher.titleResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.titleResolution.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+/**
+ * Tests the assistant-supplied `name` → title / titleMode resolution from
+ * useAgentLauncher.ts (issue #10439).
+ *
+ * The full hook has deep React/Electron dependencies that make direct rendering
+ * costly here, so we mirror the pure branching logic that builds the
+ * `AddPanelOptions.title` / `titleMode` pair — see `trimmedName` / `customTitle`
+ * in useAgentLauncher.ts. Any change to those lines should require a
+ * corresponding update here.
+ */
+import { describe, it, expect } from "vitest";
+
+// ── mirror of the hook's title-resolution block ──────────────────────────────
+// Mirrors:
+//   const trimmedName = launchOptions?.name?.trim();
+//   const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
+//   title: trimmedName || computedTitle,
+//   ...customTitle
+function resolveTitle(
+  computedTitle: string,
+  name: string | undefined
+): { title: string; titleMode?: "custom" } {
+  const trimmedName = name?.trim();
+  const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
+  return { title: trimmedName || computedTitle, ...customTitle };
+}
+
+const DEFAULT_TITLE = "Claude";
+
+describe("assistant-supplied name → title / titleMode", () => {
+  it("uses the name as the title and pins it with titleMode 'custom'", () => {
+    expect(resolveTitle(DEFAULT_TITLE, "Claude: auth refactor")).toEqual({
+      title: "Claude: auth refactor",
+      titleMode: "custom",
+    });
+  });
+
+  it("trims surrounding whitespace from a non-empty name", () => {
+    expect(resolveTitle(DEFAULT_TITLE, "  research work  ")).toEqual({
+      title: "research work",
+      titleMode: "custom",
+    });
+  });
+
+  it("falls back to the computed title and sets no titleMode when name is undefined", () => {
+    const result = resolveTitle(DEFAULT_TITLE, undefined);
+    expect(result.title).toBe(DEFAULT_TITLE);
+    expect(result.titleMode).toBeUndefined();
+  });
+
+  it("falls back to the computed title and sets no titleMode when name is empty", () => {
+    const result = resolveTitle(DEFAULT_TITLE, "");
+    expect(result.title).toBe(DEFAULT_TITLE);
+    expect(result.titleMode).toBeUndefined();
+  });
+
+  it("falls back to the computed title and sets no titleMode when name is whitespace only", () => {
+    const result = resolveTitle(DEFAULT_TITLE, "   ");
+    expect(result.title).toBe(DEFAULT_TITLE);
+    expect(result.titleMode).toBeUndefined();
+  });
+
+  it("does not pin (titleMode) merely because a computed title exists", () => {
+    // The pin is owned by the caller's name, never by the default title — so a
+    // default-titled launch stays free for agent detection to relabel.
+    const result = resolveTitle(DEFAULT_TITLE, undefined);
+    expect(result.titleMode).toBeUndefined();
+  });
+});

--- a/src/hooks/__tests__/useAgentLauncher.titleResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.titleResolution.test.ts
@@ -12,16 +12,22 @@
 import { describe, it, expect } from "vitest";
 
 // ── mirror of the hook's title-resolution block ──────────────────────────────
-// Mirrors:
-//   const trimmedName = launchOptions?.name?.trim();
-//   const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
-//   title: trimmedName || computedTitle,
-//   ...customTitle
+// Mirrors `sanitizeTerminalName` + the trimmedName/customTitle branch in
+// useAgentLauncher.ts. Any change to that logic should update this mirror.
+function sanitizeTerminalName(raw: string): string {
+  let out = "";
+  for (const ch of raw) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += code <= 0x1f || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim();
+}
+
 function resolveTitle(
   computedTitle: string,
   name: string | undefined
 ): { title: string; titleMode?: "custom" } {
-  const trimmedName = name?.trim();
+  const trimmedName = name ? sanitizeTerminalName(name) : undefined;
   const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
   return { title: trimmedName || computedTitle, ...customTitle };
 }
@@ -41,6 +47,19 @@ describe("assistant-supplied name → title / titleMode", () => {
       title: "research work",
       titleMode: "custom",
     });
+  });
+
+  it("strips control characters and collapses whitespace from the name", () => {
+    expect(resolveTitle(DEFAULT_TITLE, "Claude:\tauth\n\nrefactor")).toEqual({
+      title: "Claude: auth refactor",
+      titleMode: "custom",
+    });
+  });
+
+  it("falls back to the default when the name is only control characters", () => {
+    const result = resolveTitle(DEFAULT_TITLE, "\t\n\r");
+    expect(result.title).toBe(DEFAULT_TITLE);
+    expect(result.titleMode).toBeUndefined();
   });
 
   it("falls back to the computed title and sets no titleMode when name is undefined", () => {

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -43,6 +43,24 @@ function escapePowerShellSingleQuoted(value: string): string {
   return `'${value.replace(/'/g, "''")}'`;
 }
 
+/**
+ * Sanitize an assistant-supplied terminal name for use as a panel title.
+ * Strips ASCII control characters (an LLM could emit newlines, tabs, or ANSI
+ * escape sequences), collapses internal whitespace, and trims. Returns "" when
+ * nothing printable remains, which the caller treats as "no name" (falls back
+ * to the default computed title with no `titleMode` pin).
+ */
+function sanitizeTerminalName(raw: string): string {
+  let out = "";
+  for (const ch of raw) {
+    const code = ch.codePointAt(0) ?? 0;
+    // Drop C0 controls (0x00–0x1f) and DEL (0x7f); replace with a space so
+    // adjacent words don't fuse, then collapse the runs below.
+    out += code <= 0x1f || code === 0x7f ? " " : ch;
+  }
+  return out.replace(/\s+/g, " ").trim();
+}
+
 export interface LaunchAgentOptions {
   location?: AddPanelOptions["location"];
   cwd?: string;
@@ -486,9 +504,14 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
 
         const presetTitle = isAgent && preset ? preset.name : title;
         // A caller-supplied name overrides the computed title and pins it so
-        // agent detection can't rewrite it. Empty/whitespace is treated as no
-        // name — fall back to the default title with no `titleMode`.
-        const trimmedName = launchOptions?.name?.trim();
+        // agent detection can't rewrite it. Strip control characters (an LLM
+        // assistant could emit newlines/ANSI/tabs) and collapse whitespace so
+        // tab chrome and aria labels stay intact. Empty/whitespace after
+        // sanitizing is treated as no name — fall back to the default title
+        // with no `titleMode`.
+        const trimmedName = launchOptions?.name
+          ? sanitizeTerminalName(launchOptions.name)
+          : undefined;
         const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
         const spawnedBy = launchOptions?.spawnedBy;
         const focusPolicy =

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -103,6 +103,13 @@ export interface LaunchAgentOptions {
    * (#6951, #7651).
    */
   requestedId?: string;
+  /**
+   * Caller-supplied terminal name (e.g. an assistant naming the agent at
+   * spawn time). When non-empty after trimming, it overrides the computed
+   * title and pins it with `titleMode: "custom"` so agent detection can't
+   * rewrite it. Empty/whitespace falls back to the default computed title.
+   */
+  name?: string;
 }
 
 export interface UseAgentLauncherReturn {
@@ -478,6 +485,11 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         }
 
         const presetTitle = isAgent && preset ? preset.name : title;
+        // A caller-supplied name overrides the computed title and pins it so
+        // agent detection can't rewrite it. Empty/whitespace is treated as no
+        // name — fall back to the default title with no `titleMode`.
+        const trimmedName = launchOptions?.name?.trim();
+        const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
         const spawnedBy = launchOptions?.spawnedBy;
         const focusPolicy =
           launchOptions?.focusPolicy ?? (isMcpSpawnFocusSuppressed() ? "preserve" : undefined);
@@ -487,7 +499,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               kind: "terminal",
               launchAgentId: agentId,
               command: command as string,
-              title: presetTitle,
+              title: trimmedName || presetTitle,
+              ...customTitle,
               cwd,
               worktreeId: targetWorktreeId || undefined,
               location: launchOptions?.location,
@@ -505,7 +518,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             }
           : {
               kind: "terminal",
-              title,
+              title: trimmedName || title,
+              ...customTitle,
               cwd,
               worktreeId: targetWorktreeId || undefined,
               command,
@@ -534,7 +548,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               id: gateId,
               kind: "terminal",
               launchAgentId: agentId,
-              title: presetTitle,
+              title: trimmedName || presetTitle,
+              ...customTitle,
               worktreeId: targetWorktreeId || undefined,
               cwd,
               cols: 80,

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -67,6 +67,7 @@ export interface ActionCallbacks {
       focusPolicy?: AddPanelFocusPolicy;
       requestedId?: string;
       force?: boolean;
+      name?: string;
     }
   ) => Promise<{ terminalId: string; location: "grid" | "dock" } | null>;
   onInject: (worktreeId: string) => void;

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -116,6 +116,44 @@ describe("agentActions adversarial", () => {
     expect(result).toEqual({ terminalId: "term-1", location: "grid" });
   });
 
+  it("agent.launch forwards 'name' to the launch callback", async () => {
+    const callbacks = makeCallbacks();
+    const actions = setupActions(callbacks);
+
+    await callAction(actions, "agent.launch", {
+      agentId: "claude",
+      prompt: "do the thing",
+      name: "Claude: auth refactor",
+    });
+
+    expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
+      "claude",
+      expect.objectContaining({ name: "Claude: auth refactor" })
+    );
+  });
+
+  it("agent.launch omits 'name' from the callback when not provided", async () => {
+    const callbacks = makeCallbacks();
+    const actions = setupActions(callbacks);
+
+    await callAction(actions, "agent.launch", { agentId: "claude" });
+
+    const [, options] = callbacks.onLaunchAgent.mock.calls[0] ?? [];
+    expect(options?.name).toBeUndefined();
+  });
+
+  it("agent.launch forwards a whitespace-only 'name' verbatim (downstream decides fallback)", async () => {
+    const callbacks = makeCallbacks();
+    const actions = setupActions(callbacks);
+
+    await callAction(actions, "agent.launch", { agentId: "claude", name: "   " });
+
+    expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
+      "claude",
+      expect.objectContaining({ name: "   " })
+    );
+  });
+
   it("one agent.<id> action is registered per AGENT_REGISTRY entry", () => {
     const callbacks = makeCallbacks();
     const actions = setupActions(callbacks);

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -218,6 +218,47 @@ describe("agentActions adversarial", () => {
     });
   });
 
+  it("agent.launch accepts 'name' through ActionService schema validation", async () => {
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+    for (const [, factory] of registry) service.register(factory());
+
+    const result = await service.dispatch(
+      "agent.launch",
+      { agentId: "claude", name: "Claude: auth refactor" },
+      { source: "agent" }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
+      "claude",
+      expect.objectContaining({ name: "Claude: auth refactor" })
+    );
+  });
+
+  it("agent.launch rejects a 'name' longer than the 200-char cap", async () => {
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+    for (const [, factory] of registry) service.register(factory());
+
+    const result = await service.dispatch(
+      "agent.launch",
+      { agentId: "claude", name: "x".repeat(201) },
+      { source: "agent" }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(callbacks.onLaunchAgent).not.toHaveBeenCalled();
+  });
+
   it("agent.palette only opens the quick switcher and does not launch", async () => {
     const callbacks = makeCallbacks();
     const actions = setupActions(callbacks);

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -42,6 +42,12 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       focusPolicy: AddPanelFocusPolicySchema.optional(),
       requestedId: z.string().optional(),
       force: z.boolean().optional(),
+      name: z
+        .string()
+        .optional()
+        .describe(
+          'Always provide a short, task-descriptive name for the terminal tab (e.g. "Claude: auth refactor") so the user can tell parallel agents apart. Pins the title so agent detection cannot overwrite it. Empty/whitespace falls back to the default title.'
+        ),
     }),
     resultSchema: z
       .object({
@@ -69,6 +75,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         focusPolicy,
         requestedId,
         force,
+        name,
       } = args as {
         agentId: string;
         location?: "grid" | "dock" | "overlay";
@@ -87,6 +94,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         focusPolicy?: "auto" | "preserve" | "take";
         requestedId?: string;
         force?: boolean;
+        name?: string;
       };
       const result = await callbacks.onLaunchAgent(agentId, {
         location,
@@ -105,6 +113,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         focusPolicy,
         requestedId,
         force,
+        name,
       });
       if (!result) return null;
       return { terminalId: result.terminalId, location: result.location };

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -44,6 +44,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       force: z.boolean().optional(),
       name: z
         .string()
+        .max(200)
         .optional()
         .describe(
           'Always provide a short, task-descriptive name for the terminal tab (e.g. "Claude: auth refactor") so the user can tell parallel agents apart. Pins the title so agent detection cannot overwrite it. Empty/whitespace falls back to the default title.'

--- a/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests that addPanel propagates a caller-supplied `titleMode` onto the created
+ * PTY panel (issue #10439).
+ *
+ * `titleMode: "custom"` is how an assistant-named agent launch pins its title so
+ * the identity reducer's agent-detected/exited rewrites skip it. The field was
+ * previously dropped on the floor between AddPanelOptions and the panel object.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+    waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    electron: {
+      globalEnv: {
+        get: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+
+function getPtyPanel(id: string): PtyPanelData | undefined {
+  return usePanelStore.getState().panelsById[id] as PtyPanelData | undefined;
+}
+
+describe("addPanel titleMode propagation (#10439)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockReset();
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
+  });
+
+  it("stamps titleMode 'custom' and the supplied title onto the panel", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      title: "Claude: auth refactor",
+      titleMode: "custom",
+      requestedId: "named-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("named-1");
+    const panel = getPtyPanel("named-1");
+    expect(panel?.title).toBe("Claude: auth refactor");
+    expect(panel?.titleMode).toBe("custom");
+  });
+
+  it("leaves titleMode unset when the caller does not supply one", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "default-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("default-1");
+    const panel = getPtyPanel("default-1");
+    expect(panel?.titleMode).toBeUndefined();
+  });
+});

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -336,6 +336,11 @@ export const createAddPanelActions = (
       kind,
       launchAgentId,
       title,
+      // Pin the title when the caller owns it (e.g. an assistant-named agent
+      // launch). `titleMode: "custom"` makes the identity reducer skip its
+      // agent-detected/exited title rewrites. Conditional spread avoids
+      // stamping `undefined`, which would read as an explicit "default".
+      ...(options.titleMode && { titleMode: options.titleMode }),
       worktreeId: options.worktreeId,
       cwd: options.cwd ?? "",
       cols: 80,


### PR DESCRIPTION
## Summary

- Adds an optional `name` argument to `agent.launch` so the help assistant can give a spawned agent terminal a descriptive tab title in the same call that launches it.
- Pins the title with `titleMode: "custom"` so the agent state machine (`identityReducer`) never overwrites it — without the pin, the next detection event clobbers the custom name.
- Fixes a latent gap where `addPanel` received `titleMode` in `AddPanelOptions` but never copied it onto the created panel.

Resolves #10439.

## Changes

- `agent.launch` `argsSchema` gains `name` (max 200 chars); forwarded through `ActionCallbacks.onLaunchAgent` → `LaunchAgentOptions` → `useAgentLauncher`.
- `useAgentLauncher` applies the name across all three launch branches (agent, plain terminal, soft-launch missing-CLI gate); a `sanitizeTerminalName` helper strips ASCII control chars and collapses whitespace.
- `addPanel` now copies `titleMode` from `AddPanelOptions` onto the created PTY panel.
- `help/CLAUDE.md` spawn guidance updated to encourage naming each new agent terminal.

Custom names don't survive app restart (`serializePtyPanel` doesn't persist `titleMode`) — the issue doesn't ask for persistence, so that's intentional.

## Testing

- 80 targeted unit tests covering title resolution across all three launch branches, adversarial name inputs (control chars, overlong strings, whitespace-only), and `addPanel` `titleMode` propagation.