### PR TITLE
fix(onboarding): persist recommendation and teaching dismissals across sessions

### DIFF
--- a/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
+++ b/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
@@ -42,6 +42,10 @@ import {
   SHORTCUT_HINTS_METHOD_CHANNELS,
   buildShortcutHintsPreloadBindings,
 } from "../handlers/shortcutHints.preload.js";
+import {
+  FORGE_RECOMMENDATION_METHOD_CHANNELS,
+  buildForgeRecommendationPreloadBindings,
+} from "../handlers/forgeRecommendation.preload.js";
 import { CLI_METHOD_CHANNELS, buildCliPreloadBindings } from "../handlers/cli.preload.js";
 import { GEMINI_METHOD_CHANNELS, buildGeminiPreloadBindings } from "../handlers/gemini.preload.js";
 import {
@@ -175,6 +179,21 @@ describe("leaf preload namespace bindings", () => {
       expect(SHORTCUT_HINTS_METHOD_CHANNELS.getCounts).toBe(CHANNELS.SHORTCUT_HINTS_GET_COUNTS);
       expect(SHORTCUT_HINTS_METHOD_CHANNELS.incrementCount).toBe(
         CHANNELS.SHORTCUT_HINTS_INCREMENT_COUNT
+      );
+      expect(SHORTCUT_HINTS_METHOD_CHANNELS.getHintedHover).toBe(
+        CHANNELS.SHORTCUT_HINTS_GET_HINTED_HOVER
+      );
+      expect(SHORTCUT_HINTS_METHOD_CHANNELS.setHintedHover).toBe(
+        CHANNELS.SHORTCUT_HINTS_SET_HINTED_HOVER
+      );
+    });
+
+    it("forgeRecommendation matches", () => {
+      expect(FORGE_RECOMMENDATION_METHOD_CHANNELS.getDismissed).toBe(
+        CHANNELS.FORGE_RECOMMENDATION_GET_DISMISSED
+      );
+      expect(FORGE_RECOMMENDATION_METHOD_CHANNELS.markDismissed).toBe(
+        CHANNELS.FORGE_RECOMMENDATION_MARK_DISMISSED
       );
     });
 
@@ -584,6 +603,48 @@ describe("leaf preload namespace bindings", () => {
 
       expect(invoke).toHaveBeenCalledTimes(1);
       expect(invoke).toHaveBeenCalledWith("shortcut-hints:increment-count", "act-1");
+    });
+
+    it("routes getHintedHover() to shortcut-hints:get-hinted-hover with no args", async () => {
+      const invoke = vi.fn().mockResolvedValue([]);
+      const bindings = buildShortcutHintsPreloadBindings(invoke);
+
+      await bindings.getHintedHover();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("shortcut-hints:get-hinted-hover");
+    });
+
+    it("routes setHintedHover(keys) to shortcut-hints:set-hinted-hover with the keys forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue(undefined);
+      const bindings = buildShortcutHintsPreloadBindings(invoke);
+
+      await bindings.setHintedHover(["act-1@1"]);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("shortcut-hints:set-hinted-hover", ["act-1@1"]);
+    });
+  });
+
+  describe("forgeRecommendation", () => {
+    it("routes getDismissed() to forge-recommendation:get-dismissed with no args", async () => {
+      const invoke = vi.fn().mockResolvedValue({});
+      const bindings = buildForgeRecommendationPreloadBindings(invoke);
+
+      await bindings.getDismissed();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("forge-recommendation:get-dismissed");
+    });
+
+    it("routes markDismissed(path) to forge-recommendation:mark-dismissed with the path forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue(undefined);
+      const bindings = buildForgeRecommendationPreloadBindings(invoke);
+
+      await bindings.markDismissed("/tmp/project");
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("forge-recommendation:mark-dismissed", "/tmp/project");
     });
   });
 

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -731,6 +731,12 @@ export const CHANNELS = {
   // Shortcut Hints channels
   SHORTCUT_HINTS_GET_COUNTS: "shortcut-hints:get-counts",
   SHORTCUT_HINTS_INCREMENT_COUNT: "shortcut-hints:increment-count",
+  SHORTCUT_HINTS_GET_HINTED_HOVER: "shortcut-hints:get-hinted-hover",
+  SHORTCUT_HINTS_SET_HINTED_HOVER: "shortcut-hints:set-hinted-hover",
+
+  // Forge recommendation channels
+  FORGE_RECOMMENDATION_GET_DISMISSED: "forge-recommendation:get-dismissed",
+  FORGE_RECOMMENDATION_MARK_DISMISSED: "forge-recommendation:mark-dismissed",
 
   // GPU channels
   GPU_GET_STATUS: "gpu:get-status",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -43,6 +43,7 @@ import { registerSentryHandlers } from "./handlers/sentry.js";
 import { registerOnboardingHandlers } from "./handlers/onboarding.js";
 import { registerMilestonesHandlers } from "./handlers/milestones.js";
 import { registerShortcutHintsHandlers } from "./handlers/shortcutHints.js";
+import { registerForgeRecommendationHandlers } from "./handlers/forgeRecommendation.js";
 import { registerForgeHandlers } from "./handlers/forge.js";
 import { registerForgeDataHandlers } from "./handlers/forgeData.js";
 import { registerForgeSettingsHandlers } from "./handlers/forgeSettings.js";
@@ -156,6 +157,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerOnboardingHandlers());
     register(() => registerMilestonesHandlers());
     register(() => registerShortcutHintsHandlers());
