### PR TITLE
fix(plugin): scaffold + manifest-schema correctness (#10513)

### DIFF
--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -18,7 +18,7 @@ import type {
   ForgeProviderContribution,
 } from "../../shared/types/forge.js";
 
-const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+export const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 export const SCOPED_PLUGIN_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
@@ -529,7 +529,12 @@ export const PluginToastOptionsSchema = z
  */
 export const SettingDefinitionSchema = z
   .object({
-    id: z.string().min(1),
+    // Constrained to the shared safe-id grammar so a declared setting id can
+    // always be referenced by a `${settings:id}` token — the MCP supervisor's
+    // substitution gate (`SETTINGS_TEMPLATE_RE` in PluginMcpSupervisor.ts) only
+    // matches `[a-zA-Z0-9._-]+`, so an id outside that grammar could be declared
+    // but never resolved at runtime.
+    id: z.string().min(1).regex(SAFE_ID_PATTERN),
     type: z
       .enum(["string", "number", "boolean", "enum", "json", "secret", "path", "directory", "file"])
       .optional(),

--- a/packages/daintree-plugin/src/__tests__/new.test.ts
+++ b/packages/daintree-plugin/src/__tests__/new.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { scaffoldPlugin } from "../commands/new.js";
+import { scaffoldPlugin, runNew } from "../commands/new.js";
 import { getPluginManifestSchema } from "../../../../electron/schemas/plugin.js";
+import { isValidPanelIconId } from "../../../../shared/config/panelIconIds.js";
 import { TEMPLATE_KINDS } from "../scaffold/templates.js";
 
 let tmpDir: string;
@@ -194,5 +195,193 @@ describe("scaffoldPlugin", () => {
       const pkg = await readJson(path.join(result.dir, "package.json"));
       expect((pkg.scripts as Record<string, string>).build).toBe("vite build");
     });
+  }
+
+  // #10513: the scaffold's engine range must satisfy host versions past 0.11.
+  // `^0.11.0` resolves to `>=0.11.0 <0.12.0` and would be rejected by the host.
+  for (const template of TEMPLATE_KINDS) {
+    it(`"${template}" template pins an open-ended engine range satisfying recent hosts`, async () => {
+      const result = await scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: "engine-check",
+        publisher: "acme",
+        displayName: "Engine Check",
+        template,
+      });
+      const manifest = await readJson(path.join(result.dir, "plugin.json"));
+      const range = (manifest.engines as { daintree?: string }).daintree;
+      expect(range).toBeDefined();
+      const semver = await import("semver");
+      // A current host version must satisfy the scaffolded range — the bug was a
+      // caret range that excluded everything past 0.11.x.
+      expect(semver.satisfies("0.19.1", range!)).toBe(true);
+      expect(semver.satisfies("1.0.0", range!)).toBe(true);
+    });
+  }
+
+  it("React templates declare @types/react devDependencies; non-React ones don't (#10513)", async () => {
+    const viewPkg = (await scaffoldView("typed-view")).pkg;
+    const viewDev = viewPkg.devDependencies as Record<string, string>;
+    expect(viewDev["@types/react"]).toBeDefined();
+    expect(viewDev["@types/react-dom"]).toBeDefined();
+
+    const cmd = await scaffoldPlugin({
+      cwd: tmpDir,
+      targetDir: "typed-cmd",
+      publisher: "acme",
+      displayName: "Typed Cmd",
+      template: "command",
+    });
+    const cmdDev = (await readJson(path.join(cmd.dir, "package.json"))).devDependencies as Record<
+      string,
+      string
+    >;
+    expect(cmdDev["@types/react"]).toBeUndefined();
+  });
+
+  it("MCP templates ship a working SDK server, not a hanging stdin stub (#10513)", async () => {
+    for (const template of ["mcp", "full"] as const) {
+      const result = await scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: `sdk-${template}`,
+        publisher: "acme",
+        displayName: "Server Demo",
+        template,
+      });
+      const pkg = await readJson(path.join(result.dir, "package.json"));
+      // The SDK is a runtime dependency (the spawned `node dist/server.js` needs
+      // it at runtime), not a devDependency.
+      const deps = pkg.dependencies as Record<string, string>;
+      expect(deps["@modelcontextprotocol/sdk"]).toBeDefined();
+      expect((pkg.devDependencies as Record<string, string>)["@modelcontextprotocol/sdk"]).toBe(
+        undefined
+      );
+
+      const server = await fs.readFile(path.join(result.dir, "src", "server.ts"), "utf8");
+      expect(server).toContain("StdioServerTransport");
+      expect(server).toContain("McpServer");
+      // The old stub listened on stdin and never answered the handshake.
+      expect(server).not.toContain("process.stdin");
+    }
+  });
+
+  it("MCP template ships an SDK version that contains McpServer + registerTool (#10513)", async () => {
+    // McpServer (server/mcp.js) arrived in 1.3.0 and registerTool in 1.12.0, so a
+    // `^1.0.0` range could resolve to a release missing the APIs the generated
+    // server imports. Assert the floor is >=1.12.
+    const result = await scaffoldPlugin({
+      cwd: tmpDir,
+      targetDir: "sdkver",
+      publisher: "acme",
+      displayName: "Sdk Ver",
+      template: "mcp",
+    });
+    const deps = (await readJson(path.join(result.dir, "package.json"))).dependencies as Record<
+      string,
+      string
+    >;
+    const range = deps["@modelcontextprotocol/sdk"];
+    expect(range).toBeDefined();
+    const semver = await import("semver");
+    const min = semver.minVersion(range!);
+    expect(min).not.toBeNull();
+    expect(semver.gte(min!, "1.12.0")).toBe(true);
+  });
+
+  it("non-React MCP template needs no @types/node (server avoids Node globals) (#10513)", async () => {
+    const result = await scaffoldPlugin({
+      cwd: tmpDir,
+      targetDir: "mcp-types",
+      publisher: "acme",
+      displayName: "Mcp Types",
+      template: "mcp",
+    });
+    const pkg = await readJson(path.join(result.dir, "package.json"));
+    expect((pkg.devDependencies as Record<string, string>)["@types/node"]).toBeUndefined();
+    const server = await fs.readFile(path.join(result.dir, "src", "server.ts"), "utf8");
+    // No bare `process.`/`console.` usage that would require @types/node under the
+    // template's ES2022-only lib.
+    expect(server).not.toMatch(/\bprocess\./);
+  });
+
+  it("emits a well-aligned vite entry map — closing brace matches the opener (#10513)", async () => {
+    const result = await scaffoldView("aligned");
+    const vite = await fs.readFile(path.join(result.dir, "vite.config.ts"), "utf8");
+    const lines = vite.split("\n");
+    const openIdx = lines.findIndex((l) => l.trimStart().startsWith("entry:"));
+    expect(openIdx).toBeGreaterThanOrEqual(0);
+    const indentOf = (l: string) => l.length - l.trimStart().length;
+    const openIndent = indentOf(lines[openIdx]);
+    const closeIdx = lines.findIndex((l, i) => i > openIdx && l.trimStart() === "},");
+    expect(closeIdx).toBeGreaterThan(openIdx);
+    // The bug left the closing brace at 2 spaces while `entry:` sat at 6.
+    expect(indentOf(lines[closeIdx])).toBe(openIndent);
+  });
+
+  it("scaffolds panels with a recognized panel iconId (#10513)", async () => {
+    const result = await scaffoldView("iconic");
+    const manifest = await readJson(path.join(result.dir, "plugin.json"));
+    const panels = (manifest.contributes as { panels: Array<{ iconId: string }> }).panels;
+    expect(panels.length).toBeGreaterThan(0);
+    for (const panel of panels) {
+      // Guards against the scaffold drifting to an iconId that renders as the
+      // generic terminal fallback (the advisory validator would flag it).
+      expect(isValidPanelIconId(panel.iconId)).toBe(true);
+    }
+  });
+
+  describe("runNew non-interactive (--yes)", () => {
+    let cwd: string;
+    beforeEach(() => {
+      cwd = process.cwd();
+      process.chdir(tmpDir);
+    });
+    afterEach(() => {
+      process.chdir(cwd);
+    });
+
+    it("scaffolds from flags with a title-cased display name", async () => {
+      await runNew("issue-helper", { yes: true, publisher: "acme", template: "command" });
+      const manifest = await readJson(path.join(tmpDir, "issue-helper", "plugin.json"));
+      expect(manifest.name).toBe("acme.issue-helper");
+      expect(manifest.displayName).toBe("Issue Helper");
+      const parsed = getPluginManifestSchema(false).safeParse(manifest);
+      expect(parsed.success).toBe(true);
+    });
+
+    it("defaults the template to command when --template is omitted", async () => {
+      await runNew("defaulted", { yes: true, publisher: "acme" });
+      const manifest = (await readJson(path.join(tmpDir, "defaulted", "plugin.json"))) as {
+        contributes: { commands: unknown[] };
+      };
+      expect(manifest.contributes.commands.length).toBeGreaterThan(0);
+    });
+
+    it("errors when --publisher is missing", async () => {
+      await expect(runNew("nopub", { yes: true })).rejects.toThrow(/--publisher/);
+    });
+
+    it("errors when the name argument is missing", async () => {
+      await expect(runNew(undefined, { yes: true, publisher: "acme" })).rejects.toThrow(/name/);
+    });
+
+    it("errors on an unknown --template value", async () => {
+      await expect(
+        runNew("badtmpl", { yes: true, publisher: "acme", template: "wizard" })
+      ).rejects.toThrow(/Unknown template/);
+    });
+  });
+
+  async function scaffoldView(
+    targetDir: string
+  ): Promise<{ dir: string; pkg: Record<string, unknown> }> {
+    const result = await scaffoldPlugin({
+      cwd: tmpDir,
+      targetDir,
+      publisher: "acme",
+      displayName: "View Plugin",
+      template: "view",
+    });
+    return { dir: result.dir, pkg: await readJson(path.join(result.dir, "package.json")) };
   }
 });

