### PR TITLE
fix(plugins): cut agent detection field from 1.0 schema

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -546,11 +546,10 @@ Teaches Daintree about a launchable agent CLI it doesn't ship in-tree, so the CL
 | `color` | yes | Brand color as a 6-digit hex (`#rrggbb`). |
 | `iconId` | yes | Icon id used for the agent. |
 | `supportsContextInjection` | no | Whether copy-tree context injection targets this agent. Defaults to `false`. |
-| `detection` | no | Reserved for the full-tracking tier. The shape (bounded, well-formed detection patterns) is **validated** at manifest-parse time but not yet wired into the live PTY matcher — minimal-tier agents launch as named, untracked terminals. |
 
-The **minimal tier** (shipped) makes the agent launchable and selectable as a named entry in the effective registry; detection is not run, so the agent always launches as a named terminal. The **full tier** (planned) will relax the built-in-only gate in output detection so a plugin-supplied `detection` config drives working/waiting state, resume, and MCP wiring.
+A plugin agent is launchable and selectable as a named entry in the effective registry. It launches as a named terminal; Daintree does not track its working/waiting state.
 
-A malformed `detection` config (an un-compilable pattern, an over-long or over-numerous pattern set, or a construct prone to catastrophic backtracking) is rejected at manifest validation — the plugin fails to load loudly rather than silently shipping a bad matcher. Once the full tier lands, a _well-formed_ config that simply never matches at runtime leaves the agent launching as a named terminal and never affects detection for other terminals.
+Output-pattern detection is **not part of the 1.0 plugin schema** — the live PTY matcher is owned by built-in agents only. A manifest that declares a `detection` block on an agent contribution is rejected at validation (unknown key), so the plugin fails to load loudly rather than carrying a field that never runs.
 
 ## What's missing and why
 

