### PR TITLE
feat(plugin): give forge provider methods the project path; ease authless providers

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -108,8 +108,11 @@ describe("resolveForCwd", () => {
     expect(parseRemote).toHaveBeenCalledWith("https://gitea.example.com/owner/repo.git");
   });
 
-  it("stamps the worktree root onto repoRef.projectPath (#10563)", async () => {
-    gitServiceMock.getRepositoryRoot.mockResolvedValue("/repo-worktrees/feature");
+  it("stamps the project root (main worktree), not the linked-worktree cwd, onto projectPath (#10563)", async () => {
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      { path: "/repo", branch: "main", bare: false, isMainWorktree: true },
+      { path: "/repo-worktrees/feature", branch: "feature", bare: false, isMainWorktree: false },
+    ]);
     const parseRemote = vi.fn(() => ({ owner: "owner", repo: "repo", rawData: null }));
     registryMock.getForgeProviderImpl.mockReturnValue({ parseRemote });
     resolverMock.resolveForgeProvider.mockReturnValue({
@@ -119,12 +122,16 @@ describe("resolveForCwd", () => {
 
     const result = await resolveForCwd("/repo-worktrees/feature/src");
 
-    expect(result.repoRef.projectPath).toBe("/repo-worktrees/feature");
-    expect(gitServiceMock.getRepositoryRoot).toHaveBeenCalledWith("/repo-worktrees/feature/src");
+    // Project root, not the linked worktree the call came from — matches the
+    // path PullRequestService stamps on the RPC path.
+    expect(result.repoRef.projectPath).toBe("/repo");
   });
 
-  it("falls back to the raw cwd for projectPath when getRepositoryRoot fails (#10563)", async () => {
-    gitServiceMock.getRepositoryRoot.mockRejectedValue(new Error("not a git repo"));
+  it("falls back to getRepositoryRoot for projectPath when no worktree is marked main (#10563)", async () => {
+    gitServiceMock.listWorktrees.mockResolvedValue([
+      { path: "/elsewhere", branch: "x", bare: false, isMainWorktree: false },
+    ]);
+    gitServiceMock.getRepositoryRoot.mockResolvedValue("/repo");
     const parseRemote = vi.fn(() => ({ owner: "owner", repo: "repo", rawData: null }));
     registryMock.getForgeProviderImpl.mockReturnValue({ parseRemote });
     resolverMock.resolveForgeProvider.mockReturnValue({
@@ -134,7 +141,7 @@ describe("resolveForCwd", () => {
 
     const result = await resolveForCwd("/repo/src");
 
-    expect(result.repoRef.projectPath).toBe("/repo/src");
+    expect(result.repoRef.projectPath).toBe("/repo");
   });
 
   it("looks up the project by the main worktree path, not the linked-worktree cwd", async () => {

--- a/electron/ipc/handlers/__tests__/forgeResolution.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeResolution.test.ts
@@ -103,8 +103,38 @@ describe("resolveForCwd", () => {
     });
     expect(result.providerId).toBe("gitea");
     expect(result.namespaceId).toBe("acme.gitea");
-    expect(result.repoRef).toEqual({ owner: "owner", repo: "repo" });
+    // `projectPath` is the worktree root, stamped onto the parsed ref (#10563).
+    expect(result.repoRef).toEqual({ owner: "owner", repo: "repo", projectPath: "/repo" });
     expect(parseRemote).toHaveBeenCalledWith("https://gitea.example.com/owner/repo.git");
+  });
+
+  it("stamps the worktree root onto repoRef.projectPath (#10563)", async () => {
+    gitServiceMock.getRepositoryRoot.mockResolvedValue("/repo-worktrees/feature");
+    const parseRemote = vi.fn(() => ({ owner: "owner", repo: "repo", rawData: null }));
+    registryMock.getForgeProviderImpl.mockReturnValue({ parseRemote });
+    resolverMock.resolveForgeProvider.mockReturnValue({
+      entry: giteaEntry,
+      resolvedVia: "hostname",
+    });
+
+    const result = await resolveForCwd("/repo-worktrees/feature/src");
+
+    expect(result.repoRef.projectPath).toBe("/repo-worktrees/feature");
+    expect(gitServiceMock.getRepositoryRoot).toHaveBeenCalledWith("/repo-worktrees/feature/src");
+  });
+
+  it("falls back to the raw cwd for projectPath when getRepositoryRoot fails (#10563)", async () => {
+    gitServiceMock.getRepositoryRoot.mockRejectedValue(new Error("not a git repo"));
+    const parseRemote = vi.fn(() => ({ owner: "owner", repo: "repo", rawData: null }));
+    registryMock.getForgeProviderImpl.mockReturnValue({ parseRemote });
+    resolverMock.resolveForgeProvider.mockReturnValue({
+      entry: giteaEntry,
+      resolvedVia: "hostname",
+    });
+
+    const result = await resolveForCwd("/repo/src");
+
+    expect(result.repoRef.projectPath).toBe("/repo/src");
   });
 
   it("looks up the project by the main worktree path, not the linked-worktree cwd", async () => {

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -86,7 +86,17 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
     throw new Error("Could not parse repository identity from remote URL");
   }
 
-  return { namespaceId, providerId: resolved.entry.contribution.id, repoRef, impl };
+  // Hand the provider the worktree this call pertains to so a file/CLI-backed
+  // provider doesn't have to reconstruct it from `repo` (#10563). `cwd` may be a
+  // linked-worktree subdirectory, so normalize to that worktree's top level.
+  const projectPath = (await gitService.getRepositoryRoot(cwd).catch(() => null)) ?? cwd;
+
+  return {
+    namespaceId,
+    providerId: resolved.entry.contribution.id,
+    repoRef: { ...repoRef, projectPath },
+    impl,
+  };
 }
 
 export function getImplForNamespace(namespaceId: string): ForgeProviderImpl {

--- a/electron/ipc/handlers/forgeResolution.ts
+++ b/electron/ipc/handlers/forgeResolution.ts
@@ -86,15 +86,14 @@ export async function resolveForCwd(cwd: string): Promise<ResolvedForgeContext> 
     throw new Error("Could not parse repository identity from remote URL");
   }
 
-  // Hand the provider the worktree this call pertains to so a file/CLI-backed
-  // provider doesn't have to reconstruct it from `repo` (#10563). `cwd` may be a
-  // linked-worktree subdirectory, so normalize to that worktree's top level.
-  const projectPath = (await gitService.getRepositoryRoot(cwd).catch(() => null)) ?? cwd;
-
+  // Hand the provider the project's on-disk root so a file/CLI-backed provider
+  // doesn't have to reconstruct it from `repo` (#10563). `mainWorktreePath` is
+  // already the project root (resolved above for the ProjectStore lookup), which
+  // matches the project-root path `PullRequestService` stamps on the RPC path.
   return {
     namespaceId,
     providerId: resolved.entry.contribution.id,
-    repoRef: { ...repoRef, projectPath },
+    repoRef: { ...repoRef, projectPath: mainWorktreePath },
     impl,
   };
 }

--- a/electron/schemas/__tests__/forgeProviderContribution.test.ts
+++ b/electron/schemas/__tests__/forgeProviderContribution.test.ts
@@ -90,4 +90,22 @@ describe("ForgeProviderContributionSchema (issue #10471)", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("accepts the local/network kind values (#10563)", () => {
+    for (const kind of ["local", "network"] as const) {
+      expect(ForgeProviderContributionSchema.safeParse({ ...base, kind }).success).toBe(true);
+    }
+  });
+
+  it("rejects an unknown kind value", () => {
+    expect(ForgeProviderContributionSchema.safeParse({ ...base, kind: "offline" }).success).toBe(
+      false
+    );
+  });
+
+  it("treats kind as optional (minimal contribution still valid)", () => {
+    const result = ForgeProviderContributionSchema.safeParse(base);
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.kind).toBeUndefined();
+  });
 });

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -234,6 +234,7 @@ export const ForgeProviderContributionSchema = z
     id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
     name: z.string().min(1),
     matches: z.array(z.string().min(1)).min(1),
+    kind: z.enum(["local", "network"]).optional(),
     capabilities: z.array(z.string().min(1)).optional(),
     credentialFields: z.array(CredentialFieldSchema).optional(),
     settingsScopeRef: z.string().min(1).optional(),

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -415,6 +415,9 @@ class PullRequestService {
         remoteUrl,
         forgeProviderOverride: this.forgeProviderOverride,
         globalDefaultProviderId: this.globalDefaultProviderId,
+        // This service is scoped to one worktree, so `this.cwd` is the worktree
+        // root main stamps onto `RepoRef.projectPath` (#10563).
+        projectPath: this.cwd,
       });
       if (resolved.status !== "resolved") {
         this.providerResolutionStatus = resolved.status;

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -415,8 +415,9 @@ class PullRequestService {
         remoteUrl,
         forgeProviderOverride: this.forgeProviderOverride,
         globalDefaultProviderId: this.globalDefaultProviderId,
-        // This service is scoped to one worktree, so `this.cwd` is the worktree
-        // root main stamps onto `RepoRef.projectPath` (#10563).
+        // This service is a project-level singleton initialized with the project
+        // root, so `this.cwd` is the main worktree path main stamps onto
+        // `RepoRef.projectPath` (#10563).
         projectPath: this.cwd,
       });
       if (resolved.status !== "resolved") {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -63,6 +63,7 @@ function makeMockBridge(impl: ForgeProviderImpl) {
         remoteUrl: string | null;
         forgeProviderOverride: string | null;
         globalDefaultProviderId: string | null;
+        projectPath?: string | null;
       }) => Promise<ForgeResolveProviderResult>
     >(async () => ({
       status: "resolved",
@@ -464,6 +465,22 @@ describe("PullRequestService", () => {
 
     expect(bridge.resolveProvider).toHaveBeenCalledWith(
       expect.objectContaining({ remoteUrl: "https://github.com/originowner/originrepo.git" })
+    );
+
+    pullRequestService.destroy();
+  });
+
+  it("forwards the worktree cwd as projectPath so main can stamp the RepoRef (#10563)", async () => {
+    mockForgeProviderUnresolved();
+    const bridge = lastMockBridge!;
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+
+    pullRequestService.initialize("/repo-worktrees/feature");
+    await pullRequestService.refresh();
+
+    expect(bridge.resolveProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ projectPath: "/repo-worktrees/feature" })
     );
 
     pullRequestService.destroy();

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -470,17 +470,17 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
-  it("forwards the worktree cwd as projectPath so main can stamp the RepoRef (#10563)", async () => {
+  it("forwards the initialized project root as projectPath so main can stamp the RepoRef (#10563)", async () => {
     mockForgeProviderUnresolved();
     const bridge = lastMockBridge!;
 
     const { pullRequestService } = await import("../PullRequestService.js");
 
-    pullRequestService.initialize("/repo-worktrees/feature");
+    pullRequestService.initialize("/repo");
     await pullRequestService.refresh();
 
     expect(bridge.resolveProvider).toHaveBeenCalledWith(
-      expect.objectContaining({ projectPath: "/repo-worktrees/feature" })
+      expect.objectContaining({ projectPath: "/repo" })
     );
 
     pullRequestService.destroy();

--- a/electron/services/__tests__/forgeRpcServer.test.ts
+++ b/electron/services/__tests__/forgeRpcServer.test.ts
@@ -427,7 +427,7 @@ describe("resolveProvider miss discrimination (#9997)", () => {
     ]);
     const parseRemote = vi.fn(() => repo);
     registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ parseRemote }));
-    const { send } = captureSender();
+    const { send, sent } = captureSender();
 
     const mk = (projectPath: string, forgeRequestId: string) =>
       dispatchForgeRpc(
@@ -451,5 +451,15 @@ describe("resolveProvider miss discrimination (#9997)", () => {
     // Distinct projectPaths must each produce their own parse rather than sharing
     // one in-flight result, or one worktree would get the other's path.
     expect(parseRemote).toHaveBeenCalledTimes(2);
+
+    // And each request must receive its OWN projectPath back — a fan-out bug that
+    // delivered one waiter's result to both would slip past the call-count check.
+    const pathFor = (id: string) => {
+      const result = sent.find((s) => s.forgeRequestId === id);
+      if (!result?.ok) throw new Error(`no ok result for ${id}`);
+      return (result.value as { repo: RepoRef }).repo.projectPath;
+    };
+    expect(pathFor("ra")).toBe("/repo-a");
+    expect(pathFor("rb")).toBe("/repo-b");
   });
 });

--- a/electron/services/__tests__/forgeRpcServer.test.ts
+++ b/electron/services/__tests__/forgeRpcServer.test.ts
@@ -374,4 +374,82 @@ describe("resolveProvider miss discrimination (#9997)", () => {
       value: { status: "resolved", namespacedId: NAMESPACED_ID, repo: { owner: "owner" } },
     });
   });
+
+  it("stamps projectPath from the opts onto the returned repo (#10563)", async () => {
+    registerForgeProviders(PLUGIN_ID, [
+      { id: CONTRIBUTION_ID, name: "Test Provider", matches: ["gitlab.com"] },
+    ]);
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl());
+    const { send, sent } = captureSender();
+
+    await dispatchForgeRpc(
+      {
+        forgeRequestId: "resolve-path",
+        method: "resolveProvider",
+        args: [
+          {
+            remoteUrl: "https://gitlab.com/owner/repo.git",
+            forgeProviderOverride: null,
+            globalDefaultProviderId: null,
+            projectPath: "/repo-worktrees/feature",
+          },
+        ],
+      },
+      send
+    );
+
+    expect(sent[0]).toMatchObject({
+      ok: true,
+      value: {
+        status: "resolved",
+        repo: { owner: "owner", projectPath: "/repo-worktrees/feature" },
+      },
+    });
+  });
+
+  it("leaves repo unchanged when no projectPath is supplied (#10563)", async () => {
+    registerForgeProviders(PLUGIN_ID, [
+      { id: CONTRIBUTION_ID, name: "Test Provider", matches: ["gitlab.com"] },
+    ]);
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl());
+    const { send, sent } = captureSender();
+
+    await dispatchResolve(send);
+
+    if (sent[0].ok) {
+      expect((sent[0].value as { repo: RepoRef }).repo.projectPath).toBeUndefined();
+    }
+  });
+
+  it("does not coalesce resolves that differ only by projectPath (#10563)", async () => {
+    registerForgeProviders(PLUGIN_ID, [
+      { id: CONTRIBUTION_ID, name: "Test Provider", matches: ["gitlab.com"] },
+    ]);
+    const parseRemote = vi.fn(() => repo);
+    registerForgeProviderImpl(PLUGIN_ID, CONTRIBUTION_ID, makeImpl({ parseRemote }));
+    const { send } = captureSender();
+
+    const mk = (projectPath: string, forgeRequestId: string) =>
+      dispatchForgeRpc(
+        {
+          forgeRequestId,
+          method: "resolveProvider",
+          args: [
+            {
+              remoteUrl: "https://gitlab.com/owner/repo.git",
+              forgeProviderOverride: null,
+              globalDefaultProviderId: null,
+              projectPath,
+            },
+          ],
+        },
+        send
+      );
+
+    await Promise.all([mk("/repo-a", "ra"), mk("/repo-b", "rb")]);
+
+    // Distinct projectPaths must each produce their own parse rather than sharing
+    // one in-flight result, or one worktree would get the other's path.
+    expect(parseRemote).toHaveBeenCalledTimes(2);
+  });
 });

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -242,6 +242,7 @@ async function invokeResolveProvider(args: unknown[]): Promise<ForgeResolveProvi
       remoteUrl: string | null;
       forgeProviderOverride: string | null;
       globalDefaultProviderId: string | null;
+      projectPath?: string | null;
     },
   ];
   const pluginService = await getPluginService();
@@ -272,7 +273,12 @@ async function invokeResolveProvider(args: unknown[]): Promise<ForgeResolveProvi
   const repo = impl.parseRemote(opts.remoteUrl);
   if (!repo) return miss;
 
-  return { status: "resolved", namespacedId, repo };
+  // Stamp the caller's worktree path onto the ref so the provider receives the
+  // on-disk path without reconstructing it from `repo` (#10563). Main is the
+  // authority here: the workspace-host supplies its `cwd`, main returns it on
+  // the parsed ref.
+  const stamped: RepoRef = opts.projectPath ? { ...repo, projectPath: opts.projectPath } : repo;
+  return { status: "resolved", namespacedId, repo: stamped };
 }
 
 function invokeFindPRByBranch(impl: ForgeProviderImpl, args: unknown[]): Promise<PR | null> {

--- a/electron/services/forgeRpcServer.ts
+++ b/electron/services/forgeRpcServer.ts
@@ -91,6 +91,10 @@ const inFlight = new Map<string, InFlightEntry>();
 // before this; only misbehaving plugins ever reach it.
 const FORGE_INVOKE_TIMEOUT_MS = 35_000;
 
+// The key serializes the full args array, so `resolveProvider` calls that
+// differ only by `opts.projectPath` (and other methods whose `RepoRef` arg
+// carries a distinct `projectPath`) no longer coalesce — intended, since each
+// caller must get its own project root stamped back rather than a peer's (#10563).
 function buildSingleflightKey(req: ForgeRpcRequest): string {
   return `${req.method}\0${req.namespacedId ?? ""}\0${stringifyArgs(req.args) ?? ""}`;
 }

--- a/electron/workspace-host/forgeBridge.ts
+++ b/electron/workspace-host/forgeBridge.ts
@@ -58,6 +58,9 @@ export class ForgeBridge {
     remoteUrl: string | null;
     forgeProviderOverride: string | null;
     globalDefaultProviderId: string | null;
+    // Worktree root this resolution is for; main stamps it onto the returned
+    // `RepoRef.projectPath` so the provider gets the on-disk path (#10563).
+    projectPath?: string | null;
   }): Promise<ForgeResolveProviderResult> {
     return this.invoke<ForgeResolveProviderResult>("resolveProvider", undefined, [opts]);
   }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -5,3 +5,6 @@ export type * from "../../../shared/types/plugin-sdk.js";
 // a real string so `plugin.on(pluginId, PLUGIN_PROCESS_STREAM_CHANNEL)` resolves
 // the channel at runtime — a type-only re-export would emit `undefined` (#10515).
 export { PLUGIN_PROCESS_STREAM_CHANNEL } from "../../../shared/types/plugin-sdk.js";
