### PR TITLE
Fire forge hover prefetch instantly and cache-first

### DIFF
--- a/plugins/builtin/github/renderer/components/GitHubStatsDropdown.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubStatsDropdown.tsx
@@ -24,7 +24,11 @@ if (typeof window !== "undefined") {
     void importCommitList();
   };
   if (typeof window.requestIdleCallback === "function") {
-    window.requestIdleCallback(preload);
+    // Cap the idle wait: under sustained main-thread load (launch hydration,
+    // Electron IPC bursts) an untimed idle callback can be deferred for
+    // seconds, so a first click would still hit the Suspense skeleton. The
+    // timeout forces the preload to run within 2s regardless.
+    window.requestIdleCallback(preload, { timeout: 2000 });
   } else {
     window.setTimeout(preload, 2000);
   }

--- a/src/components/Layout/ForgeStatsToolbarButton.tsx
+++ b/src/components/Layout/ForgeStatsToolbarButton.tsx
@@ -41,13 +41,14 @@ import {
 import { ForgeStatPill } from "./ForgeStatPill";
 import { LocalCommitsDropdown } from "./LocalCommitsDropdown";
 
-// Hover-to-prefetch tuning. 150ms matches the codebase's Tier 1 state-change
-// timing and is long enough to filter mouse traversal across the toolbar pill
-// while remaining imperceptible to a deliberate hover. The 10s freshness skip
-// dedups against a recent click-time fetch without stacking on the 45s SWR
-// cache TTL — well under either, leaving plenty of headroom for click-time
-// `bypassCache: true` to still see fresh data.
-const HOVER_PREFETCH_DELAY_MS = 150;
+// Hover-to-prefetch tuning. The prefetch fires immediately on pointerenter
+// (mouse only) — no debounce: hovering a toolbar pill is strong click intent,
+// so warming the list the moment the cursor lands maximizes the head-start
+// before the click. The fly-by cost of firing on every hover is bounded by
+// two things: the prefetch is cache-first (`bypassCache: false`, served from
+// the main-process 60s list cache with zero GraphQL on a warm slot), and the
+// in-flight + freshness guards below collapse repeat hovers. The 10s freshness
+// skip dedups against a recent fetch without stacking on the 45s SWR cache TTL.
 const PREFETCH_FRESHNESS_MS = 10_000;
 
 // When the user opens a dropdown and its count hasn't been read from the forge
@@ -380,8 +381,6 @@ export const ForgeStatsToolbarButton = memo(
     const prsButtonRef = useRef<HTMLButtonElement>(null);
     const commitsButtonRef = useRef<HTMLButtonElement>(null);
 
-    const issuesHoverTimerRef = useRef<number | null>(null);
-    const prsHoverTimerRef = useRef<number | null>(null);
     const issuesPrefetchInFlightRef = useRef(false);
     const prsPrefetchInFlightRef = useRef(false);
 
@@ -392,12 +391,11 @@ export const ForgeStatsToolbarButton = memo(
     const issuesHiddenAtRef = useRef<number | null>(null);
     const prsHiddenAtRef = useRef<number | null>(null);
 
-    // Mirror open state into refs so the trailing-edge timer can re-check at
-    // fire time. The guard inside `handlePrefetchPointerEnter` is evaluated at
-    // schedule time; if the user clicks during the 150ms debounce window the
-    // dropdown opens and the mounted list view starts its own fetch — without
-    // this ref the timer would still fire and race a duplicate request that
-    // could overwrite fresh mount-fetch data in the cache.
+    // Mirror open state into refs so `prefetchResourceList` can re-check the
+    // live open state at fire time without widening its dependency array. If a
+    // click opens the dropdown in the same tick as the hover, the mounted list
+    // view starts its own fetch — this guard stops the hover prefetch from
+    // racing a duplicate request that could overwrite fresh mount-fetch data.
     const issuesOpenRef = useRef(issuesOpen);
     const prsOpenRef = useRef(prsOpen);
     const commitsOpenRef = useRef(commitsOpen);
@@ -577,19 +575,6 @@ export const ForgeStatsToolbarButton = memo(
       };
     }, [prsPulseAt]);
 
-    useEffect(() => {
-      return () => {
-        if (issuesHoverTimerRef.current !== null) {
-          window.clearTimeout(issuesHoverTimerRef.current);
-          issuesHoverTimerRef.current = null;
-        }
-        if (prsHoverTimerRef.current !== null) {
-          window.clearTimeout(prsHoverTimerRef.current);
-          prsHoverTimerRef.current = null;
-        }
-      };
-    }, []);
-
     // Wired to the dropdown view's `onFreshFetch` callback. When the
     // dropdown's SWR revalidation lands fresh first-page data, the provider
     // has already written the new total count to its stats cache. Calling
@@ -604,9 +589,9 @@ export const ForgeStatsToolbarButton = memo(
     const prefetchResourceList = useCallback(
       (type: "issue" | "pr") => {
         if (!currentProject || isTokenError || rateLimitActive) return;
-        // Mount-time race guard: a click during the debounce window flips the
-        // open state. Re-check here so a queued timer doesn't fire a duplicate
-        // request alongside the dropdown's own mount fetch.
+        // Open-state race guard: if a click opened the dropdown in the same
+        // tick as this hover, re-check here so the prefetch doesn't fire a
+        // duplicate request alongside the dropdown's own mount fetch.
         const isOpenRef = type === "issue" ? issuesOpenRef : prsOpenRef;
         if (isOpenRef.current) return;
 
@@ -626,10 +611,15 @@ export const ForgeStatsToolbarButton = memo(
         // refreshing stats here would flicker the toolbar status indicator.
         inFlightRef.current = true;
         const startedAt = Date.now();
+        // Cache-first: a warm main-process list cache (60s TTL) serves this
+        // hover with zero GraphQL; only a cold slot spends a query — the same
+        // query the click would have made anyway. This is what makes firing on
+        // every hover quota-safe. `bypassCache: true` stays reserved for
+        // explicit intent (dropdown open / manual refresh).
         const fetchOptions = {
           state: "open" as const,
           sort: "created",
-          bypassCache: true,
+          bypassCache: false,
         };
         const request =
           type === "issue"
@@ -650,11 +640,12 @@ export const ForgeStatsToolbarButton = memo(
               nextCursor: result.nextCursor,
               hasMore: result.hasMore,
               timestamp: now,
-              // This request bypassed the backend cache, so the entry
-              // qualifies for the SWR hook's skip-revalidate window — the
-              // whole point of the prefetch: hover→click costs one GraphQL
-              // query, not two.
-              freshBypassAt: now,
+              // Deliberately NO `freshBypassAt`: a cache-first prefetch may have
+              // been served from the main-process list cache, so it must not arm
+              // the SWR hook's skip-revalidate window (reserved for real
+              // `bypassCache: true` fetches). The dropdown still opens instantly
+              // on these warmed rows, then runs its normal cheap, cache-honoring
+              // open-time revalidate.
               // The prefetch always targets the `open` slot (see `cacheKey`),
               // so the count fingerprint arms the count-as-cache-buster.
               ...(result.totalCount != null ? { countAtWrite: result.totalCount } : {}),
@@ -677,26 +668,13 @@ export const ForgeStatsToolbarButton = memo(
         if (e.pointerType !== "mouse") return;
         const isOpen = type === "issue" ? issuesOpen : prsOpen;
         if (isOpen) return;
-        const timerRef = type === "issue" ? issuesHoverTimerRef : prsHoverTimerRef;
-        if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-        timerRef.current = window.setTimeout(() => {
-          timerRef.current = null;
-          prefetchResourceList(type);
-        }, HOVER_PREFETCH_DELAY_MS);
+        // Fire immediately — no debounce. The in-flight + freshness guards in
+        // `prefetchResourceList` collapse repeat and fly-by hovers, and the
+        // cache-first fetch keeps a stray hover cheap, so warming the moment the
+        // cursor lands buys the maximum head-start before the click.
+        prefetchResourceList(type);
       },
       [issuesOpen, prsOpen, prefetchResourceList]
-    );
-
-    const handlePrefetchPointerLeave = useCallback(
-      (type: "issue" | "pr", e: React.PointerEvent) => {
-        if (e.pointerType !== "mouse") return;
-        const timerRef = type === "issue" ? issuesHoverTimerRef : prsHoverTimerRef;
-        if (timerRef.current !== null) {
-          window.clearTimeout(timerRef.current);
-          timerRef.current = null;
-        }
-      },
-      []
     );
 
     // Delta check for the digit-pulse animation. Wrapped in useEffectEvent so
@@ -944,7 +922,6 @@ export const ForgeStatsToolbarButton = memo(
                   }
                 }}
                 onPointerEnter={(e) => handlePrefetchPointerEnter("issue", e)}
-                onPointerLeave={(e) => handlePrefetchPointerLeave("issue", e)}
                 activityChip={
                   <span
                     aria-hidden="true"
@@ -1028,7 +1005,6 @@ export const ForgeStatsToolbarButton = memo(
                   }
                 }}
                 onPointerEnter={(e) => handlePrefetchPointerEnter("pr", e)}
-                onPointerLeave={(e) => handlePrefetchPointerLeave("pr", e)}
                 activityChip={
                   <span
                     aria-hidden="true"

--- a/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
+++ b/src/components/Layout/__tests__/ForgeStatsToolbarButton.hoverPrefetch.test.tsx
@@ -4,11 +4,13 @@
  *
  * The Issues and PRs toolbar buttons silently prime the list cache on
  * pointerenter (mouse only) so the dropdown opens with no spinner. The
- * 150ms trailing-edge debounce filters mouse traversal across the toolbar;
- * pointerleave cancels a pending prefetch. Cache freshness, token errors,
- * rate limits, and open dropdowns short-circuit the prefetch so it never
- * duplicates work. Hover never triggers the toolbar status indicator —
- * only an actual click drives visible loading/success state.
+ * prefetch fires immediately — no debounce — and is cache-first
+ * (`bypassCache: false`), so a warm slot costs zero GraphQL and a stray
+ * fly-by hover is cheap. Cache freshness (<10s), an in-flight guard, token
+ * errors, rate limits, and open dropdowns short-circuit the prefetch so it
+ * never duplicates work. The cache-first entry deliberately omits
+ * `freshBypassAt` (reserved for real bypass fetches). Hover never triggers
+ * the toolbar status indicator — only an actual click drives visible state.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup, act } from "@testing-library/react";
@@ -174,12 +176,15 @@ function pointerEnter(el: Element, pointerType: "mouse" | "touch" | "pen" = "mou
   fireEvent.pointerEnter(el, { pointerType });
 }
 
-function pointerLeave(el: Element, pointerType: "mouse" | "touch" | "pen" = "mouse"): void {
-  fireEvent.pointerLeave(el, { pointerType });
+// Flush the prefetch request's `.then/.catch/.finally` microtask chain.
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
 }
 
 beforeEach(() => {
-  vi.useFakeTimers({ shouldAdvanceTime: true });
   _resetForTests();
   mockListIssues.mockReset();
   mockListPRs.mockReset();
@@ -192,44 +197,39 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  vi.useRealTimers();
 });
 
 describe("ForgeStatsToolbarButton hover prefetch", () => {
-  it("fires listIssues 150ms after pointerenter on the Issues button", async () => {
+  it("fires listIssues immediately on pointerenter (no debounce), cache-first", () => {
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container));
-
-    expect(mockListIssues).not.toHaveBeenCalled();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+    // Synchronous act: the call must be registered within the event dispatch
+    // itself, proving there is no debounce/microtask deferral.
+    act(() => {
+      pointerEnter(getIssuesButton(container));
     });
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
     expect(mockListIssues.mock.calls[0]?.[0]).toBe("/test/proj");
     expect(mockListIssues.mock.calls[0]?.[1]).toMatchObject({
       state: "open",
-      bypassCache: true,
+      bypassCache: false,
       sort: "created",
     });
   });
 
-  it("fires listPRs 150ms after pointerenter on the PRs button", async () => {
+  it("fires listPRs immediately on pointerenter (no debounce), cache-first", () => {
     const { container } = renderToolbar();
 
-    pointerEnter(getPrsButton(container));
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+    act(() => {
+      pointerEnter(getPrsButton(container));
     });
 
     expect(mockListPRs).toHaveBeenCalledTimes(1);
     expect(mockListPRs.mock.calls[0]?.[0]).toBe("/test/proj");
     expect(mockListPRs.mock.calls[0]?.[1]).toMatchObject({
       state: "open",
-      bypassCache: true,
+      bypassCache: false,
       sort: "created",
     });
   });
@@ -237,14 +237,10 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
   it("does not call refreshStats from the hover path — prefetch must stay silent", async () => {
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      pointerEnter(getIssuesButton(container));
     });
-    // Let the prefetch promise settle in case a stats refresh were chained.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
+    await settle();
 
     expect(refreshStatsMock).not.toHaveBeenCalled();
     expect(mockListIssues).toHaveBeenCalledTimes(1);
@@ -258,14 +254,10 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     });
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      pointerEnter(getIssuesButton(container));
     });
-    // Allow the request promise to settle.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
+    await settle();
 
     const cached = getCache(buildCacheKey("/test/proj", "issue", "open", "created"));
     expect(cached).toBeDefined();
@@ -274,29 +266,13 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     expect(cached!.hasMore).toBe(true);
   });
 
