### PR TITLE
fix(plugins): harden and finalize experimental_views registration

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -118,7 +118,7 @@ Plugins declare a `react` peer dependency in their own `package.json`. The host 
 
 Plugin view modules are loaded via Daintree's `plugin://` privileged protocol. When `PluginService.loadPlugin` matches a `contributes.experimental_views` entry to a panel by bare id, it stores the resolved URL — `plugin://{pluginId}/{componentPath}` — on the `PanelKindConfig` and broadcasts it through `plugin:panel-kinds-changed`. The renderer's `PluginViewHost` calls `React.lazy(() => import(componentPath))` against that URL; Chromium 146 resolves the protocol, the response carries the `plugin://` security headers, and the bare `react` / `react/jsx-runtime` specifiers in the bundle resolve through the host import map to Daintree's single React instance.
 
-The resolved URL travels through the renderer over the existing panel-kinds IPC broadcast — no separate channel is required. A view that targets a panel id with no matching `contributes.panels` entry, or `location: "sidebar"` (reserved), or an unsafe `componentPath` (absolute paths, `..` segments) logs a `[PluginService]` warning at load time and is skipped.
+The resolved URL travels through the renderer over the existing panel-kinds IPC broadcast — no separate channel is required. `location: "sidebar"` and an unsafe `componentPath` (absolute paths, URL schemes, `..` segments) are rejected at manifest validation, so the whole plugin fails to load loudly rather than silently dropping the view. A view that targets a panel id with no matching `contributes.panels` entry still logs a `[PluginService]` warning at load time and is skipped.
 
 ### Hot reload — dev only
 
@@ -304,8 +304,8 @@ Types a plugin author uses to write `plugin.json`:
 | `ToolbarButtonContribution` | `plugin.ts` |  |
 | `MenuItemContribution` | `plugin.ts` |  |
 | `MenuItemLocation` | `plugin.ts` | `"terminal" \| "file" \| "view" \| "help"` |
-| `ViewContribution` | `plugin.ts` | Panel location wired; sidebar reserved |
-| `ViewLocation` | `plugin.ts` | `"panel" \| "sidebar"` |
+| `ViewContribution` | `plugin.ts` | Panel location only; sidebar rejected at validation |
+| `ViewLocation` | `plugin.ts` | `"panel"` |
 | `McpServerContribution` | `plugin.ts` | Wired via `PluginMcpSupervisor` (`experimental_` prefix retained) |
 | `PluginCapability` | `plugin.ts` |  |
 | `BuiltInPluginCapability` | `plugin.ts` |  |

--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -122,9 +122,9 @@ Panels are full-sized workspaces in Daintree's grid (alongside terminal panels, 
 
 **Component registration** is covered by the **views** contribution point below — panels declare the slot, views provide the component.
 
-## Views — _Shipped (panel surface; sidebar surface pending)_
+## Views — _Shipped (panel surface)_
 