--- a/packages/daintree-plugin/src/__tests__/new.test.ts
+++ b/packages/daintree-plugin/src/__tests__/new.test.ts
@@ -265,27 +265,45 @@ describe("scaffoldPlugin", () => {
     }
   });
 
-  it("MCP template ships an SDK version that contains McpServer + registerTool (#10513)", async () => {
+  it("pins an SDK range that actually contains McpServer + registerTool (#10513)", async () => {
     // McpServer (server/mcp.js) arrived in 1.3.0 and registerTool in 1.12.0, so a
     // `^1.0.0` range could resolve to a release missing the APIs the generated
     // server imports. Assert the floor is >=1.12.
+    for (const template of ["mcp", "full"] as const) {
+      const result = await scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: `sdkver-${template}`,
+        publisher: "acme",
+        displayName: "Sdk Ver",
+        template,
+      });
+      const deps = (await readJson(path.join(result.dir, "package.json"))).dependencies as Record<
+        string,
+        string
+      >;
+      const range = deps["@modelcontextprotocol/sdk"];
+      expect(range).toBeDefined();
+      const semver = await import("semver");
+      const min = semver.minVersion(range!);
+      expect(min).not.toBeNull();
+      expect(semver.gte(min!, "1.12.0")).toBe(true);
+    }
+  });
+
+  it("full template ships both React types and the MCP SDK dep (#10513)", async () => {
     const result = await scaffoldPlugin({
       cwd: tmpDir,
-      targetDir: "sdkver",
+      targetDir: "full-deps",
       publisher: "acme",
-      displayName: "Sdk Ver",
-      template: "mcp",
+      displayName: "Full Deps",
+      template: "full",
     });
-    const deps = (await readJson(path.join(result.dir, "package.json"))).dependencies as Record<
-      string,
-      string
-    >;
-    const range = deps["@modelcontextprotocol/sdk"];
-    expect(range).toBeDefined();
-    const semver = await import("semver");
-    const min = semver.minVersion(range!);
-    expect(min).not.toBeNull();
-    expect(semver.gte(min!, "1.12.0")).toBe(true);
+    const pkg = await readJson(path.join(result.dir, "package.json"));
+    const dev = pkg.devDependencies as Record<string, string>;
+    const deps = pkg.dependencies as Record<string, string>;
+    expect(dev["@types/react"]).toBeDefined();
+    expect(dev["@types/react-dom"]).toBeDefined();
+    expect(deps["@modelcontextprotocol/sdk"]).toBeDefined();
   });
 
   it("non-React MCP template needs no @types/node (server avoids Node globals) (#10513)", async () => {

--- a/packages/daintree-plugin/src/__tests__/validate.test.ts
+++ b/packages/daintree-plugin/src/__tests__/validate.test.ts
@@ -150,4 +150,95 @@ describe("runValidate", () => {
     const result = await runValidate({ dir: tmpDir, env: true });
     expect(result.ok).toBe(true);
   });
+
+  it("suggests the open-ended engine range in the omitted-engines warning (#10513)", async () => {
+    await writeManifest({ name: "acme.demo", version: "1.0.0" });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.warnings.join("\n")).toMatch(/>=0\.11\.0/);
+    // The old caret suggestion would be rejected by the host past 0.11.x.
+    expect(result.warnings.join("\n")).not.toMatch(/\^0\.11\.0/);
+  });
+
+  it("warns (non-fatally) on an unrecognized panel iconId (#10513)", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      contributes: {
+        panels: [{ id: "main", name: "Main", iconId: "layout-panel-top", color: "var(--x)" }],
+      },
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).toMatch(/iconId "layout-panel-top".*terminal icon/);
+  });
+
+  it("does not warn on a recognized panel iconId (#10513)", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      contributes: {
+        panels: [{ id: "main", name: "Main", iconId: "puzzle", color: "var(--x)" }],
+      },
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).not.toMatch(/iconId/);
+  });
+
+  it("rejects a setting id outside the safe-id grammar (#10513)", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      contributes: {
+        settings: [{ id: "bad id", type: "string" }],
+      },
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/settings\.0\.id/);
+  });
+
+  it("ignores a ${settings:…} token whose key breaks the safe-id grammar (#10513)", async () => {
+    // The host's substitution gate would never resolve `bad key`, so --env must
+    // not flag it as a missing value — it sees no resolvable tokens at all.
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      contributes: {
+        mcpServers: [{ id: "main", name: "S", command: "node", env: { T: "${settings:bad key}" } }],
+      },
+    });
+    const result = await runValidate({ dir: tmpDir, env: true });
+    expect(result.warnings.join("\n")).toMatch(/no \$\{settings:…\} tokens/);
+    expect(result.errors.join("\n")).not.toMatch(/bad key/);
+  });
+
+  it("warns when main points at a missing file whose dir exists (#10513)", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      main: "src/missing.js",
+    });
+    await fs.mkdir(path.join(tmpDir, "src"));
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).toMatch(/main "src\/missing\.js" doesn't exist/);
+  });
+
+  it("stays quiet about an unbuilt dist/ main (#10513)", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      main: "dist/index.js",
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).not.toMatch(/doesn't exist/);
+  });
 });

