### PR TITLE
perf(hydration): parallelize priority terminal restore + adaptive batch sizing

### DIFF
--- a/src/utils/stateHydration/__tests__/batchScheduler.test.ts
+++ b/src/utils/stateHydration/__tests__/batchScheduler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { scheduleBackgroundFetchAndRestore } from "../batchScheduler";
+import { scheduleBackgroundFetchAndRestore, getRestoreBatchParams } from "../batchScheduler";
+import type { ResourceProfile } from "@shared/types/resourceProfile";
 
 vi.mock("@/utils/logger", () => ({
   logWarn: vi.fn(),
@@ -81,5 +82,35 @@ describe("scheduleBackgroundFetchAndRestore", () => {
       "Background scrollback restore failed",
       expect.objectContaining({ error })
     );
+  });
+});
+
+describe("getRestoreBatchParams", () => {
+  it("scales batch size up and delay down as the profile gets more capable", () => {
+    const performance = getRestoreBatchParams("performance");
+    const balanced = getRestoreBatchParams("balanced");
+    const efficiency = getRestoreBatchParams("efficiency");
+
+    // Monotonic: more capable profile => larger batches, shorter gaps.
+    expect(performance.batchSize).toBeGreaterThan(balanced.batchSize);
+    expect(balanced.batchSize).toBeGreaterThan(efficiency.batchSize);
+    expect(performance.delayMs).toBeLessThan(balanced.delayMs);
+    expect(balanced.delayMs).toBeLessThan(efficiency.delayMs);
+  });
+
+  it("keeps every batch size positive and below the fd-leak ceiling (#9544)", () => {
+    for (const profile of ["performance", "balanced", "efficiency"] as ResourceProfile[]) {
+      const { batchSize, delayMs } = getRestoreBatchParams(profile);
+      expect(batchSize).toBeGreaterThan(0);
+      expect(batchSize).toBeLessThanOrEqual(8);
+      expect(delayMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("falls back to the balanced params for missing or unknown profiles", () => {
+    const balanced = getRestoreBatchParams("balanced");
+    expect(getRestoreBatchParams(undefined)).toEqual(balanced);
+    expect(getRestoreBatchParams(null)).toEqual(balanced);
+    expect(getRestoreBatchParams("nonsense" as ResourceProfile)).toEqual(balanced);
   });
 });

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -108,6 +108,9 @@ vi.mock("../batchScheduler", async () => {
     ...actual,
     RESTORE_SPAWN_BATCH_SIZE: 2,
     RESTORE_SPAWN_BATCH_DELAY_MS: 0,
+    // Fast, deterministic batches regardless of resource profile so existing
+    // batching/ordering assertions stay stable (#10528).
+    getRestoreBatchParams: () => ({ batchSize: 2, delayMs: 0 }),
   };
 });
 
@@ -267,6 +270,35 @@ describe("restorePanelsPhase — saved panels", () => {
     );
     expect(restoreTerminalOrder).toHaveBeenCalledTimes(1);
     expect(restoreTerminalOrder.mock.calls[0]![0]).toEqual(["new-t1", "new-t2", "new-t3"]);
+  });
+
+  it("restores every priority PTY panel even when one rejects (#10528 parallel tier)", async () => {
+    // All three are priority (active worktree). The middle addPanel rejects;
+    // the parallel Promise.allSettled tier must still attempt all three rather
+    // than aborting the rest as the old sequential loop's throw would.
+    const ctx = makeContext({ activeWorktreeId: "wA" });
+    ctx.backendTerminalMap.set("p1", backend("p1"));
+    ctx.backendTerminalMap.set("p2", backend("p2"));
+    ctx.backendTerminalMap.set("p3", backend("p3"));
+    const attempted: string[] = [];
+    ctx.addPanel.mockImplementation(async (args: { existingId?: string; requestedId?: string }) => {
+      const id = args.existingId ?? args.requestedId ?? "";
+      attempted.push(id);
+      if (id === "p2") throw new Error("spawn failed");
+      return id;
+    });
+    await restorePanelsPhase(
+      [
+        panel("p1", { worktreeId: "wA" }),
+        panel("p2", { worktreeId: "wA" }),
+        panel("p3", { worktreeId: "wA" }),
+      ],
+      ctx
+    );
+    // p1 and p3 must have been attempted even though p2 rejected — proving the
+    // parallel tier did not abort on the first failure.
+    expect(attempted).toContain("p1");
+    expect(attempted).toContain("p3");
   });
 
   it("does not call restoreTerminalOrder when no panels were restored", async () => {

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -102,15 +102,20 @@ vi.mock("@shared/utils/smokeTestTerminals", () => ({
 }));
 
 // Override stagger constants so tests don't have to wait 100ms × N
+// Spy on getRestoreBatchParams so tests can both pin fast/deterministic batches
+// (batchSize 2, delayMs 0) AND assert the resource profile is threaded through
+// from the context (#10528).
+const { getRestoreBatchParamsMock } = vi.hoisted(() => ({
+  getRestoreBatchParamsMock: vi.fn(() => ({ batchSize: 2, delayMs: 0 })),
+}));
+
 vi.mock("../batchScheduler", async () => {
   const actual = await vi.importActual<typeof import("../batchScheduler")>("../batchScheduler");
   return {
     ...actual,
     RESTORE_SPAWN_BATCH_SIZE: 2,
     RESTORE_SPAWN_BATCH_DELAY_MS: 0,
-    // Fast, deterministic batches regardless of resource profile so existing
-    // batching/ordering assertions stay stable (#10528).
-    getRestoreBatchParams: () => ({ batchSize: 2, delayMs: 0 }),
+    getRestoreBatchParams: getRestoreBatchParamsMock,
   };
 });
 
@@ -175,6 +180,8 @@ beforeEach(() => {
   initializeBackendTierMock.mockReset();
   setTargetSizeMock.mockReset();
   reconnectWithTimeoutMock.mockReset();
+  getRestoreBatchParamsMock.mockClear();
+  getRestoreBatchParamsMock.mockReturnValue({ batchSize: 2, delayMs: 0 });
 });
 
 describe("restorePanelsPhase — saved panels", () => {
@@ -299,6 +306,38 @@ describe("restorePanelsPhase — saved panels", () => {
     // parallel tier did not abort on the first failure.
     expect(attempted).toContain("p1");
     expect(attempted).toContain("p3");
+  });
+
+  it("runs priority PTY restores concurrently, not sequentially (#10528)", async () => {
+    // p1's addPanel only resolves once p3's addPanel has been called. A
+    // sequential loop would call p1 first and deadlock (p3 never reached); the
+    // Promise.allSettled tier fires both, so p3 unblocks p1. If this resolves,
+    // the tier is genuinely concurrent.
+    const ctx = makeContext({ activeWorktreeId: "wA" });
+    ctx.backendTerminalMap.set("p1", backend("p1"));
+    ctx.backendTerminalMap.set("p3", backend("p3"));
+    let resolveP3Seen!: () => void;
+    const p3Seen = new Promise<void>((resolve) => {
+      resolveP3Seen = resolve;
+    });
+    ctx.addPanel.mockImplementation(async (args: { existingId?: string; requestedId?: string }) => {
+      const id = args.existingId ?? args.requestedId ?? "";
+      if (id === "p3") resolveP3Seen();
+      if (id === "p1") await p3Seen;
+      return id;
+    });
+    await restorePanelsPhase(
+      [panel("p1", { worktreeId: "wA" }), panel("p3", { worktreeId: "wA" })],
+      ctx
+    );
+    expect(ctx.addPanel).toHaveBeenCalledTimes(2);
+  });
+
+  it("threads the context resource profile into getRestoreBatchParams (#10528)", async () => {
+    const ctx = makeContext({ activeWorktreeId: "wA", resourceProfile: "performance" });
+    ctx.backendTerminalMap.set("b1", backend("b1"));
+    await restorePanelsPhase([panel("b1", { worktreeId: "wOther" })], ctx);
+    expect(getRestoreBatchParamsMock).toHaveBeenCalledWith("performance");
   });
 
   it("does not call restoreTerminalOrder when no panels were restored", async () => {

--- a/src/utils/stateHydration/batchScheduler.ts
+++ b/src/utils/stateHydration/batchScheduler.ts
@@ -1,9 +1,38 @@
 import { logWarn } from "@/utils/logger";
+import type { ResourceProfile } from "@shared/types/resourceProfile";
 
 export const RESTORE_SPAWN_BATCH_SIZE = 3;
 export const RESTORE_SPAWN_BATCH_DELAY_MS = 100;
 
 const BACKGROUND_RESTORE_FALLBACK_DELAY_MS = 0;
+
+export interface RestoreBatchParams {
+  /** Number of background/orphan PTY panels spawned per staggered batch. */
+  batchSize: number;
+  /** Delay between staggered batches, in milliseconds. */
+  delayMs: number;
+}
+
+/**
+ * Adaptive batch size + inter-batch delay for staggered PTY restore, scaled to
+ * the machine's resource profile (#10528). The profile already encodes hardware
+ * capability — `performance` machines spawn larger batches with shorter gaps,
+ * `efficiency` machines stay conservative to limit simultaneous shell-init
+ * bursts and PTY fd pressure. Unknown/missing profiles fall back to `balanced`,
+ * matching the resource-profile store's default. Kept upper-bounded (8) to stay
+ * below the fd-leak ceiling flagged in #9544.
+ */
+export function getRestoreBatchParams(profile?: ResourceProfile | null): RestoreBatchParams {
+  switch (profile) {
+    case "performance":
+      return { batchSize: 8, delayMs: 50 };
+    case "efficiency":
+      return { batchSize: 2, delayMs: 150 };
+    case "balanced":
+    default:
+      return { batchSize: 5, delayMs: 80 };
+  }
+}
 
 export interface TerminalRestoreTask {
   terminalId: string;

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -470,6 +470,11 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
           restoreTerminalOrder: options.restoreTerminalOrder,
           safeMode: hydrateResult.safeMode,
           visiblePanelId,
+          // May still read the "balanced" default if the useResourceProfile
+          // hook's getResourceProfile() IPC hasn't resolved yet on a cold
+          // first hydration (#10528). Acceptable: it only affects background/
+          // orphan stagger sizing, errs toward more-aggressive, and self-
+          // corrects on the next project switch.
           resourceProfile: useResourceProfileStore.getState().profile,
           logHydrationInfo,
         });

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -30,6 +30,7 @@ import {
 import { isDaintreeEnvEnabled } from "@/utils/env";
 import { useSafeModeStore } from "@/store/safeModeStore";
 import { useDistributionStore } from "@/store/distributionStore";
+import { useResourceProfileStore } from "@/store/resourceProfileStore";
 import type { AgentPreset } from "@/config/agents";
 import type { HydrationBatchToken } from "@/store/slices/panelRegistry/types";
 import { normalizeAndApplyScrollback } from "./scrollbackConfig";
@@ -469,6 +470,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
           restoreTerminalOrder: options.restoreTerminalOrder,
           safeMode: hydrateResult.safeMode,
           visiblePanelId,
+          resourceProfile: useResourceProfileStore.getState().profile,
           logHydrationInfo,
         });
         const { restoreTasks } = restoreResult;

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -10,12 +10,8 @@ import type {
 import type { AgentSettings } from "@shared/types/agentSettings";
 import type { WorktreeState } from "@shared/types";
 import type { AgentPreset } from "@/config/agents";
-import {
-  type TerminalRestoreTask,
-  RESTORE_SPAWN_BATCH_SIZE,
-  RESTORE_SPAWN_BATCH_DELAY_MS,
-  delay,
-} from "./batchScheduler";
+import type { ResourceProfile } from "@shared/types/resourceProfile";
+import { type TerminalRestoreTask, getRestoreBatchParams, delay } from "./batchScheduler";
 import { reconnectWithTimeout } from "./reconnectManager";
 import {
   inferKind,
@@ -61,6 +57,13 @@ export interface PanelRestoreContext {
    * MRU head) degrades cleanly to the existing worktree/recency ordering.
    */
   visiblePanelId?: string;
+  /**
+   * Active resource profile, read once by the caller (#10528). Scales the
+   * staggered PTY restore batch size and inter-batch delay via
+   * `getRestoreBatchParams` so capable machines restore faster. Defaults to
+   * `balanced` when omitted.
+   */
+  resourceProfile?: ResourceProfile;
   logHydrationInfo: (message: string, context?: Record<string, unknown>) => void;
 }
 
@@ -111,11 +114,17 @@ export async function restorePanelsPhase(
     restoreTerminalOrder,
     safeMode,
     visiblePanelId,
+    resourceProfile,
     logHydrationInfo,
   } = ctx;
 
   const restoreTasks: TerminalRestoreTask[] = [];
   const savedIdToRestoredId = new Map<string, string>();
+  // Adaptive staggered-restore params scaled to the machine's resource
+  // profile (#10528). One source of truth for both the background and orphan
+  // PTY phases below.
+  const { batchSize: restoreBatchSize, delayMs: restoreBatchDelayMs } =
+    getRestoreBatchParams(resourceProfile);
 
   if (savedPanels && savedPanels.length > 0) {
     // Build a single-pass map of worktreeId → highest lastActiveAt across saved
@@ -436,32 +445,37 @@ export async function restorePanelsPhase(
       });
     }
 
-    // Restore priority PTY panels sequentially (active worktree, for instant
-    // interactivity). Batched so the sequential `await`s — which normally break
-    // React 19 auto-batching and cause one render per panel — collapse into a
-    // single store commit at phase end.
+    // Restore priority PTY panels in parallel (active worktree + each other
+    // worktree's last-focused panel, for instant interactivity). The main
+    // process serializes the spawn IPC anyway, so firing them concurrently
+    // only removes the renderer-side sequential `await` latency ((N-1)×RTT)
+    // without adding OS-level spawn pressure (#10528). The single
+    // `withHydrationBatch` wrapper collapses all N addPanel mutations into one
+    // store commit; a rejection in one task never blocks the others.
     if (ptyPriorityTasks.length > 0) {
       await withHydrationBatch(async () => {
-        for (const task of ptyPriorityTasks) {
-          try {
-            await task.execute();
-          } catch (error) {
-            logWarn("Failed to restore priority panel", { error });
-          }
-        }
+        await Promise.allSettled(
+          ptyPriorityTasks.map(async (task) => {
+            try {
+              await task.execute();
+            } catch (error) {
+              logWarn("Failed to restore priority panel", { error });
+            }
+          })
+        );
       });
     }
 
     // Restore background PTY panels in staggered batches. Each batch is its own
     // hydration batch: we still want staggered spawning to throttle PTY pressure,
     // but within a batch the N panels commit in one render rather than N.
-    // N background panels -> ceil(N / RESTORE_SPAWN_BATCH_SIZE) renders instead of N.
+    // N background panels -> ceil(N / restoreBatchSize) renders instead of N.
     if (ptyBackgroundTasks.length > 0) {
       logHydrationInfo(
-        `Staggering ${ptyBackgroundTasks.length} background PTY panel(s) in batches of ${RESTORE_SPAWN_BATCH_SIZE}`
+        `Staggering ${ptyBackgroundTasks.length} background PTY panel(s) in batches of ${restoreBatchSize}`
       );
-      for (let i = 0; i < ptyBackgroundTasks.length; i += RESTORE_SPAWN_BATCH_SIZE) {
-        const batch = ptyBackgroundTasks.slice(i, i + RESTORE_SPAWN_BATCH_SIZE);
+      for (let i = 0; i < ptyBackgroundTasks.length; i += restoreBatchSize) {
+        const batch = ptyBackgroundTasks.slice(i, i + restoreBatchSize);
         await withHydrationBatch(async () => {
           await Promise.allSettled(
             batch.map(async (task) => {
@@ -473,8 +487,8 @@ export async function restorePanelsPhase(
             })
           );
         });
-        if (i + RESTORE_SPAWN_BATCH_SIZE < ptyBackgroundTasks.length) {
-          await delay(RESTORE_SPAWN_BATCH_DELAY_MS);
+        if (i + restoreBatchSize < ptyBackgroundTasks.length) {
+          await delay(restoreBatchDelayMs);
         }
       }
     }
@@ -573,13 +587,13 @@ export async function restorePanelsPhase(
     // Same staggered-batch pattern as the background PTY phase: one hydration
     // batch per spawn batch so orphan restores commit once per batch rather
     // than once per terminal.
-    for (let i = 0; i < orphanedTerminals.length; i += RESTORE_SPAWN_BATCH_SIZE) {
-      const batch = orphanedTerminals.slice(i, i + RESTORE_SPAWN_BATCH_SIZE);
+    for (let i = 0; i < orphanedTerminals.length; i += restoreBatchSize) {
+      const batch = orphanedTerminals.slice(i, i + restoreBatchSize);
       await withHydrationBatch(async () => {
         await Promise.allSettled(batch.map(restoreOrphan));
       });
-      if (i + RESTORE_SPAWN_BATCH_SIZE < orphanedTerminals.length) {
-        await delay(RESTORE_SPAWN_BATCH_DELAY_MS);
+      if (i + restoreBatchSize < orphanedTerminals.length) {
+        await delay(restoreBatchDelayMs);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Priority PTY restore was sequential — each panel waited on the previous one before spawning. Switching to `Promise.allSettled` inside the existing `withHydrationBatch` wrapper removes the (N-1)x round-trip latency with no new OS-level fd/spawn pressure. A rejection in one panel no longer blocks the rest; ordering is preserved via index-keyed remapping.
- Background/orphan batch parameters were hardcoded at 3 panels / 100ms. `getRestoreBatchParams(profile)` in `batchScheduler.ts` scales these to the active resource profile: performance `{8, 50ms}`, balanced `{5, 80ms}`, efficiency `{2, 150ms}`, with `batchSize` capped at 8 to stay below the fd-leak ceiling (#9544).
- `resourceProfile` is threaded through `PanelRestoreContext` and read once at the hydrate call site from `useResourceProfileStore`.

Closes #10528

## Changes

- `panelRestorePhase.ts` — priority tier now uses `Promise.allSettled`; reads `resourceProfile` from context for batch scheduling
- `batchScheduler.ts` — new `getRestoreBatchParams(profile)` function; single source of truth for batch size + delay
- `batchScheduler.test.ts` — covers scaling, ceiling enforcement, and balanced fallback
- `panelRestorePhase.test.ts` — real concurrency proof, profile wiring assertion, single-rejection resilience

## Testing

43 unit tests pass. Prettier + ESLint clean on all changed files.