### PR TITLE
fix(panels): give addPanelToGroup a success signal and clean up orphaned add-tab panels

### DIFF
--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -77,6 +77,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
     async (panel: PtyPanelData) => {
       let groupId: string;
       let createdNewGroup = false;
+      let newPanelId: string | undefined;
 
       try {
         const existingGroup = getPanelGroup(panel.id);
@@ -90,7 +91,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         const options = await buildPanelDuplicateOptions(panel, "dock");
         // `activateDockOnCreate` folds dock activation into the panel commit so
         // the watchdog effect cannot collapse the just-created tab. See #6590.
-        const newPanelId = await addPanel({ ...options, activateDockOnCreate: true });
+        newPanelId = await addPanel({ ...options, activateDockOnCreate: true });
         if (!newPanelId) {
           if (createdNewGroup && groupId!) deleteTabGroup(groupId);
           return;
@@ -109,6 +110,10 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         setActiveTab(groupId, newPanelId);
       } catch (error) {
         logError("Failed to add tab", error);
+        // Mirror the rejection path: trash a created-but-unjoined panel before
+        // deleting a group this call created, so a mid-flight throw can't orphan
+        // it for the dock watchdog to find (#10441, #6596).
+        if (newPanelId) trashPanel(newPanelId);
         if (createdNewGroup && groupId!) {
           deleteTabGroup(groupId);
         }

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -52,6 +52,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
 
   const closeDockTerminal = usePanelStore((s) => s.closeDockTerminal);
   const addPanel = usePanelStore((s) => s.addPanel);
+  const trashPanel = usePanelStore((s) => s.trashPanel);
   const getPanelGroup = usePanelStore((s) => s.getPanelGroup);
   const createTabGroup = usePanelStore((s) => s.createTabGroup);
   const addPanelToGroup = usePanelStore((s) => s.addPanelToGroup);
@@ -95,7 +96,16 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
           return;
         }
 
-        addPanelToGroup(groupId, newPanelId);
+        // On a rejected add (worktree mismatch, group vanished), the freshly
+        // created panel would otherwise be orphaned outside any group — and the
+        // dock watchdog effect above could read it as a stray and tear down the
+        // dock pointer (#6596). Trash it first, then delete the group this call
+        // created, and skip activation since the panel never joined the group.
+        if (!addPanelToGroup(groupId, newPanelId)) {
+          trashPanel(newPanelId);
+          if (createdNewGroup && groupId!) deleteTabGroup(groupId);
+          return;
+        }
         setActiveTab(groupId, newPanelId);
       } catch (error) {
         logError("Failed to add tab", error);
@@ -104,7 +114,15 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         }
       }
     },