+// `localAuthStubs` is a runtime const a local/offline forge provider spreads
+// into its impl, so it needs an explicit value re-export for the same reason.
+export { localAuthStubs } from "../../../shared/types/plugin-sdk.js";

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -31,6 +31,7 @@ import type {
   ForgeProviderImpl,
   ForgeProviderDescriptor,
   ForgeProviderContribution,
+  ForgeProviderKind,
   FileDecorationProviderImpl,
   FileDecorationProviderDescriptor,
   FileDecorationContribution,
@@ -59,7 +60,7 @@ import type {
   ActionError,
   ActionErrorCode,
 } from "../plugin-sdk.js";
-import { PLUGIN_PROCESS_STREAM_CHANNEL } from "../plugin-sdk.js";
+import { PLUGIN_PROCESS_STREAM_CHANNEL, localAuthStubs } from "../plugin-sdk.js";
 import type { UseHostChannelResult, PluginEventHandler } from "../plugin-sdk-react.js";
 
 /**
@@ -120,6 +121,15 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf<ForgeProviderImpl>().toMatchTypeOf<object>();
       expectTypeOf<ForgeProviderDescriptor>().toMatchTypeOf<object>();
       expectTypeOf<ForgeProviderContribution>().toMatchTypeOf<object>();
+      expectTypeOf<ForgeProviderKind>().toEqualTypeOf<"local" | "network">();
+    });
+
+    it("exports localAuthStubs as a runtime value (#10563)", () => {
+      // Value export, not type-only — a local/offline provider spreads it into
+      // its impl at runtime, so a type-only re-export would emit `undefined`.
+      expect(typeof localAuthStubs.getCredentials).toBe("function");
+      expect(typeof localAuthStubs.validateCredentials).toBe("function");
+      expect(typeof localAuthStubs.validateToken).toBe("function");
     });
 
     it("exports file decoration contract", () => {

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -28,6 +28,16 @@ export interface RepoRef {
   owner: string;
   repo: string;
   rawData: unknown;
+  /**
+   * Absolute on-disk root of the worktree this call pertains to, injected by
+   * the host so a file- or CLI-backed provider doesn't have to reconstruct the
+   * directory from `repo` via `getActiveWorktree()`. Present on refs the host
+   * resolves for a concrete project/worktree; absent for synthetic refs or
+   * legacy callers, so consume it defensively (`if (repo.projectPath)`). A
+   * network provider ignores it. Never embed it in a remote API payload or a
+   * persisted cache key — it's host-local context, not repository identity.
+   */
+  projectPath?: string;
 }
 
 /**
@@ -984,6 +994,13 @@ export interface RegisteredForgeProvider {
 }
 
 /**
+ * Whether a forge provider reaches a remote forge over the network or serves a
+ * local/offline data source. Display-only signal; see
+ * {@link ForgeProviderContribution.kind}.
+ */
+export type ForgeProviderKind = "local" | "network";
+
+/**
  * `forgeProviders` manifest entry. Eager (manifest-driven) registration
  * populates the Preferences UI and remote-routing table before any plugin
  * code runs; the implementation handler binds lazily on first use.
@@ -993,6 +1010,16 @@ export interface ForgeProviderContribution {
   id: string;
   /** Display label in Preferences → Forge Integrations. */
   name: string;
