### PR TITLE
feat(plugin): add multi-author attribution to the plugin manifest

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -21,6 +21,15 @@ Daintree reads the manifest eagerly at startup. Contribution points declared her
   // One-sentence description, shown in UI listings.
   "description": "Plan Linear issues as multi-step agent workflows.",
 
+  // Attribution credits, shown in the plugin detail pane's "Contributors"
+  // block. Optional. Up to 10 entries; each needs a `name`, plus optional
+  // `url` (https-only, same private-host/credential discipline as
+  // scopes.network.allowedUrls), `email`, and free-form `role`.
+  "authors": [
+    { "name": "Ada Lovelace", "url": "https://ada.example.com", "role": "Maintainer" },
+    { "name": "Grace Hopper", "email": "grace@example.com" },
+  ],
+
   // Path to the compiled ESM entry, relative to the plugin directory.
   // Optional — plugins with only static contributions (themes, static MCP
   // server configs) don't need one.
@@ -122,6 +131,17 @@ The human-readable name shown in UI listings (plugin palette, installed-plugins 
 ### `description`
 
 One-sentence description shown in plugin listings. Keep it short; UI truncates long descriptions.
+
+### `authors`
+
+Optional attribution credits, surfaced as a "Contributors" block in the plugin detail pane. An array of up to 10 entries; each entry is an object where `name` is required and `url`, `email`, and `role` are optional. Unknown keys on an entry are rejected. `url` must be `https://` and follows the same discipline as `scopes.network.allowedUrls` — no wildcards, embedded credentials, or private/loopback hosts — because it surfaces as a user-clickable link; `email` must be a valid address; `role` is a free-form label (e.g. `"Maintainer"`, `"Contributor"`). The SDK exports the `PluginAuthor` type for authoring against this shape.
+
+```jsonc
+"authors": [
+  { "name": "Ada Lovelace", "url": "https://ada.example.com", "role": "Maintainer" },
+  { "name": "Grace Hopper", "email": "grace@example.com" },
+]
+```
 
 ### `main`
 

--- a/electron/schemas/__tests__/authorContribution.test.ts
+++ b/electron/schemas/__tests__/authorContribution.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { MANIFEST_AUTHORS_CAP, PluginAuthorSchema, getPluginManifestSchema } from "../plugin.js";
+
+function manifestWith(overrides: Record<string, unknown>) {
+  return {
+    name: "acme.my-plugin",
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+function authorIssueCode(result: { success: boolean; error?: { issues: unknown[] } }): string[] {
+  if (result.success || !result.error) return [];
+  return result.error.issues
+    .map((i) => (i as { params?: { errorCode?: string } }).params?.errorCode)
+    .filter((c): c is string => typeof c === "string");
+}
+
+describe("PluginAuthorSchema (issue #10516)", () => {
+  it("accepts a minimal author with only a name", () => {
+    const result = PluginAuthorSchema.safeParse({ name: "Alice" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an author with all fields valid", () => {
+    const result = PluginAuthorSchema.safeParse({
+      name: "Alice Example",
+      url: "https://alice.example.com",
+      email: "alice@example.com",
+      role: "Maintainer",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims and rejects a blank name", () => {
+    expect(PluginAuthorSchema.safeParse({ name: "" }).success).toBe(false);
+    expect(PluginAuthorSchema.safeParse({ name: "   " }).success).toBe(false);
+  });
+
+  it("rejects unknown keys (strict object)", () => {
+    const result = PluginAuthorSchema.safeParse({ name: "Alice", twitter: "@alice" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-string name", () => {
+    expect(PluginAuthorSchema.safeParse({ name: 42 }).success).toBe(false);
+  });
+
+  it.each([
+    ["http://alice.dev", "scope_url_not_https"],
+    ["ftp://alice.dev", "scope_url_not_https"],
+    ["https://localhost", "scope_url_private_target"],
+    ["https://intranet", "scope_url_hostname_unqualified"],
+    ["https://127.0.0.1", "scope_url_private_target"],
+    ["https://192.168.1.1", "scope_url_private_target"],
+    ["https://user:pass@alice.dev", "scope_url_has_credentials"],
+    ["https://*.alice.dev", "scope_wildcard_rejected"],
+    ["not-a-url", "scope_url_invalid"],
+  ])("rejects url %j with errorCode %s (same discipline as network scopes)", (url, errorCode) => {
+    const result = PluginAuthorSchema.safeParse({ name: "Alice", url });
+    expect(result.success).toBe(false);
+    expect(authorIssueCode(result)).toContain(errorCode);
+  });
+
+  it("accepts a multi-label https url for a personal site", () => {
+    expect(
+      PluginAuthorSchema.safeParse({ name: "Greg", url: "https://siteorigin.com" }).success
+    ).toBe(true);
+  });
+
+  it("rejects a malformed email", () => {
+    expect(PluginAuthorSchema.safeParse({ name: "Alice", email: "not-an-email" }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects a blank role", () => {
+    expect(PluginAuthorSchema.safeParse({ name: "Alice", role: "  " }).success).toBe(false);
+  });
+});
+
+describe("manifest authors field (issue #10516)", () => {
+  it("accepts a manifest with no authors field (backward-safe optional)", () => {
+    expect(getPluginManifestSchema(false).safeParse(manifestWith({})).success).toBe(true);
+  });
+
+  it("accepts a manifest with a valid authors array", () => {
+    const result = getPluginManifestSchema(false).safeParse(
+      manifestWith({
+        authors: [
+          { name: "Alice", url: "https://alice.example.com", role: "Author" },
+          { name: "Bob", email: "bob@example.com" },
+        ],
+      })
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.authors).toHaveLength(2);
+      expect(result.data.authors?.[0]?.name).toBe("Alice");
+    }
+  });
+
+  it("accepts exactly the author cap and rejects one over", () => {
+    const make = (count: number) =>
+      getPluginManifestSchema(false).safeParse(
+        manifestWith({
+          authors: Array.from({ length: count }, (_, i) => ({ name: `Author ${i}` })),
+        })
+      );
+    expect(make(MANIFEST_AUTHORS_CAP).success).toBe(true);
+    expect(make(MANIFEST_AUTHORS_CAP + 1).success).toBe(false);
+  });
+
+  it("rejects a manifest whose author has an invalid url", () => {
+    const result = getPluginManifestSchema(false).safeParse(
+      manifestWith({ authors: [{ name: "Alice", url: "http://alice.dev" }] })
+    );
+    expect(result.success).toBe(false);
+    expect(authorIssueCode(result)).toContain("scope_url_not_https");
+  });
+
+  it("rejects a non-array authors value", () => {
+    expect(
+      getPluginManifestSchema(false).safeParse(manifestWith({ authors: "Alice" })).success
+    ).toBe(false);
+  });
+});

--- a/electron/schemas/__tests__/authorContribution.test.ts
+++ b/electron/schemas/__tests__/authorContribution.test.ts
@@ -37,6 +37,29 @@ describe("PluginAuthorSchema (issue #10516)", () => {
     expect(PluginAuthorSchema.safeParse({ name: "   " }).success).toBe(false);
   });
 
+  it("trims surrounding whitespace from name and role in the parsed output", () => {
+    const result = PluginAuthorSchema.safeParse({ name: "  Alice  ", role: "  Maintainer  " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.name).toBe("Alice");
+      expect(result.data.role).toBe("Maintainer");
+    }
+  });
+
+  it("reports the failing path for a nested invalid url", () => {
+    const result = getPluginManifestSchema(false).safeParse(
+      manifestWith({ authors: [{ name: "Alice", url: "http://alice.dev" }] })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) =>
+          (i as { params?: { errorCode?: string } }).params?.errorCode === "scope_url_not_https"
+      );
+      expect(issue?.path).toEqual(["authors", 0, "url"]);
+    }
+  });
+
   it("rejects unknown keys (strict object)", () => {
     const result = PluginAuthorSchema.safeParse({ name: "Alice", twitter: "@alice" });
     expect(result.success).toBe(false);

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -373,21 +373,25 @@ export function isPrivateOrLoopbackHostname(hostname: string): boolean {
 }
 
 /**
- * Per-entry validator for `scopes.network.allowedUrls`. Each entry must:
+ * Shared per-entry validator body for manifest URL fields. Each entry must:
  *
  * - Parse as a `https:` URL (no `http:`, `file:`, custom schemes).
  * - Contain no `*` substring (wildcards are rejected so a tightly-bound
  *   declaration cannot smuggle a permissive value past the manifest gate).
  * - Carry no embedded credentials (no `https://user:pass@host`).
  * - Target a multi-label hostname (at least one `.` after parse). Single-label
- *   intranet hosts are rejected to keep allowlists auditable from the manifest.
+ *   intranet hosts are rejected to keep URLs auditable from the manifest.
  * - Not target a private/loopback/link-local address (SSRF mitigation).
+ *
+ * `fieldLabel` names the offending field in error messages so the same
+ * discipline can back both `scopes.network.allowedUrls` and `authors[].url`
+ * without leaking a misleading field name into the other's validation errors.
  */
-const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
+function refinePluginHttpsUrl(value: string, ctx: z.RefinementCtx, fieldLabel: string): void {
   if (value.includes("*")) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `Wildcard characters are not allowed in scopes.network.allowedUrls: "${value}"`,
+      message: `Wildcard characters are not allowed in ${fieldLabel}: "${value}"`,
       params: { errorCode: "scope_wildcard_rejected" },
     });
     return;
@@ -398,7 +402,7 @@ const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
   } catch {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `scopes.network.allowedUrls entry is not a valid URL: "${value}"`,
+      message: `${fieldLabel} entry is not a valid URL: "${value}"`,
       params: { errorCode: "scope_url_invalid" },
     });
     return;
@@ -406,7 +410,7 @@ const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
   if (parsed.protocol !== "https:") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `scopes.network.allowedUrls entries must use https:// — got "${parsed.protocol}" in "${value}"`,
+      message: `${fieldLabel} entries must use https:// — got "${parsed.protocol}" in "${value}"`,
       params: { errorCode: "scope_url_not_https" },
     });
     return;
@@ -414,7 +418,7 @@ const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
   if (parsed.username !== "" || parsed.password !== "") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `scopes.network.allowedUrls entries must not embed credentials: "${value}"`,
+      message: `${fieldLabel} entries must not embed credentials: "${value}"`,
       params: { errorCode: "scope_url_has_credentials" },
     });
     return;
@@ -423,7 +427,7 @@ const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
   if (isPrivateOrLoopbackHostname(hostname)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `scopes.network.allowedUrls entry targets a private or loopback address: "${value}"`,
+      message: `${fieldLabel} entry targets a private or loopback address: "${value}"`,
       params: { errorCode: "scope_url_private_target" },
     });
     return;
@@ -431,11 +435,41 @@ const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
   if (hostname === "" || !hostname.includes(".")) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `scopes.network.allowedUrls hostnames must be multi-label (got "${hostname}" in "${value}")`,
+      message: `${fieldLabel} hostnames must be multi-label (got "${hostname}" in "${value}")`,
       params: { errorCode: "scope_url_hostname_unqualified" },
     });
     return;
   }