-  it("does not fire when pointerleave happens before the debounce elapses", async () => {
-    const { container } = renderToolbar();
-    const button = getIssuesButton(container);
-
-    pointerEnter(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
-    });
-    pointerLeave(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(200);
-    });
-
-    expect(mockListIssues).not.toHaveBeenCalled();
-  });
-
   it("ignores non-mouse pointer types (touch)", async () => {
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container), "touch");
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(300);
+      pointerEnter(getIssuesButton(container), "touch");
     });
+    await settle();
 
     expect(mockListIssues).not.toHaveBeenCalled();
     expect(refreshStatsMock).not.toHaveBeenCalled();
@@ -311,9 +287,8 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     });
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      pointerEnter(getIssuesButton(container));
     });
 
     expect(mockListIssues).not.toHaveBeenCalled();
@@ -329,162 +304,11 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     });
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      pointerEnter(getIssuesButton(container));
     });
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not fire when isTokenError is true", async () => {
-    mockIsTokenError = true;
-    const { container } = renderToolbar();
-
-    pointerEnter(getIssuesButton(container));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-
-    expect(mockListIssues).not.toHaveBeenCalled();
-    expect(refreshStatsMock).not.toHaveBeenCalled();
-  });
-
-  it("does not fire when rate limit is active", async () => {
-    mockRateLimitResetAt = Date.now() + 60_000;
-    const { container } = renderToolbar();
-
-    pointerEnter(getIssuesButton(container));
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-
-    expect(mockListIssues).not.toHaveBeenCalled();
-  });
-
-  it("coalesces concurrent hovers — pointerenter while a prefetch is in flight does not re-fetch", async () => {
-    let resolveFirst: (v: Page<Issue>) => void = () => {};
-    mockListIssues.mockImplementationOnce(
-      () =>
-        new Promise<Page<Issue>>((resolve) => {
-          resolveFirst = resolve;
-        })
-    );
-    const { container } = renderToolbar();
-    const button = getIssuesButton(container);
-
-    pointerEnter(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-    expect(mockListIssues).toHaveBeenCalledTimes(1);
-
-    // Hover again while the first request is still in flight.
-    pointerLeave(button);
-    pointerEnter(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-    expect(mockListIssues).toHaveBeenCalledTimes(1);
-
-    // Settle the first request.
-    resolveFirst(makeIssuePage([makeIssue(1)]));
-  });
-
-  it("does not prefetch when the dropdown is already open (would duplicate the list's mount fetch)", async () => {
-    // Simulate the open state by clicking the button first — onClick toggles
-    // open and triggers a forced refresh. The dropdown slot view resolves to
-    // null in this suite, but the toolbar tracks issuesOpen=true.
-    const { container } = renderToolbar();
-    const button = getIssuesButton(container);
-
-    fireEvent.click(button);
-    refreshStatsMock.mockClear();
-    mockListIssues.mockClear();
-
-    pointerEnter(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-
-    expect(mockListIssues).not.toHaveBeenCalled();
-    expect(refreshStatsMock).not.toHaveBeenCalled();
-  });
-
-  it("clears pending hover timer on unmount (no fetch after unmount)", async () => {
-    const { container, unmount } = renderToolbar();
-
-    pointerEnter(getIssuesButton(container));
-    unmount();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(300);
-    });
-
-    expect(mockListIssues).not.toHaveBeenCalled();
-  });
-
-  it("does NOT force-refresh on click when stats are within the freshness window", async () => {
-    // Default mock: lastUpdated is Date.now() so the polled stats are fresh.
-    // Click should rely on the hot cache populated by the 30s poll instead
-    // of triggering a full reload.
-    const { container } = renderToolbar();
-    const button = getIssuesButton(container);
-
-    fireEvent.click(button);
-
-    expect(refreshStatsMock).not.toHaveBeenCalled();
-  });
-
-  it("hover-then-click within the debounce window cancels the pending prefetch", async () => {
-    const { container } = renderToolbar();
-    const button = getIssuesButton(container);
-
-    pointerEnter(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(50);
-    });
-    fireEvent.click(button);
-    refreshStatsMock.mockClear();
-    mockListIssues.mockClear();
-
-    // Even though the timer was scheduled before the click, the dropdown is
-    // now open and the timer must short-circuit when it fires.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-
-    expect(mockListIssues).not.toHaveBeenCalled();
-    expect(refreshStatsMock).not.toHaveBeenCalled();
-  });
-
-  it("clears the in-flight ref after a rejection so a subsequent hover refetches", async () => {
-    mockListIssues
-      .mockRejectedValueOnce(new Error("network blip"))
-      .mockResolvedValue(makeIssuePage([makeIssue(7)]));
-    const { container } = renderToolbar();
-    const button = getIssuesButton(container);
-
-    pointerEnter(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-    // Let the rejection settle through the .catch/.finally chain.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
-    expect(mockListIssues).toHaveBeenCalledTimes(1);
-
-    // Second hover after rejection should refetch — but the cached freshness
-    // skip would block it if a stale entry got written. Verify no entry
-    // exists, then re-hover.
-    expect(getCache(buildCacheKey("/test/proj", "issue", "open", "created"))).toBeUndefined();
-    pointerLeave(button);
-    pointerEnter(button);
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
-    });
-
-    expect(mockListIssues).toHaveBeenCalledTimes(2);
   });
 
   it("treats a cache entry exactly at the freshness boundary (10s old) as stale", async () => {
@@ -496,15 +320,120 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     });
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      pointerEnter(getIssuesButton(container));
     });
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
 
