### PR TITLE
fix(worktree): reflect self-assign in open issues dropdown immediately

### DIFF
--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -627,7 +627,16 @@ export function NewWorktreeDialog({
         useWorktreeSelectionStore.getState().setPendingWorktree(worktreeId);
         useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
 
-        if (!snapUseExisting && snapIssue && snapAssignToSelf && snapCurrentUser) {
+        // Skip when the selected issue already lists the current user as an
+        // assignee: the assign call would be a no-op and the resulting Undo
+        // would strip a pre-existing assignment this flow never created.
+        if (
+          !snapUseExisting &&
+          snapIssue &&
+          snapAssignToSelf &&
+          snapCurrentUser &&
+          !snapIssue.assignees.some((a) => a.login === snapCurrentUser)
+        ) {
           try {
             await forgeClient.assignIssue(rootPath, snapIssue.number, snapCurrentUser);
             const assignIssueNumber = snapIssue.number;
@@ -665,7 +674,13 @@ export function NewWorktreeDialog({
                 return changed ? { ...entry, items } : null;
               });
             };
-            patchAssigneeCache(true);
+            // A cache-layer throw must not masquerade as an assignment failure:
+            // the server-side assign already succeeded by this point.
+            try {
+              patchAssigneeCache(true);
+            } catch (cacheErr) {
+              logError("Failed to patch issue cache after self-assign", cacheErr);
+            }
             const undoFiredRef = { current: false };
             const undoOnClick = (): void => {
               if (undoFiredRef.current) return;

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -11,6 +11,7 @@ import { worktreeClient, forgeClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { notify } from "@/lib/notify";
+import { mutateCacheEntries } from "@/lib/forgeResourceCache";
 import { systemClient } from "@/clients/systemClient";
 import { useRecipeStore } from "@/store/recipeStore";
 import { notifyRecipeSpawnFailures } from "@/utils/recipeNotify";
@@ -560,6 +561,7 @@ export function NewWorktreeDialog({
     const snapBranches = branches;
     const snapAssignToSelf = assignWorktreeToSelf;
     const snapCurrentUser = currentUser;
+    const snapCurrentUserAvatar = currentUserAvatar;
     const snapBaseBranch = baseBranch;
     // Anchor the sidebar placeholder by the path the host will normalize to as
     // the worktree id. Relative paths can't anchor a placeholder because the
@@ -630,12 +632,49 @@ export function NewWorktreeDialog({
             await forgeClient.assignIssue(rootPath, snapIssue.number, snapCurrentUser);
             const assignIssueNumber = snapIssue.number;
             const assignUsername = snapCurrentUser;
+            // Optimistically patch every cached issue-list slot so the open
+            // issues dropdown reflects the assignment immediately instead of
+            // waiting ~30s for the next SWR revalidate (#10529). Provider-
+            // agnostic: only touches the renderer cache through the forge
+            // abstraction. The forge refresh remains the correctness backstop.
+            const patchAssigneeCache = (assigned: boolean): void => {
+              mutateCacheEntries(rootPath, "issue", (entry) => {
+                let changed = false;
+                const items = entry.items.map((item) => {
+                  const issue = item as Issue;
+                  if (issue.number !== assignIssueNumber) return item;
+                  const hasUser = issue.assignees.some((a) => a.login === assignUsername);
+                  if (assigned) {
+                    if (hasUser) return item;
+                    changed = true;
+                    return {
+                      ...issue,
+                      assignees: [
+                        ...issue.assignees,
+                        { login: assignUsername, avatarUrl: snapCurrentUserAvatar, rawData: null },
+                      ],
+                    };
+                  }
+                  if (!hasUser) return item;
+                  changed = true;
+                  return {
+                    ...issue,
+                    assignees: issue.assignees.filter((a) => a.login !== assignUsername),
+                  };
+                });
+                return changed ? { ...entry, items } : null;
+              });
+            };
+            patchAssigneeCache(true);
             const undoFiredRef = { current: false };
             const undoOnClick = (): void => {
               if (undoFiredRef.current) return;
               undoFiredRef.current = true;
               void forgeClient
                 .unassignIssue(rootPath, assignIssueNumber, assignUsername)
+                .then(() => {
+                  patchAssigneeCache(false);
+                })
                 .catch((err: unknown) => {
                   // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
                   notify({

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -650,16 +650,17 @@ export function NewWorktreeDialog({
               mutateCacheEntries(rootPath, "issue", (entry) => {
                 let changed = false;
                 const items = entry.items.map((item) => {
-                  const issue = item as Issue;
-                  if (issue.number !== assignIssueNumber) return item;
-                  const hasUser = issue.assignees.some((a) => a.login === assignUsername);
+                  // `assignees` exists only on Issue, so this `in` check narrows
+                  // the Issue|PR union safely and skips any non-issue slot.
+                  if (!("assignees" in item) || item.number !== assignIssueNumber) return item;
+                  const hasUser = item.assignees.some((a) => a.login === assignUsername);
                   if (assigned) {
                     if (hasUser) return item;
                     changed = true;
                     return {
-                      ...issue,
+                      ...item,
                       assignees: [
-                        ...issue.assignees,
+                        ...item.assignees,
                         { login: assignUsername, avatarUrl: snapCurrentUserAvatar, rawData: null },
                       ],
                     };
@@ -667,8 +668,8 @@ export function NewWorktreeDialog({
                   if (!hasUser) return item;
                   changed = true;
                   return {
-                    ...issue,
-                    assignees: issue.assignees.filter((a) => a.login !== assignUsername),
+                    ...item,
+                    assignees: item.assignees.filter((a) => a.login !== assignUsername),
                   };
                 });
                 return changed ? { ...entry, items } : null;

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -1002,4 +1002,58 @@ describe("NewWorktreeDialog — self-assign cache mutation", () => {
     // Unassign rejected → cache must NOT be reverted.
     expect(cachedIssue().assignees.map((a) => a.login)).toContain("testuser");
   });
+
+  it("patches every cached issue slot, not just one filter/sort view", async () => {
+    const updatedKey = buildCacheKey(ROOT, "issue", "open", "updated");
+    seedIssueCache(makeIssue());
+    setCache(updatedKey, {
+      items: [makeIssue()],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: 0,
+    });
+
+    await createWithSelfAssign();
+
+    expect(cachedIssue().assignees.map((a) => a.login)).toContain("testuser");
+    expect((getCache(updatedKey)?.items[0] as Issue).assignees.map((a) => a.login)).toContain(
+      "testuser"
+    );
+  });
+
+  it("does not assign or mutate the cache when self-assign is disabled", async () => {
+    mockAssignWorktreeToSelf = false;
+    seedIssueCache(makeIssue());
+
+    await createWithSelfAssign();
+
+    expect(mockAssignIssue).not.toHaveBeenCalled();
+    expect(cachedIssue().assignees).toHaveLength(0);
+    expect(getGeneration(ISSUE_CACHE_KEY)).toBe(0);
+  });
+
+  it("skips the assign flow when the selected issue already lists the current user", async () => {
+    seedIssueCache(makeIssue());
+
+    renderDialog({
+      initialIssue: makeIssue({
+        assignees: [{ login: "testuser", avatarUrl: undefined, rawData: null }],
+      }),
+    });
+    await advanceTimersGradually(500);
+    const branchInput = screen.getByTestId("branch-name-input");
+    await act(async () => {
+      fireEvent.change(branchInput, { target: { value: "feature/fix-thing" } });
+    });
+    await advanceTimersGradually(500);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockAssignIssue).not.toHaveBeenCalled();
+    expect(getGeneration(ISSUE_CACHE_KEY)).toBe(0);
+  });
 });

--- a/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
+++ b/src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx
@@ -28,6 +28,7 @@ const mockFetchPRBranch = vi.fn();
 const mockGetRecentBranches = vi.fn();
 const mockGetCurrentUser = vi.fn();
 const mockAssignIssue = vi.fn();
+const mockUnassignIssue = vi.fn();
 
 const mockAgentSettingsGet = vi.fn().mockResolvedValue({ agents: {} });
 vi.mock("@/clients", () => ({
@@ -42,6 +43,7 @@ vi.mock("@/clients", () => ({
   forgeClient: {
     getCurrentUser: (...args: unknown[]) => mockGetCurrentUser(...args),
     assignIssue: (...args: unknown[]) => mockAssignIssue(...args),
+    unassignIssue: (...args: unknown[]) => mockUnassignIssue(...args),
   },
   agentSettingsClient: {
     get: (...args: unknown[]) => mockAgentSettingsGet(...args),
@@ -88,10 +90,11 @@ vi.mock("@/store/recipeStore", () => {
   };
 });
 
+let mockAssignWorktreeToSelf = false;
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({
-      assignWorktreeToSelf: false,
+      assignWorktreeToSelf: mockAssignWorktreeToSelf,
       setAssignWorktreeToSelf: vi.fn(),
       lastSelectedWorktreeRecipeIdByProject: {},
       setLastSelectedWorktreeRecipeIdByProject: vi.fn(),
@@ -261,6 +264,14 @@ vi.mock("@/components/Worktree/worktreeCreationErrors", () => ({
 Element.prototype.scrollIntoView = vi.fn();
 
 import { NewWorktreeDialog, clearBranchListCache } from "../NewWorktreeDialog";
+import {
+  buildCacheKey,
+  setCache,
+  getCache,
+  getGeneration,
+  _resetForTests as resetForgeResourceCache,
+} from "@/lib/forgeResourceCache";
+import type { Issue } from "@shared/types/forge";
 
 beforeEach(() => {
   clearBranchListCache();
@@ -815,5 +826,180 @@ describe("NewWorktreeDialog — ARIA validation wiring", () => {
     expect(branchInput.getAttribute("aria-invalid")).toBeNull();
     expect(pathInput.getAttribute("aria-invalid")).toBeNull();
     expect(baseBranchButton?.getAttribute("aria-invalid")).toBeNull();
+  });
+});
+
+describe("NewWorktreeDialog — self-assign cache mutation", () => {
+  const ROOT = "/test/root";
+  const ISSUE_CACHE_KEY = buildCacheKey(ROOT, "issue", "open", "created");
+
+  function makeIssue(overrides: Partial<Issue> = {}): Issue {
+    return {
+      number: 42,
+      title: "Fix the thing",
+      body: "",
+      state: "open",
+      rawState: "open",
+      url: "https://example.com/issues/42",
+      assignees: [],
+      labels: [],
+      createdAt: 0,
+      updatedAt: 0,
+      rawData: null,
+      ...overrides,
+    };
+  }
+
+  function seedIssueCache(issue: Issue): void {
+    setCache(ISSUE_CACHE_KEY, {
+      items: [issue],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: 0,
+    });
+  }
+
+  function cachedIssue(): Issue {
+    const entry = getCache(ISSUE_CACHE_KEY);
+    if (!entry) throw new Error("expected cache entry to exist");
+    return entry.items[0] as Issue;
+  }
+
+  // Drive the dialog through a successful create with self-assign enabled.
+  async function createWithSelfAssign(): Promise<void> {
+    renderDialog({ initialIssue: makeIssue() });
+    await advanceTimersGradually(500);
+
+    const branchInput = screen.getByTestId("branch-name-input");
+    await act(async () => {
+      fireEvent.change(branchInput, { target: { value: "feature/fix-thing" } });
+    });
+    await advanceTimersGradually(500);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("create-worktree-button"));
+    });
+    // Flush the void-fired async create/assign block.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetForgeResourceCache();
+    mockAssignWorktreeToSelf = true;
+    mockListBranches.mockResolvedValue(TEST_BRANCHES);
+    mockGetRecentBranches.mockResolvedValue([]);
+    mockGetAvailableBranch.mockImplementation((_root: string, name: string) =>
+      Promise.resolve(name)
+    );
+    mockGetDefaultPath.mockImplementation((_root: string, branch: string) =>
+      Promise.resolve(`/test/root-worktrees/${branch}`)
+    );
+    mockDispatch.mockResolvedValue({ ok: true, result: "new-wt-id" });
+    mockGetCurrentUser.mockResolvedValue({
+      login: "testuser",
+      avatarUrl: "https://example.com/avatar.png",
+      rawData: null,
+    });
+    mockAssignIssue.mockResolvedValue(undefined);
+    mockUnassignIssue.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.clearAllMocks();
+    mockAssignWorktreeToSelf = false;
+    resetForgeResourceCache();
+  });
+
+  it("patches the cached issue assignees after a successful self-assign", async () => {
+    seedIssueCache(makeIssue());
+    const genBefore = getGeneration(ISSUE_CACHE_KEY);
+
+    await createWithSelfAssign();
+
+    expect(mockAssignIssue).toHaveBeenCalledWith(ROOT, 42, "testuser");
+    expect(cachedIssue().assignees.map((a) => a.login)).toContain("testuser");
+    // The current user's avatar rides along so the optimistic row matches.
+    expect(cachedIssue().assignees.find((a) => a.login === "testuser")?.avatarUrl).toBe(
+      "https://example.com/avatar.png"
+    );
+    // Generation bumps so any in-flight list fetch is discarded.
+    expect(getGeneration(ISSUE_CACHE_KEY)).toBeGreaterThan(genBefore);
+  });
+
+  it("does not duplicate an already-present assignee", async () => {
+    seedIssueCache(
+      makeIssue({ assignees: [{ login: "testuser", avatarUrl: undefined, rawData: null }] })
+    );
+    const genBefore = getGeneration(ISSUE_CACHE_KEY);
+
+    await createWithSelfAssign();
+
+    expect(cachedIssue().assignees.filter((a) => a.login === "testuser")).toHaveLength(1);
+    // No effective change → no generation bump (in-flight fetches stay valid).
+    expect(getGeneration(ISSUE_CACHE_KEY)).toBe(genBefore);
+  });
+
+  it("leaves unrelated issues untouched", async () => {
+    const other = makeIssue({ number: 99, assignees: [] });
+    setCache(ISSUE_CACHE_KEY, {
+      items: [other],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: 0,
+    });
+    const genBefore = getGeneration(ISSUE_CACHE_KEY);
+
+    await createWithSelfAssign();
+
+    expect((getCache(ISSUE_CACHE_KEY)?.items[0] as Issue).assignees).toHaveLength(0);
+    expect(getGeneration(ISSUE_CACHE_KEY)).toBe(genBefore);
+  });
+
+  it("reverses the optimistic patch when the undo action fires", async () => {
+    const { notify } = await import("@/lib/notify");
+    seedIssueCache(makeIssue());
+
+    await createWithSelfAssign();
+    expect(cachedIssue().assignees.map((a) => a.login)).toContain("testuser");
+
+    const assignedCall = vi
+      .mocked(notify)
+      .mock.calls.find(([payload]) => payload.title === "Issue assigned");
+    expect(assignedCall).toBeDefined();
+    const onUndo = assignedCall?.[0].action?.onClick;
+    expect(onUndo).toBeTypeOf("function");
+
+    await act(async () => {
+      onUndo?.();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockUnassignIssue).toHaveBeenCalledWith(ROOT, 42, "testuser");
+    expect(cachedIssue().assignees.map((a) => a.login)).not.toContain("testuser");
+  });
+
+  it("keeps the optimistic patch when the unassign call fails", async () => {
+    const { notify } = await import("@/lib/notify");
+    mockUnassignIssue.mockRejectedValue(new Error("network down"));
+    seedIssueCache(makeIssue());
+
+    await createWithSelfAssign();
+
+    const onUndo = vi
+      .mocked(notify)
+      .mock.calls.find(([payload]) => payload.title === "Issue assigned")?.[0].action?.onClick;
+
+    await act(async () => {
+      onUndo?.();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Unassign rejected → cache must NOT be reverted.
+    expect(cachedIssue().assignees.map((a) => a.login)).toContain("testuser");
   });
 });


### PR DESCRIPTION
## Summary

- When creating a new worktree with self-assign enabled, the assignment succeeded server-side but the renderer forge cache was never updated — so the open issues dropdown showed the issue as unassigned until the next SWR revalidate (~30s).
- Fix uses `mutateCacheEntries` to optimistically patch every cached issue-list slot after a successful `assignIssue`, and mirrors the patch in the undo path after `unassignIssue` resolves.
- Also guards the no-op case (issue already lists the current user → skip the assign so undo can't strip a pre-existing assignment) and isolates cache-layer throws from being misreported as assignment failures. Works through the forge abstraction — provider-agnostic.

Resolves #10529

## Changes

- `src/components/Worktree/NewWorktreeDialog.tsx` — optimistic cache patch on assign/unassign, no-op guard, cache-throw isolation
- `src/components/Worktree/__tests__/NewWorktreeDialog.test.tsx` — 8 new cache-mutation tests covering assign patch, idempotency, unrelated-issue no-op, multi-slot patch, undo reversal, unassign-failure non-reversal, self-assign-disabled gate, and already-assigned skip

## Testing

56 unit tests pass across `NewWorktreeDialog` and `forgeResourceCache`. The forge background refresh remains the correctness backstop; this patch just closes the ~30s gap before it fires.