### PR TITLE
feat(plugins): type the host dispatch surface against ActionId

### DIFF
--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -66,7 +66,7 @@ interface PluginHostApi {
   invalidateFileDecorations(scope: string, paths?: string[]): void;
 
   // Action dispatch
-  dispatch(actionId: string, args?: unknown): Promise<ActionDispatchResult>;
+  dispatch(actionId: ActionId, args?: unknown): Promise<ActionDispatchResult>;
 
   // Settings
   readonly settings: SettingsApi;

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -9,7 +9,7 @@
  * method this mock doesn't implement.
  */
 
-import type { ActionDispatchResult } from "../types/actions.js";
+import type { ActionDispatchResult, ActionId } from "../types/actions.js";
 import type {
   FileDecorationProviderDescriptor,
   FileDecorationProviderImpl,
@@ -70,7 +70,7 @@ export interface SpawnRecord {
 }
 
 export interface DispatchedActionRecord {
-  actionId: string;
+  actionId: ActionId;
   args: unknown;
 }
 
@@ -143,7 +143,7 @@ export interface MockHostState {
    * Pre-seed a deterministic `dispatch()` result for one action id. Overrides
    * the default in-memory routing (which resolves the registered handler).
    */
-  setDispatchResult(actionId: string, result: ActionDispatchResult): void;
+  setDispatchResult(actionId: ActionId, result: ActionDispatchResult): void;
 }
 
 export interface CreateMockHostOptions {
@@ -165,7 +165,7 @@ export interface CreateMockHostOptions {
    * matching `registerAction` handler, returning `NOT_FOUND` otherwise — which
    * mirrors `ActionService.dispatch` closely enough for activation-time tests.
    */
-  dispatch?: (actionId: string, args?: unknown) => Promise<ActionDispatchResult>;
+  dispatch?: (actionId: ActionId, args?: unknown) => Promise<ActionDispatchResult>;
 }
 
 /**
@@ -230,7 +230,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     worktree: new Map(),
   };
 
-  const dispatchOverrides = new Map<string, ActionDispatchResult>();
+  const dispatchOverrides = new Map<ActionId, ActionDispatchResult>();
 
   const settings: SettingsApi = {
     async get<T = unknown>(

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -192,8 +192,9 @@ describe("plugin-sdk boundary", () => {
     });
 
     it("exports the built-in action catalog types (#10561)", () => {
-      // host.actions.list()/get() project the manifest; the typed BuiltInActionId
-      // union turns a wrong action id into a compile error at the dispatch site.
+      // host.actions.list()/get() project the manifest; the dispatch surface is
+      // typed against ActionId, which autocompletes built-ins while staying open
+      // to plugin-authored ids (#10581).
       expectTypeOf<PluginHostActionsApi>().toMatchTypeOf<object>();
       expectTypeOf<PluginActionManifestEntry>().toMatchTypeOf<object>();
       expectTypeOf<PluginCanDispatchResult>().toMatchTypeOf<string>();
@@ -277,6 +278,22 @@ describe("plugin-sdk boundary", () => {
       >();
       expectTypeOf<BuiltInActionId>().toMatchTypeOf<Parameters<PluginHostApi["dispatch"]>[0]>();
       expectTypeOf<string>().toMatchTypeOf<Parameters<PluginHostApi["dispatch"]>[0]>();
+
+      // Compile-only: the body is type-checked by tsc but never invoked, so the
+      // value access on `{} as PluginHostApi` (whose `actions`/`dispatch` are
+      // undefined at runtime) never throws.
+      const _typeChecks = (host: PluginHostApi, entry: PluginActionManifestEntry) => {
+        // The union is open to strings but still rejects non-string ids — guards
+        // against a regression to `unknown`/`any` on the param.
+        // @ts-expect-error — a numeric id is not an ActionId
+        void host.dispatch(42);
+        // A catalog entry's id round-trips back into dispatch/get/canDispatch
+        // with no cast — the reason PluginActionManifestEntry.id is ActionId.
+        void host.dispatch(entry.id);
+        void host.actions.get(entry.id);
+        void host.actions.canDispatch(entry.id);
+      };
+      void _typeChecks;
     });
 
     it("PluginCanDispatchResult is the three-state pre-flight verdict", () => {

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -65,6 +65,7 @@ import type {
   PluginActionManifestEntry,
   PluginCanDispatchResult,
   BuiltInActionId,
+  ActionId,
   ActionKind,
   ActionDanger,
   ActionExample,
@@ -197,6 +198,11 @@ describe("plugin-sdk boundary", () => {
       expectTypeOf<PluginActionManifestEntry>().toMatchTypeOf<object>();
       expectTypeOf<PluginCanDispatchResult>().toMatchTypeOf<string>();
       expectTypeOf<BuiltInActionId>().toMatchTypeOf<string>();
+      // ActionId is the open union (BuiltInActionId | (string & {})) used by the
+      // dispatch surface — narrow enough to autocomplete built-ins, open enough
+      // to still accept a plugin-authored id without a cast (#10581).
+      expectTypeOf<ActionId>().toMatchTypeOf<string>();
+      expectTypeOf<BuiltInActionId>().toMatchTypeOf<ActionId>();
       expectTypeOf<ActionKind>().toMatchTypeOf<string>();
       expectTypeOf<ActionDanger>().toMatchTypeOf<string>();
       expectTypeOf<ActionExample>().toMatchTypeOf<object>();
@@ -256,11 +262,21 @@ describe("plugin-sdk boundary", () => {
         () => Promise<PluginActionManifestEntry[]>
       >();
       expectTypeOf<PluginHostApi["actions"]["get"]>().toEqualTypeOf<
-        (actionId: string) => Promise<PluginActionManifestEntry | null>
+        (actionId: ActionId) => Promise<PluginActionManifestEntry | null>
       >();
       expectTypeOf<PluginHostApi["actions"]["canDispatch"]>().toEqualTypeOf<
-        (actionId: string) => Promise<PluginCanDispatchResult>
+        (actionId: ActionId) => Promise<PluginCanDispatchResult>
       >();
+    });
+
+    it("PluginHostApi.dispatch accepts a BuiltInActionId and the open ActionId union (#10581)", () => {
+      // dispatch is typed against ActionId, so a built-in id autocompletes and a
+      // plugin-authored id (a plain string) still type-checks without a cast.
+      expectTypeOf<PluginHostApi["dispatch"]>().toEqualTypeOf<
+        (actionId: ActionId, args?: unknown) => Promise<ActionDispatchResult>
+      >();
+      expectTypeOf<BuiltInActionId>().toMatchTypeOf<Parameters<PluginHostApi["dispatch"]>[0]>();
+      expectTypeOf<string>().toMatchTypeOf<Parameters<PluginHostApi["dispatch"]>[0]>();
     });
 
     it("PluginCanDispatchResult is the three-state pre-flight verdict", () => {
@@ -274,7 +290,9 @@ describe("plugin-sdk boundary", () => {
 
     it("PluginActionManifestEntry drops renderer-internal manifest fields", () => {
       const entry = {} as PluginActionManifestEntry;
-      expectTypeOf(entry.id).toEqualTypeOf<string>();
+      // `id` is the open ActionId union so it round-trips straight into
+      // host.dispatch()/get()/canDispatch() without a cast (#10581).
+      expectTypeOf(entry.id).toEqualTypeOf<ActionId>();
       expectTypeOf(entry.danger).toEqualTypeOf<ActionDanger>();
       expectTypeOf(entry.requiresArgs).toEqualTypeOf<boolean>();
       // @ts-expect-error — `enabled` is live renderer-context state, not on the projection

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -342,7 +342,7 @@ export interface ActionFrecencyEntry {
  */
 export interface PluginActionManifestEntry {
   /** The action id to pass to `host.dispatch()`. */
-  id: string;
+  id: ActionId;
   title: string;
   description: string;
   category: string;

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -186,11 +186,12 @@ export type {
   ActionErrorCode,
 } from "./actions.js";
 
-// ── Built-in action catalog (host.actions.*) — #10561 ───────────────
-// host.actions.list()/get() project the ActionService manifest to plugins, and
-// the typed BuiltInActionId union turns a wrong action id into a compile error
-// at the dispatch site. ActionKind/ActionDanger/ActionExample appear on the
-// projected entry, so authors must be able to name them too.
+// ── Built-in action catalog (host.actions.*) — #10561, #10581 ───────
+// host.actions.list()/get() project the ActionService manifest to plugins. The
+// dispatch surface is typed against ActionId, which narrows to BuiltInActionId
+// for IDE autocomplete while staying open to plugin-authored ids (no cast
+// needed). ActionKind/ActionDanger/ActionExample appear on the projected entry,
+// so authors must be able to name them too.
 
 export type {
   PluginActionManifestEntry,

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -196,6 +196,7 @@ export type {
   PluginActionManifestEntry,
   PluginCanDispatchResult,
   BuiltInActionId,
+  ActionId,
   ActionKind,
   ActionDanger,
   ActionExample,

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -14,6 +14,7 @@ import type {
 import type { NotificationType } from "./notification.js";
 import type {
   ActionDispatchResult,
+  ActionId,
   PluginActionManifestEntry,
   PluginCanDispatchResult,
 } from "./actions.js";
@@ -35,7 +36,7 @@ export interface ToolbarButtonContribution {
   id: string;
   label: string;
   iconId: string;
-  actionId: string;
+  actionId: ActionId;
   priority?: 1 | 2 | 3 | 4 | 5;
 }
 
@@ -68,14 +69,14 @@ export type PluginCapability = BuiltInPluginCapability;
 
 export interface MenuItemContribution {
   label: string;
-  actionId: string;
+  actionId: ActionId;
   location: MenuItemLocation;
   accelerator?: string;
   when?: string;
 }
 
 export interface KeybindingContribution {
-  actionId: string;
+  actionId: ActionId;
   combo: string;
   scope?: string;
   description?: string;
@@ -88,7 +89,7 @@ export interface PluginKeybindingDescriptor {
 }
 
 export interface ContextMenuContribution {
-  actionId: string;
+  actionId: ActionId;
   location: ContextMenuLocation;
   label: string;
   when?: string;
@@ -1578,7 +1579,7 @@ export interface PluginHostActionsApi {
    * {@link list}). Prefer this over {@link list} for a single lookup — it avoids
    * projecting the whole catalog.
    */
-  get(actionId: string): Promise<PluginActionManifestEntry | null>;
+  get(actionId: ActionId): Promise<PluginActionManifestEntry | null>;
   /**
    * Pre-flight a dispatch without triggering it: `"ok"` for a safe action,
    * `"confirm"` for a confirm-gated one (which {@link PluginHostApi.dispatch}
@@ -1586,7 +1587,7 @@ export interface PluginHostActionsApi {
    * unknown or `danger:"restricted"` action. Lets a plugin warn the user before
    * triggering a confirm prompt. See {@link PluginCanDispatchResult}.
    */
-  canDispatch(actionId: string): Promise<PluginCanDispatchResult>;
+  canDispatch(actionId: ActionId): Promise<PluginCanDispatchResult>;
 }
 
 export interface PluginHostApi extends PluginActivationApi {
@@ -1713,7 +1714,7 @@ export interface PluginHostApi extends PluginActivationApi {
    * `{ ok: false, error: { code: "PLUGIN_UNLOADED" } }` without attempting a
    * dispatch.
    */
-  dispatch(actionId: string, args?: unknown): Promise<ActionDispatchResult>;
+  dispatch(actionId: ActionId, args?: unknown): Promise<ActionDispatchResult>;
   /**
    * Built-in action catalog: discover what `dispatch()` accepts (ids, arg
    * schemas, danger) and pre-flight a dispatch. Projects the app's


### PR DESCRIPTION
## Summary

- The plugin SDK already exported `BuiltInActionId` but `dispatch`, `get`, `canDispatch`, and every contribution `actionId` field still accepted plain `string` — a typo'd id compiled fine and only blew up at runtime with `NOT_FOUND`.
- This narrows those signatures to `ActionId` (`BuiltInActionId | (string & {})`): narrow enough to autocomplete built-in ids in the IDE, open enough that plugin-authored ids like `"myplugin.action"` still pass without a cast.
- `createMockHost` updated in lockstep (`DispatchedActionRecord`, `setDispatchResult`, `dispatch` option, overrides map) to avoid the CI dts-build trap.

Resolves #10581

## Changes

- `host.dispatch` / `host.actions.get` / `host.actions.canDispatch` params: `string` → `ActionId`
- Four contribution `actionId` fields (toolbar, menu, keybinding, context menu): `string` → `ActionId`
- `PluginActionManifestEntry.id`: `string` → `ActionId` so catalog entries round-trip into dispatch without a cast
- `ActionId` exported from the plugin SDK barrel (`packages/plugin-sdk`)
- `docs/plugins/host-api.md` signature updated
- Type tests extended: `ActionId`/`BuiltInActionId` relationships, a compile-only numeric-id rejection guard, and the `entry.id` → `dispatch`/`get`/`canDispatch` round-trip

The `ArgsFor<Id>` generic overload is explicitly out of scope — no static per-action arg types exist yet; args are Zod-validated at runtime only.

## Testing

`tsc --noEmit` (root), `tsc -b electron`, `tsc -p packages/plugin-sdk`, `tsc -p packages/plugin-testing`, and vitest (plugin-sdk + createMockHost tests) all pass clean.