### PR TITLE
fix(plugin-sdk): export forge domain & process-stream types for plugin authors

### DIFF
--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,1 +1,7 @@
 export type * from "../../../shared/types/plugin-sdk.js";
+// Runtime value re-exports — `export type *` above strips value bindings, so
+// each runtime const the SDK surfaces needs an explicit value line (mirrors the
+// pattern in `react.ts`). `PLUGIN_PROCESS_STREAM_CHANNEL` must reach authors as
+// a real string so `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)` resolves
+// the channel at runtime — a type-only re-export would emit `undefined` (#10515).
+export { PLUGIN_PROCESS_STREAM_CHANNEL } from "../../../shared/types/plugin-sdk.js";

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -36,12 +36,29 @@ import type {
   NormalizedPRState,
   ResourceRef,
   CIStatus,
+  Issue,
+  PR,
+  RepoRef,
+  Page,
+  Credentials,
+  AuthValidation,
+  FetchOptions,
+  ListOptions,
+  RepoMetadata,
+  CreateIssueInput,
+  ForgeUser,
+  ForgeLabel,
+  NormalizedIssueState,
+  RateLimitInfo,
+  FileDecoration,
+  PluginProcessStreamEvent,
   ActionDispatchResult,
   ActionDispatchSuccess,
   ActionDispatchError,
   ActionError,
   ActionErrorCode,
 } from "../plugin-sdk.js";
