### PR TITLE
feat(plugin): add private host.storage namespace with worktree scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ reports/
 *.deb
 *.rpm
 .daintree/daintree-remote
+# Private plugin storage (#10556) — machine-owned plugin state, never tracked.
+.daintree/plugin-storage/
 
 # Native addon build outputs (electron-rebuild + node-gyp)
 electron/native/*/build/

--- a/e2e/full/plugins/core-plugin-storage.spec.ts
+++ b/e2e/full/plugins/core-plugin-storage.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from "@playwright/test";
+import { closeApp, type AppContext } from "../../helpers/launch";
+import { launchWithSamplePlugin, waitForRichPluginReady } from "../../helpers/plugins";
+
+const PLUGIN_ID = "daintree.rich";
+
+/** Dispatch a renderer action through the E2E-only bridge and return its result. */
+async function dispatchAction(page: Page, actionId: string, args?: unknown): Promise<unknown> {
+  return page.evaluate(
+    async (payload) => {
+      const dispatch = (
+        window as unknown as {
+          __daintreeDispatchAction?: (
+            id: string,
+            a?: unknown,
+            opts?: { source: string }
+          ) => Promise<unknown>;
+        }
+      ).__daintreeDispatchAction;
+      if (typeof dispatch !== "function") {
+        throw new Error("__daintreeDispatchAction is not available");
+      }
+      return dispatch(payload.actionId, payload.args, { source: "menu" });
+    },
+    { actionId, args }
+  );
+}
+
+/** Read the rich plugin's stored user-scope setting values over IPC. */
+async function userSettingValues(page: Page): Promise<Record<string, unknown>> {
+  return page.evaluate(async (pluginId) => {
+    const res = await window.electron.plugin.getSettingValues(pluginId, "user", null);
+    return res.values;
+  }, PLUGIN_ID);
+}
+
+/**
+ * Private `host.storage` API (#10556). The rich sample plugin registers a
+ * `storage-roundtrip` action that writes / reads / deletes across the three
+ * storage scopes (`user`, `project`, `worktree`) and returns what it observed.
+ * This drives that action through the real plugin host and asserts the
+ * round-trip, the `delete` semantics, and — the central guarantee of the issue —
+ * that storage is a store distinct from settings: a storage key that collides
+ * with a declared setting id never surfaces in the settings UI.
+ */
+test.describe.serial("Core: Plugin private storage", () => {
+  let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { ctx: launched, cleanup } = await launchWithSamplePlugin("plugin-storage");
+    ctx = launched;
+    fixtureCleanup = cleanup;
+    await waitForRichPluginReady(ctx.window);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("round-trips values across scopes and honours delete", async () => {
+    const result = (await dispatchAction(ctx.window, `${PLUGIN_ID}.storage-roundtrip`)) as {
+      ok: boolean;
+      result: Record<string, unknown>;
+    };
+
+    expect(result.ok).toBe(true);
+    const report = result.result;
+
+    // user + project scopes always have a target in the onboarded-project layout.
+    expect(report.user).toEqual({ n: 1 });
+    expect(report.project).toEqual({ n: 2 });
+
+    // The onboarded project root is itself the active worktree, so worktree scope
+    // resolves; if a layout ever lacks an active worktree the host throws a clear
+    // "no active worktree" error rather than writing to the wrong place.
+    if (report.worktreeError === undefined) {
+      expect(report.worktree).toEqual({ n: 3 });
+    } else {
+      expect(String(report.worktreeError)).toMatch(/no active worktree/i);
+    }
+
+    // delete removes the key (storage has a real delete; settings does not).
+    expect(report.userAfterDelete).toBeUndefined();
+  });
+
+  test("storage is a separate store from settings — no key collision leaks", async () => {
+    const result = (await dispatchAction(ctx.window, `${PLUGIN_ID}.storage-roundtrip`)) as {
+      ok: boolean;
+      result: Record<string, unknown>;
+    };
+    expect(result.ok).toBe(true);
+
+    // The storage write under the "greeting" key (which is also a declared
+    // setting id) lands in the storage store and reads back from it...
+    expect(result.result.storageGreeting).toBe("STORAGE-ONLY");
+
+    // ...but never appears in the settings store the UI reads from.
+    const settings = await userSettingValues(ctx.window);
+    expect(settings.greeting).not.toBe("STORAGE-ONLY");
+  });
+});

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -64,6 +64,7 @@ import type {
   PluginInstallOptions,
   PluginCheckUpdateResult,
   PluginSettingsScope,
+  PluginStorageScope,
   PluginSettingsUiValues,
   PluginWorktreeStatus,
   PluginAgentSnapshot,
@@ -84,6 +85,7 @@ import { PluginContributionBroadcaster } from "./plugin/PluginContributionBroadc
 import { PluginRendererDispatcher } from "./plugin/PluginRendererDispatcher.js";
 import { PluginUIPromptDispatcher } from "./plugin/PluginUIPromptDispatcher.js";
 import { PluginSettingsManager, assertSettingsKey } from "./plugin/PluginSettingsManager.js";
+import { PluginStorageManager, assertStorageKey } from "./plugin/PluginStorageManager.js";
 import { PluginChannelRegistry, isChannelSchema } from "./plugin/PluginChannelRegistry.js";
 import { PluginInstaller } from "./plugin/PluginInstaller.js";
 import { PluginDevWorkerHost } from "./plugin/PluginDevWorkerHost.js";
@@ -779,6 +781,15 @@ export class PluginService {
    */
   private readonly settings: PluginSettingsManager;
   /**
+   * Owns the per-(plugin, scope, path) private-storage store cache, scope and
+   * file-path resolution (including the `"worktree"` scope that resolves the
+   * active worktree at call time), and subscriber notification for the machine-
+   * owned `host.storage` API. Deliberately separate from {@link settings}: storage
+   * has no declared-key gating, no secret routing, and never surfaces in the
+   * settings UI.
+   */
+  private readonly storage: PluginStorageManager;
+  /**
    * Owns the atomic install/upgrade orchestration, the manual update-check
    * download/compare flow, the uninstall flow, and the stale-temp-dir sweep at
    * init. Reaches core lifecycle (load/unload/activate, record CRUD, archive
@@ -822,6 +833,19 @@ export class PluginService {
       // renders a settings form whether or not the plugin is running.
       getManifest: (pluginId) =>
         (this.plugins.get(pluginId) ?? this.disabledPlugins.get(pluginId))?.manifest,
+    });
+
+    this.storage = new PluginStorageManager({
+      getPluginsRoot: () => this.pluginsRoot,
+      // Resolve the active worktree's path the same way host.getActiveWorktree
+      // does — first isCurrent snapshot — so "worktree"-scoped storage tracks the
+      // user's active worktree. Returns undefined when none is active or the
+      // workspace client isn't wired yet, which the storage API treats as
+      // "no target" (read → undefined, write → throw).
+      getActiveWorktreePath: async () => {
+        const snapshots = await this.fetchAllWorktreeSnapshots();
+        return snapshots.find((s) => s.isCurrent === true)?.path;
+      },
     });
 
     this.channels = new PluginChannelRegistry({
@@ -2701,6 +2725,99 @@ export class PluginService {
           return Promise.resolve(dispose);
         },
       },
+      // Private machine-owned key/value storage (#10556). NOT revoke-guarded
+      // (except onDidChange): plugins read/write storage throughout their
+      // lifetime. The "worktree"/"project" scopes resolve their target
+      // asynchronously, so set/delete re-check liveness after the await — a
+      // plugin unloaded mid-resolution silently no-ops rather than writing into
+      // a torn-down plugin's file (lessons #9322/#9428/#9533).
+      storage: {
+        get: async <T = unknown>(
+          key: string,
+          scope: PluginStorageScope = "user"
+        ): Promise<T | undefined> => {
+          assertStorageKey(pluginId, "get", key);
+          const filePath = await this.storage.resolveStorageFilePath(pluginId, scope);
+          // No active project/worktree (or unset key): read resolves to undefined
+          // rather than throwing, matching the "unset key" return.
+          if (!filePath || !isBound()) return undefined;
+          return this.storage.getOrCreateStorageStore(pluginId, scope, filePath).get<T>(key);
+        },
+        set: async <T = unknown>(
+          key: string,
+          value: T,
+          scope: PluginStorageScope = "user"
+        ): Promise<void> => {
+          assertStorageKey(pluginId, "set", key);
+          if (value === undefined) {
+            throw new Error(
+              `Plugin "${pluginId}" storage.set: value for "${key}" is undefined — storage cannot store undefined`
+            );
+          }
+          this.storage.assertStorageSerializable(pluginId, key, value);
+          const filePath = await this.storage.resolveStorageFilePath(pluginId, scope);
+          // Re-check liveness after the async resolve so a racing unloadPlugin()
+          // doesn't write into a torn-down plugin's storage file.
+          if (!isBound()) return;
+          if (!filePath) {
+            throw new Error(
+              `Plugin "${pluginId}" storage.set: no active ${scope} — "${scope}" scope has no target`
+            );
+          }
+          const store = this.storage.getOrCreateStorageStore(pluginId, scope, filePath);
+          const changed = await store.set(key, value);
+          if (changed) this.storage.notifyStorageSubscribers(pluginId, scope, key, value);
+        },
+        delete: async (key: string, scope: PluginStorageScope = "user"): Promise<void> => {
+          assertStorageKey(pluginId, "delete", key);
+          const filePath = await this.storage.resolveStorageFilePath(pluginId, scope);
+          // Missing target or unloaded plugin: a delete is a no-op rather than a
+          // throw (matching the "already absent" return of the store).
+          if (!filePath || !isBound()) return;
+          const store = this.storage.getOrCreateStorageStore(pluginId, scope, filePath);
+          const changed = await store.delete(key);
+          if (changed) this.storage.notifyStorageSubscribers(pluginId, scope, key, undefined);
+        },
+        onDidChange: <T = unknown>(
+          key: string,
+          callback: (value: T | undefined) => void,
+          scope: PluginStorageScope = "user"
+        ): Promise<() => void> => {
+          if (revoked) {
+            throw new Error(
+              `Plugin "${pluginId}" host revoked: storage.onDidChange called after activate() returned or timed out`
+            );
+          }
+          assertStorageKey(pluginId, "onDidChange", key);
+          if (typeof callback !== "function") {
+            throw new Error(
+              `Plugin "${pluginId}" storage.onDidChange: callback must be a function`
+            );
+          }
+          const sub = { key, scope, cb: callback as (value: unknown) => void };
+          this.storage.addSubscriber(pluginId, sub);
+
+          let disposed = false;
+          const dispose = (): void => {
+            if (disposed) return;
+            disposed = true;
+            this.storage.removeSubscriber(pluginId, sub);
+            const list = this.pluginEventCleanups.get(pluginId);
+            if (!list) return;
+            const idx = list.indexOf(dispose);
+            if (idx >= 0) list.splice(idx, 1);
+            if (list.length === 0) this.pluginEventCleanups.delete(pluginId);
+          };
+
+          let list = this.pluginEventCleanups.get(pluginId);
+          if (!list) {
+            list = [];
+            this.pluginEventCleanups.set(pluginId, list);
+          }
+          list.push(dispose);
+          return Promise.resolve(dispose);
+        },
+      },
     };
     return {
       host,
@@ -3925,6 +4042,13 @@ export class PluginService {
     // store caches so a reload starts from disk.
     runUnloadStep(pluginId, "clearPluginSettingsState", () =>
       this.settings.clearPluginSettingsState(pluginId)
+    );
+    // Same teardown for private storage: drops leftover subscriber-set entries
+    // and the in-memory storage store caches so a reload starts from disk. A
+    // discrete step (not bundled with settings) per the unload-cascade contract
+    // — a throw here can't strand later cleanup (lessons #9322/#9533).
+    runUnloadStep(pluginId, "clearPluginStorageState", () =>
+      this.storage.clearPluginStorageState(pluginId)
     );
 
     // Kill every child process this plugin spawned via host.process.spawn

--- a/electron/services/PluginSettingsStore.ts
+++ b/electron/services/PluginSettingsStore.ts
@@ -273,7 +273,11 @@ export class PluginSettingsStore {
   }
 
   private async persist(cache: Map<string, unknown>): Promise<void> {
-    const obj: Record<string, unknown> = {};
+    // Null-prototype target so a literal `__proto__` key (a valid storage key,
+    // since storage keys are undeclared) becomes an own enumerable property
+    // instead of silently mutating Object.prototype — which would drop the value
+    // from JSON.stringify and lose it on the next reload.
+    const obj: Record<string, unknown> = Object.create(null);
     for (const [k, v] of cache) obj[k] = v;
     await fs.mkdir(path.dirname(this.filePath), { recursive: true });
     await resilientAtomicWriteFile(this.filePath, JSON.stringify(obj, null, 2), "utf-8", {

--- a/electron/services/__tests__/PluginStorageManager.test.ts
+++ b/electron/services/__tests__/PluginStorageManager.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
+
+const projectStoreMock = vi.hoisted(() => ({
+  getCurrentProject: vi.fn((): { path: string } | null => null),
+  getProjectById: vi.fn((_id: string): { path: string } | null => null),
+}));
+
+vi.mock("../ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+const { PluginStorageManager } = await import("../plugin/PluginStorageManager.js");
+
+const PLUGIN_ID = "acme.storage-test";
+
+let tmpDir: string;
+let activeWorktreePath: string | undefined;
+
+function managerFor(): InstanceType<typeof PluginStorageManager> {
+  return new PluginStorageManager({
+    getPluginsRoot: () => path.join(tmpDir, "plugins"),
+    getActiveWorktreePath: async () => activeWorktreePath,
+  });
+}
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-plugin-storage-"));
+  activeWorktreePath = undefined;
+  projectStoreMock.getCurrentProject.mockReturnValue(null);
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("PluginStorageManager path resolution", () => {
+  it("resolves user scope to the plugin-storage root (sibling of plugin-settings)", async () => {
+    const mgr = managerFor();
+    const filePath = await mgr.resolveStorageFilePath(PLUGIN_ID, "user");
+    // The storage root is a sibling of the plugins dir, not under plugin-settings.
+    expect(filePath).toBe(path.join(tmpDir, "plugin-storage", `${PLUGIN_ID}.json`));
+    expect(filePath).not.toContain("plugin-settings");
+  });
+
+  it("resolves project scope inside the active project's .daintree dir", async () => {
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: "/projects/alpha" });
+    const mgr = managerFor();
+    const filePath = await mgr.resolveStorageFilePath(PLUGIN_ID, "project");
+    expect(filePath).toBe(
+      path.join("/projects/alpha", ".daintree", "plugin-storage", `${PLUGIN_ID}.json`)
+    );
+  });
+
+  it("resolves worktree scope inside the active worktree's .daintree dir", async () => {
+    activeWorktreePath = "/worktrees/feature-x";
+    const mgr = managerFor();
+    const filePath = await mgr.resolveStorageFilePath(PLUGIN_ID, "worktree");
+    expect(filePath).toBe(
+      path.join("/worktrees/feature-x", ".daintree", "plugin-storage", `${PLUGIN_ID}.json`)
+    );
+  });
+
+  it("returns undefined when no project is active (project scope)", async () => {
+    const mgr = managerFor();
+    expect(await mgr.resolveStorageFilePath(PLUGIN_ID, "project")).toBeUndefined();
+  });
+
+  it("returns undefined when no worktree is active (worktree scope)", async () => {
+    activeWorktreePath = undefined;
+    const mgr = managerFor();
+    expect(await mgr.resolveStorageFilePath(PLUGIN_ID, "worktree")).toBeUndefined();
+  });
+});
+
+describe("PluginStorageManager store cache", () => {
+  it("returns the same store for a repeated (plugin, scope, path) and a fresh one per path", async () => {
+    const mgr = managerFor();
+    const a = mgr.getOrCreateStorageStore(PLUGIN_ID, "user", path.join(tmpDir, "a.json"));
+    const aAgain = mgr.getOrCreateStorageStore(PLUGIN_ID, "user", path.join(tmpDir, "a.json"));
+    const b = mgr.getOrCreateStorageStore(PLUGIN_ID, "user", path.join(tmpDir, "b.json"));
+    expect(aAgain).toBe(a);
+    expect(b).not.toBe(a);
+  });
+
+  it("persists, reads back, and deletes a value through the backing store", async () => {
+    const mgr = managerFor();
+    const filePath = (await mgr.resolveStorageFilePath(PLUGIN_ID, "user"))!;
+    const store = mgr.getOrCreateStorageStore(PLUGIN_ID, "user", filePath);
+
+    expect(await store.set("count", 3)).toBe(true);
+    expect(await store.get<number>("count")).toBe(3);
+
+    // The value is written to the plugin-storage path on disk, not plugin-settings.
+    const onDisk = JSON.parse(await fs.readFile(filePath, "utf-8"));
+    expect(onDisk).toEqual({ count: 3 });
+
+    expect(await store.delete("count")).toBe(true);
+    expect(await store.get("count")).toBeUndefined();
+    // Deleting an already-absent key is a no-op (false), not a throw.
+    expect(await store.delete("count")).toBe(false);
+  });
+});
+
+describe("PluginStorageManager serialization guard", () => {
+  it("rejects a non-JSON-serializable value", () => {
+    const mgr = managerFor();
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => mgr.assertStorageSerializable(PLUGIN_ID, "k", circular)).toThrow(
+      /not JSON-serializable/
+    );
+  });
+
+  it("accepts plain JSON values", () => {
+    const mgr = managerFor();
+    expect(() =>
+      mgr.assertStorageSerializable(PLUGIN_ID, "k", { a: 1, b: ["x"], c: null })
+    ).not.toThrow();
+  });
+});
+
+describe("PluginStorageManager subscribers", () => {
+  it("fires only the matching (key, scope) subscriber and snapshots the live set", () => {
+    const mgr = managerFor();
+    const userCb = vi.fn();
+    const worktreeCb = vi.fn();
+    mgr.addSubscriber(PLUGIN_ID, { key: "k", scope: "user", cb: userCb });
+    mgr.addSubscriber(PLUGIN_ID, { key: "k", scope: "worktree", cb: worktreeCb });
+
+    mgr.notifyStorageSubscribers(PLUGIN_ID, "user", "k", "v");
+    expect(userCb).toHaveBeenCalledWith("v");
+    expect(worktreeCb).not.toHaveBeenCalled();
+
+    mgr.notifyStorageSubscribers(PLUGIN_ID, "worktree", "k", "w");
+    expect(worktreeCb).toHaveBeenCalledWith("w");
+    // A different key in the same scope does not fire.
+    mgr.notifyStorageSubscribers(PLUGIN_ID, "user", "other", "z");
+    expect(userCb).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops firing after removeSubscriber", () => {
+    const mgr = managerFor();
+    const cb = vi.fn();
+    const sub = { key: "k", scope: "user" as const, cb };
+    mgr.addSubscriber(PLUGIN_ID, sub);
+    mgr.notifyStorageSubscribers(PLUGIN_ID, "user", "k", "v1");
+    mgr.removeSubscriber(PLUGIN_ID, sub);
+    mgr.notifyStorageSubscribers(PLUGIN_ID, "user", "k", "v2");
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates a throwing subscriber so siblings still fire", () => {
+    const mgr = managerFor();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const good = vi.fn();
+    mgr.addSubscriber(PLUGIN_ID, { key: "k", scope: "user", cb: bad });
+    mgr.addSubscriber(PLUGIN_ID, { key: "k", scope: "user", cb: good });
+    expect(() => mgr.notifyStorageSubscribers(PLUGIN_ID, "user", "k", "v")).not.toThrow();
+    expect(good).toHaveBeenCalledWith("v");
+    errorSpy.mockRestore();
+  });
+});
+
+describe("PluginStorageManager clearPluginStorageState", () => {
+  it("drops the plugin's subscribers and store caches", async () => {
+    const mgr = managerFor();
+    const cb = vi.fn();
+    mgr.addSubscriber(PLUGIN_ID, { key: "k", scope: "user", cb });
+    const filePath = (await mgr.resolveStorageFilePath(PLUGIN_ID, "user"))!;
+    mgr.getOrCreateStorageStore(PLUGIN_ID, "user", filePath);
+
+    mgr.clearPluginStorageState(PLUGIN_ID);
+
+    const internals = mgr as unknown as {
+      storageSubscribers: Map<string, unknown>;
+      storageStores: Map<string, unknown>;
+    };
+    expect(internals.storageSubscribers.has(PLUGIN_ID)).toBe(false);
+    expect(
+      [...internals.storageStores.keys()].some((k) => k.startsWith(`${PLUGIN_ID}\u0000`))
+    ).toBe(false);
+
+    // A later notify is a no-op once the plugin's state is cleared.
+    mgr.notifyStorageSubscribers(PLUGIN_ID, "user", "k", "v");
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("only clears the target plugin's entries", async () => {
+    const mgr = managerFor();
+    const other = "acme.other";
+    mgr.getOrCreateStorageStore(PLUGIN_ID, "user", path.join(tmpDir, `${PLUGIN_ID}.json`));
+    mgr.getOrCreateStorageStore(other, "user", path.join(tmpDir, `${other}.json`));
+
+    mgr.clearPluginStorageState(PLUGIN_ID);
+
+    const stores = (mgr as unknown as { storageStores: Map<string, unknown> }).storageStores;
+    expect([...stores.keys()].some((k) => k.startsWith(`${other}\u0000`))).toBe(true);
+    expect([...stores.keys()].some((k) => k.startsWith(`${PLUGIN_ID}\u0000`))).toBe(false);
+  });
+});

--- a/electron/services/__tests__/PluginStorageManager.test.ts
+++ b/electron/services/__tests__/PluginStorageManager.test.ts
@@ -101,6 +101,23 @@ describe("PluginStorageManager store cache", () => {
     // Deleting an already-absent key is a no-op (false), not a throw.
     expect(await store.delete("count")).toBe(false);
   });
+
+  it("round-trips a literal __proto__ key without prototype pollution", async () => {
+    const mgr = managerFor();
+    const filePath = (await mgr.resolveStorageFilePath(PLUGIN_ID, "user"))!;
+    const store = mgr.getOrCreateStorageStore(PLUGIN_ID, "user", filePath);
+
+    // "__proto__" is a valid (undeclared) storage key. A naive `obj[k] = v`
+    // persist would mutate Object.prototype and drop the value on reload.
+    expect(await store.set("__proto__", { x: 1 })).toBe(true);
+
+    // Force a cold read from disk through a brand-new manager/store instance.
+    const fresh = managerFor();
+    const reread = fresh.getOrCreateStorageStore(PLUGIN_ID, "user", filePath);
+    expect(await reread.get("__proto__")).toEqual({ x: 1 });
+    // The global prototype was not polluted.
+    expect(({} as Record<string, unknown>).x).toBeUndefined();
+  });
 });
 
 describe("PluginStorageManager serialization guard", () => {

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -19,6 +19,8 @@ import type {
   PluginHostApi,
   PluginIpcContext,
   PluginProcessHandle,
+  PluginSettingsScope,
+  PluginStorageScope,
 } from "../../../shared/types/plugin.js";
 import type { FileDecoration, FileDecorationProviderImpl } from "../../../shared/types/forge.js";
 import type {
@@ -33,6 +35,9 @@ import type {
   RegisterHandlerParams,
   SettingsGetParams,
   SettingsSetParams,
+  StorageGetParams,
+  StorageSetParams,
+  StorageDeleteParams,
   ShowToastParams,
   ShowQuickPickParams,
   ShowInputBoxParams,
@@ -384,6 +389,20 @@ export class PluginDevWorkerMainBridge {
         await this.host.settings.set(p.key, p.value, p.scope);
         return undefined;
       }
+      case "storage.get": {
+        const p = params as StorageGetParams;
+        return this.host.storage.get(p.key, p.scope);
+      }
+      case "storage.set": {
+        const p = params as StorageSetParams;
+        await this.host.storage.set(p.key, p.value, p.scope);
+        return undefined;
+      }
+      case "storage.delete": {
+        const p = params as StorageDeleteParams;
+        await this.host.storage.delete(p.key, p.scope);
+        return undefined;
+      }
       case "fs.readFile":
         return this.host.fs.readFile((params as FsPathParams).path, { signal });
       case "fs.writeFile": {
@@ -648,13 +667,27 @@ export class PluginDevWorkerMainBridge {
           kind === "process-exit"
             ? handle.onExit((info) => push(info))
             : handle.onCrash((info) => push(info));
+      } else if (kind === "storage") {
+        if (!msg.key) {
+          logger.warn(`[${this.pluginId}] storage subscribe missing key`);
+          return;
+        }
+        dispose = await this.host.storage.onDidChange(
+          msg.key,
+          (value) => push(value),
+          msg.scope as PluginStorageScope | undefined
+        );
       } else {
         // settings
         if (!msg.key) {
           logger.warn(`[${this.pluginId}] settings subscribe missing key`);
           return;
         }
-        dispose = await this.host.settings.onDidChange(msg.key, (value) => push(value), msg.scope);
+        dispose = await this.host.settings.onDidChange(
+          msg.key,
+          (value) => push(value),
+          msg.scope as PluginSettingsScope | undefined
+        );
       }
       // The bridge may have been disposed or reloaded while the subscription was
       // settling — tear it down rather than leak it past the cleanup pass.

--- a/electron/services/plugin/PluginStorageManager.ts
+++ b/electron/services/plugin/PluginStorageManager.ts
@@ -1,0 +1,186 @@
+import path from "path";
+import { PluginSettingsStore } from "../PluginSettingsStore.js";
+import { projectStore } from "../ProjectStore.js";
+import type { PluginStorageScope } from "../../../shared/types/plugin.js";
+
+export function assertStorageKey(
+  pluginId: string,
+  method: string,
+  key: unknown
+): asserts key is string {
+  if (typeof key !== "string" || key.length === 0) {
+    throw new Error(`Plugin "${pluginId}" storage.${method}: key must be a non-empty string`);
+  }
+}
+
+interface StorageSubscriber {
+  key: string;
+  scope: PluginStorageScope;
+  cb: (value: unknown) => void;
+}
+
+interface PluginStorageManagerDeps {
+  /** Getter for the user-plugins root; {@link PluginStorageManager.storageRoot} derives from it. */
+  getPluginsRoot: () => string;
+  /**
+   * Resolve the active worktree's absolute path, or `undefined` when none is
+   * active (or the workspace client isn't wired yet). Injected so the manager
+   * stays testable without the Electron workspace host — `PluginService` wires
+   * it to the same `getAllStatesAsync()` / `isCurrent` lookup `getActiveWorktree`
+   * uses.
+   */
+  getActiveWorktreePath: () => Promise<string | undefined>;
+}
+
+/**
+ * Owns the per-(plugin, scope, path) {@link PluginSettingsStore} cache, scope and
+ * file-path resolution, the subscriber set and notification, and serializability
+ * guards for the private {@link import("../../../shared/types/plugin.js").StorageApi}.
+ *
+ * This is the machine-owned counterpart to {@link import("./PluginSettingsManager.js").PluginSettingsManager}:
+ * deliberately stripped of every settings-specific concern (declared-key gating,
+ * secret routing, the settings-UI bridge). Storage values are plaintext JSON,
+ * never declared, never surfaced in the settings UI. The `"worktree"` scope —
+ * which settings has no analog for — resolves the active worktree at call time
+ * through the injected `getActiveWorktreePath` callback, so storage paths track
+ * worktree switches exactly as the `"project"` scope tracks project switches.
+ */
+export class PluginStorageManager {
+  private readonly deps: PluginStorageManagerDeps;
+
+  /**
+   * Storage stores keyed by `{pluginId}\u0000{scope}\u0000{filePath}`. The NUL
+   * (`\u0000`) separator is unambiguous because a valid plugin id can never
+   * contain it. Keyed on the resolved path (not just scope) so a project /
+   * worktree switch — which changes the resolved path — creates a fresh store
+   * without evicting the old target's cache. Entries for a plugin are dropped on
+   * unload.
+   */
+  private storageStores = new Map<string, PluginSettingsStore>();
+  /**
+   * Active `host.storage.onDidChange` subscriptions per plugin. Held here (not on
+   * the store) so they survive project / worktree switches and are flushed in one
+   * place on unload. Each disposer is also tracked in the facade's
+   * `pluginEventCleanups`.
+   */
+  private storageSubscribers = new Map<string, Set<StorageSubscriber>>();
+
+  constructor(deps: PluginStorageManagerDeps) {
+    this.deps = deps;
+  }
+
+  /**
+   * Root directory for user-scope plugin storage: a sibling of the plugins dir
+   * and of `plugin-settings`. Production: `~/.daintree/plugin-storage`. Derived
+   * from the plugins root so tests that pass a custom root stay isolated. A
+   * distinct dir from `plugin-settings` so machine-owned state can be
+   * `.gitignore`'d independently of user config.
+   */
+  storageRoot(): string {
+    return path.join(path.dirname(this.deps.getPluginsRoot()), "plugin-storage");
+  }
+
+  /**
+   * Resolve the JSON file backing a plugin's storage for a scope. User scope is
+   * fixed; project scope resolves the active project at call time; worktree scope
+   * resolves the active worktree (async) via the injected callback. Returns
+   * `undefined` when the `"project"` / `"worktree"` target is not active.
+   */
+  async resolveStorageFilePath(
+    pluginId: string,
+    scope: PluginStorageScope
+  ): Promise<string | undefined> {
+    if (scope === "worktree") {
+      const root = await this.deps.getActiveWorktreePath();
+      if (!root) return undefined;
+      return path.join(root, ".daintree", "plugin-storage", `${pluginId}.json`);
+    }
+    if (scope === "project") {
+      const root = projectStore.getCurrentProject()?.path;
+      if (!root) return undefined;
+      return path.join(root, ".daintree", "plugin-storage", `${pluginId}.json`);
+    }
+    return path.join(this.storageRoot(), `${pluginId}.json`);
+  }
+
+  getOrCreateStorageStore(
+    pluginId: string,
+    scope: PluginStorageScope,
+    filePath: string
+  ): PluginSettingsStore {
+    const cacheKey = `${pluginId}\u0000${scope}\u0000${filePath}`;
+    let store = this.storageStores.get(cacheKey);
+    if (!store) {
+      store = new PluginSettingsStore(filePath);
+      this.storageStores.set(cacheKey, store);
+    }
+    return store;
+  }
+
+  /**
+   * Storage persists through `PluginSettingsStore.cloneValue`, which
+   * JSON-round-trips the value. Probe serializability up front so a
+   * non-serializable value surfaces a clear error rather than a raw JSON failure
+   * deep in the store.
+   */
+  assertStorageSerializable(pluginId: string, key: string, value: unknown): void {
+    let serialized: string | undefined;
+    try {
+      serialized = JSON.stringify(value);
+    } catch {
+      serialized = undefined;
+    }
+    if (serialized === undefined) {
+      throw new Error(`Plugin "${pluginId}" storage: value for "${key}" is not JSON-serializable`);
+    }
+  }
+
+  /** Register a `host.storage.onDidChange` subscriber. */
+  addSubscriber(pluginId: string, sub: StorageSubscriber): void {
+    let subs = this.storageSubscribers.get(pluginId);
+    if (!subs) {
+      subs = new Set();
+      this.storageSubscribers.set(pluginId, subs);
+    }
+    subs.add(sub);
+  }
+
+  /** Drop a `host.storage.onDidChange` subscriber, pruning the plugin's set when empty. */
+  removeSubscriber(pluginId: string, sub: StorageSubscriber): void {
+    const set = this.storageSubscribers.get(pluginId);
+    if (!set) return;
+    set.delete(sub);
+    if (set.size === 0) this.storageSubscribers.delete(pluginId);
+  }
+
+  notifyStorageSubscribers(
+    pluginId: string,
+    scope: PluginStorageScope,
+    key: string,
+    value: unknown
+  ): void {
+    const subs = this.storageSubscribers.get(pluginId);
+    if (!subs) return;
+    // Snapshot so a callback that disposes itself doesn't mutate the live set
+    // mid-iteration.
+    for (const sub of [...subs]) {
+      if (sub.key !== key || sub.scope !== scope) continue;
+      try {
+        sub.cb(value);
+      } catch (err) {
+        console.error(
+          `[PluginService] storage.onDidChange callback for "${pluginId}" key "${key}" failed:`,
+          err
+        );
+      }
+    }
+  }
+
+  clearPluginStorageState(pluginId: string): void {
+    this.storageSubscribers.delete(pluginId);
+    const prefix = `${pluginId}\u0000`;
+    for (const cacheKey of [...this.storageStores.keys()]) {
+      if (cacheKey.startsWith(prefix)) this.storageStores.delete(cacheKey);
+    }
+  }
+}

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -40,6 +40,12 @@ function makeHost() {
       set: vi.fn(async () => {}),
       onDidChange: vi.fn(() => vi.fn()),
     },
+    storage: {
+      get: vi.fn(async () => undefined),
+      set: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+      onDidChange: vi.fn((_key: any, _cb: any) => vi.fn()),
+    },
     process: {
       spawn: vi.fn(async () => ({
         id: "p0",
@@ -231,6 +237,74 @@ describe("PluginDevWorkerMainBridge", () => {
     await flush();
     workerHost.emit("worker-message", { type: "unsubscribe", subscriptionId: "s2" });
     expect(dispose).toHaveBeenCalled();
+  });
+
+  it("routes storage.get/set/delete host-calls to the real host", async () => {
+    const { host, workerHost } = makeBridge();
+    host.storage.get.mockResolvedValueOnce("stored");
+
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "sg",
+      method: "storage.get",
+      params: { key: "k", scope: "worktree" },
+    });
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "ss",
+      method: "storage.set",
+      params: { key: "k", value: 7, scope: "project" },
+    });
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "sd",
+      method: "storage.delete",
+      params: { key: "k", scope: "user" },
+    });
+    await flush();
+
+    expect(host.storage.get).toHaveBeenCalledWith("k", "worktree");
+    expect(host.storage.set).toHaveBeenCalledWith("k", 7, "project");
+    expect(host.storage.delete).toHaveBeenCalledWith("k", "user");
+
+    const getReply = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "sg");
+    expect(getReply).toMatchObject({ ok: true, result: "stored" });
+    const setReply = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "ss");
+    expect(setReply).toMatchObject({ ok: true, result: undefined });
+    const delReply = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "sd");
+    expect(delReply).toMatchObject({ ok: true, result: undefined });
+  });
+
+  it("opens a storage subscription and pushes events to the worker", async () => {
+    const { host, workerHost } = makeBridge();
+    let emit: ((v: unknown) => void) | undefined;
+    host.storage.onDidChange.mockImplementation((_key: any, cb: any) => {
+      emit = cb;
+      return vi.fn();
+    });
+    workerHost.emit("worker-message", {
+      type: "subscribe",
+      subscriptionId: "st1",
+      kind: "storage",
+      key: "k",
+      scope: "worktree",
+    });
+    await flush();
+    expect(host.storage.onDidChange).toHaveBeenCalledWith("k", expect.any(Function), "worktree");
+    emit?.("v9");
+    const evt = workerHost.sent.find((m) => m.type === "subscription-event");
+    expect(evt).toMatchObject({ subscriptionId: "st1", payload: "v9" });
+  });
+
+  it("drops a storage subscription that is missing its key", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "subscribe",
+      subscriptionId: "st2",
+      kind: "storage",
+    });
+    await flush();
+    expect(host.storage.onDidChange).not.toHaveBeenCalled();
   });
 
   it("resolves waitForActivation on `activated` and rejects on `activate-error`", async () => {

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -305,6 +305,8 @@ describe("PluginDevWorkerMainBridge", () => {
     });
     await flush();
     expect(host.storage.onDidChange).not.toHaveBeenCalled();
+    // The bridge never sends a subscription-event for the dropped subscription.
+    expect(workerHost.sent.some((m) => m.type === "subscription-event")).toBe(false);
   });
 
   it("resolves waitForActivation on `activated` and rejects on `activate-error`", async () => {

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -41,7 +41,9 @@ function makeHost() {
       onDidChange: vi.fn(() => vi.fn()),
     },
     storage: {
-      get: vi.fn(async () => undefined),
+      // Annotated `Promise<unknown>` so a test can `mockResolvedValueOnce` a
+      // concrete value (the default-inferred `Promise<undefined>` would reject it).
+      get: vi.fn(async (): Promise<unknown> => undefined),
       set: vi.fn(async () => {}),
       delete: vi.fn(async () => {}),
       onDidChange: vi.fn((_key: any, _cb: any) => vi.fn()),

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -21,6 +21,7 @@ import type {
   PluginIpcContext,
   PluginIpcHandler,
   PluginSettingsScope,
+  PluginStorageScope,
   PluginToastOptions,
   PluginQuickPickItem,
   PluginQuickPickOptions,
@@ -622,6 +623,28 @@ export class PluginDevWorkerHostProxy {
           return Promise.resolve(dispose);
         },
       },
+      storage: {
+        get: <T = unknown>(key: string, scope: PluginStorageScope = "user") =>
+          this.call<T | undefined>("storage.get", { key, scope }),
+        set: <T = unknown>(key: string, value: T, scope: PluginStorageScope = "user") =>
+          this.call<void>("storage.set", { key, value, scope }),
+        delete: (key: string, scope: PluginStorageScope = "user") =>
+          this.call<void>("storage.delete", { key, scope }),
+        onDidChange: <T = unknown>(
+          key: string,
+          callback: (value: T | undefined) => void,
+          scope: PluginStorageScope = "user"
+        ) => {
+          this.assertActivationOpen("storage.onDidChange");
+          const dispose = this.subscribe(
+            "storage",
+            (payload) => callback(payload as T | undefined),
+            key,
+            scope
+          );
+          return Promise.resolve(dispose);
+        },
+      },
     };
     return host;
   }
@@ -630,7 +653,7 @@ export class PluginDevWorkerHostProxy {
     kind: PluginWorkerSubscriptionKind,
     callback: (payload: unknown) => void,
     key?: string,
-    scope?: PluginSettingsScope,
+    scope?: PluginSettingsScope | PluginStorageScope,
     debounceMs?: number
   ): () => void {
     const subscriptionId = `s${this.nextId++}`;

--- a/plugins/sample/rich-daintree/main/index.ts
+++ b/plugins/sample/rich-daintree/main/index.ts
@@ -60,7 +60,9 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
         await host.storage.set(KEY, { n: 3 }, "worktree");
         report.worktree = await host.storage.get(KEY, "worktree");
       } catch (err) {
-        report.worktreeError = err instanceof Error ? err.message : String(err);
+        // String() (not the instanceof-Error ternary) keeps the sample plugin
+        // bundle dependency-free; the thrown host message is what the spec checks.
+        report.worktreeError = String(err);
       }
 
       // Delete is a real method (settings has none) — confirm it removes the key.

--- a/plugins/sample/rich-daintree/main/index.ts
+++ b/plugins/sample/rich-daintree/main/index.ts
@@ -28,5 +28,58 @@ export async function activate(host: PluginHostApi): Promise<() => void> {
     () => ({ ready: true })
   );
 
+  // Private storage round-trip (#10556) — exercised by core-plugin-storage.spec.
+  // Writes/reads/deletes across all three scopes and reports what it observed, so
+  // the E2E can assert the host.storage API works end-to-end through the real
+  // plugin host AND that storage is a separate store from settings (writing a
+  // key that collides with a declared setting id must not surface in the
+  // settings UI). The action cleans up every key it wrote so it leaves no
+  // residue for other specs.
+  await host.registerAction(
+    {
+      id: "storage-roundtrip",
+      title: "Rich: Storage round-trip",
+      description: "Exercises host.storage across user/project/worktree scopes (E2E only).",
+      category: "Rich Daintree",
+      kind: "command",
+      danger: "safe",
+    },
+    async () => {
+      const KEY = "e2e-roundtrip";
+      const report: Record<string, unknown> = {};
+
+      await host.storage.set(KEY, { n: 1 }, "user");
+      report.user = await host.storage.get(KEY, "user");
+
+      await host.storage.set(KEY, { n: 2 }, "project");
+      report.project = await host.storage.get(KEY, "project");
+
+      // A worktree may not be active in every harness layout; report the throw
+      // instead of failing the action so the spec can branch on it.
+      try {
+        await host.storage.set(KEY, { n: 3 }, "worktree");
+        report.worktree = await host.storage.get(KEY, "worktree");
+      } catch (err) {
+        report.worktreeError = err instanceof Error ? err.message : String(err);
+      }
+
+      // Delete is a real method (settings has none) — confirm it removes the key.
+      await host.storage.delete(KEY, "user");
+      report.userAfterDelete = await host.storage.get(KEY, "user");
+
+      // Collision guard: a storage key matching a declared setting id must live
+      // in the storage store, never the settings store.
+      await host.storage.set("greeting", "STORAGE-ONLY", "user");
+      report.storageGreeting = await host.storage.get("greeting", "user");
+
+      // Clean up every remaining key so the fixture leaves no residue.
+      await host.storage.delete("greeting", "user");
+      await host.storage.delete(KEY, "project");
+      await host.storage.delete(KEY, "worktree").catch(() => {});
+
+      return report;
+    }
+  );
+
   return () => {};
 }

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -26,12 +26,14 @@ import type {
   PluginProcessHandle,
   PluginProcessSpawnOptions,
   PluginSettingsScope,
+  PluginStorageScope,
   PluginToastOptions,
   PluginTypedIpcHandler,
   PluginWorktreeSnapshot,
   PluginAgentSnapshot,
   PluginGitCommitResult,
   SettingsApi,
+  StorageApi,
 } from "../types/plugin.js";
 
 export interface RegisteredActionRecord {
@@ -143,6 +145,12 @@ export interface CreateMockHostOptions {
     user?: Record<string, unknown>;
     project?: Record<string, unknown>;
   };
+  /** Pre-seed private `host.storage` values per scope. */
+  storage?: {
+    user?: Record<string, unknown>;
+    project?: Record<string, unknown>;
+    worktree?: Record<string, unknown>;
+  };
   /**
    * Custom resolver for `host.dispatch`. The default routes the call to a
    * matching `registerAction` handler, returning `NOT_FOUND` otherwise — which
@@ -198,6 +206,18 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     project: new Map(),
   };
 
+  const storageStore: Record<PluginStorageScope, Map<string, unknown>> = {
+    user: new Map(Object.entries(options.storage?.user ?? {})),
+    project: new Map(Object.entries(options.storage?.project ?? {})),
+    worktree: new Map(Object.entries(options.storage?.worktree ?? {})),
+  };
+
+  const storageSubs: Record<PluginStorageScope, Map<string, Set<(value: unknown) => void>>> = {
+    user: new Map(),
+    project: new Map(),
+    worktree: new Map(),
+  };
+
   const dispatchOverrides = new Map<string, ActionDispatchResult>();
 
   const settings: SettingsApi = {
@@ -244,6 +264,68 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         if (set) {
           set.delete(cb);
           if (set.size === 0) settingsSubs[scope].delete(key);
+        }
+      };
+      return Promise.resolve(dispose);
+    },
+  };
+
+  // Private machine-owned storage (#10556). Mirrors the settings mock but adds
+  // the "worktree" scope and a `delete` method, and never gates on declared keys.
+  const storage: StorageApi = {
+    async get<T = unknown>(
+      key: string,
+      scope: PluginStorageScope = "user"
+    ): Promise<T | undefined> {
+      return storageStore[scope].get(key) as T | undefined;
+    },
+    async set<T = unknown>(
+      key: string,
+      value: T,
+      scope: PluginStorageScope = "user"
+    ): Promise<void> {
+      if (value === undefined) {
+        throw new Error("storage.set: value cannot be undefined");
+      }
+      const prev = storageStore[scope].get(key);
+      storageStore[scope].set(key, value);
+      if (!Object.is(prev, value)) {
+        const subs = storageSubs[scope].get(key);
+        if (subs) {
+          for (const cb of subs) cb(value as unknown);
+        }
+      }
+    },
+    async delete(key: string, scope: PluginStorageScope = "user"): Promise<void> {
+      const had = storageStore[scope].has(key);
+      storageStore[scope].delete(key);
+      if (had) {
+        const subs = storageSubs[scope].get(key);
+        if (subs) {
+          for (const cb of subs) cb(undefined);
+        }
+      }
+    },
+    onDidChange<T = unknown>(
+      key: string,
+      callback: (value: T | undefined) => void,
+      scope: PluginStorageScope = "user"
+    ): Promise<() => void> {
+      let subs = storageSubs[scope].get(key);
+      if (!subs) {
+        subs = new Set();
+        storageSubs[scope].set(key, subs);
+      }
+      const cb = callback as (value: unknown) => void;
+      subs.add(cb);
+      let disposed = false;
+      const dispose = () => {
+        if (disposed) return;
+        disposed = true;
+        const set = storageSubs[scope].get(key);
+        if (set) {
+          set.delete(cb);
+          if (set.size === 0) storageSubs[scope].delete(key);
         }
       };
       return Promise.resolve(dispose);
@@ -622,6 +704,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       },
     },
     settings,
+    storage,
     logger: {
       info: () => {},
       warn: () => {},

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -288,8 +288,13 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         throw new Error("storage.set: value cannot be undefined");
       }
       const prev = storageStore[scope].get(key);
+      const had = storageStore[scope].has(key);
       storageStore[scope].set(key, value);
-      if (!Object.is(prev, value)) {
+      // Mirror the real store's `valuesEqual` (JSON) change detection rather than
+      // `Object.is`, so two equal-but-distinct object literals fire onDidChange
+      // exactly once — matching production, not reference identity.
+      const changed = !had || !jsonEqual(prev, value);
+      if (changed) {
         const subs = storageSubs[scope].get(key);
         if (subs) {
           for (const cb of subs) cb(value as unknown);
@@ -742,4 +747,18 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   };
 
   return host;
+}
+
+/**
+ * Value equality matching `PluginSettingsStore.valuesEqual`: reference-equal or
+ * JSON-equal. Used by the storage mock so its change detection (and therefore
+ * its onDidChange firing) matches the real store rather than reference identity.
+ */
+function jsonEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
 }

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -3,6 +3,8 @@ import type {
   PluginManifest,
   PluginHostApi,
   PluginActivationApi,
+  PluginSettingsScope,
+  PluginStorageScope,
   PluginHostCallOptions,
   PluginActivate,
   PanelContribution,
@@ -204,6 +206,28 @@ describe("plugin-sdk boundary", () => {
       >();
     });
 
+    it("PluginHostApi.storage exposes get/set/delete/onDidChange", () => {
+      // Purely type-level — `{} as PluginHostApi` has no runtime `storage`, so
+      // dereferencing it would throw; assert on the types directly.
+      expectTypeOf<PluginHostApi["storage"]["get"]>().toBeFunction();
+      expectTypeOf<PluginHostApi["storage"]["set"]>().toBeFunction();
+      expectTypeOf<PluginHostApi["storage"]["delete"]>().toBeFunction();
+      expectTypeOf<PluginHostApi["storage"]["onDidChange"]>().toBeFunction();
+      // The disposer return type guards against a regression to void / a
+      // non-promise disposer, matching the settings.onDidChange contract.
+      expectTypeOf<ReturnType<PluginHostApi["storage"]["onDidChange"]>>().toEqualTypeOf<
+        Promise<() => void>
+      >();
+    });
+
+    it("PluginStorageScope adds 'worktree' beyond the settings scopes", () => {
+      // "worktree" is assignable to the storage scope but not the settings scope —
+      // the two are intentionally distinct so the settings UI never sees it.
+      expectTypeOf<"worktree">().toMatchTypeOf<PluginStorageScope>();
+      expectTypeOf<PluginSettingsScope>().toMatchTypeOf<PluginStorageScope>();
+      expectTypeOf<"worktree">().not.toMatchTypeOf<PluginSettingsScope>();
+    });
+
     it("PluginHostApi extends the revoke-guarded PluginActivationApi", () => {
       // The full host surface is assignable to the activation slice, but not
       // vice versa — PluginHostApi adds the post-activation-safe methods.
@@ -248,6 +272,8 @@ describe("plugin-sdk boundary", () => {
       const _getAll = activation.getWorktrees;
       // @ts-expect-error — settings accessor is not on the slice
       const _settings = activation.settings;
+      // @ts-expect-error — storage accessor is not on the slice
+      const _storage = activation.storage;
       // @ts-expect-error — process accessor is post-activation-safe, not on the slice
       const _process = activation.process;
       expect([
@@ -259,8 +285,9 @@ describe("plugin-sdk boundary", () => {
         _getActive,
         _getAll,
         _settings,
+        _storage,
         _process,
-      ]).toHaveLength(9);
+      ]).toHaveLength(10);
     });
 
     it("PluginProcessHandle carries the lifecycle controls", () => {

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -83,6 +83,10 @@ export type {
   SettingFieldType,
 } from "./plugin.js";
 
+// ── Storage (host.storage) ──────────────────────────────────────────
+
+export type { StorageApi, PluginStorageScope } from "./plugin.js";
+
 // ── IPC (registerHandler, broadcastToRenderer) — ships in v1 ────────
 
 export type {

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -427,6 +427,17 @@ export interface PluginPickPathFilter {
 export type PluginSettingsScope = "user" | "project";
 
 /**
+ * Scope for the private {@link StorageApi} key/value store. Unlike
+ * {@link PluginSettingsScope} this adds a `"worktree"` scope that auto-resolves
+ * the currently-active worktree at call time (parallel to how `"project"`
+ * resolves the active project), so a plugin can keep per-worktree machine state
+ * without hand-rolling its own per-worktree keying inside a project blob. Kept a
+ * distinct type from `PluginSettingsScope` so the settings UI / manifest schema
+ * never has to reason about `"worktree"`.
+ */
+export type PluginStorageScope = "user" | "project" | "worktree";
+
+/**
  * Snapshot of one plugin's stored setting values for a single scope, returned to
  * the settings UI (#9301). Secret values are deliberately never included —
  * `secretsSet` only reports *which* secret keys have a stored value so the form
@@ -525,6 +536,57 @@ export interface SettingsApi {
     key: string,
     callback: (value: T | undefined) => void,
     scope?: PluginSettingsScope
+  ): Promise<() => void>;
+}
+
+/**
+ * Private, plugin-scoped key/value storage exposed on
+ * {@link PluginHostApi.storage}. This is the machine-owned counterpart to
+ * {@link SettingsApi}: values never surface in the plugin settings UI and are
+ * NOT gated by `contributes.settings` declarations, so a plugin can persist its
+ * own working state freely without declaring every key. Values are stored as
+ * plaintext JSON (no secret encryption — never store credentials here) at
+ * `~/.daintree/plugin-storage/{pluginId}.json` (user scope),
+ * `<projectRoot>/.daintree/plugin-storage/{pluginId}.json` (project scope), or
+ * `<worktreePath>/.daintree/plugin-storage/{pluginId}.json` (worktree scope),
+ * with `chmod 0o600` applied on POSIX.
+ *
+ * `scope` defaults to `"user"`. The `"project"` and `"worktree"` scopes resolve
+ * the active project / active worktree at call time, so they track switches:
+ * `get` and `delete` resolve to a no-op (returning `undefined` / void) and
+ * `set` throws when no project / worktree is active.
+ */
+export interface StorageApi {
+  /**
+   * Read a stored value. Resolves to `undefined` when the key is unset, or when
+   * the requested `"project"` / `"worktree"` scope has no active target.
+   */
+  get<T = unknown>(key: string, scope?: PluginStorageScope): Promise<T | undefined>;
+  /**
+   * Persist a value. Rejects `undefined` and non-JSON-serializable values. For
+   * `"project"` / `"worktree"` scope with no active target, throws.
+   */
+  set<T = unknown>(key: string, value: T, scope?: PluginStorageScope): Promise<void>;
+  /**
+   * Remove a stored value. A missing key (or a `"project"` / `"worktree"` scope
+   * with no active target) resolves to a no-op rather than throwing.
+   */
+  delete(key: string, scope?: PluginStorageScope): Promise<void>;
+  /**
+   * Subscribe to in-process writes of `key` in `scope` (default `"user"`). The
+   * callback fires with the new value after each `set`/`delete` that changes it.
+   * Edits made to the JSON file by other processes do NOT fire until the plugin
+   * reloads. Must be called during `activate()` — subscribing is revoke-guarded.
+   * Resolves to a disposer; calling it more than once is a no-op. All
+   * subscriptions are automatically disposed when the plugin is unloaded.
+   *
+   * @throws {Error} If called after activation resolves or times out — the host
+   *   is revoked and the subscription is rejected (the promise rejects).
+   */
+  onDidChange<T = unknown>(
+    key: string,
+    callback: (value: T | undefined) => void,
+    scope?: PluginStorageScope
   ): Promise<() => void>;
 }
 
@@ -1603,6 +1665,18 @@ export interface PluginHostApi extends PluginActivationApi {
    * `chmod 0o600` on POSIX — no OS keychain (#9167). See {@link SettingsApi}.
    */
   readonly settings: SettingsApi;
+  /**
+   * Private, plugin-scoped key/value storage — the machine-owned counterpart to
+   * {@link settings}. Values never surface in the settings UI and are not gated
+   * by `contributes.settings` declarations. Plaintext JSON, three scopes
+   * (`"user"`, `"project"`, `"worktree"`). See {@link StorageApi}.
+   *
+   * Like {@link settings} this is NOT revoke-guarded: plugins read/write storage
+   * throughout their lifetime. The store is the source of truth, so a late call
+   * is harmless. `onDidChange` is the one revoke-guarded member (subscribe only
+   * during `activate()`).
+   */
+  readonly storage: StorageApi;
   /**
    * Structured diagnostic logger backed by a bounded per-plugin ring buffer in
    * the main process. Lines are forwarded to the host console (prefixed

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -20,6 +20,7 @@
 import type {
   PluginIpcContext,
   PluginSettingsScope,
+  PluginStorageScope,
   PluginQuickPickItem,
   PluginQuickPickOptions,
   PluginInputBoxOptions,
@@ -37,6 +38,9 @@ export type PluginHostCallMethod =
   | "dispatch"
   | "settings.get"
   | "settings.set"
+  | "storage.get"
+  | "storage.set"
+  | "storage.delete"
   | "fs.readFile"
   | "fs.writeFile"
   | "fs.readdir"
@@ -75,6 +79,7 @@ export type PluginWorkerSubscriptionKind =
   | "active-worktree"
   | "worktrees"
   | "settings"
+  | "storage"
   | "agent-state"
   | "process-exit"
   | "process-crash";
@@ -172,7 +177,7 @@ export type PluginWorkerToHostMessage =
       subscriptionId: string;
       kind: PluginWorkerSubscriptionKind;
       key?: string;
-      scope?: PluginSettingsScope;
+      scope?: PluginSettingsScope | PluginStorageScope;
       /**
        * Opt-in debounce for the `worktrees` subscription (host-side coalescing).
        * Ignored for other kinds. Mirrors `PluginHostSubscriptionOptions.debounceMs`.
@@ -271,6 +276,25 @@ export interface SettingsSetParams {
   key: string;
   value: unknown;
   scope: PluginSettingsScope;
+}
+
+/** Params for `storage.get` (`host-call`). */
+export interface StorageGetParams {
+  key: string;
+  scope: PluginStorageScope;
+}
+
+/** Params for `storage.set` (`host-call`). */
+export interface StorageSetParams {
+  key: string;
+  value: unknown;
+  scope: PluginStorageScope;
+}
+
+/** Params for `storage.delete` (`host-call`). */
+export interface StorageDeleteParams {
+  key: string;
+  scope: PluginStorageScope;
 }
 
 /** Params for `showToast` (`host-call`). */


### PR DESCRIPTION
## Summary

- Adds `host.storage` to the plugin host API — a private key/value namespace separate from `host.settings`, with no `contributes.settings` gating and no settings UI exposure
- Three scopes: `user`, `project`, and `worktree` (worktree auto-resolves the active worktree at call time via `PluginService`)
- New `PluginStorageManager` reuses `PluginSettingsStore` for I/O; wired into `PluginService.createHost` (`get`/`set`/`delete`/`onDidChange`) with post-await liveness re-checks for the unload race and a `clearPluginStorageState` unload step

Resolves #10556

## Changes

- `electron/services/plugin/PluginStorageManager.ts` — new storage manager with per-scope isolation
- `electron/services/PluginService.ts` — `host.storage` wired into host factory; unload cleanup
- `electron/services/plugin/PluginDevWorkerMainBridge.ts` / `pluginDevWorkerHostProxy.ts` — dev-worker protocol extended to bridge `host.storage` calls
- `shared/types/plugin.ts` / `plugin-sdk.ts` / `pluginDevWorker.ts` — type definitions for the storage API and worker message protocol
- `shared/testing/createMockHost.ts` — mock updated to cover storage
- `electron/services/PluginSettingsStore.ts` — `persist` hardens against a literal `__proto__` key (null-prototype object)
- `.gitignore` — adds `.daintree/plugin-storage/` exclusion
- `plugins/sample/rich-daintree/main/index.ts` — storage roundtrip action added to the rich sample plugin
- Unit tests: `PluginStorageManager.test.ts`, `PluginDevWorkerMainBridge.test.ts`, `plugin-sdk.test.ts`
- E2E: `e2e/full/plugins/core-plugin-storage.spec.ts`

## Testing

- Unit tests cover storage manager CRUD, scope isolation, `onDidChange` listeners, unload cleanup, and `__proto__` hardening
- Bridge unit tests cover the dev-worker proxy path end-to-end
- SDK boundary tests confirm the worktree scope type is exported correctly
- E2E spec drives a storage roundtrip action on the rich sample plugin and asserts persisted values survive a get/set/delete cycle