### PR TITLE
fix(plugin): validate contributed actionIds resolve to a known namespace (#10565)

### DIFF
--- a/electron/schemas/__tests__/actionIdContribution.test.ts
+++ b/electron/schemas/__tests__/actionIdContribution.test.ts
@@ -41,10 +41,25 @@ describe("manifest-level actionId namespace gate (issue #10565)", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts a keybinding-driven built-in action (BuiltInKeyAction half of the union)", () => {
+    // BuiltInActionId = BuiltInKeyAction | BuiltInRuntimeActionId. The allowlist
+    // must cover both halves, or a legitimate keybinding to a key-action like
+    // app.settings is rejected and the whole plugin fails to load.
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: { keybindings: [contributionEntry.keybindings("app.settings")] },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
   it("accepts an own-namespace actionId even without a matching contributes.commands entry", () => {
     // Plugin actions are frequently registered imperatively via
     // host.registerAction, which is invisible at parse time — so an id in the
-    // plugin's own namespace must pass without a declared command.
+    // plugin's own namespace must pass without a declared command. A typo within
+    // the own namespace (e.g. acme.my-plugin.typoo) also passes — that is an
+    // intentional consequence of namespace-ownership gating, not a gap to close;
+    // catching a non-existent own-namespace suffix requires the runtime registry.
     const result = schema.safeParse(
       manifestWith({
         contributes: {
@@ -95,6 +110,32 @@ describe("manifest-level actionId namespace gate (issue #10565)", () => {
       }
     }
   );
+
+  it("reports a separate issue at the correct index for each invalid entry", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          toolbarButtons: [
+            contributionEntry.toolbarButtons("acme.my-plugin.ok"),
+            contributionEntry.toolbarButtons("other.plugin.foo"),
+            contributionEntry.toolbarButtons("another.plugin.bar"),
+          ],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const unknownNamespaceIssues = result.error.issues.filter(
+        (i) =>
+          (i as { params?: { errorCode?: string } }).params?.errorCode ===
+          "action_id_unknown_namespace"
+      );
+      expect(unknownNamespaceIssues.map((i) => i.path)).toEqual([
+        ["contributes", "toolbarButtons", 1, "actionId"],
+        ["contributes", "toolbarButtons", 2, "actionId"],
+      ]);
+    }
+  });
 
   it.each(CONTRIBUTION_ARRAYS)("accepts a built-in actionId contributed via %s", (arrayName) => {
     const result = schema.safeParse(

--- a/electron/schemas/__tests__/actionIdContribution.test.ts
+++ b/electron/schemas/__tests__/actionIdContribution.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { getPluginManifestSchema } from "../plugin.js";
+
+// A real built-in action id (see shared/config/actionIds.ts) — referencing one
+// from a plugin contribution is valid and common.
+const BUILT_IN_ACTION_ID = "terminal.list";
+
+function manifestWith(overrides: Record<string, unknown>) {
+  return {
+    name: "acme.my-plugin",
+    version: "1.0.0",
+    ...overrides,
+  };
+}
+
+// Build a valid contribution entry of each kind carrying the given actionId, so
+// only the actionId namespace gate decides accept/reject.
+const contributionEntry: Record<string, (actionId: string) => Record<string, unknown>> = {
+  toolbarButtons: (actionId) => ({
+    id: "btn",
+    label: "Btn",
+    iconId: "sparkles",
+    actionId,
+  }),
+  menuItems: (actionId) => ({ label: "Item", actionId, location: "help" }),
+  keybindings: (actionId) => ({ actionId, combo: "ctrl+k" }),
+  contextMenus: (actionId) => ({ actionId, location: "terminal", label: "Item" }),
+};
+
+const CONTRIBUTION_ARRAYS = Object.keys(contributionEntry);
+
+describe("manifest-level actionId namespace gate (issue #10565)", () => {
+  const schema = getPluginManifestSchema(false);
+
+  it("accepts a contribution referencing a built-in action", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: { toolbarButtons: [contributionEntry.toolbarButtons(BUILT_IN_ACTION_ID)] },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an own-namespace actionId even without a matching contributes.commands entry", () => {
+    // Plugin actions are frequently registered imperatively via
+    // host.registerAction, which is invisible at parse time — so an id in the
+    // plugin's own namespace must pass without a declared command.
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          toolbarButtons: [contributionEntry.toolbarButtons("acme.my-plugin.greet")],
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a foreign-namespace actionId with a precise error code and path", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          toolbarButtons: [contributionEntry.toolbarButtons("other.plugin.foo")],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) =>
+          (i as { params?: { errorCode?: string } }).params?.errorCode ===
+          "action_id_unknown_namespace"
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.path).toEqual(["contributes", "toolbarButtons", 0, "actionId"]);
+    }
+  });
+
+  it.each(CONTRIBUTION_ARRAYS)(
+    "rejects a foreign-namespace actionId contributed via %s",
+    (arrayName) => {
+      const result = schema.safeParse(
+        manifestWith({
+          contributes: { [arrayName]: [contributionEntry[arrayName]("other.plugin.foo")] },
+        })
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) =>
+            (i as { params?: { errorCode?: string } }).params?.errorCode ===
+            "action_id_unknown_namespace"
+        );
+        expect(issue).toBeDefined();
+        expect(issue?.path).toEqual(["contributes", arrayName, 0, "actionId"]);
+      }
+    }
+  );
+
+  it.each(CONTRIBUTION_ARRAYS)("accepts a built-in actionId contributed via %s", (arrayName) => {
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: { [arrayName]: [contributionEntry[arrayName](BUILT_IN_ACTION_ID)] },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { BUILT_IN_PLUGIN_CAPABILITIES, PLUGIN_CATEGORY_IDS } from "../../shared/types/plugin.js";
 import { isBuiltInAgentId } from "../../shared/config/agentIds.js";
 import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
+import { KEY_ACTION_VALUES } from "../../shared/types/keymap.js";
 import type {
   PluginManifest,
   PanelContribution,
@@ -23,7 +24,16 @@ export const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 export const SCOPED_PLUGIN_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set(BUILT_IN_ACTION_IDS);
+// The full set of built-in action ids a plugin contribution may reference:
+// `BuiltInActionId = BuiltInKeyAction | BuiltInRuntimeActionId`
+// (shared/types/actions.ts). `BUILT_IN_ACTION_IDS` covers only the runtime
+// half — keybinding-driven ids (nav.*, tab.*, app.settings, layout.undo, …)
+// live in `KEY_ACTION_VALUES` and are equally valid dispatch targets, so both
+// must seed the allowlist or a legitimate keybinding contribution is rejected.
+const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set([
+  ...BUILT_IN_ACTION_IDS,
+  ...KEY_ACTION_VALUES,
+]);
 
 export const PanelContributionSchema = z
   .object({

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -4,6 +4,7 @@ import * as semver from "semver";
 import { z } from "zod";
 import { BUILT_IN_PLUGIN_CAPABILITIES, PLUGIN_CATEGORY_IDS } from "../../shared/types/plugin.js";
 import { isBuiltInAgentId } from "../../shared/config/agentIds.js";
+import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
 import type {
   PluginManifest,
   PanelContribution,
@@ -21,6 +22,8 @@ import type {
 export const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 export const SCOPED_PLUGIN_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set(BUILT_IN_ACTION_IDS);
 
 export const PanelContributionSchema = z
   .object({
@@ -849,6 +852,37 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           });
         }
       });
+
+      // Every contributed `actionId` (toolbar buttons, menu items, keybindings,
+      // context menus) must resolve to a real action at runtime, else the
+      // contribution paints an inert button/binding that silently does nothing
+      // when invoked (#10565). An `actionId` resolves if it is a built-in action
+      // or lives in the plugin's own namespace — the latter is either declared in
+      // `contributes.commands` (namespaced `{name}.{id}` at load) or registered
+      // imperatively via `host.registerAction`, which is invisible at parse time,
+      // so we gate on namespace ownership rather than command membership. A
+      // reference into a foreign namespace can never resolve and is rejected.
+      const ownNamespacePrefix = `${manifest.name}.`;
+      const actionIdContributions = [
+        ["toolbarButtons", manifest.contributes.toolbarButtons],
+        ["menuItems", manifest.contributes.menuItems],
+        ["keybindings", manifest.contributes.keybindings],
+        ["contextMenus", manifest.contributes.contextMenus],
+      ] as const;
+      for (const [arrayName, entries] of actionIdContributions) {
+        entries.forEach((entry, index) => {
+          const { actionId } = entry;
+          if (BUILT_IN_ACTION_ID_SET.has(actionId) || actionId.startsWith(ownNamespacePrefix)) {
+            return;
+          }
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["contributes", arrayName, index, "actionId"],
+            message: `Contributed actionId "${actionId}" does not reference a built-in action or an action in this plugin's "${manifest.name}" namespace — it can never resolve.`,
+            params: { errorCode: "action_id_unknown_namespace" },
+          });
+        });
+      }
     });
 }
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1449,7 +1449,7 @@ describe("PluginService", () => {
             id: "btn",
             label: "Btn",
             iconId: "icon",
-            actionId: "test.action",
+            actionId: "acme.default-priority.action",
           },
         ],
       },
@@ -3534,8 +3534,10 @@ describe("engines.daintree compatibility gate", () => {
       engines: { daintree: "^1.0.0" },
       contributes: {
         panels: [{ id: "p", name: "P", iconId: "i", color: "#000" }],
-        toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "x.y" }],
-        menuItems: [{ label: "L", actionId: "x.y", location: "terminal" }],
+        toolbarButtons: [
+          { id: "b", label: "B", iconId: "i", actionId: "acme.skip-side-effects.act" },
+        ],
+        menuItems: [{ label: "L", actionId: "acme.skip-side-effects.act", location: "terminal" }],
       },
     });
 
@@ -3681,8 +3683,10 @@ describe("Plugin unload lifecycle", () => {
       version: "1.0.0",
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
-        toolbarButtons: [{ id: "btn", label: "Btn", iconId: "icon", actionId: "x.y" }],
-        menuItems: [{ label: "L", actionId: "x.y", location: "terminal" }],
+        toolbarButtons: [
+          { id: "btn", label: "Btn", iconId: "icon", actionId: "acme.unloadable.act" },
+        ],
+        menuItems: [{ label: "L", actionId: "acme.unloadable.act", location: "terminal" }],
       },
     });
 
