### PR TITLE
feat(plugin): render file decorations on local worktree file list + collision diagnostic

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -516,9 +516,20 @@ Registers a provider that decorates files (or other scoped resources) with statu
 | `id` | yes | Namespaced at runtime as `{pluginId}.{id}`. Must match the `id` passed when the provider binds at runtime. |
 | `scopes` | yes | Non-empty list of scope patterns the provider answers for. A scope like `worktree-diff:*` matches every resource the host routes under the `worktree-diff` namespace; the host dispatches decoration pulls to the first provider whose scope matches. |
 
+**Host-routed scopes:**
+
+| Scope | Surface | Notes |
+| --- | --- | --- |
+| `worktree-diff:<worktreePath>` | Review Hub changed-file rows (base-branch diff, linked PR) | Used by the first-party GitHub plugin to badge PR-review state. |
+| `worktree-files:<worktreePath>` | Local worktree file-change list (`FileChangeList` in the worktree card) | Local-only — no PR or remote required. Use this to badge a worktree's changed files from a lint/leak/status plugin. |
+
+Keep these scopes distinct: a provider registered for `worktree-diff:*` is **not** invoked on the local `worktree-files:*` list and vice versa, so PR-review badges don't leak onto the plain change list. The path strings the host passes (and that your provider keys its returned map by) are the worktree's changed-file paths as the surface renders them.
+
 The manifest entry is read eagerly so the host's decoration-routing table (`electron/services/fileDecorationRegistry.ts`) knows which provider owns a scope before any plugin code runs; the implementation binds lazily in `activate()`. See [Host API](./host-api.md) for the runtime registration signature.
 
-Today the only mounted decoration consumer is the worktree diff/review surface (the Review Hub's changed-file rows); the routing and host API are general, but no other path list in Daintree pulls decorations yet, so badges from a lint/leak/status plugin currently appear only there. (Widening this to arbitrary path lists is tracked separately — see #10512.) From your `activate()` subscriptions and timers, call `host.invalidateFileDecorations(scope, paths?)` to signal that a scope's decorations changed and any renderer showing them should re-pull.
+When two providers declare the **same exact scope string**, their decorations merge first-writer-wins per field in plugin load order — so the second provider's badge for a shared path can be silently dropped. The host emits a `console.warn` at registration time naming both plugins and the duplicated scope so the collision is detectable. (Broad/narrow coexistence — a `worktree-files:*` provider alongside a `worktree-files:/some/path` one — is intentional and not warned.)
+
+From your `activate()` subscriptions and timers, call `host.invalidateFileDecorations(scope, paths?)` to signal that a scope's decorations changed and any renderer showing them should re-pull.
 
 ## Agents — _Shipped (minimal tier)_
 

--- a/electron/services/__tests__/fileDecorationRegistry.test.ts
+++ b/electron/services/__tests__/fileDecorationRegistry.test.ts
@@ -179,4 +179,23 @@ describe("fileDecorationRegistry — scope collision diagnostic", () => {
     ]);
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("warns once per colliding existing plugin (attributing each distinct pair)", () => {
+    registerFileDecorationProviders("first.plugin", [
+      { id: "a", scopes: ["worktree-files:/repo"] },
+    ]);
+    registerFileDecorationProviders("second.plugin", [
+      { id: "b", scopes: ["worktree-files:/repo"] },
+    ]);
+    warnSpy.mockClear();
+    // third collides with both already-registered plugins — one warning each so
+    // every colliding pair is named, none silently folded away.
+    registerFileDecorationProviders("third.plugin", [
+      { id: "c", scopes: ["worktree-files:/repo"] },
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    const named = warnSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+    expect(named).toContain("first.plugin");
+    expect(named).toContain("second.plugin");
+  });
 });

--- a/electron/services/__tests__/fileDecorationRegistry.test.ts
+++ b/electron/services/__tests__/fileDecorationRegistry.test.ts
@@ -194,7 +194,7 @@ describe("fileDecorationRegistry — scope collision diagnostic", () => {
       { id: "c", scopes: ["worktree-files:/repo"] },
     ]);
     expect(warnSpy).toHaveBeenCalledTimes(2);
-    const named = warnSpy.mock.calls.map((c) => String(c[0] ?? "")).join("\n");
+    const named = warnSpy.mock.calls.map((c: unknown[]) => String(c[0] ?? "")).join("\n");
     expect(named).toContain("first.plugin");
     expect(named).toContain("second.plugin");
   });

