### PR TITLE
feat(plugins): lazy, event-driven plugin activation (#10523)

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -54,11 +54,11 @@ Daintree reads the manifest eagerly at startup. Contribution points declared her
     "fs": { "allowedPaths": ["/Users/me/.acme/data"] },
   },
 
-  // Activation triggers. Optional. Currently only "onStartupFinished" is
-  // recognised. In v1 every plugin with a `main` entry activates at startup —
-  // omitting this field (or passing an empty array) is treated the same as
-  // ["onStartupFinished"]. Lazy first-use activation is planned but not wired
-  // yet, so there is no way to opt out of startup activation today.
+  // Activation triggers. Optional. Plugins are lazy by default — omitting this
+  // field (or passing an empty array) defers the `main` import and `activate()`
+  // until a contribution is first used. The sole recognised value,
+  // "onStartupFinished", is the explicit opt-in for plugins that must run at
+  // boot. Contributions are registered eagerly either way.
   "activationEvents": ["onStartupFinished"],
 
   // The plugin's UI and functional contributions.
@@ -207,7 +207,7 @@ A misspelled bucket (e.g. `networking`) is rejected as a manifest error rather t
 
 Activation triggers. The sole supported value is `"onStartupFinished"`, which activates the plugin once the app finishes starting.
 
-In v1, startup activation is the only behavior: any plugin with a `main` entry activates once the app finishes starting. Omitting `activationEvents` (or passing an empty array) is treated identically to `["onStartupFinished"]` — there is no way to opt out of startup activation yet. Lazy first-use triggers (`onCommand:*`, `onView:*`, …) are planned; once they land, a plugin will be able to drop `"onStartupFinished"` from a non-empty list to defer activation until a contribution is first used. Note that contributions (commands, panels, keybindings) are still registered eagerly from the manifest at startup regardless — only the plugin's `main` module import and `activate()` call are governed by activation.
+Plugins are lazy by default. Omitting `activationEvents` (or passing an empty array) defers the plugin's `main` module import and `activate()` call until one of its contributions is first used — a contributed command is dispatched, a forge provider or file decoration is queried, or a contributed panel view is opened. List `"onStartupFinished"` to opt a plugin into eager activation when it genuinely needs to run at boot. Either way, contributions (commands, panels, keybindings, …) are registered eagerly from the manifest at startup — only the `main` import and `activate()` call are governed by activation, so a lazy plugin's commands and panels still appear in the palette before any of its code runs.
 
 ### `contributes`
 

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -870,6 +870,8 @@ export const CHANNELS = {
   PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
   PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
   PLUGIN_PANEL_KINDS_GET: "plugin:panel-kinds-get",
+  /** Lazy activation: force the plugin owning a contributed panel view to `activate()` before its module loads. */
+  PLUGIN_ACTIVATE_FOR_VIEW: "plugin:activate-for-view",
   PLUGIN_AGENTS_GET: "plugin:agents-get",
   PLUGIN_FORGE_PROVIDERS_GET: "plugin:forge-providers-get",
   PLUGIN_FILE_DECORATIONS_GET: "plugin:file-decorations-get",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -114,7 +114,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(34);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(35);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:install", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:set-enabled", expect.any(Function));
@@ -147,6 +147,10 @@ describe("registerPluginHandlers", () => {
       expect.any(Function)
     );
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:panel-kinds-get", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:activate-for-view",
+      expect.any(Function)
+    );
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:agents-get", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith(
       "plugin:forge-providers-get",

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -22,6 +22,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   registerAction: "plugin:actions-register",
   unregisterAction: "plugin:actions-unregister",
   getPanelKinds: "plugin:panel-kinds-get",
+  activateForView: "plugin:activate-for-view",
   getAgents: "plugin:agents-get",
   getForgeProviders: "plugin:forge-providers-get",
   getDecorations: "plugin:file-decorations-get",

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -496,6 +496,19 @@ async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
   return getPluginPanelKinds();
 }
 
