### PR TITLE
feat(plugins): read-only agent-state observation host API (#10521)

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -60,6 +60,7 @@ import type {
   PluginSettingsScope,
   PluginSettingsUiValues,
   PluginWorktreeStatus,
+  PluginAgentSnapshot,
   PluginProcessApi,
   PluginProcessHandle,
   PluginProcessSpawnOptions,
@@ -86,6 +87,11 @@ import {
   toPluginWorktreeSnapshot,
   toPluginWorktreeStatus,
 } from "../../shared/utils/pluginWorktreeSnapshot.js";
+import {
+  toPluginAgentSnapshot,
+  type AgentStateChangePayload,
+} from "../../shared/utils/pluginAgentSnapshot.js";
+import { events } from "./events.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
 import {
   registerPanelKind,
@@ -1824,6 +1830,10 @@ export class PluginService {
     // into the current same-id instance's panels or read its worktrees.
     const isBound = (): boolean =>
       boundPlugin !== undefined && this.plugins.get(pluginId) === boundPlugin;
+    // Last agent-state snapshot observed for this host since it subscribed via
+    // onDidChangeAgentState. The host keeps no pre-subscription history, so
+    // getAgentState() returns null until the first transition is observed.
+    let lastAgentSnapshot: PluginAgentSnapshot | null = null;
     const host: PluginHostApi = {
       get pluginId() {
         return pluginId;
@@ -1970,6 +1980,15 @@ export class PluginService {
         const match = snapshots.find((s) => s.path === path);
         return match ? toPluginWorktreeStatus(match.worktreeChanges) : null;
       },
+      getAgentState: async () => {
+        if (!this.declaredCapabilities(pluginId).has("agent:read")) {
+          throw new Error(
+            `PERMISSION_REQUIRED: plugin "${pluginId}" getAgentState requires "agent:read", which is not declared in manifest.capabilities`
+          );
+        }
+        if (!isBound()) return null;
+        return lastAgentSnapshot;
+      },
       onDidChangeActiveWorktree: (callback) => {
         if (revoked) {
           throw new Error(
@@ -2053,6 +2072,54 @@ export class PluginService {
           disposeUpdate();
           disposeRemove();
         };
+        return Promise.resolve(dispose);
+      },
+      onDidChangeAgentState: (callback) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: onDidChangeAgentState called after activate() returned or timed out`
+          );
+        }
+        if (!this.declaredCapabilities(pluginId).has("agent:read")) {
+          throw new Error(
+            `PERMISSION_REQUIRED: plugin "${pluginId}" onDidChangeAgentState requires "agent:read", which is not declared in manifest.capabilities`
+          );
+        }
+        // The agent:state-changed bus is a synchronous module-level singleton
+        // (unlike WorkspaceClient), so we subscribe directly — no deferred
+        // replay queue is needed. The handler caches the latest snapshot so
+        // getAgentState() can serve it without re-deriving state.
+        const handler = (payload: AgentStateChangePayload): void => {
+          if (!this.plugins.has(pluginId)) return;
+          try {
+            const snapshot = toPluginAgentSnapshot(payload);
+            lastAgentSnapshot = snapshot;
+            callback(snapshot);
+          } catch (err) {
+            console.error(
+              `[PluginService] onDidChangeAgentState callback for "${pluginId}" failed:`,
+              err
+            );
+          }
+        };
+        const unsub = events.on("agent:state-changed", handler);
+        let disposed = false;
+        const dispose = (): void => {
+          if (disposed) return;
+          disposed = true;
+          unsub();
+          const list = this.pluginEventCleanups.get(pluginId);
+          if (!list) return;
+          const idx = list.indexOf(dispose);
+          if (idx >= 0) list.splice(idx, 1);
+          if (list.length === 0) this.pluginEventCleanups.delete(pluginId);
+        };
+        let list = this.pluginEventCleanups.get(pluginId);
+        if (!list) {
+          list = [];
+          this.pluginEventCleanups.set(pluginId, list);
+        }
+        list.push(dispose);
         return Promise.resolve(dispose);
       },
       registerForgeProvider: (descriptor, impl) => {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1981,12 +1981,17 @@ export class PluginService {
         return match ? toPluginWorktreeStatus(match.worktreeChanges) : null;
       },
       getAgentState: async () => {
+        // Liveness first (mirrors getActiveWorktree/getWorktrees): once unloaded
+        // the method degrades to null rather than throwing, so a plugin calling
+        // it from a stray timer after unload doesn't get an unhandled rejection.
+        // declaredCapabilities() also returns [] post-unload, so a capability
+        // check first would mis-report PERMISSION_REQUIRED for a torn-down plugin.
+        if (!isBound()) return null;
         if (!this.declaredCapabilities(pluginId).has("agent:read")) {
           throw new Error(
             `PERMISSION_REQUIRED: plugin "${pluginId}" getAgentState requires "agent:read", which is not declared in manifest.capabilities`
           );
         }
-        if (!isBound()) return null;
         return lastAgentSnapshot;
       },
       onDidChangeActiveWorktree: (callback) => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -6480,12 +6480,62 @@ describe("Plugin agent-state host API (#10521)", () => {
     emitState({ state: "working" });
     expect(received).toHaveLength(1);
 
-    (
-      service as unknown as { unloadPlugin: (id: string) => void }
-    ).unloadPlugin("acme.agent-host");
+    (service as unknown as { unloadPlugin: (id: string) => void }).unloadPlugin("acme.agent-host");
 
     emitState({ state: "idle" });
     expect(received).toHaveLength(1);
+  });
+
+  it("getAgentState returns null (not an error) after the plugin is unloaded", async () => {
+    const { service, host } = await setupAgentHost(["agent:read"]);
+    await host.onDidChangeAgentState(() => {});
+    emitState({ agentId: "a-pre", state: "working", previousState: "idle" });
+    expect(await host.getAgentState()).not.toBeNull();
+
+    (service as unknown as { unloadPlugin: (id: string) => void }).unloadPlugin("acme.agent-host");
+
+    // declaredCapabilities() returns [] post-unload, so a capability check first
+    // would mis-throw PERMISSION_REQUIRED — the liveness check must win.
+    expect(await host.getAgentState()).toBeNull();
+  });
+
+  it("getAgentState stays null when events fire but the plugin never subscribed", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    emitState({ state: "working", previousState: "idle" });
+    // No subscription means no handler caches the snapshot — the host keeps no
+    // pre-subscription history.
+    expect(await host.getAgentState()).toBeNull();
+  });
+
+  it("getAgentState inside the callback observes the just-delivered snapshot", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    let insidePromise: Promise<unknown> | null = null;
+    await host.onDidChangeAgentState(() => {
+      insidePromise = host.getAgentState();
+    });
+
+    emitState({ agentId: "a9", state: "working", previousState: "idle" });
+
+    const inside = (await insidePromise) as Record<string, unknown> | null;
+    expect(inside).not.toBeNull();
+    expect(inside?.agentId).toBe("a9");
+  });
+
+  it("multiple subscriptions from the same plugin dispose independently", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    const a: unknown[] = [];
+    const b: unknown[] = [];
+    const disposeA = await host.onDidChangeAgentState((s) => a.push(s));
+    await host.onDidChangeAgentState((s) => b.push(s));
+
+    emitState({ state: "working" });
+    expect(a).toHaveLength(1);
+    expect(b).toHaveLength(1);
+
+    disposeA();
+    emitState({ state: "idle" });
+    expect(a).toHaveLength(1); // disposed — no more deliveries
+    expect(b).toHaveLength(2); // still active
   });
 
   it("onDidChangeAgentState throws once the host is revoked", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -167,6 +167,7 @@ vi.mock("../plugin/PluginDevWorkerMainBridge.js", () => ({
 
 import { z } from "zod";
 import { PluginService } from "../PluginService.js";
+import { events } from "../events.js";
 import { PluginProcessManager, type ManagedChildProcess } from "../plugin/PluginProcessManager.js";
 import { getPluginActionAuditService } from "../PluginActionAuditService.js";
 import { isAuditedHandlerFailure } from "../../utils/pluginAuditMarker.js";
@@ -6289,6 +6290,208 @@ describe("Plugin worktree host API", () => {
     ]) {
       expect(removed in active).toBe(false);
     }
+  });
+});
+
+describe("Plugin agent-state host API (#10521)", () => {
+  type AgentHost = {
+    pluginId: string;
+    getAgentState: () => Promise<unknown>;
+    onDidChangeAgentState: (cb: (s: unknown) => void) => Promise<() => void>;
+  };
+
+  /**
+   * Load a plugin with the given capabilities and build a host for it. The
+   * `agent:read`-gated methods read declared capabilities off the loaded
+   * manifest, so the capability must be present on disk before initialize().
+   */
+  async function setupAgentHost(
+    capabilities: string[]
+  ): Promise<{ service: PluginService; host: AgentHost; revoke: () => void }> {
+    await writePlugin("agent-host", {
+      name: "acme.agent-host",
+      version: "1.0.0",
+      capabilities,
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    const { host, revoke } = (
+      service as unknown as {
+        createHost: (id: string) => { host: AgentHost; revoke: () => void };
+      }
+    ).createHost("acme.agent-host");
+    return { service, host, revoke };
+  }
+
+  function emitState(
+    over: Partial<{
+      agentId: string;
+      state: string;
+      previousState: string;
+      waitingReason: string;
+      sessionCost: number;
+      sessionTokens: number;
+      timestamp: number;
+    }> = {}
+  ): void {
+    events.emit("agent:state-changed", {
+      state: "working",
+      previousState: "idle",
+      trigger: "output",
+      confidence: 1,
+      timestamp: 1000,
+      ...over,
+    } as never);
+  }
+
+  it("getAgentState rejects with PERMISSION_REQUIRED when agent:read is not declared", async () => {
+    const { host } = await setupAgentHost([]);
+    await expect(host.getAgentState()).rejects.toThrow(/PERMISSION_REQUIRED/);
+  });
+
+  it("onDidChangeAgentState throws PERMISSION_REQUIRED when agent:read is not declared", async () => {
+    const { host } = await setupAgentHost([]);
+    // The capability guard throws synchronously before returning the disposer
+    // promise (same shape as onDidChangeWorktrees).
+    expect(() => host.onDidChangeAgentState(() => {})).toThrow(/PERMISSION_REQUIRED/);
+  });
+
+  it("getAgentState returns null before any agent state change is observed", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    expect(await host.getAgentState()).toBeNull();
+  });
+
+  it("onDidChangeAgentState delivers a frozen projected snapshot on state-changed", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    const received: Array<Record<string, unknown>> = [];
+    await host.onDidChangeAgentState((s) => received.push(s as Record<string, unknown>));
+
+    emitState({
+      agentId: "agent-1",
+      state: "waiting",
+      previousState: "working",
+      waitingReason: "question",
+      timestamp: 4242,
+    });
+
+    expect(received).toHaveLength(1);
+    const snap = received[0];
+    expect(snap.agentId).toBe("agent-1");
+    expect(snap.state).toBe("waiting");
+    expect(snap.previousState).toBe("working");
+    expect(snap.running).toBe(true);
+    expect(snap.waitingReason).toBe("question");
+    expect(snap.timestamp).toBe(4242);
+    expect(Object.isFrozen(snap)).toBe(true);
+  });
+
+  it("getAgentState returns the last projected snapshot after a state change", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    await host.onDidChangeAgentState(() => {});
+
+    emitState({ agentId: "agent-2", state: "completed", previousState: "working", timestamp: 99 });
+
+    const snap = (await host.getAgentState()) as Record<string, unknown>;
+    expect(snap).not.toBeNull();
+    expect(snap.agentId).toBe("agent-2");
+    expect(snap.state).toBe("completed");
+    expect(snap.running).toBe(false);
+  });
+
+  it("derives running=true only for working/waiting/directing", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    const received: Array<Record<string, unknown>> = [];
+    await host.onDidChangeAgentState((s) => received.push(s as Record<string, unknown>));
+
+    for (const state of ["idle", "working", "waiting", "directing", "completed", "exited"]) {
+      emitState({ state, previousState: "idle" });
+    }
+
+    const byState = new Map(received.map((s) => [s.state as string, s.running as boolean]));
+    expect(byState.get("idle")).toBe(false);
+    expect(byState.get("working")).toBe(true);
+    expect(byState.get("waiting")).toBe(true);
+    expect(byState.get("directing")).toBe(true);
+    expect(byState.get("completed")).toBe(false);
+    expect(byState.get("exited")).toBe(false);
+  });
+
+  it("the snapshot omits internal routing ids and activity-detector internals", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    const received: Array<Record<string, unknown>> = [];
+    await host.onDidChangeAgentState((s) => received.push(s as Record<string, unknown>));
+
+    events.emit("agent:state-changed", {
+      agentId: "agent-3",
+      state: "working",
+      previousState: "idle",
+      trigger: "output",
+      confidence: 0.9,
+      cwd: "/secret/path",
+      terminalId: "term-internal",
+      worktreeId: "wt-internal",
+      temperature: 42,
+      heatAdded: 7,
+      changedChars: 3,
+      timestamp: 1,
+    } as never);
+
+    const snap = received[0];
+    for (const leaked of [
+      "terminalId",
+      "worktreeId",
+      "cwd",
+      "trigger",
+      "confidence",
+      "temperature",
+      "heatAdded",
+      "changedChars",
+    ]) {
+      expect(leaked in snap).toBe(false);
+    }
+    expect(Object.keys(snap).sort()).toEqual([
+      "agentId",
+      "previousState",
+      "running",
+      "state",
+      "timestamp",
+    ]);
+  });
+
+  it("the disposer stops further callbacks and is safe to call twice", async () => {
+    const { host } = await setupAgentHost(["agent:read"]);
+    const received: unknown[] = [];
+    const dispose = await host.onDidChangeAgentState((s) => received.push(s));
+
+    emitState({ state: "working" });
+    expect(received).toHaveLength(1);
+
+    dispose();
+    dispose(); // double-dispose must not throw
+    emitState({ state: "idle" });
+    expect(received).toHaveLength(1);
+  });
+
+  it("unloading the plugin disposes the subscription and stops callbacks", async () => {
+    const { service, host } = await setupAgentHost(["agent:read"]);
+    const received: unknown[] = [];
+    await host.onDidChangeAgentState((s) => received.push(s));
+
+    emitState({ state: "working" });
+    expect(received).toHaveLength(1);
+
+    (
+      service as unknown as { unloadPlugin: (id: string) => void }
+    ).unloadPlugin("acme.agent-host");
+
+    emitState({ state: "idle" });
+    expect(received).toHaveLength(1);
+  });
+
+  it("onDidChangeAgentState throws once the host is revoked", async () => {
+    const { host, revoke } = await setupAgentHost(["agent:read"]);
+    revoke();
+    expect(() => host.onDidChangeAgentState(() => {})).toThrow(/host revoked/);
   });
 });
 

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -303,6 +303,8 @@ export class PluginDevWorkerMainBridge {
         return this.host.getWorktrees();
       case "getWorktreeStatus":
         return this.host.getWorktreeStatus(params as string, { signal });
+      case "getAgentState":
+        return this.host.getAgentState();
       case "showToast": {
         const p = params as ShowToastParams;
         // `type` is validated against the NotificationType enum by the host's
@@ -506,6 +508,8 @@ export class PluginDevWorkerMainBridge {
         dispose = await this.host.onDidChangeWorktrees((snapshots) => push(snapshots), {
           debounceMs: msg.debounceMs,
         });
+      } else if (kind === "agent-state") {
+        dispose = await this.host.onDidChangeAgentState((snapshot) => push(snapshot));
       } else {
         // settings
         if (!msg.key) {

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -25,6 +25,7 @@ import type {
   PluginTypedIpcHandler,
   PluginWorktreeSnapshot,
   PluginWorktreeStatus,
+  PluginAgentSnapshot,
   PluginFsDirEntry,
   PluginFsStat,
   PluginGitStatus,
@@ -42,6 +43,7 @@ import type {
   PluginHostCallMethod,
   PluginHostNotifyMethod,
   PluginHostToWorkerMessage,
+  PluginWorkerSubscriptionKind,
   PluginWorkerToHostMessage,
 } from "../../../shared/types/pluginDevWorker.js";
 
@@ -368,6 +370,15 @@ export class PluginDevWorkerHostProxy {
       getWorktrees: () => this.call<PluginWorktreeSnapshot[]>("getWorktrees", undefined),
       getWorktreeStatus: (path, options) =>
         this.call<PluginWorktreeStatus | null>("getWorktreeStatus", path, options?.signal),
+      getAgentState: () => this.call<PluginAgentSnapshot | null>("getAgentState", undefined),
+      onDidChangeAgentState: (callback) => {
+        this.assertActivationOpen("onDidChangeAgentState");
+        // Subscription wired synchronously; only the disposer is async.
+        const dispose = this.subscribe("agent-state", (payload) =>
+          callback(payload as PluginAgentSnapshot)
+        );
+        return Promise.resolve(dispose);
+      },
       onDidChangeActiveWorktree: (callback) => {
         this.assertActivationOpen("onDidChangeActiveWorktree");
         // Subscription wired synchronously; only the disposer is async.
@@ -544,7 +555,7 @@ export class PluginDevWorkerHostProxy {
   }
 
   private subscribe(
-    kind: "active-worktree" | "worktrees" | "settings",
+    kind: PluginWorkerSubscriptionKind,
     callback: (payload: unknown) => void,
     key?: string,
     scope?: PluginSettingsScope,

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -287,6 +287,31 @@ describe("createMockHost", () => {
     expect(cb).toHaveBeenCalledWith([sampleSnapshot]);
   });
 
+  it("getAgentState returns null until a state change is simulated", async () => {
+    const host = createMockHost();
+    expect(await host.getAgentState()).toBeNull();
+  });
+
+  it("delivers agent-state updates and reflects the last one in getAgentState", async () => {
+    const host = createMockHost();
+    const cb = vi.fn();
+    const dispose = await host.onDidChangeAgentState(cb);
+    const snapshot = {
+      agentId: "a1",
+      state: "working" as const,
+      previousState: "idle" as const,
+      running: true,
+      timestamp: 7,
+    };
+    host.simulateAgentStateChange(snapshot);
+    expect(cb).toHaveBeenCalledWith(snapshot);
+    expect(await host.getAgentState()).toEqual(snapshot);
+    dispose();
+    dispose(); // no-op
+    host.simulateAgentStateChange({ ...snapshot, state: "idle", running: false });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
   it("registers forge providers and unregisters via disposer", async () => {
     const host = createMockHost();
     const impl = { parseRemote: vi.fn() } as unknown as Parameters<

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -29,6 +29,7 @@ import type {
   PluginToastOptions,
   PluginTypedIpcHandler,
   PluginWorktreeSnapshot,
+  PluginAgentSnapshot,
   PluginGitCommitResult,
   SettingsApi,
 } from "../types/plugin.js";
@@ -121,6 +122,13 @@ export interface MockHostState {
   simulateWorktreesChange(snapshots: PluginWorktreeSnapshot[]): void;
 
   /**
+   * Push an agent-state snapshot to every `onDidChangeAgentState` subscriber and
+   * update the value `getAgentState()` returns. Mirrors the production host's
+   * cache-then-notify behaviour.
+   */
+  simulateAgentStateChange(snapshot: PluginAgentSnapshot): void;
+
+  /**
    * Pre-seed a deterministic `dispatch()` result for one action id. Overrides
    * the default in-memory routing (which resolves the registered handler).
    */
@@ -176,6 +184,9 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
 
   const activeWorktreeSubs = new Set<(snapshot: PluginWorktreeSnapshot | null) => void>();
   const worktreesSubs = new Set<(snapshots: PluginWorktreeSnapshot[]) => void>();
+
+  let lastAgentSnapshot: PluginAgentSnapshot | null = null;
+  const agentStateSubs = new Set<(snapshot: PluginAgentSnapshot) => void>();
 
   const settingsStore: Record<PluginSettingsScope, Map<string, unknown>> = {
     user: new Map(Object.entries(options.settings?.user ?? {})),
@@ -375,6 +386,19 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         if (disposed) return;
         disposed = true;
         worktreesSubs.delete(callback);
+      };
+      return Promise.resolve(dispose);
+    },
+    async getAgentState() {
+      return lastAgentSnapshot;
+    },
+    onDidChangeAgentState(callback) {
+      agentStateSubs.add(callback);
+      let disposed = false;
+      const dispose = () => {
+        if (disposed) return;
+        disposed = true;
+        agentStateSubs.delete(callback);
       };
       return Promise.resolve(dispose);
     },
@@ -613,6 +637,10 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     simulateWorktreesChange(snapshots) {
       worktrees = snapshots;
       for (const cb of worktreesSubs) cb(snapshots);
+    },
+    simulateAgentStateChange(snapshot) {
+      lastAgentSnapshot = snapshot;
+      for (const cb of agentStateSubs) cb(snapshot);
     },
     setDispatchResult(actionId, result) {
       dispatchOverrides.set(actionId, result);

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -100,6 +100,11 @@ export type {
   PluginWorktreeFileState,
 } from "./plugin.js";
 
+// ── Agent observability ─────────────────────────────────────────────
+
+export type { PluginAgentSnapshot } from "./plugin.js";
+export type { AgentState, WaitingReason } from "./agent.js";
+
 // ── Forge provider contract ─────────────────────────────────────────
 
 export type {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -13,6 +13,7 @@ import type {
 } from "./forge.js";
 import type { NotificationType } from "./notification.js";
 import type { ActionDispatchResult } from "./actions.js";
+import type { AgentState, WaitingReason } from "./agent.js";
 import type { z } from "zod";
 
 export interface PanelContribution {
@@ -895,6 +896,49 @@ export interface PluginWorktreeSnapshot {
 }
 
 /**
+ * Read-only, frozen projection of an agent session's coarse state, exposed to
+ * plugins behind the `agent:read` capability. This is an explicit allowlist of
+ * fields from the internal `agent:state-changed` event payload; do NOT add
+ * fields by spreading — every field must be intentionally exposed so internal
+ * shape changes (and internal routing identifiers) don't leak to third-party
+ * plugins. Observation only: nothing on this surface can drive, pause, resume,
+ * or inject into an agent session.
+ *
+ * Deliberately omits the internal routing ids (`terminalId`, `worktreeId`,
+ * `cwd`) and the activity-detector internals (`trigger`, `confidence`,
+ * `temperature`, …): a plugin holding only `agent:read` has no declared
+ * capability to access PTY/worktree internals, so exposing them here would let
+ * it cross-reference state it can't otherwise reach.
+ */
+export interface PluginAgentSnapshot {
+  /**
+   * Stable id of the agent session, when the host could attribute the
+   * transition to one. Absent for runtime-detected-only flows that route by
+   * terminal rather than a resolved agent id.
+   */
+  readonly agentId?: string;
+  /** Coarse lifecycle state: idle | working | waiting | directing | completed | exited. */
+  readonly state: AgentState;
+  /** The state the session transitioned away from. */
+  readonly previousState: AgentState;
+  /**
+   * Convenience flag — `true` while the session is doing in-flight work
+   * (`working` | `waiting` | `directing`), `false` otherwise. Derived from the
+   * same `ACTIVE_AGENT_STATES` set the host uses, so a plugin doesn't have to
+   * re-maintain the membership list.
+   */
+  readonly running: boolean;
+  /** Why the session is waiting; present only when `state === "waiting"`. */
+  readonly waitingReason?: WaitingReason;
+  /** Cumulative session cost in USD; present only on `completed`/`exited` transitions. */
+  readonly sessionCost?: number;
+  /** Cumulative session token count; present only on `completed`/`exited` transitions. */
+  readonly sessionTokens?: number;
+  /** Unix timestamp in milliseconds when the transition was committed. */
+  readonly timestamp: number;
+}
+
+/**
  * Options for {@link PluginHostApi.showToast}. Intentionally narrower than the
  * app's internal `notify()` surface: plugins cannot set `priority` (a
  * `priority:"low"` + `type:"error"` toast silently drops — see the lint rule at
@@ -1316,6 +1360,29 @@ export interface PluginActivationApi {
     callback: (snapshots: PluginWorktreeSnapshot[]) => void,
     options?: PluginHostSubscriptionOptions
   ): Promise<() => void>;
+  /**
+   * Subscribe to agent-session state changes, gated on the `agent:read`
+   * capability. The callback fires with a frozen {@link PluginAgentSnapshot}
+   * on every accepted agent state transition across all sessions (unscoped,
+   * like {@link onDidChangeWorktrees} — a plugin filters by `snapshot.agentId`
+   * if it cares about one session). Resolves to a disposer; calling it more
+   * than once is a no-op. All subscriptions are automatically disposed when the
+   * plugin is unloaded.
+   *
+   * Observation only — there is no companion method to drive, pause, resume, or
+   * inject into a session.
+   *
+   * Subscribing is revoke-guarded — call it during `activate()`. The callback
+   * itself fires for the plugin's whole lifetime; only the act of subscribing
+   * is restricted to the activation window.
+   *
+   * @throws {Error} `PERMISSION_REQUIRED:` if the plugin did not declare the
+   *   `agent:read` capability, or if called after activation resolves or times
+   *   out (the host is revoked).
+   */
+  onDidChangeAgentState(
+    callback: (snapshot: PluginAgentSnapshot) => void
+  ): Promise<() => void>;
 }
 
 /**
@@ -1368,6 +1435,21 @@ export interface PluginHostApi extends PluginActivationApi {
     path: string,
     options?: PluginHostCallOptions
   ): Promise<PluginWorktreeStatus | null>;
+  /**
+   * Returns the most recent agent-session state observed since the plugin
+   * subscribed via {@link onDidChangeAgentState}, as a frozen
+   * {@link PluginAgentSnapshot}, or `null` when no transition has been observed
+   * yet (the host keeps no pre-subscription history). Gated on the `agent:read`
+   * capability.
+   *
+   * Like {@link postToPanel} this is NOT revoke-guarded: it stays callable from
+   * the plugin's timers and subscription callbacks and degrades to `null` once
+   * the plugin is unloaded. Observation only.
+   *
+   * @throws {Error} `PERMISSION_REQUIRED:` if the plugin did not declare the
+   *   `agent:read` capability.
+   */
+  getAgentState(): Promise<PluginAgentSnapshot | null>;
   /**
    * Signal that decorations for `scope` (optionally narrowed to `paths`) have
    * changed and any renderer showing them should re-pull. Unlike the

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1380,9 +1380,7 @@ export interface PluginActivationApi {
    *   `agent:read` capability, or if called after activation resolves or times
    *   out (the host is revoked).
    */
-  onDidChangeAgentState(
-    callback: (snapshot: PluginAgentSnapshot) => void
-  ): Promise<() => void>;
+  onDidChangeAgentState(callback: (snapshot: PluginAgentSnapshot) => void): Promise<() => void>;
 }
 
 /**

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -24,6 +24,7 @@ export type PluginHostCallMethod =
   | "getActiveWorktree"
   | "getWorktrees"
   | "getWorktreeStatus"
+  | "getAgentState"
   | "showToast"
   | "dispatch"
   | "settings.get"
@@ -51,7 +52,11 @@ export type PluginHostNotifyMethod =
   | "logger.error";
 
 /** Event subscriptions the worker proxy can open against the host. */
-export type PluginWorkerSubscriptionKind = "active-worktree" | "worktrees" | "settings";
+export type PluginWorkerSubscriptionKind =
+  | "active-worktree"
+  | "worktrees"
+  | "settings"
+  | "agent-state";
 
 /**
  * Callback kinds main invokes back in the worker. `file-decoration-method`

--- a/shared/utils/pluginAgentSnapshot.ts
+++ b/shared/utils/pluginAgentSnapshot.ts
@@ -1,0 +1,56 @@
+import type { PluginAgentSnapshot } from "../types/plugin.js";
+import type { AgentState, WaitingReason } from "../types/agent.js";
+import { ACTIVE_AGENT_STATES } from "../types/agent.js";
+
+/**
+ * The subset of the internal `agent:state-changed` event payload that the agent
+ * snapshot projection reads. Declared structurally (not imported from
+ * `electron/services/events.ts`) so this helper stays in `shared/` and is usable
+ * from both processes without pulling a main-process module across the boundary.
+ */
+export interface AgentStateChangePayload {
+  agentId?: string;
+  state: AgentState;
+  previousState: AgentState;
+  waitingReason?: WaitingReason;
+  sessionCost?: number;
+  sessionTokens?: number;
+  timestamp: number;
+}
+
+/**
+ * Project an internal `agent:state-changed` payload down to the read-only
+ * {@link PluginAgentSnapshot} allowlist, then freeze it.
+ *
+ * Explicit field assignment — do NOT spread. Internal routing identifiers
+ * (`terminalId`, `worktreeId`, `cwd`) and activity-detector internals
+ * (`trigger`, `confidence`, `temperature`, `heatAdded`, `changedChars`) are
+ * deliberately omitted: a plugin holding only `agent:read` must not be able to
+ * cross-reference PTY/worktree internals it has no capability to access.
+ * Optional fields are only assigned when present so the frozen shape mirrors the
+ * payload (no `undefined`-valued keys).
+ */
+export function toPluginAgentSnapshot(payload: AgentStateChangePayload): PluginAgentSnapshot {
+  const projection: {
+    agentId?: string;
+    state: AgentState;
+    previousState: AgentState;
+    running: boolean;
+    waitingReason?: WaitingReason;
+    sessionCost?: number;
+    sessionTokens?: number;
+    timestamp: number;
+  } = {
+    state: payload.state,
+    previousState: payload.previousState,
+    running: ACTIVE_AGENT_STATES.has(payload.state),
+    timestamp: payload.timestamp,
+  };
+
+  if (payload.agentId !== undefined) projection.agentId = payload.agentId;
+  if (payload.waitingReason !== undefined) projection.waitingReason = payload.waitingReason;
+  if (payload.sessionCost !== undefined) projection.sessionCost = payload.sessionCost;
+  if (payload.sessionTokens !== undefined) projection.sessionTokens = payload.sessionTokens;
+
+  return Object.freeze(projection);
+}


### PR DESCRIPTION
## Summary

- Wires the previously-inert `agent:read` plugin capability to a real observation surface on `PluginHostApi` — until now plugins could declare it, alarm the user during install, and get nothing back
- Adds `PluginAgentSnapshot` (coarse `AgentState` + `previousState` + derived `running` flag + `waitingReason`/`sessionCost`/`sessionTokens` + `timestamp`), exported from the plugin SDK
- Adds `getAgentState(): Promise<PluginAgentSnapshot | null>` on `PluginHostApi` and `onDidChangeAgentState(callback)` on `PluginActivationApi`, both gated on `agent:read`; calls without the capability declared reject with `PERMISSION_REQUIRED`

Resolves #10521

## Changes

- `PluginAgentSnapshot` type projected via `toPluginAgentSnapshot` (explicit-field freeze, no spread) — deliberately omits `terminalId`/`worktreeId`/`cwd` and activity-detector internals so a plugin holding only `agent:read` can't cross-reference PTY/worktree state
- `getAgentState()` is post-activation-safe and not revoke-guarded; `onDidChangeAgentState` is revoke-guarded and registered during `activate()`
- Wired through the dev-worker host proxy, main bridge, and protocol types so dev-mode plugins get the same surface
- `createMockHost` extended with `getAgentState`/`onDidChangeAgentState` + a `simulateAgentStateChange` helper
- Observation only — nothing here drives, pauses, resumes, or injects into a session (per the #4100 agent-config-boundary precedent)

## Testing

607 tests passing across `PluginService`, `createMockHost`, dev-worker proxy/bridge, and plugin-sdk suites. Full typecheck clean.