-Views are the React components that render inside a panel. A view binds to a panel slot declared in `contributes.panels` by matching its bare `id`; at plugin load the matching panel kind gains a `componentPath` resolved to a `plugin://` URL. The renderer host (`PluginViewHost`) lazy-imports the module over Daintree's `plugin://` protocol and mounts it under an `ErrorBoundary` + `Suspense`. `location: "panel"` is wired today; `location: "sidebar"` logs a warning and is skipped until the future sidebar host ships. The contribution key keeps the `experimental_` prefix until the props contract has lived through a release; the shape below is the contract today.
+Views are the React components that render inside a panel. A view binds to a panel slot declared in `contributes.panels` by matching its bare `id`; at plugin load the matching panel kind gains a `componentPath` resolved to a `plugin://` URL. The renderer host (`PluginViewHost`) lazy-imports the module over Daintree's `plugin://` protocol and mounts it under an `ErrorBoundary` + `Suspense`. `location: "panel"` is the only supported value; `"sidebar"` is rejected at manifest validation because the sidebar host does not exist yet. The contribution key keeps the `experimental_` prefix until the props contract has lived through a release; the shape below is the contract today.
 
 ```json
 {
@@ -153,8 +153,8 @@ Views are the React components that render inside a panel. A view binds to a pan
 | --- | --- | --- |
 | `id` | yes | Matches the panel `id` it provides a component for. Namespaced at runtime as `{pluginId}.{id}`. |
 | `name` | yes | Display label, also used in the loading skeleton's accessible label. |
-| `componentPath` | yes | POSIX-relative path to an ESM module inside the plugin. The module's default export is a React component. Absolute paths and `..` segments are rejected at load time. |
-| `location` | yes | `"panel"` (docked in the grid — wired today) or `"sidebar"` (reserved for a future sidebar host; currently logs a warning and is skipped). |
+| `componentPath` | yes | POSIX-relative path to an ESM module inside the plugin. The module's default export is a React component. Absolute paths, URL schemes, and `..` segments are rejected at manifest validation. |
+| `location` | yes | `"panel"` (docked in the grid). `"sidebar"` is rejected at manifest validation — the sidebar host does not exist yet. |
 | `iconId` | no | Override the panel's icon for this view. |
 | `description` | no | Surface text for palette/preferences. |
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -195,7 +195,7 @@ Object containing arrays for each contribution type. All fields are optional; un
 
 Fields prefixed with `experimental_` **do** have runtime behavior — the prefix signals only that their shape may still change before it's locked, not that they're inert:
 
-- `experimental_views` — `location: "panel"` is wired today (the renderer host mounts the contributed component in a grid panel). `location: "sidebar"` logs a warning and is skipped until the sidebar host ships.
+- `experimental_views` — `location: "panel"` is wired today (the renderer host mounts the contributed component in a grid panel). `location: "sidebar"` is rejected at manifest validation — the sidebar host does not exist yet, so accepting it would validate a view the runtime cannot render.
 - `experimental_mcpServers` — wired: the declared `command` is lazily spawned as a real subprocess the first time its tools are enumerated, and is supervised (restart-on-crash, killed on exit). Treat a contributed MCP server as trust-gated, not inert.
 
 The non-experimental `forgeProviders` and `fileDecorationProviders` contributions are also live at runtime. `agents` registers a launchable agent CLI as a selectable agent and requires the `agent:register` capability — see the [Contribution points reference](./contribution-points.md) for its shape. That reference also lists the per-point status of every type.

--- a/electron/schemas/__tests__/viewContribution.test.ts
+++ b/electron/schemas/__tests__/viewContribution.test.ts
@@ -38,12 +38,16 @@ describe("ViewContributionSchema (issue #10464)", () => {
 
   it.each([
     ["a traversal escape", "../escape.js"],
+    ["a mid-path traversal", "dist/../escape.js"],
+    ["a leading-dot traversal", "./../escape.js"],
     ["an absolute path", "/abs/path.js"],
     ["an http URL scheme", "https://evil.example/view.js"],
     ["a backslash separator", "dist\\view.js"],
     ["a query string", "view.js?cache=1"],
     ["a fragment", "view.js#frag"],
     ["an embedded NUL", "view\0.js"],
+    ["a bare current-dir", "."],
+    ["a bare current-dir with slash", "./"],
   ])("rejects an unsafe componentPath: %s", (_label, componentPath) => {
     expect(ViewContributionSchema.safeParse({ ...base, componentPath }).success).toBe(false);
   });

--- a/electron/schemas/__tests__/viewContribution.test.ts
+++ b/electron/schemas/__tests__/viewContribution.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { ViewContributionSchema } from "../plugin.js";
+
+const base = { id: "main", name: "Main", componentPath: "./dist/view.js", location: "panel" };
+
+describe("ViewContributionSchema (issue #10464)", () => {
+  it("accepts a minimal panel view contribution", () => {
+    expect(ViewContributionSchema.safeParse(base).success).toBe(true);
+  });
+
+  it("accepts a componentPath without a leading ./", () => {
+    expect(ViewContributionSchema.safeParse({ ...base, componentPath: "view.js" }).success).toBe(
+      true
+    );
+  });
+
+  it("accepts optional iconId and description", () => {
+    const result = ViewContributionSchema.safeParse({
+      ...base,
+      iconId: "Plug",
+      description: "A view",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects location 'sidebar' at the schema boundary (no sidebar host yet)", () => {
+    expect(ViewContributionSchema.safeParse({ ...base, location: "sidebar" }).success).toBe(false);
+  });
+
+  it("rejects an unknown location value", () => {
+    expect(ViewContributionSchema.safeParse({ ...base, location: "floating" }).success).toBe(false);
+  });
+
+  it("rejects a missing location", () => {
+    const { location: _omit, ...withoutLocation } = base;
+    expect(ViewContributionSchema.safeParse(withoutLocation).success).toBe(false);
+  });
+
+  it.each([
+    ["a traversal escape", "../escape.js"],
+    ["an absolute path", "/abs/path.js"],
+    ["an http URL scheme", "https://evil.example/view.js"],
+    ["a backslash separator", "dist\\view.js"],
+    ["a query string", "view.js?cache=1"],
+    ["a fragment", "view.js#frag"],
+    ["an embedded NUL", "view\0.js"],
+  ])("rejects an unsafe componentPath: %s", (_label, componentPath) => {
+    expect(ViewContributionSchema.safeParse({ ...base, componentPath }).success).toBe(false);
+  });
+
+  it("rejects an empty componentPath", () => {
+    expect(ViewContributionSchema.safeParse({ ...base, componentPath: "" }).success).toBe(false);
+  });
+
+  it("rejects unknown top-level fields (strict)", () => {
+    expect(ViewContributionSchema.safeParse({ ...base, extra: true }).success).toBe(false);
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -133,6 +133,10 @@ function isSafePluginViewComponentPath(componentPath: string): boolean {
   if (componentPath.includes(":")) return false;
   if (componentPath.includes("?")) return false;
   if (componentPath.includes("#")) return false;
+  // A bare current-dir / root path (`.`, `./`) resolves to no module file — a
+  // 404 from the protocol handler — so reject it at the manifest gate.
+  const normalized = componentPath.startsWith("./") ? componentPath.slice(2) : componentPath;
+  if (normalized === "" || normalized === ".") return false;
   return !componentPath.split("/").includes("..");
 }
 

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -113,22 +113,50 @@ export const CommandContributionSchema = z
   .strict();
 
 /**
+ * Validate a `componentPath` before it is resolved to a `plugin://` URL and
+ * handed to the renderer host's `import()` (#9229). The `plugin://` protocol
+ * handler at `electron/setup/protocols.ts` is the security boundary — it
+ * rejects traversal at request time via realpath containment. This check is
+ * the manifest gate: it rejects an absolute path, a Windows separator, an
+ * embedded URL scheme/query/fragment, a NUL, or a `..` segment at parse time
+ * so the failure is a loud manifest-validation error, not a silent 404 from
+ * `import('plugin://...')` later. Accepts relative POSIX paths only — a
+ * leading `./` is preserved (the URL builder normalizes it).
+ */
+function isSafePluginViewComponentPath(componentPath: string): boolean {
+  if (componentPath.startsWith("/")) return false;
+  if (componentPath.includes("\\")) return false;
+  if (componentPath.includes("\0")) return false;
+  // Reject embedded URL structure markers — `https://...` (`:`), `?query`, or
+  // `#fragment` — to catch typos early and avoid polluting the V8 module cache
+  // with duplicate query-string variants.
+  if (componentPath.includes(":")) return false;
+  if (componentPath.includes("?")) return false;
+  if (componentPath.includes("#")) return false;
+  return !componentPath.split("/").includes("..");
+}
+
+/**
  * View contribution. A view renders into a `contributes.panels` entry with a
  * matching `id`; at plugin load (`PluginService.loadPlugin`) the panels loop
  * attaches the view's `componentPath` to that panel kind. A view with no
- * matching panel entry is ignored. `location: "panel"` sets
- * `showInPalette: true` so the view is spawnable from the panel palette;
- * `location: "sidebar"` registers silently with `showInPalette: false`,
- * reserving the kind for the future sidebar host. The `experimental_` prefix
- * on the contribution point signals that the shape may change before the
- * renderer host ships. See `docs/plugins/architecture.md`.
+ * matching panel entry is ignored. Only `location: "panel"` is supported — it
+ * sets `showInPalette: true` so the view is spawnable from the panel palette.
+ * `"sidebar"` is rejected at the schema boundary: the sidebar host does not
+ * exist yet, so accepting it would validate a manifest the runtime cannot
+ * honor. The `experimental_` prefix on the contribution point signals that the
+ * shape may change before the renderer host ships. See
+ * `docs/plugins/architecture.md`.
  */
 export const ViewContributionSchema = z
   .object({
     id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
     name: z.string().min(1),
-    componentPath: z.string().min(1),
-    location: z.enum(["panel", "sidebar"]),
+    componentPath: z.string().min(1).refine(isSafePluginViewComponentPath, {
+      message:
+        "componentPath must be a relative plugin asset path (no leading /, backslash, URL scheme, NUL, or .. segments)",
+    }),
+    location: z.literal("panel"),
     iconId: z.string().min(1).optional(),
     description: z.string().optional(),
   })

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -388,35 +388,6 @@ function safeArgsHash(args: unknown[]): string {
 }
 
 /**
- * Validate a manifest-declared `experimental_views[].componentPath` before we
- * resolve it to a `plugin://` URL (#9229). The protocol handler at
- * `electron/setup/protocols.ts` rejects traversal at request time, but
- * pre-validating here surfaces a noisy authoring mistake (`/abs/path` or
- * `../escape`) as a `[PluginService]` warn during load, instead of a silent
- * 404 from `import('plugin://...')` later. Accepts relative POSIX paths only —
- * a leading `./` is preserved (the URL builder normalizes it).
- */
-function isSafePluginViewComponentPath(componentPath: string): boolean {
-  if (typeof componentPath !== "string" || componentPath.length === 0) return false;
-  if (componentPath.startsWith("/")) return false;
-  if (componentPath.includes("\\")) return false;
-  if (componentPath.includes("\0")) return false;
-  // Reject embedded URL structure markers — `https://...` (`:`), `?query`, or
-  // `#fragment`. The `plugin://` protocol handler defends against traversal at
-  // request time via realpath containment, so these are authoring-mistake
-  // guards (catch typos early, don't pollute the V8 module cache with
-  // duplicate query-string variants), not the security boundary.
-  if (componentPath.includes(":")) return false;
-  if (componentPath.includes("?")) return false;
-  if (componentPath.includes("#")) return false;
-  const segments = componentPath.split("/");
-  for (const seg of segments) {
-    if (seg === "..") return false;
-  }
-  return true;
-}
-
-/**
  * Build the `plugin://{pluginId}/{path}` URL that `PluginViewHost` passes to
  * `import()`. Strips a single leading `./` so the host segment doesn't end up
  * with an awkward `./dist/view.js` path component — the URL handler accepts
@@ -1068,18 +1039,9 @@ export class PluginService {
     const viewsByBareId = new Map<string, ViewContribution>();
     const unmatchedViewIds = new Set<string>();
     for (const view of manifest.contributes.experimental_views) {
-      if (view.location === "sidebar") {
-        console.warn(
-          `[PluginService] Plugin "${manifest.name}": experimental_views entry "${view.id}" has location "sidebar" which is not yet implemented and will be ignored`
-        );
-        continue;
-      }
-      if (!isSafePluginViewComponentPath(view.componentPath)) {
-        console.warn(
-          `[PluginService] Plugin "${manifest.name}": experimental_views entry "${view.id}" has an unsafe componentPath ${JSON.stringify(view.componentPath)} and will be ignored`
-        );
-        continue;
-      }
+      // `location` is narrowed to `"panel"` and `componentPath` safety is
+      // enforced by `ViewContributionSchema` at manifest parse — an unsupported
+      // location or unsafe path fails validation before we reach this loop.
       if (viewsByBareId.has(view.id)) {
         // Two entries with the same bare id — last would silently overwrite
         // earlier. Surface the authoring mistake; keep the first to make the

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -6067,6 +6067,7 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
+    expect(registerPanelKind).toHaveBeenCalledTimes(1);
     const panelCall = (registerPanelKind as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
       componentPath?: string;
     };

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -5926,7 +5926,7 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
-  it("warns and skips a sidebar-location view entry until the sidebar host ships", async () => {
+  it("rejects the whole manifest when a view targets the unimplemented sidebar location (#10464)", async () => {
     await writePlugin("sidebar", {
       name: "acme.sidebar",
       version: "1.0.0",
@@ -5947,14 +5947,14 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    const panelCall = (registerPanelKind as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
-      componentPath?: string;
-    };
-    expect(panelCall.componentPath).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Plugin "acme.sidebar": experimental_views entry "main" has location "sidebar" which is not yet implemented'
-      )
+    // `location: "sidebar"` fails ViewContributionSchema at parse time, so the
+    // manifest is invalid and the plugin never loads — no panel kind, no
+    // sibling registration, surfaced as a manifest error rather than a warning.
+    expect(service.listPlugins()).toHaveLength(0);
+    expect(registerPanelKind).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest in sidebar"),
+      expect.anything()
     );
   });
 
@@ -5990,7 +5990,7 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
-  it("rejects an unsafe experimental_views componentPath", async () => {
+  it("rejects the whole manifest when a view declares a traversal componentPath (#10464)", async () => {
     await writePlugin("unsafe", {
       name: "acme.unsafe",
       version: "1.0.0",
@@ -6011,16 +6011,17 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    const panelCall = (registerPanelKind as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
-      componentPath?: string;
-    };
-    expect(panelCall.componentPath).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('experimental_views entry "main" has an unsafe componentPath')
+    // An unsafe componentPath fails ViewContributionSchema's refine at parse
+    // time, so the manifest is invalid and the plugin never loads.
+    expect(service.listPlugins()).toHaveLength(0);
+    expect(registerPanelKind).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest in unsafe"),
+      expect.anything()
     );
   });
 
-  it("rejects an absolute https componentPath as unsafe", async () => {
+  it("rejects the whole manifest when a view declares an https componentPath (#10464)", async () => {
     await writePlugin("https", {
       name: "acme.https",
       version: "1.0.0",
@@ -6041,12 +6042,11 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    const panelCall = (registerPanelKind as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
-      componentPath?: string;
-    };
-    expect(panelCall.componentPath).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('experimental_views entry "main" has an unsafe componentPath')
+    expect(service.listPlugins()).toHaveLength(0);
+    expect(registerPanelKind).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest in https"),
+      expect.anything()
     );
   });
 
@@ -6220,7 +6220,7 @@ describe("reserved contribution point warnings", () => {
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
         experimental_views: [
-          { id: "main", name: "Main", componentPath: "./v.js", location: "sidebar" },
+          { id: "viewer", name: "Viewer", componentPath: "./v.js", location: "panel" },
         ],
         experimental_mcpServers: [{ id: "svc", name: "Svc", command: "node" }],
       },
@@ -6231,30 +6231,23 @@ describe("reserved contribution point warnings", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
     expect(registerPanelKind).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'experimental_views entry "main" has location "sidebar" which is not yet implemented'
-      )
-    );
     // experimental_mcpServers is registered (no warning) but, under lazy
     // discovery (#9235), is NOT spawned at activation.
     expect(mockPluginMcpSupervisor.start).not.toHaveBeenCalled();
     expect(service.findMcpServerContribution("acme.mixed", "svc")).toBeDefined();
   });
 
-  it("logs one warning per orphan or unsupported view entry", async () => {
+  it("logs one warning per orphan view entry", async () => {
     await writePlugin("many", {
       name: "acme.many",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
       contributes: {
-        // `a` matches a panel and binds; `b` is a sidebar view; `c` is an
-        // orphan with no matching panel id. Each non-binding entry should log
-        // exactly one warning naming the entry id.
+        // `a` matches a panel and binds; `c` is an orphan with no matching
+        // panel id. The orphan should log exactly one warning naming its id.
         panels: [{ id: "a", name: "A", iconId: "eye", color: "#000" }],
         experimental_views: [
           { id: "a", name: "A", componentPath: "./a.js", location: "panel" },
-          { id: "b", name: "B", componentPath: "./b.js", location: "sidebar" },
           { id: "c", name: "C", componentPath: "./c.js", location: "panel" },
         ],
       },
@@ -6263,13 +6256,9 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    const sidebarWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
-      String(call[0]).includes('"b" has location "sidebar"')
-    );
     const orphanWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
       String(call[0]).includes('"c" has no matching contributes.panels')
     );
-    expect(sidebarWarnings).toHaveLength(1);
     expect(orphanWarnings).toHaveLength(1);
   });
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -86,17 +86,17 @@ export interface ContextMenuContribution {
 }
 
 /**
- * View contribution location. Both values register a panel kind at plugin
- * load time; the difference is palette visibility. `panel` sets
- * `showInPalette: true` so the view is spawnable from the panel palette.
- * `sidebar` registers silently with `showInPalette: false`, reserving the
- * kind for the future sidebar host without surfacing it as a spawn target.
- * `location: "panel"` is wired today by the inline renderer host (#9229); see
- * `docs/plugins/architecture.md` for the renderer host design. The
- * `experimental_` prefix on the contribution point signals that the shape may
- * still change before the feature exits experiment status.
+ * View contribution location. Only `panel` is supported — it registers a panel
+ * kind at plugin load with `showInPalette: true` so the view is spawnable from
+ * the panel palette. It is wired today by the inline renderer host (#9229); see
+ * `docs/plugins/architecture.md` for the renderer host design. `sidebar` is
+ * rejected at the manifest gate (`ViewContributionSchema`) because the sidebar
+ * host does not exist yet — accepting it would validate a contribution the
+ * runtime cannot honor. The `experimental_` prefix on the contribution point
+ * signals that the shape may still change before the feature exits experiment
+ * status.
  */
