### PR TITLE
test(plugins): add sample coverage + E2E for panels, keybindings, contextMenus, agents

### DIFF
--- a/e2e/full/plugins/core-plugin-agents.spec.ts
+++ b/e2e/full/plugins/core-plugin-agents.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { launchWithSamplePlugin } from "../../helpers/plugins";
+
+/**
+ * Plugin `agents` contribution (#10473). The sample manifest declares one agent
+ * (`id: "hello-sample"`) and the matching `agent:register` capability the
+ * manifest gate requires. Plugin agent ids are additive and not namespaced, so
+ * the contributed agent surfaces under its bare id in the effective registry.
+ * This proves the declared agent reaches the main-process agent registry — the
+ * runtime source the agent picker reads from.
+ *
+ * `getAgents()` returns a `Record<string, AgentConfig>` keyed by agent id, so
+ * the assertion indexes by key rather than scanning an array.
+ */
+test.describe.serial("Core: Plugin agents contribution", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-agents");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("registers the contributed agent in the main-process registry", async () => {
+    const agents = await ctx.window.evaluate(() => window.electron.plugin.getAgents());
+
+    expect(agents["hello-sample"]).toBeDefined();
+    expect(agents["hello-sample"]).toMatchObject({
+      id: "hello-sample",
+      name: "Hello Sample",
+      command: "echo",
+      color: "#6366f1",
+      iconId: "bot",
+    });
+  });
+});

--- a/e2e/full/plugins/core-plugin-agents.spec.ts
+++ b/e2e/full/plugins/core-plugin-agents.spec.ts
@@ -1,17 +1,20 @@
 import { test, expect } from "@playwright/test";
 import { closeApp, type AppContext } from "../../helpers/launch";
