### PR TITLE
fix(ui): right-size two over-tiered confirmation prompts

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -831,29 +831,13 @@ export function DaintreeAssistantSettingsTab() {
         isOpen={showRotateConfirm}
         onClose={isRotating ? undefined : handleCancelRotate}
         title="Rotate API key?"
-        description={
-          <>
-            The current key will be invalidated immediately. External clients using this key will
-            need to update their configuration.
-            {apiKeySuffix && (
-              <>
-                {" "}
-                Type the last 4 characters of the current key (
-                <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
-                  {apiKeySuffix}
-                </code>
-                ) to confirm.
-              </>
-            )}
-          </>
-        }
+        description="The current key will be invalidated immediately. External clients using this key will need to update their configuration."
         confirmLabel="Rotate key"
         cancelLabel="Cancel"
         onConfirm={confirmRotateKey}
         isConfirmLoading={isRotating}
         variant="destructive"
         zIndex="nested"
-        typedNameTarget={apiKeySuffix || undefined}
       />
     </div>
   );

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -957,29 +957,13 @@ export function McpServerSettingsTab() {
         isOpen={showRotateConfirm}
         onClose={isRotating ? undefined : handleCancelRotate}
         title="Rotate API key?"
-        description={
-          <>
-            The current key will be invalidated immediately. External clients using this key will
-            need to update their configuration.
-            {apiKeySuffix && (
-              <>
-                {" "}
-                Type the last 4 characters of the current key (
-                <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
-                  {apiKeySuffix}
-                </code>
-                ) to confirm.
-              </>
-            )}
-          </>
-        }
+        description="The current key will be invalidated immediately. External clients using this key will need to update their configuration."
         confirmLabel="Rotate key"
         cancelLabel="Cancel"
         onConfirm={confirmRotateApiKey}
         isConfirmLoading={isRotating}
         variant="destructive"
         zIndex="nested"
-        typedNameTarget={apiKeySuffix || undefined}
       />
 
       <ConfirmDialog

--- a/src/components/Settings/TerminalSettingsTab.tsx
+++ b/src/components/Settings/TerminalSettingsTab.tsx
@@ -453,7 +453,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
           <SettingsSwitchCard
             icon={AlertTriangle}
             title="Panel warnings"
-            subtitle="Show warning banner and confirmation dialog when panel count is high"
+            subtitle="Show warning banners as you open more panels; batch spawns confirm past the limit"
             isEnabled={!panelLimits.warningsDisabled}
             onChange={() => setWarningsDisabled(!panelLimits.warningsDisabled)}
             ariaLabel="Panel Warnings Toggle"
@@ -482,7 +482,7 @@ export function TerminalSettingsTab({ activeSubtab, onSubtabChange }: TerminalSe
 
             <SettingsNumberInput
               label="Confirmation Required"
-              description="Require explicit confirmation before adding panels beyond this count."
+              description="Confirm before a batch spawn (recipe or worktree spin-up) pushes the panel count beyond this number."
               min={4}
               max={100}
               value={panelLimits.confirmationLimit}

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -337,14 +337,9 @@ describe("DaintreeAssistantSettingsTab", () => {
     const confirmButton = screen.getByRole("button", {
       name: /^rotate key$/i,
     }) as HTMLButtonElement;
-    expect(confirmButton.disabled).toBe(true);
-
-    const typedInput = screen.getByLabelText(/^Type .* to confirm$/i) as HTMLInputElement;
-    fireEvent.change(typedInput, { target: { value: "y-abc" } });
-    expect(confirmButton.disabled).toBe(true);
-
-    fireEvent.change(typedInput, { target: { value: "-abc" } });
+    // Rotation is recoverable (#10547): no typed-name gate, button is live immediately.
     expect(confirmButton.disabled).toBe(false);
+    expect(screen.queryByLabelText(/^Type .* to confirm$/i)).toBeNull();
 
     fireEvent.click(confirmButton);
 
@@ -395,8 +390,10 @@ describe("DaintreeAssistantSettingsTab", () => {
     });
 
     const dialogText = document.body.textContent ?? "";
+    // The rotate dialog no longer echoes the key suffix (#10547 dropped the typed-name
+    // gate), so neither the full key nor any fragment of it appears in the dialog body.
     expect(dialogText).not.toContain("dnt-key-abc");
-    expect(dialogText).toContain("-abc");
+    expect(dialogText).toContain("The current key will be invalidated immediately");
   });
 
   it("rotate key dialog can be canceled without rotating", async () => {

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -228,11 +228,9 @@ describe("McpServerSettingsTab", () => {
     const confirmButton = screen.getByRole("button", {
       name: /^rotate key$/i,
     }) as HTMLButtonElement;
-    expect(confirmButton.disabled).toBe(true);
-
-    const typedInput = screen.getByLabelText(/^Type .* to confirm$/i) as HTMLInputElement;
-    fireEvent.change(typedInput, { target: { value: "c123" } });
+    // Rotation is recoverable (#10547): no typed-name gate, button is live immediately.
     expect(confirmButton.disabled).toBe(false);
+    expect(screen.queryByLabelText(/^Type .* to confirm$/i)).toBeNull();
 
     fireEvent.click(confirmButton);
 
@@ -287,9 +285,6 @@ describe("McpServerSettingsTab", () => {
       expect(screen.getByRole("heading", { name: /rotate api key\?/i })).toBeTruthy();
     });
 
-    fireEvent.change(screen.getByLabelText(/^Type .* to confirm$/i), {
-      target: { value: "c123" },
-    });
     fireEvent.click(screen.getByRole("button", { name: /^rotate key$/i }));
 
     await waitFor(() => {
@@ -319,9 +314,6 @@ describe("McpServerSettingsTab", () => {
       expect(screen.getByRole("heading", { name: /rotate api key\?/i })).toBeTruthy();
     });
 
-    fireEvent.change(screen.getByLabelText(/^Type .* to confirm$/i), {
-      target: { value: "c123" },
-    });
     fireEvent.click(screen.getByRole("button", { name: /^rotate key$/i }));
 
     await waitForContent(container, "rotate failed");

--- a/src/store/__tests__/panelLimitStore.test.ts
+++ b/src/store/__tests__/panelLimitStore.test.ts
@@ -205,6 +205,32 @@ describe("preflightSpawnBatchLimit", () => {
     expect(await preflightSpawnBatchLimit(30, 10)).toEqual({ allowed: 2 });
     expect(confirm).toHaveBeenCalledWith(32, null);
   });
+
+  it("does not confirm when the projected total lands exactly on the confirm limit", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    usePanelLimitStore.setState({
+      confirmationLimit: 20,
+      hardLimit: 32,
+      warningsDisabled: false,
+      requestConfirmation: confirm,
+    });
+    // 18 + 2 = 20 == confirmationLimit; the gate is strictly `> confirmationLimit`.
+    expect(await preflightSpawnBatchLimit(18, 2)).toEqual({ allowed: 2 });
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("allows nothing without confirming once the hard limit is already reached", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    usePanelLimitStore.setState({
+      confirmationLimit: 20,
+      hardLimit: 32,
+      warningsDisabled: false,
+      requestConfirmation: confirm,
+    });
+    // Already at the hard limit: no slots, short-circuits before any confirm.
+    expect(await preflightSpawnBatchLimit(32, 4)).toEqual({ allowed: 0 });
+    expect(confirm).not.toHaveBeenCalled();
+  });
 });
 
 describe("panelLimitStore persist migration", () => {

--- a/src/store/__tests__/panelLimitStore.test.ts
+++ b/src/store/__tests__/panelLimitStore.test.ts
@@ -4,6 +4,8 @@ import {
   evaluatePanelLimit,
   shouldShowSoftWarning,
   computeHardwareDefaults,
+  preflightSpawnBatchLimit,
+  usePanelLimitStore,
   DEFAULT_SOFT_WARNING_LIMIT,
   DEFAULT_CONFIRMATION_LIMIT,
   DEFAULT_HARD_LIMIT,
@@ -115,6 +117,93 @@ describe("computeHardwareDefaults", () => {
     expect(computeHardwareDefaults(16 * GB + 1)).toEqual({ soft: 24, confirm: 48, hard: 72 });
     // Just over 32GB -> 64GB+ tier
     expect(computeHardwareDefaults(32 * GB + 1)).toEqual({ soft: 32, confirm: 64, hard: 100 });
+  });
+});
+
+describe("preflightSpawnBatchLimit", () => {
+  // Single-panel adds dropped the blocking confirm (#10547). Batch spawns keep
+  // it because adding many panels at once is not trivially reversible — these
+  // tests guard that the batch gate survives.
+  const originalRequestConfirmation = usePanelLimitStore.getState().requestConfirmation;
+
+  afterEach(() => {
+    usePanelLimitStore.setState({
+      softWarningLimit: DEFAULT_SOFT_WARNING_LIMIT,
+      confirmationLimit: DEFAULT_CONFIRMATION_LIMIT,
+      hardLimit: DEFAULT_HARD_LIMIT,
+      warningsDisabled: false,
+      requestConfirmation: originalRequestConfirmation,
+    });
+  });
+
+  it("returns 0 allowed when no requested panels", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    usePanelLimitStore.setState({ requestConfirmation: confirm });
+    expect(await preflightSpawnBatchLimit(0, 0)).toEqual({ allowed: 0 });
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("does not confirm when the projected total stays at or below the confirm limit", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    usePanelLimitStore.setState({
+      confirmationLimit: 20,
+      hardLimit: 32,
+      warningsDisabled: false,
+      requestConfirmation: confirm,
+    });
+    // 10 + 5 = 15, below the 20 confirm threshold.
+    expect(await preflightSpawnBatchLimit(10, 5)).toEqual({ allowed: 5 });
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("confirms and allows the full batch when the user accepts crossing the confirm limit", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    usePanelLimitStore.setState({
+      confirmationLimit: 20,
+      hardLimit: 32,
+      warningsDisabled: false,
+      requestConfirmation: confirm,
+    });
+    // 18 + 5 = 23, crosses the 20 confirm threshold.
+    expect(await preflightSpawnBatchLimit(18, 5)).toEqual({ allowed: 5 });
+    expect(confirm).toHaveBeenCalledWith(23, null);
+  });
+
+  it("allows nothing when the user declines the confirm", async () => {
+    const confirm = vi.fn().mockResolvedValue(false);
+    usePanelLimitStore.setState({
+      confirmationLimit: 20,
+      hardLimit: 32,
+      warningsDisabled: false,
+      requestConfirmation: confirm,
+    });
+    expect(await preflightSpawnBatchLimit(18, 5)).toEqual({ allowed: 0 });
+    expect(confirm).toHaveBeenCalledWith(23, null);
+  });
+
+  it("skips the confirm entirely when warnings are disabled", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    usePanelLimitStore.setState({
+      confirmationLimit: 20,
+      hardLimit: 32,
+      warningsDisabled: true,
+      requestConfirmation: confirm,
+    });
+    expect(await preflightSpawnBatchLimit(18, 5)).toEqual({ allowed: 5 });
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("clamps the allowed count to the hard ceiling", async () => {
+    const confirm = vi.fn().mockResolvedValue(true);
+    usePanelLimitStore.setState({
+      confirmationLimit: 20,
+      hardLimit: 32,
+      warningsDisabled: false,
+      requestConfirmation: confirm,
+    });
+    // 30 open, 10 requested, only 2 slots before the hard limit of 32.
+    expect(await preflightSpawnBatchLimit(30, 10)).toEqual({ allowed: 2 });
+    expect(confirm).toHaveBeenCalledWith(32, null);
   });
 });
 

--- a/src/store/panelLimitStore.ts
+++ b/src/store/panelLimitStore.ts
@@ -259,9 +259,10 @@ export async function preflightSpawnBatchLimit(
   const allowed = Math.min(available, requestedCount);
   const projected = currentCount + allowed;
 
-  // Mirror `addPanel`'s per-call confirm tier: a panel added while the count is
-  // at or above `confirmationLimit` triggers a confirm. The batch crosses that
-  // threshold exactly when `projected > confirmationLimit`.
+  // Batch spawns (recipes, worktree spin-up) add many panels at once and are not
+  // trivially reversible the way a single-panel add is (one-click close), so they
+  // keep the blocking confirm even though `addPanel` dropped it for single adds
+  // (#10547). The batch crosses the confirm threshold when `projected > confirmationLimit`.
   if (!warningsDisabled && projected > confirmationLimit) {
     // Pass `null` for memory rather than firing an extra metrics IPC before the
     // batch — the dialog renders without the memory hint, never blocks on it.

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -97,15 +97,15 @@ export const createAddPanelActions = (
   get: Get
 ): Pick<PanelRegistrySlice, "addPanel"> => ({
   addPanel: async (options) => {
-    // Panel limit enforcement (Tier 2: confirmation, Tier 3: hard block)
+    // Panel limit enforcement: only the hard ceiling blocks a single-panel add.
+    // The confirm band (>= confirmationLimit) is intentionally non-blocking —
+    // adding a panel is reversible (one-click close), so the step-throttled
+    // `TerminalCountWarning` banner (shown from `softWarningLimit` upward, with
+    // no upper bound) is the right calibration, not a focus-stealing modal. The
+    // blocking confirm survives only for batch spawns (`preflightSpawnBatchLimit`),
+    // where the blast radius of many panels at once warrants it. See #10547.
     if (!options.bypassLimits) {
-      const {
-        softWarningLimit,
-        confirmationLimit,
-        hardLimit,
-        warningsDisabled,
-        requestConfirmation,
-      } = usePanelLimitStore.getState();
+      const { softWarningLimit, confirmationLimit, hardLimit } = usePanelLimitStore.getState();
       const globalCount = countNonTrashTerminals(get());
       const tier = evaluatePanelLimit(globalCount, {
         softWarningLimit,
@@ -122,27 +122,6 @@ export const createAddPanelActions = (
           duration: 5000,
         });
         return null;
-      }
-
-      if (tier === "confirm" && !warningsDisabled) {
-        // Pass `null` for memory rather than blocking the dialog on a metrics
-        // IPC — same call `preflightSpawnBatchLimit` makes; the dialog renders
-        // without the memory hint, never waits on it.
-        const confirmed = await requestConfirmation(globalCount, null);
-        if (!confirmed) return null;
-
-        // Re-check count after confirmation in case panels were closed during the dialog
-        const postConfirmCount = countNonTrashTerminals(get());
-        if (postConfirmCount >= hardLimit) {
-          notify({
-            type: "warning",
-            priority: "high",
-            title: "Panel limit reached",
-            message: `Maximum of ${hardLimit} panels reached. Close some panels before adding new ones.`,
-            duration: 5000,
-          });
-          return null;
-        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Removes the blocking confirm modal on single-panel adds in the `[confirmationLimit, hardLimit)` band — adding a panel is reversible, and `TerminalCountWarning` already covers that range with a soft banner. Batch spawns keep the blocking confirm.
- Drops the `typedNameTarget` gate from the rotate-key `ConfirmDialog` in `McpServerSettingsTab` and `DaintreeAssistantSettingsTab` — key rotation is recoverable (hand the new key to clients), so it's a D2 action, not D3.

Resolves #10547

## Changes

- `src/store/slices/panelRegistry/addPanel.ts` — removed the `[confirmationLimit, hardLimit)` single-add confirm branch; hard ceiling still blocks; `preflightSpawnBatchLimit` path unchanged
- `src/components/Settings/McpServerSettingsTab.tsx` + `DaintreeAssistantSettingsTab.tsx` — dropped `typedNameTarget` from both rotate-key dialogs
- `src/components/Settings/TerminalSettingsTab.tsx` — corrected stale panel-limits settings copy
- `src/store/__tests__/panelLimitStore.test.ts` — added `preflightSpawnBatchLimit` coverage (accept / decline / disabled / clamp / exact-limit / hard-limit short-circuit)
- `src/components/Settings/__tests__/McpServerSettingsTab.test.tsx` + `DaintreeAssistantSettingsTab.test.tsx` — updated to assert the rotate-key button is live immediately with no typed-name input

## Testing

545 tests pass across the panel-registry and settings suites. ESLint and Prettier clean on all changed files.