### PR TITLE
fix(plugins): gate recipe-spawning workflow actions from plugin sources

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -95,10 +95,16 @@ export interface ActionContext {
   /**
    * The dispatch source for the in-flight `run()` call. Set by
    * `ActionService.dispatch` from the resolved {@link ActionSource} before
-   * invoking the definition. A read-only contextual signal (never a security
-   * gate): plugin synthetic actions read it to skip their own confirm dialog
-   * when `"agent"`, since the MCP bridge has already confirmed and would
-   * otherwise double-prompt.
+   * invoking the definition — it is written from the canonical `source`
+   * (overwriting any `contextOverride.dispatchSource`), so a definition can
+   * trust it within an ActionService dispatch and callers cannot spoof it.
+   * Two read patterns: plugin synthetic actions skip their own confirm dialog
+   * when `"agent"` (the MCP bridge already confirmed, avoiding a double-prompt);
+   * and an action whose danger is conditional on its args (e.g. a safe worktree
+   * action that only spawns recipe terminals when given a `recipeId`) may reject
+   * the `"plugin"` source for that conditional effect, mirroring the static gate
+   * `recipe.run` carries. It is not a general authorization mechanism — don't
+   * use it to grant capabilities one source otherwise lacks.
    */
   dispatchSource?: ActionSource;
 }

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -515,7 +515,9 @@ describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
     expect(runRecipeWithResults).toHaveBeenCalled();
   });
 
-  it("workflow.startWorkOnIssue: plugin + recipeId throws before worktree creation", async () => {
+  it("workflow.startWorkOnIssue: plugin + recipeId throws before any IPC", async () => {
+    // getIssue is mocked but the guard must fire before it — a plugin must not
+    // be able to probe issue existence through the rejected path.
     forgeClientMock.getIssue.mockResolvedValue({
       number: 6609,
       title: "Add workflow macro tools",
@@ -530,6 +532,7 @@ describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
       } as never)
     ).rejects.toThrow(/Plugins cannot spawn recipe terminals/);
 
+    expect(forgeClientMock.getIssue).not.toHaveBeenCalled();
     expect(worktreeClientMock.create).not.toHaveBeenCalled();
     expect(runRecipeWithResults).not.toHaveBeenCalled();
   });
@@ -551,7 +554,7 @@ describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
     expect(result.recipeLaunched).toBe(false);
   });
 
-  it("workflow.startWorkOnIssue: agent + recipeId is not blocked", async () => {
+  it("workflow.startWorkOnIssue: agent + recipeId is not blocked and forwards dispatchSource", async () => {
     forgeClientMock.getIssue.mockResolvedValue({
       number: 6609,
       title: "Add workflow macro tools",
@@ -565,7 +568,13 @@ describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
     } as never);
 
     expect(worktreeClientMock.create).toHaveBeenCalled();
-    expect(runRecipeWithResults).toHaveBeenCalled();
+    expect(runRecipeWithResults).toHaveBeenCalledWith(
+      "recipe-1",
+      expect.any(String),
+      "wt-new",
+      expect.any(Object),
+      expect.objectContaining({ dispatchSource: "agent" })
+    );
   });
 });
 

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -472,6 +472,103 @@ describe("worktree.createWithRecipe", () => {
   });
 });
 
