### PR TITLE
feat(plugins): gate agent injection behind agent:input + host.sendToActiveAgent (#10558)

### DIFF
--- a/electron/pty-host/handlers/terminalIO.ts
+++ b/electron/pty-host/handlers/terminalIO.ts
@@ -13,6 +13,10 @@ export function createTerminalIOHandlers(ctx: HostContext): HandlerMap {
       ptyManager.submit(msg.id, msg.text);
     },
 
+    stage: (msg) => {
+      ptyManager.stage(msg.id, msg.text);
+    },
+
     resize: (msg) => {
       ptyManager.resize(msg.id, msg.cols, msg.rows);
     },

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -102,6 +102,7 @@ import {
   type AgentStateChangePayload,
 } from "../../shared/utils/pluginAgentSnapshot.js";
 import { events } from "./events.js";
+import { getPtyClient } from "../window/serviceRefs.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
 import {
   registerPanelKind,
@@ -2206,6 +2207,45 @@ export class PluginService {
         }
         return lastAgentSnapshot;
       },
+      sendToActiveAgent: async (text, options) => {
+        // Liveness first (mirrors getAgentState): once unloaded the method
+        // degrades to a no-op rather than throwing into a stray post-unload
+        // timer. declaredCapabilities() also returns [] post-unload, so a
+        // capability check first would mis-report PERMISSION_REQUIRED.
+        if (!isBound()) return;
+        if (!this.declaredCapabilities(pluginId).has("agent:input")) {
+          throw new Error(
+            `PERMISSION_REQUIRED: plugin "${pluginId}" sendToActiveAgent requires "agent:input", which is not declared in manifest.capabilities`
+          );
+        }
+        // Validate BEFORE prompting for consent so an invalid call can't bank a
+        // silent grant and then inject real text unprompted (mirrors the
+        // process.spawn ordering for #10524).
+        if (typeof text !== "string" || text.length === 0) {
+          throw new Error(
+            `Plugin "${pluginId}" sendToActiveAgent: text must be a non-empty string`
+          );
+        }
+        // JIT consent fires before any side effect — first use prompts the user;
+        // the grant covers later calls. Throws PERMISSION_REQUIRED on denial.
+        // Re-check binding after the prompt await so a racing unload doesn't
+        // inject into a torn-down session.
+        await this.ensureCapabilityConsent(pluginId, "agent:input");
+        if (!isBound()) return;
+        const terminalId = await this.resolveActiveAgentTerminalId();
+        if (!isBound()) return;
+        const ptyClient = getPtyClient();
+        if (!ptyClient) {
+          throw new Error("NO_ACTIVE_AGENT: terminal host is not available");
+        }
+        // submit defaults to false — stage-only (no Enter) is the default-safe
+        // mode per #10558. submit:true appends Enter and runs the text.
+        if (options?.submit === true) {
+          ptyClient.submit(terminalId, text);
+        } else {
+          ptyClient.stage(terminalId, text);
+        }
+      },
       onDidChangeActiveWorktree: (callback) => {
         if (revoked) {
           throw new Error(
@@ -3046,6 +3086,53 @@ export class PluginService {
       capability,
       plugin.manifest.capabilities ?? []
     );
+  }
+
+  /**
+   * Resolve the terminal id of the "active agent" for `host.sendToActiveAgent`
+   * (#10558). Centralised here so plugins stop reinventing `terminal.list`-based
+   * selection heuristics that drift. Scopes to the active project when one is
+   * set (falling back to all terminals if it holds no agent), then ranks:
+   * focused/visible agent (`activityTier: "active"`) first, then a `waiting`
+   * agent, then the most recently active by output — with a deterministic id
+   * tiebreak. Terminals with no agent or in an ended state (`exited` /
+   * `completed`, or no live PTY) are excluded.
+   *
+   * @throws {Error} `NO_ACTIVE_AGENT:` when no eligible agent terminal exists.
+   */
+  private async resolveActiveAgentTerminalId(): Promise<string> {
+    const ptyClient = getPtyClient();
+    if (!ptyClient) {
+      throw new Error("NO_ACTIVE_AGENT: terminal host is not available");
+    }
+    const all = await ptyClient.getAllTerminalsAsync();
+    const activeProjectId = ptyClient.getActiveProjectId();
+    type Term = (typeof all)[number];
+    const eligible = (t: Term): boolean =>
+      Boolean(t.detectedAgentId ?? t.launchAgentId) &&
+      t.hasPty !== false &&
+      t.agentState !== "exited" &&
+      t.agentState !== "completed";
+    // Prefer the active project's terminals; fall back to all only if the active
+    // project has no eligible agent (e.g. plugin acting before a project loads).
+    const inProject = activeProjectId != null ? all.filter((t) => t.projectId === activeProjectId) : all;
+    const pool = inProject.some(eligible) ? inProject : all;
+    const candidates = pool.filter(eligible);
+    if (candidates.length === 0) {
+      throw new Error(
+        "NO_ACTIVE_AGENT: no agent terminal is available to receive input in the current project"
+      );
+    }
+    const score = (t: Term): number =>
+      (t.activityTier === "active" ? 2 : 0) + (t.agentState === "waiting" ? 1 : 0);
+    candidates.sort((a, b) => {
+      const byScore = score(b) - score(a);
+      if (byScore !== 0) return byScore;
+      const byOutput = (b.lastOutputTime ?? 0) - (a.lastOutputTime ?? 0);
+      if (byOutput !== 0) return byOutput;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+    return candidates[0].id;
   }
 
   /** The capabilities a loaded plugin declared, as a Set. Empty when unloaded. */

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2220,10 +2220,13 @@ export class PluginService {
         }
         // Validate BEFORE prompting for consent so an invalid call can't bank a
         // silent grant and then inject real text unprompted (mirrors the
-        // process.spawn ordering for #10524).
-        if (typeof text !== "string" || text.length === 0) {
+        // process.spawn ordering for #10524). Reject whitespace-only text too:
+        // it stages to nothing but with submit:true would fire a bare Enter,
+        // submitting whatever is already in the agent's input buffer — an effect
+        // the consent prompt never showed the user.
+        if (typeof text !== "string" || text.trim().length === 0) {
           throw new Error(
-            `Plugin "${pluginId}" sendToActiveAgent: text must be a non-empty string`
+            `Plugin "${pluginId}" sendToActiveAgent: text must be a non-empty, non-whitespace string`
           );
         }
         // JIT consent fires before any side effect — first use prompts the user;
@@ -3091,8 +3094,10 @@ export class PluginService {
   /**
    * Resolve the terminal id of the "active agent" for `host.sendToActiveAgent`
    * (#10558). Centralised here so plugins stop reinventing `terminal.list`-based
-   * selection heuristics that drift. Scopes to the active project when one is
-   * set (falling back to all terminals if it holds no agent), then ranks:
+   * selection heuristics that drift. Scopes strictly to the active project when
+   * one is set — it never crosses a project boundary, since "the active agent"
+   * the user consented to is the one in front of them; only when no project is
+   * active (e.g. before any project loads) does it consider all terminals. Ranks
    * focused/visible agent (`activityTier: "active"`) first, then a `waiting`
    * agent, then the most recently active by output — with a deterministic id
    * tiebreak. Terminals with no agent or in an ended state (`exited` /
@@ -3113,10 +3118,8 @@ export class PluginService {
       t.hasPty !== false &&
       t.agentState !== "exited" &&
       t.agentState !== "completed";
-    // Prefer the active project's terminals; fall back to all only if the active
-    // project has no eligible agent (e.g. plugin acting before a project loads).
-    const inProject = activeProjectId != null ? all.filter((t) => t.projectId === activeProjectId) : all;
-    const pool = inProject.some(eligible) ? inProject : all;
+    // Scope to the active project; never cross into another project's terminals.
+    const pool = activeProjectId != null ? all.filter((t) => t.projectId === activeProjectId) : all;
     const candidates = pool.filter(eligible);
     if (candidates.length === 0) {
       throw new Error(

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -699,6 +699,14 @@ export class PtyClient extends EventEmitter {
     this.send({ type: "submit", id, text });
   }
 
+  /**
+   * Stage text into a terminal's input without submitting it (no Enter). The
+   * no-execute counterpart to {@link submit}; see {@link TerminalProcess.stage}.
+   */
+  stage(id: string, text: string): void {
+    this.send({ type: "stage", id, text });
+  }
+
   sendKey(id: string, key: string): void {
     const sequence = this.resolveKeySequence(key);
     if (!sequence) {
@@ -869,6 +877,15 @@ export class PtyClient extends EventEmitter {
         });
       }
     }
+  }
+
+  /**
+   * The project most recently marked active (across windows). Used by host-side
+   * consumers — e.g. `PluginService.sendToActiveAgent` — to scope active-agent
+   * resolution to the project the user is currently in.
+   */
+  getActiveProjectId(): string | null {
+    return this.activeProjectId;
   }
 
   setActiveProject(

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -372,6 +372,19 @@ export class PtyManager extends EventEmitter {
   }
 
   /**
+   * Stage text into a terminal's input without submitting it (no Enter). The
+   * no-execute counterpart to {@link submit}; see {@link TerminalProcess.stage}.
+   */
+  stage(id: string, text: string): void {
+    const terminal = this.registry.get(id);
+    if (!terminal) {
+      logWarn(`Terminal ${id} not found, cannot stage`);
+      return;
+    }
+    terminal.stage(text);
+  }
+
+  /**
    * Resize terminal.
    */
   resize(id: string, cols: number, rows: number): void {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -7016,7 +7016,9 @@ describe("Plugin agent-input host API (#10558)", () => {
       { id: "t1", detectedAgentId: "claude", agentState: "waiting", hasPty: true },
     ]);
     const { host } = await setupInputHost(["agent:read"]);
-    await expect(host.sendToActiveAgent("hello")).rejects.toThrow(/PERMISSION_REQUIRED.*agent:input/);
+    await expect(host.sendToActiveAgent("hello")).rejects.toThrow(
+      /PERMISSION_REQUIRED.*agent:input/
+    );
     expect(fake.submit).not.toHaveBeenCalled();
     expect(fake.stage).not.toHaveBeenCalled();
   });
@@ -7091,8 +7093,20 @@ describe("Plugin agent-input host API (#10558)", () => {
 
   it("falls back to most-recently-active agent when none are focused/waiting", async () => {
     const fake = installFakePtyClient([
-      { id: "old", detectedAgentId: "claude", agentState: "idle", lastOutputTime: 10, hasPty: true },
-      { id: "new", detectedAgentId: "claude", agentState: "idle", lastOutputTime: 99, hasPty: true },
+      {
+        id: "old",
+        detectedAgentId: "claude",
+        agentState: "idle",
+        lastOutputTime: 10,
+        hasPty: true,
+      },
+      {
+        id: "new",
+        detectedAgentId: "claude",
+        agentState: "idle",
+        lastOutputTime: 99,
+        hasPty: true,
+      },
     ]);
     const { host } = await setupInputHost(["agent:input"]);
     await host.sendToActiveAgent("x");
@@ -7102,7 +7116,13 @@ describe("Plugin agent-input host API (#10558)", () => {
   it("scopes selection to the active project when one is set", async () => {
     const fake = installFakePtyClient(
       [
-        { id: "other", detectedAgentId: "claude", projectId: "p2", lastOutputTime: 999, hasPty: true },
+        {
+          id: "other",
+          detectedAgentId: "claude",
+          projectId: "p2",
+          lastOutputTime: 999,
+          hasPty: true,
+        },
         { id: "mine", detectedAgentId: "claude", projectId: "p1", lastOutputTime: 1, hasPty: true },
       ],
       "p1"
@@ -7114,7 +7134,15 @@ describe("Plugin agent-input host API (#10558)", () => {
 
   it("never crosses into another project's terminals (#10558)", async () => {
     const fake = installFakePtyClient(
-      [{ id: "other", detectedAgentId: "claude", projectId: "p2", lastOutputTime: 999, hasPty: true }],
+      [
+        {
+          id: "other",
+          detectedAgentId: "claude",
+          projectId: "p2",
+          lastOutputTime: 999,
+          hasPty: true,
+        },
+      ],
       "p1"
     );
     const { host } = await setupInputHost(["agent:input"]);
@@ -7128,7 +7156,13 @@ describe("Plugin agent-input host API (#10558)", () => {
       { id: "exited", detectedAgentId: "claude", agentState: "exited", hasPty: true },
       { id: "completed", detectedAgentId: "claude", agentState: "completed", hasPty: true },
       { id: "dead", detectedAgentId: "claude", agentState: "idle", hasPty: false },
-      { id: "live", detectedAgentId: "claude", agentState: "idle", lastOutputTime: 5, hasPty: true },
+      {
+        id: "live",
+        detectedAgentId: "claude",
+        agentState: "idle",
+        lastOutputTime: 5,
+        hasPty: true,
+      },
     ]);
     const { host } = await setupInputHost(["agent:input"]);
     await host.sendToActiveAgent("x");

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -7027,8 +7027,22 @@ describe("Plugin agent-input host API (#10558)", () => {
     const bridge = vi.fn(async () => "approved-once" as const);
     consent.setConsentBridge(bridge);
     const { host } = await setupInputHost(["agent:input"]);
-    await expect(host.sendToActiveAgent("")).rejects.toThrow(/non-empty string/);
+    await expect(host.sendToActiveAgent("")).rejects.toThrow(/non-empty/);
     expect(bridge).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only text without banking consent or writing (#10558)", async () => {
+    const fake = installFakePtyClient([
+      { id: "t1", detectedAgentId: "claude", agentState: "waiting", hasPty: true },
+    ]);
+    const bridge = vi.fn(async () => "approved-once" as const);
+    getPluginCapabilityConsentService().setConsentBridge(bridge);
+    const { host } = await setupInputHost(["agent:input"]);
+    await expect(host.sendToActiveAgent("\n")).rejects.toThrow(/non-empty/);
+    await expect(host.sendToActiveAgent("   ", { submit: true })).rejects.toThrow(/non-empty/);
+    expect(bridge).not.toHaveBeenCalled();
+    expect(fake.stage).not.toHaveBeenCalled();
+    expect(fake.submit).not.toHaveBeenCalled();
   });
 
   it("stages (no Enter) by default when submit is omitted", async () => {
@@ -7096,6 +7110,16 @@ describe("Plugin agent-input host API (#10558)", () => {
     const { host } = await setupInputHost(["agent:input"]);
     await host.sendToActiveAgent("x");
     expect(fake.stage).toHaveBeenCalledWith("mine", "x");
+  });
+
+  it("never crosses into another project's terminals (#10558)", async () => {
+    const fake = installFakePtyClient(
+      [{ id: "other", detectedAgentId: "claude", projectId: "p2", lastOutputTime: 999, hasPty: true }],
+      "p1"
+    );
+    const { host } = await setupInputHost(["agent:input"]);
+    await expect(host.sendToActiveAgent("x")).rejects.toThrow(/NO_ACTIVE_AGENT/);
+    expect(fake.stage).not.toHaveBeenCalled();
   });
 
   it("excludes exited, completed, and non-agent terminals", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -220,6 +220,7 @@ import {
   _resetPluginCapabilityServicesForTest,
 } from "../plugin-capability/instances.js";
 import { getPluginActionAuditService } from "../PluginActionAuditService.js";
+import { setPtyClientRef } from "../../window/serviceRefs.js";
 import { isAuditedHandlerFailure } from "../../utils/pluginAuditMarker.js";
 import { PluginInvokeOwnershipError } from "../plugin/PluginInvokeErrors.js";
 import { getPluginManifestSchema, isPrivateOrLoopbackHostname } from "../../schemas/plugin.js";
@@ -502,6 +503,7 @@ describe("PluginManifestSchema capabilities field", () => {
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("agent:invoke");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("agent:read");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("agent:register");
+    expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("agent:input");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("git:read");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("git:write");
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("clipboard:read");
@@ -509,9 +511,9 @@ describe("PluginManifestSchema capabilities field", () => {
     expect(BUILT_IN_PLUGIN_CAPABILITIES).toContain("shell:exec");
   });
 
-  it("BUILT_IN_PLUGIN_CAPABILITIES has exactly 13 unique entries", () => {
-    expect(BUILT_IN_PLUGIN_CAPABILITIES).toHaveLength(13);
-    expect(new Set(BUILT_IN_PLUGIN_CAPABILITIES).size).toBe(13);
+  it("BUILT_IN_PLUGIN_CAPABILITIES has exactly 14 unique entries", () => {
+    expect(BUILT_IN_PLUGIN_CAPABILITIES).toHaveLength(14);
+    expect(new Set(BUILT_IN_PLUGIN_CAPABILITIES).size).toBe(14);
   });
 
   it("rejects null capabilities value", () => {
@@ -1278,6 +1280,7 @@ describe("PluginService", () => {
       "fs:user-data-write",
       "agent:invoke",
       "agent:register",
+      "agent:input",
     ])("reports confirm for the flat-elevated capability %s", async (capability) => {
       await writePlugin("flat", {
         name: "acme.flat",
@@ -5358,6 +5361,7 @@ describe("Plugin action registry", () => {
     "fs:user-data-write",
     "agent:invoke",
     "agent:register",
+    "agent:input",
   ])(
     "raises a self-declared 'safe' action to confirm when the manifest grants %s",
     async (capability) => {
@@ -6942,6 +6946,200 @@ describe("Plugin agent-state host API (#10521)", () => {
     const { host, revoke } = await setupAgentHost(["agent:read"]);
     revoke();
     expect(() => host.onDidChangeAgentState(() => {})).toThrow(/host revoked/);
+  });
+});
+
+describe("Plugin agent-input host API (#10558)", () => {
+  type FakeTerminal = {
+    id: string;
+    projectId?: string;
+    agentState?: string;
+    detectedAgentId?: string;
+    launchAgentId?: string;
+    lastOutputTime?: number;
+    activityTier?: "active" | "background";
+    hasPty?: boolean;
+  };
+  type AgentInputHost = {
+    pluginId: string;
+    sendToActiveAgent: (text: string, options?: { submit?: boolean }) => Promise<void>;
+  };
+  type FakePtyClient = {
+    submit: ReturnType<typeof vi.fn>;
+    stage: ReturnType<typeof vi.fn>;
+    getActiveProjectId: () => string | null;
+    getAllTerminalsAsync: () => Promise<FakeTerminal[]>;
+  };
+
+  function installFakePtyClient(
+    terminals: FakeTerminal[],
+    activeProjectId: string | null = null
+  ): FakePtyClient {
+    const fake: FakePtyClient = {
+      submit: vi.fn(),
+      stage: vi.fn(),
+      getActiveProjectId: () => activeProjectId,
+      getAllTerminalsAsync: () => Promise.resolve(terminals),
+    };
+    setPtyClientRef(fake as never);
+    return fake;
+  }
+
+  async function setupInputHost(
+    capabilities: string[]
+  ): Promise<{ service: PluginService; host: AgentInputHost }> {
+    await writePlugin("agent-input", {
+      name: "acme.agent-input",
+      version: "1.0.0",
+      capabilities,
+    });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+    const { host } = (
+      service as unknown as { createHost: (id: string) => { host: AgentInputHost } }
+    ).createHost("acme.agent-input");
+    return { service, host };
+  }
+
+  beforeEach(() => {
+    // Auto-approve JIT consent so the write-path assertions run without a
+    // renderer; the denial branch is covered explicitly below.
+    getPluginCapabilityConsentService().setConsentBridge(async () => "approved-once");
+  });
+  afterEach(() => {
+    _resetPluginCapabilityServicesForTest();
+    setPtyClientRef(null);
+  });
+
+  it("rejects with PERMISSION_REQUIRED when agent:input is not declared", async () => {
+    const fake = installFakePtyClient([
+      { id: "t1", detectedAgentId: "claude", agentState: "waiting", hasPty: true },
+    ]);
+    const { host } = await setupInputHost(["agent:read"]);
+    await expect(host.sendToActiveAgent("hello")).rejects.toThrow(/PERMISSION_REQUIRED.*agent:input/);
+    expect(fake.submit).not.toHaveBeenCalled();
+    expect(fake.stage).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty text before consulting consent", async () => {
+    installFakePtyClient([{ id: "t1", detectedAgentId: "claude", hasPty: true }]);
+    const consent = getPluginCapabilityConsentService();
+    const bridge = vi.fn(async () => "approved-once" as const);
+    consent.setConsentBridge(bridge);
+    const { host } = await setupInputHost(["agent:input"]);
+    await expect(host.sendToActiveAgent("")).rejects.toThrow(/non-empty string/);
+    expect(bridge).not.toHaveBeenCalled();
+  });
+
+  it("stages (no Enter) by default when submit is omitted", async () => {
+    const fake = installFakePtyClient([
+      { id: "t1", detectedAgentId: "claude", agentState: "waiting", hasPty: true },
+    ]);
+    const { host } = await setupInputHost(["agent:input"]);
+    await host.sendToActiveAgent("draft prompt");
+    expect(fake.stage).toHaveBeenCalledWith("t1", "draft prompt");
+    expect(fake.submit).not.toHaveBeenCalled();
+  });
+
+  it("submits (with Enter) when submit:true", async () => {
+    const fake = installFakePtyClient([
+      { id: "t1", detectedAgentId: "claude", agentState: "waiting", hasPty: true },
+    ]);
+    const { host } = await setupInputHost(["agent:input"]);
+    await host.sendToActiveAgent("run it", { submit: true });
+    expect(fake.submit).toHaveBeenCalledWith("t1", "run it");
+    expect(fake.stage).not.toHaveBeenCalled();
+  });
+
+  it("prefers a focused/visible agent over a backgrounded waiting agent", async () => {
+    const fake = installFakePtyClient([
+      {
+        id: "bg",
+        detectedAgentId: "claude",
+        agentState: "waiting",
+        activityTier: "background",
+        lastOutputTime: 100,
+        hasPty: true,
+      },
+      {
+        id: "focused",
+        launchAgentId: "claude",
+        agentState: "working",
+        activityTier: "active",
+        lastOutputTime: 50,
+        hasPty: true,
+      },
+    ]);
+    const { host } = await setupInputHost(["agent:input"]);
+    await host.sendToActiveAgent("x");
+    expect(fake.stage).toHaveBeenCalledWith("focused", "x");
+  });
+
+  it("falls back to most-recently-active agent when none are focused/waiting", async () => {
+    const fake = installFakePtyClient([
+      { id: "old", detectedAgentId: "claude", agentState: "idle", lastOutputTime: 10, hasPty: true },
+      { id: "new", detectedAgentId: "claude", agentState: "idle", lastOutputTime: 99, hasPty: true },
+    ]);
+    const { host } = await setupInputHost(["agent:input"]);
+    await host.sendToActiveAgent("x");
+    expect(fake.stage).toHaveBeenCalledWith("new", "x");
+  });
+
+  it("scopes selection to the active project when one is set", async () => {
+    const fake = installFakePtyClient(
+      [
+        { id: "other", detectedAgentId: "claude", projectId: "p2", lastOutputTime: 999, hasPty: true },
+        { id: "mine", detectedAgentId: "claude", projectId: "p1", lastOutputTime: 1, hasPty: true },
+      ],
+      "p1"
+    );
+    const { host } = await setupInputHost(["agent:input"]);
+    await host.sendToActiveAgent("x");
+    expect(fake.stage).toHaveBeenCalledWith("mine", "x");
+  });
+
+  it("excludes exited, completed, and non-agent terminals", async () => {
+    const fake = installFakePtyClient([
+      { id: "noagent", agentState: "idle", hasPty: true },
+      { id: "exited", detectedAgentId: "claude", agentState: "exited", hasPty: true },
+      { id: "completed", detectedAgentId: "claude", agentState: "completed", hasPty: true },
+      { id: "dead", detectedAgentId: "claude", agentState: "idle", hasPty: false },
+      { id: "live", detectedAgentId: "claude", agentState: "idle", lastOutputTime: 5, hasPty: true },
+    ]);
+    const { host } = await setupInputHost(["agent:input"]);
+    await host.sendToActiveAgent("x");
+    expect(fake.stage).toHaveBeenCalledWith("live", "x");
+  });
+
+  it("throws NO_ACTIVE_AGENT when no eligible agent terminal exists", async () => {
+    const fake = installFakePtyClient([
+      { id: "noagent", agentState: "idle", hasPty: true },
+      { id: "exited", detectedAgentId: "claude", agentState: "exited", hasPty: true },
+    ]);
+    const { host } = await setupInputHost(["agent:input"]);
+    await expect(host.sendToActiveAgent("x")).rejects.toThrow(/NO_ACTIVE_AGENT/);
+    expect(fake.stage).not.toHaveBeenCalled();
+  });
+
+  it("blocks the write when consent is denied", async () => {
+    const fake = installFakePtyClient([
+      { id: "t1", detectedAgentId: "claude", agentState: "waiting", hasPty: true },
+    ]);
+    getPluginCapabilityConsentService().setConsentBridge(async () => "rejected");
+    const { host } = await setupInputHost(["agent:input"]);
+    await expect(host.sendToActiveAgent("x")).rejects.toThrow(/PERMISSION_REQUIRED/);
+    expect(fake.stage).not.toHaveBeenCalled();
+    expect(fake.submit).not.toHaveBeenCalled();
+  });
+
+  it("becomes a no-op after the plugin is unloaded", async () => {
+    const fake = installFakePtyClient([
+      { id: "t1", detectedAgentId: "claude", agentState: "waiting", hasPty: true },
+    ]);
+    const { service, host } = await setupInputHost(["agent:input"]);
+    (service as unknown as { unloadPlugin: (id: string) => void }).unloadPlugin("acme.agent-input");
+    await expect(host.sendToActiveAgent("x")).resolves.toBeUndefined();
+    expect(fake.stage).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -27,6 +27,7 @@ import type {
   ActionsGetParams,
   BroadcastToRendererParams,
   DispatchParams,
+  SendToActiveAgentParams,
   InvalidateFileDecorationsParams,
   LoggerParams,
   PluginWorkerToHostMessage,
@@ -372,6 +373,11 @@ export class PluginDevWorkerMainBridge {
       case "actions.get": {
         const p = params as ActionsGetParams;
         return this.host.actions.get(p.actionId);
+      }
+      case "sendToActiveAgent": {
+        const p = params as SendToActiveAgentParams;
+        await this.host.sendToActiveAgent(p.text, p.options);
+        return undefined;
       }
       case "showQuickPick": {
         // Reuse the real host so validation/provenance/cancellation all match

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -554,6 +554,10 @@ export class PluginDevWorkerHostProxy {
           return "restricted";
         },
       },
+      // Capability check, consent prompt, active-agent resolution, and the PTY
+      // write all run on the real main-side host — the worker only relays.
+      sendToActiveAgent: (text, options) =>
+        this.call<void>("sendToActiveAgent", { text, options }),
       // Imperative UI prompts (#10522). Post-activation-safe (no
       // assertActivationOpen): plugins prompt from command handlers. They use
       // callWithGrace so a plugin unload mid-prompt resolves the dismiss value

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -556,8 +556,7 @@ export class PluginDevWorkerHostProxy {
       },
       // Capability check, consent prompt, active-agent resolution, and the PTY
       // write all run on the real main-side host — the worker only relays.
-      sendToActiveAgent: (text, options) =>
-        this.call<void>("sendToActiveAgent", { text, options }),
+      sendToActiveAgent: (text, options) => this.call<void>("sendToActiveAgent", { text, options }),
       // Imperative UI prompts (#10522). Post-activation-safe (no
       // assertActivationOpen): plugins prompt from command handlers. They use
       // callWithGrace so a plugin unload mid-prompt resolves the dismiss value

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -955,6 +955,38 @@ export class TerminalProcess {
     this.writeQueue.submit(text);
   }
 
+  /**
+   * Stage `text` into the terminal's input WITHOUT submitting it — the no-Enter
+   * counterpart to {@link submit}. Reuses the same bracketed-paste / soft-newline
+   * encoding `performSubmit` uses for the body, then stops: no Enter is written
+   * and no output-settle bookkeeping runs. Multi-line text is always wrapped
+   * (bracketed paste when supported, soft newlines otherwise) so a stray `\n`
+   * can't trigger the shell-submit detection in {@link write} and auto-execute a
+   * line. Trailing newlines in `text` are dropped — staging never submits. Used
+   * by `host.sendToActiveAgent(text, { submit: false })` (#10558).
+   */
+  stage(text: string): void {
+    const terminal = this.terminalInfo;
+    if (terminal.isExited || !terminal.ptyProcess) {
+      return;
+    }
+    const normalized = normalizeSubmitText(text);
+    const { body } = splitTrailingNewlines(normalized);
+    if (body.length === 0) {
+      return;
+    }
+    terminal.lastInputTime = Date.now();
+    const useBracketedPaste = body.includes("\n") || body.length > PASTE_THRESHOLD_CHARS;
+    if (useBracketedPaste && supportsBracketedPaste(terminal)) {
+      const pasteBody = body.replace(/\n/g, "\r");
+      this.write(`${BRACKETED_PASTE_START}${pasteBody}${BRACKETED_PASTE_END}`);
+    } else if (body.includes("\n")) {
+      this.write(body.replace(/\n/g, getSoftNewlineSequence(terminal)));
+    } else {
+      this.write(body);
+    }
+  }
+
   private async performSubmit(text: string): Promise<void> {
     const terminal = this.terminalInfo;
     terminal.lastInputTime = Date.now();

--- a/shared/config/pluginCapabilities.ts
+++ b/shared/config/pluginCapabilities.ts
@@ -32,4 +32,9 @@ export const CONFIRM_TRIGGERING_CAPABILITIES: ReadonlySet<BuiltInPluginCapabilit
   // `agent:invoke` — a plugin holding it elevates its actions to "confirm" and
   // entitles its MCP tool surface to reach D2.
   "agent:register",
+  // Injecting text into a live agent session (`host.sendToActiveAgent`) drives
+  // the agent — even the stage-only default places text in its input — so it
+  // ranks with `agent:invoke`: actions elevate to "confirm" and the MCP tool
+  // surface may reach D2 (#10558).
+  "agent:input",
 ]);

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -74,6 +74,12 @@ export interface DispatchedActionRecord {
   args: unknown;
 }
 
+/** Captured `host.sendToActiveAgent(text, options)` calls. */
+export interface SentToActiveAgentRecord {
+  text: string;
+  submit: boolean;
+}
+
 export interface RegisteredForgeProviderRecord {
   descriptor: ForgeProviderDescriptor;
   impl: ForgeProviderImpl;
@@ -108,6 +114,7 @@ export interface MockHostState {
   readonly postToPanelCalls: ReadonlyArray<PostToPanelRecord>;
   readonly shownToasts: ReadonlyArray<ShownToastRecord>;
   readonly dispatchedActions: ReadonlyArray<DispatchedActionRecord>;
+  readonly sentToActiveAgentCalls: ReadonlyArray<SentToActiveAgentRecord>;
   readonly registeredForgeProviders: ReadonlyArray<RegisteredForgeProviderRecord>;
   readonly registeredFileDecorationProviders: ReadonlyArray<RegisteredFileDecorationProviderRecord>;
   readonly invalidationCalls: ReadonlyArray<InvalidationRecord>;
@@ -184,6 +191,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   const postToPanelCalls: PostToPanelRecord[] = [];
   const shownToasts: ShownToastRecord[] = [];
   const dispatchedActions: DispatchedActionRecord[] = [];
+  const sentToActiveAgentCalls: SentToActiveAgentRecord[] = [];
   const registeredForgeProviders: RegisteredForgeProviderRecord[] = [];
   const registeredFileDecorationProviders: RegisteredFileDecorationProviderRecord[] = [];
   const invalidationCalls: InvalidationRecord[] = [];
@@ -483,6 +491,16 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     async getAgentState() {
       return lastAgentSnapshot;
     },
+    async sendToActiveAgent(text, options) {
+      // Mirrors PluginService.createHost: reject whitespace-only text (the
+      // production host rejects it so a no-op stage can't bank consent and
+      // submit:true can't fire a bare Enter). The mock has no PTY, so a valid
+      // call just records its intent for assertions.
+      if (typeof text !== "string" || text.trim().length === 0) {
+        throw new Error("sendToActiveAgent: text must be a non-empty, non-whitespace string");
+      }
+      sentToActiveAgentCalls.push({ text, submit: options?.submit === true });
+    },
     onDidChangeAgentState(callback) {
       agentStateSubs.add(callback);
       let disposed = false;
@@ -751,6 +769,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     postToPanelCalls,
     shownToasts,
     dispatchedActions,
+    sentToActiveAgentCalls,
     registeredForgeProviders,
     registeredFileDecorationProviders,
     invalidationCalls,

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -118,6 +118,18 @@ export interface ActionDefinition<
   kind: ActionKind;
   danger: ActionDanger;
   scope: ActionScope;
+  /**
+   * When true, dispatches with `source: "plugin"` are rejected by
+   * `ActionService` with a `RESTRICTED` error, regardless of `danger`. Use this
+   * to keep an action available to user / agent (MCP) dispatch while closing it
+   * to the plugin `host.dispatch(...)` path — e.g. `terminal.sendCommand`, whose
+   * text-injection effect belongs behind the `agent:input` capability and the
+   * first-class `host.sendToActiveAgent(...)` API rather than the ungated `safe`
+   * built-in side door (#10558). `danger`-based gating is the wrong tool here:
+   * `confirm` would force an elicitation prompt on every agent/MCP call, and
+   * `restricted` would block agents too.
+   */
+  denyPluginDispatch?: boolean;
   argsSchema?: S;
   resultSchema?: z.ZodType<Result>;
   isEnabled?: (ctx: ActionContext) => boolean;

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -54,6 +54,7 @@ export const BUILT_IN_PLUGIN_CAPABILITIES = [
   "agent:invoke",
   "agent:read",
   "agent:register",
+  "agent:input",
   "git:read",
   "git:write",
   "clipboard:read",
@@ -1646,6 +1647,31 @@ export interface PluginHostApi extends PluginActivationApi {
    *   `agent:read` capability.
    */
   getAgentState(): Promise<PluginAgentSnapshot | null>;
+  /**
+   * Send `text` to the currently-active agent terminal, gated on the
+   * `agent:input` capability. The host resolves the target itself (focused /
+   * visible agent terminal first, then a `waiting` agent, then the most recently
+   * active agent terminal in the active project) so plugins stop reinventing
+   * `terminal.list`-based selection heuristics that drift (#10558). The raw
+   * `terminal.sendCommand` action is closed to plugin dispatch — this is the
+   * sanctioned injection path.
+   *
+   * `options.submit` controls whether the text is executed. It defaults to
+   * `false` — the **stage-only** default-safe mode: the text is pasted into the
+   * agent's input for the user to review and submit, with no Enter appended.
+   * Pass `{ submit: true }` to append Enter and run it immediately.
+   *
+   * First use raises a just-in-time consent prompt (like `shell:exec`); a
+   * granted consent covers later calls. Like {@link dispatch} this is NOT
+   * revoke-guarded: liveness is plugin membership, so it becomes a no-op once the
+   * plugin is unloaded.
+   *
+   * @throws {Error} `PERMISSION_REQUIRED:` if the plugin did not declare the
+   *   `agent:input` capability, or if the user denies the consent prompt.
+   * @throws {Error} `NO_ACTIVE_AGENT:` if no agent terminal is available to
+   *   receive the input.
+   */
+  sendToActiveAgent(text: string, options?: { submit?: boolean }): Promise<void>;
   /**
    * Signal that decorations for `scope` (optionally narrowed to `paths`) have
    * changed and any renderer showing them should re-pull. Unlike the

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -34,6 +34,7 @@ export type PluginHostCallMethod =
   | "getWorktrees"
   | "getWorktreeStatus"
   | "getAgentState"
+  | "sendToActiveAgent"
   | "showToast"
   | "dispatch"
   | "actions.list"
@@ -321,6 +322,12 @@ export interface DispatchParams {
  */
 export interface ActionsGetParams {
   actionId: string;
+}
+
+/** Params for `sendToActiveAgent` (`host-call`). */
+export interface SendToActiveAgentParams {
+  text: string;
+  options?: { submit?: boolean };
 }
 
 /** Params for `showQuickPick` (`host-call`). */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -84,6 +84,7 @@ export type PtyHostRequest =
   | { type: "write"; id: string; data: string; traceId?: string }
   | { type: "broadcast-write"; ids: string[]; data: string }
   | { type: "submit"; id: string; text: string }
+  | { type: "stage"; id: string; text: string }
   | { type: "batch-double-escape"; ids: string[] }
   | { type: "kill"; id: string; reason?: string; escalationDelayMs?: number }
   | { type: "trash"; id: string }

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -101,6 +101,11 @@ const CAPABILITY_META = {
     description: "Add launchable agent commands",
     severity: "warning",
   },
+  "agent:input": {
+    label: "Send input to agents",
+    description: "Type and submit text into running agent sessions",
+    severity: "warning",
+  },
   "git:read": {
     label: "Read git status",
     description: "View branch and change information",

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -405,6 +405,19 @@ export class ActionService {
       return { ok: false, error };
     }
 
+    // Close the plugin `host.dispatch(...)` side door for actions whose effect
+    // belongs behind a plugin capability rather than the ungated `safe` built-in
+    // path (#10558). Agent (MCP) and user dispatch are unaffected — only the
+    // "plugin" source is rejected. `danger` stays "safe" so this carries no
+    // collateral confirm/elicitation cost for legitimate callers.
+    if (definition.denyPluginDispatch && source === "plugin") {
+      const error: ActionError = {
+        code: "RESTRICTED",
+        message: `Action "${actionId}" is not available to plugin dispatch; use the corresponding capability-gated host API instead.`,
+      };
+      return { ok: false, error };
+    }
+
     // Enforce confirmation for destructive actions from agent and plugin
     // sources. Agents may explicitly confirm via { confirmed: true }; plugins
     // have NO confirm bypass — the `confirmed` flag is ignored for plugin

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -364,6 +364,49 @@ describe("ActionService", () => {
       expect(mockRun).not.toHaveBeenCalled();
     });
 
+    it("returns RESTRICTED for a denyPluginDispatch action from a plugin source (#10558)", async () => {
+      const mockRun = vi.fn().mockResolvedValue(undefined);
+      service.register({
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        denyPluginDispatch: true,
+        scope: "renderer",
+        run: mockRun,
+      });
+
+      const result = await service.dispatch("actions.list", undefined, { source: "plugin" });
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.code).toBe("RESTRICTED");
+      expect(mockRun).not.toHaveBeenCalled();
+    });
+
+    it("allows a denyPluginDispatch action from agent and user sources (#10558)", async () => {
+      const mockRun = vi.fn().mockResolvedValue(undefined);
+      service.register({
+        id: "actions.list" as ActionId,
+        title: "Test Action",
+        description:
+          "A test action for validating ActionService dispatch, registration, and manifest entry generation.",
+        category: "test",
+        kind: "command",
+        danger: "safe",
+        denyPluginDispatch: true,
+        scope: "renderer",
+        run: mockRun,
+      });
+
+      const agentResult = await service.dispatch("actions.list", undefined, { source: "agent" });
+      expect(agentResult.ok).toBe(true);
+      const userResult = await service.dispatch("actions.list", undefined, { source: "user" });
+      expect(userResult.ok).toBe(true);
+      expect(mockRun).toHaveBeenCalledTimes(2);
+    });
+
     it("should validate arguments with Zod schema", async () => {
       const nameSchema = z.object({ name: z.string() });
       const action: ActionDefinition<typeof nameSchema, void> = {

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -543,6 +543,49 @@ describe("destructive-action danger metadata", () => {
   });
 });
 
+/**
+ * Built-in actions that inject text/keystrokes into terminals and therefore must
+ * be closed to plugin `host.dispatch` (#10558) — plugins inject only through the
+ * `agent:input`-gated `host.sendToActiveAgent`. If a new terminal-writing action
+ * is added without `denyPluginDispatch`, add it here AND set the flag, or the
+ * capability gate has a fresh side door.
+ */
+const PLUGIN_DENIED_INJECTION_ACTIONS: ReadonlyArray<ActionId> = [
+  "terminal.sendCommand",
+  "terminal.paste",
+  "fleet.accept",
+  "fleet.reject",
+  "fleet.interrupt",
+  "fleet.retryFailures",
+] as unknown as ActionId[];
+
+describe("plugin-dispatch injection guard (#10558)", () => {
+  it("rejects plugin-source dispatch with RESTRICTED for every injection action", async () => {
+    const { ActionService } = await import("../../ActionService");
+    const { registry } = await createRegistryWithAudit();
+    const service = new ActionService();
+    for (const [, factory] of registry) {
+      service.register(factory());
+    }
+    // Valid args so dispatch reaches the plugin-dispatch gate rather than
+    // short-circuiting on VALIDATION_ERROR (terminal.sendCommand requires both).
+    const args = { terminalId: "t-placeholder", command: "noop", url: "https://example.com" };
+
+    const failures: string[] = [];
+    for (const id of PLUGIN_DENIED_INJECTION_ACTIONS) {
+      const result = await service.dispatch(id, args, { source: "plugin" });
+      if (result.ok) {
+        failures.push(`${id} (plugin dispatch succeeded — side door open)`);
+        continue;
+      }
+      if (result.error.code !== "RESTRICTED") {
+        failures.push(`${id} (got "${result.error.code}", expected RESTRICTED)`);
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});
+
 describe("dangerRationale backfill", () => {
   it("every EXPECTED_CONFIRM_DANGER action has a non-empty dangerRationale", async () => {
     const { registry } = await createRegistryWithAudit();

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -114,6 +114,9 @@ export function registerFleetActions(actions: ActionRegistry): void {
     category: "terminal",
     kind: "command",
     danger: "safe",
+    // Injects keystrokes into agent terminals — closed to plugin dispatch so it
+    // can't be an end-run around the `agent:input` capability (#10558).
+    denyPluginDispatch: true,
     scope: "renderer",
     run: async () => {
       const snap = snapshotArmed();
@@ -142,6 +145,8 @@ export function registerFleetActions(actions: ActionRegistry): void {
     category: "terminal",
     kind: "command",
     danger: "safe",
+    // Injects keystrokes into agent terminals — closed to plugin dispatch (#10558).
+    denyPluginDispatch: true,
     scope: "renderer",
     argsSchema: confirmedArgsSchema,
     run: async (args: unknown) => {
@@ -187,6 +192,8 @@ export function registerFleetActions(actions: ActionRegistry): void {
     category: "terminal",
     kind: "command",
     danger: "safe",
+    // Injects control keystrokes into agent terminals — closed to plugin dispatch (#10558).
+    denyPluginDispatch: true,
     scope: "renderer",
     argsSchema: confirmedArgsSchema,
     run: async (args: unknown) => {
@@ -342,6 +349,9 @@ export function registerFleetActions(actions: ActionRegistry): void {
     category: "terminal",
     kind: "command",
     danger: "safe",
+    // Re-broadcasts the last (arbitrary, often \r-terminated) payload into
+    // terminals — closed to plugin dispatch so it can't inject commands (#10558).
+    denyPluginDispatch: true,
     scope: "renderer",
     run: async () => {
       // Re-entrancy guard: a fast double-click on "Retry failed" would

--- a/src/services/actions/definitions/terminalInputActions.ts
+++ b/src/services/actions/definitions/terminalInputActions.ts
@@ -61,6 +61,10 @@ export function registerTerminalInputActions(
     category: "terminal",
     kind: "command",
     danger: "safe",
+    // Writes clipboard text (including \r-terminated, auto-executing commands in
+    // non-bracketed mode) into a terminal — closed to plugin dispatch so it
+    // can't be an end-run around the `agent:input` capability (#10558).
+    denyPluginDispatch: true,
     scope: "renderer",
     argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
     run: async (args: unknown) => {

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -412,6 +412,12 @@ export function registerTerminalQueryActions(
     category: "terminal",
     kind: "command",
     danger: "safe",
+    // Reachable by user and agent (MCP) dispatch, but NOT by plugin
+    // host.dispatch — sending text into an agent terminal is exactly the
+    // injection the capability model gates. Plugins must declare `agent:input`
+    // and use `host.sendToActiveAgent(...)` instead of routing around the
+    // capability through this ungated `safe` action (#10558).
+    denyPluginDispatch: true,
     scope: "renderer",
     argsSchema: z.object({
       terminalId: z.string().min(1).describe("Terminal instance ID from terminal.list"),


### PR DESCRIPTION
## Summary

- A zero-capability plugin could bypass the capability model by dispatching `terminal.sendCommand` and related terminal-write actions directly — sending arbitrary text to any agent terminal without user consent.
- This adds a proper `agent:input` capability, a first-class `host.sendToActiveAgent(text, { submit? })` method resolved entirely in main with a JIT consent check, and a `denyPluginDispatch` flag on `ActionDefinition` that closes the dispatch side-door without touching MCP or user dispatch paths.

Resolves #10558. Part of #10511; relates to #10521.

## Changes

- **`agent:input` capability** — added to `BUILT_IN_PLUGIN_CAPABILITIES` and `CONFIRM_TRIGGERING_CAPABILITIES`; labelled "Send input to agents" in `CAPABILITY_META`. Shows in `PluginDetailPane`.
- **`host.sendToActiveAgent(text, { submit? })`** — resolved in `PluginService`: capability gate → JIT consent → active-agent resolution → write. Default is stage-only (no Enter); `submit: true` sends with Enter. Whitespace-only text rejected before consent is even triggered.
- **PTY staging path** — new `TerminalProcess.stage` / `PtyManager.stage` / `PtyClient.stage` / pty-host `"stage"` message. Uses bracketed-paste encoding so multi-line text can't auto-execute.
- **`denyPluginDispatch` flag** — added to `ActionDefinition` and enforced in `ActionService`: plugin-source dispatch returns `RESTRICTED`; agent (MCP) and user dispatch are unaffected, so no MCP elicitation regression. Applied to `terminal.sendCommand`, `terminal.paste`, `fleet.accept`, `fleet.reject`, `fleet.interrupt`, `fleet.retryFailures`.
- **Active-agent selection** — strictly scoped to the active project (no cross-project writes); ranks focused/visible → waiting → most-recent-output.

## Testing

- Unit tests in `PluginService.test.ts`: capability gate, JIT consent approve/deny, stage vs submit, selection heuristics, cross-project exclusion, whitespace rejection.
- `ActionService.test.ts` + `actionDefinitions.quality.test.ts`: behavioral guard that every `denyPluginDispatch` action returns `RESTRICTED` for plugin source.
- 844 tests pass locally; lint 0 errors.