--- a/electron/services/__tests__/fileDecorationRegistry.test.ts
+++ b/electron/services/__tests__/fileDecorationRegistry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FileDecoration, FileDecorationProviderImpl } from "../../../shared/types/forge.js";
 import {
   clearFileDecorationImplRegistry,
@@ -114,5 +114,69 @@ describe("fileDecorationRegistry", () => {
     registerFileDecorationProviders("p", [{ id: "a", scopes: ["*"] }]);
     registerFileDecorationProviders("p", []);
     expect(getRegisteredFileDecorationProviders()).toEqual([]);
+  });
+});
+
+describe("fileDecorationRegistry — scope collision diagnostic", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("warns when two different plugins declare the same exact scope, naming both", () => {
+    registerFileDecorationProviders("first.plugin", [
+      { id: "a", scopes: ["worktree-files:/repo"] },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    registerFileDecorationProviders("second.plugin", [
+      { id: "b", scopes: ["worktree-files:/repo"] },
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(msg).toContain("first.plugin");
+    expect(msg).toContain("second.plugin");
+    expect(msg).toContain("worktree-files:/repo");
+  });
+
+  it("does not block registration — both providers remain registered after a collision", () => {
+    registerFileDecorationProviders("first.plugin", [
+      { id: "a", scopes: ["worktree-files:/repo"] },
+    ]);
+    registerFileDecorationProviders("second.plugin", [
+      { id: "b", scopes: ["worktree-files:/repo"] },
+    ]);
+    const ids = getRegisteredFileDecorationProviders().map((r) => r.pluginId);
+    expect(new Set(ids)).toEqual(new Set(["first.plugin", "second.plugin"]));
+  });
+
+  it("does not warn when the same plugin re-registers (hot-reload replaces its own entry)", () => {
+    registerFileDecorationProviders("acme.plugin", [{ id: "a", scopes: ["worktree-files:/repo"] }]);
+    registerFileDecorationProviders("acme.plugin", [{ id: "a", scopes: ["worktree-files:/repo"] }]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn on wildcard/exact coexistence (broad and narrow are intentional)", () => {
+    registerFileDecorationProviders("broad.plugin", [{ id: "a", scopes: ["worktree-files:*"] }]);
+    registerFileDecorationProviders("narrow.plugin", [
+      { id: "b", scopes: ["worktree-files:/repo"] },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns once per colliding scope, not per existing contribution", () => {
+    registerFileDecorationProviders("first.plugin", [
+      { id: "a", scopes: ["worktree-files:/repo"] },
+      { id: "b", scopes: ["worktree-files:/repo"] },
+    ]);
+    registerFileDecorationProviders("second.plugin", [
+      { id: "c", scopes: ["worktree-files:/repo"] },
+    ]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/services/fileDecorationRegistry.ts
+++ b/electron/services/fileDecorationRegistry.ts
@@ -41,6 +41,56 @@ function freezeContribution(c: FileDecorationContribution): FileDecorationContri
   });
 }
 
+/**
+ * Best-effort load-time diagnostic: warn when an incoming plugin declares a
+ * scope string that another already-registered plugin also declares verbatim.
+ * Such an exact collision makes the per-field, first-writer-wins merge in
+ * `handleFileDecorationsGet` order-dependent — the second provider's badge for
+ * a shared path is silently dropped — so surfacing it at registration time
+ * gives plugin authors something to act on (issue #10559).
+ *
+ * Only exact string equality is flagged. Wildcard-vs-exact coexistence
+ * (`worktree-files:*` alongside `worktree-files:/repo`) is a legitimate
+ * broad/narrow pattern, not a mistake, so it is intentionally not warned.
+ * Self-comparison is skipped so a plugin re-registering on hot-reload (which
+ * replaces its own entry via `.set()`) never warns about itself. Iteration is
+ * defensive — a partial unload may have left a malformed entry — and never
+ * throws, so a diagnostic can't block registration (lesson #9533).
+ */
+function warnOnScopeCollision(pluginId: string, contributions: FileDecorationContribution[]): void {
+  try {
+    const incoming = new Set<string>();
+    for (const c of contributions) {
+      if (!c || !Array.isArray(c.scopes)) continue;
+      for (const scope of c.scopes) {
+        if (typeof scope === "string" && scope.length > 0) incoming.add(scope);
+      }
+    }
+    if (incoming.size === 0) return;
+
+    for (const [existingPluginId, existingContributions] of PLUGIN_FILE_DECORATION_PROVIDERS) {
+      if (existingPluginId === pluginId) continue;
+      const reported = new Set<string>();
+      for (const c of existingContributions) {
+        if (!c || !Array.isArray(c.scopes)) continue;
+        for (const scope of c.scopes) {
+          if (!incoming.has(scope) || reported.has(scope)) continue;
+          reported.add(scope);
+          console.warn(
+            `[Plugin] fileDecorationProvider scope collision: "${pluginId}" and ` +
+              `"${existingPluginId}" both declare scope "${scope}". Decorations merge ` +
+              `first-writer-wins per field in plugin load order, so one provider's badge ` +
+              `for a shared path may be silently dropped.`
+          );
+        }
+      }
+    }
+  } catch {
+    // Diagnostics are best-effort; never let a malformed registry entry block
+    // registration of a well-formed plugin.
+  }
+}
+
 export function registerFileDecorationProviders(
   pluginId: string,
   contributions: FileDecorationContribution[]
@@ -50,6 +100,7 @@ export function registerFileDecorationProviders(
     PLUGIN_FILE_DECORATION_PROVIDERS.delete(pluginId);
     return;
   }
+  warnOnScopeCollision(pluginId, contributions);
   PLUGIN_FILE_DECORATION_PROVIDERS.set(pluginId, contributions.map(freezeContribution));
 }
 

--- a/src/components/Plugin/FileDecorationBadge.tsx
+++ b/src/components/Plugin/FileDecorationBadge.tsx
@@ -28,15 +28,17 @@ export function FileDecorationBadge({ decoration, className }: FileDecorationBad
   const label = decoration?.tooltip ?? badge;
   const url =
     typeof decoration?.url === "string" && decoration.url.length > 0 ? decoration.url : null;
-  // Provider-authored color is opt-in; fall back to a neutral muted surface so
-  // a decoration without an explicit color is never mistaken for the scarce
-  // accent (CLAUDE.md accent-restraint rule).
-  const style = decoration?.color ? { color: decoration.color } : undefined;
 
+  // Provider-authored `color` is an opaque token/class passed straight to
+  // `className` (per the `FileDecoration.color` contract), layered after the
+  // neutral default so a provider can override it; absent it, the muted surface
+  // keeps the badge from being mistaken for the scarce accent (CLAUDE.md
+  // accent-restraint rule).
   const shared = cn(
     "shrink-0 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full",
     "text-[10px] font-semibold tabular-nums",
     "bg-overlay-subtle text-daintree-text/80",
+    decoration?.color,
     className
   );
 
@@ -44,9 +46,14 @@ export function FileDecorationBadge({ decoration, className }: FileDecorationBad
     return (
       <button
         type="button"
-        onClick={() => void systemClient.openExternal(url)}
+        // Stop the click from bubbling to an enclosing row handler (e.g. a
+        // `FileChangeList` row opens the diff modal on click) — a URL badge
+        // should open its link and nothing else.
+        onClick={(e) => {
+          e.stopPropagation();
+          void systemClient.openExternal(url);
+        }}
         aria-label={label}
-        style={style}
         className={cn(
           shared,
           "hover:bg-tint/10 transition-colors cursor-pointer",
@@ -59,7 +66,7 @@ export function FileDecorationBadge({ decoration, className }: FileDecorationBad
   }
 
   return (
-    <span aria-label={label} title={label} style={style} className={shared}>
+    <span aria-label={label} title={label} className={shared}>
       {badge}
     </span>
   );

--- a/src/components/Plugin/__tests__/FileDecorationBadge.test.tsx
+++ b/src/components/Plugin/__tests__/FileDecorationBadge.test.tsx
@@ -44,4 +44,29 @@ describe("FileDecorationBadge", () => {
     fireEvent.click(btn);
     expect(openExternalMock).toHaveBeenCalledWith("https://x/report");
   });
+
+  it("applies provider color as a className token, not an inline style", async () => {
+    const FileDecorationBadge = await load();
+    // Per the FileDecoration.color contract the value is an opaque class token
+    // passed to className — it must not land in the inline style attribute.
+    const deco: FileDecoration = { badge: "3", tooltip: "warn", color: "text-status-warning" };
+    render(<FileDecorationBadge decoration={deco} />);
+    const el = screen.getByLabelText("warn");
+    expect(el.className).toContain("text-status-warning");
+    expect(el.getAttribute("style")).toBeNull();
+  });
+
+  it("stops a url-badge click from bubbling to an enclosing row handler", async () => {
+    const FileDecorationBadge = await load();
+    const parentClick = vi.fn();
+    const deco: FileDecoration = { badge: "↗", tooltip: "Open PR", url: "https://x/pr" };
+    render(
+      <div onClick={parentClick}>
+        <FileDecorationBadge decoration={deco} />
+      </div>
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open PR" }));
+    expect(openExternalMock).toHaveBeenCalledWith("https://x/pr");
+    expect(parentClick).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -8,6 +8,8 @@ import { isAbsolute, basename, dirname, normalize, join } from "@shared/utils/pa
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
 import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
+import { useFileTreeDecorations } from "@/hooks/useFileTreeDecorations";
+import { FileDecorationBadge } from "@/components/Plugin/FileDecorationBadge";
 
 function getRelativePath(from: string, to: string): string {
   const normalizedFrom = normalize(from);
@@ -124,6 +126,16 @@ export function FileChangeList({
         return a.path.localeCompare(b.path);
       });
   }, [changes, rootPath]);
+
+  // Plugin-contributed file decorations for the local worktree file list. Pulled
+  // once for the whole list under a `worktree-files:<root>` scope — distinct from
+  // the Review Hub's `worktree-diff:` scope so a PR-review provider's badges don't
+  // leak onto the local change list. Keyed by the same `change.path` strings that
+  // were sent to the host, so `decorations[change.path]` resolves per row. The
+  // hook early-outs (stable empty map) when no plugin registers the scope, so this
+  // costs nothing on a zero-plugin file list.
+  const decorationPaths = useMemo(() => sortedChanges.map((c) => c.path), [sortedChanges]);
+  const decorations = useFileTreeDecorations(`worktree-files:${rootPath}`, decorationPaths);
 
   // Map each row key to its position in `sortedChanges` so file stepping spans
   // the whole change set (not just the visible cap) and grouped rows resolve to
@@ -283,6 +295,7 @@ export function FileChangeList({
               {(change.deletions ?? 0) > 0 && (
                 <span className="text-status-error/80">-{change.deletions}</span>
               )}
+              <FileDecorationBadge decoration={decorations[change.path]} />
             </div>
           </div>
         </TooltipTrigger>

--- a/src/components/Worktree/__tests__/FileChangeList.decorations.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.decorations.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import type { FileChangeDetail } from "../../../types";
+import type { FileDecoration } from "@shared/types/forge";
+
+// The diff modal and tooltip are irrelevant to the decoration rendering under test.
+vi.mock("../FileDiffModal", () => ({ FileDiffModal: () => null }));
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+// No plugin context-menu items — keep the plain-row DOM so badges are the only
+// plugin surface under test.
+vi.mock("@/hooks/usePluginContextMenuItems", () => ({
+  usePluginContextMenuItems: () => [],
+}));
+
+// systemClient is only touched on a url-badge click; stub it to avoid pulling
+// window.electron at import time.
+vi.mock("@/clients/systemClient", () => ({
+  systemClient: { openExternal: vi.fn() },
+}));
+
+const { decorationsRef, scopeRef, pathsRef } = vi.hoisted(() => ({
+  decorationsRef: { current: {} as Record<string, FileDecoration> },
+  scopeRef: { current: "" },
+  pathsRef: { current: [] as string[] },
+}));
+vi.mock("@/hooks/useFileTreeDecorations", () => ({
+  useFileTreeDecorations: (scope: string, paths: string[]) => {
+    scopeRef.current = scope;
+    pathsRef.current = paths;
+    return decorationsRef.current;
+  },
+}));
+
+import { FileChangeList } from "../FileChangeList";
+
+const ROOT = "/repo";
+
+function file(path: string, status: FileChangeDetail["status"] = "modified"): FileChangeDetail {
+  return { path, status, insertions: 1, deletions: 0 };
+}
+
+beforeEach(() => {
+  decorationsRef.current = {};
+  scopeRef.current = "";
+  pathsRef.current = [];
+});
+
+afterEach(() => cleanup());
+
+describe("FileChangeList — plugin file decorations", () => {
+  it("passes the worktree-files scope and the raw change paths to the hook", () => {
+    render(
+      <FileChangeList changes={[file("/repo/src/a.ts"), file("/repo/src/b.ts")]} rootPath={ROOT} />
+    );
+    expect(scopeRef.current).toBe("worktree-files:/repo");
+    expect(new Set(pathsRef.current)).toEqual(new Set(["/repo/src/a.ts", "/repo/src/b.ts"]));
+  });
+
+  it("renders a badge for a decorated path and nothing for an undecorated one", () => {
+    decorationsRef.current = {
+      "/repo/src/a.ts": { badge: "3", tooltip: "3 issues" },
+    };
+    const { container, getByLabelText } = render(
+      <FileChangeList changes={[file("/repo/src/a.ts"), file("/repo/src/b.ts")]} rootPath={ROOT} />
+    );
+    const badge = getByLabelText("3 issues");
+    expect(badge.textContent).toBe("3");
+    // Only one badge in the whole list — the undecorated row has none.
+    expect(container.querySelectorAll('[aria-label="3 issues"]')).toHaveLength(1);
+  });
+
+  it("renders no badge DOM when the hook returns an empty map", () => {
+    decorationsRef.current = {};
+    const { container } = render(
+      <FileChangeList changes={[file("/repo/src/a.ts")]} rootPath={ROOT} />
+    );
+    // FileDecorationBadge returns null without a badge string, so the row carries
+    // no rounded-pill badge element.
+    expect(container.querySelector(".rounded-full")).toBeNull();
+  });
+
+  it("looks decorations up by the raw change.path, not the display relative path", () => {
+    // Absolute change path; the component derives a relativePath for display, but
+    // the decoration lookup must use the original absolute path the host saw.
+    decorationsRef.current = { "/repo/src/deep/x.ts": { badge: "!" } };
+    const { getByLabelText } = render(
+      <FileChangeList changes={[file("/repo/src/deep/x.ts")]} rootPath={ROOT} />
+    );
+    expect(getByLabelText("!").textContent).toBe("!");
+  });
+});


### PR DESCRIPTION
## Summary

- Wires `FileChangeList` to plugin file-decoration providers via a new `worktree-files:<rootPath>` scope, rendering `FileDecorationBadge` per row — the first local-only (non-PR) decoration surface
- Adds a load-time collision diagnostic: `console.warn` when two different plugins declare the same exact decoration scope string, making the first-writer-wins drop detectable; self re-registration and wildcard/exact coexistence are both skipped silently
- Fixes two latent `FileDecorationBadge` bugs that became visible with the first in-row consumer: `color` is now applied via `className` per the `FileDecoration.color` contract (was inline style), and url-badge clicks call `stopPropagation` so they no longer also open the diff modal

Resolves #10559

## Changes

- `electron/services/fileDecorationRegistry.ts` — collision diagnostic added; warns with both plugin names on exact-scope clash, skips self re-registration and wildcard/exact pairs without warning
- `src/components/Worktree/FileChangeList.tsx` — pulls decorations from the registry under a `worktree-files:<rootPath>` scope and renders `FileDecorationBadge` per row using `change.path` as the lookup key
- `src/components/Plugin/FileDecorationBadge.tsx` — `color` applied via `className` not inline style; url-badge click handler calls `e.stopPropagation()`
- `docs/plugins/contribution-points.md` — documents the `worktree-files` scope and the collision diagnostic behaviour

The `worktree-files` scope is intentionally distinct from `worktree-diff` so PR-review badges don't leak onto the local change list. `ReviewHubContent` is unaffected. No `FileDecorationContribution` shape changes; fully backwards-compatible.

## Testing

61 targeted tests pass locally across three new test files:

- `fileDecorationRegistry.test.ts` — collision diagnostic: warns with both plugin names, no-block behaviour, no self-warn, no wildcard/exact warn, per-pair attribution
- `FileChangeList.decorations.test.tsx` — scope + raw-path wiring, badge present/absent, lookup by raw `change.path`
- `FileDecorationBadge.test.tsx` — `color`-as-className and click-propagation