### PR TITLE
refactor(plugins): consolidate high-risk capability set into one source of truth

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -120,6 +120,7 @@ import type {
   PluginDiagnosticsSnapshot,
 } from "../../shared/types/ipc/pluginDiagnostics.js";
 import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
+import { CONFIRM_TRIGGERING_CAPABILITIES } from "../../shared/config/pluginCapabilities.js";
 
 /** Plugin action IDs must be `{pluginId}.{actionId}`. Built-in IDs use colons, so the formats cannot collide. */
 const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
@@ -146,30 +147,6 @@ const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set<string>(BUILT_IN_ACT
  * happens until dispatch time.
  */
 const COMMAND_HANDLER_EXTENSIONS = [".ts", ".tsx", ".js", ".mjs"] as const;
-
-/**
- * Capabilities whose presence in a plugin's manifest forces every action that
- * plugin contributes up to `effectiveDanger: "confirm"`, regardless of the
- * `danger` the plugin self-declared. These are the capabilities that grant
- * irreversible or hard-to-undo side effects: arbitrary process execution,
- * git history mutation, project/user-config filesystem writes, and agent
- * invocation. Read-only or trivially-reversible capabilities (`*-read`,
- * `network:fetch`, `clipboard:*`) are intentionally excluded — promoting on
- * those would over-confirm and train users to dismiss the dialog. The host
- * may only raise danger; a plugin declaring `"confirm"` always stays
- * `"confirm"` even with none of these.
- */
-const CONFIRM_TRIGGERING_CAPABILITIES: ReadonlySet<BuiltInPluginCapability> = new Set([
-  "shell:exec",
-  "git:write",
-  "fs:project-write",
-  "fs:user-data-write",
-  "agent:invoke",
-  // Registering a launchable agent CLI (with its own command/args, and a
-  // detection config in the full tier) is a runtime side effect on par with
-  // `agent:invoke` — a plugin holding it elevates its actions to "confirm".
-  "agent:register",
-]);
 
 /**
  * Compound-capability lattice (#9247). The flat

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4588,7 +4588,14 @@ describe("Plugin action registry", () => {
     expect(action?.effectiveDanger).toBe("confirm"); // host raised it
   });
 
-  it.each(["shell:exec", "git:write", "fs:project-write", "fs:user-data-write", "agent:invoke"])(
+  it.each([
+    "shell:exec",
+    "git:write",
+    "fs:project-write",
+    "fs:user-data-write",
+    "agent:invoke",
+    "agent:register",
+  ])(
     "raises a self-declared 'safe' action to confirm when the manifest grants %s",
     async (capability) => {
       const name = `acme.perm-${capability.replace(/[^a-z]/g, "-")}`;

--- a/electron/services/plugin-mcp/PluginMcpTierAuth.ts
+++ b/electron/services/plugin-mcp/PluginMcpTierAuth.ts
@@ -1,6 +1,7 @@
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import type { PluginCapability } from "../../../shared/types/plugin.js";
 import type { PluginMcpDangerTier } from "../../../shared/types/pluginMcpConsent.js";
+import { CONFIRM_TRIGGERING_CAPABILITIES } from "../../../shared/config/pluginCapabilities.js";
 
 /**
  * Capability cap on the host-derived danger tier. The cap classifies what a
@@ -16,18 +17,12 @@ import type { PluginMcpDangerTier } from "../../../shared/types/pluginMcpConsent
  * server to reach D2. Read-only and network-fetch capabilities cap at D1 — the
  * server can still ask for a confirmation, but cannot reach the "shared-state
  * mutation" tier.
+ *
+ * The high-risk set is `CONFIRM_TRIGGERING_CAPABILITIES` from
+ * `shared/config/pluginCapabilities.ts` — the single source of truth shared with
+ * `PluginService`'s action-danger model, so the MCP tier cap and the action
+ * elevation can never drift apart.
  */
-// Keep in lockstep with `CONFIRM_TRIGGERING_CAPABILITIES` in PluginService.ts —
-// both classify the same high-risk capabilities (irreversible side effects) and
-// must stay in sync so the MCP tier cap matches the action-danger model.
-const HIGH_RISK_CAPABILITIES: ReadonlySet<PluginCapability> = new Set([
-  "fs:project-write",
-  "fs:user-data-write",
-  "git:write",
-  "shell:exec",
-  "agent:invoke",
-]);
-
 export type PluginMcpTierClassification =
   | { kind: "tier"; tier: PluginMcpDangerTier }
   | {
@@ -97,7 +92,7 @@ function raiseForOpenWorld(
 
 function deriveCapabilityCap(capabilities: readonly PluginCapability[]): PluginMcpDangerTier {
   for (const cap of capabilities) {
-    if (HIGH_RISK_CAPABILITIES.has(cap)) return "D2";
+    if (CONFIRM_TRIGGERING_CAPABILITIES.has(cap)) return "D2";
   }
   return "D1";
 }

--- a/electron/services/plugin-mcp/__tests__/PluginMcpTierAuth.test.ts
+++ b/electron/services/plugin-mcp/__tests__/PluginMcpTierAuth.test.ts
@@ -80,6 +80,15 @@ describe("PluginMcpTierAuth.deriveDangerTier", () => {
       expect(result).toEqual({ kind: "tier", tier: "D2" });
     });
 
+    it("allows D2 when the plugin declares agent:register", () => {
+      // agent:register registers a launchable agent CLI — a runtime side effect
+      // on par with agent:invoke. It is in CONFIRM_TRIGGERING_CAPABILITIES, so a
+      // destructiveHint tool reaches D2. (Regression guard: the cap previously
+      // diverged from the action-danger set and omitted agent:register.)
+      const result = deriveDangerTier({ destructiveHint: true }, ["agent:register"]);
+      expect(result).toEqual({ kind: "tier", tier: "D2" });
+    });
+
     it("treats an empty capability set as the read-only cap (D1)", () => {
       // Mirrors a plugin manifest that omits `capabilities` entirely.
       const result = deriveDangerTier({ destructiveHint: true }, undefined);

--- a/electron/services/plugin-mcp/__tests__/PluginMcpTierAuth.test.ts
+++ b/electron/services/plugin-mcp/__tests__/PluginMcpTierAuth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { deriveDangerTier } from "../PluginMcpTierAuth.js";
+import { CONFIRM_TRIGGERING_CAPABILITIES } from "../../../../shared/config/pluginCapabilities.js";
 
 describe("PluginMcpTierAuth.deriveDangerTier", () => {
   describe("annotation floor", () => {
@@ -88,6 +89,17 @@ describe("PluginMcpTierAuth.deriveDangerTier", () => {
       const result = deriveDangerTier({ destructiveHint: true }, ["agent:register"]);
       expect(result).toEqual({ kind: "tier", tier: "D2" });
     });
+
+    // Every member of the shared CONFIRM_TRIGGERING_CAPABILITIES set must reach
+    // D2 — guards against membership drift between the MCP tier cap and the
+    // action-danger model now that both read the same constant.
+    it.each([...CONFIRM_TRIGGERING_CAPABILITIES])(
+      "allows D2 for high-risk capability %s",
+      (capability) => {
+        const result = deriveDangerTier({ destructiveHint: true }, [capability]);
+        expect(result).toEqual({ kind: "tier", tier: "D2" });
+      }
+    );
 
     it("treats an empty capability set as the read-only cap (D1)", () => {
       // Mirrors a plugin manifest that omits `capabilities` entirely.

--- a/shared/config/pluginCapabilities.ts
+++ b/shared/config/pluginCapabilities.ts
@@ -1,0 +1,35 @@
+import type { BuiltInPluginCapability } from "../types/plugin.js";
+
+/**
+ * Single source of truth for the plugin capabilities that grant irreversible or
+ * hard-to-undo side effects: arbitrary process execution, git history mutation,
+ * project/user-config filesystem writes, and agent invocation/registration.
+ *
+ * Two subsystems classify "is this capability high-risk" and must agree, so the
+ * set lives here rather than being declared twice:
+ *
+ * 1. **Action danger elevation** (`PluginService`) — any action a plugin
+ *    contributes is forced up to `effectiveDanger: "confirm"` if the plugin
+ *    declares one of these, regardless of the `danger` it self-declared. The
+ *    host may only raise danger, never lower it.
+ * 2. **MCP tier cap** (`PluginMcpTierAuth`) — a plugin's MCP tool surface can
+ *    only *reach* the D2 ("shared-state mutation") confirmation tier if the
+ *    plugin declares one of these. A call whose annotation floor exceeds the
+ *    cap is denied, not silently downgraded.
+ *
+ * Read-only or trivially-reversible capabilities (`*-read`, `network:fetch`,
+ * `clipboard:*`) are intentionally excluded — promoting on those would
+ * over-confirm and train users to dismiss the dialog.
+ */
+export const CONFIRM_TRIGGERING_CAPABILITIES: ReadonlySet<BuiltInPluginCapability> = new Set([
+  "shell:exec",
+  "git:write",
+  "fs:project-write",
+  "fs:user-data-write",
+  "agent:invoke",
+  // Registering a launchable agent CLI (with its own command/args, and a
+  // detection config in the full tier) is a runtime side effect on par with
+  // `agent:invoke` — a plugin holding it elevates its actions to "confirm" and
+  // entitles its MCP tool surface to reach D2.
+  "agent:register",
+]);

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -610,9 +610,10 @@ export interface LoadedPluginInfo {
    * least one individually high-risk capability, or a compound pair the lattice
    * elevates (e.g. a sensitive read + an unconstrained network sink). The
    * renderer reads this for the manager's effective-danger summary instead of
-   * re-deriving the lattice — the security logic stays single-source on main
-   * (the flat set is already duplicated once with `HIGH_RISK_CAPABILITIES` and
-   * must not gain a third copy).
+   * re-deriving the lattice — the security logic stays single-source on main.
+   * The flat high-risk set lives in `shared/config/pluginCapabilities.ts`
+   * (`CONFIRM_TRIGGERING_CAPABILITIES`), shared with the MCP tier cap in
+   * `PluginMcpTierAuth`; do not re-declare it anywhere else.
    */
   pluginDanger: "safe" | "confirm";
 }


### PR DESCRIPTION
## Summary

- Two hard-coded lists of high-risk plugin capabilities in `PluginService.ts` and `PluginMcpTierAuth.ts` had diverged; this PR merges them into a single constant in `shared/config/pluginCapabilities.ts` (`CONFIRM_TRIGGERING_CAPABILITIES`)
- Along the way, fixed a real divergence bug: `PluginMcpTierAuth`'s list was missing `agent:register`, so a plugin using only that capability was capped at D1 instead of the correct D2
- Added `agent:register` coverage to the `effectiveDanger` elevation table in `PluginService.test.ts` and a full-membership drift-guard table in `PluginMcpTierAuth.test.ts`

Resolves #10470. Part of the plugin 1.0 freeze (#10459).

## Changes

- `shared/config/pluginCapabilities.ts` — new file, exports `CONFIRM_TRIGGERING_CAPABILITIES` (6 members)
- `electron/services/PluginService.ts` — imports the shared constant, drops its own copy
- `electron/services/plugin-mcp/PluginMcpTierAuth.ts` — imports the shared constant, removes the local `HIGH_RISK_CAPABILITIES` and the stale "Keep in lockstep" comment
- `shared/types/plugin.ts` — updated `LoadedPluginInfo.pluginDanger` JSDoc to point at the new constant

## Testing

- `PluginMcpTierAuth.test.ts` — 20 tests pass; new drift-guard table asserts full membership of `CONFIRM_TRIGGERING_CAPABILITIES`
- `PluginService.test.ts` — 466 tests pass; new row covers `agent:register` in the `effectiveDanger` elevation table
- Own-file prettier and eslint clean