-    [getPanelGroup, createTabGroup, addPanelToGroup, deleteTabGroup, addPanel, setActiveTab]
+    [
+      getPanelGroup,
+      createTabGroup,
+      addPanelToGroup,
+      deleteTabGroup,
+      addPanel,
+      trashPanel,
+      setActiveTab,
+    ]
   );
 
   // Create the stable wrapper for each panel eagerly after the container mounts,

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -77,7 +77,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
     async (panel: PtyPanelData) => {
       let groupId: string;
       let createdNewGroup = false;
-      let newPanelId: string | undefined;
+      let newPanelId: string | null = null;
 
       try {
         const existingGroup = getPanelGroup(panel.id);

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -421,11 +421,12 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const handleAddTab = useCallback(async () => {
     if (!activePanel) return;
 
+    let newPanelId: string | undefined;
     try {
       const options = await buildPanelDuplicateOptions(activePanel, "dock");
       // `activateDockOnCreate` folds dock activation into the panel commit so
       // the watchdog effect cannot collapse the just-created tab. See #6590.
-      const newPanelId = await addPanel({ ...options, activateDockOnCreate: true });
+      newPanelId = await addPanel({ ...options, activateDockOnCreate: true });
       if (!newPanelId) return;
 
       // If the add is rejected (worktree mismatch, group vanished), trash the
@@ -438,6 +439,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       setActiveTab(group.id, newPanelId);
     } catch (error) {
       logError("Failed to add tab", error);
+      // Trash a created-but-unjoined panel so a mid-flight throw can't orphan it.
+      if (newPanelId) trashPanel(newPanelId);
     }
   }, [activePanel, group.id, addPanel, addPanelToGroup, trashPanel, setActiveTab]);
 

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -421,7 +421,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const handleAddTab = useCallback(async () => {
     if (!activePanel) return;
 
-    let newPanelId: string | undefined;
+    let newPanelId: string | null = null;
     try {
       const options = await buildPanelDuplicateOptions(activePanel, "dock");
       // `activateDockOnCreate` folds dock activation into the panel commit so

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -428,12 +428,18 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       const newPanelId = await addPanel({ ...options, activateDockOnCreate: true });
       if (!newPanelId) return;
 
-      addPanelToGroup(group.id, newPanelId);
+      // If the add is rejected (worktree mismatch, group vanished), trash the
+      // freshly created panel so it isn't orphaned outside any group, and skip
+      // activation since it never joined the group (#10441).
+      if (!addPanelToGroup(group.id, newPanelId)) {
+        trashPanel(newPanelId);
+        return;
+      }
       setActiveTab(group.id, newPanelId);
     } catch (error) {
       logError("Failed to add tab", error);
     }
-  }, [activePanel, group.id, addPanel, addPanelToGroup, setActiveTab]);
+  }, [activePanel, group.id, addPanel, addPanelToGroup, trashPanel, setActiveTab]);
 
   const groupBlockedState = getGroupBlockedAgentState(panels);
   const blockedState = useDockBlockedState(groupBlockedState);

--- a/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
+++ b/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
@@ -74,9 +74,10 @@ function setPanels(panels: PtyPanelData[]) {
   mockState.activeDockTerminalId = null;
   mockState.closeDockTerminal = closeDockTerminalMock;
   mockState.addPanel = vi.fn();
+  mockState.trashPanel = vi.fn();
   mockState.getPanelGroup = vi.fn(() => undefined);
   mockState.createTabGroup = vi.fn();
-  mockState.addPanelToGroup = vi.fn();
+  mockState.addPanelToGroup = vi.fn(() => true);
   mockState.deleteTabGroup = vi.fn();
   mockState.setActiveTab = vi.fn();
 }

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -22,7 +22,7 @@ const moveTerminalToGridMock = vi.fn();
 const updateTitleMock = vi.fn();
 const reorderPanelsInGroupMock = vi.fn();
 const addPanelMock = vi.fn();
-const addPanelToGroupMock = vi.fn();
+const addPanelToGroupMock = vi.fn(() => true);
 
 let mockActiveDockTerminalId: string | null = null;
 let mockTabGroups = new Map<string, TabGroup>();
