### PR TITLE
feat(plugin): add host.clipboard API backing clipboard capability tokens

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -3,7 +3,7 @@ import { existsSync, watch as fsWatch, type FSWatcher } from "node:fs";
 import path from "path";
 import os from "os";
 import { pathToFileURL } from "url";
-import { app } from "electron";
+import { app, clipboard } from "electron";
 import * as semver from "semver";
 // Aliased to avoid colliding with Vite's auto-injected ESM shim
 // (`import { createRequire } from 'module'; const require = createRequire(import.meta.url);`),
@@ -75,6 +75,7 @@ import type {
   PluginFsDirEntry,
   PluginFsStat,
   PluginGitApi,
+  PluginClipboardApi,
   PluginGitStatus,
   PluginGitCommitOptions,
   PluginGitCommitResult,
@@ -2673,6 +2674,12 @@ export class PluginService {
       // this is the runtime enforcement of allowedPaths (formerly advisory).
       fs: this.buildFsApi(pluginId),
       git: this.buildGitApi(pluginId),
+      // Host-mediated OS clipboard surface backing the clipboard:read /
+      // clipboard:write tokens. Runs in the main process (Electron's clipboard
+      // module is unavailable in the dev-worker utility process), so it works
+      // from a headless plugin with no mounted panel. NOT revoke-guarded —
+      // liveness is plugin membership; once unloaded every method rejects.
+      clipboard: this.buildClipboardApi(pluginId),
       // NOT revoke-guarded: plugins read/write settings throughout their
       // lifetime (IPC handlers, timers), long after activate() resolves. The
       // store is the source of truth, so a late call is harmless.
@@ -3532,6 +3539,59 @@ export class PluginService {
           durationMs: 0,
         });
         return result;
+      },
+    };
+  }
+
+  /**
+   * Host-mediated OS clipboard surface backing the `clipboard:read` /
+   * `clipboard:write` tokens. Text-only; both methods run here in the main
+   * process because Electron's `clipboard` module is undefined inside the
+   * dev-worker utility process (a worker-side call would silently no-op). Like
+   * {@link buildGitApi} the liveness check precedes the capability check so a
+   * torn-down plugin reports `PLUGIN_UNLOADED`, not `PERMISSION_REQUIRED`
+   * (declaredCapabilities() also returns [] post-unload). Clipboard ops are
+   * stateless — no watchers or handles — so there is nothing to tear down on
+   * unload.
+   */
+  private buildClipboardApi(pluginId: string): PluginClipboardApi {
+    // Mirror the renderer IPC clipboard write guard (electron/ipc/handlers/
+    // clipboard.ts) so a runaway plugin can't exhaust the main-process heap.
+    const MAX_TEXT_BYTES = 8 * 1024 * 1024;
+    const requireLoaded = (op: string): void => {
+      if (!this.plugins.has(pluginId)) {
+        throw new Error(
+          `PLUGIN_UNLOADED: plugin "${pluginId}" clipboard.${op}: plugin is no longer loaded`
+        );
+      }
+    };
+    return {
+      writeText: async (text): Promise<void> => {
+        requireLoaded("writeText");
+        if (!this.declaredCapabilities(pluginId).has("clipboard:write")) {
+          throw new Error(
+            `PERMISSION_REQUIRED: plugin "${pluginId}" clipboard.writeText requires the "clipboard:write" capability, which is not declared in manifest.capabilities`
+          );
+        }
+        if (typeof text !== "string") {
+          throw new Error(`VALIDATION: plugin "${pluginId}" clipboard.writeText requires a string`);
+        }
+        if (Buffer.byteLength(text, "utf8") > MAX_TEXT_BYTES) {
+          throw new Error(
+            `PAYLOAD_TOO_LARGE: plugin "${pluginId}" clipboard.writeText text exceeds the ${MAX_TEXT_BYTES} byte limit`
+          );
+        }
+        clipboard.writeText(text);
+      },
+      readText: async (): Promise<string> => {
+        requireLoaded("readText");
+        if (!this.declaredCapabilities(pluginId).has("clipboard:read")) {
+          throw new Error(
+            `PERMISSION_REQUIRED: plugin "${pluginId}" clipboard.readText requires the "clipboard:read" capability, which is not declared in manifest.capabilities`
+          );
+        }
+        // Electron returns "" for empty or non-text clipboard content.
+        return clipboard.readText();
       },
     };
   }

