### PR TITLE
feat(plugins): implement daintree-plugin dev hot-reload and close dev-worker decoration gap

### DIFF
--- a/electron/services/PluginCliServer.ts
+++ b/electron/services/PluginCliServer.ts
@@ -46,9 +46,17 @@ const UninstallParamsSchema = z.object({
   deleteSettings: z.boolean().optional(),
 });
 
+const DevParamsSchema = z.object({
+  pluginId: z.string().min(1),
+});
+
 export interface PluginCliServerHandlers {
   install: (params: { path?: string; url?: string }) => Promise<unknown>;
   uninstall: (params: { pluginId: string; deleteSettings?: boolean }) => Promise<void>;
+  /** Load + activate a dev plugin the CLI symlinked into the plugins root. */
+  devStart: (params: { pluginId: string }) => Promise<void>;
+  /** Unload a dev plugin when the CLI's `dev` session stops. */
+  devStop: (params: { pluginId: string }) => Promise<void>;
 }
 
 export interface PluginCliServerConfig {
@@ -102,6 +110,16 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
       case "plugin.uninstall": {
         const p = UninstallParamsSchema.parse(params ?? {});
         await handlers.uninstall(p);
+        return { status: "ok" };
+      }
+      case "plugin.dev.start": {
+        const p = DevParamsSchema.parse(params ?? {});
+        await handlers.devStart(p);
+        return { status: "ok" };
+      }
+      case "plugin.dev.stop": {
+        const p = DevParamsSchema.parse(params ?? {});
+        await handlers.devStop(p);
         return { status: "ok" };
       }
       default:
@@ -251,6 +269,11 @@ export async function startPluginCliServer(): Promise<void> {
         return Promise.reject(new Error("install requires exactly one of 'path' or 'url'"));
       },
       uninstall: ({ pluginId, deleteSettings }) => handleUninstall(pluginId, deleteSettings),
+      devStart: ({ pluginId }) => pluginService.loadDevPlugin(pluginId),
+      devStop: ({ pluginId }) => {
+        pluginService.unloadPlugin(pluginId);
+        return Promise.resolve();
+      },
     },
   });
   // Only claim the singleton once the socket is actually bound — if listen()

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2630,6 +2630,35 @@ export class PluginService {
     return this.installer.checkForUpdate(pluginId);
   }
 
+  /**
+   * Load and activate a dev plugin the `daintree-plugin dev` CLI has already
+   * symlinked into {@link pluginsRoot} and stamped with a `.dev-marker`. Called
+   * over the CLI control socket (`plugin.dev.start`) once the first build is in
+   * place. Reuses the standard {@link loadPlugin} path — the `.dev-marker`
+   * detection there routes it through the hot-reload worker. The CLI owns the
+   * symlink; this method only reads from `pluginsRoot`, so it doesn't touch the
+   * installer's content-mutation invariant (#9292).
+   *
+   * Idempotent across dev sessions: if the plugin is already loaded (a prior
+   * session that didn't clean up, or a crashed CLI), it's unloaded first so the
+   * duplicate-name guard in {@link loadPlugin} doesn't reject the reload.
+   */
+  async loadDevPlugin(pluginId: string): Promise<void> {
+    if (this.plugins.has(pluginId)) {
+      this.unloadPlugin(pluginId);
+    }
+    const loaded = await this.loadPlugin(this.pluginsRoot, pluginId, {
+      isBuiltin: false,
+      disabled: new Set(),
+    });
+    if (!loaded) {
+      throw new Error(
+        `Couldn't load dev plugin "${pluginId}" from ${this.pluginsRoot} — check the symlink and that plugin.json is valid`
+      );
+    }
+    await this.activatePlugin(pluginId);
+  }
+
   unloadPlugin(pluginId: string): void {
     if (!this.plugins.has(pluginId)) return;
     // Drop activation state so a runtime reload (e.g. dev-mode re-scan) can

--- a/electron/services/__tests__/PluginCliServer.test.ts
+++ b/electron/services/__tests__/PluginCliServer.test.ts
@@ -58,6 +58,8 @@ function noopHandlers() {
   return {
     install: vi.fn(async () => ({ status: "installed" })),
     uninstall: vi.fn(async () => {}),
+    devStart: vi.fn(async () => {}),
+    devStop: vi.fn(async () => {}),
   };
 }
 
@@ -126,6 +128,59 @@ describe("createPluginCliServer", () => {
       pluginId: "acme.demo",
       deleteSettings: true,
     });
+  });
+
+  it("routes plugin.dev.start to the devStart handler", async () => {
+    const handlers = noopHandlers();
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers,
+    });
+    await server.listen();
+
+    const res = await request({
+      id: "d1",
+      method: "plugin.dev.start",
+      params: { pluginId: "acme.demo" },
+    });
+    expect(res.id).toBe("d1");
+    expect(res.result).toEqual({ status: "ok" });
+    expect(handlers.devStart).toHaveBeenCalledWith({ pluginId: "acme.demo" });
+  });
+
+  it("routes plugin.dev.stop to the devStop handler", async () => {
+    const handlers = noopHandlers();
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers,
+    });
+    await server.listen();
+
+    const res = await request({
+      id: "d2",
+      method: "plugin.dev.stop",
+      params: { pluginId: "acme.demo" },
+    });
+    expect(res.id).toBe("d2");
+    expect(res.result).toEqual({ status: "ok" });
+    expect(handlers.devStop).toHaveBeenCalledWith({ pluginId: "acme.demo" });
+  });
+
+  it("returns an error frame when a dev call is missing pluginId", async () => {
+    const handlers = noopHandlers();
+    server = createPluginCliServer({
+      socketPath,
+      waitForReady: () => Promise.resolve(),
+      handlers,
+    });
+    await server.listen();
+
+    const res = await request({ id: "d3", method: "plugin.dev.start", params: {} });
+    expect(res.id).toBe("d3");
+    expect(res.error).toBeTruthy();
+    expect(handlers.devStart).not.toHaveBeenCalled();
   });
 
   it("answers plugin.ping for liveness checks", async () => {
@@ -244,6 +299,8 @@ describe("createPluginCliServer", () => {
           throw new Error("disk on fire");
         }),
         uninstall: vi.fn(async () => {}),
+        devStart: vi.fn(async () => {}),
+        devStop: vi.fn(async () => {}),
       },
     });
     await server.listen();
@@ -263,6 +320,8 @@ describe("createPluginCliServer", () => {
       handlers: {
         install: vi.fn(async () => ({ status: "installed" })),
         uninstall: vi.fn(async () => {}),
+        devStart: vi.fn(async () => {}),
+        devStop: vi.fn(async () => {}),
       },
     });
     await server.listen();

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -16,6 +16,7 @@
 import { createLogger } from "../../utils/logger.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import type { PluginHostApi, PluginIpcContext } from "../../../shared/types/plugin.js";
