### PR TITLE
docs(plugins): reconcile scopes with no-enforcement reality and fix stale schema comments

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -176,12 +176,12 @@ Declare honestly. The plugin manager's detail pane lists what you've declared (a
 
 ### `scopes`
 
-Per-capability allowlists that _attenuate_ the capability lattice — they narrow what a declared capability can reach, they never widen it. Two buckets:
+Per-capability allowlists that declare what a capability intends to reach. Both buckets are schema-validated, but neither is a runtime sandbox — they do not block actual calls or writes. Two buckets, with different runtime weight today:
 
-- `scopes.network.allowedUrls` — outbound request targets permitted under `network:fetch`. Wildcards and private/loopback targets are rejected.
-- `scopes.fs.allowedPaths` — paths the filesystem capabilities may touch.
+- `scopes.network.allowedUrls` — outbound request targets the plugin intends to reach under `network:fetch`. Wildcards and private/loopback targets are rejected. **Live but advisory:** a non-empty allowlist suppresses the compound-capability elevation (the host won't force a confirm dialog when `network:fetch` is paired with a sensitive read), proving the fetch is tightly bound rather than a generic exfiltration channel. It does not actually block requests to other URLs.
+- `scopes.fs.allowedPaths` — absolute paths the filesystem capabilities intend to touch. Wildcards, relative paths, and `..` segments are rejected. **Advisory only:** the value is schema-validated but not consulted at runtime — it neither gates filesystem access nor attenuates the lattice (fs writes already elevate unconditionally).
 
-A misspelled bucket (e.g. `networking`) is rejected as a manifest error rather than silently failing to attenuate. See the [trust model](./trust-model.md) for the full scopes semantics and how they compose with capabilities.
+A misspelled bucket (e.g. `networking`) is rejected as a manifest error rather than silently dropped. See the [trust model](./trust-model.md) for the full scopes semantics and how they compose with capabilities.
 
 ### `activationEvents`
 

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -478,6 +478,13 @@ export const PluginNetworkScopeSchema = z
   })
   .strict();
 
