### PR TITLE
fix(plugins): node build target, import-map lockstep, dev import map, lean .dntr (#10514)

### DIFF
--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -18,6 +18,38 @@ const REQUIRED_EXCLUSIONS: readonly string[] = ["node_modules/", ".git/"];
 const SOURCE_EXTS = new Set([".ts", ".tsx"]);
 const SOURCEMAP_EXTS = new Set([".js.map", ".mjs.map"]);
 
+// Dev-only metadata that must never ship in a `.dntr`: package manifests,
+// lockfiles, TS config, and build configs. `package.json` is the worst
+// offender — it carries the author's full dependency layout and, in a
+// monorepo/`file:` setup, leaks the author's absolute home path into every
+// distributed copy (#10514); `package-lock.json` is also usually the bulk of
+// the archive. A `.dntr` should contain only the manifest, built outputs, and
+// declared assets, so these are excluded from packing AND rejected by
+// {@link verifyPluginArchive}.
+const ROOT_DEV_FILE_NAMES: ReadonlySet<string> = new Set([
+  "package.json",
+  "package-lock.json",
+  "npm-shrinkwrap.json",
+  "yarn.lock",
+  "pnpm-lock.yaml",
+  "bun.lockb",
+]);
+
+// `*.config.*` at the archive root: vite.config.ts, tsup.config.mjs,
+// vitest.config.ts, etc.
+const ROOT_CONFIG_FILE = /^[^/]+\.config\.[^/]+$/;
+
+// Scope to the archive ROOT only (no `/` in the path) so a plugin that
+// legitimately ships e.g. `dist/app.config.json` as a runtime asset keeps it —
+// the leak and bloat we're guarding against live at the package root.
+function isExcludedRootDevFile(name: string): boolean {
+  if (name.includes("/")) return false;
+  if (ROOT_DEV_FILE_NAMES.has(name)) return true;
+  // tsconfig.json, tsconfig.build.json, tsconfig.node.json, …
+  if (name.startsWith("tsconfig") && name.endsWith(".json")) return true;
+  return ROOT_CONFIG_FILE.test(name);
+}
+
 export interface PackOptions {
   sourcemaps?: boolean;
 }
@@ -67,6 +99,7 @@ function matchesExclusionPattern(name: string, sourcemaps: boolean): boolean {
   }
   const ext = path.extname(name);
   if (SOURCE_EXTS.has(ext)) return true;
+  if (isExcludedRootDevFile(name)) return true;
   if (!sourcemaps) {
     for (const smExt of SOURCEMAP_EXTS) {
       if (name.endsWith(smExt)) return true;

--- a/electron/services/PluginArchive.ts
+++ b/electron/services/PluginArchive.ts
@@ -32,6 +32,7 @@ const ROOT_DEV_FILE_NAMES: ReadonlySet<string> = new Set([
   "npm-shrinkwrap.json",
   "yarn.lock",
   "pnpm-lock.yaml",
+  "bun.lock",
   "bun.lockb",
 ]);
 
@@ -69,6 +70,13 @@ function normalizePath(filePath: string): string {
   let normalised = filePath.replace(/\\/g, "/");
   if (normalised.startsWith("/")) {
     normalised = normalised.slice(1);
+  }
+  // Strip a leading `./` so a crafted entry like `./package.json` normalizes to
+  // its bare root name — otherwise the leading dot keeps it out of the
+  // root-level dev-file exclusion (the privacy/bloat guard). It also aligns with
+  // the `stripLeading` the manifest.main/view checks already apply.
+  if (normalised.startsWith("./")) {
+    normalised = normalised.slice(2);
   }
   return normalised;
 }

--- a/electron/services/__tests__/PluginArchive.integration.test.ts
+++ b/electron/services/__tests__/PluginArchive.integration.test.ts
@@ -176,6 +176,27 @@ describe("exclusion patterns", () => {
     expect(r2.valid).toBe(true);
     if (r2.valid) expect(r2.entryCount).toBe(4);
   });
+
+  it("excludes dev-only files (package.json, lockfile, tsconfig, configs) when packing", async () => {
+    const sourceDir = path.join(tmpDir, "source");
+    await createFixture(sourceDir, {
+      "plugin.json": JSON.stringify(validManifest()),
+      "dist/index.js": "module.exports = {};",
+      "package.json": JSON.stringify({ name: "leaky", dependencies: {} }),
+      "package-lock.json": "{}",
+      "tsconfig.json": "{}",
+      "vite.config.ts": "export default {};",
+      "README.md": "# keep me",
+    });
+
+    const archivePath = path.join(tmpDir, "out.dntr");
+    await packPluginArchive(sourceDir, archivePath);
+
+    const result = await verifyPluginArchive(archivePath);
+    expect(result.valid).toBe(true);
+    // plugin.json, dist/index.js, README.md — the dev files are dropped.
+    if (result.valid) expect(result.entryCount).toBe(3);
+  });
 });
 
 describe("packPluginArchive", () => {
@@ -552,5 +573,31 @@ describe("isExcludedArchiveEntry (shared CLI exclusion predicate)", () => {
     expect(isExcludedArchiveEntry("plugin.json")).toBe(false);
     expect(isExcludedArchiveEntry("dist/index.js")).toBe(false);
     expect(isExcludedArchiveEntry("icons/logo.svg")).toBe(false);
+  });
+
+  it("excludes root-level package metadata, lockfiles, and tsconfig", () => {
+    expect(isExcludedArchiveEntry("package.json")).toBe(true);
+    expect(isExcludedArchiveEntry("package-lock.json")).toBe(true);
+    expect(isExcludedArchiveEntry("npm-shrinkwrap.json")).toBe(true);
+    expect(isExcludedArchiveEntry("yarn.lock")).toBe(true);
+    expect(isExcludedArchiveEntry("pnpm-lock.yaml")).toBe(true);
+    expect(isExcludedArchiveEntry("bun.lockb")).toBe(true);
+    expect(isExcludedArchiveEntry("tsconfig.json")).toBe(true);
+    expect(isExcludedArchiveEntry("tsconfig.build.json")).toBe(true);
+  });
+
+  it("excludes root-level build configs", () => {
+    expect(isExcludedArchiveEntry("vite.config.ts")).toBe(true);
+    expect(isExcludedArchiveEntry("vite.config.server.ts")).toBe(true);
+    expect(isExcludedArchiveEntry("tsup.config.mjs")).toBe(true);
+    expect(isExcludedArchiveEntry("vitest.config.js")).toBe(true);
+  });
+
+  it("scopes dev-file exclusions to the archive root", () => {
+    // A plugin may legitimately ship config/JSON inside its built output —
+    // only root-level dev metadata leaks the author's environment.
+    expect(isExcludedArchiveEntry("dist/app.config.js")).toBe(false);
+    expect(isExcludedArchiveEntry("dist/package.json")).toBe(false);
+    expect(isExcludedArchiveEntry("assets/tsconfig.json")).toBe(false);
   });
 });

--- a/electron/services/__tests__/PluginArchive.integration.test.ts
+++ b/electron/services/__tests__/PluginArchive.integration.test.ts
@@ -431,6 +431,22 @@ describe("verifyPluginArchive", () => {
     if (!result.valid) expect(result.error).toContain("entry limit");
   });
 
+  it("rejects a crafted dev file disguised with a ./ prefix", async () => {
+    // `./package.json` must not slip past the dev-file exclusion via the leading
+    // dot — normalizePath strips it so the guard (and the raw-name check) catch it.
+    const archivePath = path.join(tmpDir, "dotslash.dntr");
+    await fs.writeFile(
+      archivePath,
+      buildRawZip([
+        { name: "plugin.json", content: JSON.stringify(validManifest()) },
+        { name: "./package.json", content: JSON.stringify({ name: "leaky" }) },
+      ])
+    );
+
+    const result = await verifyPluginArchive(archivePath);
+    expect(result.valid).toBe(false);
+  });
+
   it("rejects an archive with a duplicate normalized entry name", async () => {
     const archivePath = path.join(tmpDir, "dup.dntr");
     await fs.writeFile(
@@ -581,6 +597,7 @@ describe("isExcludedArchiveEntry (shared CLI exclusion predicate)", () => {
     expect(isExcludedArchiveEntry("npm-shrinkwrap.json")).toBe(true);
     expect(isExcludedArchiveEntry("yarn.lock")).toBe(true);
     expect(isExcludedArchiveEntry("pnpm-lock.yaml")).toBe(true);
+    expect(isExcludedArchiveEntry("bun.lock")).toBe(true);
     expect(isExcludedArchiveEntry("bun.lockb")).toBe(true);
     expect(isExcludedArchiveEntry("tsconfig.json")).toBe(true);
     expect(isExcludedArchiveEntry("tsconfig.build.json")).toBe(true);

--- a/packages/daintree-plugin/src/__tests__/new.test.ts
+++ b/packages/daintree-plugin/src/__tests__/new.test.ts
@@ -147,4 +147,52 @@ describe("scaffoldPlugin", () => {
     expect(panel).toBeDefined();
     expect(panel?.hasPty ?? false).toBe(false);
   });
+
+  for (const template of ["mcp", "full"] as const) {
+    it(`"${template}" template builds the server entry through a separate node config`, async () => {
+      const result = await scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: `srv-${template}`,
+        publisher: "acme",
+        displayName: "Srv",
+        template,
+      });
+
+      const clientConfig = await fs.readFile(path.join(result.dir, "vite.config.ts"), "utf8");
+      const serverConfig = await fs.readFile(
+        path.join(result.dir, "vite.config.server.ts"),
+        "utf8"
+      );
+
+      // The server entry must NOT go through the browser config — that's the
+      // bug where node code is built for the client environment and crashes.
+      expect(clientConfig).not.toContain("src/server.ts");
+      expect(serverConfig).toContain("src/server.ts");
+      expect(serverConfig).toContain('daintreePlugin({ target: "node" })');
+      // The second build pass must not wipe the browser output.
+      expect(serverConfig).toContain("emptyOutDir: false");
+
+      // The build script chains both passes so a plain `npm run build` produces
+      // both bundles.
+      const pkg = await readJson(path.join(result.dir, "package.json"));
+      const buildScript = (pkg.scripts as Record<string, string>).build;
+      expect(buildScript).toContain("vite build");
+      expect(buildScript).toContain("--config vite.config.server.ts");
+    });
+  }
+
+  for (const template of ["command", "view"] as const) {
+    it(`"${template}" template has no separate server config`, async () => {
+      const result = await scaffoldPlugin({
+        cwd: tmpDir,
+        targetDir: `nosrv-${template}`,
+        publisher: "acme",
+        displayName: "NoSrv",
+        template,
+      });
+      await expect(fs.access(path.join(result.dir, "vite.config.server.ts"))).rejects.toThrow();
+      const pkg = await readJson(path.join(result.dir, "package.json"));
+      expect((pkg.scripts as Record<string, string>).build).toBe("vite build");
+    });
+  }
 });

--- a/packages/daintree-plugin/src/__tests__/package.test.ts
+++ b/packages/daintree-plugin/src/__tests__/package.test.ts
@@ -59,6 +59,22 @@ describe("runPackage", () => {
     expect(result.files).not.toContain("dist/index.js.map");
   });
 
+  it("excludes dev-only files (package.json, lockfile, tsconfig, configs)", async () => {
+    await fixture();
+    await writeFile("package.json", JSON.stringify({ name: "acme.packtest", private: true }));
+    await writeFile("package-lock.json", "{}");
+    await writeFile("tsconfig.json", "{}");
+    await writeFile("vite.config.ts", "export default {};");
+    const result = await runPackage({ dir: tmpDir, dryRun: true, skipBuild: true });
+    expect(result.files).not.toContain("package.json");
+    expect(result.files).not.toContain("package-lock.json");
+    expect(result.files).not.toContain("tsconfig.json");
+    expect(result.files).not.toContain("vite.config.ts");
+    // Real plugin output still ships.
+    expect(result.files).toContain("plugin.json");
+    expect(result.files).toContain("dist/index.js");
+  });
+
   it("includes source maps when sourcemaps=true", async () => {
     await fixture();
     const result = await runPackage({

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -65,7 +65,7 @@ function manifest(ctx: ScaffoldContext, contributes: Record<string, unknown>): s
   return JSON.stringify(obj, null, 2) + "\n";
 }
 
-function packageJson(ctx: ScaffoldContext, needsReact: boolean): string {
+function packageJson(ctx: ScaffoldContext, needsReact: boolean, needsServer = false): string {
   const deps: Record<string, string> = {};
   const devDeps: Record<string, string> = {
     "@daintreehq/plugin-sdk": "^0.1.0",
@@ -84,7 +84,9 @@ function packageJson(ctx: ScaffoldContext, needsReact: boolean): string {
     type: "module",
     private: true,
     scripts: {
-      build: "vite build",
+      // `vite build` runs one config object at a time, so the Node server entry
+      // is built by a second pass against vite.config.server.ts (see that file).
+      build: needsServer ? "vite build && vite build --config vite.config.server.ts" : "vite build",
       validate: "daintree-plugin validate",
       package: "daintree-plugin package",
     },
@@ -123,6 +125,34 @@ export default defineConfig({
       formats: ["es"],
     },
     outDir: "dist",
+    sourcemap: true,
+  },
+});
+`;
+}
+
+/**
+ * Vite config for Node entries (stdio MCP servers). Separate from the browser
+ * config because a single \`vite build\` runs one config object at a time, and a
+ * Node target must not be applied to the renderer/panel bundles. \`target:
+ * "node"\` externalizes Node built-ins instead of browser-shimming them — the
+ * root cause of a stdio server crashing with \`process.stdin === undefined\`.
+ * \`emptyOutDir: false\` preserves the browser build that ran first.
+ */
+function viteServerConfig(entries: Record<string, string>): string {
+  const entryLiteral = JSON.stringify(entries, null, 6).replace(/\n/g, "\n  ");
+  return `import { daintreePlugin } from "@daintreehq/plugin-vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [daintreePlugin({ target: "node" })],
+  build: {
+    lib: {
+      entry: ${entryLiteral},
+      formats: ["es"],
+    },
+    outDir: "dist",
+    emptyOutDir: false,
     sourcemap: true,
   },
 });
@@ -278,9 +308,10 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
             },
           ],
         }),
-        "package.json": packageJson(ctx, false),
+        "package.json": packageJson(ctx, false, true),
         "tsconfig.json": tsconfig(false),
-        "vite.config.ts": viteConfig({ index: "src/index.ts", server: "src/server.ts" }),
+        "vite.config.ts": viteConfig({ index: "src/index.ts" }),
+        "vite.config.server.ts": viteServerConfig({ server: "src/server.ts" }),
         ".gitignore": GITIGNORE,
         "src/index.ts": mcpEntry(ctx),
         "src/server.ts": mcpServer(ctx),
@@ -318,13 +349,13 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
             },
           ],
         }),
