### PR TITLE
feat(plugins): run user plugins out-of-process via utilityProcess worker (#10526)

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1642,6 +1642,7 @@ export class PluginService {
       // and a freshly-introduced one is recorded — the first-activation promise
       // alone can't see post-reload outcomes.
       onActivationResult: (result) => {
+        lastActivationOk = result.ok;
         if (plugin.isBuiltin) return;
         if (result.ok) {
           if (!this.pluginsWithLoadTimeErrors.has(pluginId)) {
@@ -1654,6 +1655,12 @@ export class PluginService {
         }
       },
     });
+
+    // Tracks the most recent activate() outcome reported by the bridge. A failed
+    // first activation must not be cached as "activated" (#10523 retry-on-reopen):
+    // for a prod worker — which has no file watcher to auto-recover — we tear the
+    // worker down below so a re-open (Settings → Retry) re-forks and re-runs.
+    let lastActivationOk: boolean | undefined;
 
     const entry = { workerHost, bridge, revoke };
     this.pluginWorkers.set(pluginId, entry);
@@ -1724,6 +1731,20 @@ export class PluginService {
       console.error(`[PluginService] Plugin "${pluginId}" activation:`, err);
     } finally {
       if (timer) clearTimeout(timer);
+    }
+
+    // A failed first activation must not be cached as a successful one
+    // (#10523): `activatePlugin` adds the id to `activatedPlugins` when this
+    // method resolves, which would short-circuit every later re-open. A dev
+    // worker keeps watching so the author can fix the error and save to reload —
+    // its retry path is the watcher, not a re-activation — so leave it alive.
+    // A prod worker has no watcher, so the only recovery is a re-open / Settings
+    // → Retry that re-runs `activatePlugin`; tear the failed worker down and
+    // rethrow so the in-flight entry is dropped and the id is never cached,
+    // mirroring the in-process loader's rethrow-on-activate-failure semantics.
+    if (lastActivationOk === false && !plugin.devMode) {
+      cleanup();
+      throw new Error(`Plugin "${pluginId}" activate() failed`);
     }
   }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -46,6 +46,7 @@ import type {
   PluginIpcHandler,
   PluginIpcContext,
   PluginHostApi,
+  PluginActivate,
   PluginActionContribution,
   PluginActionDescriptor,
   PluginChannelSchema,
@@ -705,10 +706,11 @@ export class PluginService {
    */
   private hostGitFactory: HostGitFactory | undefined = undefined;
   /**
-   * Live plugin workers, keyed by pluginId (#9304, #10526). Every plugin (dev
-   * and prod) runs in a forked `utilityProcess`; each entry holds that lifecycle,
-   * the message bridge to the real host, and the host `revoke` to call on unload.
-   * Disposed via the {@link cleanupMap} disposer registered at activation, so
+   * Live plugin workers, keyed by pluginId (#9304, #10526). Every user-installed
+   * plugin (dev and prod) runs in a forked `utilityProcess`; built-ins activate
+   * in-process and are absent here. Each entry holds that lifecycle, the message
+   * bridge to the real host, and the host `revoke` to call on unload. Disposed
+   * via the {@link cleanupMap} disposer registered at activation, so
    * `unloadPlugin` tears the worker down through its normal cascade.
    */
   private pluginWorkers = new Map<
@@ -1541,15 +1543,51 @@ export class PluginService {
   private async _doActivate(pluginId: string): Promise<void> {
     const plugin = this.plugins.get(pluginId);
     if (!plugin || !plugin.resolvedMain) return;
-    // Every plugin activates inside a `utilityProcess.fork` worker (#10526).
-    // Dev plugins hot-reload on each `dist/index.js` rebuild; prod plugins run
-    // the same worker without the file watcher. Out-of-process gives each
-    // plugin a fresh module realm per lifecycle — so uninstall/disable/reload
-    // truly reclaims its module state by killing the worker (no ESM cache
-    // leak) — plus OS-level crash isolation. The in-process `import()` loader
-    // that prod plugins used is gone; `runImport` survives only for the
-    // separate command-module loader (see {@link loadManifestCommandHandler}).
-    return this.activateViaWorker(pluginId, plugin);
+    // User-installed plugins activate inside a `utilityProcess.fork` worker
+    // (#10526). Dev plugins hot-reload on each `dist/index.js` rebuild; packaged
+    // prod plugins run the same worker without the file watcher. Out-of-process
+    // gives each a fresh module realm per lifecycle — so uninstall/disable/reload
+    // truly reclaims its module state by killing the worker (no ESM cache leak)
+    // — plus OS-level crash isolation.
+    //
+    // Built-in plugins stay on the in-process `import()` loader: they are trusted
+    // app-bundled code, never uninstalled, and never dev-symlinked, so the
+    // unload/divergence problems don't apply. Crucially, the GitHub built-in's
+    // `host.registerForgeProvider` binds a forge impl whose `parseRemote` and URL
+    // builders are SYNCHRONOUS — they can't cross the worker's async MessagePort
+    // (#8879), so routing built-ins through the worker would silently break forge.
+    if (!plugin.isBuiltin) {
+      return this.activateViaWorker(pluginId, plugin);
+    }
+    try {
+      // Bound the dynamic import — a built-in with a hanging top-level await
+      // would otherwise pin this promise forever and stall `Promise.allSettled`
+      // fan-outs (file-decoration scope, startup activation).
+      const mod = (await this.runImport(pluginId, plugin.resolvedMain)) as {
+        activate?: unknown;
+      };
+      if (typeof mod.activate === "function") {
+        const activate = mod.activate as PluginActivate;
+        const { host, revoke } = this.createHost(pluginId);
+        try {
+          const cleanup = await this.runActivate(pluginId, activate, host);
+          // Guard against an unload that ran concurrently with this activation:
+          // by the time `runActivate` resolves, `unloadPlugin` may have already
+          // cleared `cleanupMap` — writing a cleanup back after that fires would
+          // leak. Drop it on the floor instead (#9428).
+          if (typeof cleanup === "function" && this.plugins.has(pluginId)) {
+            this.cleanupMap.set(pluginId, cleanup);
+          }
+        } finally {
+          revoke();
+        }
+      }
+    } catch (err) {
+      // Built-ins don't carry a provenance record (they're not user-installed),
+      // so a failure is logged but not persisted — mirrors the prior loader.
+      console.error(`[PluginService] Failed to load main entry for ${pluginId}:`, err);
+      throw err;
+    }
   }
 
   /**
@@ -3345,6 +3383,33 @@ export class PluginService {
     }
 
     return dispose;
+  }
+
+  /**
+   * Run a built-in plugin's `activate(host)` bounded by a timeout so a hanging
+   * activate can't stall the host. Used only for the in-process built-in path;
+   * user plugins activate in the worker (see {@link activateViaWorker}).
+   */
+  private async runActivate(
+    pluginId: string,
+    activate: PluginActivate,
+    host: PluginHostApi
+  ): Promise<void | (() => void)> {
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        Promise.resolve().then(() => activate(host)),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new Error(`Plugin "${pluginId}" activate() timed out after ${ACTIVATE_TIMEOUT_MS}ms`)
+            );
+          }, ACTIVATE_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   private resolveEntryPath(pluginDir: string, relativePath: string): string | null {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -46,7 +46,6 @@ import type {
   PluginIpcHandler,
   PluginIpcContext,
   PluginHostApi,
-  PluginActivate,
   PluginActionContribution,
   PluginActionDescriptor,
   PluginChannelSchema,
@@ -706,13 +705,13 @@ export class PluginService {
    */
   private hostGitFactory: HostGitFactory | undefined = undefined;
   /**
-   * Live dev-mode hot-reload workers, keyed by pluginId (#9304). Each holds the
-   * forked `utilityProcess` lifecycle, the message bridge to the real host, and
-   * the host `revoke` to call on unload. Disposed via the {@link cleanupMap}
-   * disposer registered at activation, so `unloadPlugin` tears the worker down
-   * through its normal cascade.
+   * Live plugin workers, keyed by pluginId (#9304, #10526). Every plugin (dev
+   * and prod) runs in a forked `utilityProcess`; each entry holds that lifecycle,
+   * the message bridge to the real host, and the host `revoke` to call on unload.
+   * Disposed via the {@link cleanupMap} disposer registered at activation, so
+   * `unloadPlugin` tears the worker down through its normal cascade.
    */
-  private devWorkers = new Map<
+  private pluginWorkers = new Map<
     string,
     { workerHost: PluginDevWorkerHost; bridge: PluginDevWorkerMainBridge; revoke: () => void }
   >();
@@ -1542,81 +1541,48 @@ export class PluginService {
   private async _doActivate(pluginId: string): Promise<void> {
     const plugin = this.plugins.get(pluginId);
     if (!plugin || !plugin.resolvedMain) return;
-    // Dev-mode plugins run inside a hot-reload worker instead of the in-process
-    // import() loader (#9304).
-    if (plugin.devMode) {
-      return this.activateViaDevWorker(pluginId, plugin);
-    }
-    try {
-      // Bound the dynamic import — a plugin with a hanging top-level await
-      // would otherwise pin this promise forever and stall `Promise.allSettled`
-      // fan-outs (file-decoration scope, startup activation).
-      const mod = (await this.runImport(pluginId, plugin.resolvedMain)) as {
-        activate?: unknown;
-      };
-      if (typeof mod.activate === "function") {
-        const activate = mod.activate as PluginActivate;
-        const { host, revoke } = this.createHost(pluginId);
-        try {
-          const cleanup = await this.runActivate(pluginId, activate, host);
-          // Guard against an unload that ran concurrently with this activation:
-          // by the time `runActivate` resolves, `unloadPlugin` may have already
-          // cleared `cleanupMap` — writing a cleanup back after that fires
-          // would leak (e.g. a setInterval the plugin set up in activate()
-          // would never be cleared). Drop it on the floor instead.
-          if (typeof cleanup === "function" && this.plugins.has(pluginId)) {
-            this.cleanupMap.set(pluginId, cleanup);
-          }
-        } finally {
-          revoke();
-        }
-      }
-      // Successful activation (or a main with no activate fn) clears any
-      // diagnostic record left over from a prior failed attempt — persisted
-      // to the provenance record so it survives a host restart. Plugins with
-      // a load-time error that is independent of `main` activation (e.g. a
-      // manifest command id collision, #9281) are exempted: their diagnostic
-      // is a manifest-level fact that doesn't go away when `main` activates.
-      if (!plugin.isBuiltin && !this.pluginsWithLoadTimeErrors.has(pluginId)) {
-        this.records.upsertInstalledRecord(pluginId, { loadError: null });
-      }
-    } catch (err) {
-      const loadError = toPluginLoadError(err);
-      if (!plugin.isBuiltin) {
-        this.records.upsertInstalledRecord(pluginId, { loadError });
-      }
-      console.error(`[PluginService] Failed to load main entry for ${pluginId}:`, err);
-      throw err;
-    }
+    // Every plugin activates inside a `utilityProcess.fork` worker (#10526).
+    // Dev plugins hot-reload on each `dist/index.js` rebuild; prod plugins run
+    // the same worker without the file watcher. Out-of-process gives each
+    // plugin a fresh module realm per lifecycle — so uninstall/disable/reload
+    // truly reclaims its module state by killing the worker (no ESM cache
+    // leak) — plus OS-level crash isolation. The in-process `import()` loader
+    // that prod plugins used is gone; `runImport` survives only for the
+    // separate command-module loader (see {@link loadManifestCommandHandler}).
+    return this.activateViaWorker(pluginId, plugin);
   }
 
   /**
-   * Activate a dev-mode plugin inside a hot-reload worker (#9304). The plugin's
-   * code runs in a `utilityProcess.fork` child; the real host (from
-   * {@link createHost}) is bridged to the worker over MessagePort. The worker
-   * watches `dist/index.js` and respawns on every rebuild, so module-scope state
-   * never leaks across reloads (the robust fix for the Vite ESM cache leak).
+   * Activate a plugin inside a `utilityProcess.fork` worker (#9304, #10526).
+   * The plugin's code runs in the child; the real host (from {@link createHost})
+   * is bridged to the worker over MessagePort. Dev plugins (`mode: "dev"`) watch
+   * `dist/index.js` and respawn on every rebuild, so module-scope state never
+   * leaks across reloads (the robust fix for the Vite ESM cache leak); prod
+   * plugins (`mode: "prod"`) run the same worker without the watcher, getting a
+   * fresh module realm per load/unload — uninstall truly reclaims their memory.
    *
-   * The host is left un-revoked for the worker's lifetime — unlike the
-   * in-process path, the worker legitimately re-registers on every reload, and
-   * the activation-window contract is enforced worker-side by its own proxy.
+   * The host is left un-revoked for the worker's lifetime: the worker
+   * legitimately re-registers on every reload, post-activation host calls
+   * (dispatch, toast, spawn, fs.watch) keep relaying at runtime, and the
+   * activation-window contract is enforced worker-side by its own proxy.
    *
-   * A failed `activate()` is recorded but does NOT tear the worker down: the
+   * A failed `activate()` is recorded but does NOT tear the worker down: a dev
    * worker keeps watching so the author can fix the error and save to reload.
    * Only a fork failure (no worker at all) rejects.
    */
-  private async activateViaDevWorker(pluginId: string, plugin: LoadedPlugin): Promise<void> {
+  private async activateViaWorker(pluginId: string, plugin: LoadedPlugin): Promise<void> {
     if (!plugin.resolvedMain) return;
     // A re-activation while a worker is already live is a no-op — the worker
     // owns its own reload cycle; activatePlugin's idempotency normally prevents
     // this, but guard defensively against the unload-race re-entry path.
-    if (this.devWorkers.has(pluginId)) return;
+    if (this.pluginWorkers.has(pluginId)) return;
 
     const { host, revoke } = this.createHost(pluginId);
     const workerHost = new PluginDevWorkerHost({
       pluginId,
       pluginDir: plugin.dir,
       bundlePath: plugin.resolvedMain,
+      mode: plugin.devMode ? "dev" : "prod",
     });
     const bridge = new PluginDevWorkerMainBridge({
       pluginId,
@@ -1645,14 +1611,14 @@ export class PluginService {
           }
         } else {
           this.records.upsertInstalledRecord(pluginId, {
-            loadError: { message: result.error, at: Date.now() },
+            loadError: { message: result.error, stack: result.stack, at: Date.now() },
           });
         }
       },
     });
 
     const entry = { workerHost, bridge, revoke };
-    this.devWorkers.set(pluginId, entry);
+    this.pluginWorkers.set(pluginId, entry);
 
     // Register the teardown disposer up front so a concurrent unloadPlugin()
     // during fork/activation tears the worker down through the normal cascade.
@@ -1660,8 +1626,8 @@ export class PluginService {
       bridge.dispose();
       workerHost.dispose();
       revoke();
-      if (this.devWorkers.get(pluginId) === entry) {
-        this.devWorkers.delete(pluginId);
+      if (this.pluginWorkers.get(pluginId) === entry) {
+        this.pluginWorkers.delete(pluginId);
       }
     };
     this.cleanupMap.set(pluginId, cleanup);
@@ -1675,12 +1641,12 @@ export class PluginService {
       if (!plugin.isBuiltin) {
         this.records.upsertInstalledRecord(pluginId, { loadError });
       }
-      console.error(`[PluginService] Failed to start dev worker for ${pluginId}:`, err);
+      console.error(`[PluginService] Failed to start worker for ${pluginId}:`, err);
       throw err;
     }
 
     // If an unload raced the fork, the cleanup already disposed everything.
-    if (!this.plugins.has(pluginId) || this.devWorkers.get(pluginId) !== entry) {
+    if (!this.plugins.has(pluginId) || this.pluginWorkers.get(pluginId) !== entry) {
       cleanup();
       return;
     }
@@ -1688,10 +1654,10 @@ export class PluginService {
     // Bound the first activation so a plugin with a hanging `activate()` (or a
     // never-resolving top-level await in the worker) can't stall the
     // `Promise.allSettled` startup gate forever. On timeout the worker stays
-    // alive and watching — `onActivationResult` will clear/record the error if
-    // activation eventually settles or a reload follows. Mirrors the in-process
-    // ACTIVATE_TIMEOUT_MS contract. The provenance `loadError` is owned by
-    // `onActivationResult`; this catch only logs and unblocks startup.
+    // alive — `onActivationResult` will clear/record the error if activation
+    // eventually settles (or, for a dev worker, a reload follows). The
+    // provenance `loadError` is owned by `onActivationResult`; this catch only
+    // logs and unblocks startup.
     let timer: NodeJS.Timeout | undefined;
     try {
       await Promise.race([
@@ -1700,7 +1666,7 @@ export class PluginService {
           timer = setTimeout(() => {
             reject(
               new Error(
-                `Dev plugin "${pluginId}" activate() did not settle within ${ACTIVATE_TIMEOUT_MS}ms`
+                `Plugin "${pluginId}" activate() did not settle within ${ACTIVATE_TIMEOUT_MS}ms`
               )
             );
           }, ACTIVATE_TIMEOUT_MS);
@@ -1708,7 +1674,16 @@ export class PluginService {
         }),
       ]);
     } catch (err) {
-      console.error(`[PluginService] Dev plugin "${pluginId}" activation:`, err);
+      // The worker didn't settle in time — typically a hanging `activate()` or a
+      // never-resolving top-level await in the bundle. The worker stays alive in
+      // isolation (it can't stall the main process); record the timeout as the
+      // provenance loadError so diagnostics surface why the plugin never came up.
+      // If activation eventually settles (or a dev reload follows),
+      // `onActivationResult` overwrites this.
+      if (!plugin.isBuiltin) {
+        this.records.upsertInstalledRecord(pluginId, { loadError: toPluginLoadError(err) });
+      }
+      console.error(`[PluginService] Plugin "${pluginId}" activation:`, err);
     } finally {
       if (timer) clearTimeout(timer);
     }
@@ -3370,28 +3345,6 @@ export class PluginService {
     }
 
     return dispose;
-  }
-
-  private async runActivate(
-    pluginId: string,
-    activate: PluginActivate,
-    host: PluginHostApi
-  ): Promise<void | (() => void)> {
-    let timer: NodeJS.Timeout | undefined;
-    try {
-      return await Promise.race([
-        Promise.resolve().then(() => activate(host)),
-        new Promise<never>((_resolve, reject) => {
-          timer = setTimeout(() => {
-            reject(
-              new Error(`Plugin "${pluginId}" activate() timed out after ${ACTIVATE_TIMEOUT_MS}ms`)
-            );
-          }, ACTIVATE_TIMEOUT_MS);
-        }),
-      ]);
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
   }
 
   private resolveEntryPath(pluginDir: string, relativePath: string): string | null {

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -49,6 +49,84 @@ vi.mock("../../store.js", () => ({
   },
 }));
 
+// Every plugin activates out-of-process via utilityProcess.fork (#10526), which
+// vitest can't run. Mock the worker host/bridge so the bridge imports the
+// fixture bundle and runs `activate(host)` IN-PROCESS against the real host —
+// preserving this suite's end-to-end coverage of real contribution registries.
+const devWorkerMock = vi.hoisted(() => {
+  interface DevWorkerOpts {
+    pluginId: string;
+    pluginDir: string;
+    bundlePath: string;
+    mode?: "dev" | "prod";
+  }
+  class MockPluginDevWorkerHost {
+    opts: DevWorkerOpts;
+    start = vi.fn(async () => undefined);
+    dispose = vi.fn();
+    isReady = (): boolean => true;
+    on = vi.fn();
+    off = vi.fn();
+    constructor(opts: DevWorkerOpts) {
+      this.opts = opts;
+    }
+  }
+  interface MockBridgeDeps {
+    workerHost: { opts: DevWorkerOpts };
+    host: unknown;
+    onActivationResult?: (
+      result: { ok: true } | { ok: false; error: string; stack?: string }
+    ) => void;
+  }
+  class MockPluginDevWorkerMainBridge {
+    deps: MockBridgeDeps;
+    private cleanup: (() => void) | null = null;
+    waitForActivation = vi.fn(async () => {
+      const bundlePath = this.deps.workerHost?.opts?.bundlePath;
+      const onResult = this.deps.onActivationResult;
+      if (!bundlePath) {
+        onResult?.({ ok: true });
+        return;
+      }
+      const { pathToFileURL } = await import("node:url");
+      const { formatErrorMessage } = await import("../../../shared/utils/errorMessage.js");
+      try {
+        const mod = (await import(pathToFileURL(bundlePath).href)) as { activate?: unknown };
+        if (typeof mod.activate === "function") {
+          const result = await (mod.activate as (h: unknown) => unknown)(this.deps.host);
+          if (typeof result === "function") this.cleanup = result as () => void;
+        }
+        onResult?.({ ok: true });
+      } catch (err) {
+        onResult?.({
+          ok: false,
+          error: formatErrorMessage(err, "activate() threw"),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+      }
+    });
+    dispose = vi.fn(() => {
+      try {
+        this.cleanup?.();
+      } catch {
+        // best-effort
+      }
+      this.cleanup = null;
+    });
+    constructor(deps: MockBridgeDeps) {
+      this.deps = deps;
+    }
+  }
+  return { MockPluginDevWorkerHost, MockPluginDevWorkerMainBridge };
+});
+vi.mock("../plugin/PluginDevWorkerHost.js", () => ({
+  PluginDevWorkerHost: devWorkerMock.MockPluginDevWorkerHost,
+  CRASH_WINDOW_MS: 30 * 60 * 1000,
+}));
+vi.mock("../plugin/PluginDevWorkerMainBridge.js", () => ({
+  PluginDevWorkerMainBridge: devWorkerMock.MockPluginDevWorkerMainBridge,
+}));
+
 import { PluginService } from "../PluginService.js";
 import type { PluginIpcContext } from "../../../shared/types/plugin.js";
 import {
@@ -898,9 +976,11 @@ describe("PluginService integration — main entry execution", () => {
       await initializeAndActivate(service);
 
       expect(service.hasPlugin("acme.bad-main")).toBe(true);
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to load main entry for acme.bad-main"),
-        expect.anything()
+      // The worker reports the import failure via onActivationResult, which
+      // PluginService persists as the provenance loadError (#10526) — the
+      // in-process console.error of the old loader is gone.
+      expect(service.getPluginLoadError("acme.bad-main")?.message).toContain(
+        "intentional fixture failure"
       );
       expect(getPanelKindConfig("acme.bad-main.p")).toBeDefined();
       expect(getToolbarButtonConfig("acme.bad-main.b")).toBeDefined();
@@ -1082,7 +1162,8 @@ describe("PluginService integration — activate() lifecycle", () => {
     );
     expect(result).toEqual({ echoed: { issue: 7 } });
 
-    // Unload tears the handler down — a later dispatch finds nothing.
+    // Unload tears the handler down — a later dispatch is short-circuited by
+    // the #10462 ownership guard (the plugin left `this.plugins`).
     service.unloadPlugin("acme.action-plugin");
     expect(service.listPluginActions()).toEqual([]);
     await expect(
@@ -1092,7 +1173,7 @@ describe("PluginService integration — activate() lifecycle", () => {
         makeCtx("acme.action-plugin"),
         [{}]
       )
-    ).rejects.toThrow(/No plugin handler registered/);
+    ).rejects.toThrow(/is not loaded/);
   });
 
   it("invokes activate's returned cleanup before handlers are removed on unload", async () => {
@@ -1161,7 +1242,7 @@ describe("PluginService integration — activate() lifecycle", () => {
     }
   });
 
-  it("logs an error and still registers the plugin when activate throws", async () => {
+  it("records a load error and still registers the plugin when activate throws", async () => {
     const pluginDir = await writePlugin("acme.throwing-activate", {
       name: "acme.throwing-activate",
       version: "1.0.0",
@@ -1180,19 +1261,13 @@ describe("PluginService integration — activate() lifecycle", () => {
       })
     );
 
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    try {
-      const service = new PluginService(tmpDir, "0.0.0");
-      await initializeAndActivate(service);
+    const service = new PluginService(tmpDir, "0.0.0");
+    await initializeAndActivate(service);
 
-      expect(service.hasPlugin("acme.throwing-activate")).toBe(true);
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Failed to load main entry for acme.throwing-activate"),
-        expect.anything()
-      );
-    } finally {
-      errorSpy.mockRestore();
-    }
+    expect(service.hasPlugin("acme.throwing-activate")).toBe(true);
+    // The worker's activate-error is persisted as the provenance loadError
+    // (#10526) — the in-process console.error of the old loader is gone.
+    expect(service.getPluginLoadError("acme.throwing-activate")?.message).toContain("boom");
   });
 
   it("host.registerHandler enforces the plugin's own namespace", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -8638,13 +8638,40 @@ describe("dev-mode hot reload (#9304)", () => {
     await service.initialize();
     await service.activatePlugin("acme.prod");
 
-    // Every plugin runs out-of-process now: a prod plugin forks the same worker
-    // as a dev plugin, but in "prod" mode (no hot-reload file watcher).
+    // Every user plugin runs out-of-process now: a prod plugin forks the same
+    // worker as a dev plugin, but in "prod" mode (no hot-reload file watcher).
     expect(devWorkerMock.instances).toHaveLength(1);
     expect(devWorkerMock.instances[0].opts.pluginId).toBe("acme.prod");
     expect(devWorkerMock.instances[0].opts.mode).toBe("prod");
     const info = service.listPlugins().find((p) => p.manifest.name === "acme.prod");
     expect(info?.devMode).toBe(false);
+  });
+
+  it("activates a built-in plugin in-process, NOT via a worker (#10526)", async () => {
+    // Built-ins stay on the in-process loader: they're trusted app-bundled code
+    // that may use synchronous host surfaces (registerForgeProvider) which can't
+    // cross the worker's async port — routing them through it would break forge.
+    const builtinRoot = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-builtin-route-"));
+    try {
+      const dir = path.join(builtinRoot, "daintree.builtin");
+      await fs.mkdir(path.join(dir, "dist"), { recursive: true });
+      await fs.writeFile(
+        path.join(dir, "plugin.json"),
+        JSON.stringify({ name: "daintree.builtin", version: "1.0.0", main: "dist/index.js" })
+      );
+      await fs.writeFile(path.join(dir, "dist", "index.js"), "export function activate() {}");
+
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinRoot });
+      await service.initialize();
+      await service.activatePlugin("daintree.builtin");
+
+      // No worker forked for the built-in; it activated via the in-process loader.
+      expect(devWorkerMock.instances).toHaveLength(0);
+      const info = service.listPlugins().find((p) => p.manifest.name === "daintree.builtin");
+      expect(info?.isBuiltin).toBe(true);
+    } finally {
+      await fs.rm(builtinRoot, { recursive: true, force: true });
+    }
   });
 
   it("disposes the worker and bridge when the dev plugin is unloaded", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -131,6 +131,7 @@ const devWorkerMock = vi.hoisted(() => {
     pluginId: string;
     pluginDir: string;
     bundlePath: string;
+    mode?: "dev" | "prod";
   }
   const instances: MockPluginDevWorkerHost[] = [];
   const bridges: MockPluginDevWorkerMainBridge[] = [];
@@ -146,11 +147,56 @@ const devWorkerMock = vi.hoisted(() => {
       instances.push(this);
     }
   }
+  // The real worker forks a child that imports the plugin bundle, runs
+  // `activate(host)`, and reports the outcome via `onActivationResult`. vitest
+  // can't fork, so the mock bridge does that import + activate in-process
+  // against the real host and drives the same callback — exercising
+  // PluginService's activation/provenance wiring without a worker. (#10526)
+  interface MockBridgeDeps {
+    workerHost: { opts: DevWorkerOpts };
+    host: unknown;
+    onActivationResult?: (
+      result: { ok: true } | { ok: false; error: string; stack?: string }
+    ) => void;
+  }
   class MockPluginDevWorkerMainBridge {
-    deps: unknown;
-    waitForActivation = vi.fn(async () => undefined);
-    dispose = vi.fn();
-    constructor(deps: unknown) {
+    deps: MockBridgeDeps;
+    private cleanup: (() => void) | null = null;
+    waitForActivation = vi.fn(async () => {
+      const bundlePath = this.deps.workerHost?.opts?.bundlePath;
+      const onResult = this.deps.onActivationResult;
+      if (!bundlePath) {
+        onResult?.({ ok: true });
+        return;
+      }
+      const { pathToFileURL } = await import("node:url");
+      const { formatErrorMessage } = await import("../../../shared/utils/errorMessage.js");
+      try {
+        const mod = (await import(pathToFileURL(bundlePath).href)) as { activate?: unknown };
+        if (typeof mod.activate === "function") {
+          const result = await (mod.activate as (h: unknown) => unknown)(this.deps.host);
+          if (typeof result === "function") this.cleanup = result as () => void;
+        }
+        onResult?.({ ok: true });
+      } catch (err) {
+        // Mirror the worker entry's failure shaping (formatErrorMessage + raw
+        // Error stack) so provenance records match the real path.
+        onResult?.({
+          ok: false,
+          error: formatErrorMessage(err, "activate() threw"),
+          stack: err instanceof Error ? err.stack : undefined,
+        });
+      }
+    });
+    dispose = vi.fn(() => {
+      try {
+        this.cleanup?.();
+      } catch {
+        // best-effort
+      }
+      this.cleanup = null;
+    });
+    constructor(deps: MockBridgeDeps) {
       this.deps = deps;
       bridges.push(this);
     }
@@ -8109,16 +8155,16 @@ describe("Deferred activation — activatePlugin", () => {
     }
   });
 
-  it("import() with a hanging top-level await times out instead of stalling forever", async () => {
+  it("a hanging activation times out instead of stalling forever", async () => {
     const pluginDir = path.join(tmpDir, "hanging-import");
     await fs.mkdir(pluginDir);
     await fs.writeFile(
       path.join(pluginDir, "plugin.json"),
       JSON.stringify({ name: "acme.hanging-import", version: "1.0.0", main: "main.mjs" })
     );
-    // Top-level `await new Promise(() => {})` hangs forever. Without the
-    // import-timeout guard this would pin `_doActivate` and any
-    // `Promise.allSettled` fan-out behind it.
+    // Top-level `await new Promise(() => {})` hangs the worker's import forever.
+    // The worker is isolated (it can't stall main), but the activation gate must
+    // still time out so `Promise.allSettled` startup fan-outs aren't pinned.
     await fs.writeFile(
       path.join(pluginDir, "main.mjs"),
       "await new Promise(() => {}); export function activate() {}"
@@ -8128,12 +8174,12 @@ describe("Deferred activation — activatePlugin", () => {
     try {
       const service = new PluginService(tmpDir);
       await service.initialize();
-      // The promise resolves (it doesn't reject — `activatePlugin` swallows)
-      // and the timeout error is persisted as the loadError so diagnostics
+      // The promise resolves (it doesn't reject — `activatePlugin` swallows) and
+      // the activation-timeout error is persisted as the loadError so diagnostics
       // surface why the plugin never came up.
       await service.activatePlugin("acme.hanging-import");
       const record = service.getPluginLoadError("acme.hanging-import");
-      expect(record?.message).toContain("timed out");
+      expect(record?.message).toContain("did not settle");
     } finally {
       errorSpy.mockRestore();
     }
@@ -8575,11 +8621,12 @@ describe("dev-mode hot reload (#9304)", () => {
     expect(devWorkerMock.instances).toHaveLength(1);
     expect(devWorkerMock.instances[0].opts.pluginId).toBe("acme.dev");
     expect(devWorkerMock.instances[0].opts.bundlePath).toMatch(/dist[/\\]index\.js$/);
+    expect(devWorkerMock.instances[0].opts.mode).toBe("dev");
     expect(devWorkerMock.instances[0].start).toHaveBeenCalledTimes(1);
     expect(devWorkerMock.bridges[0].waitForActivation).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fork a worker for a plugin without a marker", async () => {
+  it("forks a prod-mode worker for a plugin without a dev marker (#10526)", async () => {
     const dir = path.join(tmpDir, "prod-plugin");
     await fs.mkdir(path.join(dir, "dist"), { recursive: true });
     await fs.writeFile(
@@ -8591,7 +8638,11 @@ describe("dev-mode hot reload (#9304)", () => {
     await service.initialize();
     await service.activatePlugin("acme.prod");
 
-    expect(devWorkerMock.instances).toHaveLength(0);
+    // Every plugin runs out-of-process now: a prod plugin forks the same worker
+    // as a dev plugin, but in "prod" mode (no hot-reload file watcher).
+    expect(devWorkerMock.instances).toHaveLength(1);
+    expect(devWorkerMock.instances[0].opts.pluginId).toBe("acme.prod");
+    expect(devWorkerMock.instances[0].opts.mode).toBe("prod");
     const info = service.listPlugins().find((p) => p.manifest.name === "acme.prod");
     expect(info?.devMode).toBe(false);
   });
@@ -8646,7 +8697,7 @@ describe("dev-mode hot reload (#9304)", () => {
     // worker re-registers. Manifest commands must survive — only imperative
     // (host.registerAction) actions are dropped.
     const clearPriorRegistrations = (
-      devWorkerMock.bridges[0].deps as { clearPriorRegistrations: () => void }
+      devWorkerMock.bridges[0].deps as unknown as { clearPriorRegistrations: () => void }
     ).clearPriorRegistrations;
     clearPriorRegistrations();
 

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -7,7 +7,10 @@ import os from "os";
 import { fileURLToPath, pathToFileURL } from "url";
 import { createLogger } from "../../utils/logger.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
-import { PLUGIN_DEV_WORKER_KIND } from "../../../shared/types/pluginDevWorker.js";
+import {
+  PLUGIN_DEV_WORKER_KIND,
+  PLUGIN_PROD_WORKER_KIND,
+} from "../../../shared/types/pluginDevWorker.js";
 import type {
   PluginHostToWorkerMessage,
   PluginWorkerToHostMessage,
@@ -45,12 +48,21 @@ export interface PluginDevWorkerHostOptions {
   pluginDir: string;
   /** Absolute path to the built bundle (`dist/index.js`) the worker imports. */
   bundlePath: string;
+  /**
+   * `"dev"` (default) hot-reloads the worker on every `bundlePath` rebuild;
+   * `"prod"` runs the same worker without the file watcher (production bundles
+   * never rebuild in place, so there is nothing to watch). Crash supervision,
+   * fork lifecycle, and graceful dispose are identical in both modes.
+   */
+  mode?: "dev" | "prod";
 }
 
 /**
- * Owns the `utilityProcess.fork` lifecycle for one dev-mode plugin: fork the
- * worker, hand it the bundle to import, watch `bundlePath` for rebuilds, and
- * kill + respawn on each change. Crash supervision mirrors
+ * Owns the `utilityProcess.fork` lifecycle for one plugin: fork the worker,
+ * hand it the bundle to import, and (in `"dev"` mode only) watch `bundlePath`
+ * for rebuilds, killing + respawning on each change. Production plugins reuse
+ * the same host with `mode: "prod"` and no file watcher. Crash supervision
+ * mirrors
  * {@link WorkspaceHostProcess} (sliding crash window, `child-process-gone`
  * filtering, exit/gone ordering defer).
  *
@@ -67,6 +79,8 @@ export class PluginDevWorkerHost extends EventEmitter {
   private readonly pluginDir: string;
   private readonly bundlePath: string;
   private readonly serviceName: string;
+  private readonly mode: "dev" | "prod";
+  private readonly workerKind: string;
 
   private watcher: fs.FSWatcher | null = null;
   private reloadTimer: NodeJS.Timeout | null = null;
@@ -95,13 +109,15 @@ export class PluginDevWorkerHost extends EventEmitter {
     this.pluginId = options.pluginId;
     this.pluginDir = options.pluginDir;
     this.bundlePath = options.bundlePath;
+    this.mode = options.mode ?? "dev";
+    this.workerKind = this.mode === "prod" ? PLUGIN_PROD_WORKER_KIND : PLUGIN_DEV_WORKER_KIND;
 
     const safeName = options.pluginId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 40);
-    // Hash the plugin dir so two dev plugins sharing a sanitized name still get
+    // Hash the plugin dir so two plugins sharing a sanitized name still get
     // distinct service names — otherwise the per-instance `child-process-gone`
     // filter would cross-attribute crashes.
     const dirHash = createHash("sha1").update(options.pluginDir).digest("hex").slice(0, 8);
-    this.serviceName = `daintree-plugin-dev:${safeName}-${dirHash}`;
+    this.serviceName = `daintree-plugin-${this.mode}:${safeName}-${dirHash}`;
 
     this.readyPromise = new Promise((resolve, reject) => {
       this.readyResolve = resolve;
@@ -124,7 +140,9 @@ export class PluginDevWorkerHost extends EventEmitter {
    * never throw synchronously, so awaiting callers still observe rejections. */
   start(): Promise<void> {
     this.startWorker();
-    this.startWatching();
+    // Production workers never rebuild their bundle in place, so there is
+    // nothing to hot-reload — skip the file watcher entirely.
+    if (this.mode === "dev") this.startWatching();
     return this.readyPromise;
   }
 
@@ -377,7 +395,7 @@ export class PluginDevWorkerHost extends EventEmitter {
           // env REPLACES process.env in a utility process (#6081) — spread first.
           ...(process.env as Record<string, string>),
           DAINTREE_USER_DATA: app.getPath("userData"),
-          DAINTREE_UTILITY_PROCESS_KIND: PLUGIN_DEV_WORKER_KIND,
+          DAINTREE_UTILITY_PROCESS_KIND: this.workerKind,
           // io_uring disabled on Linux for utility-process stability (#6081).
           ...(process.platform === "linux" ? { UV_USE_IO_URING: "0" } : {}),
         },

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -633,7 +633,9 @@ export class PluginDevWorkerMainBridge {
         const handle = this.processHandles.get(msg.processId);
         if (!handle) {
           // The handle was killed (reload/dispose) between spawn and subscribe.
-          logger.warn(`[${this.pluginId}] ${kind} subscribe for unknown process "${msg.processId}"`);
+          logger.warn(
+            `[${this.pluginId}] ${kind} subscribe for unknown process "${msg.processId}"`
+          );
           return;
         }
         dispose =

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -127,6 +127,12 @@ export class PluginDevWorkerMainBridge {
       this.activationResolve = resolve;
       this.activationReject = reject;
     });
+    // Guard the first-activation promise so a rejection that lands before any
+    // consumer awaited it (dispose / crash-loop right after construction) can't
+    // surface as an unhandled rejection. The real consumer still observes the
+    // rejection via `waitForActivation()`. Mirrors `PluginDevWorkerHost`'s
+    // `readyPromise.catch` guard.
+    this.activationPromise.catch(() => undefined);
 
     this.workerHost.on("worker-message", this.onWorkerMessage);
     this.workerHost.on("reloading", this.onReloading);

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -15,7 +15,11 @@
 
 import { createLogger } from "../../utils/logger.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
-import type { PluginHostApi, PluginIpcContext } from "../../../shared/types/plugin.js";
+import type {
+  PluginHostApi,
+  PluginIpcContext,
+  PluginProcessHandle,
+} from "../../../shared/types/plugin.js";
 import type { FileDecoration, FileDecorationProviderImpl } from "../../../shared/types/forge.js";
 import type {
   BroadcastToRendererParams,
@@ -36,7 +40,10 @@ import type {
   UnregisterFileDecorationProviderParams,
   FsPathParams,
   FsWriteFileParams,
+  FsWatchParams,
   GitOpParams,
+  ProcessSpawnParams,
+  ProcessHandleRefParams,
 } from "../../../shared/types/pluginDevWorker.js";
 import type { PluginDevWorkerHost } from "./PluginDevWorkerHost.js";
 
@@ -57,8 +64,12 @@ export interface PluginDevWorkerMainBridgeDeps {
    * Fires on EVERY activation outcome — the initial activation and each reload.
    * Lets the owner keep the provenance `loadError` in sync across reloads (the
    * first-activation promise settles once and can't observe later outcomes).
+   * `stack` carries the worker's `activate-error` stack so the provenance record
+   * keeps it (parity with the old in-process `toPluginLoadError` path).
    */
-  onActivationResult?: (result: { ok: true } | { ok: false; error: string }) => void;
+  onActivationResult?: (
+    result: { ok: true } | { ok: false; error: string; stack?: string }
+  ) => void;
 }
 
 interface PendingInvoke {
@@ -73,7 +84,7 @@ export class PluginDevWorkerMainBridge {
   private readonly getCapabilities: () => readonly string[];
   private readonly clearPriorRegistrations: () => void;
   private readonly onActivationResult?: (
-    result: { ok: true } | { ok: false; error: string }
+    result: { ok: true } | { ok: false; error: string; stack?: string }
   ) => void;
 
   private disposed = false;
@@ -91,6 +102,11 @@ export class PluginDevWorkerMainBridge {
    * host, keyed by provider id. Torn down on reload and dispose so a reloaded
    * generation re-registers cleanly. */
   private readonly providerDisposers = new Map<string, () => void>();
+  /** Live handles for processes the worker spawned via `host.process.spawn`,
+   * keyed by the host-assigned handle id. The worker addresses `kill` /
+   * `restart` / `onExit` / `onCrash` by id; all are killed on reload and dispose
+   * (a reloaded generation re-spawns from its fresh module realm). */
+  private readonly processHandles = new Map<string, PluginProcessHandle>();
 
   /** First-activation gate. Resolved on `activated`, rejected on activate/crash
    * errors. Subsequent reload activations don't re-await this. */
@@ -137,6 +153,7 @@ export class PluginDevWorkerMainBridge {
     }
     this.subscriptionDisposers.clear();
     this.disposeProviders();
+    this.disposeProcessHandles();
     this.abortAllHostCalls();
     for (const pending of this.pendingInvokes.values()) {
       pending.reject(new Error("Plugin dev worker bridge disposed"));
@@ -169,6 +186,19 @@ export class PluginDevWorkerMainBridge {
     this.providerDisposers.clear();
   }
 
+  /** Kill every process the worker spawned (worker is going away or reloading —
+   * a fresh generation re-spawns from its own module realm). */
+  private disposeProcessHandles(): void {
+    for (const handle of this.processHandles.values()) {
+      try {
+        handle.kill();
+      } catch {
+        // best-effort
+      }
+    }
+    this.processHandles.clear();
+  }
+
   private onReloading = (): void => {
     // The new worker generation will re-register from scratch; drop the prior
     // generation's activate-time registrations and tear down subscriptions so
@@ -184,6 +214,7 @@ export class PluginDevWorkerMainBridge {
     }
     this.subscriptionDisposers.clear();
     this.disposeProviders();
+    this.disposeProcessHandles();
     this.abortAllHostCalls();
     for (const pending of this.pendingInvokes.values()) {
       pending.reject(new Error("Plugin reloaded before invocation completed"));
@@ -219,7 +250,7 @@ export class PluginDevWorkerMainBridge {
         logger.error(`[${this.pluginId}] activate() failed: ${msg.error}`, {
           stack: msg.stack,
         });
-        this.onActivationResult?.({ ok: false, error: msg.error });
+        this.onActivationResult?.({ ok: false, error: msg.error, stack: msg.stack });
         this.rejectActivation(new Error(msg.error));
         return;
       case "error":
@@ -358,6 +389,62 @@ export class PluginDevWorkerMainBridge {
         return this.host.fs.readdir((params as FsPathParams).path, { signal });
       case "fs.stat":
         return this.host.fs.stat((params as FsPathParams).path, { signal });
+      case "fs.watch": {
+        const p = params as FsWatchParams;
+        const generation = this.reloadGeneration;
+        // The real watcher lives in main; relay each change as a
+        // subscription-event keyed by the worker-supplied subscription id.
+        const dispose = await this.host.fs.watch(
+          p.paths,
+          (changedPath) => {
+            if (this.disposed) return;
+            this.workerHost.send({
+              type: "subscription-event",
+              subscriptionId: p.subscriptionId,
+              payload: changedPath,
+            });
+          },
+          { signal }
+        );
+        // Disposed or reloaded while the watch was settling — tear it down
+        // rather than leak it past the cleanup pass that already ran.
+        if (this.disposed || generation !== this.reloadGeneration) {
+          try {
+            dispose();
+          } catch {
+            // best-effort
+          }
+          return undefined;
+        }
+        this.subscriptionDisposers.set(p.subscriptionId, dispose);
+        return undefined;
+      }
+      case "process.spawn": {
+        const p = params as ProcessSpawnParams;
+        const generation = this.reloadGeneration;
+        const handle = await this.host.process.spawn(p.command, p.options);
+        // Disposed or reloaded while the spawn was settling — the worker that
+        // requested it is gone; kill the orphan rather than leak it.
+        if (this.disposed || generation !== this.reloadGeneration) {
+          try {
+            handle.kill();
+          } catch {
+            // best-effort
+          }
+          return { id: handle.id };
+        }
+        this.processHandles.set(handle.id, handle);
+        return { id: handle.id };
+      }
+      case "process.restart": {
+        const p = params as ProcessHandleRefParams;
+        const handle = this.processHandles.get(p.processId);
+        if (!handle) {
+          throw new Error(`No live process "${p.processId}" to restart`);
+        }
+        await handle.restart();
+        return undefined;
+      }
       case "git.status":
         return this.host.git.status((params as GitOpParams).worktreePath, { signal });
       case "git.diff": {
@@ -504,6 +591,13 @@ export class PluginDevWorkerMainBridge {
         this.host.logger[level](p.message, p.fields);
         return;
       }
+      case "process.kill": {
+        // `PluginProcessHandle.kill()` is sync (no reply) — fire-and-forget. A
+        // no-op if the handle already exited or was torn down on reload.
+        const { processId } = params as ProcessHandleRefParams;
+        this.processHandles.get(processId)?.kill();
+        return;
+      }
       default:
         logger.warn(`[${this.pluginId}] unknown host-notify method "${method}"`);
     }
@@ -528,6 +622,21 @@ export class PluginDevWorkerMainBridge {
         });
       } else if (kind === "agent-state") {
         dispose = await this.host.onDidChangeAgentState((snapshot) => push(snapshot));
+      } else if (kind === "process-exit" || kind === "process-crash") {
+        if (!msg.processId) {
+          logger.warn(`[${this.pluginId}] ${kind} subscribe missing processId`);
+          return;
+        }
+        const handle = this.processHandles.get(msg.processId);
+        if (!handle) {
+          // The handle was killed (reload/dispose) between spawn and subscribe.
+          logger.warn(`[${this.pluginId}] ${kind} subscribe for unknown process "${msg.processId}"`);
+          return;
+        }
+        dispose =
+          kind === "process-exit"
+            ? handle.onExit((info) => push(info))
+            : handle.onCrash((info) => push(info));
       } else {
         // settings
         if (!msg.key) {

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -607,11 +607,14 @@ export class PluginDevWorkerMainBridge {
     msg: Extract<PluginWorkerToHostMessage, { type: "subscribe" }>
   ): Promise<void> {
     const { subscriptionId, kind } = msg;
+    const generation = this.reloadGeneration;
     const push = (payload: unknown): void => {
-      if (this.disposed) return;
+      // Drop events queued before a reload tore this subscription down: the new
+      // worker generation resets its requestId/subscriptionId counter, so a
+      // stale event could otherwise misdeliver to a same-id new subscription.
+      if (this.disposed || generation !== this.reloadGeneration) return;
       this.workerHost.send({ type: "subscription-event", subscriptionId, payload });
     };
-    const generation = this.reloadGeneration;
     try {
       let dispose: () => void;
       if (kind === "active-worktree") {

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -233,6 +233,34 @@ describe("PluginDevWorkerHost", () => {
     expect(child.kill).toHaveBeenCalled();
   });
 
+  it("prod mode forks with the prod-worker kind and starts NO file watcher (#10526)", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost({ ...OPTS, mode: "prod" });
+    host.waitForReady().catch(() => {});
+    void host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    // Forked with the prod kind for process-monitor observability...
+    const [, , options] = forkMock.mock.calls[0];
+    expect(options.env.DAINTREE_UTILITY_PROCESS_KIND).toBe("plugin-prod-worker");
+    // ...and crucially never arms the hot-reload bundle watcher.
+    expect(watchCalls).toHaveLength(0);
+    host.dispose();
+  });
+
+  it("dev mode arms the file watcher (contrast with prod) (#10526)", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost({ ...OPTS, mode: "dev" });
+    void host.start();
+    (mockChildren[0] as MockUtilityChild).emit("message", { type: "ready" });
+
+    expect(watchCalls).toHaveLength(1);
+    const [, , options] = forkMock.mock.calls[0];
+    expect(options.env.DAINTREE_UTILITY_PROCESS_KIND).toBe("plugin-dev-worker");
+    host.dispose();
+  });
+
   it("re-emits non-lifecycle worker messages as `worker-message`", async () => {
     const { PluginDevWorkerHost } = await loadModule();
     const host = new PluginDevWorkerHost(OPTS);

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -450,7 +450,9 @@ describe("PluginDevWorkerMainBridge", () => {
       const { host, workerHost } = makeBridge();
       await spawn(workerHost, host);
       expect(host.process.spawn).toHaveBeenCalledWith("node", { args: ["x.js"] });
-      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "spawn1");
+      const res = workerHost.sent.find(
+        (m: any) => m.type === "host-result" && m.requestId === "spawn1"
+      );
       expect(res).toMatchObject({ ok: true, result: { id: "p1" } });
     });
 
@@ -477,7 +479,9 @@ describe("PluginDevWorkerMainBridge", () => {
       });
       await flush();
       expect(handle.restart).toHaveBeenCalled();
-      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "r1");
+      const res = workerHost.sent.find(
+        (m: any) => m.type === "host-result" && m.requestId === "r1"
+      );
       expect(res).toMatchObject({ ok: true });
     });
 
@@ -490,7 +494,9 @@ describe("PluginDevWorkerMainBridge", () => {
         params: { processId: "ghost" },
       });
       await flush();
-      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "r2");
+      const res = workerHost.sent.find(
+        (m: any) => m.type === "host-result" && m.requestId === "r2"
+      );
       expect(res).toMatchObject({ ok: false });
       expect(res.error).toMatch(/No live process/);
     });
@@ -592,7 +598,9 @@ describe("PluginDevWorkerMainBridge", () => {
         params: { subscriptionId: "fs3", paths: ["/nope"] },
       });
       await flush();
-      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "w3");
+      const res = workerHost.sent.find(
+        (m: any) => m.type === "host-result" && m.requestId === "w3"
+      );
       expect(res).toMatchObject({ ok: false });
       expect(res.error).toMatch(/PERMISSION_REQUIRED/);
     });

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -40,6 +40,43 @@ function makeHost() {
       set: vi.fn(async () => {}),
       onDidChange: vi.fn(() => vi.fn()),
     },
+    process: {
+      spawn: vi.fn(async () => ({
+        id: "p0",
+        kill: vi.fn(),
+        restart: vi.fn(async () => {}),
+        onExit: vi.fn(() => vi.fn()),
+        onCrash: vi.fn(() => vi.fn()),
+      })),
+    },
+    fs: {
+      readFile: vi.fn(async () => ""),
+      writeFile: vi.fn(async () => {}),
+      readdir: vi.fn(async () => []),
+      stat: vi.fn(async () => ({})),
+      watch: vi.fn(async (_paths: string[], _cb: (p: string) => void) => vi.fn()),
+    },
+  };
+}
+
+/** A controllable spawned-process handle whose lifecycle callbacks can be fired. */
+function makeProcessHandle(id = "p1") {
+  let exitCb: ((info: unknown) => void) | undefined;
+  let crashCb: ((info: unknown) => void) | undefined;
+  return {
+    id,
+    kill: vi.fn(),
+    restart: vi.fn(async () => {}),
+    onExit: vi.fn((cb: (info: unknown) => void) => {
+      exitCb = cb;
+      return vi.fn();
+    }),
+    onCrash: vi.fn((cb: (info: unknown) => void) => {
+      crashCb = cb;
+      return vi.fn();
+    }),
+    emitExit: (info: unknown) => exitCb?.(info),
+    emitCrash: (info: unknown) => crashCb?.(info),
   };
 }
 
@@ -47,7 +84,7 @@ function makeBridge(
   overrides?: Partial<{
     capabilities: string[];
     clear: () => void;
-    onActivationResult: (r: { ok: true } | { ok: false; error: string }) => void;
+    onActivationResult: (r: { ok: true } | { ok: false; error: string; stack?: string }) => void;
   }>
 ) {
   const host = makeHost();
@@ -355,5 +392,186 @@ describe("PluginDevWorkerMainBridge", () => {
     workerHost.emit("reloading");
     expect(clear).toHaveBeenCalled();
     await expect(pending).rejects.toThrow(/reloaded/);
+  });
+
+  it("forwards the activate-error stack through onActivationResult (#10526)", async () => {
+    const onActivationResult = vi.fn();
+    const { workerHost, bridge } = makeBridge({ onActivationResult });
+    bridge.waitForActivation().catch(() => {});
+    workerHost.emit("worker-message", {
+      type: "activate-error",
+      error: "boom",
+      stack: "Error: boom\n  at activate",
+    });
+    expect(onActivationResult).toHaveBeenCalledWith({
+      ok: false,
+      error: "boom",
+      stack: "Error: boom\n  at activate",
+    });
+  });
+
+  describe("host.process relay (#10526)", () => {
+    async function spawn(workerHost: any, host: any, handle = makeProcessHandle("p1")) {
+      host.process.spawn.mockResolvedValueOnce(handle);
+      workerHost.emit("worker-message", {
+        type: "host-call",
+        requestId: "spawn1",
+        method: "process.spawn",
+        params: { command: "node", options: { args: ["x.js"] } },
+      });
+      await flush();
+      return handle;
+    }
+
+    it("relays spawn to the host and replies with the handle id", async () => {
+      const { host, workerHost } = makeBridge();
+      await spawn(workerHost, host);
+      expect(host.process.spawn).toHaveBeenCalledWith("node", { args: ["x.js"] });
+      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "spawn1");
+      expect(res).toMatchObject({ ok: true, result: { id: "p1" } });
+    });
+
+    it("process.kill notify kills the stored handle", async () => {
+      const { host, workerHost } = makeBridge();
+      const handle = await spawn(workerHost, host);
+      workerHost.emit("worker-message", {
+        type: "host-notify",
+        method: "process.kill",
+        params: { processId: "p1" },
+      });
+      await flush();
+      expect(handle.kill).toHaveBeenCalled();
+    });
+
+    it("process.restart awaits the stored handle's restart", async () => {
+      const { host, workerHost } = makeBridge();
+      const handle = await spawn(workerHost, host);
+      workerHost.emit("worker-message", {
+        type: "host-call",
+        requestId: "r1",
+        method: "process.restart",
+        params: { processId: "p1" },
+      });
+      await flush();
+      expect(handle.restart).toHaveBeenCalled();
+      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "r1");
+      expect(res).toMatchObject({ ok: true });
+    });
+
+    it("process.restart for an unknown process replies with an error", async () => {
+      const { workerHost } = makeBridge();
+      workerHost.emit("worker-message", {
+        type: "host-call",
+        requestId: "r2",
+        method: "process.restart",
+        params: { processId: "ghost" },
+      });
+      await flush();
+      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "r2");
+      expect(res).toMatchObject({ ok: false });
+      expect(res.error).toMatch(/No live process/);
+    });
+
+    it("process-exit subscription pushes exit events to the worker", async () => {
+      const { host, workerHost } = makeBridge();
+      const handle = await spawn(workerHost, host);
+      workerHost.emit("worker-message", {
+        type: "subscribe",
+        subscriptionId: "s1",
+        kind: "process-exit",
+        processId: "p1",
+      });
+      expect(handle.onExit).toHaveBeenCalled();
+      handle.emitExit({ exitCode: 0, signal: null });
+      const evt = workerHost.sent.find(
+        (m: any) => m.type === "subscription-event" && m.subscriptionId === "s1"
+      );
+      expect(evt).toMatchObject({ payload: { exitCode: 0, signal: null } });
+    });
+
+    it("process-crash subscription wires onCrash", async () => {
+      const { host, workerHost } = makeBridge();
+      const handle = await spawn(workerHost, host);
+      workerHost.emit("worker-message", {
+        type: "subscribe",
+        subscriptionId: "s2",
+        kind: "process-crash",
+        processId: "p1",
+      });
+      expect(handle.onCrash).toHaveBeenCalled();
+    });
+
+    it("kills spawned processes on dispose", async () => {
+      const { host, workerHost, bridge } = makeBridge();
+      const handle = await spawn(workerHost, host);
+      bridge.dispose();
+      expect(handle.kill).toHaveBeenCalled();
+    });
+
+    it("kills spawned processes on reload", async () => {
+      const { host, workerHost, bridge } = makeBridge();
+      bridge.waitForActivation().catch(() => {});
+      const handle = await spawn(workerHost, host);
+      workerHost.emit("reloading");
+      expect(handle.kill).toHaveBeenCalled();
+    });
+  });
+
+  describe("host.fs.watch relay (#10526)", () => {
+    it("wires the host watcher and pushes change events keyed by subscription id", async () => {
+      const { host, workerHost } = makeBridge();
+      let changeCb: ((p: string) => void) | undefined;
+      host.fs.watch.mockImplementationOnce(async (_paths: string[], cb: (p: string) => void) => {
+        changeCb = cb;
+        return vi.fn();
+      });
+      workerHost.emit("worker-message", {
+        type: "host-call",
+        requestId: "w1",
+        method: "fs.watch",
+        params: { subscriptionId: "fs1", paths: ["/repo/a.ts"] },
+      });
+      await flush();
+      expect(host.fs.watch).toHaveBeenCalledWith(
+        ["/repo/a.ts"],
+        expect.any(Function),
+        expect.objectContaining({ signal: expect.anything() })
+      );
+      changeCb?.("/repo/a.ts");
+      const evt = workerHost.sent.find(
+        (m: any) => m.type === "subscription-event" && m.subscriptionId === "fs1"
+      );
+      expect(evt).toMatchObject({ payload: "/repo/a.ts" });
+    });
+
+    it("disposes the watcher on unsubscribe", async () => {
+      const { host, workerHost } = makeBridge();
+      const dispose = vi.fn();
+      host.fs.watch.mockResolvedValueOnce(dispose);
+      workerHost.emit("worker-message", {
+        type: "host-call",
+        requestId: "w2",
+        method: "fs.watch",
+        params: { subscriptionId: "fs2", paths: ["/repo"] },
+      });
+      await flush();
+      workerHost.emit("worker-message", { type: "unsubscribe", subscriptionId: "fs2" });
+      expect(dispose).toHaveBeenCalled();
+    });
+
+    it("replies with an error when the host watch rejects", async () => {
+      const { host, workerHost } = makeBridge();
+      host.fs.watch.mockRejectedValueOnce(new Error("PERMISSION_REQUIRED: fs:project-read"));
+      workerHost.emit("worker-message", {
+        type: "host-call",
+        requestId: "w3",
+        method: "fs.watch",
+        params: { subscriptionId: "fs3", paths: ["/nope"] },
+      });
+      await flush();
+      const res = workerHost.sent.find((m: any) => m.type === "host-result" && m.requestId === "w3");
+      expect(res).toMatchObject({ ok: false });
+      expect(res.error).toMatch(/PERMISSION_REQUIRED/);
+    });
   });
 });

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -394,6 +394,29 @@ describe("PluginDevWorkerMainBridge", () => {
     await expect(pending).rejects.toThrow(/reloaded/);
   });
 
+  it("drops a subscription event queued before a reload (generation guard) (#10526)", async () => {
+    const { host, workerHost, bridge } = makeBridge();
+    bridge.waitForActivation().catch(() => {});
+    let emitActive: ((s: unknown) => void) | undefined;
+    host.onDidChangeActiveWorktree.mockImplementation((cb: any) => {
+      emitActive = cb;
+      return vi.fn();
+    });
+    workerHost.emit("worker-message", {
+      type: "subscribe",
+      subscriptionId: "s1",
+      kind: "active-worktree",
+    });
+    await flush();
+    // A reload bumps the generation and tears the old subscription down.
+    workerHost.emit("reloading");
+    workerHost.sent.length = 0;
+    // A late event from the now-dead subscription must NOT reach the new worker
+    // (its proxy resets subscriptionIds and could collide on "s1").
+    emitActive?.({ id: "stale" });
+    expect(workerHost.sent.find((m) => m.type === "subscription-event")).toBeUndefined();
+  });
+
   it("forwards the activate-error stack through onActivationResult (#10526)", async () => {
     const onActivationResult = vi.fn();
     const { workerHost, bridge } = makeBridge({ onActivationResult });

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -532,6 +532,7 @@ describe("PluginDevWorkerMainBridge", () => {
 
     it("kills spawned processes on dispose", async () => {
       const { host, workerHost, bridge } = makeBridge();
+      bridge.waitForActivation().catch(() => {});
       const handle = await spawn(workerHost, host);
       bridge.dispose();
       expect(handle.kill).toHaveBeenCalled();

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -167,9 +167,11 @@ describe("PluginDevWorkerHostProxy host.process (#10526)", () => {
   it("kill posts a fire-and-forget process.kill notify keyed by id", async () => {
     const { sent, handle } = await spawnHandle();
     handle.kill();
-    expect(sent.find((m) => m.type === "host-notify" && m.method === "process.kill")).toMatchObject({
-      params: { processId: "p1" },
-    });
+    expect(sent.find((m) => m.type === "host-notify" && m.method === "process.kill")).toMatchObject(
+      {
+        params: { processId: "p1" },
+      }
+    );
   });
 
   it("restart awaits a process.restart host-call", async () => {
@@ -234,7 +236,12 @@ describe("PluginDevWorkerHostProxy host.fs.watch (#10526)", () => {
     const call = sent.find((m) => m.type === "host-call" && m.method === "fs.watch");
     expect(call.params.paths).toEqual(["/repo/a.ts"]);
     const subscriptionId = call.params.subscriptionId;
-    proxy.handleMessage({ type: "host-result", requestId: call.requestId, ok: true, result: undefined });
+    proxy.handleMessage({
+      type: "host-result",
+      requestId: call.requestId,
+      ok: true,
+      result: undefined,
+    });
     const dispose = await promise;
 
     proxy.handleMessage({ type: "subscription-event", subscriptionId, payload: "/repo/a.ts" });

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -132,9 +132,136 @@ describe("PluginDevWorkerHostProxy file decoration providers", () => {
     const { proxy, sent } = makeProxy();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const dispose = await proxy.host.registerForgeProvider({ id: "gh" } as any, {} as any);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("not supported in dev mode"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("is not supported"));
     expect(sent.find((m) => m.type === "host-notify")).toBeUndefined();
     expect(typeof dispose).toBe("function");
     expect(dispose()).toBeUndefined();
+  });
+});
+
+/** Reply to the most recent pending `host-call` of `method` with a success result. */
+function resolveCall(proxy: any, sent: any[], method: string, result: unknown): void {
+  const call = [...sent].reverse().find((m) => m.type === "host-call" && m.method === method);
+  proxy.handleMessage({ type: "host-result", requestId: call.requestId, ok: true, result });
+}
+
+describe("PluginDevWorkerHostProxy host.process (#10526)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  async function spawnHandle(): Promise<{ proxy: any; sent: any[]; handle: any }> {
+    const { proxy, sent } = makeProxy();
+    const promise = proxy.host.process.spawn("node", { args: ["x.js"] });
+    const call = sent.find((m) => m.type === "host-call" && m.method === "process.spawn");
+    expect(call).toMatchObject({ params: { command: "node", options: { args: ["x.js"] } } });
+    resolveCall(proxy, sent, "process.spawn", { id: "p1" });
+    const handle = await promise;
+    return { proxy, sent, handle };
+  }
+
+  it("relays spawn over a host-call and returns a handle addressed by id", async () => {
+    const { handle } = await spawnHandle();
+    expect(handle.id).toBe("p1");
+  });
+
+  it("kill posts a fire-and-forget process.kill notify keyed by id", async () => {
+    const { sent, handle } = await spawnHandle();
+    handle.kill();
+    expect(sent.find((m) => m.type === "host-notify" && m.method === "process.kill")).toMatchObject({
+      params: { processId: "p1" },
+    });
+  });
+
+  it("restart awaits a process.restart host-call", async () => {
+    const { proxy, sent, handle } = await spawnHandle();
+    const restarted = handle.restart();
+    const call = sent.find((m) => m.type === "host-call" && m.method === "process.restart");
+    expect(call).toMatchObject({ params: { processId: "p1" } });
+    resolveCall(proxy, sent, "process.restart", undefined);
+    await expect(restarted).resolves.toBeUndefined();
+  });
+
+  it("onExit opens a processId-scoped subscription and delivers exit events", async () => {
+    const { proxy, sent, handle } = await spawnHandle();
+    const onExit = vi.fn();
+    const dispose = handle.onExit(onExit);
+    const sub = sent.find((m) => m.type === "subscribe" && m.kind === "process-exit");
+    expect(sub).toMatchObject({ processId: "p1" });
+
+    proxy.handleMessage({
+      type: "subscription-event",
+      subscriptionId: sub.subscriptionId,
+      payload: { exitCode: 0, signal: null },
+    });
+    expect(onExit).toHaveBeenCalledWith({ exitCode: 0, signal: null });
+
+    dispose();
+    expect(
+      sent.find((m) => m.type === "unsubscribe" && m.subscriptionId === sub.subscriptionId)
+    ).toBeDefined();
+  });
+
+  it("onCrash opens a process-crash subscription", async () => {
+    const { sent, handle } = await spawnHandle();
+    const onCrash = vi.fn();
+    handle.onCrash(onCrash);
+    const sub = sent.find((m) => m.type === "subscribe" && m.kind === "process-crash");
+    expect(sub).toMatchObject({ processId: "p1" });
+  });
+
+  it("propagates a spawn rejection (e.g. missing shell:exec capability)", async () => {
+    const { proxy, sent } = makeProxy();
+    const promise = proxy.host.process.spawn("node");
+    const call = sent.find((m) => m.type === "host-call" && m.method === "process.spawn");
+    proxy.handleMessage({
+      type: "host-result",
+      requestId: call.requestId,
+      ok: false,
+      error: "PERMISSION_REQUIRED: shell:exec",
+    });
+    await expect(promise).rejects.toThrow(/PERMISSION_REQUIRED/);
+  });
+});
+
+describe("PluginDevWorkerHostProxy host.fs.watch (#10526)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("relays watch as a host-call, delivers change events, and disposes via unsubscribe", async () => {
+    const { proxy, sent } = makeProxy();
+    const onChange = vi.fn();
+    const promise = proxy.host.fs.watch(["/repo/a.ts"], onChange);
+    const call = sent.find((m) => m.type === "host-call" && m.method === "fs.watch");
+    expect(call.params.paths).toEqual(["/repo/a.ts"]);
+    const subscriptionId = call.params.subscriptionId;
+    proxy.handleMessage({ type: "host-result", requestId: call.requestId, ok: true, result: undefined });
+    const dispose = await promise;
+
+    proxy.handleMessage({ type: "subscription-event", subscriptionId, payload: "/repo/a.ts" });
+    expect(onChange).toHaveBeenCalledWith("/repo/a.ts");
+
+    dispose();
+    expect(
+      sent.find((m) => m.type === "unsubscribe" && m.subscriptionId === subscriptionId)
+    ).toBeDefined();
+  });
+
+  it("rejects when the host watch fails and stops delivering events", async () => {
+    const { proxy, sent } = makeProxy();
+    const onChange = vi.fn();
+    const promise = proxy.host.fs.watch(["/nope"], onChange);
+    const call = sent.find((m) => m.type === "host-call" && m.method === "fs.watch");
+    const subscriptionId = call.params.subscriptionId;
+    proxy.handleMessage({
+      type: "host-result",
+      requestId: call.requestId,
+      ok: false,
+      error: "PERMISSION_REQUIRED: fs:project-read",
+    });
+    await expect(promise).rejects.toThrow(/PERMISSION_REQUIRED/);
+
+    // The change callback was removed on rejection — a late event is a no-op.
+    proxy.handleMessage({ type: "subscription-event", subscriptionId, payload: "/nope" });
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -265,3 +265,17 @@ describe("PluginDevWorkerHostProxy host.fs.watch (#10526)", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+describe("PluginDevWorkerHostProxy host-call post failure (#10526)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects (and drops the pending call) when post throws a DataCloneError", async () => {
+    const post = vi.fn(() => {
+      throw new Error("DataCloneError: value could not be cloned");
+    });
+    const proxy = new PluginDevWorkerHostProxy("acme.demo", post);
+    await expect(proxy.host.getWorktrees()).rejects.toThrow(/could not be cloned/);
+    // The proxy isn't wedged — the failed call posted exactly once and rejected.
+    expect(post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -272,7 +272,16 @@ export class PluginDevWorkerHostProxy {
         };
         signal.addEventListener("abort", onAbort, { once: true });
       }
-      this.post({ type: "host-call", requestId, method, params });
+      try {
+        this.post({ type: "host-call", requestId, method, params });
+      } catch (err) {
+        // A non-structured-clone-safe `params` makes `postMessage` throw
+        // (DataCloneError). Drop the pending entry so it doesn't leak until
+        // dispose, then reject the caller.
+        this.pendingCalls.delete(requestId);
+        cleanup();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     });
   }
 

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -32,6 +32,7 @@ import type {
   PluginFsStat,
   PluginGitStatus,
   PluginGitCommitResult,
+  PluginProcessHandle,
 } from "../../../shared/types/plugin.js";
 import type {
   FileDecorationProviderDescriptor,
@@ -438,16 +439,17 @@ export class PluginDevWorkerHostProxy {
       },
       registerForgeProvider: (descriptor: ForgeProviderDescriptor, _impl: ForgeProviderImpl) => {
         this.assertActivationOpen("registerForgeProvider");
-        // Forge providers can't run from the dev worker: `ForgeProviderImpl`'s
+        // Forge providers can't run from the worker: `ForgeProviderImpl`'s
         // required `parseRemote` (the routing gate), URL builders, and
         // `classifyPushError` are SYNCHRONOUS — the host calls them and uses the
-        // return value immediately — but every dev-worker host call is async
-        // over this MessagePort. A partial async-only proxy would be worse than
+        // return value immediately — but every worker host call is async over
+        // this MessagePort. A partial async-only proxy would be worse than
         // honest: the provider would never become routable because
-        // `parseRemote` resolves to a Promise. Package + install to test forge
-        // providers; a fix needs the forge API's sync surface to change.
+        // `parseRemote` resolves to a Promise. This is the ONE permanent
+        // dev/prod-identical gap — both run in the worker, so neither supports
+        // it; a fix needs the forge API's sync surface to change.
         console.warn(
-          `[plugin-dev:${this.pluginId}] registerForgeProvider("${descriptor?.id}") is not supported in dev mode — forge providers require synchronous host methods (parseRemote, URL builders) that can't cross the dev worker's async boundary. Package + install the plugin to test forge providers.`
+          `[plugin:${this.pluginId}] registerForgeProvider("${descriptor?.id}") is not supported — forge providers require synchronous host methods (parseRemote, URL builders) that can't cross the worker's async boundary.`
         );
         return Promise.resolve(() => {});
       },
@@ -529,24 +531,22 @@ export class PluginDevWorkerHostProxy {
         error: (message, fields) => this.notify("logger.error", { message, fields }),
       },
       process: {
-        // Managed child processes can't run from the dev worker. The
-        // `PluginProcessHandle` returned by spawn exposes SYNCHRONOUS `kill()`
-        // and registers `onExit`/`onCrash` callbacks the host invokes directly
-        // — none of that survives the structured-clone async MessagePort. The
-        // streaming would also fan out from main, not the worker. Mirror the
-        // forge-provider stance: reject honestly in dev mode rather than ship a
-        // half-working proxy. Package + install to exercise host.process.
-        spawn: (_command, _options) => {
-          const message = `[plugin-dev:${this.pluginId}] host.process.spawn is not supported in dev mode — managed processes use synchronous handle methods (kill, onExit/onCrash callbacks) that can't cross the dev worker's async boundary. Package + install the plugin to test host.process.`;
-          console.warn(message);
-          return Promise.reject(new Error(message));
+        // The real `PluginProcessHandle` lives in main (PluginProcessManager);
+        // `spawn` relays over the port and returns a proxy handle whose id
+        // addresses `kill` / `restart` and the exit/crash subscriptions. `kill`
+        // is sync (a fire-and-forget notify); `restart` awaits the host. Late
+        // exit/crash events ride the existing subscription-event channel.
+        spawn: async (command, options) => {
+          const { id } = await this.call<{ id: string }>("process.spawn", { command, options });
+          return this.buildProcessHandle(id);
         },
       },
       // host.fs request/response methods are fully async, so they relay over the
       // port to the real (contained, capability-gated) host like settings/get.
-      // `watch` is the exception — it returns a disposer and fires a callback
-      // back, a subscription whose teardown semantics don't survive a whole-
-      // worker reload cleanly; reject it honestly in dev mode (mirrors process).
+      // `watch` is a host-call that BOTH wires the watcher (rejecting on a
+      // missing capability / out-of-scope path, preserving the in-process
+      // contract) and opens a subscription whose change events arrive over the
+      // subscription-event channel keyed by the same id.
       fs: {
         readFile: (filePath, options) =>
           this.call<string>("fs.readFile", { path: filePath }, options?.signal),
@@ -556,10 +556,24 @@ export class PluginDevWorkerHostProxy {
           this.call<PluginFsDirEntry[]>("fs.readdir", { path: dirPath }, options?.signal),
         stat: (targetPath, options) =>
           this.call<PluginFsStat>("fs.stat", { path: targetPath }, options?.signal),
-        watch: (_paths, _callback, _options) => {
-          const message = `[plugin-dev:${this.pluginId}] host.fs.watch is not supported in dev mode — the watcher subscription's disposer and change callback can't survive a whole-worker reload. Package + install the plugin to test host.fs.watch.`;
-          console.warn(message);
-          return Promise.reject(new Error(message));
+        watch: async (paths, callback, options) => {
+          const subscriptionId = `s${this.nextId++}`;
+          // Register the change callback before the call so an event can't race
+          // ahead of the subscription map; tear it down if the watch rejects.
+          this.subscriptions.set(subscriptionId, (payload) => callback(payload as string));
+          try {
+            await this.call<void>("fs.watch", { subscriptionId, paths }, options?.signal);
+          } catch (err) {
+            this.subscriptions.delete(subscriptionId);
+            throw err;
+          }
+          let disposed = false;
+          return () => {
+            if (disposed) return;
+            disposed = true;
+            this.subscriptions.delete(subscriptionId);
+            this.post({ type: "unsubscribe", subscriptionId });
+          };
         },
       },
       git: {
@@ -611,14 +625,49 @@ export class PluginDevWorkerHostProxy {
     debounceMs?: number
   ): () => void {
     const subscriptionId = `s${this.nextId++}`;
-    this.subscriptions.set(subscriptionId, callback);
-    this.post({ type: "subscribe", subscriptionId, kind, key, scope, debounceMs });
+    return this.openSubscription(
+      { type: "subscribe", subscriptionId, kind, key, scope, debounceMs },
+      callback
+    );
+  }
+
+  /** Register `callback`, post the (fully-formed) subscribe message, and return
+   * an idempotent disposer that drops the callback and posts `unsubscribe`. */
+  private openSubscription(
+    message: Extract<PluginWorkerToHostMessage, { type: "subscribe" }>,
+    callback: (payload: unknown) => void
+  ): () => void {
+    this.subscriptions.set(message.subscriptionId, callback);
+    this.post(message);
     let disposed = false;
     return () => {
       if (disposed) return;
       disposed = true;
-      this.subscriptions.delete(subscriptionId);
-      this.post({ type: "unsubscribe", subscriptionId });
+      this.subscriptions.delete(message.subscriptionId);
+      this.post({ type: "unsubscribe", subscriptionId: message.subscriptionId });
+    };
+  }
+
+  /** Build a worker-side {@link PluginProcessHandle} proxy for a process the host
+   * spawned on our behalf, addressing it by the host-assigned `id`. */
+  private buildProcessHandle(id: string): PluginProcessHandle {
+    const subscribeLifecycle = (
+      kind: "process-exit" | "process-crash",
+      callback: (info: { exitCode: number | null; signal: string | null }) => void
+    ): (() => void) =>
+      this.openSubscription(
+        { type: "subscribe", subscriptionId: `s${this.nextId++}`, kind, processId: id },
+        (payload) => callback(payload as { exitCode: number | null; signal: string | null })
+      );
+    return {
+      id,
+      kill: () => {
+        // Sync in the public contract — fire-and-forget over the port.
+        this.notify("process.kill", { processId: id });
+      },
+      restart: () => this.call<void>("process.restart", { processId: id }),
+      onExit: (callback) => subscribeLifecycle("process-exit", callback),
+      onCrash: (callback) => subscribeLifecycle("process-crash", callback),
     };
   }
 }

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -24,6 +24,7 @@ import type {
   PluginQuickPickOptions,
   PluginInputBoxOptions,
   PluginConfirmOptions,
+  PluginProcessSpawnOptions,
 } from "./plugin.js";
 
 /** Async host methods the worker proxy relays to main and awaits a reply for. */
@@ -40,13 +41,16 @@ export type PluginHostCallMethod =
   | "fs.writeFile"
   | "fs.readdir"
   | "fs.stat"
+  | "fs.watch"
   | "git.status"
   | "git.diff"
   | "git.add"
   | "git.commit"
   | "showQuickPick"
   | "showInputBox"
-  | "showConfirm";
+  | "showConfirm"
+  | "process.spawn"
+  | "process.restart";
 
 /** Fire-and-forget host methods (no reply needed). */
 export type PluginHostNotifyMethod =
@@ -59,14 +63,21 @@ export type PluginHostNotifyMethod =
   | "unregisterFileDecorationProvider"
   | "logger.info"
   | "logger.warn"
-  | "logger.error";
+  | "logger.error"
+  | "process.kill";
 
-/** Event subscriptions the worker proxy can open against the host. */
+/**
+ * Event subscriptions the worker proxy can open against the host. The
+ * `process-exit` / `process-crash` kinds wire a spawned process's lifecycle
+ * callbacks back to the worker, keyed by the handle id carried in `processId`.
+ */
 export type PluginWorkerSubscriptionKind =
   | "active-worktree"
   | "worktrees"
   | "settings"
-  | "agent-state";
+  | "agent-state"
+  | "process-exit"
+  | "process-crash";
 
 /**
  * Callback kinds main invokes back in the worker. `file-decoration-method`
@@ -167,6 +178,8 @@ export type PluginWorkerToHostMessage =
        * Ignored for other kinds. Mirrors `PluginHostSubscriptionOptions.debounceMs`.
        */
       debounceMs?: number;
+      /** Handle id for `process-exit` / `process-crash` subscriptions. */
+      processId?: string;
     }
   /** Close a previously opened subscription. */
   | { type: "unsubscribe"; subscriptionId: string }
@@ -308,9 +321,47 @@ export interface GitOpParams {
   message?: string;
 }
 
+/** Params for `process.spawn` (`host-call`). */
+export interface ProcessSpawnParams {
+  command: string;
+  options?: PluginProcessSpawnOptions;
+}
+
+/**
+ * Result of `process.spawn` (`host-call`). The host-assigned handle id the
+ * worker proxy uses to address `process.kill` / `process.restart` and to open
+ * the `process-exit` / `process-crash` subscriptions.
+ */
+export interface ProcessSpawnResult {
+  id: string;
+}
+
+/** Params for `process.kill` (`host-notify`) and `process.restart` (`host-call`). */
+export interface ProcessHandleRefParams {
+  processId: string;
+}
+
+/**
+ * Params for `fs.watch` (`host-call`). The call both establishes the watcher —
+ * rejecting on a missing capability / out-of-scope path so the in-process
+ * `watch` rejection contract is preserved — and opens the subscription whose
+ * change events arrive as `subscription-event`s keyed by `subscriptionId`.
+ */
+export interface FsWatchParams {
+  subscriptionId: string;
+  paths: string[];
+}
+
 /**
  * Env var name set on the forked worker so the worker module can assert it is
  * running in the intended utility-process kind (mirrors the
  * `DAINTREE_UTILITY_PROCESS_KIND` convention used by the other hosts).
  */
 export const PLUGIN_DEV_WORKER_KIND = "plugin-dev-worker";
+
+/**
+ * Sibling of {@link PLUGIN_DEV_WORKER_KIND} for production plugins. They run in
+ * the same `utilityProcess.fork` worker but without the dev hot-reload file
+ * watcher; the distinct kind keeps the two apart in process-monitor logs.
+ */
+export const PLUGIN_PROD_WORKER_KIND = "plugin-prod-worker";


### PR DESCRIPTION
## Summary

- Routes all user-installed plugins out-of-process via a `utilityProcess` worker instead of in-process `import()`. Production plugins previously caused a V8 module cache leak on uninstall/disable/reload, and `host.process.spawn` and `host.fs.watch` were dev-only unavailable. Now every user plugin runs in a fresh module realm per lifecycle with OS-level crash isolation and a uniform host API across dev and prod.
- `PluginDevWorkerHost` gains a `"dev" | "prod"` mode: prod skips the hot-reload file watcher and forks under the `plugin-prod-worker` kind. Crash supervision, fork lifecycle, and dispose are shared. `registerForgeProvider` stays stubbed in both modes — its synchronous `parseRemote`/URL-builder contract can't cross the async `MessagePort` (#8879), so dev and prod are now identical here rather than prod being a silent gap.
- Built-in plugins (e.g. the GitHub forge provider) stay on the in-process loader: trusted, never uninstalled, never dev-symlinked, and they rely on `registerForgeProvider`'s synchronous surface. Routing them through the worker would silently break GitHub forge integration.

Resolves #10526.

## Changes

- `PluginService`: routes user plugins through `PluginDevWorkerHost` (prod mode); built-ins keep the in-process path
- `PluginDevWorkerHost`: adds `mode` param, skips file watcher in prod, forks under correct worker kind
- `PluginDevWorkerMainBridge`: `process.spawn`/`restart` relay as host-calls, `kill` as fire-and-forget notify, `onExit`/`onCrash` as `processId`-scoped subscriptions; `fs.watch` as an awaitable host-call that also wires a subscription; spawned processes are killed on reload and dispose
- `pluginDevWorkerHostProxy`: forwards `process` and `fs.watch` host API over the `MessagePort`
- `shared/types/pluginDevWorker.ts`: new message types for spawn, kill, restart, fs.watch relay
- Activation error stack forwarded through `onActivationResult`; `loadError` recorded on activation timeout

## Testing

553 unit tests pass across `PluginService.test.ts` and the four plugin `__tests__` suites — new coverage for `process.spawn`/`kill`/`restart`/`onExit`/`onCrash` relay, `fs.watch` relay + rejection + teardown, prod-mode no-watcher, dispose/reload process teardown, stack forwarding, built-in-stays-in-process routing, `DataCloneError` pending-call cleanup, and stale-event generation guard. 44 integration tests pass in `PluginService.integration.test.ts`. Full `npm run typecheck` clean; eslint + prettier clean on all changed files.