+  /**
+   * Whether the provider talks to a remote forge over the network (`"network"`,
+   * the default when omitted) or serves a local/offline data source backed by
+   * files or a CLI (`"local"`). Display-only and frozen at 1.0: the host never
+   * gates auth or routing on it — a `"local"` provider still owns its auth
+   * methods (use {@link localAuthStubs} to satisfy them). Preferences uses it
+   * only to label a provider that declares no {@link credentialFields} as
+   * deliberately authless rather than unconfigured.
+   */
+  kind?: ForgeProviderKind;
   /**
    * Exact hostnames for git remote URLs; first matching provider wins.
    *
@@ -1061,6 +1088,8 @@ export interface ForgeProviderDescriptor {
   id: string;
   name?: string;
   matches?: string[];
+  /** See {@link ForgeProviderContribution.kind}. */
+  kind?: ForgeProviderKind;
   capabilities?: ForgeCapabilityHint[];
   settingsScopeRef?: string;
   viewRefs?: string[];

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -29,13 +29,16 @@ export interface RepoRef {
   repo: string;
   rawData: unknown;
   /**
-   * Absolute on-disk root of the worktree this call pertains to, injected by
-   * the host so a file- or CLI-backed provider doesn't have to reconstruct the
-   * directory from `repo` via `getActiveWorktree()`. Present on refs the host
-   * resolves for a concrete project/worktree; absent for synthetic refs or
-   * legacy callers, so consume it defensively (`if (repo.projectPath)`). A
-   * network provider ignores it. Never embed it in a remote API payload or a
-   * persisted cache key — it's host-local context, not repository identity.
+   * Absolute on-disk root of the project (its main worktree), injected by the
+   * host so a file- or CLI-backed provider doesn't have to reconstruct the
+   * directory from `repo` via `getActiveWorktree()`. It's the project root, not
+   * the active linked worktree — project-scoped forge data lives once at the
+   * root; a provider that genuinely needs the active worktree still reads it
+   * from `getActiveWorktree()`. Present on refs the host resolves for a concrete
+   * project; absent for synthetic refs or legacy callers, so consume it
+   * defensively (`if (repo.projectPath)`). A network provider ignores it. Never
+   * embed it in a remote API payload or a persisted cache key — it's host-local
+   * context, not repository identity.
    */
   projectPath?: string;
 }

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -115,7 +115,13 @@ export type {
   ForgeProviderImpl,
   ForgeProviderDescriptor,
   ForgeProviderContribution,
+  ForgeProviderKind,
 } from "./forge.js";
