### PR TITLE
feat(settings): show build architecture in About Daintree

### DIFF
--- a/electron/ipc/handlers/appVersionInfo.ts
+++ b/electron/ipc/handlers/appVersionInfo.ts
@@ -2,6 +2,7 @@ import { app } from "electron";
 import os from "node:os";
 import { defineIpcNamespace, op } from "../define.js";
 import { APP_VERSION_INFO_METHOD_CHANNELS } from "./appVersionInfo.preload.js";
+import { buildArchLabel } from "../../utils/archLabel.js";
 import type { AppVersionInfo } from "../../../shared/types/ipc/app.js";
 
 export const appVersionInfoNamespace = defineIpcNamespace({
@@ -15,6 +16,7 @@ export const appVersionInfoNamespace = defineIpcNamespace({
           electron: process.versions.electron ?? "",
           chrome: process.versions.chrome ?? "",
           os: `${os.platform()} ${os.release()} (${os.arch()})`,
+          arch: buildArchLabel(),
         };
       }
     ),

--- a/electron/utils/__tests__/archLabel.test.ts
+++ b/electron/utils/__tests__/archLabel.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const electronMock = vi.hoisted(() => ({
+  app: { runningUnderARM64Translation: undefined as boolean | undefined },
+}));
+
+vi.mock("electron", () => ({
+  app: electronMock.app,
+}));
+
+import { buildArchLabel } from "../archLabel.js";
+
+const originalPlatform = process.platform;
+const originalArch = process.arch;
+
+function setPlatform(value: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value, writable: true });
+}
+
+function setArch(value: string) {
+  Object.defineProperty(process, "arch", { value, writable: true });
+}
+
+describe("buildArchLabel", () => {
+  beforeEach(() => {
+    electronMock.app.runningUnderARM64Translation = undefined;
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    setArch(originalArch);
+  });
+
+  it("labels native Apple Silicon as 'Apple Silicon'", () => {
+    setPlatform("darwin");
+    setArch("arm64");
+    electronMock.app.runningUnderARM64Translation = false;
+    expect(buildArchLabel()).toBe("Apple Silicon");
+  });
+
+  it("labels native Intel macOS as 'Intel'", () => {
+    setPlatform("darwin");
+    setArch("x64");
+    electronMock.app.runningUnderARM64Translation = false;
+    expect(buildArchLabel()).toBe("Intel");
+  });
+
+  it("flags Rosetta translation as 'Intel (Rosetta)'", () => {
+    setPlatform("darwin");
+    setArch("x64");
+    electronMock.app.runningUnderARM64Translation = true;
+    expect(buildArchLabel()).toBe("Intel (Rosetta)");
+  });
+
+  it("prioritizes the Rosetta signal over the raw arch on macOS", () => {
+    // The running slice always reports x64 under Rosetta; the label must not
+    // collapse to a bare "Intel" and hide the translation state.
+    setPlatform("darwin");
+    setArch("x64");
+    electronMock.app.runningUnderARM64Translation = true;
+    expect(buildArchLabel()).not.toBe("Intel");
+    expect(buildArchLabel()).toContain("Rosetta");
+  });
+
+  it("falls back to the raw arch on non-macOS platforms", () => {
+    setPlatform("linux");
+    setArch("arm64");
+    expect(buildArchLabel()).toBe("arm64");
+  });
+
+  it("returns the raw arch for unknown macOS slices", () => {
+    setPlatform("darwin");
+    setArch("ia32");
+    electronMock.app.runningUnderARM64Translation = false;
+    expect(buildArchLabel()).toBe("ia32");
+  });
+});

--- a/electron/utils/__tests__/archLabel.test.ts
+++ b/electron/utils/__tests__/archLabel.test.ts
@@ -74,4 +74,33 @@ describe("buildArchLabel", () => {
     electronMock.app.runningUnderARM64Translation = false;
     expect(buildArchLabel()).toBe("ia32");
   });