+import type { FileDecoration, FileDecorationProviderImpl } from "../../../shared/types/forge.js";
 import type {
   BroadcastToRendererParams,
   DispatchParams,
@@ -23,10 +24,12 @@ import type {
   LoggerParams,
   PluginWorkerToHostMessage,
   RegisterActionParams,
+  RegisterFileDecorationProviderParams,
   RegisterHandlerParams,
   SettingsGetParams,
   SettingsSetParams,
   ShowToastParams,
+  UnregisterFileDecorationProviderParams,
 } from "../../../shared/types/pluginDevWorker.js";
 import type { PluginDevWorkerHost } from "./PluginDevWorkerHost.js";
 
@@ -70,6 +73,10 @@ export class PluginDevWorkerMainBridge {
   private invokeSeq = 1;
   private readonly pendingInvokes = new Map<string, PendingInvoke>();
   private readonly subscriptionDisposers = new Map<string, () => void>();
+  /** Disposers for providers (file decoration) the worker registered on the real
+   * host, keyed by provider id. Torn down on reload and dispose so a reloaded
+   * generation re-registers cleanly. */
+  private readonly providerDisposers = new Map<string, () => void>();
 
   /** First-activation gate. Resolved on `activated`, rejected on activate/crash
    * errors. Subsequent reload activations don't re-await this. */
@@ -115,11 +122,24 @@ export class PluginDevWorkerMainBridge {
       }
     }
     this.subscriptionDisposers.clear();
+    this.disposeProviders();
     for (const pending of this.pendingInvokes.values()) {
       pending.reject(new Error("Plugin dev worker bridge disposed"));
     }
     this.pendingInvokes.clear();
     this.rejectActivation(new Error(`Plugin dev worker "${this.pluginId}" disposed`));
+  }
+
+  /** Tear down every provider the worker registered on the real host. */
+  private disposeProviders(): void {
+    for (const dispose of this.providerDisposers.values()) {
+      try {
+        dispose();
+      } catch {
+        // best-effort
+      }
+    }
+    this.providerDisposers.clear();
   }
 
   private onReloading = (): void => {
@@ -135,6 +155,7 @@ export class PluginDevWorkerMainBridge {
       }
     }
     this.subscriptionDisposers.clear();
+    this.disposeProviders();
     for (const pending of this.pendingInvokes.values()) {
       pending.reject(new Error("Plugin reloaded before invocation completed"));
     }
@@ -313,6 +334,44 @@ export class PluginDevWorkerMainBridge {
         this.host.invalidateFileDecorations(p.scope, p.paths);
         return;
       }
