### PR TITLE
fix(terminal): reflow agent terminal grid on project switch-back

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1101,12 +1101,27 @@ class TerminalInstanceService {
       logWarn(`repaintForReveal reflow failed for ${id}`, { error });
     }
 
-    // Re-fit and unpause IO through the shared post-wake resize path. Going via
-    // handlePostWake (not a bare fit()) honors the settled-strategy atomic-resize
-    // contract: for settled agents a plain fit() would resize xterm ahead of the
-    // deferred PTY resize and break atomicity — handlePostWake routes those
-    // through sendPtyResize instead, and still fit()s + reflows standard agents.
-    this.handlePostWake(id);
+    // Reconcile geometry from a FRESH DOM measurement. handlePostWake could not
+    // do this on reveal: the project-switch resize lock is still active here
+    // (reveal fires ~0.5–1.5s after the switch, lock TTL 5s), so its fit()
+    // returns null under isResizeLocked and falls back to a PTY-only resize; and
+    // for settled-strategy agents (Codex, Gemini, …) it skips fit() entirely and
+    // only re-sends CACHED dims. Either way xterm's grid was never re-fit, so a
+    // container size change that happened while the view was backgrounded left
+    // the buffer wrapping at the wrong column until a manual Redraw fired after
+    // the lock expired (the long-standing garbled-line-flow-on-return bug).
+    // reconcileGeometryFresh measures the live box, ignores the lock for this one
+    // reveal correction WITHOUT clearing it (so the ResizeObserver-storm damping
+    // the lock provides survives), and resizes xterm + PTY atomically — safe for
+    // settled agents. It returns false on an unmeasurable transitional box
+    // (zero/occluded), so report "not paintable yet" and let the reveal sweep
+    // retry on a later frame.
+    // Clear any stale "directing" agent state the wake path would have cleared.
+    // Runs before the geometry guard so it still fires on a not-yet-measurable
+    // box, matching the old handlePostWake ordering.
+    this.agentStateController.checkStaleDirecting(id);
+
+    if (!this.resizeController.reconcileGeometryFresh(id)) return false;
 
     // Clear the reflow throttle so the next write or the 3s heartbeat reflows
     // immediately rather than being debounced away (mirrors resetRenderer).

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -337,6 +337,67 @@ export class TerminalResizeController {
     terminalClient.resize(id, targetCols, targetRows);
   }
 