-        "package.json": packageJson(ctx, true),
+        "package.json": packageJson(ctx, true, true),
         "tsconfig.json": tsconfig(true),
         "vite.config.ts": viteConfig({
           index: "src/index.ts",
           panel: "src/panel.tsx",
-          server: "src/server.ts",
         }),
+        "vite.config.server.ts": viteServerConfig({ server: "src/server.ts" }),
         ".gitignore": GITIGNORE,
         "src/index.ts": commandEntry(ctx),
         "src/panel.tsx": panelComponent(ctx),

--- a/packages/plugin-vite/src/__tests__/index.test.ts
+++ b/packages/plugin-vite/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { reactExternals, daintreePlugin } from "../index.js";
+import { reactExternals, daintreePlugin, HOST_IMPORTMAP_SPECIFIERS } from "../index.js";
 
 describe("@daintreehq/plugin-vite — reactExternals", () => {
   function matchesAny(specifier: string): boolean {
@@ -60,5 +60,105 @@ describe("@daintreehq/plugin-vite — daintreePlugin", () => {
     const externals = configFn().build.rollupOptions.external;
     expect(externals).toContain("@host/shared-ui");
     expect(externals.length).toBe(reactExternals.length + 2);
+  });
+});
+
+describe("@daintreehq/plugin-vite — HOST_IMPORTMAP_SPECIFIERS", () => {
+  function matchesAny(specifier: string): boolean {
+    return reactExternals.some((re) => re.test(specifier));
+  }
+
+  it("only lists specifiers that the React externals would strip", () => {
+    // The host-mapped set must be a subset of what gets externalized — a mapped
+    // specifier the externals didn't strip would be bundled, never resolved
+    // through the import map.
+    for (const specifier of HOST_IMPORTMAP_SPECIFIERS) {
+      expect(matchesAny(specifier)).toBe(true);
+    }
+  });
+
+  it("does not list React subpaths the host cannot resolve", () => {
+    // The externals are broader than the import map on purpose; these subpaths
+    // externalize but must NOT be advertised as host-served.
+    const list = HOST_IMPORTMAP_SPECIFIERS as readonly string[];
+    expect(matchesAny("react-dom/server")).toBe(true);
+    expect(list).not.toContain("react-dom/server");
+    expect(list).not.toContain("react/compiler-runtime");
+  });
+
+  it("has no duplicate entries", () => {
+    expect(new Set(HOST_IMPORTMAP_SPECIFIERS).size).toBe(HOST_IMPORTMAP_SPECIFIERS.length);
+  });
+});
+
+describe("@daintreehq/plugin-vite — unmapped subpath guard", () => {
+  type ResolveIdFn = (id: string) => string | null;
+
+  function resolveIdOf(plugin: ReturnType<typeof daintreePlugin>): ResolveIdFn {
+    return plugin.resolveId as unknown as ResolveIdFn;
+  }
+
+  it("throws on a React subpath the host import map does not serve", () => {
+    const resolveId = resolveIdOf(daintreePlugin());
+    expect(() => resolveId("react-dom/server")).toThrow(/react-dom\/server/);
+    expect(() => resolveId("react/compiler-runtime")).toThrow(/import map/);
+  });
+
+  it("allows every host-served specifier through (returns null to externalize)", () => {
+    const resolveId = resolveIdOf(daintreePlugin());
+    for (const specifier of HOST_IMPORTMAP_SPECIFIERS) {
+      expect(resolveId(specifier)).toBeNull();
+    }
+  });
+
+  it("ignores non-React specifiers", () => {
+    const resolveId = resolveIdOf(daintreePlugin());
+    expect(resolveId("react-router")).toBeNull();
+    expect(resolveId("@scope/react")).toBeNull();
+    expect(resolveId("./local-module")).toBeNull();
+  });
+});
+
+describe("@daintreehq/plugin-vite — node target", () => {
+  type NodeConfig = {
+    resolve: { conditions: string[]; mainFields: string[] };
+    build: { target: string; rollupOptions: { external: ReadonlyArray<string | RegExp> } };
+  };
+
+  function nodeConfig(plugin: ReturnType<typeof daintreePlugin>): NodeConfig {
+    return (plugin.config as unknown as () => NodeConfig)();
+  }
+
+  it("externalizes Node built-ins in both bare and node: forms", () => {
+    const external = nodeConfig(daintreePlugin({ target: "node" })).build.rollupOptions.external;
+    expect(external).toContain("process");
+    expect(external).toContain("node:process");
+    expect(external).toContain("fs");
+    expect(external).toContain("node:fs");
+  });
+
+  it("does not externalize React (node code has no host import map)", () => {
+    const external = nodeConfig(daintreePlugin({ target: "node" })).build.rollupOptions.external;
+    for (const re of reactExternals) {
+      expect(external).not.toContain(re);
+    }
+  });
+
+  it("prefers Node resolve conditions over browser", () => {
+    const { resolve } = nodeConfig(daintreePlugin({ target: "node" }));
+    expect(resolve.conditions).toContain("node");
+    expect(resolve.conditions).not.toContain("browser");
+    expect(resolve.mainFields).not.toContain("browser");
+  });
+
+  it("merges caller-supplied externals alongside the Node built-ins", () => {
+    const external = nodeConfig(daintreePlugin({ target: "node", externals: ["better-sqlite3"] }))
+      .build.rollupOptions.external;
+    expect(external).toContain("better-sqlite3");
+    expect(external).toContain("node:fs");
+  });
+
+  it("does not attach the React subpath guard to node builds", () => {
+    expect(daintreePlugin({ target: "node" }).resolveId).toBeUndefined();
   });
 });

--- a/packages/plugin-vite/src/index.ts
+++ b/packages/plugin-vite/src/index.ts
@@ -1,41 +1,90 @@
+import { builtinModules } from "node:module";
 import type { Plugin } from "vite";
 
 /**
+ * The exact React specifiers the Daintree host import map serves. This is the
+ * single source of truth for the host/plugin contract: `vite.config.ts` imports
+ * this list to build the `<script type="importmap">` it injects, and the plugin
+ * build (below) errors at build time on any React subpath outside it. Keeping
+ * the two sides on one constant is what stops the "externalized but unresolved
+ * at runtime" drift (e.g. `react-dom/server`) that this list previously had to
+ * be hand-synced against.
+ */
+export const HOST_IMPORTMAP_SPECIFIERS = [
+  "react",
+  "react/jsx-runtime",
+  "react/jsx-dev-runtime",
+  "react-dom",
+  "react-dom/client",
+] as const;
+
+/**
  * Rolldown/Rollup external patterns that strip React, ReactDOM, and every
- * documented subpath (`react/jsx-runtime`, `react/jsx-dev-runtime`,
- * `react-dom/client`, …) from plugin bundles. The regex form covers future
- * subpaths automatically — Rolldown does NOT auto-include subpaths when
- * `external` lists only the bare package name (e.g. `external: ["react"]`
- * matches the literal string `"react"` and bundles `react/jsx-runtime` into
- * the plugin output, producing a second React copy and `Invalid hook call`
- * at runtime).
+ * subpath (`react/jsx-runtime`, `react-dom/client`, …) from browser plugin
+ * bundles. The regex form is deliberately broad: it catches every `react*` /
+ * `react-dom*` subpath so none is accidentally bundled (a second React copy
+ * triggers `Invalid hook call` at the first render — `external: ["react"]`
+ * matches only the literal string and would bundle `react/jsx-runtime`).
  *
  * Paired with the host import map (injected into Daintree's index.html), the
  * stripped imports resolve at load time to Daintree's single `vendor-react`
  * chunk, sharing one React instance across the host and every loaded plugin.
  *
- * Note: the regex also externalizes subpaths the host import map does not yet
- * provide (e.g. `react-dom/server`). The host map currently serves `react`,
- * `react/jsx-runtime`, `react/jsx-dev-runtime`, `react-dom`, and
- * `react-dom/client`. A plugin importing an unmapped subpath would have it
- * externalized but unresolved at runtime — keep the two sides in lockstep
- * (`HOST_IMPORTMAP_SPECIFIERS` in the host `vite.config.ts`).
+ * Breadth here is safe only because {@link daintreePlugin} also runs a
+ * `resolveId` guard that fails the build on any React subpath the host import
+ * map does NOT serve (anything outside {@link HOST_IMPORTMAP_SPECIFIERS}) —
+ * so an externalized-but-unmapped specifier is caught at build time, not at
+ * runtime as an unresolved bare specifier.
  */
 export const reactExternals: readonly RegExp[] = [/^react($|\/)/, /^react-dom($|\/)/] as const;
 
-export interface DaintreePluginOptions {
-  /**
-   * Extra externals to merge with the React preset. Useful when a plugin
-   * needs to externalize additional host-provided modules (e.g. a future
-   * shared component library).
-   */
-  readonly externals?: ReadonlyArray<string | RegExp>;
+function isReactSpecifier(id: string): boolean {
+  return reactExternals.some((re) => re.test(id));
+}
+
+function isHostMappedSpecifier(id: string): boolean {
+  return (HOST_IMPORTMAP_SPECIFIERS as readonly string[]).includes(id);
 }
 
 /**
- * Vite plugin that wires the React externals preset into a plugin's build.
+ * Node built-ins, both bare (`fs`, `process`) and `node:`-prefixed. A node
+ * target externalizes these so they resolve to the real runtime modules
+ * instead of being replaced with empty browser shims — the shim is exactly why
+ * a stdio MCP server built for the client environment crashes at runtime
+ * (`process.stdin === undefined`).
+ */
+const NODE_BUILTIN_EXTERNALS: readonly string[] = [
+  ...builtinModules,
+  ...builtinModules.map((m) => `node:${m}`),
+];
+
+/** Build target for a plugin entry. `"browser"` (default) is the renderer/panel
+ * preset; `"node"` is for stdio MCP servers and other Node entries. */
+export type DaintreeBuildTarget = "browser" | "node";
+
+export interface DaintreePluginOptions {
+  /**
+   * Extra externals to merge with the preset. Useful when a plugin needs to
+   * externalize additional host-provided modules (e.g. a future shared
+   * component library), or additional Node-resolved modules for a node target.
+   */
+  readonly externals?: ReadonlyArray<string | RegExp>;
+  /**
+   * Build target. `"browser"` (default) wires the React externals + host
+   * import-map guard for renderer/panel bundles. `"node"` configures a
+   * Node-targeting build for stdio MCP servers: Node built-ins are externalized
+   * (not browser-shimmed), node resolve conditions are preferred, and React is
+   * NOT externalized (node code has no host import map). Use a separate config
+   * file for the node entry (e.g. `vite.config.server.ts`) since `vite build`
+   * runs one config object at a time.
+   */
+  readonly target?: DaintreeBuildTarget;
+}
+
+/**
+ * Vite plugin that wires Daintree's build presets into a plugin's build.
  *
- * Usage in a plugin's vite.config.ts:
+ * Browser usage (renderer/panel) in a plugin's vite.config.ts:
  *
  * ```ts
  * import { daintreePlugin } from "@daintreehq/plugin-vite";
@@ -43,7 +92,19 @@ export interface DaintreePluginOptions {
  *
  * export default defineConfig({
  *   plugins: [daintreePlugin()],
- *   build: { lib: { entry: "src/index.tsx", formats: ["es"] } },
+ *   build: { lib: { entry: "src/panel.tsx", formats: ["es"] } },
+ * });
+ * ```
+ *
+ * Node usage (stdio MCP server) in a separate `vite.config.server.ts`:
+ *
+ * ```ts
+ * import { daintreePlugin } from "@daintreehq/plugin-vite";
+ * import { defineConfig } from "vite";
+ *
+ * export default defineConfig({
+ *   plugins: [daintreePlugin({ target: "node" })],
+ *   build: { lib: { entry: { server: "src/server.ts" }, formats: ["es"] } },
  * });
  * ```
  *
@@ -52,6 +113,30 @@ export interface DaintreePluginOptions {
  */
 export function daintreePlugin(options: DaintreePluginOptions = {}): Plugin {
   const extras = options.externals ?? [];
+  const target = options.target ?? "browser";
+
+  if (target === "node") {
+    return {
+      name: "daintree-plugin-vite",
+      config: () => ({
+        resolve: {
+          // Prefer Node export conditions and main fields (drop "browser") so
+          // dependencies resolve to their Node builds, not browser shims.
+          conditions: ["node", "module", "import", "default"],
+          mainFields: ["module", "jsnext:main", "jsnext", "main"],
+        },
+        build: {
+          // Modern Node target so esbuild/Rolldown don't down-level or shim
+          // built-ins. Daintree spawns the server with the bundled Node.
+          target: "node18",
+          rollupOptions: {
+            external: [...NODE_BUILTIN_EXTERNALS, ...extras],
+          },
+        },
+      }),
+    };
+  }
+
   return {
     name: "daintree-plugin-vite",
     config: () => ({
@@ -61,5 +146,21 @@ export function daintreePlugin(options: DaintreePluginOptions = {}): Plugin {
         },
       },
     }),
+    // Fail the build on any React subpath that is externalized (matched by the
+    // regexes above) but is NOT served by the host import map. Without this the
+    // bundle builds clean and only fails at load with an unresolved bare
+    // specifier (the classic `react-dom/server` trap). Returns `null` for
+    // mapped specifiers so the `external` config above still externalizes them,
+    // and for non-React ids so normal resolution proceeds.
+    resolveId(id) {
+      if (isReactSpecifier(id) && !isHostMappedSpecifier(id)) {
+        throw new Error(
+          `[daintree-plugin-vite] "${id}" is externalized as React but the Daintree host ` +
+            `import map does not serve it, so it would fail at runtime as an unresolved bare ` +
+            `specifier. Supported specifiers: ${HOST_IMPORTMAP_SPECIFIERS.join(", ")}.`
+        );
+      }
+      return null;
+    },
   };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,13 @@ import { createHash } from "node:crypto";
 import { gzipSync } from "node:zlib";
 import { getDevServerConfig } from "./shared/config/devServer";
 import { getDaintreeAppDevCSP, getDaintreeAppProdCSP } from "./shared/config/csp";
+// Source of truth for the host/plugin React contract. The plugin build
+// (@daintreehq/plugin-vite) errors on any React subpath outside this list, and
+// here it drives the injected `<script type="importmap">` — one constant keeps
+// the two sides from drifting (the `react-dom/server` "externalized but
+// unresolved" class of bug). Imported from source (not the built dist) the same
+// way this config already imports from `./shared/*`.
+import { HOST_IMPORTMAP_SPECIFIERS } from "./packages/plugin-vite/src/index";
 import { getFirstRenderPreloadSeeds } from "./shared/config/panelKindRegistry";
 import { computeFirstRenderPreloadFiles } from "./scripts/first-render-closure-lib.mjs";
 
@@ -266,25 +273,17 @@ function cspTransformPlugin(state: ImportMapBuildState): Plugin {
   };
 }
 
-// Specifiers exposed to externalized plugin bundles. Each bare specifier points
-// at the same `vendor-react` chunk because Rolldown bundles `react`, `react-dom`,
-// `scheduler`, and `use-sync-external-store` into one file (see the
-// `vendor-react` codeSplitting group below). Trailing-slash mappings ("react/")
-// can't substitute here — a single chunk file has no subpath structure to
-// concatenate against — so every JSX/React entrypoint plugins might import is
-// listed explicitly. `react/jsx-dev-runtime` is included so the dev-mode JSX
-// transform (used by plugins building with mode=development) resolves to the
-// host React instance instead of bundling a separate copy. `scheduler` is
+// `HOST_IMPORTMAP_SPECIFIERS` (imported from @daintreehq/plugin-vite above) is
+// the set of specifiers exposed to externalized plugin bundles. In production
+// each bare specifier points at the same `vendor-react` chunk because Rolldown
+// bundles `react`, `react-dom`, `scheduler`, and `use-sync-external-store` into
+// one file (see the `vendor-react` codeSplitting group below). Trailing-slash
+// mappings ("react/") can't substitute — a single chunk file has no subpath
+// structure to concatenate against — so every JSX/React entrypoint plugins
+// might import is listed explicitly in the shared constant. `scheduler` is
 // internal to React and not exposed because no documented plugin path imports
-// it directly; if that changes, add it here and to the plugin-vite externals
-// regex in lockstep.
-const HOST_IMPORTMAP_SPECIFIERS = [
-  "react",
-  "react/jsx-runtime",
-  "react/jsx-dev-runtime",
-  "react-dom",
-  "react-dom/client",
-] as const;
+// it directly; if that changes, add it to the shared constant (plugin-vite),
+// which keeps the externals regex and this import map in lockstep by design.
 
 const HOST_APP_ORIGIN = "app://daintree";
 
@@ -377,6 +376,69 @@ function hostImportMapPlugin(state: ImportMapBuildState): Plugin {
         sidecarPath,
         JSON.stringify({ scriptSrcHashes: [state.scriptSrcHash] }, null, 2) + "\n"
       );
+    },
+  };
+}
+
+// Prefix for the dev-only virtual modules that re-export the host's React. Each
+// `HOST_IMPORTMAP_SPECIFIERS` entry gets one (`…/react`, `…/react-dom/client`,
+// …). Vite serves a resolved virtual id at `/@id/<id>` in dev, so that URL is
+// stable across runs — unlike the optimized-dep path (`/node_modules/.vite/
+// deps/react.js?v=<hash>`), whose hash changes per optimize pass and can't be
+// referenced statically from an import map.
+const DEV_HOST_REACT_PREFIX = "virtual:daintree-host-react/";
+
+// Dev counterpart to hostImportMapPlugin. In production the import map points
+// plugin bundles at the hashed `vendor-react` chunk; in dev that chunk doesn't
+// exist (Vite serves React from the module graph), so a sideloaded plugin view
+// that externalizes React has nothing to resolve `react` against and fails to
+// mount (#10514). This plugin closes that gap: it injects an import map into the
+// dev index.html mapping each host specifier to a stable virtual module that
+// re-exports the host's React. Because the virtual module's own `import` is
+// resolved by Vite server-side (not via the browser import map), it lands on the
+// exact React instance the host uses — one instance shared with every plugin,
+// same guarantee as production. Serve-only; the dev CSP carries `'unsafe-inline'`
+// so the inline `<script type="importmap">` needs no hash.
+function hostImportMapDevPlugin(): Plugin {
+  return {
+    name: "host-import-map-dev",
+    apply: "serve",
+    resolveId(id) {
+      if (id.startsWith(DEV_HOST_REACT_PREFIX)) return id;
+      return null;
+    },
+    load(id) {
+      if (!id.startsWith(DEV_HOST_REACT_PREFIX)) return null;
+      const specifier = id.slice(DEV_HOST_REACT_PREFIX.length);
+      const target = JSON.stringify(specifier);
+      // `export *` carries the named exports (`useState`, `jsx`, …); the
+      // computed default keeps `import React from "react"` working without a
+      // direct `export { default }` that would throw for subpaths (e.g.
+      // jsx-runtime) that have no own default export.
+      return (
+        `import * as m from ${target};\n` +
+        `export * from ${target};\n` +
+        `export default m.default ?? m;\n`
+      );
+    },
+    transformIndexHtml(_html, ctx) {
+      if (!ctx.server) return;
+      const importMapPayload = {
+        imports: Object.fromEntries(
+          HOST_IMPORTMAP_SPECIFIERS.map((specifier) => [
+            specifier,
+            `/@id/${DEV_HOST_REACT_PREFIX}${specifier}`,
+          ])
+        ),
+      };
+      return [
+        {
+          tag: "script",
+          attrs: { type: "importmap" },
+          injectTo: "head-prepend",
+          children: JSON.stringify(importMapPayload),
+        },
+      ];
     },
   };
 }