--- a/electron/services/__tests__/PluginService.hostClipboard.test.ts
+++ b/electron/services/__tests__/PluginService.hostClipboard.test.ts
@@ -162,6 +162,16 @@ describe("host.clipboard write size guard", () => {
     expect(mockClipboard.writeText).not.toHaveBeenCalled();
   });
 
+  it("accepts multi-byte text exactly at the byte limit", async () => {
+    const host = registerPlugin(["clipboard:write"]);
+    // 4-byte emoji × (LIMIT / 4) === exactly 8 MiB UTF-8, well under LIMIT by
+    // .length — exercises the boundary on the byte axis, not the char axis.
+    const atLimit = "😀".repeat(LIMIT / 4);
+    expect(Buffer.byteLength(atLimit, "utf8")).toBe(LIMIT);
+    await expect(host.clipboard.writeText(atLimit)).resolves.toBeUndefined();
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(atLimit);
+  });
+
   it("measures by UTF-8 byte length, not JS string length (multi-byte chars)", async () => {
     const host = registerPlugin(["clipboard:write"]);
     // "😀" is 2 UTF-16 code units (.length === 2) but 4 UTF-8 bytes. A string

--- a/electron/services/__tests__/PluginService.hostClipboard.test.ts
+++ b/electron/services/__tests__/PluginService.hostClipboard.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn((key: string) => `/mock/electron/${key}`),
+    getVersion: vi.fn(() => "0.15.0"),
+  },
+  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  // unloadPlugin broadcasts plugin-agent changes to all renderers; without a
+  // BrowserWindow stub that path throws asynchronously after the test ends.
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  webContents: { getAllWebContents: vi.fn(() => []) },
+  clipboard: {
+    writeText: vi.fn(),
+    readText: vi.fn(() => ""),
+  },
+}));
+
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: {
+    getAllProjects: vi.fn(() => []),
+    getCurrentProjectId: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../PluginActionAuditService.js", () => ({
+  getPluginActionAuditService: () => ({ append: vi.fn() }),
+}));
+
+import { clipboard } from "electron";
+import { PluginService } from "../PluginService.js";
+import type { PluginManifest, PluginHostApi } from "../../../shared/types/plugin.js";
+
+const mockClipboard = vi.mocked(clipboard);
+
+let svc: PluginService;
+let baseDir: string;
+
+interface FakeLoadedPlugin {
+  manifest: PluginManifest;
+  dir: string;
+  loadedAt: number;
+  isBuiltin: boolean;
+}
+
+function makeManifest(capabilities: string[]): PluginManifest {
+  return {
+    name: "acme.clip",
+    version: "1.0.0",
+    capabilities,
+    scopes: { fs: { allowedPaths: [] } },
+    contributes: { fileDecorationProviders: [], forgeProviders: [] },
+  } as unknown as PluginManifest;
+}
+
+function registerPlugin(capabilities: string[]): PluginHostApi {
+  const seam = svc as unknown as {
+    _registerFakePluginForTests(p: FakeLoadedPlugin): void;
+    _createHostForTests(id: string): PluginHostApi;
+  };
+  seam._registerFakePluginForTests({
+    manifest: makeManifest(capabilities),
+    dir: baseDir,
+    loadedAt: 0,
+    isBuiltin: false,
+  });
+  return seam._createHostForTests("acme.clip");
+}
+
+beforeEach(() => {
+  mockClipboard.writeText.mockClear();
+  mockClipboard.readText.mockClear();
+  mockClipboard.readText.mockReturnValue("");
+  baseDir = mkdtempSync(join(tmpdir(), "plugin-clip-"));
+  const pluginsRoot = join(baseDir, "plugins");
+  mkdirSync(pluginsRoot, { recursive: true });
+  svc = new PluginService(pluginsRoot);
+});
+
+afterEach(() => {
+  rmSync(baseDir, { recursive: true, force: true });
+});
+
+describe("host.clipboard capability gating", () => {
+  it("writes text when clipboard:write is declared", async () => {
+    const host = registerPlugin(["clipboard:write"]);
+    await host.clipboard.writeText("hello");
+    expect(mockClipboard.writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("rejects writeText without clipboard:write", async () => {
+    const host = registerPlugin([]);
+    await expect(host.clipboard.writeText("nope")).rejects.toThrow(/PERMISSION_REQUIRED/);
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("reads text when clipboard:read is declared", async () => {
+    mockClipboard.readText.mockReturnValue("from-os");
+    const host = registerPlugin(["clipboard:read"]);
+    expect(await host.clipboard.readText()).toBe("from-os");
+  });
+
+  it("rejects readText without clipboard:read", async () => {
+    const host = registerPlugin([]);
+    await expect(host.clipboard.readText()).rejects.toThrow(/PERMISSION_REQUIRED/);
+    expect(mockClipboard.readText).not.toHaveBeenCalled();
+  });
+
+  it("returns the empty string for non-text / empty clipboard content", async () => {
+    mockClipboard.readText.mockReturnValue("");
+    const host = registerPlugin(["clipboard:read"]);
+    expect(await host.clipboard.readText()).toBe("");
+  });
+
+  it("write and read are independently gated", async () => {
+    // A plugin declaring only write cannot read, and vice versa.
+    const writeOnly = registerPlugin(["clipboard:write"]);
+    await expect(writeOnly.clipboard.readText()).rejects.toThrow(/PERMISSION_REQUIRED/);
+
+    svc.unloadPlugin("acme.clip");
+    mockClipboard.writeText.mockClear();
+
+    const readOnly = registerPlugin(["clipboard:read"]);
+    await expect(readOnly.clipboard.writeText("x")).rejects.toThrow(/PERMISSION_REQUIRED/);
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe("host.clipboard liveness guard", () => {
+  it("rejects with PLUGIN_UNLOADED before the capability check after unload", async () => {
+    const host = registerPlugin(["clipboard:read", "clipboard:write"]);
+    svc.unloadPlugin("acme.clip");
+
+    // Liveness fires first: an unloaded plugin reports PLUGIN_UNLOADED, never
+    // PERMISSION_REQUIRED — declaredCapabilities() returns [] post-unload, so a
+    // capability check first would mis-report a permission error.
+    await expect(host.clipboard.writeText("x")).rejects.toThrow(/PLUGIN_UNLOADED/);
+    await expect(host.clipboard.readText()).rejects.toThrow(/PLUGIN_UNLOADED/);
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+    expect(mockClipboard.readText).not.toHaveBeenCalled();
+  });
+});
+
+describe("host.clipboard write size guard", () => {
+  const LIMIT = 8 * 1024 * 1024;
+
+  it("accepts text exactly at the 8 MiB byte limit", async () => {
+    const host = registerPlugin(["clipboard:write"]);
+    const atLimit = "a".repeat(LIMIT);
+    await expect(host.clipboard.writeText(atLimit)).resolves.toBeUndefined();
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(atLimit);
+  });
+
+  it("rejects text one byte over the limit", async () => {
+    const host = registerPlugin(["clipboard:write"]);
+    const overLimit = "a".repeat(LIMIT + 1);
+    await expect(host.clipboard.writeText(overLimit)).rejects.toThrow(/PAYLOAD_TOO_LARGE/);
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("measures by UTF-8 byte length, not JS string length (multi-byte chars)", async () => {
+    const host = registerPlugin(["clipboard:write"]);
+    // "😀" is 2 UTF-16 code units (.length === 2) but 4 UTF-8 bytes. A string
+    // whose .length is under the limit can still exceed it by byte count.
+    const emojiCount = Math.floor(LIMIT / 4) + 1; // > 8 MiB by bytes
+    const payload = "😀".repeat(emojiCount);
+    expect(payload.length).toBeLessThan(LIMIT); // under the limit by .length
+    await expect(host.clipboard.writeText(payload)).rejects.toThrow(/PAYLOAD_TOO_LARGE/);
+    expect(mockClipboard.writeText).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -48,6 +48,7 @@ import type {
   FsWriteFileParams,
   FsWatchParams,
   GitOpParams,
+  ClipboardWriteTextParams,
   ProcessSpawnParams,
   ProcessHandleRefParams,
 } from "../../../shared/types/pluginDevWorker.js";
@@ -492,6 +493,12 @@ export class PluginDevWorkerMainBridge {
         const p = params as GitOpParams;
         return this.host.git.commit(p.worktreePath, { message: p.message ?? "" }, { signal });
       }
+      case "clipboard.writeText": {
+        await this.host.clipboard.writeText((params as ClipboardWriteTextParams).text);
+        return undefined;
+      }
+      case "clipboard.readText":
+        return this.host.clipboard.readText();
       default:
         throw new Error(`Unknown host-call method "${method}"`);
     }

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -167,6 +167,20 @@ describe("PluginDevWorkerMainBridge", () => {
     expect(result).toMatchObject({ ok: true, result: "clip-contents" });
   });
 
+  it("relays an empty clipboard read as ok:true with an empty string", async () => {
+    const { host, workerHost } = makeBridge();
+    host.clipboard.readText.mockResolvedValueOnce("");
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "ce",
+      method: "clipboard.readText",
+      params: undefined,
+    });
+    await flush();
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "ce");
+    expect(result).toMatchObject({ ok: true, result: "" });
+  });
+
   it("replies host-result ok:false when the host method throws", async () => {
     const { host, workerHost } = makeBridge();
     host.getWorktrees.mockRejectedValueOnce(new Error("boom"));

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -69,6 +69,10 @@ function makeHost() {
       stat: vi.fn(async () => ({})),
       watch: vi.fn(async (_paths: string[], _cb: (p: string) => void) => vi.fn()),
     },
+    clipboard: {
+      writeText: vi.fn(async () => {}),
+      readText: vi.fn(async () => "clip-contents"),
+    },
   };
 }
 
@@ -133,6 +137,34 @@ describe("PluginDevWorkerMainBridge", () => {
     expect(host.getWorktrees).toHaveBeenCalled();
     const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "c1");
     expect(result).toMatchObject({ ok: true, result: [{ id: "w1" }] });
+  });
+
+  it("routes clipboard.writeText to the host and replies with undefined", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "cw",
+      method: "clipboard.writeText",
+      params: { text: "hello" },
+    });
+    await flush();
+    expect(host.clipboard.writeText).toHaveBeenCalledWith("hello");
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "cw");
+    expect(result).toMatchObject({ ok: true, result: undefined });
+  });
+
+  it("routes clipboard.readText to the host and replies with its text", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "cr",
+      method: "clipboard.readText",
+      params: undefined,
+    });
+    await flush();
+    expect(host.clipboard.readText).toHaveBeenCalled();
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "cr");
+    expect(result).toMatchObject({ ok: true, result: "clip-contents" });
   });
 
   it("replies host-result ok:false when the host method throws", async () => {

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -635,6 +635,10 @@ export class PluginDevWorkerHostProxy {
             callOptions?.signal
           ),
       },
+      clipboard: {
+        writeText: (text) => this.call<void>("clipboard.writeText", { text }),
+        readText: () => this.call<string>("clipboard.readText", undefined),
+      },
       settings: {
         get: <T = unknown>(key: string, scope: PluginSettingsScope = "user") =>
           this.call<T | undefined>("settings.get", { key, scope }),

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -114,6 +114,8 @@ export interface MockHostState {
   readonly spawnCalls: ReadonlyArray<SpawnRecord>;
   readonly fsWriteCalls: ReadonlyArray<FsWriteRecord>;
   readonly gitCommitCalls: ReadonlyArray<GitCommitRecord>;
+  /** Captured `host.clipboard.writeText(text)` calls, in order. */
+  readonly clipboardWriteCalls: ReadonlyArray<string>;
 
   /**
    * Replace the active worktree and notify every `onDidChangeActiveWorktree`
@@ -189,6 +191,8 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   const fsFiles = new Map<string, string>();
   const fsWriteCalls: FsWriteRecord[] = [];
   const gitCommitCalls: GitCommitRecord[] = [];
+  const clipboardWriteCalls: string[] = [];
+  let clipboardText = "";
 
   const activeWorktreeSubs = new Set<(snapshot: PluginWorktreeSnapshot | null) => void>();
   const worktreesSubs = new Set<(snapshots: PluginWorktreeSnapshot[]) => void>();
@@ -719,6 +723,20 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         return { commit: `mock-${gitCommitCalls.length}`, message, preview: "" };
       },
     },
+    // In-memory clipboard mock. `writeText` records the text and updates the
+    // in-memory buffer `readText` returns, so a round-trip works in tests. No
+    // capability gating is modeled (matches the fs/git mocks — gating lives in
+    // PluginService and is unit-tested there); `readText` returns "" until the
+    // first write, mirroring Electron's empty-clipboard behaviour.
+    clipboard: {
+      async writeText(text) {
+        clipboardWriteCalls.push(text);
+        clipboardText = text;
+      },
+      async readText() {
+        return clipboardText;
+      },
+    },
     settings,
     storage,
     logger: {
@@ -739,6 +757,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     spawnCalls,
     fsWriteCalls,
     gitCommitCalls,
+    clipboardWriteCalls,
 
     simulateActiveWorktreeChange(snapshot) {
       activeWorktree = snapshot;

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -73,6 +73,7 @@ export type {
   PluginGitStatusFile,
   PluginGitCommitOptions,
   PluginGitCommitResult,
+  PluginClipboardApi,
 } from "./plugin.js";
 
 // ── Settings (host.settings) ────────────────────────────────────────

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1339,6 +1339,33 @@ export interface PluginGitApi {
 }
 
 /**
+ * Host-mediated access to the OS clipboard, backing the `clipboard:read` /
+ * `clipboard:write` capability tokens. Text-only — the surface deliberately
+ * omits image/HTML/file-list variants so a plugin cannot read or smuggle
+ * richer payloads than it declared. Both methods run in the main process
+ * (Electron's `clipboard` module is unavailable in the plugin utility worker),
+ * so they remain callable from a headless plugin with no mounted panel.
+ *
+ * Like {@link PluginFsApi} and {@link PluginGitApi} this is NOT revoke-guarded:
+ * plugins read/write from post-activation timers and callbacks. Once the plugin
+ * is unloaded every method rejects.
+ */
+export interface PluginClipboardApi {
+  /**
+   * Replace the clipboard's contents with `text`. Gated on `clipboard:write`.
+   * Rejects with a `PAYLOAD_TOO_LARGE:` prefix when `text` exceeds 8 MiB by
+   * UTF-8 byte count (mirroring the renderer IPC clipboard guard).
+   */
+  writeText(text: string): Promise<void>;
+  /**
+   * Read the clipboard's text contents. Gated on `clipboard:read`. Resolves to
+   * `""` when the clipboard is empty or holds non-text content (image, file
+   * list) — it never rejects on content type.
+   */
+  readText(): Promise<string>;
+}
+
+/**
  * The revoke-guarded slice of {@link PluginHostApi}: the registration methods
  * that are only valid during `activate()`. The host revokes this surface once
  * activation resolves or times out — every method here throws if called
@@ -1772,6 +1799,14 @@ export interface PluginHostApi extends PluginActivationApi {
    * NOT revoke-guarded — same membership lifetime as {@link fs}.
    */
   readonly git: PluginGitApi;
+  /**
+   * Host-mediated OS clipboard surface. Reads gated on `clipboard:read`, writes
+   * on `clipboard:write`. Text-only; runs in the main process so it works from a
+   * headless plugin. See {@link PluginClipboardApi}.
+   *
+   * NOT revoke-guarded — same membership lifetime as {@link fs}.
+   */
+  readonly clipboard: PluginClipboardApi;
 }
 
 /**

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -52,6 +52,8 @@ export type PluginHostCallMethod =
   | "git.diff"
   | "git.add"
   | "git.commit"
+  | "clipboard.writeText"
+  | "clipboard.readText"
   | "showQuickPick"
   | "showInputBox"
   | "showConfirm"
@@ -354,6 +356,11 @@ export interface GitOpParams {
   filePath?: string;
   paths?: string[];
   message?: string;
+}
+
+/** Params for `clipboard.writeText` (`host-call`). `clipboard.readText` takes no params. */
+export interface ClipboardWriteTextParams {
+  text: string;
 }
 
 /** Params for `process.spawn` (`host-call`). */


### PR DESCRIPTION
## Summary

- Adds `host.clipboard.writeText(text)` and `host.clipboard.readText()` to `PluginHostApi`, fulfilling the previously-declared but unimplemented `clipboard:read` / `clipboard:write` capability tokens
- Implementation follows the same pattern as `buildGitApi` — liveness guard first, then capability check, then an 8 MiB UTF-8 byte cap on `writeText` (mirrors the renderer IPC guard); `readText` returns `""` for empty or non-text content
- Dev-worker path relays clipboard calls over the `MessagePort`; Electron's `clipboard` module is main-process-only so it never runs in the utility worker

Resolves #10557

## Changes

- `electron/services/PluginService.ts` — new `buildClipboardApi`, wired into `PluginHostApi`
- `shared/types/plugin.ts` — new `PluginClipboardApi` interface
- `shared/types/plugin-sdk.ts` — exports `PluginClipboardApi` from the SDK barrel
- `electron/services/plugin/PluginDevWorkerMainBridge.ts` + `pluginDevWorkerHostProxy.ts` — `clipboard.writeText` / `readText` relay over `MessagePort`
- `shared/testing/createMockHost.ts` — mock `clipboard` namespace with `clipboardWriteCalls` recording

## Testing

- `PluginService.hostClipboard.test.ts` — 11 tests: capability gating, liveness-before-capability ordering, UTF-8 byte-limit boundaries including multi-byte characters
- `PluginDevWorkerMainBridge.test.ts` — 31 tests: clipboard routing and empty-read relay over the `MessagePort`