@@ -7362,8 +7366,10 @@ describe("Plugin exception containment (#9276)", () => {
         version: "1.0.0",
         contributes: {
           panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
-          toolbarButtons: [{ id: "btn", label: "Btn", iconId: "icon", actionId: "x.y" }],
-          menuItems: [{ label: "L", actionId: "x.y", location: "terminal" }],
+          toolbarButtons: [
+            { id: "btn", label: "Btn", iconId: "icon", actionId: "acme.cascade-test.act" },
+          ],
+          menuItems: [{ label: "L", actionId: "acme.cascade-test.act", location: "terminal" }],
         },
       });
 
@@ -7487,8 +7493,12 @@ describe("Plugin exception containment (#9276)", () => {
         version: "1.0.0",
         contributes: {
           panels: [{ id: "p", name: "P", iconId: "i", color: "#000" }],
-          toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "x.y" }],
-          menuItems: [{ label: "L", actionId: "x.y", location: "terminal" }],
+          toolbarButtons: [
+            { id: "b", label: "B", iconId: "i", actionId: "acme.remove-handlers-throws.act" },
+          ],
+          menuItems: [
+            { label: "L", actionId: "acme.remove-handlers-throws.act", location: "terminal" },
+          ],
         },
       });
       const service = new PluginService(tmpDir);

