### PR TITLE
fix(plugin): close MCP consent fingerprint and dispatch audit gaps (#10517)

### DIFF
--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -64,8 +64,9 @@ vi.mock("../../../services/fileDecorationRegistry.js", () => ({
 }));
 
 const mockAuditAppend = vi.fn();
+const mockAuditClear = vi.fn();
 vi.mock("../../../services/PluginActionAuditService.js", () => ({
-  getPluginActionAuditService: () => ({ append: mockAuditAppend }),
+  getPluginActionAuditService: () => ({ append: mockAuditAppend, clear: mockAuditClear }),
 }));
 
 const mockIpcMainHandle = vi.fn();
@@ -1233,6 +1234,43 @@ describe("registerPluginHandlers", () => {
     );
 
     expect(mockDispatchHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("PLUGIN_CLEAR_AUDIT_LOG clears the log for a trusted first-party sender", async () => {
+    const handler = getHandler("plugin:clear-audit-log");
+    await handler({ senderFrame: { url: "app://daintree/" }, sender: { id: 1 } });
+    expect(mockAuditClear).toHaveBeenCalledTimes(1);
+    // A trusted clear is the legitimate path — no restricted record is written.
+    expect(mockAuditAppend).not.toHaveBeenCalled();
+  });
+
+  it("PLUGIN_CLEAR_AUDIT_LOG rejects an untrusted sender and leaves the log intact", async () => {
+    const handler = getHandler("plugin:clear-audit-log");
+    await expect(
+      handler({ senderFrame: { url: "https://evil.com/attack.html" }, sender: { id: 1 } })
+    ).rejects.toThrow("untrusted sender");
+    // The forensic trail must survive the rejected wipe...
+    expect(mockAuditClear).not.toHaveBeenCalled();
+    // ...and the attempt itself is recorded as a restricted ipc-invoke.
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
+    const record = mockAuditAppend.mock.calls[0]![0];
+    expect(record).toMatchObject({
+      recordType: "ipc-invoke",
+      channel: "plugin:clear-audit-log",
+      result: "restricted",
+    });
+    expect(record.errorMessage).toContain("untrusted sender");
+    // The attacker-controlled URL is captured (capped) for forensics.
+    expect(record.errorMessage).toContain("evil.com");
+  });
+
+  it("PLUGIN_CLEAR_AUDIT_LOG rejects when senderFrame is missing and does not clear", async () => {
+    const handler = getHandler("plugin:clear-audit-log");
+    await expect(handler({ senderFrame: null, sender: { id: 1 } })).rejects.toThrow(
+      "untrusted sender"
+    );
+    expect(mockAuditClear).not.toHaveBeenCalled();
+    expect(mockAuditAppend).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/electron/ipc/handlers/__tests__/pluginMcpCallTool.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginMcpCallTool.test.ts
@@ -1,3 +1,4 @@
+import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Stable mock boundaries so importing the handler stays cheap and free of the
@@ -116,10 +117,14 @@ function setSchema(tool: unknown): void {
 }
 
 /** Pin a TOFU approval so `authorizeToolCall` resolves without a prompt. */
-function pinApproval(tool: { description?: string; inputSchema: unknown }): void {
+function pinApproval(tool: {
+  description?: string;
+  inputSchema: unknown;
+  annotations?: ToolAnnotations;
+}): void {
   (h.consentStore as PluginMcpConsentStore).pin(
     { pluginId: input.pluginId, serverId: input.serverId, toolName: input.toolName },
-    fingerprintTool(tool.description ?? "", tool.inputSchema)
+    fingerprintTool(tool.description ?? "", tool.inputSchema, tool.annotations)
   );
 }
 

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -725,7 +725,37 @@ async function handleGetAuditConfig(): Promise<PluginAuditConfig> {
   return getPluginActionAuditService().getConfig();
 }
 
-async function handleClearAuditLog(): Promise<void> {
+/**
+ * Wipe every plugin's audit records. Unlike the read-only audit getters, this
+ * destroys the shared forensic trail, so it carries a sender-trust gate that
+ * the read paths don't need (#10517). Plugin view modules are `import()`ed
+ * into the shared renderer realm, but a frame outside the first-party origin
+ * (a cross-origin iframe, `<webview>`, or portal WebContents) must never reach
+ * this — it would let an untrusted surface erase the evidence of its own and
+ * every other plugin's activity. The rejected attempt is itself audited (the
+ * security-relevant signal is "an untrusted frame tried to clear the log"),
+ * mirroring the `plugin:invoke` trust check.
+ */
+async function handleClearAuditLog(ctx: IpcContext): Promise<void> {
+  const senderUrl = ctx.event.senderFrame?.url;
+  if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
+    const safeUrl = senderUrl
+      ? scrubSecrets(senderUrl.slice(0, UNTRUSTED_URL_MAX_CHARS))
+      : "unknown";
+    safeAppend({
+      pluginId: "",
+      actionId: PLUGIN_METHOD_CHANNELS.clearAuditLog,
+      recordType: "ipc-invoke",
+      channel: PLUGIN_METHOD_CHANNELS.clearAuditLog,
+      result: "restricted",
+      errorMessage: `untrusted sender (url=${safeUrl})`,
+      argsHash: "",
+      durationMs: 0,
+    });
+    throw new Error(
+      `plugin:clear-audit-log rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
+    );
+  }
   getPluginActionAuditService().clear();
 }
 
@@ -899,7 +929,9 @@ export const pluginNamespace = defineIpcNamespace({
     getWorktreeStatus: op(PLUGIN_METHOD_CHANNELS.getWorktreeStatus, handleWorktreeStatusGet),
     getAuditRecords: op(PLUGIN_METHOD_CHANNELS.getAuditRecords, handleGetAuditRecords),
     getAuditConfig: op(PLUGIN_METHOD_CHANNELS.getAuditConfig, handleGetAuditConfig),
-    clearAuditLog: op(PLUGIN_METHOD_CHANNELS.clearAuditLog, handleClearAuditLog),
+    clearAuditLog: op(PLUGIN_METHOD_CHANNELS.clearAuditLog, handleClearAuditLog, {
+      withContext: true,
+    }),
     setAuditEnabled: op(PLUGIN_METHOD_CHANNELS.setAuditEnabled, handleSetAuditEnabled),
     setAuditMaxRecords: op(PLUGIN_METHOD_CHANNELS.setAuditMaxRecords, handleSetAuditMaxRecords),
     exportAuditLog: op(PLUGIN_METHOD_CHANNELS.exportAuditLog, handleExportAuditLog),

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -752,9 +752,7 @@ async function handleClearAuditLog(ctx: IpcContext): Promise<void> {
       argsHash: "",
       durationMs: 0,
     });
-    throw new Error(
-      `plugin:clear-audit-log rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
-    );
+    throw new Error(`plugin:clear-audit-log rejected: untrusted sender (url=${safeUrl})`);
   }
   getPluginActionAuditService().clear();
 }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3005,8 +3005,9 @@ export class PluginService {
     // handler sees the same value the input-schema validation accepted above
     // (which also defaults the empty case to `{}`).
     if (actionHandler) {
+      let actionResult: unknown;
       try {
-        return await actionHandler(args.length > 0 ? args[0] : {});
+        actionResult = await actionHandler(args.length > 0 ? args[0] : {});
       } catch (err) {
         // Contain at the boundary so a throwing handler can't propagate up
         // through `ipcMain.handle` as an unhandled rejection. The error still
@@ -3028,6 +3029,20 @@ export class PluginService {
         markAuditedHandlerFailure(err);
         throw err;
       }
+      // Audit the success path too (#10517). A plugin calling its own
+      // registered action handler from its view must leave the same durable
+      // trail on success as on failure — otherwise a benign-looking action can
+      // run unobserved while only its failures are recorded.
+      safeAppendAudit({
+        pluginId,
+        actionId: channel,
+        recordType: "action-dispatch",
+        result: "success",
+        errorMessage: "",
+        argsHash: safeArgsHash(args),
+        durationMs: Date.now() - dispatchStart,
+      });
+      return actionResult;
     }
 
     if (!handler) {
@@ -3092,6 +3107,7 @@ export class PluginService {
       throw err;
     }
 
+    let finalResult: unknown = result;
     if (channelSchema) {
       const parsedResult = channelSchema.result.safeParse(result);
       if (!parsedResult.success) {
@@ -3099,10 +3115,25 @@ export class PluginService {
           `SCHEMA_ERROR: result for channel "${channel}" failed validation: ${z.prettifyError(parsedResult.error)}`
         );
       }
-      return parsedResult.data;
+      finalResult = parsedResult.data;
     }
 
-    return result;
+    // Audit the success path too (#10517). The catch above records IPC-handler
+    // failures; without this, a plugin invoking its own registered handler via
+    // `plugin:invoke` runs with zero audit trail on success. Recorded only once
+    // the dispatch will truly return (after result-schema validation), so a
+    // host-side schema rejection isn't logged as a success.
+    safeAppendAudit({
+      pluginId,
+      actionId: channel,
+      recordType: "ipc-invoke",
+      channel,
+      result: "success",
+      errorMessage: "",
+      argsHash: safeArgsHash(args),
+      durationMs: Date.now() - dispatchStart,
+    });
+    return finalResult;
   }
 
   removeHandlers(pluginId: string): void {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2565,16 +2565,31 @@ describe("Plugin IPC handler registration", () => {
       }
     });
 
-    it("does not audit when the typed-channel handler succeeds", async () => {
+    it("audits a successful typed-channel handler as an ipc-invoke success record (#10517)", async () => {
       const appendSpy = vi
         .spyOn(getPluginActionAuditService(), "append")
         .mockImplementation(() => {});
       try {
         service.registerHandler("acme.test-plugin", "get-data", vi.fn().mockResolvedValue("ok"));
-        await service.dispatchHandler("acme.test-plugin", "get-data", makeCtx("acme.test-plugin"), [
-          "a",
-        ]);
-        expect(appendSpy).not.toHaveBeenCalled();
+        const result = await service.dispatchHandler(
+          "acme.test-plugin",
+          "get-data",
+          makeCtx("acme.test-plugin"),
+          ["a"]
+        );
+        expect(result).toBe("ok");
+        expect(appendSpy).toHaveBeenCalledTimes(1);
+        const record = appendSpy.mock.calls[0][0];
+        expect(record).toMatchObject({
+          pluginId: "acme.test-plugin",
+          actionId: "get-data",
+          recordType: "ipc-invoke",
+          channel: "get-data",
+          result: "success",
+        });
+        expect(record.errorMessage).toBe("");
+        expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
+        expect(typeof record.durationMs).toBe("number");
       } finally {
         appendSpy.mockRestore();
       }
@@ -5339,6 +5354,38 @@ describe("createHost — registerAction", () => {
       expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
       // Marked so the outer plugin:invoke catch won't record a duplicate.
       expect(isAuditedHandlerFailure(boom)).toBe(true);
+    } finally {
+      appendSpy.mockRestore();
+    }
+  });
+
+  it("audits a successful action handler as an action-dispatch success record (#10517)", async () => {
+    const appendSpy = vi
+      .spyOn(getPluginActionAuditService(), "append")
+      .mockImplementation(() => {});
+    try {
+      const { host } = getHost("acme.act-test");
+      host.registerAction(descriptor(), () => "done");
+
+      const result = await service.dispatchHandler(
+        "acme.act-test",
+        "acme.act-test.plan-from-issue",
+        makeCtx("acme.act-test"),
+        [{ issue: 7 }]
+      );
+      expect(result).toBe("done");
+
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+      const record = appendSpy.mock.calls[0][0];
+      expect(record).toMatchObject({
+        pluginId: "acme.act-test",
+        actionId: "acme.act-test.plan-from-issue",
+        recordType: "action-dispatch",
+        result: "success",
+      });
+      expect(record.errorMessage).toBe("");
+      expect(record.argsHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(typeof record.durationMs).toBe("number");
     } finally {
       appendSpy.mockRestore();
     }

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3109,6 +3109,40 @@ describe("Plugin IPC handler registration", () => {
       ).rejects.toThrow(/^SCHEMA_ERROR: result for channel "broken" failed validation/);
     });
 
+    it("does NOT emit a success audit when the result schema rejects (#10517)", async () => {
+      // The success record is written only after result-schema validation
+      // passes — a host-side schema rejection of a handler that otherwise ran
+      // must never be logged as a successful dispatch.
+      const appendSpy = vi
+        .spyOn(getPluginActionAuditService(), "append")
+        .mockImplementation(() => {});
+      try {
+        const schema = {
+          args: z.object({}).passthrough(),
+          result: z.object({ count: z.number() }),
+        };
+        typedService.registerHandler(
+          "acme.typed",
+          "broken",
+          schema,
+          vi.fn(async () => ({ count: "nope" as unknown as number }))
+        );
+
+        await expect(
+          typedService.dispatchHandler("acme.typed", "broken", makeCtx("acme.typed"), [{}])
+        ).rejects.toThrow(/^SCHEMA_ERROR:/);
+
+        // No success record from the inner dispatch boundary (the schema
+        // rejection is owned by the outer plugin:invoke boundary instead).
+        const successCalls = appendSpy.mock.calls.filter(
+          (c) => (c[0] as { result?: string }).result === "success"
+        );
+        expect(successCalls).toHaveLength(0);
+      } finally {
+        appendSpy.mockRestore();
+      }
+    });
+
     it("rejects registration with PERMISSION_REQUIRED when a required capability is not declared", () => {
       const schema = {
         args: z.object({}),

--- a/electron/services/plugin-mcp/PluginMcpConsentService.ts
+++ b/electron/services/plugin-mcp/PluginMcpConsentService.ts
@@ -140,7 +140,7 @@ export class PluginMcpConsentService {
     }
 
     const dangerTier = tierResult.tier;
-    const fingerprint = fingerprintTool(input.descriptionRaw, input.inputSchema);
+    const fingerprint = fingerprintTool(input.descriptionRaw, input.inputSchema, input.annotations);
     const lookup = this.consentStore.lookup(input.identity, fingerprint);
 
     // D0 with a pinned (matching) approval auto-approves; otherwise the user
@@ -211,16 +211,21 @@ export class PluginMcpConsentService {
 }
 
 /**
- * Compute the three-component fingerprint used by the TOFU pin store. The
+ * Compute the four-component fingerprint used by the TOFU pin store. The
  * `rawHash` is over the raw description bytes (NOT stripped) so a rug-pull
  * payload hidden in invisible Unicode still flips the pin. The `displayHash`
  * is over the stripped string for diagnostics. The `schemaHash` is over the
  * input-schema JSON with keys sorted at every depth so a stable schema does
- * not produce different fingerprints in different runs.
+ * not produce different fingerprints in different runs. The `annotationHash`
+ * is over the three tier-influencing `ToolAnnotations` hints so a server that
+ * flips `readOnlyHint` → `destructiveHint` (raising the danger tier without
+ * touching the description or schema) still re-prompts. Only those three
+ * fields are hashed — future SDK annotation fields must not re-prompt.
  */
 export function fingerprintTool(
   descriptionRaw: string,
-  inputSchema: unknown
+  inputSchema: unknown,
+  annotations: ToolAnnotations | undefined
 ): PluginMcpToolFingerprint {
   const displayHash = sha256Hex(stripAnsiAndOscCodes(descriptionRaw));
   // Match the audit service's null-schema sentinel (sha256Hex("")) so an
@@ -234,11 +239,29 @@ export function fingerprintTool(
     rawHash: sha256Hex(descriptionRaw),
     displayHash,
     schemaHash,
+    annotationHash: hashAnnotations(annotations),
   };
 }
 
+/**
+ * Hash the three tier-influencing annotation hints, null-normalised and
+ * emitted in a fixed key order so an absent hint and an explicit `undefined`
+ * hash identically and key ordering can't perturb the digest. Confining the
+ * input to these three fields keeps the fingerprint stable when the MCP SDK
+ * adds new (non-tier) annotation fields.
+ */
+function hashAnnotations(annotations: ToolAnnotations | undefined): string {
+  return sha256Hex(
+    JSON.stringify({
+      d: annotations?.destructiveHint ?? null,
+      o: annotations?.openWorldHint ?? null,
+      r: annotations?.readOnlyHint ?? null,
+    })
+  );
+}
+
 function lookupToReason(
-  kind: "first-use" | "raw-changed" | "schema-changed" | "revoked"
+  kind: "first-use" | "raw-changed" | "schema-changed" | "annotation-changed" | "revoked"
 ): PluginMcpConsentReason {
   return kind;
 }

--- a/electron/services/plugin-mcp/PluginMcpConsentStore.ts
+++ b/electron/services/plugin-mcp/PluginMcpConsentStore.ts
@@ -37,10 +37,13 @@ export class PluginMcpConsentStore {
    * against the persisted pin (if any) and classifies the result so the
    * dispatch chain knows whether to prompt and which framing to use.
    *
-   * `raw-changed` is checked before `schema-changed` deliberately: a raw
-   * mutation is more security-relevant (it could carry a prompt-injection
-   * payload invisible in the display string), so the user must always see it
-   * even when both changed simultaneously.
+   * `raw-changed` is checked before `schema-changed` before `annotation-changed`
+   * deliberately: a raw mutation is the most security-relevant (it could carry a
+   * prompt-injection payload invisible in the display string), so the user must
+   * always see it even when several fields changed simultaneously. A legacy pin
+   * minted before `annotationHash` existed carries the `""` sentinel (see
+   * {@link normalizeRecord}), which never equals a real 64-char digest, so it
+   * surfaces as `annotation-changed` and re-prompts.
    */
   lookup(
     identity: PluginMcpToolIdentity,
@@ -56,6 +59,9 @@ export class PluginMcpConsentStore {
     }
     if (pin.fingerprint.schemaHash !== current.schemaHash) {
       return { kind: "schema-changed", previousPin: pin };
+    }
+    if (pin.fingerprint.annotationHash !== current.annotationHash) {
+      return { kind: "annotation-changed", previousPin: pin };
     }
     return { kind: "approved", pin };
   }
@@ -237,6 +243,11 @@ function normalizeRecord(raw: unknown): PluginMcpConsentRecord | null {
       rawHash: fpRec.rawHash,
       displayHash: fpRec.displayHash,
       schemaHash: fpRec.schemaHash,
+      // Legacy pins predate `annotationHash`. The `""` sentinel never equals a
+      // real digest, so the next lookup classifies them as `annotation-changed`
+      // and re-prompts — the tool was approved without annotation coverage, so
+      // re-consent is the fail-safe behaviour.
+      annotationHash: typeof fpRec.annotationHash === "string" ? fpRec.annotationHash : "",
     },
   };
 }

--- a/electron/services/plugin-mcp/__tests__/PluginMcpConsentService.test.ts
+++ b/electron/services/plugin-mcp/__tests__/PluginMcpConsentService.test.ts
@@ -75,7 +75,11 @@ describe("PluginMcpConsentService", () => {
     expect(result.kind).toBe("approved");
     expect(bridge).toHaveBeenCalledTimes(1);
 
-    const fp = fingerprintTool(baseInput.descriptionRaw, baseInput.inputSchema);
+    const fp = fingerprintTool(
+      baseInput.descriptionRaw,
+      baseInput.inputSchema,
+      baseInput.annotations
+    );
     expect(consentStore.lookup(baseInput.identity, fp).kind).toBe("approved");
   });
 
@@ -86,7 +90,11 @@ describe("PluginMcpConsentService", () => {
     const result = await service.authorizeToolCall(baseInput);
     expect(result.kind).toBe("approved");
 
-    const fp = fingerprintTool(baseInput.descriptionRaw, baseInput.inputSchema);
+    const fp = fingerprintTool(
+      baseInput.descriptionRaw,
+      baseInput.inputSchema,
+      baseInput.annotations
+    );
     expect(consentStore.lookup(baseInput.identity, fp).kind).toBe("first-use");
   });
 
@@ -152,6 +160,48 @@ describe("PluginMcpConsentService", () => {
     expect((bridge as any).mock.calls[1]![0].reason).toBe("schema-changed");
   });
 
+  it("re-prompts when only the tier-relevant annotations flip — benign→destructive rug-pull", async () => {
+    const bridge = vi
+      .fn()
+      .mockResolvedValueOnce("approved-and-pin") // first-use, pinned as read-only
+      .mockResolvedValueOnce("approved-once"); // annotation-changed re-prompt
+    service.setConsentBridge(bridge as any as PluginMcpConsentBridge);
+
+    // Pin a benign read-only tool.
+    await service.authorizeToolCall({ ...baseInput, annotations: { readOnlyHint: true } });
+    expect(bridge).toHaveBeenCalledTimes(1);
+    expect((bridge as any).mock.calls[0]![0].reason).toBe("first-use");
+
+    // Same description + schema, but the server now advertises a destructive
+    // tool — the tier rose without touching the bytes the old fingerprint
+    // covered, so the pin must NOT auto-approve.
+    const second = await service.authorizeToolCall({
+      ...baseInput,
+      annotations: { destructiveHint: true },
+    });
+    expect(second.kind).toBe("approved");
+    expect(bridge).toHaveBeenCalledTimes(2);
+    expect((bridge as any).mock.calls[1]![0].reason).toBe("annotation-changed");
+  });
+
+  it("does not re-prompt when a non-tier annotation field changes", async () => {
+    const bridge = vi.fn().mockResolvedValue("approved-and-pin");
+    service.setConsentBridge(bridge as any as PluginMcpConsentBridge);
+
+    await service.authorizeToolCall({ ...baseInput, annotations: { readOnlyHint: true } });
+    (bridge as any).mockClear();
+
+    // `title` is advisory metadata, not a tier input — the fingerprint must
+    // stay stable so the SDK adding non-tier fields can't trigger spurious
+    // re-consent.
+    const second = await service.authorizeToolCall({
+      ...baseInput,
+      annotations: { readOnlyHint: true, title: "Renamed Tool" },
+    });
+    expect(second.kind).toBe("approved");
+    expect(bridge).not.toHaveBeenCalled();
+  });
+
   it("does not prompt when a matching pin already exists", async () => {
     const bridge = vi.fn().mockResolvedValue("approved-and-pin");
     service.setConsentBridge(bridge as any as PluginMcpConsentBridge);
@@ -184,8 +234,8 @@ describe("PluginMcpConsentService", () => {
     // The audit service stores `input_schema_sha = sha256Hex("")` for null
     // schemas; the consent fingerprint must match so cross-referencing a
     // pinned tool against its audit row works.
-    const fp = fingerprintTool("desc", null);
-    const fpUndef = fingerprintTool("desc", undefined);
+    const fp = fingerprintTool("desc", null, undefined);
+    const fpUndef = fingerprintTool("desc", undefined, undefined);
     expect(fp.schemaHash).toEqual(fpUndef.schemaHash);
     // The non-empty sentinel makes the consistency check observable —
     // an accidental return-to-"" would fail this assertion.

--- a/electron/services/plugin-mcp/__tests__/PluginMcpConsentStore.test.ts
+++ b/electron/services/plugin-mcp/__tests__/PluginMcpConsentStore.test.ts
@@ -13,9 +13,20 @@ function makeConfig() {
 }
 
 const identity = { pluginId: "acme", serverId: "main", toolName: "read_file" };
-const fpA = { rawHash: "a".repeat(64), displayHash: "x".repeat(64), schemaHash: "s".repeat(64) };
-const fpB = { rawHash: "b".repeat(64), displayHash: "x".repeat(64), schemaHash: "s".repeat(64) };
+const fpA = {
+  rawHash: "a".repeat(64),
+  displayHash: "x".repeat(64),
+  schemaHash: "s".repeat(64),
+  annotationHash: "n".repeat(64),
+};
+const fpB = {
+  rawHash: "b".repeat(64),
+  displayHash: "x".repeat(64),
+  schemaHash: "s".repeat(64),
+  annotationHash: "n".repeat(64),
+};
 const fpSchemaChanged = { ...fpA, schemaHash: "t".repeat(64) };
+const fpAnnotationChanged = { ...fpA, annotationHash: "m".repeat(64) };
 
 describe("PluginMcpConsentStore", () => {
   let cfg: ReturnType<typeof makeConfig>;
@@ -58,8 +69,42 @@ describe("PluginMcpConsentStore", () => {
       rawHash: "c".repeat(64),
       displayHash: "y".repeat(64),
       schemaHash: "u".repeat(64),
+      annotationHash: "z".repeat(64),
     };
     expect(store.lookup(identity, both).kind).toBe("raw-changed");
+  });
+
+  it("returns annotation-changed when only the annotation hash flips — tier rug-pull", () => {
+    store.pin(identity, fpA);
+    const result = store.lookup(identity, fpAnnotationChanged);
+    expect(result.kind).toBe("annotation-changed");
+  });
+
+  it("prefers schema-changed over annotation-changed when both differ", () => {
+    store.pin(identity, fpA);
+    const both = { ...fpA, schemaHash: "t".repeat(64), annotationHash: "m".repeat(64) };
+    expect(store.lookup(identity, both).kind).toBe("schema-changed");
+  });
+
+  it("treats a legacy pin lacking annotationHash as annotation-changed so it re-prompts", () => {
+    // Hydrate from a persisted snapshot minted before annotationHash existed.
+    // normalizeRecord backfills the "" sentinel, which never equals a real
+    // 64-char digest — so the next lookup forces re-consent rather than
+    // silently inheriting an approval that never covered the annotation tier.
+    const legacy = {
+      pluginId: identity.pluginId,
+      serverId: identity.serverId,
+      toolName: identity.toolName,
+      approvedAt: 1,
+      fingerprint: {
+        rawHash: fpA.rawHash,
+        displayHash: fpA.displayHash,
+        schemaHash: fpA.schemaHash,
+        // no annotationHash
+      },
+    };
+    const rebuilt = new PluginMcpConsentStore(cfg.save, () => ({ pins: [legacy] }));
+    expect(rebuilt.lookup(identity, fpA).kind).toBe("annotation-changed");
   });
 
   it("returns revoked after revoke()", () => {

--- a/shared/types/ipc/pluginAudit.ts
+++ b/shared/types/ipc/pluginAudit.ts
@@ -21,9 +21,11 @@ export type PluginActionAuditResult = "success" | "error" | "disabled" | "restri
  *
  * - `action-dispatch`: a plugin-contributed action dispatched through
  *   `ActionService` (the original record type).
- * - `ipc-invoke`: a raw `plugin:invoke` IPC call from the renderer. Only
- *   failure outcomes (`error` / `restricted`) are recorded — successful
- *   invokes are high-frequency and would dominate the ring buffer.
+ * - `ipc-invoke`: a `plugin:invoke` IPC call from the renderer. Both success
+ *   and failure (`error` / `restricted`) outcomes for a plugin's own
+ *   registered handler are recorded at the dispatch boundary (#10517) so a
+ *   benign-looking invoke can't run unobserved. Trust-check rejections at the
+ *   raw `plugin:invoke` channel (untrusted sender) are also recorded here.
  * - `decoration-failure`: a file-decoration provider rejected or exceeded
  *   the per-provider timeout. Successful settles are never audited.
  */

--- a/shared/types/pluginMcpConsent.ts
+++ b/shared/types/pluginMcpConsent.ts
@@ -49,11 +49,22 @@ export interface PluginMcpToolIdentity {
  * - `schemaHash` is over the JSON-stringified `inputSchema` with keys sorted
  *   lexicographically (via `stableArgsSha256`'s normaliser). A schema mutation
  *   changes the call surface — re-prompt is mandatory.
+ * - `annotationHash` is over the three tier-influencing `ToolAnnotations`
+ *   hints (`readOnlyHint`, `destructiveHint`, `openWorldHint`), null-normalised
+ *   and key-sorted. A server flipping `readOnlyHint: true` → `destructiveHint:
+ *   true` raises the danger tier without touching the description or schema;
+ *   folding the triple into the fingerprint forces re-consent on that flip.
+ *   Only the three tier-relevant fields are hashed — future SDK annotation
+ *   fields must not produce spurious re-prompts. The empty string is a legacy
+ *   sentinel (see `PluginMcpConsentStore.normalizeRecord`): records pinned
+ *   before this field existed carry `""`, which never matches a real 64-char
+ *   digest and therefore re-prompts on the next lookup.
  */
 export interface PluginMcpToolFingerprint {
   rawHash: string;
   displayHash: string;
   schemaHash: string;
+  annotationHash: string;
 }
 
 /**
@@ -82,6 +93,11 @@ export interface PluginMcpConsentRecord {
  *   regardless of whether the displayed text looks the same.
  * - `schema-changed` — pin exists, raw matches, but the input schema mutated.
  *   The call surface changed — re-prompt.
+ * - `annotation-changed` — pin exists, raw and schema match, but the
+ *   tier-influencing annotation hints (`readOnlyHint` / `destructiveHint` /
+ *   `openWorldHint`) mutated. The advertised danger surface changed — re-prompt.
+ *   Also fires for legacy pins minted before `annotationHash` existed (their
+ *   `""` sentinel never matches a real digest).
  * - `revoked` — the user explicitly revoked this pin; prompt with the
  *   "previously revoked" framing.
  */
@@ -90,6 +106,7 @@ export type PluginMcpConsentLookup =
   | { kind: "first-use" }
   | { kind: "raw-changed"; previousPin: PluginMcpConsentRecord }
   | { kind: "schema-changed"; previousPin: PluginMcpConsentRecord }
+  | { kind: "annotation-changed"; previousPin: PluginMcpConsentRecord }
   | { kind: "revoked" };
 
 /**
@@ -114,6 +131,7 @@ export type PluginMcpConsentReason =
   | "first-use"
   | "raw-changed"
   | "schema-changed"
+  | "annotation-changed"
   | "revoked"
   | "explicit-confirm";
 

--- a/src/components/Plugin/PluginMcpConfirmDialog.tsx
+++ b/src/components/Plugin/PluginMcpConfirmDialog.tsx
@@ -79,14 +79,10 @@ export function PluginMcpConfirmDialog() {
         <div className="space-y-3">
           <div className="flex items-center gap-2 text-xs">
             <DangerTierBadge tier={current.dangerTier} />
-            {current.reason === "raw-changed" && (
-              <span className="text-status-warning font-medium">Tool description changed</span>
-            )}
-            {current.reason === "schema-changed" && (
-              <span className="text-status-warning font-medium">Tool inputs changed</span>
-            )}
-            {current.reason === "revoked" && (
-              <span className="text-status-warning font-medium">Previously revoked</span>
+            {warningLabelFor(current.reason) !== null && (
+              <span className="text-status-warning font-medium">
+                {warningLabelFor(current.reason)}
+              </span>
             )}
           </div>
 
@@ -128,17 +124,47 @@ export function PluginMcpConfirmDialog() {
   );
 }
 
-function titleFor(reason: string, toolName: string): string {
+/**
+ * Dialog title for a consent reason. Every re-prompt reason (the tool changed
+ * since it was pinned, or was revoked) gets a distinct "review and re-approve"
+ * framing so a user can tell a rug-pull re-prompt apart from a first-use one —
+ * `annotation-changed` in particular must NOT fall through to the generic
+ * first-use title, or a server raising a pinned tool's danger tier would be
+ * indistinguishable from approving it for the first time. Exported for tests.
+ */
+export function titleFor(reason: string, toolName: string): string {
   switch (reason) {
     case "raw-changed":
       return `'${toolName}' has changed — review and re-approve?`;
     case "schema-changed":
       return `'${toolName}' inputs changed — review and re-approve?`;
+    case "annotation-changed":
+      return `'${toolName}' danger level changed — review and re-approve?`;
     case "revoked":
       return `'${toolName}' was previously revoked — allow again?`;
     case "first-use":
     default:
       return `Allow '${toolName}' to run?`;
+  }
+}
+
+/**
+ * Inline warning badge label for a consent reason, or `null` for first-use
+ * (no badge — nothing changed). Each re-prompt reason maps to its own label so
+ * the badge names what changed. Exported for tests.
+ */
+export function warningLabelFor(reason: string): string | null {
+  switch (reason) {
+    case "raw-changed":
+      return "Tool description changed";
+    case "schema-changed":
+      return "Tool inputs changed";
+    case "annotation-changed":
+      return "Danger level changed";
+    case "revoked":
+      return "Previously revoked";
+    default:
+      return null;
   }
 }
 

--- a/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
+++ b/src/components/Plugin/__tests__/PluginMcpConfirmDialog.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { titleFor, warningLabelFor } from "../PluginMcpConfirmDialog";
+import type { PluginMcpConsentReason } from "@shared/types/pluginMcpConsent";
+
+// Reasons that mean "you approved this before, but something changed" — each
+// must re-prompt with a distinct, non-first-use framing so a user can tell a
+// rug-pull re-prompt apart from a routine first-time approval.
+const REPROMPT_REASONS: PluginMcpConsentReason[] = [
+  "raw-changed",
+  "schema-changed",
+  "annotation-changed",
+  "revoked",
+];
+
+describe("PluginMcpConfirmDialog copy", () => {
+  it("gives first-use a plain allow prompt with no warning badge", () => {
+    expect(titleFor("first-use", "do_thing")).toBe("Allow 'do_thing' to run?");
+    expect(warningLabelFor("first-use")).toBeNull();
+  });
+
+  it("frames every re-prompt reason distinctly from first-use", () => {
+    const firstUse = titleFor("first-use", "do_thing");
+    for (const reason of REPROMPT_REASONS) {
+      expect(titleFor(reason, "do_thing")).not.toBe(firstUse);
+    }
+  });
+
+  it("gives every re-prompt reason its own warning badge", () => {
+    const labels = REPROMPT_REASONS.map((r) => warningLabelFor(r));
+    // Each is present...
+    expect(labels.every((l) => typeof l === "string" && l.length > 0)).toBe(true);
+    // ...and distinct, so the badge names what actually changed.
+    expect(new Set(labels).size).toBe(REPROMPT_REASONS.length);
+  });
+
+  it("does NOT let annotation-changed fall through to the generic first-use copy", () => {
+    // This is the security-critical case: a server raising a pinned tool's
+    // danger tier must re-prompt with a danger-specific framing, not a prompt
+    // indistinguishable from approving the tool for the first time.
+    expect(titleFor("annotation-changed", "do_thing")).not.toBe(titleFor("first-use", "do_thing"));
+    expect(titleFor("annotation-changed", "do_thing").toLowerCase()).toContain("danger");
+    expect(warningLabelFor("annotation-changed")).toBe("Danger level changed");
+  });
+
+  it("interpolates the tool name into re-prompt titles", () => {
+    expect(titleFor("annotation-changed", "delete_repo")).toContain("delete_repo");
+    expect(titleFor("raw-changed", "delete_repo")).toContain("delete_repo");
+  });
+});


### PR DESCRIPTION
## Summary

- Folds the danger-tier annotation triple (`readOnlyHint`/`destructiveHint`/`openWorldHint`) into the TOFU tool fingerprint as a new `annotationHash` field, so a server flipping a pinned tool from benign to destructive forces re-consent rather than silently inheriting the existing pin. Legacy pins without the field re-consent once via a `""` sentinel in `normalizeRecord`; the consent dialog surfaces a distinct "Danger level changed" reason.
- Gates `plugin:clear-audit-log` behind a `senderFrame` `isTrustedRendererUrl` check so an untrusted plugin frame can't wipe the shared audit trail. Rejected attempts are themselves audited.
- Audits the success path of `dispatchHandler` (both action-handler and IPC-handler branches) so a plugin's own invocations always leave a trace, not just failures.

Resolves #10517

## Changes

- `PluginMcpConsentService`: new `annotationHash` in `fingerprintTool`; `normalizeRecord` sentinel migration for legacy pins; `lookup` compares the new field and returns `"annotation-changed"` as a distinct reason
- `PluginMcpConfirmDialog`: renders "Danger level changed" framing when reason is `annotation-changed`
- `plugin.ts` (IPC handler): `handleClearAuditLog` is now a `withContext` op gated on `isTrustedRendererUrl`; rejected attempts emit an audit record
- `PluginService.dispatchHandler`: success-path `safeAppendAudit` calls added for both the action-handler and IPC-handler branches
- `shared/types/pluginMcpConsent.ts`: `annotationHash` field added to `PluginMcpConsentRecord`; `PluginMcpConsentLookupReason` union extended

## Testing

Renderer and Electron typecheck clean. Targeted vitest run across all affected suites (`PluginMcpConsentService`, `PluginMcpConsentStore`, `PluginMcpConfirmDialog`, `plugin.handlers`, `pluginMcpCallTool`, `PluginService`) — 660 tests pass. Own-file prettier and eslint clean.