### PR TITLE
feat(plugins): just-in-time host capability consent (#10524)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -920,6 +920,12 @@ export const CHANNELS = {
   PLUGIN_MCP_CALL_TOOL: "plugin-mcp:call-tool",
   PLUGIN_MCP_RESOLVE_CONSENT: "plugin-mcp:resolve-consent",
 
+  // Just-in-time plugin host-capability consent (#10524). The renderer's reply
+  // to a `plugin-capability:consent-request` push; the request itself rides the
+  // typed event bus. Distinct from the per-tool plugin-MCP consent above —
+  // this gates first use of a host capability (shell:exec, fs:*-write, git:write).
+  PLUGIN_CAPABILITY_RESOLVE_CONSENT: "plugin-capability:resolve-consent",
+
   // Plugin managed-process channels (#9234) — child processes spawned by a
   // plugin via `host.process.spawn` (gated on `shell:exec`). `list` is the
   // read-only renderer observability surface (e.g. a process dashboard);

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -66,6 +66,7 @@ import { registerSafeModeHandlers } from "./handlers/safeMode.js";
 import { registerWatchdogHandlers } from "./handlers/watchdog.js";
 import { registerPluginHandlers } from "./handlers/plugin.js";
 import { registerPluginMcpHandlers } from "./handlers/pluginMcp.js";
+import { registerPluginCapabilityHandlers } from "./handlers/pluginCapability.js";
 import { registerPluginProcessHandlers } from "./handlers/pluginProcess.js";
 import { registerConnectivityHandlers } from "./handlers/connectivity.js";
 import { registerScratchHandlers } from "./handlers/scratch/index.js";
@@ -181,6 +182,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerWatchdogHandlers(deps));
     register(() => registerPluginHandlers());
     register(() => registerPluginMcpHandlers());
+    register(() => registerPluginCapabilityHandlers());
     register(() => registerPluginProcessHandlers());
     register(() => registerPerfHandlers(deps));
     register(() => registerConnectivityHandlers());

