### PR TITLE
fix(plugin): make plugin-contributed agents launchable end-to-end

### DIFF
--- a/electron/ipc/handlers/slashCommands.ts
+++ b/electron/ipc/handlers/slashCommands.ts
@@ -1,13 +1,20 @@
 import path from "path";
+import type { z } from "zod";
 import { defineIpcNamespace, opValidated } from "../define.js";
 import { SLASH_COMMANDS_METHOD_CHANNELS } from "./slashCommands.preload.js";
 import { SlashCommandListRequestSchema } from "../../schemas/ipc.js";
+import { isBuiltInAgentId } from "../../../shared/config/agentIds.js";
 import { slashCommandService } from "../../services/SlashCommandService.js";
-import type { SlashCommand, SlashCommandListRequest } from "../../../shared/types/index.js";
+import type { SlashCommand } from "../../../shared/types/index.js";
 
-async function handleList(payload: SlashCommandListRequest): Promise<SlashCommand[]> {
+async function handleList(
+  payload: z.output<typeof SlashCommandListRequestSchema>
+): Promise<SlashCommand[]> {
   const { agentId, projectPath } = payload;
   const safeProjectPath = projectPath && path.isAbsolute(projectPath) ? projectPath : undefined;
+  // The schema accepts plugin-contributed agent ids (#10560), but only built-in
+  // agents have slash commands — a plugin id yields none rather than erroring.
+  if (!isBuiltInAgentId(agentId)) return [];
   return slashCommandService.list(agentId, safeProjectPath);
 }
 

--- a/electron/schemas/__tests__/agentContribution.test.ts
+++ b/electron/schemas/__tests__/agentContribution.test.ts
@@ -79,6 +79,45 @@ describe("AgentContributionSchema (issue #9560)", () => {
     }
   });
 