+/**
+ * Implicit activation for contributed panel views (#10523): force the plugin
+ * owning `panelKindId` to `activate()` before the renderer imports its
+ * `plugin://` module, so handlers bound during `activate()` are live when the
+ * view first renders. `activatePlugin` never rejects, so this resolves even
+ * when activation fails — the failure surfaces as a `loadError` and the view's
+ * module import then fails through the host's ErrorBoundary retry path. A no-op
+ * once the owning plugin is already activated, or when the kind id is unknown.
+ */
+async function handleActivateForView(panelKindId: string): Promise<void> {
+  await (await getPluginService()).activatePluginForView(panelKindId);
+}
+
 async function handleForgeProvidersGet(): Promise<RegisteredForgeProvider[]> {
   // Same init-race guard as the surrounding pull-on-mount handlers (#9285) —
   // forge descriptors register during the deferred initialize().
@@ -921,6 +934,7 @@ export const pluginNamespace = defineIpcNamespace({
     registerAction: op(PLUGIN_METHOD_CHANNELS.registerAction, handleActionsRegister),
     unregisterAction: op(PLUGIN_METHOD_CHANNELS.unregisterAction, handleActionsUnregister),
     getPanelKinds: op(PLUGIN_METHOD_CHANNELS.getPanelKinds, handlePanelKindsGet),
+    activateForView: op(PLUGIN_METHOD_CHANNELS.activateForView, handleActivateForView),
     getAgents: op(PLUGIN_METHOD_CHANNELS.getAgents, handleAgentsGet),
     getForgeProviders: op(PLUGIN_METHOD_CHANNELS.getForgeProviders, handleForgeProvidersGet),
     getDecorations: op(PLUGIN_METHOD_CHANNELS.getDecorations, handleFileDecorationsGet),

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1387,16 +1387,20 @@ export class PluginService {
   }
 
   /**
-   * In v1 only `"onStartupFinished"` is recognised. An empty `activationEvents`
-   * array is treated the same as `["onStartupFinished"]` — every plugin with a
-   * `main` entry activates at startup unless it explicitly lists other events
-   * (none of which exist yet). When `onCommand:*`, `onView:*` etc. land, a
-   * plugin will be able to opt out of startup activation by omitting
-   * `"onStartupFinished"` from a non-empty list.
+   * Plugins are lazy by default (#10523): an absent or empty `activationEvents`
+   * means the plugin's `main` is imported and `activate()` is run only on first
+   * use — a contributed command being dispatched, a forge provider or file
+   * decoration being queried, or a contributed panel view being opened. Their
+   * static contributions (commands, panels, keybindings, …) are still registered
+   * eagerly at load time, so they appear in the palette before any plugin code
+   * runs. `"onStartupFinished"` is the explicit opt-in for plugins that genuinely
+   * need to run at boot. It is still the only recognised literal; lazy triggers
+   * call `activatePlugin` directly rather than matching inferred `onCommand:*` /
+   * `onView:*` event strings.
    */
   private shouldActivateOnStartup(manifest: PluginManifest): boolean {
     const events = manifest.activationEvents;
-    if (!events || events.length === 0) return true;
+    if (!events || events.length === 0) return false;
     return events.includes("onStartupFinished");
   }
 
@@ -1685,6 +1689,30 @@ export class PluginService {
     for (const [pluginId, plugin] of this.plugins) {
       for (const contribution of plugin.manifest.contributes.forgeProviders) {
         if (`${pluginId}.${contribution.id}` === namespacedId) {
+          await this.activatePlugin(pluginId);
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * Activate the plugin that owns the contributed panel view identified by
+   * `panelKindId` before its `plugin://` module is imported in the renderer.
+   * Without this hook a lazy plugin's view module would load before its
+   * `activate()` ran, so the `host.registerHandler` calls the view depends on
+   * would not yet have fired (#10523). Mirrors {@link activatePluginForForgeProvider}:
+   * the owning plugin is resolved by matching the registered panel-kind id
+   * (`${pluginId}.${panel.id}`, exactly as built in `loadPlugin`) against the
+   * manifest registry rather than splitting `panelKindId` on a dot — plugin ids
+   * are `publisher.name` and already contain dots. A no-op when the kind id is
+   * unknown.
+   */
+  async activatePluginForView(panelKindId: string): Promise<void> {
+    if (typeof panelKindId !== "string" || panelKindId.length === 0) return;
+    for (const [pluginId, plugin] of this.plugins) {
+      for (const panel of plugin.manifest.contributes.panels) {
+        if (`${pluginId}.${panel.id}` === panelKindId) {
           await this.activatePlugin(pluginId);
           return;
         }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1648,12 +1648,13 @@ export class PluginService {
   }
 
   /**
-   * Fan out activation for every plugin whose manifest opts into
-   * `"onStartupFinished"` (or whose `activationEvents` is unset / empty —
-   * see {@link shouldActivateOnStartup}). Activations run in parallel via
-   * `Promise.allSettled`; one slow plugin must not block the rest. Wired
-   * fire-and-forget from the `plugin-service` deferred task so the renderer
-   * keeps progressing while plugins warm up in the background.
+   * Fan out activation for every plugin that opts into `"onStartupFinished"`
+   * (see {@link shouldActivateOnStartup}). Plugins without `activationEvents`
+   * are lazy (#10523) and are deliberately excluded here — they activate on
+   * first use instead. Activations run in parallel via `Promise.allSettled`;
+   * one slow plugin must not block the rest. Wired fire-and-forget from the
+   * `plugin-service` deferred task so the renderer keeps progressing while
+   * plugins warm up in the background.
    */
   async activateStartupFinishedPlugins(): Promise<void> {
     try {

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -139,6 +139,14 @@ function readMarker(key: string): unknown {
 async function initializeAndActivate(service: PluginService): Promise<void> {
   await service.initialize();
   await service.activateStartupFinishedPlugins();
+  // Lazy by default (#10523): plugins without `activationEvents` no longer
+  // activate via the startup fan-out. These integration fixtures exercise
+  // activated-plugin behavior, so explicitly activate every loaded plugin.
+  // `activatePlugin` is a no-op for disabled plugins (rejected at scan, never
+  // in the registry) and idempotent for any already activated above.
+  for (const plugin of service.listPlugins()) {
+    await service.activatePlugin(plugin.manifest.name);
+  }
 }
 
 beforeEach(async () => {
@@ -1056,10 +1064,11 @@ describe("PluginService integration — activate() lifecycle", () => {
 
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
-    // Activation is deferred: startup plugins activate via this fan-out (the
-    // production trigger is globalServicesInit). registerAction runs inside
-    // activate(), so the action only surfaces once activation has run.
-    await service.activateStartupFinishedPlugins();
+    // Activation is deferred and lazy by default (#10523): registerAction runs
+    // inside activate(), so the action only surfaces once activation has run.
+    // A lazy plugin activates on first use — here, dispatch would trigger it,
+    // but the pre-dispatch list assertion below needs it activated up front.
+    await service.activatePlugin("acme.action-plugin");
 
     // The action surfaces in the renderer-facing list with the namespaced id.
     expect(service.listPluginActions().map((a) => a.id)).toContain("acme.action-plugin.do-thing");
@@ -1486,9 +1495,9 @@ describe("PluginService integration — diagnostic logger", () => {
     );
     const service = new PluginService(tmpDir, "0.0.0");
     await service.initialize();
-    // Activation is deferred — the logger is wired inside activate(), so it
-    // only fires once the startup fan-out runs (mirrors the line-918 pattern).
-    await service.activateStartupFinishedPlugins();
+    // Activation is deferred and lazy by default (#10523) — the logger is wired
+    // inside activate(), so trigger first-use activation explicitly here.
+    await service.activatePlugin(pluginName);
     return service;
   }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -7732,9 +7732,7 @@ describe("Deferred activation — activatePlugin", () => {
               showInPalette: true,
             },
           ],
-          views: [
-            { id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" },
-          ],
+          views: [{ id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" }],
         },
       })
     );
@@ -7781,9 +7779,7 @@ describe("Deferred activation — activatePlugin", () => {
               showInPalette: true,
             },
           ],
-          views: [
-            { id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" },
-          ],
+          views: [{ id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" }],
         },
       })
     );
@@ -7828,9 +7824,7 @@ describe("Deferred activation — activatePlugin", () => {
               showInPalette: true,
             },
           ],
-          views: [
-            { id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" },
-          ],
+          views: [{ id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" }],
         },
       })
     );

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -7836,7 +7836,7 @@ describe("Deferred activation — activatePlugin", () => {
     );
     await fs.writeFile(
       path.join(pluginDir, "main.mjs"),
-      "globalThis.__viewFailCount = (globalThis.__viewFailCount ?? 0) + 1; export function activate() { throw new Error('view-activate-boom'); }"
+      "export function activate() { globalThis.__viewFailActivateCount = (globalThis.__viewFailActivateCount ?? 0) + 1; throw new Error('view-activate-boom'); }"
     );
 
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -7848,14 +7848,17 @@ describe("Deferred activation — activatePlugin", () => {
       await expect(service.activatePluginForView("acme.view-fail.viewer")).resolves.toBeUndefined();
       expect(service.getPluginLoadError("acme.view-fail")?.message).toBe("view-activate-boom");
       expect(service.hasPlugin("acme.view-fail")).toBe(true);
+      expect((globalThis as Record<string, unknown>).__viewFailActivateCount).toBe(1);
 
       // Second open: the failed in-flight entry was cleared, so activation runs
-      // again (Settings → Retry / re-open semantics).
+      // again (Settings → Retry / re-open semantics) rather than returning a
+      // cached settled promise — proven by the activate() invocation count.
       await expect(service.activatePluginForView("acme.view-fail.viewer")).resolves.toBeUndefined();
       expect(service.getPluginLoadError("acme.view-fail")?.message).toBe("view-activate-boom");
+      expect((globalThis as Record<string, unknown>).__viewFailActivateCount).toBe(2);
     } finally {
       errorSpy.mockRestore();
-      delete (globalThis as Record<string, unknown>).__viewFailCount;
+      delete (globalThis as Record<string, unknown>).__viewFailActivateCount;
     }
   });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3734,7 +3734,7 @@ describe("Plugin unload lifecycle", () => {
 
     try {
       await service.initialize();
-      await service.activateStartupFinishedPlugins();
+      await service.activatePlugin("acme.sync-init");
       expect((globalThis as { __pluginInitObserved?: boolean }).__pluginInitObserved).toBe(true);
     } finally {
       delete (globalThis as { __pluginInitCheck?: unknown }).__pluginInitCheck;
@@ -6851,7 +6851,10 @@ describe("Plugin exception containment (#9276)", () => {
       const service = new PluginService(tmpDir);
       // The host MUST NOT crash — initialize() should resolve.
       await expect(service.initialize()).resolves.toBeUndefined();
-      await service.activateStartupFinishedPlugins();
+      // Lazy by default (#10523): trigger activation explicitly rather than via
+      // the startup path, which no longer activates plugins without
+      // activationEvents.
+      await service.activatePlugin("acme.throws-activate");
 
       const record = service.getPluginLoadError("acme.throws-activate");
       expect(record).toBeDefined();
@@ -6877,7 +6880,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
-      await service.activateStartupFinishedPlugins();
+      await service.activatePlugin("acme.clean-activate");
 
       expect(service.getPluginLoadError("acme.clean-activate")).toBeUndefined();
     });
@@ -6904,7 +6907,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
-      await service.activateStartupFinishedPlugins();
+      await service.activatePlugin("acme.throws-then-unload");
       expect(service.getPluginLoadError("acme.throws-then-unload")).toBeDefined();
 
       // Unload removes the plugin from the registry, but the persisted
@@ -6930,7 +6933,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
-      await service.activateStartupFinishedPlugins();
+      await service.activatePlugin("acme.throws-string");
 
       const record = service.getPluginLoadError("acme.throws-string");
       expect(record?.message).toBe("plain-string-failure");
@@ -7173,7 +7176,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
-      await service.activateStartupFinishedPlugins();
+      await service.activatePlugin("acme.throws-undefined");
 
       const record = service.getPluginLoadError("acme.throws-undefined");
       expect(record).toBeDefined();
@@ -7195,7 +7198,7 @@ describe("Plugin exception containment (#9276)", () => {
 
       const service = new PluginService(tmpDir);
       await service.initialize();
-      await service.activateStartupFinishedPlugins();
+      await service.activatePlugin("acme.throws-null");
 
       const record = service.getPluginLoadError("acme.throws-null");
       expect(record).toBeDefined();
@@ -7332,11 +7335,11 @@ describe("Plugin provenance persistence", () => {
 
     const service = new PluginService(tmpDir);
     await service.initialize();
-    // Force the startup activation pass so this test exercises the path that
-    // would normally import every onStartupFinished plugin. The disabled plugin
-    // is rejected at scan time (never inserted into the plugins map), so the
-    // activation pass cannot pick it up — that's exactly what we assert below.
+    // Run the startup activation pass and an explicit trigger: the disabled
+    // plugin is rejected at scan time (never inserted into the plugins map), so
+    // neither path can pick it up — that's exactly what we assert below.
     await service.activateStartupFinishedPlugins();
+    await service.activatePlugin("acme.disabled-nb");
 
     const plugins = service.listPlugins();
     expect(plugins).toHaveLength(1);
@@ -7362,7 +7365,7 @@ describe("Plugin provenance persistence", () => {
 
     const service = new PluginService(tmpDir);
     await service.initialize();
-    await service.activateStartupFinishedPlugins();
+    await service.activatePlugin("acme.err-persist");
 
     const record = service.getPluginLoadError("acme.err-persist");
     expect(record?.message).toBe("persisted-boom");
@@ -7389,7 +7392,7 @@ describe("Plugin provenance persistence", () => {
 
     const first = new PluginService(tmpDir);
     await first.initialize();
-    await first.activateStartupFinishedPlugins();
+    await first.activatePlugin("acme.heal-fail");
     expect(first.getPluginLoadError("acme.heal-fail")?.message).toBe("first-fail");
 
     // Second plugin: same concept but different dir + name, so ESM cache
@@ -7408,7 +7411,7 @@ describe("Plugin provenance persistence", () => {
 
     const second = new PluginService(tmpDir);
     await second.initialize();
-    await second.activateStartupFinishedPlugins();
+    await second.activatePlugin("acme.heal-ok");
 
     // New plugin loaded successfully — no error
     expect(second.getPluginLoadError("acme.heal-ok")).toBeUndefined();
@@ -7547,7 +7550,7 @@ describe("PluginManifestSchema activationEvents field", () => {
 });
 
 describe("Deferred activation — activatePlugin", () => {
-  it("initialize() does not import plugin main; activateStartupFinishedPlugins does", async () => {
+  it("lazy by default: no activationEvents stays deferred through activateStartupFinishedPlugins, activates on first use (#10523)", async () => {
     const pluginDir = path.join(tmpDir, "deferred-import");
     await fs.mkdir(pluginDir);
     await fs.writeFile(
@@ -7555,7 +7558,7 @@ describe("Deferred activation — activatePlugin", () => {
       JSON.stringify({ name: "acme.deferred-import", version: "1.0.0", main: "main.mjs" })
     );
     // The module sets a global as a side effect at import time. If the
-    // module were imported during initialize() the global would be set
+    // module were imported during initialize()/startup the global would be set
     // before we explicitly activate.
     await fs.writeFile(
       path.join(pluginDir, "main.mjs"),
@@ -7570,7 +7573,13 @@ describe("Deferred activation — activatePlugin", () => {
       expect(service.hasPlugin("acme.deferred-import")).toBe(true);
       expect((globalThis as Record<string, unknown>).__deferredImportRan).toBeUndefined();
 
+      // With no activationEvents the plugin is lazy: startup activation must
+      // leave it deferred (the inverse of the pre-#10523 behavior).
       await service.activateStartupFinishedPlugins();
+      expect((globalThis as Record<string, unknown>).__deferredImportRan).toBeUndefined();
+
+      // An explicit first-use trigger imports main and runs activate().
+      await service.activatePlugin("acme.deferred-import");
       expect((globalThis as Record<string, unknown>).__deferredImportRan).toBe(true);
     } finally {
       delete (globalThis as Record<string, unknown>).__deferredImportRan;
@@ -7698,6 +7707,155 @@ describe("Deferred activation — activatePlugin", () => {
       expect((globalThis as Record<string, unknown>).__explicitOnstartupRan).toBe(true);
     } finally {
       delete (globalThis as Record<string, unknown>).__explicitOnstartupRan;
+    }
+  });
+
+  it("activatePluginForView resolves the owning plugin from contributes.panels and activates it (#10523)", async () => {
+    const pluginDir = path.join(tmpDir, "view-owner");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.view-owner",
+        version: "1.0.0",
+        main: "main.mjs",
+        contributes: {
+          panels: [
+            {
+              id: "viewer",
+              name: "Viewer",
+              iconId: "eye",
+              color: "#000",
+              hasPty: false,
+              canRestart: false,
+              canConvert: false,
+              showInPalette: true,
+            },
+          ],
+          views: [
+            { id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" },
+          ],
+        },
+      })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__viewOwnerActivated = true; export function activate() {}"
+    );
+
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+      // Lazy: registered but not yet activated.
+      expect(service.hasPlugin("acme.view-owner")).toBe(true);
+      expect((globalThis as Record<string, unknown>).__viewOwnerActivated).toBeUndefined();
+
+      // Opening the contributed panel view (kind id `${pluginId}.${panel.id}`)
+      // triggers first-use activation.
+      await service.activatePluginForView("acme.view-owner.viewer");
+      expect((globalThis as Record<string, unknown>).__viewOwnerActivated).toBe(true);
+    } finally {
+      delete (globalThis as Record<string, unknown>).__viewOwnerActivated;
+    }
+  });
+
+  it("activatePluginForView is a no-op for an unknown or empty panel kind id (#10523)", async () => {
+    const pluginDir = path.join(tmpDir, "view-noop");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.view-noop",
+        version: "1.0.0",
+        main: "main.mjs",
+        contributes: {
+          panels: [
+            {
+              id: "viewer",
+              name: "Viewer",
+              iconId: "eye",
+              color: "#000",
+              hasPty: false,
+              canRestart: false,
+              canConvert: false,
+              showInPalette: true,
+            },
+          ],
+          views: [
+            { id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" },
+          ],
+        },
+      })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__viewNoopActivated = true; export function activate() {}"
+    );
+
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      // Unknown kind id — and a non-matching bare id — must not activate anything.
+      await service.activatePluginForView("acme.view-noop.nope");
+      await service.activatePluginForView("viewer");
+      await service.activatePluginForView("");
+      expect((globalThis as Record<string, unknown>).__viewNoopActivated).toBeUndefined();
+    } finally {
+      delete (globalThis as Record<string, unknown>).__viewNoopActivated;
+    }
+  });
+
+  it("activatePluginForView records loadError on activation failure and retries on a second open (#10523)", async () => {
+    const pluginDir = path.join(tmpDir, "view-fail");
+    await fs.mkdir(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.view-fail",
+        version: "1.0.0",
+        main: "main.mjs",
+        contributes: {
+          panels: [
+            {
+              id: "viewer",
+              name: "Viewer",
+              iconId: "eye",
+              color: "#000",
+              hasPty: false,
+              canRestart: false,
+              canConvert: false,
+              showInPalette: true,
+            },
+          ],
+          views: [
+            { id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" },
+          ],
+        },
+      })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "main.mjs"),
+      "globalThis.__viewFailCount = (globalThis.__viewFailCount ?? 0) + 1; export function activate() { throw new Error('view-activate-boom'); }"
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = new PluginService(tmpDir);
+      await service.initialize();
+
+      // First open: activation fails but never rejects; contributions survive.
+      await expect(service.activatePluginForView("acme.view-fail.viewer")).resolves.toBeUndefined();
+      expect(service.getPluginLoadError("acme.view-fail")?.message).toBe("view-activate-boom");
+      expect(service.hasPlugin("acme.view-fail")).toBe(true);
+
+      // Second open: the failed in-flight entry was cleared, so activation runs
+      // again (Settings → Retry / re-open semantics).
+      await expect(service.activatePluginForView("acme.view-fail.viewer")).resolves.toBeUndefined();
+      expect(service.getPluginLoadError("acme.view-fail")?.message).toBe("view-activate-boom");
+    } finally {
+      errorSpy.mockRestore();
+      delete (globalThis as Record<string, unknown>).__viewFailCount;
     }
   });
 

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -353,6 +353,9 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["os-dnd:get-state"]["result"]>;
   };
   plugin: {
+    activateForView(
+      ...args: IpcInvokeMap["plugin:activate-for-view"]["args"]
+    ): Promise<IpcInvokeMap["plugin:activate-for-view"]["result"]>;
     checkForUpdate(
       ...args: IpcInvokeMap["plugin:check-for-update"]["args"]
     ): Promise<IpcInvokeMap["plugin:check-for-update"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -711,6 +711,10 @@ export interface GeneratedIpcInvokeMap {
     args: [pluginId: string, actionId: string];
     result: void;
   };
+  "plugin:activate-for-view": {
+    args: [panelKindId: string];
+    result: void;
+  };
   "plugin:agents-get": {
     args: [];
     result: Record<string, import("../../config/agentRegistry.js").AgentConfig>;

--- a/src/components/Plugin/PluginViewHost.tsx
+++ b/src/components/Plugin/PluginViewHost.tsx
@@ -89,9 +89,21 @@ export function makePluginViewHost(config: PanelKindConfig): ComponentType<Panel
       // pending promise. Rejecting on timeout routes through Suspense to the
       // boundary's "Try again", and because the race lives inside the factory a
       // retry (a fresh `createLazyView()`) restarts the timer cleanly (#10512).
+      // The activation + import sequence shares one timeout so a stalled
+      // `activate()` surfaces the same recovery path as a stalled import.
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       const mod: unknown = await Promise.race([
-        import(/* @vite-ignore */ componentPath!).finally(() => {
+        (async () => {
+          // Implicit lazy activation (#10523): force the owning plugin to
+          // `activate()` before importing its module, so handlers it registers
+          // during activate() are live when the view first renders. Optional
+          // chaining keeps the host working in test environments without
+          // `window.electron`. `activateForView` resolves even on activation
+          // failure (loadError surfaces and the import below then rejects),
+          // and is a no-op once the plugin is already activated.
+          await window.electron?.plugin?.activateForView?.(kindId);
+          return import(/* @vite-ignore */ componentPath!);
+        })().finally(() => {
           if (timeoutId !== undefined) clearTimeout(timeoutId);
         }),
         new Promise<never>((_, reject) => {

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -229,8 +229,12 @@ describe("makePluginViewHost", () => {
     vi.doUnmock("react");
   });
 
-  it("calls plugin.activateForView with the kind id before importing the view module (#10523)", async () => {
-    const activateForView = vi.fn().mockResolvedValue(undefined);
+  it("awaits plugin.activateForView with the kind id before importing the view module (#10523)", async () => {
+    // Reject activation with a sentinel so we can prove the import is *gated*
+    // on activation, not merely fired alongside it: if the `await` were dropped
+    // the factory would reject with the `plugin://` import error (module not
+    // found) instead of this sentinel.
+    const activateForView = vi.fn().mockRejectedValue(new Error("ACTIVATION_FAILED"));
     Object.defineProperty(window, "electron", {
       configurable: true,
       writable: true,
@@ -238,8 +242,7 @@ describe("makePluginViewHost", () => {
     });
 
     // Capture the lazy factory so we can drive it directly — the real
-    // `plugin://` import never resolves in jsdom, but the factory calls
-    // `activateForView` synchronously before it ever reaches `import()`.
+    // `plugin://` import never resolves in jsdom.
     let capturedFactory: (() => Promise<unknown>) | undefined;
     vi.doMock("react", async () => {
       const actual = await vi.importActual<typeof import("react")>("react");
@@ -268,11 +271,9 @@ describe("makePluginViewHost", () => {
     );
 
     await waitFor(() => expect(capturedFactory).toBeDefined());
-    // Invoking the factory calls activateForView synchronously (before the
-    // awaited `import()`); swallow the eventual import rejection in jsdom.
-    const settled = capturedFactory!().catch(() => {});
+    // Activation rejects, so the awaited call short-circuits before `import()`.
+    await expect(capturedFactory!()).rejects.toThrow("ACTIVATION_FAILED");
     expect(activateForView).toHaveBeenCalledWith("acme.dashboard");
-    await settled;
     vi.doUnmock("react");
   });
 

--- a/src/components/Plugin/__tests__/PluginViewHost.test.tsx
+++ b/src/components/Plugin/__tests__/PluginViewHost.test.tsx
@@ -229,6 +229,102 @@ describe("makePluginViewHost", () => {
     vi.doUnmock("react");
   });
 
+  it("calls plugin.activateForView with the kind id before importing the view module (#10523)", async () => {
+    const activateForView = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: { plugin: { onPanelKindsChanged: onPanelKindsChangedMock, activateForView } },
+    });
+
+    // Capture the lazy factory so we can drive it directly — the real
+    // `plugin://` import never resolves in jsdom, but the factory calls
+    // `activateForView` synchronously before it ever reaches `import()`.
+    let capturedFactory: (() => Promise<unknown>) | undefined;
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: (factory: () => Promise<unknown>) => {
+          capturedFactory = factory;
+          return function StubView() {
+            return <div data-testid="plugin-view" />;
+          };
+        },
+      };
+    });
+
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    render(
+      <Host
+        id="panel-act"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+
+    await waitFor(() => expect(capturedFactory).toBeDefined());
+    // Invoking the factory calls activateForView synchronously (before the
+    // awaited `import()`); swallow the eventual import rejection in jsdom.
+    const settled = capturedFactory!().catch(() => {});
+    expect(activateForView).toHaveBeenCalledWith("acme.dashboard");
+    await settled;
+    vi.doUnmock("react");
+  });
+
+  it("tolerates a missing activateForView binding without throwing (#10523)", async () => {
+    // beforeEach installs window.electron.plugin without activateForView, so the
+    // optional-chained call must no-op and the import must still proceed.
+    let capturedFactory: (() => Promise<unknown>) | undefined;
+    vi.doMock("react", async () => {
+      const actual = await vi.importActual<typeof import("react")>("react");
+      return {
+        ...actual,
+        lazy: (factory: () => Promise<unknown>) => {
+          capturedFactory = factory;
+          return function StubView() {
+            return <div data-testid="plugin-view" />;
+          };
+        },
+      };
+    });
+
+    const { makePluginViewHost } = await import("../PluginViewHost");
+    const Host = makePluginViewHost(makeConfig());
+
+    render(
+      <Host
+        id="panel-noact"
+        title="Dashboard"
+        isFocused={false}
+        onFocus={(): void => {}}
+        onClose={(): void => {}}
+      />
+    );
+
+    await waitFor(() => expect(capturedFactory).toBeDefined());
+    // No activateForView present — the factory must not throw synchronously.
+    let threw = false;
+    const settled = (async () => {
+      try {
+        await capturedFactory!();
+      } catch {
+        // jsdom can't resolve the plugin:// import; that's expected here.
+      }
+    })().catch(() => {
+      threw = true;
+    });
+    await settled;
+    expect(threw).toBe(false);
+    // The host still mounted its (stubbed) view rather than crashing.
+    expect(screen.getByTestId("plugin-view")).toBeTruthy();
+    vi.doUnmock("react");
+  });
+
   it("reads the AbortController through a ref so post-retry removals abort the current signal", async () => {
     // Regression guard for the renderer-first teardown contract: if the
     // useEffect captured controllerRef.current into a const at setup time,


### PR DESCRIPTION
## Summary

- Plugins are now lazy by default -- `activationEvents` being empty or absent means activate on first use, with `onStartupFinished` as the explicit opt-in for eager startup. This is the inverse of the old behaviour.
- Contributions still register eagerly from the static manifest so commands and panels appear in the palette before any plugin code runs.
- Added `PluginService.activatePluginForView(panelKindId)` (mirrors the forge-provider lazy hook), wired through a new `plugin:activate-for-view` IPC op. `PluginViewHost` calls this before importing its `plugin://` view module so handlers bound during `activate()` are live on first render.

Resolves #10523

## Changes

- `PluginService`: flipped `shouldActivateOnStartup` logic; added `activatePluginForView(panelKindId)`
- `electron/ipc/channels.ts` + `plugin.ts` + `plugin.preload.ts`: new `plugin:activate-for-view` channel
- `src/components/Plugin/PluginViewHost.tsx`: activates owning plugin before importing the view module
- `shared/types/ipc/generated-api.ts` + `generated.ts`: regenerated with new channel
- `docs/plugins/manifest.md`: updated activation lifecycle docs
- `PluginService.test.ts` + `PluginService.integration.test.ts` + `PluginViewHost.test.tsx`: new and strengthened tests

## Testing

495 tests passing. IPC/channel guards and typecheck clean.