@@ -776,6 +838,7 @@ export default defineConfig(({ command, mode }) => {
       }),
       tailwindcss(),
       hostImportMapPlugin(importMapState),
+      hostImportMapDevPlugin(),
       cspTransformPlugin(importMapState),
       compilerReportPlugin,
       rendererBundleSizePlugin(),


### PR DESCRIPTION
## Summary

- Fixes 4 plugin build problems from #10514: stdio MCP servers crashing under Node, React subpath lockstep between `plugin-vite` and the host import map, missing dev-mode import map for sideloaded panels, and `.dntr` archives shipping `package.json`/lockfiles that leak author home paths.
- `plugin-vite` gets a `daintreePlugin({ target: "node" })` mode that externalizes Node built-ins and sets node resolve conditions; `HOST_IMPORTMAP_SPECIFIERS` is now the single source of truth shared between `plugin-vite` and `vite.config.ts`; a `resolveId` guard fails the build on any React subpath the host import map doesn't serve.
- `PluginArchive` exclusion list now strips root-level `package.json`, lockfiles (including `bun.lock`), `tsconfig*`, and `*.config.*` from `.dntr` output; `normalizePath` strips leading `./` so crafted entries can't bypass it; the CLI packager and `verify` share the same list.

Resolves #10514

## Changes

- `packages/plugin-vite/src/index.ts`: node target mode, exported `HOST_IMPORTMAP_SPECIFIERS`, unmapped-subpath `resolveId` guard
- `vite.config.ts`: imports the shared specifier list; adds dev-mode import map via stable Vite virtual re-export modules (serve-only, prod unchanged); scaffold `mcp`/`full` templates split into `vite.config.ts` (browser) + `vite.config.server.ts` (node) with a chained build script
- `electron/services/PluginArchive.ts`: expanded `REQUIRED_EXCLUSIONS`, `normalizePath` path-traversal hardening
- Tests: `plugin-vite` (node target, unmapped-subpath guard, specifier contract), `PluginArchive` integration (dev-file exclusion including crafted `./` entries and `bun.lock`), scaffold split tests, CLI packager exclusion test

## Testing

Targeted vitest suites and typechecks pass locally; own-file lint/format clean. Full suite, build, and `full-plugins` E2E deferred to CI.