--- a/electron/ipc/handlers/__tests__/pluginCapability.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginCapability.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeWebContents {
+  id: number;
+  isDestroyed: () => boolean;
+  send: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeWindow(id: number): { webContents: FakeWebContents; isDestroyed: () => boolean } {
+  const wc: FakeWebContents = {
+    id,
+    isDestroyed: () => false,
+    send: vi.fn(),
+    once: vi.fn(),
+    removeListener: vi.fn(),
+  };
+  return { webContents: wc, isDestroyed: () => false };
+}
+
+let focusedWindow: ReturnType<typeof makeFakeWindow> | null = null;
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn((key: string) => `/mock/electron/${key}`),
+    getVersion: vi.fn(() => "0.0.0"),
+  },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  BrowserWindow: {
+    getFocusedWindow: () => focusedWindow,
+    getAllWindows: () => (focusedWindow ? [focusedWindow] : []),
+  },
+}));
+
+vi.mock("../../../window/windowRef.js", () => ({
+  getMainWindow: () => focusedWindow,
+}));
+
+import { handleResolveConsent, _resetCapabilityConsentBridgeForTest } from "../pluginCapability.js";
+import {
+  getPluginCapabilityConsentService,
+  _resetPluginCapabilityServicesForTest,
+} from "../../../services/plugin-capability/instances.js";
+import type { IpcContext } from "../../types.js";
+
+function ctx(webContentsId: number): IpcContext {
+  return { event: {} as never, webContentsId, senderWindow: null, projectId: null };
+}
+
+beforeEach(() => {
+  focusedWindow = makeFakeWindow(7);
+  // Install the bridge directly (mirrors registerPluginCapabilityHandlers).
+  getPluginCapabilityConsentService();
+});
+
+afterEach(() => {
+  _resetCapabilityConsentBridgeForTest();
+  _resetPluginCapabilityServicesForTest();
+  focusedWindow = null;
+});
+
+describe("pluginCapability consent bridge", () => {
+  it("pushes a consent-request to the focused window and ignores a reply from a different sender", async () => {
+    // Wire the real bridge onto the service via the handler's install path.
+    const { registerPluginCapabilityHandlers } = await import("../pluginCapability.js");
+    const dispose = registerPluginCapabilityHandlers();
+
+    const decisionPromise = getPluginCapabilityConsentService().ensureAllowed(
+      "acme.x",
+      "Acme",
+      "shell:exec",
+      ["shell:exec"]
+    );
+
+    // The bridge pushed exactly one consent-request to the focused window.
+    const send = focusedWindow!.webContents.send;
+    expect(send).toHaveBeenCalledTimes(1);
+    const pushed = send.mock.calls[0][1] as {
+      name: string;
+      payload: { requestId: string; capability: string };
+    };
+    expect(pushed.name).toBe("plugin-capability:consent-request");
+    expect(pushed.payload.capability).toBe("shell:exec");
+    const requestId = pushed.payload.requestId;
+
+    // A reply from the WRONG WebContents must not settle the prompt.
+    await handleResolveConsent(ctx(999), { requestId, decision: "approved-and-pin" });
+
+    // The correct sender settles it.
+    await handleResolveConsent(ctx(7), { requestId, decision: "approved-and-pin" });
+    await expect(decisionPromise).resolves.toBeUndefined();
+
+    dispose();
+  });
+
+  it("is a no-op for an unknown requestId", async () => {
+    await expect(
+      handleResolveConsent(ctx(7), { requestId: "does-not-exist", decision: "rejected" })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -43,6 +43,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "app-agent:dispatch-action-request": "external",
   "app-agent:confirmation-request": "external",
   "plugin-mcp:consent-request": "external",
+  "plugin-capability:consent-request": "external",
   "terminal:backend-crashed": "external",
   "terminal:backend-recovering": "external",
   "terminal:backend-ready": "external",

--- a/electron/ipc/handlers/pluginCapability.preload.ts
+++ b/electron/ipc/handlers/pluginCapability.preload.ts
@@ -1,0 +1,26 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const PLUGIN_CAPABILITY_METHOD_CHANNELS = {
+  resolveConsent: "plugin-capability:resolve-consent",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof PLUGIN_CAPABILITY_METHOD_CHANNELS;
+
+export type PluginCapabilityPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildPluginCapabilityPreloadBindings(
+  invoke: Invoker
+): PluginCapabilityPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(PLUGIN_CAPABILITY_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = PLUGIN_CAPABILITY_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as PluginCapabilityPreloadBindings;
+}

--- a/electron/ipc/handlers/pluginCapability.ts
+++ b/electron/ipc/handlers/pluginCapability.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from "node:crypto";
+import { BrowserWindow } from "electron";
+import { defineIpcNamespace, op } from "../define.js";
+import type { IpcContext } from "../types.js";
+import { CHANNELS } from "../channels.js";
+import { PLUGIN_CAPABILITY_METHOD_CHANNELS } from "./pluginCapability.preload.js";
+import { getPluginCapabilityConsentService } from "../../services/plugin-capability/instances.js";
+import type {
+  PluginCapabilityConsentBridge,
+  PluginCapabilityConsentRequest,
+} from "../../services/plugin-capability/PluginCapabilityConsentService.js";
+import { getMainWindow } from "../../window/windowRef.js";
+import type {
+  PluginCapabilityConsentDecision,
+  PluginCapabilityResolveConsentInput,
+} from "../../../shared/types/pluginCapabilityConsent.js";
+
+// --- Consent bridge (main → renderer prompt, renderer → main decision) --------
+//
+// `PluginCapabilityConsentService.ensureAllowed` blocks on an injected bridge
+// when a first-use prompt is required. Unlike the plugin-MCP consent bridge,
+// the gated call originates in the plugin's own utility process — there is no
+// initiating renderer to pin to — so the prompt is sent to the focused window,
+// falling back to the primary window. The renderer replies via
+// `plugin-capability:resolve-consent`, correlated by `requestId`.
+
+interface PendingConsent {
+  resolve: (decision: PluginCapabilityConsentDecision) => void;
+  webContentsId: number;
+  cleanup: () => void;
+}
+
+const pendingConsents = new Map<string, PendingConsent>();
+let consentBridgeInstalled = false;
+
+/** Pick the window that should host a capability consent prompt. */
+function resolvePromptWindow(): BrowserWindow | null {
+  const focused = BrowserWindow.getFocusedWindow();
+  if (focused && !focused.isDestroyed()) return focused;
+  const primary = getMainWindow();
+  if (primary && !primary.isDestroyed()) return primary;
+  return null;
+}
+
+function settleConsent(requestId: string, decision: PluginCapabilityConsentDecision): void {
+  const pending = pendingConsents.get(requestId);
+  if (!pending) return;
+  pendingConsents.delete(requestId);
+  pending.cleanup();
+  pending.resolve(decision);
+}
+
+const consentBridge: PluginCapabilityConsentBridge = (request: PluginCapabilityConsentRequest) => {
+  const win = resolvePromptWindow();
+  const wc = win?.webContents;
+  if (!wc || wc.isDestroyed()) {
+    // Fail closed: no window to surface a prompt, so no one can approve.
+    return Promise.resolve("rejected");
+  }
+  return new Promise<PluginCapabilityConsentDecision>((resolve) => {
+    const requestId = randomUUID();
+    const onDestroyed = () => settleConsent(requestId, "rejected");
+    const cleanup = () => {
+      try {
+        wc.removeListener("destroyed", onDestroyed);
+      } catch {
+        // best-effort — the WebContents may already be torn down
+      }
+    };
+    pendingConsents.set(requestId, { resolve, webContentsId: wc.id, cleanup });
+    wc.once("destroyed", onDestroyed);
+    try {
+      wc.send(CHANNELS.EVENTS_PUSH, {
+        name: "plugin-capability:consent-request",
+        payload: {
+          requestId,
+          pluginId: request.pluginId,
+          pluginDisplayName: request.pluginDisplayName,
+          capability: request.capability,
+          declaredCapabilities: request.declaredCapabilities,
+        },
+      });
+    } catch {
+      settleConsent(requestId, "rejected");
+    }
+  });
+};
+
+/** Install the consent bridge once, lazily — keeps an unused boot path bridge-free. */
+function ensureConsentBridge(): void {
+  if (consentBridgeInstalled) return;
+  consentBridgeInstalled = true;
+  getPluginCapabilityConsentService().setConsentBridge(consentBridge);
+}
+
+/** Test-only: drop installed-bridge state and reject any pending prompts. */
+export function _resetCapabilityConsentBridgeForTest(): void {
+  for (const requestId of [...pendingConsents.keys()]) {
+    settleConsent(requestId, "rejected");
+  }
+  consentBridgeInstalled = false;
+}
+
+/**
+ * Renderer reply to a `plugin-capability:consent-request` push. The pending
+ * consent is dropped (resolving the bridge promise) only when the responding
+ * WebContents is the one the prompt was sent to — a sibling window cannot answer
+ * another window's prompt.
+ */
+export async function handleResolveConsent(
+  ctx: IpcContext,
+  input: PluginCapabilityResolveConsentInput
+): Promise<void> {
+  const pending = pendingConsents.get(input.requestId);
+  if (!pending) return;
+  if (ctx.webContentsId !== pending.webContentsId) {
+    console.warn(
+      `[plugin-capability] Ignoring consent reply from unexpected sender ${ctx.webContentsId} (expected ${pending.webContentsId}, requestId=${input.requestId})`
+    );
+    return;
+  }
+  settleConsent(input.requestId, input.decision);
+}
+
+export const pluginCapabilityNamespace = defineIpcNamespace({
+  name: "pluginCapability",
+  ops: {
+    resolveConsent: op(PLUGIN_CAPABILITY_METHOD_CHANNELS.resolveConsent, handleResolveConsent, {
+      withContext: true,
+    }),
+  },
+});
+
+export function registerPluginCapabilityHandlers(): () => void {
+  ensureConsentBridge();
+  const unregister = pluginCapabilityNamespace.register();
+  return () => {
+    unregister();
+    // Tear down the consent bridge so a re-registration reinstalls cleanly and
+    // no stale prompt resolves against a torn-down renderer. Pending prompts are
+    // rejected (fail closed) rather than left dangling.
+    if (consentBridgeInstalled) {
+      getPluginCapabilityConsentService().setConsentBridge(null);
+      consentBridgeInstalled = false;
+    }
+    for (const requestId of [...pendingConsents.keys()]) {
+      settleConsent(requestId, "rejected");
+    }
+  };
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -43,6 +43,7 @@ import { buildPortalPreloadBindings } from "./ipc/handlers/portal.preload.js";
 import { buildDevPreviewPreloadBindings } from "./ipc/handlers/devPreview.preload.js";
 import { buildPluginPreloadBindings } from "./ipc/handlers/plugin.preload.js";
 import { buildPluginMcpPreloadBindings } from "./ipc/handlers/pluginMcp.preload.js";
+import { buildPluginCapabilityPreloadBindings } from "./ipc/handlers/pluginCapability.preload.js";
 import { buildPluginProcessPreloadBindings } from "./ipc/handlers/pluginProcess.preload.js";
 import { buildScratchPreloadBindings } from "./ipc/handlers/scratch/preload.js";
 import { buildMcpServerPreloadBindings } from "./ipc/handlers/mcpServer.preload.js";
@@ -2634,6 +2635,8 @@ function buildElectronApi(): ElectronAPI {
     },
 
     pluginMcp: buildPluginMcpPreloadBindings(_unwrappingInvoke),
+
+    pluginCapability: buildPluginCapabilityPreloadBindings(_unwrappingInvoke),
 
     pluginProcess: buildPluginProcessPreloadBindings(_unwrappingInvoke),
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2770,13 +2770,10 @@ export class PluginService {
           `PERMISSION_REQUIRED: plugin "${pluginId}" process.spawn requires the "shell:exec" capability, which is not declared in manifest.capabilities`
         );
       }
-      // JIT consent: first use of shell:exec prompts the user; the grant covers
-      // every later spawn by this plugin (#10524). Throws PERMISSION_REQUIRED on
-      // denial. Re-check membership after the await — the prompt is async.
-      await this.ensureCapabilityConsent(pluginId, "shell:exec");
-      if (!this.plugins.has(pluginId)) {
-        throw new Error(`Plugin "${pluginId}" process.spawn: plugin is no longer loaded`);
-      }
+      // Validate inputs BEFORE prompting for consent so a call that would fail
+      // anyway never spends — or banks — a user grant. A plugin must not be able
+      // to harvest a silent shell:exec grant via a deliberately invalid call
+      // (e.g. spawn("")) and then execute real commands unprompted (#10524).
       if (typeof command !== "string" || command.length === 0) {
         throw new Error(`Plugin "${pluginId}" process.spawn: command must be a non-empty string`);
       }
@@ -2797,6 +2794,13 @@ export class PluginService {
       }
       // Re-check membership after the async cwd resolution so a racing unload
       // doesn't spawn into a disposed plugin.
+      if (!this.plugins.has(pluginId)) {
+        throw new Error(`Plugin "${pluginId}" process.spawn: plugin is no longer loaded`);
+      }
+      // JIT consent fires LAST, right before the spawn — first use prompts the
+      // user; the grant covers every later spawn by this plugin. Throws
+      // PERMISSION_REQUIRED on denial. Re-check membership after the prompt await.
+      await this.ensureCapabilityConsent(pluginId, "shell:exec");
       if (!this.plugins.has(pluginId)) {
         throw new Error(`Plugin "${pluginId}" process.spawn: plugin is no longer loaded`);
       }
@@ -2979,29 +2983,19 @@ export class PluginService {
         );
       }
     };
-    const requireAnyWriteCap = (op: string): void => {
+    // Sync capability check; returns the write capability JIT consent gates on.
+    // A plugin holding both prompts once on the project-write grant — the path
+    // containment already bounds where the write can land, so a single fs-write
+    // grant is the meaningful unit. Consent itself fires later (after input
+    // validation + containment), so an invalid call never banks a grant.
+    const requireWriteCap = (op: string): BuiltInPluginCapability => {
       const caps = this.declaredCapabilities(pluginId);
       if (!caps.has("fs:project-write") && !caps.has("fs:user-data-write")) {
         throw new Error(
           `PERMISSION_REQUIRED: plugin "${pluginId}" fs.${op} requires "fs:project-write" or "fs:user-data-write", which is not declared in manifest.capabilities`
         );
       }
-    };
-    const requireWriteCap = async (op: string): Promise<void> => {
-      const caps = this.declaredCapabilities(pluginId);
-      if (!caps.has("fs:project-write") && !caps.has("fs:user-data-write")) {
-        throw new Error(
-          `PERMISSION_REQUIRED: plugin "${pluginId}" fs.${op} requires "fs:project-write" or "fs:user-data-write", which is not declared in manifest.capabilities`
-        );
-      }
-      // JIT consent gates the first host-mediated write on the declared write
-      // capability (#10524). A plugin holding both prompts once on the
-      // project-write grant — the path containment already bounds where the
-      // write can land, so a single fs-write grant is the meaningful unit.
-      const writeCap: BuiltInPluginCapability = caps.has("fs:project-write")
-        ? "fs:project-write"
-        : "fs:user-data-write";
-      await this.ensureCapabilityConsent(pluginId, writeCap);
+      return caps.has("fs:project-write") ? "fs:project-write" : "fs:user-data-write";
     };
     // Precise per-root-class gate, applied AFTER containment resolves which root
     // class the path falls under: project/worktree paths need `fs:project-*`,
@@ -3059,9 +3053,7 @@ export class PluginService {
       },
       writeFile: async (filePath, contents) => {
         requireLoaded("writeFile");
-        requireAnyWriteCap("writeFile");
-        await requireWriteCap("writeFile");
-        requireLoaded("writeFile");
+        const writeCap = requireWriteCap("writeFile");
         if (typeof contents !== "string") {
           throw new Error(`Plugin "${pluginId}" fs.writeFile: contents must be a string`);
         }
@@ -3095,6 +3087,10 @@ export class PluginService {
         if (isDataDirWrite) {
           await fs.mkdir(path.dirname(resolved), { recursive: true });
         }
+        // Consent fires after validation + containment so a call that would fail
+        // anyway never banks a grant (#10524). Re-check liveness after the await.
+        await this.ensureCapabilityConsent(pluginId, writeCap);
+        requireLoaded("writeFile");
         await fs.writeFile(resolved, contents, "utf-8");
         // Audit every write so host-mediated filesystem mutation is observable.
         safeAppendAudit({
@@ -3244,15 +3240,12 @@ export class PluginService {
         );
       }
     };
-    const requireWriteCap = async (op: string): Promise<void> => {
+    const requireWriteCap = (op: string): void => {
       if (!this.declaredCapabilities(pluginId).has("git:write")) {
         throw new Error(
           `PERMISSION_REQUIRED: plugin "${pluginId}" git.${op} requires the "git:write" capability, which is not declared in manifest.capabilities`
         );
       }
-      // JIT consent: first git mutation prompts; the grant covers every later
-      // git:write op by this plugin (#10524). Throws PERMISSION_REQUIRED on denial.
-      await this.ensureCapabilityConsent(pluginId, "git:write");
     };
     // A worktree the plugin may access = one contained inside its declared
     // allowedPaths (with `${project}` / `${worktree}` tokens expanded at call
@@ -3296,9 +3289,12 @@ export class PluginService {
       add: async (worktreePath, paths, options): Promise<void> => {
         options?.signal?.throwIfAborted();
         requireLoaded("add");
-        await requireWriteCap("add");
-        requireLoaded("add");
+        requireWriteCap("add");
         const resolved = await containWorktree(worktreePath);
+        requireLoaded("add");
+        // Consent fires after containment so an out-of-scope path never banks a
+        // git:write grant (#10524). Re-check liveness after the prompt await.
+        await this.ensureCapabilityConsent(pluginId, "git:write");
         requireLoaded("add");
         await git.add(resolved, paths, options?.signal);
         safeAppendAudit({
@@ -3319,15 +3315,28 @@ export class PluginService {
       ): Promise<PluginGitCommitResult> => {
         callOptions?.signal?.throwIfAborted();
         requireLoaded("commit");
-        await requireWriteCap("commit");
-        requireLoaded("commit");
+        requireWriteCap("commit");
         // commit returns the staged diff as its change-preview, so it discloses
         // repo content — require read alongside write.
         requireReadCap("commit");
+        // Reject an empty message BEFORE prompting for consent, mirroring the
+        // #7880 no-silent-fallback guard git.commit enforces internally, so a
+        // doomed commit can't bank a git:write grant (#10524).
+        if (
+          !options ||
+          typeof options.message !== "string" ||
+          options.message.trim().length === 0
+        ) {
+          throw new Error(
+            `COMMIT_MESSAGE_REQUIRED: plugin "${pluginId}" git.commit requires a non-empty message`
+          );
+        }
         const resolved = await containWorktree(worktreePath);
         requireLoaded("commit");
-        // git.commit throws COMMIT_MESSAGE_REQUIRED before any mutation when the
-        // message is empty — the #7880 no-silent-fallback guard at the host.
+        // Consent fires after containment + message validation so a doomed call
+        // never banks a grant (#10524). Re-check liveness after the prompt await.
+        await this.ensureCapabilityConsent(pluginId, "git:write");
+        requireLoaded("commit");
         const result = await git.commit(resolved, options, callOptions?.signal);
         safeAppendAudit({
           pluginId,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -34,6 +34,7 @@ import {
 } from "../schemas/plugin.js";
 import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
 import { PluginProcessManager } from "./plugin/PluginProcessManager.js";
+import { getPluginCapabilityConsentService } from "./plugin-capability/instances.js";
 import { resolveContainedPath, PluginPathNotAllowedError } from "./plugin/pluginFsContainment.js";
 import { PluginHostGit, type HostGitFactory } from "./plugin/pluginHostGit.js";
 import {
@@ -2769,6 +2770,13 @@ export class PluginService {
           `PERMISSION_REQUIRED: plugin "${pluginId}" process.spawn requires the "shell:exec" capability, which is not declared in manifest.capabilities`
         );
       }
+      // JIT consent: first use of shell:exec prompts the user; the grant covers
+      // every later spawn by this plugin (#10524). Throws PERMISSION_REQUIRED on
+      // denial. Re-check membership after the await — the prompt is async.
+      await this.ensureCapabilityConsent(pluginId, "shell:exec");
+      if (!this.plugins.has(pluginId)) {
+        throw new Error(`Plugin "${pluginId}" process.spawn: plugin is no longer loaded`);
+      }
       if (typeof command !== "string" || command.length === 0) {
         throw new Error(`Plugin "${pluginId}" process.spawn: command must be a non-empty string`);
       }
@@ -2814,6 +2822,36 @@ export class PluginService {
       };
     };
     return { spawn };
+  }
+
+  /**
+   * Just-in-time consent gate for a high-risk host capability (#10524).
+   * Resolves silently for built-in (first-party) plugins and for capabilities
+   * the user has already granted; otherwise raises a first-use prompt and
+   * throws a `PERMISSION_REQUIRED:` error on denial. Callers invoke this AFTER
+   * the static `manifest.capabilities` check passes, at the top of each gated
+   * host API closure — the static check answers "may this plugin ever do X",
+   * this answers "has the user agreed to it doing X now".
+   */
+  private async ensureCapabilityConsent(
+    pluginId: string,
+    capability: BuiltInPluginCapability
+  ): Promise<void> {
+    const plugin = this.plugins.get(pluginId);
+    // Membership is re-checked by the caller after this await; a missing plugin
+    // here means it unloaded mid-call, so skip the prompt and let the caller's
+    // liveness guard reject.
+    if (!plugin) return;
+    // Built-ins are bundled first-party code — they skip the install-time
+    // capability disclosure and likewise skip JIT consent.
+    if (plugin.isBuiltin) return;
+    const displayName = plugin.manifest.displayName ?? plugin.manifest.name;
+    await getPluginCapabilityConsentService().ensureAllowed(
+      pluginId,
+      displayName,
+      capability,
+      plugin.manifest.capabilities ?? []
+    );
   }
 
   /** The capabilities a loaded plugin declared, as a Set. Empty when unloaded. */
@@ -2949,6 +2987,22 @@ export class PluginService {
         );
       }
     };
+    const requireWriteCap = async (op: string): Promise<void> => {
+      const caps = this.declaredCapabilities(pluginId);
+      if (!caps.has("fs:project-write") && !caps.has("fs:user-data-write")) {
+        throw new Error(
+          `PERMISSION_REQUIRED: plugin "${pluginId}" fs.${op} requires "fs:project-write" or "fs:user-data-write", which is not declared in manifest.capabilities`
+        );
+      }
+      // JIT consent gates the first host-mediated write on the declared write
+      // capability (#10524). A plugin holding both prompts once on the
+      // project-write grant — the path containment already bounds where the
+      // write can land, so a single fs-write grant is the meaningful unit.
+      const writeCap: BuiltInPluginCapability = caps.has("fs:project-write")
+        ? "fs:project-write"
+        : "fs:user-data-write";
+      await this.ensureCapabilityConsent(pluginId, writeCap);
+    };
     // Precise per-root-class gate, applied AFTER containment resolves which root
     // class the path falls under: project/worktree paths need `fs:project-*`,
     // the data dir / home paths need `fs:user-data-*`. A plugin can't reach a
@@ -3006,6 +3060,8 @@ export class PluginService {
       writeFile: async (filePath, contents) => {
         requireLoaded("writeFile");
         requireAnyWriteCap("writeFile");
+        await requireWriteCap("writeFile");
+        requireLoaded("writeFile");
         if (typeof contents !== "string") {
           throw new Error(`Plugin "${pluginId}" fs.writeFile: contents must be a string`);
         }
@@ -3188,12 +3244,15 @@ export class PluginService {
         );
       }
     };
-    const requireWriteCap = (op: string): void => {
+    const requireWriteCap = async (op: string): Promise<void> => {
       if (!this.declaredCapabilities(pluginId).has("git:write")) {
         throw new Error(
           `PERMISSION_REQUIRED: plugin "${pluginId}" git.${op} requires the "git:write" capability, which is not declared in manifest.capabilities`
         );
       }
+      // JIT consent: first git mutation prompts; the grant covers every later
+      // git:write op by this plugin (#10524). Throws PERMISSION_REQUIRED on denial.
+      await this.ensureCapabilityConsent(pluginId, "git:write");
     };
     // A worktree the plugin may access = one contained inside its declared
     // allowedPaths (with `${project}` / `${worktree}` tokens expanded at call
@@ -3237,7 +3296,8 @@ export class PluginService {
       add: async (worktreePath, paths, options): Promise<void> => {
         options?.signal?.throwIfAborted();
         requireLoaded("add");
-        requireWriteCap("add");
+        await requireWriteCap("add");
+        requireLoaded("add");
         const resolved = await containWorktree(worktreePath);
         requireLoaded("add");
         await git.add(resolved, paths, options?.signal);
@@ -3259,7 +3319,8 @@ export class PluginService {
       ): Promise<PluginGitCommitResult> => {
         callOptions?.signal?.throwIfAborted();
         requireLoaded("commit");
-        requireWriteCap("commit");
+        await requireWriteCap("commit");
+        requireLoaded("commit");
         // commit returns the staged diff as its change-preview, so it discloses
         // repo content — require read alongside write.
         requireReadCap("commit");

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -32,6 +32,10 @@ vi.mock("../PluginActionAuditService.js", () => ({
 }));
 
 import { PluginService } from "../PluginService.js";
+import {
+  getPluginCapabilityConsentService,
+  _resetPluginCapabilityServicesForTest,
+} from "../plugin-capability/instances.js";
 import type { SimpleGit } from "simple-git";
 import type { PluginManifest, PluginHostApi } from "../../../shared/types/plugin.js";
 
@@ -98,10 +102,15 @@ beforeEach(async () => {
   await fs.mkdir(homeDir, { recursive: true });
   homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(homeDir);
   svc = new PluginService(pluginsRoot);
+  // JIT capability consent (#10524) gates the first host-mediated write/spawn.
+  // Auto-approve without pinning so the happy-path containment assertions run
+  // without a renderer; the dedicated consent tests cover the prompt branch.
+  getPluginCapabilityConsentService().setConsentBridge(async () => "approved-once");
 });
 
 afterEach(() => {
   homedirSpy.mockRestore();
+  _resetPluginCapabilityServicesForTest();
   rmSync(baseDir, { recursive: true, force: true });
 });
 
@@ -433,5 +442,48 @@ describe("host.git token expansion", () => {
     // containment before any git work runs.
     await fs.mkdir(dataDir(), { recursive: true });
     await expect(host.git.diff(dataDir())).rejects.toThrow(/PATH_NOT_ALLOWED/);
+  });
+});
+
+describe("JIT capability consent gating (#10524)", () => {
+  function registerWith(isBuiltin: boolean): PluginHostApi {
+    const seam = svc as unknown as {
+      _registerFakePluginForTests(p: FakeLoadedPlugin): void;
+      _createHostForTests(id: string): PluginHostApi;
+    };
+    seam._registerFakePluginForTests({
+      manifest: makeManifest(["fs:project-read", "fs:project-write"], [allowed]),
+      dir: baseDir,
+      loadedAt: 0,
+      isBuiltin,
+    });
+    return seam._createHostForTests("acme.fsgit");
+  }
+
+  it("blocks a host write when the user denies consent, even with the capability declared", async () => {
+    getPluginCapabilityConsentService().setConsentBridge(async () => "rejected");
+    const host = registerWith(false);
+    await expect(host.fs.writeFile(join(allowed, "denied.txt"), "x")).rejects.toThrow(
+      /PERMISSION_REQUIRED/
+    );
+    // The write never lands.
+    await expect(fs.readFile(join(allowed, "denied.txt"), "utf-8")).rejects.toThrow();
+  });
+
+  it("prompts only once, then runs silently after approve-and-pin", async () => {
+    const bridge = vi.fn(async () => "approved-and-pin" as const);
+    getPluginCapabilityConsentService().setConsentBridge(bridge);
+    const host = registerWith(false);
+    await host.fs.writeFile(join(allowed, "a.txt"), "1");
+    await host.fs.writeFile(join(allowed, "b.txt"), "2");
+    expect(bridge).toHaveBeenCalledTimes(1);
+  });
+
+  it("exempts built-in (first-party) plugins from the consent prompt", async () => {
+    const bridge = vi.fn(async () => "rejected" as const);
+    getPluginCapabilityConsentService().setConsentBridge(bridge);
+    const host = registerWith(true);
+    await expect(host.fs.writeFile(join(allowed, "builtin.txt"), "x")).resolves.toBeUndefined();
+    expect(bridge).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/PluginService.hostFsGit.test.ts
+++ b/electron/services/__tests__/PluginService.hostFsGit.test.ts
@@ -486,4 +486,34 @@ describe("JIT capability consent gating (#10524)", () => {
     await expect(host.fs.writeFile(join(allowed, "builtin.txt"), "x")).resolves.toBeUndefined();
     expect(bridge).not.toHaveBeenCalled();
   });
+
+  it("blocks git.add and git.commit and never reaches simple-git when consent is denied", async () => {
+    getPluginCapabilityConsentService().setConsentBridge(async () => "rejected");
+    const git = {
+      diff: vi.fn().mockResolvedValue("diff --git a/x b/x\n+line"),
+      add: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue({ commit: "abc1234" }),
+    } as unknown as SimpleGit;
+    (
+      svc as unknown as { _setHostGitFactoryForTests(f: () => Promise<SimpleGit>): void }
+    )._setHostGitFactoryForTests(async () => git);
+    const seam = svc as unknown as {
+      _registerFakePluginForTests(p: FakeLoadedPlugin): void;
+      _createHostForTests(id: string): PluginHostApi;
+    };
+    seam._registerFakePluginForTests({
+      manifest: makeManifest(["git:read", "git:write"], [allowed]),
+      dir: baseDir,
+      loadedAt: 0,
+      isBuiltin: false,
+    });
+    const host = seam._createHostForTests("acme.fsgit");
+
+    await expect(host.git.add(allowed, ["a.txt"])).rejects.toThrow(/PERMISSION_REQUIRED/);
+    await expect(host.git.commit(allowed, { message: "feat: x" })).rejects.toThrow(
+      /PERMISSION_REQUIRED/
+    );
+    expect(git.add).not.toHaveBeenCalled();
+    expect(git.commit).not.toHaveBeenCalled();
+  });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4056,6 +4056,53 @@ describe("createHost — host.process (managed processes, #9234)", () => {
     expect(manager.runningCount("acme.proc-cap")).toBe(1);
   });
 
+  it("blocks the spawn and never reaches the manager when consent is denied (#10524)", async () => {
+    await writePlugin("proc-deny", {
+      name: "acme.proc-deny",
+      version: "1.0.0",
+      capabilities: ["shell:exec"],
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const spawner = vi.fn(() => makeFakeChild().child);
+    const manager = new PluginProcessManager({ streamSink: () => {}, spawner, killGraceMs: 10 });
+    service._setProcessManagerForTests(manager);
+    getPluginCapabilityConsentService().setConsentBridge(async () => "rejected");
+
+    const { host } = (service as unknown as { createHost: ProcessHostShape }).createHost(
+      "acme.proc-deny"
+    );
+
+    await expect(host.process.spawn("node", { args: ["server.js"] })).rejects.toThrow(
+      /PERMISSION_REQUIRED/
+    );
+    expect(spawner).not.toHaveBeenCalled();
+    expect(manager.runningCount("acme.proc-deny")).toBe(0);
+  });
+
+  it("does not spend a consent prompt on an invalid spawn that fails validation (#10524)", async () => {
+    await writePlugin("proc-invalid", {
+      name: "acme.proc-invalid",
+      version: "1.0.0",
+      capabilities: ["shell:exec"],
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const bridge = vi.fn(async () => "approved-and-pin" as const);
+    getPluginCapabilityConsentService().setConsentBridge(bridge);
+
+    const { host } = (service as unknown as { createHost: ProcessHostShape }).createHost(
+      "acme.proc-invalid"
+    );
+
+    // An empty command fails validation; the prompt must NOT fire (else a plugin
+    // could bank a silent grant via a deliberately-doomed call).
+    await expect(host.process.spawn("")).rejects.toThrow(/non-empty string/);
+    expect(bridge).not.toHaveBeenCalled();
+  });
+
   it("kills outstanding processes when the plugin is unloaded", async () => {
     await writePlugin("proc-unload", {
       name: "acme.proc-unload",

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -169,6 +169,10 @@ import { z } from "zod";
 import { PluginService } from "../PluginService.js";
 import { events } from "../events.js";
 import { PluginProcessManager, type ManagedChildProcess } from "../plugin/PluginProcessManager.js";
+import {
+  getPluginCapabilityConsentService,
+  _resetPluginCapabilityServicesForTest,
+} from "../plugin-capability/instances.js";
 import { getPluginActionAuditService } from "../PluginActionAuditService.js";
 import { isAuditedHandlerFailure } from "../../utils/pluginAuditMarker.js";
 import { PluginInvokeOwnershipError } from "../plugin/PluginInvokeErrors.js";
@@ -3996,6 +4000,17 @@ function makeFakeChild() {
 }
 
 describe("createHost — host.process (managed processes, #9234)", () => {
+  // JIT capability consent (#10524) gates the first shell:exec spawn. Auto-approve
+  // without pinning so the spawn-path assertions run without a renderer; the
+  // dedicated consent tests cover the prompt/denial branch. The no-capability
+  // test below rejects before consent is even consulted, so it is unaffected.
+  beforeEach(() => {
+    getPluginCapabilityConsentService().setConsentBridge(async () => "approved-once");
+  });
+  afterEach(() => {
+    _resetPluginCapabilityServicesForTest();
+  });
+
   it("rejects spawn from a plugin without the shell:exec capability", async () => {
     await writePlugin("proc-nocap", { name: "acme.proc-nocap", version: "1.0.0" });
     const service = new PluginService(tmpDir);

--- a/electron/services/plugin-capability/PluginCapabilityConsentService.ts
+++ b/electron/services/plugin-capability/PluginCapabilityConsentService.ts
@@ -1,0 +1,140 @@
+import type { BuiltInPluginCapability } from "../../../shared/types/plugin.js";
+import type { PluginCapabilityConsentDecision } from "../../../shared/types/pluginCapabilityConsent.js";
+import type { PluginCapabilityConsentStore } from "./PluginCapabilityConsentStore.js";
+
+/** Prefix on the thrown error so `useHostChannel` discriminates a denial. */
+export const PLUGIN_CAPABILITY_DENIED_PREFIX = "PERMISSION_REQUIRED";
+
+/**
+ * Display-safe payload handed to the consent UI bridge when a first-use prompt
+ * is required. Every field is renderer-safe.
+ */
+export interface PluginCapabilityConsentRequest {
+  pluginId: string;
+  /** Human-readable plugin display name (manifest `displayName ?? name`). */
+  pluginDisplayName: string;
+  capability: BuiltInPluginCapability;
+  /** Plugin's manifest `capabilities[]` list — surfaced for transparency. */
+  declaredCapabilities: readonly BuiltInPluginCapability[];
+}
+
+/** Bridge that owns the consent UI surface (renderer dialog). */
+export type PluginCapabilityConsentBridge = (
+  request: PluginCapabilityConsentRequest
+) => Promise<PluginCapabilityConsentDecision>;
+
+/**
+ * Orchestrates just-in-time consent for a single plugin host capability
+ * (#10524). The first time a plugin exercises a gated capability
+ * (`shell:exec`, `fs:*-write`, `git:write`) the service raises a prompt via the
+ * injected bridge and, on `approved-and-pin`, persists the grant so later calls
+ * run silently. A granted capability short-circuits without a prompt.
+ *
+ * Wiring: `PluginService` calls `ensureAllowed()` at the top of each gated host
+ * API closure (after the static `manifest.capabilities` check passes) and only
+ * proceeds when it resolves; on denial it rejects, and the closure surfaces the
+ * `PERMISSION_REQUIRED:` error to the plugin.
+ *
+ * Concurrent first-use calls for the same `(pluginId, capability)` are coalesced
+ * onto a single in-flight prompt — a plugin firing several `host.process.spawn`
+ * calls at once raises one dialog, not a stack of duplicates.
+ */
+export class PluginCapabilityConsentService {
+  private bridge: PluginCapabilityConsentBridge | null = null;
+  private readonly inFlight = new Map<string, Promise<PluginCapabilityConsentDecision>>();
+
+  constructor(private readonly consentStore: PluginCapabilityConsentStore) {}
+
+  /**
+   * Inject the UI consent bridge. A null bridge causes the service to deny any
+   * call that needs a prompt (already-granted capabilities still pass) — the
+   * fail-closed default, so a capability never runs unprompted just because the
+   * renderer isn't ready to host the dialog yet.
+   */
+  setConsentBridge(bridge: PluginCapabilityConsentBridge | null): void {
+    this.bridge = bridge;
+  }
+
+  /** Whether a UI bridge is currently installed (test/diagnostic introspection). */
+  hasBridge(): boolean {
+    return this.bridge !== null;
+  }
+
+  /**
+   * Purge every grant for a plugin. Delegated to the store (which is private to
+   * this service) so uninstall callers go through the service. Returns whether
+   * the purge was durably persisted so the caller can retry or escalate.
+   */
+  revokeAllForPlugin(pluginId: string): boolean {
+    return this.consentStore.revokeAllForPlugin(pluginId);
+  }
+
+  /**
+   * Gate a gated host capability call. Resolves silently when the capability is
+   * already granted or the user approves; throws a `PERMISSION_REQUIRED:` error
+   * when the user rejects or no consent bridge is installed.
+   */
+  async ensureAllowed(
+    pluginId: string,
+    pluginDisplayName: string,
+    capability: BuiltInPluginCapability,
+    declaredCapabilities: readonly BuiltInPluginCapability[]
+  ): Promise<void> {
+    if (this.consentStore.hasGrant({ pluginId, capability })) return;
+
+    const decision = await this.requestDecision(
+      pluginId,
+      pluginDisplayName,
+      capability,
+      declaredCapabilities
+    );
+
+    if (decision === "approved-and-pin") {
+      this.consentStore.grant({ pluginId, capability });
+      return;
+    }
+    if (decision === "approved-once") return;
+
+    throw new Error(
+      `${PLUGIN_CAPABILITY_DENIED_PREFIX}: plugin "${pluginId}" was denied use of the "${capability}" capability`
+    );
+  }
+
+  /**
+   * Resolve the user's decision for a `(pluginId, capability)`, coalescing
+   * concurrent first-use requests onto one in-flight prompt. Re-checks the grant
+   * store after awaiting a coalesced prompt so a sibling call that just got
+   * `approved-and-pin` lets the rest through without a second decision.
+   */
+  private requestDecision(
+    pluginId: string,
+    pluginDisplayName: string,
+    capability: BuiltInPluginCapability,
+    declaredCapabilities: readonly BuiltInPluginCapability[]
+  ): Promise<PluginCapabilityConsentDecision> {
+    if (this.bridge === null) {
+      // Fail closed — no UI to approve through.
+      return Promise.resolve("rejected");
+    }
+    const key = JSON.stringify([pluginId, capability]);
+    const existing = this.inFlight.get(key);
+    if (existing) return existing;
+
+    const bridge = this.bridge;
+    const promise = bridge({ pluginId, pluginDisplayName, capability, declaredCapabilities })
+      .catch((err) => {
+        console.error("[PluginCapabilityConsentService] Consent bridge threw:", err);
+        return "rejected" as PluginCapabilityConsentDecision;
+      })
+      .finally(() => {
+        this.inFlight.delete(key);
+      });
+    this.inFlight.set(key, promise);
+    return promise;
+  }
+
+  _resetForTest(): void {
+    this.bridge = null;
+    this.inFlight.clear();
+  }
+}

--- a/electron/services/plugin-capability/PluginCapabilityConsentStore.ts
+++ b/electron/services/plugin-capability/PluginCapabilityConsentStore.ts
@@ -1,0 +1,154 @@
+import type { BuiltInPluginCapability } from "../../../shared/types/plugin.js";
+import type {
+  PluginCapabilityConsentRecord,
+  PluginCapabilityIdentity,
+} from "../../../shared/types/pluginCapabilityConsent.js";
+
+/**
+ * Just-in-time (JIT) grant store for plugin host capabilities (#10524).
+ * Persists each `(pluginId, capability)` pair the user has approved so the
+ * first call into a high-risk capability prompts once and every later call runs
+ * silently. Mirrors {@link PluginMcpConsentStore} but is simpler — there is no
+ * fingerprint and no rug-pull re-prompt, because a capability is a static
+ * manifest declaration, not a mutable advertised surface.
+ *
+ * Persistence is delegated to electron-store via the inject point: the caller
+ * supplies a `(patch) => void` saver and a `() => record` reader. The store
+ * itself is process-local in-memory; the saver/reader pair owns durability.
+ */
+export class PluginCapabilityConsentStore {
+  private grants: Map<string, PluginCapabilityConsentRecord> = new Map();
+  private hydrated = false;
+
+  constructor(
+    private readonly saveConfig: (patch: Record<string, unknown>) => void,
+    private readonly readConfig: () => Record<string, unknown>
+  ) {}
+
+  /** Whether the user has an active grant for this `(pluginId, capability)`. */
+  hasGrant(identity: PluginCapabilityIdentity): boolean {
+    this.hydrate();
+    return this.grants.has(makeKey(identity));
+  }
+
+  /**
+   * Mint or refresh a grant for a `(pluginId, capability)`. Idempotent — a
+   * re-approval just refreshes `approvedAt`.
+   */
+  grant(identity: PluginCapabilityIdentity): PluginCapabilityConsentRecord {
+    this.hydrate();
+    const record: PluginCapabilityConsentRecord = {
+      pluginId: identity.pluginId,
+      capability: identity.capability,
+      approvedAt: Date.now(),
+    };
+    this.grants.set(makeKey(identity), record);
+    this.flush();
+    return record;
+  }
+
+  /**
+   * Revoke a single grant. Subsequent calls into the capability re-prompt.
+   * Revoking a never-granted identity is a no-op.
+   */
+  revoke(identity: PluginCapabilityIdentity): void {
+    this.hydrate();
+    const key = makeKey(identity);
+    if (!this.grants.has(key)) return;
+    this.grants.delete(key);
+    this.flush();
+  }
+
+  /** Read all live grants. Newest-first. */
+  list(): PluginCapabilityConsentRecord[] {
+    this.hydrate();
+    return [...this.grants.values()].sort((a, b) => b.approvedAt - a.approvedAt);
+  }
+
+  /** Drop every grant. Persists immediately. */
+  clear(): void {
+    this.hydrate();
+    this.grants.clear();
+    this.flush();
+  }
+
+  /**
+   * Purge all grants for a plugin. Used on uninstall so a same-name reinstall
+   * starts from first-use rather than inheriting prior approvals (the pluginId
+   * is author-controlled, so a reinstalled or rebuilt plugin must re-prompt).
+   * Flushes only when at least one grant was removed.
+   *
+   * Returns whether the purge is durable: `true` if nothing changed (nothing to
+   * purge) or the flush persisted; `false` if the flush threw, so the caller
+   * knows the in-memory grants were dropped but the persisted snapshot may still
+   * hold them — they'd rehydrate on the next launch (a consent-bypass for a
+   * same-name reinstall) unless the caller retries or escalates.
+   */
+  revokeAllForPlugin(pluginId: string): boolean {
+    this.hydrate();
+    let changed = false;
+    for (const [key, record] of this.grants) {
+      if (record.pluginId === pluginId) {
+        this.grants.delete(key);
+        changed = true;
+      }
+    }
+    if (!changed) return true;
+    return this.flush();
+  }
+
+  private hydrate(): void {
+    if (this.hydrated) return;
+    const config = this.readConfig();
+    const persisted = config.grants;
+    if (Array.isArray(persisted)) {
+      for (const raw of persisted) {
+        const record = normalizeRecord(raw);
+        if (record) this.grants.set(makeKey(record), record);
+      }
+    }
+    this.hydrated = true;
+  }
+
+  private flush(): boolean {
+    try {
+      this.saveConfig({ grants: [...this.grants.values()] });
+      return true;
+    } catch (err) {
+      console.error("[PluginCapabilityConsentStore] Failed to flush grants:", err);
+      return false;
+    }
+  }
+
+  _resetForTest(): void {
+    this.grants.clear();
+    this.hydrated = false;
+  }
+}
+
+/**
+ * Build the grant-store lookup key for an identity. JSON-encoded so a pluginId
+ * containing `"::"` cannot collide with a differently-split pair. PluginIds are
+ * author-controlled in the manifest, so the encoded form is the only invariant
+ * that prevents a crafted manifest from inheriting another plugin's grant.
+ */
+function makeKey(identity: PluginCapabilityIdentity): string {
+  return JSON.stringify([identity.pluginId, identity.capability]);
+}
+
+function normalizeRecord(raw: unknown): PluginCapabilityConsentRecord | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (
+    typeof r.pluginId !== "string" ||
+    typeof r.capability !== "string" ||
+    typeof r.approvedAt !== "number"
+  ) {
+    return null;
+  }
+  return {
+    pluginId: r.pluginId,
+    capability: r.capability as BuiltInPluginCapability,
+    approvedAt: r.approvedAt,
+  };
+}

--- a/electron/services/plugin-capability/PluginCapabilityConsentStore.ts
+++ b/electron/services/plugin-capability/PluginCapabilityConsentStore.ts
@@ -94,6 +94,12 @@ export class PluginCapabilityConsentStore {
       }
     }
     if (!changed) return true;
+    // Retry the flush once internally on a transient failure. The in-memory
+    // grants are already dropped, so a caller-side `revoke() || revoke()` retry
+    // would short-circuit on the second call (nothing left to delete →
+    // `!changed` → `true`) and never re-attempt the persist — the flush must be
+    // retried here, where the empty snapshot is what we re-write.
+    if (this.flush()) return true;
     return this.flush();
   }
 

--- a/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
+++ b/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import { PluginCapabilityConsentService } from "../PluginCapabilityConsentService.js";
+import { PluginCapabilityConsentStore } from "../PluginCapabilityConsentStore.js";
+import type { PluginCapabilityConsentDecision } from "../../../../shared/types/pluginCapabilityConsent.js";
+
+function makeService() {
+  let config: Record<string, unknown> = {};
+  const store = new PluginCapabilityConsentStore(
+    (patch) => {
+      config = { ...config, ...patch };
+    },
+    () => config
+  );
+  const service = new PluginCapabilityConsentService(store);
+  return { service, store };
+}
+
+const CAPS = ["shell:exec"] as const;
+
+describe("PluginCapabilityConsentService", () => {
+  it("denies (fail-closed) when no consent bridge is installed", async () => {
+    const { service, store } = makeService();
+    await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
+      /PERMISSION_REQUIRED/
+    );
+    // A denial must not leave a grant behind.
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+  });
+
+  it("short-circuits without prompting once a capability is granted", async () => {
+    const { service, store } = makeService();
+    store.grant({ pluginId: "acme.x", capability: "shell:exec" });
+    const bridge = vi.fn(async () => "rejected" as PluginCapabilityConsentDecision);
+    service.setConsentBridge(bridge);
+    await expect(
+      service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)
+    ).resolves.toBeUndefined();
+    expect(bridge).not.toHaveBeenCalled();
+  });
+
+  it("approved-and-pin persists the grant so later calls skip the prompt", async () => {
+    const { service, store } = makeService();
+    const bridge = vi.fn(async () => "approved-and-pin" as PluginCapabilityConsentDecision);
+    service.setConsentBridge(bridge);
+
+    await service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS);
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(true);
+
+    // Second call short-circuits — bridge invoked only once.
+    await service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS);
+    expect(bridge).toHaveBeenCalledTimes(1);
+  });
+
+  it("approved-once allows the call but does not persist a grant", async () => {
+    const { service, store } = makeService();
+    const bridge = vi.fn(async () => "approved-once" as PluginCapabilityConsentDecision);
+    service.setConsentBridge(bridge);
+
+    await expect(
+      service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)
+    ).resolves.toBeUndefined();
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+
+    // Not pinned, so the next call prompts again.
+    await service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS);
+    expect(bridge).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejected throws PERMISSION_REQUIRED", async () => {
+    const { service } = makeService();
+    service.setConsentBridge(async () => "rejected");
+    await expect(
+      service.ensureAllowed("acme.x", "Acme", "git:write", ["git:write"])
+    ).rejects.toThrow(/PERMISSION_REQUIRED.*git:write/);
+  });
+
+  it("treats a thrown bridge as a rejection (fail-closed)", async () => {
+    const { service } = makeService();
+    service.setConsentBridge(async () => {
+      throw new Error("renderer blew up");
+    });
+    await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
+      /PERMISSION_REQUIRED/
+    );
+  });
+
+  it("coalesces concurrent first-use calls for the same (plugin, capability) onto one prompt", async () => {
+    const { service, store } = makeService();
+    let resolveBridge!: (d: PluginCapabilityConsentDecision) => void;
+    const bridge = vi.fn(
+      () =>
+        new Promise<PluginCapabilityConsentDecision>((resolve) => {
+          resolveBridge = resolve;
+        })
+    );
+    service.setConsentBridge(bridge);
+
+    const a = service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS);
+    const b = service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS);
+    const c = service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS);
+
+    // All three are waiting on a single in-flight prompt.
+    expect(bridge).toHaveBeenCalledTimes(1);
+
+    resolveBridge("approved-and-pin");
+    await expect(Promise.all([a, b, c])).resolves.toEqual([undefined, undefined, undefined]);
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(true);
+  });
+
+  it("does not coalesce across distinct capabilities", async () => {
+    const { service } = makeService();
+    const bridge = vi.fn(async () => "approved-once" as PluginCapabilityConsentDecision);
+    service.setConsentBridge(bridge);
+
+    await Promise.all([
+      service.ensureAllowed("acme.x", "Acme", "shell:exec", ["shell:exec", "git:write"]),
+      service.ensureAllowed("acme.x", "Acme", "git:write", ["shell:exec", "git:write"]),
+    ]);
+    expect(bridge).toHaveBeenCalledTimes(2);
+  });
+
+  it("revokeAllForPlugin clears grants through the service", async () => {
+    const { service, store } = makeService();
+    store.grant({ pluginId: "acme.x", capability: "shell:exec" });
+    expect(service.revokeAllForPlugin("acme.x")).toBe(true);
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+  });
+});

--- a/electron/services/plugin-capability/__tests__/PluginCapabilityConsentStore.test.ts
+++ b/electron/services/plugin-capability/__tests__/PluginCapabilityConsentStore.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { PluginCapabilityConsentStore } from "../PluginCapabilityConsentStore.js";
+
+function makeStore(initial: Record<string, unknown> = {}) {
+  let config: Record<string, unknown> = { ...initial };
+  const saveConfig = vi.fn((patch: Record<string, unknown>) => {
+    config = { ...config, ...patch };
+  });
+  const store = new PluginCapabilityConsentStore(saveConfig, () => config);
+  return { store, saveConfig, getConfig: () => config };
+}
+
+describe("PluginCapabilityConsentStore", () => {
+  it("reports no grant before one is minted, and a grant after", () => {
+    const { store } = makeStore();
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+    store.grant({ pluginId: "acme.x", capability: "shell:exec" });
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(true);
+  });
+
+  it("scopes a grant to its exact (pluginId, capability) pair", () => {
+    const { store } = makeStore();
+    store.grant({ pluginId: "acme.x", capability: "shell:exec" });
+    // Same plugin, different capability — not granted.
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "git:write" })).toBe(false);
+    // Different plugin, same capability — not granted.
+    expect(store.hasGrant({ pluginId: "acme.y", capability: "shell:exec" })).toBe(false);
+  });
+
+  it("does not let a separator-bearing pluginId inherit another plugin's grant", () => {
+    const { store } = makeStore();
+    // JSON-encoded keys, so these two identities must stay distinct even though
+    // a naive `::` join of their parts would collide.
+    store.grant({ pluginId: "a", capability: "git:write" });
+    expect(store.hasGrant({ pluginId: "a", capability: "git:write" })).toBe(true);
+    expect(
+      store.hasGrant({
+        pluginId: 'a","git:write"]',
+        capability: "git:write",
+      })
+    ).toBe(false);
+  });
+
+  it("persists grants through the saver and rehydrates them", () => {
+    const { store, getConfig } = makeStore();
+    store.grant({ pluginId: "acme.x", capability: "fs:project-write" });
+
+    // A fresh store reading the same persisted config sees the grant.
+    const reopened = new PluginCapabilityConsentStore(
+      () => {},
+      () => getConfig()
+    );
+    expect(reopened.hasGrant({ pluginId: "acme.x", capability: "fs:project-write" })).toBe(true);
+  });
+
+  it("revoke drops a single grant and leaves others intact", () => {
+    const { store } = makeStore();
+    store.grant({ pluginId: "acme.x", capability: "shell:exec" });
+    store.grant({ pluginId: "acme.x", capability: "git:write" });
+    store.revoke({ pluginId: "acme.x", capability: "shell:exec" });
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "git:write" })).toBe(true);
+  });
+
+  it("revokeAllForPlugin removes only that plugin's grants and reports durable", () => {
+    const { store } = makeStore();
+    store.grant({ pluginId: "acme.x", capability: "shell:exec" });
+    store.grant({ pluginId: "acme.x", capability: "git:write" });
+    store.grant({ pluginId: "acme.y", capability: "shell:exec" });
+
+    expect(store.revokeAllForPlugin("acme.x")).toBe(true);
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "git:write" })).toBe(false);
+    // Sibling plugin untouched.
+    expect(store.hasGrant({ pluginId: "acme.y", capability: "shell:exec" })).toBe(true);
+  });
+
+  it("revokeAllForPlugin is a durable no-op when there is nothing to purge", () => {
+    const { store, saveConfig } = makeStore();
+    expect(store.revokeAllForPlugin("acme.absent")).toBe(true);
+    // Nothing changed, so no flush.
+    expect(saveConfig).not.toHaveBeenCalled();
+  });
+
+  it("revokeAllForPlugin reports non-durable when the flush throws", () => {
+    let config: Record<string, unknown> = {};
+    let failOnNextSave = false;
+    const saveConfig = vi.fn((patch: Record<string, unknown>) => {
+      if (failOnNextSave) throw new Error("disk full");
+      config = { ...config, ...patch };
+    });
+    const store = new PluginCapabilityConsentStore(saveConfig, () => config);
+    store.grant({ pluginId: "acme.x", capability: "shell:exec" });
+    failOnNextSave = true;
+    expect(store.revokeAllForPlugin("acme.x")).toBe(false);
+  });
+
+  it("ignores malformed persisted records on hydrate", () => {
+    const { store } = makeStore({
+      grants: [
+        { pluginId: "acme.x", capability: "shell:exec", approvedAt: 123 },
+        { pluginId: 42, capability: "shell:exec", approvedAt: 1 }, // bad pluginId
+        { capability: "git:write", approvedAt: 1 }, // missing pluginId
+        null,
+      ],
+    });
+    expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(true);
+    expect(store.list()).toHaveLength(1);
+  });
+});

--- a/electron/services/plugin-capability/instances.ts
+++ b/electron/services/plugin-capability/instances.ts
@@ -1,0 +1,53 @@
+import { store } from "../../store.js";
+import { PluginCapabilityConsentService } from "./PluginCapabilityConsentService.js";
+import { PluginCapabilityConsentStore } from "./PluginCapabilityConsentStore.js";
+
+let consentStoreInstance: PluginCapabilityConsentStore | null = null;
+let consentServiceInstance: PluginCapabilityConsentService | null = null;
+
+/**
+ * JIT plugin-capability grant store singleton. Wired to the
+ * `pluginCapabilityConsent` electron-store slice (plaintext, matching the
+ * `pluginMcpConsent` precedent — grants hold no secrets, only a `(pluginId,
+ * capability)` pair and a timestamp).
+ */
+export function getPluginCapabilityConsentStore(): PluginCapabilityConsentStore {
+  if (!consentStoreInstance) {
+    consentStoreInstance = new PluginCapabilityConsentStore(
+      (patch) => {
+        const current = (store.get("pluginCapabilityConsent") ?? {}) as Record<string, unknown>;
+        store.set("pluginCapabilityConsent", { ...current, ...patch });
+      },
+      () => (store.get("pluginCapabilityConsent") ?? {}) as Record<string, unknown>
+    );
+  }
+  return consentStoreInstance;
+}
+
+/**
+ * JIT plugin-capability consent orchestrator singleton. `PluginService` calls
+ * `ensureAllowed()` at the top of each gated host API closure. Constructed
+ * lazily so a boot path with no capability-gated plugin traffic never allocates
+ * it.
+ */
+export function getPluginCapabilityConsentService(): PluginCapabilityConsentService {
+  if (!consentServiceInstance) {
+    consentServiceInstance = new PluginCapabilityConsentService(getPluginCapabilityConsentStore());
+  }
+  return consentServiceInstance;
+}
+
+/**
+ * Test-only escape hatch — clears persisted grants then drops every singleton so
+ * the next call rebuilds them. The persisted clear is what stops a grant pinned
+ * in one test from rehydrating into the next via the shared electron-store.
+ */
+export function _resetPluginCapabilityServicesForTest(): void {
+  // clear() flushes an empty grants array to the persisted slice; the flush
+  // swallows any write error, so this is safe even in a sandboxed store.
+  consentStoreInstance?.clear();
+  consentStoreInstance?._resetForTest();
+  consentServiceInstance?._resetForTest();
+  consentStoreInstance = null;
+  consentServiceInstance = null;
+}

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -20,6 +20,7 @@ import {
 import { resilientRename } from "../../utils/fs.js";
 import { getPluginMcpSupervisor } from "../PluginMcpSupervisor.js";
 import { getPluginMcpConsentService, getPluginMcpRateLimiter } from "../plugin-mcp/instances.js";
+import { getPluginCapabilityConsentService } from "../plugin-capability/instances.js";
 import type {
   PluginManifest,
   PluginInstallError,
@@ -941,6 +942,27 @@ export class PluginInstaller {
       } catch (err) {
         console.error(
           `[PluginService] consent purge during uninstall of "${pluginId}" threw:`,
+          err
+        );
+      }
+
+      // Purge JIT host-capability grants for the same reason — a same-name
+      // reinstall must re-prompt on first use of shell:exec / fs:*-write /
+      // git:write rather than inherit a prior grant (#10524). Same durability
+      // contract as the MCP consent purge above: retry once, log loudly on a
+      // persist failure, never strand the uninstall.
+      try {
+        const capConsent = getPluginCapabilityConsentService();
+        const purged =
+          capConsent.revokeAllForPlugin(pluginId) || capConsent.revokeAllForPlugin(pluginId);
+        if (!purged) {
+          console.error(
+            `[PluginService] capability consent purge for "${pluginId}" failed to persist after a retry; stale grants may rehydrate on restart — revoke them manually from plugin capability settings`
+          );
+        }
+      } catch (err) {
+        console.error(
+          `[PluginService] capability consent purge during uninstall of "${pluginId}" threw:`,
           err
         );
       }

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -948,13 +948,13 @@ export class PluginInstaller {
 
       // Purge JIT host-capability grants for the same reason — a same-name
       // reinstall must re-prompt on first use of shell:exec / fs:*-write /
-      // git:write rather than inherit a prior grant (#10524). Same durability
-      // contract as the MCP consent purge above: retry once, log loudly on a
-      // persist failure, never strand the uninstall.
+      // git:write rather than inherit a prior grant (#10524). Durable by
+      // contract: revokeAllForPlugin retries the flush internally, so a single
+      // call already covers a transient persist failure (a caller-side
+      // `x() || x()` retry would no-op the second call).
       try {
         const capConsent = getPluginCapabilityConsentService();
-        const purged =
-          capConsent.revokeAllForPlugin(pluginId) || capConsent.revokeAllForPlugin(pluginId);
+        const purged = capConsent.revokeAllForPlugin(pluginId);
         if (!purged) {
           console.error(
             `[PluginService] capability consent purge for "${pluginId}" failed to persist after a retry; stale grants may rehydrate on restart — revoke them manually from plugin capability settings`

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -24,6 +24,7 @@ import { PLUGIN_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/pluginAudi
 import type { PluginMcpAuditRecord } from "../shared/types/ipc/pluginMcpAudit.js";
 import { PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS } from "../shared/types/ipc/pluginMcpAudit.js";
 import type { PluginMcpConsentRecord } from "../shared/types/pluginMcpConsent.js";
+import type { PluginCapabilityConsentRecord } from "../shared/types/pluginCapabilityConsent.js";
 import { PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION } from "../shared/types/ipc/pluginMcp.js";
 import type { ForgeAuditRecord } from "../shared/types/ipc/forge.js";
 import type { RunHistoryRecord } from "../shared/types/ipc/runHistory.js";
@@ -447,6 +448,17 @@ export interface StoreSchema {
   pluginMcpConfig: {
     maxToolsPerSession: number;
   };
+  /**
+   * Just-in-time (JIT) consent grants for plugin host capabilities (#10524).
+   * Each grant is a `(pluginId, capability)` pair the user approved on first
+   * use of a high-risk host surface (`shell:exec`, `fs:*-write`, `git:write`),
+   * so later calls run without re-prompting. Plaintext, matching the
+   * `pluginMcpConsent` precedent — a grant holds no secret, only the pair and a
+   * timestamp.
+   */
+  pluginCapabilityConsent: {
+    grants?: PluginCapabilityConsentRecord[];
+  };
 }
 
 const storeOptions = {
@@ -623,6 +635,7 @@ const storeOptions = {
     pluginMcpConfig: {
       maxToolsPerSession: PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION,
     },
+    pluginCapabilityConsent: {},
   },
   cwd: process.env.DAINTREE_USER_DATA,
 };

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -456,6 +456,11 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["plugin:validate-action-ids"]["args"]
     ): Promise<IpcInvokeMap["plugin:validate-action-ids"]["result"]>;
   };
+  pluginCapability: {
+    resolveConsent(
+      ...args: IpcInvokeMap["plugin-capability:resolve-consent"]["args"]
+    ): Promise<IpcInvokeMap["plugin-capability:resolve-consent"]["result"]>;
+  };
   pluginMcp: {
     callTool(
       ...args: IpcInvokeMap["plugin-mcp:call-tool"]["args"]

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -659,6 +659,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: boolean | undefined;
   };
+  "plugin-capability:resolve-consent": {
+    args: [input: import("../pluginCapabilityConsent.js").PluginCapabilityResolveConsentInput];
+    result: void;
+  };
   "plugin-mcp:call-tool": {
     args: [input: import("./pluginMcp.js").PluginMcpCallToolInput];
     result: import("./pluginMcp.js").PluginMcpCallToolResult;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1896,6 +1896,17 @@ export interface IpcEventMap {
    */
   "plugin-mcp:consent-request": import("../pluginMcpConsent.js").PluginMcpConsentRequestEvent;
 
+  /**
+   * Targeted push: a plugin is exercising a high-risk host capability
+   * (`shell:exec`, `fs:*-write`, `git:write`) for the first time and needs
+   * just-in-time consent (#10524). Sent to the focused window (falling back to
+   * the primary) — unlike the MCP consent push there is no initiating renderer,
+   * because the call originates in the plugin's own utility process. The
+   * renderer replies via `plugin-capability:resolve-consent`, correlated by
+   * `requestId`.
+   */
+  "plugin-capability:consent-request": import("../pluginCapabilityConsent.js").PluginCapabilityConsentRequestEvent;
+
   // Typed event bus envelope (multiplexed main → renderer for IpcEventBusMap)
   "events:push": EventBusEnvelope;
 }
@@ -1942,6 +1953,8 @@ export type IpcEventBusMap = Pick<
   | "app-agent:confirmation-request"
   // Plugin-MCP tool-call consent prompt (window-scoped — pinned to the caller)
   | "plugin-mcp:consent-request"
+  // Plugin host-capability JIT consent prompt (window-scoped — focused window)
+  | "plugin-capability:consent-request"
   // Plugin action registry (global broadcast)
   | "plugin:actions-changed"
   // Plugin panel kind registry (global broadcast)

--- a/shared/types/pluginCapabilityConsent.ts
+++ b/shared/types/pluginCapabilityConsent.ts
@@ -1,0 +1,79 @@
+import type { BuiltInPluginCapability } from "./plugin.js";
+
+/**
+ * Just-in-time (JIT) capability consent for plugin host-API surfaces (#10524).
+ *
+ * Distinct from the per-tool plugin-MCP TOFU machinery (`pluginMcpConsent.ts`):
+ * that gates each `(pluginId, serverId, toolName)` MCP `tools/call` on a
+ * fingerprint of the advertised tool surface. This gates the FIRST runtime use
+ * of a high-risk host capability — `shell:exec`, `fs:*-write`, `git:write` —
+ * on a single `(pluginId, capability)` grant. A plugin declares the capability
+ * in its manifest (static gate), but the user is no longer asked to consent at
+ * install/activation time; instead the consent prompt is deferred to the first
+ * call into that capability and the grant is cached so later calls run silently.
+ *
+ * The grant is coarse and stable: one `shell:exec` consent covers every
+ * `host.process.spawn` the plugin makes for its lifetime, not one per spawn.
+ * There is no fingerprint and no rug-pull re-prompt — capabilities are static
+ * manifest declarations, so a grant only resets when the plugin is uninstalled
+ * (`revokeAllForPlugin`) or the user explicitly revokes it.
+ */
+
+/**
+ * Stable pin-store identity for a single plugin capability grant. Keyed in the
+ * store by the JSON-encoded `[pluginId, capability]` pair (see
+ * `PluginCapabilityConsentStore.makeKey`) — JSON-encoded, never `::`-joined, so
+ * a pluginId containing the separator cannot collide with another plugin's
+ * grant (pluginIds are author-controlled in the manifest).
+ */
+export interface PluginCapabilityIdentity {
+  /** Contributing plugin id (`manifest.name`). */
+  pluginId: string;
+  /** The high-risk capability being gated. */
+  capability: BuiltInPluginCapability;
+}
+
+/**
+ * Persisted grant record. Minted on `approved-and-pin`. No fingerprint — the
+ * grant is for the capability, which is a static manifest declaration.
+ */
+export interface PluginCapabilityConsentRecord {
+  pluginId: string;
+  capability: BuiltInPluginCapability;
+  /** Wall-clock epoch millis the grant was minted. */
+  approvedAt: number;
+}
+
+/**
+ * User decision returned by the consent dialog. `rejected` aborts the gated
+ * host call (the closure throws a `PERMISSION_REQUIRED:` error); `approved-once`
+ * runs the call without persisting; `approved-and-pin` runs it and writes the
+ * grant so future calls skip the prompt.
+ */
+export type PluginCapabilityConsentDecision = "approved-once" | "approved-and-pin" | "rejected";
+
+/**
+ * Display-safe consent prompt pushed from main to the renderer over the typed
+ * event bus (`plugin-capability:consent-request`) when a plugin first exercises
+ * a gated capability. Unlike the MCP consent payload there is no args preview or
+ * danger tier — the capability itself names the risk. The renderer enqueues it
+ * into the consent dialog FIFO and replies via `plugin-capability:resolve-consent`,
+ * correlated by `requestId`.
+ */
+export interface PluginCapabilityConsentRequestEvent {
+  /** Correlation id for the matching `plugin-capability:resolve-consent` reply. */
+  requestId: string;
+  pluginId: string;
+  /** Human-readable plugin display name (manifest `displayName ?? name`). */
+  pluginDisplayName: string;
+  /** The capability the plugin is asking to use for the first time. */
+  capability: BuiltInPluginCapability;
+  /** Plugin's manifest `capabilities[]` list — surfaced for transparency. */
+  declaredCapabilities: readonly BuiltInPluginCapability[];
+}
+
+/** Renderer → main reply to a `plugin-capability:consent-request` push. */
+export interface PluginCapabilityResolveConsentInput {
+  requestId: string;
+  decision: PluginCapabilityConsentDecision;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { usePluginPanelKinds } from "./hooks/usePluginPanelKinds";
 import { usePluginAgents } from "./hooks/usePluginAgents";
 import { usePluginKeybindings } from "./hooks/usePluginKeybindings";
 import { usePluginMcpConsentBridge } from "./hooks/usePluginMcpConsentBridge";
+import { usePluginCapabilityConsentBridge } from "./hooks/usePluginCapabilityConsentBridge";
 import { useUpdateListener } from "./hooks/useUpdateListener";
 import { useMainProcessToastListener } from "./hooks/useMainProcessToastListener";
 
@@ -334,6 +335,14 @@ const LazyPluginConfirmPromptDialog = lazy(() =>
     default: m.PluginConfirmPromptDialog,
   }))
 );
+function preloadPluginCapabilityConfirmDialog() {
+  return import("./components/Plugin/PluginCapabilityConfirmDialog");
+}
+const LazyPluginCapabilityConfirmDialog = lazy(() =>
+  preloadPluginCapabilityConfirmDialog().then((m) => ({
+    default: m.PluginCapabilityConfirmDialog,
+  }))
+);
 
 function preloadPanelLimitConfirmDialog() {
   return import("./components/Terminal/PanelLimitConfirmDialog");
@@ -404,6 +413,7 @@ import { usePanelLimitStore } from "./store/panelLimitStore";
 import { useMcpConfirmStore } from "./store/mcpConfirmStore";
 import { usePluginConfirmStore } from "./store/pluginConfirmStore";
 import { usePluginMcpConfirmStore } from "./store/pluginMcpConfirmStore";
+import { usePluginCapabilityConfirmStore } from "./store/pluginCapabilityConfirmStore";
 import { useDiagnosticsReviewStore } from "./store/diagnosticsReviewStore";
 import { useAgentSettingsStore } from "./store/agentSettingsStore";
 // Eager side-effect import: auto-discovers every built-in plugin renderer and
@@ -713,6 +723,9 @@ function AppInner() {
   const mcpConfirmResetKey = useMcpConfirmStore((s) => s.current?.requestId ?? "");
   const pluginConfirmResetKey = usePluginConfirmStore((s) => s.current?.requestId ?? "");
   const pluginMcpConfirmResetKey = usePluginMcpConfirmStore((s) => s.current?.requestId ?? "");
+  const pluginCapabilityConfirmResetKey = usePluginCapabilityConfirmStore(
+    (s) => s.current?.requestId ?? ""
+  );
   const diagnosticsReviewResetKey = useDiagnosticsReviewStore((s) => s.requestSeq);
   const [terminalInfoResetKey, setTerminalInfoResetKey] = useState(0);
   const [fileViewerResetKey, setFileViewerResetKey] = useState(0);
@@ -921,6 +934,7 @@ function AppInner() {
   usePluginAgents();
   usePluginKeybindings();
   usePluginMcpConsentBridge();
+  usePluginCapabilityConsentBridge();
 
   useMenuActions();
 
@@ -1552,6 +1566,17 @@ function AppInner() {
               <ErrorBoundary variant="component" componentName="PluginConfirmPromptDialog">
                 <Suspense fallback={null}>
                   <LazyPluginConfirmPromptDialog />
+                </Suspense>
+              </ErrorBoundary>
+            )}
+            {isStateLoaded && (
+              <ErrorBoundary
+                variant="component"
+                componentName="PluginCapabilityConfirmDialog"
+                resetKeys={[pluginCapabilityConfirmResetKey]}
+              >
+                <Suspense fallback={null}>
+                  <LazyPluginCapabilityConfirmDialog />
                 </Suspense>
               </ErrorBoundary>
             )}

--- a/src/components/Plugin/PluginCapabilityConfirmDialog.tsx
+++ b/src/components/Plugin/PluginCapabilityConfirmDialog.tsx
@@ -1,0 +1,130 @@
+import { useCallback, useRef } from "react";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { usePluginCapabilityConfirmStore } from "@/store/pluginCapabilityConfirmStore";
+import type { PluginCapabilityConsentDecision } from "@shared/types/pluginCapabilityConsent";
+import type { BuiltInPluginCapability } from "@shared/types/plugin";
+
+/**
+ * Singleton dialog driven by the just-in-time capability consent queue (#10524).
+ * Mounted once near the top of `App.tsx`, sibling to `PluginMcpConfirmDialog`.
+ *
+ * Surfaces the first time a plugin exercises a high-risk host capability
+ * (`shell:exec`, `fs:*-write`, `git:write`). "Allow and remember" grants the
+ * capability for the plugin's lifetime; closing/rejecting denies this call.
+ */
+export function PluginCapabilityConfirmDialog() {
+  const current = usePluginCapabilityConfirmStore((state) => state.current);
+  const resolveCurrent = usePluginCapabilityConfirmStore((state) => state.resolveCurrent);
+  const resetKey = current?.requestId ?? "null";
+
+  const handledRequestIdRef = useRef<string | null>(null);
+  const resolveOnce = useCallback(
+    (requestId: string, decision: PluginCapabilityConsentDecision) => {
+      if (handledRequestIdRef.current === requestId) return;
+      handledRequestIdRef.current = requestId;
+      resolveCurrent(decision);
+    },
+    [resolveCurrent]
+  );
+
+  if (current === null) {
+    return (
+      <ErrorBoundary
+        variant="component"
+        componentName="PluginCapabilityConfirmDialog"
+        resetKeys={[resetKey]}
+      >
+        <ConfirmDialog
+          isOpen={false}
+          title=""
+          confirmLabel="Allow"
+          onConfirm={() => {}}
+          variant="default"
+        />
+      </ErrorBoundary>
+    );
+  }
+
+  return (
+    <ErrorBoundary
+      variant="component"
+      componentName="PluginCapabilityConfirmDialog"
+      resetKeys={[resetKey]}
+    >
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => resolveOnce(current.requestId, "rejected")}
+        title={titleFor(current.pluginDisplayName, current.capability)}
+        description={`'${current.pluginDisplayName}' is asking to ${capabilityAction(current.capability)} for the first time. Allowing remembers this for the plugin until you uninstall or revoke it.`}
+        confirmLabel="Allow and remember"
+        cancelLabel="Deny"
+        onConfirm={() => resolveOnce(current.requestId, "approved-and-pin")}
+        variant="destructive"
+      >
+        <div className="space-y-3">
+          <div>
+            <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
+              Capability
+            </div>
+            <p className="text-sm text-daintree-text/80">
+              <span className="font-mono text-xs">{current.capability}</span>
+              {" — "}
+              {capabilityDescription(current.capability)}
+            </p>
+          </div>
+
+          {current.declaredCapabilities.length > 0 && (
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 mb-1">
+                All declared capabilities
+              </div>
+              <ul className="text-xs font-mono text-daintree-text/70 space-y-0.5">
+                {current.declaredCapabilities.map((cap) => (
+                  <li key={cap}>{cap}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </ConfirmDialog>
+    </ErrorBoundary>
+  );
+}
+
+/** Dialog title — sentence case, no trailing period (UI microcopy rules). Exported for tests. */
+export function titleFor(pluginDisplayName: string, capability: BuiltInPluginCapability): string {
+  return `Allow '${pluginDisplayName}' to ${capabilityAction(capability)}?`;
+}
+
+/** Short verb phrase for the title/description. Exported for tests. */
+export function capabilityAction(capability: BuiltInPluginCapability): string {
+  switch (capability) {
+    case "shell:exec":
+      return "run commands";
+    case "fs:project-write":
+      return "write files in your project";
+    case "fs:user-data-write":
+      return "write to its data folder";
+    case "git:write":
+      return "make git changes";
+    default:
+      return `use the '${capability}' capability`;
+  }
+}
+
+/** Longer human description of what the capability grants. Exported for tests. */
+export function capabilityDescription(capability: BuiltInPluginCapability): string {
+  switch (capability) {
+    case "shell:exec":
+      return "run executables and shell commands on your machine";
+    case "fs:project-write":
+      return "create and modify files inside your project worktrees";
+    case "fs:user-data-write":
+      return "create and modify files in its own data folder";
+    case "git:write":
+      return "stage and commit changes in your repositories";
+    default:
+      return "perform a privileged host operation";
+  }
+}

--- a/src/components/Plugin/__tests__/PluginCapabilityConfirmDialog.test.ts
+++ b/src/components/Plugin/__tests__/PluginCapabilityConfirmDialog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  capabilityAction,
+  capabilityDescription,
+  titleFor,
+} from "../PluginCapabilityConfirmDialog";
+import { BUILT_IN_PLUGIN_CAPABILITIES, type BuiltInPluginCapability } from "@shared/types/plugin";
+
+const GATED: BuiltInPluginCapability[] = [
+  "shell:exec",
+  "fs:project-write",
+  "fs:user-data-write",
+  "git:write",
+];
+
+describe("PluginCapabilityConfirmDialog microcopy", () => {
+  it("gives each gated capability a distinct, non-empty action phrase", () => {
+    const phrases = GATED.map(capabilityAction);
+    for (const phrase of phrases) {
+      expect(phrase.length).toBeGreaterThan(0);
+      // Sentence-fragment verb phrase — no trailing period (UI microcopy rules).
+      expect(phrase.endsWith(".")).toBe(false);
+    }
+    expect(new Set(phrases).size).toBe(GATED.length);
+  });
+
+  it("gives each gated capability a distinct, non-empty description", () => {
+    const descriptions = GATED.map(capabilityDescription);
+    for (const d of descriptions) expect(d.length).toBeGreaterThan(0);
+    expect(new Set(descriptions).size).toBe(GATED.length);
+  });
+
+  it("builds a sentence-case title that names the plugin and ends with a question mark", () => {
+    const title = titleFor("Acme Tools", "shell:exec");
+    expect(title).toContain("Acme Tools");
+    expect(title.endsWith("?")).toBe(true);
+  });
+
+  it("falls back to a generic phrase for any non-gated capability without throwing", () => {
+    for (const cap of BUILT_IN_PLUGIN_CAPABILITIES) {
+      expect(capabilityAction(cap).length).toBeGreaterThan(0);
+      expect(capabilityDescription(cap).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/hooks/usePluginCapabilityConsentBridge.ts
+++ b/src/hooks/usePluginCapabilityConsentBridge.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { requestPluginCapabilityConsent } from "@/store/pluginCapabilityConfirmStore";
+
+/**
+ * Wires main-process just-in-time capability consent prompts into the renderer
+ * dialog queue (#10524). Subscribes to the `plugin-capability:consent-request`
+ * push (sent to the focused window by main), enqueues each prompt through the
+ * FIFO consent store, and replies with the user's decision via
+ * `plugin-capability:resolve-consent`.
+ *
+ * Mounted once near the app root alongside the consent dialog. The store's
+ * resolver map serialises concurrent prompts, so this hook only forwards.
+ */
+export function usePluginCapabilityConsentBridge(): void {
+  useEffect(() => {
+    return window.electron.events.on("plugin-capability:consent-request", (payload) => {
+      void requestPluginCapabilityConsent(payload).then((decision) =>
+        window.electron.pluginCapability.resolveConsent({
+          requestId: payload.requestId,
+          decision,
+        })
+      );
+    });
+  }, []);
+}

--- a/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
+++ b/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetPluginCapabilityConfirmStoreForTesting,
+  requestPluginCapabilityConsent,
+  usePluginCapabilityConfirmStore,
+} from "../pluginCapabilityConfirmStore";
+import type { PluginCapabilityConsentRequestEvent } from "@shared/types/pluginCapabilityConsent";
+
+function req(id: string): Omit<PluginCapabilityConsentRequestEvent, never> {
+  return {
+    requestId: id,
+    pluginId: "acme.x",
+    pluginDisplayName: "Acme",
+    capability: "shell:exec",
+    declaredCapabilities: ["shell:exec"],
+  };
+}
+
+afterEach(() => {
+  __resetPluginCapabilityConfirmStoreForTesting();
+});
+
+describe("pluginCapabilityConfirmStore", () => {
+  it("surfaces the first request immediately and resolves its promise on decision", async () => {
+    const p = requestPluginCapabilityConsent(req("r1"));
+    expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("r1");
+
+    usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-and-pin");
+    await expect(p).resolves.toBe("approved-and-pin");
+    expect(usePluginCapabilityConfirmStore.getState().current).toBeNull();
+  });
+
+  it("queues concurrent requests and advances in FIFO order", async () => {
+    const p1 = requestPluginCapabilityConsent(req("r1"));
+    const p2 = requestPluginCapabilityConsent(req("r2"));
+
+    const state = usePluginCapabilityConfirmStore.getState();
+    expect(state.current?.requestId).toBe("r1");
+    expect(state.queue.map((q) => q.requestId)).toEqual(["r2"]);
+
+    usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-once");
+    await expect(p1).resolves.toBe("approved-once");
+    // Second prompt becomes current.
+    expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("r2");
+
+    usePluginCapabilityConfirmStore.getState().resolveCurrent("rejected");
+    await expect(p2).resolves.toBe("rejected");
+  });
+
+  it("rejects a duplicate requestId without disturbing the live prompt", async () => {
+    const p1 = requestPluginCapabilityConsent(req("dup"));
+    const dup = requestPluginCapabilityConsent(req("dup"));
+    await expect(dup).resolves.toBe("rejected");
+    // The original is still pending and current.
+    expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("dup");
+
+    usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-and-pin");
+    await expect(p1).resolves.toBe("approved-and-pin");
+  });
+
+  it("drop rejects a queued request and removes it from the queue", async () => {
+    const p1 = requestPluginCapabilityConsent(req("r1"));
+    const p2 = requestPluginCapabilityConsent(req("r2"));
+
+    usePluginCapabilityConfirmStore.getState().drop("r2");
+    await expect(p2).resolves.toBe("rejected");
+    expect(usePluginCapabilityConfirmStore.getState().queue).toHaveLength(0);
+    // r1 unaffected.
+    expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("r1");
+    usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-once");
+    await expect(p1).resolves.toBe("approved-once");
+  });
+});

--- a/src/store/pluginCapabilityConfirmStore.ts
+++ b/src/store/pluginCapabilityConfirmStore.ts
@@ -1,0 +1,112 @@
+import { create } from "zustand";
+import type {
+  PluginCapabilityConsentDecision,
+  PluginCapabilityConsentRequestEvent,
+} from "@shared/types/pluginCapabilityConsent";
+
+/**
+ * One pending just-in-time capability consent prompt (#10524). Stored in a FIFO
+ * queue; only the first item drives the visible modal so concurrent first-use
+ * prompts from different plugins never stack overlapping dialogs. Mirrors the
+ * plugin-MCP confirm store but for host capabilities rather than MCP tools.
+ */
+export interface PendingPluginCapabilityConsent extends PluginCapabilityConsentRequestEvent {
+  enqueuedAt: number;
+}
+
+interface PluginCapabilityConfirmState {
+  queue: PendingPluginCapabilityConsent[];
+  current: PendingPluginCapabilityConsent | null;
+}
+
+interface PluginCapabilityConfirmActions {
+  enqueue: (item: PendingPluginCapabilityConsent) => void;
+  resolveCurrent: (decision: PluginCapabilityConsentDecision) => void;
+  drop: (requestId: string) => void;
+  reset: () => void;
+}
+
+const resolvers = new Map<string, (decision: PluginCapabilityConsentDecision) => void>();
+
+function advance(
+  set: (partial: Partial<PluginCapabilityConfirmState>) => void,
+  queue: PendingPluginCapabilityConsent[]
+) {
+  if (queue.length === 0) {
+    set({ current: null, queue: [] });
+    return;
+  }
+  const [next, ...rest] = queue;
+  set({ current: next, queue: rest });
+}
+
+export const usePluginCapabilityConfirmStore = create<
+  PluginCapabilityConfirmState & PluginCapabilityConfirmActions
+>((set, get) => ({
+  queue: [],
+  current: null,
+
+  enqueue: (item) => {
+    const { current, queue } = get();
+    if (current === null) {
+      set({ current: item });
+    } else {
+      set({ queue: [...queue, item] });
+    }
+  },
+
+  resolveCurrent: (decision) => {
+    const { current, queue } = get();
+    if (current === null) return;
+    const resolve = resolvers.get(current.requestId);
+    resolvers.delete(current.requestId);
+    resolve?.(decision);
+    advance(set, queue);
+  },
+
+  drop: (requestId) => {
+    const { current, queue } = get();
+    const resolve = resolvers.get(requestId);
+    resolvers.delete(requestId);
+    resolve?.("rejected");
+    if (current?.requestId === requestId) {
+      advance(set, queue);
+      return;
+    }
+    const filtered = queue.filter((item) => item.requestId !== requestId);
+    if (filtered.length !== queue.length) {
+      set({ queue: filtered });
+    }
+  },
+
+  reset: () => {
+    resolvers.clear();
+    set({ queue: [], current: null });
+  },
+}));
+
+/**
+ * Push a consent prompt into the queue and return a Promise that resolves with
+ * the user's decision. The returned Promise never rejects — callers branch on
+ * the discriminated decision value.
+ */
+export function requestPluginCapabilityConsent(
+  item: Omit<PendingPluginCapabilityConsent, "enqueuedAt">
+): Promise<PluginCapabilityConsentDecision> {
+  return new Promise((resolve) => {
+    if (resolvers.has(item.requestId)) {
+      console.warn(
+        `[PluginCapabilityConfirmStore] duplicate requestId rejected: ${item.requestId}`
+      );
+      resolve("rejected");
+      return;
+    }
+    resolvers.set(item.requestId, resolve);
+    usePluginCapabilityConfirmStore.getState().enqueue({ ...item, enqueuedAt: Date.now() });
+  });
+}
+
+/** Test-only escape hatch — resets store and clears the resolver map. */
+export function __resetPluginCapabilityConfirmStoreForTesting(): void {
+  usePluginCapabilityConfirmStore.getState().reset();
+}


### PR DESCRIPTION
## Summary

- Adds just-in-time consent for high-risk plugin host capabilities — `shell:exec`, `fs:project-write`, `fs:user-data-write`, and `git:write`. The first time a third-party plugin exercises one of these, it gets a one-time prompt before the call proceeds; on "Allow and remember" the grant is cached and subsequent calls run silently.
- Generalises the existing plugin-MCP TOFU consent machinery rather than building a parallel system. Built-in plugins are exempt. Concurrent first-use calls for the same `(pluginId, capability)` pair coalesce onto a single prompt; the gate fails closed with no consent bridge installed.
- Consent fires after input validation and path containment in every gated path, so a deliberately-doomed call can never bank a silent grant.

Resolves #10524

## Changes

**Consent store and service (`electron/services/plugin-capability/`)**
- `PluginCapabilityConsentStore` — persists grants to a `pluginCapabilityConsent` electron-store slice keyed by `(pluginId, capability)`. `revokeAllForPlugin` retries its flush internally for durability on uninstall.
- `PluginCapabilityConsentService` — wraps the store, manages in-flight promise coalescing, and exposes `requestConsent(pluginId, capability)`.

**IPC bridge (`electron/ipc/handlers/pluginCapability.ts`)**
- `plugin-capability:consent-request` — targets the focused window (falls back to primary); includes a sender-mismatch guard on `plugin-capability:resolve-consent` replies.
- Preload in `pluginCapability.preload.ts`; channels registered in `channels.ts` and `maps.ts`.

**PluginService interception (`electron/services/PluginService.ts`)**
- `host.process.spawn`, `host.fs.writeFile`, `host.git.add`, and `host.git.commit` all call `requestConsent` before reaching the underlying implementation. Denial throws; the downstream call is never made.
- Grants purged on uninstall alongside the MCP consent purge (`PluginInstaller.ts`).

**Renderer (`src/`)**
- `pluginCapabilityConfirmStore` — FIFO queue for pending consent requests.
- `usePluginCapabilityConsentBridge` — IPC bridge hook.
- `PluginCapabilityConfirmDialog` — `ConfirmDialog`-based consent UI, mounted once in `App.tsx`.

**Shared types (`shared/types/pluginCapabilityConsent.ts`, `generated*.ts`)**

## Testing

New unit tests: `PluginCapabilityConsentStore`, `PluginCapabilityConsentService` (coalescing, fail-closed, approve/pin/once/reject), `pluginCapability` IPC handler (sender-mismatch guard), `pluginCapabilityConfirmStore`, `PluginCapabilityConfirmDialog` microcopy, and `PluginService.hostFsGit` (denial blocks write/spawn before reaching simple-git or the process manager; prompt-once; built-in bypass; invalid call never prompts). Existing host-API tests updated with an auto-approve bridge. Typecheck clean; all affected suites green locally.

**Deferred (intentionally out of scope)**
- Keyless Sigstore/cosign signing (work item 2 of #10524) — blocked on the publish-side pipeline; no signed plugins to verify against yet.
- `network:fetch` and `agent:*` JIT consent — no host-mediated closure to intercept; can be added as load-time consent in a follow-up once the pattern is established.