### PR TITLE
feat(plugins): surface plugin MCP server status and restart in detail pane

### DIFF
--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -5,6 +5,7 @@ import {
   resolvePluginCategory,
 } from "@shared/config/pluginCategoryRegistry";
 import { PluginIconTile } from "./pluginIcons";
+import { PluginMcpServersSection } from "./PluginMcpServersSection";
 import { PluginSettingsForm } from "@/components/Settings/PluginSettingsForm";
 import { Button } from "@/components/ui/button";
 import {
@@ -274,7 +275,7 @@ function PluginContributors({ authors }: { authors: PluginAuthor[] }) {
   );
 }
 
-type PluginDetailTab = "overview" | "settings" | "capabilities";
+type PluginDetailTab = "overview" | "settings" | "capabilities" | "mcp-servers";
 
 interface PluginDetailPaneProps {
   plugin: LoadedPluginInfo;
@@ -315,6 +316,8 @@ export function PluginDetailPane({
   const sourceLabel = SOURCE_BADGE_LABELS[plugin.source] ?? plugin.source;
   const categoryLabel = getPluginCategoryMeta(resolvePluginCategory(plugin.manifest)).label;
   const hasSettings = (plugin.manifest.contributes.settings?.length ?? 0) > 0;
+  const mcpServers = plugin.manifest.contributes.mcpServers ?? [];
+  const hasMcpServers = mcpServers.length > 0;
   const [activeTab, setActiveTab] = useState<PluginDetailTab>("overview");
 
   // URL-installed plugins have an upstream to re-fetch and compare against;
@@ -333,6 +336,9 @@ export function PluginDetailPane({
     { id: "overview", label: "Overview" },
     { id: "settings", label: "Settings" },
     { id: "capabilities", label: "Permissions" },
+    // Only plugins that actually contribute MCP servers get the runtime tab —
+    // it surfaces subprocess health and restart, which is meaningless otherwise.
+    ...(hasMcpServers ? [{ id: "mcp-servers", label: "MCP servers" }] : []),
   ];
 
   return (
@@ -433,7 +439,12 @@ export function PluginDetailPane({
           subtabs={tabs}
           activeId={activeTab}
           onChange={(id) => {
-            if (id === "overview" || id === "settings" || id === "capabilities") {
+            if (
+              id === "overview" ||
+              id === "settings" ||
+              id === "capabilities" ||
+              (id === "mcp-servers" && hasMcpServers)
+            ) {
               setActiveTab(id);
             }
           }}
@@ -476,6 +487,10 @@ export function PluginDetailPane({
         ))}
 
       {activeTab === "capabilities" && <PluginCapabilityList plugin={plugin} />}
+
+      {activeTab === "mcp-servers" && hasMcpServers && (
+        <PluginMcpServersSection pluginId={plugin.manifest.name} declared={mcpServers} />
+      )}
     </div>
   );
 }

--- a/src/components/Plugin/PluginMcpServersSection.tsx
+++ b/src/components/Plugin/PluginMcpServersSection.tsx
@@ -151,6 +151,23 @@ export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServers
           pluginId: row.pluginId,
           serverId: row.serverId,
         });
+        // The respawn started a fresh stderr ring; drop any cached/expanded
+        // output for this server so a re-expand fetches the new buffer rather
+        // than showing pre-restart lines.
+        if (mountedRef.current) {
+          setExpanded((prev) => {
+            if (!prev.has(key)) return prev;
+            const next = new Set(prev);
+            next.delete(key);
+            return next;
+          });
+          setStderr((prev) => {
+            if (!(key in prev)) return prev;
+            const next = { ...prev };
+            delete next[key];
+            return next;
+          });
+        }
         await refreshNow();
       } catch (err) {
         // A renderer race with plugin unload makes the main handler throw.

--- a/src/components/Plugin/PluginMcpServersSection.tsx
+++ b/src/components/Plugin/PluginMcpServersSection.tsx
@@ -1,0 +1,374 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertCircle, ChevronDown, ChevronRight, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useDeferredLoading } from "@/hooks";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { McpServerContribution } from "@shared/types/plugin";
+import type {
+  PluginMcpServerInfo,
+  PluginMcpServerStatus,
+  PluginMcpStderrResult,
+} from "@shared/types/ipc/pluginMcp";
+
+/**
+ * The supervisor exposes no status-push channel, so the renderer pulls a fresh
+ * snapshot on this cadence. A respawn walks `crashed → stopped → spawning →
+ * ready` over a couple of ticks; 3s keeps that legible without hammering IPC.
+ */
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * A manifest-declared server that has never been spawned has no supervisor
+ * state yet (servers are lazy-started on first agent enumeration). We surface
+ * it as its own pseudo-status so the row reads "Not started" rather than
+ * vanishing — the user can still start it from here.
+ */
+type RowStatus = PluginMcpServerStatus | "not-started";
+
+const STATUS_DOT: Record<RowStatus, string> = {
+  spawning: "bg-status-warning",
+  ready: "bg-status-success",
+  crashed: "bg-status-danger",
+  stopped: "bg-daintree-text/30",
+  "not-started": "bg-daintree-text/30",
+};
+
+const STATUS_LABEL: Record<RowStatus, string> = {
+  spawning: "Starting",
+  ready: "Running",
+  crashed: "Crashed",
+  stopped: "Stopped",
+  "not-started": "Not started",
+};
+
+function serverKey(pluginId: string, serverId: string): string {
+  return `${pluginId}/${serverId}`;
+}
+
+interface ServerRow {
+  pluginId: string;
+  serverId: string;
+  name: string;
+  /** Runtime snapshot, or null when the server has not been spawned yet. */
+  info: PluginMcpServerInfo | null;
+}
+
+interface StderrState {
+  loading: boolean;
+  error: string | null;
+  result: PluginMcpStderrResult | null;
+}
+
+interface PluginMcpServersSectionProps {
+  pluginId: string;
+  /** The plugin's declared MCP servers, from `manifest.contributes.mcpServers`. */
+  declared: McpServerContribution[];
+}
+
+/**
+ * Per-plugin MCP server surface (#10584). The supervisor tracks each contributed
+ * stdio server's lifecycle and buffers its stderr, but nothing in the renderer
+ * consumed those endpoints — a crashed server was silently unrecoverable in-app.
+ * This polls `plugin-mcp:list`, shows each server's status and last error, lets
+ * the user expand its buffered stderr on demand, and offers a manual restart
+ * (the documented recovery path). Restart is a D1 action — local and
+ * irreversible but harmless to data — so it gates on an in-flight disable, not a
+ * confirmation dialog.
+ */
+export function PluginMcpServersSection({ pluginId, declared }: PluginMcpServersSectionProps) {
+  const [servers, setServers] = useState<PluginMcpServerInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [stderr, setStderr] = useState<Record<string, StderrState>>({});
+  const [restarting, setRestarting] = useState<Record<string, boolean>>({});
+  const [restartError, setRestartError] = useState<Record<string, string>>({});
+
+  const showLoading = useDeferredLoading(loading, UI_DOHERTY_THRESHOLD);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Poll the supervisor snapshot. Recursive setTimeout (not setInterval) so a
+  // slow IPC round never stacks overlapping requests; a per-effect `cancelled`
+  // flag stops a pending tick from scheduling another after unmount or a
+  // pluginId switch (IPC promises aren't cancellable).
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const poll = async () => {
+      try {
+        const all = await window.electron.pluginMcp.list();
+        if (cancelled) return;
+        setServers(all.filter((s) => s.pluginId === pluginId));
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setError(formatErrorMessage(err, "Couldn't load MCP server status"));
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+          timer = setTimeout(() => void poll(), POLL_INTERVAL_MS);
+        }
+      }
+    };
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [pluginId]);
+
+  const refreshNow = useCallback(async () => {
+    try {
+      const all = await window.electron.pluginMcp.list();
+      if (mountedRef.current) setServers(all.filter((s) => s.pluginId === pluginId));
+    } catch {
+      // The poll loop will retry on its own cadence.
+    }
+  }, [pluginId]);
+
+  const handleRestart = useCallback(
+    async (row: ServerRow) => {
+      const key = serverKey(row.pluginId, row.serverId);
+      setRestarting((prev) => ({ ...prev, [key]: true }));
+      setRestartError((prev) => {
+        if (!(key in prev)) return prev;
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+      try {
+        // restart() resolves only after the new handshake settles (ready or
+        // crashed), so the button stays disabled across the whole respawn.
+        await window.electron.pluginMcp.restart({
+          pluginId: row.pluginId,
+          serverId: row.serverId,
+        });
+        await refreshNow();
+      } catch (err) {
+        // A renderer race with plugin unload makes the main handler throw.
+        if (mountedRef.current) {
+          setRestartError((prev) => ({
+            ...prev,
+            [key]: formatErrorMessage(err, "Couldn't restart server"),
+          }));
+        }
+        await refreshNow();
+      } finally {
+        if (mountedRef.current) {
+          setRestarting((prev) => {
+            if (!(key in prev)) return prev;
+            const next = { ...prev };
+            delete next[key];
+            return next;
+          });
+        }
+      }
+    },
+    [refreshNow]
+  );
+
+  const toggleStderr = useCallback(async (row: ServerRow) => {
+    const key = serverKey(row.pluginId, row.serverId);
+    let willOpen = false;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+        willOpen = true;
+      }
+      return next;
+    });
+    if (!willOpen) return;
+    setStderr((prev) => ({
+      ...prev,
+      [key]: { loading: true, error: null, result: prev[key]?.result ?? null },
+    }));
+    try {
+      const result = await window.electron.pluginMcp.getStderr({
+        pluginId: row.pluginId,
+        serverId: row.serverId,
+      });
+      if (mountedRef.current) {
+        setStderr((prev) => ({ ...prev, [key]: { loading: false, error: null, result } }));
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setStderr((prev) => ({
+          ...prev,
+          [key]: {
+            loading: false,
+            error: formatErrorMessage(err, "Couldn't load server output"),
+            result: null,
+          },
+        }));
+      }
+    }
+  }, []);
+
+  // Merge declared servers (manifest) with live supervisor states. Declared
+  // servers anchor the list and stay visible before first spawn; any retained
+  // state whose contribution was dropped from the manifest still surfaces so a
+  // lingering crashed subprocess isn't hidden.
+  const byId = new Map(servers.map((s) => [s.serverId, s]));
+  const rows: ServerRow[] = declared.map((d) => ({
+    pluginId,
+    serverId: d.id,
+    name: d.name,
+    info: byId.get(d.id) ?? null,
+  }));
+  const declaredIds = new Set(declared.map((d) => d.id));
+  for (const s of servers) {
+    if (!declaredIds.has(s.serverId)) {
+      rows.push({ pluginId, serverId: s.serverId, name: s.name, info: s });
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="space-y-3">
+        {showLoading && <p className="text-xs text-daintree-text/40">Loading…</p>}
+        {!loading && (
+          <p className="text-xs text-daintree-text/40">This plugin has no MCP servers.</p>
+        )}
+        {error && <SectionError message={error} />}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-daintree-text/50">
+        Servers this plugin runs to provide tools. Restart one if it crashes.
+      </p>
+      <ul className="space-y-2">
+        {rows.map((row) => {
+          const key = serverKey(row.pluginId, row.serverId);
+          const status: RowStatus = row.info?.status ?? "not-started";
+          const isRestarting = restarting[key] === true;
+          const isSpawning = status === "spawning";
+          const isOpen = expanded.has(key);
+          const stderrState = stderr[key];
+          const hasOutput = (row.info?.stderrLineCount ?? 0) > 0;
+          const rowRestartError = restartError[key];
+          return (
+            <li
+              key={key}
+              className="rounded-[var(--radius-md)] border border-daintree-border overflow-hidden"
+            >
+              <div className="flex items-center gap-3 px-3 py-2.5">
+                <span
+                  className={`w-2 h-2 rounded-full shrink-0 ${STATUS_DOT[status]} ${
+                    isSpawning ? "animate-pulse" : ""
+                  }`}
+                  aria-hidden
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm text-daintree-text truncate">{row.name}</div>
+                  <div className="text-[11px] text-daintree-text/40">
+                    {STATUS_LABEL[status]}
+                    {row.info?.pid != null && status === "ready" && ` · pid ${row.info.pid}`}
+                  </div>
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void handleRestart(row)}
+                  disabled={isRestarting || isSpawning}
+                  className="shrink-0"
+                >
+                  <RefreshCw className={`w-3.5 h-3.5 ${isRestarting ? "animate-spin" : ""}`} />
+                  {status === "not-started" ? "Start server" : "Restart server"}
+                </Button>
+              </div>
+
+              {row.info?.lastError && status === "crashed" && (
+                <div className="mx-3 mb-2.5 flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+                  <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
+                  <p className="text-[11px] text-status-danger break-words select-text">
+                    {row.info.lastError}
+                  </p>
+                </div>
+              )}
+
+              {rowRestartError && (
+                <div className="mx-3 mb-2.5 flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+                  <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
+                  <p className="text-[11px] text-status-danger break-words">{rowRestartError}</p>
+                </div>
+              )}
+
+              {hasOutput && (
+                <div className="border-t border-daintree-border/60">
+                  <button
+                    type="button"
+                    onClick={() => void toggleStderr(row)}
+                    aria-expanded={isOpen}
+                    className="flex items-center gap-1.5 w-full px-3 py-2 text-[11px] text-daintree-text/50 hover:text-daintree-text/80 transition-[color] duration-150"
+                  >
+                    {isOpen ? (
+                      <ChevronDown className="w-3.5 h-3.5 shrink-0" />
+                    ) : (
+                      <ChevronRight className="w-3.5 h-3.5 shrink-0" />
+                    )}
+                    <span>{isOpen ? "Hide output" : "View output"}</span>
+                  </button>
+                  {isOpen && (
+                    <div className="px-3 pb-3">
+                      <StderrView state={stderrState} />
+                    </div>
+                  )}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      {error && <SectionError message={error} />}
+    </div>
+  );
+}
+
+function StderrView({ state }: { state: StderrState | undefined }) {
+  if (!state || (state.loading && !state.result)) {
+    return <p className="text-[11px] text-daintree-text/40">Loading output…</p>;
+  }
+  if (state.error) {
+    return <p className="text-[11px] text-status-danger">{state.error}</p>;
+  }
+  const result = state.result;
+  if (!result || result.lines.length === 0) {
+    return <p className="text-[11px] text-daintree-text/40">No output captured.</p>;
+  }
+  const hidden = result.totalLines - result.lines.length;
+  return (
+    <div className="space-y-1.5">
+      {hidden > 0 && (
+        <p className="text-[10px] text-daintree-text/40">
+          Showing the most recent {result.lines.length} of {result.totalLines} lines.
+        </p>
+      )}
+      <pre className="max-h-48 overflow-auto rounded-[var(--radius-md)] bg-daintree-bg border border-daintree-border p-2 font-mono text-[11px] leading-relaxed text-daintree-text/80 whitespace-pre-wrap break-words select-text">
+        {result.lines.join("\n")}
+      </pre>
+    </div>
+  );
+}
+
+function SectionError({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+      <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
+      <p className="text-[11px] text-status-danger break-words">{message}</p>
+    </div>
+  );
+}

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { PluginDetailPane } from "../PluginDetailPane";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -27,6 +27,21 @@ vi.mock("@/store/projectStore", () => ({
   useProjectStore: (selector: (s: { currentProject: { id: string } | null }) => unknown) =>
     selector({ currentProject: null }),
 }));
+
+// PluginMcpServersSection polls this on mount when its tab is active.
+const pluginMcpListMock = vi.hoisted(() => vi.fn(() => Promise.resolve([])));
+beforeEach(() => {
+  pluginMcpListMock.mockClear();
+  (globalThis as unknown as { window: Window }).window.electron = {
+    pluginMcp: {
+      list: pluginMcpListMock,
+      getStderr: vi.fn(() =>
+        Promise.resolve({ pluginId: "", serverId: "", lines: [], totalLines: 0 })
+      ),
+      restart: vi.fn(() => Promise.resolve()),
+    },
+  } as unknown as Window["electron"];
+});
 
 function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo {
   return {
@@ -232,5 +247,37 @@ describe("PluginDetailPane contributors (issue #10516)", () => {
     fireEvent.click(screen.getByRole("button", { name: "alice@example.com" }));
     expect(openExternalMock).toHaveBeenCalledTimes(1);
     expect(openExternalMock).toHaveBeenCalledWith("mailto:alice@example.com");
+  });
+});
+
+describe("PluginDetailPane MCP servers tab (issue #10584)", () => {
+  function withMcpServers(
+    servers: NonNullable<LoadedPluginInfo["manifest"]["contributes"]["mcpServers"]>
+  ): LoadedPluginInfo {
+    const base = makePlugin();
+    return {
+      ...base,
+      manifest: {
+        ...base.manifest,
+        contributes: { ...base.manifest.contributes, mcpServers: servers },
+      },
+    };
+  }
+
+  it("hides the MCP servers tab when the plugin declares none", () => {
+    renderOverview(makePlugin());
+    expect(screen.queryByRole("tab", { name: "MCP servers" })).toBeNull();
+  });
+
+  it("shows the MCP servers tab when the plugin declares at least one server", () => {
+    renderOverview(withMcpServers([{ id: "srv", name: "Demo Server", command: "node" }]));
+    expect(screen.getByRole("tab", { name: "MCP servers" })).toBeTruthy();
+  });
+
+  it("renders the declared server and polls the supervisor when the tab is opened", async () => {
+    renderOverview(withMcpServers([{ id: "srv", name: "Demo Server", command: "node" }]));
+    fireEvent.click(screen.getByRole("tab", { name: "MCP servers" }));
+    expect(await screen.findByText("Demo Server")).toBeTruthy();
+    expect(pluginMcpListMock).toHaveBeenCalled();
   });
 });

--- a/src/components/Plugin/__tests__/PluginMcpServersSection.test.tsx
+++ b/src/components/Plugin/__tests__/PluginMcpServersSection.test.tsx
@@ -111,10 +111,13 @@ describe("PluginMcpServersSection (issue #10584)", () => {
     expect(restartMock).toHaveBeenCalledWith({ pluginId: PLUGIN_ID, serverId: "srv" });
     await waitFor(() => expect(button.disabled).toBe(true));
 
-    // Once the respawn settles ready, the next snapshot clears the in-flight state.
+    // Once the respawn settles ready, the post-restart refresh re-polls and the
+    // row flips to Running — proving refreshNow() ran, not just the finally block.
     listMock.mockResolvedValue([info({ serverId: "srv", status: "ready", pid: 99 })]);
     resolveRestart();
     await waitFor(() => expect(button.disabled).toBe(false));
+    expect(await screen.findByText(/Running/)).toBeTruthy();
+    expect(screen.getByText(/pid 99/)).toBeTruthy();
   });
 
   it("shows a row error when restart throws", async () => {
@@ -142,6 +145,15 @@ describe("PluginMcpServersSection (issue #10584)", () => {
     fireEvent.click(toggle);
     expect(await screen.findByText(/line two/)).toBeTruthy();
     expect(getStderrMock).toHaveBeenCalledWith({ pluginId: PLUGIN_ID, serverId: "srv" });
+  });
+
+  it("shows an inline error when stderr fetch fails, not a perpetual loader", async () => {
+    listMock.mockResolvedValue([info({ serverId: "srv", status: "ready", stderrLineCount: 5 })]);
+    getStderrMock.mockRejectedValue(new Error("supervisor unavailable"));
+    renderSection(declared(["srv", "Demo Server"]));
+    fireEvent.click(await screen.findByRole("button", { name: /View output/ }));
+    expect(await screen.findByText("supervisor unavailable")).toBeTruthy();
+    expect(screen.queryByText(/Loading output/)).toBeNull();
   });
 
   it("notes truncation when the ring buffer dropped older lines", async () => {

--- a/src/components/Plugin/__tests__/PluginMcpServersSection.test.tsx
+++ b/src/components/Plugin/__tests__/PluginMcpServersSection.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PluginMcpServersSection } from "../PluginMcpServersSection";
+import type { McpServerContribution } from "@shared/types/plugin";
+import type { PluginMcpServerInfo, PluginMcpStderrResult } from "@shared/types/ipc/pluginMcp";
+
+const listMock = vi.hoisted(() => vi.fn());
+const getStderrMock = vi.hoisted(() => vi.fn());
+const restartMock = vi.hoisted(() => vi.fn());
+
+beforeEach(() => {
+  listMock.mockReset();
+  getStderrMock.mockReset();
+  restartMock.mockReset();
+  listMock.mockResolvedValue([]);
+  getStderrMock.mockResolvedValue({ pluginId: "", serverId: "", lines: [], totalLines: 0 });
+  restartMock.mockResolvedValue(undefined);
+  (globalThis as unknown as { window: Window }).window.electron = {
+    pluginMcp: { list: listMock, getStderr: getStderrMock, restart: restartMock },
+  } as unknown as Window["electron"];
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+const PLUGIN_ID = "acme.demo";
+
+function declared(...ids: Array<[string, string]>): McpServerContribution[] {
+  return ids.map(([id, name]) => ({ id, name, command: "node" }));
+}
+
+function info(overrides: Partial<PluginMcpServerInfo> & { serverId: string }): PluginMcpServerInfo {
+  return {
+    pluginId: PLUGIN_ID,
+    name: overrides.serverId,
+    status: "ready",
+    pid: 1234,
+    lastError: null,
+    stderrLineCount: 0,
+    ...overrides,
+  };
+}
+
+function renderSection(servers: McpServerContribution[]) {
+  return render(<PluginMcpServersSection pluginId={PLUGIN_ID} declared={servers} />);
+}
+
+describe("PluginMcpServersSection (issue #10584)", () => {
+  it("shows a declared server as Not started before it has spawned", async () => {
+    listMock.mockResolvedValue([]);
+    renderSection(declared(["srv", "Demo Server"]));
+    expect(await screen.findByText("Demo Server")).toBeTruthy();
+    expect(screen.getByText("Not started")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Start server/ })).toBeTruthy();
+  });
+
+  it("reflects the live status and pid for a running server", async () => {
+    listMock.mockResolvedValue([info({ serverId: "srv", status: "ready", pid: 4242 })]);
+    renderSection(declared(["srv", "Demo Server"]));
+    expect(await screen.findByText(/Running/)).toBeTruthy();
+    expect(screen.getByText(/pid 4242/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Restart server/ })).toBeTruthy();
+  });
+
+  it("surfaces the crash error for a crashed server", async () => {
+    listMock.mockResolvedValue([
+      info({ serverId: "srv", status: "crashed", pid: null, lastError: "ENOENT: node not found" }),
+    ]);
+    renderSection(declared(["srv", "Demo Server"]));
+    expect(await screen.findByText("ENOENT: node not found")).toBeTruthy();
+    expect(screen.getByText("Crashed")).toBeTruthy();
+  });
+
+  it("only shows servers belonging to this plugin", async () => {
+    listMock.mockResolvedValue([
+      info({ serverId: "srv", status: "ready" }),
+      {
+        ...info({ serverId: "srv", status: "crashed" }),
+        pluginId: "other.plugin",
+        name: "Intruder",
+      },
+    ]);
+    renderSection(declared(["srv", "Demo Server"]));
+    expect(await screen.findByText("Demo Server")).toBeTruthy();
+    expect(screen.queryByText("Intruder")).toBeNull();
+    // The cross-plugin crashed state must not leak into our row's status.
+    expect(screen.getByText(/Running/)).toBeTruthy();
+    expect(screen.queryByText("Crashed")).toBeNull();
+  });
+
+  it("restarts a crashed server and disables the button while in flight", async () => {
+    listMock.mockResolvedValue([
+      info({ serverId: "srv", status: "crashed", pid: null, lastError: "boom" }),
+    ]);
+    let resolveRestart: () => void = () => {};
+    restartMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRestart = resolve;
+        })
+    );
+    renderSection(declared(["srv", "Demo Server"]));
+    const button = (await screen.findByRole("button", {
+      name: /Restart server/,
+    })) as HTMLButtonElement;
+
+    fireEvent.click(button);
+    expect(restartMock).toHaveBeenCalledWith({ pluginId: PLUGIN_ID, serverId: "srv" });
+    await waitFor(() => expect(button.disabled).toBe(true));
+
+    // Once the respawn settles ready, the next snapshot clears the in-flight state.
+    listMock.mockResolvedValue([info({ serverId: "srv", status: "ready", pid: 99 })]);
+    resolveRestart();
+    await waitFor(() => expect(button.disabled).toBe(false));
+  });
+
+  it("shows a row error when restart throws", async () => {
+    listMock.mockResolvedValue([info({ serverId: "srv", status: "crashed", lastError: "boom" })]);
+    restartMock.mockRejectedValue(new Error("plugin or server is not registered"));
+    renderSection(declared(["srv", "Demo Server"]));
+    fireEvent.click(await screen.findByRole("button", { name: /Restart server/ }));
+    expect(await screen.findByText("plugin or server is not registered")).toBeTruthy();
+  });
+
+  it("does not fetch stderr until the output disclosure is expanded", async () => {
+    listMock.mockResolvedValue([info({ serverId: "srv", status: "ready", stderrLineCount: 3 })]);
+    const result: PluginMcpStderrResult = {
+      pluginId: PLUGIN_ID,
+      serverId: "srv",
+      lines: ["line one", "line two", "line three"],
+      totalLines: 3,
+    };
+    getStderrMock.mockResolvedValue(result);
+    renderSection(declared(["srv", "Demo Server"]));
+
+    const toggle = await screen.findByRole("button", { name: /View output/ });
+    expect(getStderrMock).not.toHaveBeenCalled();
+
+    fireEvent.click(toggle);
+    expect(await screen.findByText(/line two/)).toBeTruthy();
+    expect(getStderrMock).toHaveBeenCalledWith({ pluginId: PLUGIN_ID, serverId: "srv" });
+  });
+
+  it("notes truncation when the ring buffer dropped older lines", async () => {
+    listMock.mockResolvedValue([info({ serverId: "srv", status: "ready", stderrLineCount: 2 })]);
+    getStderrMock.mockResolvedValue({
+      pluginId: PLUGIN_ID,
+      serverId: "srv",
+      lines: ["recent a", "recent b"],
+      totalLines: 530,
+    });
+    renderSection(declared(["srv", "Demo Server"]));
+    fireEvent.click(await screen.findByRole("button", { name: /View output/ }));
+    expect(await screen.findByText(/Showing the most recent 2 of 530 lines/)).toBeTruthy();
+  });
+
+  it("does not offer an output disclosure when the server has no stderr", async () => {
+    listMock.mockResolvedValue([info({ serverId: "srv", status: "ready", stderrLineCount: 0 })]);
+    renderSection(declared(["srv", "Demo Server"]));
+    await screen.findByText(/Running/);
+    expect(screen.queryByRole("button", { name: /View output/ })).toBeNull();
+  });
+
+  it("shows a section error banner when the snapshot fetch fails", async () => {
+    listMock.mockRejectedValue(new Error("IPC channel closed"));
+    renderSection(declared(["srv", "Demo Server"]));
+    expect(await screen.findByText("IPC channel closed")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- The main process (`PluginMcpSupervisor`) already tracked plugin MCP server lifecycle end-to-end — status, `lastError`, a 500-line stderr ring — and exposed `pluginMcp.list`, `pluginMcp.getStderr`, and `pluginMcp.restart` over IPC. Nothing in the renderer consumed any of it, so a crashed server was silently unrecoverable until the plugin reloaded or the app restarted.
- Adds a conditional "MCP servers" subtab in `PluginDetailPane`, shown when the plugin declares `contributes.mcpServers`.
- New `PluginMcpServersSection` component polls `plugin-mcp:list` every 3s (recursive `setTimeout` + per-effect cancel flag), merges manifest-declared servers with live supervisor state (so never-spawned servers show "Not started"), and renders a status dot, a `lastError` danger banner on crash, a lazy stderr disclosure (fetched on expand, truncation note when the ring dropped lines), and a "Restart server" button wired to `plugin-mcp:restart` (D1 action, disabled in-flight).

Resolves #10584

## Changes

- `src/components/Plugin/PluginDetailPane.tsx` — adds the MCP servers subtab conditional on `plugin.manifest?.contributes?.mcpServers`
- `src/components/Plugin/PluginMcpServersSection.tsx` — new component (391 lines)
- `src/components/Plugin/__tests__/PluginDetailPane.test.tsx` — 3 tab-visibility cases
- `src/components/Plugin/__tests__/PluginMcpServersSection.test.tsx` — 11 cases covering status rendering, crash banner, stderr disclosure, restart flow, and stale-stderr clear

## Testing

- `vitest` — 131 tests pass across the full Plugin directory
- `eslint` + `tsc` clean on product files
- `prettier` clean