+import { PLUGIN_PROCESS_STREAM_CHANNEL } from "../plugin-sdk.js";
 import type { UseHostChannelResult, PluginEventHandler } from "../plugin-sdk-react.js";
 
 /**
@@ -114,6 +131,33 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf<NormalizedPRState>().toMatchTypeOf<string>();
       expectTypeOf<ResourceRef>().toMatchTypeOf<object>();
       expectTypeOf<CIStatus>().toMatchTypeOf<object>();
+    });
+
+    it("exports forge domain types for provider authoring", () => {
+      expectTypeOf<Issue>().toMatchTypeOf<object>();
+      expectTypeOf<PR>().toMatchTypeOf<object>();
+      expectTypeOf<RepoRef>().toMatchTypeOf<object>();
+      expectTypeOf<Page<unknown>>().toMatchTypeOf<object>();
+      expectTypeOf<Credentials>().toMatchTypeOf<object>();
+      expectTypeOf<AuthValidation>().toMatchTypeOf<object>();
+      expectTypeOf<FetchOptions>().toMatchTypeOf<object>();
+      expectTypeOf<ListOptions>().toMatchTypeOf<object>();
+      expectTypeOf<RepoMetadata>().toMatchTypeOf<object>();
+      expectTypeOf<CreateIssueInput>().toMatchTypeOf<object>();
+      expectTypeOf<ForgeUser>().toMatchTypeOf<object>();
+      expectTypeOf<ForgeLabel>().toMatchTypeOf<object>();
+      expectTypeOf<NormalizedIssueState>().toMatchTypeOf<string>();
+      expectTypeOf<RateLimitInfo>().toMatchTypeOf<object>();
+      expectTypeOf<FileDecoration>().toMatchTypeOf<object>();
+    });
+
+    it("exports the process-stream event type and channel constant", () => {
+      expectTypeOf<PluginProcessStreamEvent>().toMatchTypeOf<object>();
+      // PLUGIN_PROCESS_STREAM_CHANNEL is a value export, not type-only — it must
+      // survive to runtime so `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)`
+      // resolves the real channel string.
+      expect(typeof PLUGIN_PROCESS_STREAM_CHANNEL).toBe("string");
+      expectTypeOf(PLUGIN_PROCESS_STREAM_CHANNEL).toEqualTypeOf<"process">();
     });
 
     it("exports the host.dispatch result types", () => {
@@ -283,6 +327,43 @@ describe("plugin-sdk boundary", () => {
       };
       expectTypeOf(status.state).toMatchTypeOf<string>();
     });
+
+    it("forge-provider helpers can be typed entirely against the SDK", () => {
+      // The issue's acceptance criterion: an author writes named toIssue/toPR
+      // helpers and provider methods using only @daintreehq/plugin-sdk imports,
+      // with no relative internal paths.
+      function toIssue(node: unknown): Issue {
+        return node as Issue;
+      }
+      function toPR(node: unknown): PR {
+        return node as PR;
+      }
+      const listIssues = (_repo: RepoRef, _opts?: ListOptions): Promise<Page<Issue>> =>
+        Promise.resolve({} as Page<Issue>);
+      const createIssue = (_repo: RepoRef, _input: CreateIssueInput): Promise<Issue> =>
+        Promise.resolve({} as Issue);
+      expectTypeOf(toIssue).returns.toEqualTypeOf<Issue>();
+      expectTypeOf(toPR).returns.toEqualTypeOf<PR>();
+      expectTypeOf(listIssues).returns.toEqualTypeOf<Promise<Page<Issue>>>();
+      expectTypeOf(createIssue).returns.toEqualTypeOf<Promise<Issue>>();
+    });
+
+    it("PluginProcessStreamEvent discriminates on kind", () => {
+      const onEvent = (event: PluginProcessStreamEvent): string => {
+        switch (event.kind) {
+          case "stdout":
+          case "stderr":
+            return event.chunk;
+          case "exit":
+          case "crash":
+            return event.signal ?? String(event.exitCode);
+        }
+      };
+      expectTypeOf(onEvent).parameter(0).toEqualTypeOf<PluginProcessStreamEvent>();
+      expectTypeOf<PluginProcessStreamEvent["kind"]>().toEqualTypeOf<
+        "stdout" | "stderr" | "exit" | "crash"
+      >();
+    });
   });
 
   describe("react entry point", () => {
@@ -313,6 +394,18 @@ describe("plugin-sdk boundary", () => {
     it("BUILT_IN_PLUGIN_CAPABILITIES is not in the SDK barrel", () => {
       // @ts-expect-error — BUILT_IN_PLUGIN_CAPABILITIES is host-internal
       const _check: import("../plugin-sdk.js").BUILT_IN_PLUGIN_CAPABILITIES = null;
+    });
+
+    it("PluginProcessInfo is not in the SDK barrel", () => {
+      // The process-stream event type and channel constant are SDK-public, but
+      // the renderer-IPC observability snapshot stays host-internal.
+      // @ts-expect-error — PluginProcessInfo is host-internal
+      const _check: import("../plugin-sdk.js").PluginProcessInfo = null;
+    });
+
+    it("PluginProcessStatus is not in the SDK barrel", () => {
+      // @ts-expect-error — PluginProcessStatus is host-internal
+      const _check: import("../plugin-sdk.js").PluginProcessStatus = null;
     });
   });
 });

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -160,17 +160,6 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf(PLUGIN_PROCESS_STREAM_CHANNEL).toEqualTypeOf<"process">();
     });
 
-    it("surfaces the channel constant as a runtime value through the package entry", async () => {
-      // The barrel emits a value export, but the published `@daintreehq/plugin-sdk`
-      // entry re-exports with `export type *`, which strips value bindings. The
-      // entry needs an explicit value re-export line; without it a plugin author
-      // gets `undefined` for the channel constant. Import the package SOURCE entry
-      // (vitest transpiles it like the build would) and assert the value survives.
-      const pkg = await import("../../../packages/plugin-sdk/src/index.js");
-      expect(pkg.PLUGIN_PROCESS_STREAM_CHANNEL).toBe(PLUGIN_PROCESS_STREAM_CHANNEL);
-      expect(typeof pkg.PLUGIN_PROCESS_STREAM_CHANNEL).toBe("string");
-    });
-
     it("exports the host.dispatch result types", () => {
       // host.dispatch() resolves to ActionDispatchResult; a plugin author must be
       // able to name it and its error-code union from the public SDK.

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -160,6 +160,17 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf(PLUGIN_PROCESS_STREAM_CHANNEL).toEqualTypeOf<"process">();
     });
 
+    it("surfaces the channel constant as a runtime value through the package entry", async () => {
+      // The barrel emits a value export, but the published `@daintreehq/plugin-sdk`
+      // entry re-exports with `export type *`, which strips value bindings. The
+      // entry needs an explicit value re-export line; without it a plugin author
+      // gets `undefined` for the channel constant. Import the package SOURCE entry
+      // (vitest transpiles it like the build would) and assert the value survives.
+      const pkg = await import("../../../packages/plugin-sdk/src/index.js");
+      expect(pkg.PLUGIN_PROCESS_STREAM_CHANNEL).toBe(PLUGIN_PROCESS_STREAM_CHANNEL);
+      expect(typeof pkg.PLUGIN_PROCESS_STREAM_CHANNEL).toBe("string");
+    });
+
     it("exports the host.dispatch result types", () => {
       // host.dispatch() resolves to ActionDispatchResult; a plugin author must be
       // able to name it and its error-code union from the public SDK.
@@ -346,6 +357,24 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf(toPR).returns.toEqualTypeOf<PR>();
       expectTypeOf(listIssues).returns.toEqualTypeOf<Promise<Page<Issue>>>();
       expectTypeOf(createIssue).returns.toEqualTypeOf<Promise<Issue>>();
+
+      // A no-cast literal proves Issue still carries its required-field contract
+      // (would compile even if Issue were broadened to `any`/`{}` — the casts
+      // above wouldn't catch that).
+      const issue: Issue = {
+        number: 1,
+        title: "t",
+        body: "b",
+        state: "open",
+        rawState: "OPEN",
+        url: "https://example.test/1",
+        assignees: [],
+        labels: [],
+        createdAt: 0,
+        updatedAt: 0,
+        rawData: null,
+      };
+      expectTypeOf(issue.state).toEqualTypeOf<NormalizedIssueState>();
     });
 
     it("PluginProcessStreamEvent discriminates on kind", () => {
@@ -363,6 +392,16 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf<PluginProcessStreamEvent["kind"]>().toEqualTypeOf<
         "stdout" | "stderr" | "exit" | "crash"
       >();
+
+      // Per-variant payload guards — the chunk/exit fields must stay bound to
+      // their own kinds (catches an accidental union merge that would let a
+      // stdout event carry exitCode or an exit event carry chunk).
+      // @ts-expect-error — stdout carries a chunk, not exitCode
+      const _badStdout: PluginProcessStreamEvent = { kind: "stdout", id: "x", exitCode: 0 };
+      // @ts-expect-error — exit carries exitCode/signal, not chunk
+      const _badExit: PluginProcessStreamEvent = { kind: "exit", id: "x", chunk: "" };
+      void _badStdout;
+      void _badExit;
     });
   });
 

--- a/shared/types/ipc/pluginProcess.ts
+++ b/shared/types/ipc/pluginProcess.ts
@@ -5,10 +5,14 @@
  * over the `postToPanel` transport and exposes this read-only snapshot to the
  * renderer (e.g. a process/task dashboard) via `plugin-process:list`.
  *
- * Deliberately NOT part of the public `@daintreehq/plugin-sdk` barrel — these
- * are renderer-IPC observability types, not the plugin-author surface. The
- * plugin-author surface is `PluginProcessApi` / `PluginProcessHandle` in
- * `shared/types/plugin.ts`.
+ * The observability types here (`PluginProcessInfo`, `PluginProcessStatus`,
+ * `PLUGIN_PROCESS_MAX_CONCURRENT`, `PLUGIN_PROCESS_KILL_GRACE_MS`) are
+ * renderer-IPC internals, NOT the plugin-author surface — that lives in
+ * `PluginProcessApi` / `PluginProcessHandle` in `shared/types/plugin.ts`. The
+ * two exceptions are `PluginProcessStreamEvent` and `PLUGIN_PROCESS_STREAM_CHANNEL`:
+ * panel authors subscribe to the process stream via the documented
+ * `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)` pattern, so those two ARE
+ * re-exported from the public `@daintreehq/plugin-sdk` barrel (#10515).
  */
 
 /**

--- a/shared/types/ipc/pluginProcess.ts
+++ b/shared/types/ipc/pluginProcess.ts
@@ -67,8 +67,14 @@ export const PLUGIN_PROCESS_MAX_CONCURRENT = 8;
  */
 export const PLUGIN_PROCESS_KILL_GRACE_MS = 3_000;
 