+    register(() => registerForgeRecommendationHandlers());
     register(() => registerForgeSettingsHandlers());
     register(() => registerForgeHandlers());
     register(() => registerForgeDataHandlers());

--- a/electron/ipc/handlers/__tests__/forgeRecommendation.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeRecommendation.handlers.test.ts
@@ -106,4 +106,16 @@ describe("registerForgeRecommendationHandlers", () => {
     mark(null, "");
     expect(storeMock.set).not.toHaveBeenCalled();
   });
+
+  it("markDismissed recovers from a field-level corrupt value", () => {
+    registerForgeRecommendationHandlers();
+    const mark = getHandler("forge-recommendation:mark-dismissed");
+
+    storeMock._data["forgeEnableDismissedPaths"] = "corrupted";
+    mark(null, "/Users/dev/project-a");
+    // The corrupt scalar is discarded — not spread into character indices.
+    expect(storeMock.set).toHaveBeenCalledWith("forgeEnableDismissedPaths", {
+      "/Users/dev/project-a": true,
+    });
+  });
 });

--- a/electron/ipc/handlers/__tests__/forgeRecommendation.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeRecommendation.handlers.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+const storeMock = vi.hoisted(() => {
+  const data: Record<string, unknown> = {};
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+    _data: data,
+  };
+});
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+import { registerForgeRecommendationHandlers } from "../forgeRecommendation.js";
+
+function getHandler(channel: string) {
+  return ipcMainMock.handle.mock.calls.find((c: unknown[]) => c[0] === channel)![1] as (
+    _e: unknown,
+    ...args: unknown[]
+  ) => unknown;
+}
+
+describe("registerForgeRecommendationHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(storeMock._data)) {
+      delete storeMock._data[key];
+    }
+  });
+
+  it("registers two IPC handlers and cleanup removes them", () => {
+    const cleanup = registerForgeRecommendationHandlers();
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(2);
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "forge-recommendation:get-dismissed",
+      expect.any(Function)
+    );
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "forge-recommendation:mark-dismissed",
+      expect.any(Function)
+    );
+    cleanup();
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(2);
+  });
+
+  it("getDismissed returns empty object for a fresh store", () => {
+    registerForgeRecommendationHandlers();
+    expect(getHandler("forge-recommendation:get-dismissed")(null)).toEqual({});
+  });
+
+  it("markDismissed persists a project path and getDismissed returns it", () => {
+    registerForgeRecommendationHandlers();
+    const mark = getHandler("forge-recommendation:mark-dismissed");
+
+    mark(null, "/Users/dev/project-a");
+    expect(storeMock.set).toHaveBeenCalledWith("forgeEnableDismissedPaths", {
+      "/Users/dev/project-a": true,
+    });
+
+    const result = getHandler("forge-recommendation:get-dismissed")(null);
+    expect(result).toEqual({ "/Users/dev/project-a": true });
+  });
+
+  it("markDismissed preserves existing paths", () => {
+    registerForgeRecommendationHandlers();
+    const mark = getHandler("forge-recommendation:mark-dismissed");
+
+    storeMock._data["forgeEnableDismissedPaths"] = { "/Users/dev/project-a": true };
+    mark(null, "/Users/dev/project-b");
+    expect(storeMock.set).toHaveBeenCalledWith("forgeEnableDismissedPaths", {
+      "/Users/dev/project-a": true,
+      "/Users/dev/project-b": true,
+    });
+  });
+
+  it("markDismissed is idempotent", () => {
+    registerForgeRecommendationHandlers();
+    const mark = getHandler("forge-recommendation:mark-dismissed");
+
+    storeMock._data["forgeEnableDismissedPaths"] = { "/Users/dev/project-a": true };
+    mark(null, "/Users/dev/project-a");
+    expect(storeMock.set).toHaveBeenCalledWith("forgeEnableDismissedPaths", {
+      "/Users/dev/project-a": true,
+    });
+  });
+
+  it("markDismissed ignores non-string input", () => {
+    registerForgeRecommendationHandlers();
+    const mark = getHandler("forge-recommendation:mark-dismissed");
+    mark(null, 42);
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("markDismissed ignores an empty string", () => {
+    registerForgeRecommendationHandlers();
+    const mark = getHandler("forge-recommendation:mark-dismissed");
+    mark(null, "");
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/shortcutHints.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/shortcutHints.handlers.test.ts
@@ -135,6 +135,28 @@ describe("registerShortcutHintsHandlers", () => {
     expect(storeMock.set).not.toHaveBeenCalled();
   });
 
+  it("setHintedHover replaces (not merges) the persisted keys", () => {
+    registerShortcutHintsHandlers();
+    const setHandler = ipcMainMock.handle.mock.calls.find(
+      (c: unknown[]) => c[0] === "shortcut-hints:set-hinted-hover"
+    )![1] as (_e: unknown, keys: unknown) => void;
+
+    storeMock._data["shortcutHintHoveredKeys"] = ["nav.commandPalette@2"];
+    setHandler(null, ["nav.quickSwitcher@1"]);
+    expect(storeMock.set).toHaveBeenCalledWith("shortcutHintHoveredKeys", ["nav.quickSwitcher@1"]);
+  });
+
+  it("setHintedHover with an empty array clears all keys", () => {
+    registerShortcutHintsHandlers();
+    const setHandler = ipcMainMock.handle.mock.calls.find(
+      (c: unknown[]) => c[0] === "shortcut-hints:set-hinted-hover"
+    )![1] as (_e: unknown, keys: unknown) => void;
+
+    storeMock._data["shortcutHintHoveredKeys"] = ["nav.quickSwitcher@1"];
+    setHandler(null, []);
+    expect(storeMock.set).toHaveBeenCalledWith("shortcutHintHoveredKeys", []);
+  });
+
   it("setHintedHover drops non-string entries", () => {
     registerShortcutHintsHandlers();
     const setHandler = ipcMainMock.handle.mock.calls.find(

--- a/electron/ipc/handlers/__tests__/shortcutHints.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/shortcutHints.handlers.test.ts
@@ -30,15 +30,23 @@ describe("registerShortcutHintsHandlers", () => {
     }
   });
 
-  it("registers two IPC handlers", () => {
+  it("registers four IPC handlers", () => {
     const cleanup = registerShortcutHintsHandlers();
-    expect(ipcMainMock.handle).toHaveBeenCalledTimes(2);
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(4);
     expect(ipcMainMock.handle).toHaveBeenCalledWith(
       "shortcut-hints:get-counts",
       expect.any(Function)
     );
     expect(ipcMainMock.handle).toHaveBeenCalledWith(
       "shortcut-hints:increment-count",
+      expect.any(Function)
+    );
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "shortcut-hints:get-hinted-hover",
+      expect.any(Function)
+    );
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "shortcut-hints:set-hinted-hover",
       expect.any(Function)
     );
     cleanup();
@@ -88,9 +96,61 @@ describe("registerShortcutHintsHandlers", () => {
     expect(storeMock.set).not.toHaveBeenCalled();
   });
 
-  it("cleanup removes both handlers", () => {
+  it("getHintedHover returns empty array by default", () => {
+    registerShortcutHintsHandlers();
+    const getHandler = ipcMainMock.handle.mock.calls.find(
+      (c: unknown[]) => c[0] === "shortcut-hints:get-hinted-hover"
+    )![1] as () => string[];
+
+    expect(getHandler()).toEqual([]);
+  });
+
+  it("getHintedHover returns persisted keys", () => {
+    registerShortcutHintsHandlers();
+    const getHandler = ipcMainMock.handle.mock.calls.find(
+      (c: unknown[]) => c[0] === "shortcut-hints:get-hinted-hover"
+    )![1] as () => string[];
+
+    storeMock._data["shortcutHintHoveredKeys"] = ["nav.quickSwitcher@1", "nav.commandPalette@0"];
+    expect(getHandler()).toEqual(["nav.quickSwitcher@1", "nav.commandPalette@0"]);
+  });
+
+  it("setHintedHover persists the provided keys", () => {
+    registerShortcutHintsHandlers();
+    const setHandler = ipcMainMock.handle.mock.calls.find(
+      (c: unknown[]) => c[0] === "shortcut-hints:set-hinted-hover"
+    )![1] as (_e: unknown, keys: unknown) => void;
+
+    setHandler(null, ["nav.quickSwitcher@1"]);
+    expect(storeMock.set).toHaveBeenCalledWith("shortcutHintHoveredKeys", ["nav.quickSwitcher@1"]);
+  });
+
+  it("setHintedHover ignores a non-array payload", () => {
+    registerShortcutHintsHandlers();
+    const setHandler = ipcMainMock.handle.mock.calls.find(
+      (c: unknown[]) => c[0] === "shortcut-hints:set-hinted-hover"
+    )![1] as (_e: unknown, keys: unknown) => void;
+
+    setHandler(null, "not-an-array");
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("setHintedHover drops non-string entries", () => {
+    registerShortcutHintsHandlers();
+    const setHandler = ipcMainMock.handle.mock.calls.find(
+      (c: unknown[]) => c[0] === "shortcut-hints:set-hinted-hover"
+    )![1] as (_e: unknown, keys: unknown) => void;
+
+    setHandler(null, ["nav.quickSwitcher@1", 42, null, "nav.commandPalette@0"]);
+    expect(storeMock.set).toHaveBeenCalledWith("shortcutHintHoveredKeys", [
+      "nav.quickSwitcher@1",
+      "nav.commandPalette@0",
+    ]);
+  });
+
+  it("cleanup removes all handlers", () => {
     const cleanup = registerShortcutHintsHandlers();
     cleanup();
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(2);
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(4);
   });
 });

--- a/electron/ipc/handlers/forgeRecommendation.preload.ts
+++ b/electron/ipc/handlers/forgeRecommendation.preload.ts
@@ -1,0 +1,27 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const FORGE_RECOMMENDATION_METHOD_CHANNELS = {
+  getDismissed: "forge-recommendation:get-dismissed",
+  markDismissed: "forge-recommendation:mark-dismissed",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof FORGE_RECOMMENDATION_METHOD_CHANNELS;
+
+export type ForgeRecommendationPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildForgeRecommendationPreloadBindings(
+  invoke: Invoker
+): ForgeRecommendationPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(FORGE_RECOMMENDATION_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = FORGE_RECOMMENDATION_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as ForgeRecommendationPreloadBindings;
+}

--- a/electron/ipc/handlers/forgeRecommendation.ts
+++ b/electron/ipc/handlers/forgeRecommendation.ts
@@ -1,0 +1,28 @@
+// eager-import-allow: reads forge-recommendation state via store.get synchronously at module scope
+import { store } from "../../store.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { FORGE_RECOMMENDATION_METHOD_CHANNELS } from "./forgeRecommendation.preload.js";
+
+export const forgeRecommendationNamespace = defineIpcNamespace({
+  name: "forgeRecommendation",
+  ops: {
+    getDismissed: op(
+      FORGE_RECOMMENDATION_METHOD_CHANNELS.getDismissed,
+      (): Record<string, true> => {
+        return store.get("forgeEnableDismissedPaths") ?? {};
+      }
+    ),
+    markDismissed: op(
+      FORGE_RECOMMENDATION_METHOD_CHANNELS.markDismissed,
+      (projectPath: string): void => {
+        if (typeof projectPath !== "string" || projectPath.length === 0) return;
+        const current = store.get("forgeEnableDismissedPaths") ?? {};
+        store.set("forgeEnableDismissedPaths", { ...current, [projectPath]: true });
+      }
+    ),
+  },
+});
+
+export function registerForgeRecommendationHandlers(): () => void {
+  return forgeRecommendationNamespace.register();
+}

--- a/electron/ipc/handlers/forgeRecommendation.ts
+++ b/electron/ipc/handlers/forgeRecommendation.ts
@@ -17,7 +17,11 @@ export const forgeRecommendationNamespace = defineIpcNamespace({
       (projectPath: string): void => {
         if (typeof projectPath !== "string" || projectPath.length === 0) return;
         const current = store.get("forgeEnableDismissedPaths") ?? {};
-        store.set("forgeEnableDismissedPaths", { ...current, [projectPath]: true });
+        // Defend against a field-level corrupt value (e.g. an array or string)
+        // that survived the store's JSON parse — spreading it would otherwise
+        // produce character-indexed garbage.
+        const base = typeof current === "object" && !Array.isArray(current) ? current : {};
+        store.set("forgeEnableDismissedPaths", { ...base, [projectPath]: true });
       }
     ),
   },

--- a/electron/ipc/handlers/shortcutHints.preload.ts
+++ b/electron/ipc/handlers/shortcutHints.preload.ts
@@ -3,6 +3,8 @@ import type { IpcInvokeMap } from "../../types/index.js";
 export const SHORTCUT_HINTS_METHOD_CHANNELS = {
   getCounts: "shortcut-hints:get-counts",
   incrementCount: "shortcut-hints:increment-count",
+  getHintedHover: "shortcut-hints:get-hinted-hover",
+  setHintedHover: "shortcut-hints:set-hinted-hover",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof SHORTCUT_HINTS_METHOD_CHANNELS;

--- a/electron/ipc/handlers/shortcutHints.ts
+++ b/electron/ipc/handlers/shortcutHints.ts
@@ -15,6 +15,16 @@ export const shortcutHintsNamespace = defineIpcNamespace({
       counts[actionId] = (counts[actionId] ?? 0) + 1;
       store.set("shortcutHintCounts", counts);
     }),
+    getHintedHover: op(SHORTCUT_HINTS_METHOD_CHANNELS.getHintedHover, (): string[] => {
+      return store.get("shortcutHintHoveredKeys") ?? [];
+    }),
+    setHintedHover: op(SHORTCUT_HINTS_METHOD_CHANNELS.setHintedHover, (keys: string[]): void => {
+      if (!Array.isArray(keys)) return;
+      store.set(
+        "shortcutHintHoveredKeys",
+        keys.filter((key): key is string => typeof key === "string")
+      );
+    }),
   },
 });
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -52,6 +52,7 @@ import { buildGeminiPreloadBindings } from "./ipc/handlers/gemini.preload.js";
 import { buildMilestonesPreloadBindings } from "./ipc/handlers/milestones.preload.js";
 import { buildOnboardingPreloadBindings } from "./ipc/handlers/onboarding.preload.js";
 import { buildShortcutHintsPreloadBindings } from "./ipc/handlers/shortcutHints.preload.js";
+import { buildForgeRecommendationPreloadBindings } from "./ipc/handlers/forgeRecommendation.preload.js";
 import { buildSentryPreloadBindings } from "./ipc/handlers/sentry.preload.js";
 import { buildPrivacyPreloadBindings } from "./ipc/handlers/privacy.preload.js";
 import { buildTelemetryPreloadBindings } from "./ipc/handlers/telemetry.preload.js";
@@ -2334,6 +2335,8 @@ function buildElectronApi(): ElectronAPI {
     milestones: buildMilestonesPreloadBindings(_unwrappingInvoke),
 
     shortcutHints: buildShortcutHintsPreloadBindings(_unwrappingInvoke),
+
+    forgeRecommendation: buildForgeRecommendationPreloadBindings(_unwrappingInvoke),
 
     forge: {
       getSettings: () => _unwrappingInvoke(CHANNELS.FORGE_GET_SETTINGS),

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -317,6 +317,18 @@ export interface StoreSchema {
   };
   orchestrationMilestones: Record<string, boolean>;
   shortcutHintCounts: Record<string, number>;
+  /**
+   * One-shot hover-hint keys (`actionId@count`) already shown to the user.
+   * Persisted so keyboard-shortcut teaching tooltips don't reappear every
+   * session. Bounded by `|actionIds| × |HINT_MILESTONES|`.
+   */
+  shortcutHintHoveredKeys?: string[];
+  /**
+   * Project paths for which the "enable forge plugin" recommendation has
+   * already fired or been dismissed. Persisted so the nudge doesn't reappear
+   * on every launch. Bounded by the number of distinct projects opened.
+   */
+  forgeEnableDismissedPaths?: Record<string, true>;
   updateChannel: "stable" | "nightly";
   dismissedUpdateVersion?: string;
   dismissedUpdateAt?: number;
@@ -601,6 +613,8 @@ const storeOptions = {
     },
     orchestrationMilestones: {},
     shortcutHintCounts: {},
+    shortcutHintHoveredKeys: [],
+    forgeEnableDismissedPaths: {},
     updateChannel: "stable" as const,
     lastUpdateCheck: null,
     logLevelOverrides: {},

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -166,6 +166,14 @@ export interface GeneratedElectronAPI {
       ...args: IpcInvokeMap["forge-audit:set-enabled"]["args"]
     ): Promise<IpcInvokeMap["forge-audit:set-enabled"]["result"]>;
   };
+  forgeRecommendation: {
+    getDismissed(
+      ...args: IpcInvokeMap["forge-recommendation:get-dismissed"]["args"]
+    ): Promise<IpcInvokeMap["forge-recommendation:get-dismissed"]["result"]>;
+    markDismissed(
+      ...args: IpcInvokeMap["forge-recommendation:mark-dismissed"]["args"]
+    ): Promise<IpcInvokeMap["forge-recommendation:mark-dismissed"]["result"]>;
+  };
   gemini: {
     enableAlternateBuffer(
       ...args: IpcInvokeMap["gemini:enable-alternate-buffer"]["args"]
@@ -562,9 +570,15 @@ export interface GeneratedElectronAPI {
     getCounts(
       ...args: IpcInvokeMap["shortcut-hints:get-counts"]["args"]
     ): Promise<IpcInvokeMap["shortcut-hints:get-counts"]["result"]>;
+    getHintedHover(
+      ...args: IpcInvokeMap["shortcut-hints:get-hinted-hover"]["args"]
+    ): Promise<IpcInvokeMap["shortcut-hints:get-hinted-hover"]["result"]>;
     incrementCount(
       ...args: IpcInvokeMap["shortcut-hints:increment-count"]["args"]
     ): Promise<IpcInvokeMap["shortcut-hints:increment-count"]["result"]>;
+    setHintedHover(
+      ...args: IpcInvokeMap["shortcut-hints:set-hinted-hover"]["args"]
+    ): Promise<IpcInvokeMap["shortcut-hints:set-hinted-hover"]["result"]>;
   };
   slashCommands: {
     list(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -319,6 +319,14 @@ export interface GeneratedIpcInvokeMap {
     args: [enabled: boolean];
     result: { enabled: boolean; maxRecords: number };
   };
+  "forge-recommendation:get-dismissed": {
+    args: [];
+    result: Record<string, true>;
+  };
+  "forge-recommendation:mark-dismissed": {
+    args: [projectPath: string];
+    result: void;
+  };
   "forge:get-first-page-cache": {
     args: [payload: { cwd: string }];
     result: import("./forge.js").ForgeFirstPageCachePayload | null;
@@ -1033,8 +1041,16 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: Record<string, number>;
   };
+  "shortcut-hints:get-hinted-hover": {
+    args: [];
+    result: string[];
+  };
   "shortcut-hints:increment-count": {
     args: [actionId: string];
+    result: void;
+  };
+  "shortcut-hints:set-hinted-hover": {
+    args: [keys: string[]];
     result: void;
   };
   "slash-commands:list": {

--- a/src/hooks/app/__tests__/useForgeEnableRecommendation.test.tsx
+++ b/src/hooks/app/__tests__/useForgeEnableRecommendation.test.tsx
@@ -46,6 +46,8 @@ vi.mock("@/utils/logger", () => ({
 const listMock = vi.fn();
 const listRemotesMock = vi.fn();
 const setEnabledMock = vi.fn(async () => {});
+const getDismissedMock = vi.fn(async (): Promise<Record<string, true>> => ({}));
+const markDismissedMock = vi.fn(async () => {});
 
 interface PluginRow {
   name: string;
@@ -69,6 +71,7 @@ function installElectronMocks(opts: { plugins: PluginRow[]; remotes: string[] })
   window.electron = {
     plugin: { list: listMock, setEnabled: setEnabledMock },
     project: { listRemotes: listRemotesMock },
+    forgeRecommendation: { getDismissed: getDismissedMock, markDismissed: markDismissedMock },
   } as unknown as typeof window.electron;
 }
 
@@ -82,6 +85,8 @@ const githubPlugin = (disabled: boolean): PluginRow => ({
 beforeEach(() => {
   vi.clearAllMocks();
   notifyMock.mockReturnValue("notif-1");
+  getDismissedMock.mockResolvedValue({});
+  markDismissedMock.mockResolvedValue(undefined);
   _resetForgeEnableRecommendationForTest();
   currentProjectRef.value = { path: "/Users/test/Projects/sample" };
 });
@@ -219,5 +224,45 @@ describe("useForgeEnableRecommendation", () => {
     renderHook(() => useForgeEnableRecommendation(true));
     await new Promise((r) => setTimeout(r, 0));
     expect(notifyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the dismissal at evaluation time, not only on a Not now click", async () => {
+    installElectronMocks({
+      plugins: [githubPlugin(true)],
+      remotes: ["git@github.com:owner/repo.git"],
+    });
+
+    renderHook(() => useForgeEnableRecommendation(true));
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+    // Persisted as soon as the nudge fires — no user click required.
+    expect(markDismissedMock).toHaveBeenCalledWith("/Users/test/Projects/sample");
+  });
+
+  it("does not re-fire across restart for a path persisted as dismissed", async () => {
+    installElectronMocks({
+      plugins: [githubPlugin(true)],
+      remotes: ["git@github.com:owner/repo.git"],
+    });
+    // Simulate a fresh session where the path was dismissed previously.
+    getDismissedMock.mockResolvedValue({ "/Users/test/Projects/sample": true });
+
+    renderHook(() => useForgeEnableRecommendation(true));
+
+    await waitFor(() => expect(getDismissedMock).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0));
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to evaluating when reading persisted dismissals fails", async () => {
+    installElectronMocks({
+      plugins: [githubPlugin(true)],
+      remotes: ["git@github.com:owner/repo.git"],
+    });
+    getDismissedMock.mockRejectedValue(new Error("store unavailable"));
+
+    renderHook(() => useForgeEnableRecommendation(true));
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/hooks/app/__tests__/useForgeEnableRecommendation.test.tsx
+++ b/src/hooks/app/__tests__/useForgeEnableRecommendation.test.tsx
@@ -264,5 +264,8 @@ describe("useForgeEnableRecommendation", () => {
     renderHook(() => useForgeEnableRecommendation(true));
 
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+    // The dismissal must still be persisted on the failure path so the nudge
+    // doesn't re-fire next launch once the store recovers.
+    expect(markDismissedMock).toHaveBeenCalledWith("/Users/test/Projects/sample");
   });
 });

--- a/src/hooks/app/useForgeEnableRecommendation.ts
+++ b/src/hooks/app/useForgeEnableRecommendation.ts
@@ -18,9 +18,31 @@ import { makeForgeProviderId } from "@shared/utils/forgeProviderIds";
  *
  * Evaluation runs on project switch, not on toggle: a user who just disabled
  * a plugin must not be immediately nudged to undo their own action. Fired
- * or dismissed projects are remembered for the session.
+ * or dismissed projects are remembered across sessions: the in-memory set is
+ * the fast path, seeded once from electron-store so the nudge doesn't reappear
+ * on every launch.
  */
 const handledProjectPaths = new Set<string>();
+
+/**
+ * Seeds `handledProjectPaths` from persisted dismissals. Memoized so the IPC
+ * round-trip happens once per session regardless of how many hook instances
+ * mount; best-effort — failure falls back to per-session memory only.
+ */
+let dismissedHydration: Promise<void> | null = null;
+function hydrateDismissedPaths(): Promise<void> {
+  if (!dismissedHydration) {
+    dismissedHydration = window.electron.forgeRecommendation
+      .getDismissed()
+      .then((dismissed) => {
+        for (const path of Object.keys(dismissed)) {
+          handledProjectPaths.add(path);
+        }
+      })
+      .catch(() => {});
+  }
+  return dismissedHydration;
+}
 
 interface DisabledProviderMatch {
   pluginId: string;
@@ -84,6 +106,13 @@ export function useForgeEnableRecommendation(isStateLoaded: boolean): void {
     let cancelled = false;
 
     async function evaluate(projectPath: string) {
+      // Seed from persisted dismissals before evaluating so a recommendation
+      // dismissed in a previous session doesn't re-fire while hydration is
+      // still in flight on cold start.
+      await hydrateDismissedPaths();
+      if (cancelled) return;
+      if (handledProjectPaths.has(projectPath)) return;
+
       // Query main directly rather than the pluginRuntimeStore snapshot — on
       // cold start the project can load before the store's first pull lands,
       // and a missed evaluation here never re-runs for this project. The
@@ -114,6 +143,12 @@ export function useForgeEnableRecommendation(isStateLoaded: boolean): void {
       const { pluginId, displayName, providerName } = match;
 
       handledProjectPaths.add(projectPath);
+      // Persist at the same point as the in-memory guard so the nudge stays
+      // suppressed across restarts (mirrors session behaviour exactly — a
+      // project that showed the recommendation won't show it again).
+      safeFireAndForget(window.electron.forgeRecommendation.markDismissed(projectPath), {
+        context: "Persisting forge enable recommendation dismissal",
+      });
 
       const dismissSelf = (id: string | undefined) => {
         if (!id) return;
@@ -178,4 +213,5 @@ export function useForgeEnableRecommendation(isStateLoaded: boolean): void {
 /** Test-only: reset the per-session fired/dismissed project memory. */
 export function _resetForgeEnableRecommendationForTest(): void {
   handledProjectPaths.clear();
+  dismissedHydration = null;
 }

--- a/src/hooks/app/useShortcutHints.ts
+++ b/src/hooks/app/useShortcutHints.ts
@@ -14,6 +14,15 @@ export function useShortcutHints(isStateLoaded: boolean) {
       .catch(() => {
         shortcutHintStore.getState().hydrateCounts({});
       });
+
+    window.electron?.shortcutHints
+      ?.getHintedHover()
+      .then((keys) => {
+        shortcutHintStore.getState().hydrateHintedHover(keys);
+      })
+      .catch(() => {
+        shortcutHintStore.getState().hydrateHintedHover([]);
+      });
   }, [isStateLoaded]);
 
   // Track mouse position for hint placement

--- a/src/hooks/app/useShortcutHints.ts
+++ b/src/hooks/app/useShortcutHints.ts
@@ -6,22 +6,32 @@ export function useShortcutHints(isStateLoaded: boolean) {
   useEffect(() => {
     if (!isElectronAvailable() || !isStateLoaded) return;
 
-    window.electron?.shortcutHints
-      ?.getCounts()
-      .then((counts) => {
-        shortcutHintStore.getState().hydrateCounts(counts);
-      })
-      .catch(() => {
-        shortcutHintStore.getState().hydrateCounts({});
-      });
+    const hints = window.electron?.shortcutHints;
+    if (!hints) return;
 
-    window.electron?.shortcutHints
-      ?.getHintedHover()
+    // Seed the one-shot hover gate BEFORE counts hydration flips `hydrated`,
+    // which is what opens `isHoverEligible`. Loading these in parallel leaves a
+    // window where counts win the race, the gate opens with an empty set, and a
+    // hover re-shows an already-dismissed hint (and the late `hydrateHintedHover`
+    // would then wipe that in-session mark). `markHoverShown` is unreachable
+    // while `hydrated` is false, so sequencing closes the window entirely.
+    hints
+      .getHintedHover()
       .then((keys) => {
         shortcutHintStore.getState().hydrateHintedHover(keys);
       })
       .catch(() => {
         shortcutHintStore.getState().hydrateHintedHover([]);
+      })
+      .finally(() => {
+        hints
+          .getCounts()
+          .then((counts) => {
+            shortcutHintStore.getState().hydrateCounts(counts);
+          })
+          .catch(() => {
+            shortcutHintStore.getState().hydrateCounts({});
+          });
       });
   }, [isStateLoaded]);
 

--- a/src/store/__tests__/shortcutHintStore.test.ts
+++ b/src/store/__tests__/shortcutHintStore.test.ts
@@ -330,6 +330,19 @@ describe("shortcutHintStore", () => {
     ]);
   });
 
+  it("markHoverShown flushes the full gate, preserving keys from a prior session", () => {
+    const s = shortcutHintStore.getState();
+    s.hydrateHintedHover(["nav.commandPalette@0"]);
+    s.hydrateCounts({ "nav.quickSwitcher": 1 });
+    s.markHoverShown("nav.quickSwitcher");
+
+    // The flushed array must include the pre-hydrated key, not just the new one.
+    expect(window.electron?.shortcutHints?.setHintedHover).toHaveBeenCalledWith([
+      "nav.commandPalette@0",
+      "nav.quickSwitcher@1",
+    ]);
+  });
+
   it("incrementCount persists the cleared gate to IPC", () => {
     const s = shortcutHintStore.getState();
     s.hydrateCounts({ "nav.quickSwitcher": 1, "terminal.new": 2 });

--- a/src/store/__tests__/shortcutHintStore.test.ts
+++ b/src/store/__tests__/shortcutHintStore.test.ts
@@ -14,6 +14,7 @@ describe("shortcutHintStore", () => {
       electron: {
         shortcutHints: {
           incrementCount: vi.fn(),
+          setHintedHover: vi.fn(),
         },
       },
     });
@@ -296,5 +297,49 @@ describe("shortcutHintStore", () => {
     // terminal.new hover tracking should still be present
     expect(s.isHoverEligible("nav.quickSwitcher")).toBe(true); // cleared + now at milestone 2
     expect(s.isHoverEligible("terminal.new")).toBe(false); // still tracked at count 2
+  });
+
+  // --- Persisted hover-gate hydration & flush ---
+
+  it("hydrateHintedHover seeds the one-shot gate so a persisted hint stays suppressed", () => {
+    const s = shortcutHintStore.getState();
+    s.hydrateCounts({ "nav.quickSwitcher": 1 });
+    expect(s.isHoverEligible("nav.quickSwitcher")).toBe(true);
+
+    s.hydrateHintedHover(["nav.quickSwitcher@1"]);
+    expect(s.isHoverEligible("nav.quickSwitcher")).toBe(false);
+  });
+
+  it("hydrateHintedHover replaces any prior in-memory gate state", () => {
+    const s = shortcutHintStore.getState();
+    s.hydrateCounts({ "nav.quickSwitcher": 0 });
+    s.markHoverShown("nav.quickSwitcher");
+    expect(s.isHoverEligible("nav.quickSwitcher")).toBe(false);
+
+    s.hydrateHintedHover([]);
+    expect(s.isHoverEligible("nav.quickSwitcher")).toBe(true);
+  });
+
+  it("markHoverShown persists the updated gate to IPC", () => {
+    const s = shortcutHintStore.getState();
+    s.hydrateCounts({ "nav.quickSwitcher": 1 });
+    s.markHoverShown("nav.quickSwitcher");
+
+    expect(window.electron?.shortcutHints?.setHintedHover).toHaveBeenCalledWith([
+      "nav.quickSwitcher@1",
+    ]);
+  });
+
+  it("incrementCount persists the cleared gate to IPC", () => {
+    const s = shortcutHintStore.getState();
+    s.hydrateCounts({ "nav.quickSwitcher": 1, "terminal.new": 2 });
+    s.markHoverShown("nav.quickSwitcher");
+    s.markHoverShown("terminal.new");
+
+    (window.electron!.shortcutHints!.setHintedHover as ReturnType<typeof vi.fn>).mockClear();
+    s.incrementCount("nav.quickSwitcher");
+
+    // nav.quickSwitcher@1 dropped, terminal.new@2 retained
+    expect(window.electron?.shortcutHints?.setHintedHover).toHaveBeenCalledWith(["terminal.new@2"]);
   });
 });

--- a/src/store/__tests__/shortcutHintStore.test.ts
+++ b/src/store/__tests__/shortcutHintStore.test.ts
@@ -349,10 +349,11 @@ describe("shortcutHintStore", () => {
     s.markHoverShown("nav.quickSwitcher");
     s.markHoverShown("terminal.new");
 
-    (window.electron!.shortcutHints!.setHintedHover as ReturnType<typeof vi.fn>).mockClear();
     s.incrementCount("nav.quickSwitcher");
 
-    // nav.quickSwitcher@1 dropped, terminal.new@2 retained
-    expect(window.electron?.shortcutHints?.setHintedHover).toHaveBeenCalledWith(["terminal.new@2"]);
+    // The final flush (from incrementCount) drops nav.quickSwitcher@1, keeps terminal.new@2.
+    expect(window.electron?.shortcutHints?.setHintedHover).toHaveBeenLastCalledWith([
+      "terminal.new@2",
+    ]);
   });
 });

--- a/src/store/shortcutHintStore.ts
+++ b/src/store/shortcutHintStore.ts
@@ -8,6 +8,16 @@ function hoverOneShotKey(actionId: string, count: number): string {
   return `${actionId}@${count}`;
 }
 
+/**
+ * Persist the one-shot hover gate so teaching tooltips don't reappear next
+ * session. Called only when the set actually mutates — adds are one-shot
+ * gated (`markHoverShown` runs once per actionId@count) and clears happen on
+ * `incrementCount`, so this never fires on every hover (lesson #7586).
+ */
+function flushHintedHover(hintedHover: Set<string>): void {
+  window.electron?.shortcutHints?.setHintedHover([...hintedHover])?.catch(() => {});
+}
+
 export interface ShortcutHintState {
   counts: Record<string, number>;
   hydrated: boolean;
@@ -19,6 +29,8 @@ export interface ShortcutHintState {
 
 export interface ShortcutHintActions {
   hydrateCounts(counts: Record<string, number>): void;
+  /** Seeds the one-shot hover gate from persisted keys (`actionId@count`). */
+  hydrateHintedHover(keys: string[]): void;
   recordPointer(x: number, y: number): void;
   show(actionId: string, displayCombo: string, position?: { x: number; y: number }): boolean;
   hide(): void;
@@ -40,6 +52,10 @@ export const shortcutHintStore = createStore<ShortcutHintStore>((set, get) => ({
 
   hydrateCounts(counts: Record<string, number>) {
     set({ counts, hydrated: true });
+  },
+
+  hydrateHintedHover(keys: string[]) {
+    set({ hintedHover: new Set(keys) });
   },
 
   recordPointer(x: number, y: number) {
@@ -86,6 +102,7 @@ export const shortcutHintStore = createStore<ShortcutHintStore>((set, get) => ({
     }
     set({ counts: updated, hintedHover: newHintedHover });
     window.electron?.shortcutHints?.incrementCount(actionId)?.catch(() => {});
+    flushHintedHover(newHintedHover);
   },
 
   isHoverEligible(actionId: string): boolean {
@@ -109,5 +126,6 @@ export const shortcutHintStore = createStore<ShortcutHintStore>((set, get) => ({
     const next = new Set(hintedHover);
     next.add(hoverOneShotKey(actionId, count));
     set({ hintedHover: next });
+    flushHintedHover(next);
   },
 }));


### PR DESCRIPTION
Both the forge enable-plugin recommendation and the shortcut hint hover gate were re-firing on every launch after being dismissed. Both guards lived only in memory, so a restart reset them.

This persists both dismissals to `electron-store`, following the existing `shortcutHintCounts` pattern — additive optional keys with defaults, no migration needed.

Resolves #10546.

## Changes

**Forge enable-plugin recommendation**
- New store key `forgeEnableDismissedPaths: Record<string, true>` tracks dismissed project paths persistently.
- In-memory guard is seeded from the store on startup (awaited before evaluation to close the cold-start race).
- Dismissal is persisted at evaluate-time, mirroring the existing in-memory add point.
- New `forgeRecommendation` IPC namespace (`getDismissed` / `markDismissed`) mirroring `milestones`.

**Shortcut hint hover gate**
- New store key `shortcutHintHoveredKeys: string[]` persists the one-shot hover gate.
- `hintedHover` hydrates from the store before counts hydration flips the `hydrated` flag, closing a startup race where a hover could re-show a dismissed hint.
- Store flushes only on set mutations (`markHoverShown`, `incrementCount`) — bounded, never per-hover.
- New `shortcutHints` ops `getHintedHover` / `setHintedHover`.

**Other**
- IPC type maps regenerated via codegen.
- Defensive guard against a corrupt field-level store value in `markDismissed`.

## Testing

123 targeted tests pass. Coverage includes: corrupt-value recovery, `setHintedHover` replace/clear semantics, full-gate flush preserving prior-session keys, persist-at-evaluate, suppress-across-restart, and dismissal persisted on the IPC-failure fallback path.