### PR TITLE
feat(plugins): dynamic ${project}/${worktree} fs scope tokens + per-plugin data dir

### DIFF
--- a/electron/schemas/__tests__/pluginAllowedPaths.test.ts
+++ b/electron/schemas/__tests__/pluginAllowedPaths.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { PluginFsScopeSchema } from "../plugin.js";
+
+function accepts(entry: string): boolean {
+  return PluginFsScopeSchema.safeParse({ allowedPaths: [entry] }).success;
+}
+
+const ABS = path.resolve("/", "abs", "project", "src");
+
+describe("PluginFsScopeSchema allowedPaths entries", () => {
+  it("accepts literal absolute paths", () => {
+    expect(accepts(ABS)).toBe(true);
+  });
+
+  it("accepts the ${project} and ${worktree} tokens, bare and with a suffix", () => {
+    expect(accepts("${project}")).toBe(true);
+    expect(accepts("${worktree}")).toBe(true);
+    expect(accepts("${project}/src")).toBe(true);
+    expect(accepts("${worktree}/deep/nested/path")).toBe(true);
+  });
+
+  it("rejects relative paths", () => {
+    expect(accepts("relative/path")).toBe(false);
+    expect(accepts("./rel")).toBe(false);
+  });
+
+  it("rejects unknown or malformed tokens", () => {
+    expect(accepts("${workspace}")).toBe(false);
+    expect(accepts("${project")).toBe(false);
+    expect(accepts("$project")).toBe(false);
+    expect(accepts("${project}suffix")).toBe(false);
+    expect(accepts("prefix${project}")).toBe(false);
+  });
+
+  it("rejects `..` traversal in both tokens and literals", () => {
+    expect(accepts("${project}/../secret")).toBe(false);
+    expect(accepts("${worktree}/sub/../../escape")).toBe(false);
+    // A raw `..` segment in a literal (not pre-collapsed by path.join) is rejected.
+    expect(accepts("/abs/project/../escape")).toBe(false);
+  });
+
+  it("rejects wildcards anywhere", () => {
+    expect(accepts(path.join(ABS, "*"))).toBe(false);
+    expect(accepts("${project}/*")).toBe(false);
+    expect(accepts("${worktree}/sub/*.ts")).toBe(false);
+  });
+
+  it("requires at least one entry", () => {
+    expect(PluginFsScopeSchema.safeParse({ allowedPaths: [] }).success).toBe(false);
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -476,10 +476,19 @@ export const PluginAuthorSchema = z.strictObject({
 });
 
 /**
- * Per-entry validator for `scopes.fs.allowedPaths`. Each entry must be a
- * literal absolute path with no `..` segment and no `*` glob — the schema
- * boundary is the load-bearing gate (#4593, #4702), so substring `..` checks
- * are insufficient (segment-by-segment rejection).
+ * Matches a dynamic scope token (`${project}` / `${worktree}`) at the start of
+ * an `allowedPaths` entry, with an optional `/sub/path` suffix. These expand at
+ * call time against the live active project / worktree root (PluginService),
+ * letting a plugin scope to "the active worktree" without a hardcoded path.
+ */
+const ALLOWED_PATH_TOKEN_RE = /^\$\{(?:project|worktree)\}(?:\/.*)?$/;
+
+/**
+ * Per-entry validator for `scopes.fs.allowedPaths`. Each entry must be either a
+ * literal absolute path or a dynamic scope token (`${project}` / `${worktree}`,
+ * optionally with a `/sub/path` suffix), with no `..` segment and no `*` glob —
+ * the schema boundary is the load-bearing gate (#4593, #4702), so substring
+ * `..` checks are insufficient (segment-by-segment rejection).
  */
 const PluginAllowedPathSchema = z.string().superRefine((value, ctx) => {
   if (value.includes("*")) {
@@ -490,10 +499,11 @@ const PluginAllowedPathSchema = z.string().superRefine((value, ctx) => {
     });
     return;
   }
-  if (!path.isAbsolute(value)) {
+  const isToken = ALLOWED_PATH_TOKEN_RE.test(value);
+  if (!isToken && !path.isAbsolute(value)) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: `scopes.fs.allowedPaths entries must be absolute paths: "${value}"`,
+      message: `scopes.fs.allowedPaths entries must be absolute paths or a "\${project}"/"\${worktree}" token: "${value}"`,
       params: { errorCode: "scope_path_relative" },
     });
     return;
@@ -516,11 +526,13 @@ export const PluginNetworkScopeSchema = z
   .strict();
 
 /**
- * `scopes.fs.allowedPaths` is advisory: entries are schema-validated here but
- * not consulted at runtime — they neither gate filesystem access nor attenuate
- * the compound-capability lattice (unlike `scopes.network`, which suppresses
- * compound elevation). Validation is retained so frozen manifests carry
- * well-formed intent metadata.
+ * `scopes.fs.allowedPaths` is enforced at runtime: the host-mediated
+ * `host.fs` / `host.git` surface realpath-contains every path argument to these
+ * roots (PluginService), rejecting traversal and symlink escapes. Entries may be
+ * literal absolute paths or `${project}` / `${worktree}` tokens that expand at
+ * call time against the live active project / worktree. Independently, every
+ * plugin is always granted an implicit per-plugin data root
+ * (`~/.daintree/plugin-data/{pluginId}/`) so `allowedPaths` is optional.
  */
 export const PluginFsScopeSchema = z
   .object({

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2596,11 +2596,14 @@ export class PluginService {
    * Expand the plugin's declared `scopes.fs.allowedPaths` into concrete,
    * capability-classified roots at call time. `${project}` / `${worktree}`
    * tokens resolve against the live worktree snapshots — fail-closed: a token
-   * with no matching live worktree throws {@link PluginPathNotAllowedError}
-   * rather than producing a fallback or empty path that could widen scope
-   * (#9492). When `includeDataDir`, the implicit per-plugin data dir is prepended
-   * as a `user-data` root so every plugin always has a private scratch space.
-   * Literal absolute paths are classified by home-dir membership.
+   * with no matching live worktree contributes NO root (it is dropped, never
+   * resolved to a fallback or empty path that could widen scope — #9492), so a
+   * path that only that token would have matched is still rejected by
+   * containment. Dropping just the unresolvable entry (rather than aborting the
+   * whole expansion) preserves the always-on data dir and any literal / other
+   * resolvable token roots. When `includeDataDir`, the implicit per-plugin data
+   * dir is prepended as a `user-data` root so every plugin always has a private
+   * scratch space. Literal absolute paths are classified by home-dir membership.
    *
    * The caller is responsible for `requireLoaded()` re-checks around the await
    * (the plugin may unload mid-call — #9533).
@@ -2620,7 +2623,16 @@ export class PluginService {
       entries.push({ path: this.pluginDataDir(pluginId), rootClass: "user-data" });
     }
     for (const raw of declared) {
-      entries.push(this.expandAllowedPathEntry(pluginId, raw, snapshots));
+      try {
+        entries.push(this.expandAllowedPathEntry(pluginId, raw, snapshots));
+      } catch (err) {
+        // Fail-closed on a token with no live worktree: drop just that entry
+        // (it contributes no root, so a path that only matched it is still
+        // rejected by containment) rather than discarding the whole list — the
+        // implicit data dir and any literal/other-token roots stay usable.
+        if (err instanceof PluginPathNotAllowedError) continue;
+        throw err;
+      }
     }
     return entries;
   }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2767,7 +2767,14 @@ export class PluginService {
         // lexical check only gates the mkdir; realpath containment below stays
         // the security authority.
         const dataDir = this.pluginDataDir(pluginId);
-        if (path.isAbsolute(filePath) && this.isPathUnder(dataDir, path.normalize(filePath))) {
+        // Identify a data-dir write from the (lexical) request path, not the
+        // realpath-resolved one: on macOS the resolved path picks up the
+        // /private prefix while `dataDir` does not, so comparing against
+        // `resolved` would wrongly miss the match. The realpath containment
+        // below remains the security authority either way.
+        const isDataDirWrite =
+          path.isAbsolute(filePath) && this.isPathUnder(dataDir, path.normalize(filePath));
+        if (isDataDirWrite) {
           // A data-dir write is always user-data class — gate before the mkdir
           // so a plugin lacking the cap doesn't materialize the dir as a side
           // effect (the post-containment check below re-asserts it).
@@ -2780,7 +2787,7 @@ export class PluginService {
         requireWriteCapForClass("writeFile", rootClass);
         // Create intermediate dirs for a nested write inside the data dir so a
         // plugin can lay out its own subtree without a separate mkdir API.
-        if (this.isPathUnder(dataDir, resolved)) {
+        if (isDataDirWrite) {
           await fs.mkdir(path.dirname(resolved), { recursive: true });
         }
         await fs.writeFile(resolved, contents, "utf-8");

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -34,7 +34,7 @@ import {
 } from "../schemas/plugin.js";
 import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
 import { PluginProcessManager } from "./plugin/PluginProcessManager.js";
-import { resolveContainedPath } from "./plugin/pluginFsContainment.js";
+import { resolveContainedPath, PluginPathNotAllowedError } from "./plugin/pluginFsContainment.js";
 import { PluginHostGit, type HostGitFactory } from "./plugin/pluginHostGit.js";
 import {
   PLUGIN_PROCESS_STREAM_CHANNEL,
@@ -443,6 +443,19 @@ function isParkedOrTempDirName(name: string): boolean {
 }
 
 type WorkspaceWorktreeEvent = "worktree-update" | "worktree-activated" | "worktree-removed";
+
+/**
+ * Capability class of an expanded `scopes.fs.allowedPaths` root. Project /
+ * worktree roots gate on `fs:project-*`; the implicit per-plugin data dir and
+ * any path under the user's home dir gate on `fs:user-data-*`.
+ */
+type FsRootClass = "project" | "user-data";
+
+/** An `allowedPaths` entry after token expansion, with its capability class. */
+interface ExpandedFsPath {
+  path: string;
+  rootClass: FsRootClass;
+}
 
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
@@ -2566,6 +2579,82 @@ export class PluginService {
     return this.plugins.get(pluginId)?.manifest.scopes?.fs?.allowedPaths ?? [];
   }
 
+  /** The implicit per-plugin data dir, always an allowed `user-data` root. */
+  private pluginDataDir(pluginId: string): string {
+    return path.join(os.homedir(), ".daintree", "plugin-data", pluginId);
+  }
+
+  /** Lexical containment: is `candidate` inside (or equal to) `root`? */
+  private isPathUnder(root: string, candidate: string): boolean {
+    const rel = path.relative(root, candidate);
+    return (
+      rel === "" || (rel !== ".." && !rel.startsWith(".." + path.sep) && !path.isAbsolute(rel))
+    );
+  }
+
+  /**
+   * Expand the plugin's declared `scopes.fs.allowedPaths` into concrete,
+   * capability-classified roots at call time. `${project}` / `${worktree}`
+   * tokens resolve against the live worktree snapshots — fail-closed: a token
+   * with no matching live worktree throws {@link PluginPathNotAllowedError}
+   * rather than producing a fallback or empty path that could widen scope
+   * (#9492). When `includeDataDir`, the implicit per-plugin data dir is prepended
+   * as a `user-data` root so every plugin always has a private scratch space.
+   * Literal absolute paths are classified by home-dir membership.
+   *
+   * The caller is responsible for `requireLoaded()` re-checks around the await
+   * (the plugin may unload mid-call — #9533).
+   */
+  private async expandAllowedPathEntries(
+    pluginId: string,
+    opts: { includeDataDir: boolean }
+  ): Promise<ExpandedFsPath[]> {
+    const declared = this.declaredAllowedPaths(pluginId);
+    const needsSnapshots = declared.some(
+      (entry) => entry.startsWith("${project}") || entry.startsWith("${worktree}")
+    );
+    const snapshots = needsSnapshots ? await this.fetchAllWorktreeSnapshots() : [];
+
+    const entries: ExpandedFsPath[] = [];
+    if (opts.includeDataDir) {
+      entries.push({ path: this.pluginDataDir(pluginId), rootClass: "user-data" });
+    }
+    for (const raw of declared) {
+      entries.push(this.expandAllowedPathEntry(pluginId, raw, snapshots));
+    }
+    return entries;
+  }
+
+  /** Expand a single `allowedPaths` entry (token or literal) into a typed root. */
+  private expandAllowedPathEntry(
+    pluginId: string,
+    raw: string,
+    snapshots: readonly WorktreeSnapshot[]
+  ): ExpandedFsPath {
+    const token = raw.startsWith("${worktree}")
+      ? "worktree"
+      : raw.startsWith("${project}")
+        ? "project"
+        : null;
+    if (token === null) {
+      // Literal absolute path: a path under the user's home dir is user-data
+      // class; anything else (project trees, system paths) is project class.
+      return {
+        path: raw,
+        rootClass: this.isPathUnder(os.homedir(), raw) ? "user-data" : "project",
+      };
+    }
+    const base =
+      token === "worktree"
+        ? snapshots.find((s) => s.isCurrent === true)?.path
+        : snapshots.find((s) => s.isMainWorktree === true)?.path;
+    if (typeof base !== "string" || base.length === 0) {
+      throw new PluginPathNotAllowedError(pluginId, raw);
+    }
+    const suffix = raw.slice(`\${${token}}`.length);
+    return { path: suffix.length > 0 ? path.join(base, suffix) : base, rootClass: "project" };
+  }
+
   /**
    * Build the host-mediated `host.fs` surface for one plugin. Every path
    * argument is realpath-contained to the declared `scopes.fs.allowedPaths`
@@ -2581,7 +2670,9 @@ export class PluginService {
         );
       }
     };
-    const requireReadCap = (op: string): void => {
+    // Fast-fail before any filesystem work: a plugin with no fs read/write cap
+    // of any class can't touch the surface at all.
+    const requireAnyReadCap = (op: string): void => {
       const caps = this.declaredCapabilities(pluginId);
       if (!caps.has("fs:project-read") && !caps.has("fs:user-data-read")) {
         throw new Error(
@@ -2589,7 +2680,7 @@ export class PluginService {
         );
       }
     };
-    const requireWriteCap = (op: string): void => {
+    const requireAnyWriteCap = (op: string): void => {
       const caps = this.declaredCapabilities(pluginId);
       if (!caps.has("fs:project-write") && !caps.has("fs:user-data-write")) {
         throw new Error(
@@ -2597,16 +2688,55 @@ export class PluginService {
         );
       }
     };
-    const contain = (targetPath: string): Promise<string> =>
-      resolveContainedPath(pluginId, targetPath, this.declaredAllowedPaths(pluginId));
+    // Precise per-root-class gate, applied AFTER containment resolves which root
+    // class the path falls under: project/worktree paths need `fs:project-*`,
+    // the data dir / home paths need `fs:user-data-*`. A plugin can't reach a
+    // project path with only a user-data cap (or vice versa).
+    const requireReadCapForClass = (op: string, rootClass: FsRootClass): void => {
+      const needed = rootClass === "project" ? "fs:project-read" : "fs:user-data-read";
+      if (!this.declaredCapabilities(pluginId).has(needed)) {
+        throw new Error(
+          `PERMISSION_REQUIRED: plugin "${pluginId}" fs.${op} requires the "${needed}" capability for ${rootClass} paths, which is not declared in manifest.capabilities`
+        );
+      }
+    };
+    const requireWriteCapForClass = (op: string, rootClass: FsRootClass): void => {
+      const needed = rootClass === "project" ? "fs:project-write" : "fs:user-data-write";
+      if (!this.declaredCapabilities(pluginId).has(needed)) {
+        throw new Error(
+          `PERMISSION_REQUIRED: plugin "${pluginId}" fs.${op} requires the "${needed}" capability for ${rootClass} paths, which is not declared in manifest.capabilities`
+        );
+      }
+    };
+    // Contain against the call-time-expanded roots and report which root class
+    // matched. We contain per-entry so the matched entry's class is exact (the
+    // first containing root wins, same "any allowed root" semantics as before).
+    const containWithClass = async (
+      targetPath: string
+    ): Promise<{ resolved: string; rootClass: FsRootClass }> => {
+      const entries = await this.expandAllowedPathEntries(pluginId, { includeDataDir: true });
+      let lastErr: unknown;
+      for (const entry of entries) {
+        try {
+          const resolved = await resolveContainedPath(pluginId, targetPath, [entry.path]);
+          return { resolved, rootClass: entry.rootClass };
+        } catch (err) {
+          lastErr = err;
+        }
+      }
+      throw lastErr instanceof Error
+        ? lastErr
+        : new PluginPathNotAllowedError(pluginId, targetPath);
+    };
 
     return {
       readFile: async (filePath, options) => {
         options?.signal?.throwIfAborted();
         requireLoaded("readFile");
-        requireReadCap("readFile");
-        const resolved = await contain(filePath);
+        requireAnyReadCap("readFile");
+        const { resolved, rootClass } = await containWithClass(filePath);
         requireLoaded("readFile");
+        requireReadCapForClass("readFile", rootClass);
         // Deliberately no 500KB / binary cap — this is a sanctioned plugin API,
         // not the size-limited files.read preview path. The signal cancels the
         // read itself (Node honors it) as well as the boundary checks above.
@@ -2614,12 +2744,33 @@ export class PluginService {
       },
       writeFile: async (filePath, contents) => {
         requireLoaded("writeFile");
-        requireWriteCap("writeFile");
+        requireAnyWriteCap("writeFile");
         if (typeof contents !== "string") {
           throw new Error(`Plugin "${pluginId}" fs.writeFile: contents must be a string`);
         }
-        const resolved = await contain(filePath);
+        // Lazily materialize the implicit per-plugin data dir before containment
+        // when the target (lexically) lands inside it — resolveContainedPath
+        // realpaths every root and skips ones that don't exist, so a first write
+        // into a not-yet-created data dir would otherwise fail containment. The
+        // lexical check only gates the mkdir; realpath containment below stays
+        // the security authority.
+        const dataDir = this.pluginDataDir(pluginId);
+        if (path.isAbsolute(filePath) && this.isPathUnder(dataDir, path.normalize(filePath))) {
+          // A data-dir write is always user-data class — gate before the mkdir
+          // so a plugin lacking the cap doesn't materialize the dir as a side
+          // effect (the post-containment check below re-asserts it).
+          requireWriteCapForClass("writeFile", "user-data");
+          await fs.mkdir(dataDir, { recursive: true });
+        }
         requireLoaded("writeFile");
+        const { resolved, rootClass } = await containWithClass(filePath);
+        requireLoaded("writeFile");
+        requireWriteCapForClass("writeFile", rootClass);
+        // Create intermediate dirs for a nested write inside the data dir so a
+        // plugin can lay out its own subtree without a separate mkdir API.
+        if (this.isPathUnder(dataDir, resolved)) {
+          await fs.mkdir(path.dirname(resolved), { recursive: true });
+        }
         await fs.writeFile(resolved, contents, "utf-8");
         // Audit every write so host-mediated filesystem mutation is observable.
         safeAppendAudit({
@@ -2636,10 +2787,11 @@ export class PluginService {
       readdir: async (dirPath, options) => {
         options?.signal?.throwIfAborted();
         requireLoaded("readdir");
-        requireReadCap("readdir");
-        const resolved = await contain(dirPath);
+        requireAnyReadCap("readdir");
+        const { resolved, rootClass } = await containWithClass(dirPath);
         options?.signal?.throwIfAborted();
         requireLoaded("readdir");
+        requireReadCapForClass("readdir", rootClass);
         const entries = await fs.readdir(resolved, { withFileTypes: true });
         return entries.map(
           (e): PluginFsDirEntry => ({
@@ -2653,10 +2805,11 @@ export class PluginService {
       stat: async (targetPath, options) => {
         options?.signal?.throwIfAborted();
         requireLoaded("stat");
-        requireReadCap("stat");
-        const resolved = await contain(targetPath);
+        requireAnyReadCap("stat");
+        const { resolved, rootClass } = await containWithClass(targetPath);
         options?.signal?.throwIfAborted();
         requireLoaded("stat");
+        requireReadCapForClass("stat", rootClass);
         const s = await fs.stat(resolved);
         return {
           isDirectory: s.isDirectory(),
@@ -2669,7 +2822,7 @@ export class PluginService {
       watch: async (paths, callback, options) => {
         options?.signal?.throwIfAborted();
         requireLoaded("watch");
-        requireReadCap("watch");
+        requireAnyReadCap("watch");
         if (typeof callback !== "function") {
           throw new Error(`Plugin "${pluginId}" fs.watch: callback must be a function`);
         }
@@ -2678,10 +2831,12 @@ export class PluginService {
           throw new Error(`Plugin "${pluginId}" fs.watch: paths must be a non-empty array`);
         }
         // Contain every path up front so an out-of-scope watch target rejects
-        // before any watcher is created.
-        const resolvedTargets = await Promise.all(targets.map((p) => contain(p)));
+        // before any watcher is created; gate each on its own root class.
+        const contained = await Promise.all(targets.map((p) => containWithClass(p)));
         options?.signal?.throwIfAborted();
         requireLoaded("watch");
+        for (const c of contained) requireReadCapForClass("watch", c.rootClass);
+        const resolvedTargets = contained.map((c) => c.resolved);
 
         const watchers: FSWatcher[] = [];
         let disposed = false;
@@ -2773,10 +2928,25 @@ export class PluginService {
       }
     };
     // A worktree the plugin may access = one contained inside its declared
-    // allowedPaths. We resolve the worktree root itself (not a child) so the git
-    // ops run against the realpath-verified directory.
-    const containWorktree = (worktreePath: string): Promise<string> =>
-      resolveContainedPath(pluginId, worktreePath, this.declaredAllowedPaths(pluginId));
+    // allowedPaths (with `${project}` / `${worktree}` tokens expanded at call
+    // time). We resolve the worktree root itself (not a child) so the git ops
+    // run against the realpath-verified directory. The implicit per-plugin data
+    // dir is NOT an allowed git root — git ops gate on git:read/git:write and
+    // should never reach into a plugin's private scratch space.
+    const containWorktree = async (worktreePath: string): Promise<string> => {
+      const entries = await this.expandAllowedPathEntries(pluginId, { includeDataDir: false });
+      let lastErr: unknown;
+      for (const entry of entries) {
+        try {
+          return await resolveContainedPath(pluginId, worktreePath, [entry.path]);
+        } catch (err) {
+          lastErr = err;
+        }
+      }
+      throw lastErr instanceof Error
+        ? lastErr
+        : new PluginPathNotAllowedError(pluginId, worktreePath);
+    };
     const git = new PluginHostGit(pluginId, this.hostGitFactory);
 
     return {

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -426,9 +426,12 @@ describe("host.git token expansion", () => {
     )._setHostGitFactoryForTests(async () => git);
     const host = registerPlugin(["git:read"], ["${worktree}"]);
 
-    await expect(host.git.status(worktree)).resolves.toBeDefined();
-    // The per-plugin data dir is an fs root, never a git root.
+    // diff uses the mocked SimpleGit factory (status would hit the real
+    // changes provider, which needs an actual git repo on disk).
+    await expect(host.git.diff(worktree)).resolves.toBeDefined();
+    // The per-plugin data dir is an fs root, never a git root — rejected at
+    // containment before any git work runs.
     await fs.mkdir(dataDir(), { recursive: true });
-    await expect(host.git.status(dataDir())).rejects.toThrow(/PATH_NOT_ALLOWED/);
+    await expect(host.git.diff(dataDir())).rejects.toThrow(/PATH_NOT_ALLOWED/);
   });
 });

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -329,6 +329,24 @@ describe("host.fs ${worktree}/${project} token expansion", () => {
     const host = registerPlugin(["fs:project-read"], ["${worktree}"]);
     await expect(host.fs.readFile(join(baseDir, "x.txt"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
   });
+
+  it("fails closed (no fallback) when getAllStatesAsync rejects", async () => {
+    (svc as unknown as { setWorkspaceClient(c: unknown): void }).setWorkspaceClient({
+      getAllStatesAsync: async () => {
+        throw new Error("client unavailable");
+      },
+    });
+    const host = registerPlugin(["fs:project-read"], ["${worktree}"]);
+    await expect(host.fs.readFile(join(baseDir, "x.txt"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
+  });
+
+  it("still serves a co-declared literal root when a token can't resolve", async () => {
+    // No active worktree → ${worktree} drops out, but the literal stays usable.
+    setWorktrees([{ path: join(baseDir, "main"), isMainWorktree: true }]);
+    const host = registerPlugin(["fs:project-read", "fs:project-write"], [allowed, "${worktree}"]);
+    await host.fs.writeFile(join(allowed, "ok.txt"), "ok");
+    expect(await host.fs.readFile(join(allowed, "ok.txt"))).toBe("ok");
+  });
 });
 
 describe("host.fs implicit per-plugin data dir", () => {
@@ -347,6 +365,14 @@ describe("host.fs implicit per-plugin data dir", () => {
     const nested = join(dataDir(), "cache", "v1", "blob.bin");
     await host.fs.writeFile(nested, "data");
     expect(await host.fs.readFile(nested)).toBe("data");
+  });
+
+  it("stays reachable even when a co-declared token can't resolve", async () => {
+    // The always-on data dir must survive a failing ${worktree} expansion.
+    const host = registerPlugin(["fs:user-data-read", "fs:user-data-write"], ["${worktree}"]);
+    const target = join(dataDir(), "state.json");
+    await host.fs.writeFile(target, "{}");
+    expect(await host.fs.readFile(target)).toBe("{}");
   });
 
   it("denies the data dir to a plugin holding only project caps", async () => {

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, existsSync } from "node:fs";
 import fs from "node:fs/promises";
-import { tmpdir } from "node:os";
+import os, { tmpdir } from "node:os";
 import { join } from "node:path";
 import path from "node:path";
+import type { WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 
 vi.mock("electron", () => ({
   app: {
@@ -37,6 +38,20 @@ import type { PluginManifest, PluginHostApi } from "../../../shared/types/plugin
 let svc: PluginService;
 let baseDir: string;
 let allowed: string;
+let homeDir: string;
+let homedirSpy: MockInstance<() => string>;
+
+/** The implicit per-plugin data dir for the fixture plugin under the faked home. */
+function dataDir(): string {
+  return join(homeDir, ".daintree", "plugin-data", "acme.fsgit");
+}
+
+/** Inject a fake WorkspaceClient that returns the given worktree snapshots. */
+function setWorktrees(snapshots: Array<Partial<WorktreeSnapshot> & { path: string }>): void {
+  (svc as unknown as { setWorkspaceClient(c: unknown): void }).setWorkspaceClient({
+    getAllStatesAsync: async () => snapshots,
+  });
+}
 
 interface FakeLoadedPlugin {
   manifest: PluginManifest;
@@ -76,10 +91,17 @@ beforeEach(async () => {
   mkdirSync(pluginsRoot, { recursive: true });
   allowed = join(baseDir, "allowed");
   await fs.mkdir(allowed, { recursive: true });
+  // Redirect the home dir into the fixture so the implicit per-plugin data dir
+  // (~/.daintree/plugin-data/{id}/) lands under the temp tree, never the real
+  // home. PluginService imports the same `os` singleton, so this spy is shared.
+  homeDir = join(baseDir, "home");
+  await fs.mkdir(homeDir, { recursive: true });
+  homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(homeDir);
   svc = new PluginService(pluginsRoot);
 });
 
 afterEach(() => {
+  homedirSpy.mockRestore();
   rmSync(baseDir, { recursive: true, force: true });
 });
 
@@ -231,5 +253,156 @@ describe("host.git capability gating + commit safeguard", () => {
     )._setHostGitFactoryForTests(async () => git);
     const host = registerPlugin(["git:read"], [allowed]);
     await expect(host.git.status(path.join(baseDir, "other"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
+  });
+});
+
+describe("host.fs ${worktree}/${project} token expansion", () => {
+  it("expands ${worktree} to the active worktree and contains within it", async () => {
+    const worktree = join(baseDir, "wt-feature");
+    await fs.mkdir(worktree, { recursive: true });
+    setWorktrees([{ path: worktree, isCurrent: true }]);
+    const host = registerPlugin(["fs:project-read", "fs:project-write"], ["${worktree}"]);
+
+    const target = join(worktree, "note.txt");
+    await host.fs.writeFile(target, "hi");
+    expect(await host.fs.readFile(target)).toBe("hi");
+    // A sibling outside the active worktree is rejected.
+    await expect(host.fs.readFile(join(baseDir, "elsewhere.txt"))).rejects.toThrow(
+      /PATH_NOT_ALLOWED/
+    );
+  });
+
+  it("expands ${project} to the main worktree, distinct from the active one", async () => {
+    const project = join(baseDir, "wt-main");
+    const feature = join(baseDir, "wt-other");
+    await fs.mkdir(project, { recursive: true });
+    await fs.mkdir(feature, { recursive: true });
+    setWorktrees([
+      { path: project, isMainWorktree: true },
+      { path: feature, isCurrent: true },
+    ]);
+    const host = registerPlugin(["fs:project-read", "fs:project-write"], ["${project}"]);
+
+    const target = join(project, "p.txt");
+    await host.fs.writeFile(target, "x");
+    expect(await host.fs.readFile(target)).toBe("x");
+    // ${project} must NOT reach the active (non-main) worktree.
+    await fs.writeFile(join(feature, "f.txt"), "y");
+    await expect(host.fs.readFile(join(feature, "f.txt"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
+  });
+
+  it("supports a /suffix on a token (scoping to a subdirectory)", async () => {
+    const worktree = join(baseDir, "wt");
+    const sub = join(worktree, "sub");
+    await fs.mkdir(sub, { recursive: true });
+    setWorktrees([{ path: worktree, isCurrent: true }]);
+    const host = registerPlugin(["fs:project-read", "fs:project-write"], ["${worktree}/sub"]);
+
+    await host.fs.writeFile(join(sub, "ok.txt"), "ok");
+    expect(await host.fs.readFile(join(sub, "ok.txt"))).toBe("ok");
+    // The worktree root itself is above the scoped subdir → rejected.
+    await fs.writeFile(join(worktree, "root.txt"), "z");
+    await expect(host.fs.readFile(join(worktree, "root.txt"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
+  });
+
+  it("treats coinciding ${project} and ${worktree} (single worktree) as one root", async () => {
+    const only = join(baseDir, "only");
+    await fs.mkdir(only, { recursive: true });
+    setWorktrees([{ path: only, isCurrent: true, isMainWorktree: true }]);
+    const host = registerPlugin(
+      ["fs:project-read", "fs:project-write"],
+      ["${project}", "${worktree}"]
+    );
+    await host.fs.writeFile(join(only, "a.txt"), "a");
+    expect(await host.fs.readFile(join(only, "a.txt"))).toBe("a");
+  });
+
+  it("fails closed when ${worktree} has no active worktree (no fallback path)", async () => {
+    setWorktrees([{ path: join(baseDir, "main"), isMainWorktree: true }]);
+    const host = registerPlugin(["fs:project-read"], ["${worktree}"]);
+    await expect(host.fs.readFile(join(baseDir, "main", "x.txt"))).rejects.toThrow(
+      /PATH_NOT_ALLOWED/
+    );
+  });
+
+  it("fails closed when no WorkspaceClient is wired and a token is declared", async () => {
+    const host = registerPlugin(["fs:project-read"], ["${worktree}"]);
+    await expect(host.fs.readFile(join(baseDir, "x.txt"))).rejects.toThrow(/PATH_NOT_ALLOWED/);
+  });
+});
+
+describe("host.fs implicit per-plugin data dir", () => {
+  it("auto-grants the data dir to a user-data plugin and creates it lazily on write", async () => {
+    const host = registerPlugin(["fs:user-data-read", "fs:user-data-write"], []);
+    expect(existsSync(dataDir())).toBe(false);
+
+    const target = join(dataDir(), "state.json");
+    await host.fs.writeFile(target, "{}");
+    expect(existsSync(dataDir())).toBe(true);
+    expect(await host.fs.readFile(target)).toBe("{}");
+  });
+
+  it("creates intermediate dirs for a nested write inside the data dir", async () => {
+    const host = registerPlugin(["fs:user-data-read", "fs:user-data-write"], []);
+    const nested = join(dataDir(), "cache", "v1", "blob.bin");
+    await host.fs.writeFile(nested, "data");
+    expect(await host.fs.readFile(nested)).toBe("data");
+  });
+
+  it("denies the data dir to a plugin holding only project caps", async () => {
+    const host = registerPlugin(["fs:project-read", "fs:project-write"], [allowed]);
+    await expect(host.fs.writeFile(join(dataDir(), "x.txt"), "x")).rejects.toThrow(
+      /PERMISSION_REQUIRED/
+    );
+    // The deny must not have created the data dir as a side effect.
+    expect(existsSync(dataDir())).toBe(false);
+  });
+});
+
+describe("host.fs per-root-class capability gating", () => {
+  it("denies a project path to a plugin holding only user-data caps", async () => {
+    const host = registerPlugin(["fs:user-data-read", "fs:user-data-write"], [allowed]);
+    const target = join(allowed, "x.txt");
+    await fs.writeFile(target, "x");
+    await expect(host.fs.readFile(target)).rejects.toThrow(/PERMISSION_REQUIRED/);
+    await expect(host.fs.writeFile(target, "y")).rejects.toThrow(/PERMISSION_REQUIRED/);
+  });
+
+  it("allows a project path with project caps and the data dir with user-data caps", async () => {
+    const host = registerPlugin(
+      ["fs:project-read", "fs:project-write", "fs:user-data-read", "fs:user-data-write"],
+      [allowed]
+    );
+    await host.fs.writeFile(join(allowed, "p.txt"), "p");
+    expect(await host.fs.readFile(join(allowed, "p.txt"))).toBe("p");
+    await host.fs.writeFile(join(dataDir(), "u.txt"), "u");
+    expect(await host.fs.readFile(join(dataDir(), "u.txt"))).toBe("u");
+  });
+});
+
+describe("host.git token expansion", () => {
+  function fakeGitFactory(): SimpleGit {
+    return {
+      status: vi.fn().mockResolvedValue({ files: [] }),
+      diff: vi.fn().mockResolvedValue(""),
+      add: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue({ commit: "abc1234" }),
+    } as unknown as SimpleGit;
+  }
+
+  it("expands ${worktree} for git ops but never the implicit data dir", async () => {
+    const worktree = join(baseDir, "wt");
+    await fs.mkdir(worktree, { recursive: true });
+    setWorktrees([{ path: worktree, isCurrent: true }]);
+    const git = fakeGitFactory();
+    (
+      svc as unknown as { _setHostGitFactoryForTests(f: () => Promise<SimpleGit>): void }
+    )._setHostGitFactoryForTests(async () => git);
+    const host = registerPlugin(["git:read"], ["${worktree}"]);
+
+    await expect(host.git.status(worktree)).resolves.toBeDefined();
+    // The per-plugin data dir is an fs root, never a git root.
+    await fs.mkdir(dataDir(), { recursive: true });
+    await expect(host.git.status(dataDir())).rejects.toThrow(/PATH_NOT_ALLOWED/);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,7 @@
         "culori": "^4.0.2",
         "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.1",
-        "electron": "^42.3.3",
+        "electron": "^42.4.0",
         "electron-builder": "^26.8.1",
         "electron-store": "^11.0.2",
         "electron-updater": "^6.8.3",
@@ -1422,6 +1422,16 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.3.tgz",
+      "integrity": "sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
     },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
@@ -11952,15 +11962,15 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.3.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.3.tgz",
-      "integrity": "sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==",
+      "version": "42.4.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
+      "integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
         "@electron/get": "^5.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@types/node": "^24.9.0"
       },
       "bin": {
         "electron": "cli.js",
@@ -12907,43 +12917,6 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/extsprintf": {

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "culori": "^4.0.2",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.1",
-    "electron": "^42.3.3",
+    "electron": "^42.4.0",
     "electron-builder": "^26.8.1",
     "electron-store": "^11.0.2",
     "electron-updater": "^6.8.3",


### PR DESCRIPTION
## Summary

- `scopes.fs.allowedPaths` now accepts `${project}` and `${worktree}` tokens (with an optional sub-path suffix) that expand at call time against the live active project/worktree — so plugins can target the working tree without hardcoding paths.
- Every plugin gets an implicit per-plugin data dir at `~/.daintree/plugin-data/{pluginId}/`, created lazily on first write. Makes `scopes.fs` optional for plugins that only need private storage.

Resolves #10520

## Changes

- `${project}` and `${worktree}` tokens in `allowedPaths` expand at call time; fail-closed (no live worktree = no root contributed, never a fallback path).
- Path gating is now by root class: project/worktree paths require `fs:project-*` caps; the data dir and home paths require `fs:user-data-*`. Replaces the previous OR-gate where either cap unlocked any path.
- `host.git` expands the same tokens but never includes the data dir (git ops gate on `git:read`/`git:write`).
- Fixed the stale `PluginFsScopeSchema` comment claiming `allowedPaths` was advisory and not consulted at runtime.
- Files changed: `electron/schemas/plugin.ts`, `electron/services/PluginService.ts`, `electron/schemas/__tests__/pluginAllowedPaths.test.ts`, `electron/services/__tests__/PluginService.hostFsGit.test.ts`. `pluginFsContainment.ts` (realpath/symlink-escape engine) left untouched.

## Testing

48 unit tests cover token expansion, fail-close behaviour, per-root-class cap gating, data-dir lazy-create, containment, and schema validation. Prettier and ESLint clean on changed files.