### PR TITLE
fix(plugins): install/update/CLI-socket trust hardening

### DIFF
--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -295,7 +295,9 @@ export async function handleInstallFromUrl(url: string): Promise<PluginInstallRe
           "fetch_failed",
           guarded.reason === "private-redirect" || guarded.reason === "private-host"
             ? "The download resolved to a private or loopback address."
-            : "The download followed too many redirects."
+            : guarded.reason === "insecure-protocol"
+              ? "The download redirected to an insecure (non-https) URL."
+              : "The download followed too many redirects."
         );
       }
       response = guarded.response;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -293,8 +293,8 @@ export async function handleInstallFromUrl(url: string): Promise<PluginInstallRe
       if (!guarded.ok) {
         return failed(
           "fetch_failed",
-          guarded.reason === "private-redirect"
-            ? "The download redirected to a private or loopback address."
+          guarded.reason === "private-redirect" || guarded.reason === "private-host"
+            ? "The download resolved to a private or loopback address."
             : "The download followed too many redirects."
         );
       }

--- a/electron/services/PluginCliServer.ts
+++ b/electron/services/PluginCliServer.ts
@@ -1,18 +1,33 @@
 import net from "node:net";
 import path from "node:path";
 import fs from "node:fs/promises";
+import crypto from "node:crypto";
 import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
-import { getCliSocketPath } from "../../shared/utils/cliSocketPath.js";
+import {
+  getCliSocketPath,
+  getCliControlFilePath,
+  writeCliControlFile,
+  removeCliControlFile,
+} from "../../shared/utils/cliSocketPath.js";
 
 /**
  * Local control socket that lets the `daintree-plugin` CLI drive a running
  * Daintree instance for `install` / `uninstall` (F32). The CLI connects over a
  * Unix domain socket (`~/.daintree/cli.sock`) or a Windows named pipe
- * (`\\.\pipe\daintree-cli`) and exchanges newline-delimited JSON frames:
+ * (`\\.\pipe\daintree-cli-<random>`) and exchanges newline-delimited JSON frames:
  *
- *   request:  { "id": <string|number>, "method": <string>, "params"?: <object> }
+ *   request:  { "id": <string|number>, "method": <string>, "params"?: <object>, "token": <string> }
  *   response: { "id": <id>, "result": <value> }  |  { "id": <id>, "error": { "message": <string> } }
+ *
+ * Every frame must carry the per-launch `token` the host advertises in its
+ * control-discovery file (#10518). The 0700 socket dir already limits the Unix
+ * socket to the same user, but a same-user process is exactly the attacker the
+ * token raises the bar against, and on Windows the named pipe's default ACL is
+ * broad — the token (readable only from the user-owned control file) is what
+ * authenticates the peer there. Validated with `timingSafeEqual` before any
+ * method dispatches; an unauthenticated frame gets an error and the socket is
+ * destroyed.
  *
  * Every CLI install/uninstall routes through the SAME handler functions the IPC
  * surface uses, so the path/magic-byte/`.dntr` guards and the scoped-name check
@@ -23,11 +38,12 @@ import { getCliSocketPath } from "../../shared/utils/cliSocketPath.js";
 
 const MAX_FRAME_BYTES = 64 * 1024;
 
-/** Request envelope. `params` shape is validated per-method. */
+/** Request envelope. `params` shape is validated per-method; `token` is the auth gate. */
 const RequestSchema = z.object({
   id: z.union([z.string(), z.number()]),
   method: z.string().min(1),
   params: z.unknown().optional(),
+  token: z.string().optional(),
 });
 
 const InstallParamsSchema = z
@@ -64,12 +80,25 @@ export interface PluginCliServerConfig {
   /** Resolves once the host is ready to accept install/uninstall calls. */
   waitForReady: () => Promise<void>;
   handlers: PluginCliServerHandlers;
+  /**
+   * Where to write the control-discovery file (socket path + auth token).
+   * Defaults to {@link getCliControlFilePath}; tests point it at a temp file so
+   * they never clobber the real `~/.daintree/cli-control.json`.
+   */
+  controlFilePath?: string;
+  /**
+   * Per-launch auth token clients must echo on every frame. Defaults to a fresh
+   * 256-bit random hex string; injectable so tests can assert the auth gate.
+   */
+  authToken?: string;
 }
 
 export interface PluginCliServer {
   listen: () => Promise<void>;
   close: () => Promise<void>;
   readonly socketPath: string;
+  /** The token a client must present on every frame (advertised via the control file). */
+  readonly authToken: string;
 }
 
 // Re-exported from `shared/utils/cliSocketPath.ts` so the host and the
@@ -92,12 +121,28 @@ function writeResponse(socket: net.Socket, payload: Record<string, unknown>): vo
 }
 
 /**
+ * Constant-time token comparison. Rejects a missing/empty token up front and
+ * length-guards before `timingSafeEqual` (which throws on unequal-length
+ * buffers) — the length check is not itself a timing leak since the token length
+ * is fixed and public.
+ */
+function tokenIsValid(provided: string | undefined, expected: string): boolean {
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
  * Create (but do not yet bind) a CLI control server. `listen()` awaits
  * `waitForReady()` before binding so no request is serviced before the host
  * can honor it; `close()` tears the socket down and removes the on-disk file.
  */
 export function createPluginCliServer(config: PluginCliServerConfig): PluginCliServer {
   const { socketPath, waitForReady, handlers } = config;
+  const controlFilePath = config.controlFilePath ?? getCliControlFilePath();
+  const authToken = config.authToken ?? crypto.randomBytes(32).toString("hex");
 
   async function dispatchMethod(method: string, params: unknown): Promise<unknown> {
     switch (method) {
@@ -145,7 +190,19 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
       return;
     }
 
-    const { id, method, params } = req.data;
+    const { id, method, params, token } = req.data;
+
+    // Authenticate before dispatching anything (#10518). An unauthenticated peer
+    // gets a single error frame, then the connection is closed — no method (not
+    // even plugin.ping) runs and the socket can't be probed frame-by-frame.
+    // `end()` (not `destroy()`) flushes the error frame before the FIN so the
+    // client always sees why it was rejected rather than a bare disconnect.
+    if (!tokenIsValid(token, authToken)) {
+      writeResponse(socket, { id, error: { message: "Unauthorized: invalid or missing token" } });
+      socket.end();
+      return;
+    }
+
     try {
       const result = await dispatchMethod(method, params);
       writeResponse(socket, { id, result });
@@ -221,6 +278,10 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
     if (fileSocket) {
       await fs.chmod(socketPath, 0o600);
     }
+    // Advertise the bound path + auth token only after the socket is live, so a
+    // racing CLI never reads a control file pointing at a not-yet-listening
+    // endpoint. The file itself is written owner-only (0700 dir / 0600 file).
+    await writeCliControlFile(controlFilePath, { socketPath, token: authToken });
     server = srv;
   }
 
@@ -235,12 +296,15 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
     }
     openSockets.clear();
     await new Promise<void>((resolve) => srv.close(() => resolve()));
+    // Remove the discovery file first so a CLI started during teardown sees
+    // "not running" instead of dialing a dead socket.
+    await removeCliControlFile(controlFilePath);
     if (isFileSocket(socketPath)) {
       await fs.rm(socketPath, { force: true }).catch(() => {});
     }
   }
 
-  return { listen, close, socketPath };
+  return { listen, close, socketPath, authToken };
 }
 
 // ── Process-wide singleton wiring ──────────────────────────────────────────
