### PR TITLE
feat(plugins): make every host API method Promise-returning (#10519)

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -339,6 +339,13 @@ const PLUGIN_DIAGNOSTICS_AUDIT_PER_PLUGIN = 50;
  * scope-wide invalidation (no `paths`) is the correct fallback anyway.
  */
 const MAX_FILE_DECORATION_PATHS = 1000;
+/**
+ * Floor for a plugin-supplied `onDidChangeWorktrees` `debounceMs`. A positive
+ * value below this is clamped up so a plugin can't request a near-zero debounce
+ * that defeats the coalescing intent while still paying timer overhead; `0` /
+ * omitted disables debouncing entirely (fire on every change).
+ */
+const MIN_PLUGIN_SUBSCRIPTION_DEBOUNCE_MS = 50;
 
 /**
  * Serialize an arbitrary logger payload without ever throwing. Tries
@@ -1875,6 +1882,9 @@ export class PluginService {
         owners.add(namespacedId);
 
         this.broadcaster.broadcastPluginActions();
+        // All registry mutation above is synchronous (sync throws still surface
+        // at the call site during activate()); only the return value is async.
+        return Promise.resolve();
       },
       registerHandler: ((
         channel: string,
@@ -1904,6 +1914,7 @@ export class PluginService {
         } else {
           this.registerHandler(pluginId, channel, schemaOrHandler as PluginIpcHandler);
         }
+        return Promise.resolve();
       }) as PluginHostApi["registerHandler"],
       broadcastToRenderer: (channel, payload) => {
         if (revoked) {
@@ -1917,6 +1928,7 @@ export class PluginService {
           );
         }
         broadcastToRenderer(`plugin:${pluginId}:${channel}`, payload);
+        return Promise.resolve();
       },
       // The post-activation-safe sibling of broadcastToRenderer: same
       // `plugin:{pluginId}:{channel}` transport, but NOT revoke-guarded — it is
@@ -1926,13 +1938,14 @@ export class PluginService {
       // is plugin membership (mirrors invalidateFileDecorations/showToast): once
       // the plugin unloads this silently no-ops.
       postToPanel: (channel, payload) => {
-        if (!isBound()) return;
+        if (!isBound()) return Promise.resolve();
         if (typeof channel !== "string" || channel.length === 0 || channel.includes(":")) {
           throw new Error(
             `Plugin "${pluginId}" postToPanel: channel must be a non-empty string without colons: ${String(channel)}`
           );
         }
         broadcastToRenderer(`plugin:${pluginId}:${channel}`, payload);
+        return Promise.resolve();
       },
       getActiveWorktree: async () => {
         if (!isBound()) return null;
@@ -1947,10 +1960,12 @@ export class PluginService {
         if (!isBound()) return [];
         return snapshots.map(toPluginWorktreeSnapshot);
       },
-      getWorktreeStatus: async (path) => {
+      getWorktreeStatus: async (path, options) => {
+        options?.signal?.throwIfAborted();
         if (!isBound()) return null;
         if (typeof path !== "string" || path.length === 0) return null;
         const snapshots = await this.fetchAllWorktreeSnapshots();
+        options?.signal?.throwIfAborted();
         if (!isBound()) return null;
         const match = snapshots.find((s) => s.path === path);
         return match ? toPluginWorktreeStatus(match.worktreeChanges) : null;
@@ -1961,7 +1976,9 @@ export class PluginService {
             `Plugin "${pluginId}" host revoked: onDidChangeActiveWorktree called after activate() returned or timed out`
           );
         }
-        return this.subscribeWorktreeEvent(pluginId, "worktree-activated", async () => {
+        // Subscription wired synchronously (revoke guard already held above);
+        // only the disposer return value is wrapped in a resolved promise.
+        const dispose = this.subscribeWorktreeEvent(pluginId, "worktree-activated", async () => {
           if (!this.plugins.has(pluginId)) return;
           try {
             const snapshots = await this.fetchAllWorktreeSnapshots();
@@ -1977,14 +1994,23 @@ export class PluginService {
             );
           }
         });
+        return Promise.resolve(dispose);
       },
-      onDidChangeWorktrees: (callback) => {
+      onDidChangeWorktrees: (callback, options) => {
         if (revoked) {
           throw new Error(
             `Plugin "${pluginId}" host revoked: onDidChangeWorktrees called after activate() returned or timed out`
           );
         }
-        const emit = async (): Promise<void> => {
+        // Opt-in debounce: the host re-emits the worktree set on every git-status
+        // poll, so a UI-updating plugin can coalesce bursts into a single
+        // trailing callback. Values below the floor are clamped up; 0/omitted
+        // fires on every change. See PluginHostSubscriptionOptions.
+        const debounceMs =
+          typeof options?.debounceMs === "number" && options.debounceMs > 0
+            ? Math.max(options.debounceMs, MIN_PLUGIN_SUBSCRIPTION_DEBOUNCE_MS)
+            : 0;
+        const runEmit = async (): Promise<void> => {
           if (!this.plugins.has(pluginId)) return;
           try {
             const snapshots = await this.fetchAllWorktreeSnapshots();
@@ -1997,18 +2023,37 @@ export class PluginService {
             );
           }
         };
+        let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+        const emit =
+          debounceMs > 0
+            ? (): void => {
+                if (debounceTimer) clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(() => {
+                  debounceTimer = null;
+                  void runEmit();
+                }, debounceMs);
+              }
+            : (): void => {
+                void runEmit();
+              };
         // Fires on both add/update and remove so plugins' cached lists stay
         // correct after deletions. Each subscription is tracked separately
-        // so a single disposer stops both.
+        // so a single disposer stops both. A shared debounce timer coalesces
+        // bursts that span both event kinds.
         const disposeUpdate = this.subscribeWorktreeEvent(pluginId, "worktree-update", emit);
         const disposeRemove = this.subscribeWorktreeEvent(pluginId, "worktree-removed", emit);
         let disposed = false;
-        return () => {
+        const dispose = (): void => {
           if (disposed) return;
           disposed = true;
+          if (debounceTimer) {
+            clearTimeout(debounceTimer);
+            debounceTimer = null;
+          }
           disposeUpdate();
           disposeRemove();
         };
+        return Promise.resolve(dispose);
       },
       registerForgeProvider: (descriptor, impl) => {
         if (revoked) {
@@ -2088,7 +2133,9 @@ export class PluginService {
           this.pluginEventCleanups.set(pluginId, list);
         }
         list.push(dispose);
-        return dispose;
+        // Disposer captured and registered into the unload cascade
+        // synchronously above; only the return value is async.
+        return Promise.resolve(dispose);
       },
       registerFileDecorationProvider: (descriptor, impl) => {
         if (revoked) {
@@ -2146,14 +2193,14 @@ export class PluginService {
           this.pluginEventCleanups.set(pluginId, list);
         }
         list.push(dispose);
-        return dispose;
+        return Promise.resolve(dispose);
       },
       // NOT revoke-guarded: called from the plugin's own post-activation
       // subscription callbacks (worktree changes, polling timers). The
       // liveness guard is plugin membership, not the activation window — once
       // the plugin unloads this becomes a silent no-op.
       invalidateFileDecorations: (scope, paths) => {
-        if (!this.plugins.has(pluginId)) return;
+        if (!this.plugins.has(pluginId)) return Promise.resolve();
         if (typeof scope !== "string" || scope.length === 0) {
           throw new Error(
             `Plugin "${pluginId}" invalidateFileDecorations: scope must be a non-empty string`
@@ -2195,6 +2242,7 @@ export class PluginService {
           name: "plugin:decorations-changed",
           payload: { scope, ...(narrowed && narrowed.length > 0 ? { paths: narrowed } : {}) },
         });
+        return Promise.resolve();
       },
       // NOT revoke-guarded for the same reason as invalidateFileDecorations:
       // plugins fire toasts from post-activation callbacks and timers. Liveness
@@ -2318,7 +2366,7 @@ export class PluginService {
           key: string,
           callback: (value: T | undefined) => void,
           scope: PluginSettingsScope = "user"
-        ): (() => void) => {
+        ): Promise<() => void> => {
           if (revoked) {
             throw new Error(
               `Plugin "${pluginId}" host revoked: settings.onDidChange called after activate() returned or timed out`
@@ -2352,7 +2400,7 @@ export class PluginService {
             this.pluginEventCleanups.set(pluginId, list);
           }
           list.push(dispose);
-          return dispose;
+          return Promise.resolve(dispose);
         },
       },
     };
@@ -2553,14 +2601,16 @@ export class PluginService {
       resolveContainedPath(pluginId, targetPath, this.declaredAllowedPaths(pluginId));
 
     return {
-      readFile: async (filePath) => {
+      readFile: async (filePath, options) => {
+        options?.signal?.throwIfAborted();
         requireLoaded("readFile");
         requireReadCap("readFile");
         const resolved = await contain(filePath);
         requireLoaded("readFile");
         // Deliberately no 500KB / binary cap — this is a sanctioned plugin API,
-        // not the size-limited files.read preview path.
-        return fs.readFile(resolved, "utf-8");
+        // not the size-limited files.read preview path. The signal cancels the
+        // read itself (Node honors it) as well as the boundary checks above.
+        return fs.readFile(resolved, { encoding: "utf-8", signal: options?.signal });
       },
       writeFile: async (filePath, contents) => {
         requireLoaded("writeFile");
@@ -2583,10 +2633,12 @@ export class PluginService {
           durationMs: 0,
         });
       },
-      readdir: async (dirPath) => {
+      readdir: async (dirPath, options) => {
+        options?.signal?.throwIfAborted();
         requireLoaded("readdir");
         requireReadCap("readdir");
         const resolved = await contain(dirPath);
+        options?.signal?.throwIfAborted();
         requireLoaded("readdir");
         const entries = await fs.readdir(resolved, { withFileTypes: true });
         return entries.map(
@@ -2598,10 +2650,12 @@ export class PluginService {
           })
         );
       },
-      stat: async (targetPath) => {
+      stat: async (targetPath, options) => {
+        options?.signal?.throwIfAborted();
         requireLoaded("stat");
         requireReadCap("stat");
         const resolved = await contain(targetPath);
+        options?.signal?.throwIfAborted();
         requireLoaded("stat");
         const s = await fs.stat(resolved);
         return {
@@ -2612,7 +2666,8 @@ export class PluginService {
           mtimeMs: s.mtimeMs,
         } satisfies PluginFsStat;
       },
-      watch: async (paths, callback) => {
+      watch: async (paths, callback, options) => {
+        options?.signal?.throwIfAborted();
         requireLoaded("watch");
         requireReadCap("watch");
         if (typeof callback !== "function") {
@@ -2625,6 +2680,7 @@ export class PluginService {
         // Contain every path up front so an out-of-scope watch target rejects
         // before any watcher is created.
         const resolvedTargets = await Promise.all(targets.map((p) => contain(p)));
+        options?.signal?.throwIfAborted();
         requireLoaded("watch");
 
         const watchers: FSWatcher[] = [];
@@ -2709,26 +2765,29 @@ export class PluginService {
     const git = new PluginHostGit(pluginId, this.hostGitFactory);
 
     return {
-      status: async (worktreePath): Promise<PluginGitStatus> => {
+      status: async (worktreePath, options): Promise<PluginGitStatus> => {
+        options?.signal?.throwIfAborted();
         requireLoaded("status");
         requireReadCap("status");
         const resolved = await containWorktree(worktreePath);
         requireLoaded("status");
-        return git.status(resolved);
+        return git.status(resolved, options?.signal);
       },
-      diff: async (worktreePath, filePath): Promise<string> => {
+      diff: async (worktreePath, filePath, options): Promise<string> => {
+        options?.signal?.throwIfAborted();
         requireLoaded("diff");
         requireReadCap("diff");
         const resolved = await containWorktree(worktreePath);
         requireLoaded("diff");
-        return git.diff(resolved, filePath);
+        return git.diff(resolved, filePath, options?.signal);
       },
-      add: async (worktreePath, paths): Promise<void> => {
+      add: async (worktreePath, paths, options): Promise<void> => {
+        options?.signal?.throwIfAborted();
         requireLoaded("add");
         requireWriteCap("add");
         const resolved = await containWorktree(worktreePath);
         requireLoaded("add");
-        await git.add(resolved, paths);
+        await git.add(resolved, paths, options?.signal);
         safeAppendAudit({
           pluginId,
           actionId: `git.add:${resolved}`,
@@ -2742,8 +2801,10 @@ export class PluginService {
       },
       commit: async (
         worktreePath,
-        options: PluginGitCommitOptions
+        options: PluginGitCommitOptions,
+        callOptions
       ): Promise<PluginGitCommitResult> => {
+        callOptions?.signal?.throwIfAborted();
         requireLoaded("commit");
         requireWriteCap("commit");
         // commit returns the staged diff as its change-preview, so it discloses
@@ -2753,7 +2814,7 @@ export class PluginService {
         requireLoaded("commit");
         // git.commit throws COMMIT_MESSAGE_REQUIRED before any mutation when the
         // message is empty — the #7880 no-silent-fallback guard at the host.
-        const result = await git.commit(resolved, options);
+        const result = await git.commit(resolved, options, callOptions?.signal);
         safeAppendAudit({
           pluginId,
           actionId: `git.commit:${resolved}`,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2698,23 +2698,38 @@ export class PluginService {
           this.pluginFsWatchers.get(pluginId)?.delete(dispose);
         };
 
-        for (const resolved of resolvedTargets) {
-          const watcher = fsWatch(resolved, { persistent: false }, (_event, filename) => {
-            if (disposed || !this.plugins.has(pluginId)) return;
-            const changed =
-              typeof filename === "string" && filename.length > 0
-                ? path.join(resolved, filename)
-                : resolved;
+        try {
+          for (const resolved of resolvedTargets) {
+            const watcher = fsWatch(resolved, { persistent: false }, (_event, filename) => {
+              if (disposed || !this.plugins.has(pluginId)) return;
+              const changed =
+                typeof filename === "string" && filename.length > 0
+                  ? path.join(resolved, filename)
+                  : resolved;
+              try {
+                callback(changed);
+              } catch (err) {
+                console.error(`[PluginService] plugin "${pluginId}" fs.watch callback threw:`, err);
+              }
+            });
+            watcher.on("error", (err) => {
+              console.error(`[PluginService] plugin "${pluginId}" fs.watch error:`, err);
+            });
+            watchers.push(watcher);
+          }
+        } catch (err) {
+          // A later path's fsWatch threw (e.g. ENOENT) after earlier watchers
+          // were created — close them so a partial failure doesn't leak FDs
+          // (dispose isn't registered in pluginFsWatchers yet, so teardown
+          // wouldn't catch them).
+          for (const w of watchers) {
             try {
-              callback(changed);
-            } catch (err) {
-              console.error(`[PluginService] plugin "${pluginId}" fs.watch callback threw:`, err);
+              w.close();
+            } catch {
+              // best-effort
             }
-          });
-          watcher.on("error", (err) => {
-            console.error(`[PluginService] plugin "${pluginId}" fs.watch error:`, err);
-          });
-          watchers.push(watcher);
+          }
+          throw err;
         }
 
         let set = this.pluginFsWatchers.get(pluginId);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4605,7 +4605,7 @@ describe("createHost — registerForgeProvider", () => {
 
     vi.mocked(registerForgeProviderImpl).mockClear();
     const impl = { tag: "impl-a" };
-    host.registerForgeProvider({ id: "github" }, impl);
+    await host.registerForgeProvider({ id: "github" }, impl);
     expect(registerForgeProviderImpl).toHaveBeenCalledWith("acme.forge-host", "github", impl);
   });
 
@@ -4620,7 +4620,7 @@ describe("createHost — registerForgeProvider", () => {
 
     vi.mocked(unregisterForgeProviderImpl).mockClear();
     const impl = { tag: "impl" };
-    const dispose = host.registerForgeProvider({ id: "github" }, impl);
+    const dispose = await host.registerForgeProvider({ id: "github" }, impl);
     dispose();
     dispose(); // idempotent — only the first call should propagate
     expect(unregisterForgeProviderImpl).toHaveBeenCalledTimes(1);
@@ -4683,8 +4683,8 @@ describe("createHost — registerForgeProvider", () => {
 
     const impl1 = { tag: "first" };
     const impl2 = { tag: "second" };
-    const dispose1 = host.registerForgeProvider({ id: "github" }, impl1);
-    host.registerForgeProvider({ id: "github" }, impl2);
+    const dispose1 = await host.registerForgeProvider({ id: "github" }, impl1);
+    await host.registerForgeProvider({ id: "github" }, impl2);
 
     // Calling the older disposer must pass the older impl so the registry
     // can decline to clear an already-overwritten entry. The registry side
@@ -4717,7 +4717,7 @@ describe("createHost — registerForgeProvider", () => {
       "acme.forge-flush"
     );
     const impl = { tag: "impl" };
-    host.registerForgeProvider({ id: "github" }, impl);
+    await host.registerForgeProvider({ id: "github" }, impl);
 
     vi.mocked(unregisterForgeProviderImpl).mockClear();
     service.unloadPlugin("acme.forge-flush");
@@ -4740,7 +4740,7 @@ describe("createHost — registerForgeProvider", () => {
     );
 
     const setCredentials = vi.fn();
-    host.registerForgeProvider({ id: "github" }, { setCredentials });
+    await host.registerForgeProvider({ id: "github" }, { setCredentials });
 
     expect(setCredentials).toHaveBeenCalledWith({ kind: "bearer", value: "stored-secret" });
   });
@@ -4777,7 +4777,7 @@ describe("createHost — registerForgeProvider", () => {
     );
 
     const setCredentials = vi.fn();
-    host.registerForgeProvider({ id: "github" }, { setCredentials });
+    await host.registerForgeProvider({ id: "github" }, { setCredentials });
 
     expect(setCredentials).toHaveBeenCalledWith({ kind: "bearer", value: "stored-secret" });
   });
@@ -4813,7 +4813,7 @@ describe("createHost — registerForgeProvider", () => {
       throw new Error("boom");
     });
     // A plugin's setCredentials throwing must not propagate out of binding.
-    const dispose = host.registerForgeProvider({ id: "github" }, { setCredentials });
+    const dispose = await host.registerForgeProvider({ id: "github" }, { setCredentials });
     expect(setCredentials).toHaveBeenCalled();
     expect(typeof dispose).toBe("function");
   });
@@ -6052,7 +6052,7 @@ describe("Plugin worktree host API", () => {
 
     // Subscribe during "activate" window (before revoke), as a real plugin would.
     const cb = vi.fn();
-    const dispose = host.onDidChangeActiveWorktree(cb);
+    const dispose = await host.onDidChangeActiveWorktree(cb);
     revoke();
 
     client.setStates([mkSnap({ id: "b", isCurrent: true, branch: "dev" })]);
@@ -6077,7 +6077,7 @@ describe("Plugin worktree host API", () => {
     ]);
 
     const cb = vi.fn();
-    host.onDidChangeWorktrees(cb);
+    await host.onDidChangeWorktrees(cb);
     revoke();
 
     client.emit("worktree-update", {
@@ -6095,8 +6095,8 @@ describe("Plugin worktree host API", () => {
 
     const cbA = vi.fn();
     const cbB = vi.fn();
-    const disposeA = host.onDidChangeActiveWorktree(cbA);
-    host.onDidChangeActiveWorktree(cbB);
+    const disposeA = await host.onDidChangeActiveWorktree(cbA);
+    await host.onDidChangeActiveWorktree(cbB);
     revoke();
 
     disposeA();
@@ -6113,8 +6113,8 @@ describe("Plugin worktree host API", () => {
 
     const cb1 = vi.fn();
     const cb2 = vi.fn();
-    host.onDidChangeActiveWorktree(cb1);
-    host.onDidChangeWorktrees(cb2);
+    await host.onDidChangeActiveWorktree(cb1);
+    await host.onDidChangeWorktrees(cb2);
     revoke();
 
     expect(client.listenerCount("worktree-activated")).toBe(1);
@@ -6149,7 +6149,7 @@ describe("Plugin worktree host API", () => {
   it("callbacks do not fire after unloadPlugin even if the client emits again", async () => {
     const { service, host, client, revoke } = await setup();
     const cb = vi.fn();
-    host.onDidChangeActiveWorktree(cb);
+    await host.onDidChangeActiveWorktree(cb);
     revoke();
 
     service.unloadPlugin("acme.wt-host");
@@ -6174,7 +6174,7 @@ describe("Plugin worktree host API", () => {
     ).createHost("acme.wt-boot");
 
     const cb = vi.fn();
-    host.onDidChangeActiveWorktree(cb);
+    await host.onDidChangeActiveWorktree(cb);
     revoke();
 
     // Now the client becomes available — subscriptions must be replayed.
@@ -6200,7 +6200,7 @@ describe("Plugin worktree host API", () => {
     ).createHost("acme.wt-boot2");
 
     const cb = vi.fn();
-    const dispose = host.onDidChangeActiveWorktree(cb);
+    const dispose = await host.onDidChangeActiveWorktree(cb);
     revoke();
     dispose();
 
@@ -6220,7 +6220,7 @@ describe("Plugin worktree host API", () => {
     ]);
 
     const cb = vi.fn();
-    host.onDidChangeWorktrees(cb);
+    await host.onDidChangeWorktrees(cb);
     revoke();
 
     client.setStates([mkSnap({ id: "a", isCurrent: true })]);
@@ -6235,7 +6235,7 @@ describe("Plugin worktree host API", () => {
     const { host, client, revoke } = await setup([mkSnap({ id: "a", isCurrent: true })]);
 
     const cb = vi.fn();
-    const dispose = host.onDidChangeWorktrees(cb);
+    const dispose = await host.onDidChangeWorktrees(cb);
     revoke();
     expect(client.listenerCount("worktree-update")).toBe(1);
     expect(client.listenerCount("worktree-removed")).toBe(1);
@@ -7934,7 +7934,7 @@ describe("createHost — settings", () => {
     const { service } = await setupSettingsService("acme.settings-watch");
     const { host } = createSettingsHost(service, "acme.settings-watch");
     const cb = vi.fn();
-    host.settings.onDidChange<string>("token", cb);
+    await host.settings.onDidChange<string>("token", cb);
     await host.settings.set("token", "v1");
     expect(cb).toHaveBeenCalledTimes(1);
     expect(cb).toHaveBeenCalledWith("v1");
@@ -7944,7 +7944,7 @@ describe("createHost — settings", () => {
     const { service } = await setupSettingsService("acme.settings-noop");
     const { host } = createSettingsHost(service, "acme.settings-noop");
     const cb = vi.fn();
-    host.settings.onDidChange("token", cb);
+    await host.settings.onDidChange("token", cb);
     await host.settings.set("token", "same");
     await host.settings.set("token", "same");
     expect(cb).toHaveBeenCalledTimes(1);
@@ -7955,7 +7955,7 @@ describe("createHost — settings", () => {
     const { service } = await setupSettingsService("acme.settings-scope");
     const { host } = createSettingsHost(service, "acme.settings-scope");
     const userCb = vi.fn();
-    host.settings.onDidChange("token", userCb, "user");
+    await host.settings.onDidChange("token", userCb, "user");
     await host.settings.set("token", "proj-value", "project");
     expect(userCb).not.toHaveBeenCalled();
   });
@@ -7964,7 +7964,7 @@ describe("createHost — settings", () => {
     const { service } = await setupSettingsService("acme.settings-dispose");
     const { host } = createSettingsHost(service, "acme.settings-dispose");
     const cb = vi.fn();
-    const dispose = host.settings.onDidChange("token", cb);
+    const dispose = await host.settings.onDidChange("token", cb);
     dispose();
     await host.settings.set("token", "v1");
     expect(cb).not.toHaveBeenCalled();
@@ -7974,7 +7974,7 @@ describe("createHost — settings", () => {
     const { service } = await setupSettingsService("acme.settings-unload");
     const { host } = createSettingsHost(service, "acme.settings-unload");
     const cb = vi.fn();
-    host.settings.onDidChange("token", cb);
+    await host.settings.onDidChange("token", cb);
     service.unloadPlugin("acme.settings-unload");
     await host.settings.set("token", "after-unload");
     expect(cb).not.toHaveBeenCalled();

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -80,6 +80,10 @@ export class PluginDevWorkerMainBridge {
   /** AbortControllers for in-flight `host-call`s, keyed by requestId. A worker
    * `host-cancel` (the caller's AbortSignal fired) aborts the matching one. */
   private readonly hostCallAborts = new Map<string, AbortController>();
+  /** Bumped on every reload. A host-call that started before a reload must not
+   * deliver its late `host-result` to the new worker generation, whose proxy
+   * resets its requestId counter and could collide on the same id. */
+  private reloadGeneration = 0;
   /** Disposers for providers (file decoration) the worker registered on the real
    * host, keyed by provider id. Torn down on reload and dispose so a reloaded
    * generation re-registers cleanly. */
@@ -166,6 +170,7 @@ export class PluginDevWorkerMainBridge {
     // The new worker generation will re-register from scratch; drop the prior
     // generation's activate-time registrations and tear down subscriptions so
     // they don't double up. Pending invokes target a now-dead worker — fail them.
+    this.reloadGeneration++;
     this.clearPriorRegistrations();
     for (const dispose of this.subscriptionDisposers.values()) {
       try {
@@ -266,10 +271,15 @@ export class PluginDevWorkerMainBridge {
     // read/mutation (signal-bearing host methods honor it).
     const controller = new AbortController();
     this.hostCallAborts.set(msg.requestId, controller);
+    // Capture the generation so a result that resolves after a reload is dropped
+    // rather than mis-delivered to the new worker (whose requestIds collide).
+    const generation = this.reloadGeneration;
     try {
       const result = await this.dispatchHostCall(msg.method, msg.params, controller.signal);
+      if (this.disposed || generation !== this.reloadGeneration) return;
       this.workerHost.send({ type: "host-result", requestId: msg.requestId, ok: true, result });
     } catch (err) {
+      if (this.disposed || generation !== this.reloadGeneration) return;
       this.workerHost.send({
         type: "host-result",
         requestId: msg.requestId,
@@ -440,10 +450,12 @@ export class PluginDevWorkerMainBridge {
               args: [scope, paths],
             }) as Promise<Record<string, FileDecoration>>,
         };
+        const generation = this.reloadGeneration;
         const dispose = await this.host.registerFileDecorationProvider(descriptor, proxyImpl);
-        // The bridge may have been torn down (dispose/reload) while the host
-        // registration was settling — don't leak the freshly bound provider.
-        if (this.disposed) {
+        // The bridge may have been torn down (dispose) or reloaded while the host
+        // registration was settling — don't leak the freshly bound provider past
+        // the cleanup pass that already ran.
+        if (this.disposed || generation !== this.reloadGeneration) {
           try {
             dispose();
           } catch {
@@ -485,6 +497,7 @@ export class PluginDevWorkerMainBridge {
       if (this.disposed) return;
       this.workerHost.send({ type: "subscription-event", subscriptionId, payload });
     };
+    const generation = this.reloadGeneration;
     try {
       let dispose: () => void;
       if (kind === "active-worktree") {
@@ -501,9 +514,9 @@ export class PluginDevWorkerMainBridge {
         }
         dispose = await this.host.settings.onDidChange(msg.key, (value) => push(value), msg.scope);
       }
-      // The bridge may have been disposed/reloaded while the subscription was
+      // The bridge may have been disposed or reloaded while the subscription was
       // settling — tear it down rather than leak it past the cleanup pass.
-      if (this.disposed) {
+      if (this.disposed || generation !== this.reloadGeneration) {
         try {
           dispose();
         } catch {

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -77,6 +77,9 @@ export class PluginDevWorkerMainBridge {
   private invokeSeq = 1;
   private readonly pendingInvokes = new Map<string, PendingInvoke>();
   private readonly subscriptionDisposers = new Map<string, () => void>();
+  /** AbortControllers for in-flight `host-call`s, keyed by requestId. A worker
+   * `host-cancel` (the caller's AbortSignal fired) aborts the matching one. */
+  private readonly hostCallAborts = new Map<string, AbortController>();
   /** Disposers for providers (file decoration) the worker registered on the real
    * host, keyed by provider id. Torn down on reload and dispose so a reloaded
    * generation re-registers cleanly. */
@@ -127,11 +130,24 @@ export class PluginDevWorkerMainBridge {
     }
     this.subscriptionDisposers.clear();
     this.disposeProviders();
+    this.abortAllHostCalls();
     for (const pending of this.pendingInvokes.values()) {
       pending.reject(new Error("Plugin dev worker bridge disposed"));
     }
     this.pendingInvokes.clear();
     this.rejectActivation(new Error(`Plugin dev worker "${this.pluginId}" disposed`));
+  }
+
+  /** Abort every in-flight host call (worker is going away — cancel the I/O). */
+  private abortAllHostCalls(): void {
+    for (const controller of this.hostCallAborts.values()) {
+      try {
+        controller.abort();
+      } catch {
+        // best-effort
+      }
+    }
+    this.hostCallAborts.clear();
   }
 
   /** Tear down every provider the worker registered on the real host. */
@@ -160,6 +176,7 @@ export class PluginDevWorkerMainBridge {
     }
     this.subscriptionDisposers.clear();
     this.disposeProviders();
+    this.abortAllHostCalls();
     for (const pending of this.pendingInvokes.values()) {
       pending.reject(new Error("Plugin reloaded before invocation completed"));
     }
@@ -205,11 +222,16 @@ export class PluginDevWorkerMainBridge {
       case "host-call":
         void this.handleHostCall(msg);
         return;
+      case "host-cancel": {
+        const controller = this.hostCallAborts.get(msg.requestId);
+        if (controller) controller.abort();
+        return;
+      }
       case "host-notify":
-        this.handleHostNotify(msg);
+        void this.handleHostNotify(msg);
         return;
       case "subscribe":
-        this.handleSubscribe(msg);
+        void this.handleSubscribe(msg);
         return;
       case "unsubscribe": {
         const dispose = this.subscriptionDisposers.get(msg.subscriptionId);
@@ -240,8 +262,12 @@ export class PluginDevWorkerMainBridge {
   private async handleHostCall(
     msg: Extract<PluginWorkerToHostMessage, { type: "host-call" }>
   ): Promise<void> {
+    // Track an AbortController so a worker `host-cancel` can cancel the in-flight
+    // read/mutation (signal-bearing host methods honor it).
+    const controller = new AbortController();
+    this.hostCallAborts.set(msg.requestId, controller);
     try {
-      const result = await this.dispatchHostCall(msg.method, msg.params);
+      const result = await this.dispatchHostCall(msg.method, msg.params, controller.signal);
       this.workerHost.send({ type: "host-result", requestId: msg.requestId, ok: true, result });
     } catch (err) {
       this.workerHost.send({
@@ -250,17 +276,23 @@ export class PluginDevWorkerMainBridge {
         ok: false,
         error: formatErrorMessage(err, "host call failed"),
       });
+    } finally {
+      this.hostCallAborts.delete(msg.requestId);
     }
   }
 
-  private async dispatchHostCall(method: string, params: unknown): Promise<unknown> {
+  private async dispatchHostCall(
+    method: string,
+    params: unknown,
+    signal: AbortSignal
+  ): Promise<unknown> {
     switch (method) {
       case "getActiveWorktree":
         return this.host.getActiveWorktree();
       case "getWorktrees":
         return this.host.getWorktrees();
       case "getWorktreeStatus":
-        return this.host.getWorktreeStatus(params as string);
+        return this.host.getWorktreeStatus(params as string, { signal });
       case "showToast": {
         const p = params as ShowToastParams;
         // `type` is validated against the NotificationType enum by the host's
@@ -286,39 +318,41 @@ export class PluginDevWorkerMainBridge {
         return undefined;
       }
       case "fs.readFile":
-        return this.host.fs.readFile((params as FsPathParams).path);
+        return this.host.fs.readFile((params as FsPathParams).path, { signal });
       case "fs.writeFile": {
         const p = params as FsWriteFileParams;
         await this.host.fs.writeFile(p.path, p.contents);
         return undefined;
       }
       case "fs.readdir":
-        return this.host.fs.readdir((params as FsPathParams).path);
+        return this.host.fs.readdir((params as FsPathParams).path, { signal });
       case "fs.stat":
-        return this.host.fs.stat((params as FsPathParams).path);
+        return this.host.fs.stat((params as FsPathParams).path, { signal });
       case "git.status":
-        return this.host.git.status((params as GitOpParams).worktreePath);
+        return this.host.git.status((params as GitOpParams).worktreePath, { signal });
       case "git.diff": {
         const p = params as GitOpParams;
-        return this.host.git.diff(p.worktreePath, p.filePath);
+        return this.host.git.diff(p.worktreePath, p.filePath, { signal });
       }
       case "git.add": {
         const p = params as GitOpParams;
-        await this.host.git.add(p.worktreePath, p.paths);
+        await this.host.git.add(p.worktreePath, p.paths, { signal });
         return undefined;
       }
       case "git.commit": {
         const p = params as GitOpParams;
-        return this.host.git.commit(p.worktreePath, { message: p.message ?? "" });
+        return this.host.git.commit(p.worktreePath, { message: p.message ?? "" }, { signal });
       }
       default:
         throw new Error(`Unknown host-call method "${method}"`);
     }
   }
 
-  private handleHostNotify(msg: Extract<PluginWorkerToHostMessage, { type: "host-notify" }>): void {
+  private async handleHostNotify(
+    msg: Extract<PluginWorkerToHostMessage, { type: "host-notify" }>
+  ): Promise<void> {
     try {
-      this.dispatchHostNotify(msg.method, msg.params);
+      await this.dispatchHostNotify(msg.method, msg.params);
     } catch (err) {
       const error = formatErrorMessage(err, "registration failed");
       if (msg.registrationKey) {
@@ -335,12 +369,14 @@ export class PluginDevWorkerMainBridge {
     }
   }
 
-  private dispatchHostNotify(method: string, params: unknown): void {
+  private async dispatchHostNotify(method: string, params: unknown): Promise<void> {
     switch (method) {
       case "registerAction": {
         const { descriptor } = params as RegisterActionParams;
         const namespacedId = `${this.pluginId}.${descriptor.id}`;
-        this.host.registerAction(descriptor, (args) =>
+        // The host registers synchronously and resolves; await so a deep-
+        // validation rejection routes to the register-error channel.
+        await this.host.registerAction(descriptor, (args) =>
           this.invoke({ kind: "action", namespacedId, args })
         );
         return;
@@ -361,22 +397,22 @@ export class PluginDevWorkerMainBridge {
         }
         const handler = (ctx: PluginIpcContext, ...args: unknown[]) =>
           this.invoke({ kind: "handler", channel: p.channel, ctx, args });
-        this.host.registerHandler(p.channel, handler);
+        await this.host.registerHandler(p.channel, handler);
         return;
       }
       case "broadcastToRenderer": {
         const p = params as BroadcastToRendererParams;
-        this.host.broadcastToRenderer(p.channel, p.payload);
+        await this.host.broadcastToRenderer(p.channel, p.payload);
         return;
       }
       case "postToPanel": {
         const p = params as PostToPanelParams;
-        this.host.postToPanel(p.channel, p.payload);
+        await this.host.postToPanel(p.channel, p.payload);
         return;
       }
       case "invalidateFileDecorations": {
         const p = params as InvalidateFileDecorationsParams;
-        this.host.invalidateFileDecorations(p.scope, p.paths);
+        await this.host.invalidateFileDecorations(p.scope, p.paths);
         return;
       }
       case "registerFileDecorationProvider": {
@@ -404,7 +440,17 @@ export class PluginDevWorkerMainBridge {
               args: [scope, paths],
             }) as Promise<Record<string, FileDecoration>>,
         };
-        const dispose = this.host.registerFileDecorationProvider(descriptor, proxyImpl);
+        const dispose = await this.host.registerFileDecorationProvider(descriptor, proxyImpl);
+        // The bridge may have been torn down (dispose/reload) while the host
+        // registration was settling — don't leak the freshly bound provider.
+        if (this.disposed) {
+          try {
+            dispose();
+          } catch {
+            // best-effort
+          }
+          return;
+        }
         this.providerDisposers.set(providerId, dispose);
         return;
       }
@@ -422,6 +468,7 @@ export class PluginDevWorkerMainBridge {
       case "logger.error": {
         const p = params as LoggerParams;
         const level = method.split(".")[1] as "info" | "warn" | "error";
+        // Logger stays synchronous fire-and-forget (the #10519 carve-out).
         this.host.logger[level](p.message, p.fields);
         return;
       }
@@ -430,7 +477,9 @@ export class PluginDevWorkerMainBridge {
     }
   }
 
-  private handleSubscribe(msg: Extract<PluginWorkerToHostMessage, { type: "subscribe" }>): void {
+  private async handleSubscribe(
+    msg: Extract<PluginWorkerToHostMessage, { type: "subscribe" }>
+  ): Promise<void> {
     const { subscriptionId, kind } = msg;
     const push = (payload: unknown): void => {
       if (this.disposed) return;
@@ -439,16 +488,28 @@ export class PluginDevWorkerMainBridge {
     try {
       let dispose: () => void;
       if (kind === "active-worktree") {
-        dispose = this.host.onDidChangeActiveWorktree((snapshot) => push(snapshot));
+        dispose = await this.host.onDidChangeActiveWorktree((snapshot) => push(snapshot));
       } else if (kind === "worktrees") {
-        dispose = this.host.onDidChangeWorktrees((snapshots) => push(snapshots));
+        dispose = await this.host.onDidChangeWorktrees((snapshots) => push(snapshots), {
+          debounceMs: msg.debounceMs,
+        });
       } else {
         // settings
         if (!msg.key) {
           logger.warn(`[${this.pluginId}] settings subscribe missing key`);
           return;
         }
-        dispose = this.host.settings.onDidChange(msg.key, (value) => push(value), msg.scope);
+        dispose = await this.host.settings.onDidChange(msg.key, (value) => push(value), msg.scope);
+      }
+      // The bridge may have been disposed/reloaded while the subscription was
+      // settling — tear it down rather than leak it past the cleanup pass.
+      if (this.disposed) {
+        try {
+          dispose();
+        } catch {
+          // best-effort
+        }
+        return;
       }
       this.subscriptionDisposers.set(subscriptionId, dispose);
     } catch (err) {

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -141,6 +141,10 @@ describe("PluginDevWorkerMainBridge", () => {
       registrationKey: "handler:secret",
       params: { channel: "secret", hasSchema: true, requires: ["worktree:read"] },
     });
+    // host-notify dispatch is async (the host registration methods are
+    // Promise-returning); flush microtasks so the capability-gate rejection
+    // routes to register-error before asserting.
+    await flush();
     expect(host.registerHandler).not.toHaveBeenCalled();
     const err = workerHost.sent.find((m) => m.type === "register-error");
     expect(err).toMatchObject({ registrationKey: "handler:secret" });
@@ -184,6 +188,10 @@ describe("PluginDevWorkerMainBridge", () => {
       subscriptionId: "s2",
       kind: "worktrees",
     });
+    // Subscribe is async now (onDidChangeWorktrees resolves the disposer); flush
+    // so the disposer is recorded before the unsubscribe looks it up — mirrors
+    // the per-message task boundary the MessagePort provides in production.
+    await flush();
     workerHost.emit("worker-message", { type: "unsubscribe", subscriptionId: "s2" });
     expect(dispose).toHaveBeenCalled();
   });
@@ -294,6 +302,9 @@ describe("PluginDevWorkerMainBridge", () => {
       method: "registerFileDecorationProvider",
       params: { descriptor: { id: "acme.demo.deco" } },
     });
+    // registerFileDecorationProvider records its disposer after awaiting the
+    // (now Promise-returning) host registration; flush so the unregister finds it.
+    await flush();
     workerHost.emit("worker-message", {
       type: "host-notify",
       method: "unregisterFileDecorationProvider",
@@ -312,6 +323,9 @@ describe("PluginDevWorkerMainBridge", () => {
       method: "registerFileDecorationProvider",
       params: { descriptor: { id: "acme.demo.deco" } },
     });
+    // Let the async registration record its disposer before reload tears it down
+    // (the register message and the reload event are distinct tasks in prod).
+    await flush();
     workerHost.emit("reloading");
     expect(dispose).toHaveBeenCalledTimes(1);
   });

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -17,10 +17,13 @@ describe("PluginDevWorkerHostProxy file decoration providers", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.restoreAllMocks());
 
-  it("notifies main on registerFileDecorationProvider and keeps the impl in the worker", () => {
+  it("notifies main on registerFileDecorationProvider and keeps the impl in the worker", async () => {
     const { proxy, sent } = makeProxy();
     const impl = { provideDecorations: vi.fn(async () => ({})) };
-    const dispose = proxy.host.registerFileDecorationProvider({ id: "deco", scopes: ["pr"] }, impl);
+    const dispose = await proxy.host.registerFileDecorationProvider(
+      { id: "deco", scopes: ["pr"] },
+      impl
+    );
 
     const notify = sent.find((m) => m.type === "host-notify");
     expect(notify).toMatchObject({
@@ -74,7 +77,7 @@ describe("PluginDevWorkerHostProxy file decoration providers", () => {
   it("notifies unregister and drops the impl on dispose", async () => {
     const { proxy, sent } = makeProxy();
     const impl = { provideDecorations: vi.fn(async () => ({})) };
-    const dispose = proxy.host.registerFileDecorationProvider({ id: "deco" }, impl);
+    const dispose = await proxy.host.registerFileDecorationProvider({ id: "deco" }, impl);
     dispose();
 
     const unregister = sent.find(
@@ -100,8 +103,8 @@ describe("PluginDevWorkerHostProxy file decoration providers", () => {
     const { proxy, sent } = makeProxy();
     const implA = { provideDecorations: vi.fn(async () => ({ a: { badge: "A" } })) };
     const implB = { provideDecorations: vi.fn(async () => ({ b: { badge: "B" } })) };
-    const disposeA = proxy.host.registerFileDecorationProvider({ id: "deco" }, implA);
-    proxy.host.registerFileDecorationProvider({ id: "deco" }, implB); // overwrites A
+    const disposeA = await proxy.host.registerFileDecorationProvider({ id: "deco" }, implA);
+    await proxy.host.registerFileDecorationProvider({ id: "deco" }, implB); // overwrites A
     disposeA(); // stale — must NOT remove B
 
     proxy.handleMessage({
@@ -125,10 +128,10 @@ describe("PluginDevWorkerHostProxy file decoration providers", () => {
     );
   });
 
-  it("warns but does not register forge providers (synchronous-contract limitation)", () => {
+  it("warns but does not register forge providers (synchronous-contract limitation)", async () => {
     const { proxy, sent } = makeProxy();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const dispose = proxy.host.registerForgeProvider({ id: "gh" } as any, {} as any);
+    const dispose = await proxy.host.registerForgeProvider({ id: "gh" } as any, {} as any);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("not supported in dev mode"));
     expect(sent.find((m) => m.type === "host-notify")).toBeUndefined();
     expect(typeof dispose).toBe("function");

--- a/electron/services/plugin/__tests__/pluginHostGit.test.ts
+++ b/electron/services/plugin/__tests__/pluginHostGit.test.ts
@@ -131,4 +131,58 @@ describe("PluginHostGit", () => {
     expect(status.changedFileCount).toBe(0);
     expect(status.files).toEqual([]);
   });
+
+  describe("AbortSignal", () => {
+    it("commit does NOT create the commit when the signal aborts during the staged-diff", async () => {
+      // The destructive-mutation regression: an abort that fires while the
+      // change-preview diff is being computed must stop the commit, not let it
+      // proceed (the re-check between diff and commit).
+      const controller = new AbortController();
+      const diff = vi.fn(async () => {
+        controller.abort();
+        return "staged diff";
+      });
+      const commit = vi.fn(async () => ({ commit: "deadbee" }));
+      const git = { diff, commit } as unknown as SimpleGit;
+      const host = new PluginHostGit("p", async () => git);
+
+      await expect(
+        host.commit("/wt", { message: "feat: thing" }, controller.signal)
+      ).rejects.toThrow();
+      expect(diff).toHaveBeenCalledTimes(1);
+      expect(commit).not.toHaveBeenCalled();
+    });
+
+    it("commit rejects before any work when the signal is already aborted", async () => {
+      const { git, diff, commit } = fakeGit();
+      const host = new PluginHostGit("p", async () => git);
+      await expect(
+        host.commit("/wt", { message: "msg" }, AbortSignal.abort())
+      ).rejects.toThrow();
+      expect(diff).not.toHaveBeenCalled();
+      expect(commit).not.toHaveBeenCalled();
+    });
+
+    it("status rejects an already-aborted signal before reading", async () => {
+      const provider = vi.fn(async () => emptyChanges);
+      const host = new PluginHostGit("p", async () => fakeGit().git, provider);
+      await expect(host.status("/wt", AbortSignal.abort())).rejects.toThrow();
+      expect(provider).not.toHaveBeenCalled();
+    });
+
+    it("add rejects an already-aborted signal before staging", async () => {
+      const { git, raw } = fakeGit();
+      const host = new PluginHostGit("p", async () => git);
+      await expect(host.add("/wt", ["a.ts"], AbortSignal.abort())).rejects.toThrow();
+      expect(raw).not.toHaveBeenCalled();
+    });
+
+    it("commit proceeds normally when the signal is not aborted", async () => {
+      const { git, commit } = fakeGit();
+      const host = new PluginHostGit("p", async () => git);
+      const result = await host.commit("/wt", { message: "msg" }, new AbortController().signal);
+      expect(commit).toHaveBeenCalledWith("msg");
+      expect(result.message).toBe("msg");
+    });
+  });
 });

--- a/electron/services/plugin/__tests__/pluginHostGit.test.ts
+++ b/electron/services/plugin/__tests__/pluginHostGit.test.ts
@@ -156,9 +156,7 @@ describe("PluginHostGit", () => {
     it("commit rejects before any work when the signal is already aborted", async () => {
       const { git, diff, commit } = fakeGit();
       const host = new PluginHostGit("p", async () => git);
-      await expect(
-        host.commit("/wt", { message: "msg" }, AbortSignal.abort())
-      ).rejects.toThrow();
+      await expect(host.commit("/wt", { message: "msg" }, AbortSignal.abort())).rejects.toThrow();
       expect(diff).not.toHaveBeenCalled();
       expect(commit).not.toHaveBeenCalled();
     });

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -50,6 +50,8 @@ type Post = (message: PluginWorkerToHostMessage) => void;
 interface PendingCall {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
+  /** Detach the abort listener once the call settles (no-op when no signal was passed). */
+  cleanup?: () => void;
 }
 
 interface RegisteredHandler {
@@ -87,6 +89,7 @@ export class PluginDevWorkerHostProxy {
   dispose(): void {
     this.disposed = true;
     for (const pending of this.pendingCalls.values()) {
+      pending.cleanup?.();
       pending.reject(new Error("Plugin dev worker disposed"));
     }
     this.pendingCalls.clear();
@@ -103,6 +106,7 @@ export class PluginDevWorkerHostProxy {
         const pending = this.pendingCalls.get(msg.requestId);
         if (!pending) return true;
         this.pendingCalls.delete(msg.requestId);
+        pending.cleanup?.();
         if (msg.ok) pending.resolve(msg.result);
         else pending.reject(new Error(msg.error));
         return true;
@@ -197,16 +201,38 @@ export class PluginDevWorkerHostProxy {
     return legacy(ctx, ...args);
   }
 
-  private call<T>(method: PluginHostCallMethod, params: unknown): Promise<T> {
+  private call<T>(method: PluginHostCallMethod, params: unknown, signal?: AbortSignal): Promise<T> {
     if (this.disposed) {
       return Promise.reject(new Error("Plugin dev worker disposed"));
     }
+    // An already-aborted signal rejects before anything crosses the port.
+    if (signal?.aborted) {
+      return Promise.reject(abortError(signal));
+    }
     const requestId = `c${this.nextId++}`;
     return new Promise<T>((resolve, reject) => {
+      let onAbort: (() => void) | undefined;
+      const cleanup = (): void => {
+        if (onAbort && signal) signal.removeEventListener("abort", onAbort);
+      };
       this.pendingCalls.set(requestId, {
         resolve: resolve as (value: unknown) => void,
         reject,
+        cleanup,
       });
+      if (signal) {
+        onAbort = (): void => {
+          const pending = this.pendingCalls.get(requestId);
+          if (!pending) return;
+          this.pendingCalls.delete(requestId);
+          cleanup();
+          // Tell main to abort the in-flight host call (AbortSignal itself is not
+          // structured-clone-safe, so the requestId is the cancellation handle).
+          this.post({ type: "host-cancel", requestId });
+          reject(abortError(signal));
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
       this.post({ type: "host-call", requestId, method, params });
     });
   }
@@ -271,6 +297,9 @@ export class PluginDevWorkerHostProxy {
           },
           `action:${namespacedId}`
         );
+        // Sync structural validation + handler capture happen above (sync throws
+        // still surface at the call site); only the return value is async.
+        return Promise.resolve();
       },
       registerHandler: ((
         channel: string,
@@ -310,6 +339,7 @@ export class PluginDevWorkerHostProxy {
           this.ipcHandlers.set(channel, { handler: schemaOrHandler as PluginIpcHandler });
           this.notify("registerHandler", { channel, hasSchema: false }, `handler:${channel}`);
         }
+        return Promise.resolve();
       }) as PluginHostApi["registerHandler"],
       broadcastToRenderer: (channel, payload) => {
         this.assertActivationOpen("broadcastToRenderer");
@@ -319,6 +349,7 @@ export class PluginDevWorkerHostProxy {
           );
         }
         this.notify("broadcastToRenderer", { channel, payload });
+        return Promise.resolve();
       },
       // Post-activation-safe sibling of broadcastToRenderer: no
       // assertActivationOpen guard, so dev-worker plugins can stream live data
@@ -330,23 +361,33 @@ export class PluginDevWorkerHostProxy {
           );
         }
         this.notify("postToPanel", { channel, payload });
+        return Promise.resolve();
       },
       getActiveWorktree: () =>
         this.call<PluginWorktreeSnapshot | null>("getActiveWorktree", undefined),
       getWorktrees: () => this.call<PluginWorktreeSnapshot[]>("getWorktrees", undefined),
-      getWorktreeStatus: (path) =>
-        this.call<PluginWorktreeStatus | null>("getWorktreeStatus", path),
+      getWorktreeStatus: (path, options) =>
+        this.call<PluginWorktreeStatus | null>("getWorktreeStatus", path, options?.signal),
       onDidChangeActiveWorktree: (callback) => {
         this.assertActivationOpen("onDidChangeActiveWorktree");
-        return this.subscribe("active-worktree", (payload) =>
+        // Subscription wired synchronously; only the disposer is async.
+        const dispose = this.subscribe("active-worktree", (payload) =>
           callback(payload as PluginWorktreeSnapshot | null)
         );
+        return Promise.resolve(dispose);
       },
-      onDidChangeWorktrees: (callback) => {
+      onDidChangeWorktrees: (callback, options) => {
         this.assertActivationOpen("onDidChangeWorktrees");
-        return this.subscribe("worktrees", (payload) =>
-          callback(payload as PluginWorktreeSnapshot[])
+        // Debounce is applied host-side: the worker forwards `debounceMs` in the
+        // subscribe message and the real host coalesces before pushing events.
+        const dispose = this.subscribe(
+          "worktrees",
+          (payload) => callback(payload as PluginWorktreeSnapshot[]),
+          undefined,
+          undefined,
+          options?.debounceMs
         );
+        return Promise.resolve(dispose);
       },
       registerForgeProvider: (descriptor: ForgeProviderDescriptor, _impl: ForgeProviderImpl) => {
         this.assertActivationOpen("registerForgeProvider");
@@ -361,7 +402,7 @@ export class PluginDevWorkerHostProxy {
         console.warn(
           `[plugin-dev:${this.pluginId}] registerForgeProvider("${descriptor?.id}") is not supported in dev mode — forge providers require synchronous host methods (parseRemote, URL builders) that can't cross the dev worker's async boundary. Package + install the plugin to test forge providers.`
         );
-        return () => {};
+        return Promise.resolve(() => {});
       },
       registerFileDecorationProvider: (
         descriptor: FileDecorationProviderDescriptor,
@@ -393,7 +434,7 @@ export class PluginDevWorkerHostProxy {
           `fileDecorationProvider:${providerId}`
         );
         let disposed = false;
-        return () => {
+        const dispose = (): void => {
           if (disposed) return;
           disposed = true;
           // Identity-guard the delete so a stale disposer (from a prior register
@@ -404,6 +445,7 @@ export class PluginDevWorkerHostProxy {
           }
           this.notify("unregisterFileDecorationProvider", { providerId });
         };
+        return Promise.resolve(dispose);
       },
       invalidateFileDecorations: (scope, paths) => {
         if (typeof scope !== "string" || scope.length === 0) {
@@ -412,6 +454,7 @@ export class PluginDevWorkerHostProxy {
           );
         }
         this.notify("invalidateFileDecorations", { scope, paths });
+        return Promise.resolve();
       },
       showToast: (options: PluginToastOptions) =>
         this.call<void>("showToast", {
@@ -445,26 +488,36 @@ export class PluginDevWorkerHostProxy {
       // back, a subscription whose teardown semantics don't survive a whole-
       // worker reload cleanly; reject it honestly in dev mode (mirrors process).
       fs: {
-        readFile: (filePath) => this.call<string>("fs.readFile", { path: filePath }),
+        readFile: (filePath, options) =>
+          this.call<string>("fs.readFile", { path: filePath }, options?.signal),
         writeFile: (filePath, contents) =>
           this.call<void>("fs.writeFile", { path: filePath, contents }),
-        readdir: (dirPath) => this.call<PluginFsDirEntry[]>("fs.readdir", { path: dirPath }),
-        stat: (targetPath) => this.call<PluginFsStat>("fs.stat", { path: targetPath }),
-        watch: (_paths, _callback) => {
+        readdir: (dirPath, options) =>
+          this.call<PluginFsDirEntry[]>("fs.readdir", { path: dirPath }, options?.signal),
+        stat: (targetPath, options) =>
+          this.call<PluginFsStat>("fs.stat", { path: targetPath }, options?.signal),
+        watch: (_paths, _callback, _options) => {
           const message = `[plugin-dev:${this.pluginId}] host.fs.watch is not supported in dev mode — the watcher subscription's disposer and change callback can't survive a whole-worker reload. Package + install the plugin to test host.fs.watch.`;
           console.warn(message);
           return Promise.reject(new Error(message));
         },
       },
       git: {
-        status: (worktreePath) => this.call<PluginGitStatus>("git.status", { worktreePath }),
-        diff: (worktreePath, filePath) => this.call<string>("git.diff", { worktreePath, filePath }),
-        add: (worktreePath, paths) => this.call<void>("git.add", { worktreePath, paths }),
-        commit: (worktreePath, options) =>
-          this.call<PluginGitCommitResult>("git.commit", {
-            worktreePath,
-            message: options?.message,
-          }),
+        status: (worktreePath, options) =>
+          this.call<PluginGitStatus>("git.status", { worktreePath }, options?.signal),
+        diff: (worktreePath, filePath, options) =>
+          this.call<string>("git.diff", { worktreePath, filePath }, options?.signal),
+        add: (worktreePath, paths, options) =>
+          this.call<void>("git.add", { worktreePath, paths }, options?.signal),
+        commit: (worktreePath, options, callOptions) =>
+          this.call<PluginGitCommitResult>(
+            "git.commit",
+            {
+              worktreePath,
+              message: options?.message,
+            },
+            callOptions?.signal
+          ),
       },
       settings: {
         get: <T = unknown>(key: string, scope: PluginSettingsScope = "user") =>
@@ -477,12 +530,13 @@ export class PluginDevWorkerHostProxy {
           scope: PluginSettingsScope = "user"
         ) => {
           this.assertActivationOpen("settings.onDidChange");
-          return this.subscribe(
+          const dispose = this.subscribe(
             "settings",
             (payload) => callback(payload as T | undefined),
             key,
             scope
           );
+          return Promise.resolve(dispose);
         },
       },
     };
@@ -493,11 +547,12 @@ export class PluginDevWorkerHostProxy {
     kind: "active-worktree" | "worktrees" | "settings",
     callback: (payload: unknown) => void,
     key?: string,
-    scope?: PluginSettingsScope
+    scope?: PluginSettingsScope,
+    debounceMs?: number
   ): () => void {
     const subscriptionId = `s${this.nextId++}`;
     this.subscriptions.set(subscriptionId, callback);
-    this.post({ type: "subscribe", subscriptionId, kind, key, scope });
+    this.post({ type: "subscribe", subscriptionId, kind, key, scope, debounceMs });
     let disposed = false;
     return () => {
       if (disposed) return;
@@ -506,6 +561,19 @@ export class PluginDevWorkerHostProxy {
       this.post({ type: "unsubscribe", subscriptionId });
     };
   }
+}
+
+/**
+ * Normalize an aborted signal's reason into an `Error` for rejection. Node sets
+ * `signal.reason` to a `DOMException` (name `AbortError`) by default, which is
+ * not an `Error` instance — wrap anything non-Error so callers always get one.
+ */
+function abortError(signal: AbortSignal): Error {
+  const reason: unknown = signal.reason;
+  if (reason instanceof Error) return reason;
+  const err = new Error(typeof reason === "string" ? reason : "The operation was aborted");
+  err.name = "AbortError";
+  return err;
 }
 
 /** Structural guard mirroring `isChannelSchema` from PluginChannelRegistry,

--- a/electron/services/plugin/pluginHostGit.ts
+++ b/electron/services/plugin/pluginHostGit.ts
@@ -139,12 +139,14 @@ export class PluginHostGit {
     }
 
     const git = await this.gitFactory(worktreePath);
-    // Re-check after acquiring the client but BEFORE computing the preview /
-    // mutating — abort must not commit work the caller already cancelled.
+    // Re-check after acquiring the client but BEFORE computing the preview.
     signal?.throwIfAborted();
     // The real change preview the D2 safeguard requires: the staged diff that is
     // about to be committed, computed before the mutation. No silent fallback.
     const preview = await git.diff(["--cached", "--no-ext-diff", "--no-textconv", "--no-color"]);
+    // Re-check immediately before the mutation — the diff above can take time on
+    // a large staged set, and an abort mid-diff must not still create the commit.
+    signal?.throwIfAborted();
     const result = await git.commit(message);
     return {
       commit: result.commit,

--- a/electron/services/plugin/pluginHostGit.ts
+++ b/electron/services/plugin/pluginHostGit.ts
@@ -80,8 +80,10 @@ export class PluginHostGit {
    * collapse the worktree snapshot uses so plugins see one status vocabulary.
    * Reads via the shared `getWorktreeChangesWithStats` (cached, hardened).
    */
-  async status(worktreePath: string): Promise<PluginGitStatus> {
+  async status(worktreePath: string, signal?: AbortSignal): Promise<PluginGitStatus> {
+    signal?.throwIfAborted();
     const changes = await this.changesProvider(worktreePath);
+    signal?.throwIfAborted();
     const projected = toPluginWorktreeStatus(changes);
     return {
       worktreePath,
@@ -91,8 +93,10 @@ export class PluginHostGit {
   }
 
   /** Unified diff for the worktree, optionally narrowed to one path. `--no-textconv` blocks user diff drivers. */
-  async diff(worktreePath: string, filePath?: string): Promise<string> {
+  async diff(worktreePath: string, filePath?: string, signal?: AbortSignal): Promise<string> {
+    signal?.throwIfAborted();
     const git = await this.gitFactory(worktreePath);
+    signal?.throwIfAborted();
     const args = ["--no-ext-diff", "--no-textconv", "--no-color"];
     if (typeof filePath === "string" && filePath.length > 0) {
       assertSafePathspec(this.pluginId, filePath);
@@ -102,8 +106,10 @@ export class PluginHostGit {
   }
 
   /** Stage paths relative to the worktree, or all changes when omitted. */
-  async add(worktreePath: string, paths?: string[]): Promise<void> {
+  async add(worktreePath: string, paths?: string[], signal?: AbortSignal): Promise<void> {
+    signal?.throwIfAborted();
     const git = await this.gitFactory(worktreePath);
+    signal?.throwIfAborted();
     const targets =
       Array.isArray(paths) && paths.length > 0
         ? paths.filter((p): p is string => typeof p === "string" && p.length > 0)
@@ -123,14 +129,19 @@ export class PluginHostGit {
    */
   async commit(
     worktreePath: string,
-    options: PluginGitCommitOptions
+    options: PluginGitCommitOptions,
+    signal?: AbortSignal
   ): Promise<PluginGitCommitResult> {
+    signal?.throwIfAborted();
     const message = typeof options?.message === "string" ? options.message : "";
     if (message.trim().length === 0) {
       throw new PluginGitCommitMessageRequiredError(this.pluginId);
     }
 
     const git = await this.gitFactory(worktreePath);
+    // Re-check after acquiring the client but BEFORE computing the preview /
+    // mutating — abort must not commit work the caller already cancelled.
+    signal?.throwIfAborted();
     // The real change preview the D2 safeguard requires: the staged diff that is
     // about to be committed, computed before the mutation. No silent fallback.
     const preview = await git.diff(["--cached", "--no-ext-diff", "--no-textconv", "--no-color"]);

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -178,7 +178,7 @@ function commandEntry(ctx: ScaffoldContext): string {
  * unregistered automatically on unload, so the disposer here is a no-op.
  */
 export async function activate(host: PluginHostApi): Promise<() => void> {
-  host.registerAction(
+  await host.registerAction(
     {
       id: "run",
       title: ${title},

--- a/plugins/builtin/github/main/__tests__/index.activate.test.ts
+++ b/plugins/builtin/github/main/__tests__/index.activate.test.ts
@@ -52,27 +52,27 @@ describe("github plugin activate", () => {
     gitHubAuthMock.getTokenVersion.mockReturnValue(0);
   });
 
-  it("initializes token storage before registering the forge provider", () => {
+  it("initializes token storage before registering the forge provider", async () => {
     const host = makeHost();
     const order: string[] = [];
     gitHubAuthMock.initializeStorage.mockImplementation(() => order.push("storage"));
     vi.mocked(host.registerForgeProvider).mockImplementation(() => {
       order.push("provider");
-      return vi.fn();
+      return Promise.resolve(vi.fn());
     });
 
-    activate(host);
+    await activate(host);
 
     expect(order).toEqual(["storage", "provider"]);
   });
 
-  it("returns synchronously even while a stored-token validate hangs (#10325)", () => {
+  it("returns synchronously even while a stored-token validate hangs (#10325)", async () => {
     gitHubAuthMock.getToken.mockReturnValue("tok-123");
     // A validate() that never resolves models a slow/offline network — it must
     // be floated, never awaited, so activation cannot stall on it.
     gitHubAuthMock.validate.mockReturnValue(new Promise<never>(() => {}));
 
-    const dispose = activate(makeHost());
+    const dispose = await activate(makeHost());
 
     expect(typeof dispose).toBe("function");
     expect(gitHubAuthMock.validate).toHaveBeenCalledWith("tok-123");
@@ -111,7 +111,7 @@ describe("github plugin activate", () => {
       scopes: ["repo"],
     });
 
-    activate(makeHost());
+    await activate(makeHost());
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(gitHubAuthMock.setValidatedUserInfo).toHaveBeenCalledWith(
@@ -126,7 +126,7 @@ describe("github plugin activate", () => {
     gitHubAuthMock.getToken.mockReturnValue("tok-123");
     gitHubAuthMock.validate.mockResolvedValue({ valid: false });
 
-    activate(makeHost());
+    await activate(makeHost());
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(updateForgeCredentialsMock).toHaveBeenCalledWith(expect.any(String), {
@@ -136,7 +136,7 @@ describe("github plugin activate", () => {
   });
 
   it("skips the credential push and validation when no token is stored", async () => {
-    activate(makeHost());
+    await activate(makeHost());
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(gitHubAuthMock.validate).not.toHaveBeenCalled();

--- a/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
+++ b/plugins/builtin/github/main/__tests__/reviewDecorationProvider.test.ts
@@ -310,9 +310,9 @@ describe("registerReviewDecorationProvider", () => {
     mockGetPRReviewThreads.mockReset();
   });
 
-  it("invalidates only PR-linked scopes on the first event", () => {
+  it("invalidates only PR-linked scopes on the first event", async () => {
     const { host, emit } = makeRegisterHost();
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
 
     emit([makeWorktree("/linked", 42), unlinkedWorktree("/plain")]);
 
@@ -320,9 +320,9 @@ describe("registerReviewDecorationProvider", () => {
     expect(host.invalidateFileDecorations).toHaveBeenCalledWith("worktree-diff:/linked");
   });
 
-  it("skips invalidation when linkage is unchanged within the TTL", () => {
+  it("skips invalidation when linkage is unchanged within the TTL", async () => {
     const { host, emit } = makeRegisterHost();
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
 
     emit([makeWorktree("/linked", 42)]);
     emit([makeWorktree("/linked", 42)]);
@@ -331,9 +331,9 @@ describe("registerReviewDecorationProvider", () => {
     expect(host.invalidateFileDecorations).toHaveBeenCalledTimes(1);
   });
 
-  it("invalidates when the linked PR number changes", () => {
+  it("invalidates when the linked PR number changes", async () => {
     const { host, emit } = makeRegisterHost();
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
 
     emit([makeWorktree("/linked", 42)]);
     emit([makeWorktree("/linked", 43)]);
@@ -341,9 +341,9 @@ describe("registerReviewDecorationProvider", () => {
     expect(host.invalidateFileDecorations).toHaveBeenCalledTimes(2);
   });
 
-  it("invalidates when a PR linkage is removed", () => {
+  it("invalidates when a PR linkage is removed", async () => {
     const { host, emit } = makeRegisterHost();
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
 
     emit([makeWorktree("/linked", 42)]);
     emit([unlinkedWorktree("/linked")]);
@@ -352,9 +352,9 @@ describe("registerReviewDecorationProvider", () => {
     expect(host.invalidateFileDecorations).toHaveBeenLastCalledWith("worktree-diff:/linked");
   });
 
-  it("invalidates an unchanged linkage again once the TTL elapses", () => {
+  it("invalidates an unchanged linkage again once the TTL elapses", async () => {
     const { host, emit } = makeRegisterHost();
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
     try {
       emit([makeWorktree("/linked", 42)]);
@@ -370,9 +370,9 @@ describe("registerReviewDecorationProvider", () => {
     }
   });
 
-  it("invalidates an unchanged linkage within the TTL after a manual cache clear", () => {
+  it("invalidates an unchanged linkage within the TTL after a manual cache clear", async () => {
     const { host, emit } = makeRegisterHost();
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
 
     emit([makeWorktree("/linked", 42)]);
     emit([makeWorktree("/linked", 42)]);
@@ -385,7 +385,7 @@ describe("registerReviewDecorationProvider", () => {
 
   it("serves linkage from the event-fed cache without a snapshot round-trip", async () => {
     const { host, emit, getProvider } = makeRegisterHost();
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
     emit([makeWorktree("/some/path", 42)]);
     mockGetPRReviewThreads.mockResolvedValueOnce({ "src/a.ts": 2 });
 
@@ -400,7 +400,7 @@ describe("registerReviewDecorationProvider", () => {
     (host.getWorktrees as ReturnType<typeof vi.fn>).mockResolvedValue([
       makeWorktree("/some/path", 42),
     ]);
-    registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
+    await registerReviewDecorationProvider(host, makeForgeProvider({ withBuildPRFileUrl: true }));
     mockGetPRReviewThreads.mockResolvedValueOnce({ "src/a.ts": 1 });
 
     const result = await getProvider().provideDecorations("worktree-diff:/some/path", ["src/a.ts"]);

--- a/plugins/builtin/github/main/index.ts
+++ b/plugins/builtin/github/main/index.ts
@@ -112,9 +112,9 @@ async function syncCredentialsToWorkspaceHosts(): Promise<void> {
  * `plugin.json`. The descriptor ids MUST match the manifest contributions or
  * the host throws. Returns a disposer that tears down both.
  */
-export function activate(host: PluginHostApi): () => void {
+export async function activate(host: PluginHostApi): Promise<() => void> {
   initializeTokenStorage();
-  const disposeForge = host.registerForgeProvider({ id: "github" }, githubForgeProvider);
+  const disposeForge = await host.registerForgeProvider({ id: "github" }, githubForgeProvider);
   validateStoredTokenInBackground();
   void syncCredentialsToWorkspaceHosts();
   // Pass the registered forge provider so the decoration hook can author
@@ -122,7 +122,7 @@ export function activate(host: PluginHostApi): () => void {
   // would inject its own equivalent). The provider instance is the same
   // object the host holds — sharing the reference keeps the capability
   // check a single source of truth.
-  const disposeDecorations = registerReviewDecorationProvider(host, githubForgeProvider);
+  const disposeDecorations = await registerReviewDecorationProvider(host, githubForgeProvider);
   // Periodic sweep of the data caches' expired entries (lazy get()-time
   // eviction can pin entries that stop being read). Cleared on deactivation.
   startCacheSweep();

--- a/plugins/builtin/github/main/reviewDecorationProvider.ts
+++ b/plugins/builtin/github/main/reviewDecorationProvider.ts
@@ -93,10 +93,10 @@ export function createReviewDecorationProvider(
  * affected scopes so an open Review Hub re-pulls when PR linkage changes.
  * Returns a disposer covering both.
  */
-export function registerReviewDecorationProvider(
+export async function registerReviewDecorationProvider(
   host: PluginHostApi,
   provider: ForgeProviderImpl
-): () => void {
+): Promise<() => void> {
   // Linkage cache (null until the first snapshots event seeds it) doubles as
   // the previous-state baseline for diffing. Invalidations fire only when a
   // scope's PR linkage changes (added / removed / renumbered / repo moved) or
@@ -116,7 +116,7 @@ export function registerReviewDecorationProvider(
     return `${ref.owner}/${ref.repo}#${ref.number}`;
   };
 
-  const disposeProvider = host.registerFileDecorationProvider(
+  const disposeProvider = await host.registerFileDecorationProvider(
     { id: "worktree-diff-review" },
     createReviewDecorationProvider(host, provider, (worktreePath) =>
       linkedByPath === null ? undefined : (linkedByPath.get(worktreePath) ?? null)
@@ -125,7 +125,7 @@ export function registerReviewDecorationProvider(
 
   // `onDidChangeWorktrees` fires after `activate()` resolves; that is exactly
   // why `invalidateFileDecorations` is not revoke-guarded on the host side.
-  const disposeWatch = host.onDidChangeWorktrees((snapshots) => {
+  const disposeWatch = await host.onDidChangeWorktrees((snapshots) => {
     const previous = linkedByPath;
     const next = new Map<string, PluginWorktreeLinked | null>();
     for (const wt of snapshots) next.set(wt.path, wt.linked);
@@ -141,13 +141,14 @@ export function registerReviewDecorationProvider(
       const fresh = now - (lastInvalidatedAt.get(wt.path) ?? 0) < REVIEW_THREADS_TTL_MS;
       if (unchanged && fresh && !cachesCleared) continue;
       lastInvalidatedAt.set(wt.path, now);
-      host.invalidateFileDecorations(`${SCOPE_PREFIX}${wt.path}`);
+      // Fire-and-forget: this runs from a post-activation subscription callback.
+      void host.invalidateFileDecorations(`${SCOPE_PREFIX}${wt.path}`);
     }
     if (previous !== null) {
       for (const [path, linked] of previous) {
         if (prKey(linked) !== undefined && prKey(next.get(path)) === undefined) {
           lastInvalidatedAt.delete(path);
-          host.invalidateFileDecorations(`${SCOPE_PREFIX}${path}`);
+          void host.invalidateFileDecorations(`${SCOPE_PREFIX}${path}`);
         }
       }
     }

--- a/plugins/sample/hello-daintree/main/index.ts
+++ b/plugins/sample/hello-daintree/main/index.ts
@@ -12,7 +12,7 @@ import type { PluginHostApi, PluginIpcContext } from "../../../../shared/types/p
  */
 export async function activate(host: PluginHostApi): Promise<() => void> {
   // IPC handler the renderer reaches over `plugin:daintree.hello:ping`.
-  host.registerHandler("ping", (ctx: PluginIpcContext) => ({
+  await host.registerHandler("ping", (ctx: PluginIpcContext) => ({
     pluginId: host.pluginId,
     worktreeId: ctx.worktreeId,
   }));
@@ -20,7 +20,7 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
   // Imperatively-registered action. The host namespaces this to
   // `daintree.hello.greet`; dispatching it surfaces a toast so the E2E spec
   // can assert the full register → dispatch → showToast loop.
-  host.registerAction(
+  await host.registerAction(
     {
       id: "greet",
       title: "Hello: Greet",
@@ -44,10 +44,10 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
   // live value through an IPC handler so the E2E spec can read it back.
   let greeting = (await safeGet(host, "greeting")) ?? "world";
   void host.settings.set("greeting", greeting).catch(() => {});
-  const disposeGreetingSub = host.settings.onDidChange<string>("greeting", (next) => {
+  const disposeGreetingSub = await host.settings.onDidChange<string>("greeting", (next) => {
     greeting = next ?? "world";
   });
-  host.registerHandler("getGreeting", () => greeting);
+  await host.registerHandler("getGreeting", () => greeting);
 
   // Activation-time toast — observable in the notification inbox so the E2E
   // spec gets a durable signal without racing the toast dismiss timer.
@@ -58,7 +58,7 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
   });
 
   // Badge every requested path with an "H" — the simplest honest decoration.
-  const disposeDecorations = host.registerFileDecorationProvider(
+  const disposeDecorations = await host.registerFileDecorationProvider(
     { id: "hello" },
     {
       provideDecorations: async (_scope, paths) => {
@@ -72,8 +72,8 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
   );
 
   // When the active worktree changes, ask the host to re-pull our decorations.
-  const disposeWorktree = host.onDidChangeActiveWorktree(() => {
-    host.invalidateFileDecorations("hello:active");
+  const disposeWorktree = await host.onDidChangeActiveWorktree(() => {
+    void host.invalidateFileDecorations("hello:active");
   });
 
   return () => {

--- a/plugins/sample/rich-daintree/main/index.ts
+++ b/plugins/sample/rich-daintree/main/index.ts
@@ -16,7 +16,7 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
   // Sentinel the E2E harness polls for: the host namespaces this to
   // `daintree.rich.ready`, so `waitForRichPluginReady` knows activation ran.
   // The host unregisters plugin actions automatically on unload.
-  host.registerAction(
+  await host.registerAction(
     {
       id: "ready",
       title: "Rich: Ready",

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -32,10 +32,10 @@ describe("createMockHost", () => {
     expect(host.pluginId).toBe("test.mock");
   });
 
-  it("records registerAction calls", () => {
+  it("records registerAction calls", async () => {
     const host = createMockHost();
     const handler = vi.fn();
-    host.registerAction(sampleAction, handler);
+    await host.registerAction(sampleAction, handler);
     expect(host.registeredActions).toHaveLength(1);
     expect(host.registeredActions[0]?.descriptor).toEqual(sampleAction);
     expect(host.registeredActions[0]?.handler).toBe(handler);
@@ -45,8 +45,8 @@ describe("createMockHost", () => {
     const host = createMockHost({ pluginId: "daintree.hello" });
     const h1 = vi.fn(async () => "v1");
     const h2 = vi.fn(async () => "v2");
-    host.registerAction(sampleAction, h1);
-    host.registerAction(sampleAction, h2);
+    await host.registerAction(sampleAction, h1);
+    await host.registerAction(sampleAction, h2);
     expect(host.registeredActions).toHaveLength(1);
     expect(host.registeredActions[0]?.handler).toBe(h2);
     const result = await host.dispatch("daintree.hello.greet");
@@ -226,17 +226,17 @@ describe("createMockHost", () => {
     });
   });
 
-  it("records registerHandler calls", () => {
+  it("records registerHandler calls", async () => {
     const host = createMockHost();
     const handler = vi.fn();
-    host.registerHandler("ping", handler);
+    await host.registerHandler("ping", handler);
     expect(host.registeredHandlers).toHaveLength(1);
     expect(host.registeredHandlers[0]).toEqual({ channel: "ping", handler });
   });
 
-  it("records broadcastToRenderer calls", () => {
+  it("records broadcastToRenderer calls", async () => {
     const host = createMockHost();
-    host.broadcastToRenderer("evt", { foo: 1 });
+    await host.broadcastToRenderer("evt", { foo: 1 });
     expect(host.broadcastCalls).toEqual([{ channel: "evt", payload: { foo: 1 } }]);
   });
 
@@ -247,10 +247,10 @@ describe("createMockHost", () => {
     await expect(host.showToast({ message: "" })).rejects.toThrow(/non-empty/);
   });
 
-  it("records invalidateFileDecorations calls", () => {
+  it("records invalidateFileDecorations calls", async () => {
     const host = createMockHost();
-    host.invalidateFileDecorations("hello:*");
-    host.invalidateFileDecorations("hello:active", ["/a", "/b"]);
+    await host.invalidateFileDecorations("hello:*");
+    await host.invalidateFileDecorations("hello:active", ["/a", "/b"]);
     expect(host.invalidationCalls).toEqual([
       { scope: "hello:*", paths: undefined },
       { scope: "hello:active", paths: ["/a", "/b"] },
@@ -266,10 +266,10 @@ describe("createMockHost", () => {
     expect(await host.getWorktrees()).toEqual([sampleSnapshot]);
   });
 
-  it("delivers active-worktree updates and supports idempotent disposal", () => {
+  it("delivers active-worktree updates and supports idempotent disposal", async () => {
     const host = createMockHost();
     const cb = vi.fn();
-    const dispose = host.onDidChangeActiveWorktree(cb);
+    const dispose = await host.onDidChangeActiveWorktree(cb);
     host.simulateActiveWorktreeChange(sampleSnapshot);
     host.simulateActiveWorktreeChange(null);
     expect(cb).toHaveBeenCalledTimes(2);
@@ -279,27 +279,27 @@ describe("createMockHost", () => {
     expect(cb).toHaveBeenCalledTimes(2);
   });
 
-  it("delivers worktree-set updates", () => {
+  it("delivers worktree-set updates", async () => {
     const host = createMockHost();
     const cb = vi.fn();
-    host.onDidChangeWorktrees(cb);
+    await host.onDidChangeWorktrees(cb);
     host.simulateWorktreesChange([sampleSnapshot]);
     expect(cb).toHaveBeenCalledWith([sampleSnapshot]);
   });
 
-  it("registers forge providers and unregisters via disposer", () => {
+  it("registers forge providers and unregisters via disposer", async () => {
     const host = createMockHost();
     const impl = { parseRemote: vi.fn() } as unknown as Parameters<
       typeof host.registerForgeProvider
     >[1];
-    const dispose = host.registerForgeProvider({ id: "ghe" }, impl);
+    const dispose = await host.registerForgeProvider({ id: "ghe" }, impl);
     expect(host.registeredForgeProviders).toHaveLength(1);
     dispose();
     expect(host.registeredForgeProviders).toHaveLength(0);
   });
 
   describe("registerForgeProvider", () => {
-    it("replaces a prior registration with the same id (replace-by-id)", () => {
+    it("replaces a prior registration with the same id (replace-by-id)", async () => {
       const host = createMockHost();
       const impl1 = { parseRemote: vi.fn() } as unknown as Parameters<
         typeof host.registerForgeProvider
@@ -307,13 +307,13 @@ describe("createMockHost", () => {
       const impl2 = { parseRemote: vi.fn() } as unknown as Parameters<
         typeof host.registerForgeProvider
       >[1];
-      host.registerForgeProvider({ id: "ghe" }, impl1);
-      host.registerForgeProvider({ id: "ghe" }, impl2);
+      await host.registerForgeProvider({ id: "ghe" }, impl1);
+      await host.registerForgeProvider({ id: "ghe" }, impl2);
       expect(host.registeredForgeProviders).toHaveLength(1);
       expect(host.registeredForgeProviders[0]?.impl).toBe(impl2);
     });
 
-    it("makes the prior disposer inert when the id is re-registered with a different impl", () => {
+    it("makes the prior disposer inert when the id is re-registered with a different impl", async () => {
       // Matches `unregisterForgeProviderImpl(pluginId, contributionId, expected)`
       // semantics: a stale disposer (captured against the first impl) must not
       // remove the second impl that has overwritten the slot.
@@ -324,8 +324,8 @@ describe("createMockHost", () => {
       const impl2 = { parseRemote: vi.fn() } as unknown as Parameters<
         typeof host.registerForgeProvider
       >[1];
-      const dispose1 = host.registerForgeProvider({ id: "ghe" }, impl1);
-      const dispose2 = host.registerForgeProvider({ id: "ghe" }, impl2);
+      const dispose1 = await host.registerForgeProvider({ id: "ghe" }, impl1);
+      const dispose2 = await host.registerForgeProvider({ id: "ghe" }, impl2);
       dispose1(); // stale — should no-op
       expect(host.registeredForgeProviders).toHaveLength(1);
       expect(host.registeredForgeProviders[0]?.impl).toBe(impl2);
@@ -333,7 +333,7 @@ describe("createMockHost", () => {
       expect(host.registeredForgeProviders).toHaveLength(0);
     });
 
-    it("removes the active entry when the same impl is re-registered and the prior disposer fires", () => {
+    it("removes the active entry when the same impl is re-registered and the prior disposer fires", async () => {
       // Pinned case: if the second registration passes the same impl, the
       // identity guard's `currentImpl === capturedImpl` check matches and the
       // prior disposer does remove. This mirrors the production
@@ -342,8 +342,8 @@ describe("createMockHost", () => {
       const impl = { parseRemote: vi.fn() } as unknown as Parameters<
         typeof host.registerForgeProvider
       >[1];
-      const dispose1 = host.registerForgeProvider({ id: "ghe" }, impl);
-      const dispose2 = host.registerForgeProvider({ id: "ghe" }, impl);
+      const dispose1 = await host.registerForgeProvider({ id: "ghe" }, impl);
+      const dispose2 = await host.registerForgeProvider({ id: "ghe" }, impl);
       expect(host.registeredForgeProviders).toHaveLength(1);
       dispose1();
       expect(host.registeredForgeProviders).toHaveLength(0);
@@ -353,12 +353,12 @@ describe("createMockHost", () => {
       expect(host.registeredForgeProviders).toHaveLength(0);
     });
 
-    it("disposer is idempotent (calling twice is a no-op)", () => {
+    it("disposer is idempotent (calling twice is a no-op)", async () => {
       const host = createMockHost();
       const impl = { parseRemote: vi.fn() } as unknown as Parameters<
         typeof host.registerForgeProvider
       >[1];
-      const dispose = host.registerForgeProvider({ id: "ghe" }, impl);
+      const dispose = await host.registerForgeProvider({ id: "ghe" }, impl);
       dispose();
       dispose();
       expect(host.registeredForgeProviders).toHaveLength(0);
@@ -413,32 +413,32 @@ describe("createMockHost", () => {
     });
   });
 
-  it("registers file-decoration providers and unregisters via disposer", () => {
+  it("registers file-decoration providers and unregisters via disposer", async () => {
     const host = createMockHost();
     const impl = { provideDecorations: vi.fn(async () => ({})) };
-    const dispose = host.registerFileDecorationProvider({ id: "hello" }, impl);
+    const dispose = await host.registerFileDecorationProvider({ id: "hello" }, impl);
     expect(host.registeredFileDecorationProviders).toHaveLength(1);
     dispose();
     expect(host.registeredFileDecorationProviders).toHaveLength(0);
   });
 
   describe("registerFileDecorationProvider", () => {
-    it("replaces a prior registration with the same id (replace-by-id)", () => {
+    it("replaces a prior registration with the same id (replace-by-id)", async () => {
       const host = createMockHost();
       const impl1 = { provideDecorations: vi.fn(async () => ({})) };
       const impl2 = { provideDecorations: vi.fn(async () => ({})) };
-      host.registerFileDecorationProvider({ id: "hello" }, impl1);
-      host.registerFileDecorationProvider({ id: "hello" }, impl2);
+      await host.registerFileDecorationProvider({ id: "hello" }, impl1);
+      await host.registerFileDecorationProvider({ id: "hello" }, impl2);
       expect(host.registeredFileDecorationProviders).toHaveLength(1);
       expect(host.registeredFileDecorationProviders[0]?.impl).toBe(impl2);
     });
 
-    it("makes the prior disposer inert when the id is re-registered with a different impl", () => {
+    it("makes the prior disposer inert when the id is re-registered with a different impl", async () => {
       const host = createMockHost();
       const impl1 = { provideDecorations: vi.fn(async () => ({})) };
       const impl2 = { provideDecorations: vi.fn(async () => ({})) };
-      const dispose1 = host.registerFileDecorationProvider({ id: "hello" }, impl1);
-      const dispose2 = host.registerFileDecorationProvider({ id: "hello" }, impl2);
+      const dispose1 = await host.registerFileDecorationProvider({ id: "hello" }, impl1);
+      const dispose2 = await host.registerFileDecorationProvider({ id: "hello" }, impl2);
       dispose1(); // stale — should no-op
       expect(host.registeredFileDecorationProviders).toHaveLength(1);
       expect(host.registeredFileDecorationProviders[0]?.impl).toBe(impl2);
@@ -446,11 +446,11 @@ describe("createMockHost", () => {
       expect(host.registeredFileDecorationProviders).toHaveLength(0);
     });
 
-    it("removes the active entry when the same impl is re-registered and the prior disposer fires", () => {
+    it("removes the active entry when the same impl is re-registered and the prior disposer fires", async () => {
       const host = createMockHost();
       const impl = { provideDecorations: vi.fn(async () => ({})) };
-      const dispose1 = host.registerFileDecorationProvider({ id: "hello" }, impl);
-      const dispose2 = host.registerFileDecorationProvider({ id: "hello" }, impl);
+      const dispose1 = await host.registerFileDecorationProvider({ id: "hello" }, impl);
+      const dispose2 = await host.registerFileDecorationProvider({ id: "hello" }, impl);
       expect(host.registeredFileDecorationProviders).toHaveLength(1);
       dispose1();
       expect(host.registeredFileDecorationProviders).toHaveLength(0);
@@ -459,10 +459,10 @@ describe("createMockHost", () => {
       expect(host.registeredFileDecorationProviders).toHaveLength(0);
     });
 
-    it("disposer is idempotent (calling twice is a no-op)", () => {
+    it("disposer is idempotent (calling twice is a no-op)", async () => {
       const host = createMockHost();
       const impl = { provideDecorations: vi.fn(async () => ({})) };
-      const dispose = host.registerFileDecorationProvider({ id: "hello" }, impl);
+      const dispose = await host.registerFileDecorationProvider({ id: "hello" }, impl);
       dispose();
       dispose();
       expect(host.registeredFileDecorationProviders).toHaveLength(0);
@@ -538,7 +538,7 @@ describe("createMockHost", () => {
     it("fires onDidChange only on value changes and respects disposal", async () => {
       const host = createMockHost();
       const cb = vi.fn();
-      const dispose = host.settings.onDidChange<string>("k", cb);
+      const dispose = await host.settings.onDidChange<string>("k", cb);
       await host.settings.set("k", "v1");
       await host.settings.set("k", "v1"); // unchanged → no fire
       await host.settings.set("k", "v2");
@@ -554,8 +554,8 @@ describe("createMockHost", () => {
       const host = createMockHost();
       const user = vi.fn();
       const project = vi.fn();
-      host.settings.onDidChange("k", user, "user");
-      host.settings.onDidChange("k", project, "project");
+      await host.settings.onDidChange("k", user, "user");
+      await host.settings.onDidChange("k", project, "project");
       await host.settings.set("k", "uv", "user");
       await host.settings.set("k", "pv", "project");
       expect(user).toHaveBeenCalledWith("uv");
@@ -567,7 +567,7 @@ describe("createMockHost", () => {
   describe("dispatch", () => {
     it("routes through registered action handler and records the call", async () => {
       const host = createMockHost({ pluginId: "daintree.hello" });
-      host.registerAction(sampleAction, async (args) => ({ echoed: args }));
+      await host.registerAction(sampleAction, async (args) => ({ echoed: args }));
       const result = await host.dispatch("daintree.hello.greet", { name: "ada" });
       expect(host.dispatchedActions).toEqual([
         { actionId: "daintree.hello.greet", args: { name: "ada" } },
@@ -586,7 +586,7 @@ describe("createMockHost", () => {
 
     it("requires the plugin-id prefix when the host has one bound", async () => {
       const host = createMockHost({ pluginId: "daintree.hello" });
-      host.registerAction(sampleAction, async () => "ok");
+      await host.registerAction(sampleAction, async () => "ok");
       // Real host receives the fully-namespaced id; an unprefixed local id is
       // not a valid built-in action and must not silently resolve.
       const result = await host.dispatch("greet");
@@ -595,7 +595,7 @@ describe("createMockHost", () => {
 
     it("returns EXECUTION_ERROR when the handler throws", async () => {
       const host = createMockHost();
-      host.registerAction(sampleAction, async () => {
+      await host.registerAction(sampleAction, async () => {
         throw new Error("boom");
       });
       const result = await host.dispatch("test.mock.greet");

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -217,7 +217,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       key: string,
       callback: (value: T | undefined) => void,
       scope: PluginSettingsScope = "user"
-    ): () => void {
+    ): Promise<() => void> {
       let subs = settingsSubs[scope].get(key);
       if (!subs) {
         subs = new Set();
@@ -226,7 +226,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       const cb = callback as (value: unknown) => void;
       subs.add(cb);
       let disposed = false;
-      return () => {
+      const dispose = () => {
         if (disposed) return;
         disposed = true;
         const set = settingsSubs[scope].get(key);
@@ -235,6 +235,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
           if (set.size === 0) settingsSubs[scope].delete(key);
         }
       };
+      return Promise.resolve(dispose);
     },
   };
 
@@ -304,12 +305,15 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       } else {
         registeredActions.push({ descriptor, handler });
       }
+      // Validation/registry mutation runs synchronously above (sync throws still
+      // surface at the call site); only the return value is a resolved promise.
+      return Promise.resolve();
     },
     registerHandler<TArgs = unknown, TResult = unknown>(
       channel: string,
       schemaOrHandler: PluginChannelSchema<TArgs, TResult> | PluginIpcHandler,
       handler?: PluginTypedIpcHandler<TArgs, TResult>
-    ) {
+    ): Promise<void> {
       // Handle both overloads:
       // 1. registerHandler(channel, schema, handler) — typed
       // 2. registerHandler(channel, handler) — untyped
@@ -328,12 +332,15 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
           handler: schemaOrHandler as PluginIpcHandler,
         });
       }
+      return Promise.resolve();
     },
     broadcastToRenderer(channel, payload) {
       broadcastCalls.push({ channel, payload });
+      return Promise.resolve();
     },
     postToPanel(channel, payload) {
       postToPanelCalls.push({ channel, payload });
+      return Promise.resolve();
     },
     async getActiveWorktree() {
       return activeWorktree;
@@ -341,7 +348,8 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     async getWorktrees() {
       return worktrees;
     },
-    async getWorktreeStatus(path) {
+    async getWorktreeStatus(path, options) {
+      options?.signal?.throwIfAborted();
       const match =
         worktrees.find((w) => w.path === path) ??
         (activeWorktree?.path === path ? activeWorktree : null);
@@ -350,20 +358,25 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     onDidChangeActiveWorktree(callback) {
       activeWorktreeSubs.add(callback);
       let disposed = false;
-      return () => {
+      const dispose = () => {
         if (disposed) return;
         disposed = true;
         activeWorktreeSubs.delete(callback);
       };
+      return Promise.resolve(dispose);
     },
-    onDidChangeWorktrees(callback) {
+    onDidChangeWorktrees(callback, _options) {
+      // The mock ignores `debounceMs` — coalescing is a host-side concern and is
+      // unit-tested against PluginService directly; activation tests just need
+      // the subscription wired.
       worktreesSubs.add(callback);
       let disposed = false;
-      return () => {
+      const dispose = () => {
         if (disposed) return;
         disposed = true;
         worktreesSubs.delete(callback);
       };
+      return Promise.resolve(dispose);
     },
     registerForgeProvider(descriptor, impl) {
       // Mirrors PluginService.createHost L1738-L1817. Validation order matches
@@ -393,7 +406,9 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         registeredForgeProviders.push({ descriptor, impl });
       }
       let disposed = false;
-      return () => {
+      // Disposer captured synchronously (registry mutation already done above) —
+      // only the return value is a resolved promise, never a deferred write.
+      const dispose = () => {
         if (disposed) return;
         disposed = true;
         // Identity guard: only remove if the currently active entry is still
@@ -404,6 +419,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         );
         if (i >= 0) registeredForgeProviders.splice(i, 1);
       };
+      return Promise.resolve(dispose);
     },
     registerFileDecorationProvider(descriptor, impl) {
       // Mirrors PluginService.createHost L1818-L1875. Validation order matches
@@ -432,7 +448,8 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         registeredFileDecorationProviders.push({ descriptor, impl });
       }
       let disposed = false;
-      return () => {
+      // Disposer captured synchronously (registry mutation already done above).
+      const dispose = () => {
         if (disposed) return;
         disposed = true;
         // Identity guard: only remove if the currently active entry is still
@@ -443,9 +460,11 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         );
         if (i >= 0) registeredFileDecorationProviders.splice(i, 1);
       };
+      return Promise.resolve(dispose);
     },
     invalidateFileDecorations(scope, paths) {
       invalidationCalls.push({ scope, paths });
+      return Promise.resolve();
     },
     async showToast(opts: PluginToastOptions) {
       if (!opts.message) {
@@ -509,7 +528,8 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     // (containment lives in pluginFsContainment and is unit-tested directly) —
     // this mock is for exercising a plugin's activate()/handlers, not the guard.
     fs: {
-      async readFile(filePath) {
+      async readFile(filePath, options) {
+        options?.signal?.throwIfAborted();
         const v = fsFiles.get(filePath);
         if (v === undefined) {
           throw new Error(`ENOENT: mock fs has no file "${filePath}"`);
@@ -520,10 +540,12 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         fsFiles.set(filePath, contents);
         fsWriteCalls.push({ path: filePath, contents });
       },
-      async readdir() {
+      async readdir(_dirPath, options) {
+        options?.signal?.throwIfAborted();
         return [];
       },
-      async stat(targetPath) {
+      async stat(targetPath, options) {
+        options?.signal?.throwIfAborted();
         return {
           isDirectory: false,
           isFile: fsFiles.has(targetPath),
@@ -532,7 +554,8 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
           mtimeMs: 0,
         };
       },
-      async watch() {
+      async watch(_paths, _callback, options) {
+        options?.signal?.throwIfAborted();
         return () => {};
       },
     },
@@ -540,14 +563,19 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     // message rejects — so a plugin tested against the mock sees the same
     // no-silent-fallback contract as production.
     git: {
-      async status(worktreePath) {
+      async status(worktreePath, options) {
+        options?.signal?.throwIfAborted();
         return { worktreePath, files: [], changedFileCount: 0 };
       },
-      async diff() {
+      async diff(_worktreePath, _filePath, options) {
+        options?.signal?.throwIfAborted();
         return "";
       },
-      async add() {},
-      async commit(worktreePath, options): Promise<PluginGitCommitResult> {
+      async add(_worktreePath, _paths, options) {
+        options?.signal?.throwIfAborted();
+      },
+      async commit(worktreePath, options, callOptions): Promise<PluginGitCommitResult> {
+        callOptions?.signal?.throwIfAborted();
         const message = typeof options?.message === "string" ? options.message : "";
         if (message.trim().length === 0) {
           throw new Error(

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -3,6 +3,7 @@ import type {
   PluginManifest,
   PluginHostApi,
   PluginActivationApi,
+  PluginHostCallOptions,
   PluginActivate,
   PanelContribution,
   ToolbarButtonContribution,
@@ -189,7 +190,7 @@ describe("plugin-sdk boundary", () => {
     it("PluginHostApi.getWorktreeStatus takes a path and returns the status projection or null", () => {
       const host = {} as PluginHostApi;
       expectTypeOf(host.getWorktreeStatus).toEqualTypeOf<
-        (path: string) => Promise<PluginWorktreeStatus | null>
+        (path: string, options?: PluginHostCallOptions) => Promise<PluginWorktreeStatus | null>
       >();
     });
 
@@ -211,10 +212,12 @@ describe("plugin-sdk boundary", () => {
       // activation-window op), so they belong on the slice.
       expectTypeOf(activation.onDidChangeActiveWorktree).toBeFunction();
       expectTypeOf(activation.onDidChangeWorktrees).toBeFunction();
-      // The provider registrars hand back a disposer — guard the return type so
-      // a signature regression to `void` is caught.
-      expectTypeOf(activation.registerForgeProvider).returns.toEqualTypeOf<() => void>();
-      expectTypeOf(activation.registerFileDecorationProvider).returns.toEqualTypeOf<() => void>();
+      // The provider registrars resolve to a disposer — guard the return type so
+      // a signature regression (to `void`, or to a non-promise disposer) is caught.
+      expectTypeOf(activation.registerForgeProvider).returns.toEqualTypeOf<Promise<() => void>>();
+      expectTypeOf(activation.registerFileDecorationProvider).returns.toEqualTypeOf<
+        Promise<() => void>
+      >();
     });
 
     it("PluginActivationApi excludes the post-activation-safe methods", () => {

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -52,6 +52,8 @@ export type {
   PluginActivate,
   PluginHostApi,
   PluginActivationApi,
+  PluginHostCallOptions,
+  PluginHostSubscriptionOptions,
   ActionHandler,
   PluginToastOptions,
   PluginLogger,

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1137,11 +1137,7 @@ export interface PluginGitApi {
    * Unified diff for the worktree (or one `filePath` relative to it). Returns
    * the raw diff text. Gated on `git:read`. Pass `options.signal` to cancel.
    */
-  diff(
-    worktreePath: string,
-    filePath?: string,
-    options?: PluginHostCallOptions
-  ): Promise<string>;
+  diff(worktreePath: string, filePath?: string, options?: PluginHostCallOptions): Promise<string>;
   /**
    * Stage paths (relative to `worktreePath`, or all changes when omitted).
    * Gated on `git:write`. Recorded in the audit trail. Pass `options.signal` to cancel.

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -468,6 +468,32 @@ export type PluginSecretStorageTier = "keychain" | "plaintext";
  * call time, so it tracks project switches: `get` returns `undefined` and `set`
  * throws when no project is active.
  */
+/**
+ * Options accepted by long-running host calls (filesystem reads/writes, git
+ * reads and mutations, the on-demand worktree-status accessor). Carries an
+ * optional {@link AbortSignal} so a plugin can cancel a call it no longer needs
+ * — e.g. when a panel the read was feeding has unmounted. An already-aborted
+ * signal rejects the call before any I/O; aborting mid-flight rejects with the
+ * signal's reason. Always the trailing argument so it never collides with a
+ * method's positional parameters.
+ */
+export interface PluginHostCallOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * Options accepted by high-frequency event subscriptions (today
+ * {@link PluginActivationApi.onDidChangeWorktrees}). `debounceMs` coalesces a
+ * burst of change events into a single trailing callback fired `debounceMs`
+ * after the last event — the host re-emits the worktree set on every git-status
+ * poll, so a UI-updating plugin can opt into far fewer callbacks. Values below a
+ * small floor (~50ms) are clamped up; `0` / omitted means no debounce (fire on
+ * every change). The coalesced callback receives the most recent snapshot list.
+ */
+export interface PluginHostSubscriptionOptions {
+  debounceMs?: number;
+}
+
 export interface SettingsApi {
   /**
    * Read a setting. Resolves to `undefined` when the key is unset, or (for
@@ -485,17 +511,17 @@ export interface SettingsApi {
    * callback fires with the new value after each `set` that changes it. Edits
    * made to the JSON file by other processes do NOT fire until the plugin
    * reloads. Must be called during `activate()` — subscribing is revoke-guarded.
-   * Returns a disposer; calling it more than once is a no-op. All subscriptions
-   * are automatically disposed when the plugin is unloaded.
+   * Resolves to a disposer; calling it more than once is a no-op. All
+   * subscriptions are automatically disposed when the plugin is unloaded.
    *
    * @throws {Error} If called after activation resolves or times out — the host
-   *   is revoked and the subscription is rejected.
+   *   is revoked and the subscription is rejected (the promise rejects).
    */
   onDidChange<T = unknown>(
     key: string,
     callback: (value: T | undefined) => void,
     scope?: PluginSettingsScope
-  ): () => void;
+  ): Promise<() => void>;
 }
 
 export type PluginInstallSource = "builtin" | "sideload" | "url" | "catalog";
@@ -1018,28 +1044,35 @@ export interface PluginFsStat {
 export interface PluginFsApi {
   /**
    * Read a file as UTF-8 text. Resolves the contained absolute path; rejects on
-   * a missing read capability, an out-of-scope path, or a non-file target.
+   * a missing read capability, an out-of-scope path, or a non-file target. Pass
+   * `options.signal` to cancel a read that is no longer needed.
    */
-  readFile(filePath: string): Promise<string>;
+  readFile(filePath: string, options?: PluginHostCallOptions): Promise<string>;
   /**
    * Write UTF-8 text to a file, creating it if absent (parent directories must
    * already exist within scope). Rejects on a missing write capability or an
-   * out-of-scope path. Recorded in the audit trail.
+   * out-of-scope path. Recorded in the audit trail. No cancellation signal —
+   * partial-write semantics are deliberately out of scope.
    */
   writeFile(filePath: string, contents: string): Promise<void>;
   /** List a directory's immediate children. Rejects on a missing read capability or an out-of-scope path. */
-  readdir(dirPath: string): Promise<PluginFsDirEntry[]>;
+  readdir(dirPath: string, options?: PluginHostCallOptions): Promise<PluginFsDirEntry[]>;
   /** Stat a path. Rejects on a missing read capability or an out-of-scope path. */
-  stat(targetPath: string): Promise<PluginFsStat>;
+  stat(targetPath: string, options?: PluginHostCallOptions): Promise<PluginFsStat>;
   /**
    * Watch one or more contained paths for changes, invoking `callback` with the
    * changed absolute path. `paths` are each resolved and contained at
    * subscription time; an out-of-scope or missing-capability path rejects.
-   * Returns a disposer that tears the watcher down; all watchers are
-   * automatically torn down on unload. Rejects synchronously (throws) on a
-   * missing read capability so authoring mistakes surface loudly.
+   * Resolves to a disposer that tears the watcher down; all watchers are
+   * automatically torn down on unload. Rejects on a missing read capability so
+   * authoring mistakes surface loudly. Pass `options.signal` to abort the
+   * subscription attempt before it is wired.
    */
-  watch(paths: string[], callback: (changedPath: string) => void): Promise<() => void>;
+  watch(
+    paths: string[],
+    callback: (changedPath: string) => void,
+    options?: PluginHostCallOptions
+  ): Promise<() => void>;
 }
 
 /** A single changed file in {@link PluginGitApi.status}. Mirrors {@link PluginWorktreeStatusFile}. */
@@ -1098,25 +1131,34 @@ export interface PluginGitCommitResult {
  * NOT revoke-guarded — same lifetime/membership semantics as {@link PluginFsApi}.
  */
 export interface PluginGitApi {
-  /** Changed-file status for the worktree. Gated on `git:read`. */
-  status(worktreePath: string): Promise<PluginGitStatus>;
+  /** Changed-file status for the worktree. Gated on `git:read`. Pass `options.signal` to cancel. */
+  status(worktreePath: string, options?: PluginHostCallOptions): Promise<PluginGitStatus>;
   /**
    * Unified diff for the worktree (or one `filePath` relative to it). Returns
-   * the raw diff text. Gated on `git:read`.
+   * the raw diff text. Gated on `git:read`. Pass `options.signal` to cancel.
    */
-  diff(worktreePath: string, filePath?: string): Promise<string>;
+  diff(
+    worktreePath: string,
+    filePath?: string,
+    options?: PluginHostCallOptions
+  ): Promise<string>;
   /**
    * Stage paths (relative to `worktreePath`, or all changes when omitted).
-   * Gated on `git:write`. Recorded in the audit trail.
+   * Gated on `git:write`. Recorded in the audit trail. Pass `options.signal` to cancel.
    */
-  add(worktreePath: string, paths?: string[]): Promise<void>;
+  add(worktreePath: string, paths?: string[], options?: PluginHostCallOptions): Promise<void>;
   /**
    * Commit staged changes. Gated on `git:write`. Refuses without an explicit
    * non-empty {@link PluginGitCommitOptions.message} — no silent fallback (the
    * #7880 guard) — and returns the real staged diff as a change preview.
-   * Recorded in the audit trail.
+   * Recorded in the audit trail. Pass `callOptions.signal` to cancel before the
+   * commit is created.
    */
-  commit(worktreePath: string, options: PluginGitCommitOptions): Promise<PluginGitCommitResult>;
+  commit(
+    worktreePath: string,
+    options: PluginGitCommitOptions,
+    callOptions?: PluginHostCallOptions
+  ): Promise<PluginGitCommitResult>;
 }
 
 /**
@@ -1152,10 +1194,14 @@ export interface PluginActivationApi {
    * handler. Must be called during `activate()` — the host is revoked once
    * activation resolves or times out. Unregistered automatically on unload.
    *
+   * Resolves once the registration is accepted. The revoke / validation guard
+   * still throws synchronously, so a rejected registration surfaces both as a
+   * synchronous throw at the call site and is reflected by the promise.
+   *
    * @throws {Error} If called after activation resolves or times out — the host
    *   is revoked and registration is rejected.
    */
-  registerAction(descriptor: PluginActionContribution, handler: ActionHandler): void;
+  registerAction(descriptor: PluginActionContribution, handler: ActionHandler): Promise<void>;
   /**
    * Bind a typed IPC handler whose args and result are validated against the
    * provided Zod schemas, gated on the listed plugin capabilities. The host
@@ -1176,14 +1222,14 @@ export interface PluginActivationApi {
     channel: string,
     schema: PluginChannelSchema<TArgs, TResult>,
     handler: PluginTypedIpcHandler<TArgs, TResult>
-  ): void;
+  ): Promise<void>;
   /**
    * Legacy untyped overload: a variadic handler with no host-side validation.
    * Retained for plugins that haven't migrated to per-channel schemas. The
    * typed overload above is preferred for new code. Also revoke-guarded — must
    * be called during `activate()`.
    */
-  registerHandler(channel: string, handler: PluginIpcHandler): void;
+  registerHandler(channel: string, handler: PluginIpcHandler): Promise<void>;
   /**
    * Push a fire-and-forget payload to all renderers listening on `channel`.
    * Intended for the activation window — wiring up the renderer-side view of a
@@ -1192,7 +1238,7 @@ export interface PluginActivationApi {
    * @throws {Error} If called after activation resolves or times out — the host
    *   is revoked and the broadcast is rejected.
    */
-  broadcastToRenderer(channel: string, payload: unknown): void;
+  broadcastToRenderer(channel: string, payload: unknown): Promise<void>;
   /**
    * Bind a runtime {@link ForgeProviderImpl} to the descriptor declared in
    * `contributes.forgeProviders`. The descriptor's `id` is namespaced to the
@@ -1211,7 +1257,10 @@ export interface PluginActivationApi {
    * @throws {Error} If called after activation resolves or times out — the host
    *   is revoked and registration is rejected.
    */
-  registerForgeProvider(descriptor: ForgeProviderDescriptor, impl: ForgeProviderImpl): () => void;
+  registerForgeProvider(
+    descriptor: ForgeProviderDescriptor,
+    impl: ForgeProviderImpl
+  ): Promise<() => void>;
   /**
    * Bind a runtime {@link FileDecorationProviderImpl} to a descriptor declared
    * in `contributes.fileDecorationProviders`. The descriptor's `id` is
@@ -1230,7 +1279,7 @@ export interface PluginActivationApi {
   registerFileDecorationProvider(
     descriptor: FileDecorationProviderDescriptor,
     impl: FileDecorationProviderImpl
-  ): () => void;
+  ): Promise<() => void>;
   /**
    * Subscribe to active-worktree changes. The callback fires with the new
    * active snapshot (or `null` when none is active). Returns a disposer;
@@ -1246,12 +1295,16 @@ export interface PluginActivationApi {
    */
   onDidChangeActiveWorktree(
     callback: (snapshot: PluginWorktreeSnapshot | null) => void
-  ): () => void;
+  ): Promise<() => void>;
   /**
    * Subscribe to the worktree set changing. The callback fires with the full
-   * current list on any worktree add/update/remove. Returns a disposer;
+   * current list on any worktree add/update/remove. Resolves to a disposer;
    * calling it more than once is a no-op. All subscriptions are automatically
    * disposed when the plugin is unloaded.
+   *
+   * Pass `options.debounceMs` to coalesce bursts (the host re-emits on every
+   * git-status poll) into a single trailing callback — see
+   * {@link PluginHostSubscriptionOptions}. Omitted means fire on every change.
    *
    * Subscribing is revoke-guarded — call it during `activate()`. The callback
    * itself fires for the plugin's whole lifetime; only the act of subscribing
@@ -1260,7 +1313,10 @@ export interface PluginActivationApi {
    * @throws {Error} If called after activation resolves or times out — the host
    *   is revoked and the subscription is rejected.
    */
-  onDidChangeWorktrees(callback: (snapshots: PluginWorktreeSnapshot[]) => void): () => void;
+  onDidChangeWorktrees(
+    callback: (snapshots: PluginWorktreeSnapshot[]) => void,
+    options?: PluginHostSubscriptionOptions
+  ): Promise<() => void>;
 }
 
 /**
@@ -1288,7 +1344,7 @@ export interface PluginHostApi extends PluginActivationApi {
    * a non-empty string without colons (the namespace separator); an invalid
    * channel throws so authoring mistakes surface loudly.
    */
-  postToPanel(channel: string, payload: unknown): void;
+  postToPanel(channel: string, payload: unknown): Promise<void>;
   /**
    * Returns the currently-active worktree (`isCurrent === true`) across all
    * projects as a frozen snapshot, or `null` if none is active. In multi-project
@@ -1307,9 +1363,12 @@ export interface PluginHostApi extends PluginActivationApi {
    *
    * Like {@link postToPanel} this is NOT revoke-guarded: it stays callable from
    * the plugin's timers and subscription callbacks and degrades to `null` once
-   * the plugin is unloaded.
+   * the plugin is unloaded. Pass `options.signal` to cancel.
    */
-  getWorktreeStatus(path: string): Promise<PluginWorktreeStatus | null>;
+  getWorktreeStatus(
+    path: string,
+    options?: PluginHostCallOptions
+  ): Promise<PluginWorktreeStatus | null>;
   /**
    * Signal that decorations for `scope` (optionally narrowed to `paths`) have
    * changed and any renderer showing them should re-pull. Unlike the
@@ -1319,7 +1378,7 @@ export interface PluginHostApi extends PluginActivationApi {
    * the plugin's whole lifetime. It becomes a silent no-op once the plugin is
    * unloaded.
    */
-  invalidateFileDecorations(scope: string, paths?: string[]): void;
+  invalidateFileDecorations(scope: string, paths?: string[]): Promise<void>;
   /**
    * Surface a toast notification. The host namespaces the message as
    * `{pluginId}: {message}` for provenance — a plugin cannot spoof another
@@ -1410,6 +1469,13 @@ export interface PluginHostApi extends PluginActivationApi {
  * structured payload serialized alongside the message; an unserializable
  * payload is coerced to a string rather than thrown. Calls return `void` — the
  * write is enqueued internally and never rejects.
+ *
+ * Deliberate carve-out: every other host method is Promise-returning (#10519),
+ * but the logger stays synchronous. Logging happens from error handlers and
+ * sync callbacks where forcing `await` is ergonomic noise, the write genuinely
+ * cannot fail (it is enqueued, never awaited), and the precedent — VS Code's
+ * own `OutputChannel.appendLine` — is synchronous. Do not "complete" the async
+ * conversion by making these return `Promise<void>`.
  */
 export interface PluginLogger {
   info(message: string, fields?: Record<string, unknown>): void;

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -126,6 +126,13 @@ export type PluginWorkerToHostMessage =
       method: PluginHostCallMethod;
       params: unknown;
     }
+  /**
+   * Cancel an in-flight `host-call`. The proxy posts this when the caller's
+   * `AbortSignal` fires — the signal itself isn't structured-clone-safe, so the
+   * `requestId` is the cancellation handle. The bridge aborts the matching
+   * in-flight host call; a no-op if it already settled.
+   */
+  | { type: "host-cancel"; requestId: string }
   /** Fire-and-forget host method call. `registrationKey` correlates `register-error`. */
   | {
       type: "host-notify";
@@ -140,6 +147,11 @@ export type PluginWorkerToHostMessage =
       kind: PluginWorkerSubscriptionKind;
       key?: string;
       scope?: PluginSettingsScope;
+      /**
+       * Opt-in debounce for the `worktrees` subscription (host-side coalescing).
+       * Ignored for other kinds. Mirrors `PluginHostSubscriptionOptions.debounceMs`.
+       */
+      debounceMs?: number;
     }
   /** Close a previously opened subscription. */
   | { type: "unsubscribe"; subscriptionId: string }


### PR DESCRIPTION
Converts the entire plugin host API surface so every method returns a `Promise`. This is the prep step for moving the plugin host across a process boundary — the new host APIs in #10520, #10521, and #10522 land after this. Intentionally breaking for out-of-repo plugins; we want to get there before the 1.0 API freeze.

Part of #10511. Closes #10519.

## Changes

**`shared/types/plugin.ts`**

- `void` → `Promise<void>`: `registerAction`, `registerHandler` (both overloads), `broadcastToRenderer`, `postToPanel`, `invalidateFileDecorations`
- `() => void` → `Promise<() => void>`: `registerForgeProvider`, `registerFileDecorationProvider`, `onDidChangeActiveWorktree`, `onDidChangeWorktrees`, `settings.onDidChange`

**Cancellation via `PluginHostCallOptions { signal? }`**

New optional `signal` on `fs.readFile`, `fs.readdir`, `fs.stat`, `fs.watch`, `git.status`, `git.diff`, `git.add`, `git.commit`, and `getWorktreeStatus`. Cancellation is honoured at I/O boundaries. `git.commit` re-checks the signal after computing the staged-diff preview so an abort mid-diff can't still create the commit.

**Opt-in debounce via `PluginHostSubscriptionOptions { debounceMs? }`**

`onDidChangeWorktrees` now accepts `debounceMs` with a 50ms floor, coalescing the per-poll re-emits.

**`PluginLogger` stays synchronous** — deliberate fire-and-forget carve-out, documented inline (VS Code `OutputChannel` precedent).

**Implementations** (`PluginService.createHost`, `pluginHostGit`, dev-worker proxy + bridge): all registry mutation happens synchronously before the resolved `Promise` returns, preserving synchronous revoke/validation throws and unload-cascade integrity.

**Dev-worker**: Promise-returning proxy, a minimal host-cancel protocol so `AbortSignal` works in dev mode, `debounceMs` forwarding, and a reload-generation guard so a late host result can't mis-deliver to the next worker generation.

**In-repo plugins updated**: `github` builtin, `hello-daintree` and `rich-daintree` samples, and the `daintree-plugin` scaffold template — all `await` the now-async registrations.

## Testing

- `tsc` compiles clean across all passes
- 645 Vitest tests pass across the plugin/host suites, including new `AbortSignal` regression tests for `git.commit`
- E2E not run locally; `full-plugins` bucket runs in CI/nightly