+
+// `localAuthStubs` is a runtime value (the no-op auth methods a local/offline
+// provider spreads into its impl), so it is a value export — `export type`
+// would strip the binding and break `{ ...localAuthStubs }` at runtime.
+export { localAuthStubs } from "../utils/forgeProviderHelpers.js";
 
 // ── File decoration provider contract ───────────────────────────────
 

--- a/shared/utils/__tests__/forgeProviderHelpers.test.ts
+++ b/shared/utils/__tests__/forgeProviderHelpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { localAuthStubs } from "../forgeProviderHelpers.js";
+
+describe("localAuthStubs (#10563)", () => {
+  it("getCredentials resolves null (no stored credentials)", async () => {
+    await expect(localAuthStubs.getCredentials()).resolves.toBeNull();
+  });
+
+  it("validateCredentials resolves valid", async () => {
+    await expect(localAuthStubs.validateCredentials()).resolves.toEqual({ valid: true });
+  });
+
+  it("validateToken resolves valid for any token", async () => {
+    await expect(localAuthStubs.validateToken("")).resolves.toEqual({ valid: true });
+    await expect(localAuthStubs.validateToken("anything")).resolves.toEqual({ valid: true });
+  });
+
+  it("can be spread into an impl without overwriting other methods", () => {
+    const parseRemote = () => null;
+    const impl = { ...localAuthStubs, parseRemote };
+    expect(impl.getCredentials).toBe(localAuthStubs.getCredentials);
+    expect(impl.parseRemote).toBe(parseRemote);
+  });
+});