-export type ViewLocation = "panel" | "sidebar";
+export type ViewLocation = "panel";
 
 export interface ViewContribution {
   id: string;


### PR DESCRIPTION
## Summary

- `ViewContributionSchema` now rejects `location: "sidebar"` at parse time with `z.literal("panel")` — previously the enum accepted it and the runtime silently dropped the view; an author declaring a sidebar contribution got nothing and no error.
- `componentPath` is validated at the schema boundary via `.refine(isSafePluginViewComponentPath)`, rejecting leading slashes, backslashes, NUL bytes, URL schemes, query/fragment strings, `..` segments, and bare-dot paths. The predicate moved from `PluginService` into `electron/schemas/plugin.ts` where it belongs.
- `ViewLocation` narrowed to `"panel"` in `shared/types/plugin.ts`; dead warn-and-skip branches removed from `PluginService`.

The main behavioral change: a single invalid `experimental_views` entry now fails the whole manifest parse rather than being silently dropped. Loud and early, which is what the issue requires. No first-party or sample manifests use `sidebar` or `experimental_views`, so there's no first-party breakage.

Part of the plugin-API freeze (#10459), covering freeze gaps #2 (sidebar) and #15 (componentPath).

Resolves #10464

## Changes

- `electron/schemas/plugin.ts` — `ViewContributionSchema` location narrowed to literal; `isSafePluginViewComponentPath` moved here and extended to reject bare-dot paths.
- `electron/services/PluginService.ts` — dead `sidebar` warn-and-skip branches removed; `componentPath` check removed (now handled at parse).
- `shared/types/plugin.ts` — `ViewLocation` union narrowed to `"panel"`.
- `electron/schemas/__tests__/viewContribution.test.ts` — new accept/reject matrix (19 cases).
- `electron/services/__tests__/PluginService.test.ts` — updated from warn-and-skip expectations to manifest-rejection.
- `docs/plugins/` — `contribution-points.md`, `manifest.md`, `architecture.md` updated to reflect the new contract.

## Testing

Targeted test run: 19 schema tests + 465 PluginService tests, all passing. Invalid `experimental_views` entries (bad location, bad componentPath) now produce manifest parse errors rather than silent drops.