+}
+
+/**
+ * Per-entry validator for `scopes.network.allowedUrls`. See
+ * {@link refinePluginHttpsUrl} for the enforced discipline.
+ */
+const PluginAllowedUrlSchema = z.string().superRefine((value, ctx) => {
+  refinePluginHttpsUrl(value, ctx, "scopes.network.allowedUrls");
+});
+
+/**
+ * Per-entry validator for `authors[].url`. Author homepage links surface as
+ * user-clickable buttons in the plugin detail pane, so they carry the same
+ * https-only, no-credentials, no-private-host discipline as network scopes
+ * (anti-phishing / SSRF) — only the error-message field name differs.
+ */
+const PluginAuthorUrlSchema = z.string().superRefine((value, ctx) => {
+  refinePluginHttpsUrl(value, ctx, "authors[].url");
+});
+
+/**
+ * A single attribution entry in the plugin manifest's `authors` array. `name`
+ * is required; `url`, `email`, and `role` are optional. `strictObject` rejects
+ * unknown keys so manifest typos surface loudly.
+ */
+export const PluginAuthorSchema = z.strictObject({
+  name: z.string().trim().min(1).max(100),
+  url: PluginAuthorUrlSchema.optional(),
+  email: z.email().optional(),
+  role: z.string().trim().min(1).max(50).optional(),
 });
 
 /**
@@ -608,6 +642,14 @@ export const MANIFEST_CONTRIBUTION_CAPS = {
 } as const;
 
 /**
+ * Upper bound on the top-level `authors` array. Attribution is metadata, not a
+ * registration loop, so the cap is small — generous for any real plugin's
+ * credits list while rejecting pathological manifests. Exported so tests
+ * reference it without a magic number.
+ */
+export const MANIFEST_AUTHORS_CAP = 10;
+
+/**
  * Deprecated `contributes` keys promoted to stable names in the 1.0 freeze.
  * Old manifests are still accepted (the value is migrated to the canonical key);
  * `PluginService` surfaces a deprecation warning when an alias is encountered.
@@ -663,6 +705,7 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
       displayName: z.string().optional(),
       description: z.string().optional(),
       tagline: z.string().trim().min(1).max(120).optional(),
+      authors: z.array(PluginAuthorSchema).max(MANIFEST_AUTHORS_CAP).optional(),
       category: z.enum(PLUGIN_CATEGORY_IDS).optional(),
       main: z.string().optional(),
       engines: z

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -44,7 +44,7 @@ export type { PanelViewProps } from "./plugin.js";
 
 // ── Manifest root ───────────────────────────────────────────────────
 
-export type { PluginManifest } from "./plugin.js";
+export type { PluginManifest, PluginAuthor } from "./plugin.js";
 
 // ── Activation contract ─────────────────────────────────────────────
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -244,6 +244,20 @@ export const PLUGIN_CATEGORY_IDS = ["forge", "ai", "workspace", "other"] as cons
 
 export type PluginCategoryId = (typeof PLUGIN_CATEGORY_IDS)[number];
 
+/**
+ * A single attribution entry in {@link PluginManifest.authors}. `name` is
+ * required; the rest are optional. `url` (when present) is validated to the
+ * same https-only, no-credentials, no-private-host discipline as network
+ * scopes — see `PluginAuthorUrlSchema` in `electron/schemas/plugin.ts` — since
+ * it surfaces as a user-clickable link in the detail pane.
+ */
+export interface PluginAuthor {
+  name: string;
+  url?: string;
+  email?: string;
+  role?: string;
+}
+
 export interface PluginManifest {
   name: string;
   version: string;
@@ -254,6 +268,11 @@ export interface PluginManifest {
    * stays the long-form copy for the detail pane.
    */
   tagline?: string;
+  /**
+   * Optional attribution credits shown in the detail pane's "Contributors"
+   * block. Each entry credits a person who worked on the plugin.
+   */
+  authors?: PluginAuthor[];
   /**
    * Declared catalog category. Optional — when absent the manager derives one
    * from `contributes` (see `resolvePluginCategory`).

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -13,10 +13,12 @@ import {
 } from "@/components/Settings/SettingsSubtabBar";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatRelativeTime } from "@/lib/formatRelativeTime";
+import { systemClient } from "@/clients/systemClient";
 import {
   BUILT_IN_PLUGIN_CAPABILITIES,
   type BuiltInPluginCapability,
   type LoadedPluginInfo,
+  type PluginAuthor,
   type PluginInstallSource,
 } from "@shared/types/plugin";
 
@@ -213,6 +215,60 @@ function PluginCapabilityList({ plugin }: { plugin: LoadedPluginInfo }) {
   );
 }
 
+/**
+ * Attribution credits (#10516) for the selected plugin. Each author's `name` is
+ * plain text; `url` and `email` (when present) are clickable, routed through
+ * `systemClient.openExternal` (the established external-navigation path) rather
+ * than bare anchors. Styled neutrally — credits are reference metadata, not a
+ * focus signal, so they never take the accent colour (CLAUDE.md accent-restraint).
+ * The `url`/`email` were https/format-validated at the manifest gate, so the
+ * values handed to `openExternal` are safe to construct.
+ */
+function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
+  return (
+    <div className="space-y-2">
+      <h4 className="text-[11px] font-medium uppercase tracking-wide text-daintree-text/40">
+        Contributors
+      </h4>
+      <ul className="space-y-2">
+        {authors.map((author, index) => {
+          const { name, url, email, role } = author;
+          return (
+            <li key={`${name}-${index}`} className="text-xs">
+              <div className="text-daintree-text/80">
+                {name}
+                {role && <span className="text-[11px] text-daintree-text/40"> · {role}</span>}
+              </div>
+              {(url || email) && (
+                <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+                  {url && (
+                    <button
+                      type="button"
+                      onClick={() => void systemClient.openExternal(url)}
+                      className="text-[11px] text-daintree-text/50 hover:text-daintree-text/80 hover:underline break-all"
+                    >
+                      {url}
+                    </button>
+                  )}
+                  {email && (
+                    <button
+                      type="button"
+                      onClick={() => void systemClient.openExternal(`mailto:${email}`)}
+                      className="text-[11px] text-daintree-text/50 hover:text-daintree-text/80 hover:underline break-all"
+                    >
+                      {email}
+                    </button>
+                  )}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 type PluginDetailTab = "overview" | "settings" | "capabilities";
 
 interface PluginDetailPaneProps {
@@ -387,6 +443,10 @@ export function PluginDetailPane({
             </p>
           ) : (
             <p className="text-xs text-daintree-text/40">No description provided.</p>
+          )}
+
+          {plugin.manifest.authors && plugin.manifest.authors.length > 0 && (
+            <PluginContributors authors={plugin.manifest.authors} />
           )}
 
           {plugin.loadError && (

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -193,25 +193,44 @@ describe("PluginDetailPane contributors (issue #10516)", () => {
     expect(screen.queryByText("Contributors")).toBeNull();
   });
 
-  it("renders each author's name and role", () => {
+  it("renders each author's name, with the role attached to the right author", () => {
     renderOverview(withAuthors([{ name: "Alice", role: "Maintainer" }, { name: "Bob" }]));
     expect(screen.getByText("Contributors")).toBeTruthy();
-    expect(screen.getByText("Alice")).toBeTruthy();
-    expect(screen.getByText(/Maintainer/)).toBeTruthy();
     expect(screen.getByText("Bob")).toBeTruthy();
+    // Role must sit within Alice's list item, not Bob's.
+    const aliceItem = screen.getByText("Alice").closest("li");
+    expect(aliceItem).toBeTruthy();
+    if (aliceItem) {
+      expect(within(aliceItem).getByText(/Maintainer/)).toBeTruthy();
+    }
+    const bobItem = screen.getByText("Bob").closest("li");
+    if (bobItem) {
+      expect(within(bobItem).queryByText(/Maintainer/)).toBeNull();
+    }
   });
 
-  it("opens an author url through systemClient.openExternal", () => {
+  it("renders no contact buttons for a name-only author", () => {
+    renderOverview(withAuthors([{ name: "Alice" }]));
+    const aliceItem = screen.getByText("Alice").closest("li");
+    expect(aliceItem).toBeTruthy();
+    if (aliceItem) {
+      expect(within(aliceItem).queryAllByRole("button")).toHaveLength(0);
+    }
+  });
+
+  it("opens an author url through systemClient.openExternal exactly once", () => {
     openExternalMock.mockClear();
     renderOverview(withAuthors([{ name: "Alice", url: "https://alice.example.com" }]));
-    fireEvent.click(screen.getByText("https://alice.example.com"));
+    fireEvent.click(screen.getByRole("button", { name: "https://alice.example.com" }));
+    expect(openExternalMock).toHaveBeenCalledTimes(1);
     expect(openExternalMock).toHaveBeenCalledWith("https://alice.example.com");
   });
 
   it("opens an author email as a mailto link through systemClient.openExternal", () => {
     openExternalMock.mockClear();
     renderOverview(withAuthors([{ name: "Alice", email: "alice@example.com" }]));
-    fireEvent.click(screen.getByText("alice@example.com"));
+    fireEvent.click(screen.getByRole("button", { name: "alice@example.com" }));
+    expect(openExternalMock).toHaveBeenCalledTimes(1);
     expect(openExternalMock).toHaveBeenCalledWith("mailto:alice@example.com");
   });
 });

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -17,6 +17,11 @@ vi.mock("@/utils/logger", () => ({
   logDebug: vi.fn(),
 }));
 
+const openExternalMock = vi.hoisted(() => vi.fn());
+vi.mock("@/clients/systemClient", () => ({
+  systemClient: { openExternal: openExternalMock },
+}));
+
 // PluginSettingsForm reads the active project via this selector.
 vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
@@ -89,6 +94,28 @@ function renderPane(plugin: LoadedPluginInfo) {
   return result;
 }
 
+// Overview is the default tab, so no subtab click is needed.
+function renderOverview(plugin: LoadedPluginInfo) {
+  return render(
+    <TooltipProvider>
+      <PluginDetailPane
+        plugin={plugin}
+        checkingUpdate={false}
+        upToDate={false}
+        onUninstall={vi.fn()}
+        onCheckForUpdate={vi.fn()}
+      />
+    </TooltipProvider>
+  );
+}
+
+function withAuthors(
+  authors: NonNullable<LoadedPluginInfo["manifest"]["authors"]>
+): LoadedPluginInfo {
+  const base = makePlugin();
+  return { ...base, manifest: { ...base.manifest, authors } };
+}
+
 describe("PluginDetailPane capabilities", () => {
   it("shows the no-permissions empty state when no capabilities are declared", () => {
     renderPane(makePlugin());
@@ -152,5 +179,39 @@ describe("PluginDetailPane capabilities", () => {
       .map((el) => el.textContent);
     expect(labels[0]).toBe("Read project files");
     expect(labels[1]).toBe("Run shell commands");
+  });
+});
+
+describe("PluginDetailPane contributors (issue #10516)", () => {
+  it("does not render a Contributors section when authors are absent", () => {
+    renderOverview(makePlugin());
+    expect(screen.queryByText("Contributors")).toBeNull();
+  });
+
+  it("does not render a Contributors section when authors is empty", () => {
+    renderOverview(withAuthors([]));
+    expect(screen.queryByText("Contributors")).toBeNull();
+  });
+
+  it("renders each author's name and role", () => {
+    renderOverview(withAuthors([{ name: "Alice", role: "Maintainer" }, { name: "Bob" }]));
+    expect(screen.getByText("Contributors")).toBeTruthy();
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText(/Maintainer/)).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
+  it("opens an author url through systemClient.openExternal", () => {
+    openExternalMock.mockClear();
+    renderOverview(withAuthors([{ name: "Alice", url: "https://alice.example.com" }]));
+    fireEvent.click(screen.getByText("https://alice.example.com"));
+    expect(openExternalMock).toHaveBeenCalledWith("https://alice.example.com");
+  });
+
+  it("opens an author email as a mailto link through systemClient.openExternal", () => {
+    openExternalMock.mockClear();
+    renderOverview(withAuthors([{ name: "Alice", email: "alice@example.com" }]));
+    fireEvent.click(screen.getByText("alice@example.com"));
+    expect(openExternalMock).toHaveBeenCalledWith("mailto:alice@example.com");
   });
 });


### PR DESCRIPTION
## Summary

- Adds an optional `authors` array to the plugin manifest schema; each entry has a required `name` plus optional `url`, `email`, and `role`, capped at 10 via `MANIFEST_AUTHORS_CAP`.
- URL validation reuses the same https-only, no-credentials, no-private-host discipline as `scopes.network.allowedUrls`, factored into a shared `refinePluginHttpsUrl` helper; email uses Zod v4 `z.email()`.
- `PluginAuthor` interface added to `shared/types/plugin.ts` and re-exported from the SDK barrel (`shared/types/plugin-sdk.ts`); neutral-styled "Contributors" block rendered in `PluginDetailPane.tsx` with links opened via `systemClient.openExternal`.

Resolves #10516.

## Changes

- `electron/schemas/plugin.ts` — `authorSchema` + `MANIFEST_AUTHORS_CAP`; `refinePluginHttpsUrl` extracted as shared helper (replaces inline validator used by `scopes.network.allowedUrls`)
- `shared/types/plugin.ts` — `PluginAuthor` interface
- `shared/types/plugin-sdk.ts` — re-exports `PluginAuthor`
- `src/components/Plugin/PluginDetailPane.tsx` — "Contributors" block; `mailto:` routing for email links
- `docs/plugins/manifest.md` — documents the `authors` field with shape and validation rules

## Testing

- `electron/schemas/__tests__/authorContribution.test.ts` — 24 new schema cases (valid shapes, missing name, non-https url, bad email, array cap)
- `src/components/Plugin/__tests__/PluginDetailPane.test.tsx` — 13 new pane cases (renders names, linked urls, email links, empty/absent block)
- Full `PluginService` suite (482 tests) still green, confirming the `refinePluginHttpsUrl` refactor preserved all existing `scopes.network.allowedUrls` error codes

Note: a pre-existing edge case in the shared URL validator (trailing-dot single-label hostnames) was identified during review. It predates this PR and affects `scopes.network.allowedUrls` as well — left for a separate fix.