### PR TITLE
fix(keybindings): close Daintree Assistant on Cmd+W when focused

### DIFF
--- a/src/hooks/__tests__/useGlobalKeybindings.test.tsx
+++ b/src/hooks/__tests__/useGlobalKeybindings.test.tsx
@@ -36,7 +36,15 @@ const mocks = vi.hoisted(() => ({
     }),
   },
   actionService: {
-    dispatch: vi.fn(async () => ({ ok: true, result: undefined })),
+    // Typed signature so mock.calls is a labeled tuple (not the empty tuple),
+    // letting tests destructure the dispatched actionId without TS2493.
+    dispatch: vi.fn<
+      (
+        actionId: string,
+        args?: unknown,
+        options?: unknown
+      ) => Promise<{ ok: boolean; result?: unknown; error?: unknown }>
+    >(async () => ({ ok: true, result: undefined })),
   },
 }));
 

--- a/src/hooks/__tests__/useGlobalKeybindings.test.tsx
+++ b/src/hooks/__tests__/useGlobalKeybindings.test.tsx
@@ -247,15 +247,17 @@ describe("useGlobalKeybindings — Cmd+W escape stack guard", () => {
       pressCmdW();
 
       expect(escapeHandler).not.toHaveBeenCalled();
+      expect(mocks.actionService.dispatch).toHaveBeenCalledTimes(1);
       expect(mocks.actionService.dispatch).toHaveBeenCalledWith(
         "help.togglePanel",
         undefined,
         expect.objectContaining({ source: "keybinding" })
       );
-      expect(mocks.actionService.dispatch).not.toHaveBeenCalledWith(
-        "terminal.close",
-        expect.anything(),
-        expect.anything()
+      // terminal.close must NOT also fire — the assistant branch returns early.
+      // expect.anything() would not match the production `undefined` second arg,
+      // so assert against the dispatched action ids directly.
+      expect(mocks.actionService.dispatch.mock.calls.map(([id]) => id)).not.toContain(
+        "terminal.close"
       );
     } finally {
       assistant.remove();

--- a/src/hooks/__tests__/useGlobalKeybindings.test.tsx
+++ b/src/hooks/__tests__/useGlobalKeybindings.test.tsx
@@ -219,6 +219,49 @@ describe("useGlobalKeybindings — Cmd+W escape stack guard", () => {
     }
   });
 
+  it("closes the Daintree Assistant via help.togglePanel when its panel is focused (issue #10509)", () => {
+    mocks.keybindingService.resolveKeybinding.mockReturnValue({
+      match: { actionId: "terminal.close" },
+      chordPrefix: false,
+      shouldConsume: true,
+    });
+
+    // The assistant runs an embedded xterm whose focused escape handler bails
+    // to let Escape reach the PTY, so routing Cmd+W through the escape stack
+    // would swallow it. Focus inside the aside must close the assistant instead.
+    const assistant = document.createElement("aside");
+    assistant.id = "daintree-assistant-panel";
+    const focusable = document.createElement("div");
+    focusable.tabIndex = -1;
+    assistant.appendChild(focusable);
+    document.body.appendChild(assistant);
+
+    try {
+      const escapeHandler = vi.fn();
+      registerEscape(escapeHandler);
+
+      render(<Host />);
+      focusable.focus();
+      expect(document.activeElement).toBe(focusable);
+
+      pressCmdW();
+
+      expect(escapeHandler).not.toHaveBeenCalled();
+      expect(mocks.actionService.dispatch).toHaveBeenCalledWith(
+        "help.togglePanel",
+        undefined,
+        expect.objectContaining({ source: "keybinding" })
+      );
+      expect(mocks.actionService.dispatch).not.toHaveBeenCalledWith(
+        "terminal.close",
+        expect.anything(),
+        expect.anything()
+      );
+    } finally {
+      assistant.remove();
+    }
+  });
+
   it("routes Cmd+W to escape stack when focus has no panel ancestor (dialog/body)", () => {
     mocks.keybindingService.resolveKeybinding.mockReturnValue({
       match: { actionId: "terminal.close" },

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -168,7 +168,9 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
           // dialog/palette dismisses its topmost layer, and a focused grid or
           // dock panel closes that panel. See the branches below.
           if (result.match.actionId === "terminal.close") {
-            const active = document.activeElement as HTMLElement | null;
+            // Element (not HTMLElement) — only closest() is needed below, and
+            // an unchecked HTMLElement cast trips no-unsafe-type-assertion.
+            const active = document.activeElement;
             // Cmd+W inside the Daintree Assistant closes the assistant itself.
             // Its escape handler intentionally bails when the embedded xterm /
             // CodeMirror has focus (so a bare Escape reaches the running PTY),

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -176,9 +176,15 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
             // (#10509). Route to help.togglePanel — focus is inside the aside,
             // so its open-and-focused branch closes the panel.
             if (active?.closest("#daintree-assistant-panel") != null) {
-              void actionService.dispatch("help.togglePanel", undefined, {
-                source: "keybinding",
-              });
+              void actionService
+                .dispatch("help.togglePanel", undefined, { source: "keybinding" })
+                .then((dispatchResult) => {
+                  if (!dispatchResult.ok) {
+                    logError('[GlobalKeybinding] Action "help.togglePanel" failed', undefined, {
+                      error: dispatchResult.error,
+                    });
+                  }
+                });
               return;
             }
             // When a dialog/palette keeps an escape handler registered, route

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -163,19 +163,36 @@ export function useGlobalKeybindings(enabled: boolean = true): void {
         e.stopPropagation();
 
         if (result.match) {
-          // When a dialog/palette is open, route Cmd+W to the escape stack so it
-          // dismisses the topmost layer instead of falling through to the terminal.
-          // Skip this diversion when focus is inside a grid or dock panel —
-          // persistent docks like the assistant keep an escape handler registered
-          // the whole time they are open, but Cmd+W from a focused terminal panel
-          // (grid or dock) must close that panel rather than the dock.
-          if (result.match.actionId === "terminal.close" && hasHandlers()) {
+          // Cmd+W resolves to terminal.close, but where it actually lands
+          // depends on focus: the Daintree Assistant closes itself, an open
+          // dialog/palette dismisses its topmost layer, and a focused grid or
+          // dock panel closes that panel. See the branches below.
+          if (result.match.actionId === "terminal.close") {
             const active = document.activeElement as HTMLElement | null;
-            const isFocusInsidePanel =
-              active?.closest("[data-panel-location='grid'],[data-panel-location='dock']") != null;
-            if (!isFocusInsidePanel) {
-              dispatchEscape();
+            // Cmd+W inside the Daintree Assistant closes the assistant itself.
+            // Its escape handler intentionally bails when the embedded xterm /
+            // CodeMirror has focus (so a bare Escape reaches the running PTY),
+            // which would otherwise swallow Cmd+W and leave the panel open
+            // (#10509). Route to help.togglePanel — focus is inside the aside,
+            // so its open-and-focused branch closes the panel.
+            if (active?.closest("#daintree-assistant-panel") != null) {
+              void actionService.dispatch("help.togglePanel", undefined, {
+                source: "keybinding",
+              });
               return;
+            }
+            // When a dialog/palette keeps an escape handler registered, route
+            // Cmd+W to the escape stack so it dismisses the topmost layer
+            // instead of falling through to the terminal — unless focus is
+            // inside a grid or dock panel, where Cmd+W must close that panel.
+            if (hasHandlers()) {
+              const isFocusInsidePanel =
+                active?.closest("[data-panel-location='grid'],[data-panel-location='dock']") !=
+                null;
+              if (!isFocusInsidePanel) {
+                dispatchEscape();
+                return;
+              }
             }
           }
 


### PR DESCRIPTION
## Summary

- `Cmd+W` did nothing when the Daintree Assistant panel was focused — the shortcut was diverted to the escape stack, which silently swallowed it
- Fixed in `useGlobalKeybindings.ts`: when focus is inside `#daintree-assistant-panel`, dispatch `help.togglePanel` directly instead of routing through the escape stack
- Existing dialog, palette dismiss, and grid/dock panel close behavior is unchanged

Resolves #10509

## Changes

- `src/hooks/useGlobalKeybindings.ts` — intercept `terminal.close` earlier when focus is inside `#daintree-assistant-panel` and dispatch `help.togglePanel` instead
- `src/hooks/__tests__/useGlobalKeybindings.test.tsx` — unit test covering the new branch

## Testing

- Unit test added for the `Cmd+W` → `help.togglePanel` path when focus is inside the assistant panel
- Existing escape-stack and panel-close behavior exercised by the existing test suite