-/** Channel name (under the plugin's `postToPanel` namespace) carrying process stream events. */
-export const PLUGIN_PROCESS_STREAM_CHANNEL = "process";
+/**
+ * Channel name (under the plugin's `postToPanel` namespace) carrying process
+ * stream events. `as const` pins the literal `"process"` type through
+ * declaration emit — without it, the re-exported constant widens to `string`
+ * in the composite build's emitted `.d.ts`, which plugin authors depend on for
+ * `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)` channel-key narrowing.
+ */
+export const PLUGIN_PROCESS_STREAM_CHANNEL = "process" as const;
 
 /**
  * Event payloads streamed to a plugin's panels over

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -118,6 +118,39 @@ export type {
 
 export type { NormalizedPRState, ResourceRef, CIStatus } from "./forge.js";
 
+// ── Forge domain types (ForgeProviderImpl method params & returns) ──
+// A forge-provider author writing named `toIssue`/`toPR` helpers and typing
+// the provider's method signatures must be able to name these from the public
+// SDK without reaching into internal app paths. FetchOptions and FileDecoration
+// appear directly in ForgeProviderImpl / FileDecorationProviderImpl signatures.
+
+export type {
+  Issue,
+  PR,
+  RepoRef,
+  Page,
+  Credentials,
+  AuthValidation,
+  FetchOptions,
+  ListOptions,
+  RepoMetadata,
+  CreateIssueInput,
+  ForgeUser,
+  ForgeLabel,
+  NormalizedIssueState,
+  RateLimitInfo,
+  FileDecoration,
+} from "./forge.js";
+
+// ── Plugin-managed process stream events ────────────────────────────
+// A panel author subscribing via `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)`
+// discriminates the streamed events on `kind`. PLUGIN_PROCESS_STREAM_CHANNEL is a
+// runtime constant, so it is a value export (not `export type`) — type-only would
+// strip the value and break `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)`.
+
+export type { PluginProcessStreamEvent } from "./ipc/pluginProcess.js";
+export { PLUGIN_PROCESS_STREAM_CHANNEL } from "./ipc/pluginProcess.js";
+
 // ── Action dispatch result (host.dispatch return type) ──────────────
 // host.dispatch() resolves to ActionDispatchResult, so plugin authors must be
 // able to name it and narrow on its error codes from the public SDK.


### PR DESCRIPTION
## Summary

- The `@daintreehq/plugin-sdk` barrel was missing the forge domain types (`Issue`, `PR`, `RepoRef`, `Page`, `Credentials`, `AuthValidation`, `FetchOptions`, `ListOptions`, `RepoMetadata`, `CreateIssueInput`, `ForgeUser`, `ForgeLabel`, `NormalizedIssueState`, `RateLimitInfo`, `FileDecoration`) and process-stream types (`PluginProcessStreamEvent`, `PLUGIN_PROCESS_STREAM_CHANNEL`) that documented authoring patterns require — forcing authors to reach into internal app paths.
- `PLUGIN_PROCESS_STREAM_CHANNEL` was being stripped to `undefined` at runtime because `packages/plugin-sdk/src/index.ts` used `export type *`, which drops values — breaking `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)`.
- All changes are additive and backwards compatible.

Resolves #10515

## Changes

- Re-export the missing forge domain types and `PluginProcessStreamEvent` from `shared/types/plugin-sdk.ts`.
- Value-export `PLUGIN_PROCESS_STREAM_CHANNEL` from both the barrel and `packages/plugin-sdk/src/index.ts` (switched from `export type *` to a named value export for this constant).
- Narrowed the `pluginProcess.ts` header comment to reflect that these two items are now SDK-public while the IPC-observability snapshot types remain internal.

## Testing

Extended `shared/types/__tests__/plugin-sdk.test.ts` with:

- Forge domain export resolution — all 14 previously-missing types are importable from the SDK.
- Named `toIssue`/`toPR`/`listIssues`/`createIssue` helper compilation against only the SDK barrel.
- No-cast `Issue` literal guarding the required-field contract.
- `PluginProcessStreamEvent` union discrimination with per-variant `@ts-expect-error` guards.
- Package-boundary test asserting the channel value survives the entry re-export (not `undefined`).
- Negative guards confirming `PluginProcessInfo` and `PluginProcessStatus` remain unexported.

35/35 vitest pass; root tsc and plugin-sdk tsc clean; eslint/prettier clean on changed files.