### PR TITLE
feat(hydration): jump the visible terminal to the front of the restore queue

### DIFF
--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -497,6 +497,89 @@ describe("restorePanelsPhase — lastActiveAt promotion (issue #8703)", () => {
   });
 });
 
+describe("restorePanelsPhase — visible-panel priority tier (issue #10527)", () => {
+  // addPanel order is the observable. Visible PTY panels run in a dedicated
+  // tier ahead of the active-worktree priority tier; non-PTY visible panels are
+  // unaffected (they stay on the concurrent non-PTY path).
+  const restoredIds = (addPanel: Mock): (string | undefined)[] =>
+    addPanel.mock.calls.map((c) => {
+      const args = c[0] as { existingId?: string; requestedId?: string };
+      return args.existingId ?? args.requestedId;
+    });
+
+  it("restores the visible PTY panel first, ahead of the active-worktree tier", async () => {
+    const ctx = makeContext({ activeWorktreeId: "wA", visiblePanelId: "b1" });
+    ctx.backendTerminalMap.set("a1", backend("a1"));
+    ctx.backendTerminalMap.set("b1", backend("b1"));
+    ctx.backendTerminalMap.set("b2", backend("b2"));
+    await restorePanelsPhase(
+      [
+        panel("a1", { worktreeId: "wA" }), // active -> priority 0
+        panel("b1", { worktreeId: "wB", lastActiveAt: 10 }), // visible -> -1 (would be background)
+        panel("b2", { worktreeId: "wB", lastActiveAt: 200 }), // max in wB -> priority 0
+      ],
+      ctx
+    );
+    // Without the visible tier b1 is background and restores last (a1, b2, b1).
+    // The visible tier pulls it to the front.
+    expect(restoredIds(ctx.addPanel)).toEqual(["b1", "a1", "b2"]);
+    // Restored exactly once — the -1 tier replaces, not duplicates, its slot.
+    expect(ctx.addPanel).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not let a visible non-PTY panel jump the PTY restore queue", async () => {
+    const ctx = makeContext({ activeWorktreeId: "wA", visiblePanelId: "br1" });
+    ctx.backendTerminalMap.set("a1", backend("a1"));
+    ctx.backendTerminalMap.set("b1", backend("b1"));
+    await restorePanelsPhase(
+      [
+        panel("a1", { worktreeId: "wA" }), // active PTY -> priority 0
+        panel("br1", { kind: "browser", worktreeId: "wB" }), // non-PTY, visible
+        panel("b1", { worktreeId: "wB", lastActiveAt: 5 }), // background PTY
+      ],
+      ctx
+    );
+    // br1 restores via the concurrent non-PTY phase (first), but it never enters
+    // the -1 PTY tier, so the PTY ordering (a1 priority, b1 background) is
+    // unchanged — the visible non-PTY does not promote the background PTY.
+    expect(restoredIds(ctx.addPanel)).toEqual(["br1", "a1", "b1"]);
+  });
+
+  it("preserves existing ordering when no visiblePanelId is supplied", async () => {
+    const ctx = makeContext({ activeWorktreeId: "wA" }); // visiblePanelId undefined
+    ctx.backendTerminalMap.set("a1", backend("a1"));
+    ctx.backendTerminalMap.set("b1", backend("b1"));
+    ctx.backendTerminalMap.set("b2", backend("b2"));
+    await restorePanelsPhase(
+      [
+        panel("a1", { worktreeId: "wA" }),
+        panel("b1", { worktreeId: "wB", lastActiveAt: 10 }),
+        panel("b2", { worktreeId: "wB", lastActiveAt: 200 }),
+      ],
+      ctx
+    );
+    // a1 (active) + b2 (max in wB) are priority; b1 is background and last.
+    expect(restoredIds(ctx.addPanel)).toEqual(["a1", "b2", "b1"]);
+  });
+
+  it("degrades to existing ordering when visiblePanelId matches no saved panel", async () => {
+    const ctx = makeContext({ activeWorktreeId: "wA", visiblePanelId: "ghost" });
+    ctx.backendTerminalMap.set("a1", backend("a1"));
+    ctx.backendTerminalMap.set("b1", backend("b1"));
+    ctx.backendTerminalMap.set("b2", backend("b2"));
+    await restorePanelsPhase(
+      [
+        panel("a1", { worktreeId: "wA" }),
+        panel("b1", { worktreeId: "wB", lastActiveAt: 10 }),
+        panel("b2", { worktreeId: "wB", lastActiveAt: 200 }),
+      ],
+      ctx
+    );
+    // Identical to the no-signal case — a stale MRU head is harmless.
+    expect(restoredIds(ctx.addPanel)).toEqual(["a1", "b2", "b1"]);
+  });
+});
+
 describe("restorePanelsPhase — matched backend not re-appended as orphan", () => {
   it("matched backend terminals are removed from the map before orphan scan (no double restore)", async () => {
     // Pins backendTerminalMap.delete() inside the saved-panels execute() — if the

--- a/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
+++ b/src/utils/stateHydration/__tests__/panelRestorePhase.test.ts
@@ -578,6 +578,58 @@ describe("restorePanelsPhase — visible-panel priority tier (issue #10527)", ()
     // Identical to the no-signal case — a stale MRU head is harmless.
     expect(restoredIds(ctx.addPanel)).toEqual(["a1", "b2", "b1"]);
   });
+
+  it("restores a visible panel first via the respawn path on cold restart (no backend match)", async () => {
+    // No backend terminal for the visible panel → it takes the reconnect/respawn
+    // path. It must still jump ahead of the active-worktree PTY.
+    reconnectWithTimeoutMock.mockResolvedValue({ status: "not_found" });
+    const ctx = makeContext({ activeWorktreeId: "wA", visiblePanelId: "v1" });
+    ctx.backendTerminalMap.set("a1", backend("a1"));
+    await restorePanelsPhase(
+      [
+        panel("a1", { worktreeId: "wA" }), // active PTY (backend match)
+        panel("v1", { kind: "agent", launchAgentId: "claude", worktreeId: "wB" }), // visible, respawn
+      ],
+      ctx
+    );
+    // v1 (visible, respawned with requestedId v1) restores before a1.
+    expect(restoredIds(ctx.addPanel)).toEqual(["v1", "a1"]);
+  });
+
+  it("restores the visible panel exactly once when it is also the active-worktree panel", async () => {
+    // Overlap: the visible panel is in the active worktree. priority -1 wins over
+    // priority 0, so it lands only in the visible tier — never double-restored.
+    const ctx = makeContext({ activeWorktreeId: "wA", visiblePanelId: "a1" });
+    ctx.backendTerminalMap.set("a1", backend("a1"));
+    ctx.backendTerminalMap.set("a2", backend("a2"));
+    await restorePanelsPhase(
+      [panel("a1", { worktreeId: "wA" }), panel("a2", { worktreeId: "wA" })],
+      ctx
+    );
+    expect(restoredIds(ctx.addPanel)).toEqual(["a1", "a2"]);
+    expect(ctx.addPanel).toHaveBeenCalledTimes(2);
+  });
+
+  it("wraps the visible tier in its own hydration batch separate from background", async () => {
+    // v1 is the max-lastActiveAt in wB but is visible → priority -1, so b1/b2
+    // (lower stamps, same worktree) are NOT promoted and both go to background.
+    // Tiers: visible[v1], background[b1,b2] (one batch, size 2) → 2 batch calls.
+    // A regression that forgot to wrap the visible tier would drop to 1.
+    const ctx = makeContext({ visiblePanelId: "v1" });
+    ctx.backendTerminalMap.set("v1", backend("v1"));
+    ctx.backendTerminalMap.set("b1", backend("b1"));
+    ctx.backendTerminalMap.set("b2", backend("b2"));
+    await restorePanelsPhase(
+      [
+        panel("v1", { worktreeId: "wB", lastActiveAt: 100 }), // visible
+        panel("b1", { worktreeId: "wB", lastActiveAt: 5 }), // background
+        panel("b2", { worktreeId: "wB", lastActiveAt: 5 }), // background
+      ],
+      ctx
+    );
+    expect(restoredIds(ctx.addPanel)).toEqual(["v1", "b1", "b2"]);
+    expect(ctx.withHydrationBatch).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("restorePanelsPhase — matched backend not re-appended as orphan", () => {

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -442,6 +442,18 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
 
         const prefetchedReconnectResults = await reconnectPrefetchPromise;
 
+        // The per-project MRU head is the terminal the user last had on screen.
+        // It is persisted as `terminal:<id>`; strip the prefix to recover the
+        // saved panel id so restorePanelsPhase can jump it to the front of the
+        // restore queue (#10527). A non-terminal head (browser/dev-preview MRU
+        // entry) yields undefined, degrading to the existing ordering.
+        const MRU_TERMINAL_PREFIX = "terminal:";
+        const mruHead = appState.mruList?.[0];
+        const visiblePanelId =
+          mruHead && mruHead.startsWith(MRU_TERMINAL_PREFIX)
+            ? mruHead.slice(MRU_TERMINAL_PREFIX.length)
+            : undefined;
+
         const restoreResult = await restorePanelsPhase(appState.terminals, {
           addPanel,
           withHydrationBatch,
@@ -456,6 +468,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
           worktreesPromise,
           restoreTerminalOrder: options.restoreTerminalOrder,
           safeMode: hydrateResult.safeMode,
+          visiblePanelId,
           logHydrationInfo,
         });
         const { restoreTasks } = restoreResult;

--- a/src/utils/stateHydration/index.ts
+++ b/src/utils/stateHydration/index.ts
@@ -450,7 +450,7 @@ export async function hydrateAppState(options: HydrationOptions): Promise<void> 
         const MRU_TERMINAL_PREFIX = "terminal:";
         const mruHead = appState.mruList?.[0];
         const visiblePanelId =
-          mruHead && mruHead.startsWith(MRU_TERMINAL_PREFIX)
+          typeof mruHead === "string" && mruHead.startsWith(MRU_TERMINAL_PREFIX)
             ? mruHead.slice(MRU_TERMINAL_PREFIX.length)
             : undefined;
 

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -52,6 +52,15 @@ export interface PanelRestoreContext {
   worktreesPromise: Promise<WorktreeState[] | null>;
   restoreTerminalOrder?: RestoreTerminalOrderFn;
   safeMode: boolean;
+  /**
+   * Saved id of the panel the user last had on screen (the head of the
+   * per-project MRU list, see #10527). A matching PTY panel jumps to the front
+   * of the restore queue ahead of the active-worktree priority tier, so the
+   * terminal the user was actually looking at reconnects first instead of
+   * waiting behind background batches. `undefined` (no MRU, or a non-terminal
+   * MRU head) degrades cleanly to the existing worktree/recency ordering.
+   */
+  visiblePanelId?: string;
   logHydrationInfo: (message: string, context?: Record<string, unknown>) => void;
 }
 
@@ -101,6 +110,7 @@ export async function restorePanelsPhase(
     worktreesPromise,
     restoreTerminalOrder,
     safeMode,
+    visiblePanelId,
     logHydrationInfo,
   } = ctx;
 
@@ -150,7 +160,6 @@ export async function restorePanelsPhase(
         Number.isFinite(saved.lastActiveAt) &&
         (saved.lastActiveAt ?? 0) > 0 &&
         saved.lastActiveAt === maxLastActiveAtByWorktree.get(saved.worktreeId);
-      const priority = isActiveWorktree || isMostRecentInOtherWorktree ? 0 : 1;
 
       // Determine isPty at task-build time so we can partition tasks
       // for concurrent (non-PTY) vs staggered (PTY) execution.
@@ -162,6 +171,14 @@ export async function restorePanelsPhase(
         const inferredKind = inferKind(saved);
         taskIsPty = inferredKind === "assistant" ? false : panelKindHasPty(inferredKind);
       }
+
+      // The panel the user last had on screen (per-project MRU head, #10527)
+      // jumps to a dedicated priority `-1` tier ahead of the active-worktree
+      // queue, so the terminal they were actually looking at reconnects first.
+      // Gated on `taskIsPty`: the `-1` tier only reorders PTY spawning, so a
+      // visible non-PTY panel stays on the concurrent non-PTY path.
+      const isVisible = taskIsPty && visiblePanelId !== undefined && saved.id === visiblePanelId;
+      const priority = isVisible ? -1 : isActiveWorktree || isMostRecentInOtherWorktree ? 0 : 1;
 
       const capturedIndex = savedIndex;
       panelTasks.push({
@@ -379,6 +396,7 @@ export async function restorePanelsPhase(
     // do synchronous Zustand mutations with no IPC), then PTY panels restore
     // with priority ordering and staggered batching to throttle process spawning.
     const nonPtyTasks = panelTasks.filter((t) => !t.isPty);
+    const ptyVisibleTasks = panelTasks.filter((t) => t.isPty && t.priority === -1);
     const ptyPriorityTasks = panelTasks.filter((t) => t.isPty && t.priority === 0);
     const ptyBackgroundTasks = panelTasks.filter((t) => t.isPty && t.priority === 1);
 
@@ -398,6 +416,23 @@ export async function restorePanelsPhase(
             }
           })
         );
+      });
+    }
+
+    // Restore the visible panel first (#10527). The terminal the user last had
+    // on screen reconnects ahead of the active-worktree tier so it is
+    // interactive the instant the grid paints, instead of waiting behind
+    // background batches. At most one task here (a single MRU head), but
+    // filtered like the others to stay robust; batched to match the rest.
+    if (ptyVisibleTasks.length > 0) {
+      await withHydrationBatch(async () => {
+        for (const task of ptyVisibleTasks) {
+          try {
+            await task.execute();
+          } catch (error) {
+            logWarn("Failed to restore visible panel", { error });
+          }
+        }
       });
     }
 


### PR DESCRIPTION
## Summary

- Adds a priority -1 tier to the terminal restore queue so the terminal currently on screen always restores first, ahead of the existing active-worktree and last-active ordering
- On project load or switch, hydration reads `mruList[0]` from the hydrate payload, strips the `terminal:` prefix, and runs that PTY panel in a dedicated `withHydrationBatch` phase before the priority 0 tier — no new IPC needed
- Non-PTY panels (browser, dev-preview) skip the fast path and stay on the concurrent restore path

Resolves #10527

## Changes

- `src/utils/stateHydration/panelRestorePhase.ts` — added optional `visiblePanelId` to `PanelRestoreContext`; assigned priority -1 to the matching PTY panel; new pre-priority batch phase runs it first
- `src/utils/stateHydration/index.ts` — derives `visiblePanelId` from `appState.mruList[0]`, guarded for non-string and non-terminal heads
- `src/__tests__/panelRestorePhase.test.ts` — 7 new tests covering the visible tier (visible PTY jumps front, visible non-PTY doesn't affect PTY queue, missing/stale `visiblePanelId` degrades cleanly, respawn-path visible jump, no double-restore when active and visible overlap, visible-tier batch wrapping)

## Testing

41 tests passing in `panelRestorePhase.test.ts`. The new visible-tier cases verify the priority ordering, the non-PTY guard, graceful degradation with no MRU head or a stale panel ID, and that a panel appearing in both the active-worktree tier and the visible tier doesn't restore twice.