+  /**
+   * One-shot, lock-exempt geometry reconciliation for the project-switch reveal
+   * path (the garbled-line-flow-on-return fix). Unlike {@link fit}:
+   *  - It does NOT consult the resize lock — the reveal is the one legitimate
+   *    resize moment during the project-switch suppression window — and it does
+   *    NOT clear the shared lock, so ResizeObserver-storm damping survives for
+   *    every other resize entry point.
+   *  - It resizes xterm AND the PTY atomically in one synchronous step (never
+   *    xterm-first-then-PTY), so it is safe for settled-strategy agents: no
+   *    500ms split that would jitter Ink TUIs like the Gemini CLI.
+   *
+   * Unlike {@link applyDeferredResize} it measures FRESH cols/rows from the live
+   * DOM box rather than trusting cached latestCols/latestRows — while the view
+   * was backgrounded the container can change size without xterm reflowing (the
+   * cached dims can equal the now-stale xterm grid), which applyDeferredResize's
+   * cache==current early-return would miss.
+   *
+   * @returns true once a fresh measurement landed (whether or not a resize was
+   * needed); false when the box is not measurable yet (zero/occluded/transitional
+   * layout) so the reveal sweep retries on a later frame.
+   */
+  reconcileGeometryFresh(id: string): boolean {
+    const managed = this.deps.getInstance(id);
+    if (!managed) return false;
+    if (!managed.hostElement.checkVisibility()) return false;
+
+    const rect = managed.hostElement.getBoundingClientRect();
+    if (rect.width < 50 || rect.height < 50) return false;
+
+    // Prefer the fit addon's own DOM measurement so the grid matches exactly
+    // what a manual Redraw's fit() would compute; fall back to cell-metric math
+    // when the renderer hasn't published proposable dimensions yet.
+    let cols: number;
+    let rows: number;
+    const proposal = managed.fitAddon.proposeDimensions?.();
+    if (proposal && proposal.cols > 1 && proposal.rows > 1) {
+      cols = proposal.cols;
+      rows = proposal.rows;
+    } else {
+      const cellDims = getXtermCellDimensions(managed.terminal);
+      if (!cellDims) return false;
+      cols = Math.max(2, Math.floor(rect.width / cellDims.width));
+      rows = Math.max(1, Math.floor(rect.height / cellDims.height));
+    }
+
+    managed.lastWidth = rect.width;
+    managed.lastHeight = rect.height;
+    managed.latestCols = cols;
+    managed.latestRows = rows;
+
+    // Cancel any pending settled (500ms) resize so this one-shot is the final
+    // word, then apply atomically: resize xterm only when its grid actually
+    // drifted, and always (re)assert the PTY size so the two agree.
+    this.clearSettledTimer(id);
+    if (managed.terminal.cols !== cols || managed.terminal.rows !== rows) {
+      this.resizeTerminal(managed, cols, rows);
+    }
+    terminalClient.resize(id, cols, rows);
+    return true;
+  }
+
   applyResize(id: string, cols: number, rows: number): void {
     const managed = this.deps.getInstance(id);
     if (!managed) return;

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -95,9 +95,13 @@ type FullWakeTestService = {
   resizeController: {
     applyDeferredResize: (id: string) => void;
     lockResize: (id: string, locked: boolean, ms?: number) => void;
+    reconcileGeometryFresh: (id: string) => boolean;
   };
   dataBuffer: { resumeFlush: (id: string) => void; resetForTerminal: (id: string) => void };
-  webGLManager: { repairAtlasForReactivation: (id: string) => boolean };
+  webGLManager: {
+    repairAtlasForReactivation: (id: string) => boolean;
+    isActive: (id: string) => boolean;
+  };
   handlePostWake: (id: string) => void;
   unhibernate: (id: string) => void;
   ensureOpened: (id: string, managed: ManagedTerminalMock) => void;
@@ -801,5 +805,69 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
 
     expect(fullWake).not.toHaveBeenCalled();
     expect(repaint).not.toHaveBeenCalled();
+  });
+});
+
+describe("TerminalInstanceService.repaintForReveal grid reconcile", () => {
+  let service: FullWakeTestService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Sibling describes spy repaintForReveal with mockImplementation on the
+    // shared singleton; clearAllMocks keeps that impl, so restore the real
+    // method before exercising it here.
+    vi.restoreAllMocks();
+    forceXtermReflowMock.mockReset();
+    const imported = await import("../TerminalInstanceService");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    service = imported.terminalInstanceService as unknown as FullWakeTestService;
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (service) service.instances.clear();
+  });
+
+  function openedLiveInstance(): ManagedTerminalMock {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    return makeInstance({
+      isOpened: true,
+      isHibernated: false,
+      isVisible: true,
+      hostElement: renderableHost(),
+      terminal: { cols: 80, rows: 24, element, refresh: vi.fn() },
+    });
+  }
+
+  it("reconciles the grid through resizeController.reconcileGeometryFresh", () => {
+    const id = "repaint-1";
+    service.instances.set(id, openedLiveInstance());
+
+    vi.spyOn(service.webGLManager, "isActive").mockReturnValue(true);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    const reconcile = vi
+      .spyOn(service.resizeController, "reconcileGeometryFresh")
+      .mockReturnValue(true);
+
+    expect(service.repaintForReveal(id)).toBe(true);
+    // The reveal repaint must drive a fresh-measure grid reflow — the one step
+    // that fixes garbled wrapping and that the old handlePostWake path could not
+    // perform under the project-switch resize lock.
+    expect(reconcile).toHaveBeenCalledWith(id);
+  });
+
+  it("reports not-paintable (retry) when the fresh reconcile finds no measurable box", () => {
+    const id = "repaint-2";
+    service.instances.set(id, openedLiveInstance());
+
+    vi.spyOn(service.webGLManager, "isActive").mockReturnValue(true);
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    vi.spyOn(service.resizeController, "reconcileGeometryFresh").mockReturnValue(false);
+
+    // A false reconcile must propagate so revealUntilStable retries on a later
+    // frame rather than spending a confirm paint against an unmeasurable pane.
+    expect(service.repaintForReveal(id)).toBe(false);
   });
 });

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1386,7 +1386,11 @@ describe("TerminalResizeController", () => {
 
     it("returns false for a zero/too-small layout box", () => {
       const managed = createManagedTerminal();
-      managed.hostElement.getBoundingClientRect = vi.fn(() => ({ left: 0, width: 10, height: 10 })) as any;
+      managed.hostElement.getBoundingClientRect = vi.fn(() => ({
+        left: 0,
+        width: 10,
+        height: 10,
+      })) as any;
 
       const controller = makeController(managed);
       expect(controller.reconcileGeometryFresh("term-1")).toBe(false);

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1246,4 +1246,167 @@ describe("TerminalResizeController", () => {
       expect(managed.terminal.resize).not.toHaveBeenCalled();
     });
   });
+
+  describe("reconcileGeometryFresh (project-switch reveal)", () => {
+    function makeController(managed: ReturnType<typeof createManagedTerminal> | undefined) {
+      return new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: {
+          flushForTerminal: vi.fn(),
+          resetForTerminal: vi.fn(),
+        } as any,
+      });
+    }
+
+    it("reflows xterm AND the PTY atomically from a fresh DOM measurement", () => {
+      const managed = createManagedTerminal();
+      // DOM box proposes 100x30; xterm grid is stale at 80x24.
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+      expect(managed.latestCols).toBe(100);
+      expect(managed.latestRows).toBe(30);
+      // Must NOT route through fitAddon.fit() — that resizes xterm before the PTY
+      // and would break settled-strategy atomicity.
+      expect(managed.fitAddon.fit).not.toHaveBeenCalled();
+    });
+
+    it("ignores an active resize lock without clearing it (the reveal exception)", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+
+      const controller = makeController(managed);
+      controller.lockResize("term-1", true);
+      // Under the same lock a normal fit() no-ops.
+      expect(controller.fit("term-1")).toBeNull();
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+      // The shared lock survives so ResizeObserver-storm damping keeps working.
+      expect(controller.isResizeLocked("term-1")).toBe(true);
+    });
+
+    it("applies atomically for a settled-strategy agent with no 500ms deferral", () => {
+      const managed = createManagedTerminal();
+      managed.runtimeAgentId = "codex";
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+
+      const controller = makeController(managed);
+      controller.lockResize("term-1", true);
+
+      // Arm a pending settled (500ms) PTY resize carrying STALE dims; the
+      // one-shot reveal reconcile must cancel it so that geometry never lands.
+      controller.sendPtyResize("term-1", 50, 10);
+      expect(resizeMock).not.toHaveBeenCalled();
+
+      controller.reconcileGeometryFresh("term-1");
+
+      // xterm + PTY both move now to the FRESH dims — not deferred behind 500ms.
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+
+      vi.advanceTimersByTime(500);
+      // The stale settled timer was cancelled — no 50x10 resize fires afterward.
+      expect(resizeMock).toHaveBeenCalledTimes(1);
+      expect(managed.terminal.resize).not.toHaveBeenCalledWith(50, 10);
+    });
+
+    it("uses fresh DOM dims even when cached latestCols equals the current grid", () => {
+      const managed = createManagedTerminal();
+      // Cache matches the stale xterm grid (80x24) — applyDeferredResize would
+      // early-return here — but the live box actually grew to 100x30.
+      managed.latestCols = 80;
+      managed.latestRows = 24;
+      managed.terminal.cols = 80;
+      managed.terminal.rows = 24;
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+
+      const controller = makeController(managed);
+      controller.reconcileGeometryFresh("term-1");
+
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+    });
+
+    it("re-asserts only the PTY when the grid is already correct", () => {
+      const managed = createManagedTerminal();
+      managed.terminal.cols = 100;
+      managed.terminal.rows = 30;
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+    });
+
+    it("falls back to cell-metric math when no proposable dimensions exist", () => {
+      const managed = createManagedTerminal();
+      // host box is 1000x700; cell is 10x20 → 100 cols x 35 rows.
+      managed.fitAddon.proposeDimensions = vi.fn(() => undefined);
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 35);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 35);
+    });
+
+    it("returns false (retry next frame) when the box is not measurable yet", () => {
+      const managed = createManagedTerminal();
+      // No proposable dims and no cell metrics → unmeasurable transitional box.
+      managed.fitAddon.proposeDimensions = vi.fn(() => undefined);
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns false for a zero/too-small layout box", () => {
+      const managed = createManagedTerminal();
+      managed.hostElement.getBoundingClientRect = vi.fn(() => ({ left: 0, width: 10, height: 10 })) as any;
+
+      const controller = makeController(managed);
+      expect(controller.reconcileGeometryFresh("term-1")).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns false when the host is not visible", () => {
+      const managed = createManagedTerminal();
+      managed.hostElement.checkVisibility = vi.fn(() => false);
+
+      const controller = makeController(managed);
+      expect(controller.reconcileGeometryFresh("term-1")).toBe(false);
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
+    it("returns false for a missing instance", () => {
+      const controller = makeController(undefined);
+      expect(controller.reconcileGeometryFresh("term-1")).toBe(false);
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
When you switch away from a project and back, the agent terminals come back with their line wrapping garbled. You can rescue a pane by clicking Redraw in the panel three-dots menu, but you shouldn't have to, and it's been coming back for a while.

This one took a multi-agent investigation (Codex included) to finally pin down. The short version: the automatic reveal path never does the one thing the manual Redraw does, which is re-fit the terminal grid.

## Root cause

The manual Redraw (`resetRenderer`) works because it calls `fit()`, which re-measures the box and reflows the grid. The automatic reveal path (`repaintForReveal`) does repaint, but it never reconciles the grid, for two reasons:

- **The resize lock.** Switching projects installs a resize lock on every terminal (`RESIZE_LOCK_TTL_MS`, 5s). The reveal fires ~0.5–1.5s after the switch, well inside that window, so `repaintForReveal` → `handlePostWake` → `fit()` returns `null` under `isResizeLocked` and never reflows.
- **The settled-strategy skip.** For settled agents (Codex, Gemini, Cursor, etc.) `handlePostWake` skips `fit()` entirely and only re-sends cached PTY dims.

`forceXtermReflow` and the atlas repair can only unpause and repaint. They can't fix a stale column count, which is exactly what the garbled wrapping is. The manual Redraw only works because you click it after the 5s lock has expired, when `fit()` finally runs.

Every prior attempt (#10362, the retry-until-stable reveal sweep, the hibernation rehydration path) added more repaint/unpause/retry machinery but never made the reveal do a lock-bypassing fresh fit. That's why it kept coming back.

## The fix

New `TerminalResizeController.reconcileGeometryFresh(id)`: a one-shot geometry reconcile that measures the live box fresh (`proposeDimensions`, with a cell-metric fallback) and resizes xterm and the PTY together in one atomic step. It deliberately ignores the resize lock for this single reveal correction **without clearing it**, so the ResizeObserver-storm damping the lock provides still works for every other path. It's atomic, so settled agents keep their no-jitter contract, and because it measures fresh it catches a container size change that happened while the view was backgrounded (the cached-dims `applyDeferredResize` path misses that case).

`repaintForReveal` now drives `reconcileGeometryFresh` instead of `handlePostWake`, and propagates its `false` (unmeasurable box) result so the existing `revealUntilStable` retry handles a not-yet-laid-out pane on a later frame.

## Testing

- 13 new behavioral unit tests: reflow happens under an active lock for both default **and** settled agents, the fresh measurement is used even when cached dims equal the stale grid, the shared lock is not cleared, a pending stale settled timer is cancelled, and the false-return retry wiring works.
- Full terminal suite green (1211 tests). `typecheck`, `prettier`, `eslint`, and `lint:ratchet` all clean.
- Reviewed by Codex (no blockers or majors).

This is static and test-verified only. It still needs a runtime check before merge.

## How to verify

1. Open a project with live agent panes (mix in a Gemini or Codex session, since those are the settled-strategy ones).
2. Switch to another project, then switch back.
3. The terminals should come back with correct line wrapping, without touching Redraw.