+  it("accepts a bare PATH binary name as the command", () => {
+    expect(
+      AgentContributionSchema.safeParse({ ...VALID_AGENT, command: "claude-cli" }).success
+    ).toBe(true);
+  });
+
+  it("accepts a plugin-relative ./ command path (#10560)", () => {
+    for (const command of ["./bin/agent.mjs", "./agent", "./dist/cli/run.js"]) {
+      expect(AgentContributionSchema.safeParse({ ...VALID_AGENT, command }).success).toBe(true);
+    }
+  });
+
+  it("rejects relative paths without an explicit ./ prefix (#10560)", () => {
+    // A bare relative path is ambiguous with a PATH name, so it must be rejected
+    // — only ./-prefixed paths or separator-free PATH names are allowed.
+    expect(
+      AgentContributionSchema.safeParse({ ...VALID_AGENT, command: "bin/agent.mjs" }).success
+    ).toBe(false);
+  });
+
+  it("rejects traversal, absolute, and Windows-separator command paths (#10560)", () => {
+    for (const command of [
+      "../agent",
+      "./../agent",
+      "./bin/../../escape",
+      "/usr/bin/agent",
+      ".\\bin\\agent.cmd",
+      "./bin\\agent.cmd",
+    ]) {
+      expect(AgentContributionSchema.safeParse({ ...VALID_AGENT, command }).success).toBe(false);
+    }
+  });
+
+  it("rejects bare-dot and empty relative command paths (#10560)", () => {
+    for (const command of ["./", "./."]) {
+      expect(AgentContributionSchema.safeParse({ ...VALID_AGENT, command }).success).toBe(false);
+    }
+  });
+
   it("rejects control characters in args and caps arg count at 20", () => {
     expect(
       AgentContributionSchema.safeParse({ ...VALID_AGENT, args: ["ok", "bad\nflag"] }).success

--- a/electron/schemas/__tests__/agentContribution.test.ts
+++ b/electron/schemas/__tests__/agentContribution.test.ts
@@ -118,6 +118,12 @@ describe("AgentContributionSchema (issue #9560)", () => {
     }
   });
 
+  it("rejects empty, current-dir, and trailing segments in relative command paths (#10560)", () => {
+    for (const command of ["./bin//agent", "./bin/./agent", "./bin/agent/"]) {
+      expect(AgentContributionSchema.safeParse({ ...VALID_AGENT, command }).success).toBe(false);
+    }
+  });
+
   it("rejects control characters in args and caps arg count at 20", () => {
     expect(
       AgentContributionSchema.safeParse({ ...VALID_AGENT, args: ["ok", "bad\nflag"] }).success

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -329,7 +329,10 @@ export const FileSearchPayloadSchema = z.object({
 });
 
 export const SlashCommandListRequestSchema = z.object({
-  agentId: z.enum(BUILT_IN_AGENT_IDS),
+  // Accept plugin-contributed agent ids too (#10560), not just built-ins. The
+  // handler's `SlashCommandService.list()` returns [] for any unrecognized id,
+  // so plugin agents simply have no slash commands rather than erroring.
+  agentId: LaunchAgentIdSchema,
   projectPath: z.string().optional(),
 });
 

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -310,7 +310,11 @@ function isSafePluginAgentCommand(command: string): boolean {
   if (command.includes("\0")) return false;
   const normalized = command.slice(2);
   if (normalized === "" || normalized === ".") return false;
-  return !command.split("/").includes("..");
+  // Reject empty (`//`), current-dir (`.`), and traversal (`..`) segments so the
+  // registration-time resolve cannot escape the plugin dir or normalize oddly.
+  return normalized
+    .split("/")
+    .every((segment) => segment !== "" && segment !== "." && segment !== "..");
 }
 
 export const AgentContributionSchema = z

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -288,6 +288,31 @@ export const FileDecorationContributionSchema = z
  */
 const RESERVED_AGENT_IDS = new Set(["__proto__", "constructor", "prototype"]);
 
+/**
+ * Validate a `contributes.agents` `command` before it is registered and later
+ * spawned by node-pty. Two shapes are allowed: a bare PATH-resolvable binary
+ * name (no path separators — the original `SAFE_ID_PATTERN` behavior), or an
+ * explicit plugin-relative POSIX path prefixed with `./` that resolves against
+ * the plugin's install dir at registration time (`pluginAgentRegistry`). The
+ * `./` prefix is required for relative paths so intent is unambiguous — a bare
+ * `bin/agent.mjs` would be ambiguous with a PATH name. Rejects absolute paths,
+ * Windows separators, NUL, and any `..` traversal segment so the failure is a
+ * loud manifest error rather than a spawn-time ENOENT or an escape from the
+ * plugin dir. node-pty resolves the command before switching cwd, so the
+ * relative form is resolved to an absolute path at registration, not spawn.
+ */
+function isSafePluginAgentCommand(command: string): boolean {
+  // Bare PATH-resolvable binary name (e.g. "claude", "node") — original behavior.
+  if (SAFE_ID_PATTERN.test(command)) return true;
+  // Otherwise only an explicit plugin-relative POSIX path is allowed.
+  if (!command.startsWith("./")) return false;
+  if (command.includes("\\")) return false;
+  if (command.includes("\0")) return false;
+  const normalized = command.slice(2);
+  if (normalized === "" || normalized === ".") return false;
+  return !command.split("/").includes("..");
+}
+
 export const AgentContributionSchema = z
   .object({
     id: z
@@ -299,7 +324,10 @@ export const AgentContributionSchema = z
         message: "Agent id cannot be a reserved key (__proto__, constructor, prototype)",
       }),
     name: z.string().min(1).max(100),
-    command: z.string().min(1).max(256).regex(SAFE_ID_PATTERN),
+    command: z.string().min(1).max(256).refine(isSafePluginAgentCommand, {
+      message:
+        "command must be a bare PATH binary name or a plugin-relative path starting with ./ (no absolute path, backslash, NUL, or .. segments)",
+    }),
     args: z
       .array(
         z

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -1,7 +1,7 @@
 // eager-import-allow: reads the CLI-availability cache via store.get synchronously
 import { execFile } from "child_process";
 import { access, constants } from "fs/promises";
-import { delimiter, dirname, join, win32 as pathWin32 } from "path";
+import { delimiter, dirname, isAbsolute, join, win32 as pathWin32 } from "path";
 import { homedir } from "os";
 import type {
   CliAvailability,
@@ -445,6 +445,13 @@ export class CliAvailabilityService {
     const command = config.command;
     if (typeof command !== "string" || !command.trim()) {
       return { status: "missing" };
+    }
+    // Plugin-contributed agents (#10560) resolve a `./`-relative manifest command
+    // to an absolute path at registration. Such a command has path separators and
+    // would be rejected by VALID_COMMAND_RE below, so probe the file directly
+    // instead — `probeNativePaths` checks existence + executability (X_OK).
+    if (isAbsolute(command)) {
+      return this.probeNativePaths([command]);
     }
     if (!CliAvailabilityService.VALID_COMMAND_RE.test(command)) {
       console.warn(

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1366,7 +1366,7 @@ export class PluginService {
     }
 
     if (manifest.contributes.agents.length > 0) {
-      registerPluginAgents(manifest.name, manifest.contributes.agents);
+      registerPluginAgents(manifest.name, manifest.contributes.agents, pluginDir);
       this.broadcaster.scheduleAgentsBroadcast(false);
     }
 

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -2186,4 +2186,73 @@ describe("CliAvailabilityService", () => {
       expect(stored["duplicate-cli-warning:claude"]).toBe(true);
     });
   });
+
+  describe("plugin-contributed agent commands (issue #10560)", () => {
+    it("probes an absolute plugin command path via the filesystem instead of rejecting it", async () => {
+      const { registerPluginAgents, clearPluginAgentRegistryForTests } =
+        await import("../../../shared/config/pluginAgentRegistry.js");
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+      const absoluteCommand = join(homedir(), "plugins", "acme", "bin", "agent");
+
+      try {
+        registerPluginAgents("acme.plugin", [
+          {
+            id: "acme-agent",
+            name: "Acme Agent",
+            command: absoluteCommand,
+            color: "#3366ff",
+            iconId: "terminal",
+          },
+        ]);
+
+        // Built-in PATH binaries stay missing; only the plugin's absolute file resolves.
+        mockedExecFileSync.mockImplementation(() => {
+          throw new Error("Command not found");
+        });
+        mockedAccess.mockImplementation(async (p) => {
+          if (String(p) === absoluteCommand) return undefined;
+          throw new Error("ENOENT");
+        });
+
+        const result = await service.checkAvailability();
+
+        // The absolute path is not rejected by VALID_COMMAND_RE — it is probed and found.
+        expect(result["acme-agent"]).toBe("ready");
+        expect(service.getDetails()?.["acme-agent"]?.resolvedPath).toBe(absoluteCommand);
+      } finally {
+        clearPluginAgentRegistryForTests();
+      }
+    });
+
+    it("reports an absolute plugin command as missing when the file does not exist", async () => {
+      const { registerPluginAgents, clearPluginAgentRegistryForTests } =
+        await import("../../../shared/config/pluginAgentRegistry.js");
+      const { access } = await import("fs/promises");
+      const mockedAccess = vi.mocked(access);
+
+      try {
+        registerPluginAgents("acme.plugin", [
+          {
+            id: "acme-agent",
+            name: "Acme Agent",
+            command: join(homedir(), "plugins", "acme", "bin", "agent"),
+            color: "#3366ff",
+            iconId: "terminal",
+          },
+        ]);
+
+        mockedExecFileSync.mockImplementation(() => {
+          throw new Error("Command not found");
+        });
+        mockedAccess.mockRejectedValue(new Error("ENOENT"));
+
+        const result = await service.checkAvailability();
+
+        expect(result["acme-agent"]).toBe("missing");
+      } finally {
+        clearPluginAgentRegistryForTests();
+      }
+    });
+  });
 });

--- a/shared/config/__tests__/pluginAgentRegistry.test.ts
+++ b/shared/config/__tests__/pluginAgentRegistry.test.ts
@@ -137,6 +137,41 @@ describe("pluginAgentRegistry (issue #9560)", () => {
     expect(registry["claude"]).toBeDefined();
   });
 
+  it("resolves a ./-prefixed command to an absolute path against pluginDir (#10560)", () => {
+    registerPluginAgents(
+      "acme.plugin",
+      [{ ...ACME_AGENT, command: "./bin/agent.mjs" }],
+      "/plugins/acme"
+    );
+    expect(getEffectiveAgentConfig("acme-agent")?.command).toBe("/plugins/acme/bin/agent.mjs");
+  });
+
+  it("leaves a bare PATH command unchanged even when pluginDir is provided (#10560)", () => {
+    registerPluginAgents("acme.plugin", [ACME_AGENT], "/plugins/acme");
+    expect(getEffectiveAgentConfig("acme-agent")?.command).toBe("acme");
+  });
+
+  it("leaves a ./-prefixed command unresolved when no pluginDir is provided (#10560)", () => {
+    registerPluginAgents("acme.plugin", [{ ...ACME_AGENT, command: "./bin/agent.mjs" }]);
+    expect(getEffectiveAgentConfig("acme-agent")?.command).toBe("./bin/agent.mjs");
+  });
+
+  it("joins a Windows-style pluginDir with backslashes (#10560)", () => {
+    registerPluginAgents(
+      "acme.plugin",
+      [{ ...ACME_AGENT, command: "./bin/agent.cmd" }],
+      String.raw`C:\plugins\acme`
+    );
+    expect(getEffectiveAgentConfig("acme-agent")?.command).toBe(
+      String.raw`C:\plugins\acme\bin\agent.cmd`
+    );
+  });
+
+  it("does not double a trailing separator on pluginDir (#10560)", () => {
+    registerPluginAgents("acme.plugin", [{ ...ACME_AGENT, command: "./agent" }], "/plugins/acme/");
+    expect(getEffectiveAgentConfig("acme-agent")?.command).toBe("/plugins/acme/agent");
+  });
+
   it("does not let a reserved id pollute the snapshot prototype", () => {
     // The manifest schema rejects reserved ids, but the registry must also be
     // defensive: a `__proto__` id must not reassign the snapshot's prototype.

--- a/shared/config/pluginAgentRegistry.ts
+++ b/shared/config/pluginAgentRegistry.ts
@@ -65,13 +65,33 @@ export function getPluginAgentRegistrySnapshot(): Record<string, AgentConfig> {
   return snapshot;
 }
 
-function contributionToAgentConfig(contribution: PluginAgentContribution): AgentConfig {
+/**
+ * Resolve a plugin-relative `./` command to an absolute path against the
+ * plugin's install dir so node-pty can spawn it (node-pty resolves the command
+ * before switching cwd, so a relative path would ENOENT). A bare PATH name
+ * (e.g. "claude") is returned unchanged. Done with a pure separator-aware join
+ * rather than `node:path` so this module stays safe to bundle in the renderer
+ * (which imports it via `agentRegistry`); the manifest schema
+ * (`AgentContributionSchema.command`) already guarantees the relative form is
+ * POSIX (`./seg/seg`) with no backslashes or `..` traversal segments.
+ */
+function resolvePluginAgentCommand(command: string, pluginDir?: string): string {
+  if (!pluginDir || !command.startsWith("./")) return command;
+  const sep = pluginDir.includes("\\") && !pluginDir.includes("/") ? "\\" : "/";
+  const base = pluginDir.endsWith(sep) ? pluginDir.slice(0, -1) : pluginDir;
+  return base + sep + command.slice(2).split("/").join(sep);
+}
+
+function contributionToAgentConfig(
+  contribution: PluginAgentContribution,
+  pluginDir?: string
+): AgentConfig {
   // Surface only the launch-relevant fields. Plugin agents launch as named,
   // untracked terminals; output-pattern detection is not part of the 1.0 schema.
   return {
     id: contribution.id,
     name: contribution.name,
-    command: contribution.command,
+    command: resolvePluginAgentCommand(contribution.command, pluginDir),
     args: contribution.args,
     color: contribution.color,
     iconId: contribution.iconId,
@@ -108,11 +128,14 @@ function rebuildSnapshot(): void {
 /**
  * Register the agents one plugin contributes. Replaces any prior set for the
  * same `pluginId` (idempotent reload). Pass an empty array to clear the
- * plugin's entries. Main-process only.
+ * plugin's entries. `pluginDir` is the plugin's install dir; when provided, a
+ * `./`-prefixed command is resolved to an absolute path against it (see
+ * {@link resolvePluginAgentCommand}). Main-process only.
  */
 export function registerPluginAgents(
   pluginId: string,
-  contributions: PluginAgentContribution[]
+  contributions: PluginAgentContribution[],
+  pluginDir?: string
 ): void {
   if (typeof pluginId !== "string" || pluginId.length === 0) return;
   if (!Array.isArray(contributions) || contributions.length === 0) {
@@ -121,7 +144,7 @@ export function registerPluginAgents(
   }
   const agents = new Map<string, AgentConfig>();
   for (const contribution of contributions) {
-    agents.set(contribution.id, Object.freeze(contributionToAgentConfig(contribution)));
+    agents.set(contribution.id, Object.freeze(contributionToAgentConfig(contribution, pluginDir)));
   }
   byPlugin.set(pluginId, agents);
   rebuildSnapshot();

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1062,7 +1062,7 @@ export interface GeneratedIpcInvokeMap {
     result: void;
   };
   "slash-commands:list": {
-    args: [payload: import("../slashCommands.js").SlashCommandListRequest];
+    args: [payload: { agentId: string; projectPath?: string | undefined }];
     result: import("../slashCommands.js").SlashCommand[];
   };
   "system-sleep:get-awake-time": {

--- a/src/components/TerminalPalette/__tests__/launchOptions.test.tsx
+++ b/src/components/TerminalPalette/__tests__/launchOptions.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getLaunchOptions } from "../launchOptions";
+import {
+  setPluginAgentRegistry,
+  clearPluginAgentRegistryForTests,
+} from "@shared/config/pluginAgentRegistry";
+
+describe("getLaunchOptions (issue #10560)", () => {
+  beforeEach(() => {
+    clearPluginAgentRegistryForTests();
+  });
+  afterEach(() => {
+    clearPluginAgentRegistryForTests();
+  });
+
+  it("includes built-in agents plus terminal and browser entries", () => {
+    const options = getLaunchOptions();
+    const ids = options.map((o) => o.id);
+    expect(ids).toContain("claude");
+    expect(ids).toContain("terminal");
+    expect(ids).toContain("browser");
+  });
+
+  it("includes a plugin-contributed agent as a launchable option", () => {
+    setPluginAgentRegistry({
+      "acme-agent": {
+        id: "acme-agent",
+        name: "Acme Agent",
+        command: "/plugins/acme/bin/agent",
+        color: "#3366ff",
+        iconId: "terminal",
+        supportsContextInjection: false,
+      },
+    });
+
+    const option = getLaunchOptions().find((o) => o.id === "acme-agent");
+    expect(option).toBeDefined();
+    // The launch hint must carry the plugin agent id so agent.launch can resolve it.
+    expect(option?.launchAgentId).toBe("acme-agent");
+    expect(option?.label).toBe("Acme Agent");
+  });
+
+  it("drops a plugin agent from the options once its registry entry is removed", () => {
+    setPluginAgentRegistry({
+      "acme-agent": {
+        id: "acme-agent",
+        name: "Acme Agent",
+        command: "acme",
+        color: "#3366ff",
+        iconId: "terminal",
+        supportsContextInjection: false,
+      },
+    });
+    expect(getLaunchOptions().some((o) => o.id === "acme-agent")).toBe(true);
+
+    setPluginAgentRegistry({});
+    expect(getLaunchOptions().some((o) => o.id === "acme-agent")).toBe(false);
+  });
+});

--- a/src/components/TerminalPalette/launchOptions.tsx
+++ b/src/components/TerminalPalette/launchOptions.tsx
@@ -1,15 +1,14 @@
 import { SquareTerminal, Globe, Settings } from "lucide-react";
 import { getBrandColorHex } from "@/lib/colorUtils";
 import type { PanelKind } from "@/types";
-import type { BuiltInAgentId } from "@shared/config/agentIds";
 import { AGENT_REGISTRY } from "@/config/agents";
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { getEffectiveAgentIds, getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { resolveAgentIcon } from "@/config/agentIcons";
 
 export interface LaunchOption {
   id: string;
-  /** Agent id when this option launches an agent; absent for plain terminal/browser. */
-  launchAgentId?: BuiltInAgentId;
+  /** Agent id when this option launches an agent; absent for plain terminal/browser. Plain string so plugin-contributed agent ids are accepted, not just built-ins. */
+  launchAgentId?: string;
   kind?: PanelKind;
   label: string;
   description: string;
@@ -17,11 +16,16 @@ export interface LaunchOption {
 }
 
 export function getLaunchOptions(): LaunchOption[] {
-  const agentOptions: LaunchOption[] = BUILT_IN_AGENT_IDS.map((id) => {
-    const config = AGENT_REGISTRY[id];
+  // Iterate the effective registry so plugin-contributed agents (merged below
+  // built-ins by `getEffectiveRegistry`) are launchable here too, not just the
+  // built-in set. Built-in metadata (presets, tooltip) lives in the richer
+  // renderer `AGENT_REGISTRY`; plugin agents fall back to the effective config.
+  const agentOptions: LaunchOption[] = getEffectiveAgentIds().map((id) => {
+    const builtIn = AGENT_REGISTRY[id];
+    const config = builtIn ?? getEffectiveAgentConfig(id);
     const Icon = resolveAgentIcon(config?.iconId ?? id);
-    const presetCount = config?.presets?.length ?? 0;
-    const description = config?.tooltip ?? "";
+    const presetCount = builtIn?.presets?.length ?? 0;
+    const description = builtIn?.tooltip ?? "";
     const presetSuffix = presetCount > 0 ? ` (${presetCount} presets)` : "";
     return {
       id,

--- a/src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.commandResolution.test.ts
@@ -57,4 +57,34 @@ describe("resolveAgentLaunchBaseCommand", () => {
       )
     ).toBe("claude");
   });
+
+  it("passes a bare PATH registry command through unchanged (built-in agents)", () => {
+    // No separator => not a path => never quoted, preserving existing behavior.
+    expect(resolveAgentLaunchBaseCommand("acme-cli", undefined, "posix")).toBe("acme-cli");
+  });
+
+  it("quotes a plugin-contributed absolute command path with spaces (#10560)", () => {
+    // A ./-relative manifest command resolves to an absolute path that may live
+    // under a spaced dir (e.g. macOS "Application Support"); it must be quoted so
+    // the space doesn't split the spawned command string.
+    expect(
+      resolveAgentLaunchBaseCommand(
+        "/Users/x/Application Support/Daintree/plugins/acme/bin/agent",
+        undefined,
+        "posix"
+      )
+    ).toBe("'/Users/x/Application Support/Daintree/plugins/acme/bin/agent'");
+  });
+
+  it("leaves a space-free absolute command path unquoted (#10560)", () => {
+    expect(resolveAgentLaunchBaseCommand("/plugins/acme/bin/agent", undefined, "posix")).toBe(
+      "/plugins/acme/bin/agent"
+    );
+  });
+
+  it("uses PowerShell call syntax for a plugin-contributed Windows command path (#10560)", () => {
+    expect(
+      resolveAgentLaunchBaseCommand(String.raw`C:\plugins\acme\bin\agent.cmd`, undefined, "windows")
+    ).toBe(String.raw`& 'C:\plugins\acme\bin\agent.cmd'`);
+  });
 });

--- a/src/hooks/__tests__/useNewTerminalPalette.test.tsx
+++ b/src/hooks/__tests__/useNewTerminalPalette.test.tsx
@@ -169,6 +169,38 @@ describe("useNewTerminalPalette", () => {
     expect(ids).not.toContain("codex");
   });
 
+  it("keeps a plugin-contributed agent visible even when its availability is missing (#10560)", () => {
+    // A plugin agent is never hidden by availability the way a built-in is — it
+    // stays reachable so the user can launch it (or hit the install path).
+    cliAvailabilityState.availability = { claude: "ready", "acme-agent": "missing" };
+    getEffectiveAgentIdsMock.mockReturnValue(["claude", "acme-agent"]);
+    getLaunchOptionsMock.mockReturnValue([
+      makeOption("claude", { launchAgentId: "claude" }),
+      makeOption("acme-agent", { launchAgentId: "acme-agent" }),
+      makeOption("terminal"),
+    ]);
+
+    const { result } = render();
+
+    const ids = result.current.results.map((opt) => opt.id);
+    expect(ids).toContain("acme-agent");
+  });
+
+  it("hides a built-in agent that is missing but keeps a missing plugin agent (#10560)", () => {
+    cliAvailabilityState.availability = { codex: "missing", "acme-agent": "missing" };
+    getEffectiveAgentIdsMock.mockReturnValue(["codex", "acme-agent"]);
+    getLaunchOptionsMock.mockReturnValue([
+      makeOption("codex", { launchAgentId: "codex" }),
+      makeOption("acme-agent", { launchAgentId: "acme-agent" }),
+    ]);
+
+    const { result } = render();
+
+    const ids = result.current.results.map((opt) => opt.id);
+    expect(ids).not.toContain("codex");
+    expect(ids).toContain("acme-agent");
+  });
+
   it("includes non-agent options (terminal, browser) regardless of availability", () => {
     cliAvailabilityState.availability = {
       claude: "missing",

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -398,6 +398,42 @@ describe("usePanelPalette", () => {
       expect(gemini).toBeUndefined();
     });
 
+    it("shows a plugin agent with undefined availability as installed=false, not hidden (#10560)", () => {
+      // A plugin-contributed agent that CliAvailabilityService has not probed
+      // has no availability entry. It must surface greyed-out, not vanish the
+      // way an uninstalled built-in does.
+      getEffectiveAgentIdsMock.mockReturnValue(["acme-agent"]);
+      getEffectiveAgentConfigMock.mockReturnValue({
+        name: "Acme Agent",
+        iconId: "terminal",
+        color: "#3366ff",
+        tooltip: "Acme plugin agent",
+      });
+      cliAvailabilityState.availability = {};
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const acme = result.current.results.find((item) => item.id === "agent:acme-agent");
+      expect(acme).toBeDefined();
+      expect(acme?.installed).toBe(false);
+    });
+
+    it("shows a plugin agent even when its command is probed as missing (#10560)", () => {
+      getEffectiveAgentIdsMock.mockReturnValue(["acme-agent"]);
+      getEffectiveAgentConfigMock.mockReturnValue({
+        name: "Acme Agent",
+        iconId: "terminal",
+        color: "#3366ff",
+      });
+      cliAvailabilityState.availability = { "acme-agent": "missing" };
+
+      const { result } = renderHook(() => usePanelPalette());
+
+      const acme = result.current.results.find((item) => item.id === "agent:acme-agent");
+      expect(acme).toBeDefined();
+      expect(acme?.installed).toBe(false);
+    });
+
     it("sets installed=undefined before availability is initialized", () => {
       getEffectiveAgentIdsMock.mockReturnValue(["claude"]);
       cliAvailabilityState.isInitialized = false;

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -154,14 +154,22 @@ export function resolveAgentLaunchBaseCommand(
     detail.state !== "installed"
       ? detail.resolvedPath?.trim()
       : undefined;
-  if (!resolvedPath) return registryCommand;
+
+  // When there's no availability-resolved path, fall back to the registry
+  // command. A bare PATH binary name (built-in agents) passes through unchanged.
+  // A plugin-contributed command resolved to an absolute path (#10560) is
+  // escaped like a resolved path so spaces in the plugin dir — e.g. macOS's
+  // "Application Support" — don't split the spawned command string.
+  const effective = resolvedPath ?? registryCommand;
+  const isPathLike = effective.includes("/") || effective.includes("\\");
+  if (!resolvedPath && !isPathLike) return registryCommand;
 
   const useWindows = platform ? platform === "windows" : isWindows();
   if (useWindows) {
-    return `& ${escapePowerShellSingleQuoted(resolvedPath)}`;
+    return `& ${escapePowerShellSingleQuoted(effective)}`;
   }
 
-  return escapeShellArgOptional(resolvedPath, "posix");
+  return escapeShellArgOptional(effective, "posix");
 }
 
 async function getCurrentLaunchCliDetail(agentId: string): Promise<AgentCliDetail | undefined> {

--- a/src/hooks/useNewTerminalPalette.ts
+++ b/src/hooks/useNewTerminalPalette.ts
@@ -57,7 +57,14 @@ export function useNewTerminalPalette({
 
   const options = useMemo(() => {
     const allOptions = getLaunchOptions();
-    const registryAgentIds = new Set(getEffectiveAgentIds());
+    // Union plugin agent ids (mirrored by pluginAgentSnapshot) with the effective
+    // set so this memo recomputes when plugins register/unregister mid-session;
+    // getEffectiveAgentIds already includes them, so the union is purely a
+    // recompute trigger.
+    const registryAgentIds = new Set([
+      ...getEffectiveAgentIds(),
+      ...Object.keys(pluginAgentSnapshot),
+    ]);
 
     // Before availability is known, show all agents (avoids startup flicker).
     // Once known, hide built-in agents that are not installed. Plugin-contributed

--- a/src/hooks/useNewTerminalPalette.ts
+++ b/src/hooks/useNewTerminalPalette.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import {
   getLaunchOptions,
   getMoreAgentsOption,
@@ -12,6 +12,11 @@ import type { WorktreeState } from "@/types";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { actionService } from "@/services/ActionService";
 import { getEffectiveAgentIds } from "@shared/config/agentRegistry";
+import {
+  subscribeToPluginAgentRegistry,
+  getPluginAgentRegistrySnapshot,
+} from "@shared/config/pluginAgentRegistry";
+import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 interface UseNewTerminalPaletteProps {
@@ -43,15 +48,24 @@ export function useNewTerminalPalette({
   const addPanel = usePanelStore((state) => state.addPanel);
   const availability = useCliAvailabilityStore((state) => state.availability);
   const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
+  // Re-derive options when plugins register/unregister agents mid-session;
+  // getLaunchOptions reads the effective registry, which the snapshot mirrors.
+  const pluginAgentSnapshot = useSyncExternalStore(
+    subscribeToPluginAgentRegistry,
+    getPluginAgentRegistrySnapshot
+  );
 
   const options = useMemo(() => {
     const allOptions = getLaunchOptions();
     const registryAgentIds = new Set(getEffectiveAgentIds());
 
     // Before availability is known, show all agents (avoids startup flicker).
-    // Once known, hide agents that are not installed.
+    // Once known, hide built-in agents that are not installed. Plugin-contributed
+    // agents are never hidden here (#10560) — kept consistent with usePanelPalette
+    // so a plugin agent stays reachable rather than silently dropping.
     const isAgentHidden = (id: string): boolean => {
       if (!isAvailabilityInitialized) return false;
+      if (!isBuiltInAgentId(id)) return false;
       return !isAgentInstalled(availability[id]);
     };
 
@@ -62,7 +76,7 @@ export function useNewTerminalPalette({
     filtered.push(getMoreAgentsOption());
 
     return filtered;
-  }, [availability, isAvailabilityInitialized]);
+  }, [availability, isAvailabilityInitialized, pluginAgentSnapshot]);
 
   const { results, selectedIndex, close, ...paletteRest } = useSearchablePalette<LaunchOption>({
     items: options,

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -34,7 +34,7 @@ export type UsePanelPaletteReturn = UseSearchablePaletteReturn<PanelKindOption> 
   confirmSelection: () => PanelKindOption | null;
 };
 
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { BUILT_IN_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
@@ -112,6 +112,12 @@ export function usePanelPalette(): UsePanelPaletteReturn {
 
     const isAgentHidden = (agentId: string): boolean => {
       if (!isAvailabilityInitialized) return false;
+      // Plugin-contributed agents are always shown — greyed-out via the
+      // `installed` field when their command is unresolved/uninstalled — rather
+      // than silently dropped the way an uninstalled built-in agent is (#10560).
+      // Without this, a plugin agent whose availability is still `undefined`
+      // (never probed) fails `isAgentInstalled` and vanishes from the palette.
+      if (!isBuiltInAgentId(agentId)) return false;
       return !isAgentInstalled(availability[agentId]);
     };
 

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -575,7 +575,7 @@ describe("agent.launch dispatch integration", () => {
     });
   });
 
-  it("rejects malformed args with a VALIDATION_ERROR targeting agentId and never invokes the callback", async () => {
+  it("rejects an empty agentId with a VALIDATION_ERROR targeting agentId and never invokes the callback", async () => {
     const { ActionService } = await import("../../../ActionService");
     const service = new ActionService();
 
@@ -587,11 +587,10 @@ describe("agent.launch dispatch integration", () => {
       service.register(factory());
     }
 
-    const result = await service.dispatch(
-      "agent.launch",
-      { agentId: "not-a-real-agent" },
-      { source: "user" }
-    );
+    // An empty string is the genuinely-malformed case: the schema now accepts
+    // arbitrary non-empty ids (plugin-contributed agents, #10560), but still
+    // rejects empty/missing ids at the boundary.
+    const result = await service.dispatch("agent.launch", { agentId: "" }, { source: "user" });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -599,6 +598,34 @@ describe("agent.launch dispatch integration", () => {
       expect(JSON.stringify(result.error.details)).toContain("agentId");
     }
     expect(callbacks.onLaunchAgent).not.toHaveBeenCalled();
+  });
+
+  it("accepts an unknown (plugin-contributed) agentId through the schema so plugin agents launch (#10560)", async () => {
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+
+    for (const [, factory] of registry) {
+      service.register(factory());
+    }
+
+    // Plugin agent ids are dynamic and unknown at schema-definition time, so the
+    // schema must let them through; existence is resolved downstream in the
+    // launcher (an unresolved id falls back to a plain terminal, never a crash).
+    const result = await service.dispatch(
+      "agent.launch",
+      { agentId: "acme-agent", worktreeId: "wt-1", location: "grid" },
+      { source: "user" }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(callbacks.onLaunchAgent).toHaveBeenCalledWith(
+      "acme-agent",
+      expect.objectContaining({ worktreeId: "wt-1", location: "grid" })
+    );
   });
 
   it("accepts dev-preview through the schema so worktree-card dev-preview launches don't silently fail", async () => {

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -5,7 +5,14 @@ import {
   PROJECT_SETTINGS_TAB_IDS,
 } from "@/components/Settings/settingsTabIds";
 
-export const AgentIdSchema = z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser", "dev-preview"]);
+// Built-in agent ids plus the synthetic terminal/browser kinds, OR any non-empty
+// string so plugin-contributed agent ids (#10560) validate through the action
+// system (`agent.launch`). Plugin ids are validated at registration time in
+// `pluginAgentRegistry`; this schema is not the authoritative boundary for them.
+export const AgentIdSchema = z.union([
+  z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser", "dev-preview"]),
+  z.string().min(1),
+]);
 
 export const LaunchLocationSchema = z
   .enum(["grid", "dock", "overlay"])


### PR DESCRIPTION
## Summary

- `AgentContributionSchema.command` now accepts `./`-prefixed plugin-relative paths (absolute paths, Windows separators, and `../` traversal are rejected), matching the same contract as MCP server commands on the same docs page
- Plugin agents are surfaced everywhere built-ins are: `getLaunchOptions`, `usePanelPalette`, and `useNewTerminalPalette` all draw from the effective registry; unresolved agents show greyed-out instead of being silently dropped
- `AgentIdSchema` and `SlashCommandListRequestSchema` are widened to accept plugin agent ids, opening the programmatic launch path

Resolves #10560

## Changes

- **`electron/schemas/plugin.ts`** — widen `AgentContributionSchema.command` to accept `./`-prefixed relative paths; reject traversal, absolute paths, Windows separators, and empty/dot-only segments
- **`shared/config/pluginAgentRegistry.ts`** — resolve `./` commands to absolute paths against the plugin dir at registration time; thread `pluginDir` into `registerPluginAgents` (node-pty resolves the command before applying `cwd`, so this must happen early)
- **`electron/services/CliAvailabilityService.ts`** — probe absolute (plugin-resolved) command paths via the filesystem instead of rejecting them with the PATH-binary regex
- **`src/components/TerminalPalette/launchOptions.tsx`** / **`src/hooks/usePanelPalette.ts`** / **`src/hooks/useNewTerminalPalette.ts`** — build options from the effective registry so plugin agents appear; `useNewTerminalPalette` subscribes to the plugin registry so it refreshes on install/unload
- **`electron/schemas/ipc.ts`** — widen `AgentIdSchema`; slash-command list returns `[]` for non-built-ins
- **`electron/ipc/handlers/slashCommands.ts`** — guard slash-command lookup against non-built-in agent ids
- **`src/hooks/useAgentLauncher.ts`** / **`src/services/actions/definitions/schemas.ts`** — quote path-like resolved commands so spaces in the plugin dir (e.g. macOS Application Support) don't split the spawn string

## Testing

186 tests passing across `agentContribution`, `pluginAgentRegistry` (including `pluginDir` resolution and Windows backslash rejection), `CliAvailabilityService` (absolute-path probe), `useAgentLauncher` command escaping, `launchOptions`, `usePanelPalette`, and `useNewTerminalPalette`.