### PR TITLE
feat(plugins): post-1.0 plugin hardening (#10477)

### DIFF
--- a/electron/schemas/__tests__/contributionCaps.test.ts
+++ b/electron/schemas/__tests__/contributionCaps.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { getPluginManifestSchema, MANIFEST_CONTRIBUTION_CAPS } from "../plugin.js";
+
+function parseContributes(contributes: Record<string, unknown>, isBuiltin = false) {
+  return getPluginManifestSchema(isBuiltin).safeParse({
+    name: "acme.caps-test",
+    version: "1.0.0",
+    contributes,
+  });
+}
+
+const setting = (i: number) => ({ id: `setting-${i}`, type: "string" });
+const menuItem = (i: number) => ({
+  label: `Item ${i}`,
+  actionId: `acme.caps-test.action-${i}`,
+  location: "terminal" as const,
+});
+
+describe("contributes.* array-size caps (#10477)", () => {
+  it("accepts an array exactly at the cap", () => {
+    const cap = MANIFEST_CONTRIBUTION_CAPS.settings;
+    const result = parseContributes({
+      settings: Array.from({ length: cap }, (_, i) => setting(i)),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an array one over the cap", () => {
+    const cap = MANIFEST_CONTRIBUTION_CAPS.settings;
+    const result = parseContributes({
+      settings: Array.from({ length: cap + 1 }, (_, i) => setting(i)),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("enforces a distinct cap per contribution point", () => {
+    const menuCap = MANIFEST_CONTRIBUTION_CAPS.menuItems;
+    expect(
+      parseContributes({
+        menuItems: Array.from({ length: menuCap }, (_, i) => menuItem(i)),
+      }).success
+    ).toBe(true);
+    expect(
+      parseContributes({
+        menuItems: Array.from({ length: menuCap + 1 }, (_, i) => menuItem(i)),
+      }).success
+    ).toBe(false);
+  });
+
+  it("exposes a cap for every contributes.* array key", () => {
+    // Guard against a new contribution point being added to the schema without a
+    // matching cap — every declared array must be bounded.
+    const parsed = parseContributes({});
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    for (const key of Object.keys(parsed.data.contributes)) {
+      expect(MANIFEST_CONTRIBUTION_CAPS).toHaveProperty(key);
+      expect(
+        MANIFEST_CONTRIBUTION_CAPS[key as keyof typeof MANIFEST_CONTRIBUTION_CAPS]
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/electron/schemas/__tests__/contributionCaps.test.ts
+++ b/electron/schemas/__tests__/contributionCaps.test.ts
@@ -47,6 +47,18 @@ describe("contributes.* array-size caps (#10477)", () => {
     ).toBe(false);
   });
 
+  it.each(Object.keys(MANIFEST_CONTRIBUTION_CAPS))(
+    "rejects contributes.%s when one entry over its cap",
+    (key) => {
+      const cap = MANIFEST_CONTRIBUTION_CAPS[key as keyof typeof MANIFEST_CONTRIBUTION_CAPS];
+      // Fill with `null` entries: the array-length `.max()` check runs before
+      // per-element validation, so an over-length array is rejected regardless of
+      // element shape. (At/under cap, element validation would apply.)
+      const result = parseContributes({ [key]: new Array(cap + 1).fill(null) });
+      expect(result.success).toBe(false);
+    }
+  );
+
   it("exposes a cap for every contributes.* array key", () => {
     // Guard against a new contribution point being added to the schema without a
     // matching cap — every declared array must be bounded.

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -565,6 +565,29 @@ export const SettingDefinitionSchema = z
     return val;
   });
 
+/**
+ * Per-array upper bounds for `contributes.*`. A crafted manifest with tens of
+ * thousands of entries would otherwise exhaust the registration loops in
+ * `PluginService.loadPlugin`. These caps are generous relative to any plausible
+ * real plugin — they exist to reject pathological/adversarial manifests, not to
+ * constrain legitimate authors. Exported so tests reference the values without
+ * magic numbers.
+ */
+export const MANIFEST_CONTRIBUTION_CAPS = {
+  panels: 50,
+  toolbarButtons: 100,
+  menuItems: 200,
+  keybindings: 200,
+  contextMenus: 200,
+  commands: 200,
+  experimental_views: 50,
+  experimental_mcpServers: 20,
+  forgeProviders: 20,
+  fileDecorationProviders: 50,
+  agents: 50,
+  settings: 200,
+} as const;
+
 export function getPluginManifestSchema(isBuiltin: boolean) {
   return z
     .strictObject({
@@ -600,18 +623,54 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
       activationEvents: z.array(z.literal("onStartupFinished")).default([]),
       contributes: z
         .strictObject({
-          panels: z.array(PanelContributionSchema).default([]),
-          toolbarButtons: z.array(ToolbarButtonContributionSchema).default([]),
-          menuItems: z.array(MenuItemContributionSchema).default([]),
-          keybindings: z.array(KeybindingContributionSchema).default([]),
-          contextMenus: z.array(ContextMenuContributionSchema).default([]),
-          commands: z.array(CommandContributionSchema).default([]),
-          experimental_views: z.array(ViewContributionSchema).default([]),
-          experimental_mcpServers: z.array(McpServerContributionSchema).default([]),
-          forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
-          fileDecorationProviders: z.array(FileDecorationContributionSchema).default([]),
-          agents: z.array(AgentContributionSchema).default([]),
-          settings: z.array(SettingDefinitionSchema).default([]),
+          panels: z
+            .array(PanelContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.panels)
+            .default([]),
+          toolbarButtons: z
+            .array(ToolbarButtonContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.toolbarButtons)
+            .default([]),
+          menuItems: z
+            .array(MenuItemContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.menuItems)
+            .default([]),
+          keybindings: z
+            .array(KeybindingContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.keybindings)
+            .default([]),
+          contextMenus: z
+            .array(ContextMenuContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.contextMenus)
+            .default([]),
+          commands: z
+            .array(CommandContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.commands)
+            .default([]),
+          experimental_views: z
+            .array(ViewContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.experimental_views)
+            .default([]),
+          experimental_mcpServers: z
+            .array(McpServerContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.experimental_mcpServers)
+            .default([]),
+          forgeProviders: z
+            .array(ForgeProviderContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.forgeProviders)
+            .default([]),
+          fileDecorationProviders: z
+            .array(FileDecorationContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.fileDecorationProviders)
+            .default([]),
+          agents: z
+            .array(AgentContributionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.agents)
+            .default([]),
+          settings: z
+            .array(SettingDefinitionSchema)
+            .max(MANIFEST_CONTRIBUTION_CAPS.settings)
+            .default([]),
         })
         .default({
           panels: [],

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -107,6 +107,7 @@ import {
   unregisterPluginAgents,
 } from "../../shared/config/pluginAgentRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
+import { deepFreeze } from "../utils/deepFreeze.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
@@ -232,7 +233,8 @@ function computePluginDanger(manifest: PluginManifest | undefined): "safe" | "co
 }
 
 interface LoadedPlugin {
-  manifest: PluginManifest;
+  /** Deep-frozen at load (see `deepFreeze` call in `loadPlugin`); `Readonly` is the compile-time half of that invariant. */
+  manifest: Readonly<PluginManifest>;
   dir: string;
   resolvedMain?: string;
   loadedAt: number;
@@ -305,6 +307,13 @@ const PLUGIN_LOG_BUFFER_MAX = 500;
 const PLUGIN_LOG_LINE_MAX_CHARS = 2048;
 /** Max audit records included per plugin in a diagnostics snapshot. */
 const PLUGIN_DIAGNOSTICS_AUDIT_PER_PLUGIN = 50;
+/**
+ * Max file paths a single `host.invalidateFileDecorations` call broadcasts.
+ * A misbehaving plugin could otherwise pass an unbounded array, forcing an
+ * arbitrarily large IPC payload to every renderer view. Beyond the cap the
+ * scope-wide invalidation (no `paths`) is the correct fallback anyway.
+ */
+const MAX_FILE_DECORATION_PATHS = 1000;
 
 /**
  * Serialize an arbitrary logger payload without ever throwing. Tries
@@ -896,6 +905,13 @@ export class PluginService {
     }
 
     const manifest = parseResult.data;
+    // Manifest-immutability invariant: the parsed manifest is stored on
+    // LoadedPlugin.manifest and read across the whole PluginService lifecycle
+    // (capability checks, contribution loops, host closures). Deep-freeze it so
+    // an accidental in-place mutation of a declared contribution can't poison the
+    // shared record. DEV-only (see deepFreeze) — the Readonly<PluginManifest>
+    // type below is the compile-time half of the same invariant.
+    deepFreeze(manifest);
 
     // Plugins disabled in Preferences are skipped entirely — neither
     // registered in the plugins map nor activated — for both built-in and
@@ -2062,10 +2078,16 @@ export class PluginService {
             `Plugin "${pluginId}" invalidateFileDecorations: scope "${scope}" is not covered by any declared contributes.fileDecorationProviders[].scopes`
           );
         }
-        const narrowed =
+        let narrowed =
           Array.isArray(paths) && paths.length > 0
             ? paths.filter((p): p is string => typeof p === "string" && p.length > 0)
             : undefined;
+        if (narrowed && narrowed.length > MAX_FILE_DECORATION_PATHS) {
+          console.warn(
+            `Plugin "${pluginId}" invalidateFileDecorations: ${narrowed.length} paths exceeds cap of ${MAX_FILE_DECORATION_PATHS} for scope "${scope}"; truncating`
+          );
+          narrowed = narrowed.slice(0, MAX_FILE_DECORATION_PATHS);
+        }
         broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
           name: "plugin:decorations-changed",
           payload: { scope, ...(narrowed && narrowed.length > 0 ? { paths: narrowed } : {}) },

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2083,10 +2083,16 @@ export class PluginService {
             ? paths.filter((p): p is string => typeof p === "string" && p.length > 0)
             : undefined;
         if (narrowed && narrowed.length > MAX_FILE_DECORATION_PATHS) {
+          // Over the cap, fall back to a scope-wide invalidation (drop `paths`)
+          // rather than truncating: a truncated list would silently omit the
+          // tail, and the renderer skips a re-pull for any visible file not in
+          // the list — leaving stale decorations with no error surfaced. A
+          // path-less broadcast forces an unconditional re-pull, which is
+          // correct (just broader) for this pathological case.
           console.warn(
-            `Plugin "${pluginId}" invalidateFileDecorations: ${narrowed.length} paths exceeds cap of ${MAX_FILE_DECORATION_PATHS} for scope "${scope}"; truncating`
+            `Plugin "${pluginId}" invalidateFileDecorations: ${narrowed.length} paths exceeds cap of ${MAX_FILE_DECORATION_PATHS} for scope "${scope}"; falling back to scope-wide invalidation`
           );
-          narrowed = narrowed.slice(0, MAX_FILE_DECORATION_PATHS);
+          narrowed = undefined;
         }
         broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
           name: "plugin:decorations-changed",

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -636,6 +636,55 @@ describe("PluginService integration — file decoration provider contributions",
     expect(getFileDecorationImpls("my-scope:/x")).toEqual([]);
   });
 
+  it("caps the paths broadcast by invalidateFileDecorations (#10477)", async () => {
+    // A misbehaving plugin passing an unbounded paths array must not force an
+    // arbitrarily large IPC payload to every renderer — the broadcast is capped.
+    const oversized = 1500;
+    const cap = 1000;
+    const pluginDir = await writePlugin("acme.flood-decor", {
+      name: "acme.flood-decor",
+      version: "1.0.0",
+    });
+    const mainFile = `decor-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) {
+  const paths = Array.from({ length: ${oversized} }, (_, i) => "f" + i + ".ts");
+  host.invalidateFileDecorations("my-scope:/x", paths);
+}
+`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.flood-decor",
+        version: "1.0.0",
+        main: mainFile,
+        contributes: {
+          fileDecorationProviders: [{ id: "badges", scopes: ["my-scope:*"] }],
+        },
+      })
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const service = new PluginService(tmpDir, "0.0.0");
+    await initializeAndActivate(service);
+
+    const call = vi
+      .mocked(broadcastToRenderer)
+      .mock.calls.find(
+        ([channel, evt]) =>
+          channel === "events:push" &&
+          (evt as { name?: string }).name === "plugin:decorations-changed"
+      );
+    expect(call).toBeDefined();
+    const payload = (call![1] as { payload: { paths?: string[] } }).payload;
+    expect(payload.paths).toHaveLength(cap);
+    expect(payload.paths!.length).toBeLessThan(oversized);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("exceeds cap"));
+    warnSpy.mockRestore();
+  });
+
   it("rejects registering a provider id not declared in the manifest", async () => {
     const pluginDir = await writePlugin("acme.bad-decor", {
       name: "acme.bad-decor",

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -638,9 +638,10 @@ describe("PluginService integration — file decoration provider contributions",
 
   it("caps the paths broadcast by invalidateFileDecorations (#10477)", async () => {
     // A misbehaving plugin passing an unbounded paths array must not force an
-    // arbitrarily large IPC payload to every renderer — the broadcast is capped.
+    // arbitrarily large IPC payload to every renderer. Over the cap we fall back
+    // to a scope-wide invalidation (no `paths`) rather than truncating, so no
+    // visible file silently misses its refresh.
     const oversized = 1500;
-    const cap = 1000;
     const pluginDir = await writePlugin("acme.flood-decor", {
       name: "acme.flood-decor",
       version: "1.0.0",
@@ -678,9 +679,11 @@ describe("PluginService integration — file decoration provider contributions",
           (evt as { name?: string }).name === "plugin:decorations-changed"
       );
     expect(call).toBeDefined();
-    const payload = (call![1] as { payload: { paths?: string[] } }).payload;
-    expect(payload.paths).toHaveLength(cap);
-    expect(payload.paths!.length).toBeLessThan(oversized);
+    const payload = (call![1] as { payload: { scope: string; paths?: string[] } }).payload;
+    // Over-cap drops `paths` entirely — a scope-wide invalidation — so the
+    // renderer does an unconditional re-pull instead of missing the tail.
+    expect(payload.scope).toBe("my-scope:/x");
+    expect(payload.paths).toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("exceeds cap"));
     warnSpy.mockRestore();
   });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -987,6 +987,29 @@ describe("PluginService", () => {
     expect(names).toEqual(["acme.good-1", "acme.good-2"]);
   });
 
+  it("deep-freezes the stored manifest as an immutability invariant (#10477)", async () => {
+    await writePlugin("frozen", {
+      name: "acme.frozen",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
+      },
+    });
+
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const stored = (
+      service as unknown as { plugins: Map<string, { manifest: unknown }> }
+    ).plugins.get("acme.frozen")?.manifest as { contributes: { panels: unknown[] } } | undefined;
+    expect(stored).toBeDefined();
+    // Deep freeze: top level and nested contribution arrays/objects are sealed.
+    expect(Object.isFrozen(stored)).toBe(true);
+    expect(Object.isFrozen(stored!.contributes)).toBe(true);
+    expect(Object.isFrozen(stored!.contributes.panels)).toBe(true);
+    expect(Object.isFrozen(stored!.contributes.panels[0])).toBe(true);
+  });
+
   it("is idempotent — second initialize is a no-op", async () => {
     await writePlugin("test-plugin", { name: "acme.test-plugin", version: "1.0.0" });
 

--- a/electron/services/__tests__/PluginSettingsManager.scope.test.ts
+++ b/electron/services/__tests__/PluginSettingsManager.scope.test.ts
@@ -113,3 +113,28 @@ describe("PluginSettingsManager declared-scope enforcement", () => {
     expect(() => mgr.assertSettingScope("acme.scope-test", "anything", "project")).not.toThrow();
   });
 });
+
+describe("PluginSettingsManager subscriber cleanup on unload (#10477)", () => {
+  it("drops a plugin's onDidChange subscribers when its settings state is cleared", () => {
+    const mgr = managerFor([{ id: "token", type: "string", scope: "user" }]);
+    const cb = vi.fn();
+    mgr.addSubscriber("acme.scope-test", { key: "token", scope: "user", cb });
+
+    // Before cleanup the subscriber fires. Signature is (pluginId, scope, key, value).
+    mgr.notifySettingsSubscribers("acme.scope-test", "user", "token", "v1");
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // clearPluginSettingsState is the belt-and-suspenders step unloadPlugin runs
+    // to guarantee no subscriber outlives the plugin.
+    mgr.clearPluginSettingsState("acme.scope-test");
+
+    // The plugin's subscriber set is gone, and a later notify is a no-op.
+    expect(
+      (mgr as unknown as { settingsSubscribers: Map<string, unknown> }).settingsSubscribers.has(
+        "acme.scope-test"
+      )
+    ).toBe(false);
+    mgr.notifySettingsSubscribers("acme.scope-test", "user", "token", "v2");
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -392,7 +392,10 @@ export class PluginDevWorkerHost extends EventEmitter {
         );
         this.readyReject = null;
       }
-      this.emit("crash-loop", -1);
+      // A fork failure is a hard non-start, not a crash loop: `start()` rejects
+      // and `activateViaDevWorker`'s catch records the (more informative)
+      // loadError. Emitting `crash-loop` here would make the bridge write a
+      // second, racy "crash loop (code -1)" provenance entry over that one.
       return;
     }
 

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -166,6 +166,14 @@ export class PluginDevWorkerMainBridge {
     logger.error(
       `[${this.pluginId}] dev worker entered a crash loop (code ${code}); reload halted until next edit`
     );
+    // Persist the crash to the owner's provenance — unlike activate-error/error,
+    // a crash loop can trip after a successful activation (on a later reload), so
+    // the loadError write must go through onActivationResult, not just the
+    // activation promise rejection (which has no listener post-activation).
+    this.onActivationResult?.({
+      ok: false,
+      error: `Plugin "${this.pluginId}" dev worker crash loop (code ${code})`,
+    });
     this.rejectActivation(new Error(`Plugin "${this.pluginId}" dev worker crash loop`));
   };
 

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -234,6 +234,22 @@ describe("PluginDevWorkerMainBridge", () => {
     });
   });
 
+  it("surfaces a crash loop that trips before the first activation", async () => {
+    const onActivationResult = vi.fn();
+    const { workerHost, bridge } = makeBridge({ onActivationResult });
+    const activation = bridge.waitForActivation();
+    activation.catch(() => {});
+
+    workerHost.emit("crash-loop", 7);
+
+    await expect(activation).rejects.toThrow("crash loop");
+    expect(onActivationResult).toHaveBeenCalledTimes(1);
+    expect(onActivationResult).toHaveBeenCalledWith({
+      ok: false,
+      error: expect.stringContaining("crash loop (code 7)"),
+    });
+  });
+
   it("registerFileDecorationProvider wires a proxy impl that round-trips provideDecorations", async () => {
     const { host, workerHost } = makeBridge();
     workerHost.emit("worker-message", {

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -215,6 +215,25 @@ describe("PluginDevWorkerMainBridge", () => {
     expect(onActivationResult).toHaveBeenNthCalledWith(2, { ok: false, error: "broke on reload" });
   });
 
+  it("surfaces a dev-worker crash loop as a loadError via onActivationResult", async () => {
+    const onActivationResult = vi.fn();
+    const { workerHost, bridge } = makeBridge({ onActivationResult });
+    bridge.waitForActivation().catch(() => {});
+
+    // Activate first, so the crash loop trips after a successful activation —
+    // the regression this guards: the post-activation crash never reached
+    // provenance because onCrashLoop only rejected the (already-settled)
+    // activation promise.
+    workerHost.emit("worker-message", { type: "activated", hasCleanup: false });
+    workerHost.emit("crash-loop", 42);
+
+    expect(onActivationResult).toHaveBeenNthCalledWith(1, { ok: true });
+    expect(onActivationResult).toHaveBeenNthCalledWith(2, {
+      ok: false,
+      error: expect.stringContaining("crash loop (code 42)"),
+    });
+  });
+
   it("registerFileDecorationProvider wires a proxy impl that round-trips provideDecorations", async () => {
     const { host, workerHost } = makeBridge();
     workerHost.emit("worker-message", {

--- a/electron/utils/__tests__/deepFreeze.test.ts
+++ b/electron/utils/__tests__/deepFreeze.test.ts
@@ -14,9 +14,8 @@ describe("deepFreeze", () => {
     expect(Object.isFrozen(obj.list[0])).toBe(true);
   });
 
-  it("makes a nested write throw in strict mode", () => {
+  it("makes a nested write throw (ESM modules are always strict mode)", () => {
     vi.stubEnv("NODE_ENV", "development");
-    ("use strict");
     const obj: { nested: { b: number } } = { nested: { b: 2 } };
     deepFreeze(obj);
     expect(() => {

--- a/electron/utils/__tests__/deepFreeze.test.ts
+++ b/electron/utils/__tests__/deepFreeze.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { deepFreeze } from "../deepFreeze.js";
+
+describe("deepFreeze", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("freezes nested objects and arrays (not just the top level)", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const obj = { a: 1, nested: { b: 2 }, list: [{ c: 3 }] };
+    deepFreeze(obj);
+    expect(Object.isFrozen(obj)).toBe(true);
+    expect(Object.isFrozen(obj.nested)).toBe(true);
+    expect(Object.isFrozen(obj.list)).toBe(true);
+    expect(Object.isFrozen(obj.list[0])).toBe(true);
+  });
+
+  it("makes a nested write throw in strict mode", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    ("use strict");
+    const obj: { nested: { b: number } } = { nested: { b: 2 } };
+    deepFreeze(obj);
+    expect(() => {
+      (obj.nested as { b: number }).b = 99;
+    }).toThrow();
+  });
+
+  it("is a no-op in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const obj = { a: 1, nested: { b: 2 } };
+    deepFreeze(obj);
+    expect(Object.isFrozen(obj)).toBe(false);
+    expect(Object.isFrozen(obj.nested)).toBe(false);
+  });
+
+  it("tolerates cyclic input without overflowing the stack", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const a: Record<string, unknown> = { name: "a" };
+    const b: Record<string, unknown> = { name: "b", a };
+    a.b = b;
+    expect(() => deepFreeze(a)).not.toThrow();
+    expect(Object.isFrozen(a)).toBe(true);
+    expect(Object.isFrozen(b)).toBe(true);
+  });
+});

--- a/electron/utils/deepFreeze.ts
+++ b/electron/utils/deepFreeze.ts
@@ -1,0 +1,26 @@
+/**
+ * Recursively `Object.freeze` a value and every nested object/array it reaches.
+ *
+ * Main-process counterpart to the renderer's `deepFreeze` in `ActionService`
+ * (issue #9569). Used to enforce immutability invariants on shared, parsed data
+ * — e.g. a plugin manifest stored on `LoadedPlugin.manifest` and read across the
+ * whole `PluginService` lifecycle. A shallow `Object.freeze` leaves nested
+ * `contributes.*` arrays writable, so an accidental in-place mutation of a
+ * declared contribution would silently poison the shared record.
+ *
+ * DEV-only: a no-op when `NODE_ENV === "production"`, so the invariant fails
+ * loudly in dev/test (strict-mode writes throw) without risking a production
+ * crash on some untyped mutation path. The `seen` guard keeps it stack-safe
+ * against cyclic input (plugin-supplied data is untrusted).
+ */
+export function deepFreeze(val: unknown, seen: WeakSet<object> = new WeakSet()): void {
+  if (process.env.NODE_ENV === "production" || val === null || typeof val !== "object") {
+    return;
+  }
+  if (seen.has(val)) return;
+  seen.add(val);
+  Object.freeze(val);
+  for (const child of Object.values(val as Record<string, unknown>)) {
+    deepFreeze(child, seen);
+  }
+}


### PR DESCRIPTION
Lower-severity plugin system hardening deferred past the 1.0 freeze, part of #10459.

## Changes

**Crash-loop provenance** — a crash loop that trips after a successful activation now records a `loadError` in the owner's provenance via `onActivationResult`. Previously this only rejected the already-settled activation promise, so post-activation crash loops were invisible in diagnostics. Fork failures no longer double-write provenance.

**Manifest immutability** — parsed manifests are deep-frozen at load via a new `deepFreeze` utility (`electron/utils/deepFreeze.ts`, DEV-only no-op in production). The `Readonly<PluginManifest>` compile-time type catches accidental mutations at the type level.

**Defensive bounds** — `host.invalidateFileDecorations` caps its broadcast at 1000 paths, falling back to a scope-wide invalidation when exceeded. All `contributes.*` manifest arrays now carry `.max()` size caps via the new exported `MANIFEST_CONTRIBUTION_CAPS`.

**Test depth** — new and extended coverage for crash-loop provenance (including before-first-activation), `deepFreeze` behaviour, manifest-frozen-after-load, settings-subscriber cleanup on unload, path-cap fallback, and per-key schema caps.

## Testing

`npm run check` (typecheck + lint + format + channel/IPC/confirm-wiring guards) all green. Full unit suite passes — 34,212 tests. No E2E added; no crash-loop fixture exists, so this is covered via unit/integration tests instead.

Closes #10477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)