### PR TITLE
fix(plugins): enforce pluginId ownership at the plugin:invoke boundary

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -91,6 +91,7 @@ vi.mock("electron", () => ({
 
 import { registerPluginHandlers } from "../plugin.js";
 import { _resetIpcGuardForTesting, markIpcSecurityReady } from "../../ipcGuard.js";
+import { PluginInvokeOwnershipError } from "../../../services/plugin/PluginInvokeErrors.js";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -973,6 +974,60 @@ describe("registerPluginHandlers", () => {
     };
     await expect(invokeHandler(trustedEvent, "p", "ch", "arg1")).rejects.toBe(marked);
     expect(mockAuditAppend).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_INVOKE audits an ownership rejection as restricted with a forensic hash (#10462)", async () => {
+    // A trusted sender that targets an unloaded pluginId is a denied
+    // invocation, not a handler failure — it must be classified "restricted"
+    // (grouping with the untrusted-sender path) while still hashing the args,
+    // since the frame already passed the origin-trust check.
+    mockDispatchHandler.mockRejectedValue(
+      new PluginInvokeOwnershipError("acme.missing", "get-data")
+    );
+
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 5 },
+    };
+    await expect(invokeHandler(trustedEvent, "acme.missing", "get-data", "arg1")).rejects.toThrow(
+      'plugin:invoke rejected: plugin "acme.missing" is not loaded'
+    );
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+    const record = mockAuditAppend.mock.calls[0][0];
+    expect(record).toMatchObject({
+      pluginId: "acme.missing",
+      actionId: "get-data",
+      recordType: "ipc-invoke",
+      channel: "plugin:invoke",
+      result: "restricted",
+    });
+    // Sender was trusted, so unlike the untrusted-URL path the args ARE hashed.
+    expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("PLUGIN_INVOKE keeps a genuine dispatch error classified as error, not restricted (#10462)", async () => {
+    // Regression guard: only ownership rejections become "restricted" — an
+    // ordinary handler failure for a loaded plugin must stay "error".
+    mockDispatchHandler.mockRejectedValue(new Error("handler exploded"));
+
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 6 },
+    };
+    await expect(invokeHandler(trustedEvent, "acme.loaded", "get-data", "arg1")).rejects.toThrow(
+      "handler exploded"
+    );
+    expect(mockAuditAppend.mock.calls[0][0]).toMatchObject({ result: "error" });
   });
 
   it("PLUGIN_INVOKE audit hash discriminates by arg content (#9240)", async () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -42,6 +42,7 @@ import {
   getPluginPanelKinds,
   type PanelKindConfig,
 } from "../../../shared/config/panelKindRegistry.js";
+import { isPluginInvokeOwnershipError } from "../../services/plugin/PluginInvokeErrors.js";
 import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
 import { getPluginKeybindings } from "../../services/pluginKeybindingRegistry.js";
 import { getPluginContextMenuItems } from "../../services/pluginContextMenuRegistry.js";
@@ -906,12 +907,20 @@ export function registerPluginHandlers(): () => void {
             // Hashing is best-effort — a serialization throw here must not
             // mask the original handler error.
           }
+          // An ownership rejection (#10462) is a denied invocation, not a
+          // handler failure — record it as "restricted" so it groups with the
+          // untrusted-sender rejection above rather than with genuine dispatch
+          // errors. The sender already passed `isTrustedRendererUrl`, so the
+          // args are from a trusted frame and the forensic `argsHash` is still
+          // useful. An ownership error is thrown before any handler runs, so it
+          // is never marked as an audited handler failure and always reaches
+          // this block.
           safeAppend({
             pluginId,
             actionId: channel,
             recordType: "ipc-invoke",
             channel: CHANNELS.PLUGIN_INVOKE,
-            result: "error",
+            result: isPluginInvokeOwnershipError(err) ? "restricted" : "error",
             errorMessage: formatErrorMessage(err, "plugin:invoke dispatch failed"),
             argsHash,
             durationMs: Date.now() - start,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -58,6 +58,7 @@ import { PluginChannelRegistry, isChannelSchema } from "./plugin/PluginChannelRe
 import { PluginInstaller } from "./plugin/PluginInstaller.js";
 import { PluginDevWorkerHost } from "./plugin/PluginDevWorkerHost.js";
 import { PluginDevWorkerMainBridge } from "./plugin/PluginDevWorkerMainBridge.js";
+import { PluginInvokeOwnershipError } from "./plugin/PluginInvokeErrors.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import { toPluginWorktreeSnapshot } from "../../shared/utils/pluginWorktreeSnapshot.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
@@ -2423,6 +2424,16 @@ export class PluginService {
     ctx: PluginIpcContext,
     args: unknown[]
   ): Promise<unknown> {
+    // Ownership guard (#10462): the renderer is a single shared WebContents in
+    // which every plugin runs in the same realm, so a caller can pass an
+    // arbitrary `pluginId`. Reject any id the host has not actually loaded
+    // before activation or routing — this is the boundary's only achievable
+    // ownership guarantee and it also covers the dev-worker bridge, which calls
+    // `dispatchHandler` directly without passing through `ipcMain.handle`.
+    if (!this.plugins.has(pluginId)) {
+      throw new PluginInvokeOwnershipError(pluginId, channel);
+    }
+
     // Start the clock before activation so a failure record carries the full
     // dispatch cost (cold activation included) the renderer actually waited on.
     const dispatchStart = Date.now();

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2428,8 +2428,11 @@ export class PluginService {
     // which every plugin runs in the same realm, so a caller can pass an
     // arbitrary `pluginId`. Reject any id the host has not actually loaded
     // before activation or routing — this is the boundary's only achievable
-    // ownership guarantee and it also covers the dev-worker bridge, which calls
-    // `dispatchHandler` directly without passing through `ipcMain.handle`.
+    // ownership guarantee given that shared realm. It lives here, in the single
+    // chokepoint every plugin:invoke flows through, rather than in the IPC
+    // handler, so no current or future caller of `dispatchHandler` can reach a
+    // handler for an unloaded plugin (dev-worker channels are dispatched here
+    // too, via their `host.registerHandler` registrations).
     if (!this.plugins.has(pluginId)) {
       throw new PluginInvokeOwnershipError(pluginId, channel);
     }

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -169,6 +169,7 @@ import { z } from "zod";
 import { PluginService } from "../PluginService.js";
 import { getPluginActionAuditService } from "../PluginActionAuditService.js";
 import { isAuditedHandlerFailure } from "../../utils/pluginAuditMarker.js";
+import { PluginInvokeOwnershipError } from "../plugin/PluginInvokeErrors.js";
 import { getPluginManifestSchema, isPrivateOrLoopbackHostname } from "../../schemas/plugin.js";
 import {
   BUILT_IN_PLUGIN_CAPABILITIES,
@@ -2345,6 +2346,31 @@ describe("Plugin IPC handler registration", () => {
     ).rejects.toThrow("No plugin handler registered for acme.test-plugin:unknown");
   });
 
+  it("dispatchHandler rejects an unknown pluginId with PluginInvokeOwnershipError (#10462)", async () => {
+    await expect(
+      service.dispatchHandler("acme.unknown-plugin", "get-data", makeCtx("acme.unknown-plugin"), [])
+    ).rejects.toThrow(PluginInvokeOwnershipError);
+  });
+
+  it("dispatchHandler does not activate when the pluginId is not loaded (#10462)", async () => {
+    // The ownership guard must fire before activation, so impersonating an
+    // unloaded plugin can never trigger any plugin code to run.
+    const activateSpy = vi.spyOn(service, "activatePlugin");
+    await expect(
+      service.dispatchHandler("acme.unknown-plugin", "get-data", makeCtx("acme.unknown-plugin"), [])
+    ).rejects.toBeInstanceOf(PluginInvokeOwnershipError);
+    expect(activateSpy).not.toHaveBeenCalled();
+  });
+
+  it("dispatchHandler treats an unknown channel on a loaded plugin as a normal error, not an ownership rejection (#10462)", async () => {
+    // Regression guard: the ownership rejection keys on the pluginId being
+    // loaded, not on whether the channel resolves — a real plugin with a bad
+    // channel must still surface the generic handler error.
+    await expect(
+      service.dispatchHandler("acme.test-plugin", "unknown", makeCtx("acme.test-plugin"), [])
+    ).rejects.not.toBeInstanceOf(PluginInvokeOwnershipError);
+  });
+
   it("registering same (pluginId, channel) twice overwrites the handler", async () => {
     const handler1 = vi.fn().mockReturnValue("first");
     const handler2 = vi.fn().mockReturnValue("second");
@@ -3498,9 +3524,11 @@ describe("Plugin unload lifecycle", () => {
 
     service.unloadPlugin("acme.handler-host");
 
+    // After unload the plugin leaves `this.plugins`, so the ownership guard
+    // (#10462) now short-circuits dispatch before the handler lookup.
     await expect(
       service.dispatchHandler("acme.handler-host", "ping", makeCtx("acme.handler-host"), [])
-    ).rejects.toThrow("No plugin handler registered for acme.handler-host:ping");
+    ).rejects.toThrow('plugin:invoke rejected: plugin "acme.handler-host" is not loaded');
   });
 
   it("unloadPlugin is a no-op when the plugin is not loaded", async () => {
@@ -5212,6 +5240,8 @@ describe("createHost — registerAction", () => {
     service.unloadPlugin("acme.act-test");
 
     expect(service.listPluginActions()).toEqual([]);
+    // Once unloaded the plugin is no longer in `this.plugins`, so the ownership
+    // guard (#10462) rejects the dispatch before the action lookup runs.
     await expect(
       service.dispatchHandler(
         "acme.act-test",
@@ -5219,9 +5249,7 @@ describe("createHost — registerAction", () => {
         makeCtx("acme.act-test"),
         [{}]
       )
-    ).rejects.toThrow(
-      "No plugin handler registered for acme.act-test:acme.act-test.plan-from-issue"
-    );
+    ).rejects.toThrow('plugin:invoke rejected: plugin "acme.act-test" is not loaded');
   });
 });
 

--- a/electron/services/plugin/PluginInvokeErrors.ts
+++ b/electron/services/plugin/PluginInvokeErrors.ts
@@ -1,0 +1,26 @@
+import { DaintreeError } from "../../utils/errorTypes.js";
+
+/**
+ * Thrown when a `plugin:invoke` targets a `pluginId` that is not a loaded
+ * plugin. The renderer is a single shared `app://daintree` WebContents in which
+ * every plugin runs in the same JS realm, so the host cannot bind an invocation
+ * to a particular plugin by sender identity. The achievable ownership guarantee
+ * is therefore: a sender may only address plugins the host has actually loaded —
+ * an unknown or unloaded `pluginId` is rejected before any handler runs.
+ *
+ * Kept in its own module (importing only {@link DaintreeError}) so both
+ * `PluginService` and the `plugin:invoke` IPC handler can reference it without a
+ * circular import.
+ */
+export class PluginInvokeOwnershipError extends DaintreeError {
+  constructor(
+    public readonly pluginId: string,
+    public readonly channel: string
+  ) {
+    super(`plugin:invoke rejected: plugin "${pluginId}" is not loaded`, { pluginId, channel });
+  }
+}
+
+export function isPluginInvokeOwnershipError(error: unknown): error is PluginInvokeOwnershipError {
+  return error instanceof PluginInvokeOwnershipError;
+}


### PR DESCRIPTION
## Summary

- `plugin:invoke` was validating sender origin trust but never verifying that the caller owns the `pluginId` it passed — any trusted plugin renderer could invoke another plugin's channels by supplying an arbitrary ID.
- All plugins share a single `app://daintree` WebContents in one JS realm, so per-sender ownership is architecturally impossible. The achievable guarantee is: reject any `pluginId` that isn't currently loaded.
- New `PluginInvokeOwnershipError` (in its own module to avoid a circular import) lets the `PLUGIN_INVOKE` catch path classify ownership rejections as `"restricted"` vs genuine dispatch failures as `"error"`.

Resolves #10462

## Changes

- `electron/services/plugin/PluginInvokeErrors.ts` — `PluginInvokeOwnershipError` + `isPluginInvokeOwnershipError` type guard.
- `PluginService.dispatchHandler` — rejects `!this.plugins.has(pluginId)` before activation or routing; the single dispatch chokepoint means the check can't be bypassed.
- `electron/ipc/handlers/plugin.ts` — `PLUGIN_INVOKE` catch now branches on `isPluginInvokeOwnershipError` to set audit result `"restricted"` (args still hashed, sender passed origin trust) vs `"error"` for real failures.

## Testing

- Unit tests for the ownership guard and audit classification added to `PluginService.test.ts` and `plugin.handlers.test.ts`.
- Regression test confirms genuine dispatch errors still surface as `"error"`.
- Two pre-existing unload tests updated — dispatch-after-unload now correctly hits the ownership rejection path.
- Vitest: 576 tests across both affected suites pass. Prettier + ESLint clean on all 5 changed files.