-  it("stamps freshBypassAt and the open-count fingerprint on the prefetched entry", async () => {
+  it("does not fire when isTokenError is true", async () => {
+    mockIsTokenError = true;
+    const { container } = renderToolbar();
+
+    await act(async () => {
+      pointerEnter(getIssuesButton(container));
+    });
+
+    expect(mockListIssues).not.toHaveBeenCalled();
+    expect(refreshStatsMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when rate limit is active", async () => {
+    mockRateLimitResetAt = Date.now() + 60_000;
+    const { container } = renderToolbar();
+
+    await act(async () => {
+      pointerEnter(getIssuesButton(container));
+    });
+
+    expect(mockListIssues).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent hovers — a re-enter while a prefetch is in flight does not re-fetch", async () => {
+    let resolveFirst: (v: Page<Issue>) => void = () => {};
+    mockListIssues.mockImplementationOnce(
+      () =>
+        new Promise<Page<Issue>>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+    const { container } = renderToolbar();
+    const button = getIssuesButton(container);
+
+    await act(async () => {
+      pointerEnter(button);
+    });
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+
+    // Re-enter while the first request is still in flight — the in-flight guard
+    // must suppress the duplicate.
+    await act(async () => {
+      pointerEnter(button);
+    });
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+
+    // Settle the first request and flush its chain so no .then/.finally work
+    // drifts past the end of the test.
+    await act(async () => {
+      resolveFirst(makeIssuePage([makeIssue(1)]));
+    });
+    await settle();
+  });
+
+  it("does not prefetch when the dropdown is already open (would duplicate the list's mount fetch)", async () => {
+    // Clicking toggles the open state; the dropdown slot view resolves to null
+    // in this suite, but the toolbar tracks issuesOpen=true.
+    const { container } = renderToolbar();
+    const button = getIssuesButton(container);
+
+    fireEvent.click(button);
+    refreshStatsMock.mockClear();
+    mockListIssues.mockClear();
+
+    await act(async () => {
+      pointerEnter(button);
+    });
+
+    expect(mockListIssues).not.toHaveBeenCalled();
+    expect(refreshStatsMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT force-refresh on click when stats are within the freshness window", () => {
+    // Default mock: lastUpdated is Date.now() so the polled stats are fresh.
+    // Click should rely on the hot cache instead of triggering a full reload.
+    const { container } = renderToolbar();
+    const button = getIssuesButton(container);
+
+    fireEvent.click(button);
+
+    expect(refreshStatsMock).not.toHaveBeenCalled();
+  });
+
+  it("clears the in-flight ref after a rejection so a subsequent hover refetches", async () => {
+    mockListIssues
+      .mockRejectedValueOnce(new Error("network blip"))
+      .mockResolvedValue(makeIssuePage([makeIssue(7)]));
+    const { container } = renderToolbar();
+    const button = getIssuesButton(container);
+
+    await act(async () => {
+      pointerEnter(button);
+    });
+    await settle();
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
+
+    // A failed prefetch writes nothing, so the freshness skip can't block the
+    // retry.
+    expect(getCache(buildCacheKey("/test/proj", "issue", "open", "created"))).toBeUndefined();
+
+    await act(async () => {
+      pointerEnter(button);
+    });
+    expect(mockListIssues).toHaveBeenCalledTimes(2);
+  });
+
+  it("stamps the open-count fingerprint but NOT freshBypassAt (cache-first prefetch)", async () => {
     mockListIssues.mockResolvedValue({
       items: [makeIssue(11)],
       nextCursor: "c1",
@@ -513,16 +442,13 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     });
     const { container } = renderToolbar();
 
-    pointerEnter(getIssuesButton(container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150);
+      pointerEnter(getIssuesButton(container));
     });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(0);
-    });
+    await settle();
 
     const cached = getCache(buildCacheKey("/test/proj", "issue", "open", "created"));
-    expect(typeof cached?.freshBypassAt).toBe("number");
+    expect(cached?.freshBypassAt).toBeUndefined();
     expect(cached?.countAtWrite).toBe(7);
   });
 
@@ -537,30 +463,26 @@ describe("ForgeStatsToolbarButton hover prefetch", () => {
     const { container } = renderToolbar();
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
 
-    pointerEnter(getIssuesButton(container));
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(150); // prefetch request starts
+      pointerEnter(getIssuesButton(container));
     });
     expect(mockListIssues).toHaveBeenCalledTimes(1);
 
     // While the prefetch hangs, a competing path (the dropdown's own bypass
     // revalidate) commits a fresher page.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(20);
-    });
     setCache(cacheKey, {
       items: [makeIssue(99)],
       nextCursor: null,
       hasMore: false,
-      timestamp: Date.now(),
-      freshBypassAt: Date.now(),
+      timestamp: Date.now() + 1,
+      freshBypassAt: Date.now() + 1,
     });
 
     // The slow prefetch finally lands — it must not overwrite the newer entry.
     await act(async () => {
       resolvePrefetch(makeIssuePage([makeIssue(11)]));
-      await vi.advanceTimersByTimeAsync(0);
     });