+
+  it("does not treat Windows-on-ARM x64 translation as Rosetta", () => {
+    // WOW64 also sets the translation flag; the darwin gate must keep this off
+    // the Mac path so it reports the raw slice, never "Intel (Rosetta)".
+    setPlatform("win32");
+    setArch("x64");
+    electronMock.app.runningUnderARM64Translation = true;
+    expect(buildArchLabel()).toBe("x64");
+  });
+
+  it("falls back to the raw arch when detection throws", () => {
+    setPlatform("darwin");
+    setArch("x64");
+    // A getter that throws simulates isRunningUnderRosetta blowing up; the
+    // label must never propagate the error into the IPC layer.
+    Object.defineProperty(electronMock.app, "runningUnderARM64Translation", {
+      get() {
+        throw new Error("boom");
+      },
+      configurable: true,
+    });
+    expect(buildArchLabel()).toBe("x64");
+    // Restore a plain data property for subsequent tests.
+    Object.defineProperty(electronMock.app, "runningUnderARM64Translation", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  });
 });

--- a/electron/utils/archLabel.ts
+++ b/electron/utils/archLabel.ts
@@ -1,0 +1,26 @@
+import { isRunningUnderRosetta } from "./rosettaDetection.js";
+
+/**
+ * Human-readable label for the running build architecture, for the "About
+ * Daintree" card and GitHub issue bodies. Reports the *running* slice, not the
+ * package type — a Universal binary running natively on Apple Silicon is
+ * indistinguishable from a single-arch arm64 build by `process.arch` alone, so
+ * we deliberately surface the running arch plus Rosetta state (the support
+ * signal behind #10341/#10498) rather than guessing "Universal".
+ *
+ * On non-macOS platforms there is no Rosetta equivalent, so the raw
+ * `process.arch` value (e.g. `x64`, `arm64`) is returned. Any failure falls
+ * back to the raw arch so this never throws into the IPC layer.
+ */
+export function buildArchLabel(): string {
+  try {
+    if (process.platform === "darwin") {
+      if (isRunningUnderRosetta()) return "Intel (Rosetta)";
+      if (process.arch === "arm64") return "Apple Silicon";
+      if (process.arch === "x64") return "Intel";
+    }
+    return process.arch;
+  } catch {
+    return process.arch;
+  }
+}