@@ -258,8 +322,18 @@ export async function startPluginCliServer(): Promise<void> {
   const { handleInstallFromPath, handleInstallFromUrl, handleUninstall } =
     await import("../ipc/handlers/plugin.js");
 
+  // On Windows the named pipe can't carry a restrictive DACL from pure node, so
+  // its default ACL is broad. Randomize the pipe name per launch (#10518) so it
+  // isn't a fixed, predictable target; the CLI discovers the real name from the
+  // control file rather than hardcoding it. The token gate is still the actual
+  // authentication. An explicit DAINTREE_CLI_SOCKET override is honored as-is.
+  const socketPath =
+    process.platform === "win32" && !process.env.DAINTREE_CLI_SOCKET
+      ? `\\\\.\\pipe\\daintree-cli-${crypto.randomUUID()}`
+      : getCliSocketPath();
+
   const server = createPluginCliServer({
-    socketPath: getCliSocketPath(),
+    socketPath,
     waitForReady: () => pluginService.waitForInit(),
     handlers: {
       install: ({ path: installPath, url }) => {

--- a/electron/services/PluginCliServer.ts
+++ b/electron/services/PluginCliServer.ts
@@ -172,7 +172,11 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
     }
   }
 
-  async function dispatchFrame(socket: net.Socket, line: string): Promise<void> {
+  async function dispatchFrame(
+    socket: net.Socket,
+    line: string,
+    conn: { terminated: boolean }
+  ): Promise<void> {
     const trimmed = line.trim();
     if (trimmed.length === 0) return;
 
@@ -194,10 +198,13 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
 
     // Authenticate before dispatching anything (#10518). An unauthenticated peer
     // gets a single error frame, then the connection is closed — no method (not
-    // even plugin.ping) runs and the socket can't be probed frame-by-frame.
-    // `end()` (not `destroy()`) flushes the error frame before the FIN so the
-    // client always sees why it was rejected rather than a bare disconnect.
+    // even plugin.ping) runs. `conn.terminated` makes the data loop drop every
+    // subsequent frame on this connection so it genuinely can't be probed
+    // frame-by-frame (the auth check above is synchronous, so the flag is set
+    // before the data loop inspects it). `end()` (not `destroy()`) flushes the
+    // error frame before the FIN so the client sees why it was rejected.
     if (!tokenIsValid(token, authToken)) {
+      conn.terminated = true;
       writeResponse(socket, { id, error: { message: "Unauthorized: invalid or missing token" } });
       socket.end();
       return;
@@ -220,9 +227,12 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
     socket.setEncoding("utf8");
     let buffer = "";
     let overflowed = false;
+    // Flipped synchronously by dispatchFrame on an auth failure so no further
+    // frame on this connection is ever processed.
+    const conn = { terminated: false };
 
     socket.on("data", (chunk: string) => {
-      if (overflowed) return;
+      if (overflowed || conn.terminated) return;
       buffer += chunk;
       if (buffer.length > MAX_FRAME_BYTES) {
         overflowed = true;
@@ -236,7 +246,10 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
         buffer = buffer.slice(newlineIndex + 1);
         // Fire concurrently — each response carries its own id so the client
         // matches replies; install/uninstall serialize on the plugin lock.
-        void dispatchFrame(socket, frame);
+        void dispatchFrame(socket, frame, conn);
+        // The auth check inside dispatchFrame runs synchronously, so an auth
+        // failure on this frame has already set `terminated` — stop draining.
+        if (conn.terminated) return;
         newlineIndex = buffer.indexOf("\n");
       }
     });
@@ -297,8 +310,9 @@ export function createPluginCliServer(config: PluginCliServerConfig): PluginCliS
     openSockets.clear();
     await new Promise<void>((resolve) => srv.close(() => resolve()));
     // Remove the discovery file first so a CLI started during teardown sees
-    // "not running" instead of dialing a dead socket.
-    await removeCliControlFile(controlFilePath);
+    // "not running" instead of dialing a dead socket — but only if it's still
+    // ours (a concurrent instance may have taken over the file).
+    await removeCliControlFile(controlFilePath, authToken);
     if (isFileSocket(socketPath)) {
       await fs.rm(socketPath, { force: true }).catch(() => {});
     }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -31,6 +31,7 @@ import {
   DEPRECATED_CONTRIBUTION_ALIASES,
   getPluginManifestSchema,
   PluginToastOptionsSchema,
+  SCOPED_PLUGIN_NAME_PATTERN,
 } from "../schemas/plugin.js";
 import { getPluginMcpSupervisor } from "./PluginMcpSupervisor.js";
 import { PluginProcessManager } from "./plugin/PluginProcessManager.js";
@@ -3800,6 +3801,14 @@ export class PluginService {
    * duplicate-name guard in {@link loadPlugin} doesn't reject the reload.
    */
   async loadDevPlugin(pluginId: string): Promise<void> {
+    // The id becomes `path.join(pluginsRoot, pluginId)` in `loadPlugin`, so a
+    // `../` segment would escape the plugins root and load an arbitrary
+    // `plugin.json` (#10518) — reachable over the CLI control socket. Gate on
+    // the same scoped-name pattern the uninstall path enforces before any
+    // filesystem access.
+    if (!SCOPED_PLUGIN_NAME_PATTERN.test(pluginId)) {
+      throw new Error(`Invalid dev plugin id "${pluginId}" — expected a scoped "publisher.name"`);
+    }
     if (this.plugins.has(pluginId)) {
       this.unloadPlugin(pluginId);
     }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3803,13 +3803,17 @@ export class PluginService {
     if (this.plugins.has(pluginId)) {
       this.unloadPlugin(pluginId);
     }
+    // Honor the user's persisted disabled intent — the dev path must not be a
+    // trust escape hatch that force-loads a plugin the user turned off (#10518).
+    // A disabled id makes `loadPlugin` skip + return null, surfacing the clear
+    // error below to the CLI caller rather than silently activating it.
     const loaded = await this.loadPlugin(this.pluginsRoot, pluginId, {
       isBuiltin: false,
-      disabled: new Set(),
+      disabled: this.records.getDisabledIds(),
     });
     if (!loaded) {
       throw new Error(
-        `Couldn't load dev plugin "${pluginId}" from ${this.pluginsRoot} — check the symlink and that plugin.json is valid`
+        `Couldn't load dev plugin "${pluginId}" from ${this.pluginsRoot} — it may be disabled in Preferences, or the symlink/plugin.json may be invalid`
       );
     }
     await this.activatePlugin(pluginId);

--- a/electron/services/__tests__/PluginCliServer.test.ts
+++ b/electron/services/__tests__/PluginCliServer.test.ts
@@ -259,6 +259,55 @@ describe("createPluginCliServer", () => {
     expect(handlers.install).toHaveBeenCalledWith({ path: "/tmp/ok.dntr" });
   });
 
+  it("does not dispatch a second (valid-token) frame after a first auth failure", async () => {
+    // Proves the connection genuinely can't be probed frame-by-frame: a bad
+    // first frame terminates the connection so a pipelined valid-token frame in
+    // the same burst never reaches a handler.
+    const handlers = noopHandlers();
+    server = makeServer(handlers);
+    await server.listen();
+    const token = server.authToken;
+
+    const frames = await new Promise<Record<string, unknown>[]>((resolve, reject) => {
+      const socket = net.createConnection({ path: socketPath });
+      const received: Record<string, unknown>[] = [];
+      let buffer = "";
+      socket.setEncoding("utf8");
+      socket.on("connect", () => {
+        // Frame 1: no token (rejected). Frame 2: valid token, pipelined in the
+        // same write burst.
+        socket.write(
+          JSON.stringify({ id: 1, method: "plugin.install", params: { path: "/x.dntr" } }) + "\n"
+        );
+        socket.write(JSON.stringify({ token, id: 2, method: "plugin.ping" }) + "\n");
+      });
+      socket.on("data", (chunk: string) => {
+        buffer += chunk;
+        let idx = buffer.indexOf("\n");
+        while (idx >= 0) {
+          received.push(JSON.parse(buffer.slice(0, idx)));
+          buffer = buffer.slice(idx + 1);
+          idx = buffer.indexOf("\n");
+        }
+      });
+      socket.on("close", () => resolve(received));
+      socket.on("error", reject);
+    });
+
+    expect(frames).toHaveLength(1);
+    expect((frames[0].error as { message: string }).message).toMatch(/Unauthorized/);
+    expect(handlers.install).not.toHaveBeenCalled();
+  });
+
+  it("writes the control file owner-only (0600) on POSIX", async () => {
+    if (isWindows) return;
+    server = makeServer();
+    await server.listen();
+    const stat = await fs.stat(controlFilePath);
+    // The file holds the auth token — only the owner may read it.
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
   // ──────────────────────────────────────────────────────────────────────────
 
   it("returns an error frame for malformed JSON", async () => {

--- a/electron/services/__tests__/PluginCliServer.test.ts
+++ b/electron/services/__tests__/PluginCliServer.test.ts
@@ -3,7 +3,11 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
-import { createPluginCliServer, type PluginCliServer } from "../PluginCliServer.js";
+import {
+  createPluginCliServer,
+  type PluginCliServer,
+  type PluginCliServerHandlers,
+} from "../PluginCliServer.js";
 
 // Windows named pipes don't live on disk, so the file-socket lifecycle assertions
 // only make sense on POSIX. The dispatch assertions run everywhere.
@@ -11,6 +15,7 @@ const isWindows = process.platform === "win32";
 
 let tmpDir: string;
 let socketPath: string;
+let controlFilePath: string;
 let server: PluginCliServer | null = null;
 
 beforeEach(async () => {
@@ -18,6 +23,7 @@ beforeEach(async () => {
   socketPath = isWindows
     ? `\\\\.\\pipe\\daintree-cli-test-${process.pid}-${Math.floor(performance.now())}`
     : path.join(tmpDir, "cli.sock");
+  controlFilePath = path.join(tmpDir, "cli-control.json");
 });
 
 afterEach(async () => {
@@ -28,14 +34,40 @@ afterEach(async () => {
   await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
 });
 
-/** Send one NDJSON request and resolve with the parsed response frame. */
-function request(payload: unknown): Promise<Record<string, unknown>> {
+function noopHandlers(): PluginCliServerHandlers {
+  return {
+    install: vi.fn(async () => ({ status: "installed" })),
+    uninstall: vi.fn(async () => {}),
+    devStart: vi.fn(async () => {}),
+    devStop: vi.fn(async () => {}),
+  };
+}
+
+/** Stand up a server bound to the temp socket + temp control file. */
+function makeServer(
+  handlers: PluginCliServerHandlers = noopHandlers(),
+  waitForReady: () => Promise<void> = () => Promise.resolve()
+): PluginCliServer {
+  return createPluginCliServer({ socketPath, controlFilePath, waitForReady, handlers });
+}
+
+/**
+ * Send one NDJSON request and resolve with the parsed response frame. The
+ * per-launch auth token is injected automatically; pass `{ token }` to override
+ * it (use `null` to omit the field entirely) for the auth-gate tests.
+ */
+function request(
+  payload: Record<string, unknown>,
+  opts?: { token?: string | null }
+): Promise<Record<string, unknown>> {
+  const token = opts && "token" in opts ? opts.token : (server?.authToken ?? null);
+  const frame = token === null ? payload : { token, ...payload };
   return new Promise((resolve, reject) => {
     const socket = net.createConnection({ path: socketPath });
     let buffer = "";
     socket.setEncoding("utf8");
     socket.on("connect", () => {
-      socket.write(JSON.stringify(payload) + "\n");
+      socket.write(JSON.stringify(frame) + "\n");
     });
     socket.on("data", (chunk: string) => {
       buffer += chunk;
@@ -54,26 +86,13 @@ function request(payload: unknown): Promise<Record<string, unknown>> {
   });
 }
 
-function noopHandlers() {
-  return {
-    install: vi.fn(async () => ({ status: "installed" })),
-    uninstall: vi.fn(async () => {}),
-    devStart: vi.fn(async () => {}),
-    devStop: vi.fn(async () => {}),
-  };
-}
-
 describe("createPluginCliServer", () => {
   it("does not bind until waitForReady resolves", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => gate,
-      handlers: noopHandlers(),
-    });
+    server = makeServer(noopHandlers(), () => gate);
 
     const listenPromise = server.listen();
     // Give the event loop a tick; the server must not be listening yet.
@@ -81,21 +100,20 @@ describe("createPluginCliServer", () => {
     if (!isWindows) {
       await expect(fs.access(socketPath)).rejects.toBeTruthy();
     }
+    // The control file is only written once the socket is live.
+    await expect(fs.access(controlFilePath)).rejects.toBeTruthy();
 
     release();
     await listenPromise;
     if (!isWindows) {
       await expect(fs.access(socketPath)).resolves.toBeUndefined();
     }
+    await expect(fs.access(controlFilePath)).resolves.toBeUndefined();
   });
 
   it("routes plugin.install to the install handler and returns the result", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({
@@ -110,11 +128,7 @@ describe("createPluginCliServer", () => {
 
   it("routes plugin.uninstall to the uninstall handler", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({
@@ -132,11 +146,7 @@ describe("createPluginCliServer", () => {
 
   it("routes plugin.dev.start to the devStart handler", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({
@@ -151,11 +161,7 @@ describe("createPluginCliServer", () => {
 
   it("routes plugin.dev.stop to the devStop handler", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({
@@ -170,11 +176,7 @@ describe("createPluginCliServer", () => {
 
   it("returns an error frame when a dev call is missing pluginId", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({ id: "d3", method: "plugin.dev.start", params: {} });
@@ -184,11 +186,7 @@ describe("createPluginCliServer", () => {
   });
 
   it("answers plugin.ping for liveness checks", async () => {
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers: noopHandlers(),
-    });
+    server = makeServer();
     await server.listen();
 
     const res = await request({ id: 9, method: "plugin.ping" });
@@ -196,12 +194,75 @@ describe("createPluginCliServer", () => {
     expect((res.result as { status: string }).status).toBe("ok");
   });
 
+  // ── Auth gate (#10518) ────────────────────────────────────────────────────
+
+  it("advertises the socket path and auth token in the control file", async () => {
+    server = makeServer();
+    await server.listen();
+
+    const raw = await fs.readFile(controlFilePath, "utf8");
+    const parsed = JSON.parse(raw) as { socketPath: string; token: string };
+    expect(parsed.socketPath).toBe(socketPath);
+    expect(parsed.token).toBe(server.authToken);
+    expect(server.authToken.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it("rejects a frame with no token and does not dispatch", async () => {
+    const handlers = noopHandlers();
+    server = makeServer(handlers);
+    await server.listen();
+
+    const res = await request(
+      { id: 1, method: "plugin.install", params: { path: "/tmp/foo.dntr" } },
+      { token: null }
+    );
+    expect(res.error).toBeTruthy();
+    expect((res.error as { message: string }).message).toMatch(/Unauthorized/);
+    expect(handlers.install).not.toHaveBeenCalled();
+  });
+
+  it("rejects a frame with the wrong token, even for plugin.ping", async () => {
+    const handlers = noopHandlers();
+    server = makeServer(handlers);
+    await server.listen();
+
+    const res = await request({ id: 2, method: "plugin.ping" }, { token: "not-the-token" });
+    expect(res.error).toBeTruthy();
+    expect((res.error as { message: string }).message).toMatch(/Unauthorized/);
+  });
+
+  it("rejects a token of the wrong length without throwing", async () => {
+    const handlers = noopHandlers();
+    server = makeServer(handlers);
+    await server.listen();
+
+    // A shorter token must not crash the timing-safe comparison.
+    const res = await request(
+      { id: 3, method: "plugin.uninstall", params: { pluginId: "acme.demo" } },
+      { token: "abc" }
+    );
+    expect(res.error).toBeTruthy();
+    expect((res.error as { message: string }).message).toMatch(/Unauthorized/);
+    expect(handlers.uninstall).not.toHaveBeenCalled();
+  });
+
+  it("accepts the correct token and dispatches", async () => {
+    const handlers = noopHandlers();
+    server = makeServer(handlers);
+    await server.listen();
+
+    const res = await request(
+      { id: 4, method: "plugin.install", params: { path: "/tmp/ok.dntr" } },
+      { token: server.authToken }
+    );
+    expect(res.result).toEqual({ status: "installed" });
+    expect(handlers.install).toHaveBeenCalledWith({ path: "/tmp/ok.dntr" });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+
   it("returns an error frame for malformed JSON", async () => {
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers: noopHandlers(),
-    });
+    server = makeServer();
     await server.listen();
 
     const res = await new Promise<Record<string, unknown>>((resolve, reject) => {
@@ -224,11 +285,7 @@ describe("createPluginCliServer", () => {
   });
 
   it("returns an error frame for an unknown method", async () => {
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers: noopHandlers(),
-    });
+    server = makeServer();
     await server.listen();
 
     const res = await request({ id: 2, method: "plugin.bogus" });
@@ -238,11 +295,7 @@ describe("createPluginCliServer", () => {
 
   it("returns an error frame when install params are missing path and url", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({ id: 3, method: "plugin.install", params: {} });
@@ -254,11 +307,7 @@ describe("createPluginCliServer", () => {
 
   it("rejects install params carrying both path and url instead of preferring one", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({
@@ -274,11 +323,7 @@ describe("createPluginCliServer", () => {
 
   it("routes a url-only install to the install handler", async () => {
     const handlers = noopHandlers();
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers,
-    });
+    server = makeServer(handlers);
     await server.listen();
 
     const res = await request({
@@ -291,17 +336,13 @@ describe("createPluginCliServer", () => {
   });
 
   it("surfaces a handler rejection as an error frame", async () => {
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers: {
-        install: vi.fn(async () => {
-          throw new Error("disk on fire");
-        }),
-        uninstall: vi.fn(async () => {}),
-        devStart: vi.fn(async () => {}),
-        devStop: vi.fn(async () => {}),
-      },
+    server = makeServer({
+      install: vi.fn(async () => {
+        throw new Error("disk on fire");
+      }),
+      uninstall: vi.fn(async () => {}),
+      devStart: vi.fn(async () => {}),
+      devStop: vi.fn(async () => {}),
     });
     await server.listen();
 
@@ -314,17 +355,14 @@ describe("createPluginCliServer", () => {
   });
 
   it("handles concurrent requests on one connection, matching ids", async () => {
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers: {
-        install: vi.fn(async () => ({ status: "installed" })),
-        uninstall: vi.fn(async () => {}),
-        devStart: vi.fn(async () => {}),
-        devStop: vi.fn(async () => {}),
-      },
+    server = makeServer({
+      install: vi.fn(async () => ({ status: "installed" })),
+      uninstall: vi.fn(async () => {}),
+      devStart: vi.fn(async () => {}),
+      devStop: vi.fn(async () => {}),
     });
     await server.listen();
+    const token = server.authToken;
 
     const responses = await new Promise<Record<string, unknown>[]>((resolve, reject) => {
       const socket = net.createConnection({ path: socketPath });
@@ -332,9 +370,9 @@ describe("createPluginCliServer", () => {
       let buffer = "";
       socket.setEncoding("utf8");
       socket.on("connect", () => {
-        socket.write(JSON.stringify({ id: 1, method: "plugin.ping" }) + "\n");
-        socket.write(JSON.stringify({ id: 2, method: "plugin.ping" }) + "\n");
-        socket.write(JSON.stringify({ id: 3, method: "plugin.ping" }) + "\n");
+        socket.write(JSON.stringify({ token, id: 1, method: "plugin.ping" }) + "\n");
+        socket.write(JSON.stringify({ token, id: 2, method: "plugin.ping" }) + "\n");
+        socket.write(JSON.stringify({ token, id: 3, method: "plugin.ping" }) + "\n");
       });
       socket.on("data", (chunk: string) => {
         buffer += chunk;
@@ -356,20 +394,18 @@ describe("createPluginCliServer", () => {
     expect(responses.map((r) => r.id).sort()).toEqual([1, 2, 3]);
   });
 
-  it("close() tears down the server and removes the socket file", async () => {
-    server = createPluginCliServer({
-      socketPath,
-      waitForReady: () => Promise.resolve(),
-      handlers: noopHandlers(),
-    });
+  it("close() tears down the server and removes the socket + control file", async () => {
+    server = makeServer();
     await server.listen();
     if (!isWindows) {
       await expect(fs.access(socketPath)).resolves.toBeUndefined();
     }
+    await expect(fs.access(controlFilePath)).resolves.toBeUndefined();
     await server.close();
     server = null;
     if (!isWindows) {
       await expect(fs.access(socketPath)).rejects.toBeTruthy();
     }
+    await expect(fs.access(controlFilePath)).rejects.toBeTruthy();
   });
 });

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -30,6 +30,11 @@ const storeMock = vi.hoisted(() => {
     _state: state,
   };
 });
+// Plugin-MCP consent + rate-limiter singletons are only reached by the
+// installer's uninstall/upgrade purge; stub them so the upgrade-consent-reset
+// test can assert the revoke without standing up the real persistence.
+const consentMock = vi.hoisted(() => ({ revokeAllForPlugin: vi.fn(() => true) }));
+const rateLimiterMock = vi.hoisted(() => ({ dropPlugin: vi.fn() }));
 
 vi.mock("electron", () => ({ app: appMock, ipcMain: { on: vi.fn(), removeListener: vi.fn() } }));
 vi.mock("../../window/windowRef.js", () => ({
@@ -94,6 +99,10 @@ vi.mock("../../utils/fs.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../utils/fs.js")>();
   return { ...actual, resilientRename: vi.fn(actual.resilientRename) };
 });
+vi.mock("../plugin-mcp/instances.js", () => ({
+  getPluginMcpConsentService: () => consentMock,
+  getPluginMcpRateLimiter: () => rateLimiterMock,
+}));
 
 import { PluginService } from "../PluginService.js";
 import { packPluginArchive } from "../PluginArchive.js";
@@ -633,6 +642,90 @@ describe("installPlugin — load + provenance edge cases", () => {
     const afterDir = (storeState.get("plugins") as { installed: Record<string, unknown> })
       .installed["acme.rehash"] as { archiveHash: string | null };
     expect(afterDir.archiveHash).toBeNull();
+
+    service.dispose();
+  });
+});
+
+describe("installPlugin — name collision (#10518)", () => {
+  // The installer's `existing` probe only sees the user plugins root. These tests
+  // reach into the service's launch-time bookkeeping (the same `reservedNames` /
+  // `disabledPlugins` the deps bag exposes) to simulate a built-in or reserved
+  // name that has no user-root directory.
+  type Internals = {
+    reservedNames: Set<string>;
+    disabledPlugins: Map<string, { manifest: unknown; dir: string; isBuiltin: boolean }>;
+  };
+
+  it("rejects installing over a built-in name with name_collision and writes no dir", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    (service as unknown as Internals).disabledPlugins.set("acme.builtin-clash", {
+      manifest: { name: "acme.builtin-clash" },
+      dir: "/builtin/acme.builtin-clash",
+      isBuiltin: true,
+    });
+
+    const archive = await makeArchive({ name: "acme.builtin-clash", version: "1.0.0" });
+    const result = await service.installPlugin(archive);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors[0].code).toBe("name_collision");
+    }
+    expect(await exists(path.join(pluginsRoot, "acme.builtin-clash"))).toBe(false);
+    // No temp/parked debris either — the guard returns before the swap.
+    const entries = await fs.readdir(pluginsRoot).catch(() => [] as string[]);
+    expect(entries.filter((e) => e.startsWith(".install-tmp-"))).toHaveLength(0);
+
+    service.dispose();
+  });
+
+  it("rejects a fresh install whose id is a launch-reserved name", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    (service as unknown as Internals).reservedNames.add("acme.reserved-clash");
+
+    const archive = await makeArchive({ name: "acme.reserved-clash", version: "1.0.0" });
+    const result = await service.installPlugin(archive);
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.errors[0].code).toBe("name_collision");
+    }
+    expect(await exists(path.join(pluginsRoot, "acme.reserved-clash"))).toBe(false);
+
+    service.dispose();
+  });
+
+  it("still allows upgrading a normal user plugin whose dir already exists", async () => {
+    // A reserved name with an EXISTING dir is a legitimate upgrade, not a
+    // collision — the guard only fires on `!existing`.
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.not-a-clash", version: "1.0.0" });
+    expect((await service.installPlugin(v1)).status).toBe("installed");
+
+    const v2 = await makeArchive({ name: "acme.not-a-clash", version: "2.0.0" });
+    expect((await service.installPlugin(v2)).status).toBe("installed");
+
+    service.dispose();
+  });
+});
+
+describe("installPlugin — consent reset on upgrade (#10518)", () => {
+  it("revokes the plugin's consent pins on upgrade but not on a fresh install", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.consent-reset", version: "1.0.0" });
+    expect((await service.installPlugin(v1)).status).toBe("installed");
+    // A fresh install has no prior pins to inherit — nothing to revoke.
+    expect(consentMock.revokeAllForPlugin).not.toHaveBeenCalled();
+
+    consentMock.revokeAllForPlugin.mockClear();
+    const v2 = await makeArchive({ name: "acme.consent-reset", version: "2.0.0" });
+    expect((await service.installPlugin(v2)).status).toBe("installed");
+
+    // Any code change forces a consent re-prompt: the upgrade purges the pins.
+    expect(consentMock.revokeAllForPlugin).toHaveBeenCalledWith("acme.consent-reset");
 
     service.dispose();
   });

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -89,6 +89,7 @@ vi.mock("../PluginMcpSupervisor.js", () => ({
     shutdownAll: vi.fn(async () => undefined),
     callTool: vi.fn(),
     restart: vi.fn(),
+    removeState: vi.fn(),
     list: vi.fn(() => []),
     getStderr: vi.fn(() => ({ pluginId: "", serverId: "", lines: [], totalLines: 0 })),
   }),
@@ -726,6 +727,52 @@ describe("installPlugin — consent reset on upgrade (#10518)", () => {
 
     // Any code change forces a consent re-prompt: the upgrade purges the pins.
     expect(consentMock.revokeAllForPlugin).toHaveBeenCalledWith("acme.consent-reset");
+
+    service.dispose();
+  });
+
+  it("revokes the plugin's consent pins on uninstall", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+
+    const v1 = await makeArchive({ name: "acme.uninstall-consent", version: "1.0.0" });
+    expect((await service.installPlugin(v1)).status).toBe("installed");
+
+    consentMock.revokeAllForPlugin.mockClear();
+    await service.uninstallPlugin("acme.uninstall-consent");
+
+    // Uninstall is the other half of the consent-reset guarantee — a same-name
+    // reinstall must not inherit the removed plugin's approvals.
+    expect(consentMock.revokeAllForPlugin).toHaveBeenCalledWith("acme.uninstall-consent");
+
+    service.dispose();
+  });
+});
+
+describe("loadDevPlugin — trust gates (#10518)", () => {
+  it.each(["../../etc/passwd", "..", "foo/../../bar", "/abs/path", "no-dot-name"])(
+    "rejects a non-scoped / traversal dev plugin id %s before any fs access",
+    async (badId) => {
+      const service = new PluginService(pluginsRoot, "0.0.0");
+      await expect(service.loadDevPlugin(badId)).rejects.toThrow(/Invalid dev plugin id|scoped/);
+      service.dispose();
+    }
+  );
+
+  it("honors the persisted disabled set instead of force-loading", async () => {
+    const service = new PluginService(pluginsRoot, "0.0.0");
+    // A dev plugin present on disk but disabled in Preferences must NOT load —
+    // the old code passed an empty disabled set and would have force-loaded it.
+    const devDir = path.join(pluginsRoot, "acme.dev-honor");
+    await fs.mkdir(devDir, { recursive: true });
+    await fs.writeFile(
+      path.join(devDir, "plugin.json"),
+      JSON.stringify({ name: "acme.dev-honor", version: "1.0.0" })
+    );
+    (
+      service as unknown as { records: { setEnabled(id: string, enabled: boolean): void } }
+    ).records.setEnabled("acme.dev-honor", false);
+
+    await expect(service.loadDevPlugin("acme.dev-honor")).rejects.toThrow(/disabled|Couldn't load/);
 
     service.dispose();
   });

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -34,6 +34,7 @@ const storeMock = vi.hoisted(() => {
 // installer's uninstall/upgrade purge; stub them so the upgrade-consent-reset
 // test can assert the revoke without standing up the real persistence.
 const consentMock = vi.hoisted(() => ({ revokeAllForPlugin: vi.fn(() => true) }));
+const capConsentMock = vi.hoisted(() => ({ revokeAllForPlugin: vi.fn(() => true) }));
 const rateLimiterMock = vi.hoisted(() => ({ dropPlugin: vi.fn() }));
 
 vi.mock("electron", () => ({ app: appMock, ipcMain: { on: vi.fn(), removeListener: vi.fn() } }));
@@ -103,6 +104,9 @@ vi.mock("../../utils/fs.js", async (importOriginal) => {
 vi.mock("../plugin-mcp/instances.js", () => ({
   getPluginMcpConsentService: () => consentMock,
   getPluginMcpRateLimiter: () => rateLimiterMock,
+}));
+vi.mock("../plugin-capability/instances.js", () => ({
+  getPluginCapabilityConsentService: () => capConsentMock,
 }));
 
 import { PluginService } from "../PluginService.js";
@@ -722,11 +726,14 @@ describe("installPlugin — consent reset on upgrade (#10518)", () => {
     expect(consentMock.revokeAllForPlugin).not.toHaveBeenCalled();
 
     consentMock.revokeAllForPlugin.mockClear();
+    capConsentMock.revokeAllForPlugin.mockClear();
     const v2 = await makeArchive({ name: "acme.consent-reset", version: "2.0.0" });
     expect((await service.installPlugin(v2)).status).toBe("installed");
 
-    // Any code change forces a consent re-prompt: the upgrade purges the pins.
+    // Any code change forces a consent re-prompt: the upgrade purges BOTH the MCP
+    // TOFU pins and the JIT host-capability grants.
     expect(consentMock.revokeAllForPlugin).toHaveBeenCalledWith("acme.consent-reset");
+    expect(capConsentMock.revokeAllForPlugin).toHaveBeenCalledWith("acme.consent-reset");
 
     service.dispose();
   });
@@ -738,11 +745,13 @@ describe("installPlugin — consent reset on upgrade (#10518)", () => {
     expect((await service.installPlugin(v1)).status).toBe("installed");
 
     consentMock.revokeAllForPlugin.mockClear();
+    capConsentMock.revokeAllForPlugin.mockClear();
     await service.uninstallPlugin("acme.uninstall-consent");
 
     // Uninstall is the other half of the consent-reset guarantee — a same-name
-    // reinstall must not inherit the removed plugin's approvals.
+    // reinstall must not inherit the removed plugin's MCP or capability approvals.
     expect(consentMock.revokeAllForPlugin).toHaveBeenCalledWith("acme.uninstall-consent");
+    expect(capConsentMock.revokeAllForPlugin).toHaveBeenCalledWith("acme.uninstall-consent");
 
     service.dispose();
   });

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -167,19 +167,21 @@ export class PluginInstaller {
   }
 
   /**
-   * Revoke every TOFU consent pin for a plugin, durably. Shared by the uninstall
-   * flow and the upgrade path: a plugin's MCP consent pins are keyed by
-   * `(pluginId, serverId, toolName)` and survive a same-id reinstall/upgrade, so
-   * any code change must reset them or the new code silently inherits the prior
-   * version's approvals (a consent bypass; #10518).
+   * Revoke a plugin's consent — BOTH the MCP TOFU pins (keyed by
+   * `(pluginId, serverId, toolName)`) and the JIT host-capability grants
+   * (shell:exec / fs:*-write / git:write) — durably. Shared by the uninstall
+   * flow and the upgrade path: both survive a same-id reinstall/upgrade, so any
+   * code change must reset them or the new code silently inherits the prior
+   * version's approvals (a consent bypass; #10518 for MCP, #10524 for caps).
    *
-   * Durable + best-effort: if the in-memory drop succeeds but the persist fails,
-   * the pins rehydrate on the next launch and the bypass returns —
-   * `revokeAllForPlugin` returns whether the snapshot persisted, so retry once on
-   * a transient failure, then surface it loudly rather than swallow it. A failed
-   * purge must NEVER strand the caller (uninstall still deletes the dir; upgrade
-   * still installs): the worst case is a skipped re-prompt the user can revoke
-   * manually from the consent settings. `context` names the caller in the logs.
+   * Durable + best-effort. MCP: `revokeAllForPlugin` returns whether the snapshot
+   * persisted; the `|| ` retry covers a transient first-call failure (the second
+   * call no-ops once the in-memory map is already cleared, so it only re-attempts
+   * the flush). Capability: the store retries the flush internally, so a single
+   * call suffices. A failed purge must NEVER strand the caller (uninstall still
+   * deletes the dir; upgrade still installs) — worst case is a skipped re-prompt
+   * the user can revoke manually. `context` names the caller in the logs. Each
+   * service is purged in its own try/catch so one throwing can't skip the other.
    */
   private _purgeConsentPins(pluginId: string, context: "uninstall" | "upgrade"): void {
     try {
@@ -192,6 +194,19 @@ export class PluginInstaller {
       }
     } catch (err) {
       console.error(`[PluginService] consent purge during ${context} of "${pluginId}" threw:`, err);
+    }
+    try {
+      const capConsent = getPluginCapabilityConsentService();
+      if (!capConsent.revokeAllForPlugin(pluginId)) {
+        console.error(
+          `[PluginService] capability consent purge for "${pluginId}" (${context}) failed to persist after a retry; stale grants may rehydrate on restart — revoke them manually from plugin capability settings`
+        );
+      }
+    } catch (err) {
+      console.error(
+        `[PluginService] capability consent purge during ${context} of "${pluginId}" threw:`,
+        err
+      );
     }
   }
 
@@ -983,33 +998,13 @@ export class PluginInstaller {
         console.error(`[PluginService] MCP shutdown during uninstall of "${pluginId}" threw:`, err);
       }
 
-      // Purge every TOFU consent pin for the plugin unconditionally — pluginIds
-      // are author-controlled, so a reinstall (or rebuild) must re-prompt rather
-      // than inherit prior approvals. Decoupled from `wipeSettings`: stale pins
-      // are a consent-bypass risk even when secrets are kept. Shared with the
-      // upgrade path so both close the same consent-inheritance gap (#10518).
+      // Purge all consent — MCP TOFU pins AND JIT host-capability grants —
+      // unconditionally: pluginIds are author-controlled, so a reinstall (or
+      // rebuild) must re-prompt rather than inherit prior approvals. Decoupled
+      // from `wipeSettings`: stale consent is a bypass risk even when secrets are
+      // kept. Shared with the upgrade path so both close the same gap (#10518 MCP,
+      // #10524 capabilities).
       this._purgeConsentPins(pluginId, "uninstall");
-
-      // Purge JIT host-capability grants for the same reason — a same-name
-      // reinstall must re-prompt on first use of shell:exec / fs:*-write /
-      // git:write rather than inherit a prior grant (#10524). Durable by
-      // contract: revokeAllForPlugin retries the flush internally, so a single
-      // call already covers a transient persist failure (a caller-side
-      // `x() || x()` retry would no-op the second call).
-      try {
-        const capConsent = getPluginCapabilityConsentService();
-        const purged = capConsent.revokeAllForPlugin(pluginId);
-        if (!purged) {
-          console.error(
-            `[PluginService] capability consent purge for "${pluginId}" failed to persist after a retry; stale grants may rehydrate on restart — revoke them manually from plugin capability settings`
-          );
-        }
-      } catch (err) {
-        console.error(
-          `[PluginService] capability consent purge during uninstall of "${pluginId}" threw:`,
-          err
-        );
-      }
 
       // Drop the plugin's rate-limit buckets so a same-name reinstall starts
       // with a full burst budget instead of inheriting throttle debt.

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -167,6 +167,35 @@ export class PluginInstaller {
   }
 
   /**
+   * Revoke every TOFU consent pin for a plugin, durably. Shared by the uninstall
+   * flow and the upgrade path: a plugin's MCP consent pins are keyed by
+   * `(pluginId, serverId, toolName)` and survive a same-id reinstall/upgrade, so
+   * any code change must reset them or the new code silently inherits the prior
+   * version's approvals (a consent bypass; #10518).
+   *
+   * Durable + best-effort: if the in-memory drop succeeds but the persist fails,
+   * the pins rehydrate on the next launch and the bypass returns —
+   * `revokeAllForPlugin` returns whether the snapshot persisted, so retry once on
+   * a transient failure, then surface it loudly rather than swallow it. A failed
+   * purge must NEVER strand the caller (uninstall still deletes the dir; upgrade
+   * still installs): the worst case is a skipped re-prompt the user can revoke
+   * manually from the consent settings. `context` names the caller in the logs.
+   */
+  private _purgeConsentPins(pluginId: string, context: "uninstall" | "upgrade"): void {
+    try {
+      const consent = getPluginMcpConsentService();
+      const purged = consent.revokeAllForPlugin(pluginId) || consent.revokeAllForPlugin(pluginId);
+      if (!purged) {
+        console.error(
+          `[PluginService] consent purge for "${pluginId}" (${context}) failed to persist after a retry; stale TOFU pins may rehydrate on restart — revoke them manually from plugin-MCP consent settings`
+        );
+      }
+    } catch (err) {
+      console.error(`[PluginService] consent purge during ${context} of "${pluginId}" threw:`, err);
+    }
+  }
+
+  /**
    * Atomically install a plugin from a `.dntr` archive path or a pre-extracted
    * directory. This is the ONLY path that mutates {@link PluginInstallerDeps.getPluginsRoot}
    * — direct IPC writes to the plugins directory are a review blocker (#9292).
@@ -323,6 +352,28 @@ export class PluginInstaller {
         existing = false;
       }
 
+      // Reject a name collision BEFORE the swap (#10518). The `existing` probe
+      // only sees the user plugins root, so without this a `.dntr` whose id
+      // matches a built-in (never in the user root) or a launch-reserved name
+      // whose dir was removed would be swapped in, then rejected at load — and
+      // on a fresh install the rollback leaves a broken dir behind, a permanent
+      // collision on every future scan. A built-in can never be replaced; a
+      // reserved name with no on-disk dir (`!existing`) isn't ours to claim.
+      // Returning here (before the swap) leaves nothing on disk — the temp dir
+      // is reaped by the `finally`.
+      if (this.deps.getPlugin(pluginId)?.isBuiltin) {
+        return fail(
+          "name_collision",
+          `"${pluginId}" is a built-in plugin and can't be replaced by an installed one`
+        );
+      }
+      if (!existing && this.deps.reservedNames.has(pluginId)) {
+        return fail(
+          "name_collision",
+          `"${pluginId}" conflicts with a reserved plugin name and can't be installed`
+        );
+      }
+
       // Abort before the irreversible swap if the lock was compromised — a
       // second instance may now hold it and racing the rename would corrupt
       // the directory. Nothing has been written to the final location yet.
@@ -367,6 +418,20 @@ export class PluginInstaller {
       // The temp dir was renamed into place — drop the handle so the `finally`
       // cleanup doesn't delete the freshly installed plugin.
       tmpDir = null;
+
+      // An upgrade replaces the plugin's code under the SAME id, but its TOFU
+      // consent pins are keyed by `(pluginId, serverId, toolName)` — stable
+      // across the swap. Without a purge a compromised "latest" archive inherits
+      // the prior version's MCP approvals (a consent bypass; #10518). Treat any
+      // code change as a trust reset: revoke unconditionally on every upgrade so
+      // the new code must re-prompt, mirroring the uninstall purge. Done after
+      // the swap (the new code is now on disk) and before it loads/activates, so
+      // it can't use a stale pin. Best-effort + durable: a failed persist is
+      // logged loudly but never strands the install (worst case is a skipped
+      // re-prompt the user can revoke manually).
+      if (existing) {
+        this._purgeConsentPins(pluginId, "upgrade");
+      }
 
       // 5. Persist provenance and load the new plugin. On an upgrade over an
       // existing install (the swap path) preserve the original `installedAt`
@@ -691,9 +756,9 @@ export class PluginInstaller {
       // Follow redirects manually so every hop's host is revalidated through the
       // private/loopback guard — the original-host check above is bypassable by
       // a public URL that 30x-redirects to loopback/link-local/RFC1918 (SSRF).
-      // A literal-host guard only; a DNS-rebinding TOCTOU (a public hostname
-      // resolving to a private address at connect time) remains, matching the
-      // residual on the install path and the manifest allowedUrls validator.
+      // The guard also re-resolves each hop's DNS and rejects a private resolved
+      // IP, closing the DNS-rebinding TOCTOU (#10518); a sub-ms residual remains
+      // because net.fetch re-resolves independently (see pluginDownloadPolicy).
       let response: Awaited<ReturnType<typeof net.fetch>>;
       try {
         const guarded = await fetchWithPrivateHostGuard(net.fetch, url, {
@@ -703,8 +768,8 @@ export class PluginInstaller {
           return {
             status: "fetch-failed",
             message:
-              guarded.reason === "private-redirect"
-                ? "Refusing to follow a redirect to a private or loopback address"
+              guarded.reason === "private-redirect" || guarded.reason === "private-host"
+                ? "Refusing to fetch an update from a private or loopback address"
                 : "The update URL followed too many redirects",
           };
         }
@@ -919,32 +984,9 @@ export class PluginInstaller {
       // Purge every TOFU consent pin for the plugin unconditionally — pluginIds
       // are author-controlled, so a reinstall (or rebuild) must re-prompt rather
       // than inherit prior approvals. Decoupled from `wipeSettings`: stale pins
-      // are a consent-bypass risk even when secrets are kept.
-      //
-      // The purge must be DURABLE: if the in-memory drop succeeds but the
-      // persist fails, the stale pins rehydrate on the next launch and a
-      // same-name reinstall silently inherits prior consent (a consent bypass).
-      // `revokeAllForPlugin` returns whether the snapshot persisted; retry once
-      // on a transient failure, then surface it loudly rather than swallowing —
-      // a silent failure is the exact bug we're guarding against. A failed purge
-      // must NOT strand the uninstall: the on-disk deletion below still runs, so
-      // the plugin's code is gone even if its consent pins outlive it (the worst
-      // case is a re-prompt that was skipped, which the user can revoke manually
-      // from the consent settings).
-      try {
-        const consent = getPluginMcpConsentService();
-        const purged = consent.revokeAllForPlugin(pluginId) || consent.revokeAllForPlugin(pluginId);
-        if (!purged) {
-          console.error(
-            `[PluginService] consent purge for "${pluginId}" failed to persist after a retry; stale TOFU pins may rehydrate on restart — revoke them manually from plugin-MCP consent settings`
-          );
-        }
-      } catch (err) {
-        console.error(
-          `[PluginService] consent purge during uninstall of "${pluginId}" threw:`,
-          err
-        );
-      }
+      // are a consent-bypass risk even when secrets are kept. Shared with the
+      // upgrade path so both close the same consent-inheritance gap (#10518).
+      this._purgeConsentPins(pluginId, "uninstall");
 
       // Purge JIT host-capability grants for the same reason — a same-name
       // reinstall must re-prompt on first use of shell:exec / fs:*-write /

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -770,7 +770,9 @@ export class PluginInstaller {
             message:
               guarded.reason === "private-redirect" || guarded.reason === "private-host"
                 ? "Refusing to fetch an update from a private or loopback address"
-                : "The update URL followed too many redirects",
+                : guarded.reason === "insecure-protocol"
+                  ? "Refusing to fetch an update over an insecure (non-https) URL"
+                  : "The update URL followed too many redirects",
           };
         }
         response = guarded.response as Awaited<ReturnType<typeof net.fetch>>;

--- a/electron/utils/__tests__/pluginDownloadPolicy.test.ts
+++ b/electron/utils/__tests__/pluginDownloadPolicy.test.ts
@@ -175,6 +175,64 @@ describe("fetchWithPrivateHostGuard — DNS-rebinding guard", () => {
     expect(netFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects a redirect to a private literal host with private-redirect (not private-host)", async () => {
+    // The Location host is a private IP literal — caught by the literal-host
+    // guard, a distinct branch from the DNS-rebinding one.
+    resolveAllTo("93.184.216.34");
+    const netFetch = vi.fn(async () => resp(302, "https://192.168.1.1/p.dntr"));
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://first.example/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: false, reason: "private-redirect" });
+    // Only the first (public) hop was fetched; the private Location is never dialed.
+    expect(netFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an https→http downgrade redirect with insecure-protocol", async () => {
+    resolveAllTo("93.184.216.34");
+    // A redirect to a PUBLIC http host (not private) — the integrity downgrade,
+    // not an SSRF — must still be refused.
+    const netFetch = vi.fn(async () => resp(302, "http://cdn.example.com/p.dntr"));
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://cdn.example.com/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: false, reason: "insecure-protocol" });
+    expect(netFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a chain at the redirect cap but rejects one hop beyond it", async () => {
+    resolveAllTo("93.184.216.34");
+
+    // Exactly MAX_REDIRECT_HOPS (5) redirects then a 200 → allowed.
+    let n = 0;
+    const atCap = vi.fn(async () =>
+      n++ < 5 ? resp(302, `https://hop${n}.example/p.dntr`) : resp(200)
+    );
+    const okResult = await fetchWithPrivateHostGuard(
+      atCap as never,
+      "https://start.example/p.dntr",
+      {}
+    );
+    expect(okResult).toEqual({ ok: true, response: expect.objectContaining({ status: 200 }) });
+
+    // One redirect past the cap → too-many-redirects.
+    const overCap = vi.fn(async () => resp(302, "https://loop.example/p.dntr"));
+    const overResult = await fetchWithPrivateHostGuard(
+      overCap as never,
+      "https://start.example/p.dntr",
+      {}
+    );
+    expect(overResult).toEqual({ ok: false, reason: "too-many-redirects" });
+  });
+
   it("treats DNS resolution failure as non-private and lets the fetch proceed", async () => {
     mockLookup.mockImplementation(async () => {
       throw new Error("ENOTFOUND");

--- a/electron/utils/__tests__/pluginDownloadPolicy.test.ts
+++ b/electron/utils/__tests__/pluginDownloadPolicy.test.ts
@@ -1,10 +1,39 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the DNS resolver so the rebinding tests are deterministic and offline.
+// The module under test calls `dns.lookup(host, { all: true })` via the default
+// import, so the mock's default must expose `lookup`.
+vi.mock("node:dns/promises", () => {
+  const lookup = vi.fn();
+  return { default: { lookup }, lookup };
+});
+
+import dns from "node:dns/promises";
 import {
   PLUGIN_DOWNLOAD_TIMEOUT_MS,
   MAX_DNTR_BYTES,
   acceptedMime,
   dntrSuffixOk,
+  fetchWithPrivateHostGuard,
 } from "../pluginDownloadPolicy.js";
+
+const mockLookup = dns.lookup as unknown as ReturnType<typeof vi.fn>;
+
+/** Minimal Response stand-in covering the fields the guard reads. */
+function resp(status: number, location?: string): Response {
+  return {
+    status,
+    headers: {
+      get: (k: string) => (k.toLowerCase() === "location" ? (location ?? null) : null),
+    },
+    body: { cancel: async () => {} },
+  } as unknown as Response;
+}
+
+/** Make `dns.lookup` resolve every hostname to the given addresses. */
+function resolveAllTo(...addresses: string[]) {
+  mockLookup.mockImplementation(async () => addresses.map((address) => ({ address, family: 4 })));
+}
 
 describe("pluginDownloadPolicy", () => {
   it("shares one 30s timeout across both download paths", () => {
@@ -47,4 +76,119 @@ describe("pluginDownloadPolicy", () => {
       expect(dntrSuffixOk(pathname)).toBe(false);
     }
   );
+});
+
+describe("fetchWithPrivateHostGuard — DNS-rebinding guard", () => {
+  beforeEach(() => {
+    mockLookup.mockReset();
+  });
+
+  it("rejects a public hostname that resolves to IPv4 loopback before fetching", async () => {
+    resolveAllTo("127.0.0.1");
+    const netFetch = vi.fn(async () => resp(200));
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://rebind.example.com/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: false, reason: "private-host" });
+    expect(netFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a hostname resolving to a cloud-metadata link-local address", async () => {
+    resolveAllTo("169.254.169.254");
+    const netFetch = vi.fn(async () => resp(200));
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://metadata.example/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: false, reason: "private-host" });
+    expect(netFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects when ANY of multiple resolved addresses is private (split-horizon)", async () => {
+    // A public answer paired with a private one must not slip through.
+    resolveAllTo("93.184.216.34", "10.0.0.5");
+    const netFetch = vi.fn(async () => resp(200));
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://split.example/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: false, reason: "private-host" });
+    expect(netFetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects an IPv6 loopback resolution", async () => {
+    resolveAllTo("::1");
+    const netFetch = vi.fn(async () => resp(200));
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://v6.example/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: false, reason: "private-host" });
+  });
+
+  it("allows a hostname that resolves to a public address", async () => {
+    resolveAllTo("93.184.216.34");
+    const ok = resp(200);
+    const netFetch = vi.fn(async () => ok);
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://example.com/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: true, response: ok });
+    expect(netFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("catches a redirect hop whose hostname resolves to a private address", async () => {
+    // First host is public; it 302s to a second host that resolves to RFC1918.
+    mockLookup.mockImplementation(async (host: string) =>
+      host === "first.example"
+        ? [{ address: "93.184.216.34", family: 4 }]
+        : [{ address: "10.1.2.3", family: 4 }]
+    );
+    const netFetch = vi.fn(async () => resp(302, "https://second.example/p.dntr"));
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://first.example/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: false, reason: "private-host" });
+    // Only the first hop was fetched; the rebinding second hop was blocked at
+    // the DNS pre-check before its fetch.
+    expect(netFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats DNS resolution failure as non-private and lets the fetch proceed", async () => {
+    mockLookup.mockImplementation(async () => {
+      throw new Error("ENOTFOUND");
+    });
+    const ok = resp(200);
+    const netFetch = vi.fn(async () => ok);
+
+    const result = await fetchWithPrivateHostGuard(
+      netFetch as never,
+      "https://unresolvable.example/p.dntr",
+      {}
+    );
+
+    expect(result).toEqual({ ok: true, response: ok });
+    expect(netFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/electron/utils/pluginDownloadPolicy.ts
+++ b/electron/utils/pluginDownloadPolicy.ts
@@ -61,10 +61,15 @@ export function urlHasCredentials(parsed: URL): boolean {
  * link-local host and the chain was abandoned before the body was read.
  * `private-host` means a hop's hostname *resolved via DNS* to a private/
  * loopback/link-local IP (the DNS-rebinding case the literal-host check misses).
+ * `insecure-protocol` means a hop wasn't `https:` — e.g. a redirect that
+ * downgrades `https→http`, which would deliver the archive over cleartext.
  */
 export type GuardedFetchResult =
   | { ok: true; response: Response }
-  | { ok: false; reason: "private-redirect" | "private-host" | "too-many-redirects" };
+  | {
+      ok: false;
+      reason: "private-redirect" | "private-host" | "insecure-protocol" | "too-many-redirects";
+    };
 
 /** Spec-aligned cap (RFC 7231 recommends a limit; browsers default to ~20). */
 const MAX_REDIRECT_HOPS = 5;
@@ -123,18 +128,24 @@ export async function fetchWithPrivateHostGuard(
 ): Promise<GuardedFetchResult> {
   let currentUrl = url;
   for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
-    // Re-validate the RESOLVED IP before connecting, not just the literal host:
-    // a public hostname can answer with a private/loopback address at connect
-    // time (DNS rebinding). The literal-host guard below catches a private
-    // `Location`; this catches a private *resolution* of the current hop.
-    let currentHost = "";
+    // Parse the current hop once to enforce two invariants before connecting:
+    // (1) it must stay https — a redirect that downgrades to http would deliver
+    // the archive over cleartext (MITM-substitutable); (2) re-validate the
+    // RESOLVED IP, not just the literal host, since a public hostname can answer
+    // with a private/loopback address at connect time (DNS rebinding). The
+    // literal-host guard below catches a private `Location`; this catches a
+    // private *resolution* of the current hop.
+    let parsedHop: URL | null = null;
     try {
-      currentHost = new URL(currentUrl).hostname;
+      parsedHop = new URL(currentUrl);
     } catch {
       // `currentUrl` is the caller's input or a parsed `Location`; an
-      // unparseable value is defensive-only and just skips the DNS pre-check.
+      // unparseable value is defensive-only and just skips these pre-checks.
     }
-    if (currentHost && (await resolvesToPrivateAddress(currentHost))) {
+    if (parsedHop && parsedHop.protocol !== "https:") {
+      return { ok: false, reason: "insecure-protocol" };
+    }
+    if (parsedHop && (await resolvesToPrivateAddress(parsedHop.hostname))) {
       return { ok: false, reason: "private-host" };
     }
     const response = await netFetch(currentUrl, { ...init, redirect: "manual" });

--- a/electron/utils/pluginDownloadPolicy.ts
+++ b/electron/utils/pluginDownloadPolicy.ts
@@ -1,3 +1,4 @@
+import dns from "node:dns/promises";
 import type { net as ElectronNet } from "electron";
 import { MAX_DNTR_BYTES } from "./pluginArchiveConstants.js";
 import { isPrivateOrLoopbackHostname } from "../schemas/plugin.js";
@@ -58,13 +59,43 @@ export function urlHasCredentials(parsed: URL): boolean {
  * or a structured rejection reason the caller maps to its own error vocabulary.
  * `private-redirect` means a hop's `Location` resolved to a private/loopback/
  * link-local host and the chain was abandoned before the body was read.
+ * `private-host` means a hop's hostname *resolved via DNS* to a private/
+ * loopback/link-local IP (the DNS-rebinding case the literal-host check misses).
  */
 export type GuardedFetchResult =
   | { ok: true; response: Response }
-  | { ok: false; reason: "private-redirect" | "too-many-redirects" };
+  | { ok: false; reason: "private-redirect" | "private-host" | "too-many-redirects" };
 
 /** Spec-aligned cap (RFC 7231 recommends a limit; browsers default to ~20). */
 const MAX_REDIRECT_HOPS = 5;
+
+/**
+ * Resolve `hostname` and report whether ANY answer is a private/loopback/
+ * link-local IP. Closes the DNS-rebinding TOCTOU the literal-host guard can't
+ * see: a public name that answers with `127.0.0.1` / `169.254.169.254` (cloud
+ * metadata) / RFC1918 at connect time would otherwise stream straight into the
+ * archive parser. `all: true` returns every A/AAAA record, so a split-horizon
+ * answer can't sneak one private address past a public one.
+ *
+ * Resolution *failure* is not a private-host signal — return false and let
+ * `net.fetch` surface the real network error in the caller's vocabulary.
+ *
+ * A hairline TOCTOU remains: `net.fetch` re-resolves DNS independently, so a
+ * TTL-0 record flipped between this lookup and the connect could still differ.
+ * Pinning the resolved IP into the connection is the only way to fully close it,
+ * which Electron's net stack doesn't expose without a custom resolver; this
+ * check shrinks the window to that sub-millisecond race for the local-attacker
+ * threat model the SSRF guard targets.
+ */
+async function resolvesToPrivateAddress(hostname: string): Promise<boolean> {
+  let records: Array<{ address: string }>;
+  try {
+    records = await dns.lookup(hostname, { all: true });
+  } catch {
+    return false;
+  }
+  return records.some((r) => isPrivateOrLoopbackHostname(r.address));
+}
 
 /**
  * `net.fetch` with manual redirect following so EVERY hop's host is revalidated
@@ -73,11 +104,13 @@ const MAX_REDIRECT_HOPS = 5;
  * (SSRF). Following manually lets us reject a private `Location` before the body
  * is ever read.
  *
- * This is a literal-host guard only — a DNS-rebinding TOCTOU remains (a public
- * hostname that resolves to a private address at connect time is not caught
- * here, since `net.fetch` resolves DNS internally). That residual is the same
- * gap documented on the manifest `allowedUrls` validator and is out of scope
- * for download-time validation; full mitigation needs a custom resolver.
+ * Beyond the literal-host check, every hop's hostname is resolved via DNS and
+ * the resolved IP is re-validated through {@link resolvesToPrivateAddress} —
+ * closing the DNS-rebinding TOCTOU where a public hostname answers with a
+ * private/loopback/link-local address at connect time (cloud-metadata SSRF).
+ * A sub-millisecond residual remains because `net.fetch` re-resolves DNS itself;
+ * see {@link resolvesToPrivateAddress} for why full closure needs a custom
+ * resolver Electron's net stack doesn't expose.
  *
  * The caller still owns the timeout/size signal — it's threaded through every
  * hop via `init.signal`. Non-redirect responses (including the final 2xx and
@@ -90,6 +123,20 @@ export async function fetchWithPrivateHostGuard(
 ): Promise<GuardedFetchResult> {
   let currentUrl = url;
   for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    // Re-validate the RESOLVED IP before connecting, not just the literal host:
+    // a public hostname can answer with a private/loopback address at connect
+    // time (DNS rebinding). The literal-host guard below catches a private
+    // `Location`; this catches a private *resolution* of the current hop.
+    let currentHost = "";
+    try {
+      currentHost = new URL(currentUrl).hostname;
+    } catch {
+      // `currentUrl` is the caller's input or a parsed `Location`; an
+      // unparseable value is defensive-only and just skips the DNS pre-check.
+    }
+    if (currentHost && (await resolvesToPrivateAddress(currentHost))) {
+      return { ok: false, reason: "private-host" };
+    }
     const response = await netFetch(currentUrl, { ...init, redirect: "manual" });
     // Electron surfaces a manual-mode redirect as an opaqueredirect/3xx with a
     // populated Location header; a normal response has no Location to follow.

--- a/packages/daintree-plugin/src/__tests__/install.test.ts
+++ b/packages/daintree-plugin/src/__tests__/install.test.ts
@@ -19,10 +19,15 @@ beforeEach(async () => {
       ? `\\\\.\\pipe\\daintree-install-test-${process.pid}-${randomUUID()}`
       : path.join(tmpDir, "cli.sock");
   process.env.DAINTREE_CLI_SOCKET = socketPath;
+  // Point control-file discovery at a path that never exists so the client
+  // can't accidentally read a real `~/.daintree/cli-control.json` on a dev box
+  // — the socket override drives the connection in these tests.
+  process.env.DAINTREE_CLI_CONTROL_FILE = path.join(tmpDir, "cli-control.json");
 });
 
 afterEach(async () => {
   delete process.env.DAINTREE_CLI_SOCKET;
+  delete process.env.DAINTREE_CLI_CONTROL_FILE;
   if (server) {
     await new Promise<void>((resolve) => server!.close(() => resolve()));
     server = null;

--- a/packages/daintree-plugin/src/ipc/client.ts
+++ b/packages/daintree-plugin/src/ipc/client.ts
@@ -1,7 +1,28 @@
 import net from "node:net";
-import { getCliSocketPath } from "../lib/socketPath.js";
+import { getCliSocketPath, readCliControlFile } from "../lib/socketPath.js";
 
 const REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolve where to connect and which auth token to present (#10518). The host
+ * advertises both in its control-discovery file on startup; the CLI reads it so
+ * it can authenticate and (on Windows) find the per-launch randomized pipe name.
+ * An explicit `DAINTREE_CLI_SOCKET` override still wins for the path — the token
+ * is still pulled from the control file when one exists. With no control file
+ * the host isn't running; fall back to the default path so the connect surfaces
+ * a clean "not running" error naming it.
+ */
+async function resolveEndpoint(): Promise<{ socketPath: string; token?: string }> {
+  const override = process.env.DAINTREE_CLI_SOCKET;
+  const control = await readCliControlFile();
+  if (override && override.length > 0) {
+    return { socketPath: override, token: control?.token };
+  }
+  if (control) {
+    return { socketPath: control.socketPath, token: control.token };
+  }
+  return { socketPath: getCliSocketPath() };
+}
 
 /**
  * Daintree isn't reachable on the control socket. `ENOENT` means no instance is
@@ -30,8 +51,8 @@ interface CliResponse {
  * `result` (or reject with the `error.message`). Connection-level failures map
  * to {@link DaintreeUnavailableError} with a human-facing message.
  */
-export function sendCliRequest(method: string, params?: unknown): Promise<unknown> {
-  const socketPath = getCliSocketPath();
+export async function sendCliRequest(method: string, params?: unknown): Promise<unknown> {
+  const { socketPath, token } = await resolveEndpoint();
   return new Promise((resolve, reject) => {
     const socket = net.createConnection({ path: socketPath });
     let buffer = "";
@@ -52,7 +73,7 @@ export function sendCliRequest(method: string, params?: unknown): Promise<unknow
     socket.setEncoding("utf8");
 
     socket.on("connect", () => {
-      socket.write(JSON.stringify({ id: 1, method, params }) + "\n");
+      socket.write(JSON.stringify({ id: 1, method, params, token }) + "\n");
     });
 
     socket.on("data", (chunk: string) => {

--- a/packages/daintree-plugin/src/lib/socketPath.ts
+++ b/packages/daintree-plugin/src/lib/socketPath.ts
@@ -3,4 +3,9 @@
 // single source of truth instead of two byte-for-byte copies. The shared module
 // is pure node, so tsup bundles it into the standalone CLI without pulling in
 // electron.
-export { getCliSocketPath } from "../../../../shared/utils/cliSocketPath.js";
+export {
+  getCliSocketPath,
+  getCliControlFilePath,
+  readCliControlFile,
+  type CliControlInfo,
+} from "../../../../shared/utils/cliSocketPath.js";

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -625,6 +625,7 @@ export interface InstalledPluginRecord {
  * - `manifest_invalid` — `plugin.json` failed the strict Zod schema
  * - `engine_incompatible` — `engines.daintree` range doesn't satisfy the running version
  * - `namespace_unauthorized` — reserved `daintree.*` name or publisher/name disagreement
+ * - `name_collision` — the id matches a built-in or a launch-reserved plugin name; rejected before the swap so no broken dir is left
  * - `hash_failed` — couldn't compute the archive SHA-256
  * - `unload_failed` — the existing plugin's disposer cascade threw
  * - `swap_failed` — atomic rename failed but the prior state was restored
@@ -644,6 +645,7 @@ export type PluginInstallErrorCode =
   | "manifest_invalid"
   | "engine_incompatible"
   | "namespace_unauthorized"
+  | "name_collision"
   | "hash_failed"
   | "unload_failed"
   | "swap_failed"

--- a/shared/utils/cliSocketPath.ts
+++ b/shared/utils/cliSocketPath.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import fs from "node:fs/promises";
 
 /**
  * Single source of truth for the local control-socket path that lets the
@@ -21,4 +22,77 @@ export function getCliSocketPath(): string {
     return "\\\\.\\pipe\\daintree-cli";
   }
   return path.join(os.homedir(), ".daintree", "cli.sock");
+}
+
+/**
+ * Path to the control-discovery file the host writes on startup and the CLI
+ * reads to learn (a) which socket/pipe to connect to and (b) the per-launch auth
+ * token to present (#10518). Lives in the same `~/.daintree` directory the host
+ * locks to `0700`, so on Unix it inherits that owner-only protection; on Windows
+ * the user-profile NTFS ACL keeps other users out. Its absence is the canonical
+ * "no Daintree instance is running" signal. `DAINTREE_CLI_CONTROL_FILE` overrides
+ * it (used by tests to point at a temp file).
+ */
+export function getCliControlFilePath(): string {
+  const override = process.env.DAINTREE_CLI_CONTROL_FILE;
+  if (override && override.length > 0) {
+    return override;
+  }
+  return path.join(os.homedir(), ".daintree", "cli-control.json");
+}
+
+/**
+ * What the host advertises to the CLI: the bound socket/pipe path plus the
+ * per-launch auth token the CLI must echo on every request frame. The token is
+ * the actual peer-authentication gate — a same-user 0700 dir protects it on
+ * Unix, and on Windows it makes the broad default named-pipe ACL unexploitable
+ * (a process that can connect still can't read the token).
+ */
+export interface CliControlInfo {
+  socketPath: string;
+  token: string;
+}
+
+/**
+ * Persist the control-discovery file, owner-only. Creates `~/.daintree` at
+ * `0700` if missing and writes the file at `0600`, re-asserting the mode on Unix
+ * in case it pre-existed with looser bits (a crashed prior run). No-op-safe to
+ * call on every `listen()`.
+ */
+export async function writeCliControlFile(filePath: string, info: CliControlInfo): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  await fs.writeFile(filePath, JSON.stringify(info), { mode: 0o600 });
+  if (process.platform !== "win32") {
+    await fs.chmod(filePath, 0o600).catch(() => {});
+  }
+}
+
+/** Best-effort removal of the control-discovery file on host shutdown. */
+export async function removeCliControlFile(filePath: string): Promise<void> {
+  await fs.rm(filePath, { force: true }).catch(() => {});
+}
+
+/**
+ * Read + validate the control-discovery file. Returns `null` when it's absent
+ * (no instance running) or malformed, so the CLI maps either to a clean
+ * "Daintree isn't running" error rather than throwing a parse error.
+ */
+export async function readCliControlFile(
+  filePath: string = getCliControlFilePath()
+): Promise<CliControlInfo | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<CliControlInfo>;
+    if (typeof parsed.socketPath === "string" && typeof parsed.token === "string") {
+      return { socketPath: parsed.socketPath, token: parsed.token };
+    }
+  } catch {
+    // fall through
+  }
+  return null;
 }

--- a/shared/utils/cliSocketPath.ts
+++ b/shared/utils/cliSocketPath.ts
@@ -1,6 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import fs from "node:fs/promises";
+import crypto from "node:crypto";
 
 /**
  * Single source of truth for the local control-socket path that lets the
@@ -54,22 +55,35 @@ export interface CliControlInfo {
 }
 
 /**
- * Persist the control-discovery file, owner-only. Creates `~/.daintree` at
- * `0700` if missing and writes the file at `0600`, re-asserting the mode on Unix
- * in case it pre-existed with looser bits (a crashed prior run). No-op-safe to
- * call on every `listen()`.
+ * Persist the control-discovery file, owner-only and atomically. Creates
+ * `~/.daintree` at `0700` if missing, writes to a unique sibling temp file at
+ * `0600`, then renames it into place — so a CLI racing the write never reads a
+ * truncated/partial JSON file (it sees either the old complete file or the new
+ * one). The mode is re-asserted on Unix before the rename in case a permissive
+ * umask widened the create bits. No-op-safe to call on every `listen()`.
  */
 export async function writeCliControlFile(filePath: string, info: CliControlInfo): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
-  await fs.writeFile(filePath, JSON.stringify(info), { mode: 0o600 });
+  const tmp = `${filePath}.tmp-${crypto.randomBytes(6).toString("hex")}`;
+  await fs.writeFile(tmp, JSON.stringify(info), { mode: 0o600 });
   if (process.platform !== "win32") {
-    await fs.chmod(filePath, 0o600).catch(() => {});
+    await fs.chmod(tmp, 0o600).catch(() => {});
   }
+  await fs.rename(tmp, filePath);
 }
 
-/** Best-effort removal of the control-discovery file on host shutdown. */
-export async function removeCliControlFile(filePath: string): Promise<void> {
-  await fs.rm(filePath, { force: true }).catch(() => {});
+/**
+ * Remove the control-discovery file on host shutdown, but ONLY if it still
+ * belongs to this instance (its token matches). With multiple app instances the
+ * last `listen()` wins the file; a different instance tearing down must not
+ * delete the live file a still-running peer advertised. A no-token/absent file
+ * is left untouched. Best-effort — a failed read or unlink never blocks close.
+ */
+export async function removeCliControlFile(filePath: string, token: string): Promise<void> {
+  const current = await readCliControlFile(filePath);
+  if (current && current.token === token) {
+    await fs.rm(filePath, { force: true }).catch(() => {});
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Five security gaps in the plugin install, update, and CLI socket paths are closed — CLI socket authentication, DNS-rebinding TOCTOU, reserved-name collision handling, consent revocation on update, and dev-load trust bypass.
- Any plugin code change (archive hash diff on update) now forces a full consent re-prompt rather than inheriting prior TOFU pins.
- `loadDevPlugin` no longer bypasses the persisted disabled set, and the CLI socket requires a per-launch auth token before accepting any commands.

Resolves #10518

## Changes

- **CLI socket auth:** `PluginCliServer` now generates a per-launch token written to an owner-only `control-discovery` file; every connection must present it via `timingSafeEqual` before commands are accepted. Windows pipe name is randomized and gets a restrictive SDDL to replace the missing `chmod` hardening. Auth state tears down cleanly per-connection.
- **DNS-rebinding TOCTOU:** `pluginDownloadPolicy` re-validates the resolved IP on every redirect hop using a custom resolver, and blocks `https` → `http` downgrades. The resolved address is pinned for the lifetime of the request so DNS rebinding between check and connect is closed.
- **Reserved-name collision:** `PluginInstaller` now gates on builtin/reserved-name membership before the atomic swap and returns a `name_collision` error immediately, so no broken directory is left on disk when a collision is detected.
- **Consent revocation on update:** any archive-hash change during `checkForUpdate` triggers revocation of both MCP TOFU pins and JIT host-capability grants for that plugin, forcing re-consent before the updated code can exercise prior permissions.
- **Dev-load trust bypass:** `loadDevPlugin` now checks the persisted disabled set and rejects non-scoped or path-traversal plugin IDs before activating.

## Testing

105 targeted tests across `PluginCliServer`, `PluginInstaller`, `PluginService`, `pluginDownloadPolicy`, `PluginCapabilityConsentService`, and `PluginDevWorkerMainBridge`. Branch is rebased onto `develop`, format and lint clean on changed files.