### PR TITLE
fix(plugins): typecheck plugin main-process code via dedicated tsconfig

### DIFF
--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -18,12 +18,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "./**/*.ts",
-    "../plugins/builtin/github/main/**/*.ts",
-    "../plugins/builtin/github/shared/**/*.ts",
-    "../plugins/sample/*/main/**/*.ts"
-  ],
+  "include": ["./**/*.ts"],
   "exclude": ["node_modules", "preload.cts"],
   "references": [{ "path": "../shared/tsconfig.json" }]
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "knip": "knip",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "typecheck": "tsc --noEmit && tsc -b electron/tsconfig.json && tsc --noEmit -p electron/tsconfig.preload.json && tsc --noEmit -p packages/daintree-plugin/tsconfig.json && tsc --noEmit -p packages/create-daintree-plugin/tsconfig.json && tsc --noEmit -p packages/plugin-sdk/tsconfig.json && tsc --noEmit -p packages/plugin-testing/tsconfig.json && tsc --noEmit -p packages/plugin-vite/tsconfig.json",
+    "typecheck": "tsc --noEmit && tsc -b electron/tsconfig.json && tsc --noEmit -p electron/tsconfig.preload.json && tsc --noEmit -p packages/daintree-plugin/tsconfig.json && tsc --noEmit -p packages/create-daintree-plugin/tsconfig.json && tsc --noEmit -p packages/plugin-sdk/tsconfig.json && tsc --noEmit -p packages/plugin-testing/tsconfig.json && tsc --noEmit -p packages/plugin-vite/tsconfig.json && tsc --noEmit -p tsconfig.plugins.json",
     "packages:build": "npm run build --workspace=packages/plugin-sdk --workspace=packages/plugin-testing --workspace=packages/plugin-vite --workspace=packages/daintree-plugin --workspace=packages/create-daintree-plugin",
     "check:channels": "node scripts/ci/check-channel-drift.mjs",
     "check:preload-backdoors": "node scripts/ci/check-preload-backdoors.mjs",

--- a/tsconfig.plugins.json
+++ b/tsconfig.plugins.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["plugins/builtin/*/main/**/*.ts", "plugins/sample/*/main/**/*.ts"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/tsconfig.plugins.json
+++ b/tsconfig.plugins.json
@@ -16,6 +16,9 @@
     "forceConsistentCasingInFileNames": true,
     "noEmit": true
   },
-  "include": ["plugins/builtin/*/main/**/*.ts", "plugins/sample/*/main/**/*.ts"],
-  "exclude": ["**/__tests__/**", "**/*.test.ts", "**/*.spec.ts"]
+  "include": [
+    "plugins/builtin/*/main/**/*.ts",
+    "plugins/sample/*/main/**/*.ts",
+    "electron/types/**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
## Summary

- Plugin main-process code (`plugins/{builtin,sample}/*/main`) wasn't covered by any tsconfig — esbuild compiled it, but no type checking ran
- Adds `tsconfig.plugins.json`: `noEmit`, `NodeNext` module/resolution, `types: ["node"]`, full strict suite (`strict`, `noUnusedLocals`, `noUnusedParameters`, `noImplicitReturns`, `noFallthroughCasesInSwitch`), `resolveJsonModule`, `skipLibCheck`; includes `electron/types/**/*.d.ts` so ambient shims (e.g. the untyped `archiver` dynamic import in `PluginArchive`) resolve the same way the electron build sees them
- Removes the three plugin globs from `electron/tsconfig.json` so the composite build no longer emits plugin source into `dist-typecheck/plugins`; wires `tsc --noEmit -p tsconfig.plugins.json` into the `typecheck` script

Resolves #10588

## Changes

- `tsconfig.plugins.json` — new typecheck-only tsconfig for plugin mains
- `electron/tsconfig.json` — plugin globs removed from composite project
- `package.json` — `typecheck` script extended with `tsc --noEmit -p tsconfig.plugins.json`

## Testing

- Full `npm run typecheck` passes clean
- Injected type errors in both plugin main code and plugin main test files are caught
- `dist-typecheck/plugins` is no longer generated