--- a/shared/types/ipc/app.ts
+++ b/shared/types/ipc/app.ts
@@ -102,6 +102,8 @@ export interface AppVersionInfo {
   electron: string;
   chrome: string;
   os: string;
+  /** Human-readable running architecture (e.g. "Apple Silicon", "Intel (Rosetta)", "x64"). */
+  arch?: string;
 }
 
 /**

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -393,6 +393,28 @@ describe("buildNotificationReportUrl", () => {
     expect(result.fullBody).toContain("electron: 41.0.0");
   });
 
+  it("emits an arch line in the Environment block when arch is present", () => {
+    const result = buildNotificationReportUrl(
+      makeNotificationInput({
+        envInfo: {
+          appVersion: "1.2.3",
+          electron: "41.0.0",
+          chrome: "146.0.0.0",
+          os: "darwin 24.0.0 (arm64)",
+          arch: "Intel (Rosetta)",
+        } satisfies ReportEnvInfo,
+      })
+    );
+    expect(result.fullBody).toContain("arch: Intel (Rosetta)");
+  });
+
+  it("omits the arch line when arch is absent", () => {
+    // The default envInfo has no arch field; the block must not emit a bare
+    // "arch:" line that reads as an empty/unknown value.
+    const result = buildNotificationReportUrl(makeNotificationInput());
+    expect(result.fullBody).not.toContain("arch:");
+  });
+
   it("titles the issue with the Notification Report prefix", () => {
     const result = buildNotificationReportUrl(makeNotificationInput());
     const title = new URL(result.url).searchParams.get("title") ?? "";

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -35,6 +35,8 @@ export interface ReportEnvInfo {
   electron: string;
   chrome: string;
   os: string;
+  /** Human-readable running architecture; surfaces Rosetta translation for triage. */
+  arch?: string;
 }
 
 export interface ReportIssueInput {
@@ -226,6 +228,7 @@ function formatEnvBlock(envInfo: ReportEnvInfo | undefined): string {
     `electron: ${envInfo.electron || "unknown"}\n` +
     `chrome: ${envInfo.chrome || "unknown"}\n` +
     `os: ${envInfo.os || "unknown"}\n` +
+    (envInfo.arch ? `arch: ${envInfo.arch}\n` : "") +
     "```\n\n"
   );
 }

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -354,7 +354,13 @@ async function reportNotificationOnGitHub(
       envInfo = await appClient.getVersionInfo();
     } catch (envError) {
       logError("Failed to load version info for inbox report", envError);
-      envInfo = { appVersion: "unknown", electron: "unknown", chrome: "unknown", os: "unknown" };
+      envInfo = {
+        appVersion: "unknown",
+        electron: "unknown",
+        chrome: "unknown",
+        os: "unknown",
+        arch: "unknown",
+      };
     }
 
     const reportMessage =

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -16,6 +16,7 @@ const getVersionInfoMock = vi.hoisted(() =>
     electron: "41.0.0",
     chrome: "146.0.0.0",
     os: "darwin 24.0.0 (arm64)",
+    arch: "Apple Silicon",
   })
 );
 vi.mock("@/clients/appClient", () => ({

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -50,6 +50,8 @@ const GENERAL_SUBTABS: SettingsSubtabItem[] = [
 
 interface GeneralTabProps {
   appVersion: string;
+  /** Human-readable running architecture (e.g. "Apple Silicon", "Intel (Rosetta)"). */
+  buildArch?: string;
   onNavigateToAgents?: (agentId?: string) => void;
   activeSubtab: string | null;
   onSubtabChange: (id: string) => void;
@@ -110,6 +112,7 @@ interface ShortcutCategory {
 
 export function GeneralTab({
   appVersion,
+  buildArch,
   onNavigateToAgents,
   activeSubtab,
   onSubtabChange,
@@ -591,6 +594,11 @@ export function GeneralTab({
                 </span>
                 <span className="text-xs text-text-muted font-mono ml-auto">v{appVersion}</span>
               </div>
+              {buildArch && (
+                <p data-testid="about-build-arch" className="text-xs text-text-muted font-mono">
+                  {buildArch}
+                </p>
+              )}
               <p className="text-xs text-text-secondary leading-relaxed">
                 An orchestration board for AI coding agents. Start agents on worktrees, monitor
                 progress, and inject context.

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -33,6 +33,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { appClient } from "@/clients";
+import type { AppVersionInfo } from "@shared/types/ipc/app";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { GeneralTab } from "./GeneralTab";
@@ -84,9 +85,9 @@ const SETTINGS_HIGHLIGHT_DECAY_MS = 1500;
 // doesn't mount every tab at once.
 export const SETTINGS_TAB_HOVER_INTENT_MS = 150;
 
-// The app version is immutable for the process lifetime — fetch it once and
-// reuse across dialog opens so the sidebar slot never shows a placeholder.
-let cachedAppVersion: string | null = null;
+// Version info is immutable for the process lifetime — fetch it once and reuse
+// across dialog opens so the About card never shows a placeholder.
+let cachedVersionInfo: AppVersionInfo | null = null;
 
 // Lowercase the first letter so the label reads naturally mid-sentence
 // ("Requires voice input"), unless it starts with an initialism like
@@ -195,7 +196,8 @@ function SettingsDialogInner({
     }
   }, [isOpen, setPortalOpen]);
 
-  const [appVersion, setAppVersion] = useState<string>(cachedAppVersion ?? "");
+  const [appVersion, setAppVersion] = useState<string>(cachedVersionInfo?.appVersion ?? "");
+  const [buildArch, setBuildArch] = useState<string | undefined>(cachedVersionInfo?.arch);
 
   const [hiddenSettingBanner, setHiddenSettingBanner] = useState<{
     label: string;
@@ -245,15 +247,16 @@ function SettingsDialogInner({
   }, [isOpen, defaultTab, defaultSubtab, defaultSectionId]);
 
   useEffect(() => {
-    if (isOpen && cachedAppVersion === null) {
+    if (isOpen && cachedVersionInfo === null) {
       appClient
-        .getVersion()
-        .then((version) => {
-          cachedAppVersion = version;
-          setAppVersion(version);
+        .getVersionInfo()
+        .then((info) => {
+          cachedVersionInfo = info;
+          setAppVersion(info.appVersion);
+          setBuildArch(info.arch);
         })
         .catch((error) => {
-          logError("Failed to fetch app version", error);
+          logError("Failed to fetch app version info", error);
           setAppVersion("Unavailable");
         });
     }
@@ -767,6 +770,7 @@ function SettingsDialogInner({
                         <>
                           <GeneralTab
                             appVersion={appVersion}
+                            buildArch={buildArch}
                             onNavigateToAgents={(agentId?: string) => {
                               markTabVisited("agents");
                               if (agentId) {

--- a/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
+++ b/src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx
@@ -398,3 +398,55 @@ describe("GeneralTab — System Status filtering (issue #5072)", () => {
     });
   });
 });
+
+describe("GeneralTab — build architecture line (issue #10501)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupElectron();
+    setupDispatchMock(
+      {
+        claude: "ready",
+        gemini: "missing",
+        codex: "missing",
+        opencode: "missing",
+        cursor: "missing",
+      },
+      { agents: { claude: { pinned: true } } } as unknown as AgentSettings
+    );
+  });
+
+  it("renders the architecture line when buildArch is provided", async () => {
+    const { GeneralTab } = await import("../GeneralTab");
+    render(
+      <GeneralTab
+        appVersion="1.0.0"
+        buildArch="Intel (Rosetta)"
+        onNavigateToAgents={vi.fn()}
+        activeSubtab="overview"
+        onSubtabChange={vi.fn()}
+      />
+    );
+
+    const archLine = await screen.findByTestId("about-build-arch");
+    // Assert the provided value is surfaced verbatim, not a hardcoded label.
+    expect(archLine.textContent).toBe("Intel (Rosetta)");
+  });
+
+  it("omits the architecture line when buildArch is absent", async () => {
+    const { GeneralTab } = await import("../GeneralTab");
+    render(
+      <GeneralTab
+        appVersion="1.0.0"
+        onNavigateToAgents={vi.fn()}
+        activeSubtab="overview"
+        onSubtabChange={vi.fn()}
+      />
+    );
+
+    // The version label still renders, so the card is present — only the arch line is gated.
+    await waitFor(() => {
+      expect(screen.getByText("v1.0.0")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("about-build-arch")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a build architecture line to the About Daintree card (Settings > General) so users can see exactly which slice is running — Apple Silicon, Intel, or Intel (Rosetta)
- The Rosetta case is the key one: an Apple Silicon Mac silently running the Intel build under Rosetta now shows up clearly, which was the failure mode behind #10341 and #10498
- Arch is also included in the "Report on GitHub" issue body for support triage, with `arch: unknown` preserved on version-info fetch failure so a transient error stays distinguishable

Resolves #10501

## Changes

- `electron/utils/archLabel.ts` — new `buildArchLabel()` utility; maps running slice + Rosetta state to a human-readable label, falls back to `process.arch` on error
- `electron/ipc/handlers/appVersionInfo.ts` — populates the optional `arch` field on `AppVersionInfo`
- `shared/types/ipc/app.ts` — adds optional `arch` to `AppVersionInfo`
- `src/components/Settings/SettingsDialog.tsx` — switches from `getVersion()` to `getVersionInfo()`, threads `buildArch` down to `GeneralTab`
- `src/components/Settings/GeneralTab.tsx` — renders the arch label as a quiet muted/monospace line beneath the version (no accent color)
- `src/components/ErrorBoundary/buildReportIssueUrl.ts` — includes arch in the issue body env block
- `src/components/Notifications/NotificationCenterEntry.tsx` — mock updated for the new field

## Testing

- `electron/utils/__tests__/archLabel.test.ts` — label mapping, Rosetta-priority, win32 darwin-gate, try/catch fallback
- `src/components/Settings/__tests__/GeneralTab.systemStatus.test.tsx` — arch line renders when present, absent when not
- `src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts` — env block includes/omits arch correctly
- 114 tests pass locally; lint clean on changed files