--- a/shared/utils/forgeProviderHelpers.ts
+++ b/shared/utils/forgeProviderHelpers.ts
@@ -1,0 +1,41 @@
+/**
+ * Authoring helpers for forge providers.
+ *
+ * Lives in `shared/` so the main process, the workspace-host UtilityProcess,
+ * and a third-party plugin (via the SDK) can all import the same runtime
+ * binding without dragging any electron-only code across the process boundary.
+ */
+
+import type { ForgeProviderImpl } from "../types/forge.js";
+
+/**
+ * Ready-made auth methods for a local/offline forge provider that has no
+ * credentials to manage. The base {@link ForgeProviderImpl} contract requires
+ * `getCredentials` / `validateCredentials` / `validateToken` even for a
+ * token-less, network-free provider; spreading `localAuthStubs` into the impl
+ * satisfies all three with the obvious no-op answers:
+ *
+ * ```ts
+ * const provider: ForgeProviderImpl = {
+ *   ...localAuthStubs,
+ *   parseRemote,
+ *   listIssues,
+ *   // …the methods that actually do work
+ * };
+ * ```
+ *
+ * `getCredentials` resolves `null` (no stored credentials), and both validation
+ * methods resolve `{ valid: true }` (nothing to reject). Pair it with
+ * `kind: "local"` on the manifest contribution so Preferences labels the
+ * provider as deliberately authless. The host never inspects these results
+ * for a `"local"` provider, but implementing them keeps the impl a valid
+ * structural {@link ForgeProviderImpl}.
+ */
+export const localAuthStubs: Pick<
+  ForgeProviderImpl,
+  "getCredentials" | "validateCredentials" | "validateToken"
+> = {
+  getCredentials: () => Promise.resolve(null),
+  validateCredentials: () => Promise.resolve({ valid: true }),
+  validateToken: (_token: string) => Promise.resolve({ valid: true }),
+};

