### PR TITLE
feat(onboarding): add first-run global skip-permissions step

### DIFF
--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -36,9 +36,18 @@ interface AgentCliStepProps {
   availability: CliAvailability;
   selections: Record<string, boolean>;
   onInstallComplete?: () => void;
+  // During first-run, the dedicated permissions step owns the global trust
+  // decision, so the per-agent dangerous toggles here are suppressed to avoid
+  // a competing control.
+  isFirstRun?: boolean;
 }
 
-export function AgentCliStep({ availability, selections, onInstallComplete }: AgentCliStepProps) {
+export function AgentCliStep({
+  availability,
+  selections,
+  onInstallComplete,
+  isFirstRun = false,
+}: AgentCliStepProps) {
   const [cardStatuses, setCardStatuses] = useState<Record<string, CardStatus>>({});
   const [cardErrors, setCardErrors] = useState<Record<string, string>>({});
   const [expandedErrors, setExpandedErrors] = useState<Record<string, boolean>>({});
@@ -403,7 +412,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
         </button>
       )}
 
-      {agentsWithDangerousToggle.length > 0 && (
+      {!isFirstRun && agentsWithDangerousToggle.length > 0 && (
         <div className="border-t border-daintree-border pt-3 space-y-2">
           <div className="text-xs font-medium text-daintree-text/60">Skip permissions</div>
           <div className="space-y-1.5">

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -228,6 +228,7 @@ export type WizardStep =
   | { type: "agents" }
   | { type: "privacy" }
   | { type: "cli" }
+  | { type: "permissions" }
   | { type: "complete" };
 
 export interface WizardState {
@@ -244,21 +245,23 @@ export type WizardAction =
   | { type: "AGENTS_CONTINUE" }
   | { type: "PRIVACY_CONTINUE" }
   | { type: "CLI_CONTINUE" }
+  | { type: "PERMISSIONS_CONTINUE" }
   | { type: "BACK" }
   | { type: "SET_AVAILABILITY"; payload: CliAvailability }
   | { type: "INIT_SELECTIONS"; payload: Record<string, boolean> }
   | { type: "TOGGLE_SELECTION"; agentId: string; checked: boolean }
   | { type: "RESET"; availability: CliAvailability; isFirstRun: boolean };
 
-// First-run walks every step (appearance → agents → privacy → cli → complete);
-// re-runs from Settings start at `agents` and skip the first-run-only consent
-// steps. The `cli` step is conditionally skipped when all selected agents are
-// already installed, but the dot count reflects the maximum flow length —
-// mirroring the pre-split behavior where the skippable `cli` step still
-// counted toward the total.
+// First-run walks every step (appearance → agents → privacy → cli →
+// permissions → complete); re-runs from Settings start at `agents` and skip the
+// first-run-only consent steps (privacy, permissions — returning users already
+// have those toggles in Settings). The `cli` step is conditionally skipped when
+// all selected agents are already installed, but the dot count reflects the
+// maximum flow length — mirroring the pre-split behavior where the skippable
+// `cli` step still counted toward the total.
 export function flowSteps(isFirstRun: boolean): WizardStep["type"][] {
   return isFirstRun
-    ? ["appearance", "agents", "privacy", "cli", "complete"]
+    ? ["appearance", "agents", "privacy", "cli", "permissions", "complete"]
     : ["agents", "cli", "complete"];
 }
 
@@ -308,6 +311,16 @@ export function wizardReducer(state: WizardState, action: WizardAction): WizardS
       };
 
     case "CLI_CONTINUE":
+      // First-run users get the global skip-permissions consent step before the
+      // summary; re-runs branch straight to complete (the toggle lives in
+      // Settings for returning users).
+      return {
+        ...state,
+        step: state.isFirstRun ? { type: "permissions" } : { type: "complete" },
+        history: [...state.history, state.step],
+      };
+
+    case "PERMISSIONS_CONTINUE":
       return {
         ...state,
         step: { type: "complete" },
@@ -375,7 +388,7 @@ export function AgentSetupWizard({
   const [hasFatalHealthFailure, setHasFatalHealthFailure] = useState(false);
   const [isHealthChecking, setIsHealthChecking] = useState(true);
 
-  const { setAgentPinned } = useAgentSettingsStore();
+  const { setAgentPinned, setGlobalSkipPermissions } = useAgentSettingsStore();
   const isAvailabilityLoading = useCliAvailabilityStore((s) => s.isLoading || s.isRefreshing);
   const [isSaving, setIsSaving] = useState(false);
 
@@ -384,6 +397,10 @@ export function AgentSetupWizard({
   const setSelectedSchemeId = useAppThemeStore((s) => s.setSelectedSchemeId);
   const setSelectedSchemeIdSilent = useAppThemeStore((s) => s.setSelectedSchemeIdSilent);
   const hasAutoSelected = useRef(false);
+
+  // Global skip-permissions state (first-run only). Default off — silence is not
+  // consent. Committed via setGlobalSkipPermissions only on Continue.
+  const [permissionsEnabled, setPermissionsEnabled] = useState(false);
 
   // Telemetry state (first-run only)
   const [telemetryEnabled, setTelemetryEnabled] = useState(false);
@@ -417,6 +434,7 @@ export function AgentSetupWizard({
       telemetryCommittedRef.current = false;
       telemetryToggleTouchedRef.current = false;
       setTelemetryEnabled(false);
+      setPermissionsEnabled(false);
       void useAgentSettingsStore.getState().initialize();
       directionRef.current = 1;
     }
@@ -565,6 +583,33 @@ export function AgentSetupWizard({
     dispatch({ type: "CLI_CONTINUE" });
   }, []);
 
+  const handlePermissionsContinue = useCallback(async () => {
+    directionRef.current = 1;
+    // Default off — nothing to persist, just advance. The store already holds
+    // false (or whatever the user had); a no-op write is avoided.
+    if (!permissionsEnabled) {
+      dispatch({ type: "PERMISSIONS_CONTINUE" });
+      return;
+    }
+    setIsSaving(true);
+    try {
+      // Forward-fail: only advance once the write resolves. On failure the
+      // store rolls back and re-throws; stay on the step so the user can retry.
+      await setGlobalSkipPermissions(true);
+      dispatch({ type: "PERMISSIONS_CONTINUE" });
+    } catch {
+      // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Skip-permissions wasn't saved. Try again.",
+        priority: "high",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  }, [permissionsEnabled, setGlobalSkipPermissions]);
+
   const handleBack = useCallback(() => {
     directionRef.current = -1;
     dispatch({ type: "BACK" });
@@ -674,6 +719,7 @@ export function AgentSetupWizard({
                 <AgentCliStep
                   availability={state.availability}
                   selections={state.selections}
+                  isFirstRun={isFirstRun}
                   onInstallComplete={() => {
                     void cliAvailabilityClient.refresh().then((result) => {
                       if (isOpenRef.current) {
@@ -681,6 +727,12 @@ export function AgentSetupWizard({
                       }
                     });
                   }}
+                />
+              )}
+              {state.step.type === "permissions" && (
+                <PermissionsStep
+                  permissionsEnabled={permissionsEnabled}
+                  onPermissionsChange={setPermissionsEnabled}
                 />
               )}
               {state.step.type === "complete" && (
@@ -767,6 +819,12 @@ export function AgentSetupWizard({
               <Button onClick={handleCliContinue}>
                 Continue
                 <ChevronRight className="w-4 h-4 ml-1" />
+              </Button>
+            )}
+            {state.step.type === "permissions" && (
+              <Button onClick={handlePermissionsContinue} disabled={isSaving}>
+                Continue
+                <ArrowRight className="w-4 h-4 ml-1" />
               </Button>
             )}
             {state.step.type === "complete" && <Button onClick={handleFinish}>Finish setup</Button>}
@@ -1001,6 +1059,60 @@ function PrivacyStep({
         >
           Preview what would be sent
         </button>
+      </div>
+    </section>
+  );
+}
+
+// --- Permissions step (first-run global skip-permissions consent) ---
+
+function PermissionsStep({
+  permissionsEnabled,
+  onPermissionsChange,
+}: {
+  permissionsEnabled?: boolean;
+  onPermissionsChange: (enabled: boolean) => void;
+}) {
+  const labelId = useId();
+  const descriptionId = useId();
+
+  return (
+    <section>
+      <h3 className="text-base font-semibold text-daintree-text mb-2">Agent permissions</h3>
+      <p className="text-sm text-daintree-text/60 mb-4">
+        Keep prompts on unless you trust agents to run commands and edit files without asking
+      </p>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <p id={labelId} className="text-sm font-medium text-daintree-text">
+            Skip permission prompts for agents
+          </p>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={permissionsEnabled}
+            aria-labelledby={labelId}
+            aria-describedby={descriptionId}
+            onClick={() => onPermissionsChange(!permissionsEnabled)}
+            className={cn(
+              "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors",
+              permissionsEnabled ? "bg-daintree-accent" : "bg-daintree-border"
+            )}
+          >
+            <span
+              className={cn(
+                "pointer-events-none inline-block h-4 w-4 rounded-full shadow transform transition-transform mt-0.5",
+                permissionsEnabled
+                  ? "translate-x-4 ml-0.5 bg-text-inverse"
+                  : "translate-x-0 ml-0.5 bg-daintree-text"
+              )}
+            />
+          </button>
+        </div>
+        <p id={descriptionId} className="text-xs text-daintree-text/50">
+          Agents act without confirmation — faster, but they run commands and edit files on their
+          own. You can change this anytime in Settings → Agents.
+        </p>
       </div>
     </section>
   );

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -277,12 +277,17 @@ export function buildInitialState(availability: CliAvailability, isFirstRun = fa
 }
 
 // The cli step is skipped when every selected agent is already launchable —
-// there is nothing left to install, so jump straight to the summary.
+// there is nothing left to install. First-run users must still pass through the
+// global permissions consent gate before the summary even when cli is skipped;
+// returning users go straight to complete.
 function resolvePostInstallStep(state: WizardState): WizardStep {
   const selectedIds = Object.keys(state.selections).filter((id) => state.selections[id]);
   const allSelectedInstalled =
     selectedIds.length > 0 && selectedIds.every((id) => isAgentLaunchable(state.availability[id]));
-  return allSelectedInstalled ? { type: "complete" } : { type: "cli" };
+  if (allSelectedInstalled) {
+    return state.isFirstRun ? { type: "permissions" } : { type: "complete" };
+  }
+  return { type: "cli" };
 }
 
 export function wizardReducer(state: WizardState, action: WizardAction): WizardState {
@@ -585,17 +590,14 @@ export function AgentSetupWizard({
 
   const handlePermissionsContinue = useCallback(async () => {
     directionRef.current = 1;
-    // Default off — nothing to persist, just advance. The store already holds
-    // false (or whatever the user had); a no-op write is avoided.
-    if (!permissionsEnabled) {
-      dispatch({ type: "PERMISSIONS_CONTINUE" });
-      return;
-    }
     setIsSaving(true);
     try {
-      // Forward-fail: only advance once the write resolves. On failure the
-      // store rolls back and re-throws; stay on the step so the user can retry.
-      await setGlobalSkipPermissions(true);
+      // Always persist the explicit choice (on or off) so a pre-existing `true`
+      // from an interrupted prior run can't override the default-off decision —
+      // mirrors how telemetry commits even for the off state. Forward-fail: only
+      // advance once the write resolves; on failure the store rolls back and
+      // re-throws, so stay on the step for retry.
+      await setGlobalSkipPermissions(permissionsEnabled);
       dispatch({ type: "PERMISSIONS_CONTINUE" });
     } catch {
       // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
@@ -603,7 +605,10 @@ export function AgentSetupWizard({
         type: "error",
         title: "Couldn't save setting",
         message: "Skip-permissions wasn't saved. Try again.",
+        // Explicit high priority so the failure surfaces a toast (the
+        // permissions step itself is the retry surface, so no action button).
         priority: "high",
+        context: { eventKind: "settings" },
       });
     } finally {
       setIsSaving(false);

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -173,7 +173,9 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.step).toEqual({ type: "cli" });
   });
 
-  it("privacy skips to complete when all selected agents are installed", () => {
+  it("privacy routes first-run to permissions (not complete) when all selected agents are installed", () => {
+    // cli is skipped (nothing to install) but the global permissions consent
+    // gate must still fire on first run before the summary.
     const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
     let state = buildInitialState(allInstalled, true);
     state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
@@ -183,10 +185,10 @@ describe("AgentSetupWizard reducer", () => {
     });
     state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
-    expect(state.step).toEqual({ type: "complete" });
+    expect(state.step).toEqual({ type: "permissions" });
   });
 
-  it("privacy skips to complete when only selected agents are installed (unselected missing)", () => {
+  it("privacy routes first-run to permissions when only selected agents are installed (unselected missing)", () => {
     const avail = { claude: "ready", gemini: "missing" } as CliAvailability;
     let state = buildInitialState(avail, true);
     state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
@@ -196,7 +198,27 @@ describe("AgentSetupWizard reducer", () => {
     });
     state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
     state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
+    expect(state.step).toEqual({ type: "permissions" });
+  });
+
+  it("permissions still fires on first run when all agents pre-installed, then advances to complete", () => {
+    const allInstalled = { claude: "ready", gemini: "ready" } as CliAvailability;
+    let state = buildInitialState(allInstalled, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
+    expect(state.step).toEqual({ type: "permissions" });
+
+    state = wizardReducer(state, { type: "PERMISSIONS_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
+
+    // BACK from complete returns to permissions, not cli (cli was skipped).
+    state = wizardReducer(state, { type: "BACK" });
+    expect(state.step).toEqual({ type: "permissions" });
   });
 
   it("BACK from complete returns to the prior step, preserving history", () => {

--- a/src/components/Setup/__tests__/AgentSetupWizard.test.ts
+++ b/src/components/Setup/__tests__/AgentSetupWizard.test.ts
@@ -3,6 +3,7 @@ import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import {
   buildInitialState,
   FEATURED_AGENT_IDS,
+  flowSteps,
   MORE_AGENT_IDS,
   sortTierByInstalled,
   wizardReducer,
@@ -80,6 +81,19 @@ describe("tier partition completeness", () => {
 
     const overlap = FEATURED_AGENT_IDS.filter((id) => MORE_AGENT_IDS.includes(id));
     expect(overlap).toEqual([]);
+  });
+});
+
+describe("flowSteps", () => {
+  it("includes the permissions step on first run, after cli and before complete", () => {
+    const steps = flowSteps(true);
+    expect(steps).toContain("permissions");
+    expect(steps.indexOf("permissions")).toBeGreaterThan(steps.indexOf("cli"));
+    expect(steps.indexOf("permissions")).toBeLessThan(steps.indexOf("complete"));
+  });
+
+  it("omits the permissions step for returning users", () => {
+    expect(flowSteps(false)).not.toContain("permissions");
   });
 });
 
@@ -239,7 +253,7 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.step).toEqual({ type: "cli" });
   });
 
-  it("advances from cli to complete", () => {
+  it("advances from cli to complete (non-first-run, no permissions step)", () => {
     let state = buildInitialState(emptyAvail);
     state = wizardReducer(state, {
       type: "INIT_SELECTIONS",
@@ -252,7 +266,47 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.step).toEqual({ type: "complete" });
   });
 
-  it("follows full first-run flow: appearance -> agents -> privacy -> cli -> complete", () => {
+  it("advances from cli to permissions on first run", () => {
+    const partial = { claude: "ready", gemini: "missing" } as CliAvailability;
+    let state = buildInitialState(partial, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
+    expect(state.step).toEqual({ type: "cli" });
+
+    state = wizardReducer(state, { type: "CLI_CONTINUE" });
+    expect(state.step).toEqual({ type: "permissions" });
+  });
+
+  it("advances from permissions to complete", () => {
+    let state = buildInitialState(emptyAvail, true);
+    state.step = { type: "permissions" };
+    state = wizardReducer(state, { type: "PERMISSIONS_CONTINUE" });
+    expect(state.step).toEqual({ type: "complete" });
+  });
+
+  it("BACK from permissions returns to cli", () => {
+    const partial = { claude: "ready", gemini: "missing" } as CliAvailability;
+    let state = buildInitialState(partial, true);
+    state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
+    state = wizardReducer(state, {
+      type: "INIT_SELECTIONS",
+      payload: { claude: true, gemini: true },
+    });
+    state = wizardReducer(state, { type: "AGENTS_CONTINUE" });
+    state = wizardReducer(state, { type: "PRIVACY_CONTINUE" });
+    state = wizardReducer(state, { type: "CLI_CONTINUE" });
+    expect(state.step).toEqual({ type: "permissions" });
+
+    state = wizardReducer(state, { type: "BACK" });
+    expect(state.step).toEqual({ type: "cli" });
+  });
+
+  it("follows full first-run flow: appearance -> agents -> privacy -> cli -> permissions -> complete", () => {
     let state = buildInitialState(emptyAvail, true);
 
     state = wizardReducer(state, { type: "APPEARANCE_CONTINUE" });
@@ -269,6 +323,9 @@ describe("AgentSetupWizard reducer", () => {
     expect(state.step).toEqual({ type: "cli" });
 
     state = wizardReducer(state, { type: "CLI_CONTINUE" });
+    expect(state.step).toEqual({ type: "permissions" });
+
+    state = wizardReducer(state, { type: "PERMISSIONS_CONTINUE" });
     expect(state.step).toEqual({ type: "complete" });
 
     expect(state.history).toEqual([
@@ -276,6 +333,7 @@ describe("AgentSetupWizard reducer", () => {
       { type: "agents" },
       { type: "privacy" },
       { type: "cli" },
+      { type: "permissions" },
     ]);
   });
 

--- a/src/components/Setup/__tests__/AgentSetupWizardPermissions.test.tsx
+++ b/src/components/Setup/__tests__/AgentSetupWizardPermissions.test.tsx
@@ -1,0 +1,339 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, act } from "@testing-library/react";
+
+const { notifyMock } = vi.hoisted(() => ({
+  notifyMock: vi.fn(),
+}));
+const { setGlobalSkipPermissionsMock } = vi.hoisted(() => ({
+  setGlobalSkipPermissionsMock: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
+vi.mock("framer-motion", () => {
+  const Passthrough = React.forwardRef<HTMLDivElement, React.PropsWithChildren<unknown>>(
+    ({ children }, _ref) => <>{children}</>
+  );
+  return {
+    AnimatePresence: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    LazyMotion: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    LayoutGroup: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    useReducedMotion: () => true,
+    m: { div: Passthrough },
+    motion: { div: Passthrough },
+  };
+});
+
+const agentSettingsStoreState = {
+  setAgentPinned: vi.fn(() => Promise.resolve()),
+  setGlobalSkipPermissions: setGlobalSkipPermissionsMock,
+  initialize: vi.fn(() => Promise.resolve()),
+};
+vi.mock("@/store", () => ({
+  useAgentSettingsStore: Object.assign(
+    (selector?: (s: unknown) => unknown) =>
+      selector ? selector(agentSettingsStoreState) : agentSettingsStoreState,
+    { getState: () => agentSettingsStoreState }
+  ),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: (selector: (s: unknown) => unknown) =>
+    selector({ isLoading: false, isRefreshing: false, availability: {}, hasRealData: true }),
+}));
+
+vi.mock("@/store/appThemeStore", () => ({
+  useAppThemeStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      selectedSchemeId: "daintree",
+      setSelectedSchemeId: vi.fn(),
+      setSelectedSchemeIdSilent: vi.fn(),
+    }),
+}));
+
+vi.mock("@/clients", () => ({
+  cliAvailabilityClient: { refresh: vi.fn(() => Promise.resolve({})) },
+}));
+
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: { setColorScheme: vi.fn(() => Promise.resolve()) },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn(() => Promise.resolve()) },
+}));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: { getDisplayCombo: () => "" },
+}));
+
+vi.mock("../useAgentSetupPoll", () => ({
+  useAgentSetupPoll: () => undefined,
+}));
+
+vi.mock("../SystemRequirementsSection", () => ({
+  SystemRequirementsSection: ({ onCheckingChange }: { onCheckingChange: (v: boolean) => void }) => {
+    React.useEffect(() => {
+      onCheckingChange(false);
+    }, [onCheckingChange]);
+    return <div data-testid="system-requirements-stub" />;
+  },
+}));
+
+vi.mock("../AgentCliStep", () => ({
+  AgentCliStep: () => <div data-testid="agent-cli-step-stub" />,
+}));
+
+vi.mock("@/components/agents/AgentCard", () => ({
+  AgentCard: ({ agentId }: { agentId: string }) => <div data-testid={`agent-card-${agentId}`} />,
+}));
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const Dialog = ({
+    isOpen,
+    onClose,
+    onBeforeClose,
+    children,
+  }: {
+    isOpen: boolean;
+    onClose?: () => void;
+    onBeforeClose?: () => boolean | Promise<boolean>;
+    children: React.ReactNode;
+  }) =>
+    isOpen ? (
+      <div data-testid="app-dialog">
+        <button
+          data-testid="dialog-dismiss"
+          onClick={async () => {
+            const proceed = onBeforeClose ? await onBeforeClose() : true;
+            if (proceed && onClose) onClose();
+          }}
+        />
+        {children}
+      </div>
+    ) : null;
+  const Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const Title = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  const CloseButton = () => <button data-testid="close-button-stub" />;
+  Dialog.Header = Header;
+  Dialog.Body = Body;
+  Dialog.Footer = Footer;
+  Dialog.Title = Title;
+  Dialog.CloseButton = CloseButton;
+  return { AppDialog: Dialog };
+});
+
+vi.mock("@/components/ui/Spinner", () => ({
+  Spinner: () => <div data-testid="spinner-stub" />,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/icons", () => ({
+  Plug: () => null,
+  BrandMark: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const electronStub = {
+  privacy: { setTelemetryLevel: vi.fn(() => Promise.resolve()) },
+  telemetry: { markPromptShown: vi.fn(() => Promise.resolve()) },
+};
+
+vi.stubGlobal("window", {
+  ...globalThis.window,
+  electron: electronStub,
+  matchMedia: () => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    media: "",
+    onchange: null,
+  }),
+});
+
+import { AgentSetupWizard } from "../AgentSetupWizard";
+
+async function clickButton(label: string) {
+  const button = Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label
+  );
+  expect(button, `expected a "${label}" button to be present`).toBeDefined();
+  await act(async () => {
+    button!.click();
+  });
+}
+
+// Navigate appearance -> agents -> privacy -> permissions. All selected agents
+// are pre-installed, so cli is skipped and the permissions step renders after
+// three Continue clicks.
+async function gotoPermissionsStep() {
+  await clickButton("Continue"); // appearance -> agents
+  await clickButton("Continue"); // agents -> privacy
+  await clickButton("Continue"); // privacy -> permissions
+}
+
+function permissionsToggle(): HTMLButtonElement {
+  const toggle = document.querySelector('button[role="switch"]') as HTMLButtonElement | null;
+  expect(toggle, "permissions toggle should be present on the permissions step").not.toBeNull();
+  return toggle!;
+}
+
+describe("AgentSetupWizard permissions step", () => {
+  beforeEach(() => {
+    notifyMock.mockClear();
+    setGlobalSkipPermissionsMock.mockClear();
+    setGlobalSkipPermissionsMock.mockImplementation(() => Promise.resolve());
+  });
+
+  it("renders the permissions step with the toggle defaulting to off", async () => {
+    await act(async () => {
+      render(
+        <AgentSetupWizard
+          isOpen
+          onClose={vi.fn()}
+          isFirstRun
+          initialAvailability={{ claude: "ready" }}
+        />
+      );
+    });
+
+    await gotoPermissionsStep();
+
+    const toggle = permissionsToggle();
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    // Accessibility: the switch points at the risk copy via aria-describedby.
+    const describedBy = toggle.getAttribute("aria-describedby");
+    expect(describedBy, "switch must wire aria-describedby to the risk copy").toBeTruthy();
+    expect(document.getElementById(describedBy!)).not.toBeNull();
+    // No autofocus on the switch.
+    expect(document.activeElement).not.toBe(toggle);
+  });
+
+  it("writes the explicit off choice and advances on Continue when the toggle is left off", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(
+        <AgentSetupWizard
+          isOpen
+          onClose={onClose}
+          isFirstRun
+          initialAvailability={{ claude: "ready" }}
+        />
+      );
+    });
+
+    await gotoPermissionsStep();
+    await clickButton("Continue"); // permissions -> complete
+
+    // Explicit off is persisted so a stale `true` can't survive first-run.
+    expect(setGlobalSkipPermissionsMock).toHaveBeenCalledTimes(1);
+    expect(setGlobalSkipPermissionsMock).toHaveBeenCalledWith(false);
+    expect(notifyMock).not.toHaveBeenCalled();
+    // Advanced to the summary, not closed.
+    expect(document.body.textContent).toContain("Setup complete");
+  });
+
+  it("commits true before advancing when the toggle is enabled", async () => {
+    await act(async () => {
+      render(
+        <AgentSetupWizard
+          isOpen
+          onClose={vi.fn()}
+          isFirstRun
+          initialAvailability={{ claude: "ready" }}
+        />
+      );
+    });
+
+    await gotoPermissionsStep();
+    await act(async () => {
+      permissionsToggle().click();
+    });
+    await clickButton("Continue");
+
+    expect(setGlobalSkipPermissionsMock).toHaveBeenCalledWith(true);
+    expect(notifyMock).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain("Setup complete");
+  });
+
+  it("stays on the permissions step and surfaces an error when the save fails", async () => {
+    setGlobalSkipPermissionsMock.mockRejectedValueOnce(new Error("IPC down"));
+
+    const onClose = vi.fn();
+    await act(async () => {
+      render(
+        <AgentSetupWizard
+          isOpen
+          onClose={onClose}
+          isFirstRun
+          initialAvailability={{ claude: "ready" }}
+        />
+      );
+    });
+
+    await gotoPermissionsStep();
+    await act(async () => {
+      permissionsToggle().click();
+    });
+    await clickButton("Continue");
+
+    expect(setGlobalSkipPermissionsMock).toHaveBeenCalledWith(true);
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+    // Did not advance — still on the permissions step, summary not shown.
+    expect(document.body.textContent).toContain("Agent permissions");
+    expect(document.body.textContent).not.toContain("Setup complete");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not write the setting when the user closes from the permissions step", async () => {
+    const onClose = vi.fn();
+    await act(async () => {
+      render(
+        <AgentSetupWizard
+          isOpen
+          onClose={onClose}
+          isFirstRun
+          initialAvailability={{ claude: "ready" }}
+        />
+      );
+    });
+
+    await gotoPermissionsStep();
+    const dismiss = document.querySelector(
+      '[data-testid="dialog-dismiss"]'
+    ) as HTMLButtonElement | null;
+    await act(async () => {
+      dismiss!.click();
+    });
+
+    // Close is not consent — the global skip setting must never be written here.
+    expect(setGlobalSkipPermissionsMock).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `permissions` step to `AgentSetupWizard` — first-run only, inserted after the CLI step and before the completion step — that surfaces the `globalSkipPermissions` toggle in a place new users are actually looking.
- The toggle defaults off and only commits via `setGlobalSkipPermissions` on Continue; backing out or closing the dialog never writes. On save failure the wizard stays on the step and fires an error toast.
- Per-agent dangerous toggles in `AgentCliStep` are suppressed during first run so the two trust decisions don't compete. Routing is also fixed so the permissions gate fires even when the CLI step is skipped (all agents pre-installed).

Resolves #10433

## Changes

- `AgentSetupWizard.tsx` — new `permissions` step with accessible switch (`aria-labelledby` + `aria-describedby` to the risk copy, no autofocus), wizard reducer handling, first-run routing fix
- `AgentCliStep.tsx` — suppress per-agent skip-permissions toggles when `isFirstRun` is true
- `AgentSetupWizard.test.ts` — reducer tests for the new step
- `AgentSetupWizardPermissions.test.tsx` — render tests covering toggle state, Continue/back behaviour, and save-failure toast

## Testing

Reducer tests cover step transitions, toggle state, and the continue/back no-write invariant. Render tests cover the full step UI, aria wiring, save failure path, and suppression of the per-agent toggles during first run.