### PR TITLE
fix(plugins): render contributed panel views in the grid (#10512)

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -366,7 +366,7 @@ Adds entries to right-click menus on specific UI elements.
 }
 ```
 
-**Locations:** `worktree`, `terminal`, `panel`, `file`. More may be added. The `file` location is mounted on the Review Hub's changed-file rows: a contributed `file` item appears in the right-click menu of a changed file, and its action is dispatched with `{ path, worktreePath, status }` for the clicked file (so your handler receives the file, not `undefined`). A changed-file list with no plugin-contributed `file` items keeps its plain rows — the context menu only wraps a row when a plugin contributes to that location.
+**Locations:** `worktree`, `terminal`, `file`. More may be added. The `file` location is mounted on the Review Hub's changed-file rows: a contributed `file` item appears in the right-click menu of a changed file, and its action is dispatched with `{ path, worktreePath, status }` for the clicked file (so your handler receives the file, not `undefined`). A changed-file list with no plugin-contributed `file` items keeps its plain rows — the context menu only wraps a row when a plugin contributes to that location.
 
 Context menus follow the same `actionId` dispatch pattern as menu items, but a `file`-location item additionally receives the clicked file's context as dispatch args. Two built-in actions pair well here: `file.openDiff` opens the side-by-side diff for the dispatched `{ path, worktreePath, status }`, and `panel.openPluginPanel` spawns (or focuses) one of your plugin panels, passing `initialArgs` straight through to the view's `initialArgs` prop — so a context-menu item can open your panel scoped to the file the user clicked.
 
@@ -518,7 +518,7 @@ Registers a provider that decorates files (or other scoped resources) with statu
 
 The manifest entry is read eagerly so the host's decoration-routing table (`electron/services/fileDecorationRegistry.ts`) knows which provider owns a scope before any plugin code runs; the implementation binds lazily in `activate()`. See [Host API](./host-api.md) for the runtime registration signature.
 
-Decorations are no longer confined to the worktree diff/review surface: any file-path list in Daintree can pull a declared decoration scope for the paths it renders, so a lint/leak/status plugin can badge files wherever a path list appears, not just in the Review Hub. From your `activate()` subscriptions and timers, call `host.invalidateFileDecorations(scope, paths?)` to signal that a scope's decorations changed and any renderer showing them should re-pull.
+Today the only mounted decoration consumer is the worktree diff/review surface (the Review Hub's changed-file rows); the routing and host API are general, but no other path list in Daintree pulls decorations yet, so badges from a lint/leak/status plugin currently appear only there. (Widening this to arbitrary path lists is tracked separately — see #10512.) From your `activate()` subscriptions and timers, call `host.invalidateFileDecorations(scope, paths?)` to signal that a scope's decorations changed and any renderer showing them should re-pull.
 
 ## Agents — _Shipped (minimal tier)_
 

--- a/e2e/full/plugins/core-plugin-panels.spec.ts
+++ b/e2e/full/plugins/core-plugin-panels.spec.ts
@@ -1,6 +1,29 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { closeApp, type AppContext } from "../../helpers/launch";
 import { launchWithSamplePlugin, waitForRichPluginReady } from "../../helpers/plugins";
+import { T_LONG } from "../../helpers/timeouts";
+
+/** Dispatch a renderer action through the E2E-only bridge. */
+async function dispatchAction(page: Page, actionId: string, args?: unknown): Promise<unknown> {
+  return page.evaluate(
+    async (payload) => {
+      const dispatch = (
+        window as unknown as {
+          __daintreeDispatchAction?: (
+            id: string,
+            a?: unknown,
+            opts?: { source: string }
+          ) => Promise<unknown>;
+        }
+      ).__daintreeDispatchAction;
+      if (typeof dispatch !== "function") {
+        throw new Error("__daintreeDispatchAction is not available");
+      }
+      return dispatch(payload.actionId, payload.args, { source: "menu" });
+    },
+    { actionId, args }
+  );
+}
 
 /**
  * Plugin `panels` contribution (#10473). The capability-rich `rich-daintree`
@@ -43,5 +66,23 @@ test.describe.serial("Core: Plugin panels contribution", () => {
       hasPty: false,
       showInPalette: true,
     });
+  });
+
+  // Regression for #10512: registration alone (above) is NOT enough — the bug
+  // was that a registered plugin panel never reached a mounted GridPanel because
+  // the grid membership selectors dropped non-built-in kinds. This opens the
+  // panel and asserts its React component actually MOUNTS over `plugin://`,
+  // which is the coverage gap that let the bug ship.
+  test("mounts the contributed view's React component in the grid", async () => {
+    const result = (await dispatchAction(ctx.window, "panel.openPluginPanel", {
+      kind: "daintree.rich.rich-panel",
+    })) as { panelId?: string };
+    expect(result?.panelId).toBeTruthy();
+
+    // The view lazy-imports over `plugin://` and resolves `react` through the
+    // host import map — allow generous time for the cold protocol load.
+    const view = ctx.window.locator('[data-testid="rich-panel-view"]');
+    await expect(view).toBeVisible({ timeout: T_LONG });
+    await expect(view).toContainText("Rich panel view mounted");
   });
 });

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -84,7 +84,10 @@ export const KeybindingContributionSchema = z
 export const ContextMenuContributionSchema = z
   .object({
     actionId: z.string().min(1),
-    location: z.enum(["worktree", "terminal", "panel", "file"]),
+    // `"panel"` removed (#10512) — no renderer surface consumed it, so a
+    // contributed panel context-menu item was dead. Reject it at the manifest
+    // gate so authors get a clear error instead of a silently-ignored item.
+    location: z.enum(["worktree", "terminal", "file"]),
     label: z.string().min(1),
     when: z.string().min(1).optional(),
   })

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1141,6 +1141,11 @@ export default tseslint.config(
       // and binding.gyp aren't part of the TypeScript build graph; they're
       // packaged build infrastructure (analogous to scripts/).
       "electron/native/**",
+      // Sample plugin view assets are hand-authored, browser-ready ESM served
+      // verbatim over `plugin://` (bare `react` resolved via the host import
+      // map). They're test fixtures, not part of the TS build graph — like
+      // packages/*/dist (#10512).
+      "plugins/sample/*/view/**",
     ],
   }
 );

