### PR TITLE
fix(plugins): ship all plugin asset dirs in build output

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -158,6 +158,12 @@ module.exports = async function () {
       // electron-builder's smart-unpack detection.
       "node_modules/@parcel/watcher/**/*",
       "node_modules/@parcel/watcher-*/**/*",
+      // Built-in plugins may bundle `bin/`/`mcp/` scripts spawned via node-pty,
+      // which uses native OS spawn and bypasses Electron's ASAR filesystem patch
+      // — a `./bin/*.mjs` packed inside app.asar ENOENTs at spawn time. Unpack
+      // the whole built-in plugin tree so those `./`-relative paths resolve on
+      // the real filesystem (#10579). Sample plugins are excluded from `files`.
+      "dist-electron/plugins/builtin/**/*",
     ],
     electronFuses: {
       runAsNode: false,

--- a/scripts/__tests__/plugin-build-assets.test.mjs
+++ b/scripts/__tests__/plugin-build-assets.test.mjs
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  PLUGIN_EXTRA_ASSET_SKIP_DIRS,
+  copyPluginExtraAssets,
+  findMissingPluginAssets,
+} from "../build-main.mjs";
+
+let workDir;
+
+beforeEach(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-build-assets-"));
+});
+
+afterEach(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeFile(filePath, contents = "// stub\n") {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, contents);
+}
+
+describe("copyPluginExtraAssets", () => {
+  it("copies bundled asset directories (bin, mcp, view) verbatim", () => {
+    const src = path.join(workDir, "src");
+    const dest = path.join(workDir, "dest");
+    writeFile(path.join(src, "bin", "demo-agent.mjs"), "agent\n");
+    writeFile(path.join(src, "mcp", "server.mjs"), "server\n");
+    writeFile(path.join(src, "view", "panel.mjs"), "view\n");
+
+    const copied = copyPluginExtraAssets(src, dest);
+
+    expect(copied.sort()).toEqual(["bin", "mcp", "view"]);
+    expect(fs.readFileSync(path.join(dest, "bin", "demo-agent.mjs"), "utf8")).toBe("agent\n");
+    expect(fs.readFileSync(path.join(dest, "mcp", "server.mjs"), "utf8")).toBe("server\n");
+    expect(fs.readFileSync(path.join(dest, "view", "panel.mjs"), "utf8")).toBe("view\n");
+  });
+
+  it("skips compiled/host-owned directories", () => {
+    const src = path.join(workDir, "src");
+    const dest = path.join(workDir, "dest");
+    for (const skipped of PLUGIN_EXTRA_ASSET_SKIP_DIRS) {
+      writeFile(path.join(src, skipped, "index.ts"), "skip\n");
+    }
+    writeFile(path.join(src, "bin", "keep.mjs"));
+
+    const copied = copyPluginExtraAssets(src, dest);
+
+    expect(copied).toEqual(["bin"]);
+    for (const skipped of PLUGIN_EXTRA_ASSET_SKIP_DIRS) {
+      expect(fs.existsSync(path.join(dest, skipped))).toBe(false);
+    }
+  });
+
+  it("ignores top-level files, copying only directories", () => {
+    const src = path.join(workDir, "src");
+    const dest = path.join(workDir, "dest");
+    writeFile(path.join(src, "plugin.json"), "{}");
+    writeFile(path.join(src, "README.md"), "readme\n");
+    writeFile(path.join(src, "bin", "keep.mjs"));
+
+    const copied = copyPluginExtraAssets(src, dest);
+
+    expect(copied).toEqual(["bin"]);
+    expect(fs.existsSync(path.join(dest, "plugin.json"))).toBe(false);
+    expect(fs.existsSync(path.join(dest, "README.md"))).toBe(false);
+  });
+
+  it("returns an empty list when the source directory does not exist", () => {
+    expect(copyPluginExtraAssets(path.join(workDir, "missing"), path.join(workDir, "dest"))).toEqual(
+      []
+    );
+  });
+
+  it("is idempotent across repeated runs", () => {
+    const src = path.join(workDir, "src");
+    const dest = path.join(workDir, "dest");
+    writeFile(path.join(src, "bin", "demo-agent.mjs"), "v1\n");
+
+    copyPluginExtraAssets(src, dest);
+    copyPluginExtraAssets(src, dest);
+
+    expect(fs.readFileSync(path.join(dest, "bin", "demo-agent.mjs"), "utf8")).toBe("v1\n");
+  });
+});
+
+describe("findMissingPluginAssets", () => {
+  function writeManifest(tier, name, manifest, assets = {}) {
+    const pluginDir = path.join(workDir, tier, name);
+    writeFile(path.join(pluginDir, "plugin.json"), JSON.stringify(manifest));
+    for (const [relPath, contents] of Object.entries(assets)) {
+      writeFile(path.join(pluginDir, relPath), contents);
+    }
+  }
+
+  it("returns no findings when every ./relative path exists", () => {
+    writeManifest(
+      "sample",
+      "ok",
+      {
+        contributes: {
+          agents: [{ command: "./bin/demo-agent.mjs" }],
+          mcpServers: [{ command: "node", args: ["./mcp/server.mjs"] }],
+        },
+      },
+      { "bin/demo-agent.mjs": "agent\n", "mcp/server.mjs": "server\n" }
+    );
+
+    expect(findMissingPluginAssets(workDir)).toEqual([]);
+  });
+
+  it("flags an agent command whose file is absent", () => {
+    writeManifest("sample", "broken", {
+      contributes: { agents: [{ command: "./bin/demo-agent.mjs" }] },
+    });
+
+    const missing = findMissingPluginAssets(workDir);
+
+    expect(missing).toHaveLength(1);
+    expect(missing[0]).toContain("sample/broken");
+    expect(missing[0]).toContain("./bin/demo-agent.mjs");
+  });
+
+  it("flags a missing MCP server arg path", () => {
+    writeManifest("builtin", "broken-mcp", {
+      contributes: { mcpServers: [{ command: "node", args: ["./mcp/server.mjs"] }] },
+    });
+
+    const missing = findMissingPluginAssets(workDir);
+
+    expect(missing).toHaveLength(1);
+    expect(missing[0]).toContain("builtin/broken-mcp");
+    expect(missing[0]).toContain("./mcp/server.mjs");
+  });
+
+  it("ignores bare PATH commands and non-relative args", () => {
+    writeManifest("sample", "path-binary", {
+      contributes: {
+        agents: [{ command: "echo", args: ["hello"] }],
+        mcpServers: [{ command: "node", args: ["--version"] }],
+      },
+    });
+
+    expect(findMissingPluginAssets(workDir)).toEqual([]);
+  });
+
+  it("returns no findings when the dist plugins root does not exist", () => {
+    expect(findMissingPluginAssets(path.join(workDir, "never-built"))).toEqual([]);
+  });
+
+  it("reports an unreadable manifest instead of throwing", () => {
+    const pluginDir = path.join(workDir, "sample", "bad-json");
+    writeFile(path.join(pluginDir, "plugin.json"), "{ not json");
+
+    const missing = findMissingPluginAssets(workDir);
+
+    expect(missing).toHaveLength(1);
+    expect(missing[0]).toContain("sample/bad-json");
+  });
+});

