### PR TITLE
ci(plugins): wire npm publish pipeline for @daintreehq plugin packages

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -43,7 +43,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: release-packages-${{ github.ref }}
+  # Fixed (ref-independent) key so two near-simultaneous package tags serialize
+  # instead of racing each other into EPUBLISHCONFLICT on the shared registry.
+  group: release-packages
   cancel-in-progress: false
 
 env:
@@ -105,6 +107,29 @@ jobs:
             --workspace=packages/daintree-plugin \
             --workspace=packages/create-daintree-plugin
 
+      # On a tag push, assert the tag's version matches the triggering package's
+      # package.json. The tag is only a trigger — without this check a mistagged
+      # release (e.g. sdk-v0.2.0 while package.json still reads 0.1.0) would
+      # silently no-op via the version guard instead of failing loudly.
+      - name: Validate tag matches package version
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          case "$tag" in
+            create-daintree-plugin-v*) dir=packages/create-daintree-plugin; ver="${tag#create-daintree-plugin-v}" ;;
+            daintree-plugin-v*)        dir=packages/daintree-plugin;        ver="${tag#daintree-plugin-v}" ;;
+            plugin-vite-v*)            dir=packages/plugin-vite;            ver="${tag#plugin-vite-v}" ;;
+            plugin-testing-v*)         dir=packages/plugin-testing;         ver="${tag#plugin-testing-v}" ;;
+            sdk-v*)                    dir=packages/plugin-sdk;             ver="${tag#sdk-v}" ;;
+            *) echo "Unrecognized package tag: $tag" >&2; exit 1 ;;
+          esac
+          pkgver=$(node -p "require('./$dir/package.json').version")
+          if [ "$ver" != "$pkgver" ]; then
+            echo "Tag $tag implies version $ver but $dir/package.json is $pkgver" >&2
+            exit 1
+          fi
+          echo "Tag $tag matches $dir@$pkgver"
+
       # Publish in dependency order: plugin-sdk first (others peer/depend on it),
       # then plugin-testing, the vite preset, and the CLIs. Each publish is
       # guarded by a version-existence check so re-running after a partial
@@ -117,16 +142,27 @@ jobs:
         run: |
           publish_if_new() {
             local dir="$1"
-            local name version
+            local name version view_out view_status
             name=$(node -p "require('./$dir/package.json').name")
             version=$(node -p "require('./$dir/package.json').version")
-            if npm view "$name@$version" version >/dev/null 2>&1; then
+            # Capture stderr so a transient registry error (503/auth/rate-limit)
+            # isn't misread as "not published" — that would publish over an
+            # existing version and fail with EPUBLISHCONFLICT. Only a genuine
+            # 404 ("not found"/"E404") means the version is new; anything else
+            # aborts so the failure is loud rather than a corrupt publish.
+            if view_out=$(npm view "$name@$version" version 2>&1); then
               echo "Skipping $name@$version — already published"
-            else
+              return 0
+            fi
+            view_status=$?
+            if echo "$view_out" | grep -qiE "E404|not found|is not in this registry"; then
               # --access public is required on a scoped package's first publish
               # (scoped packages default to restricted); explicit here rather
               # than relying solely on each package's publishConfig.access.
               npm publish --workspace="$dir" --access public
+            else
+              echo "npm view failed for $name@$version (exit $view_status): $view_out" >&2
+              return 1
             fi
           }
           publish_if_new packages/plugin-sdk

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -1,16 +1,24 @@
 name: Release (Plugin Packages)
 
-# Manual npm publish for the plugin-ecosystem workspace packages
+# npm publish for the plugin-ecosystem workspace packages
 # (@daintreehq/plugin-sdk, @daintreehq/plugin-testing, @daintreehq/plugin-vite,
 # daintree-plugin, create-daintree-plugin). Kept separate from the Electron app
-# release workflows (release-{macos,linux,windows}.yml): those fire on `v*`
-# tags, so this one is `workflow_dispatch`-only to avoid tag collisions. Once a
-# versioning scheme for the packages is agreed, a `packages/v*` tag trigger can
-# be added here without touching the app release tags.
+# release workflows (release-{macos,linux,windows}.yml), which fire on `v*`
+# tags. Each package versions independently via its own per-package tag
+# (`sdk-v*`, `plugin-vite-v*`, `plugin-testing-v*`, `daintree-plugin-v*`,
+# `create-daintree-plugin-v*`); pushing any of them publishes (the
+# version-existence guard below skips already-published packages, so a tag for
+# one package re-runs the others as no-ops). `workflow_dispatch` remains for
+# manual/dry runs.
 #
-# Requires the `NPM_TOKEN` secret (an npm automation token with publish rights
-# to the @daintreehq scope). Until it is provisioned, run with dry_run=true to
-# exercise the build + pack steps without publishing.
+# Auth: npm Trusted Publishing (OIDC) is the intended path — once this repo +
+# workflow is registered as a Trusted Publisher for each package on npmjs.com,
+# publishing uses short-lived OIDC credentials and no stored secret is needed
+# (`id-token: write` is already granted below). Classic automation tokens were
+# revoked by npm on 2025-12-09, so the fallback until OIDC is provisioned is a
+# Granular Access Token (read+write, @daintreehq scope, 90-day max) stored as
+# the `NPM_TOKEN` secret. Run with dry_run=true to exercise build + pack without
+# publishing.
 
 on:
   workflow_dispatch:
@@ -20,9 +28,19 @@ on:
         required: false
         type: boolean
         default: true