--- a/packages/daintree-plugin/src/__tests__/validate.test.ts
+++ b/packages/daintree-plugin/src/__tests__/validate.test.ts
@@ -241,4 +241,52 @@ describe("runValidate", () => {
     expect(result.ok).toBe(true);
     expect(result.warnings.join("\n")).not.toMatch(/doesn't exist/);
   });
+
+  it("stays quiet about a ./-prefixed unbuilt dist/ main (#10513)", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      main: "./dist/index.js",
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).not.toMatch(/doesn't exist/);
+  });
+
+  it("warns when a view componentPath is missing but its dir exists (#10513)", async () => {
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      contributes: {
+        panels: [{ id: "main", name: "Main", iconId: "puzzle", color: "var(--x)" }],
+        views: [
+          { id: "main", name: "Main", componentPath: "src/missing-panel.js", location: "panel" },
+        ],
+      },
+    });
+    await fs.mkdir(path.join(tmpDir, "src"));
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).toMatch(
+      /views\[0\]\.componentPath "src\/missing-panel\.js" doesn't exist/
+    );
+  });
+
+  it("does not warn when a panel iconId is a built-in agent id (#10513)", async () => {
+    // `claude` resolves to the agent brand icon via getAgentConfig, so the
+    // "renders as terminal" advisory would be wrong — it must be suppressed.
+    await writeManifest({
+      name: "acme.demo",
+      version: "1.0.0",
+      engines: { daintree: ">=0.11.0" },
+      contributes: {
+        panels: [{ id: "main", name: "Main", iconId: "claude", color: "var(--x)" }],
+      },
+    });
+    const result = await runValidate({ dir: tmpDir });
+    expect(result.ok).toBe(true);
+    expect(result.warnings.join("\n")).not.toMatch(/iconId/);
+  });
 });