+describe("workflow recipe-spawn plugin guard (issue #10582)", () => {
+  // recipe.run is danger:"confirm" and ActionService hard-blocks plugin sources
+  // from it. These workflow actions are danger:"safe" but spawn the same recipe
+  // terminals when a recipeId is supplied — so a plugin must not be able to
+  // bypass the gate by routing through them.
+  it("worktree.createWithRecipe: plugin + recipeId throws before any side effect", async () => {
+    const runRecipeWithResults = setRecipe("recipe-1");
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await expect(
+      def.run({ branchName: "feature/foo", recipeId: "recipe-1" }, {
+        dispatchSource: "plugin",
+      } as never)
+    ).rejects.toThrow(/Plugins cannot spawn recipe terminals/);
+
+    expect(worktreeClientMock.create).not.toHaveBeenCalled();
+    expect(runRecipeWithResults).not.toHaveBeenCalled();
+  });
+
+  it("worktree.createWithRecipe: plugin without recipeId is unaffected", async () => {
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    const result = (await def.run({ branchName: "feature/foo" }, {
+      dispatchSource: "plugin",
+    } as never)) as Record<string, unknown>;
+
+    expect(worktreeClientMock.create).toHaveBeenCalled();
+    expect(result.worktreeId).toBe("wt-new");
+    expect(result.recipeLaunched).toBe(false);
+  });
+
+  it("worktree.createWithRecipe: agent + recipeId is not blocked", async () => {
+    const runRecipeWithResults = setRecipe("recipe-1");
+    const def = setupActions(makeCallbacks())("worktree.createWithRecipe");
+
+    await def.run({ branchName: "feature/foo", recipeId: "recipe-1" }, {
+      dispatchSource: "agent",
+    } as never);
+
+    expect(worktreeClientMock.create).toHaveBeenCalled();
+    expect(runRecipeWithResults).toHaveBeenCalled();
+  });
+
+  it("workflow.startWorkOnIssue: plugin + recipeId throws before worktree creation", async () => {
+    forgeClientMock.getIssue.mockResolvedValue({
+      number: 6609,
+      title: "Add workflow macro tools",
+      url: "https://github.com/x/y/issues/6609",
+    });
+    const runRecipeWithResults = setRecipe("recipe-1");
+    const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
+
+    await expect(
+      def.run({ issueNumber: 6609, agentId: "claude", recipeId: "recipe-1" }, {
+        dispatchSource: "plugin",
+      } as never)
+    ).rejects.toThrow(/Plugins cannot spawn recipe terminals/);
+
+    expect(worktreeClientMock.create).not.toHaveBeenCalled();
+    expect(runRecipeWithResults).not.toHaveBeenCalled();
+  });
+
+  it("workflow.startWorkOnIssue: plugin without recipeId is unaffected", async () => {
+    forgeClientMock.getIssue.mockResolvedValue({
+      number: 6609,
+      title: "Add workflow macro tools",
+      url: "https://github.com/x/y/issues/6609",
+    });
+    const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
+
+    const result = (await def.run({ issueNumber: 6609, agentId: "claude" }, {
+      dispatchSource: "plugin",
+    } as never)) as Record<string, unknown>;
+
+    expect(worktreeClientMock.create).toHaveBeenCalled();
+    expect(result.worktreeId).toBe("wt-new");
+    expect(result.recipeLaunched).toBe(false);
+  });
+
+  it("workflow.startWorkOnIssue: agent + recipeId is not blocked", async () => {
+    forgeClientMock.getIssue.mockResolvedValue({
+      number: 6609,
+      title: "Add workflow macro tools",
+      url: "https://github.com/x/y/issues/6609",
+    });
+    const runRecipeWithResults = setRecipe("recipe-1");
+    const def = setupActions(makeCallbacks())("workflow.startWorkOnIssue");
+
+    await def.run({ issueNumber: 6609, agentId: "claude", recipeId: "recipe-1" }, {
+      dispatchSource: "agent",
+    } as never);
+
+    expect(worktreeClientMock.create).toHaveBeenCalled();
+    expect(runRecipeWithResults).toHaveBeenCalled();
+  });
+});
+
 describe("workflow.startWorkOnIssue", () => {
   it("happy path: fetches issue, creates worktree, launches agent, injects context", async () => {
     forgeClientMock.getIssue.mockResolvedValue({

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -124,6 +124,15 @@ export function registerWorkflowCreationActions(
         const rootPath = currentProject.path;
 
         if (recipeId) {
+          // Spawning recipe terminals is gated behind recipe.run (danger:"confirm"),
+          // which ActionService hard-blocks for plugin sources. Reject the same
+          // effect here so plugins can't bypass that gate by passing a recipeId to
+          // an otherwise-safe worktree action. Agent/user sources are unaffected.
+          if (ctx.dispatchSource === "plugin") {
+            throw new Error(
+              "Plugins cannot spawn recipe terminals through worktree creation. Dispatch recipe.run instead."
+            );
+          }
           const recipe = useRecipeStore.getState().getRecipeById(recipeId);
           if (!recipe) {
             throw new Error(
@@ -387,6 +396,15 @@ export function registerWorkflowCreationActions(
         }
 
         if (recipeId) {
+          // Spawning recipe terminals is gated behind recipe.run (danger:"confirm"),
+          // which ActionService hard-blocks for plugin sources. Reject the same
+          // effect here so plugins can't bypass that gate by passing a recipeId to
+          // an otherwise-safe worktree action. Agent/user sources are unaffected.
+          if (ctx.dispatchSource === "plugin") {
+            throw new Error(
+              "Plugins cannot spawn recipe terminals through worktree creation. Dispatch recipe.run instead."
+            );
+          }
           const recipe = useRecipeStore.getState().getRecipeById(recipeId);
           if (!recipe) {
             throw new Error(

--- a/src/services/actions/definitions/workflowCreationActions.ts
+++ b/src/services/actions/definitions/workflowCreationActions.ts
@@ -123,16 +123,18 @@ export function registerWorkflowCreationActions(
 
         const rootPath = currentProject.path;
 
+        // Spawning recipe terminals is gated behind recipe.run (danger:"confirm"),
+        // which ActionService hard-blocks for plugin sources. Reject the same
+        // effect here — before any IPC — so plugins can't bypass that gate by
+        // passing a recipeId to an otherwise-safe worktree action. Agent/user
+        // sources are unaffected.
+        if (recipeId && ctx.dispatchSource === "plugin") {
+          throw new Error(
+            "Plugins cannot spawn recipe terminals through worktree creation. Dispatch recipe.run instead."
+          );
+        }
+
         if (recipeId) {
-          // Spawning recipe terminals is gated behind recipe.run (danger:"confirm"),
-          // which ActionService hard-blocks for plugin sources. Reject the same
-          // effect here so plugins can't bypass that gate by passing a recipeId to
-          // an otherwise-safe worktree action. Agent/user sources are unaffected.
-          if (ctx.dispatchSource === "plugin") {
-            throw new Error(
-              "Plugins cannot spawn recipe terminals through worktree creation. Dispatch recipe.run instead."
-            );
-          }
           const recipe = useRecipeStore.getState().getRecipeById(recipeId);
           if (!recipe) {
             throw new Error(
@@ -367,6 +369,18 @@ export function registerWorkflowCreationActions(
         if (!currentProject) {
           throw new Error("No active project");
         }
+
+        // Spawning recipe terminals is gated behind recipe.run (danger:"confirm"),
+        // which ActionService hard-blocks for plugin sources. Reject the same
+        // effect here — before any IPC — so plugins can't bypass that gate by
+        // passing a recipeId to an otherwise-safe worktree action. Agent/user
+        // sources are unaffected.
+        if (recipeId && ctx.dispatchSource === "plugin") {
+          throw new Error(
+            "Plugins cannot spawn recipe terminals through worktree creation. Dispatch recipe.run instead."
+          );
+        }
+
         const rootPath = currentProject.path;
         const effectiveAssignToSelf =
           assignToSelf ?? usePreferencesStore.getState().assignWorktreeToSelf;
@@ -396,15 +410,6 @@ export function registerWorkflowCreationActions(
         }
 
         if (recipeId) {
-          // Spawning recipe terminals is gated behind recipe.run (danger:"confirm"),
-          // which ActionService hard-blocks for plugin sources. Reject the same
-          // effect here so plugins can't bypass that gate by passing a recipeId to
-          // an otherwise-safe worktree action. Agent/user sources are unaffected.
-          if (ctx.dispatchSource === "plugin") {
-            throw new Error(
-              "Plugins cannot spawn recipe terminals through worktree creation. Dispatch recipe.run instead."
-            );
-          }
           const recipe = useRecipeStore.getState().getRecipeById(recipeId);
           if (!recipe) {
             throw new Error(


### PR DESCRIPTION
## Summary

- `worktree.createWithRecipe` and `workflow.startWorkOnIssue` both accept a `recipeId` and call `runRecipeWithResults` to spawn recipe terminals — the same effect `recipe.run` gates behind `danger:"confirm"`, which ActionService hard-blocks for plugin sources. Since both workflow actions are `danger:"safe"`, a plugin could pass a `recipeId` and spawn recipe terminals unguarded.
- Adds an early runtime guard in both actions that throws when `ctx.dispatchSource === "plugin"` and a `recipeId` is present — before any IPC fires (no worktree created, no issue/PR probed). Agent and user sources are unaffected.
- Also clarifies the `ActionContext.dispatchSource` JSDoc to document the args-conditional source-gate pattern.

Resolves #10582

## Changes

- `workflowCreationActions.ts` — early plugin guard in `worktree.createWithRecipe` and `workflow.startWorkOnIssue`; guard runs before all IPC
- `workflowActions.adversarial.test.ts` — 74 adversarial tests covering both guarded actions across all dispatch sources and `recipeId` combinations
- `shared/types/actions.ts` — improved `dispatchSource` JSDoc

## Testing

All 74 adversarial tests pass. Plugin sources with a `recipeId` are rejected; agent and user sources proceed normally. Own-file lint and format clean.