-import { launchWithSamplePlugin } from "../../helpers/plugins";
+import { launchWithSamplePlugin, waitForRichPluginReady } from "../../helpers/plugins";
 
 /**
- * Plugin `agents` contribution (#10473). The sample manifest declares one agent
- * (`id: "hello-sample"`) and the matching `agent:register` capability the
+ * Plugin `agents` contribution (#10473). The `rich-daintree` sample declares one
+ * agent (`id: "rich-sample"`) and the matching `agent:register` capability the
  * manifest gate requires. Plugin agent ids are additive and not namespaced, so
  * the contributed agent surfaces under its bare id in the effective registry.
  * This proves the declared agent reaches the main-process agent registry — the
  * runtime source the agent picker reads from.
  *
  * `getAgents()` returns a `Record<string, AgentConfig>` keyed by agent id, so
- * the assertion indexes by key rather than scanning an array.
+ * the assertion indexes by key rather than scanning an array. The agent rides on
+ * `rich-daintree` (which already carries confirm-danger capabilities) rather
+ * than the capability-free `hello-daintree`, so the reference plugin's
+ * empty-permissions and safe-dispatch assertions stay intact.
  */
 test.describe.serial("Core: Plugin agents contribution", () => {
   let ctx: AppContext;
@@ -21,6 +24,7 @@ test.describe.serial("Core: Plugin agents contribution", () => {
     const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-agents");
     ctx = launched;
     fixtureCleanup = cleanup;
+    await waitForRichPluginReady(ctx.window);
   });
 
   test.afterAll(async () => {
@@ -31,10 +35,10 @@ test.describe.serial("Core: Plugin agents contribution", () => {
   test("registers the contributed agent in the main-process registry", async () => {
     const agents = await ctx.window.evaluate(() => window.electron.plugin.getAgents());
 
-    expect(agents["hello-sample"]).toBeDefined();
-    expect(agents["hello-sample"]).toMatchObject({
-      id: "hello-sample",
-      name: "Hello Sample",
+    expect(agents["rich-sample"]).toBeDefined();
+    expect(agents["rich-sample"]).toMatchObject({
+      id: "rich-sample",
+      name: "Rich Sample",
       command: "echo",
       color: "#6366f1",
       iconId: "bot",

--- a/e2e/full/plugins/core-plugin-context-menus.spec.ts
+++ b/e2e/full/plugins/core-plugin-context-menus.spec.ts
@@ -1,13 +1,14 @@
 import { test, expect } from "@playwright/test";
 import { closeApp, type AppContext } from "../../helpers/launch";
-import { launchWithSamplePlugin } from "../../helpers/plugins";
+import { launchWithSamplePlugin, waitForRichPluginReady } from "../../helpers/plugins";
 
 /**
- * Plugin `contextMenus` contribution (#10473). The sample manifest declares one
- * context-menu item (label "Say hello", location `worktree`) bound to the
- * plugin's own `daintree.hello.greet` action. This asserts the declared item
- * reaches the main-process context-menu registry — the runtime source the
- * renderer's `PluginContextMenuSection` reads when building a worktree menu.
+ * Plugin `contextMenus` contribution (#10473). The `rich-daintree` sample
+ * declares one context-menu item (label "Rich sample action", location
+ * `worktree`) bound to the plugin's own `daintree.rich.ready` action. This
+ * asserts the declared item reaches the main-process context-menu registry —
+ * the runtime source the renderer's `PluginContextMenuSection` reads when
+ * building a worktree menu.
  */
 test.describe.serial("Core: Plugin context menus contribution", () => {
   let ctx: AppContext;
@@ -17,6 +18,7 @@ test.describe.serial("Core: Plugin context menus contribution", () => {
     const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-context-menus");
     ctx = launched;
     fixtureCleanup = cleanup;
+    await waitForRichPluginReady(ctx.window);
   });
 
   test.afterAll(async () => {
@@ -26,15 +28,15 @@ test.describe.serial("Core: Plugin context menus contribution", () => {
 
   test("registers the contributed context-menu item in the main-process registry", async () => {
     const items = await ctx.window.evaluate(() => window.electron.plugin.contextMenuItems());
-    const helloItem = items.find((entry) => entry.item.label === "Say hello");
+    const richItem = items.find((entry) => entry.item.label === "Rich sample action");
 
-    expect(helloItem).toBeDefined();
-    expect(helloItem).toMatchObject({
-      pluginId: "daintree.hello",
+    expect(richItem).toBeDefined();
+    expect(richItem).toMatchObject({
+      pluginId: "daintree.rich",
       item: {
-        actionId: "daintree.hello.greet",
+        actionId: "daintree.rich.ready",
         location: "worktree",
-        label: "Say hello",
+        label: "Rich sample action",
       },
     });
   });

--- a/e2e/full/plugins/core-plugin-context-menus.spec.ts
+++ b/e2e/full/plugins/core-plugin-context-menus.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { launchWithSamplePlugin } from "../../helpers/plugins";
+
+/**
+ * Plugin `contextMenus` contribution (#10473). The sample manifest declares one
+ * context-menu item (label "Say hello", location `worktree`) bound to the
+ * plugin's own `daintree.hello.greet` action. This asserts the declared item
+ * reaches the main-process context-menu registry — the runtime source the
+ * renderer's `PluginContextMenuSection` reads when building a worktree menu.
+ */
+test.describe.serial("Core: Plugin context menus contribution", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-context-menus");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("registers the contributed context-menu item in the main-process registry", async () => {
+    const items = await ctx.window.evaluate(() => window.electron.plugin.contextMenuItems());
+    const helloItem = items.find((entry) => entry.item.label === "Say hello");
+
+    expect(helloItem).toBeDefined();
+    expect(helloItem).toMatchObject({
+      pluginId: "daintree.hello",
+      item: {
+        actionId: "daintree.hello.greet",
+        location: "worktree",
+        label: "Say hello",
+      },
+    });
+  });
+});

--- a/e2e/full/plugins/core-plugin-keybindings.spec.ts
+++ b/e2e/full/plugins/core-plugin-keybindings.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from "@playwright/test";
 import { closeApp, type AppContext } from "../../helpers/launch";
-import { launchWithSamplePlugin } from "../../helpers/plugins";
+import { launchWithSamplePlugin, waitForRichPluginReady } from "../../helpers/plugins";
 
 /**
- * Plugin `keybindings` contribution (#10473). The sample manifest declares one
- * keybinding (`CmdOrCtrl+Shift+H`) bound to the plugin's own
- * `daintree.hello.greet` action. This asserts the declared binding reaches the
+ * Plugin `keybindings` contribution (#10473). The `rich-daintree` sample
+ * declares one keybinding (`CmdOrCtrl+Shift+R`) bound to the plugin's own
+ * `daintree.rich.ready` action. This asserts the declared binding reaches the
  * main-process keybinding registry — the runtime source the renderer's
  * `usePluginKeybindings` hook pulls from.
  *
@@ -22,6 +22,7 @@ test.describe.serial("Core: Plugin keybindings contribution", () => {
     const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-keybindings");
     ctx = launched;
     fixtureCleanup = cleanup;
+    await waitForRichPluginReady(ctx.window);
   });
 
   test.afterAll(async () => {
@@ -31,16 +32,14 @@ test.describe.serial("Core: Plugin keybindings contribution", () => {
 
   test("registers the contributed keybinding in the main-process registry", async () => {
     const keybindings = await ctx.window.evaluate(() => window.electron.plugin.keybindings());
-    const helloBinding = keybindings.find(
-      (entry) => entry.item.actionId === "daintree.hello.greet"
-    );
+    const richBinding = keybindings.find((entry) => entry.item.actionId === "daintree.rich.ready");
 
-    expect(helloBinding).toBeDefined();
-    expect(helloBinding).toMatchObject({
-      pluginId: "daintree.hello",
+    expect(richBinding).toBeDefined();
+    expect(richBinding).toMatchObject({
+      pluginId: "daintree.rich",
       item: {
-        actionId: "daintree.hello.greet",
-        combo: "CmdOrCtrl+Shift+H",
+        actionId: "daintree.rich.ready",
+        combo: "CmdOrCtrl+Shift+R",
         scope: "global",
       },
     });

--- a/e2e/full/plugins/core-plugin-keybindings.spec.ts
+++ b/e2e/full/plugins/core-plugin-keybindings.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { launchWithSamplePlugin } from "../../helpers/plugins";
+
+/**
+ * Plugin `keybindings` contribution (#10473). The sample manifest declares one
+ * keybinding (`CmdOrCtrl+Shift+H`) bound to the plugin's own
+ * `daintree.hello.greet` action. This asserts the declared binding reaches the
+ * main-process keybinding registry — the runtime source the renderer's
+ * `usePluginKeybindings` hook pulls from.
+ *
+ * The assertion is registry-only by design: firing the combo and observing the
+ * effect is flaky in headless CI (scope matching needs a focused element, and
+ * `CmdOrCtrl` resolves to `Control` on Linux vs `Meta` on macOS), so the
+ * registry is the stable cross-platform proof the contribution point is wired.
+ */
+test.describe.serial("Core: Plugin keybindings contribution", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-keybindings");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("registers the contributed keybinding in the main-process registry", async () => {
+    const keybindings = await ctx.window.evaluate(() => window.electron.plugin.keybindings());
+    const helloBinding = keybindings.find(
+      (entry) => entry.item.actionId === "daintree.hello.greet"
+    );
+
+    expect(helloBinding).toBeDefined();
+    expect(helloBinding).toMatchObject({
+      pluginId: "daintree.hello",
+      item: {
+        actionId: "daintree.hello.greet",
+        combo: "CmdOrCtrl+Shift+H",
+        scope: "global",
+      },
+    });
+  });
+});

--- a/e2e/full/plugins/core-plugin-panels.spec.ts
+++ b/e2e/full/plugins/core-plugin-panels.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { launchWithSamplePlugin } from "../../helpers/plugins";
+
+/**
+ * Plugin `panels` contribution (#10473). The sample manifest declares one
+ * non-PTY panel (`id: "hello-panel"`). `PluginService` namespaces the kind id
+ * as `${pluginId}.${panelId}`, so the contributed kind surfaces as
+ * `daintree.hello.hello-panel`. This proves a declared panel contribution
+ * actually registers a spawnable panel kind against the main-process registry
+ * — the runtime source of truth the panel palette reads from.
+ */
+test.describe.serial("Core: Plugin panels contribution", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-panels");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("registers the contributed panel kind in the main-process registry", async () => {
+    const kinds = await ctx.window.evaluate(() => window.electron.plugin.getPanelKinds());
+    const helloPanel = kinds.find((kind) => kind.id === "daintree.hello.hello-panel");
+
+    expect(helloPanel).toBeDefined();
+    expect(helloPanel).toMatchObject({
+      id: "daintree.hello.hello-panel",
+      name: "Hello Panel",
+      extensionId: "daintree.hello",
+      hasPty: false,
+      showInPalette: true,
+    });
+  });
+});

--- a/e2e/full/plugins/core-plugin-panels.spec.ts
+++ b/e2e/full/plugins/core-plugin-panels.spec.ts
@@ -1,14 +1,19 @@
 import { test, expect } from "@playwright/test";
 import { closeApp, type AppContext } from "../../helpers/launch";
-import { launchWithSamplePlugin } from "../../helpers/plugins";
+import { launchWithSamplePlugin, waitForRichPluginReady } from "../../helpers/plugins";
 
 /**
- * Plugin `panels` contribution (#10473). The sample manifest declares one
- * non-PTY panel (`id: "hello-panel"`). `PluginService` namespaces the kind id
- * as `${pluginId}.${panelId}`, so the contributed kind surfaces as
- * `daintree.hello.hello-panel`. This proves a declared panel contribution
- * actually registers a spawnable panel kind against the main-process registry
- * — the runtime source of truth the panel palette reads from.
+ * Plugin `panels` contribution (#10473). The capability-rich `rich-daintree`
+ * sample declares one non-PTY panel (`id: "rich-panel"`). `PluginService`
+ * namespaces the kind id as `${pluginId}.${panelId}`, so the contributed kind
+ * surfaces as `daintree.rich.rich-panel`. This proves a declared panel
+ * contribution actually registers a spawnable panel kind against the
+ * main-process registry — the runtime source of truth the panel palette reads
+ * from.
+ *
+ * The contribution rides on `rich-daintree` rather than the minimal
+ * `hello-daintree` so the reference plugin's empty-manifest assertions (its
+ * "Other" category and "No special permissions" cases) stay intact.
  */
 test.describe.serial("Core: Plugin panels contribution", () => {
   let ctx: AppContext;
@@ -18,6 +23,7 @@ test.describe.serial("Core: Plugin panels contribution", () => {
     const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-panels");
     ctx = launched;
     fixtureCleanup = cleanup;
+    await waitForRichPluginReady(ctx.window);
   });
 
   test.afterAll(async () => {
@@ -27,13 +33,13 @@ test.describe.serial("Core: Plugin panels contribution", () => {
 
   test("registers the contributed panel kind in the main-process registry", async () => {
     const kinds = await ctx.window.evaluate(() => window.electron.plugin.getPanelKinds());
-    const helloPanel = kinds.find((kind) => kind.id === "daintree.hello.hello-panel");
+    const richPanel = kinds.find((kind) => kind.id === "daintree.rich.rich-panel");
 
-    expect(helloPanel).toBeDefined();
-    expect(helloPanel).toMatchObject({
-      id: "daintree.hello.hello-panel",
-      name: "Hello Panel",
-      extensionId: "daintree.hello",
+    expect(richPanel).toBeDefined();
+    expect(richPanel).toMatchObject({
+      id: "daintree.rich.rich-panel",
+      name: "Rich Panel",
+      extensionId: "daintree.rich",
       hasPty: false,
       showInPalette: true,
     });

--- a/plugins/sample/hello-daintree/plugin.json
+++ b/plugins/sample/hello-daintree/plugin.json
@@ -7,7 +7,7 @@
   "engines": {
     "daintree": ">=0.11.0"
   },
-  "capabilities": [],
+  "capabilities": ["agent:register"],
   "contributes": {
     "toolbarButtons": [
       {
@@ -23,6 +23,42 @@
         "label": "Hello ping",
         "actionId": "daintree.hello.ping",
         "location": "help"
+      }
+    ],
+    "panels": [
+      {
+        "id": "hello-panel",
+        "name": "Hello Panel",
+        "iconId": "layout-panel-top",
+        "color": "#6366f1",
+        "hasPty": false,
+        "canRestart": false,
+        "canConvert": false,
+        "showInPalette": true
+      }
+    ],
+    "keybindings": [
+      {
+        "actionId": "daintree.hello.greet",
+        "combo": "CmdOrCtrl+Shift+H",
+        "scope": "global",
+        "description": "Greet from the Hello Daintree sample plugin"
+      }
+    ],
+    "contextMenus": [
+      {
+        "actionId": "daintree.hello.greet",
+        "location": "worktree",
+        "label": "Say hello"
+      }
+    ],
+    "agents": [
+      {
+        "id": "hello-sample",
+        "name": "Hello Sample",
+        "command": "echo",
+        "color": "#6366f1",
+        "iconId": "bot"
       }
     ],
     "fileDecorationProviders": [

--- a/plugins/sample/hello-daintree/plugin.json
+++ b/plugins/sample/hello-daintree/plugin.json
@@ -7,7 +7,7 @@
   "engines": {
     "daintree": ">=0.11.0"
   },
-  "capabilities": ["agent:register"],
+  "capabilities": [],
   "contributes": {
     "toolbarButtons": [
       {
@@ -23,42 +23,6 @@
         "label": "Hello ping",
         "actionId": "daintree.hello.ping",
         "location": "help"
-      }
-    ],
-    "panels": [
-      {
-        "id": "hello-panel",
-        "name": "Hello Panel",
-        "iconId": "layout-panel-top",
-        "color": "#6366f1",
-        "hasPty": false,
-        "canRestart": false,
-        "canConvert": false,
-        "showInPalette": true
-      }
-    ],
-    "keybindings": [
-      {
-        "actionId": "daintree.hello.greet",
-        "combo": "CmdOrCtrl+Shift+H",
-        "scope": "global",
-        "description": "Greet from the Hello Daintree sample plugin"
-      }
-    ],
-    "contextMenus": [
-      {
-        "actionId": "daintree.hello.greet",
-        "location": "worktree",
-        "label": "Say hello"
-      }
-    ],
-    "agents": [
-      {
-        "id": "hello-sample",
-        "name": "Hello Sample",
-        "command": "echo",
-        "color": "#6366f1",
-        "iconId": "bot"
       }
     ],
     "fileDecorationProviders": [

--- a/plugins/sample/rich-daintree/plugin.json
+++ b/plugins/sample/rich-daintree/plugin.json
@@ -2,18 +2,54 @@
   "name": "daintree.rich",
   "version": "0.1.0",
   "displayName": "Rich Daintree",
-  "description": "Capability- and settings-rich sample plugin (#9592). Sideloaded alongside hello-daintree so the full-plugins E2E bucket can exercise the Permissions tab, the generated settings form, and the danger summary — surfaces hello-daintree's empty manifest leaves uncovered.",
+  "description": "Capability- and settings-rich sample plugin (#9592, #10473). Sideloaded alongside hello-daintree so the full-plugins E2E bucket can exercise the Permissions tab, the generated settings form, the danger summary, and the panel / keybinding / context-menu / agent contribution points — surfaces hello-daintree's empty manifest leaves uncovered.",
   "main": "main/index.js",
   "engines": {
     "daintree": ">=0.11.0"
   },
-  "capabilities": ["fs:project-read", "fs:project-write", "network:fetch"],
+  "capabilities": ["fs:project-read", "fs:project-write", "network:fetch", "agent:register"],
   "scopes": {
     "network": {
       "allowedUrls": ["https://api.example.com"]
     }
   },
   "contributes": {
+    "panels": [
+      {
+        "id": "rich-panel",
+        "name": "Rich Panel",
+        "iconId": "layout-panel-top",
+        "color": "#6366f1",
+        "hasPty": false,
+        "canRestart": false,
+        "canConvert": false,
+        "showInPalette": true
+      }
+    ],
+    "keybindings": [
+      {
+        "actionId": "daintree.rich.ready",
+        "combo": "CmdOrCtrl+Shift+R",
+        "scope": "global",
+        "description": "Sentinel keybinding from the Rich Daintree sample plugin"
+      }
+    ],
+    "contextMenus": [
+      {
+        "actionId": "daintree.rich.ready",
+        "location": "worktree",
+        "label": "Rich sample action"
+      }
+    ],
+    "agents": [
+      {
+        "id": "rich-sample",
+        "name": "Rich Sample",
+        "command": "echo",
+        "color": "#6366f1",
+        "iconId": "bot"
+      }
+    ],
     "settings": [
       {
         "id": "greeting",


### PR DESCRIPTION
## Summary

- Extends `rich-daintree` sample plugin with one each of the four wired-but-untested contribution points: panel, keybinding, contextMenu, and agent (plus the `agent:register` capability)
- Keeps `hello-daintree` untouched so its empty-manifest specs stay green
- Adds four E2E specs verifying each contribution reaches the main-process registry via the plugin IPC getters (`getPanelKinds`, `keybindings`, `contextMenuItems`, `getAgents`)

Resolves #10473

## Changes

- `plugins/sample/rich-daintree/plugin.json` — adds panel, keybinding, contextMenu, and agent contributions + `agent:register` capability
- `e2e/full/plugins/core-plugin-panels.spec.ts` — asserts panel contribution registers via `getPanelKinds`
- `e2e/full/plugins/core-plugin-keybindings.spec.ts` — asserts keybinding contribution registers via `keybindings`
- `e2e/full/plugins/core-plugin-context-menus.spec.ts` — asserts contextMenu contribution registers via `contextMenuItems`
- `e2e/full/plugins/core-plugin-agents.spec.ts` — asserts agent contribution registers via `getAgents`

## Testing

Assertions are registry-only. Verifying that contributions actually fire in the UI isn't reliable in headless CI, and the registry check is the right seam to test against anyway — if the contribution reaches the main-process registry, the plumbing is correct.