@@ -248,6 +248,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 import { DockedTabGroup } from "../DockedTabGroup";
 import { handleDockFocusOutside } from "../dockPopoverGuard";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { TerminalRefreshTier } from "@/types";
 
 function makePanel(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
@@ -643,5 +644,56 @@ describe("DockedTabGroup lifecycle and pop-out (#8160)", () => {
 
     expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
     expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DockedTabGroup add-tab orphan cleanup (#10441)", () => {
+  beforeEach(() => {
+    mockActiveDockTerminalId = "t-1";
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
+    addPanelMock.mockReset();
+    addPanelToGroupMock.mockReset();
+    vi.mocked(buildPanelDuplicateOptions).mockReset();
+  });
+
+  async function clickAddTab() {
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+    const { container } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+    const addTabButton = container.querySelector(
+      '[aria-label="Duplicate panel as new tab"]'
+    ) as HTMLElement;
+    expect(addTabButton).not.toBeNull();
+    // Isolate the click's side effects from any mount-time activation.
+    trashPanelMock.mockClear();
+    setActiveTabMock.mockClear();
+    await act(async () => {
+      fireEvent.click(addTabButton);
+    });
+  }
+
+  it("trashes the new panel and skips activation when addPanelToGroup rejects the add", async () => {
+    vi.mocked(buildPanelDuplicateOptions).mockResolvedValue({} as never);
+    addPanelMock.mockResolvedValue("t-new");
+    addPanelToGroupMock.mockReturnValue(false);
+
+    await clickAddTab();
+
+    expect(addPanelToGroupMock).toHaveBeenCalledWith("g-1", "t-new");
+    expect(trashPanelMock).toHaveBeenCalledWith("t-new");
+    expect(setActiveTabMock).not.toHaveBeenCalled();
+  });
+
+  it("activates the new panel and does not trash it when the add succeeds", async () => {
+    vi.mocked(buildPanelDuplicateOptions).mockResolvedValue({} as never);
+    addPanelMock.mockResolvedValue("t-new");
+    addPanelToGroupMock.mockReturnValue(true);
+
+    await clickAddTab();
+
+    expect(trashPanelMock).not.toHaveBeenCalled();
+    expect(setActiveTabMock).toHaveBeenCalledWith("g-1", "t-new");
   });
 });

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -23,7 +23,7 @@ const moveTerminalToGridMock = vi.fn();
 const updateTitleMock = vi.fn();
 const reorderPanelsInGroupMock = vi.fn();
 const addPanelMock = vi.fn();
-const addPanelToGroupMock = vi.fn();
+const addPanelToGroupMock = vi.fn(() => true);
 
 let mockActiveDockTerminalId: string | null = null;
 let mockTabGroups = new Map<string, TabGroup>();

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -3,7 +3,6 @@ import { useShallow } from "zustand/react/shallow";
 import { usePanelStore } from "@/store";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
-import { logError } from "@/utils/logger";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
@@ -11,7 +10,7 @@ import { getMergedPresets } from "@/config/agents";
 import { GridPanel } from "./GridPanel";
 import type { TabGroup } from "@/types";
 import type { TabInfo } from "@/components/Panel/TabButton";
-import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
+import { addTabForPanel } from "./useContentGridContext";
 import { requestPanelClose } from "@/services/terminal/optimisticPanelClose";
 import { focusPanelInput } from "./terminalFocusRegistry";
 import { getGroupAmbientAgentState } from "@/components/Layout/useDockBlockedState";
@@ -46,8 +45,6 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const stampLastActive = usePanelStore((state) => state.stampLastActive);
   const setMaximizedId = usePanelStore((state) => state.setMaximizedId);
   const trashPanel = usePanelStore((state) => state.trashPanel);
-  const addPanel = usePanelStore((state) => state.addPanel);
-  const addPanelToGroup = usePanelStore((state) => state.addPanelToGroup);
   const reorderPanelsInGroup = usePanelStore((state) => state.reorderPanelsInGroup);
   const updateTitle = usePanelStore((state) => state.updateTitle);
 
@@ -257,22 +254,13 @@ export const GridTabGroup = React.memo(function GridTabGroup({
     [group.id, reorderPanelsInGroup]
   );
 
-  // Handle add tab - duplicate the current panel as a new tab
+  // Handle add tab - duplicate the current panel as a new tab. Delegates to the
+  // shared module-level helper so the create → add-to-group → activate sequence
+  // (and its orphan-cleanup on a failed add) lives in one place (#10441).
   const handleAddTab = useCallback(async () => {
     if (!activePanel) return;
-
-    try {
-      const options = await buildPanelDuplicateOptions(activePanel, "grid");
-      const newPanelId = await addPanel(options);
-      if (!newPanelId) return;
-
-      addPanelToGroup(group.id, newPanelId);
-      setActiveTab(group.id, newPanelId);
-      setFocused(newPanelId);
-    } catch (error) {
-      logError("Failed to add tab", error);
-    }
-  }, [activePanel, group.id, addPanel, addPanelToGroup, setActiveTab, setFocused]);
+    await addTabForPanel(activePanel);
+  }, [activePanel]);
 
   if (!activePanel) {
     return null;

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -101,13 +101,14 @@ const GRID_CONTEXT_MENU_COMPONENTS: DockLaunchMenuComponents = {
 // Module-level so the try/catch stays outside useContentGridContext — a
 // statement-level try block inside the hook bails React Compiler memoization
 // for the whole hook. Store actions are read at call time (see issue #8593).
-async function addTabForPanel(panel: PanelInstance): Promise<void> {
+export async function addTabForPanel(panel: PanelInstance): Promise<void> {
   const {
     getPanelGroup,
     createTabGroup,
     addPanelToGroup,
     deleteTabGroup,
     addPanel,
+    trashPanel,
     setActiveTab,
     setFocused,
   } = panelStoreApi.getState();
@@ -131,7 +132,17 @@ async function addTabForPanel(panel: PanelInstance): Promise<void> {
       return;
     }
 
-    addPanelToGroup(groupId, newPanelId);
+    // A failed add (worktree mismatch, group vanished) would otherwise leave the
+    // freshly-created duplicate orphaned outside any group. Trash it first so no
+    // reconciler ever sees a panel pointing at a deleted/empty group (#6596),
+    // then tear down the group this call created. Skip activation/focus — the
+    // panel isn't a member, so setActiveTab would no-op and setFocused would
+    // focus an orphan.
+    if (!addPanelToGroup(groupId, newPanelId)) {
+      trashPanel(newPanelId);
+      if (createdNewGroup && groupId) deleteTabGroup(groupId);
+      return;
+    }
     setActiveTab(groupId, newPanelId);
     setFocused(newPanelId);
   } catch (error) {

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -114,6 +114,7 @@ export async function addTabForPanel(panel: PanelInstance): Promise<void> {
   } = panelStoreApi.getState();
   let groupId: string | undefined;
   let createdNewGroup = false;
+  let newPanelId: string | undefined;
 
   try {
     const existingGroup = getPanelGroup(panel.id);
@@ -126,7 +127,7 @@ export async function addTabForPanel(panel: PanelInstance): Promise<void> {
     }
 
     const options = await buildPanelDuplicateOptions(panel, "grid");
-    const newPanelId = await addPanel(options);
+    newPanelId = await addPanel(options);
     if (!newPanelId) {
       if (createdNewGroup && groupId) deleteTabGroup(groupId);
       return;
@@ -147,6 +148,10 @@ export async function addTabForPanel(panel: PanelInstance): Promise<void> {
     setFocused(newPanelId);
   } catch (error) {
     logError("Failed to add tab", error);
+    // Mirror the rejection path's cleanup: if a panel was created before the
+    // throw, trash it before tearing down a group this call created, so a
+    // mid-flight failure never leaves an orphaned panel behind (#10441).
+    if (newPanelId) trashPanel(newPanelId);
     if (createdNewGroup && groupId) {
       deleteTabGroup(groupId);
     }

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -114,7 +114,7 @@ export async function addTabForPanel(panel: PanelInstance): Promise<void> {
   } = panelStoreApi.getState();
   let groupId: string | undefined;
   let createdNewGroup = false;
-  let newPanelId: string | undefined;
+  let newPanelId: string | null = null;
 
   try {
     const existingGroup = getPanelGroup(panel.id);

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -390,6 +390,31 @@ describe("Tab Group Worktree Invariant", () => {
       const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
       expect(updatedGroup?.panelIds).toEqual(["t1"]);
     });
+
+    it("returns true and collapses the source group when moving the panel out of it", () => {
+      // Unique-membership enforcement removes the panel from its prior group
+      // first; when that leaves <=1 member the source group is deleted. The
+      // post-mutation verify must still report success for the target group.
+      const anchor = createMockTerminal("anchor", "wt-a", "grid");
+      const mover = createMockTerminal("mover", "wt-a", "grid");
+      const target = createMockTabGroup("g-target", "wt-a", ["anchor"]);
+      const source = createMockTabGroup("g-source", "wt-a", ["mover", "anchor2"]);
+
+      setTerminals([anchor, mover, createMockTerminal("anchor2", "wt-a", "grid")]);
+      usePanelStore.setState({
+        tabGroups: new Map([
+          ["g-target", target],
+          ["g-source", source],
+        ]),
+      });
+
+      const result = usePanelStore.getState().addPanelToGroup("g-target", "mover");
+      expect(result).toBe(true);
+
+      const groups = usePanelStore.getState().tabGroups;
+      expect(groups.get("g-target")?.panelIds).toEqual(["anchor", "mover"]);
+      expect(groups.has("g-source")).toBe(false);
+    });
   });
 
   describe("global group support", () => {

--- a/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts
@@ -302,7 +302,8 @@ describe("Tab Group Worktree Invariant", () => {
       setTerminals([t1, t2]);
       usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
 
-      usePanelStore.getState().addPanelToGroup("g1", "t2");
+      const result = usePanelStore.getState().addPanelToGroup("g1", "t2");
+      expect(result).toBe(true);
 
       const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
       expect(updatedGroup?.panelIds).toEqual(["t1", "t2"]);
@@ -316,7 +317,8 @@ describe("Tab Group Worktree Invariant", () => {
       setTerminals([t1, t2]);
       usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
 
-      usePanelStore.getState().addPanelToGroup("g1", "t2");
+      const result = usePanelStore.getState().addPanelToGroup("g1", "t2");
+      expect(result).toBe(false);
 
       const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
       expect(updatedGroup?.panelIds).toEqual(["t1"]);
@@ -330,7 +332,8 @@ describe("Tab Group Worktree Invariant", () => {
       setTerminals([t1, t2]);
       usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
 
-      usePanelStore.getState().addPanelToGroup("g1", "t2");
+      const result = usePanelStore.getState().addPanelToGroup("g1", "t2");
+      expect(result).toBe(true);
 
       const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
       expect(updatedGroup?.panelIds).toEqual(["t1", "t2"]);
@@ -344,7 +347,45 @@ describe("Tab Group Worktree Invariant", () => {
       setTerminals([t1, t2]);
       usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
 
-      usePanelStore.getState().addPanelToGroup("g1", "t2");
+      const result = usePanelStore.getState().addPanelToGroup("g1", "t2");
+      expect(result).toBe(false);
+
+      const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
+      expect(updatedGroup?.panelIds).toEqual(["t1"]);
+    });
+
+    it("returns false when the target group does not exist", () => {
+      const t1 = createMockTerminal("t1", "wt-a", "grid");
+      setTerminals([t1]);
+      usePanelStore.setState({ tabGroups: new Map() });
+
+      const result = usePanelStore.getState().addPanelToGroup("missing-group", "t1");
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the panel does not exist", () => {
+      const t1 = createMockTerminal("t1", "wt-a", "grid");
+      const group = createMockTabGroup("g1", "wt-a", ["t1"]);
+
+      setTerminals([t1]);
+      usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
+
+      const result = usePanelStore.getState().addPanelToGroup("g1", "missing-panel");
+      expect(result).toBe(false);
+
+      const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
+      expect(updatedGroup?.panelIds).toEqual(["t1"]);
+    });
+
+    it("returns true when the panel is already a member (idempotent)", () => {
+      const t1 = createMockTerminal("t1", "wt-a", "grid");
+      const group = createMockTabGroup("g1", "wt-a", ["t1"]);
+
+      setTerminals([t1]);
+      usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
+
+      const result = usePanelStore.getState().addPanelToGroup("g1", "t1");
+      expect(result).toBe(true);
 
       const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
       expect(updatedGroup?.panelIds).toEqual(["t1"]);
@@ -404,7 +445,8 @@ describe("Tab Group Worktree Invariant", () => {
       setTerminals([t1, t2]);
       usePanelStore.setState({ tabGroups: new Map([["g1", group]]) });
 
-      usePanelStore.getState().addPanelToGroup("g1", "t2");
+      const result = usePanelStore.getState().addPanelToGroup("g1", "t2");
+      expect(result).toBe(false);
 
       const updatedGroup = usePanelStore.getState().tabGroups.get("g1");
       expect(updatedGroup?.panelIds).toEqual(["t1"]);

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -204,6 +204,12 @@ export const createTabGroupActions = (
       saveTabGroups(newTabGroups);
       return { tabGroups: newTabGroups };
     });
+
+    // Verify against the canonical store rather than a closure side-effect: the
+    // set() updater bails out (returning unchanged state) on a missing group,
+    // missing panel, or worktree mismatch, so membership is the source of truth
+    // for whether the add actually took. Callers gate cleanup on this boolean.
+    return get().tabGroups.get(groupId)?.panelIds.includes(panelId) ?? false;
   },
 
   removePanelFromGroup: (panelId) => {

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -238,8 +238,8 @@ export interface PanelRegistrySlice {
     panelIds: string[],
     activeTabId?: string
   ) => string;
-  /** Add a panel to an existing group at optional index */
-  addPanelToGroup: (groupId: string, panelId: string, index?: number) => void;
+  /** Add a panel to an existing group at optional index. Returns true if the panel is a member after the call, false if the add was rejected (missing group/panel, worktree mismatch). */
+  addPanelToGroup: (groupId: string, panelId: string, index?: number) => boolean;
   /** Remove a panel from its group (group deleted if only 1 panel remains) */
   removePanelFromGroup: (panelId: string) => void;
   /** Reorder panels within a group */


### PR DESCRIPTION
## Summary

- `addPanelToGroup` returned `void` and only `console.warn`'d on failure, so callers had no way to detect a rejected add. All add-tab paths created a panel, called `addPanelToGroup` without checking success, then unconditionally set focus — orphaning the freshly-created panel.
- `addPanelToGroup` now returns a `boolean` (post-mutation `get()` membership check). All add-tab callers gate `setActiveTab`/`setFocused` behind the boolean and delete the orphaned panel (plus any just-created group) on failure, with matching `catch`-block cleanup for mid-flight throws.
- Consolidated the two grid add-tab paths: `GridTabGroup.handleAddTab` now delegates to the shared `addTabForPanel` helper in `useContentGridContext`.

Resolves #10441

## Changes

- `src/store/slices/panelRegistry/tabGroups.ts` — `addPanelToGroup` returns `boolean`
- `src/store/slices/panelRegistry/types.ts` — updated type signature
- `src/components/Terminal/useContentGridContext.tsx` — `addTabForPanel` checks return value, trashes panel on failure
- `src/components/Terminal/GridTabGroup.tsx` — delegates to `addTabForPanel` instead of duplicating the logic
- `src/components/Layout/DockPanelOffscreenContainer.tsx` — `handleAddTabForPanel` gates focus + cleans up on failure
- `src/components/Layout/DockedTabGroup.tsx` — `handleAddTab` gates focus + cleans up on failure
- `src/store/slices/panelRegistry/__tests__/tabGroupWorktreeInvariant.test.ts` — store-level return-value, idempotent, and source-group-collapse tests
- `src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx` — dock add-tab orphan-cleanup tests

## Testing

61 targeted vitest tests pass covering the store invariants (`tabGroupWorktreeInvariant`), dock orphan cleanup (`DockedTabGroup.mountGuard`), and the offscreen container (`DockPanelOffscreenContainer`). Own-file prettier clean; eslint warnings limited to test files (excluded from the ratchet).