### PR TITLE
feat(plugin): plugin-facing built-in action catalog + typed dispatch

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -64,6 +64,12 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   "mcp:dispatch-action-response",
   "mcp:get-manifest-response",
   "plugin:dispatch-action-response",
+  // fire-and-forget — renderer→main `ipcRenderer.send` replies carrying the
+  // projected built-in action catalog / single entry (#10561). Paired with the
+  // `plugin:actions-list-request` / `plugin:actions-get-request` events declared
+  // in IpcEventMap.
+  "plugin:actions-list-response",
+  "plugin:actions-get-response",
   // fire-and-forget — renderer→main `ipcRenderer.send` reply carrying the user's
   // answer to an imperative plugin UI prompt (#10522). Paired with the
   // `plugin:ui-prompt-request` event declared in IpcEventMap.

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -901,6 +901,14 @@ export const CHANNELS = {
   PLUGIN_DISPATCH_ACTION_REQUEST: "plugin:dispatch-action-request",
   /** Bridge: renderer returns the plugin-sourced action dispatch result to the main process. */
   PLUGIN_DISPATCH_ACTION_RESPONSE: "plugin:dispatch-action-response",
+  /** Bridge: main process asks the renderer for the plugin-facing action catalog (#10561). */
+  PLUGIN_ACTIONS_LIST_REQUEST: "plugin:actions-list-request",
+  /** Bridge: renderer returns the projected action catalog to the main process. */
+  PLUGIN_ACTIONS_LIST_RESPONSE: "plugin:actions-list-response",
+  /** Bridge: main process asks the renderer for a single projected action entry (#10561). */
+  PLUGIN_ACTIONS_GET_REQUEST: "plugin:actions-get-request",
+  /** Bridge: renderer returns the single projected action entry (or null) to the main process. */
+  PLUGIN_ACTIONS_GET_RESPONSE: "plugin:actions-get-response",
   /** Bridge: main process asks the renderer to render an imperative plugin UI prompt (#10522). */
   PLUGIN_UI_PROMPT_REQUEST: "plugin:ui-prompt-request",
   /** Bridge: renderer returns the user's answer to a plugin UI prompt (fire-and-forget). */

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2560,6 +2560,26 @@ function buildElectronApi(): ElectronAPI {
         ipcRenderer.send(CHANNELS.PLUGIN_DISPATCH_ACTION_RESPONSE, payload);
       },
 
+      onActionsListRequest: (callback: (payload: { requestId: string }) => void) =>
+        _typedOn(CHANNELS.PLUGIN_ACTIONS_LIST_REQUEST, callback),
+
+      sendActionsListResponse: (payload: {
+        requestId: string;
+        entries: import("../shared/types/actions.js").PluginActionManifestEntry[];
+      }) => {
+        ipcRenderer.send(CHANNELS.PLUGIN_ACTIONS_LIST_RESPONSE, payload);
+      },
+
+      onActionsGetRequest: (callback: (payload: { requestId: string; actionId: string }) => void) =>
+        _typedOn(CHANNELS.PLUGIN_ACTIONS_GET_REQUEST, callback),
+
+      sendActionsGetResponse: (payload: {
+        requestId: string;
+        entry: import("../shared/types/actions.js").PluginActionManifestEntry | null;
+      }) => {
+        ipcRenderer.send(CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE, payload);
+      },
+
       onUiPromptRequest: (
         callback: (
           payload: import("../shared/types/pluginUiPrompt.js").PluginUiPromptRequest

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2598,8 +2598,10 @@ export class PluginService {
           const entry = await this.dispatcher.sendActionsGetToRenderer(actionId);
           if (!entry) return "restricted";
           if (entry.danger === "confirm") return "confirm";
-          if (entry.danger === "restricted") return "restricted";
-          return "ok";
+          // Fail closed: only an explicit "safe" entry is dispatchable without a
+          // prompt. Any other danger (including an unexpected value) → restricted.
+          if (entry.danger === "safe") return "ok";
+          return "restricted";
         },
       },
       // Imperative UI prompts (#10522). NOT revoke-guarded for the same reason

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2573,6 +2573,35 @@ export class PluginService {
         }
         return this.dispatcher.sendDispatchToRenderer(actionId, args);
       },
+      // Built-in action catalog (#10561). NOT revoke-guarded for the same reason
+      // as dispatch: plugins introspect from post-activation callbacks/timers.
+      // Once the plugin unloads these degrade to empty/absent results ([] / null
+      // / "restricted") without a renderer round-trip. The renderer projects
+      // ActionService.list()/get() — which already filter danger:"restricted" —
+      // to the slim PluginActionManifestEntry, so the catalog never exposes a
+      // restricted action.
+      actions: {
+        list: async () => {
+          if (!this.plugins.has(pluginId)) return [];
+          return this.dispatcher.sendActionsListToRenderer();
+        },
+        get: async (actionId) => {
+          if (!this.plugins.has(pluginId)) return null;
+          return this.dispatcher.sendActionsGetToRenderer(actionId);
+        },
+        // canDispatch derives locally from get() — no extra round-trip. A null
+        // entry (unknown id, or a restricted action the renderer projects away)
+        // maps to "restricted"; "confirm" actions surface as "confirm" so a
+        // plugin can warn before dispatch() returns CONFIRMATION_REQUIRED.
+        canDispatch: async (actionId) => {
+          if (!this.plugins.has(pluginId)) return "restricted";
+          const entry = await this.dispatcher.sendActionsGetToRenderer(actionId);
+          if (!entry) return "restricted";
+          if (entry.danger === "confirm") return "confirm";
+          if (entry.danger === "restricted") return "restricted";
+          return "ok";
+        },
+      },
       // Imperative UI prompts (#10522). NOT revoke-guarded for the same reason
       // as showToast/dispatch: plugins prompt from command handlers that run
       // long after activate() resolves. Liveness is plugin membership — once the

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4689,6 +4689,217 @@ describe("createHost — dispatch", () => {
   });
 });
 
