### PR TITLE
fix(plugins): resolve settings.get scope from manifest declaration

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2729,15 +2729,25 @@ export class PluginService {
       settings: {
         get: async <T = unknown>(
           key: string,
-          scope: PluginSettingsScope = "user"
+          scope?: PluginSettingsScope
         ): Promise<T | undefined> => {
           assertSettingsKey(pluginId, "get", key);
-          const filePath = this.settings.resolveSettingsFilePath(pluginId, scope);
+          // Resolve the manifest-declared scope so a read targets the same scope
+          // the write path enforces — otherwise a `scope: "project"` key read
+          // with no scope arg silently reads the wrong ("user") store (#10586).
+          const declaredScope = this.settings.getDeclaredScope(pluginId, key);
+          if (scope !== undefined && declaredScope !== undefined && declaredScope !== scope) {
+            throw new Error(
+              `Plugin "${pluginId}" settings.get: key "${key}" is declared in "${declaredScope}" scope, not "${scope}"`
+            );
+          }
+          const effectiveScope = declaredScope ?? scope ?? "user";
+          const filePath = this.settings.resolveSettingsFilePath(pluginId, effectiveScope);
           // Project scope with no active project: read resolves to undefined
           // rather than throwing, matching the "unset key" return.
           if (!filePath) return undefined;
           return this.settings
-            .getOrCreateSettingsStore(pluginId, scope, filePath)
+            .getOrCreateSettingsStore(pluginId, effectiveScope, filePath)
             .get<T>(key, { secret: this.settings.isSecretKey(pluginId, key) });
         },
         set: async <T = unknown>(

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -8889,15 +8889,15 @@ type SettingsHostShape = (pluginId: string) => {
 };
 
 async function setupSettingsService(
-  pluginId: string
+  pluginId: string,
+  settings?: Array<{ id: string; type: string; scope?: SettingsScope }>
 ): Promise<{ service: PluginService; settingsRoot: string }> {
   const pluginsRoot = path.join(tmpDir, "plugins");
   const dir = path.join(pluginsRoot, pluginId);
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(
-    path.join(dir, "plugin.json"),
-    JSON.stringify({ name: pluginId, version: "1.0.0" })
-  );
+  const manifest: Record<string, unknown> = { name: pluginId, version: "1.0.0" };
+  if (settings) manifest.contributes = { settings };
+  await fs.writeFile(path.join(dir, "plugin.json"), JSON.stringify(manifest));
   const service = new PluginService(pluginsRoot);
   await service.initialize();
   // User-scope settings live as a sibling of the plugins dir.
@@ -9057,6 +9057,64 @@ describe("createHost — settings", () => {
     expect(() => host.settings.onDidChange("token", () => {})).toThrow(/host revoked/);
     await expect(host.settings.set("token", "still-works")).resolves.toBeUndefined();
     expect(await host.settings.get<string>("token")).toBe("still-works");
+  });
+
+  // #10586: get must honor a key's manifest-declared scope rather than silently
+  // defaulting to "user", mirroring the set/onDidChange scope guards.
+  it("get resolves a project-scoped declared key from the project store with no scope arg", async () => {
+    const projectDir = path.join(tmpDir, "proj-declared");
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: projectDir });
+    const { service } = await setupSettingsService("acme.settings-declared-proj", [
+      { id: "ref", type: "string", scope: "project" },
+    ]);
+    const { host } = createSettingsHost(service, "acme.settings-declared-proj");
+    // Written to project scope; a no-scope read must resolve there, not "user".
+    await host.settings.set("ref", "branch-x", "project");
+    expect(await host.settings.get<string>("ref")).toBe("branch-x");
+    // The value lives in the project file — proving the read didn't fall back to
+    // the (empty) user store.
+    const raw = await fs.readFile(
+      path.join(projectDir, ".daintree", "plugin-settings", "acme.settings-declared-proj.json"),
+      "utf-8"
+    );
+    expect(JSON.parse(raw)).toEqual({ ref: "branch-x" });
+  });
+
+  it("get throws when the explicit scope conflicts with the declared scope", async () => {
+    const projectDir = path.join(tmpDir, "proj-conflict");
+    projectStoreMock.getCurrentProject.mockReturnValue({ path: projectDir });
+    const { service } = await setupSettingsService("acme.settings-declared-conflict", [
+      { id: "ref", type: "string", scope: "project" },
+    ]);
+    const { host } = createSettingsHost(service, "acme.settings-declared-conflict");
+    await expect(host.settings.get("ref", "user")).rejects.toThrow(
+      /settings\.get: key "ref" is declared in "project" scope, not "user"/
+    );
+  });
+
+  it("get falls back to user scope for an undeclared key", async () => {
+    const { service, settingsRoot } = await setupSettingsService("acme.settings-undeclared", [
+      { id: "declared", type: "string", scope: "user" },
+    ]);
+    const { host } = createSettingsHost(service, "acme.settings-undeclared");
+    // "loose" isn't declared, so a write would be rejected — seed the user-scope
+    // file directly to prove the read still resolves the permissive "user"
+    // default for undeclared keys.
+    await fs.mkdir(settingsRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(settingsRoot, "acme.settings-undeclared.json"),
+      JSON.stringify({ loose: "v" })
+    );
+    expect(await host.settings.get<string>("loose")).toBe("v");
+  });
+
+  it("get resolves a user-declared key from the user store with no scope arg", async () => {
+    const { service } = await setupSettingsService("acme.settings-declared-user", [
+      { id: "token", type: "string", scope: "user" },
+    ]);
+    const { host } = createSettingsHost(service, "acme.settings-declared-user");
+    await host.settings.set("token", "sk-1", "user");
+    expect(await host.settings.get<string>("token")).toBe("sk-1");
   });
 });
 