--- a/packages/daintree-plugin/src/cli.ts
+++ b/packages/daintree-plugin/src/cli.ts
@@ -23,13 +23,25 @@ program
   .command("new")
   .argument("[name]", "plugin name (also the directory)")
   .description("Scaffold a new plugin project")
-  .action(async (name?: string) => {
-    try {
-      await runNew(name);
-    } catch (err) {
-      fail((err as Error).message);
+  .option("--publisher <publisher>", "publisher segment (e.g. acme)")
+  .option("--template <template>", "command | view | mcp | full")
+  .option("--yes", "non-interactive: accept defaults, skip prompts (requires name + --publisher)")
+  .action(
+    async (
+      name: string | undefined,
+      opts: { publisher?: string; template?: string; yes?: boolean }
+    ) => {
+      try {
+        await runNew(name, {
+          publisher: opts.publisher,
+          template: opts.template,
+          yes: opts.yes,
+        });
+      } catch (err) {
+        fail((err as Error).message);
+      }
     }
-  });
+  );
 
 program
   .command("validate")

--- a/packages/daintree-plugin/src/commands/new.ts
+++ b/packages/daintree-plugin/src/commands/new.ts
@@ -82,12 +82,75 @@ function cancelled<T>(value: T | symbol): value is symbol {
   return p.isCancel(value);
 }
 
+/** Options surfaced as CLI flags on `daintree-plugin new` (see `cli.ts`). */
+export interface RunNewOptions {
+  /** `--publisher`: skips (or, with `--yes`, supplies) the publisher prompt. */
+  publisher?: string;
+  /** `--template`: skips (or supplies) the template prompt; validated against `TEMPLATE_KINDS`. */
+  template?: string;
+  /** `--yes`: fully non-interactive — accept defaults, never prompt (CI/scripting). */
+  yes?: boolean;
+}
+
+/** "issue-helper" → "Issue Helper", the non-interactive display-name default. */
+function titleCaseSegment(segment: string): string {
+  return segment
+    .split("-")
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function parseTemplate(value: string): TemplateKind {
+  if (!(TEMPLATE_KINDS as readonly string[]).includes(value)) {
+    throw new Error(`Unknown template "${value}" — expected one of: ${TEMPLATE_KINDS.join(", ")}`);
+  }
+  return value as TemplateKind;
+}
+
 /**
- * Interactive `daintree-plugin new`. Prompts for publisher, display name, and
- * template, then scaffolds the project. The directory name is the positional
- * `name` arg (prompted for when omitted).
+ * Non-interactive `daintree-plugin new` (the `--yes` path). Scaffolds straight
+ * from flags with no prompts, for CI and scripting. The plugin name and
+ * `--publisher` are required (there is no prompt to fall back on); the display
+ * name defaults to the title-cased plugin name and the template to `command`.
  */
-export async function runNew(name?: string): Promise<void> {
+async function runNewNonInteractive(name: string | undefined, opts: RunNewOptions): Promise<void> {
+  if (!name) {
+    throw new Error(
+      "--yes requires a plugin name argument, e.g. `daintree-plugin new issue-helper --yes --publisher acme`"
+    );
+  }
+  if (!opts.publisher) {
+    throw new Error("--yes requires --publisher (there is no interactive prompt to fall back on)");
+  }
+  const template = opts.template ? parseTemplate(opts.template) : "command";
+
+  // scaffoldPlugin validates the name/publisher segment grammar and throws a
+  // clear message, so no pre-check is needed here.
+  const result = await scaffoldPlugin({
+    cwd: process.cwd(),
+    targetDir: name,
+    publisher: opts.publisher,
+    displayName: titleCaseSegment(name),
+    template,
+  });
+
+  console.log(`Created ${result.scopedName} in ${path.relative(process.cwd(), result.dir) || "."}`);
+}
+
+/**
+ * `daintree-plugin new`. With `--yes`, runs fully non-interactively from flags
+ * (see `runNewNonInteractive`). Otherwise prompts for publisher, display name,
+ * and template — but `--publisher`/`--template` pre-fill their answers and skip
+ * the matching prompt. The directory name is the positional `name` arg
+ * (prompted for when omitted).
+ */
+export async function runNew(name?: string, opts: RunNewOptions = {}): Promise<void> {
+  if (opts.yes) {
+    await runNewNonInteractive(name, opts);
+    return;
+  }
+
   p.intro("Create a Daintree plugin");
 
   let targetDir = name;
@@ -110,14 +173,24 @@ export async function runNew(name?: string): Promise<void> {
     }
   }
 
-  const publisher = await p.text({
-    message: "Publisher",
-    placeholder: "acme",
-    validate: (value) => segmentError(value, "Publisher") ?? undefined,
-  });
-  if (cancelled(publisher)) {
-    p.cancel("Cancelled");
-    return;
+  let publisher = opts.publisher;
+  if (publisher) {
+    const err = segmentError(publisher, "Publisher");
+    if (err) {
+      p.cancel(err);
+      return;
+    }
+  } else {
+    const answer = await p.text({
+      message: "Publisher",
+      placeholder: "acme",
+      validate: (value) => segmentError(value, "Publisher") ?? undefined,
+    });
+    if (cancelled(answer)) {
+      p.cancel("Cancelled");
+      return;
+    }
+    publisher = answer;
   }
 
   const displayName = await p.text({
@@ -130,17 +203,28 @@ export async function runNew(name?: string): Promise<void> {
     return;
   }
 
-  const template = await p.select({
-    message: "Template",
-    options: TEMPLATE_KINDS.map((kind) => ({
-      value: kind,
-      label: kind,
-      hint: TEMPLATE_HINTS[kind],
-    })),
-  });
-  if (cancelled(template)) {
-    p.cancel("Cancelled");
-    return;
+  let template: TemplateKind;
+  if (opts.template) {
+    try {
+      template = parseTemplate(opts.template);
+    } catch (err) {
+      p.cancel((err as Error).message);
+      return;
+    }
+  } else {
+    const answer = await p.select({
+      message: "Template",
+      options: TEMPLATE_KINDS.map((kind) => ({
+        value: kind,
+        label: kind,
+        hint: TEMPLATE_HINTS[kind],
+      })),
+    });
+    if (cancelled(answer)) {
+      p.cancel("Cancelled");
+      return;
+    }
+    template = answer as TemplateKind;
   }
 
   const result = await scaffoldPlugin({
@@ -148,7 +232,7 @@ export async function runNew(name?: string): Promise<void> {
     targetDir,
     publisher,
     displayName: displayName || targetDir,
-    template: template as TemplateKind,
+    template,
   });
 
   p.outro(

--- a/packages/daintree-plugin/src/commands/validate.ts
+++ b/packages/daintree-plugin/src/commands/validate.ts
@@ -4,6 +4,10 @@ import {
   DEPRECATED_CONTRIBUTION_ALIASES,
   getPluginManifestSchema,
 } from "../../../../electron/schemas/plugin.js";
+import {
+  VALID_PANEL_ICON_IDS,
+  isValidPanelIconId,
+} from "../../../../shared/config/panelIconIds.js";
 
 export interface ValidateOptions {
   /** Plugin project directory (default: cwd). */
@@ -18,8 +22,45 @@ export interface ValidateResult {
   warnings: string[];
 }
 
-/** Match `${settings:KEY}` interpolation tokens used in mcpServers env/args. */
-const SETTINGS_TOKEN = /\$\{settings:([^}]+)\}/g;
+/**
+ * Match `${settings:KEY}` interpolation tokens used in mcpServers env/args. The
+ * key grammar mirrors the host's substitution gate exactly — `SETTINGS_TEMPLATE_RE`
+ * in `electron/services/PluginMcpSupervisor.ts` only resolves `[a-zA-Z0-9._-]+`,
+ * so a token with any other character (e.g. a space) would never be substituted
+ * at runtime. Validating with the same grammar means `--env` reports the same
+ * set of tokens the host will actually resolve, instead of the broader `[^}]+`
+ * that flagged tokens the supervisor silently leaves literal.
+ */
+const SETTINGS_TOKEN = /\$\{settings:([a-zA-Z0-9._-]+)\}/g;
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Advisory existence check for a relative build target (`main`, a view's
+ * `componentPath`). Pushes a warning when the file is missing but its top-level
+ * directory exists — a stale or mistyped path. Skips absolute paths, Windows
+ * separators, and the unbuilt-output case where the top-level dir (e.g. `dist`)
+ * is itself absent, so running `validate` before a build stays quiet.
+ */
+async function warnIfTargetMissing(
+  dir: string,
+  target: string | undefined,
+  label: string,
+  warnings: string[]
+): Promise<void> {
+  if (!target || path.isAbsolute(target) || target.includes("\\")) return;
+  if (await pathExists(path.join(dir, target))) return;
+  const [topSegment] = target.split("/");
+  if (target.includes("/") && !(await pathExists(path.join(dir, topSegment)))) return;
+  warnings.push(`${label} "${target}" doesn't exist on disk — build the plugin or fix the path`);
+}
 
 function parseEnvFile(content: string): Map<string, string> {
   const map = new Map<string, string>();
@@ -93,7 +134,10 @@ export async function runValidate(opts: ValidateOptions = {}): Promise<ValidateR
   }
 
   if (!manifest.engines?.daintree) {
-    warnings.push("engines.daintree omitted — consider pinning a range, e.g. ^0.11.0");
+    // `>=0.11.0` (open-ended), not `^0.11.0`: the caret on a 0.x minor resolves
+    // to `>=0.11.0 <0.12.0`, which the host's engine gate rejects on every
+    // release past 0.11.
+    warnings.push("engines.daintree omitted — consider pinning a range, e.g. >=0.11.0");
   }
 
   for (const [index, command] of manifest.contributes.commands.entries()) {
@@ -102,6 +146,34 @@ export async function runValidate(opts: ValidateOptions = {}): Promise<ValidateR
         `commands[${index}].keywords is empty — 2–3 terms help discoverability in the palette`
       );
     }
+  }
+
+  // Advisory icon check: a panel/view `iconId` outside the recognized set renders
+  // as the generic terminal icon (the renderers do no dynamic Lucide-by-name
+  // lookup). Non-fatal — the schema accepts any string and the renderer is the
+  // runtime authority.
+  for (const [index, panel] of manifest.contributes.panels.entries()) {
+    if (panel.iconId && !isValidPanelIconId(panel.iconId)) {
+      warnings.push(
+        `panels[${index}].iconId "${panel.iconId}" isn't a recognized panel icon — it will render as the default terminal icon. Known ids: ${VALID_PANEL_ICON_IDS.join(", ")}`
+      );
+    }
+  }
+  for (const [index, view] of manifest.contributes.views.entries()) {
+    if (view.iconId && !isValidPanelIconId(view.iconId)) {
+      warnings.push(
+        `views[${index}].iconId "${view.iconId}" isn't a recognized panel icon — it will render as the default terminal icon. Known ids: ${VALID_PANEL_ICON_IDS.join(", ")}`
+      );
+    }
+  }
+
+  // Advisory build-target check: warn when `main` or a view's `componentPath`
+  // points at a missing file whose parent dir exists (a typo or stale path). A
+  // missing top-level dir — typically an unbuilt `dist/` — is skipped so
+  // pre-build validation stays quiet.
+  await warnIfTargetMissing(dir, manifest.main, "main", warnings);
+  for (const [index, view] of manifest.contributes.views.entries()) {
+    await warnIfTargetMissing(dir, view.componentPath, `views[${index}].componentPath`, warnings);
   }
 
   if (opts.env) {

--- a/packages/daintree-plugin/src/commands/validate.ts
+++ b/packages/daintree-plugin/src/commands/validate.ts
@@ -8,6 +8,7 @@ import {
   VALID_PANEL_ICON_IDS,
   isValidPanelIconId,
 } from "../../../../shared/config/panelIconIds.js";
+import { isBuiltInAgentId } from "../../../../shared/config/agentIds.js";
 
 export interface ValidateOptions {
   /** Plugin project directory (default: cwd). */
@@ -57,8 +58,11 @@ async function warnIfTargetMissing(
 ): Promise<void> {
   if (!target || path.isAbsolute(target) || target.includes("\\")) return;
   if (await pathExists(path.join(dir, target))) return;
-  const [topSegment] = target.split("/");
-  if (target.includes("/") && !(await pathExists(path.join(dir, topSegment)))) return;
+  // Normalize a leading `./` so the top-segment check sees `dist`, not `.`
+  // (a bare `.` always exists and would defeat the unbuilt-output skip below).
+  const normalized = target.replace(/^\.\//, "");
+  const [topSegment] = normalized.split("/");
+  if (normalized.includes("/") && !(await pathExists(path.join(dir, topSegment)))) return;
   warnings.push(`${label} "${target}" doesn't exist on disk — build the plugin or fix the path`);
 }
 
@@ -150,17 +154,20 @@ export async function runValidate(opts: ValidateOptions = {}): Promise<ValidateR
 
   // Advisory icon check: a panel/view `iconId` outside the recognized set renders
   // as the generic terminal icon (the renderers do no dynamic Lucide-by-name
-  // lookup). Non-fatal — the schema accepts any string and the renderer is the
-  // runtime authority.
+  // lookup). Built-in agent ids are exempt — `PanelKindIcon` resolves them via
+  // `getAgentConfig` to the agent's brand icon before the fallback. Non-fatal:
+  // the schema accepts any string and the renderer is the runtime authority.
+  const isUnrenderableIcon = (iconId: string): boolean =>
+    !isValidPanelIconId(iconId) && !isBuiltInAgentId(iconId);
   for (const [index, panel] of manifest.contributes.panels.entries()) {
-    if (panel.iconId && !isValidPanelIconId(panel.iconId)) {
+    if (panel.iconId && isUnrenderableIcon(panel.iconId)) {
       warnings.push(
         `panels[${index}].iconId "${panel.iconId}" isn't a recognized panel icon — it will render as the default terminal icon. Known ids: ${VALID_PANEL_ICON_IDS.join(", ")}`
       );
     }
   }
   for (const [index, view] of manifest.contributes.views.entries()) {
-    if (view.iconId && !isValidPanelIconId(view.iconId)) {
+    if (view.iconId && isUnrenderableIcon(view.iconId)) {
       warnings.push(
         `views[${index}].iconId "${view.iconId}" isn't a recognized panel icon — it will render as the default terminal icon. Known ids: ${VALID_PANEL_ICON_IDS.join(", ")}`
       );

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -89,7 +89,8 @@ function packageJson(ctx: ScaffoldContext, needsReact: boolean, needsServer = fa
     // Runtime dependency, not a devDependency: the spawned `node dist/server.js`
     // imports the SDK at runtime, so it must be installed in the packaged plugin.
     // Floor at 1.12: `server/mcp.js`'s `McpServer` arrived in 1.3 and
-    // `registerTool` (used by the generated server) in 1.12.
+    // `registerTool` (used by the generated server) in 1.12, so a lower `^1.0.0`
+    // could resolve to a release missing both.
     deps["@modelcontextprotocol/sdk"] = "^1.12.0";
   }
   const obj = {

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -21,7 +21,11 @@ export interface ScaffoldContext {
   template: TemplateKind;
 }
 
-const DAINTREE_ENGINE_RANGE = "^0.11.0";
+// Open-ended lower bound: `^0.11.0` resolves to `>=0.11.0 <0.12.0` under semver's
+// 0.x caret rule, so a scaffolded plugin would be rejected by the host's
+// `engines.daintree` gate on every release past 0.11 (e.g. 0.19.x). Match the
+// reference manifests under `plugins/sample/`, which pin the open-ended range.
+const DAINTREE_ENGINE_RANGE = ">=0.11.0";
 
 /**
  * A `contributes.panels` entry paired with a `views` entry of the
@@ -76,6 +80,17 @@ function packageJson(ctx: ScaffoldContext, needsReact: boolean, needsServer = fa
   if (needsReact) {
     devDeps.react = "^19.0.0";
     devDeps["react-dom"] = "^19.0.0";
+    // React 19 still ships types separately; without these the generated
+    // `panel.tsx` fails `tsc` on the `react` import and the JSX namespace.
+    devDeps["@types/react"] = "^19.0.0";
+    devDeps["@types/react-dom"] = "^19.0.0";
+  }
+  if (needsServer) {
+    // Runtime dependency, not a devDependency: the spawned `node dist/server.js`
+    // imports the SDK at runtime, so it must be installed in the packaged plugin.
+    // Floor at 1.12: `server/mcp.js`'s `McpServer` arrived in 1.3 and
+    // `registerTool` (used by the generated server) in 1.12.
+    deps["@modelcontextprotocol/sdk"] = "^1.12.0";
   }
   const obj = {
     name: ctx.scopedName,
@@ -113,7 +128,11 @@ function tsconfig(jsx: boolean): string {
 }
 
 function viteConfig(entries: Record<string, string>): string {
-  const entryLiteral = JSON.stringify(entries, null, 6).replace(/\n/g, "\n  ");
+  // `entry:` sits at 6-space depth inside the `build.lib` block, so each line of
+  // the embedded object literal needs a 6-space lead to align — and the closing
+  // brace must land back at that depth. Stringify at 2-space indent, then offset
+  // every line by the 6 spaces of the surrounding context.
+  const entryLiteral = JSON.stringify(entries, null, 2).replace(/\n/g, "\n      ");
   return `import { daintreePlugin } from "@daintreehq/plugin-vite";
 import { defineConfig } from "vite";
 
@@ -140,7 +159,8 @@ export default defineConfig({
  * \`emptyOutDir: false\` preserves the browser build that ran first.
  */
 function viteServerConfig(entries: Record<string, string>): string {
-  const entryLiteral = JSON.stringify(entries, null, 6).replace(/\n/g, "\n  ");
+  // Same 6-space alignment as viteConfig (see the note there).
+  const entryLiteral = JSON.stringify(entries, null, 2).replace(/\n/g, "\n      ");
   return `import { daintreePlugin } from "@daintreehq/plugin-vite";
 import { defineConfig } from "vite";
 
@@ -241,13 +261,31 @@ export async function activate(_host: PluginHostApi): Promise<() => void> {
 function mcpServer(ctx: ScaffoldContext): string {
   return `#!/usr/bin/env node
 /**
- * Minimal stdio MCP server skeleton for ${c(ctx.displayName)}. Replace this with a
- * real implementation using \`@modelcontextprotocol/sdk\`. Daintree spawns it
- * per the \`command\`/\`args\` in plugin.json and speaks MCP over stdio.
+ * Minimal stdio MCP server for ${c(ctx.displayName)}. Daintree spawns it per the
+ * \`command\`/\`args\` in plugin.json and speaks MCP over stdio. The SDK answers
+ * the \`initialize\` handshake and \`tools/list\` automatically once connected —
+ * the previous skeleton only listened on stdin and never replied, so the host
+ * timed out and marked the server crashed.
+ *
+ * Never write to stdout yourself: it carries the JSON-RPC stream and stray
+ * output corrupts the protocol. Log to stderr (\`console.error\`) instead. Built
+ * with vite.config.server.ts (\`target: "node"\`) so the SDK's stdio transport
+ * gets the real Node \`process\` rather than a browser shim.
  */
-process.stdin.on("data", () => {
-  // Wire up an MCP server here (tools/list, tools/call, …).
-});
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const server = new McpServer({ name: ${q(ctx.scopedName)}, version: "0.1.0" });
+
+// Example tool — replace with your own. It takes no input and returns text;
+// add an \`inputSchema\` (a Zod raw shape) to accept arguments.
+server.registerTool(
+  "ping",
+  { description: ${q(`Health check for ${ctx.displayName}; replies with "pong".`)} },
+  async () => ({ content: [{ type: "text", text: "pong" }] })
+);
+
+await server.connect(new StdioServerTransport());
 `;
 }
 

--- a/shared/config/panelIconIds.ts
+++ b/shared/config/panelIconIds.ts
@@ -1,0 +1,37 @@
+/**
+ * Icon ids that render to a real glyph for a plugin-contributed panel or view.
+ *
+ * Panel icons are resolved by two renderers, neither of which does a dynamic
+ * Lucide-by-name lookup: `src/components/PanelPalette/PanelKindIcon.tsx`
+ * (`ICON_MAP`) for the palette, and `src/components/Terminal/TerminalIcon.tsx`
+ * (hardcoded id conditionals) for panel headers/tabs. An `iconId` outside this
+ * set silently falls back to the generic terminal icon — so the manifest schema
+ * accepts any string, but a plugin author gets no warning that their chosen icon
+ * won't show. This list is the union of both renderers' recognized ids and is
+ * kept in `shared/` so the offline `daintree-plugin validate` CLI can advise on
+ * it without importing renderer/React code.
+ *
+ * Advisory only: this is NOT wired into the Zod manifest schema as an enum.
+ * Validation stays non-fatal because the renderer is the runtime authority and
+ * a future panel-icon registry could broaden the set; a hard schema enum would
+ * reject manifests the runtime could otherwise grow to honor.
+ */
+export const VALID_PANEL_ICON_IDS = [
+  "terminal",
+  "globe",
+  "file-text",
+  "git-branch",
+  "monitor",
+  "monitor-play",
+  "sticky-note",
+  "daintree",
+  "puzzle",
+  "git-pull-request",
+] as const satisfies readonly string[];
+
+export type ValidPanelIconId = (typeof VALID_PANEL_ICON_IDS)[number];
+
+/** True when `id` renders to a real panel glyph (rather than the terminal fallback). */
+export function isValidPanelIconId(id: string): boolean {
+  return (VALID_PANEL_ICON_IDS as readonly string[]).includes(id);
+}


### PR DESCRIPTION
## Summary

- Fixes 8 correctness bugs in the `daintree-plugin` CLI scaffold and manifest schema — wrong engine range, missing type deps, broken MCP server stub, unvalidated icon IDs, misaligned `${settings:}` grammar, and a malformed `vite.config.ts`.
- Adds `--publisher`, `--template`, and `--yes` flags to `new` for non-interactive use.
- Adds advisory warnings in `validate` for unrecognised icon IDs (agent-id exempt) and missing build targets.

Closes #10513

## Changes

1. Engine range changed to `>=0.11.0` (open-ended).
2. `@types/react` and `@types/react-dom` added for React templates; `@modelcontextprotocol/sdk ^1.12.0` runtime dep added for MCP templates.
3. `McpServer` + `StdioServerTransport` scaffold replaced the hanging stdin stub.
4. `VALID_PANEL_ICON_IDS` shared constant wired into `validate`; advisory icon warnings emitted (agent-id exempt).
5. `SAFE_ID_PATTERN` constraint enforced on setting IDs; `${settings:}` grammar aligned to what the supervisor actually accepts.
6. `--publisher`, `--template`, `--yes` flags on `new` for headless/CI use.
7. Fixed malformed `vite.config.ts` entry-map indentation in the scaffold template.
8. Advisory build-target existence warnings added to `validate`.

## Testing

110 unit tests pass. Typecheck clean. Own-file ESLint + Prettier clean. Rebased onto `develop`.