### PR TITLE
fix(github): restore comment count in issue and PR dropdowns

### DIFF
--- a/plugins/builtin/github/main/GitHubQueries.ts
+++ b/plugins/builtin/github/main/GitHubQueries.ts
@@ -725,9 +725,10 @@ export const BATCH_BRANCH_CHUNK_SIZE = 20;
  *
  * Field shape matches the per-branch `SEARCH_QUERY` PR fragment subset that
  * `toForgePR` reads: number, title, bodyText, url, state, isDraft, merged,
- * baseRefName, headRefName, createdAt, updatedAt, closedAt, mergedAt, author.
- * Also carries `assignees`/`labels` so `findPRsByBranches` can pre-warm the PR
- * tooltip cache with complete hover data (parity with `buildBatchPRQuery`).
+ * baseRefName, headRefName, createdAt, updatedAt, closedAt, mergedAt, author,
+ * and `comments { totalCount }`. Also carries `assignees`/`labels` so
+ * `findPRsByBranches` can pre-warm the PR tooltip cache with complete hover
+ * data (parity with `buildBatchPRQuery`).
  */
 export function buildBatchBranchPRQuery(owner: string, repo: string, branches: string[]): string {
   if (branches.length === 0) return "";
@@ -756,6 +757,7 @@ export function buildBatchBranchPRQuery(owner: string, repo: string, branches: s
             author { login avatarUrl }
             assignees(first: 10) { nodes { login avatarUrl } }
             labels(first: 10) { nodes { name color } }
+            comments { totalCount }
           }
         }
       }

--- a/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
+++ b/plugins/builtin/github/main/__tests__/GitHubQueries.test.ts
@@ -503,6 +503,8 @@ describe("buildBatchBranchPRQuery", () => {
     expect(query).toContain("closedAt");
     expect(query).toContain("mergedAt");
     expect(query).toContain("author { login avatarUrl }");
+    // toForgePR now reads node.comments.totalCount — the batch shape must carry it.
+    expect(query).toContain("comments { totalCount }");
   });
 
   it("uses bodyText (not body) — parity with SEARCH_QUERY and getPRTooltip", () => {

--- a/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/forgeProvider.test.ts
@@ -491,6 +491,119 @@ describe("listPRs ciStatus", () => {
   });
 });
 