--- a/scripts/__tests__/plugin-build-assets.test.mjs
+++ b/scripts/__tests__/plugin-build-assets.test.mjs
@@ -71,9 +71,9 @@ describe("copyPluginExtraAssets", () => {
   });
 
   it("returns an empty list when the source directory does not exist", () => {
-    expect(copyPluginExtraAssets(path.join(workDir, "missing"), path.join(workDir, "dest"))).toEqual(
-      []
-    );
+    expect(
+      copyPluginExtraAssets(path.join(workDir, "missing"), path.join(workDir, "dest"))
+    ).toEqual([]);
   });
 
   it("is idempotent across repeated runs", () => {

--- a/scripts/__tests__/plugin-build-assets.test.mjs
+++ b/scripts/__tests__/plugin-build-assets.test.mjs
@@ -86,6 +86,49 @@ describe("copyPluginExtraAssets", () => {
 
     expect(fs.readFileSync(path.join(dest, "bin", "demo-agent.mjs"), "utf8")).toBe("v1\n");
   });
+
+  it("overwrites a changed source file on the next copy", () => {
+    const src = path.join(workDir, "src");
+    const dest = path.join(workDir, "dest");
+    writeFile(path.join(src, "bin", "demo-agent.mjs"), "v1\n");
+    copyPluginExtraAssets(src, dest);
+
+    writeFile(path.join(src, "bin", "demo-agent.mjs"), "v2\n");
+    copyPluginExtraAssets(src, dest);
+
+    expect(fs.readFileSync(path.join(dest, "bin", "demo-agent.mjs"), "utf8")).toBe("v2\n");
+  });
+
+  it("copies a top-level asset file named by a ./relative command", () => {
+    const src = path.join(workDir, "src");
+    const dest = path.join(workDir, "dest");
+    writeFile(
+      path.join(src, "plugin.json"),
+      JSON.stringify({ contributes: { agents: [{ command: "./agent.mjs" }] } })
+    );
+    writeFile(path.join(src, "agent.mjs"), "agent\n");
+
+    const copied = copyPluginExtraAssets(src, dest);
+
+    expect(copied).toContain("./agent.mjs");
+    expect(fs.readFileSync(path.join(dest, "agent.mjs"), "utf8")).toBe("agent\n");
+  });
+
+  it("does not copy a top-level asset file that escapes the plugin dir", () => {
+    const src = path.join(workDir, "src");
+    const dest = path.join(workDir, "dest");
+    writeFile(
+      path.join(src, "plugin.json"),
+      JSON.stringify({ contributes: { mcpServers: [{ command: "./../secret.mjs" }] } })
+    );
+    writeFile(path.join(workDir, "secret.mjs"), "secret\n");
+
+    const copied = copyPluginExtraAssets(src, dest);
+
+    expect(copied).not.toContain("./../secret.mjs");
+    expect(fs.existsSync(path.join(dest, "secret.mjs"))).toBe(false);
+    expect(fs.existsSync(path.join(workDir, "dest", "..", "secret.mjs"))).toBe(true); // untouched original
+  });
 });
 
 describe("findMissingPluginAssets", () => {
@@ -123,6 +166,47 @@ describe("findMissingPluginAssets", () => {
     expect(missing).toHaveLength(1);
     expect(missing[0]).toContain("sample/broken");
     expect(missing[0]).toContain("./bin/demo-agent.mjs");
+  });
+
+  it("reports only the missing path when a plugin mixes present and absent assets", () => {
+    writeManifest(
+      "sample",
+      "mixed",
+      {
+        contributes: {
+          agents: [{ command: "./bin/present.mjs" }],
+          mcpServers: [{ command: "./mcp/absent.mjs" }],
+        },
+      },
+      { "bin/present.mjs": "ok\n" }
+    );
+
+    const missing = findMissingPluginAssets(workDir);
+
+    expect(missing).toHaveLength(1);
+    expect(missing[0]).toContain("./mcp/absent.mjs");
+  });
+
+  it("resolves a ./relative MCP server command path", () => {
+    writeManifest(
+      "builtin",
+      "mcp-command",
+      { contributes: { mcpServers: [{ command: "./mcp/server.mjs" }] } },
+      { "mcp/server.mjs": "server\n" }
+    );
+
+    expect(findMissingPluginAssets(workDir)).toEqual([]);
+  });
+
+  it("flags a ./relative path that escapes the plugin directory", () => {
+    writeManifest("sample", "traversal", {
+      contributes: { mcpServers: [{ command: "./../sibling/server.mjs" }] },
+    });
+
+    const missing = findMissingPluginAssets(workDir);
+
+    expect(missing).toHaveLength(1);
+    expect(missing[0]).toContain("escapes the plugin directory");
   });
 
   it("flags a missing MCP server arg path", () => {

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -162,12 +162,7 @@ function copyBuiltInWorkflows() {
  * `mcp/`, `view/`, …) is shipped as-is so `./`-relative `command`/`args` paths
  * resolve at runtime instead of ENOENT-ing (#10579).
  */
-export const PLUGIN_EXTRA_ASSET_SKIP_DIRS = new Set([
-  "main",
-  "renderer",
-  "shared",
-  "__tests__",
-]);
+export const PLUGIN_EXTRA_ASSET_SKIP_DIRS = new Set(["main", "renderer", "shared", "__tests__"]);
 
 /**
  * True when `child` resolves to a path strictly inside `parent` — guards the

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -153,10 +153,44 @@ function copyBuiltInWorkflows() {
 }
 
 /**
+ * Plugin source subdirectories the asset-copy step must NOT mirror verbatim:
+ * `main/` is compiled by esbuild into the same output tree, `renderer/` is
+ * consumed by the host's Vite renderer build (not loaded by the plugin at
+ * runtime), and `__tests__/` is dev-only. Every other subdirectory a plugin
+ * bundles (`bin/`, `mcp/`, `view/`, …) is shipped as-is so `./`-relative
+ * `command`/`args` paths resolve at runtime instead of ENOENT-ing (#10579).
+ */
+export const PLUGIN_EXTRA_ASSET_SKIP_DIRS = new Set(["main", "renderer", "__tests__"]);
+
+/**
+ * Mirror every non-compiled plugin asset directory next to the compiled main
+ * entry. Before #10579 only `plugin.json` (and a hardcoded `view/` for samples)
+ * was copied, so a plugin's `bin/` agent scripts or `mcp/` servers were silently
+ * dropped from the build and failed at spawn time. This copies all subdirectories
+ * except those in `PLUGIN_EXTRA_ASSET_SKIP_DIRS` verbatim — `fs.cpSync` preserves
+ * executable bits on macOS/Linux (Node 22). Top-level files other than the
+ * manifest are left to their dedicated copy steps.
+ */
+export function copyPluginExtraAssets(srcPluginDir, destPluginDir) {
+  if (!fs.existsSync(srcPluginDir)) return [];
+  const copied = [];
+  for (const entry of fs.readdirSync(srcPluginDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (PLUGIN_EXTRA_ASSET_SKIP_DIRS.has(entry.name)) continue;
+    const src = path.join(srcPluginDir, entry.name);
+    const dest = path.join(destPluginDir, entry.name);
+    fs.mkdirSync(destPluginDir, { recursive: true });
+    fs.cpSync(src, dest, { recursive: true });
+    copied.push(entry.name);
+  }
+  return copied;
+}
+
+/**
  * Copy each built-in plugin's `plugin.json` next to its compiled main entry so
  * `PluginService.loadPlugin` can read the manifest from the same directory
  * tree it scans at runtime. The compiled JS lands via esbuild; this step
- * mirrors the static manifest alongside it.
+ * mirrors the static manifest and any bundled asset directories alongside it.
  */
 function copyBuiltInPluginManifests() {
   const pluginsRoot = path.join(root, "plugins/builtin");
@@ -164,17 +198,16 @@ function copyBuiltInPluginManifests() {
   const entries = fs.readdirSync(pluginsRoot, { withFileTypes: true });
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
-    const manifestSrc = path.join(pluginsRoot, entry.name, "plugin.json");
+    const srcPluginDir = path.join(pluginsRoot, entry.name);
+    const manifestSrc = path.join(srcPluginDir, "plugin.json");
     if (!fs.existsSync(manifestSrc)) continue;
-    const manifestDest = path.join(
-      root,
-      "dist-electron/plugins/builtin",
-      entry.name,
-      "plugin.json"
-    );
-    fs.mkdirSync(path.dirname(manifestDest), { recursive: true });
+    const destPluginDir = path.join(root, "dist-electron/plugins/builtin", entry.name);
+    const manifestDest = path.join(destPluginDir, "plugin.json");
+    fs.mkdirSync(destPluginDir, { recursive: true });
     fs.copyFileSync(manifestSrc, manifestDest);
-    console.log(`[Build] Copied built-in plugin manifest: ${entry.name}`);
+    const copied = copyPluginExtraAssets(srcPluginDir, destPluginDir);
+    const extra = copied.length > 0 ? ` (+ ${copied.join(", ")})` : "";
+    console.log(`[Build] Copied built-in plugin manifest: ${entry.name}${extra}`);
   }
 }
 
@@ -190,26 +223,96 @@ function copySamplePluginManifests() {
   const entries = fs.readdirSync(pluginsRoot, { withFileTypes: true });
   for (const entry of entries) {
     if (!entry.isDirectory()) continue;
-    const manifestSrc = path.join(pluginsRoot, entry.name, "plugin.json");
+    const srcPluginDir = path.join(pluginsRoot, entry.name);
+    const manifestSrc = path.join(srcPluginDir, "plugin.json");
     if (!fs.existsSync(manifestSrc)) continue;
-    const manifestDest = path.join(root, "dist-electron/plugins/sample", entry.name, "plugin.json");
-    fs.mkdirSync(path.dirname(manifestDest), { recursive: true });
+    const destPluginDir = path.join(root, "dist-electron/plugins/sample", entry.name);
+    const manifestDest = path.join(destPluginDir, "plugin.json");
+    fs.mkdirSync(destPluginDir, { recursive: true });
     fs.copyFileSync(manifestSrc, manifestDest);
-    console.log(`[Build] Copied sample plugin manifest: ${entry.name}`);
 
-    // Copy any hand-authored `view/` assets verbatim. Plugin view modules are
-    // browser-ready ESM served over `plugin://` with bare `react` specifiers
-    // resolved through the host import map — esbuild must NOT process them
-    // (it would bundle React in and break the single-instance contract), so
-    // these are copied, not built. Used by the rich-daintree panel-view E2E
-    // (#10512).
-    const viewSrc = path.join(pluginsRoot, entry.name, "view");
-    if (fs.existsSync(viewSrc)) {
-      const viewDest = path.join(root, "dist-electron/plugins/sample", entry.name, "view");
-      fs.cpSync(viewSrc, viewDest, { recursive: true });
-      console.log(`[Build] Copied sample plugin view assets: ${entry.name}`);
+    // Copy every bundled asset directory verbatim — `view/` (browser-ready ESM
+    // served over `plugin://`; esbuild must NOT process it or it would bundle
+    // React in and break the single-instance contract — used by the
+    // rich-daintree panel-view E2E #10512), plus any `bin/`/`mcp/` scripts a
+    // plugin spawns via `./`-relative `command`/`args` (#10579).
+    const copied = copyPluginExtraAssets(srcPluginDir, destPluginDir);
+    const extra = copied.length > 0 ? ` (+ ${copied.join(", ")})` : "";
+    console.log(`[Build] Copied sample plugin manifest: ${entry.name}${extra}`);
+  }
+}
+
+/**
+ * Collect the `./`-relative file paths a copied plugin manifest will spawn —
+ * agent `command`/`args` and MCP server `command`/`args`. Bare PATH binaries
+ * (`echo`, `node`) and absolute/`..` paths are rejected at manifest-validation
+ * time, so only `./`-prefixed entries name a file the build must have shipped.
+ */
+function collectRelativeAssetPaths(manifest) {
+  const paths = [];
+  const contributes = manifest?.contributes ?? {};
+  const sources = [...(contributes.agents ?? []), ...(contributes.mcpServers ?? [])];
+  for (const source of sources) {
+    for (const value of [source?.command, ...(source?.args ?? [])]) {
+      if (typeof value === "string" && value.startsWith("./")) paths.push(value);
     }
   }
+  return paths;
+}
+
+/**
+ * Walk the copied plugin output and report every `./`-relative `command`/`args`
+ * path that does not resolve to a real file. The copy step ships whole
+ * directories, but a manifest can still reference a path the author never
+ * created — that surfaced only as a runtime ENOENT before #10579. Pure (no
+ * exit/logging) and parameterized on the dist plugins root so it is unit
+ * testable; `distPluginsRoot` missing entirely (cold build) yields `[]`.
+ */
+export function findMissingPluginAssets(distPluginsRoot) {
+  const missing = [];
+  for (const tier of ["builtin", "sample"]) {
+    const tierRoot = path.join(distPluginsRoot, tier);
+    if (!fs.existsSync(tierRoot)) continue;
+    for (const entry of fs.readdirSync(tierRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const pluginDir = path.join(tierRoot, entry.name);
+      const manifestPath = path.join(pluginDir, "plugin.json");
+      if (!fs.existsSync(manifestPath)) continue;
+      let manifest;
+      try {
+        manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      } catch (error) {
+        missing.push(`${tier}/${entry.name}: unreadable plugin.json (${error.message})`);
+        continue;
+      }
+      for (const relPath of collectRelativeAssetPaths(manifest)) {
+        const resolved = path.join(pluginDir, relPath);
+        if (!fs.existsSync(resolved)) {
+          missing.push(`${tier}/${entry.name}: "${relPath}" not found in built output`);
+        }
+      }
+    }
+  }
+  return missing;
+}
+
+/**
+ * After the manifests and their asset directories are copied, fail the build if
+ * any `./`-relative `command`/`args` path is missing from the output. In watch
+ * mode unresolved paths only warn (a cold build may not have emitted output
+ * yet); in a single/production build they fail the build loudly.
+ */
+function validateCopiedPluginAssets() {
+  const missing = findMissingPluginAssets(path.join(root, "dist-electron/plugins"));
+  if (missing.length === 0) return;
+
+  const detail = missing.map((m) => `  - ${m}`).join("\n");
+  if (isWatch) {
+    console.warn(`[Build] Plugin asset paths missing from output:\n${detail}`);
+    return;
+  }
+  console.error(`[Build] Plugin asset paths missing from output:\n${detail}`);
+  process.exit(1);
 }
 
 function createReadyMarkerPlugin() {
@@ -307,12 +410,14 @@ async function run() {
       copyBuiltInWorkflows();
       copyBuiltInPluginManifests();
       copySamplePluginManifests();
+      validateCopiedPluginAssets();
       console.log("[Build] Watching for changes...");
     } else {
       await Promise.all([build(esmConfig), build(cjsConfig)]);
       copyBuiltInWorkflows();
       copyBuiltInPluginManifests();
       copySamplePluginManifests();
+      validateCopiedPluginAssets();
       writeBuildReadyMarker();
       console.log("[Build] Complete.");
     }
@@ -322,4 +427,8 @@ async function run() {
   }
 }
 
-run();
+// Only kick off a build when run as a script (`node scripts/build-main.mjs`),
+// not when a test imports the exported copy/validate helpers.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  run();
+}

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -163,25 +163,66 @@ function copyBuiltInWorkflows() {
 export const PLUGIN_EXTRA_ASSET_SKIP_DIRS = new Set(["main", "renderer", "__tests__"]);
 
 /**
- * Mirror every non-compiled plugin asset directory next to the compiled main
- * entry. Before #10579 only `plugin.json` (and a hardcoded `view/` for samples)
- * was copied, so a plugin's `bin/` agent scripts or `mcp/` servers were silently
- * dropped from the build and failed at spawn time. This copies all subdirectories
- * except those in `PLUGIN_EXTRA_ASSET_SKIP_DIRS` verbatim — `fs.cpSync` preserves
- * executable bits on macOS/Linux (Node 22). Top-level files other than the
- * manifest are left to their dedicated copy steps.
+ * True when `child` resolves to a path strictly inside `parent` — guards the
+ * asset copy/validation against `./`-relative manifest paths that escape the
+ * plugin directory via `..` segments. `mcpServers[].command` is not refined the
+ * way agent commands are (electron/schemas/plugin.ts), so a manifest can name
+ * `./../sibling` and pass schema validation.
+ */
+function isInsideDir(child, parent) {
+  const rel = path.relative(parent, child);
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+/**
+ * Read a plugin's `plugin.json` and return its `./`-relative `command`/`args`
+ * asset paths. Tolerant of a missing/unparseable manifest (returns `[]`) — the
+ * dedicated manifest validation step is what reports those loudly.
+ */
+function readManifestRelativeAssetPaths(pluginDir) {
+  const manifestPath = path.join(pluginDir, "plugin.json");
+  if (!fs.existsSync(manifestPath)) return [];
+  try {
+    return collectRelativeAssetPaths(JSON.parse(fs.readFileSync(manifestPath, "utf8")));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Mirror every non-compiled plugin asset next to the compiled main entry. Before
+ * #10579 only `plugin.json` (and a hardcoded `view/` for samples) was copied, so
+ * a plugin's `bin/` agent scripts or `mcp/` servers were silently dropped from
+ * the build and failed at spawn time. This copies all subdirectories except
+ * those in `PLUGIN_EXTRA_ASSET_SKIP_DIRS` verbatim, plus any top-level file a
+ * `./`-relative `command`/`args` path names directly (a script can live beside
+ * `plugin.json` rather than in a bundled dir). `fs.cpSync` preserves executable
+ * bits on macOS/Linux (Node 22).
  */
 export function copyPluginExtraAssets(srcPluginDir, destPluginDir) {
   if (!fs.existsSync(srcPluginDir)) return [];
   const copied = [];
+  fs.mkdirSync(destPluginDir, { recursive: true });
   for (const entry of fs.readdirSync(srcPluginDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     if (PLUGIN_EXTRA_ASSET_SKIP_DIRS.has(entry.name)) continue;
     const src = path.join(srcPluginDir, entry.name);
     const dest = path.join(destPluginDir, entry.name);
-    fs.mkdirSync(destPluginDir, { recursive: true });
     fs.cpSync(src, dest, { recursive: true });
     copied.push(entry.name);
+  }
+  // Top-level asset files named by a `./`-relative command/arg that live beside
+  // the manifest rather than inside a bundled dir; files already shipped via
+  // their directory above are skipped (dest exists).
+  for (const relPath of readManifestRelativeAssetPaths(srcPluginDir)) {
+    const src = path.resolve(srcPluginDir, relPath);
+    if (!isInsideDir(src, srcPluginDir)) continue;
+    if (!fs.existsSync(src) || !fs.statSync(src).isFile()) continue;
+    const dest = path.resolve(destPluginDir, relPath);
+    if (fs.existsSync(dest)) continue;
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+    copied.push(relPath);
   }
   return copied;
 }
@@ -286,7 +327,11 @@ export function findMissingPluginAssets(distPluginsRoot) {
         continue;
       }
       for (const relPath of collectRelativeAssetPaths(manifest)) {
-        const resolved = path.join(pluginDir, relPath);
+        const resolved = path.resolve(pluginDir, relPath);
+        if (!isInsideDir(resolved, pluginDir)) {
+          missing.push(`${tier}/${entry.name}: "${relPath}" escapes the plugin directory`);
+          continue;
+        }
         if (!fs.existsSync(resolved)) {
           missing.push(`${tier}/${entry.name}: "${relPath}" not found in built output`);
         }

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -156,11 +156,18 @@ function copyBuiltInWorkflows() {
  * Plugin source subdirectories the asset-copy step must NOT mirror verbatim:
  * `main/` is compiled by esbuild into the same output tree, `renderer/` is
  * consumed by the host's Vite renderer build (not loaded by the plugin at
- * runtime), and `__tests__/` is dev-only. Every other subdirectory a plugin
- * bundles (`bin/`, `mcp/`, `view/`, …) is shipped as-is so `./`-relative
- * `command`/`args` paths resolve at runtime instead of ENOENT-ing (#10579).
+ * runtime), `shared/` holds `import type`-only siblings esbuild erases (never
+ * loaded at runtime — same compile-time category as `main`/`renderer`), and
+ * `__tests__/` is dev-only. Every other subdirectory a plugin bundles (`bin/`,
+ * `mcp/`, `view/`, …) is shipped as-is so `./`-relative `command`/`args` paths
+ * resolve at runtime instead of ENOENT-ing (#10579).
  */
-export const PLUGIN_EXTRA_ASSET_SKIP_DIRS = new Set(["main", "renderer", "__tests__"]);
+export const PLUGIN_EXTRA_ASSET_SKIP_DIRS = new Set([
+  "main",
+  "renderer",
+  "shared",
+  "__tests__",
+]);
 
 /**
  * True when `child` resolves to a path strictly inside `parent` — guards the


### PR DESCRIPTION
## Summary

- The plugin build pipeline only shipped `plugin.json` and a hardcoded `view/` dir, silently dropping `bin/` and `mcp/` subdirs. A green build was followed by a runtime `ENOENT` when `node-pty` or the MCP supervisor tried to spawn `./bin/*.mjs` or `./mcp/*.mjs` paths.
- Adds a shared `copyPluginExtraAssets()` helper that mirrors every non-compiled plugin subdir into `dist-electron/plugins/`, used by both builtin and sample copy paths. A post-copy `validateCopiedPluginAssets()` check fails the build (warns in watch mode) when any `./relative` command/args path is absent, with an `isInsideDir()` guard against `../` traversal.
- Adds `dist-electron/plugins/builtin/**/*` to `asarUnpack` so native-spawn paths (`node-pty`, MCP supervisor) can reach plugin scripts in packaged builds.

Resolves #10579

## Changes

- `scripts/build-main.mjs`: `copyPluginExtraAssets()`, `findMissingPluginAssets()`, `validateCopiedPluginAssets()`, `isInsideDir()` helpers; `run()` gated behind a main-module check so helpers are importable from tests; removed the sample-only `view/` special-case.
- `electron-builder.config.cjs`: `asarUnpack` entry for `dist-electron/plugins/builtin/**/*`.
- `scripts/__tests__/plugin-build-assets.test.mjs`: 17 vitest unit tests covering the copy and validate helpers.

## Testing

17 unit tests pass locally. Prettier and ESLint clean on all changed files.