--- a/src/components/Settings/CodeForgeSettingsTab.tsx
+++ b/src/components/Settings/CodeForgeSettingsTab.tsx
@@ -391,7 +391,11 @@ function ProviderSettingsBody({ providerId, pluginId, contribution }: ProviderSe
           fields={credentialFields}
         />
       ) : (
-        <p className="text-xs text-daintree-text/50">No configuration needed</p>
+        <p className="text-xs text-daintree-text/50">
+          {contribution.kind === "local"
+            ? "Local provider — no authentication needed"
+            : "No configuration needed"}
+        </p>
       )}
 
       <div className="space-y-2 pt-2 border-t border-daintree-border">

--- a/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
+++ b/src/components/Settings/__tests__/CodeForgeSettingsTab.credentials.test.tsx
@@ -211,6 +211,22 @@ describe("CodeForgeSettingsTab — generic credential form", () => {
     expect(screen.queryByTestId("forge-credential-form")).toBeNull();
   });
 
+  it("labels a local authless provider instead of 'No configuration needed' (#10563)", async () => {
+    const localProvider: ForgeProviderEntry = {
+      pluginId: "acme",
+      contribution: { id: "mock", name: "Mock Forge", matches: ["mock.local"], kind: "local" },
+    };
+    installForgeMocks({ providers: [localProvider] });
+
+    render(<CodeForgeSettingsTab activeSubtab="acme.mock" onSubtabChange={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Local provider — no authentication needed")).toBeTruthy();
+    });
+    expect(screen.queryByText("No configuration needed")).toBeNull();
+    expect(screen.queryByTestId("forge-credential-form")).toBeNull();
+  });
+
   it("reloads credential status when the selected provider changes", async () => {
     const { getCredentialStatus } = installForgeMocks({
       providers: [


### PR DESCRIPTION
## Summary

- `RepoRef` gains an optional `projectPath` field (absolute project root), host-injected at both forge call sites so file- or CLI-backed providers no longer have to reconstruct the working directory from a repo reference.
- New `localAuthStubs` helper in `shared/utils/forgeProviderHelpers.ts` provides no-op `getCredentials`/`validateCredentials`/`validateToken` stubs; re-exported from the plugin SDK barrel to keep authless providers lean.
- New display-only `kind?: "local" | "network"` field on `ForgeProviderContribution` (+ Zod schema); Preferences labels `kind: "local"` authless providers distinctly instead of "No configuration needed".

All additions are backward-compatible — the `ForgeProviderImpl` contract is frozen at 1.0.

Resolves #10563

## Changes

- `shared/types/forge.ts` — `projectPath` on `RepoRef`; injected in `forgeResolution.ts` (IPC path) and `forgeRpcServer.ts` / `forgeBridge.ts` (workspace-host RPC path), both using project root.
- `shared/utils/forgeProviderHelpers.ts` — `localAuthStubs` helper (new file).
- `packages/plugin-sdk/src/index.ts` — re-exports `localAuthStubs` and its type.
- `electron/schemas/plugin.ts` — `kind` field on the `ForgeProviderContribution` Zod schema.
- `shared/types/plugin-sdk.ts` — `kind` on the TypeScript type.
- `src/components/Settings/CodeForgeSettingsTab.tsx` — renders `kind: "local"` providers with distinct copy.
- Docs for the provider id shape and local-forge path pattern deferred to the docs sweep (#10525) per the issue.

## Testing

175 targeted tests pass. Added/updated coverage for:

- `localAuthStubs` helper behaviour.
- SDK value + type export.
- `kind` Zod schema validation.
- `projectPath` injection on both host paths (including singleflight per-waiter correctness in the workspace-host path).
- Settings copy for `kind: "local"` providers.