+describe("commentCount mapping", () => {
+  beforeEach(() => {
+    mockGraphQLClient.mockReset();
+  });
+
+  function prListWithNodes(nodes: unknown[]) {
+    return {
+      repository: {
+        pullRequests: {
+          nodes,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          totalCount: nodes.length,
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    };
+  }
+
+  function issueListWithNodes(nodes: unknown[]) {
+    return {
+      repository: {
+        issues: {
+          nodes,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          totalCount: nodes.length,
+        },
+      },
+      rateLimit: { cost: 1, remaining: 4999, resetAt: "" },
+    };
+  }
+
+  function issueNode(number: number, comments?: unknown) {
+    return {
+      number,
+      title: `Issue ${number}`,
+      bodyText: "",
+      state: "OPEN",
+      url: `https://github.com/owner/repo/issues/${number}`,
+      author: { login: "user", avatarUrl: "" },
+      assignees: { nodes: [] },
+      labels: { nodes: [] },
+      createdAt: "2025-01-01T00:00:00Z",
+      updatedAt: "2025-01-01T00:00:00Z",
+      closedAt: null,
+      ...(comments !== undefined ? { comments } : {}),
+    };
+  }
+
+  it("extracts comments.totalCount onto the listed issue's commentCount", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(issueListWithNodes([issueNode(5, { totalCount: 7 })]));
+
+    const page = await githubForgeProvider.listIssues(repo, {});
+    expect(page.items[0].commentCount).toBe(7);
+  });
+
+  it("preserves a zero comment count from the issue node", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(issueListWithNodes([issueNode(5, { totalCount: 0 })]));
+
+    const page = await githubForgeProvider.listIssues(repo, {});
+    expect(page.items[0].commentCount).toBe(0);
+  });
+
+  it("omits commentCount when the issue node has no comments connection", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(issueListWithNodes([issueNode(5)]));
+
+    const page = await githubForgeProvider.listIssues(repo, {});
+    expect("commentCount" in page.items[0]).toBe(false);
+  });
+
+  it("omits commentCount when comments.totalCount is not a number", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      issueListWithNodes([issueNode(5, { totalCount: "7" })])
+    );
+
+    const page = await githubForgeProvider.listIssues(repo, {});
+    expect("commentCount" in page.items[0]).toBe(false);
+  });
+
+  it("extracts comments.totalCount onto the listed PR's commentCount", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListWithNodes([{ ...makePRNode(1, "feature/a"), comments: { totalCount: 3 } }])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect(page.items[0].commentCount).toBe(3);
+  });
+
+  it("preserves a zero comment count from the PR node", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListWithNodes([{ ...makePRNode(1, "feature/a"), comments: { totalCount: 0 } }])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect(page.items[0].commentCount).toBe(0);
+  });
+
+  it("omits commentCount when the PR node has no comments connection", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(prListWithNodes([makePRNode(1, "feature/a")]));
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect("commentCount" in page.items[0]).toBe(false);
+  });
+
+  it("omits commentCount when the PR comments.totalCount is malformed", async () => {
+    mockGraphQLClient.mockResolvedValueOnce(
+      prListWithNodes([{ ...makePRNode(1, "feature/a"), comments: { totalCount: null } }])
+    );
+
+    const page = await githubForgeProvider.listPRs(repo, {});
+    expect("commentCount" in page.items[0]).toBe(false);
+  });
+});
+
 function issueListResponse(totalCount?: number) {
   return {
     repository: {

--- a/plugins/builtin/github/main/forgeProvider.ts
+++ b/plugins/builtin/github/main/forgeProvider.ts
@@ -220,6 +220,8 @@ function normalizePRState(rawState: string, merged: boolean): NormalizedPRState 
 
 function toForgeIssue(node: Record<string, unknown>): Issue {
   const rawState = typeof node.state === "string" ? node.state : "OPEN";
+  const comments = node.comments as { totalCount?: unknown } | undefined;
+  const commentCount = typeof comments?.totalCount === "number" ? comments.totalCount : undefined;
   return {
     number: node.number as number,
     title: (node.title as string) ?? "",
@@ -230,6 +232,7 @@ function toForgeIssue(node: Record<string, unknown>): Issue {
     author: toForgeUser(node.author),
     assignees: toForgeUsers(node.assignees),
     labels: toForgeLabels(node.labels),
+    ...(commentCount !== undefined ? { commentCount } : {}),
     createdAt: isoToMs(node.createdAt ?? node.updatedAt),
     updatedAt: isoToMs(node.updatedAt),
     closedAt: isoToMsOrNull(node.closedAt),
@@ -309,6 +312,8 @@ function toForgePR(node: Record<string, unknown>): PR {
   const ciStatus = mapListCIStatus(
     typeof rollupState === "string" ? (rollupState as GitHubPRCIStatus) : undefined
   );
+  const comments = node.comments as { totalCount?: unknown } | undefined;
+  const commentCount = typeof comments?.totalCount === "number" ? comments.totalCount : undefined;
   return {
     number: node.number as number,
     title: (node.title as string) ?? "",
@@ -323,6 +328,7 @@ function toForgePR(node: Record<string, unknown>): PR {
     headRef: (node.headRefName as string) ?? "",
     mergeable: undefined,
     reviewDecision: node.reviewDecision as NormalizedReviewDecision | undefined,
+    ...(commentCount !== undefined ? { commentCount } : {}),
     ...(ciStatus ? { ciStatus } : {}),
     createdAt: isoToMs(node.createdAt ?? node.updatedAt),
     updatedAt: isoToMs(node.updatedAt),

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -496,23 +496,24 @@ describe("GitHubListItem", () => {
       labels: [{ name: "enhancement", color: "a2eeef" }],
     };
     const { container } = render(<GitHubListItem item={issue} type="issue" />);
-    const html = container.innerHTML;
-    const commentIdx = html.indexOf("lucide-message-square");
-    const labelIdx = html.indexOf("enhancement");
-    expect(commentIdx).toBeGreaterThanOrEqual(0);
-    expect(labelIdx).toBeGreaterThanOrEqual(0);
-    expect(commentIdx).toBeLessThan(labelIdx);
+    const commentIcon = container.querySelector("svg.lucide-message-square");
+    const label = screen.getByText("enhancement");
+    expect(commentIcon).not.toBeNull();
+    // DOCUMENT_POSITION_FOLLOWING set => label comes after the comment icon.
+    expect(
+      commentIcon!.compareDocumentPosition(label) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 
   it("renders the PR comment count before the head branch in the metadata row", () => {
     const pr: PR = { ...basePR, commentCount: 6, headRef: "feature/new-thing" };
     const { container } = render(<GitHubListItem item={pr} type="pr" />);
-    const html = container.innerHTML;
-    const commentIdx = html.indexOf("lucide-message-square");
-    const headRefIdx = html.indexOf("feature/new-thing");
-    expect(commentIdx).toBeGreaterThanOrEqual(0);
-    expect(headRefIdx).toBeGreaterThanOrEqual(0);
-    expect(commentIdx).toBeLessThan(headRefIdx);
+    const commentIcon = container.querySelector("svg.lucide-message-square");
+    const headRef = screen.getByText("feature/new-thing");
+    expect(commentIcon).not.toBeNull();
+    expect(
+      commentIcon!.compareDocumentPosition(headRef) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 
   it("does not show Copy icon - only # prefix and Check on copy", async () => {

--- a/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx
@@ -489,6 +489,32 @@ describe("GitHubListItem", () => {
     expect(svgs).toHaveLength(0);
   });
 
+  it("renders the issue comment count before labels in the metadata row", () => {
+    const issue: Issue = {
+      ...baseIssue,
+      commentCount: 4,
+      labels: [{ name: "enhancement", color: "a2eeef" }],
+    };
+    const { container } = render(<GitHubListItem item={issue} type="issue" />);
+    const html = container.innerHTML;
+    const commentIdx = html.indexOf("lucide-message-square");
+    const labelIdx = html.indexOf("enhancement");
+    expect(commentIdx).toBeGreaterThanOrEqual(0);
+    expect(labelIdx).toBeGreaterThanOrEqual(0);
+    expect(commentIdx).toBeLessThan(labelIdx);
+  });
+
+  it("renders the PR comment count before the head branch in the metadata row", () => {
+    const pr: PR = { ...basePR, commentCount: 6, headRef: "feature/new-thing" };
+    const { container } = render(<GitHubListItem item={pr} type="pr" />);
+    const html = container.innerHTML;
+    const commentIdx = html.indexOf("lucide-message-square");
+    const headRefIdx = html.indexOf("feature/new-thing");
+    expect(commentIdx).toBeGreaterThanOrEqual(0);
+    expect(headRefIdx).toBeGreaterThanOrEqual(0);
+    expect(commentIdx).toBeLessThan(headRefIdx);
+  });
+
   it("does not show Copy icon - only # prefix and Check on copy", async () => {
     const { container } = render(<GitHubListItem item={baseIssue} type="issue" />);
     // No Copy icon should exist

--- a/plugins/builtin/github/renderer/components/GitHubListItem.tsx
+++ b/plugins/builtin/github/renderer/components/GitHubListItem.tsx
@@ -240,6 +240,16 @@ export function GitHubListItem({
             <span className="shrink-0">&middot;</span>
             <span className="whitespace-nowrap shrink-0">{formatTimeAgo(item.updatedAt)}</span>
 
+            {(item.commentCount ?? 0) >= 1 && (
+              <>
+                <span className="shrink-0">&middot;</span>
+                <span className="inline-flex items-center gap-0.5 shrink-0">
+                  <MessageSquare className="w-3 h-3" />
+                  <span>{item.commentCount}</span>
+                </span>
+              </>
+            )}
+
             {isItemPR && item.headRef && (
               <>
                 <span className="shrink-0">&middot;</span>
@@ -262,16 +272,6 @@ export function GitHubListItem({
                       <span className="truncate min-w-0 max-w-[80px]">{label.name}</span>
                     </span>
                   ))}
-                </span>
-              </>
-            )}
-
-            {(item.commentCount ?? 0) >= 1 && (
-              <>
-                <span className="shrink-0">&middot;</span>
-                <span className="inline-flex items-center gap-0.5 shrink-0">
-                  <MessageSquare className="w-3 h-3" />
-                  <span>{item.commentCount}</span>
                 </span>
               </>
             )}


### PR DESCRIPTION
## Summary

- `toForgeIssue` and `toForgePR` in `forgeProvider.ts` — the node mappers used by the dropdown list/search endpoints — were dropping `commentCount` even though the GraphQL queries already fetch `comments { totalCount }`. The sibling list-shape mappers carried it through fine, so which path produced a row determined whether a count appeared.
- Added `commentCount` extraction to both node mappers (preserving `0`, omitting on absent/malformed values), and added `comments { totalCount }` to `buildBatchBranchPRQuery` so `findPRsByBranches` results flow through the same mapper correctly.
- Repositioned the comment count badge in `GitHubListItem` to render immediately after the timestamp — before the head branch and labels — so it holds its place on crowded rows.

Resolves #10502

## Changes

- `plugins/builtin/github/main/forgeProvider.ts` — extract `node.comments.totalCount` in `toForgeIssue` and `toForgePR`
- `plugins/builtin/github/main/GitHubQueries.ts` — add `comments { totalCount }` to the batch branch PR query
- `plugins/builtin/github/renderer/components/GitHubListItem.tsx` — move comment count badge before head branch and labels
- `plugins/builtin/github/main/__tests__/forgeProvider.test.ts` — new cases: present/zero/absent/malformed `commentCount` for both issue and PR node mappers, batch query field-shape assertion
- `plugins/builtin/github/renderer/__tests__/GitHubListItem.test.tsx` — DOM-ordering tests confirming badge position
- `plugins/builtin/github/main/__tests__/GitHubQueries.test.ts` — batch query field coverage

## Testing

230 targeted tests pass across the mapper, query, and renderer suites, covering: `commentCount` present/zero/absent/malformed, batch query field shape, and badge DOM ordering.