### PR TITLE
fix(plugins): catch typo'd own-namespace actionId in manifest validator

### DIFF
--- a/electron/schemas/__tests__/actionIdContribution.test.ts
+++ b/electron/schemas/__tests__/actionIdContribution.test.ts
@@ -29,6 +29,20 @@ const contributionEntry: Record<string, (actionId: string) => Record<string, unk
 
 const CONTRIBUTION_ARRAYS = Object.keys(contributionEntry);
 
+// A valid contributes.commands entry whose bare id namespaces to
+// `${manifest.name}.${id}` at load time. Used to test the own-namespace
+// declared-command cross-check (#10580).
+function commandEntry(id: string): Record<string, unknown> {
+  return {
+    id,
+    title: "Cmd",
+    description: "A command",
+    category: "general",
+    kind: "command",
+    danger: "safe",
+  };
+}
+
 describe("manifest-level actionId namespace gate (issue #10565)", () => {
   const schema = getPluginManifestSchema(false);
 
@@ -53,13 +67,10 @@ describe("manifest-level actionId namespace gate (issue #10565)", () => {
     expect(result.success).toBe(true);
   });
 
-  it("accepts an own-namespace actionId even without a matching contributes.commands entry", () => {
+  it("accepts an own-namespace actionId when no commands are declared (imperative escape hatch)", () => {
     // Plugin actions are frequently registered imperatively via
-    // host.registerAction, which is invisible at parse time — so an id in the
-    // plugin's own namespace must pass without a declared command. A typo within
-    // the own namespace (e.g. acme.my-plugin.typoo) also passes — that is an
-    // intentional consequence of namespace-ownership gating, not a gap to close;
-    // catching a non-existent own-namespace suffix requires the runtime registry.
+    // host.registerAction, which is invisible at parse time — so when the plugin
+    // declares no contributes.commands, any id in its own namespace must pass.
     const result = schema.safeParse(
       manifestWith({
         contributes: {
@@ -69,6 +80,108 @@ describe("manifest-level actionId namespace gate (issue #10565)", () => {
     );
     expect(result.success).toBe(true);
   });
+
+  it("accepts an own-namespace actionId that matches a declared command", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          commands: [commandEntry("greet")],
+          toolbarButtons: [contributionEntry.toolbarButtons("acme.my-plugin.greet")],
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a typo'd own-namespace actionId when commands are declared (issue #10580)", () => {
+    // With commands declared, an own-namespace id matching none of them is a typo
+    // for a command that will never exist — it must be caught at parse time.
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          commands: [commandEntry("openInBrowser")],
+          toolbarButtons: [contributionEntry.toolbarButtons("acme.my-plugin.openInBrowswer")],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) =>
+          (i as { params?: { errorCode?: string } }).params?.errorCode ===
+          "action_id_undeclared_command"
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.path).toEqual(["contributes", "toolbarButtons", 0, "actionId"]);
+    }
+  });
+
+  it.each(CONTRIBUTION_ARRAYS)(
+    "rejects a typo'd own-namespace actionId contributed via %s",
+    (arrayName) => {
+      const result = schema.safeParse(
+        manifestWith({
+          contributes: {
+            commands: [commandEntry("greet")],
+            [arrayName]: [contributionEntry[arrayName]("acme.my-plugin.greet-typo")],
+          },
+        })
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) =>
+            (i as { params?: { errorCode?: string } }).params?.errorCode ===
+            "action_id_undeclared_command"
+        );
+        expect(issue).toBeDefined();
+        expect(issue?.path).toEqual(["contributes", arrayName, 0, "actionId"]);
+      }
+    }
+  );
+
+  it("rejects a contribution referencing a denyPluginDispatch built-in (issue #10580)", () => {
+    // terminal.sendCommand exists as a built-in but is closed to plugin dispatch
+    // — wiring a contribution to it paints a button the host will never fire.
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          toolbarButtons: [contributionEntry.toolbarButtons("terminal.sendCommand")],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) =>
+          (i as { params?: { errorCode?: string } }).params?.errorCode ===
+          "action_id_plugin_dispatch_denied"
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.path).toEqual(["contributes", "toolbarButtons", 0, "actionId"]);
+    }
+  });
+
+  it.each(CONTRIBUTION_ARRAYS)(
+    "rejects a denyPluginDispatch built-in actionId contributed via %s",
+    (arrayName) => {
+      const result = schema.safeParse(
+        manifestWith({
+          contributes: { [arrayName]: [contributionEntry[arrayName]("fleet.accept")] },
+        })
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) =>
+            (i as { params?: { errorCode?: string } }).params?.errorCode ===
+            "action_id_plugin_dispatch_denied"
+        );
+        expect(issue).toBeDefined();
+        expect(issue?.path).toEqual(["contributes", arrayName, 0, "actionId"]);
+      }
+    }
+  );
 
   it("rejects a foreign-namespace actionId with a precise error code and path", () => {
     const result = schema.safeParse(

--- a/electron/schemas/__tests__/actionIdContribution.test.ts
+++ b/electron/schemas/__tests__/actionIdContribution.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { getPluginManifestSchema } from "../plugin.js";
+import { DENY_PLUGIN_DISPATCH_ACTION_IDS } from "../../../shared/config/actionIds.js";
 
 // A real built-in action id (see shared/config/actionIds.ts) — referencing one
 // from a plugin contribution is valid and common.
@@ -182,6 +183,72 @@ describe("manifest-level actionId namespace gate (issue #10565)", () => {
       }
     }
   );
+
+  it.each(DENY_PLUGIN_DISPATCH_ACTION_IDS)(
+    "rejects denyPluginDispatch built-in %s",
+    (deniedActionId) => {
+      // Cover every entry in the deny set — dropping any one of them would
+      // otherwise reopen a dead-button side door undetected.
+      const result = schema.safeParse(
+        manifestWith({
+          contributes: { toolbarButtons: [contributionEntry.toolbarButtons(deniedActionId)] },
+        })
+      );
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) =>
+            (i as { params?: { errorCode?: string } }).params?.errorCode ===
+            "action_id_plugin_dispatch_denied"
+        );
+        expect(issue).toBeDefined();
+      }
+    }
+  );
+
+  it("treats an explicit empty contributes.commands array as the imperative escape hatch", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          commands: [],
+          toolbarButtons: [contributionEntry.toolbarButtons("acme.my-plugin.greet")],
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("reports each distinct error code in one manifest (denied, foreign, undeclared own)", () => {
+    // A denied built-in, a foreign-namespace id, and a typo'd own-namespace id
+    // with commands declared should all surface independently — no early-exit
+    // should suppress a downstream issue.
+    const result = schema.safeParse(
+      manifestWith({
+        contributes: {
+          commands: [commandEntry("greet")],
+          toolbarButtons: [
+            contributionEntry.toolbarButtons("terminal.sendCommand"),
+            contributionEntry.toolbarButtons("other.plugin.foo"),
+            contributionEntry.toolbarButtons("acme.my-plugin.greet-typo"),
+          ],
+        },
+      })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const codeFor = (index: number) =>
+        result.error.issues.find(
+          (i) =>
+            Array.isArray(i.path) &&
+            i.path[0] === "contributes" &&
+            i.path[1] === "toolbarButtons" &&
+            i.path[2] === index
+        ) as { params?: { errorCode?: string } } | undefined;
+      expect(codeFor(0)?.params?.errorCode).toBe("action_id_plugin_dispatch_denied");
+      expect(codeFor(1)?.params?.errorCode).toBe("action_id_unknown_namespace");
+      expect(codeFor(2)?.params?.errorCode).toBe("action_id_undeclared_command");
+    }
+  });
 
   it("rejects a foreign-namespace actionId with a precise error code and path", () => {
     const result = schema.safeParse(

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -4,7 +4,10 @@ import * as semver from "semver";
 import { z } from "zod";
 import { BUILT_IN_PLUGIN_CAPABILITIES, PLUGIN_CATEGORY_IDS } from "../../shared/types/plugin.js";
 import { isBuiltInAgentId } from "../../shared/config/agentIds.js";
-import { BUILT_IN_ACTION_IDS } from "../../shared/config/actionIds.js";
+import {
+  BUILT_IN_ACTION_IDS,
+  DENY_PLUGIN_DISPATCH_ACTION_IDS,
+} from "../../shared/config/actionIds.js";
 import { KEY_ACTION_VALUES } from "../../shared/types/keymap.js";
 import type {
   PluginManifest,
@@ -34,6 +37,11 @@ const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set([
   ...BUILT_IN_ACTION_IDS,
   ...KEY_ACTION_VALUES,
 ]);
+
+// Built-in actions a plugin contribution may never dispatch (terminal input
+// injection, fleet command relays). The host refuses these at runtime, so a
+// contribution wired to one is a dead button — reject it at parse time (#10580).
+const DENY_PLUGIN_DISPATCH_SET: ReadonlySet<string> = new Set(DENY_PLUGIN_DISPATCH_ACTION_IDS);
 
 export const PanelContributionSchema = z
   .object({
@@ -896,15 +904,27 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
       });
 
       // Every contributed `actionId` (toolbar buttons, menu items, keybindings,
-      // context menus) must resolve to a real action at runtime, else the
-      // contribution paints an inert button/binding that silently does nothing
-      // when invoked (#10565). An `actionId` resolves if it is a built-in action
-      // or lives in the plugin's own namespace — the latter is either declared in
-      // `contributes.commands` (namespaced `{name}.{id}` at load) or registered
-      // imperatively via `host.registerAction`, which is invisible at parse time,
-      // so we gate on namespace ownership rather than command membership. A
-      // reference into a foreign namespace can never resolve and is rejected.
+      // context menus) must resolve to a real, dispatchable action at runtime,
+      // else the contribution paints an inert button/binding that silently does
+      // nothing when invoked (#10565, #10580). The resolution rules, in order:
+      //
+      //  1. A built-in flagged `denyPluginDispatch: true` is rejected outright —
+      //     the host refuses plugin dispatch for it, so the button is dead even
+      //     though the id exists (#10580). This precedes the allowlist check
+      //     because these ids ARE in `BUILT_IN_ACTION_ID_SET`.
+      //  2. Any other built-in action id resolves.
+      //  3. An id in the plugin's own namespace is cross-checked against the
+      //     declared `contributes.commands` (namespaced `{name}.{id}` at load).
+      //     If commands are declared, an own-namespace id that matches none of
+      //     them is a typo for a command that will never exist, so it is rejected
+      //     (#10580). If NO commands are declared, the plugin registers actions
+      //     imperatively via `host.registerAction` (invisible at parse time), so
+      //     any own-namespace id is allowed — the imperative escape hatch.
+      //  4. A reference into a foreign namespace can never resolve and is rejected.
       const ownNamespacePrefix = `${manifest.name}.`;
+      const declaredCommandActionIds = new Set(
+        manifest.contributes.commands.map((cmd) => `${manifest.name}.${cmd.id}`)
+      );
       const actionIdContributions = [
         ["toolbarButtons", manifest.contributes.toolbarButtons],
         ["menuItems", manifest.contributes.menuItems],
@@ -914,12 +934,39 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
       for (const [arrayName, entries] of actionIdContributions) {
         entries.forEach((entry, index) => {
           const { actionId } = entry;
-          if (BUILT_IN_ACTION_ID_SET.has(actionId) || actionId.startsWith(ownNamespacePrefix)) {
+          const issuePath = ["contributes", arrayName, index, "actionId"] as const;
+
+          if (DENY_PLUGIN_DISPATCH_SET.has(actionId)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: [...issuePath],
+              message: `Contributed actionId "${actionId}" is a built-in action closed to plugin dispatch — the host refuses it at runtime, so the contribution can never fire.`,
+              params: { errorCode: "action_id_plugin_dispatch_denied" },
+            });
             return;
           }
+
+          if (BUILT_IN_ACTION_ID_SET.has(actionId)) {
+            return;
+          }
+
+          if (actionId.startsWith(ownNamespacePrefix)) {
+            // Cross-check own-namespace ids against declared commands only when
+            // commands exist; an empty set means the plugin is fully imperative.
+            if (declaredCommandActionIds.size > 0 && !declaredCommandActionIds.has(actionId)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: [...issuePath],
+                message: `Contributed actionId "${actionId}" is in this plugin's "${manifest.name}" namespace but matches no entry in contributes.commands — likely a typo for a declared command.`,
+                params: { errorCode: "action_id_undeclared_command" },
+              });
+            }
+            return;
+          }
+
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            path: ["contributes", arrayName, index, "actionId"],
+            path: [...issuePath],
             message: `Contributed actionId "${actionId}" does not reference a built-in action or an action in this plugin's "${manifest.name}" namespace — it can never resolve.`,
             params: { errorCode: "action_id_unknown_namespace" },
           });

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -385,9 +385,9 @@ describe("PluginService integration — panel contributions", () => {
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#abc" }],
         toolbarButtons: [
-          { id: "btn", label: "B", iconId: "i", actionId: "real-plugin.act", priority: 2 },
+          { id: "btn", label: "B", iconId: "i", actionId: "acme.real-plugin.act", priority: 2 },
         ],
-        menuItems: [{ label: "M", actionId: "real-plugin.act", location: "view" }],
+        menuItems: [{ label: "M", actionId: "acme.real-plugin.act", location: "view" }],
       },
     });
 
@@ -417,7 +417,7 @@ describe("PluginService integration — toolbar button contributions", () => {
             id: "my-btn",
             label: "My Button",
             iconId: "puzzle",
-            actionId: "toolbar-plugin.doThing",
+            actionId: "acme.toolbar-plugin.doThing",
             priority: 4,
           },
         ],
@@ -433,7 +433,7 @@ describe("PluginService integration — toolbar button contributions", () => {
       id: "acme.toolbar-plugin.my-btn",
       label: "My Button",
       iconId: "puzzle",
-      actionId: "toolbar-plugin.doThing",
+      actionId: "acme.toolbar-plugin.doThing",
       priority: 4,
       pluginId: "acme.toolbar-plugin",
     });
@@ -449,7 +449,7 @@ describe("PluginService integration — toolbar button contributions", () => {
             id: "btn",
             label: "Btn",
             iconId: "icon",
-            actionId: "default-prio.action",
+            actionId: "acme.default-prio.action",
           },
         ],
       },
@@ -471,7 +471,7 @@ describe("PluginService integration — menu item contributions", () => {
         menuItems: [
           {
             label: "Do Something",
-            actionId: "menu-plugin.doSomething",
+            actionId: "acme.menu-plugin.doSomething",
             location: "terminal",
           },
         ],
@@ -487,7 +487,7 @@ describe("PluginService integration — menu item contributions", () => {
       pluginId: "acme.menu-plugin",
       item: {
         label: "Do Something",
-        actionId: "menu-plugin.doSomething",
+        actionId: "acme.menu-plugin.doSomething",
         location: "terminal",
       },
     });
@@ -964,8 +964,8 @@ describe("PluginService integration — main entry execution", () => {
         main: mainFile,
         contributes: {
           panels: [{ id: "p", name: "P", iconId: "i", color: "#000" }],
-          toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "bad-main.a" }],
-          menuItems: [{ label: "M", actionId: "bad-main.a", location: "view" }],
+          toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "acme.bad-main.a" }],
+          menuItems: [{ label: "M", actionId: "acme.bad-main.a", location: "view" }],
         },
       })
     );
