### PR TITLE
fix(plugins): audit failed plugin action dispatch + surface failure detail in Settings

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -363,6 +363,7 @@ export {
 } from "./ipc/mcpServer.js";
 export type {
   PluginActionAuditRecord,
+  PluginActionAuditRecordType,
   PluginActionAuditResult,
   PluginAuditConfig,
 } from "./ipc/pluginAudit.js";

--- a/src/components/Settings/PluginActionAuditLogViewer.tsx
+++ b/src/components/Settings/PluginActionAuditLogViewer.tsx
@@ -4,9 +4,20 @@ import { cn } from "@/lib/utils";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
-import type { PluginActionAuditRecord, PluginActionAuditResult } from "@shared/types";
+import type {
+  PluginActionAuditRecord,
+  PluginActionAuditRecordType,
+  PluginActionAuditResult,
+} from "@shared/types";
 
 type ResultFilter = "all" | PluginActionAuditResult;
+
+// Only the non-default record types get a tag — `action-dispatch` is the common
+// case and is left unlabeled to keep ordinary dispatch rows uncluttered.
+const RECORD_TYPE_LABEL: Partial<Record<PluginActionAuditRecordType, string>> = {
+  "ipc-invoke": "IPC",
+  "decoration-failure": "Decoration",
+};
 
 const RESULT_LABEL: Record<PluginActionAuditResult, string> = {
   success: "Success",
@@ -107,7 +118,12 @@ export function PluginActionAuditLogViewer({
       if (search.length > 0) {
         const args = record.argsPlaintext ?? "";
         const hash = record.argsHash ?? "";
-        if (!args.toLowerCase().includes(search) && !hash.toLowerCase().includes(search)) {
+        const error = record.errorMessage ?? "";
+        if (
+          !args.toLowerCase().includes(search) &&
+          !hash.toLowerCase().includes(search) &&
+          !error.toLowerCase().includes(search)
+        ) {
           return false;
         }
       }
@@ -138,8 +154,8 @@ export function PluginActionAuditLogViewer({
           type="text"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          placeholder="Search arguments"
-          aria-label="Search audit arguments"
+          placeholder="Search arguments or errors"
+          aria-label="Search audit arguments or error messages"
           className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-text-placeholder font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
         />
         <select
@@ -247,13 +263,27 @@ export function PluginActionAuditLogViewer({
                     <span className="font-mono text-daintree-text/90 truncate">
                       {record.actionId}
                     </span>
-                    <span className="text-[10px] uppercase tracking-wide text-daintree-text/50">
-                      {record.source}
-                    </span>
+                    {record.source ? (
+                      <span className="text-[10px] uppercase tracking-wide text-daintree-text/50">
+                        {record.source}
+                      </span>
+                    ) : record.recordType && RECORD_TYPE_LABEL[record.recordType] ? (
+                      <span className="text-[10px] uppercase tracking-wide text-daintree-text/50">
+                        {RECORD_TYPE_LABEL[record.recordType]}
+                      </span>
+                    ) : null}
                   </div>
                   <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
                     {record.pluginId}
                   </div>
+                  {record.errorMessage ? (
+                    <div
+                      className="mt-0.5 text-status-danger/80 truncate"
+                      title={record.errorMessage}
+                    >
+                      {record.errorMessage}
+                    </div>
+                  ) : null}
                   {record.argsPlaintext ? (
                     <div className="mt-0.5 font-mono text-daintree-text/40 truncate">
                       {record.argsPlaintext}

--- a/src/components/Settings/__tests__/PluginActionAuditLogViewer.test.tsx
+++ b/src/components/Settings/__tests__/PluginActionAuditLogViewer.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { PluginActionAuditLogViewer } from "../PluginActionAuditLogViewer";
+import { PLUGIN_AUDIT_SCHEMA_VERSION, type PluginActionAuditRecord } from "@shared/types";
+
+function record(overrides: Partial<PluginActionAuditRecord> = {}): PluginActionAuditRecord {
+  return {
+    id: overrides.id ?? Math.random().toString(36).slice(2),
+    ts: 1_000,
+    pluginId: "acme.plugin",
+    actionId: "acme.plugin.doThing",
+    argsHash: "a".repeat(64),
+    durationMs: 5,
+    result: "error",
+    schemaVersion: PLUGIN_AUDIT_SCHEMA_VERSION,
+    ...overrides,
+  };
+}
+
+function renderViewer(records: PluginActionAuditRecord[]) {
+  return render(
+    <PluginActionAuditLogViewer
+      records={records}
+      loading={false}
+      maxRecords={500}
+      onRefresh={vi.fn()}
+      onCopy={vi.fn()}
+      onExport={vi.fn()}
+      onClear={vi.fn()}
+    />
+  );
+}
+
+describe("PluginActionAuditLogViewer", () => {
+  it("renders the errorMessage of a failure record so failures are inspectable", () => {
+    renderViewer([
+      record({ result: "error", errorMessage: "plugin handler exploded at boundary" }),
+    ]);
+    expect(screen.getByText("plugin handler exploded at boundary")).toBeTruthy();
+  });
+
+  it("omits the error line when a record carries no errorMessage", () => {
+    renderViewer([record({ result: "restricted", errorMessage: undefined })]);
+    expect(screen.queryByText(/exploded/)).toBeNull();
+  });
+
+  it("tags an ipc-invoke record with its record type instead of an empty source", () => {
+    renderViewer([
+      record({
+        recordType: "ipc-invoke",
+        channel: "plugin:invoke",
+        result: "error",
+        errorMessage: "untrusted sender",
+      }),
+    ]);
+    // ipc-invoke records have no `source`; the record-type tag stands in for it.
+    expect(screen.getByText("IPC")).toBeTruthy();
+  });
+
+  it("shows the dispatch source for an action-dispatch record", () => {
+    // `success` rows are hidden by default, so use an `error` action-dispatch
+    // record (kept visible by the default failure-centric view) to assert the
+    // source label still renders.
+    renderViewer([
+      record({ recordType: "action-dispatch", source: "keybinding", result: "error" }),
+    ]);
+    expect(screen.getByText("keybinding")).toBeTruthy();
+  });
+
+  it("makes errorMessage searchable", () => {
+    renderViewer([
+      record({ id: "match", result: "error", errorMessage: "needle-in-haystack" }),
+      record({
+        id: "other",
+        result: "error",
+        errorMessage: "unrelated failure",
+        actionId: "acme.plugin.other",
+      }),
+    ]);
+    const search = screen.getByLabelText("Search audit arguments or error messages");
+    fireEvent.change(search, { target: { value: "needle" } });
+    expect(screen.getByText("needle-in-haystack")).toBeTruthy();
+    expect(screen.queryByText("unrelated failure")).toBeNull();
+  });
+});

--- a/src/components/Settings/__tests__/PluginActionAuditLogViewer.test.tsx
+++ b/src/components/Settings/__tests__/PluginActionAuditLogViewer.test.tsx
@@ -84,4 +84,29 @@ describe("PluginActionAuditLogViewer", () => {
     expect(screen.getByText("needle-in-haystack")).toBeTruthy();
     expect(screen.queryByText("unrelated failure")).toBeNull();
   });
+
+  it("renders a record with neither recordType nor source without leaking 'undefined'", () => {
+    renderViewer([
+      record({ recordType: undefined, source: undefined, result: "error", actionId: "acme.bare" }),
+    ]);
+    // The row still renders its identifying fields...
+    expect(screen.getByText("acme.bare")).toBeTruthy();
+    // ...and never stringifies an absent source/recordType into the DOM.
+    expect(screen.queryByText("undefined")).toBeNull();
+  });
+
+  it("hides success rows by default but reveals them via the result filter", () => {
+    renderViewer([
+      record({ id: "ok", result: "success", actionId: "acme.plugin.win" }),
+      record({ id: "bad", result: "error", actionId: "acme.plugin.lose" }),
+    ]);
+    // Default failure-centric view: the success row is suppressed.
+    expect(screen.queryByText("acme.plugin.win")).toBeNull();
+    expect(screen.getByText("acme.plugin.lose")).toBeTruthy();
+    // Explicitly filtering to "success" overrides the suppression.
+    fireEvent.change(screen.getByLabelText("Filter audit by result"), {
+      target: { value: "success" },
+    });
+    expect(screen.getByText("acme.plugin.win")).toBeTruthy();
+  });
 });

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -2,12 +2,15 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { listMock, dispatchMock, getDisplayComboMock, getContextMock } = vi.hoisted(() => ({
-  listMock: vi.fn(),
-  dispatchMock: vi.fn(),
-  getDisplayComboMock: vi.fn(() => ""),
-  getContextMock: vi.fn(),
-}));
+const { listMock, dispatchMock, getDisplayComboMock, getContextMock, notifyMock } = vi.hoisted(
+  () => ({
+    listMock: vi.fn(),
+    dispatchMock: vi.fn(),
+    getDisplayComboMock: vi.fn(() => ""),
+    getContextMock: vi.fn(),
+    notifyMock: vi.fn(),
+  })
+);
 
 vi.mock("@/services/ActionService", () => ({
   actionService: {
@@ -15,6 +18,10 @@ vi.mock("@/services/ActionService", () => ({
     dispatch: dispatchMock,
     getContext: getContextMock,
   },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
 }));
 
 vi.mock("@/services/KeybindingService", () => ({
@@ -305,6 +312,58 @@ describe("useActionPalette", () => {
     expect(sorted.length).toBe(1);
     expect(sorted[0]!.id).toBe("a.action");
     expect(dispatchMock).toHaveBeenCalledWith("a.action", {}, { source: "user" });
+  });
+
+  // The palette owns a generic `{ ok: false }` failure toast, but plugin
+  // actions self-notify (via usePluginActions) only on EXECUTION_ERROR. These
+  // lock in the precise suppression so plugin EXECUTION_ERRORs don't
+  // double-toast while every other failure still surfaces.
+  async function runFailingPaletteAction(
+    entry: ReturnType<typeof makeEntry> & { pluginId?: string },
+    query: string,
+    error: { code: string; message: string }
+  ): Promise<void> {
+    dispatchMock.mockResolvedValue({ ok: false, error });
+    listMock.mockReturnValue([entry]);
+    const { result } = renderHook(() => useActionPalette());
+    act(() => result.current.open());
+    act(() => result.current.setQuery(query));
+    await waitFor(() => expect(result.current.results.length).toBe(1));
+    act(() => result.current.executeAction(result.current.results[0]!));
+    // Flush the void dispatch().then() microtask chain.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("suppresses the palette toast for a plugin action EXECUTION_ERROR (already self-notified)", async () => {
+    await runFailingPaletteAction(
+      { ...makeEntry("acme.thing", "Acmething"), pluginId: "acme.plugin" },
+      "acmething",
+      { code: "EXECUTION_ERROR", message: "handler exploded" }
+    );
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("still toasts a plugin action that failed without self-notifying (e.g. NOT_FOUND on a stale row)", async () => {
+    await runFailingPaletteAction(
+      { ...makeEntry("acme.thing", "Acmething"), pluginId: "acme.plugin" },
+      "acmething",
+      { code: "NOT_FOUND", message: "action was unregistered" }
+    );
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Couldn't run 'Acmething'" })
+    );
+  });
+
+  it("still toasts a built-in action EXECUTION_ERROR (no pluginId, never self-notifies)", async () => {
+    await runFailingPaletteAction(makeEntry("builtin.thing", "Builtinthing"), "builtinthing", {
+      code: "EXECUTION_ERROR",
+      message: "boom",
+    });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
   });
 
   it("excludes paletteHidden commands from the palette", async () => {

--- a/src/hooks/__tests__/usePluginActions.test.ts
+++ b/src/hooks/__tests__/usePluginActions.test.ts
@@ -292,7 +292,7 @@ describe("usePluginActions", () => {
     expect(usePluginConfirmStore.getState().current).toBeNull();
   });
 
-  it("surfaces an error toast when invoke rejects and returns undefined (boundary 2 — #9276)", async () => {
+  it("surfaces a failure toast AND rethrows when invoke rejects (boundary 2 — #9276/#10476)", async () => {
     const { actionService } = await import("@/services/ActionService");
     const { usePluginActions } = await import("../usePluginActions");
 
@@ -305,11 +305,11 @@ describe("usePluginActions", () => {
 
     const result = await actionService.dispatch(action.id, { x: 1 });
 
-    // The rejection is contained at the renderer boundary: the dispatch
-    // resolves successfully with undefined, never propagating the rejection
-    // back through ActionService's own catch (which would emit a *second*
-    // error path).
-    expect(result).toEqual({ ok: true, result: undefined });
+    // The catch surfaces the toast and rethrows so ActionService reports the
+    // dispatch as failed. Returning undefined here would let ActionService
+    // emit an `action:dispatched` *success* event and write a misleading
+    // `success` audit record over the genuine main-side `error` row (#10476).
+    expect(result).toMatchObject({ ok: false, error: { code: "EXECUTION_ERROR" } });
     expect(notifyMock).toHaveBeenCalledTimes(1);
     expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -347,9 +347,9 @@ describe("usePluginActions", () => {
     rejectInvoke!(new Error("late boom"));
     const result = await pending;
 
-    // Run still returns undefined (boundary 2 swallows the throw) and
-    // ActionService wraps that as a successful dispatch.
-    expect(result).toEqual({ ok: true, result: undefined });
+    // Run rethrows the rejection, so ActionService reports the dispatch as
+    // failed — but the toast is gated on the still-mounted check.
+    expect(result).toMatchObject({ ok: false, error: { code: "EXECUTION_ERROR" } });
     // Critical: no toast on a stale in-flight rejection.
     expect(notifyMock).not.toHaveBeenCalled();
   });

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -243,16 +243,23 @@ export function useActionPalette(): UseActionPaletteReturn {
           }
         )
         .then((result) => {
-          // Plugin actions self-notify on failure (see `usePluginActions`), so
-          // skip the generic palette toast for them to avoid double-notifying.
-          if (!result.ok && result.error.code !== "DISABLED" && !item.pluginId) {
-            // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
-            notify({
-              type: "error",
-              title: `Couldn't run '${item.title}'`,
-              message: formatErrorMessage(result.error, "Action failed."),
-            });
-          }
+          if (result.ok) return;
+          // DISABLED is already visible on the originating surface (#8814).
+          if (result.error.code === "DISABLED") return;
+          // A plugin action's synthetic run() self-notifies *only* when its own
+          // handler throws — surfaced by ActionService as EXECUTION_ERROR.
+          // Suppress the generic palette toast for that exact case to avoid
+          // double-notifying. Any other plugin failure (e.g. NOT_FOUND when the
+          // action was unregistered while the palette was open) never
+          // self-notified, and built-in EXECUTION_ERRORs never self-notify, so
+          // the palette must still toast those.
+          if (item.pluginId !== undefined && result.error.code === "EXECUTION_ERROR") return;
+          // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+          notify({
+            type: "error",
+            title: `Couldn't run '${item.title}'`,
+            message: formatErrorMessage(result.error, "Action failed."),
+          });
         })
         .catch(() => {
           // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -28,6 +28,12 @@ export interface ActionPaletteItem {
   redirectTo?: string;
   keybinding?: string;
   kind: string;
+  /**
+   * Set for plugin-contributed actions. Their synthetic definition surfaces its
+   * own failure toast in `usePluginActions`, so the palette suppresses its
+   * generic `{ ok: false }` toast for these rows to avoid double-notifying.
+   */
+  pluginId?: string;
   titleLower: string;
   categoryLower: string;
   descriptionLower: string;
@@ -104,6 +110,7 @@ function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
     redirectTo,
     keybinding: keybindingService.getDisplayCombo(entry.id),
     kind: entry.kind,
+    pluginId: entry.pluginId,
     titleLower: title.toLowerCase(),
     categoryLower: category.toLowerCase(),
     descriptionLower: description.toLowerCase(),
@@ -236,7 +243,9 @@ export function useActionPalette(): UseActionPaletteReturn {
           }
         )
         .then((result) => {
-          if (!result.ok && result.error.code !== "DISABLED") {
+          // Plugin actions self-notify on failure (see `usePluginActions`), so
+          // skip the generic palette toast for them to avoid double-notifying.
+          if (!result.ok && result.error.code !== "DISABLED" && !item.pluginId) {
             // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
             notify({
               type: "error",

--- a/src/hooks/usePluginActions.ts
+++ b/src/hooks/usePluginActions.ts
@@ -179,14 +179,19 @@ function toSyntheticDefinition(
       try {
         return await window.electron.plugin.invoke(pluginId, id, args);
       } catch (err) {
-        // ActionService.dispatch already catches this rejection and returns
-        // `{ ok: false }` so the *contract* is intact — this branch exists to
-        // turn the silent failure into a user-visible toast. `isDisposed`
-        // gates the notify so an in-flight invoke that resolves after the
-        // hook unmounts (HMR, window close, project switch) can't surface a
-        // stale toast for an action the user can no longer see. We swallow
-        // the error after notifying because surfacing a second failure path
-        // (via rethrow → ActionService) would double-route the same event.
+        // Surface the failure as a user-visible toast, then rethrow so
+        // `ActionService.dispatch` returns `{ ok: false }` instead of treating
+        // the swallowed rejection as a successful run. Returning `undefined`
+        // here would let ActionService emit an `action:dispatched` *success*
+        // event, producing a misleading `success` audit record on top of the
+        // genuine `error` record the main-side dispatch boundary already wrote
+        // (#10463/#10476). Rethrowing keeps a single accurate audit row.
+        //
+        // `isDisposed` gates the notify so an in-flight invoke that resolves
+        // after the hook unmounts (HMR, window close, project switch) can't
+        // surface a stale toast for an action the user can no longer see. The
+        // command palette suppresses its own generic failure toast for plugin
+        // actions (see `useActionPalette`) so the rethrow can't double-toast.
         if (!isDisposed()) {
           // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
           notify({
@@ -196,7 +201,7 @@ function toSyntheticDefinition(
           });
         }
         logWarn(`[PluginActions] Plugin action "${id}" threw`, { error: err });
-        return undefined;
+        throw err;
       }
     },
   };


### PR DESCRIPTION
## Summary

- Most of #10476 already shipped (`develop` has the structured audit log, IPC-failure audit from #10463, and the Plugins settings tab + viewer). This PR closes the two genuine remainders.
- Failed plugin actions were being recorded as success in the audit log because `usePluginActions` swallowed the rejection, causing `ActionService` to report `{ok:true}` and `PluginActionAuditService` to write a misleading second success record for the same failed dispatch.
- The audit log viewer in Settings showed bare rows with no error message, record type, or channel for `ipc-invoke`/`decoration-failure` records.

Resolves #10476

## Changes

- `usePluginActions`: rethrow the invoke rejection after the gated failure toast instead of swallowing it, so `ActionService` gets `{ok:false}` and the main-side `error` record is the sole audit row. Cancel path still returns `undefined`.
- `useActionPalette`: carry `pluginId` on palette items and suppress the generic palette toast only when the failure is a plugin action's own `EXECUTION_ERROR` (the exact case `usePluginActions` self-notifies). Built-in `EXECUTION_ERROR`s and other plugin failure codes (e.g. `NOT_FOUND` on a stale row) still surface.
- `PluginActionAuditLogViewer`: render `errorMessage`, tag `ipc-invoke`/`decoration-failure` records, guard the empty `source` span, include error messages in search.
- `shared/types/index.ts`: re-export `PluginActionAuditRecordType` from the barrel.

## Testing

- `usePluginActions.test.ts`: rejection now asserts `{ok:false, EXECUTION_ERROR}` (was false `{ok:true}`).
- `useActionPalette.test.tsx`: new cases covering plugin `EXECUTION_ERROR` suppression, plugin `NOT_FOUND` still toasting, and built-in `EXECUTION_ERROR` still toasting.
- `PluginActionAuditLogViewer.test.tsx` (new): error message rendering, record-type tags, bare-record safety, default success-suppression behaviour.
- 69 tests pass locally; prettier/eslint clean on changed files.