+type ActionsHostShape = (pluginId: string) => {
+  host: {
+    actions: {
+      list: () => Promise<import("../../../shared/types/actions.js").PluginActionManifestEntry[]>;
+      get: (
+        actionId: string
+      ) => Promise<import("../../../shared/types/actions.js").PluginActionManifestEntry | null>;
+      canDispatch: (
+        actionId: string
+      ) => Promise<import("../../../shared/types/actions.js").PluginCanDispatchResult>;
+    };
+  };
+  revoke: () => void;
+};
+
+/** Read the request payload from the most recent `webContents.send` for `channel`. */
+function lastRequestFor(
+  wc: FakeWebContents,
+  channel: string
+): { requestId: string } & Record<string, unknown> {
+  const call = [...wc.send.mock.calls].reverse().find((c) => c[0] === channel);
+  if (!call) throw new Error(`no ${channel} send recorded`);
+  return call[1] as { requestId: string } & Record<string, unknown>;
+}
+
+describe("createHost — actions catalog (#10561)", () => {
+  beforeEach(() => {
+    ipcMainMock._reset();
+    setActiveWebContents(null);
+  });
+
+  it("list() round-trips through the renderer and resolves with the projected entries", async () => {
+    const wc = makeFakeWebContents(21);
+    setActiveWebContents(wc);
+    await writePlugin("actions-list", { name: "acme.actions-list", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-list"
+    );
+
+    const pending = host.actions.list();
+    const req = lastRequestFor(wc, CHANNELS.PLUGIN_ACTIONS_LIST_REQUEST);
+    expect(typeof req.requestId).toBe("string");
+
+    const entries = [
+      { id: "terminal.new", title: "New terminal", danger: "safe", requiresArgs: false },
+    ];
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_ACTIONS_LIST_RESPONSE,
+      { sender: { id: 21 } },
+      { requestId: req.requestId, entries }
+    );
+
+    await expect(pending).resolves.toEqual(entries);
+  });
+
+  it("list() returns [] without a round-trip once the plugin is unloaded", async () => {
+    const wc = makeFakeWebContents(21);
+    setActiveWebContents(wc);
+    await writePlugin("actions-list-unload", {
+      name: "acme.actions-list-unload",
+      version: "1.0.0",
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-list-unload"
+    );
+
+    service.unloadPlugin("acme.actions-list-unload");
+    await expect(host.actions.list()).resolves.toEqual([]);
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("list() resolves [] when no renderer is available", async () => {
+    setActiveWebContents(null);
+    await writePlugin("actions-list-norender", {
+      name: "acme.actions-list-norender",
+      version: "1.0.0",
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-list-norender"
+    );
+
+    await expect(host.actions.list()).resolves.toEqual([]);
+  });
+
+  it("get() resolves the matching entry, and a missing/absent reply resolves null", async () => {
+    const wc = makeFakeWebContents(22);
+    setActiveWebContents(wc);
+    await writePlugin("actions-get", { name: "acme.actions-get", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-get"
+    );
+
+    // Known id → entry.
+    const knownPending = host.actions.get("terminal.new");
+    const knownReq = lastRequestFor(wc, CHANNELS.PLUGIN_ACTIONS_GET_REQUEST);
+    expect(knownReq.actionId).toBe("terminal.new");
+    const entry = {
+      id: "terminal.new",
+      title: "New terminal",
+      danger: "safe",
+      requiresArgs: false,
+    };
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE,
+      { sender: { id: 22 } },
+      { requestId: knownReq.requestId, entry }
+    );
+    await expect(knownPending).resolves.toEqual(entry);
+
+    // Unknown id → renderer replies with a null entry.
+    const missingPending = host.actions.get("does.not.exist");
+    const missingReq = lastRequestFor(wc, CHANNELS.PLUGIN_ACTIONS_GET_REQUEST);
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE,
+      { sender: { id: 22 } },
+      { requestId: missingReq.requestId, entry: null }
+    );
+    await expect(missingPending).resolves.toBeNull();
+  });
+
+  it("canDispatch() derives ok/confirm/restricted from the projected danger", async () => {
+    const wc = makeFakeWebContents(23);
+    setActiveWebContents(wc);
+    await writePlugin("actions-can", { name: "acme.actions-can", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-can"
+    );
+
+    const replyGet = (entry: unknown): void => {
+      const req = lastRequestFor(wc, CHANNELS.PLUGIN_ACTIONS_GET_REQUEST);
+      ipcMainMock._emit(
+        CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE,
+        { sender: { id: 23 } },
+        { requestId: req.requestId, entry }
+      );
+    };
+
+    // safe → "ok"
+    const okPending = host.actions.canDispatch("worktree.createWithRecipe");
+    replyGet({ id: "worktree.createWithRecipe", danger: "safe", requiresArgs: false });
+    await expect(okPending).resolves.toBe("ok");
+
+    // confirm → "confirm" (the recipe.run vs createWithRecipe asymmetry is now observable)
+    const confirmPending = host.actions.canDispatch("recipe.run");
+    replyGet({ id: "recipe.run", danger: "confirm", requiresArgs: false });
+    await expect(confirmPending).resolves.toBe("confirm");
+
+    // absent entry (unknown or restricted-and-projected-away) → "restricted"
+    const restrictedPending = host.actions.canDispatch("some.restricted.action");
+    replyGet(null);
+    await expect(restrictedPending).resolves.toBe("restricted");
+  });
+
+  it("canDispatch() returns 'restricted' without a round-trip once the plugin is unloaded", async () => {
+    const wc = makeFakeWebContents(23);
+    setActiveWebContents(wc);
+    await writePlugin("actions-can-unload", {
+      name: "acme.actions-can-unload",
+      version: "1.0.0",
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-can-unload"
+    );
+
+    service.unloadPlugin("acme.actions-can-unload");
+    await expect(host.actions.canDispatch("terminal.new")).resolves.toBe("restricted");
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("dispose() drains a pending catalog request with its fallback and removes the listener", async () => {
+    const wc = makeFakeWebContents(24);
+    setActiveWebContents(wc);
+    await writePlugin("actions-dispose", { name: "acme.actions-dispose", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-dispose"
+    );
+
+    const pendingList = host.actions.list();
+    expect(ipcMainMock._listenerCount(CHANNELS.PLUGIN_ACTIONS_LIST_RESPONSE)).toBe(1);
+
+    service.dispose();
+
+    await expect(pendingList).resolves.toEqual([]);
+    expect(ipcMainMock.removeListener).toHaveBeenCalledWith(
+      CHANNELS.PLUGIN_ACTIONS_LIST_RESPONSE,
+      expect.any(Function)
+    );
+  });
+});
+
 describe("createHost — registerForgeProvider", () => {
   function forgeManifest(
     name: string,

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4855,6 +4855,83 @@ describe("createHost — actions catalog (#10561)", () => {
     const restrictedPending = host.actions.canDispatch("some.restricted.action");
     replyGet(null);
     await expect(restrictedPending).resolves.toBe("restricted");
+
+    // fail closed: an unexpected danger value is NOT treated as dispatchable
+    const bogusPending = host.actions.canDispatch("some.bogus.action");
+    replyGet({ id: "some.bogus.action", danger: "bogus", requiresArgs: false });
+    await expect(bogusPending).resolves.toBe("restricted");
+  });
+
+  it("ignores a catalog response from an unexpected sender id (cross-window guard)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const wc = makeFakeWebContents(25);
+    setActiveWebContents(wc);
+    await writePlugin("actions-guard", { name: "acme.actions-guard", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-guard"
+    );
+
+    const pending = host.actions.get("terminal.new");
+    const req = lastRequestFor(wc, CHANNELS.PLUGIN_ACTIONS_GET_REQUEST);
+    warnSpy.mockClear();
+
+    // Wrong sender — must be ignored and warned about, leaving the request pending.
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE,
+      { sender: { id: 999 } },
+      { requestId: req.requestId, entry: { id: "terminal.new", danger: "safe" } }
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("unexpected sender"));
+
+    // Correct sender — resolves with the real entry.
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE,
+      { sender: { id: 25 } },
+      { requestId: req.requestId, entry: { id: "terminal.new", danger: "safe" } }
+    );
+    await expect(pending).resolves.toMatchObject({ id: "terminal.new" });
+    warnSpy.mockRestore();
+  });
+
+  it("resolves concurrent list + get independently regardless of response order", async () => {
+    const wc = makeFakeWebContents(26);
+    setActiveWebContents(wc);
+    await writePlugin("actions-concurrent", {
+      name: "acme.actions-concurrent",
+      version: "1.0.0",
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: ActionsHostShape }).createHost(
+      "acme.actions-concurrent"
+    );
+
+    const listPending = host.actions.list();
+    const getPending = host.actions.get("terminal.new");
+    const listReq = lastRequestFor(wc, CHANNELS.PLUGIN_ACTIONS_LIST_REQUEST);
+    const getReq = lastRequestFor(wc, CHANNELS.PLUGIN_ACTIONS_GET_REQUEST);
+
+    // Deliver the get response BEFORE the list response — the shared pending map
+    // keyed by requestId must not let one resolve the other.
+    const entry = { id: "terminal.new", danger: "safe", requiresArgs: false };
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE,
+      { sender: { id: 26 } },
+      { requestId: getReq.requestId, entry }
+    );
+    const entries = [{ id: "app.openSettings", danger: "safe", requiresArgs: false }];
+    ipcMainMock._emit(
+      CHANNELS.PLUGIN_ACTIONS_LIST_RESPONSE,
+      { sender: { id: 26 } },
+      { requestId: listReq.requestId, entries }
+    );
+
+    await expect(getPending).resolves.toEqual(entry);
+    await expect(listPending).resolves.toEqual(entries);
   });
 
   it("canDispatch() returns 'restricted' without a round-trip once the plugin is unloaded", async () => {

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -24,6 +24,7 @@ import type {
 } from "../../../shared/types/plugin.js";
 import type { FileDecoration, FileDecorationProviderImpl } from "../../../shared/types/forge.js";
 import type {
+  ActionsGetParams,
   BroadcastToRendererParams,
   DispatchParams,
   InvalidateFileDecorationsParams,
@@ -364,6 +365,12 @@ export class PluginDevWorkerMainBridge {
       case "dispatch": {
         const p = params as DispatchParams;
         return this.host.dispatch(p.actionId, p.args);
+      }
+      case "actions.list":
+        return this.host.actions.list();
+      case "actions.get": {
+        const p = params as ActionsGetParams;
+        return this.host.actions.get(p.actionId);
       }
       case "showQuickPick": {
         // Reuse the real host so validation/provenance/cancellation all match

--- a/electron/services/plugin/PluginRendererDispatcher.ts
+++ b/electron/services/plugin/PluginRendererDispatcher.ts
@@ -2,7 +2,10 @@ import { ipcMain } from "electron";
 import { randomUUID } from "node:crypto";
 import { CHANNELS } from "../../ipc/channels.js";
 import { getWindowRegistry, getProjectViewManager } from "../../window/windowRef.js";
-import type { ActionDispatchResult } from "../../../shared/types/actions.js";
+import type {
+  ActionDispatchResult,
+  PluginActionManifestEntry,
+} from "../../../shared/types/actions.js";
 
 /**
  * Time budget for a `host.dispatch()` main→renderer round-trip. Matches the MCP
@@ -20,6 +23,20 @@ const PLUGIN_DISPATCH_TIMEOUT_MS = 30_000;
  */
 interface PendingPluginDispatch {
   resolve: (result: ActionDispatchResult) => void;
+  timer: ReturnType<typeof setTimeout>;
+  webContentsId: number;
+  destroyedCleanup?: () => void;
+}
+
+/**
+ * A `host.actions.list()` / `host.actions.get()` round-trip awaiting its
+ * renderer response. Like {@link PendingPluginDispatch} the promise always
+ * resolves (with the projected result or a fallback) and never rejects.
+ */
+interface PendingActionsRequest {
+  resolve: (value: unknown) => void;
+  /** Result handed back if the round-trip is torn down by {@link PluginRendererDispatcher.dispose}. */
+  fallback: unknown;
   timer: ReturnType<typeof setTimeout>;
   webContentsId: number;
   destroyedCleanup?: () => void;
@@ -51,6 +68,21 @@ export class PluginRendererDispatcher {
    * {@link dispose}.
    */
   private pluginDispatchListenerCleanup: (() => void) | null = null;
+
+  /**
+   * In-flight `host.actions.list()` / `host.actions.get()` round-trips, keyed by
+   * `requestId`. Shared across both catalog channels — request ids are UUIDs, so
+   * a single map is unambiguous. Each entry resolves with the projected result
+   * (or its fallback on failure) and never rejects, mirroring
+   * {@link pendingPluginDispatches}.
+   */
+  private pendingActionsRequests = new Map<string, PendingActionsRequest>();
+  /**
+   * Cleanups for the lazily-registered `ipcMain` response listeners, keyed by
+   * response channel so each is registered at most once. Cleared in
+   * {@link dispose}.
+   */
+  private actionsListenerCleanups = new Map<string, () => void>();
 
   constructor(deps: PluginRendererDispatcherDeps) {
     this.deps = deps;
@@ -219,7 +251,151 @@ export class PluginRendererDispatcher {
   }
 
   /**
-   * Tear down the lazily-registered response listener and reject every pending
+   * Project `ActionService.list()` to the active renderer for the plugin
+   * action catalog (#10561). Resolves `[]` (never rejects) when no renderer is
+   * available, the round-trip times out, or the view is destroyed.
+   */
+  sendActionsListToRenderer(): Promise<PluginActionManifestEntry[]> {
+    return this.requestFromRenderer<PluginActionManifestEntry[]>({
+      requestChannel: CHANNELS.PLUGIN_ACTIONS_LIST_REQUEST,
+      responseChannel: CHANNELS.PLUGIN_ACTIONS_LIST_RESPONSE,
+      buildRequest: (requestId) => ({ requestId }),
+      extract: (payload) => {
+        const entries = (payload as { entries?: unknown }).entries;
+        return Array.isArray(entries) ? (entries as PluginActionManifestEntry[]) : [];
+      },
+      fallback: [],
+    });
+  }
+
+  /**
+   * Look up a single projected action entry on the active renderer (#10561).
+   * Resolves `null` (never rejects) when the action is absent or the round-trip
+   * fails.
+   */
+  sendActionsGetToRenderer(actionId: string): Promise<PluginActionManifestEntry | null> {
+    return this.requestFromRenderer<PluginActionManifestEntry | null>({
+      requestChannel: CHANNELS.PLUGIN_ACTIONS_GET_REQUEST,
+      responseChannel: CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE,
+      buildRequest: (requestId) => ({ requestId, actionId }),
+      extract: (payload) =>
+        ((payload as { entry?: unknown }).entry ?? null) as PluginActionManifestEntry | null,
+      fallback: null,
+    });
+  }
+
+  /**
+   * Lazily register the single `ipcMain` listener for a catalog response
+   * channel, registered on first use and torn down in {@link dispose}. Mirrors
+   * {@link ensurePluginDispatchListener}'s sender-id guard so a renderer in
+   * another window cannot resolve a request initiated for a different window.
+   */
+  private ensureActionsListener(
+    responseChannel: string,
+    extract: (payload: Record<string, unknown>) => unknown
+  ): void {
+    if (this.actionsListenerCleanups.has(responseChannel)) return;
+    const handler = (
+      event: Electron.IpcMainEvent,
+      payload: { requestId?: unknown } & Record<string, unknown>
+    ) => {
+      if (!payload || typeof payload.requestId !== "string") return;
+      const pending = this.pendingActionsRequests.get(payload.requestId);
+      if (!pending) return;
+      if (event.sender.id !== pending.webContentsId) {
+        console.warn(
+          `[PluginService] Ignoring actions response from unexpected sender ${event.sender.id} (expected ${pending.webContentsId}, requestId=${payload.requestId})`
+        );
+        return;
+      }
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
+      this.pendingActionsRequests.delete(payload.requestId);
+      pending.resolve(extract(payload));
+    };
+    ipcMain.on(responseChannel, handler);
+    this.actionsListenerCleanups.set(responseChannel, () => {
+      ipcMain.removeListener(responseChannel, handler);
+    });
+  }
+
+  /**
+   * Generic main→renderer request/response round-trip for the read-only catalog
+   * surface. Always resolves with the extracted result or `fallback` — failures
+   * (no renderer, timeout, destroyed view, send error) come back as the fallback
+   * rather than a rejected promise. Shares the resolution/timeout/cleanup
+   * discipline of {@link sendDispatchToRenderer}.
+   */
+  private requestFromRenderer<T>(opts: {
+    requestChannel: string;
+    responseChannel: string;
+    buildRequest: (requestId: string) => Record<string, unknown>;
+    extract: (payload: Record<string, unknown>) => T;
+    fallback: T;
+  }): Promise<T> {
+    return new Promise((resolve) => {
+      if (this.deps.isDisposed()) {
+        resolve(opts.fallback);
+        return;
+      }
+      const webContents = this.resolveActiveWebContents();
+      if (!webContents) {
+        resolve(opts.fallback);
+        return;
+      }
+
+      this.ensureActionsListener(
+        opts.responseChannel,
+        opts.extract as (payload: Record<string, unknown>) => unknown
+      );
+
+      const requestId = randomUUID();
+      const webContentsId = webContents.id;
+      const timer = setTimeout(() => {
+        const pending = this.pendingActionsRequests.get(requestId);
+        if (!pending) return;
+        pending.destroyedCleanup?.();
+        this.pendingActionsRequests.delete(requestId);
+        resolve(opts.fallback);
+      }, PLUGIN_DISPATCH_TIMEOUT_MS);
+
+      const onDestroyed = () => {
+        const pending = this.pendingActionsRequests.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pendingActionsRequests.delete(requestId);
+        resolve(opts.fallback);
+      };
+      webContents.once("destroyed", onDestroyed);
+      const destroyedCleanup = () => {
+        try {
+          webContents.removeListener("destroyed", onDestroyed);
+        } catch {
+          // best-effort; webContents may already be gone
+        }
+      };
+
+      this.pendingActionsRequests.set(requestId, {
+        resolve: resolve as (value: unknown) => void,
+        fallback: opts.fallback,
+        timer,
+        webContentsId,
+        destroyedCleanup,
+      });
+
+      try {
+        webContents.send(opts.requestChannel, opts.buildRequest(requestId));
+      } catch {
+        clearTimeout(timer);
+        destroyedCleanup();
+        this.pendingActionsRequests.delete(requestId);
+        resolve(opts.fallback);
+      }
+    });
+  }
+
+  /**
+   * Tear down the lazily-registered response listeners and reject every pending
    * dispatch with an `EXECUTION_ERROR`. Invoked from `PluginService.dispose`.
    */
   dispose(): void {
@@ -237,5 +413,19 @@ export class PluginRendererDispatcher {
       });
     }
     this.pendingPluginDispatches.clear();
+
+    for (const cleanup of this.actionsListenerCleanups.values()) {
+      cleanup();
+    }
+    this.actionsListenerCleanups.clear();
+    // Catalog round-trips resolve with their fallback ([] / null) on disposal —
+    // the read-only surface has no error envelope, so an in-flight list/get
+    // degrades to "empty" rather than throwing into the plugin.
+    for (const pending of this.pendingActionsRequests.values()) {
+      clearTimeout(pending.timer);
+      pending.destroyedCleanup?.();
+      pending.resolve(pending.fallback);
+    }
+    this.pendingActionsRequests.clear();
   }
 }

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -34,6 +34,11 @@ function makeHost() {
     invalidateFileDecorations: vi.fn(),
     showToast: vi.fn(async () => {}),
     dispatch: vi.fn(async () => ({ ok: true, result: undefined })),
+    actions: {
+      list: vi.fn(async () => [{ id: "terminal.new", danger: "safe", requiresArgs: false }]),
+      get: vi.fn(async (id: string) => ({ id, danger: "safe", requiresArgs: false })),
+      canDispatch: vi.fn(async () => "ok"),
+    },
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     settings: {
       get: vi.fn(async () => undefined),
@@ -142,6 +147,37 @@ describe("PluginDevWorkerMainBridge", () => {
     await flush();
     const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "c2");
     expect(result).toMatchObject({ ok: false, error: "boom" });
+  });
+
+  it("routes actions.list to the real host (#10561)", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "a1",
+      method: "actions.list",
+      params: undefined,
+    });
+    await flush();
+    expect(host.actions.list).toHaveBeenCalledTimes(1);
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "a1");
+    expect(result).toMatchObject({
+      ok: true,
+      result: [{ id: "terminal.new", danger: "safe", requiresArgs: false }],
+    });
+  });
+
+  it("routes actions.get with the action id to the real host (#10561)", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "a2",
+      method: "actions.get",
+      params: { actionId: "recipe.run" },
+    });
+    await flush();
+    expect(host.actions.get).toHaveBeenCalledWith("recipe.run");
+    const result = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "a2");
+    expect(result).toMatchObject({ ok: true, result: { id: "recipe.run" } });
   });
 
   it("registerAction wires a wrapper that round-trips invocation to the worker", async () => {

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -145,6 +145,61 @@ function resolveCall(proxy: any, sent: any[], method: string, result: unknown): 
   proxy.handleMessage({ type: "host-result", requestId: call.requestId, ok: true, result });
 }
 
+describe("PluginDevWorkerHostProxy host.actions (#10561)", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("relays list() as an actions.list host-call and resolves with the entries", async () => {
+    const { proxy, sent } = makeProxy();
+    const promise = proxy.host.actions.list();
+    const call = sent.find((m) => m.type === "host-call" && m.method === "actions.list");
+    expect(call).toBeDefined();
+    const entries = [{ id: "terminal.new", danger: "safe", requiresArgs: false }];
+    resolveCall(proxy, sent, "actions.list", entries);
+    await expect(promise).resolves.toEqual(entries);
+  });
+
+  it("relays get(id) as an actions.get host-call carrying the action id", async () => {
+    const { proxy, sent } = makeProxy();
+    const promise = proxy.host.actions.get("terminal.new");
+    const call = sent.find((m) => m.type === "host-call" && m.method === "actions.get");
+    expect(call).toMatchObject({ params: { actionId: "terminal.new" } });
+    const entry = { id: "terminal.new", danger: "safe", requiresArgs: false };
+    resolveCall(proxy, sent, "actions.get", entry);
+    await expect(promise).resolves.toEqual(entry);
+  });
+
+  it("canDispatch derives the verdict from a single actions.get round-trip", async () => {
+    const { proxy, sent } = makeProxy();
+
+    const okPromise = proxy.host.actions.canDispatch("worktree.createWithRecipe");
+    // Only actions.get is relayed — there is no dedicated canDispatch host-call.
+    expect(sent.some((m) => m.type === "host-call" && m.method === "actions.get")).toBe(true);
+    expect(sent.some((m) => m.method === "actions.canDispatch")).toBe(false);
+    resolveCall(proxy, sent, "actions.get", { id: "worktree.createWithRecipe", danger: "safe" });
+    await expect(okPromise).resolves.toBe("ok");
+
+    const confirmPromise = proxy.host.actions.canDispatch("recipe.run");
+    resolveCall(proxy, sent, "actions.get", { id: "recipe.run", danger: "confirm" });
+    await expect(confirmPromise).resolves.toBe("confirm");
+
+    const restrictedPromise = proxy.host.actions.canDispatch("nope");
+    resolveCall(proxy, sent, "actions.get", null);
+    await expect(restrictedPromise).resolves.toBe("restricted");
+  });
+
+  it("resolves the empty/absent fallback on dispose instead of rejecting", async () => {
+    const { proxy } = makeProxy();
+    const listPromise = proxy.host.actions.list();
+    const getPromise = proxy.host.actions.get("terminal.new");
+    const canPromise = proxy.host.actions.canDispatch("terminal.new");
+    proxy.dispose();
+    await expect(listPromise).resolves.toEqual([]);
+    await expect(getPromise).resolves.toBeNull();
+    await expect(canPromise).resolves.toBe("restricted");
+  });
+});
+
 describe("PluginDevWorkerHostProxy host.process (#10526)", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.restoreAllMocks());

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -198,6 +198,21 @@ describe("PluginDevWorkerHostProxy host.actions (#10561)", () => {
     await expect(getPromise).resolves.toBeNull();
     await expect(canPromise).resolves.toBe("restricted");
   });
+
+  it("canDispatch honors the never-throws contract on a host error result", async () => {
+    const { proxy, sent } = makeProxy();
+    const promise = proxy.host.actions.canDispatch("terminal.new");
+    const call = sent.find((m) => m.type === "host-call" && m.method === "actions.get");
+    // Underlying get() host-call fails — canDispatch must degrade to "restricted",
+    // never reject.
+    proxy.handleMessage({
+      type: "host-result",
+      requestId: call.requestId,
+      ok: false,
+      error: "boom",
+    });
+    await expect(promise).resolves.toBe("restricted");
+  });
 });
 
 describe("PluginDevWorkerHostProxy host.process (#10526)", () => {

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -41,7 +41,10 @@ import type {
   ForgeProviderDescriptor,
   ForgeProviderImpl,
 } from "../../../shared/types/forge.js";
-import type { ActionDispatchResult } from "../../../shared/types/actions.js";
+import type {
+  ActionDispatchResult,
+  PluginActionManifestEntry,
+} from "../../../shared/types/actions.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import type {
   PluginHostCallMethod,
@@ -522,6 +525,27 @@ export class PluginDevWorkerHostProxy {
           durationMs: options?.durationMs,
         }),
       dispatch: (actionId, args) => this.call<ActionDispatchResult>("dispatch", { actionId, args }),
+      // Built-in action catalog (#10561). list/get relay over the port like
+      // dispatch; canDispatch is derived locally from get() (no extra
+      // round-trip), mirroring the real host. callWithGrace resolves the
+      // empty/absent fallback ([] / null / "restricted") on plugin unload
+      // instead of rejecting, matching the host contract.
+      actions: {
+        list: () => this.callWithGrace<PluginActionManifestEntry[]>("actions.list", undefined, []),
+        get: (actionId) =>
+          this.callWithGrace<PluginActionManifestEntry | null>("actions.get", { actionId }, null),
+        canDispatch: async (actionId) => {
+          const entry = await this.callWithGrace<PluginActionManifestEntry | null>(
+            "actions.get",
+            { actionId },
+            null
+          );
+          if (!entry) return "restricted";
+          if (entry.danger === "confirm") return "confirm";
+          if (entry.danger === "restricted") return "restricted";
+          return "ok";
+        },
+      },
       // Imperative UI prompts (#10522). Post-activation-safe (no
       // assertActivationOpen): plugins prompt from command handlers. They use
       // callWithGrace so a plugin unload mid-prompt resolves the dismiss value

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -535,15 +535,23 @@ export class PluginDevWorkerHostProxy {
         get: (actionId) =>
           this.callWithGrace<PluginActionManifestEntry | null>("actions.get", { actionId }, null),
         canDispatch: async (actionId) => {
-          const entry = await this.callWithGrace<PluginActionManifestEntry | null>(
-            "actions.get",
-            { actionId },
-            null
-          );
+          // Honor the never-throws contract: a host-side error on the underlying
+          // get() degrades to "restricted" rather than rejecting.
+          let entry: PluginActionManifestEntry | null;
+          try {
+            entry = await this.callWithGrace<PluginActionManifestEntry | null>(
+              "actions.get",
+              { actionId },
+              null
+            );
+          } catch {
+            return "restricted";
+          }
           if (!entry) return "restricted";
           if (entry.danger === "confirm") return "confirm";
-          if (entry.danger === "restricted") return "restricted";
-          return "ok";
+          // Fail closed: only an explicit "safe" entry maps to "ok".
+          if (entry.danger === "safe") return "ok";
+          return "restricted";
         },
       },
       // Imperative UI prompts (#10522). Post-activation-safe (no

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -629,6 +629,17 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     async showConfirm() {
       return false;
     },
+    actions: {
+      async list() {
+        return [];
+      },
+      async get() {
+        return null;
+      },
+      async canDispatch() {
+        return "restricted";
+      },
+    },
     process: {
       async spawn(command, options): Promise<PluginProcessHandle> {
         spawnCalls.push({ command, options });

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -61,6 +61,13 @@ import type {
   ActionDispatchError,
   ActionError,
   ActionErrorCode,
+  PluginHostActionsApi,
+  PluginActionManifestEntry,
+  PluginCanDispatchResult,
+  BuiltInActionId,
+  ActionKind,
+  ActionDanger,
+  ActionExample,
 } from "../plugin-sdk.js";
 import { PLUGIN_PROCESS_STREAM_CHANNEL, localAuthStubs } from "../plugin-sdk.js";
 import type { UseHostChannelResult, PluginEventHandler } from "../plugin-sdk-react.js";
@@ -182,6 +189,18 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf<ActionError>().toMatchTypeOf<object>();
       expectTypeOf<ActionErrorCode>().toMatchTypeOf<string>();
     });
+
+    it("exports the built-in action catalog types (#10561)", () => {
+      // host.actions.list()/get() project the manifest; the typed BuiltInActionId
+      // union turns a wrong action id into a compile error at the dispatch site.
+      expectTypeOf<PluginHostActionsApi>().toMatchTypeOf<object>();
+      expectTypeOf<PluginActionManifestEntry>().toMatchTypeOf<object>();
+      expectTypeOf<PluginCanDispatchResult>().toMatchTypeOf<string>();
+      expectTypeOf<BuiltInActionId>().toMatchTypeOf<string>();
+      expectTypeOf<ActionKind>().toMatchTypeOf<string>();
+      expectTypeOf<ActionDanger>().toMatchTypeOf<string>();
+      expectTypeOf<ActionExample>().toMatchTypeOf<object>();
+    });
   });
 
   describe("structural contracts", () => {
@@ -226,6 +245,49 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf<"worktree">().toMatchTypeOf<PluginStorageScope>();
       expectTypeOf<PluginSettingsScope>().toMatchTypeOf<PluginStorageScope>();
       expectTypeOf<"worktree">().not.toMatchTypeOf<PluginSettingsScope>();
+    });
+
+    it("PluginHostApi.actions exposes the built-in catalog surface (#10561)", () => {
+      const host = {
+        actions: {
+          list: async () => [],
+          get: async () => null,
+          canDispatch: async () => "restricted" as const,
+        },
+      } as PluginHostApi;
+      expectTypeOf(host.actions).toEqualTypeOf<PluginHostActionsApi>();
+      expectTypeOf(host.actions.list).toEqualTypeOf<() => Promise<PluginActionManifestEntry[]>>();
+      expectTypeOf(host.actions.get).toEqualTypeOf<
+        (actionId: string) => Promise<PluginActionManifestEntry | null>
+      >();
+      expectTypeOf(host.actions.canDispatch).toEqualTypeOf<
+        (actionId: string) => Promise<PluginCanDispatchResult>
+      >();
+    });
+
+    it("PluginCanDispatchResult is the three-state pre-flight verdict", () => {
+      expectTypeOf("ok" as const).toMatchTypeOf<PluginCanDispatchResult>();
+      expectTypeOf("confirm" as const).toMatchTypeOf<PluginCanDispatchResult>();
+      expectTypeOf("restricted" as const).toMatchTypeOf<PluginCanDispatchResult>();
+      // @ts-expect-error — an arbitrary verdict is not part of the union
+      const _bad: PluginCanDispatchResult = "maybe";
+      void _bad;
+    });
+
+    it("PluginActionManifestEntry drops renderer-internal manifest fields", () => {
+      const entry = {} as PluginActionManifestEntry;
+      expectTypeOf(entry.id).toEqualTypeOf<string>();
+      expectTypeOf(entry.danger).toEqualTypeOf<ActionDanger>();
+      expectTypeOf(entry.requiresArgs).toEqualTypeOf<boolean>();
+      // @ts-expect-error — `enabled` is live renderer-context state, not on the projection
+      const _enabled = entry.enabled;
+      // @ts-expect-error — `name` is the MCP alias, not on the projection
+      const _name = entry.name;
+      // @ts-expect-error — palette state is renderer-only, not on the projection
+      const _paletteHidden = entry.paletteHidden;
+      // @ts-expect-error — mcpVisibility is MCP-internal, not on the projection
+      const _mcpVisibility = entry.mcpVisibility;
+      void [_enabled, _name, _paletteHidden, _mcpVisibility];
     });
 
     it("PluginHostApi extends the revoke-guarded PluginActivationApi", () => {

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -248,13 +248,17 @@ describe("plugin-sdk boundary", () => {
     });
 
     it("PluginHostApi.actions exposes the built-in catalog surface (#10561)", () => {
-      const host = {} as PluginHostApi;
-      expectTypeOf(host.actions).toEqualTypeOf<PluginHostActionsApi>();
-      expectTypeOf(host.actions.list).toEqualTypeOf<() => Promise<PluginActionManifestEntry[]>>();
-      expectTypeOf(host.actions.get).toEqualTypeOf<
+      // Pure type-level indexed access — `actions` is a nested object, so a value
+      // access (`host.actions.list`) on an empty `{} as PluginHostApi` would throw
+      // at runtime when `expectTypeOf` evaluates its argument.
+      expectTypeOf<PluginHostApi["actions"]>().toEqualTypeOf<PluginHostActionsApi>();
+      expectTypeOf<PluginHostApi["actions"]["list"]>().toEqualTypeOf<
+        () => Promise<PluginActionManifestEntry[]>
+      >();
+      expectTypeOf<PluginHostApi["actions"]["get"]>().toEqualTypeOf<
         (actionId: string) => Promise<PluginActionManifestEntry | null>
       >();
-      expectTypeOf(host.actions.canDispatch).toEqualTypeOf<
+      expectTypeOf<PluginHostApi["actions"]["canDispatch"]>().toEqualTypeOf<
         (actionId: string) => Promise<PluginCanDispatchResult>
       >();
     });

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -248,13 +248,7 @@ describe("plugin-sdk boundary", () => {
     });
 
     it("PluginHostApi.actions exposes the built-in catalog surface (#10561)", () => {
-      const host = {
-        actions: {
-          list: async () => [],
-          get: async () => null,
-          canDispatch: async () => "restricted" as const,
-        },
-      } as PluginHostApi;
+      const host = {} as PluginHostApi;
       expectTypeOf(host.actions).toEqualTypeOf<PluginHostActionsApi>();
       expectTypeOf(host.actions.list).toEqualTypeOf<() => Promise<PluginActionManifestEntry[]>>();
       expectTypeOf(host.actions.get).toEqualTypeOf<

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -317,3 +317,53 @@ export interface ActionFrecencyEntry {
   score: number;
   lastAccessedAt: number;
 }
+
+/**
+ * Slim, IPC-safe projection of {@link ActionManifestEntry} exposed to plugins
+ * via `host.actions.list()` / `host.actions.get()` (#10561). Deliberately drops
+ * the fields that have no meaning across the plugin boundary: palette state
+ * (`paletteHidden`/`paletteRedirectTo`/…), live renderer-context state
+ * (`enabled`/`disabledReason`), the MCP-internal classification (`name`,
+ * `mcpVisibility`, `mcpAnnotations`, `band`), and `pluginId`. Every field is a
+ * plain JSON value so the entry survives Electron's structured-clone IPC
+ * boundary unchanged.
+ */
+export interface PluginActionManifestEntry {
+  /** The action id to pass to `host.dispatch()`. */
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  kind: ActionKind;
+  /**
+   * Base danger classification. `host.dispatch()` rejects `"confirm"` actions
+   * with `CONFIRMATION_REQUIRED` (plugins cannot bypass the prompt) and never
+   * exposes `"restricted"` actions in the catalog — so a listed entry is always
+   * `"safe"` or `"confirm"`. Use `host.actions.canDispatch(id)` for a pre-flight
+   * check before triggering.
+   */
+  danger: ActionDanger;
+  /** JSON Schema for the action's args, or undefined when it takes none. */
+  inputSchema?: Record<string, unknown>;
+  /** True when the action's schema rejects an empty args object. */
+  requiresArgs: boolean;
+  /** Synonyms / alternative mental-model terms, when the action declares them. */
+  keywords?: string[];
+  /** Concrete usage examples pairing args with a short description. */
+  examples?: readonly ActionExample[];
+  /** Human-readable rationale for a non-`safe` danger rating. */
+  dangerRationale?: string;
+}
+
+/**
+ * Pre-flight verdict from `host.actions.canDispatch(id)` (#10561), letting a
+ * plugin detect a confirm-gated or unavailable action before calling
+ * `host.dispatch()`:
+ * - `"ok"` — a `danger:"safe"` action; `dispatch()` proceeds without a prompt.
+ * - `"confirm"` — a `danger:"confirm"` action; `dispatch()` returns
+ *   `CONFIRMATION_REQUIRED` (plugins cannot pre-confirm). The plugin should warn
+ *   the user or route through an interactive sibling action.
+ * - `"restricted"` — the action is `danger:"restricted"`, unknown, or otherwise
+ *   not exposed to plugins; `dispatch()` would return `RESTRICTED` / `NOT_FOUND`.
+ */
+export type PluginCanDispatchResult = "ok" | "confirm" | "restricted";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1574,6 +1574,30 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       result: import("../actions.js").ActionDispatchResult;
     }): void;
     /**
+     * Listen for plugin built-in action-catalog requests from the main process (a
+     * plugin calling `host.actions.list()`, #10561). Reply with
+     * {@link sendActionsListResponse}, correlated by `requestId`.
+     */
+    onActionsListRequest(callback: (payload: { requestId: string }) => void): () => void;
+    /** Send the projected built-in action catalog back to the main process. */
+    sendActionsListResponse(payload: {
+      requestId: string;
+      entries: import("../actions.js").PluginActionManifestEntry[];
+    }): void;
+    /**
+     * Listen for plugin single-action lookup requests from the main process (a
+     * plugin calling `host.actions.get(id)` / `host.actions.canDispatch(id)`,
+     * #10561). Reply with {@link sendActionsGetResponse}, correlated by `requestId`.
+     */
+    onActionsGetRequest(
+      callback: (payload: { requestId: string; actionId: string }) => void
+    ): () => void;
+    /** Send the single projected action entry (or null) back to the main process. */
+    sendActionsGetResponse(payload: {
+      requestId: string;
+      entry: import("../actions.js").PluginActionManifestEntry | null;
+    }): void;
+    /**
      * Listen for imperative plugin UI-prompt requests from the main process (a
      * plugin calling `host.showQuickPick`/`showInputBox`/`showConfirm`, #10522).
      * Reply with {@link sendUiPromptResponse}, correlated by `promptId`.

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1513,6 +1513,32 @@ export interface IpcEventMap {
   };
 
   /**
+   * Plugin built-in action-catalog request (#10561). Main emits this on the
+   * active project WebContents when a plugin calls `host.actions.list()` and
+   * awaits a renderer `ipcRenderer.send` reply on
+   * `CHANNELS.PLUGIN_ACTIONS_LIST_RESPONSE`, correlated by `requestId`. The
+   * renderer projects `ActionService.list()` to {@link
+   * import("../actions.js").PluginActionManifestEntry}. The response channel is a
+   * renderer→main fire-and-forget send tracked in `DEAD_CHANNEL_ALLOWLIST` in
+   * channelDrift.test.ts.
+   */
+  "plugin:actions-list-request": {
+    requestId: string;
+  };
+
+  /**
+   * Plugin built-in action lookup request (#10561). Main emits this when a
+   * plugin calls `host.actions.get(id)` / `host.actions.canDispatch(id)` and
+   * awaits a renderer `ipcRenderer.send` reply on
+   * `CHANNELS.PLUGIN_ACTIONS_GET_RESPONSE`, correlated by `requestId`. Same
+   * fire-and-forget response discipline as `plugin:actions-list-request`.
+   */
+  "plugin:actions-get-request": {
+    requestId: string;
+    actionId: string;
+  };
+
+  /**
    * Imperative plugin UI-prompt request (#10522). Main emits this on the active
    * project WebContents when a plugin calls `host.showQuickPick`/`showInputBox`/
    * `showConfirm`, and awaits a renderer `ipcRenderer.send` reply on

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -51,6 +51,7 @@ export type { PluginManifest, PluginAuthor } from "./plugin.js";
 export type {
   PluginActivate,
   PluginHostApi,
+  PluginHostActionsApi,
   PluginActivationApi,
   PluginHostCallOptions,
   PluginHostSubscriptionOptions,
@@ -182,4 +183,19 @@ export type {
   ActionDispatchError,
   ActionError,
   ActionErrorCode,
+} from "./actions.js";
+
+// ── Built-in action catalog (host.actions.*) — #10561 ───────────────
+// host.actions.list()/get() project the ActionService manifest to plugins, and
+// the typed BuiltInActionId union turns a wrong action id into a compile error
+// at the dispatch site. ActionKind/ActionDanger/ActionExample appear on the
+// projected entry, so authors must be able to name them too.
+
+export type {
+  PluginActionManifestEntry,
+  PluginCanDispatchResult,
+  BuiltInActionId,
+  ActionKind,
+  ActionDanger,
+  ActionExample,
 } from "./actions.js";

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -12,7 +12,11 @@ import type {
   ResourceRef,
 } from "./forge.js";
 import type { NotificationType } from "./notification.js";
-import type { ActionDispatchResult } from "./actions.js";
+import type {
+  ActionDispatchResult,
+  PluginActionManifestEntry,
+  PluginCanDispatchResult,
+} from "./actions.js";
 import type { AgentState, WaitingReason } from "./agent.js";
 import type { z } from "zod";
 
@@ -1520,6 +1524,43 @@ export interface PluginActivationApi {
  * remain callable from subscription callbacks and timers for the plugin's whole
  * lifetime and degrade to a no-op once the plugin is unloaded.
  */
+/**
+ * Built-in action catalog surface on {@link PluginHostApi.actions} (#10561).
+ * Projects the app's `ActionService` manifest to plugins so an orchestration
+ * plugin can discover what `host.dispatch()` accepts — the ids, arg schemas, and
+ * danger classification — without reading Daintree's source.
+ *
+ * Like {@link PluginHostApi.dispatch} this is NOT revoke-guarded: plugins
+ * introspect from post-activation command handlers and timers. Once the plugin
+ * is unloaded `list()` resolves `[]` and `get()` / `canDispatch()` resolve as if
+ * the action were absent (`null` / `"restricted"`) — these never throw.
+ */
+export interface PluginHostActionsApi {
+  /**
+   * List every plugin-dispatchable action as a slim
+   * {@link PluginActionManifestEntry}. Mirrors `ActionService.list()`:
+   * `danger:"restricted"` actions are filtered out, so listed entries are always
+   * `"safe"` or `"confirm"`. Resolves `[]` when no renderer is available or the
+   * plugin has been unloaded.
+   */
+  list(): Promise<PluginActionManifestEntry[]>;
+  /**
+   * Look up a single action by id, or `null` when it doesn't exist or is
+   * `danger:"restricted"` (restricted actions are invisible to plugins, matching
+   * {@link list}). Prefer this over {@link list} for a single lookup — it avoids
+   * projecting the whole catalog.
+   */
+  get(actionId: string): Promise<PluginActionManifestEntry | null>;
+  /**
+   * Pre-flight a dispatch without triggering it: `"ok"` for a safe action,
+   * `"confirm"` for a confirm-gated one (which {@link PluginHostApi.dispatch}
+   * would reject with `CONFIRMATION_REQUIRED`), and `"restricted"` for an
+   * unknown or `danger:"restricted"` action. Lets a plugin warn the user before
+   * triggering a confirm prompt. See {@link PluginCanDispatchResult}.
+   */
+  canDispatch(actionId: string): Promise<PluginCanDispatchResult>;
+}
+
 export interface PluginHostApi extends PluginActivationApi {
   readonly pluginId: string;
   /**
@@ -1620,6 +1661,16 @@ export interface PluginHostApi extends PluginActivationApi {
    * dispatch.
    */
   dispatch(actionId: string, args?: unknown): Promise<ActionDispatchResult>;
+  /**
+   * Built-in action catalog: discover what `dispatch()` accepts (ids, arg
+   * schemas, danger) and pre-flight a dispatch. Projects the app's
+   * `ActionService` manifest to plugins (#10561). See {@link PluginHostActionsApi}.
+   *
+   * Like {@link dispatch} this is NOT revoke-guarded — it stays callable from
+   * post-activation callbacks and degrades to empty/absent results once the
+   * plugin is unloaded.
+   */
+  readonly actions: PluginHostActionsApi;
   /**
    * Imperatively prompt the user to pick from a list, rendered through the app's
    * searchable command-palette surface. Resolves with the chosen item (or an

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -36,6 +36,8 @@ export type PluginHostCallMethod =
   | "getAgentState"
   | "showToast"
   | "dispatch"
+  | "actions.list"
+  | "actions.get"
   | "settings.get"
   | "settings.set"
   | "storage.get"
@@ -308,6 +310,15 @@ export interface ShowToastParams {
 export interface DispatchParams {
   actionId: string;
   args?: unknown;
+}
+
+/**
+ * Params for `actions.get` (`host-call`, #10561). `actions.list` takes no
+ * params. `actions.canDispatch` is derived worker-side from `actions.get`, so it
+ * has no dedicated host-call method.
+ */
+export interface ActionsGetParams {
+  actionId: string;
 }
 
 /** Params for `showQuickPick` (`host-call`). */

--- a/src/hooks/usePluginBridge.ts
+++ b/src/hooks/usePluginBridge.ts
@@ -1,19 +1,51 @@
 import { useEffect } from "react";
 import { actionService } from "@/services/ActionService";
-import type { ActionId } from "@shared/types/actions";
+import type {
+  ActionId,
+  ActionManifestEntry,
+  PluginActionManifestEntry,
+} from "@shared/types/actions";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 /**
- * Sets up the renderer-side plugin dispatch bridge.
+ * Project an internal {@link ActionManifestEntry} onto the slim, IPC-safe
+ * {@link PluginActionManifestEntry} exposed to plugins via `host.actions.*`
+ * (#10561). Deliberately an explicit allowlist — palette state, live-context
+ * fields (`enabled`/`disabledReason`), and MCP-internal classification
+ * (`name`/`mcpVisibility`/`band`/`pluginId`) are dropped so internal manifest
+ * shape changes don't leak across the plugin boundary.
+ */
+function toPluginManifestEntry(entry: ActionManifestEntry): PluginActionManifestEntry {
+  return {
+    id: entry.id,
+    title: entry.title,
+    description: entry.description,
+    category: entry.category,
+    kind: entry.kind,
+    danger: entry.danger,
+    inputSchema: entry.inputSchema,
+    requiresArgs: entry.requiresArgs,
+    keywords: entry.keywords,
+    examples: entry.examples,
+    dangerRationale: entry.dangerRationale,
+  };
+}
+
+/**
+ * Sets up the renderer-side plugin dispatch + action-catalog bridge.
  *
- * Listens for plugin-sourced action dispatch requests from the main process (a
- * plugin calling `host.dispatch()`), routes them through `actionService.dispatch`
- * with `source: "plugin"`, and returns the structured result. Unlike the MCP
- * bridge there is no confirmation intercept: plugins cannot bypass confirm-gating,
- * so `danger:"confirm"` actions return `CONFIRMATION_REQUIRED` and
- * `danger:"restricted"` returns `RESTRICTED` directly from ActionService.
+ * Listens for plugin-sourced requests from the main process and answers them
+ * against the renderer-only `ActionService`:
+ * - `host.dispatch()` → `actionService.dispatch` with `source: "plugin"`. Unlike
+ *   the MCP bridge there is no confirmation intercept: plugins cannot bypass
+ *   confirm-gating, so `danger:"confirm"` returns `CONFIRMATION_REQUIRED` and
+ *   `danger:"restricted"` returns `RESTRICTED` directly from ActionService.
+ * - `host.actions.list()` / `host.actions.get()` (#10561) → project
+ *   `ActionService.list()`/`get()` to the slim {@link PluginActionManifestEntry}.
+ *   `get()` additionally filters out `danger:"restricted"` so a single lookup
+ *   matches `list()`'s "restricted is invisible to plugins" contract.
  *
- * The success response send sits inside the try block so a non-serializable
+ * The dispatch success send sits inside the try block so a non-serializable
  * action result (a DataCloneError on `ipcRenderer.send`) is caught and replaced
  * with a serializable `EXECUTION_ERROR` envelope rather than stranding the
  * main-side pending request until its timeout.
@@ -24,7 +56,7 @@ export function usePluginBridge(): void {
 
     let disposed = false;
 
-    const cleanup = window.electron.pluginBridge.onDispatchActionRequest(
+    const cleanupDispatch = window.electron.pluginBridge.onDispatchActionRequest(
       async ({ requestId, actionId, args }) => {
         try {
           const result = await actionService.dispatch(actionId as ActionId, args, {
@@ -48,9 +80,42 @@ export function usePluginBridge(): void {
       }
     );
 
+    const cleanupActionsList = window.electron.pluginBridge.onActionsListRequest(
+      ({ requestId }) => {
+        if (disposed) return;
+        try {
+          const entries = actionService
+            .list(undefined, { includeSchemas: true })
+            .map(toPluginManifestEntry);
+          window.electron.pluginBridge.sendActionsListResponse({ requestId, entries });
+        } catch {
+          window.electron.pluginBridge.sendActionsListResponse({ requestId, entries: [] });
+        }
+      }
+    );
+
+    const cleanupActionsGet = window.electron.pluginBridge.onActionsGetRequest(
+      ({ requestId, actionId }) => {
+        if (disposed) return;
+        try {
+          const entry = actionService.get(actionId as ActionId);
+          // `get()` ignores the restricted filter that `list()` applies, so drop
+          // restricted entries here to keep the single-lookup surface consistent
+          // with the catalog (restricted actions are invisible to plugins).
+          const projected =
+            entry && entry.danger !== "restricted" ? toPluginManifestEntry(entry) : null;
+          window.electron.pluginBridge.sendActionsGetResponse({ requestId, entry: projected });
+        } catch {
+          window.electron.pluginBridge.sendActionsGetResponse({ requestId, entry: null });
+        }
+      }
+    );
+
     return () => {
       disposed = true;
-      cleanup();
+      cleanupDispatch();
+      cleanupActionsList();
+      cleanupActionsGet();
     };
   }, []);
 }


### PR DESCRIPTION
## Summary

- Adds `host.actions.list`, `host.actions.get`, and `host.actions.canDispatch` to the plugin host API, projecting the existing `ActionService` manifest to a slim IPC-safe type routed through the existing `PluginRendererDispatcher`
- Exports `PluginActionManifestEntry`, `PluginCanDispatchResult`, `PluginHostActionsApi`, and the `BuiltInActionId` union from the `@daintreehq/plugin-sdk` barrel — wrong action IDs are compile errors at the dispatch site
- `host.actions.canDispatch(id)` makes the `danger` asymmetry between `recipe.run` (confirm) and `worktree.createWithRecipe` (safe) observable at runtime without changing either classification; fails closed

Resolves #10561

## Changes

- `shared/types/plugin-sdk.ts` — new `PluginActionManifestEntry`, `PluginCanDispatchResult`, `PluginHostActionsApi` types; `BuiltInActionId` re-exported from the SDK barrel
- `shared/types/plugin.ts` — `PluginHostActionsApi` wired into `PluginHostApi`
- `shared/types/actions.ts` — `PluginActionManifestEntry` projection type added alongside existing `ActionManifestEntry`
- `shared/types/ipc/` — new request/response channels in `IpcEventMap`; fire-and-forget responses added to the `channelDrift` `DEAD_CHANNEL_ALLOWLIST`
- `electron/services/PluginService.ts` — `listActions`, `getAction`, `canDispatch` handlers
- `electron/services/plugin/PluginRendererDispatcher.ts` — round-trip methods for the three new calls, using the existing focused-window resolver and sender-id guard
- `electron/services/plugin/pluginDevWorkerHostProxy.ts` + `PluginDevWorkerMainBridge.ts` — mirrored on the dev-worker path
- `src/hooks/usePluginBridge.ts` — renderer side wired up
- `electron/preload.cts` + `electron/ipc/channels.ts` — new IPC channels exposed
- Per-id `BuiltInActionArgs` map deferred to #10515

## Testing

611 targeted tests pass across `plugin-sdk`, `PluginService`, dev-worker bridge and proxy, and `channelDrift`. Lint and format clean on all changed files.