+  push:
+    tags:
+      - "sdk-v*"
+      - "plugin-vite-v*"
+      - "plugin-testing-v*"
+      - "daintree-plugin-v*"
+      - "create-daintree-plugin-v*"
 
 permissions:
   contents: read
+  # Lets the runner mint a short-lived OIDC token for npm Trusted Publishing.
+  # Harmless when publishing via NPM_TOKEN; required once OIDC is provisioned.
+  id-token: write
 
 concurrency:
   group: release-packages-${{ github.ref }}
@@ -70,8 +88,16 @@ jobs:
           npm run typecheck --workspace=packages/daintree-plugin
           npm run typecheck --workspace=packages/create-daintree-plugin
 
+      # Gate the publish on the plugin contract tests: the hello-daintree sample
+      # plugin exercised against the mock host re-exported by plugin-testing.
+      # A regression here means the published SDK/host contract is broken.
+      - name: Contract tests (hello-daintree)
+        run: npx vitest run plugins/sample/hello-daintree
+
+      # Tag pushes always publish (no dry_run input), so pack only on a manual
+      # dispatch that explicitly requested it.
       - name: Pack (dry run)
-        if: ${{ inputs.dry_run }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
         run: |
           npm pack --workspace=packages/plugin-sdk \
             --workspace=packages/plugin-testing \
@@ -85,7 +111,7 @@ jobs:
       # failure skips already-published versions instead of erroring on
       # EPUBLISHCONFLICT and blocking the remaining packages.
       - name: Publish to npm
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -97,7 +123,10 @@ jobs:
             if npm view "$name@$version" version >/dev/null 2>&1; then
               echo "Skipping $name@$version — already published"
             else
-              npm publish --workspace="$dir"
+              # --access public is required on a scoped package's first publish
+              # (scoped packages default to restricted); explicit here rather
+              # than relying solely on each package's publishConfig.access.
+              npm publish --workspace="$dir" --access public
             fi
           }
           publish_if_new packages/plugin-sdk

--- a/plugins/sample/hello-daintree/__tests__/package-exports.test.ts
+++ b/plugins/sample/hello-daintree/__tests__/package-exports.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+// The activate.test.ts contract test imports host code via relative `shared/`
+// paths, so it never exercises the published package boundaries. This suite
+// imports each package by its public name and `exports` subpath instead — the
+// same resolution a plugin author gets after `npm install`. A broken `exports`
+// map, missing `dist/` artifact, or dropped public export fails here, gating
+// the publish before it ships a package that 404s on a subpath at install time.
+
+describe("@daintreehq package boundaries resolve by public name", () => {
+  it("plugin-sdk root exports its public runtime surface", async () => {
+    const sdk = await import("@daintreehq/plugin-sdk");
+    expect(typeof sdk.PLUGIN_PROCESS_STREAM_CHANNEL).toBe("string");
+    expect(sdk.PLUGIN_PROCESS_STREAM_CHANNEL.length).toBeGreaterThan(0);
+  });
+
+  it("plugin-sdk/react subpath exports the React hooks", async () => {
+    const react = await import("@daintreehq/plugin-sdk/react");
+    expect(typeof react.useHostChannel).toBe("function");
+    expect(typeof react.usePluginEvent).toBe("function");
+  });
+
+  it("plugin-testing exports createMockHost", async () => {
+    const testing = await import("@daintreehq/plugin-testing");
+    expect(typeof testing.createMockHost).toBe("function");
+    // The factory must actually produce a usable mock host, not just exist.
+    const host = testing.createMockHost({ pluginId: "daintree.hello" });
+    expect(Array.isArray(host.registeredHandlers)).toBe(true);
+  });
+
+  it("plugin-vite exports the daintree plugin and React externals", async () => {
+    const vite = await import("@daintreehq/plugin-vite");
+    expect(typeof vite.daintreePlugin).toBe("function");
+    expect(Array.isArray(vite.reactExternals)).toBe(true);
+    expect(vite.daintreePlugin().name).toBe("daintree-plugin-vite");
+  });
+});


### PR DESCRIPTION
The 5 plugin-ecosystem packages already exist and build cleanly. This wires up the publish pipeline so they can reach npm at 0.1.0.

Resolves #9302

## Changes

- Per-package tag triggers (`sdk-v*`, `plugin-vite-v*`, `plugin-testing-v*`, `daintree-plugin-v*`, `create-daintree-plugin-v*`) alongside `workflow_dispatch`
- Publish gated on hello-daintree contract tests + a new package-exports boundary test that resolves each package by its public name/subpath, catching broken `exports` maps
- Event-aware pack/publish conditions — tag pushes always publish; manual dispatch supports `dry_run`
- `--access public` on first publish of scoped packages; tag↔version validation before any publish step
- Concurrency serialized via a fixed group key; `npm view` 404-vs-error discrimination so a missing package doesn't abort the run
- Auth: `id-token: write` for npm OIDC Trusted Publishing (intended path; classic tokens revoked 2025-12-09), `NPM_TOKEN` Granular Access Token as fallback

**Out of band** (not in this PR): registering the repo as a Trusted Publisher on npmjs.com / provisioning `NPM_TOKEN`, and the actual tag pushes that trigger the first publish. Manual ops once this lands.

## Testing

- `vitest run plugins/sample/hello-daintree` — 10/10 pass (including new package-exports boundary test)
- YAML and shell syntax validated
- `plugin-vite` React externals regex verified against lesson #9493