### PR TITLE
fix(panels): prevent duplicate-as-tab crash with two-pane split enabled (#10438)

### DIFF
--- a/e2e/full/panels/core-panel-tab-groups.spec.ts
+++ b/e2e/full/panels/core-panel-tab-groups.spec.ts
@@ -307,13 +307,37 @@ test.describe.serial("Split-mode crash regression (issue #10438)", () => {
     splitFixtureCleanup?.();
   });
 
-  test("duplicate as new tab with split mode enabled does not crash and forms a tab group", async () => {
+  // The two-pane split layout container; present only while split mode is
+  // active (TwoPaneSplitLayout renders `data-split-mode="true"`).
+  const splitLayout = '[data-split-mode="true"]';
+
+  test("split mode activates for two independent panels but duplicate-as-tab does not crash", async () => {
     const { window } = splitCtx;
+    const split = window.locator(splitLayout);
 
+    // Precondition + legitimate-path guard: two independent ungrouped panels
+    // (two virtual singleton groups) must activate the split layout. This both
+    // proves split mode is genuinely enabled in this context (so the duplicate
+    // assertion below isn't vacuously passing with split mode off) and guards
+    // the legitimate split path against regression from the new
+    // allGroupsAreVirtual predicate term.
     await openTerminal(window);
-    const panel = getFirstGridPanel(window);
-    await expect(panel).toBeVisible({ timeout: T_LONG });
+    await openTerminal(window);
+    await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(2);
+    await expect(split).toBeVisible({ timeout: T_MEDIUM });
 
+    // Reduce back to a single panel so the duplicate flow starts from the
+    // one-panel state that triggered the crash.
+    await window.locator(SEL.panel.gridPanel).last().locator(SEL.panel.close).first().click({
+      force: true,
+    });
+    await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(1);
+    await expect(split).toBeHidden({ timeout: T_MEDIUM });
+
+    // The actual regression: duplicate-as-tab on the solo panel. The old
+    // predicate matched the transient explicit+virtual group pair and activated
+    // the split layout against an already-grouped panel, crashing the renderer.
+    const panel = getFirstGridPanel(window);
     // The + button has opacity-0 on single panels, use force:true
     const duplicateBtn = panel.locator(SEL.panel.duplicate).first();
     await duplicateBtn.click({ force: true, timeout: T_MEDIUM });
@@ -328,7 +352,9 @@ test.describe.serial("Split-mode crash regression (issue #10438)", () => {
     const tabs = tabList.locator(SEL.panel.tab);
     await expect(tabs).toHaveCount(2, { timeout: T_MEDIUM });
 
-    // The two tabs stay within a single grid panel — not two split panes.
+    // The two tabs stay within a single grid panel — a tab group, never the
+    // split layout.
     expect(await getGridPanelCount(window)).toBe(1);
+    await expect(split).toBeHidden({ timeout: T_SHORT });
   });
 });

--- a/e2e/full/panels/core-panel-tab-groups.spec.ts
+++ b/e2e/full/panels/core-panel-tab-groups.spec.ts
@@ -23,11 +23,14 @@ test.describe.serial("Core: Panel Tab Groups", () => {
     fixtureCleanup = cleanup;
     ctx = await launchApp();
 
-    // Disable two-pane split mode before the project loads. The 1→2 panel
-    // transition from "Duplicate as new tab" triggers a race condition where
-    // the split layout briefly activates during the intermediate state (two
-    // single-panel groups) and crashes the app. Seeding localStorage before
-    // the zustand store hydrates avoids this.
+    // Disable two-pane split mode for this suite's isolation. The crash this
+    // workaround originally guarded against (issue #10438 — split layout
+    // briefly activating during the 1→2 "Duplicate as new tab" transition) is
+    // now fixed by the allGroupsAreVirtual predicate guard, and the dedicated
+    // regression block below exercises the fix with split mode left enabled.
+    // We keep split mode disabled here so the suite's many duplicate/tab
+    // assertions don't have to account for the split layout. Seeding
+    // localStorage before the zustand store hydrates avoids it.
     await ctx.window.evaluate(() => {
       localStorage.setItem(
         "daintree-two-pane-split",
@@ -269,5 +272,63 @@ test.describe.serial("Core: Panel Tab Groups", () => {
         // Best-effort cleanup
       }
     });
+  });
+});
+
+// Regression for issue #10438: "Duplicate as new tab" must not crash the app
+// when two-pane split mode is enabled (the default). The 1→2 panel transition
+// briefly produced two single-panel groups — one explicit, one virtual — which
+// satisfied the old useTwoPaneSplitMode predicate and activated the split
+// layout against a panel already in an explicit group, crashing the renderer.
+// This block leaves split mode at its default (enabled) — no localStorage seed.
+test.describe.serial("Split-mode crash regression (issue #10438)", () => {
+  let splitCtx: AppContext;
+  let splitFixtureDir: string;
+  let splitFixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { dir, cleanup } = createFixtureRepo({
+      name: "tab-groups-split",
+      withMultipleFiles: true,
+    });
+    splitFixtureDir = dir;
+    splitFixtureCleanup = cleanup;
+    splitCtx = await launchApp();
+    splitCtx.window = await openAndOnboardProject(
+      splitCtx.app,
+      splitCtx.window,
+      splitFixtureDir,
+      "Tab Groups Split Test"
+    );
+  });
+
+  test.afterAll(async () => {
+    if (splitCtx?.app) await closeApp(splitCtx.app);
+    splitFixtureCleanup?.();
+  });
+
+  test("duplicate as new tab with split mode enabled does not crash and forms a tab group", async () => {
+    const { window } = splitCtx;
+
+    await openTerminal(window);
+    const panel = getFirstGridPanel(window);
+    await expect(panel).toBeVisible({ timeout: T_LONG });
+
+    // The + button has opacity-0 on single panels, use force:true
+    const duplicateBtn = panel.locator(SEL.panel.duplicate).first();
+    await duplicateBtn.click({ force: true, timeout: T_MEDIUM });
+
+    // If the renderer crashed, every locator call below would reject with
+    // "Target closed". Reaching a visible tab list with two tabs proves the
+    // panel survived and the new panel was folded into the same tab group
+    // rather than spilling into the split layout.
+    const tabList = panel.locator(SEL.panel.tabList);
+    await expect(tabList).toBeVisible({ timeout: T_MEDIUM });
+
+    const tabs = tabList.locator(SEL.panel.tab);
+    await expect(tabs).toHaveCount(2, { timeout: T_MEDIUM });
+
+    // The two tabs stay within a single grid panel — not two split panes.
+    expect(await getGridPanelCount(window)).toBe(1);
   });
 });

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -934,10 +934,17 @@ export function useContentGridContext({
   ]);
 
   const allGroupsAreSinglePanel = tabGroups.every((g) => g.panelIds.length === 1);
+  // Virtual singletons use `id === panelId` (see getTabGroups in tabGroups.ts);
+  // explicit groups always use `tabgroup-${uuid}`. Requiring all groups to be
+  // virtual prevents split mode from activating during the transient window in
+  // addTabForPanel where an explicit singleton group exists before the new panel
+  // has been folded into it — which otherwise crashes the app (issue #10438).
+  const allGroupsAreVirtual = tabGroups.every((g) => g.id === (g.panelIds[0] ?? ""));
   const useTwoPaneSplitMode =
     twoPaneSplitEnabled &&
     tabGroups.length === 2 &&
     allGroupsAreSinglePanel &&
+    allGroupsAreVirtual &&
     !maximizedId &&
     !showPlaceholder;
 


### PR DESCRIPTION
## Summary

- Duplicate-as-tab crashes the app when two-pane split mode is enabled. Root cause is a transient state mid-`addTabForPanel`: after the explicit group is created but before `addPanelToGroup` completes, `getTabGroups()` returns one explicit singleton and one virtual singleton — satisfying the split-mode predicate and activating `TwoPaneSplitLayout` against a panel that's already in an explicit group.
- Fix adds an `allGroupsAreVirtual` term to `useTwoPaneSplitMode` in `useContentGridContext.tsx`, so split layout only activates for genuinely ungrouped virtual-singleton panels.
- E2E regression in `core-panel-tab-groups.spec.ts` runs with split mode left enabled: positive control asserts two independent panels do activate split layout; main assertion confirms duplicate-as-tab neither crashes nor spills into split layout.

Closes #10438

## Changes

- `src/components/Terminal/useContentGridContext.tsx` — added `allGroupsAreVirtual` guard to the `useTwoPaneSplitMode` predicate
- `e2e/full/panels/core-panel-tab-groups.spec.ts` — added `#10438` regression block with split mode enabled

## Testing

eslint, tsc, and prettier all clean. `full-panels` tab-groups spec 10/10.