--- a/electron/services/__tests__/PluginSettingsManager.scope.test.ts
+++ b/electron/services/__tests__/PluginSettingsManager.scope.test.ts
@@ -96,6 +96,20 @@ describe("PluginSettingsManager declared-scope enforcement", () => {
     expect(() => mgr.assertSettingScope("acme.scope-test", "other", "user")).not.toThrow();
   });
 
+  it("getDeclaredScope resolves the declared scope, defaulting to user, and undefined for undeclared keys (#10586)", () => {
+    const mgr = managerFor([
+      { id: "ref", type: "string", scope: "project" },
+      { id: "token", type: "string", scope: "user" },
+      { id: "implicit", type: "string" },
+    ]);
+    expect(mgr.getDeclaredScope("acme.scope-test", "ref")).toBe("project");
+    expect(mgr.getDeclaredScope("acme.scope-test", "token")).toBe("user");
+    // No explicit scope on the declaration defaults to "user".
+    expect(mgr.getDeclaredScope("acme.scope-test", "implicit")).toBe("user");
+    // Undeclared key — undefined so the read path keeps its permissive fallback.
+    expect(mgr.getDeclaredScope("acme.scope-test", "missing")).toBeUndefined();
+  });
+
   it("accepts any key when contributes.settings is an empty array", () => {
     const mgr = managerFor([]);
     expect(() => mgr.assertSettingDeclared("acme.scope-test", "anything", "project")).not.toThrow();

--- a/electron/services/plugin/PluginSettingsManager.ts
+++ b/electron/services/plugin/PluginSettingsManager.ts
@@ -141,6 +141,19 @@ export class PluginSettingsManager {
   }
 
   /**
+   * Resolve the manifest-declared scope for a key so the read path (`settings.get`)
+   * can target the same scope the write path enforces via {@link assertSettingDeclared}.
+   * Returns the declared scope (default `"user"`) when the key is declared, or
+   * `undefined` when the manifest declares no settings or doesn't declare this key —
+   * the same permissive fallback the write/secret guards take, so reads of undeclared
+   * keys keep working against the caller-supplied (or `"user"`) scope.
+   */
+  getDeclaredScope(pluginId: string, key: string): PluginSettingsScope | undefined {
+    const def = this.deps.getManifest(pluginId)?.contributes.settings?.find((s) => s.id === key);
+    return def ? (def.scope ?? "user") : undefined;
+  }
+
+  /**
    * Both settings write paths (host `settings.set` and the UI bridge) persist
    * through `PluginSettingsStore.cloneValue`, which JSON-round-trips the value.
    * Probe serializability up front so a non-serializable value surfaces a clear

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -359,6 +359,36 @@ describe("PluginDevWorkerMainBridge", () => {
     expect(delReply).toMatchObject({ ok: true, result: undefined });
   });
 
+  // #10586: an omitted scope must reach the real host as `undefined` (not a
+  // defaulted "user") so the host resolves the key's manifest-declared scope. A
+  // forwarded "user" would make the host reject a project-scoped key.
+  it("forwards settings.get with an omitted scope as undefined", async () => {
+    const { host, workerHost } = makeBridge();
+    host.settings.get.mockResolvedValueOnce("project-value");
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "sgu",
+      method: "settings.get",
+      params: { key: "ref" },
+    });
+    await flush();
+    expect(host.settings.get).toHaveBeenCalledWith("ref", undefined);
+    const reply = workerHost.sent.find((m) => m.type === "host-result" && m.requestId === "sgu");
+    expect(reply).toMatchObject({ ok: true, result: "project-value" });
+  });
+
+  it("forwards an explicit settings.get scope unchanged", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-call",
+      requestId: "sge",
+      method: "settings.get",
+      params: { key: "ref", scope: "project" },
+    });
+    await flush();
+    expect(host.settings.get).toHaveBeenCalledWith("ref", "project");
+  });
+
   it("opens a storage subscription and pushes events to the worker", async () => {
     const { host, workerHost } = makeBridge();
     let emit: ((v: unknown) => void) | undefined;

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -41,7 +41,9 @@ function makeHost() {
     },
     logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     settings: {
-      get: vi.fn(async () => undefined),
+      // Annotated `Promise<unknown>` so a test can `mockResolvedValueOnce` a
+      // concrete value (the default-inferred `Promise<undefined>` would reject it).
+      get: vi.fn(async (): Promise<unknown> => undefined),
       set: vi.fn(async () => {}),
       onDidChange: vi.fn(() => vi.fn()),
     },

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -643,7 +643,11 @@ export class PluginDevWorkerHostProxy {
         readText: () => this.call<string>("clipboard.readText", undefined),
       },
       settings: {
-        get: <T = unknown>(key: string, scope: PluginSettingsScope = "user") =>
+        // Forward an omitted scope as `undefined` (not a defaulted "user") so the
+        // real host resolves the key's manifest-declared scope on read (#10586) —
+        // defaulting here would send an explicit "user" that a project-scoped key
+        // rejects.
+        get: <T = unknown>(key: string, scope?: PluginSettingsScope) =>
           this.call<T | undefined>("settings.get", { key, scope }),
         set: <T = unknown>(key: string, value: T, scope: PluginSettingsScope = "user") =>
           this.call<void>("settings.set", { key, value, scope }),

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -587,6 +587,45 @@ describe("createMockHost", () => {
       expect(user).not.toHaveBeenCalledWith("pv");
       expect(project).toHaveBeenCalledWith("pv");
     });
+
+    // #10586: loose mode (no manifestSettings) keeps the silent "user" default;
+    // manifest-aware mode resolves a key's declared scope on read.
+    it("loose mode reads the user scope by default regardless of where a value is seeded", async () => {
+      const host = createMockHost({
+        settings: { user: {}, project: { ref: "from-project" } },
+      });
+      // No manifestSettings → a no-scope read targets "user", which is empty here.
+      expect(await host.settings.get("ref")).toBeUndefined();
+      expect(await host.settings.get("ref", "project")).toBe("from-project");
+    });
+
+    it("manifest-aware mode resolves a project-scoped key on a no-scope read", async () => {
+      const host = createMockHost({
+        settings: { project: { ref: "from-project" } },
+        manifestSettings: [{ id: "ref", type: "string", scope: "project" }],
+      });
+      expect(await host.settings.get<string>("ref")).toBe("from-project");
+    });
+
+    it("manifest-aware mode throws when the explicit scope conflicts with the declaration", async () => {
+      const host = createMockHost({
+        settings: { project: { ref: "from-project" } },
+        manifestSettings: [{ id: "ref", type: "string", scope: "project" }],
+      });
+      await expect(host.settings.get("ref", "user")).rejects.toThrow(
+        /settings\.get: key "ref" is declared in "project" scope, not "user"/
+      );
+    });
+
+    it("manifest-aware mode falls back to the caller scope for an undeclared key", async () => {
+      const host = createMockHost({
+        settings: { user: { loose: "u" }, project: { loose: "p" } },
+        manifestSettings: [{ id: "ref", type: "string", scope: "project" }],
+      });
+      // "loose" isn't declared, so it keeps the supplied (or default) scope.
+      expect(await host.settings.get("loose")).toBe("u");
+      expect(await host.settings.get("loose", "project")).toBe("p");
+    });
   });
 
   describe("dispatch", () => {

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -32,6 +32,7 @@ import type {
   PluginWorktreeSnapshot,
   PluginAgentSnapshot,
   PluginGitCommitResult,
+  SettingDefinition,
   SettingsApi,
   StorageApi,
 } from "../types/plugin.js";
@@ -154,6 +155,15 @@ export interface CreateMockHostOptions {
     user?: Record<string, unknown>;
     project?: Record<string, unknown>;
   };
+  /**
+   * Opt-in `contributes.settings` declarations (`id` + `scope` are what matter)
+   * so the mock's `settings.get` resolves a key's declared scope the way the real
+   * host does (#10586): a `scope: "project"` key reads from the project store when
+   * no scope arg is given, and an explicit conflicting scope throws. Omitted by
+   * default — the mock has no manifest model (#9878), so loose mode keeps the
+   * `scope ?? "user"` default and existing manifest-free tests are unaffected.
+   */
+  manifestSettings?: SettingDefinition[];
   /** Pre-seed private `host.storage` values per scope. */
   storage?: {
     user?: Record<string, unknown>;
@@ -232,12 +242,27 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
 
   const dispatchOverrides = new Map<ActionId, ActionDispatchResult>();
 
+  // Resolve the declared scope for a key from the opt-in `manifestSettings`,
+  // mirroring PluginSettingsManager.getDeclaredScope. Returns undefined when no
+  // declarations are provided (loose mode) or the key is undeclared.
+  const getDeclaredSettingScope = (key: string): PluginSettingsScope | undefined => {
+    const def = options.manifestSettings?.find((s) => s.id === key);
+    return def ? ((def.scope ?? "user") as PluginSettingsScope) : undefined;
+  };
+
   const settings: SettingsApi = {
-    async get<T = unknown>(
-      key: string,
-      scope: PluginSettingsScope = "user"
-    ): Promise<T | undefined> {
-      return settingsStore[scope].get(key) as T | undefined;
+    async get<T = unknown>(key: string, scope?: PluginSettingsScope): Promise<T | undefined> {
+      // Manifest-aware mode: a declared key resolves to its declared scope, and an
+      // explicit conflicting scope throws — matching the real host (#10586). Loose
+      // mode (no manifestSettings) keeps the `scope ?? "user"` default.
+      const declaredScope = getDeclaredSettingScope(key);
+      if (scope !== undefined && declaredScope !== undefined && declaredScope !== scope) {
+        throw new Error(
+          `settings.get: key "${key}" is declared in "${declaredScope}" scope, not "${scope}"`
+        );
+      }
+      const effectiveScope = declaredScope ?? scope ?? "user";
+      return settingsStore[effectiveScope].get(key) as T | undefined;
     },
     async set<T = unknown>(
       key: string,

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -519,6 +519,12 @@ export interface SettingsApi {
   /**
    * Read a setting. Resolves to `undefined` when the key is unset, or (for
    * `"project"` scope) when no project is active.
+   *
+   * When the key is declared in `contributes.settings`, its declared `scope`
+   * (default `"user"`) is authoritative: omitting `scope` reads from the declared
+   * scope, and passing a `scope` that conflicts with the declaration throws — the
+   * read counterpart to the `set`/`onDidChange` scope guards. Undeclared keys (or
+   * manifests with no declarations) fall back to the supplied `scope` or `"user"`.
    */
   get<T = unknown>(key: string, scope?: PluginSettingsScope): Promise<T | undefined>;
   /**

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -273,7 +273,12 @@ export interface LoggerParams {
 /** Params for `settings.get` (`host-call`). */
 export interface SettingsGetParams {
   key: string;
-  scope: PluginSettingsScope;
+  /**
+   * Omitted (`undefined`) when the plugin passed no scope, so the host resolves
+   * the key's manifest-declared scope on read (#10586) rather than a defaulted
+   * "user" that a project-scoped key would reject.
+   */
+  scope?: PluginSettingsScope;
 }
 
 /** Params for `settings.set` (`host-call`). */


### PR DESCRIPTION
## Summary

- `settings.get` always defaulted to the `"user"` scope, so a setting declared `scope: "project"` in the manifest was silently read from the wrong store — no error, just a wrong-scope miss
- Now resolves the declared scope when no scope arg is passed, and throws when an explicit scope conflicts with the declaration — read-side parity with the existing `set`/`onDidChange` guards
- Fixed the dev-worker host proxy and bridge to forward an omitted scope as `undefined` rather than defaulting to `"user"`, so dev-worker plugins resolve correctly too

Resolves #10586

## Changes

- `PluginSettingsManager.getDeclaredScope` — shared scope authority; consulted on reads, replacing the unconditional `"user"` default
- `PluginService`: `settings.get` handler resolves declared scope; throws on explicit scope/declaration conflict
- `pluginDevWorkerHostProxy` + `PluginDevWorkerMainBridge`: omitted scope forwarded as `undefined` instead of `"user"` (and `SettingsGetParams` updated to match)
- `createMockHost`: opt-in `manifestSettings` parameter for scope-aware reads in tests; loose mode (no manifest) keeps the `"user"` default unchanged
- Undeclared keys keep the permissive `"user"` fallback — no regressions for manifests that don't declare scope

## Testing

Tests added across four files: `PluginSettingsManager.scope.test.ts`, `PluginService.test.ts`, `createMockHost.test.ts`, and `PluginDevWorkerMainBridge.test.ts`. Audited all first-party plugins — none call `settings.get` with an explicit scope, so no first-party regressions.