### PR TITLE
fix(agent-detection): restore working/waiting detection broken in v0.19.0

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1179,13 +1179,13 @@ export class TerminalProcess {
   }
 
   getVisibleActivitySnapshot(n: number): VisibleContentSnapshot | undefined {
-    const cells = this.getVisibleActivityCells(n);
+    const cells = this.getVisibleActivityCells();
     return cells
       ? createVisibleCellContentSnapshot(cells)
       : createVisibleContentSnapshot(this.getVisibleActivityLines(n));
   }
 
-  private getVisibleActivityCells(n: number): VisibleContentCell[][] | undefined {
+  private getVisibleActivityCells(): VisibleContentCell[][] | undefined {
     const terminal = this.terminalInfo.headlessTerminal;
     if (!terminal) return undefined;
 
@@ -1201,14 +1201,16 @@ export class TerminalProcess {
     const viewportTop = buffer.baseY;
     const viewportBottom = buffer.baseY + terminal.rows;
     const end = viewportBottom;
-    // Bottom-n window, extended upward to include the cursor row: on a fresh
-    // or just-cleared screen the agent draws near the top of the viewport, and
-    // a purely bottom-anchored window would scan only blank rows there —
-    // blinding the sustained-change recovery path. Steady-state terminals
-    // (cursor at the bottom) keep the cheap n-row scan.
-    const cursorAbs =
-      viewportTop + (typeof buffer.cursorY === "number" ? buffer.cursorY : terminal.rows - 1);
-    const start = Math.max(viewportTop, Math.min(end - n, cursorAbs));
+    // Scan the FULL visible viewport. A cursor-anchored bottom-n window (the
+    // v0.19.0 regression) misses spinner/status activity that TUI agents
+    // (Claude/Gemini/Codex) stream ABOVE a pinned bottom input box: with the
+    // cursor parked low, the window collapsed to the bottom rows and the
+    // changing rows above produced changedChars=0, so the temperature decayed
+    // and a busy agent flipped to "waiting" during low-output thinking (and
+    // waiting→working recovery was starved). Blank cells are skipped below, so
+    // scanning the whole viewport costs reads but not allocations. The line
+    // budget only constrains the line-based fallback in getVisibleActivitySnapshot.
+    const start = viewportTop;
     const reusableCell = buffer.getNullCell();
 
     const rows: VisibleContentCell[][] = [];

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -472,6 +472,62 @@ describe("TerminalProcess — observer-driven exit handlers", () => {
     }
   });
 
+  it("detects spinner activity above a pinned bottom input box (regression: cursor-anchored scan window)", async () => {
+    // Regression for the v0.19.0 detection break: getVisibleActivityCells was
+    // narrowed to a cursor-anchored bottom-15-row window. A TUI agent that
+    // animates its spinner/status line ABOVE a pinned bottom input box then
+    // produced changedChars=0, so a genuinely-working agent decayed to
+    // "waiting" during long low-output thinking. The cell scan must cover the
+    // full viewport.
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const pty = createControllablePty();
+    const mutablePtyDimensions = pty as unknown as { cols: number; rows: number };
+    mutablePtyDimensions.cols = 100;
+    mutablePtyDimensions.rows = 30;
+    const terminal = createTerminal(
+      pty,
+      { cols: 100, rows: 30, kind: "terminal", launchAgentId: "claude" },
+      undefined,
+      "t-spinner-above-input"
+    );
+
+    try {
+      terminal.stopActivityMonitor();
+      terminal.getInfo().agentState = "working";
+
+      // Spinner on the top row, body filling the middle, input box at the
+      // bottom. The cursor lands in the input box (row ~27 of 30) after this
+      // write, so a bottom-15 window would start at row 15 — above which the
+      // spinner is invisible.
+      await emitDataAndFlush(
+        pty,
+        [
+          "✻ Thinking (0s · esc to interrupt)",
+          ...Array.from({ length: 26 }, (_, i) => `body line ${i + 1}`),
+          "> ",
+        ].join("\r\n")
+      );
+
+      const before = terminal.getVisibleActivitySnapshot(AGENT_OUTPUT_ACTIVITY_LINE_COUNT);
+
+      // Animate ONLY the top spinner line, restoring the cursor to the input
+      // box (DECSC/DECRC) — exactly how the agent re-renders during thinking.
+      await emitDataAndFlush(pty, "\x1b7\x1b[1;1H✻ Thinking (3s · esc to interrupt)\x1b8");
+
+      const after = terminal.getVisibleActivitySnapshot(AGENT_OUTPUT_ACTIVITY_LINE_COUNT);
+
+      expect(before).toBeDefined();
+      expect(after).toBeDefined();
+      const delta = measureVisibleContentDelta(before, after!);
+      expect(delta.changed).toBe(true);
+      expect(delta.changedChars).toBeGreaterThan(0);
+    } finally {
+      terminal.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("recovers a waiting live agent to working on sustained PTY content changes without a monitor", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1000);

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -976,9 +976,30 @@ export class ProjectViewManager {
   private freezeAllCached(): void {
     for (const [projectId, entry] of this.views) {
       if (projectId === this.activeProjectId) continue;
+      // Never freeze a view whose project has a live agent. A frozen renderer
+      // cannot run JS, so the queued agent:state-changed IPC sits in Mojo and
+      // the background dashboard stays stuck on its pre-freeze state (e.g.
+      // "waiting") until the view is foregrounded. Idle/completed projects
+      // still freeze for the efficiency win.
+      if (this.hasActiveAgent(projectId)) continue;
       const wc = entry.view.webContents;
       if (wc.isDestroyed()) continue;
       void freezeWebContents(wc);
+    }
+  }
+
+  // Wake any cached background view whose project gained a live agent after it
+  // was already frozen (the seed/state-change races freezeAllCached). Unfreeze
+  // only — CPU throttle stays applied; throttling slows JS but does not suspend
+  // it, so the queued state event still applies. No-op outside efficiency.
+  private unfreezeActiveAgentViews(): void {
+    if (!this.efficiencyFreezeEnabled) return;
+    for (const [projectId, entry] of this.views) {
+      if (projectId === this.activeProjectId) continue;
+      if (!this.hasActiveAgent(projectId)) continue;
+      const wc = entry.view.webContents;
+      if (wc.isDestroyed()) continue;
+      void unfreezeWebContents(wc);
     }
   }
 
@@ -1157,8 +1178,15 @@ export class ProjectViewManager {
 
       // Freeze AFTER GC scheduling — Page.setWebLifecycleState suspends the
       // renderer event loop, so the requestIdleCallback above would never run
-      // if we froze first (lesson #4684).
-      if (this.efficiencyFreezeEnabled && !webContents.isDestroyed()) {
+      // if we froze first (lesson #4684). Skip the freeze for a project with a
+      // live agent: a frozen renderer can't apply queued agent:state-changed
+      // events, stranding the background dashboard on a stale state (mirrors
+      // the freezeAllCached guard).
+      if (
+        this.efficiencyFreezeEnabled &&
+        !webContents.isDestroyed() &&
+        !this.hasActiveAgent(capturedProjectId)
+      ) {
         void freezeWebContents(webContents);
       }
     }
@@ -1835,6 +1863,11 @@ export class ProjectViewManager {
           if (t.projectId) this.projectByTerminal.set(t.id, t.projectId);
           if (t.agentState) this.agentStateByTerminal.set(t.id, t.agentState);
         }
+        // A background agent may have gone active (or been spawned) after the
+        // debounced freeze fired but before it was mapped here, so its view was
+        // frozen with hasActiveAgent() still false. Now that the maps are fresh,
+        // wake any such view so its queued state event applies.
+        this.unfreezeActiveAgentViews();
       } catch {
         // Host unavailable — leave maps as-is; hasActiveAgent stays conservative.
       }
@@ -1849,6 +1882,20 @@ export class ProjectViewManager {
       // spawn-result/host-crash reseed.
       if (!payload.terminalId) return;
       this.agentStateByTerminal.set(payload.terminalId, payload.state);
+      // Wake a view that was frozen before its agent became active: the freeze
+      // blocks the renderer from ever applying this very event, so unfreeze the
+      // owning project's cached view now. If the terminal isn't mapped to a
+      // project yet (pre-seed race), the spawn-result reseed's
+      // unfreezeActiveAgentViews() pass catches it.
+      if (this.efficiencyFreezeEnabled && ACTIVE_AGENT_STATES.has(payload.state)) {
+        const projectId = this.projectByTerminal.get(payload.terminalId);
+        if (projectId && projectId !== this.activeProjectId) {
+          const entry = this.views.get(projectId);
+          if (entry && !entry.view.webContents.isDestroyed()) {
+            void unfreezeWebContents(entry.view.webContents);
+          }
+        }
+      }
     };
     const offStateChanged = events.on("agent:state-changed", onStateChanged);
 

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -377,7 +377,7 @@ describe("ProjectViewManager — efficiency freeze", () => {
 
     const frozeProjA = vi
       .mocked(freezeWebContents)
-      .mock.calls.some((call) => call[0] === initialWc);
+      .mock.calls.some((call) => (call[0] as unknown) === initialWc);
     expect(frozeProjA).toBe(false);
   });
 
@@ -391,7 +391,7 @@ describe("ProjectViewManager — efficiency freeze", () => {
 
     const frozeProjA = vi
       .mocked(freezeWebContents)
-      .mock.calls.some((call) => call[0] === initialWc);
+      .mock.calls.some((call) => (call[0] as unknown) === initialWc);
     expect(frozeProjA).toBe(false);
   });
 

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -120,6 +120,7 @@ vi.mock("../../utils/webContentsLifecycle.js", () => ({
 }));
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
+import { events } from "../../services/events.js";
 import { freezeWebContents, unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
 import {
   registerCachedViewWebContents,
@@ -354,6 +355,114 @@ describe("ProjectViewManager — efficiency freeze", () => {
 
     const cachedCalls = vi.mocked(registerCachedViewWebContents).mock.calls;
     expect(cachedCalls.every((call) => (call[0] as unknown) !== initialWc)).toBe(true);
+  });
+
+  function seedActiveAgent(terminalId: string, projectId: string) {
+    const priv = manager as unknown as {
+      projectByTerminal: Map<string, string>;
+      agentStateByTerminal: Map<string, string>;
+    };
+    priv.projectByTerminal.set(terminalId, projectId);
+    priv.agentStateByTerminal.set(terminalId, "working");
+  }
+
+  it("does not batch-freeze a cached view whose project has a live agent", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    // proj-a is cached and running a working agent — freezing it would strand
+    // the queued agent:state-changed event at a renderer that can't run JS.
+    seedActiveAgent("t1", "proj-a");
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    const frozeProjA = vi
+      .mocked(freezeWebContents)
+      .mock.calls.some((call) => call[0] === initialWc);
+    expect(frozeProjA).toBe(false);
+  });
+
+  it("skips the inline deactivation freeze for a project with a live agent", async () => {
+    seedActiveAgent("t1", "proj-a");
+
+    // Enter efficiency but stay inside the debounce window so the inline
+    // deactivation path (not the batch sweep) is what would freeze proj-a.
+    manager.setEfficiencyFreeze(true);
+    await manager.switchTo("proj-b", "/path/b");
+
+    const frozeProjA = vi
+      .mocked(freezeWebContents)
+      .mock.calls.some((call) => call[0] === initialWc);
+    expect(frozeProjA).toBe(false);
+  });
+
+  it("unfreezeActiveAgentViews wakes a view that was frozen before its agent went active", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    // proj-a froze while it had no agent (the seed/state race).
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledWith(initialWc);
+    vi.mocked(unfreezeWebContents).mockClear();
+
+    seedActiveAgent("t1", "proj-a");
+    (manager as unknown as { unfreezeActiveAgentViews: () => void }).unfreezeActiveAgentViews();
+
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(initialWc);
+  });
+
+  it("wakes a frozen mapped view when its agent transitions active (agent:state-changed bus)", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    const ptyClient = {
+      getAllTerminalsAsync: vi.fn(async () => [
+        { id: "t1", projectId: "proj-a", agentState: "idle" },
+      ]),
+      on: vi.fn(),
+      off: vi.fn(),
+    };
+    await manager.initAgentStateCache(ptyClient as never);
+
+    // proj-a is cached with an idle agent → it freezes.
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledWith(initialWc);
+    vi.mocked(unfreezeWebContents).mockClear();
+
+    // The agent goes to "working" — the queued event would be stranded at the
+    // frozen renderer, so the real onStateChanged handler must wake proj-a.
+    events.emit("agent:state-changed", { terminalId: "t1", state: "working" } as never);
+
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(initialWc);
+    manager.dispose(); // remove the bus listener so it doesn't leak into later tests
+  });
+
+  it("wakes a frozen view on spawn-result reseed when its agent is now active", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    const captured: Record<string, (...a: unknown[]) => void> = {};
+    let agentState = "idle";
+    const ptyClient = {
+      getAllTerminalsAsync: vi.fn(async () => [{ id: "t1", projectId: "proj-a", agentState }]),
+      on: vi.fn((evt: string, h: (...a: unknown[]) => void) => {
+        captured[evt] = h;
+      }),
+      off: vi.fn(),
+    };
+    await manager.initAgentStateCache(ptyClient as never);
+
+    // Freeze proj-a while its agent is still idle.
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledWith(initialWc);
+    vi.mocked(unfreezeWebContents).mockClear();
+
+    // Agent became active after the freeze; a spawn-result triggers a reseed
+    // that now sees it, and the reseed's unfreezeActiveAgentViews() wakes it.
+    agentState = "working";
+    captured["spawn-result"]?.();
+    await vi.advanceTimersByTimeAsync(0); // flush the async seed()
+
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(initialWc);
+    manager.dispose();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two independent regressions introduced between v0.18.2 and v0.19.0 that broke agent working/waiting state detection. Blocks the 0.19.1 hotfix. Both were "efficiency" optimizations that narrowed a code path they shouldn't have.

### Bug A — over-eager "waiting" + hard-to-detect "working" (affects foreground too)

`4211fbf86` narrowed `getVisibleActivityCells` from a full-viewport scan to a cursor-anchored bottom-15-row window. TUI agents (Claude/Gemini/Codex) park the cursor in a bottom input box and stream the spinner / "esc to interrupt" / elapsed-time line **above** it — so with the cursor pinned low, the changing rows fell outside the window, `changedChars` stayed 0, the activity temperature decayed, and a genuinely-working agent flipped to "waiting" during long low-output thinking. The same window starved waiting→working recovery, making the transition harder to detect.

**Fix:** restore `start = viewportTop` (full-viewport scan), keeping the blank-cell skip that is the real allocation saving. The viewport is bounded by `terminal.rows` (never scrollback), so the cost is bounded reads, not allocations.

### Bug B — backgrounded worktrees stuck on "waiting"

Spawning many worktrees at once trips the aggressive Efficiency resource profile, which CDP-freezes every background project view. A frozen renderer can't run JS, so the `agent:state-changed` IPC queues in Mojo and never applies until the view is foregrounded — leaving every background worktree's dashboard stuck on its pre-freeze state. Detection runs correctly main-side; the event just never arrives. (`agent:state-changed` is broadcast unscoped — this is the freeze, not fan-out scoping.)

**Fix:** never freeze a view whose project has a live agent (`hasActiveAgent` guard on both `freezeAllCached` and the inline `deactivateEntry` freeze), plus a wake path — `unfreezeActiveAgentViews` on seed/reseed and an unfreeze on `agent:state-changed` into an active state — so a view frozen before its agent went active gets woken. CPU throttle still applies to these views (only the freeze is skipped); throttling slows JS but doesn't suspend it, so queued events still apply.

The two bugs are independent and compound only on a backgrounded Efficiency-profile terminal.

## Verification

- Diagnosed via multi-agent workflow + two focused investigators; both root causes and both fixes independently confirmed by Codex (two review passes, no blockers).
- 61/61 unit tests pass (8 new): a spinner-above-input regression test for Bug A; freeze-guard, helper, real `agent:state-changed` bus, and spawn-result reseed wake tests for Bug B.
- Typecheck + lint clean.

**Not yet runtime-verified** against a live fleet of worktrees — worth a manual multi-worktree recipe spawn before the 0.19.1 release.

## Follow-up (not in this PR)

`castReplayHarness.ts` still mirrors the old bottom-N cell snapshot, so replay tests no longer match production exactly — separate cleanup.