+    await settle();
 
     const cached = getCache(cacheKey);
     expect(cached?.items.map((i) => i.number)).toEqual([99]);


### PR DESCRIPTION
Changes how the GitHub Issues and PRs toolbar pills prefetch their dropdown lists on hover.

Background polling of these lists was removed earlier to save GitHub GraphQL quota, which made opening a dropdown feel slow. The hover prefetch was meant to hide that delay but rarely did: a 150ms debounce delayed the request and, worse, cancelled the prefetch outright when the click landed inside the window, so the dropdown routinely mounted cold. It also forced `bypassCache: true` on every sustained hover, burning a GraphQL query each time and ignoring the cache.

This PR:

- Fires the prefetch immediately on `pointerenter` (mouse only), no debounce, so warming starts the moment the cursor lands.
- Makes the hover fetch cache-first (`bypassCache: false`). A warm main-process list cache (60s TTL) serves it with zero GraphQL; only a cold slot spends a query, and that's the same one the click would have made. Net result is strictly less GraphQL on the dominant warm-hover path.
- Stops stamping `freshBypassAt` on the prefetched entry (reserved for real bypass fetches). The dropdown still opens instantly on the warmed rows, then runs its normal cheap, cache-honoring open-time revalidate. `countAtWrite` is still stamped for the count-as-cache-buster.
- Removes the now-dead hover timer refs, the `pointerleave` cancel handler, and its unmount cleanup.
- Hardens the plugin's lazy list-chunk preload with a 2s `requestIdleCallback` timeout so a first click under launch load can't land on the Suspense skeleton.

Tests rewritten for the instant/cache-first behavior. Typecheck, lint, format, and the hover + SWR suites pass locally.

### Known residual quota edge cases

A few cold-path cases still spend GraphQL and need a backend change (a served-from-cache signal) to fully resolve, so they're left for follow-up:

- Cold fast fly-by across the three adjacent pills can spend a query on a pill passed over (warm = 0).
- Cold PR hover-then-open can cost 2 GraphQL (vs 1) when the hover fully completes before the click; warm PRs and fast hover→click coalesce to 1. Inherent to PRs always bypassing on open for fresh CI status.
- Coalescing can let a warm hover's cached page back a `bypass: true` PR open, stamping a slightly optimistic `freshBypassAt` (self-heals in 10s).