### PR TITLE
fix(plugins): freeze ForgeProvider credential, capability, and slot contracts

### DIFF
--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -9,12 +9,13 @@ import {
 import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
 import { projectStore } from "../../services/ProjectStore.js";
 import { gitServiceCache } from "../../services/GitServiceCache.js";
-import {
-  makeForgeProviderId,
-  normalizeProviderId,
-} from "../../../shared/utils/forgeProviderIds.js";
+import { normalizeProviderId } from "../../../shared/utils/forgeProviderIds.js";
 import { auditForgeCall } from "../../services/forge/forgeAuditService.js";
-import type { AuthValidation, CredentialField } from "../../../shared/types/forge.js";
+import {
+  credentialFieldsFor,
+  pickPrimaryValue,
+} from "../../services/forge/forgeCredentialUtils.js";
+import type { AuthValidation } from "../../../shared/types/forge.js";
 
 /**
  * Read the persisted global default provider id, normalizing legacy forms
@@ -45,32 +46,6 @@ let pluginServicePromise: Promise<PluginInitGate> | null = null;
 function awaitPluginInit(): Promise<void> {
   pluginServicePromise ??= import("../../services/PluginService.js").then((m) => m.pluginService);
   return pluginServicePromise.then((svc) => svc.waitForInit());
-}
-
-/**
- * Look up a registered provider's declared credential fields by canonical id.
- * Returns `[]` when the provider declares none (or is not registered) — the
- * caller treats that as a single-value credential.
- */
-function credentialFieldsFor(providerId: string): CredentialField[] {
-  const entry = getRegisteredForgeProviders().find(
-    (p) => makeForgeProviderId(p.pluginId, p.contribution.id) === providerId
-  );
-  return entry?.contribution.credentialFields ?? [];
-}
-
-/**
- * Pick the value passed to `validateToken`, which takes a single string. The
- * primary field is the first `"password"`-typed declared field, else the
- * first declared field; with no declared fields, the first record value.
- */
-function pickPrimaryValue(fields: CredentialField[], credentials: Record<string, string>): string {
-  if (fields.length > 0) {
-    const primary = fields.find((f) => f.type === "password") ?? fields[0];
-    return credentials[primary.id] ?? "";
-  }
-  const first = Object.values(credentials)[0];
-  return typeof first === "string" ? first : "";
 }
 
 /** True when a stored record has at least one non-empty value. */

--- a/electron/schemas/__tests__/forgeProviderContribution.test.ts
+++ b/electron/schemas/__tests__/forgeProviderContribution.test.ts
@@ -43,6 +43,14 @@ describe("ForgeProviderContributionSchema (issue #10471)", () => {
     expect(result.success).toBe(true);
   });
 
+  it("rejects a credentialField with a reserved id (__proto__)", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      credentialFields: [{ id: "__proto__", label: "Token", type: "password" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("rejects a credentialField missing its id", () => {
     const result = ForgeProviderContributionSchema.safeParse({
       ...base,

--- a/electron/schemas/__tests__/forgeProviderContribution.test.ts
+++ b/electron/schemas/__tests__/forgeProviderContribution.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { ForgeProviderContributionSchema } from "../plugin.js";
+
+const base = {
+  id: "gitea",
+  name: "Gitea",
+  matches: ["gitea.example.com"],
+};
+
+describe("ForgeProviderContributionSchema (issue #10471)", () => {
+  it("accepts a minimal contribution (id, name, matches)", () => {
+    expect(ForgeProviderContributionSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("requires at least one match host", () => {
+    expect(ForgeProviderContributionSchema.safeParse({ ...base, matches: [] }).success).toBe(false);
+  });
+
+  it("accepts arbitrary capability hint strings (informational, unvalidated)", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      capabilities: ["issues", "pulls", "provider-defined-thing"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty-string capability hint", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      capabilities: [""],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts multiple credentialFields with a password-typed primary", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      credentialFields: [
+        { id: "token", label: "API token", type: "password" },
+        { id: "baseUrl", label: "Base URL", type: "text" },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a credentialField missing its id", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      credentialFields: [{ label: "API token", type: "password" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an opaque non-empty slot ref", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      slots: { settingsTab: "gitea.settingsTab" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty-string slot ref (format-only validation)", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      slots: { settingsTab: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown slot name", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      slots: { notARealSlot: "gitea.view" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown top-level fields (strict)", () => {
+    const result = ForgeProviderContributionSchema.safeParse({
+      ...base,
+      experimental: true,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -160,9 +160,22 @@ export const McpServerContributionSchema = z
  * reaches `validateToken` — see `ForgeProviderContribution.credentialFields`
  * in `shared/types/forge.ts` for the single-primary contract.
  */
+const RESERVED_CREDENTIAL_FIELD_IDS = new Set(["__proto__", "constructor", "prototype"]);
+
 const CredentialFieldSchema = z
   .object({
-    id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+    // A field id keys the entered value into a plain record at save time; a
+    // reserved key (`__proto__` etc.) would resolve to the object prototype
+    // rather than a stored string and crash the primary-value pick. Reject up
+    // front, mirroring AgentContributionSchema.
+    id: z
+      .string()
+      .min(1)
+      .max(64)
+      .regex(SAFE_ID_PATTERN)
+      .refine((id) => !RESERVED_CREDENTIAL_FIELD_IDS.has(id), {
+        message: "Credential field id cannot be a reserved key (__proto__, constructor, prototype)",
+      }),
     label: z.string().min(1),
     type: z.string().min(1),
     placeholder: z.string().optional(),

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -154,11 +154,11 @@ export const McpServerContributionSchema = z
   .strict();
 
 /**
- * Reserved contribution point. Shape is validated but the runtime does not
- * yet act on these entries — `PluginService` logs a warning and skips them.
- * See `docs/architecture/forge-provider-abstraction.md`. `capabilities` is an
- * uninterpreted advisory list (informational only); the host gates behavior
- * on the runtime `ForgeProviderImpl` shape, not these strings.
+ * One credential input rendered into the provider's settings form. `type` is a
+ * free string (`"password"` masks the input; anything else renders plain
+ * text). A provider may declare several fields, but only the primary value
+ * reaches `validateToken` — see `ForgeProviderContribution.credentialFields`
+ * in `shared/types/forge.ts` for the single-primary contract.
  */
 const CredentialFieldSchema = z
   .object({
@@ -170,6 +170,17 @@ const CredentialFieldSchema = z
   })
   .strict();
 
+/**
+ * `forgeProviders` manifest entry — wired: the registry populates Preferences
+ * and remote-routing before any plugin code runs. See
+ * `docs/architecture/forge-provider-abstraction.md`. Two fields are validated
+ * for SHAPE only and carry no runtime authority (frozen at 1.0):
+ *   - `capabilities` is informational; the host gates behavior on the runtime
+ *     `ForgeProviderImpl` field presence, never on these strings.
+ *   - `slots` values are opaque renderer view-ids checked for non-emptiness
+ *     only; the main process can't verify them against the renderer registry,
+ *     and an unresolved ref renders a neutral fallback (not a parse error).
+ */
 export const ForgeProviderContributionSchema = z
   .object({
     id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),

--- a/electron/services/forge/__tests__/forgeCredentialUtils.test.ts
+++ b/electron/services/forge/__tests__/forgeCredentialUtils.test.ts
@@ -20,7 +20,12 @@ const registryMock = vi.hoisted(() => ({
 
 vi.mock("../../forgeProviderRegistry.js", () => registryMock);
 
-import { buildStoredCredentials } from "../forgeCredentialUtils.js";
+import {
+  buildStoredCredentials,
+  credentialFieldsFor,
+  pickPrimaryValue,
+} from "../forgeCredentialUtils.js";
+import type { CredentialField } from "../../../../shared/types/forge.js";
 
 function registerGiteaProvider() {
   registryMock.getRegisteredForgeProviders.mockReturnValue([
@@ -141,5 +146,61 @@ describe("buildStoredCredentials", () => {
   it("returns null for an empty or invalid provider id", () => {
     registerGiteaProvider();
     expect(buildStoredCredentials("")).toBeNull();
+  });
+});
+
+// The save path (forge:set-credential in forgeSettings.ts) and the replay path
+// (buildStoredCredentials) now share these exported helpers, so the value
+// passed to validateToken and the value replayed into setCredentials are
+// guaranteed identical. These lock the single-primary selection rule directly.
+describe("pickPrimaryValue", () => {
+  const passwordSecond: CredentialField[] = [
+    { id: "baseUrl", label: "Base URL", type: "text" },
+    { id: "token", label: "API token", type: "password" },
+  ];
+
+  it("prefers the password-typed field regardless of declaration order", () => {
+    const record = { baseUrl: "https://gitea.example.com", token: "secret" };
+    expect(pickPrimaryValue(passwordSecond, record)).toBe("secret");
+  });
+
+  it("falls back to the first declared field when none is a password field", () => {
+    const fields: CredentialField[] = [
+      { id: "user", label: "User", type: "text" },
+      { id: "host", label: "Host", type: "text" },
+    ];
+    expect(pickPrimaryValue(fields, { user: "alice", host: "h" })).toBe("alice");
+  });
+
+  it("falls back to the first record value when no fields are declared", () => {
+    expect(pickPrimaryValue([], { apiKey: "lone" })).toBe("lone");
+  });
+
+  it("returns an empty string when the primary field is missing from the record", () => {
+    expect(pickPrimaryValue(passwordSecond, { baseUrl: "https://gitea.example.com" })).toBe("");
+  });
+
+  it("agrees with buildStoredCredentials on the same fixture (one source of truth)", () => {
+    registerGiteaProvider();
+    const record = { token: "secret-token", baseUrl: "https://gitea.example.com" };
+    storeMock._data["forgeCredentials"] = { "acme.gitea": JSON.stringify(record) };
+
+    const replayed = buildStoredCredentials("acme.gitea");
+    const direct = pickPrimaryValue(credentialFieldsFor("acme.gitea"), record);
+    expect(replayed).toEqual({ kind: "bearer", value: direct });
+  });
+});
+
+describe("credentialFieldsFor", () => {
+  it("returns the registered provider's declared fields", () => {
+    registerGiteaProvider();
+    expect(credentialFieldsFor("acme.gitea")).toEqual([
+      { id: "token", label: "API token", type: "password" },
+      { id: "baseUrl", label: "Base URL", type: "text" },
+    ]);
+  });
+
+  it("returns an empty array for an unregistered provider", () => {
+    expect(credentialFieldsFor("nope.missing")).toEqual([]);
   });
 });

--- a/electron/services/forge/forgeCredentialUtils.ts
+++ b/electron/services/forge/forgeCredentialUtils.ts
@@ -7,11 +7,11 @@ import type { CredentialField, Credentials } from "../../../shared/types/forge.j
 /**
  * Look up a registered provider's declared credential fields by canonical id.
  * Returns `[]` when the provider declares none (or is not registered) — the
- * caller treats that as a single-value credential. Mirrors the private helper
- * in `forgeSettings.ts`; kept here so the boot-time replay in `PluginService`
- * can reconstruct credentials without importing the IPC handler module.
+ * caller treats that as a single-value credential. Shared with the
+ * `forge:set-credential` save path in `forgeSettings.ts` so save-time and
+ * replay-time reconstruct credentials from one source of truth.
  */
-function credentialFieldsFor(providerId: string): CredentialField[] {
+export function credentialFieldsFor(providerId: string): CredentialField[] {
   const entry = getRegisteredForgeProviders().find(
     (p) => makeForgeProviderId(p.pluginId, p.contribution.id) === providerId
   );
@@ -19,12 +19,19 @@ function credentialFieldsFor(providerId: string): CredentialField[] {
 }
 
 /**
- * Pick the primary credential value from a stored record. The primary field is
+ * Pick the primary credential value from a stored record. A provider may
+ * declare multiple {@link CredentialField}s for the settings form, but the
+ * contract passes exactly one value — the primary — to
+ * {@link ForgeProviderImpl.validateToken} and `setCredentials`. The primary is
  * the first `"password"`-typed declared field, else the first declared field;
- * with no declared fields, the first record value. Matches `pickPrimaryValue`
- * in `forgeSettings.ts` so save-time and replay-time agree on the value.
+ * with no declared fields, the first record value. Shared with the
+ * `forge:set-credential` save path in `forgeSettings.ts` so save-time and
+ * replay-time agree on the value.
  */
-function pickPrimaryValue(fields: CredentialField[], credentials: Record<string, string>): string {
+export function pickPrimaryValue(
+  fields: CredentialField[],
+  credentials: Record<string, string>
+): string {
   if (fields.length > 0) {
     const primary = fields.find((f) => f.type === "password") ?? fields[0];
     return credentials[primary.id] ?? "";

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -844,6 +844,17 @@ export interface ForgeProviderImpl {
   createIssue(repo: RepoRef, input: CreateIssueInput): Promise<Issue>;
   assignIssue(repo: RepoRef, issueNumber: number, username: string): Promise<void>;
   unassignIssue(repo: RepoRef, issueNumber: number, username: string): Promise<void>;
+  /**
+   * Validate a single freshly-entered credential value at save time. The host
+   * passes exactly one string — the primary of the provider's declared
+   * {@link ForgeProviderContribution.credentialFields} (see that field for the
+   * primary-selection rule), never the full multi-field record. This signature
+   * is frozen at 1.0: a provider needing more than one value to authenticate
+   * (e.g. self-hosted forge wanting base URL + token) reads its other fields
+   * from its own settings (`settingsScopeRef`) and validates the assembled
+   * credential through {@link validateCredentials} instead, which runs against
+   * the provider's stored state rather than a host-supplied argument.
+   */
   validateToken(token: string): Promise<AuthValidation>;
 
   // Host-visible rate-limit state, parsed from the provider's own transport.
@@ -901,10 +912,14 @@ export interface ForgeProviderImpl {
 
 /**
  * Suggested capability vocabulary surfaced in the manifest's `capabilities`
- * array. The host does not interpret these strings — they are informational,
- * driving the Preferences "supports: …" display only. Behavior gates on
- * whether the matching {@link ForgeProviderImpl} capability field is present
- * at runtime, which keeps the claim honest. The open union preserves
+ * array. Frozen at 1.0 as informational only: the host never interprets these
+ * strings and no behavior — feature gating, privilege, routing — is ever
+ * derived from them. They drive the Preferences "supports: …" display and
+ * nothing else. Every actual capability gates on whether the matching
+ * {@link ForgeProviderImpl} field is present at runtime (e.g. `impl.reviews`),
+ * so a declared-but-unimplemented hint can never enable a feature, and an
+ * implemented-but-undeclared one still works. Do not add runtime checks that
+ * cross-reference these strings against the impl. The open union preserves
  * autocomplete while allowing provider-defined strings.
  */
 export type ForgeCapabilityHint =
@@ -937,8 +952,14 @@ export type CredentialFieldType = "password" | "text" | (string & {});
 /**
  * One credential input a forge provider declares in its manifest so the host
  * can render a real settings form for it instead of a "no configuration"
- * stub. The host never inspects the entered value beyond passing the primary
- * field to {@link ForgeProviderImpl.validateToken}; storage stays opaque.
+ * stub. A provider may declare several fields for the form, but the contract
+ * (frozen at 1.0) passes only the PRIMARY field's value to
+ * {@link ForgeProviderImpl.validateToken} and `setCredentials` — the primary
+ * being the first `"password"`-typed field, or the first field when none is
+ * `"password"`. Every entered value is persisted in the credential record, but
+ * the host never inspects any of them beyond the primary; storage stays
+ * opaque. Providers needing more than the primary at auth time read the rest
+ * from their own settings and use {@link ForgeProviderImpl.validateCredentials}.
  */
 export interface CredentialField {
   /** Stable key the entered value is stored under in the credential record. */
@@ -981,14 +1002,19 @@ export interface ForgeProviderContribution {
    * hostname your forge serves as a separate entry.
    */
   matches: string[];
-  /** Informational capability hints; the host does not interpret these. */
+  /**
+   * Informational capability hints; the host never interprets these and no
+   * behavior is derived from them (display only). See {@link ForgeCapabilityHint}.
+   */
   capabilities?: ForgeCapabilityHint[];
   /**
    * Credential inputs the host renders a real settings form from. Absent or
    * empty means the provider needs no host-side credential entry (the host
    * shows "No configuration needed"). The first `"password"`-typed field —
-   * or the first field when none is `"password"` — is the primary credential
-   * passed to {@link ForgeProviderImpl.validateToken}.
+   * or the first field when none is `"password"` — is the primary credential,
+   * the single value passed to {@link ForgeProviderImpl.validateToken} and
+   * `setCredentials`. See {@link CredentialField} for the full single-primary
+   * contract and the multi-field auth path.
    */
   credentialFields?: CredentialField[];
   /** ID prefix in this plugin's `settings` contributions, used to group provider settings. */
@@ -999,9 +1025,15 @@ export interface ForgeProviderContribution {
    * Named renderer view-slot refs for provider-owned UI. Each value is a
    * builtin-view id the plugin's renderer registers via
    * `registerBuiltinView`; the host resolves the ACTIVE provider's ref for
-   * each seam instead of hardcoding any one plugin's view ids. All optional —
-   * the host renders a neutral fallback (or hides the seam) when a ref is
-   * absent or the view is unregistered (e.g. plugin disabled).
+   * each seam instead of hardcoding any one plugin's view ids. All optional.
+   *
+   * Slot refs are validated for FORMAT only (non-empty string) at manifest
+   * parse time — the host cannot check a ref against the renderer's view
+   * registry from the main process, and a ref legitimately resolves to nothing
+   * while its plugin is disabled. Resolving an unregistered or disabled ref to
+   * a neutral fallback (or a hidden seam) is the defined 1.0 behavior, not an
+   * error. In dev builds the renderer logs a one-line warning when a non-empty
+   * ref was never registered at all, to flag plugin-author typos.
    */
   slots?: ForgeProviderSlots;
 }

--- a/src/registry/__tests__/builtinRendererRegistry.test.ts
+++ b/src/registry/__tests__/builtinRendererRegistry.test.ts
@@ -47,6 +47,35 @@ describe("builtinRendererRegistry", () => {
     expect(getBuiltinView("github.issueSelector")).toBeNull();
   });
 
+  describe("dev-mode warn-on-miss", () => {
+    it("warns when a non-empty slot ref was never registered", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(getBuiltinView("github.bulkCreateWorktreeDialog")).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("github.bulkCreateWorktreeDialog")
+      );
+    });
+
+    it("does not warn for an empty slot ref (the documented 'no slot' sentinel)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(getBuiltinView("")).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not warn when the slot is registered but gated off by a disabled plugin", () => {
+      registerBuiltinView("github.issueSelector", StubComponent, {
+        pluginId: "daintree.github",
+      });
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set(["daintree.github"]) });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      expect(getBuiltinView("github.issueSelector")).toBeNull();
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });
+    });
+  });
+
   describe("plugin enable-state gating", () => {
     afterEach(() => {
       usePluginRuntimeStore.setState({ disabledPluginIds: new Set<string>() });

--- a/src/registry/__tests__/builtinRendererRegistry.test.ts
+++ b/src/registry/__tests__/builtinRendererRegistry.test.ts
@@ -56,6 +56,14 @@ describe("builtinRendererRegistry", () => {
       );
     });
 
+    it("warns only once per missing slot ref, not on every resolution", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      getBuiltinView("github.bulkCreateWorktreeDialog");
+      getBuiltinView("github.bulkCreateWorktreeDialog");
+      getBuiltinView("github.bulkCreateWorktreeDialog");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("does not warn for an empty slot ref (the documented 'no slot' sentinel)", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       expect(getBuiltinView("")).toBeNull();

--- a/src/registry/builtinRendererRegistry.ts
+++ b/src/registry/builtinRendererRegistry.ts
@@ -48,7 +48,20 @@ function resolveSlot<P>(
   disabledPluginIds: ReadonlySet<string>
 ): ComponentType<P> | null {
   const entry = REGISTRY.get(slotId);
-  if (!entry) return null;
+  if (!entry) {
+    // A non-empty ref that was never registered is most likely a plugin-author
+    // typo in a `forgeProviders.slots` value — the main process can't validate
+    // these against this renderer registry, so surface it here. Dev-only and
+    // warn-not-throw: an empty ref is the documented "no slot" sentinel, and a
+    // null resolution is defined contract, not an error.
+    if (import.meta.env.DEV && slotId.length > 0) {
+      console.warn(
+        `[builtinRendererRegistry] No view registered for slot "${slotId}" — ` +
+          `check the plugin's forgeProviders.slots ref and registerBuiltinView call`
+      );
+    }
+    return null;
+  }
   if (entry.pluginId !== null && disabledPluginIds.has(entry.pluginId)) return null;
   return entry.component as ComponentType<P>;
 }

--- a/src/registry/builtinRendererRegistry.ts
+++ b/src/registry/builtinRendererRegistry.ts
@@ -28,6 +28,9 @@ interface SlotEntry {
 
 const REGISTRY = new Map<string, SlotEntry>();
 
+/** Slot ids already warned about (dev-mode), so a typo'd ref warns once, not per render. */
+const warnedMissingSlots = new Set<string>();
+
 export function registerBuiltinView(
   slotId: string,
   component: AnyComponent,
@@ -54,7 +57,8 @@ function resolveSlot<P>(
     // these against this renderer registry, so surface it here. Dev-only and
     // warn-not-throw: an empty ref is the documented "no slot" sentinel, and a
     // null resolution is defined contract, not an error.
-    if (import.meta.env.DEV && slotId.length > 0) {
+    if (import.meta.env.DEV && slotId.length > 0 && !warnedMissingSlots.has(slotId)) {
+      warnedMissingSlots.add(slotId);
       console.warn(
         `[builtinRendererRegistry] No view registered for slot "${slotId}" — ` +
           `check the plugin's forgeProviders.slots ref and registerBuiltinView call`
@@ -89,4 +93,5 @@ export function useBuiltinView<P>(slotId: string): ComponentType<P> | null {
 
 export function __resetBuiltinRendererRegistryForTests(): void {
   REGISTRY.clear();
+  warnedMissingSlots.clear();
 }


### PR DESCRIPTION
## Summary

- Resolves three `ForgeProviderContribution` contract ambiguities blocking the 1.0 plugin API freeze (#10459, freeze-plan item #12 / decision D8)
- No behavioral changes — JSDoc, documentation, and schema hardening only, plus a dev-mode warn-once for slot misses
- Consolidates duplicated `pickPrimaryValue`/`credentialFieldsFor` helpers into `forgeCredentialUtils`, shared by save and replay paths

Closes #10471

## Changes

**`shared/types/forge.ts`** — formalises the single-primary credential contract in JSDoc: the first `password`-typed field (else the first field) is the single value passed to `validateToken`/`setCredentials`; multi-field/self-hosted providers authenticate via `validateCredentials()`. Documents `capabilities` as informational-only — the host gates on `ForgeProviderImpl` field presence (`impl.reviews !== undefined`), never on these strings.

**`electron/schemas/plugin.ts`** — replaces the stale "reserved/unwired" forge schema comment; hardens `CredentialFieldSchema` to reject reserved ids (`__proto__`, `constructor`, `prototype`), mirroring `AgentContributionSchema`; adds non-empty format-only validation for slot refs at parse time.

**`src/registry/builtinRendererRegistry.ts`** — adds a dev-mode `warn-once` when a slot ref doesn't resolve, so plugin authors catch typos early. Unresolved/disabled refs render a neutral fallback as defined behavior, not an error.

**`electron/services/forge/forgeCredentialUtils.ts`** / **`electron/ipc/handlers/forgeSettings.ts`** — removes duplicated helpers; both paths now share the consolidated utils.

## Testing

Extended `forgeCredentialUtils` tests (helper agreement, reserved id edges, whitespace edges), new `forgeProviderContribution` schema tests, warn-on-miss tests in `builtinRendererRegistry`. 39 targeted tests pass locally.