### PR TITLE
fix(badge): make sidebar memory badge accurate and machine-relative (#10457)

### DIFF
--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -62,27 +62,31 @@ const collectDiagnosticsWithKeysMock = vi.hoisted(() =>
   vi.fn(() => Promise.resolve({ payload: { metadata: {} }, sectionKeys: ["metadata"] }))
 );
 
+// privateBytes is 0 here to mirror the real macOS/Linux shape: privateBytes is
+// a Windows-only field that reports 0 elsewhere (lesson #8646). Reading it would
+// sum to zero on 2 of 3 platforms, so the handlers must use workingSetSize. A
+// fixture with populated privateBytes would pass even if that bug regressed.
 const appMock = vi.hoisted(() => ({
   getAppMetrics: vi.fn(() => [
     {
       pid: 100,
       type: "Browser",
       name: "Browser",
-      memory: { privateBytes: 102400, workingSetSize: 204800 },
+      memory: { privateBytes: 0, workingSetSize: 204800 },
       cpu: { percentCPUUsage: 5.5 },
     },
     {
       pid: 200,
       type: "GPU",
       name: "GPU Process",
-      memory: { privateBytes: undefined, workingSetSize: 51200 },
+      memory: { privateBytes: 0, workingSetSize: 51200 },
       cpu: { percentCPUUsage: 2.3 },
     },
     {
       pid: 300,
       type: "Utility",
       name: "Network Service",
-      memory: { privateBytes: 30720, workingSetSize: 40960 },
+      memory: { privateBytes: 0, workingSetSize: 40960 },
       cpu: undefined,
     },
   ]),
@@ -171,6 +175,7 @@ vi.mock("../../../services/ProcessMemoryMonitor.js", () => ({
 }));
 
 import { registerDiagnosticsHandlers } from "../diagnostics.js";
+import { resetAppMetricsSnapshotForTesting } from "../../../utils/appMetricsSnapshot.js";
 
 function getHandlerFn(channelName: string): (...args: unknown[]) => unknown {
   const call = ipcMainMock.handle.mock.calls.find((c: unknown[]) => c[0] === channelName);
@@ -188,6 +193,9 @@ describe("registerDiagnosticsHandlers", () => {
     existsSyncMock.mockReturnValue(false);
     statMock.mockResolvedValue({ mtimeMs: Date.now() });
     readFileMock.mockResolvedValue("log line");
+    // The metrics handlers read through a 5s shared cache; clear it so each
+    // test's mocked getAppMetrics (incl. per-test throw overrides) actually runs.
+    resetAppMetricsSnapshotForTesting();
   });
 
   it("registers all expected IPC handlers", () => {
@@ -230,16 +238,19 @@ describe("registerDiagnosticsHandlers", () => {
       }>;
 
       expect(result).toHaveLength(3);
+      // workingSetSize 204800 KB / 1024 = 200 MB (NOT privateBytes, which is 0).
       expect(result[0].pid).toBe(100);
-      expect(result[0].memoryMB).toBe(100);
+      expect(result[0].memoryMB).toBe(200);
       expect(result[0].cpuPercent).toBe(5.5);
       expect(result[0].name).toBe("Browser");
 
-      // Falls back to workingSetSize when privateBytes is undefined
+      // workingSetSize 51200 KB / 1024 = 50 MB
       expect(result[1].pid).toBe(200);
       expect(result[1].memoryMB).toBe(50);
 
-      // CPU defaults to 0 when cpu is undefined
+      // CPU defaults to 0 when cpu is undefined; workingSetSize 40960 / 1024 = 40 MB
+      expect(result[2].pid).toBe(300);
+      expect(result[2].memoryMB).toBe(40);
       expect(result[2].cpuPercent).toBe(0);
 
       // Sorted by memoryMB descending
@@ -254,6 +265,31 @@ describe("registerDiagnosticsHandlers", () => {
       registerDiagnosticsHandlers(deps);
       const handler = getHandlerFn("diagnostics:get-process-metrics");
       expect(handler()).toEqual([]);
+    });
+  });
+
+  describe("handleGetAppMetrics", () => {
+    it("sums workingSetSize across processes (not the macOS/Linux-zero privateBytes)", () => {
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:get-app-metrics");
+      const result = handler() as { totalMemoryMB: number; unavailable?: true };
+
+      // (204800 + 51200 + 40960) KB / 1024 = 290 MB. Reading privateBytes would
+      // sum to 0 here — that's the regression this guards.
+      expect(result.totalMemoryMB).toBe(290);
+      expect(result.unavailable).toBeUndefined();
+    });
+
+    it("flags unavailable instead of returning a misleading 0 on error", () => {
+      appMock.getAppMetrics.mockImplementationOnce(() => {
+        throw new Error("fail");
+      });
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:get-app-metrics");
+      const result = handler() as { totalMemoryMB: number; unavailable?: true };
+
+      expect(result.unavailable).toBe(true);
+      expect(result.totalMemoryMB).toBe(0);
     });
   });
 

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -291,6 +291,27 @@ describe("registerDiagnosticsHandlers", () => {
       expect(result.unavailable).toBe(true);
       expect(result.totalMemoryMB).toBe(0);
     });
+
+    it("uses workingSetSize even when privateBytes is populated (no ?? regression)", () => {
+      // Simulate a Windows-shaped reading where privateBytes is large and would
+      // win under the old `privateBytes ?? workingSetSize`. The handler must
+      // still report workingSetSize so the metric is consistent cross-platform.
+      appMock.getAppMetrics.mockImplementationOnce(() => [
+        {
+          pid: 1,
+          type: "Browser",
+          name: "Browser",
+          memory: { privateBytes: 1024 * 1024, workingSetSize: 102400 },
+          cpu: { percentCPUUsage: 1 },
+        },
+      ]);
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:get-app-metrics");
+      const result = handler() as { totalMemoryMB: number };
+
+      // workingSetSize 102400 / 1024 = 100 MB, not privateBytes 1048576 / 1024 = 1024 MB.
+      expect(result.totalMemoryMB).toBe(100);
+    });
   });
 
   describe("handleGetHeapStats", () => {

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -26,6 +26,7 @@ import type {
 import { getActionBreadcrumbService } from "../../services/ActionBreadcrumbService.js";
 import type * as DiagnosticsCollectorModule from "../../services/DiagnosticsCollector.js";
 import { recordBlinkSample, recordEluSample } from "../../services/ProcessMemoryMonitor.js";
+import { getAppMetricsSnapshot } from "../../utils/appMetricsSnapshot.js";
 
 let cachedDiagnosticsCollector: typeof DiagnosticsCollectorModule | null = null;
 async function getDiagnosticsCollector(): Promise<typeof DiagnosticsCollectorModule> {
@@ -198,27 +199,34 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
 
   const handleGetAppMetrics = (): AppMetricsSummary => {
     try {
-      const metrics = app.getAppMetrics();
+      const metrics = getAppMetricsSnapshot();
       let totalKB = 0;
       for (const proc of metrics) {
-        totalKB += proc.memory.privateBytes ?? proc.memory.workingSetSize;
+        // workingSetSize is the only cross-platform field: privateBytes is
+        // Windows-only and reports 0 on macOS/Linux, so a `?? workingSetSize`
+        // fallback never fires there and silently sums to zero (lesson #8646).
+        totalKB += proc.memory.workingSetSize;
       }
       return { totalMemoryMB: Math.round(totalKB / 1024) };
     } catch {
-      return { totalMemoryMB: 0 };
+      // Distinguish a real read failure from a genuine 0 reading so the badge
+      // can suppress the value instead of rendering a misleading "0MB".
+      return { totalMemoryMB: 0, unavailable: true };
     }
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_APP_METRICS, handleGetAppMetrics));
 
   const handleGetProcessMetrics = (): ProcessMetricEntry[] => {
     try {
-      const metrics = app.getAppMetrics();
+      const metrics = getAppMetricsSnapshot();
       return metrics
         .map((proc) => ({
           pid: proc.pid,
           type: proc.type,
           name: proc.name ?? proc.type,
-          memoryMB: Math.round((proc.memory.privateBytes ?? proc.memory.workingSetSize) / 1024),
+          // workingSetSize only — privateBytes is Windows-only and reports 0
+          // on macOS/Linux (lesson #8646).
+          memoryMB: Math.round(proc.memory.workingSetSize / 1024),
           cpuPercent: Math.round((proc.cpu?.percentCPUUsage ?? 0) * 10) / 10,
         }))
         .sort((a, b) => b.memoryMB - a.memoryMB);

--- a/shared/types/ipc/system.ts
+++ b/shared/types/ipc/system.ts
@@ -211,7 +211,10 @@ export interface HardwareInfo {
 
 /** Summary of real app memory metrics from app.getAppMetrics() */
 export interface AppMetricsSummary {
+  /** Aggregate working-set across Daintree's Electron processes, in MB. 0 when unavailable. */
   totalMemoryMB: number;
+  /** Set when the metric could not be read; the renderer should suppress the value rather than show 0. */
+  unavailable?: true;
 }
 
 /** Per-process metrics entry from app.getAppMetrics() */

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -7,47 +7,21 @@ import { logError } from "@/utils/logger";
 import type { ProcessMetricEntry, HeapStats, DiagnosticsInfo } from "@shared/types/ipc/system";
 import type { BulkProjectStatsEntry } from "@shared/types/ipc/project";
 import type { Project } from "@shared/types";
+import {
+  type MemoryState,
+  type TrendDirection,
+  type MemoryThresholds,
+  FALLBACK_THRESHOLDS,
+  computeThresholds,
+  getMemoryState,
+  getTrendDirection,
+  formatMemory,
+} from "./ProjectResourceBadge.utils";
 
-type MemoryState = "normal" | "elevated" | "critical";
-type TrendDirection = "up" | "down" | "stable";
-
-const MEMORY_THRESHOLD_ELEVATED = 500;
-const MEMORY_THRESHOLD_CRITICAL = 800;
-const TREND_DEADBAND_MB_PER_MIN = 3;
 const MAX_SAMPLES = 12;
 const BADGE_POLL_MS = 10_000;
 const POPOVER_POLL_MS = 4_000;
 const SAMPLES_PER_MIN = 60_000 / BADGE_POLL_MS;
-
-function getMemoryState(totalMB: number): MemoryState {
-  if (totalMB >= MEMORY_THRESHOLD_CRITICAL) return "critical";
-  if (totalMB >= MEMORY_THRESHOLD_ELEVATED) return "elevated";
-  return "normal";
-}
-
-function computeSlope(samples: number[]): number {
-  const n = samples.length;
-  if (n < 3) return 0;
-  const sumX = (n * (n - 1)) / 2;
-  const sumX2 = (n * (n - 1) * (2 * n - 1)) / 6;
-  const sumY = samples.reduce((a, b) => a + b, 0);
-  const sumXY = samples.reduce((acc, y, i) => acc + i * y, 0);
-  const denom = n * sumX2 - sumX * sumX;
-  if (denom === 0) return 0;
-  return (n * sumXY - sumX * sumY) / denom;
-}
-
-function getTrendDirection(samples: number[]): TrendDirection {
-  const slopePerSample = computeSlope(samples);
-  const slopePerMin = slopePerSample * SAMPLES_PER_MIN;
-  if (Math.abs(slopePerMin) < TREND_DEADBAND_MB_PER_MIN) return "stable";
-  return slopePerMin > 0 ? "up" : "down";
-}
-
-function formatMemory(mb: number): string {
-  if (mb >= 1024) return `${(mb / 1024).toFixed(1)}GB`;
-  return `${mb}MB`;
-}
 
 function formatUptime(seconds: number): string {
   const h = Math.floor(seconds / 3600);
@@ -227,12 +201,13 @@ export function ProjectResourceBadge() {
   const [isLoading, setIsLoading] = useState(true);
   const [open, setOpen] = useState(false);
   const [popoverData, setPopoverData] = useState<PopoverData | null>(null);
+  const [thresholds, setThresholds] = useState<MemoryThresholds>(FALLBACK_THRESHOLDS);
   const samplesRef = useRef<number[]>([]);
   // Mirror into state so JSX doesn't read the ref during render (React Compiler).
   const [samples, setSamples] = useState<number[]>([]);
 
-  const memoryState = getMemoryState(stats.totalMemoryMB);
-  const trend = getTrendDirection(samples);
+  const memoryState = getMemoryState(stats.totalMemoryMB, thresholds);
+  const trend = getTrendDirection(samples, SAMPLES_PER_MIN);
   const projectIdsKey = useMemo(() => stats.projects.map((p) => p.id).join(","), [stats.projects]);
 
   const fetchStats = useCallback(async () => {
@@ -241,6 +216,10 @@ export function ProjectResourceBadge() {
         projectClient.getAll(),
         systemClient.getAppMetrics(),
       ]);
+
+      // Suppress the reading rather than reporting a misleading "0MB" when the
+      // main process couldn't read process metrics.
+      if (appMetrics.unavailable) return null;
 
       const currentStats = useProjectStatsStore.getState().stats;
       let running = 0;
@@ -265,21 +244,46 @@ export function ProjectResourceBadge() {
     }
   }, []);
 
+  // Read total RAM once to scale the severity thresholds to the machine.
   useEffect(() => {
     let cancelled = false;
+    void systemClient
+      .getHardwareInfo()
+      .then((info) => {
+        if (!cancelled) setThresholds(computeThresholds(info.totalMemoryBytes));
+      })
+      .catch((error) => {
+        logError("[ProjectResourceBadge] Failed to fetch hardware info", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let pending = false;
     let interval: ReturnType<typeof setInterval> | null = null;
 
     const runFetch = async () => {
-      const result = await fetchStats();
-      if (!cancelled && result) {
-        samplesRef.current = result.nextSamples;
-        setSamples(result.nextSamples);
-        setStats({
-          runningProjects: result.runningProjects,
-          totalMemoryMB: result.totalMemoryMB,
-          projects: result.projects,
-        });
-        setIsLoading(false);
+      // Skip if a previous poll is still in flight so a slow IPC round-trip
+      // can't stack overlapping calls or write results out of order.
+      if (pending) return;
+      pending = true;
+      try {
+        const result = await fetchStats();
+        if (!cancelled && result) {
+          samplesRef.current = result.nextSamples;
+          setSamples(result.nextSamples);
+          setStats({
+            runningProjects: result.runningProjects,
+            totalMemoryMB: result.totalMemoryMB,
+            projects: result.projects,
+          });
+          setIsLoading(false);
+        }
+      } finally {
+        pending = false;
       }
     };
 
@@ -298,6 +302,11 @@ export function ProjectResourceBadge() {
       if (document.hidden) {
         stopInterval();
       } else {
+        // The poll pauses while hidden, so pre-hide samples are arbitrarily old
+        // relative to the resumed cadence — drop them so the trend slope isn't
+        // computed across the gap.
+        samplesRef.current = [];
+        setSamples([]);
         void runFetch();
         startInterval();
       }
@@ -381,6 +390,14 @@ export function ProjectResourceBadge() {
         <div className="space-y-3">
           {popoverData ? (
             <>
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] text-daintree-text/50 font-medium">
+                  Daintree memory
+                </span>
+                <span className="text-[10px] font-mono tabular-nums text-daintree-text/40">
+                  {formatMemory(stats.totalMemoryMB)}
+                </span>
+              </div>
               <ProcessTable metrics={popoverData.processMetrics} />
               <HeapBar heapStats={popoverData.heapStats} />
               <ProjectBreakdown projects={stats.projects} projectStats={popoverData.projectStats} />

--- a/src/components/Project/ProjectResourceBadge.utils.ts
+++ b/src/components/Project/ProjectResourceBadge.utils.ts
@@ -1,0 +1,65 @@
+export type MemoryState = "normal" | "elevated" | "critical";
+export type TrendDirection = "up" | "down" | "stable";
+
+export interface MemoryThresholds {
+  elevated: number;
+  critical: number;
+}
+
+// Fixed-MB floor used when total RAM is unknown (hardware probe failed). Matches
+// the historical absolute thresholds so behaviour degrades gracefully.
+export const FALLBACK_THRESHOLDS: MemoryThresholds = { elevated: 500, critical: 800 };
+// Fractions of total RAM. The badge sums working-set across Daintree's Electron
+// processes (renderers double-count shared pages on macOS), so this is a
+// generous pressure heuristic — calibrated near ProcessMemoryMonitor's 25%
+// aggregate ceiling, not a precise budget.
+const ELEVATED_RAM_FRACTION = 0.2;
+const CRITICAL_RAM_FRACTION = 0.33;
+export const TREND_DEADBAND_MB_PER_MIN = 3;
+
+/**
+ * Derive RAM-relative memory thresholds from total system memory so the badge
+ * scales with the machine instead of using fixed MB values that read as
+ * "critical" on a 64 GB box and "fine" on an 8 GB one. Falls back to absolute
+ * MB when total RAM is unknown.
+ */
+export function computeThresholds(totalMemoryBytes: number): MemoryThresholds {
+  if (!Number.isFinite(totalMemoryBytes) || totalMemoryBytes <= 0) {
+    return FALLBACK_THRESHOLDS;
+  }
+  const totalMB = totalMemoryBytes / 1024 / 1024;
+  return {
+    elevated: Math.round(totalMB * ELEVATED_RAM_FRACTION),
+    critical: Math.round(totalMB * CRITICAL_RAM_FRACTION),
+  };
+}
+
+export function getMemoryState(totalMB: number, thresholds: MemoryThresholds): MemoryState {
+  if (totalMB >= thresholds.critical) return "critical";
+  if (totalMB >= thresholds.elevated) return "elevated";
+  return "normal";
+}
+
+export function computeSlope(samples: number[]): number {
+  const n = samples.length;
+  if (n < 3) return 0;
+  const sumX = (n * (n - 1)) / 2;
+  const sumX2 = (n * (n - 1) * (2 * n - 1)) / 6;
+  const sumY = samples.reduce((a, b) => a + b, 0);
+  const sumXY = samples.reduce((acc, y, i) => acc + i * y, 0);
+  const denom = n * sumX2 - sumX * sumX;
+  if (denom === 0) return 0;
+  return (n * sumXY - sumX * sumY) / denom;
+}
+
+export function getTrendDirection(samples: number[], samplesPerMin: number): TrendDirection {
+  const slopePerSample = computeSlope(samples);
+  const slopePerMin = slopePerSample * samplesPerMin;
+  if (Math.abs(slopePerMin) < TREND_DEADBAND_MB_PER_MIN) return "stable";
+  return slopePerMin > 0 ? "up" : "down";
+}
+
+export function formatMemory(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)}GB`;
+  return `${mb}MB`;
+}

--- a/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
@@ -24,9 +24,10 @@ vi.mock("@/clients", () => ({
   },
 }));
 
+const statsStoreState: { stats: Record<string, { processCount: number }> } = { stats: {} };
 vi.mock("@/store/projectStatsStore", () => ({
   useProjectStatsStore: {
-    getState: () => ({ stats: {} }),
+    getState: () => statsStoreState,
   },
 }));
 
@@ -87,6 +88,7 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
       totalMemoryBytes: 8 * 1024 * 1024 * 1024,
       logicalCpuCount: 8,
     });
+    statsStoreState.stats = {};
   });
 
   afterEach(() => {
@@ -194,6 +196,39 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
 
     // Badge still polls stats using the fallback thresholds.
     expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the running-project count and memory once a project is active", async () => {
+    mockGetAll.mockResolvedValue([{ id: "p1", name: "Proj One" }] as never);
+    statsStoreState.stats = { p1: { processCount: 1 } };
+    mockGetAppMetrics.mockResolvedValue({ totalMemoryMB: 290 });
+
+    const { container } = render(<ProjectResourceBadge />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("1 project active");
+    expect(container.textContent).toContain("290MB");
+  });
+
+  it("suppresses the value (stays hidden) when metrics are unavailable", async () => {
+    mockGetAll.mockResolvedValue([{ id: "p1", name: "Proj One" }] as never);
+    statsStoreState.stats = { p1: { processCount: 1 } };
+    mockGetAppMetrics.mockResolvedValue({ totalMemoryMB: 0, unavailable: true });
+
+    const { container } = render(<ProjectResourceBadge />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // No misleading "0MB"; the badge withholds the reading entirely.
+    expect(container.textContent ?? "").not.toContain("0MB");
+    expect(container.textContent ?? "").not.toContain("project active");
   });
 
   it("removes visibility listener on unmount", () => {

--- a/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/clients", () => ({
   },
   systemClient: {
     getAppMetrics: vi.fn(),
+    getHardwareInfo: vi.fn(),
     getProcessMetrics: vi.fn(),
     getHeapStats: vi.fn(),
     getDiagnosticsInfo: vi.fn(),
@@ -40,6 +41,7 @@ import { ProjectResourceBadge } from "../ProjectResourceBadge";
 
 const mockGetAll = vi.mocked(projectClient.getAll);
 const mockGetAppMetrics = vi.mocked(systemClient.getAppMetrics);
+const mockGetHardwareInfo = vi.mocked(systemClient.getHardwareInfo);
 
 describe("ProjectResourceBadge — visibility-aware polling", () => {
   let originalHidden: boolean;
@@ -80,6 +82,11 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
     mockGetAll.mockResolvedValue([]);
     mockGetAppMetrics.mockReset();
     mockGetAppMetrics.mockResolvedValue({ totalMemoryMB: 100 });
+    mockGetHardwareInfo.mockReset();
+    mockGetHardwareInfo.mockResolvedValue({
+      totalMemoryBytes: 8 * 1024 * 1024 * 1024,
+      logicalCpuCount: 8,
+    });
   });
 
   afterEach(() => {
@@ -162,6 +169,31 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
       await Promise.resolve();
     });
     expect(mockGetAll.mock.calls.length).toBeGreaterThan(callsAfterRestore);
+  });
+
+  it("probes hardware info once at mount to scale thresholds to the machine", async () => {
+    render(<ProjectResourceBadge />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockGetHardwareInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crash polling when hardware info probe rejects", async () => {
+    mockGetHardwareInfo.mockRejectedValue(new Error("no hw"));
+
+    render(<ProjectResourceBadge />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Badge still polls stats using the fallback thresholds.
+    expect(mockGetAll.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("removes visibility listener on unmount", () => {

--- a/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.test.tsx
@@ -38,11 +38,25 @@ vi.mock("@/components/ui/popover", () => ({
 }));
 
 import { projectClient, systemClient } from "@/clients";
+import type { Project } from "@shared/types";
 import { ProjectResourceBadge } from "../ProjectResourceBadge";
 
 const mockGetAll = vi.mocked(projectClient.getAll);
 const mockGetAppMetrics = vi.mocked(systemClient.getAppMetrics);
 const mockGetHardwareInfo = vi.mocked(systemClient.getHardwareInfo);
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "proj-1",
+    name: "Test Project",
+    path: "/tmp/test",
+    emoji: "🚀",
+    color: "blue",
+    status: "active",
+    lastOpened: 0,
+    ...overrides,
+  };
+}
 
 describe("ProjectResourceBadge — visibility-aware polling", () => {
   let originalHidden: boolean;
@@ -199,7 +213,7 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
   });
 
   it("renders the running-project count and memory once a project is active", async () => {
-    mockGetAll.mockResolvedValue([{ id: "p1", name: "Proj One" }] as never);
+    mockGetAll.mockResolvedValue([makeProject({ id: "p1", name: "Proj One" })]);
     statsStoreState.stats = { p1: { processCount: 1 } };
     mockGetAppMetrics.mockResolvedValue({ totalMemoryMB: 290 });
 
@@ -215,7 +229,7 @@ describe("ProjectResourceBadge — visibility-aware polling", () => {
   });
 
   it("suppresses the value (stays hidden) when metrics are unavailable", async () => {
-    mockGetAll.mockResolvedValue([{ id: "p1", name: "Proj One" }] as never);
+    mockGetAll.mockResolvedValue([makeProject({ id: "p1", name: "Proj One" })]);
     statsStoreState.stats = { p1: { processCount: 1 } };
     mockGetAppMetrics.mockResolvedValue({ totalMemoryMB: 0, unavailable: true });
 

--- a/src/components/Project/__tests__/ProjectResourceBadge.utils.test.ts
+++ b/src/components/Project/__tests__/ProjectResourceBadge.utils.test.ts
@@ -1,59 +1,62 @@
 import { describe, it, expect } from "vitest";
+import {
+  computeThresholds,
+  getMemoryState,
+  computeSlope,
+  getTrendDirection,
+  formatMemory,
+  FALLBACK_THRESHOLDS,
+} from "../ProjectResourceBadge.utils";
 
-// Re-implement the pure utility functions for testing since they're not exported
-// These mirror the functions in ProjectResourceBadge.tsx exactly
+const GB = 1024 * 1024 * 1024;
 
-type MemoryState = "normal" | "elevated" | "critical";
-type TrendDirection = "up" | "down" | "stable";
+describe("computeThresholds", () => {
+  it("scales thresholds as fractions of total RAM", () => {
+    // 8 GB → 20% elevated, 33% critical, expressed in MB.
+    const t = computeThresholds(8 * GB);
+    expect(t.elevated).toBe(Math.round(8 * 1024 * 0.2));
+    expect(t.critical).toBe(Math.round(8 * 1024 * 0.33));
+  });
 
-const MEMORY_THRESHOLD_ELEVATED = 500;
-const MEMORY_THRESHOLD_CRITICAL = 800;
-const TREND_DEADBAND_MB_PER_MIN = 3;
+  it("scales up on larger machines so the same MB isn't 'critical' everywhere", () => {
+    const small = computeThresholds(8 * GB);
+    const large = computeThresholds(64 * GB);
+    expect(large.elevated).toBeGreaterThan(small.elevated);
+    expect(large.critical).toBeGreaterThan(small.critical);
+    // critical must always sit above elevated.
+    expect(large.critical).toBeGreaterThan(large.elevated);
+    expect(small.critical).toBeGreaterThan(small.elevated);
+  });
 
-function getMemoryState(totalMB: number): MemoryState {
-  if (totalMB >= MEMORY_THRESHOLD_CRITICAL) return "critical";
-  if (totalMB >= MEMORY_THRESHOLD_ELEVATED) return "elevated";
-  return "normal";
-}
-
-function computeSlope(samples: number[]): number {
-  const n = samples.length;
-  if (n < 3) return 0;
-  const sumX = (n * (n - 1)) / 2;
-  const sumX2 = (n * (n - 1) * (2 * n - 1)) / 6;
-  const sumY = samples.reduce((a, b) => a + b, 0);
-  const sumXY = samples.reduce((acc, y, i) => acc + i * y, 0);
-  const denom = n * sumX2 - sumX * sumX;
-  if (denom === 0) return 0;
-  return (n * sumXY - sumX * sumY) / denom;
-}
-
-function getTrendDirection(samples: number[]): TrendDirection {
-  const slopePerSample = computeSlope(samples);
-  const slopePerMin = slopePerSample * 6;
-  if (Math.abs(slopePerMin) < TREND_DEADBAND_MB_PER_MIN) return "stable";
-  return slopePerMin > 0 ? "up" : "down";
-}
-
-function formatMemory(mb: number): string {
-  if (mb >= 1024) return `${(mb / 1024).toFixed(1)}GB`;
-  return `${mb}MB`;
-}
+  it("falls back to fixed MB when total RAM is unknown or invalid", () => {
+    expect(computeThresholds(0)).toEqual(FALLBACK_THRESHOLDS);
+    expect(computeThresholds(-1)).toEqual(FALLBACK_THRESHOLDS);
+    expect(computeThresholds(Number.NaN)).toEqual(FALLBACK_THRESHOLDS);
+  });
+});
 
 describe("getMemoryState", () => {
-  it("returns normal below 500MB", () => {
-    expect(getMemoryState(0)).toBe("normal");
-    expect(getMemoryState(499)).toBe("normal");
+  const thresholds = { elevated: 1600, critical: 2700 };
+
+  it("returns normal below the elevated threshold", () => {
+    expect(getMemoryState(0, thresholds)).toBe("normal");
+    expect(getMemoryState(thresholds.elevated - 1, thresholds)).toBe("normal");
   });
 
-  it("returns elevated at 500-799MB", () => {
-    expect(getMemoryState(500)).toBe("elevated");
-    expect(getMemoryState(799)).toBe("elevated");
+  it("returns elevated between elevated and critical", () => {
+    expect(getMemoryState(thresholds.elevated, thresholds)).toBe("elevated");
+    expect(getMemoryState(thresholds.critical - 1, thresholds)).toBe("elevated");
   });
 
-  it("returns critical at 800MB+", () => {
-    expect(getMemoryState(800)).toBe("critical");
-    expect(getMemoryState(2000)).toBe("critical");
+  it("returns critical at or above the critical threshold", () => {
+    expect(getMemoryState(thresholds.critical, thresholds)).toBe("critical");
+    expect(getMemoryState(thresholds.critical * 2, thresholds)).toBe("critical");
+  });
+
+  it("tracks the supplied thresholds, not fixed values", () => {
+    // 800 MB is critical on the old fixed scale but normal on a big machine.
+    const big = computeThresholds(64 * GB);
+    expect(getMemoryState(800, big)).toBe("normal");
   });
 });
 
@@ -78,23 +81,31 @@ describe("computeSlope", () => {
 });
 
 describe("getTrendDirection", () => {
+  const SAMPLES_PER_MIN = 6;
+
   it("returns stable with fewer than 3 samples", () => {
-    expect(getTrendDirection([])).toBe("stable");
-    expect(getTrendDirection([100, 200])).toBe("stable");
+    expect(getTrendDirection([], SAMPLES_PER_MIN)).toBe("stable");
+    expect(getTrendDirection([100, 200], SAMPLES_PER_MIN)).toBe("stable");
   });
 
-  it("returns stable when slope is within deadband", () => {
-    // slope < 0.5 MB/sample → < 3 MB/min → within deadband
-    expect(getTrendDirection([100, 100.1, 100.2, 100.3])).toBe("stable");
+  it("returns stable when the per-minute slope is within the deadband", () => {
+    // slope ≈ 0.1 MB/sample → 0.6 MB/min → within the 3 MB/min deadband
+    expect(getTrendDirection([100, 100.1, 100.2, 100.3], SAMPLES_PER_MIN)).toBe("stable");
   });
 
-  it("returns up when memory is growing fast", () => {
-    // slope = 10 MB/sample → 60 MB/min → well above deadband
-    expect(getTrendDirection([100, 110, 120, 130])).toBe("up");
+  it("returns up when memory is growing past the deadband", () => {
+    expect(getTrendDirection([100, 110, 120, 130], SAMPLES_PER_MIN)).toBe("up");
   });
 
-  it("returns down when memory is decreasing fast", () => {
-    expect(getTrendDirection([130, 120, 110, 100])).toBe("down");
+  it("returns down when memory is decreasing past the deadband", () => {
+    expect(getTrendDirection([130, 120, 110, 100], SAMPLES_PER_MIN)).toBe("down");
+  });
+
+  it("scales the slope by the sample cadence", () => {
+    // Same samples, faster cadence crosses the deadband sooner.
+    const samples = [100, 100.3, 100.6, 100.9];
+    expect(getTrendDirection(samples, 1)).toBe("stable");
+    expect(getTrendDirection(samples, 60)).toBe("up");
   });
 });
 


### PR DESCRIPTION
## Summary

- The badge was summing 0 on macOS and Linux because `privateBytes` is Windows-only. It now falls back to `workingSetSize` unconditionally, which works across all platforms.
- Severity thresholds now scale with total RAM (20% elevated / 33% critical via `systemClient.getHardwareInfo` at mount), falling back to 500 MB / 800 MB when RAM is unknown -- so the same figure isn't "critical" on a 64 GB box and "fine" on 8 GB.
- Both metric handlers are now routed through the shared 5s `getAppMetricsSnapshot` cache instead of sweeping the process table on every badge poll.

Resolves #10457

## Changes

- `electron/ipc/handlers/diagnostics.ts`: sum `workingSetSize` unconditionally; route `handleGetAppMetrics` and `handleGetProcessMetrics` through the snapshot cache.
- `shared/types/ipc/system.ts`: add `unavailable` flag to `AppMetricsSummary` so the badge can suppress the figure on a read failure rather than rendering a misleading "0 MB".
- `src/components/Project/ProjectResourceBadge.tsx`: RAM-relative thresholds, stale-sample reset on visibility restore, overlapping-fetch guard, "Daintree memory" popover header to honestly scope the figure.
- `src/components/Project/ProjectResourceBadge.utils.ts`: extracted pure helpers (threshold calculation, trend scoring, formatting).
- Tests rewritten to assert behavior -- RAM-relative thresholds, cadence-scaled trend, `workingSetSize` precedence, `unavailable` suppression, visible-badge render. Fixtures now use `privateBytes: 0` to catch the regression.

## Testing

63 targeted vitest tests pass. Own files formatted and linted. Lint ratchet passes.