### PR TITLE
fix(settings): clarify selected state in skip-permissions choicebox (#10530)

### DIFF
--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from "react";
 import { RotateCcw } from "lucide-react";
 import { SettingsSwitchCard } from "../SettingsSwitchCard";
-import { SettingsChoicebox } from "../SettingsChoicebox";
+import { SettingsChoicebox, type ChoiceboxOption } from "../SettingsChoicebox";
 import type { ScopeKind } from "./scopeUtils";
 import type { DangerousMode } from "@shared/types";
 
@@ -31,12 +32,6 @@ interface BehavioralControlsProps {
   onCustomFlagsOverrideReset: () => void;
 }
 
-const DANGEROUS_MODE_OPTIONS: ReadonlyArray<{ value: DangerousMode; label: string }> = [
-  { value: "inherit", label: "Default" },
-  { value: "on", label: "On" },
-  { value: "off", label: "Off" },
-];
-
 export function BehavioralControls({
   scopeKind,
   scopeLabel,
@@ -59,6 +54,20 @@ export function BehavioralControls({
   onInlineOverrideReset,
   onCustomFlagsOverrideReset,
 }: BehavioralControlsProps) {
+  const dangerousModeOptions = useMemo<ReadonlyArray<ChoiceboxOption<DangerousMode>>>(
+    () => [
+      {
+        value: "inherit",
+        label: "Default",
+        resolvedLabel: `(${inheritResolvesToOn ? "On" : "Off"})`,
+        muted: true,
+      },
+      { value: "on", label: "On" },
+      { value: "off", label: "Off" },
+    ],
+    [inheritResolvesToOn]
+  );
+
   return (
     <>
       <div id="agents-skip-permissions" className="space-y-1.5">
@@ -68,11 +77,11 @@ export function BehavioralControls({
           columns={3}
           value={dangerousMode}
           onChange={onDangerousModeChange}
-          options={DANGEROUS_MODE_OPTIONS}
+          options={dangerousModeOptions}
         />
         {dangerousMode === "inherit" && (
           <p className="text-xs text-daintree-text/40 select-text">
-            Default &rarr; {inheritResolvesToOn ? "On" : "Off"} (from {inheritOriginLabel})
+            Inherited from {inheritOriginLabel}
           </p>
         )}
         {effectiveSkipPerms && defaultDangerousArg && (

--- a/src/components/Settings/AgentScopeEditor/__tests__/BehavioralControls.test.tsx
+++ b/src/components/Settings/AgentScopeEditor/__tests__/BehavioralControls.test.tsx
@@ -36,8 +36,8 @@ describe("BehavioralControls — skip permissions control", () => {
   it("renders the skip-permissions control as three radios, not text inputs (issue #10530)", () => {
     const { container } = render(<BehavioralControls {...makeProps()} />);
     const region = container.querySelector("#agents-skip-permissions");
-    expect(region).toBeTruthy();
-    const scoped = within(region as HTMLElement);
+    if (!(region instanceof HTMLElement)) throw new Error("skip-permissions region not found");
+    const scoped = within(region);
     expect(scoped.getAllByRole("radio")).toHaveLength(3);
     expect(scoped.queryAllByRole("textbox")).toHaveLength(0);
   });

--- a/src/components/Settings/AgentScopeEditor/__tests__/BehavioralControls.test.tsx
+++ b/src/components/Settings/AgentScopeEditor/__tests__/BehavioralControls.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { BehavioralControls } from "../BehavioralControls";
+import type { ComponentProps } from "react";
+
+type Props = ComponentProps<typeof BehavioralControls>;
+
+function makeProps(overrides: Partial<Props> = {}): Props {
+  return {
+    scopeKind: "default",
+    scopeLabel: "Claude",
+    dangerousMode: "inherit",
+    effectiveSkipPerms: false,
+    inheritResolvesToOn: true,
+    inheritOriginLabel: "global setting",
+    effectiveInlineMode: false,
+    agentDefaultInline: false,
+    customArgsValue: "",
+    customArgsPlaceholder: "--flag",
+    customArgsDescription: "Extra CLI flags",
+    inlineOverride: undefined,
+    customFlagsOverride: undefined,
+    supportsInlineMode: true,
+    defaultDangerousArg: "--dangerously-skip-permissions",
+    onDangerousModeChange: vi.fn(),
+    onInlineModeChange: vi.fn(),
+    onCustomFlagsChange: vi.fn(),
+    onInlineOverrideReset: vi.fn(),
+    onCustomFlagsOverrideReset: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("BehavioralControls — skip permissions control", () => {
+  it("renders the skip-permissions control as three radios, not text inputs (issue #10530)", () => {
+    const { container } = render(<BehavioralControls {...makeProps()} />);
+    const region = container.querySelector("#agents-skip-permissions");
+    expect(region).toBeTruthy();
+    const scoped = within(region as HTMLElement);
+    expect(scoped.getAllByRole("radio")).toHaveLength(3);
+    expect(scoped.queryAllByRole("textbox")).toHaveLength(0);
+  });
+
+  it("surfaces the inherited resolved value inline on the Default option and updates with the parent", () => {
+    const { rerender } = render(
+      <BehavioralControls {...makeProps({ inheritResolvesToOn: true })} />
+    );
+    expect(screen.getByRole("radio", { name: /Default \(On\)/ })).toBeTruthy();
+
+    rerender(<BehavioralControls {...makeProps({ inheritResolvesToOn: false })} />);
+    expect(screen.getByRole("radio", { name: /Default \(Off\)/ })).toBeTruthy();
+  });
+
+  it("shows the inherit provenance hint only while Default is selected", () => {
+    const { rerender } = render(
+      <BehavioralControls {...makeProps({ dangerousMode: "inherit" })} />
+    );
+    expect(screen.getByText("Inherited from global setting")).toBeTruthy();
+
+    rerender(<BehavioralControls {...makeProps({ dangerousMode: "on" })} />);
+    expect(screen.queryByText("Inherited from global setting")).toBeNull();
+  });
+});

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -1,6 +1,6 @@
 import { useId, useState, useRef, useEffect } from "react";
 import type { ComponentPropsWithoutRef, KeyboardEvent, ReactNode } from "react";
-import { RotateCcw } from "lucide-react";
+import { Check, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 export interface ChoiceboxOption<T extends string = string> {
@@ -8,6 +8,10 @@ export interface ChoiceboxOption<T extends string = string> {
   label: string;
   description?: string;
   disabled?: boolean;
+  /** Subordinate annotation shown after the label, e.g. the value an inherit slot resolves to. */
+  resolvedLabel?: string;
+  /** Renders the option as a softer, subordinate slot (e.g. a reset/inherit default). */
+  muted?: boolean;
 }
 
 interface SettingsChoiceboxProps<T extends string = string> extends Omit<
@@ -32,7 +36,7 @@ interface SettingsChoiceboxProps<T extends string = string> extends Omit<
 const CARD_BASE_CLASSES =
   "flex-1 px-3 py-2 rounded-[var(--radius-md)] border text-sm text-left transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2";
 
-const CARD_SELECTED_CLASSES = "border-border-strong bg-overlay-medium text-daintree-text";
+const CARD_SELECTED_CLASSES = "border-border-strong bg-overlay-subtle text-daintree-text shadow-sm";
 
 const CARD_UNSELECTED_CLASSES =
   "border-daintree-border bg-daintree-bg text-text-secondary hover:border-daintree-text/30 hover:text-daintree-text disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-daintree-border disabled:hover:text-text-secondary";
@@ -212,10 +216,28 @@ export function SettingsChoicebox<T extends string = string>({
                 isOptionDisabled && "opacity-50 cursor-not-allowed"
               )}
             >
-              <div className="font-medium">{option.label}</div>
-              {option.description && (
-                <div className="text-xs text-text-muted mt-0.5">{option.description}</div>
-              )}
+              <div className="flex items-start gap-2">
+                <Check
+                  className={cn("w-4 h-4 shrink-0 mt-0.5", !isSelected && "invisible")}
+                  aria-hidden="true"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className={option.muted ? "font-normal" : "font-medium"}>
+                    {option.label}
+                    {option.resolvedLabel && (
+                      <>
+                        {" "}
+                        <span className="text-xs font-normal text-text-muted">
+                          {option.resolvedLabel}
+                        </span>
+                      </>
+                    )}
+                  </div>
+                  {option.description && (
+                    <div className="text-xs text-text-muted mt-0.5">{option.description}</div>
+                  )}
+                </div>
+              </div>
             </button>
           );
         })}

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -590,16 +590,20 @@ describe("SettingsChoicebox", () => {
     expect(wrapper).toBeTruthy();
   });
 
-  it("renders a check indicator only on the selected option", () => {
+  it("reserves a check-icon slot on every option, visible only on the selected one", () => {
     render(
       <SettingsChoicebox label="Density" value="normal" onChange={vi.fn()} options={MOCK_OPTIONS} />
     );
     const radios = screen.getAllByRole("radio");
-    const hasVisibleCheck = (radio: Element) => {
-      const icon = radio.querySelector("svg[aria-hidden='true']");
-      return !!icon && !icon.classList.contains("invisible");
+    // Every option keeps the slot (prevents reflow); only the selected one is visible.
+    radios.forEach((radio) => {
+      expect(radio.querySelectorAll("svg[aria-hidden='true']")).toHaveLength(1);
+    });
+    const visibleCheck = (radio: Element) => {
+      const icon = radio.querySelector("svg[aria-hidden='true']")!;
+      return !icon.classList.contains("invisible");
     };
-    expect(radios.map(hasVisibleCheck)).toEqual([false, true, false]);
+    expect(radios.map(visibleCheck)).toEqual([false, true, false]);
   });
 
   it("moves the visible check when the selected value changes", () => {
@@ -643,6 +647,19 @@ describe("SettingsChoicebox", () => {
     expect(mutedRadio.getAttribute("aria-checked")).toBe("false");
     fireEvent.click(mutedRadio);
     expect(onChange).toHaveBeenCalledWith("inherit");
+  });
+
+  it("renders the muted option with a lighter label weight than a peer option", () => {
+    const options: readonly ChoiceboxOption<string>[] = [
+      { value: "inherit", label: "Default", muted: true },
+      { value: "on", label: "On" },
+    ];
+    render(<SettingsChoicebox label="Skip" value="on" onChange={vi.fn()} options={options} />);
+    const mutedLabel = screen.getByText("Default");
+    const peerLabel = screen.getByText("On");
+    expect(mutedLabel.classList.contains("font-normal")).toBe(true);
+    expect(mutedLabel.classList.contains("font-medium")).toBe(false);
+    expect(peerLabel.classList.contains("font-medium")).toBe(true);
   });
 });
 

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -589,6 +589,61 @@ describe("SettingsChoicebox", () => {
     const wrapper = container.querySelector(".custom-class");
     expect(wrapper).toBeTruthy();
   });
+
+  it("renders a check indicator only on the selected option", () => {
+    render(
+      <SettingsChoicebox label="Density" value="normal" onChange={vi.fn()} options={MOCK_OPTIONS} />
+    );
+    const radios = screen.getAllByRole("radio");
+    const hasVisibleCheck = (radio: Element) => {
+      const icon = radio.querySelector("svg[aria-hidden='true']");
+      return !!icon && !icon.classList.contains("invisible");
+    };
+    expect(radios.map(hasVisibleCheck)).toEqual([false, true, false]);
+  });
+
+  it("moves the visible check when the selected value changes", () => {
+    const { rerender } = render(
+      <SettingsChoicebox label="Density" value="normal" onChange={vi.fn()} options={MOCK_OPTIONS} />
+    );
+    rerender(
+      <SettingsChoicebox
+        label="Density"
+        value="compact"
+        onChange={vi.fn()}
+        options={MOCK_OPTIONS}
+      />
+    );
+    const radios = screen.getAllByRole("radio");
+    const visibleCheck = (radio: Element) => {
+      const icon = radio.querySelector("svg[aria-hidden='true']");
+      return !!icon && !icon.classList.contains("invisible");
+    };
+    expect(radios.map(visibleCheck)).toEqual([true, false, false]);
+  });
+
+  it("folds resolvedLabel into the option's accessible name", () => {
+    const options: readonly ChoiceboxOption<string>[] = [
+      { value: "inherit", label: "Default", resolvedLabel: "(On)", muted: true },
+      { value: "on", label: "On" },
+      { value: "off", label: "Off" },
+    ];
+    render(<SettingsChoicebox label="Skip" value="inherit" onChange={vi.fn()} options={options} />);
+    expect(screen.getByRole("radio", { name: /Default \(On\)/ })).toBeTruthy();
+  });
+
+  it("keeps a muted option fully selectable", () => {
+    const onChange = vi.fn();
+    const options: readonly ChoiceboxOption<string>[] = [
+      { value: "inherit", label: "Default", resolvedLabel: "(Off)", muted: true },
+      { value: "on", label: "On" },
+    ];
+    render(<SettingsChoicebox label="Skip" value="on" onChange={onChange} options={options} />);
+    const mutedRadio = screen.getByRole("radio", { name: /Default \(Off\)/ });
+    expect(mutedRadio.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(mutedRadio);
+    expect(onChange).toHaveBeenCalledWith("inherit");
+  });
 });
 
 describe("SettingsCheckbox", () => {


### PR DESCRIPTION
## Summary

- The skip permissions tri-state selector (`Default`/`On`/`Off`) in the agent scope editor rendered all three options as identical neutral boxes with no visible selected state -- it read like three empty text inputs.
- `SettingsChoicebox` now lifts the selected option with `bg-overlay-subtle` + `shadow-sm` and a leading check indicator in a stable slot (no reflow, no accent color per the accent-restraint rule).
- Two new `ChoiceboxOption` props (`resolvedLabel`, `muted`) let `BehavioralControls` render the `Default` option as visually subordinate and show its resolved value inline (`Default (On)` / `Default (Off)`). The below-control hint is trimmed to provenance only ("Inherited from {origin}"). The change also improves the `DaintreeMcpTier` call site in `GeneralTab`.

Resolves #10530

## Changes

- `src/components/Settings/SettingsChoicebox.tsx` -- selected-state lift, check indicator, `resolvedLabel`/`muted` props
- `src/components/Settings/AgentScopeEditor/BehavioralControls.tsx` -- muted Default option with resolved value, trimmed hint
- `src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx` -- new behavioral tests for selection state and muted rendering
- `src/components/Settings/AgentScopeEditor/__tests__/BehavioralControls.test.tsx` -- coverage for resolved-label rendering and `instanceof` guard

## Testing

111 tests pass locally. Tests cover selection state, muted option rendering, and resolved-label display -- no class-literal assertions.