### PR TITLE
fix(plugins): emit audit records for plugin handler failures (#10463)

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { markAuditedHandlerFailure } from "../../../utils/pluginAuditMarker.js";
 
 const mockDispatchHandler = vi.fn();
 const mockListPlugins = vi.fn();
@@ -951,6 +952,27 @@ describe("registerPluginHandlers", () => {
     expect(record.errorMessage).toContain("No plugin handler registered");
     expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
     expect(typeof record.durationMs).toBe("number");
+  });
+
+  it("PLUGIN_INVOKE does not re-audit a failure already recorded at the dispatch boundary (#10463)", async () => {
+    // dispatchHandler now audits handler throws itself and marks the error.
+    // The outer handler must skip its own append to avoid a double record,
+    // while still rethrowing so the renderer sees the failure.
+    const marked = new Error("handler exploded");
+    markAuditedHandlerFailure(marked);
+    mockDispatchHandler.mockRejectedValue(marked);
+
+    registerPluginHandlers();
+    const invokeHandler = mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:invoke"
+    )![1] as (...args: unknown[]) => unknown;
+
+    const trustedEvent = {
+      senderFrame: { url: "app://daintree/" },
+      sender: { id: 1 },
+    };
+    await expect(invokeHandler(trustedEvent, "p", "ch", "arg1")).rejects.toBe(marked);
+    expect(mockAuditAppend).not.toHaveBeenCalled();
   });
 
   it("PLUGIN_INVOKE audit hash discriminates by arg content (#9240)", async () => {

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -32,6 +32,7 @@ import {
 import { isPrivateOrLoopbackHostname, SCOPED_PLUGIN_NAME_PATTERN } from "../../schemas/plugin.js";
 import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
 import { stableArgsSha256 } from "../../utils/pluginMcpHash.js";
+import { isAuditedHandlerFailure } from "../../utils/pluginAuditMarker.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import {
   getPluginToolbarButtonIds,
@@ -888,28 +889,34 @@ export function registerPluginHandlers(): () => void {
       try {
         return await (await getPluginService()).dispatchHandler(pluginId, channel, ctx, args);
       } catch (err) {
-        // `stableArgsSha256` content-discriminates without persisting any
-        // arg bytes — two structurally identical failed invokes hash the
-        // same, but distinct args produce distinct hashes. (A summary-based
-        // hash via `summarizeMcpArgs` collapses arrays to a constant, which
-        // would defeat forensic grouping.)
-        let argsHash = "";
-        try {
-          argsHash = stableArgsSha256(args);
-        } catch {
-          // Hashing is best-effort — a serialization throw here must not
-          // mask the original handler error.
+        // A throwing plugin handler is already audited at the dispatch
+        // boundary (#10463); recording it again here would double-count the
+        // failure. Errors that never reach a handler — schema/permission/
+        // no-handler — aren't marked, so the IPC boundary still owns them.
+        if (!isAuditedHandlerFailure(err)) {
+          // `stableArgsSha256` content-discriminates without persisting any
+          // arg bytes — two structurally identical failed invokes hash the
+          // same, but distinct args produce distinct hashes. (A summary-based
+          // hash via `summarizeMcpArgs` collapses arrays to a constant, which
+          // would defeat forensic grouping.)
+          let argsHash = "";
+          try {
+            argsHash = stableArgsSha256(args);
+          } catch {
+            // Hashing is best-effort — a serialization throw here must not
+            // mask the original handler error.
+          }
+          safeAppend({
+            pluginId,
+            actionId: channel,
+            recordType: "ipc-invoke",
+            channel: CHANNELS.PLUGIN_INVOKE,
+            result: "error",
+            errorMessage: formatErrorMessage(err, "plugin:invoke dispatch failed"),
+            argsHash,
+            durationMs: Date.now() - start,
+          });
         }
-        safeAppend({
-          pluginId,
-          actionId: channel,
-          recordType: "ipc-invoke",
-          channel: CHANNELS.PLUGIN_INVOKE,
-          result: "error",
-          errorMessage: formatErrorMessage(err, "plugin:invoke dispatch failed"),
-          argsHash,
-          durationMs: Date.now() - start,
-        });
         throw err;
       }
     }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -110,6 +110,9 @@ import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
 import { getPluginActionAuditService } from "./PluginActionAuditService.js";
+import { stableArgsSha256 } from "../utils/pluginMcpHash.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { markAuditedHandlerFailure } from "../utils/pluginAuditMarker.js";
 import type {
   PluginDiagnosticsAuditRecord,
   PluginDiagnosticsLogLine,
@@ -351,6 +354,35 @@ function runUnloadStep(pluginId: string, step: string, fn: () => void): void {
     fn();
   } catch (err) {
     console.warn(`[PluginService] Unload step "${step}" for "${pluginId}" threw:`, err);
+  }
+}
+
+/**
+ * Append a plugin audit record without ever surfacing an audit failure to the
+ * caller. Mirrors the `safeAppend` in `electron/ipc/handlers/plugin.ts` — a
+ * throw from `append()` (corrupt store, disk error) must never mask the
+ * handler error we're in the middle of rethrowing. Audit is a side channel.
+ */
+function safeAppendAudit(
+  input: Parameters<ReturnType<typeof getPluginActionAuditService>["append"]>[0]
+): void {
+  try {
+    getPluginActionAuditService().append(input);
+  } catch (err) {
+    console.error("[PluginService] Failed to append audit record:", err);
+  }
+}
+
+/**
+ * SHA-256 of the dispatch args for forensic grouping, best-effort. A
+ * serialization throw here must not mask the handler error, so it degrades to
+ * an empty hash (the documented "hashing failed" sentinel).
+ */
+function safeArgsHash(args: unknown[]): string {
+  try {
+    return stableArgsSha256(args);
+  } catch {
+    return "";
   }
 }
 
@@ -2391,6 +2423,9 @@ export class PluginService {
     ctx: PluginIpcContext,
     args: unknown[]
   ): Promise<unknown> {
+    // Start the clock before activation so a failure record carries the full
+    // dispatch cost (cold activation included) the renderer actually waited on.
+    const dispatchStart = Date.now();
     // Implicit activation: the first dispatch into a plugin's channel forces
     // its `activate()` to run if it hasn't yet, so handlers registered during
     // activation are available on the very first call. No-op once activated.
@@ -2463,8 +2498,21 @@ export class PluginService {
         // Contain at the boundary so a throwing handler can't propagate up
         // through `ipcMain.handle` as an unhandled rejection. The error still
         // surfaces to the renderer (rethrown after logging).
-        // TODO(#9232): emit PluginActionAuditRecord to the audit pipeline.
         console.error(`[PluginService] Action handler "${channel}" threw:`, err);
+        // Audit at the dispatch boundary (#10463) so non-IPC callers (agent
+        // automation, recipe dispatch) leave the same durable trail as a
+        // `plugin:invoke` call. Mark the error so the outer `plugin:invoke`
+        // catch doesn't record it a second time.
+        safeAppendAudit({
+          pluginId,
+          actionId: channel,
+          recordType: "action-dispatch",
+          result: "error",
+          errorMessage: formatErrorMessage(err, "plugin action handler threw"),
+          argsHash: safeArgsHash(args),
+          durationMs: Date.now() - dispatchStart,
+        });
+        markAuditedHandlerFailure(err);
         throw err;
       }
     }
@@ -2513,8 +2561,21 @@ export class PluginService {
       // process. The error still surfaces to the renderer (we rethrow after
       // logging) — the renderer-side wrapping in `usePluginActions` turns
       // that rejection into a user-facing toast.
-      // TODO(#9232): emit PluginActionAuditRecord to the audit pipeline.
       console.error(`[PluginService] Handler "${key}" threw:`, err);
+      // Audit at the dispatch boundary (#10463). `channel` carries the plugin
+      // channel string that failed (the IPC transport is always plugin:invoke);
+      // mark the error so the outer `plugin:invoke` catch doesn't double-record.
+      safeAppendAudit({
+        pluginId,
+        actionId: channel,
+        recordType: "ipc-invoke",
+        channel,
+        result: "error",
+        errorMessage: formatErrorMessage(err, "plugin IPC handler threw"),
+        argsHash: safeArgsHash(args),
+        durationMs: Date.now() - dispatchStart,
+      });
+      markAuditedHandlerFailure(err);
       throw err;
     }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2467,6 +2467,25 @@ describe("Plugin IPC handler registration", () => {
       }
     });
 
+    it("rethrows the original error even when it is frozen (marker can't attach)", async () => {
+      const appendSpy = vi
+        .spyOn(getPluginActionAuditService(), "append")
+        .mockImplementation(() => {});
+      try {
+        const frozen = Object.freeze(new Error("handler exploded"));
+        service.registerHandler("acme.test-plugin", "get-data", vi.fn().mockRejectedValue(frozen));
+        // The marker can't be written onto a frozen error; the original error
+        // must still surface (not a TypeError from the failed assignment).
+        await expect(
+          service.dispatchHandler("acme.test-plugin", "get-data", makeCtx("acme.test-plugin"), [])
+        ).rejects.toBe(frozen);
+        expect(appendSpy).toHaveBeenCalledTimes(1);
+        expect(isAuditedHandlerFailure(frozen)).toBe(false);
+      } finally {
+        appendSpy.mockRestore();
+      }
+    });
+
     it("never lets an audit append failure mask the handler error", async () => {
       const appendSpy = vi.spyOn(getPluginActionAuditService(), "append").mockImplementation(() => {
         throw new Error("audit store corrupt");

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -167,6 +167,8 @@ vi.mock("../plugin/PluginDevWorkerMainBridge.js", () => ({
 
 import { z } from "zod";
 import { PluginService } from "../PluginService.js";
+import { getPluginActionAuditService } from "../PluginActionAuditService.js";
+import { isAuditedHandlerFailure } from "../../utils/pluginAuditMarker.js";
 import { getPluginManifestSchema, isPrivateOrLoopbackHostname } from "../../schemas/plugin.js";
 import {
   BUILT_IN_PLUGIN_CAPABILITIES,
@@ -2400,6 +2402,86 @@ describe("Plugin IPC handler registration", () => {
       []
     );
     expect(result).toBe("sync-result");
+  });
+
+  describe("dispatchHandler failure auditing (#10463)", () => {
+    it("audits a throwing typed-channel handler as an ipc-invoke error record", async () => {
+      const appendSpy = vi
+        .spyOn(getPluginActionAuditService(), "append")
+        .mockImplementation(() => {});
+      try {
+        const boom = new Error("handler exploded");
+        service.registerHandler("acme.test-plugin", "get-data", vi.fn().mockRejectedValue(boom));
+
+        await expect(
+          service.dispatchHandler("acme.test-plugin", "get-data", makeCtx("acme.test-plugin"), [
+            { q: "x" },
+          ])
+        ).rejects.toBe(boom);
+
+        expect(appendSpy).toHaveBeenCalledTimes(1);
+        const record = appendSpy.mock.calls[0][0];
+        expect(record).toMatchObject({
+          pluginId: "acme.test-plugin",
+          actionId: "get-data",
+          recordType: "ipc-invoke",
+          channel: "get-data",
+          result: "error",
+        });
+        expect(record.errorMessage).toContain("handler exploded");
+        expect(typeof record.durationMs).toBe("number");
+        expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
+        // The error is marked so the outer plugin:invoke catch won't re-audit.
+        expect(isAuditedHandlerFailure(boom)).toBe(true);
+      } finally {
+        appendSpy.mockRestore();
+      }
+    });
+
+    it("does not audit when the typed-channel handler succeeds", async () => {
+      const appendSpy = vi
+        .spyOn(getPluginActionAuditService(), "append")
+        .mockImplementation(() => {});
+      try {
+        service.registerHandler("acme.test-plugin", "get-data", vi.fn().mockResolvedValue("ok"));
+        await service.dispatchHandler("acme.test-plugin", "get-data", makeCtx("acme.test-plugin"), [
+          "a",
+        ]);
+        expect(appendSpy).not.toHaveBeenCalled();
+      } finally {
+        appendSpy.mockRestore();
+      }
+    });
+
+    it("does not audit schema/no-handler errors (owned by the IPC boundary)", async () => {
+      const appendSpy = vi
+        .spyOn(getPluginActionAuditService(), "append")
+        .mockImplementation(() => {});
+      try {
+        await expect(
+          service.dispatchHandler("acme.test-plugin", "missing", makeCtx("acme.test-plugin"), [])
+        ).rejects.toThrow("No plugin handler registered");
+        expect(appendSpy).not.toHaveBeenCalled();
+      } finally {
+        appendSpy.mockRestore();
+      }
+    });
+
+    it("never lets an audit append failure mask the handler error", async () => {
+      const appendSpy = vi.spyOn(getPluginActionAuditService(), "append").mockImplementation(() => {
+        throw new Error("audit store corrupt");
+      });
+      try {
+        const boom = new Error("handler exploded");
+        service.registerHandler("acme.test-plugin", "get-data", vi.fn().mockRejectedValue(boom));
+        await expect(
+          service.dispatchHandler("acme.test-plugin", "get-data", makeCtx("acme.test-plugin"), [])
+        ).rejects.toBe(boom);
+        expect(appendSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        appendSpy.mockRestore();
+      }
+    });
   });
 
   describe("dispatchHandler args validation", () => {
@@ -4856,6 +4938,43 @@ describe("createHost — registerAction", () => {
     // undefined, so a handler can safely destructure the args object.
     expect(handler).toHaveBeenCalledWith({});
     expect(result).toBe("ran");
+  });
+
+  it("audits a throwing action handler as an action-dispatch error record (#10463)", async () => {
+    const appendSpy = vi
+      .spyOn(getPluginActionAuditService(), "append")
+      .mockImplementation(() => {});
+    try {
+      const boom = new Error("action exploded");
+      const { host } = getHost("acme.act-test");
+      host.registerAction(descriptor(), () => {
+        throw boom;
+      });
+
+      await expect(
+        service.dispatchHandler(
+          "acme.act-test",
+          "acme.act-test.plan-from-issue",
+          makeCtx("acme.act-test"),
+          [{ issue: 7 }]
+        )
+      ).rejects.toBe(boom);
+
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+      const record = appendSpy.mock.calls[0][0];
+      expect(record).toMatchObject({
+        pluginId: "acme.act-test",
+        actionId: "acme.act-test.plan-from-issue",
+        recordType: "action-dispatch",
+        result: "error",
+      });
+      expect(record.errorMessage).toContain("action exploded");
+      expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
+      // Marked so the outer plugin:invoke catch won't record a duplicate.
+      expect(isAuditedHandlerFailure(boom)).toBe(true);
+    } finally {
+      appendSpy.mockRestore();
+    }
   });
 
   it("rejects calls after the host is revoked", () => {

--- a/electron/utils/pluginAuditMarker.ts
+++ b/electron/utils/pluginAuditMarker.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared marker for plugin handler failures that have already been written to
+ * the audit pipeline at the deepest boundary that owns the operation
+ * (`PluginService.dispatchHandler`). The outer `plugin:invoke` IPC handler
+ * inspects this marker so a single failure isn't recorded twice: the inner
+ * dispatch boundary audits handler throws, while the IPC boundary stays
+ * responsible for failures that never reach a handler (untrusted sender,
+ * schema/permission/no-handler errors).
+ *
+ * Lives in its own module so both the service and the IPC handler can share it
+ * without the handler reaching into the service's internals.
+ */
+
+const PLUGIN_HANDLER_FAILURE_AUDITED = Symbol("plugin-handler-failure-audited");
+
+/**
+ * Tag a rethrown handler error as already audited. No-op on primitives — a
+ * handler that throws a string/number/null can't carry the marker, so the
+ * outer handler will audit it (a rare, acceptable double-record rather than
+ * mutating the thrown value).
+ */
+export function markAuditedHandlerFailure(err: unknown): void {
+  if (typeof err === "object" && err !== null) {
+    (err as Record<symbol, unknown>)[PLUGIN_HANDLER_FAILURE_AUDITED] = true;
+  }
+}
+
+/** Whether `err` was already audited at the dispatch boundary. */
+export function isAuditedHandlerFailure(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as Record<symbol, unknown>)[PLUGIN_HANDLER_FAILURE_AUDITED] === true
+  );
+}

--- a/electron/utils/pluginAuditMarker.ts
+++ b/electron/utils/pluginAuditMarker.ts
@@ -21,7 +21,14 @@ const PLUGIN_HANDLER_FAILURE_AUDITED = Symbol("plugin-handler-failure-audited");
  */
 export function markAuditedHandlerFailure(err: unknown): void {
   if (typeof err === "object" && err !== null) {
-    (err as Record<symbol, unknown>)[PLUGIN_HANDLER_FAILURE_AUDITED] = true;
+    try {
+      (err as Record<symbol, unknown>)[PLUGIN_HANDLER_FAILURE_AUDITED] = true;
+    } catch {
+      // A frozen/sealed error rejects the assignment in strict mode. The
+      // marker is best-effort — never let it replace the handler error we're
+      // about to rethrow. An unmarked error is simply re-audited by the outer
+      // IPC boundary (a duplicate record, not a lost one).
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Fixes an observability gap where plugin handler failures were only `console.error`'d and never reached the audit pipeline. Two TODO(#9232) stubs in `PluginService.dispatchHandler` left non-IPC callers (agent automation, recipe dispatch) without any durable failure trail.
- Emits a `PluginActionAuditRecord` with `result: "error"` at the `dispatchHandler` boundary for both the action-handler path (`recordType: "action-dispatch"`) and the typed-channel path (`recordType: "ipc-invoke"`, carrying the plugin channel string).
- Introduces `electron/utils/pluginAuditMarker.ts`: a Symbol marker so the outer `plugin:invoke` catch skips its own append when the inner boundary already recorded the failure. Marker assignment is wrapped in `try/catch` so a frozen plugin error can't mask the original handler error. The IPC boundary still owns schema/permission/no-handler/untrusted-sender failures and never receives a marked error.

Resolves #10463

Part of the plugin 1.0 freeze (#10459), failure theme 5: observability gaps.

## Changes

- `electron/utils/pluginAuditMarker.ts` (new) -- Symbol-based double-record guard with frozen-error protection
- `electron/services/PluginService.ts` -- emit audit record in both `dispatchHandler` failure paths
- `electron/ipc/handlers/plugin.ts` -- check marker before appending in the outer `plugin:invoke` catch
- `electron/services/__tests__/PluginService.test.ts` -- failure auditing for both paths, no-double-audit guard, audit-append-failure isolation, frozen-error rethrow
- `electron/ipc/handlers/__tests__/plugin.handlers.test.ts` -- no-double-audit coverage at the IPC boundary

## Testing

578 unit tests pass. `tsc --noEmit` clean. `prettier`/`eslint` clean on changed files.

**Known follow-up (out of scope):** plugin actions dispatched via `ActionService` still emit a separate `action:dispatched` "success" record even when `usePluginActions` swallows the failure for toast control -- a pre-existing renderer-side observability gap independent of this change. Worth a separate issue under #10459's failure theme 5.