--- a/plugins/sample/rich-daintree/plugin.json
+++ b/plugins/sample/rich-daintree/plugin.json
@@ -26,6 +26,14 @@
         "showInPalette": true
       }
     ],
+    "views": [
+      {
+        "id": "rich-panel",
+        "name": "Rich Panel",
+        "componentPath": "./view/rich-panel-view.js",
+        "location": "panel"
+      }
+    ],
     "keybindings": [
       {
         "actionId": "daintree.rich.ready",

--- a/plugins/sample/rich-daintree/view/rich-panel-view.js
+++ b/plugins/sample/rich-daintree/view/rich-panel-view.js
@@ -1,0 +1,23 @@
+// Hand-authored, browser-ready ESM view module for the `rich-panel` view
+// contribution (#10512). Loaded verbatim by Daintree's `plugin://` protocol —
+// NOT transpiled or bundled — so it must already be valid browser ESM. The bare
+// `react` specifier resolves through the host import map to Daintree's single
+// React instance (see docs/plugins/architecture.md). `createElement` avoids any
+// JSX transform so the file can ship as-is.
+//
+// Exists so the full-plugins E2E can assert a real plugin component actually
+// MOUNTS over `plugin://` (the coverage gap behind #10512), not just that the
+// panel kind registered.
+import { createElement } from "react";
+
+export default function RichPanelView(props) {
+  return createElement(
+    "div",
+    {
+      "data-testid": "rich-panel-view",
+      "data-panel-id": props && props.panelId ? props.panelId : "",
+      style: { padding: "16px" },
+    },
+    "Rich panel view mounted"
+  );
+}

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -158,6 +158,19 @@ function copySamplePluginManifests() {
     fs.mkdirSync(path.dirname(manifestDest), { recursive: true });
     fs.copyFileSync(manifestSrc, manifestDest);
     console.log(`[Build] Copied sample plugin manifest: ${entry.name}`);
+
+    // Copy any hand-authored `view/` assets verbatim. Plugin view modules are
+    // browser-ready ESM served over `plugin://` with bare `react` specifiers
+    // resolved through the host import map — esbuild must NOT process them
+    // (it would bundle React in and break the single-instance contract), so
+    // these are copied, not built. Used by the rich-daintree panel-view E2E
+    // (#10512).
+    const viewSrc = path.join(pluginsRoot, entry.name, "view");
+    if (fs.existsSync(viewSrc)) {
+      const viewDest = path.join(root, "dist-electron/plugins/sample", entry.name, "view");
+      fs.cpSync(viewSrc, viewDest, { recursive: true });
+      console.log(`[Build] Copied sample plugin view assets: ${entry.name}`);
+    }
   }
 }
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -35,7 +35,10 @@ export interface ToolbarButtonContribution {
 }
 
 export type MenuItemLocation = "terminal" | "file" | "view" | "help";
-export type ContextMenuLocation = "worktree" | "terminal" | "panel" | "file";
+// `"panel"` was removed (#10512): no renderer surface ever mounted
+// `usePluginContextMenuItems("panel")`, so a contributed panel context-menu item
+// was silently dead. Only `worktree` / `terminal` / `file` have live consumers.
+export type ContextMenuLocation = "worktree" | "terminal" | "file";
 
 export const BUILT_IN_PLUGIN_CAPABILITIES = [
   "fs:project-read",

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -110,6 +110,12 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   ]);
 
   const dockTerminals = useMemo<PtyPanelData[]>(() => {
+    // The dock is intentionally PTY-only: its chrome (output preview, restart,
+    // agent state) is built on terminal affordances. Non-PTY panels — browser,
+    // dev-preview, review, AND plugin-contributed kinds — are grid-only here,
+    // so `getNarrowPanel` + `isPtyPanel` is the correct gate (NOT the #10512
+    // grid render-eligibility predicate, which deliberately does not apply to
+    // the dock).
     const result: PtyPanelData[] = [];
     for (const id of storeTerminalIds) {
       const terminal = getNarrowPanel(panelsById, id);

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -168,6 +168,11 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
     }, []);
 
     const handleReset = (): void => {
+      // Abort the outgoing view's signal before swapping in a fresh controller —
+      // the prior view instance is being discarded on retry, so any fetches or
+      // subscriptions it tied to `disposeSignal` must cancel now rather than
+      // linger until the whole host unmounts (#10512 review).
+      controller.abort();
       // Fresh controller for the retry so the new lazy import sees an unaborted
       // signal; the mirror effect propagates it to controllerRef for teardown.
       setController(new AbortController());

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -15,6 +15,14 @@ import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
 import type { PanelComponentProps } from "@/panels/registry";
 import { logWarn } from "@/utils/logger";
 
+/**
+ * Upper bound on a single `plugin://` view import before the host gives up and
+ * surfaces the ErrorBoundary's retry. Generous enough to cover a cold protocol
+ * handler start; short enough that a genuinely wedged load doesn't strand the
+ * user on an indefinite skeleton (#10512).
+ */
+const PLUGIN_VIEW_IMPORT_TIMEOUT_MS = 10_000;
+
 function isPluginViewModule(mod: unknown): mod is { default: ComponentType<PanelViewProps> } {
   if (mod === null || typeof mod !== "object") return false;
   const candidate = (mod as { default?: unknown }).default;
@@ -75,7 +83,27 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
 
   const createLazyView = (): LazyExoticComponent<ComponentType<PanelViewProps>> =>
     lazy<ComponentType<PanelViewProps>>(async () => {
-      const mod: unknown = await import(/* @vite-ignore */ componentPath!);
+      // Race the `plugin://` import against a timeout. A wedged protocol load
+      // (handler hang, never-resolving fetch) would otherwise sit behind
+      // Suspense forever — the ErrorBoundary only catches rejections, never a
+      // pending promise. Rejecting on timeout routes through Suspense to the
+      // boundary's "Try again", and because the race lives inside the factory a
+      // retry (a fresh `createLazyView()`) restarts the timer cleanly (#10512).
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const mod: unknown = await Promise.race([
+        import(/* @vite-ignore */ componentPath!).finally(() => {
+          if (timeoutId !== undefined) clearTimeout(timeoutId);
+        }),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(
+              new Error(
+                `Plugin "${pluginId}" view module at ${componentPath} timed out after ${PLUGIN_VIEW_IMPORT_TIMEOUT_MS}ms`
+              )
+            );
+          }, PLUGIN_VIEW_IMPORT_TIMEOUT_MS);
+        }),
+      ]);
       if (!isPluginViewModule(mod)) {
         throw new Error(
           `Plugin "${pluginId}" view module at ${componentPath} did not export a default React component`

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -185,6 +185,37 @@ describe("PluginManagerView", () => {
     expect(toggle.getAttribute("aria-checked")).toBe("false");
   });
 
+  it("does not flash 'Restart required' when a built-in plugin is toggled (#10512)", async () => {
+    // Built-ins transition live, so their authoritative pendingRestart stays
+    // false. The optimistic update must match — not invert — to avoid a
+    // false badge flash before the next refresh.
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin({ isBuiltin: true, disabled: false, pendingRestart: false }),
+    ]);
+    renderDialog();
+    const toggle = await screen.findByRole("switch", { name: "Enable Acme Demo" });
+    fireEvent.click(toggle);
+
+    // The optimistic flip lands synchronously; wait for it to settle the switch,
+    // then assert no restart badge appeared.
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
+    expect(screen.queryByText("Restart required")).toBeNull();
+  });
+
+  it("flashes 'Restart required' when a session-fixed user plugin is toggled (#10512)", async () => {
+    // Control for the built-in case: user plugins are fixed for the session, so
+    // a toggle genuinely diverges desired vs. running state and must surface the
+    // restart cue.
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin({ isBuiltin: false, disabled: false, pendingRestart: false }),
+    ]);
+    renderDialog();
+    const toggle = await screen.findByRole("switch", { name: "Enable Acme Demo" });
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(screen.getAllByText("Restart required").length).toBeGreaterThan(0));
+  });
+
   it("renders a plugin's settings form in the detail pane once selected", async () => {
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
       makePluginWithSettings(),

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -258,11 +258,18 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     const wasPendingRestart = plugin.pendingRestart;
 
     setPending((prev) => new Set(prev).add(id));
-    // Optimistic flip: a single toggle always flips both the desired state and
-    // the running/desired mismatch, so `pendingRestart` simply inverts.
+    // Optimistic flip. For session-fixed user plugins a single toggle flips both
+    // the desired state and the running/desired mismatch, so `pendingRestart`
+    // inverts. Built-ins transition live (#9304) — `setEnabled` reconciles
+    // running and desired state immediately, so their authoritative
+    // `pendingRestart` stays false; inverting it flashes a false "restart
+    // required" badge until the next refresh (#10512). Match the authoritative
+    // value by holding built-ins at false.
     setPlugins((prev) =>
       prev.map((p) =>
-        p.manifest.name === id ? { ...p, disabled: !next, pendingRestart: !p.pendingRestart } : p
+        p.manifest.name === id
+          ? { ...p, disabled: !next, pendingRestart: p.isBuiltin ? false : !p.pendingRestart }
+          : p
       )
     );
     try {

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore } from "@/store";
-import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { getRenderablePanel } from "@/store/slices/panelRegistry/selectors";
 import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
@@ -35,7 +35,9 @@ export const GridTabGroup = React.memo(function GridTabGroup({
   const panels = usePanelStore(
     useShallow((state) =>
       group.panelIds
-        .map((id) => getNarrowPanel(state.panelsById, id))
+        // Render-eligibility, not type-narrowing: a tab group may hold a
+        // plugin-contributed panel, which must stay in the rendered set (#10512).
+        .map((id) => getRenderablePanel(state.panelsById, id))
         .filter((p): p is PanelInstance => p !== undefined)
     )
   );

--- a/src/components/Terminal/GridTabGroup.tsx
+++ b/src/components/Terminal/GridTabGroup.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useEffect, useEffectEvent, useRef } from "
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore } from "@/store";
 import { getRenderablePanel } from "@/store/slices/panelRegistry/selectors";
-import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
+import { isBuiltInPanelKind, isPtyPanel, type PanelInstance } from "@shared/types/panel";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
@@ -268,6 +268,12 @@ export const GridTabGroup = React.memo(function GridTabGroup({
     return null;
   }
 
+  // Only built-in kinds can be duplicated (panelDuplicationService throws for
+  // plugin kinds). Now that plugin panels render in tab groups (#10512), hide
+  // the add-tab affordance for them instead of surfacing a button that throws —
+  // mirrors GridPanel's single-panel add-tab gate.
+  const canAddTab = isBuiltInPanelKind(activePanel.kind);
+
   const isFocused = activePanel.id === focusedId;
 
   return (
@@ -282,7 +288,7 @@ export const GridTabGroup = React.memo(function GridTabGroup({
       onTabClick={handleTabClick}
       onTabClose={handleTabClose}
       onTabRename={handleTabRename}
-      onAddTab={handleAddTab}
+      onAddTab={canAddTab ? handleAddTab : undefined}
       onTabReorder={handleTabReorder}
     />
   );

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -21,7 +21,7 @@ import {
   usePreferencesStore,
   useTwoPaneSplitStore,
 } from "@/store";
-import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { getNarrowPanel, getRenderablePanel } from "@/store/slices/panelRegistry/selectors";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useProjectStore } from "@/store/projectStore";
@@ -405,8 +405,11 @@ export function useContentGridContext({
     const result: PanelInstance[] = [];
     for (const id of gridPanelIds) {
       if (closingIds.has(id)) continue;
-      const narrowed = getNarrowPanel(byId, id);
-      if (narrowed) result.push(narrowed);
+      // Render-eligibility (not type-narrowing): plugin-contributed kinds must
+      // count as grid members so they render and don't leave `isEmpty` stuck
+      // true (#10512). `getNarrowPanel` alone drops them.
+      const renderable = getRenderablePanel(byId, id);
+      if (renderable) result.push(renderable);
     }
     return result.length === 0 ? EMPTY_TERMINALS : result;
   }, [gridPanelIds, closingIds]);
@@ -955,7 +958,7 @@ export function useContentGridContext({
       .slice(0, 2)
       .map((g) => {
         const raw = getTabGroupPanels(g.id, "grid")[0];
-        return raw ? getNarrowPanel(byId, raw.id) : undefined;
+        return raw ? getRenderablePanel(byId, raw.id) : undefined;
       })
       .filter((p): p is PanelInstance => p !== undefined);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
@@ -1014,7 +1017,7 @@ export function useContentGridContext({
     if (!maximizedGroup) return [];
     const byId = panelStoreApi.getState().panelsById;
     return getTabGroupPanels(maximizedGroup.id, "grid")
-      .map((raw) => getNarrowPanel(byId, raw.id))
+      .map((raw) => getRenderablePanel(byId, raw.id))
       .filter((p): p is PanelInstance => p !== undefined);
   }, [getTabGroupPanels, maximizedGroup]);
   const maximizedGroupFocusTarget = useMemo(
@@ -1109,13 +1112,14 @@ export function useContentGridContext({
   );
 
   // Wrap the store's getTabGroupPanels (returns carrier shape) so the
-  // context surface exposes PanelInstance[] — narrowed via getNarrowPanel at
-  // call time so callers never touch the carrier shape.
+  // context surface exposes PanelInstance[] — resolved via getRenderablePanel
+  // at call time so callers never touch the carrier shape AND plugin-contributed
+  // kinds stay in the rendered set (#10512).
   const getTabGroupPanelsMapped = useCallback(
     (groupId: string, location?: TabGroupLocation): PanelInstance[] => {
       const byId = panelStoreApi.getState().panelsById;
       return getTabGroupPanels(groupId, location)
-        .map((raw) => getNarrowPanel(byId, raw.id))
+        .map((raw) => getRenderablePanel(byId, raw.id))
         .filter((p): p is PanelInstance => p !== undefined);
     },
     [getTabGroupPanels]

--- a/src/hooks/__tests__/usePluginPanelKinds.test.ts
+++ b/src/hooks/__tests__/usePluginPanelKinds.test.ts
@@ -249,6 +249,52 @@ describe("usePluginPanelKinds", () => {
     clearPanelKindRegistry();
   });
 
+  it("re-registers a view-host definition after the plugin is removed and re-added (#10512)", async () => {
+    // The host cache keys view entries `${id}\0${componentPath}`, but removal
+    // used a bare-id delete that never matched — so a removed-then-re-added kind
+    // found a stale cache hit and skipped both `makePluginViewHost` and the
+    // definition re-registration, leaving the panel on PluginMissingPanel.
+    // Proper eviction rebuilds the host and restores the definition.
+    let emit: ((payload: { kinds: PanelKindConfig[] }) => void) | null = null;
+    onPanelKindsChangedMock.mockImplementation(
+      (cb: (payload: { kinds: PanelKindConfig[] }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+
+    const { clearPanelKindRegistry } = await import("@shared/config/panelKindRegistry");
+    const { getPanelKindDefinition } = await import("@/registry");
+    const { makePluginViewHost } = await import("@/components/Plugin/PluginViewHost");
+    const { usePluginPanelKinds } = await import("../usePluginPanelKinds");
+
+    renderHook(() => usePluginPanelKinds());
+    await waitFor(() => expect(onPanelKindsChangedMock).toHaveBeenCalled());
+
+    const viewKind = pluginKind({
+      id: "acme.recycle",
+      hasPty: false,
+      componentPath: "plugin://acme/v.js",
+    });
+
+    act(() => emit!({ kinds: [viewKind] }));
+    expect(getPanelKindDefinition(viewKind.id)).toBeDefined();
+    const callsAfterFirst = (makePluginViewHost as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Remove the whole plugin from the snapshot.
+    act(() => emit!({ kinds: [] }));
+    expect(getPanelKindDefinition(viewKind.id)).toBeUndefined();
+
+    // Re-add the identical kind: the host must be rebuilt and re-registered.
+    act(() => emit!({ kinds: [viewKind] }));
+    expect(getPanelKindDefinition(viewKind.id)).toBeDefined();
+    expect((makePluginViewHost as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsAfterFirst + 1
+    );
+
+    clearPanelKindRegistry();
+  });
+
   it("clears registered plugin kinds on unmount", async () => {
     getPanelKindsMock.mockResolvedValue([pluginKind()]);
 

--- a/src/hooks/usePluginPanelKinds.ts
+++ b/src/hooks/usePluginPanelKinds.ts
@@ -81,6 +81,19 @@ export function usePluginPanelKinds(): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- registry component type uses unconstrained props
     const hostCache = new Map<string, ComponentType<any>>();
 
+    // View-host entries are keyed `${id}\0${componentPath}` (see below), so a
+    // bare `hostCache.delete(id)` never matches them — that was the leak in
+    // #10512: removed kinds/plugins left their `ComponentType` closures
+    // resident until the hook unmounted. Evict every entry owned by `id`
+    // (the bare key from PTY/no-view paths AND any composite view-host key).
+    const evictHostCache = (id: string): void => {
+      hostCache.delete(id);
+      const prefix = `${id}\0`;
+      for (const key of hostCache.keys()) {
+        if (key.startsWith(prefix)) hostCache.delete(key);
+      }
+    };
+
     const sync = (kinds: PanelKindConfig[]): void => {
       if (disposed) return;
 
@@ -100,7 +113,7 @@ export function usePluginPanelKinds(): void {
         if (!incomingByPlugin.has(pluginId)) {
           for (const id of kindIds) {
             unregisterPanelKindDefinition(id);
-            hostCache.delete(id);
+            evictHostCache(id);
           }
           unregisterPluginPanelKinds(pluginId);
           registeredByPlugin.delete(pluginId);
@@ -119,7 +132,7 @@ export function usePluginPanelKinds(): void {
             if (!incomingIds.has(id)) {
               unregisterPanelKindDefinition(id);
               unregisterPanelKind(id);
-              hostCache.delete(id);
+              evictHostCache(id);
             }
           }
         }
@@ -136,7 +149,7 @@ export function usePluginPanelKinds(): void {
           }
           if (config.hasPty) {
             registerPanelKindDefinition(config.id, TerminalPane);
-            hostCache.delete(config.id);
+            evictHostCache(config.id);
           } else if (config.componentPath) {
             // Non-PTY plugin panel with a matching `views`
             // contribution — render through PluginViewHost (#9229). Cache by
@@ -162,7 +175,7 @@ export function usePluginPanelKinds(): void {
             // that flipped from `hasPty: true` to `hasPty: false` without a
             // matching view: clear any prior TerminalPane definition.
             unregisterPanelKindDefinition(config.id);
-            hostCache.delete(config.id);
+            evictHostCache(config.id);
           }
         }
 

--- a/src/store/slices/panelRegistry/__tests__/addPanelWorktreeGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelWorktreeGuard.test.ts
@@ -112,6 +112,8 @@ describe("addPanel non-PTY active-worktree null guard (#10512)", () => {
 
     expect(id).toBe("plugin-1");
     expect(getPanel("plugin-1")?.runtimeStatus).toBe("running");
+    // The panel must also be indexed under its worktree so the grid can find it.
+    expect(usePanelStore.getState().panelIdsByWorktreeId["wt-1"]).toContain("plugin-1");
   });
 
   it("backgrounds a non-PTY plugin panel that belongs to a different, hydrated worktree", async () => {

--- a/src/store/slices/panelRegistry/__tests__/addPanelWorktreeGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelWorktreeGuard.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression test for #10512: the non-PTY `addPanel` branch must apply the same
+ * "active worktree not yet hydrated" null guard the PTY branch has. Without it, a
+ * non-PTY plugin panel spawned with an explicit `worktreeId` while the worktree
+ * store is still null (common mid project-switch) is mis-classified as "not in
+ * the active worktree" and backgrounded instead of running.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PanelInstance } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+    waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: vi.fn(),
+  };
+});
+
+// Drive the active-worktree snapshot per-test so we can simulate the
+// not-yet-hydrated (null) state the guard exists for.
+let activeWorktreeId: string | null = null;
+vi.mock("@/store/storeAccessors", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/store/storeAccessors")>("@/store/storeAccessors");
+  return {
+    ...actual,
+    getWorktreeSelectionSnapshot: () => ({ activeWorktreeId }),
+  };
+});
+
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    electron: {
+      globalEnv: {
+        get: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+
+function getPanel(id: string): PanelInstance | undefined {
+  return usePanelStore.getState().panelsById[id];
+}
+
+describe("addPanel non-PTY active-worktree null guard (#10512)", () => {
+  beforeEach(async () => {
+    activeWorktreeId = null;
+    const { reset } = usePanelStore.getState();
+    await reset();
+  });
+
+  it("keeps a non-PTY plugin panel running when the active worktree is not yet hydrated", async () => {
+    activeWorktreeId = null; // worktree store still null (mid project-switch)
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "acme.notes",
+      worktreeId: "wt-1",
+      requestedId: "plugin-1",
+      location: "grid",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("plugin-1");
+    expect(getPanel("plugin-1")?.runtimeStatus).toBe("running");
+  });
+
+  it("backgrounds a non-PTY plugin panel that belongs to a different, hydrated worktree", async () => {
+    activeWorktreeId = "wt-active"; // worktree store hydrated, panel is elsewhere
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "acme.notes",
+      worktreeId: "wt-other",
+      requestedId: "plugin-2",
+      location: "grid",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("plugin-2");
+    expect(getPanel("plugin-2")?.runtimeStatus).toBe("background");
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/addPanelWorktreeGuard.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelWorktreeGuard.test.ts
@@ -7,8 +7,6 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { PanelInstance } from "@shared/types/panel";
-
 vi.mock("@/clients", () => ({
   terminalClient: {
     spawn: vi.fn(),
@@ -88,8 +86,25 @@ beforeEach(() => {
 
 const { usePanelStore } = await import("../../../panelStore");
 
-function getPanel(id: string): PanelInstance | undefined {
-  return usePanelStore.getState().panelsById[id];
+// Plugin panels are cast into the carrier, and runtimeStatus is set at runtime
+// by addPanel for every kind even though it isn't declared on every
+// PanelInstance variant — read it through a structural shape.
+function getPanel(id: string): { runtimeStatus?: string } | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- carrier read; runtimeStatus is set at runtime on every kind
+  return usePanelStore.getState().panelsById[id] as { runtimeStatus?: string } | undefined;
+}
+
+// Extension panel kinds are intentionally excluded from the AddPanelOptions
+// union (a `kind: string` member would defeat discriminated-union narrowing for
+// built-in kinds), so spawning a plugin kind widens at the call boundary — the
+// same documented pattern used by panel.openPluginPanel.
+type AddPanelFn = ReturnType<typeof usePanelStore.getState>["addPanel"];
+function spawnPlugin(
+  addPanel: AddPanelFn,
+  options: Record<string, unknown>
+): Promise<string | null> {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- documented extension-panel spawn boundary
+  return addPanel(options as Parameters<AddPanelFn>[0]);
 }
 
 describe("addPanel non-PTY active-worktree null guard (#10512)", () => {
@@ -102,7 +117,7 @@ describe("addPanel non-PTY active-worktree null guard (#10512)", () => {
   it("keeps a non-PTY plugin panel running when the active worktree is not yet hydrated", async () => {
     activeWorktreeId = null; // worktree store still null (mid project-switch)
     const { addPanel } = usePanelStore.getState();
-    const id = await addPanel({
+    const id = await spawnPlugin(addPanel, {
       kind: "acme.notes",
       worktreeId: "wt-1",
       requestedId: "plugin-1",
@@ -119,7 +134,7 @@ describe("addPanel non-PTY active-worktree null guard (#10512)", () => {
   it("backgrounds a non-PTY plugin panel that belongs to a different, hydrated worktree", async () => {
     activeWorktreeId = "wt-active"; // worktree store hydrated, panel is elsewhere
     const { addPanel } = usePanelStore.getState();
-    const id = await addPanel({
+    const id = await spawnPlugin(addPanel, {
       kind: "acme.notes",
       worktreeId: "wt-other",
       requestedId: "plugin-2",

--- a/src/store/slices/panelRegistry/__tests__/selectors.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/selectors.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import type { PanelInstance } from "@shared/types/panel";
-import { _resetSelectorCacheForTests, getNarrowPanel, getNarrowPanels } from "../selectors";
+import {
+  _resetSelectorCacheForTests,
+  getNarrowPanel,
+  getNarrowPanels,
+  getRenderablePanel,
+  isPanelRenderEligible,
+} from "../selectors";
 
 // Adapter selectors that narrow the legacy `TerminalInstance` carrier to the
 // `PanelInstance` union via the kind type guards (#8957). A missing `kind`
@@ -61,6 +67,59 @@ describe("getNarrowPanel", () => {
   it("narrows a review panel", () => {
     const p = getNarrowPanel({ r: panel("r", { kind: "review" }) }, "r");
     expect(p?.kind).toBe("review");
+  });
+});
+
+describe("isPanelRenderEligible (#10512)", () => {
+  it("treats every built-in kind as renderable", () => {
+    for (const kind of ["terminal", "browser", "dev-preview", "review"] as const) {
+      expect(isPanelRenderEligible(panel(kind, { kind }))).toBe(true);
+    }
+  });
+
+  it("treats a plugin panel carrying a pluginId as renderable", () => {
+    const p = panel("x", {
+      kind: "acme.notes" as unknown as PanelInstance["kind"],
+      pluginId: "acme",
+    });
+    expect(isPanelRenderEligible(p)).toBe(true);
+  });
+
+  it("treats a dotted plugin kind without a pluginId as renderable (disabled-plugin hatch)", () => {
+    const p = panel("x", { kind: "acme.notes" as unknown as PanelInstance["kind"] });
+    expect(isPanelRenderEligible(p)).toBe(true);
+  });
+
+  it("excludes an unknown, undotted kind with no pluginId", () => {
+    const p = panel("x", { kind: "garbage" as unknown as PanelInstance["kind"] });
+    expect(isPanelRenderEligible(p)).toBe(false);
+  });
+});
+
+describe("getRenderablePanel (#10512)", () => {
+  it("returns undefined for an absent id", () => {
+    expect(getRenderablePanel({}, "missing")).toBeUndefined();
+  });
+
+  it("returns built-in panels just like getNarrowPanel", () => {
+    const b = panel("b", { kind: "browser" });
+    expect(getRenderablePanel({ b }, "b")).toBe(b);
+  });
+
+  it("returns a plugin panel that getNarrowPanel drops", () => {
+    const ext = panel("x", {
+      kind: "acme.notes" as unknown as PanelInstance["kind"],
+      pluginId: "acme",
+    });
+    // Regression guard: the type-narrowing read path still drops it...
+    expect(getNarrowPanel({ x: ext }, "x")).toBeUndefined();
+    // ...but the grid render-eligibility path keeps it.
+    expect(getRenderablePanel({ x: ext }, "x")).toBe(ext);
+  });
+
+  it("drops an unknown, undotted kind with no pluginId", () => {
+    const junk = panel("x", { kind: "garbage" as unknown as PanelInstance["kind"] });
+    expect(getRenderablePanel({ x: junk }, "x")).toBeUndefined();
   });
 });
 

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -158,7 +158,13 @@ export const createAddPanelActions = (
       // hard ceiling has already been enforced upstream by `panelLimitStore`.
       const location = options.location || "grid";
       const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? null;
-      const isInActiveWorktree = (options.worktreeId ?? null) === (activeWorktreeId ?? null);
+      // When activeWorktreeId is null (worktree store not yet hydrated — common
+      // during a project switch), treat the panel as being in the active worktree
+      // to avoid incorrectly backgrounding it. Mirrors the PTY branch guard
+      // below; without it a non-PTY plugin panel spawned mid-switch is
+      // mis-backgrounded (#10512).
+      const isInActiveWorktree =
+        activeWorktreeId === null || (options.worktreeId ?? null) === (activeWorktreeId ?? null);
       const shouldBackground = location === "dock" || (location === "grid" && !isInActiveWorktree);
       const runtimeStatus: TerminalRuntimeStatus = shouldBackground ? "background" : "running";
 

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -5,6 +5,7 @@ import {
   isPtyPanel,
   isReviewPanel,
   type PanelInstance,
+  type PanelKind,
 } from "@shared/types/panel";
 import { isRegisteredPanelKind } from "@shared/config/panelKindRegistry";
 
@@ -71,9 +72,17 @@ export function getNarrowPanel(
  * Sync and side-effect free — safe to call inside Zustand selectors and memos.
  */
 export function isPanelRenderEligible(panel: PanelInstance): boolean {
-  const kind = panel.kind ?? "terminal";
-  if (isBuiltInPanelKind(kind)) return true;
-  return isRegisteredPanelKind(kind) || Boolean(panel.pluginId) || kind.includes(".");
+  // Widen to the open `PanelKind`: the carrier types `panel.kind` as only the
+  // built-in discriminants, but plugin panels are cast into the carrier with a
+  // dotted plugin-kind string at runtime, so the plugin branches below are NOT
+  // statically dead — read the kind as the open union to keep them live.
+  const kind: PanelKind = panel.kind ?? "terminal";
+  return (
+    isBuiltInPanelKind(kind) ||
+    isRegisteredPanelKind(kind) ||
+    Boolean(panel.pluginId) ||
+    kind.includes(".")
+  );
 }
 
 /**

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -1,10 +1,12 @@
 import {
   isBrowserPanel,
+  isBuiltInPanelKind,
   isDevPreviewPanel,
   isPtyPanel,
   isReviewPanel,
   type PanelInstance,
 } from "@shared/types/panel";
+import { isRegisteredPanelKind } from "@shared/config/panelKindRegistry";
 
 let _prevById: Record<string, PanelInstance> | null = null;
 let _prevIds: string[] | null = null;
@@ -44,6 +46,55 @@ export function getNarrowPanel(
   if (isReviewPanel(panel)) return panel;
   if (isPtyPanel(panel)) return panel;
   return undefined;
+}
+
+/**
+ * Render-eligibility predicate for grid membership: should this carrier entry
+ * appear in the user-visible panel grid?
+ *
+ * Distinct from `getNarrowPanel`, which is the type-narrowing read path for
+ * callers that need the built-in `PanelInstance` discriminated union (fleet /
+ * terminal queries) and deliberately drops plugin kinds. The grid's
+ * membership/emptiness gate needs the broader question — and plugin-contributed
+ * kinds ARE renderable: `GridPanel` resolves them to a `PluginViewHost` (when
+ * the kind is registered) or a `PluginMissingPanel` placeholder (when the
+ * plugin is temporarily disabled). Filtering them out here is exactly the bug
+ * behind #10512 (plugin panels silently dropped → grid shows the empty state).
+ *
+ * Eligible when:
+ *  - the kind is built-in (always renderable), OR
+ *  - the kind is a registered plugin kind (plugin enabled), OR
+ *  - the panel carries a `pluginId` or a dotted kind — the disabled-plugin
+ *    escape hatch (#5636): the grid still renders a `PluginMissingPanel`
+ *    placeholder rather than vanishing the panel entirely.
+ *
+ * Sync and side-effect free — safe to call inside Zustand selectors and memos.
+ */
+export function isPanelRenderEligible(panel: PanelInstance): boolean {
+  const kind = panel.kind ?? "terminal";
+  if (isBuiltInPanelKind(kind)) return true;
+  return isRegisteredPanelKind(kind) || Boolean(panel.pluginId) || kind.includes(".");
+}
+
+/**
+ * Grid-membership read path: return the carrier entry for `id` when it should
+ * render in the grid (built-in OR plugin kind), else `undefined`. Mirror of
+ * `getNarrowPanel`'s signature so grid list-builders can swap one for the other.
+ *
+ * Built-in panels are returned via `getNarrowPanel` (already the carrier
+ * `PanelInstance`); plugin panels — which `getNarrowPanel` drops — are returned
+ * as-is from the carrier (typed `Record<string, PanelInstance>`). `GridPanel`
+ * resolves the actual component from the panel-kind definition registry.
+ */
+export function getRenderablePanel(
+  panelsById: Record<string, PanelInstance>,
+  id: string
+): PanelInstance | undefined {
+  const narrowed = getNarrowPanel(panelsById, id);
+  if (narrowed) return narrowed;
+  const panel = panelsById[id];
+  if (!panel) return undefined;
+  return isPanelRenderEligible(panel) ? panel : undefined;
 }
 
 let _prevNarrowById: Record<string, PanelInstance> | null = null;


### PR DESCRIPTION
## Summary

Fixes a long-standing issue where plugin-contributed panel views (`contributes.panels` + `contributes.views`) would register and open without error but never mount in the grid — just a permanent empty state.

The root cause: every grid membership selector resolved panels through `getNarrowPanel`, which is built-in-only. Plugin panels were silently dropped, `gridTerminals` stayed empty, `isEmpty` stayed true, and `ContentGridDefault` kept rendering. `GridPanel` already knew how to render plugin kinds — it just never got called.

Resolves #10512.

## Changes

- **Core fix** (`panelRegistry/selectors.ts`): add `isPanelRenderEligible(panel)` and `getRenderablePanel(panelsById, id)` — a grid-membership read path that treats registered plugin kinds (and disabled-plugin panels via the `pluginId` / dotted-kind escape hatch) as renderable. `getNarrowPanel`/`getNarrowPanels` stay built-in-only for discriminated-union callers (fleet/terminal queries).
- Route all grid list-builders through `getRenderablePanel`: `gridTerminals` (drives `isEmpty`), `getTabGroupPanelsMapped` (the actual render path), maximized + two-pane groups, and `GridTabGroup`. Fleet (agent-armed only) and the dock (PTY-only by design) keep `getNarrowPanel`.
- **`PluginViewHost`**: race the `plugin://` import against a 10 s timeout so a wedged load reaches the ErrorBoundary's "Try again" instead of an indefinite skeleton; abort the outgoing view's `AbortController` on retry.
- **`addPanel`** (non-PTY): add the active-worktree null guard the PTY branch already had, so a plugin panel spawned mid project-switch isn't mis-backgrounded.
- **`usePluginPanelKinds`**: evict host-cache entries by both bare id and the `${id}\0${componentPath}` composite key, so a removed-then-re-added kind rebuilds its view host instead of finding a stale or missing definition.
- **`usePluginManager`**: hold built-ins' optimistic `pendingRestart` at false (they toggle live) to stop a false "restart required" flash.
- **Dead-API cleanup**: drop the unused `"panel"` context-menu location from the type, manifest zod schema, and docs; narrow the file-decoration "any path list" doc claim to the only mounted consumer (Review Hub).
- **`GridTabGroup`**: hide the add-tab affordance for plugin panels — only built-in kinds are duplicable.

## Testing

- **Unit**: `isPanelRenderEligible` / `getRenderablePanel` (+ regression confirming `getNarrowPanel` still drops plugin kinds), `addPanel` worktree null-guard (both states + worktree indexing), built-in vs user-plugin `pendingRestart`, host-cache remove-then-re-add rebuild. All green (144 affected tests).
- **E2E**: `rich-daintree` now ships a real `views` contribution + a hand-authored `plugin://` React component; `core-plugin-panels.spec.ts` asserts it mounts in the grid, closing the registration-only coverage gap that let the bug ship.
- **Local**: `npm run typecheck` clean, eslint 0 errors on changed files, prettier clean.