+      case "registerFileDecorationProvider": {
+        const { descriptor } = params as RegisterFileDecorationProviderParams;
+        const providerId = descriptor.id;
+        // A re-register on the same id replaces the prior binding — dispose it
+        // first so the host registry doesn't accumulate stale proxy impls.
+        const prior = this.providerDisposers.get(providerId);
+        if (prior) {
+          try {
+            prior();
+          } catch {
+            // best-effort
+          }
+        }
+        // The impl lives in the worker; register a thin proxy whose single
+        // method round-trips each call back over the port (mirrors the action
+        // wrapper). `provideDecorations` is async, so this composes cleanly.
+        const proxyImpl: FileDecorationProviderImpl = {
+          provideDecorations: (scope: string, paths: string[]) =>
+            this.invoke({
+              kind: "file-decoration-method",
+              providerId,
+              method: "provideDecorations",
+              args: [scope, paths],
+            }) as Promise<Record<string, FileDecoration>>,
+        };
+        const dispose = this.host.registerFileDecorationProvider(descriptor, proxyImpl);
+        this.providerDisposers.set(providerId, dispose);
+        return;
+      }
+      case "unregisterFileDecorationProvider": {
+        const { providerId } = params as UnregisterFileDecorationProviderParams;
+        const dispose = this.providerDisposers.get(providerId);
+        if (dispose) {
+          this.providerDisposers.delete(providerId);
+          dispose();
+        }
+        return;
+      }
       case "logger.info":
       case "logger.warn":
       case "logger.error": {
@@ -358,6 +417,7 @@ export class PluginDevWorkerMainBridge {
     target:
       | { kind: "action"; namespacedId: string; args: unknown }
       | { kind: "handler"; channel: string; ctx: PluginIpcContext; args: unknown[] }
+      | { kind: "file-decoration-method"; providerId: string; method: string; args: unknown[] }
   ): Promise<unknown> {
     if (this.disposed || !this.workerHost.isReady()) {
       return Promise.reject(new Error(`Plugin "${this.pluginId}" dev worker is not running`));
@@ -365,23 +425,34 @@ export class PluginDevWorkerMainBridge {
     const requestId = `i${this.invokeSeq++}`;
     return new Promise<unknown>((resolve, reject) => {
       this.pendingInvokes.set(requestId, { resolve, reject });
-      const sent =
-        target.kind === "action"
-          ? this.workerHost.send({
-              type: "invoke",
-              requestId,
-              kind: "action",
-              namespacedId: target.namespacedId,
-              args: target.args,
-            })
-          : this.workerHost.send({
-              type: "invoke",
-              requestId,
-              kind: "handler",
-              channel: target.channel,
-              ctx: target.ctx,
-              args: target.args,
-            });
+      let sent: boolean;
+      if (target.kind === "action") {
+        sent = this.workerHost.send({
+          type: "invoke",
+          requestId,
+          kind: "action",
+          namespacedId: target.namespacedId,
+          args: target.args,
+        });
+      } else if (target.kind === "handler") {
+        sent = this.workerHost.send({
+          type: "invoke",
+          requestId,
+          kind: "handler",
+          channel: target.channel,
+          ctx: target.ctx,
+          args: target.args,
+        });
+      } else {
+        sent = this.workerHost.send({
+          type: "invoke",
+          requestId,
+          kind: "file-decoration-method",
+          providerId: target.providerId,
+          method: target.method,
+          args: target.args,
+        });
+      }
       if (!sent) {
         this.pendingInvokes.delete(requestId);
         reject(new Error(`Plugin "${this.pluginId}" dev worker is not running`));

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -215,6 +215,71 @@ describe("PluginDevWorkerMainBridge", () => {
     expect(onActivationResult).toHaveBeenNthCalledWith(2, { ok: false, error: "broke on reload" });
   });
 
+  it("registerFileDecorationProvider wires a proxy impl that round-trips provideDecorations", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "registerFileDecorationProvider",
+      registrationKey: "fileDecorationProvider:acme.demo.deco",
+      params: { descriptor: { id: "acme.demo.deco", scopes: ["pr"] } },
+    });
+    expect(host.registerFileDecorationProvider).toHaveBeenCalledTimes(1);
+    const [descriptor, proxyImpl] = host.registerFileDecorationProvider.mock.calls[0] as [
+      { id: string },
+      { provideDecorations: (s: string, p: string[]) => Promise<unknown> },
+    ];
+    expect(descriptor).toMatchObject({ id: "acme.demo.deco", scopes: ["pr"] });
+
+    const resultPromise = proxyImpl.provideDecorations("pr", ["a.ts", "b.ts"]);
+    const invoke = workerHost.sent.find(
+      (m) => m.type === "invoke" && m.kind === "file-decoration-method"
+    );
+    expect(invoke).toMatchObject({
+      providerId: "acme.demo.deco",
+      method: "provideDecorations",
+      args: ["pr", ["a.ts", "b.ts"]],
+    });
+
+    workerHost.emit("worker-message", {
+      type: "invoke-result",
+      requestId: invoke.requestId,
+      ok: true,
+      result: { "a.ts": { badge: "M" } },
+    });
+    await expect(resultPromise).resolves.toEqual({ "a.ts": { badge: "M" } });
+  });
+
+  it("unregisterFileDecorationProvider disposes the host registration", async () => {
+    const { host, workerHost } = makeBridge();
+    const dispose = vi.fn();
+    host.registerFileDecorationProvider.mockReturnValueOnce(dispose);
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "registerFileDecorationProvider",
+      params: { descriptor: { id: "acme.demo.deco" } },
+    });
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "unregisterFileDecorationProvider",
+      params: { providerId: "acme.demo.deco" },
+    });
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes registered providers on reload", async () => {
+    const { host, workerHost, bridge } = makeBridge();
+    bridge.waitForActivation().catch(() => {});
+    const dispose = vi.fn();
+    host.registerFileDecorationProvider.mockReturnValueOnce(dispose);
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "registerFileDecorationProvider",
+      params: { descriptor: { id: "acme.demo.deco" } },
+    });
+    workerHost.emit("reloading");
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
   it("clears prior registrations and fails pending invokes on reload", async () => {
     const { host, workerHost, bridge, clear } = makeBridge();
     bridge.waitForActivation().catch(() => {});

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -224,7 +224,8 @@ describe("PluginDevWorkerMainBridge", () => {
       params: { descriptor: { id: "acme.demo.deco", scopes: ["pr"] } },
     });
     expect(host.registerFileDecorationProvider).toHaveBeenCalledTimes(1);
-    const [descriptor, proxyImpl] = host.registerFileDecorationProvider.mock.calls[0] as [
+    const [descriptor, proxyImpl] = host.registerFileDecorationProvider.mock
+      .calls[0] as unknown as [
       { id: string },
       { provideDecorations: (s: string, p: string[]) => Promise<unknown> },
     ];

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -96,6 +96,28 @@ describe("PluginDevWorkerHostProxy file decoration providers", () => {
     expect(result).toMatchObject({ ok: false });
   });
 
+  it("a stale disposer does not drop a re-registered impl on the same id", async () => {
+    const { proxy, sent } = makeProxy();
+    const implA = { provideDecorations: vi.fn(async () => ({ a: { badge: "A" } })) };
+    const implB = { provideDecorations: vi.fn(async () => ({ b: { badge: "B" } })) };
+    const disposeA = proxy.host.registerFileDecorationProvider({ id: "deco" }, implA);
+    proxy.host.registerFileDecorationProvider({ id: "deco" }, implB); // overwrites A
+    disposeA(); // stale — must NOT remove B
+
+    proxy.handleMessage({
+      type: "invoke",
+      requestId: "i9",
+      kind: "file-decoration-method",
+      providerId: "deco",
+      method: "provideDecorations",
+      args: ["pr", ["x"]],
+    } as any);
+    await flush();
+    expect(implB.provideDecorations).toHaveBeenCalled();
+    const result = sent.find((m) => m.type === "invoke-result" && m.requestId === "i9");
+    expect(result).toMatchObject({ ok: true, result: { b: { badge: "B" } } });
+  });
+
   it("rejects an impl missing provideDecorations", () => {
     const { proxy } = makeProxy();
     expect(() => proxy.host.registerFileDecorationProvider({ id: "deco" }, {} as any)).toThrow(

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginDevWorkerHostProxy } from "../pluginDevWorkerHostProxy.js";
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+function makeProxy() {
+  const sent: any[] = [];
+  const post = vi.fn((msg: any) => {
+    sent.push(msg);
+  });
+  const proxy = new PluginDevWorkerHostProxy("acme.demo", post);
+  return { proxy, post, sent };
+}
+
+describe("PluginDevWorkerHostProxy file decoration providers", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("notifies main on registerFileDecorationProvider and keeps the impl in the worker", () => {
+    const { proxy, sent } = makeProxy();
+    const impl = { provideDecorations: vi.fn(async () => ({})) };
+    const dispose = proxy.host.registerFileDecorationProvider({ id: "deco", scopes: ["pr"] }, impl);
+
+    const notify = sent.find((m) => m.type === "host-notify");
+    expect(notify).toMatchObject({
+      method: "registerFileDecorationProvider",
+      registrationKey: "fileDecorationProvider:deco",
+      params: { descriptor: { id: "deco", scopes: ["pr"] } },
+    });
+    expect(typeof dispose).toBe("function");
+  });
+
+  it("round-trips a provideDecorations invocation back to the stored impl", async () => {
+    const { proxy, sent } = makeProxy();
+    const impl = {
+      provideDecorations: vi.fn(async (scope: string, paths: string[]) => ({
+        [paths[0]]: { badge: scope },
+      })),
+    };
+    proxy.host.registerFileDecorationProvider({ id: "deco" }, impl);
+
+    proxy.handleMessage({
+      type: "invoke",
+      requestId: "i1",
+      kind: "file-decoration-method",
+      providerId: "deco",
+      method: "provideDecorations",
+      args: ["pr", ["a.ts"]],
+    } as any);
+    await flush();
+
+    expect(impl.provideDecorations).toHaveBeenCalledWith("pr", ["a.ts"]);
+    const result = sent.find((m) => m.type === "invoke-result" && m.requestId === "i1");
+    expect(result).toMatchObject({ ok: true, result: { "a.ts": { badge: "pr" } } });
+  });
+
+  it("replies with an error when invoking an unregistered provider", async () => {
+    const { proxy, sent } = makeProxy();
+    proxy.handleMessage({
+      type: "invoke",
+      requestId: "i2",
+      kind: "file-decoration-method",
+      providerId: "missing",
+      method: "provideDecorations",
+      args: ["pr", []],
+    } as any);
+    await flush();
+    const result = sent.find((m) => m.type === "invoke-result" && m.requestId === "i2");
+    expect(result).toMatchObject({ ok: false });
+    expect(result.error).toMatch(/No file decoration provider/);
+  });
+
+  it("notifies unregister and drops the impl on dispose", async () => {
+    const { proxy, sent } = makeProxy();
+    const impl = { provideDecorations: vi.fn(async () => ({})) };
+    const dispose = proxy.host.registerFileDecorationProvider({ id: "deco" }, impl);
+    dispose();
+
+    const unregister = sent.find(
+      (m) => m.type === "host-notify" && m.method === "unregisterFileDecorationProvider"
+    );
+    expect(unregister).toMatchObject({ params: { providerId: "deco" } });
+
+    // After disposal, an invoke for that provider errors (impl was dropped).
+    proxy.handleMessage({
+      type: "invoke",
+      requestId: "i3",
+      kind: "file-decoration-method",
+      providerId: "deco",
+      method: "provideDecorations",
+      args: ["pr", []],
+    } as any);
+    await flush();
+    const result = sent.find((m) => m.type === "invoke-result" && m.requestId === "i3");
+    expect(result).toMatchObject({ ok: false });
+  });
+
+  it("rejects an impl missing provideDecorations", () => {
+    const { proxy } = makeProxy();
+    expect(() => proxy.host.registerFileDecorationProvider({ id: "deco" }, {} as any)).toThrow(
+      /provideDecorations/
+    );
+  });
+
+  it("warns but does not register forge providers (synchronous-contract limitation)", () => {
+    const { proxy, sent } = makeProxy();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const dispose = proxy.host.registerForgeProvider({ id: "gh" } as any, {} as any);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("not supported in dev mode"));
+    expect(sent.find((m) => m.type === "host-notify")).toBeUndefined();
+    expect(typeof dispose).toBe("function");
+    expect(dispose()).toBeUndefined();
+  });
+});

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -65,6 +65,7 @@ export class PluginDevWorkerHostProxy {
   private readonly actionHandlers = new Map<string, ActionHandler>();
   private readonly ipcHandlers = new Map<string, RegisteredHandler>();
   private readonly subscriptions = new Map<string, (payload: unknown) => void>();
+  private readonly fileDecorationProviders = new Map<string, FileDecorationProviderImpl>();
 
   constructor(pluginId: string, post: Post) {
     this.pluginId = pluginId;
@@ -87,6 +88,7 @@ export class PluginDevWorkerHostProxy {
     this.actionHandlers.clear();
     this.ipcHandlers.clear();
     this.subscriptions.clear();
+    this.fileDecorationProviders.clear();
   }
 
   /** Route a message received from main. Returns true if it was consumed. */
@@ -134,6 +136,19 @@ export class PluginDevWorkerHostProxy {
           throw new Error(`No action handler registered for "${msg.namespacedId}"`);
         }
         const result = await handler(msg.args);
+        this.post({ type: "invoke-result", requestId: msg.requestId, ok: true, result });
+        return;
+      }
+      if (msg.kind === "file-decoration-method") {
+        const impl = this.fileDecorationProviders.get(msg.providerId);
+        if (!impl) {
+          throw new Error(`No file decoration provider registered for "${msg.providerId}"`);
+        }
+        if (msg.method !== "provideDecorations") {
+          throw new Error(`Unknown file decoration provider method "${msg.method}"`);
+        }
+        const [scope, paths] = msg.args as [string, string[]];
+        const result = await impl.provideDecorations(scope, paths);
         this.post({ type: "invoke-result", requestId: msg.requestId, ok: true, result });
         return;
       }
@@ -316,21 +331,56 @@ export class PluginDevWorkerHostProxy {
         );
       },
       registerForgeProvider: (descriptor: ForgeProviderDescriptor, _impl: ForgeProviderImpl) => {
-        // Forge providers require bidirectional impl proxying (callbacks the host
-        // invokes per PR/CI/rate-limit query) not yet supported in dev mode.
+        this.assertActivationOpen("registerForgeProvider");
+        // Forge providers can't run from the dev worker: `ForgeProviderImpl`'s
+        // required `parseRemote` (the routing gate), URL builders, and
+        // `classifyPushError` are SYNCHRONOUS — the host calls them and uses the
+        // return value immediately — but every dev-worker host call is async
+        // over this MessagePort. A partial async-only proxy would be worse than
+        // honest: the provider would never become routable because
+        // `parseRemote` resolves to a Promise. Package + install to test forge
+        // providers; a fix needs the forge API's sync surface to change.
         console.warn(
-          `[plugin-dev:${this.pluginId}] registerForgeProvider("${descriptor?.id}") is not supported in dev mode — package + install the plugin to test forge providers`
+          `[plugin-dev:${this.pluginId}] registerForgeProvider("${descriptor?.id}") is not supported in dev mode — forge providers require synchronous host methods (parseRemote, URL builders) that can't cross the dev worker's async boundary. Package + install the plugin to test forge providers.`
         );
         return () => {};
       },
       registerFileDecorationProvider: (
         descriptor: FileDecorationProviderDescriptor,
-        _impl: FileDecorationProviderImpl
+        impl: FileDecorationProviderImpl
       ) => {
-        console.warn(
-          `[plugin-dev:${this.pluginId}] registerFileDecorationProvider("${descriptor?.id}") is not supported in dev mode — package + install the plugin to test decoration providers`
+        this.assertActivationOpen("registerFileDecorationProvider");
+        if (!descriptor || typeof descriptor !== "object") {
+          throw new Error(
+            `Plugin "${this.pluginId}" registerFileDecorationProvider: descriptor must be an object`
+          );
+        }
+        if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+          throw new Error(
+            `Plugin "${this.pluginId}" registerFileDecorationProvider: descriptor.id must be a non-empty string`
+          );
+        }
+        if (!impl || typeof impl !== "object" || typeof impl.provideDecorations !== "function") {
+          throw new Error(
+            `Plugin "${this.pluginId}" registerFileDecorationProvider: impl must expose provideDecorations()`
+          );
+        }
+        const providerId = descriptor.id;
+        // Replace semantics mirror the real host: a second register on the same
+        // id overwrites the prior impl held here.
+        this.fileDecorationProviders.set(providerId, impl);
+        this.notify(
+          "registerFileDecorationProvider",
+          { descriptor: { id: providerId, scopes: descriptor.scopes } },
+          `fileDecorationProvider:${providerId}`
         );
-        return () => {};
+        let disposed = false;
+        return () => {
+          if (disposed) return;
+          disposed = true;
+          this.fileDecorationProviders.delete(providerId);
+          this.notify("unregisterFileDecorationProvider", { providerId });
+        };
       },
       invalidateFileDecorations: (scope, paths) => {
         if (typeof scope !== "string" || scope.length === 0) {

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -378,7 +378,12 @@ export class PluginDevWorkerHostProxy {
         return () => {
           if (disposed) return;
           disposed = true;
-          this.fileDecorationProviders.delete(providerId);
+          // Identity-guard the delete so a stale disposer (from a prior register
+          // on the same id that a later register overwrote) can't drop the
+          // currently-active impl — mirrors the real host's registry semantics.
+          if (this.fileDecorationProviders.get(providerId) === impl) {
+            this.fileDecorationProviders.delete(providerId);
+          }
           this.notify("unregisterFileDecorationProvider", { providerId });
         };
       },

--- a/packages/daintree-plugin/src/__tests__/dev.test.ts
+++ b/packages/daintree-plugin/src/__tests__/dev.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";

--- a/packages/daintree-plugin/src/__tests__/dev.test.ts
+++ b/packages/daintree-plugin/src/__tests__/dev.test.ts
@@ -6,7 +6,8 @@ import path from "node:path";
 
 vi.mock("../lib/viteBuild.js", () => ({
   runViteBuild: vi.fn(async () => {}),
-  spawnViteWatch: vi.fn(async () => ({ kill: vi.fn(), catch: vi.fn() })),
+  // Synchronous like the real helper: returns a live child handle, not a Promise.
+  spawnViteWatch: vi.fn(() => ({ kill: vi.fn(), catch: vi.fn() })),
 }));
 vi.mock("../ipc/client.js", () => ({
   sendCliRequest: vi.fn(async () => ({ status: "ok" })),
@@ -132,6 +133,32 @@ describe("runDev", () => {
     const watch = await vi.mocked(spawnViteWatch).mock.results[0].value;
     expect(watch.kill).toHaveBeenCalled();
     // The dev artifacts are gone after teardown.
+    expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
+  });
+
+  it("sends plugin.dev.start before plugin.dev.stop with the plugin id", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal });
+    const calls = vi.mocked(sendCliRequest).mock.calls;
+    expect(calls[0]).toEqual(["plugin.dev.start", { pluginId: "acme.demo" }]);
+    expect(calls[calls.length - 1]).toEqual(["plugin.dev.stop", { pluginId: "acme.demo" }]);
+  });
+
+  it("unloads and cleans up when the build watcher fails to start", async () => {
+    vi.mocked(spawnViteWatch).mockImplementationOnce(() => {
+      throw new Error("Couldn't find Vite");
+    });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal })
+    ).rejects.toThrow(/Vite/);
+
+    // The plugin was already started in Daintree, so it must be stopped, and the
+    // symlink/marker removed — no dangling dev state.
+    expect(vi.mocked(sendCliRequest).mock.calls.map((c) => c[0])).toContain("plugin.dev.stop");
     expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
   });
 

--- a/packages/daintree-plugin/src/__tests__/dev.test.ts
+++ b/packages/daintree-plugin/src/__tests__/dev.test.ts
@@ -1,0 +1,172 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+vi.mock("../lib/viteBuild.js", () => ({
+  runViteBuild: vi.fn(async () => {}),
+  spawnViteWatch: vi.fn(async () => ({ kill: vi.fn(), catch: vi.fn() })),
+}));
+vi.mock("../ipc/client.js", () => ({
+  sendCliRequest: vi.fn(async () => ({ status: "ok" })),
+  DaintreeUnavailableError: class extends Error {},
+}));
+vi.mock("../commands/validate.js", () => ({
+  runValidate: vi.fn(async () => ({ ok: true, errors: [], warnings: [] })),
+}));
+
+import { linkDevPlugin, cleanupDevLink, runDev, type DevLink } from "../commands/dev.js";
+import { runViteBuild, spawnViteWatch } from "../lib/viteBuild.js";
+import { sendCliRequest } from "../ipc/client.js";
+
+let tmpDir: string;
+let pluginDir: string;
+let pluginsRoot: string;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-dev-test-"));
+  pluginDir = path.join(tmpDir, "my-plugin");
+  pluginsRoot = path.join(tmpDir, "plugins-root");
+  await fs.mkdir(pluginDir, { recursive: true });
+  await fs.writeFile(
+    path.join(pluginDir, "plugin.json"),
+    JSON.stringify({ name: "acme.demo", main: "dist/index.js" })
+  );
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+async function lstatSafe(p: string): Promise<import("node:fs").Stats | null> {
+  try {
+    return await fs.lstat(p);
+  } catch {
+    return null;
+  }
+}
+
+describe("linkDevPlugin", () => {
+  it("creates a symlink to the plugin dir and writes the marker through it", async () => {
+    const link = await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    expect(link.createdSymlink).toBe(true);
+
+    const stat = await fs.lstat(link.linkPath);
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(path.resolve(path.dirname(link.linkPath), await fs.readlink(link.linkPath))).toBe(
+      path.resolve(pluginDir)
+    );
+    // Marker is visible through the symlink, i.e. inside the real plugin dir.
+    await expect(fs.access(path.join(pluginDir, ".dev-marker"))).resolves.toBeUndefined();
+  });
+
+  it("reuses an existing symlink that already points at the plugin dir", async () => {
+    await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    const second = await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    expect(second.createdSymlink).toBe(false);
+  });
+
+  it("replaces a symlink pointing somewhere else", async () => {
+    const other = path.join(tmpDir, "other");
+    await fs.mkdir(other, { recursive: true });
+    await fs.mkdir(pluginsRoot, { recursive: true });
+    await fs.symlink(other, path.join(pluginsRoot, "acme.demo"));
+
+    const link = await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    expect(link.createdSymlink).toBe(true);
+    expect(path.resolve(path.dirname(link.linkPath), await fs.readlink(link.linkPath))).toBe(
+      path.resolve(pluginDir)
+    );
+  });
+
+  it("refuses to clobber a real directory at the link path", async () => {
+    await fs.mkdir(path.join(pluginsRoot, "acme.demo"), { recursive: true });
+    await expect(linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" })).rejects.toThrow(
+      /isn't a symlink/
+    );
+  });
+});
+
+describe("cleanupDevLink", () => {
+  it("removes the marker and the symlink it created, leaving the source intact", async () => {
+    const link = await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    await cleanupDevLink(link);
+
+    expect(await lstatSafe(link.linkPath)).toBeNull();
+    expect(await lstatSafe(path.join(pluginDir, ".dev-marker"))).toBeNull();
+    // The source dir and its manifest survive — unlink removes the link, not the target.
+    await expect(fs.access(path.join(pluginDir, "plugin.json"))).resolves.toBeUndefined();
+  });
+
+  it("is idempotent — a second cleanup does not throw", async () => {
+    const link = await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    await cleanupDevLink(link);
+    await expect(cleanupDevLink(link)).resolves.toBeUndefined();
+  });
+
+  it("leaves a reused (not created) symlink in place", async () => {
+    await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    const reused = await linkDevPlugin({ pluginDir, pluginsRoot, pluginId: "acme.demo" });
+    const link: DevLink = { ...reused };
+    await cleanupDevLink(link);
+    // Symlink stays (we didn't create it this round); marker is removed.
+    expect(await lstatSafe(reused.linkPath)).not.toBeNull();
+  });
+});
+
+describe("runDev", () => {
+  it("builds, links, starts, watches, then tears down on stop", async () => {
+    const controller = new AbortController();
+    controller.abort(); // resolve the keep-alive immediately
+
+    await runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal });
+
+    expect(runViteBuild).toHaveBeenCalledWith(pluginDir);
+    expect(spawnViteWatch).toHaveBeenCalledWith(pluginDir);
+    const calls = vi.mocked(sendCliRequest).mock.calls.map((c) => c[0]);
+    expect(calls).toContain("plugin.dev.start");
+    expect(calls).toContain("plugin.dev.stop");
+
+    const watch = await vi.mocked(spawnViteWatch).mock.results[0].value;
+    expect(watch.kill).toHaveBeenCalled();
+    // The dev artifacts are gone after teardown.
+    expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
+  });
+
+  it("skips the initial build with skipBuild but still links and starts", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await runDev({
+      dir: pluginDir,
+      pluginsRoot,
+      skipBuild: true,
+      keepAliveSignal: controller.signal,
+    });
+    expect(runViteBuild).not.toHaveBeenCalled();
+    expect(vi.mocked(sendCliRequest).mock.calls.map((c) => c[0])).toContain("plugin.dev.start");
+  });
+
+  it("cleans up the link and does not start the watcher when Daintree is unreachable", async () => {
+    vi.mocked(sendCliRequest).mockRejectedValueOnce(new Error("Daintree isn't running"));
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal })
+    ).rejects.toThrow(/isn't running/);
+
+    expect(spawnViteWatch).not.toHaveBeenCalled();
+    expect(await lstatSafe(path.join(pluginsRoot, "acme.demo"))).toBeNull();
+  });
+
+  it("rejects a plugin with no main entry", async () => {
+    await fs.writeFile(path.join(pluginDir, "plugin.json"), JSON.stringify({ name: "acme.demo" }));
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      runDev({ dir: pluginDir, pluginsRoot, keepAliveSignal: controller.signal })
+    ).rejects.toThrow(/main/);
+  });
+});