--- a/docs/plugins/freeze-plan.md
+++ b/docs/plugins/freeze-plan.md
@@ -32,13 +32,13 @@ These are product/architecture calls a human must make **first** — most freeze
 | D7 | **1.0 SDK surface.** Which packages/subpaths ship: `@daintreehq/plugin-sdk` core, `/react` (real hooks vs reserved-empty), `@daintreehq/plugin-testing` mock host, and the `plugin.json`/`.dntr` format version guarantees. | You cannot freeze an API no external author can build against. |
 | D8 | **`ForgeProvider` credentialFields: freeze single-field-only vs support multi-field credentials** (pass the full record to `validateToken`/`setCredentials`). | Shapes a frozen provider interface. |
 | D9 | **OS keychain for `type: "secret"` settings vs accept plaintext JSON as documented permanent 1.0 behavior** (#9167). | Either way it must be disclosed, not implied. |
-| D10 | **Plugin agent detection: cut the `detection` field for 1.0 (minimal tier) vs ship the full-tracking tier.** Are any in-the-wild plugins already declaring detection patterns? | Determines whether a heavily-validated manifest field stays or goes. |
+| D10 | **Plugin agent detection: cut the `detection` field for 1.0 (minimal tier) vs ship the full-tracking tier.** **Resolved — cut (#10460):** the `detection` field is removed from the 1.0 plugin schema; plugin agents launch as named, untracked terminals and the live PTY matcher stays built-in-only. | Determines whether a heavily-validated manifest field stays or goes. |
 
 ## What the audit found: cross-cutting failure classes
 
 The 23 individual findings cluster into a handful of systemic patterns. These are the themes worth internalizing — most issues are an instance of one of them.
 
-1. **Schema validates fields the runtime ignores (frozen-promise violations).** The single largest freeze-risk class. `detection` patterns, `scopes.fs.allowedPaths`, `scopes.network.allowedUrls` enforcement, `ForgeProviderContribution.capabilities`, and `ViewContribution.location:"sidebar"` are all validated at manifest-parse time but unconsulted or outright rejected at runtime. A plugin author writes a manifest, it passes validation, and nothing happens. Freezing these means freezing promises we don't keep.
+1. **Schema validates fields the runtime ignores (frozen-promise violations).** The single largest freeze-risk class. `scopes.fs.allowedPaths`, `scopes.network.allowedUrls` enforcement, `ForgeProviderContribution.capabilities`, and `ViewContribution.location:"sidebar"` are all validated at manifest-parse time but unconsulted or outright rejected at runtime. A plugin author writes a manifest, it passes validation, and nothing happens. Freezing these means freezing promises we don't keep. (Plugin agent `detection` was the canonical example; it has since been cut from the schema — #10460.)
 2. **Stale/contradictory schema-vs-implementation docs.** The `ForgeProvider` "reserved" comment, `SettingDefinition` "Reserved for F29," and `manifest.md` presenting `allowedPaths`/`allowedUrls` as enforcement all diverge from the actual code (the features are either done or never wired — the comments say the opposite). For a frozen API the schema doc must be authoritative.
 3. **Built infrastructure with no caller (dead pipelines).** The MCP consent service + audit + rug-pull detection + tier-cap are fully implemented but **never invoked** — there is no `tools/call` dispatcher wiring them in. `usePluginMenuItems` has no non-test consumer. `PluginActionAuditService` never receives error records. The plumbing exists; the last wire is missing.
 4. **Trust model is disclosure-first with no runtime sandbox — and under-disclosed.** No install-time consent gate, no signing/publisher identity, `scopes` implied as enforcement, `secret` settings stored in plaintext. The honest model ("trusted plugins only, runs as you do") is defensible, but it is currently implied rather than stated, and stated inconsistently across docs and UI.
@@ -68,7 +68,7 @@ Every issue candidate triaged into three tiers. "Blocks freeze" issues must land
 
 | # | Issue | Type | Severity | Scope |
 | --- | --- | --- | --- | --- |
-| 1 | Resolve plugin agent detection: wire it or cut it from the 1.0 schema (D10) | decision | high | large |
+| 1 | ~~Resolve plugin agent detection: wire it or cut it from the 1.0 schema (D10)~~ **Resolved — cut (#10460)** | decision | high | large |
 | 2 | Close `ViewContribution.location:"sidebar"` gap (validated by schema, rejected at runtime) | decision | high | medium |
 | 3 | Resolve plugin `menuItems`: render it somewhere or remove the contribution point | decision | high | medium |
 | 4 | Wire the MCP `tools/call` dispatch path through consent + audit + rate limiting | feature | critical | large |
@@ -116,7 +116,7 @@ The per-point disposition the freeze hinges on (resolved by D6). "Wired" means v
 | `settings` | Wired (F29 enforcement is live; comment stale) | Freeze after #16 |
 | `fileDecorationProviders` | Wired | Freeze |
 | `forgeProviders` | Wired (comment falsely says "reserved") | Freeze after #12, #16 |
-| `agents` | Launch wired; `detection` validated-but-dropped | Freeze after #1 (cut or wire detection) |
+| `agents` | Launch wired; `detection` cut from schema (#10460) | Freeze |
 | `menuItems` | Registered; **no renderer consumer** | Cut or wire (#3) |
 | `experimental_views` | `panel` partially wired; `sidebar` rejected at runtime | De-prefix or keep unstable (#2, #5) |
 | `experimental_mcpServers` | Supervisor + consent built but **dispatcher never called** | Wire dispatcher then de-prefix (#4, #5) |

--- a/electron/ipc/handlers/agentCapabilities.ts
+++ b/electron/ipc/handlers/agentCapabilities.ts
@@ -32,7 +32,6 @@ function toAgentMetadata(config: AgentConfig, agentId: string): AgentMetadata {
     tooltip: config.tooltip,
     usageUrl: config.usageUrl,
     capabilities: config.capabilities,
-    hasDetection: !!config.detection,
     hasVersionConfig: !!config.version,
     hasUpdateConfig: !!config.update,
     hasInstallHelp: !!config.install,

--- a/electron/schemas/__tests__/agentContribution.test.ts
+++ b/electron/schemas/__tests__/agentContribution.test.ts
@@ -35,12 +35,22 @@ describe("AgentContributionSchema (issue #9560)", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects a detection block — output detection is cut from the 1.0 schema (#10460)", () => {
+  it("rejects a detection block as an unknown key — output detection is cut from the 1.0 schema (#10460)", () => {
     const result = AgentContributionSchema.safeParse({
       ...VALID_AGENT,
       detection: { primaryPatterns: ["thinking"] },
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      // Assert the failure is strict unknown-key rejection of `detection`
+      // specifically, not some unrelated validation error — so a future
+      // re-introduction of the field can't silently flip this to a pass.
+      const unknownKeyIssue = result.error.issues.find(
+        (issue) => issue.code === "unrecognized_keys"
+      );
+      expect(unknownKeyIssue).toBeDefined();
+      expect((unknownKeyIssue as { keys?: string[] }).keys).toContain("detection");
+    }
   });
 
   it("rejects unknown top-level fields (strict)", () => {

--- a/electron/schemas/__tests__/agentContribution.test.ts
+++ b/electron/schemas/__tests__/agentContribution.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  AgentContributionSchema,
-  AgentDetectionContributionSchema,
-  getPluginManifestSchema,
-} from "../plugin.js";
+import { AgentContributionSchema, getPluginManifestSchema } from "../plugin.js";
 
 const VALID_AGENT = {
   id: "acme-agent",
@@ -30,14 +26,21 @@ describe("AgentContributionSchema (issue #9560)", () => {
     }
   });
 
-  it("accepts args, supportsContextInjection, and a detection block", () => {
+  it("accepts args and supportsContextInjection", () => {
     const result = AgentContributionSchema.safeParse({
       ...VALID_AGENT,
       args: ["--flag", "value"],
       supportsContextInjection: true,
-      detection: { primaryPatterns: ["thinking", "working\\.\\.\\."] },
     });
     expect(result.success).toBe(true);
+  });
+
+  it("rejects a detection block — output detection is cut from the 1.0 schema (#10460)", () => {
+    const result = AgentContributionSchema.safeParse({
+      ...VALID_AGENT,
+      detection: { primaryPatterns: ["thinking"] },
+    });
+    expect(result.success).toBe(false);
   });
 
   it("rejects unknown top-level fields (strict)", () => {
@@ -79,59 +82,6 @@ describe("AgentContributionSchema (issue #9560)", () => {
   });
 });
 
-describe("AgentDetectionContributionSchema bounded-regex contract (issue #9560)", () => {
-  it("rejects an invalid regular expression", () => {
-    expect(AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["("] }).success).toBe(
-      false
-    );
-  });
-
-  it("rejects backreferences, lookarounds, and nested quantifiers", () => {
-    expect(
-      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["(foo)\\1"] }).success
-    ).toBe(false);
-    expect(
-      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["foo(?=bar)"] }).success
-    ).toBe(false);
-    expect(AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["(a+)+"] }).success).toBe(
-      false
-    );
-  });
-
-  it("rejects ReDoS families that a naive nested-quantifier check would miss", () => {
-    // Quantified alternation, optional-quantified group, and doubly-nested
-    // quantified groups all backtrack catastrophically.
-    for (const pattern of ["(a|aa)+", "(a?)+", "((a)*)*", "(.*)*", "(a+){2,}"]) {
-      expect(
-        AgentDetectionContributionSchema.safeParse({ primaryPatterns: [pattern] }).success
-      ).toBe(false);
-    }
-  });
-
-  it("accepts a plain quantified group with no risky body", () => {
-    expect(
-      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["(foo)+", "bar*"] }).success
-    ).toBe(true);
-  });
-
-  it("rejects a pattern longer than 250 chars and more than 8 patterns", () => {
-    expect(
-      AgentDetectionContributionSchema.safeParse({ primaryPatterns: ["a".repeat(251)] }).success
-    ).toBe(false);
-    expect(
-      AgentDetectionContributionSchema.safeParse({
-        primaryPatterns: Array.from({ length: 9 }, (_, i) => `p${i}`),
-      }).success
-    ).toBe(false);
-  });
-
-  it("rejects unknown detection fields (strict)", () => {
-    expect(
-      AgentDetectionContributionSchema.safeParse({ titleStatePatterns: { working: ["x"] } }).success
-    ).toBe(false);
-  });
-});
-
 describe("manifest-level agent contribution gates (issue #9560)", () => {
   const schema = getPluginManifestSchema(false);
 
@@ -165,12 +115,12 @@ describe("manifest-level agent contribution gates (issue #9560)", () => {
     }
   });
 
-  it("rejects the whole manifest when an agent's detection config is malformed", () => {
+  it("rejects the whole manifest when an agent declares a detection block (cut in 1.0, #10460)", () => {
     const result = schema.safeParse(
       manifestWith({
         capabilities: ["agent:register"],
         contributes: {
-          agents: [{ ...VALID_AGENT, detection: { primaryPatterns: ["("] } }],
+          agents: [{ ...VALID_AGENT, detection: { primaryPatterns: ["thinking"] } }],
         },
       })
     );

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -206,93 +206,6 @@ export const FileDecorationContributionSchema = z
   .strict();
 
 /**
- * Detection patterns run against live PTY output for every terminal, so a
- * plugin-supplied pattern needs a tight contract — bounded length, a bounded
- * count, well-formedness, and no constructs prone to catastrophic backtracking.
- * RE2 (linear-time) is deliberately not added as a native dependency (#9560);
- * instead each pattern is validated structurally at manifest-parse time, which
- * is off the hot PTY path. A pattern that compiles but uses backreferences,
- * lookarounds, or nested quantifiers is rejected so a malicious manifest can't
- * stall the matcher.
- */
-const MAX_DETECTION_PATTERN_LENGTH = 250;
-const MAX_DETECTION_PATTERNS_PER_FIELD = 8;
-
-/** Backreference, e.g. `\1`. */
-const BACKREFERENCE_RE = /\\[1-9]/;
-/** Lookahead/lookbehind: `(?=`, `(?!`, `(?<=`, `(?<!`. */
-const LOOKAROUND_RE = /\(\?<?[=!]/;
-/**
- * A group whose body contains a quantifier (`* + ? {`) or an alternation (`|`)
- * and that is itself quantified with an unbounded outer quantifier
- * (`* + {`). Catches the classic catastrophic-backtracking families
- * `(a+)+`, `(.*)*`, `(a?)+`, and quantified-alternation `(a|aa)+`. Outer `?`
- * is excluded because an optional group does not repeat unboundedly.
- */
-const QUANTIFIED_COMPLEX_GROUP_RE = /\([^)]*[*+?{|][^)]*\)[*+{]/;
-/**
- * Two nested quantified groups, e.g. `((a)*)*` — the inner group is closed and
- * quantified, then re-closed and quantified again. The single-group regex above
- * can't span the inner `)`, so this catches the nesting separately.
- */
-const NESTED_QUANTIFIED_GROUP_RE = /\)[*+?][^(]*\)[*+{]/;
-
-function hasCatastrophicBacktrackingRisk(pattern: string): boolean {
-  return (
-    BACKREFERENCE_RE.test(pattern) ||
-    LOOKAROUND_RE.test(pattern) ||
-    QUANTIFIED_COMPLEX_GROUP_RE.test(pattern) ||
-    NESTED_QUANTIFIED_GROUP_RE.test(pattern)
-  );
-}
-
-const BoundedDetectionPatternSchema = z
-  .string()
-  .min(1)
-  .max(MAX_DETECTION_PATTERN_LENGTH, {
-    message: `Detection pattern must be at most ${MAX_DETECTION_PATTERN_LENGTH} characters`,
-  })
-  .refine(
-    (pattern) => {
-      try {
-        new RegExp(pattern);
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    { message: "Detection pattern is not a valid regular expression" }
-  )
-  .refine((pattern) => !hasCatastrophicBacktrackingRisk(pattern), {
-    message:
-      "Detection pattern may not use backreferences, lookarounds, quantified alternation, or nested quantifiers (catastrophic-backtracking risk)",
-  });
-
-const BoundedDetectionPatternArraySchema = z
-  .array(BoundedDetectionPatternSchema)
-  .max(MAX_DETECTION_PATTERNS_PER_FIELD, {
-    message: `At most ${MAX_DETECTION_PATTERNS_PER_FIELD} detection patterns are allowed per field`,
-  });
-
-/**
- * Plugin-supplied output-detection config (#9560). Validated here but not yet
- * wired into the live matcher — the minimal tier launches plugin agents as
- * named, untracked terminals. Strict so an unrecognised field surfaces as a
- * manifest error rather than silently dropping.
- */
-export const AgentDetectionContributionSchema = z
-  .object({
-    primaryPatterns: BoundedDetectionPatternArraySchema.optional(),
-    fallbackPatterns: BoundedDetectionPatternArraySchema.optional(),
-    promptPatterns: BoundedDetectionPatternArraySchema.optional(),
-    bootCompletePatterns: BoundedDetectionPatternArraySchema.optional(),
-    completionPatterns: BoundedDetectionPatternArraySchema.optional(),
-    scanLineCount: z.number().int().min(1).max(50).optional(),
-    debounceMs: z.number().int().min(500).max(30_000).optional(),
-  })
-  .strict();
-
-/**
  * One `contributes.agents` entry (#9560). `id` and `command` use the shared
  * safe-id pattern (no shell metacharacters); a contribution whose `id` collides
  * with a built-in agent is rejected by the manifest-level `superRefine`. Strict
@@ -328,7 +241,6 @@ export const AgentContributionSchema = z
     color: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
     iconId: z.string().min(1).max(64),
     supportsContextInjection: z.boolean().default(false),
-    detection: AgentDetectionContributionSchema.optional(),
   })
   .strict();
 

--- a/shared/config/__tests__/pluginAgentRegistry.test.ts
+++ b/shared/config/__tests__/pluginAgentRegistry.test.ts
@@ -51,6 +51,17 @@ describe("pluginAgentRegistry (issue #9560)", () => {
     expect(isBuiltInAgent("acme-agent")).toBe(false);
   });
 
+  it("never carries a detection field onto the resolved config (cut in 1.0, #10460)", () => {
+    // contributionToAgentConfig maps fields explicitly rather than spreading,
+    // so even a stray `detection` on the input must not reach the registry.
+    registerPluginAgents("acme.plugin", [
+      { ...ACME_AGENT, detection: { primaryPatterns: ["thinking"] } } as PluginAgentContribution,
+    ]);
+    const config = getEffectiveAgentConfig("acme-agent");
+    expect(config).toBeDefined();
+    expect("detection" in (config as object)).toBe(false);
+  });
+
   it("removes the agent on unregister", () => {
     registerPluginAgents("acme.plugin", [ACME_AGENT]);
     unregisterPluginAgents("acme.plugin");

--- a/shared/config/pluginAgentRegistry.ts
+++ b/shared/config/pluginAgentRegistry.ts
@@ -66,9 +66,8 @@ export function getPluginAgentRegistrySnapshot(): Record<string, AgentConfig> {
 }
 
 function contributionToAgentConfig(contribution: PluginAgentContribution): AgentConfig {
-  // Minimal tier: surface only the launch-relevant fields. `detection` is
-  // validated at the manifest gate but deliberately not mapped here — the
-  // full-tracking tier wires it into the PTY matcher separately.
+  // Surface only the launch-relevant fields. Plugin agents launch as named,
+  // untracked terminals; output-pattern detection is not part of the 1.0 schema.
   return {
     id: contribution.id,
     name: contribution.name,

--- a/shared/types/ipc/agentCapabilities.ts
+++ b/shared/types/ipc/agentCapabilities.ts
@@ -17,7 +17,6 @@ export interface AgentMetadata {
     blockAltScreen?: boolean;
     blockMouseReporting?: boolean;
   };
-  hasDetection: boolean;
   hasVersionConfig: boolean;
   hasUpdateConfig: boolean;
   hasInstallHelp: boolean;

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -189,28 +189,6 @@ export interface PluginManifestScopes {
 }
 
 /**
- * Pattern-based output-detection config a plugin may supply alongside an agent
- * contribution (#9560). The shape mirrors the safe subset of the built-in
- * `AgentDetectionConfig`. It is **validated** at manifest-parse time (each
- * pattern is length-bounded, must compile, and must not use backreferences,
- * lookarounds, or nested quantifiers — see `electron/schemas/plugin.ts`) but is
- * **not yet wired** into the live PTY matcher: the minimal tier launches plugin
- * agents as named, untracked terminals. The field exists now so manifests stay
- * forward-compatible with the full-tracking tier without the strict schema
- * rejecting an unknown key. Bad input degrades to a generic shell rather than
- * breaking detection for other terminals.
- */
-export interface PluginAgentDetectionContribution {
-  primaryPatterns?: string[];
-  fallbackPatterns?: string[];
-  promptPatterns?: string[];
-  bootCompletePatterns?: string[];
-  completionPatterns?: string[];
-  scanLineCount?: number;
-  debounceMs?: number;
-}
-
-/**
  * A plugin-contributed agent entry (#9560). Lets a plugin teach Daintree about
  * a launchable agent CLI it doesn't ship, so the CLI shows up as a named,
  * selectable agent rather than a generic shell. Requires the `agent:register`
@@ -219,9 +197,10 @@ export interface PluginAgentDetectionContribution {
  * at parse time, and built-in entries always shadow plugin entries in
  * `getEffectiveRegistry`. Cross-plugin ID conflicts resolve first-registered-wins.
  *
- * The minimal tier surfaces `id`, `name`, `command`, `args`, `color`, `iconId`,
- * and `supportsContextInjection`; `detection` is reserved for the full-tracking
- * tier (see {@link PluginAgentDetectionContribution}).
+ * Plugin agents launch as named, untracked terminals: the 1.0 schema surfaces
+ * `id`, `name`, `command`, `args`, `color`, `iconId`, and
+ * `supportsContextInjection`. Output-pattern detection is not part of the 1.0
+ * plugin schema — built-in agents own the live PTY matcher.
  */
 export interface PluginAgentContribution {
   id: string;
@@ -231,7 +210,6 @@ export interface PluginAgentContribution {
   color: string;
   iconId: string;
   supportsContextInjection?: boolean;
-  detection?: PluginAgentDetectionContribution;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `AgentContribution.detection` was validated at manifest-parse time but never consumed at runtime — `contributionToAgentConfig()` dropped it before it reached the activity matcher, so a manifest could declare detection patterns, pass validation, and have nothing happen. That's a frozen-promise violation.
- Cuts the field entirely from the 1.0 schema and types. `AgentContributionSchema` remains `.strict()`, so any manifest declaring a `detection` block now fails to load with an `unrecognized_keys` error rather than silently succeeding.
- Also removes the now-meaningless `hasDetection` field from `AgentMetadata` (zero renderer consumers) and updates docs to state detection is unsupported for plugin agents in 1.0.

Resolves #10460. Resolves decision D10 in the plugin freeze plan as "cut".

## Changes

- `electron/schemas/plugin.ts` — deleted `AgentDetectionContributionSchema` and its bounded-regex/backtracking validation block; removed `detection` from `AgentContributionSchema`
- `shared/types/plugin.ts` — removed `PluginAgentDetectionContribution` and the `detection?` field on `PluginAgentContribution`
- `shared/types/ipc/agentCapabilities.ts` + `electron/ipc/handlers/agentCapabilities.ts` — removed `hasDetection` from `AgentMetadata`
- `shared/config/pluginAgentRegistry.ts` — updated comment
- `electron/schemas/__tests__/agentContribution.test.ts` + `shared/config/__tests__/pluginAgentRegistry.test.ts` — converted detection tests into regression guards asserting a detection block is rejected as an `unrecognized_keys` strict error and never reaches resolved config
- `docs/plugins/contribution-points.md` + `docs/plugins/freeze-plan.md` — document detection as not part of the 1.0 plugin schema; mark D10 resolved

Note: built-in agent detection (`AgentConfig.detection`, the live PTY matcher) is a separate system and is untouched.

## Testing

88 targeted tests pass locally. Own-file prettier and eslint clean.