--- a/plugins/sample/hello-daintree/main/index.ts
+++ b/plugins/sample/hello-daintree/main/index.ts
@@ -8,7 +8,8 @@ import type { PluginHostApi, PluginIpcContext } from "../../../../shared/types/p
  * effect, and so a single read of this file maps 1:1 to the SDK contract.
  *
  * Declared in plugin.json: one toolbar button + one menu item pointing at the
- * `daintree.hello.ping` action, plus a `hello:*` file-decoration provider.
+ * imperatively-registered `daintree.hello.greet` action, plus a `hello:*`
+ * file-decoration provider.
  */
 export async function activate(host: PluginHostApi): Promise<() => void> {
   // IPC handler the renderer reaches over `plugin:daintree.hello:ping`.

--- a/plugins/sample/hello-daintree/plugin.json
+++ b/plugins/sample/hello-daintree/plugin.json
@@ -14,14 +14,14 @@
         "id": "ping",
         "label": "Hello ping",
         "iconId": "sparkles",
-        "actionId": "daintree.hello.ping",
+        "actionId": "daintree.hello.greet",
         "priority": 5
       }
     ],
     "menuItems": [
       {
         "label": "Hello ping",
-        "actionId": "daintree.hello.ping",
+        "actionId": "daintree.hello.greet",
         "location": "help"
       }
     ],


### PR DESCRIPTION
## Summary

- The plugin manifest validator never checked that `actionId` fields in `contributes.toolbarButtons`, `menuItems`, `keybindings`, and `contextMenus` reference a real action — a silently broken button was already shipping in the bundled `hello-daintree` sample.
- Adds a namespace-ownership gate in `getPluginManifestSchema`'s `superRefine` (`electron/schemas/plugin.ts`). Each contributed `actionId` must be a built-in action or live in the plugin's own namespace; foreign-namespace references are rejected with `action_id_unknown_namespace`, matching the existing manifest error codes.
- Fixes `hello-daintree/plugin.json` to bind its toolbar button and menu item to `daintree.hello.greet` instead of `daintree.hello.ping`. `ping` is only a `registerHandler` IPC channel, not a dispatchable action, so clicking the button was silently dispatching an unregistered id.

Resolves #10565

## Changes

- `electron/schemas/plugin.ts` — namespace-ownership `superRefine` on contributed `actionId` fields
- `plugins/sample/hello-daintree/plugin.json` — bind button/menu item to `daintree.hello.greet`; update stale JSDoc
- `plugins/sample/hello-daintree/main/index.ts` — minor comment update
- `electron/schemas/__tests__/actionIdContribution.test.ts` — new test file covering own-namespace, built-in, and foreign-namespace cases
- `electron/services/__tests__/PluginService.test.ts` — updated 5 fixtures that used placeholder foreign-namespace `actionId` values

## Testing

New unit tests in `actionIdContribution.test.ts` cover own-namespace actions, built-in actions (both `BuiltInKeyAction` and `BuiltInRuntimeActionId`), and foreign-namespace rejection. Existing `PluginService` fixtures updated to use valid `actionId` values so they continue to pass under the new validation.