+/**
+ * `scopes.fs.allowedPaths` is advisory: entries are schema-validated here but
+ * not consulted at runtime — they neither gate filesystem access nor attenuate
+ * the compound-capability lattice (unlike `scopes.network`, which suppresses
+ * compound elevation). Validation is retained so frozen manifests carry
+ * well-formed intent metadata.
+ */
 export const PluginFsScopeSchema = z
   .object({
     allowedPaths: z.array(PluginAllowedPathSchema).min(1),

--- a/electron/services/__tests__/PluginSettingsManager.scope.test.ts
+++ b/electron/services/__tests__/PluginSettingsManager.scope.test.ts
@@ -96,8 +96,19 @@ describe("PluginSettingsManager declared-scope enforcement", () => {
     expect(() => mgr.assertSettingScope("acme.scope-test", "other", "user")).not.toThrow();
   });
 
-  it("accepts any key when contributes.settings is absent or empty", () => {
+  it("accepts any key when contributes.settings is an empty array", () => {
     const mgr = managerFor([]);
+    expect(() => mgr.assertSettingDeclared("acme.scope-test", "anything", "project")).not.toThrow();
+    expect(() => mgr.assertSettingScope("acme.scope-test", "anything", "project")).not.toThrow();
+  });
+
+  it("accepts any key when contributes.settings is absent", () => {
+    const manifest = manifestWith([]);
+    delete manifest.contributes.settings;
+    const mgr = new PluginSettingsManager({
+      getPluginsRoot: () => path.join(tmpDir, "plugins"),
+      getManifest: (id) => (id === manifest.name ? manifest : undefined),
+    });
     expect(() => mgr.assertSettingDeclared("acme.scope-test", "anything", "project")).not.toThrow();
     expect(() => mgr.assertSettingScope("acme.scope-test", "anything", "project")).not.toThrow();
   });

--- a/electron/services/__tests__/PluginSettingsManager.scope.test.ts
+++ b/electron/services/__tests__/PluginSettingsManager.scope.test.ts
@@ -96,7 +96,7 @@ describe("PluginSettingsManager declared-scope enforcement", () => {
     expect(() => mgr.assertSettingScope("acme.scope-test", "other", "user")).not.toThrow();
   });
 
-  it("accepts any scope when no settings are declared (pre-F29 manifests)", () => {
+  it("accepts any key when contributes.settings is absent or empty", () => {
     const mgr = managerFor([]);
     expect(() => mgr.assertSettingDeclared("acme.scope-test", "anything", "project")).not.toThrow();
     expect(() => mgr.assertSettingScope("acme.scope-test", "anything", "project")).not.toThrow();

--- a/electron/services/plugin/PluginSettingsManager.ts
+++ b/electron/services/plugin/PluginSettingsManager.ts
@@ -101,12 +101,12 @@ export class PluginSettingsManager {
   }
 
   /**
-   * Enforce `contributes.settings` key declarations on `set`/`delete`. F29 has
-   * not landed yet, so manifests never declare settings today and any key is
-   * accepted; once a plugin declares them, undeclared keys are rejected. When a
-   * key IS declared, its declared `scope` (default `"user"`) must match the
-   * requested scope — the write counterpart to the scope filter the read/reveal
-   * paths apply, so a `user`-scoped key can't be written under `project` (or
+   * Enforce `contributes.settings` key declarations on `set`/`delete`. When a
+   * manifest declares no settings (absent or empty array), any key is accepted;
+   * once a plugin declares them, undeclared keys are rejected. When a key IS
+   * declared, its declared `scope` (default `"user"`) must match the requested
+   * scope — the write counterpart to the scope filter the read/reveal paths
+   * apply, so a `user`-scoped key can't be written under `project` (or
    * vice-versa) via the host API or the settings-UI bridge.
    */
   assertSettingDeclared(pluginId: string, key: string, scope: PluginSettingsScope): void {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -174,11 +174,12 @@ export interface PluginNetworkScope {
 
 export interface PluginFsScope {
   /**
-   * Allowlist of absolute filesystem paths the plugin's `fs:*` capabilities
-   * may touch. Each entry must be an absolute path containing no `..` segment
-   * and no `*`/`**` glob (literal-path allowlist only). Reserved for future
-   * compound rules that attenuate fs sinks; the current lattice only consults
-   * `scopes.network` for compound elevation.
+   * Advisory allowlist of absolute filesystem paths the plugin's `fs:*`
+   * capabilities intend to touch. Each entry is schema-validated at parse time
+   * (must be an absolute path containing no `..` segment and no `*`/`**` glob —
+   * literal-path allowlist only), but the value is not consulted at runtime: it
+   * does not gate filesystem access and does not attenuate the compound-capability
+   * lattice. `scopes.network` is the only bucket the lattice consults today.
    */
   allowedPaths: string[];
 }
@@ -278,9 +279,11 @@ export interface PluginManifest {
      */
     agents: PluginAgentContribution[];
     /**
-     * Declared plugin settings. Reserved for F29 — absent from parsed manifests
-     * until that schema lands, so `host.settings.set()` accepts any key for now.
-     * When present, `set()` rejects keys not declared here.
+     * Declared plugin settings. When absent or empty, `host.settings.set()` and
+     * `delete()` accept any key (permissive for plugins that declare none). When
+     * non-empty, those calls reject keys not declared here and enforce each
+     * setting's declared scope — see `assertSettingDeclared` in
+     * `electron/services/plugin/PluginSettingsManager.ts`.
      */
     settings?: SettingDefinition[];
   };

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -279,11 +279,11 @@ export interface PluginManifest {
      */
     agents: PluginAgentContribution[];
     /**
-     * Declared plugin settings. When absent or empty, `host.settings.set()` and
-     * `delete()` accept any key (permissive for plugins that declare none). When
-     * non-empty, those calls reject keys not declared here and enforce each
-     * setting's declared scope — see `assertSettingDeclared` in
-     * `electron/services/plugin/PluginSettingsManager.ts`.
+     * Declared plugin settings. When absent or empty, `host.settings.set()`
+     * accepts any key (permissive for plugins that declare none). When non-empty,
+     * `set()` (and the settings-UI write/reset paths) reject keys not declared
+     * here and enforce each setting's declared scope — see `assertSettingDeclared`
+     * in `electron/services/plugin/PluginSettingsManager.ts`.
      */
     settings?: SettingDefinition[];
   };


### PR DESCRIPTION
## Summary

- Several places in comments and docs implied that plugin scopes were enforced at runtime — they're not. This corrects the record.
- Tied to the 1.0 plugin schema freeze: the docs now accurately describe what each scope field actually does today.
- No runtime behaviour changed; this is comments and documentation only.

Closes #10467

## Changes

- `scopes.fs.allowedPaths` — documented as advisory. Schema-validated at parse time but not consulted at runtime (no fs gating, no lattice attenuation). Dropped the misleading "Reserved for future compound rules" framing in `shared/types/plugin.ts`; added a matching note above `PluginFsScopeSchema` in `electron/schemas/plugin.ts`.
- `scopes.network.allowedUrls` — documented in `docs/plugins/manifest.md` as live-but-advisory. A non-empty allowlist suppresses compound-capability elevation (skips a confirm dialog), but does NOT block outbound requests.
- `contributes.settings` — removed the stale "Reserved for F29 — absent from parsed manifests until that schema lands" comment in `shared/types/plugin.ts` and the "F29 has not landed yet" comment in `PluginSettingsManager.ts`. Declaration enforcement (`assertSettingDeclared`) is live. Docs now describe the actual conditional: absent/empty means any key accepted; non-empty means undeclared keys rejected and scope enforced.
- Renamed a pre-F29 test description and added a test covering the absent-settings guard branch in `electron/services/__tests__/PluginSettingsManager.scope.test.ts`.

## Testing

- `vitest` on `PluginSettingsManager.scope.test.ts` — 7 tests, all pass.
- Prettier and ESLint clean on all changed files.