@@ -1328,9 +1328,9 @@ describe("PluginService integration — full contribution fan-out", () => {
         contributes: {
           panels: [{ id: "v", name: "V", iconId: "eye", color: "#abc" }],
           toolbarButtons: [
-            { id: "b", label: "B", iconId: "i", actionId: "all-in-one.act", priority: 2 },
+            { id: "b", label: "B", iconId: "i", actionId: "acme.all-in-one.act", priority: 2 },
           ],
-          menuItems: [{ label: "M", actionId: "all-in-one.act", location: "view" }],
+          menuItems: [{ label: "M", actionId: "acme.all-in-one.act", location: "view" }],
         },
       })
     );
@@ -1343,7 +1343,7 @@ describe("PluginService integration — full contribution fan-out", () => {
     expect(getPluginMenuItems()).toEqual([
       {
         pluginId: "acme.all-in-one",
-        item: { label: "M", actionId: "all-in-one.act", location: "view" },
+        item: { label: "M", actionId: "acme.all-in-one.act", location: "view" },
       },
     ]);
     expect(readMarker(markerKey)).toBe(1);

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -454,3 +454,19 @@ export const BUILT_IN_ACTION_IDS = [
 ] as const;
 
 export type BuiltInRuntimeActionId = (typeof BUILT_IN_ACTION_IDS)[number];
+
+// Built-in actions flagged `denyPluginDispatch: true` (terminal input injection,
+// fleet command relays) can never be dispatched from a plugin contribution — the
+// host refuses the dispatch at runtime. A contribution wired to one of these
+// paints a button that is dead on arrival, so the manifest validator rejects it
+// at authoring time. `satisfies readonly BuiltInRuntimeActionId[]` is a
+// compile-time drift guard: renaming or removing any of these built-ins breaks
+// the build instead of silently leaving a stale entry here (#8341).
+export const DENY_PLUGIN_DISPATCH_ACTION_IDS = [
+  "terminal.sendCommand",
+  "terminal.paste",
+  "fleet.accept",
+  "fleet.reject",
+  "fleet.interrupt",
+  "fleet.retryFailures",
+] as const satisfies readonly BuiltInRuntimeActionId[];

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -4,7 +4,7 @@ import { setCurrentViewStore } from "@/store/createWorktreeStore";
 import type { WorktreeViewStore, WorktreeViewStoreApi } from "@/store/createWorktreeStore";
 import type { WorktreeSnapshot } from "@shared/types";
 import { KEY_ACTION_VALUES } from "@shared/types/keymap";
-import { BUILT_IN_ACTION_IDS } from "@shared/config/actionIds";
+import { BUILT_IN_ACTION_IDS, DENY_PLUGIN_DISPATCH_ACTION_IDS } from "@shared/config/actionIds";
 import type { ActionId } from "@shared/types/actions";
 import type { ActionRegistry, ActionCallbacks } from "../actionTypes";
 import { DEFAULT_KEYBINDINGS } from "../../defaultKeybindings";
@@ -546,20 +546,32 @@ describe("destructive-action danger metadata", () => {
 /**
  * Built-in actions that inject text/keystrokes into terminals and therefore must
  * be closed to plugin `host.dispatch` (#10558) — plugins inject only through the
- * `agent:input`-gated `host.sendToActiveAgent`. If a new terminal-writing action
- * is added without `denyPluginDispatch`, add it here AND set the flag, or the
- * capability gate has a fresh side door.
+ * `agent:input`-gated `host.sendToActiveAgent`. The single source of truth is
+ * `DENY_PLUGIN_DISPATCH_ACTION_IDS` in `shared/config/actionIds.ts`, which the
+ * plugin manifest validator (#10580) also consumes; the completeness guard below
+ * asserts it stays in lockstep with the registry's `denyPluginDispatch: true`
+ * flags so a new injection action can't silently bypass either gate.
  */
-const PLUGIN_DENIED_INJECTION_ACTIONS: ReadonlyArray<ActionId> = [
-  "terminal.sendCommand",
-  "terminal.paste",
-  "fleet.accept",
-  "fleet.reject",
-  "fleet.interrupt",
-  "fleet.retryFailures",
-] as unknown as ActionId[];
+const PLUGIN_DENIED_INJECTION_ACTIONS: ReadonlyArray<ActionId> =
+  DENY_PLUGIN_DISPATCH_ACTION_IDS as unknown as ActionId[];
 
 describe("plugin-dispatch injection guard (#10558)", () => {
+  it("DENY_PLUGIN_DISPATCH_ACTION_IDS exactly matches the registry's denyPluginDispatch flags", async () => {
+    // `satisfies readonly BuiltInRuntimeActionId[]` on the constant only catches
+    // renames/removals — a newly-flagged action omitted from the list would slip
+    // through. This is the completeness guard (#10580, lesson #8341): the exported
+    // deny-list and the actual `denyPluginDispatch: true` definitions must be the
+    // same set, or both the runtime dispatch gate and the manifest validator drift.
+    const { registry } = await createRegistryWithAudit();
+    const flaggedInRegistry = new Set<string>();
+    for (const [id, factory] of registry) {
+      if (factory().denyPluginDispatch === true) {
+        flaggedInRegistry.add(id);
+      }
+    }
+    expect([...flaggedInRegistry].sort()).toEqual([...DENY_PLUGIN_DISPATCH_ACTION_IDS].sort());
+  });
+
   it("rejects plugin-source dispatch with RESTRICTED for every injection action", async () => {
     const { ActionService } = await import("../../ActionService");
     const { registry } = await createRegistryWithAudit();


### PR DESCRIPTION
## Summary

- The manifest validator accepted any `actionId` within a plugin's own namespace via a `startsWith(prefix)` check, so a typo like `demo.x.openInBrowswer` (with no matching `contributes.commands[]` entry) passed validation and shipped a dead button.
- This PR cross-checks own-namespace `actionId` references against the plugin's declared `contributes.commands[]` entries, catching typos at validation time. The imperative `host.registerAction` escape hatch is preserved: when no commands are declared, any own-namespace ID is still allowed since imperative registration is invisible at parse time.
- Also blocks contributions wired to built-in actions flagged `denyPluginDispatch: true` (`terminal.sendCommand`, `terminal.paste`, `fleet.accept`, `fleet.reject`, `fleet.interrupt`, `fleet.retryFailures`) which the host refuses at runtime anyway.

Resolves #10580

## Changes

- `shared/config/actionIds.ts`: new `DENY_PLUGIN_DISPATCH_ACTION_IDS` export, typed `as const satisfies readonly BuiltInRuntimeActionId[]` for compile-time drift detection.
- `electron/schemas/plugin.ts`: in the existing `superRefine` contribution loop, added a deny-list check (emitting `action_id_plugin_dispatch_denied`) and an own-namespace cross-check against declared commands (emitting `action_id_undeclared_command`, gated on `commands.length > 0`).
- `electron/schemas/__tests__/actionIdContribution.test.ts`: updated the old own-namespace-typo test to reflect the escape hatch vs the new rejection; added tests for matching declared command, typo across all 4 contribution kinds, every deny-list ID, explicit empty commands array, and mixed error codes in one manifest.
- `electron/services/__tests__/PluginService.integration.test.ts`: migrated 6 fixtures to fully-qualified own-namespace `actionId`s (the #10565 gate already required this; fixtures were left unmigrated).
- `src/services/actions/__tests__/actionDefinitions.quality.test.ts`: made `DENY_PLUGIN_DISPATCH_ACTION_IDS` the single source of truth for the injection-guard test and added a completeness drift guard asserting it exactly matches the registry's `denyPluginDispatch: true` flags.

## Testing

Unit and quality tests: 52 pass (`vitest`, default config). Integration tests: 43 pass (`vitest` integration config) with 1 pre-existing unrelated failure on `develop` ("diagnostic logger keeps per-plugin log buffers isolated" — log-buffer isolation, untouched by this PR). Integration tests are excluded from the default vitest run and there is no integration-test step in PR CI (`ci.yml` runs unit + smoke only).