--- a/packages/daintree-plugin/src/__tests__/viteBuild.test.ts
+++ b/packages/daintree-plugin/src/__tests__/viteBuild.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { resolveViteBin, spawnViteWatch } from "../lib/viteBuild.js";
+
+describe("viteBuild", () => {
+  it("resolveViteBin throws a fix-it message when Vite isn't installed", () => {
+    expect(() => resolveViteBin("/nonexistent/plugin/dir")).toThrow(/Couldn't find Vite/);
+  });
+
+  it("spawnViteWatch is synchronous so it returns a live child handle, not a process-exit promise", () => {
+    // An `async` spawnViteWatch would unwrap execa's ResultPromise and resolve
+    // only on the watcher's exit, hanging the dev loop. Lock it as a plain fn.
+    expect(spawnViteWatch.constructor.name).toBe("Function");
+  });
+});

--- a/packages/daintree-plugin/src/cli.ts
+++ b/packages/daintree-plugin/src/cli.ts
@@ -5,6 +5,7 @@ import { runValidate } from "./commands/validate.js";
 import { runPackage } from "./commands/package.js";
 import { runInstall } from "./commands/install.js";
 import { runUninstall } from "./commands/uninstall.js";
+import { runDev } from "./commands/dev.js";
 
 function fail(message: string): never {
   console.error(message);
@@ -111,9 +112,14 @@ program
 
 program
   .command("dev")
-  .description("Start the hot-reload dev loop (not yet available — planned for F32b)")
-  .action(() => {
-    fail("The hot-reload dev loop isn't available yet — planned for a later release (F32b).");
+  .description("Start the hot-reload dev loop for the current plugin")
+  .option("--skip-build", "skip the initial Vite build (the watcher still rebuilds on save)")
+  .action(async (opts: { skipBuild?: boolean }) => {
+    try {
+      await runDev({ skipBuild: opts.skipBuild });
+    } catch (err) {
+      fail((err as Error).message);
+    }
   });
 
 program.parseAsync(process.argv).catch((err) => {

--- a/packages/daintree-plugin/src/commands/dev.ts
+++ b/packages/daintree-plugin/src/commands/dev.ts
@@ -60,7 +60,7 @@ export async function linkDevPlugin(args: {
 
   await fs.mkdir(pluginsRoot, { recursive: true });
 
-  let createdSymlink = false;
+  let createdSymlink: boolean;
   try {
     await fs.symlink(pluginDir, linkPath, symlinkType);
     createdSymlink = true;
@@ -69,7 +69,8 @@ export async function linkDevPlugin(args: {
     const stat = await fs.lstat(linkPath);
     if (!stat.isSymbolicLink()) {
       throw new Error(
-        `Can't dev-link "${pluginId}": ${linkPath} already exists and isn't a symlink. Remove it (or uninstall the plugin) and try again.`
+        `Can't dev-link "${pluginId}": ${linkPath} already exists and isn't a symlink. Remove it (or uninstall the plugin) and try again.`,
+        { cause: err }
       );
     }
     const existingTarget = await fs.readlink(linkPath);

--- a/packages/daintree-plugin/src/commands/dev.ts
+++ b/packages/daintree-plugin/src/commands/dev.ts
@@ -111,6 +111,15 @@ export async function cleanupDevLink(link: DevLink): Promise<void> {
   }
 }
 
+/** Best-effort unload request — Daintree may have been closed first. */
+async function sendDevStop(pluginId: string): Promise<void> {
+  try {
+    await sendCliRequest("plugin.dev.stop", { pluginId });
+  } catch {
+    // Daintree gone or unreachable — local fs cleanup still proceeds.
+  }
+}
+
 /** Stop the build watcher, ask Daintree to unload, and remove the dev artifacts. */
 async function stopDev(pluginId: string, link: DevLink, watch: ResultPromise): Promise<void> {
   try {
@@ -118,11 +127,7 @@ async function stopDev(pluginId: string, link: DevLink, watch: ResultPromise): P
   } catch {
     // already exited
   }
-  try {
-    await sendCliRequest("plugin.dev.stop", { pluginId });
-  } catch {
-    // Daintree may have been closed first — the fs cleanup below still runs.
-  }
+  await sendDevStop(pluginId);
   await cleanupDevLink(link);
 }
 
@@ -166,7 +171,18 @@ export async function runDev(opts: DevOptions = {}): Promise<void> {
     throw err;
   }
 
-  const watch = await spawnViteWatch(dir);
+  // `spawnViteWatch` returns the live child handle synchronously (do NOT await
+  // it — awaiting the ResultPromise would block until the watcher exits). If it
+  // throws (Vite missing), the plugin is already loaded in Daintree, so unload
+  // it and remove the dev artifacts before surfacing the error.
+  let watch: ResultPromise;
+  try {
+    watch = spawnViteWatch(dir);
+  } catch (err) {
+    await sendDevStop(pluginId);
+    await cleanupDevLink(link);
+    throw err;
+  }
   // A watch crash is informational, not fatal to the session — surface it via
   // its inherited stdio; don't let the rejection bubble as unhandled.
   watch.catch(() => {});

--- a/packages/daintree-plugin/src/commands/dev.ts
+++ b/packages/daintree-plugin/src/commands/dev.ts
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import type { ResultPromise } from "execa";
+import { runValidate } from "./validate.js";
+import { runViteBuild, spawnViteWatch } from "../lib/viteBuild.js";
+import { sendCliRequest } from "../ipc/client.js";
+
+// Mirrors the (unexported) DEV_MARKER_FILENAME in
+// electron/services/PluginService.ts — its presence at a plugin dir root routes
+// the plugin through the hot-reload worker. The host owns the convention; the
+// CLI writes the file. Keep these two literals in lockstep.
+const DEV_MARKER_FILENAME = ".dev-marker";
+
+export interface DevOptions {
+  /** Plugin project directory. Defaults to the cwd. */
+  dir?: string;
+  /** Skip the initial one-shot build (the watcher still rebuilds on save). */
+  skipBuild?: boolean;
+  /** Override the plugins root. Defaults to ~/.daintree/plugins. */
+  pluginsRoot?: string;
+  /**
+   * When this aborts, the dev session tears down and `runDev` returns. The
+   * SIGINT/SIGTERM handlers are the production stop path; this exists so the
+   * session can be driven programmatically (tests, embedding) without signals.
+   */
+  keepAliveSignal?: AbortSignal;
+}
+
+export interface DevLink {
+  linkPath: string;
+  markerPath: string;
+  /**
+   * True when this invocation created the symlink, so cleanup may remove it. A
+   * pre-existing symlink already pointing at this plugin dir is reused and left
+   * in place on teardown.
+   */
+  createdSymlink: boolean;
+}
+
+function defaultPluginsRoot(): string {
+  return path.join(os.homedir(), ".daintree", "plugins");
+}
+
+/**
+ * Symlink the plugin dir into the plugins root and write the `.dev-marker`
+ * through the link. The CLI owns this symlink directly (it isn't a real install,
+ * so it bypasses `PluginInstaller` and its content-mutation invariant, #9292).
+ * Never removes a real directory at the link path — that would be an installed
+ * plugin, not ours to delete.
+ */
+export async function linkDevPlugin(args: {
+  pluginDir: string;
+  pluginsRoot: string;
+  pluginId: string;
+}): Promise<DevLink> {
+  const { pluginDir, pluginsRoot, pluginId } = args;
+  const linkPath = path.join(pluginsRoot, pluginId);
+  const symlinkType = process.platform === "win32" ? "junction" : undefined;
+
+  await fs.mkdir(pluginsRoot, { recursive: true });
+
+  let createdSymlink = false;
+  try {
+    await fs.symlink(pluginDir, linkPath, symlinkType);
+    createdSymlink = true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+    const stat = await fs.lstat(linkPath);
+    if (!stat.isSymbolicLink()) {
+      throw new Error(
+        `Can't dev-link "${pluginId}": ${linkPath} already exists and isn't a symlink. Remove it (or uninstall the plugin) and try again.`
+      );
+    }
+    const existingTarget = await fs.readlink(linkPath);
+    const resolvedExisting = path.resolve(path.dirname(linkPath), existingTarget);
+    if (resolvedExisting === path.resolve(pluginDir)) {
+      // Already linked to this plugin — reuse without claiming ownership.
+      createdSymlink = false;
+    } else {
+      await fs.unlink(linkPath);
+      await fs.symlink(pluginDir, linkPath, symlinkType);
+      createdSymlink = true;
+    }
+  }
+
+  const markerPath = path.join(linkPath, DEV_MARKER_FILENAME);
+  await fs.writeFile(markerPath, "");
+
+  return { linkPath, markerPath, createdSymlink };
+}
+
+/**
+ * Remove the dev artifacts. Idempotent and per-step best-effort (one failing
+ * step must not strand the others, lesson #9322): the marker comes off first so
+ * a half-torn-down state can never leave a dangling marker that reroutes a
+ * future load through the dev worker.
+ */
+export async function cleanupDevLink(link: DevLink): Promise<void> {
+  try {
+    await fs.unlink(link.markerPath);
+  } catch {
+    // best-effort — marker may already be gone
+  }
+  if (link.createdSymlink) {
+    try {
+      await fs.unlink(link.linkPath);
+    } catch {
+      // best-effort — symlink may already be gone
+    }
+  }
+}
+
+/** Stop the build watcher, ask Daintree to unload, and remove the dev artifacts. */
+async function stopDev(pluginId: string, link: DevLink, watch: ResultPromise): Promise<void> {
+  try {
+    watch.kill();
+  } catch {
+    // already exited
+  }
+  try {
+    await sendCliRequest("plugin.dev.stop", { pluginId });
+  } catch {
+    // Daintree may have been closed first — the fs cleanup below still runs.
+  }
+  await cleanupDevLink(link);
+}
+
+/**
+ * Run the hot-reload dev loop for the plugin in `dir`: build once, symlink it
+ * into the plugins root with a `.dev-marker`, tell the running Daintree to load
+ * + activate it, then keep a `vite build --watch` alive so saves rebuild
+ * `dist/` (Daintree's dev worker watches `dist/` and reloads). Ctrl-C tears
+ * everything back down.
+ */
+export async function runDev(opts: DevOptions = {}): Promise<void> {
+  const dir = path.resolve(opts.dir ?? process.cwd());
+
+  const validation = await runValidate({ dir });
+  if (!validation.ok) {
+    throw new Error(`Manifest validation failed:\n  ${validation.errors.join("\n  ")}`);
+  }
+
+  const manifest = JSON.parse(await fs.readFile(path.join(dir, "plugin.json"), "utf8")) as {
+    name: string;
+    main?: string;
+  };
+  if (!manifest.main) {
+    throw new Error('Plugin has no "main" entry — dev hot-reload needs a built entry point.');
+  }
+  const pluginId = manifest.name;
+  const pluginsRoot = opts.pluginsRoot ?? defaultPluginsRoot();
+
+  // Build once so dist/<main> exists before Daintree loads the plugin —
+  // otherwise the marker is present but the worker has no bundle to import.
+  if (!opts.skipBuild) {
+    await runViteBuild(dir);
+  }
+
+  const link = await linkDevPlugin({ pluginDir: dir, pluginsRoot, pluginId });
+
+  try {
+    await sendCliRequest("plugin.dev.start", { pluginId });
+  } catch (err) {
+    await cleanupDevLink(link);
+    throw err;
+  }
+
+  const watch = await spawnViteWatch(dir);
+  // A watch crash is informational, not fatal to the session — surface it via
+  // its inherited stdio; don't let the rejection bubble as unhandled.
+  watch.catch(() => {});
+
+  console.log(`Watching ${pluginId} for changes. Press Ctrl-C to stop.`);
+
+  let stopping = false;
+  const stopOnce = async (exitAfter: boolean): Promise<void> => {
+    if (stopping) return;
+    stopping = true;
+    await stopDev(pluginId, link, watch);
+    if (exitAfter) process.exit(0);
+  };
+
+  const onSignal = (): void => {
+    // A second interrupt while teardown is in flight bails hard rather than
+    // waiting on a cleanup step that's stuck (lesson #7151).
+    if (stopping) {
+      process.exit(1);
+    }
+    void stopOnce(true);
+  };
+
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+
+  try {
+    await new Promise<void>((resolve) => {
+      const signal = opts.keepAliveSignal;
+      if (!signal) return; // production: only a signal ends the wait
+      if (signal.aborted) {
+        resolve();
+        return;
+      }
+      signal.addEventListener("abort", () => resolve(), { once: true });
+    });
+    // Reached only via keepAliveSignal (programmatic stop); the signal path
+    // exits the process inside stopOnce.
+    await stopOnce(false);
+  } finally {
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+  }
+}

--- a/packages/daintree-plugin/src/commands/package.ts
+++ b/packages/daintree-plugin/src/commands/package.ts
@@ -1,12 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { globby } from "globby";
-import { execa } from "execa";
 import {
   packPluginArchiveFromFiles,
   isExcludedArchiveEntry,
   verifyPluginArchive,
 } from "../../../../electron/services/PluginArchive.js";
+import { runViteBuild } from "../lib/viteBuild.js";
 import { runValidate } from "./validate.js";
 
 export interface PackageOptions {
@@ -51,19 +51,6 @@ function protectedDirs(manifest: MinimalManifest): string[] {
     add(view.componentPath);
   }
   return [...dirs];
-}
-
-async function runViteBuild(dir: string): Promise<void> {
-  const binName = process.platform === "win32" ? "vite.cmd" : "vite";
-  const bin = path.join(dir, "node_modules", ".bin", binName);
-  try {
-    await fs.access(bin);
-  } catch {
-    throw new Error(
-      `Couldn't find Vite at ${bin}. Run npm install in the plugin directory, or pass --skip-build.`
-    );
-  }
-  await execa(bin, ["build"], { cwd: dir, stdio: "inherit" });
 }
 
 /**

--- a/packages/daintree-plugin/src/lib/viteBuild.ts
+++ b/packages/daintree-plugin/src/lib/viteBuild.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execa, type ResultPromise } from "execa";
+
+/**
+ * Resolve the plugin project's local Vite binary. Both `package` (one-shot
+ * `vite build`) and `dev` (`vite build --watch`) shell out to the same bin so a
+ * plugin builds identically whichever command an author runs. Throws a
+ * fix-it-yourself message when Vite isn't installed.
+ */
+export async function resolveViteBin(dir: string): Promise<string> {
+  const binName = process.platform === "win32" ? "vite.cmd" : "vite";
+  const bin = path.join(dir, "node_modules", ".bin", binName);
+  try {
+    await fs.access(bin);
+  } catch {
+    throw new Error(
+      `Couldn't find Vite at ${bin}. Run npm install in the plugin directory, or pass --skip-build.`
+    );
+  }
+  return bin;
+}
+
+/** Run a one-shot `vite build` (or another arg set) to completion. */
+export async function runViteBuild(dir: string, args: string[] = ["build"]): Promise<void> {
+  const bin = await resolveViteBin(dir);
+  await execa(bin, args, { cwd: dir, stdio: "inherit" });
+}
+
+/**
+ * Spawn `vite build --watch` and return the long-running subprocess so the
+ * caller can kill it on shutdown. Output inherits the terminal so authors see
+ * Vite's rebuild log directly; the dev worker watches `dist/` and reloads on
+ * each rebuild, so the CLI only owns the build, not the reload.
+ */
+export async function spawnViteWatch(dir: string): Promise<ResultPromise> {
+  const bin = await resolveViteBin(dir);
+  return execa(bin, ["build", "--watch"], { cwd: dir, stdio: "inherit" });
+}

--- a/packages/daintree-plugin/src/lib/viteBuild.ts
+++ b/packages/daintree-plugin/src/lib/viteBuild.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { execa, type ResultPromise } from "execa";
 
@@ -6,14 +6,15 @@ import { execa, type ResultPromise } from "execa";
  * Resolve the plugin project's local Vite binary. Both `package` (one-shot
  * `vite build`) and `dev` (`vite build --watch`) shell out to the same bin so a
  * plugin builds identically whichever command an author runs. Throws a
- * fix-it-yourself message when Vite isn't installed.
+ * fix-it-yourself message when Vite isn't installed. Synchronous so
+ * {@link spawnViteWatch} can return the long-running `ResultPromise` directly
+ * without an `async` wrapper — an `async` wrapper would unwrap the thenable and
+ * resolve only on the watcher's *exit*, hanging the dev loop.
  */
-export async function resolveViteBin(dir: string): Promise<string> {
+export function resolveViteBin(dir: string): string {
   const binName = process.platform === "win32" ? "vite.cmd" : "vite";
   const bin = path.join(dir, "node_modules", ".bin", binName);
-  try {
-    await fs.access(bin);
-  } catch {
+  if (!existsSync(bin)) {
     throw new Error(
       `Couldn't find Vite at ${bin}. Run npm install in the plugin directory, or pass --skip-build.`
     );
@@ -23,17 +24,20 @@ export async function resolveViteBin(dir: string): Promise<string> {
 
 /** Run a one-shot `vite build` (or another arg set) to completion. */
 export async function runViteBuild(dir: string, args: string[] = ["build"]): Promise<void> {
-  const bin = await resolveViteBin(dir);
+  const bin = resolveViteBin(dir);
   await execa(bin, args, { cwd: dir, stdio: "inherit" });
 }
 
 /**
- * Spawn `vite build --watch` and return the long-running subprocess so the
- * caller can kill it on shutdown. Output inherits the terminal so authors see
- * Vite's rebuild log directly; the dev worker watches `dist/` and reloads on
+ * Spawn `vite build --watch` and return the long-running subprocess handle so
+ * the caller can kill it on shutdown. Output inherits the terminal so authors
+ * see Vite's rebuild log directly; the dev worker watches `dist/` and reloads on
  * each rebuild, so the CLI only owns the build, not the reload.
+ *
+ * NOT `async`: it returns execa's `ResultPromise`, which is both awaitable and a
+ * live child handle. Wrapping it in `async` would await the process to *exit*.
  */
-export async function spawnViteWatch(dir: string): Promise<ResultPromise> {
-  const bin = await resolveViteBin(dir);
+export function spawnViteWatch(dir: string): ResultPromise {
+  const bin = resolveViteBin(dir);
   return execa(bin, ["build", "--watch"], { cwd: dir, stdio: "inherit" });
 }

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -132,6 +132,7 @@ export default defineConfig({
 const GITIGNORE = `node_modules/
 dist/
 *.dntr
+.dev-marker
 `;
 
 function commandEntry(ctx: ScaffoldContext): string {

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -34,6 +34,8 @@ export type PluginHostNotifyMethod =
   | "registerHandler"
   | "broadcastToRenderer"
   | "invalidateFileDecorations"
+  | "registerFileDecorationProvider"
+  | "unregisterFileDecorationProvider"
   | "logger.info"
   | "logger.warn"
   | "logger.error";
@@ -41,8 +43,15 @@ export type PluginHostNotifyMethod =
 /** Event subscriptions the worker proxy can open against the host. */
 export type PluginWorkerSubscriptionKind = "active-worktree" | "worktrees" | "settings";
 
-/** Callback kinds main invokes back in the worker. */
-export type PluginWorkerInvokeKind = "action" | "handler";
+/**
+ * Callback kinds main invokes back in the worker. `file-decoration-method`
+ * round-trips a registered `FileDecorationProviderImpl` method (just
+ * `provideDecorations`, which is async — see {@link RegisterFileDecorationProviderParams}).
+ * Forge providers are deliberately absent: `ForgeProviderImpl` has required
+ * SYNCHRONOUS methods (`parseRemote`, the URL builders, `classifyPushError`)
+ * the host calls and consumes synchronously, which can't cross this async port.
+ */
+export type PluginWorkerInvokeKind = "action" | "handler" | "file-decoration-method";
 
 /** Messages sent main → worker. */
 export type PluginHostToWorkerMessage =
@@ -70,6 +79,14 @@ export type PluginHostToWorkerMessage =
       kind: "handler";
       channel: string;
       ctx: PluginIpcContext;
+      args: unknown[];
+    }
+  | {
+      type: "invoke";
+      requestId: string;
+      kind: "file-decoration-method";
+      providerId: string;
+      method: string;
       args: unknown[];
     }
   /** Deliver a subscription event to a worker-held callback (fire-and-forget). */
@@ -157,6 +174,24 @@ export interface BroadcastToRendererParams {
 export interface InvalidateFileDecorationsParams {
   scope: string;
   paths?: string[];
+}
+
+/**
+ * Params for `registerFileDecorationProvider` (`host-notify`). Only the
+ * structured-clone-safe descriptor fields travel; the `provideDecorations` impl
+ * stays in the worker and main invokes it back via a `file-decoration-method`
+ * `invoke` (mirrors the `registerAction` handler round-trip).
+ */
+export interface RegisterFileDecorationProviderParams {
+  descriptor: {
+    id: string;
+    scopes?: string[];
+  };
+}
+
+/** Params for `unregisterFileDecorationProvider` (`host-notify`). */
+export interface UnregisterFileDecorationProviderParams {
+  providerId: string;
 }
 
 /** Params for a `logger.*` call (`host-notify`). */


### PR DESCRIPTION
## Summary

- Implements the `daintree-plugin dev` CLI command, which was previously a stub. It builds once, symlinks the plugin into `~/.daintree/plugins/<name>` (junction on Windows), writes the `.dev-marker` that routes the plugin through the existing hot-reload worker, loads and activates it over the CLI control socket, then runs `vite build --watch`. Each rebuild triggers a reload. Ctrl-C tears everything down idempotently; a second interrupt force-exits. Fails clearly if Daintree isn't running.
- Closes the `FileDecorationProvider` dev-worker gap: the worker-held impl's `provideDecorations` now round-trips over the MessagePort to the real host, mirroring the existing action/handler invoke path. Provider disposers are torn down on reload and dispose.
- Forge providers stay package-and-install-only in dev mode by design. `ForgeProviderImpl` has required synchronous methods (`parseRemote`, the URL builders, `classifyPushError`) that the host consumes synchronously and can't cross the worker's async boundary. The vague stub warning is replaced with an accurate diagnostic.

Resolves #10475

## Changes

- `packages/daintree-plugin/src/commands/dev.ts`: full implementation of the dev command (symlink, `.dev-marker`, watcher, CLI socket calls, idempotent teardown)
- `packages/daintree-plugin/src/lib/viteBuild.ts`: shared `viteBuild` helper reused by both `package` and `dev`
- `electron/services/PluginCliServer.ts`: new `plugin.dev.start` / `plugin.dev.stop` methods
- `electron/services/PluginService.ts`: new `loadDevPlugin` (unload-first, then load + activate)
- `electron/services/plugin/pluginDevWorkerHostProxy.ts`: `FileDecorationProvider` MessagePort proxy
- `electron/services/plugin/PluginDevWorkerMainBridge.ts`: decoration round-trip + disposer teardown on reload/dispose
- `shared/types/pluginDevWorker.ts`: protocol additions for decoration request/response messages
- `packages/daintree-plugin/src/scaffold/templates.ts`: scaffold `.gitignore` now ignores `.dev-marker`

## Testing

New and extended unit tests cover: dev link/cleanup/run (including watcher-failure cleanup, start-before-stop ordering, Daintree-unavailable path), `plugin.dev.start` / `plugin.dev.stop` CLI dispatch, `FileDecorationProvider` round-trip, reload teardown, stale-disposer guard, and a sync guard on `spawnViteWatch`. All targeted vitest suites pass. `tsc` clean on `shared/`, `electron/`, and `daintree-plugin`. `eslint` and `prettier` clean on changed files.