### PR TITLE
feat(plugins): add host.setPanelBadge for live panel-chrome status

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -64,6 +64,8 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:context-menu-items-changed": "external",
   "plugin:agents-changed": "external",
   "plugin:decorations-changed": "external",
+  "plugin:panel-badges-changed": "external",
+  "plugin:panel-badges-cleared": "external",
   "plugin:provenance-changed": "external",
   "run-history:update": "external",
   "plugin:deep-link": "external",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -147,6 +147,7 @@ import type {
   PluginKeybindingDescriptor,
   ContextMenuContribution,
   PluginDeepLinkIntent,
+  PluginPanelBadge,
 } from "../shared/types/plugin.js";
 import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
 import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
@@ -2653,6 +2654,11 @@ function buildElectronApi(): ElectronAPI {
       ) => _eventBusOn("plugin:context-menu-items-changed", callback),
       onDecorationsChanged: (callback: (payload: { scope: string; paths?: string[] }) => void) =>
         _eventBusOn("plugin:decorations-changed", callback),
+      onPanelBadgesChanged: (
+        callback: (payload: { pluginId: string; badges: Record<string, PluginPanelBadge> }) => void
+      ) => _eventBusOn("plugin:panel-badges-changed", callback),
+      onPanelBadgesCleared: (callback: (payload: { pluginId: string }) => void) =>
+        _eventBusOn("plugin:panel-badges-cleared", callback),
       onDeepLink: (callback: (intent: PluginDeepLinkIntent) => void) =>
         _eventBusOn("plugin:deep-link", callback),
     },

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -2,7 +2,11 @@ import path from "node:path";
 import ipaddr from "ipaddr.js";
 import * as semver from "semver";
 import { z } from "zod";
-import { BUILT_IN_PLUGIN_CAPABILITIES, PLUGIN_CATEGORY_IDS } from "../../shared/types/plugin.js";
+import {
+  BUILT_IN_PLUGIN_CAPABILITIES,
+  PLUGIN_CATEGORY_IDS,
+  PLUGIN_PANEL_BADGE_LABEL_MAX,
+} from "../../shared/types/plugin.js";
 import { isBuiltInAgentId } from "../../shared/config/agentIds.js";
 import {
   BUILT_IN_ACTION_IDS,
@@ -693,6 +697,35 @@ export const PluginToastOptionsSchema = z
     durationMs: z.number().int().positive().max(60_000).optional(),
   })
   .strict();
+
+const PluginPanelBadgeColorSchema = z.enum(["default", "success", "warning", "error"]);
+const PluginPanelBadgeTooltipSchema = z.string().trim().min(1).max(200).optional();
+
+/**
+ * Validates a `host.setPanelBadge` badge at the host boundary. Discriminated on
+ * `kind`; the `label` text is rejected (not truncated) past
+ * {@link PLUGIN_PANEL_BADGE_LABEL_MAX} characters so it can't overflow the
+ * panel header — consistent with the reject-on-overflow convention of the other
+ * length-capped strings in this file. `null` (clear) is handled at the call
+ * site, not here.
+ */
+export const PluginPanelBadgeSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("dot"),
+      color: PluginPanelBadgeColorSchema.optional(),
+      tooltip: PluginPanelBadgeTooltipSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("label"),
+      text: z.string().trim().min(1).max(PLUGIN_PANEL_BADGE_LABEL_MAX),
+      color: PluginPanelBadgeColorSchema.optional(),
+      tooltip: PluginPanelBadgeTooltipSchema,
+    })
+    .strict(),
+]);
 
 /**
  * One `contributes.settings` field declaration (#9301). `type` is optional

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -30,6 +30,7 @@ interface AjvInstance {
 import {
   DEPRECATED_CONTRIBUTION_ALIASES,
   getPluginManifestSchema,
+  PluginPanelBadgeSchema,
   PluginToastOptionsSchema,
   SCOPED_PLUGIN_NAME_PATTERN,
 } from "../schemas/plugin.js";
@@ -79,6 +80,7 @@ import type {
   PluginGitStatus,
   PluginGitCommitOptions,
   PluginGitCommitResult,
+  PluginPanelBadge,
   ViewContribution,
 } from "../../shared/types/plugin.js";
 import { PluginInstalledRecordsStore } from "./plugin/PluginInstalledRecordsStore.js";
@@ -568,6 +570,16 @@ interface ExpandedFsPath {
 
 export class PluginService {
   private plugins = new Map<string, LoadedPlugin>();
+  /**
+   * Live panel badges set via `host.setPanelBadge`, keyed `pluginId → panelId →
+   * badge` (#10585). Plugin-first so {@link unloadPlugin} drops a plugin's whole
+   * set in O(1), and {@link pushSnapshotTo} can replay each plugin's current
+   * badges to a cold-restored WebContentsView (badges are ephemeral, not
+   * persisted, so without replay an LRU-evicted view loses them until the plugin
+   * next re-emits). The renderer store inverts this to `panelId → pluginId` for
+   * O(1) lookup at render time.
+   */
+  private pluginBadges = new Map<string, Map<string, PluginPanelBadge>>();
   /**
    * Per-plugin diagnostic log ring buffer, keyed by `pluginId` (= manifest
    * name). Written by `host.logger.*`, capped at {@link PLUGIN_LOG_BUFFER_MAX}
@@ -2577,6 +2589,46 @@ export class PluginService {
         return Promise.resolve();
       },
       // NOT revoke-guarded for the same reason as invalidateFileDecorations:
+      // plugins set badges from post-activation worktree/agent subscription
+      // callbacks. Liveness is plugin membership, so it no-ops once unloaded
+      // (unloadPlugin clears the plugin's whole badge set).
+      setPanelBadge: (panelId, badge) => {
+        if (!this.plugins.has(pluginId)) return Promise.resolve();
+        if (typeof panelId !== "string" || panelId.length === 0) {
+          throw new Error(`Plugin "${pluginId}" setPanelBadge: panelId must be a non-empty string`);
+        }
+        let validated: PluginPanelBadge | null = null;
+        if (badge !== null && badge !== undefined) {
+          const parsed = PluginPanelBadgeSchema.safeParse(badge);
+          if (!parsed.success) {
+            throw new Error(
+              `Plugin "${pluginId}" setPanelBadge: invalid badge — ${parsed.error.issues
+                .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+                .join("; ")}`
+            );
+          }
+          validated = parsed.data;
+        }
+        let panelMap = this.pluginBadges.get(pluginId);
+        if (validated === null) {
+          // Clear: drop just this panel's badge; prune the plugin's map when empty.
+          if (!panelMap || !panelMap.has(panelId)) return Promise.resolve();
+          panelMap.delete(panelId);
+          if (panelMap.size === 0) this.pluginBadges.delete(pluginId);
+        } else {
+          if (!panelMap) {
+            panelMap = new Map<string, PluginPanelBadge>();
+            this.pluginBadges.set(pluginId, panelMap);
+          }
+          panelMap.set(panelId, validated);
+        }
+        broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+          name: "plugin:panel-badges-changed",
+          payload: { pluginId, badges: this.serializePluginBadges(pluginId) },
+        });
+        return Promise.resolve();
+      },
+      // NOT revoke-guarded for the same reason as invalidateFileDecorations:
       // plugins fire toasts from post-activation callbacks and timers. Liveness
       // is plugin membership, so it no-ops silently once the plugin unloads.
       showToast: async (options) => {
@@ -4305,6 +4357,18 @@ export class PluginService {
 
     this.plugins.delete(pluginId);
 
+    // Drop any live panel badges this plugin set and tell the renderer to clear
+    // them (#10585). Only broadcast when the plugin actually had badges so an
+    // unload of a non-badging plugin stays silent.
+    if (this.pluginBadges.delete(pluginId)) {
+      runUnloadStep(pluginId, "clearPanelBadges", () => {
+        broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+          name: "plugin:panel-badges-cleared",
+          payload: { pluginId },
+        });
+      });
+    }
+
     if (decorationScopes && decorationScopes.length > 0) {
       runUnloadStep(pluginId, "broadcastDecorationsChanged", () => {
         for (const scope of new Set(decorationScopes)) {
@@ -4315,6 +4379,18 @@ export class PluginService {
         }
       });
     }
+  }
+
+  /**
+   * Flatten one plugin's live badges (`panelId → badge`) into a plain
+   * structured-clone-safe record for the `plugin:panel-badges-changed`
+   * broadcast. Empty when the plugin has no badges (the renderer reads that as
+   * "clear all of this plugin's badges").
+   */
+  private serializePluginBadges(pluginId: string): Record<string, PluginPanelBadge> {
+    const panelMap = this.pluginBadges.get(pluginId);
+    if (!panelMap || panelMap.size === 0) return {};
+    return Object.fromEntries(panelMap);
   }
 
   private flushPluginEventCleanups(pluginId: string): void {
@@ -4842,9 +4918,27 @@ export class PluginService {
    * against this snapshot — replay is authoritative for the target view but
    * conceptually identical to a coalesced "load tick" broadcast, not an
    * unload sweep.
+   *
+   * Panel badges (#10585) are replayed here too — one
+   * `plugin:panel-badges-changed` per badging plugin — so a cold-restored view
+   * recovers live badge state it missed while evicted, rather than waiting for
+   * each plugin to next re-emit from a subscription callback.
    */
-  pushSnapshotTo(webContents: Electron.WebContents): Promise<void> {
-    return this.broadcaster.pushSnapshotTo(webContents);
+  async pushSnapshotTo(webContents: Electron.WebContents): Promise<void> {
+    await this.broadcaster.pushSnapshotTo(webContents);
+    if (webContents.isDestroyed()) return;
+    // Each send is independently guarded against a TOCTOU destroy, matching the
+    // broadcaster's defensive pattern above.
+    for (const pluginId of this.pluginBadges.keys()) {
+      try {
+        webContents.send(CHANNELS.EVENTS_PUSH, {
+          name: "plugin:panel-badges-changed",
+          payload: { pluginId, badges: this.serializePluginBadges(pluginId) },
+        });
+      } catch {
+        // Silently ignore send failures during window initialization/disposal.
+      }
+    }
   }
 }
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -920,6 +920,128 @@ describe("PluginService integration — file decoration provider contributions",
   });
 });
 
+describe("PluginService integration — panel badges (#10585)", () => {
+  interface BadgeHost {
+    setPanelBadge: (
+      panelId: string,
+      badge: { kind: string; text?: string; color?: string } | null
+    ) => void;
+  }
+
+  async function loadBadgeHost(name: string): Promise<{ service: PluginService; host: BadgeHost }> {
+    const pluginDir = await writePlugin(name, { name, version: "1.0.0" });
+    const mainFile = `badge-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, mainFile),
+      `export function activate(host) { globalThis.__badgeHost = host; }\n`
+    );
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({ name, version: "1.0.0", main: mainFile })
+    );
+    const service = new PluginService(tmpDir, "0.0.0");
+    await initializeAndActivate(service);
+    const host = (globalThis as Record<string, unknown>).__badgeHost as BadgeHost;
+    return { service, host };
+  }
+
+  function badgeBroadcasts(eventName: string) {
+    return vi
+      .mocked(broadcastToRenderer)
+      .mock.calls.filter(
+        (c) => c[0] === "events:push" && (c[1] as { name?: string }).name === eventName
+      )
+      .map((c) => (c[1] as { payload: unknown }).payload);
+  }
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).__badgeHost;
+  });
+
+  it("broadcasts the plugin's complete badge map when a badge is set", async () => {
+    const { host } = await loadBadgeHost("acme.badge");
+    vi.mocked(broadcastToRenderer).mockClear();
+
+    host.setPanelBadge("panel-1", { kind: "label", text: "CI", color: "success" });
+
+    const payloads = badgeBroadcasts("plugin:panel-badges-changed");
+    expect(payloads).toContainEqual({
+      pluginId: "acme.badge",
+      badges: { "panel-1": { kind: "label", text: "CI", color: "success" } },
+    });
+  });
+
+  it("accumulates badges across panels and clears one with null", async () => {
+    const { host } = await loadBadgeHost("acme.badge2");
+    host.setPanelBadge("p1", { kind: "dot" });
+    host.setPanelBadge("p2", { kind: "dot", color: "error" });
+    vi.mocked(broadcastToRenderer).mockClear();
+
+    host.setPanelBadge("p1", null); // clear just p1
+
+    const last = badgeBroadcasts("plugin:panel-badges-changed").at(-1) as {
+      badges: Record<string, unknown>;
+    };
+    expect(last.badges).toEqual({ p2: { kind: "dot", color: "error" } });
+  });
+
+  it("rejects an invalid badge shape (label over the length cap) and a bad panelId", async () => {
+    const { host } = await loadBadgeHost("acme.badge3");
+    expect(() => host.setPanelBadge("p1", { kind: "label", text: "TOOLONG" })).toThrow(
+      /invalid badge/
+    );
+    expect(() => host.setPanelBadge("", { kind: "dot" })).toThrow(/non-empty string/);
+  });
+
+  it("broadcasts panel-badges-cleared on unload only when the plugin had badges", async () => {
+    const { service, host } = await loadBadgeHost("acme.badge4");
+    host.setPanelBadge("p1", { kind: "dot" });
+    vi.mocked(broadcastToRenderer).mockClear();
+
+    service.unloadPlugin("acme.badge4");
+
+    expect(badgeBroadcasts("plugin:panel-badges-cleared")).toContainEqual({
+      pluginId: "acme.badge4",
+    });
+  });
+
+  it("does not broadcast panel-badges-cleared when the plugin never set a badge", async () => {
+    const { service } = await loadBadgeHost("acme.badge5");
+    vi.mocked(broadcastToRenderer).mockClear();
+
+    service.unloadPlugin("acme.badge5");
+
+    expect(badgeBroadcasts("plugin:panel-badges-cleared")).toEqual([]);
+  });
+
+  it("setPanelBadge is a silent no-op after the plugin unloads", async () => {
+    const { service, host } = await loadBadgeHost("acme.badge6");
+    service.unloadPlugin("acme.badge6");
+    vi.mocked(broadcastToRenderer).mockClear();
+
+    expect(() => host.setPanelBadge("p1", { kind: "dot" })).not.toThrow();
+    expect(badgeBroadcasts("plugin:panel-badges-changed")).toEqual([]);
+  });
+
+  it("replays current badges to a cold-restored webContents via pushSnapshotTo", async () => {
+    const { service, host } = await loadBadgeHost("acme.badge7");
+    host.setPanelBadge("p1", { kind: "label", text: "2" });
+
+    const sent: Array<{ name: string; payload: unknown }> = [];
+    const fakeWc = {
+      isDestroyed: () => false,
+      send: (_channel: string, evt: { name: string; payload: unknown }) => sent.push(evt),
+    } as unknown as Electron.WebContents;
+
+    await service.pushSnapshotTo(fakeWc);
+
+    expect(sent).toContainEqual({
+      name: "plugin:panel-badges-changed",
+      payload: { pluginId: "acme.badge7", badges: { p1: { kind: "label", text: "2" } } },
+    });
+  });
+});
+
 describe("PluginService integration — main entry execution", () => {
   it("executes a plugin's main entry via dynamic import", async () => {
     const markerKey = makeMarkerKey();

--- a/electron/services/plugin/PluginDevWorkerMainBridge.ts
+++ b/electron/services/plugin/PluginDevWorkerMainBridge.ts
@@ -32,6 +32,7 @@ import type {
   LoggerParams,
   PluginWorkerToHostMessage,
   PostToPanelParams,
+  SetPanelBadgeParams,
   RegisterActionParams,
   RegisterFileDecorationProviderParams,
   RegisterHandlerParams,
@@ -575,6 +576,11 @@ export class PluginDevWorkerMainBridge {
       case "invalidateFileDecorations": {
         const p = params as InvalidateFileDecorationsParams;
         await this.host.invalidateFileDecorations(p.scope, p.paths);
+        return;
+      }
+      case "setPanelBadge": {
+        const p = params as SetPanelBadgeParams;
+        await this.host.setPanelBadge(p.panelId, p.badge);
         return;
       }
       case "registerFileDecorationProvider": {

--- a/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerMainBridge.test.ts
@@ -32,6 +32,7 @@ function makeHost() {
     registerForgeProvider: vi.fn(() => vi.fn()),
     registerFileDecorationProvider: vi.fn(() => vi.fn()),
     invalidateFileDecorations: vi.fn(),
+    setPanelBadge: vi.fn(async () => {}),
     showToast: vi.fn(async () => {}),
     dispatch: vi.fn(async () => ({ ok: true, result: undefined })),
     actions: {
@@ -260,6 +261,32 @@ describe("PluginDevWorkerMainBridge", () => {
       result: "hello world",
     });
     await expect(resultPromise).resolves.toBe("hello world");
+  });
+
+  it("forwards setPanelBadge host-notify to the real host (#10585)", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "setPanelBadge",
+      params: { panelId: "panel-1", badge: { kind: "label", text: "CI", color: "success" } },
+    });
+    await flush();
+    expect(host.setPanelBadge).toHaveBeenCalledWith("panel-1", {
+      kind: "label",
+      text: "CI",
+      color: "success",
+    });
+  });
+
+  it("forwards a null setPanelBadge (clear) host-notify to the real host (#10585)", async () => {
+    const { host, workerHost } = makeBridge();
+    workerHost.emit("worker-message", {
+      type: "host-notify",
+      method: "setPanelBadge",
+      params: { panelId: "panel-1", badge: null },
+    });
+    await flush();
+    expect(host.setPanelBadge).toHaveBeenCalledWith("panel-1", null);
   });
 
   it("fails closed on a typed handler whose required capability is undeclared", async () => {

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -518,6 +518,17 @@ export class PluginDevWorkerHostProxy {
         this.notify("invalidateFileDecorations", { scope, paths });
         return Promise.resolve();
       },
+      // Post-activation-safe sibling of invalidateFileDecorations: forward the
+      // badge fire-and-forget; the real host re-validates the badge shape.
+      setPanelBadge: (panelId, badge) => {
+        if (typeof panelId !== "string" || panelId.length === 0) {
+          throw new Error(
+            `Plugin "${this.pluginId}" setPanelBadge: panelId must be a non-empty string`
+          );
+        }
+        this.notify("setPanelBadge", { panelId, badge: badge ?? null });
+        return Promise.resolve();
+      },
       showToast: (options: PluginToastOptions) =>
         this.call<void>("showToast", {
           message: options?.message,

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -288,6 +288,16 @@ describe("createMockHost", () => {
     ]);
   });
 
+  it("records setPanelBadge calls, normalizing a cleared badge to null", async () => {
+    const host = createMockHost();
+    await host.setPanelBadge("panel-1", { kind: "label", text: "CI", color: "success" });
+    await host.setPanelBadge("panel-1", null);
+    expect(host.setPanelBadgeCalls).toEqual([
+      { panelId: "panel-1", badge: { kind: "label", text: "CI", color: "success" } },
+      { panelId: "panel-1", badge: null },
+    ]);
+  });
+
   it("returns initial worktree snapshots", async () => {
     const host = createMockHost({
       activeWorktree: sampleSnapshot,

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -37,6 +37,7 @@ import type {
   PluginWorktreeSnapshot,
   PluginAgentSnapshot,
   PluginGitCommitResult,
+  PluginPanelBadge,
   SettingDefinition,
   SettingsApi,
   StorageApi,
@@ -101,6 +102,12 @@ export interface InvalidationRecord {
   paths: string[] | undefined;
 }
 
+/** Captured `host.setPanelBadge(panelId, badge)` calls. `null` clears. */
+export interface SetPanelBadgeRecord {
+  panelId: string;
+  badge: PluginPanelBadge | null;
+}
+
 /** Captured `host.fs.writeFile(path, contents)` calls. */
 export interface FsWriteRecord {
   path: string;
@@ -124,6 +131,7 @@ export interface MockHostState {
   readonly registeredForgeProviders: ReadonlyArray<RegisteredForgeProviderRecord>;
   readonly registeredFileDecorationProviders: ReadonlyArray<RegisteredFileDecorationProviderRecord>;
   readonly invalidationCalls: ReadonlyArray<InvalidationRecord>;
+  readonly setPanelBadgeCalls: ReadonlyArray<SetPanelBadgeRecord>;
   readonly spawnCalls: ReadonlyArray<SpawnRecord>;
   readonly fsWriteCalls: ReadonlyArray<FsWriteRecord>;
   readonly gitCommitCalls: ReadonlyArray<GitCommitRecord>;
@@ -230,6 +238,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   const registeredForgeProviders: RegisteredForgeProviderRecord[] = [];
   const registeredFileDecorationProviders: RegisteredFileDecorationProviderRecord[] = [];
   const invalidationCalls: InvalidationRecord[] = [];
+  const setPanelBadgeCalls: SetPanelBadgeRecord[] = [];
   const spawnCalls: SpawnRecord[] = [];
   const fsFiles = new Map<string, string>();
   const fsWriteCalls: FsWriteRecord[] = [];
@@ -698,6 +707,10 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       invalidationCalls.push({ scope, paths });
       return Promise.resolve();
     },
+    setPanelBadge(panelId, badge) {
+      setPanelBadgeCalls.push({ panelId, badge: badge ?? null });
+      return Promise.resolve();
+    },
     async showToast(opts: PluginToastOptions) {
       if (!opts.message) {
         throw new Error("showToast: message must be a non-empty string");
@@ -900,6 +913,7 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     registeredForgeProviders,
     registeredFileDecorationProviders,
     invalidationCalls,
+    setPanelBadgeCalls,
     spawnCalls,
     fsWriteCalls,
     gitCommitCalls,

--- a/shared/types/__tests__/plugin-sdk.test.ts
+++ b/shared/types/__tests__/plugin-sdk.test.ts
@@ -9,6 +9,8 @@ import type {
   PluginActivate,
   PanelContribution,
   ToolbarButtonContribution,
+  PluginPanelBadge,
+  PluginPanelBadgeColor,
   MenuItemContribution,
   MenuItemLocation,
   ViewContribution,
@@ -85,6 +87,8 @@ describe("plugin-sdk boundary", () => {
     it("exports manifest authoring types", () => {
       expectTypeOf<PanelContribution>().toMatchTypeOf<object>();
       expectTypeOf<ToolbarButtonContribution>().toMatchTypeOf<object>();
+      expectTypeOf<PluginPanelBadge>().toMatchTypeOf<object>();
+      expectTypeOf<PluginPanelBadgeColor>().toMatchTypeOf<string>();
       expectTypeOf<MenuItemContribution>().toMatchTypeOf<object>();
       expectTypeOf<MenuItemLocation>().toMatchTypeOf<string>();
       expectTypeOf<ViewContribution>().toMatchTypeOf<object>();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1649,6 +1649,22 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       callback: (payload: { scope: string; paths?: string[] }) => void
     ): () => void;
     /**
+     * Subscribe to plugin panel-badge changes (#10585). The callback fires with
+     * one plugin's COMPLETE current badge map (`panelId → badge`); an empty map
+     * clears that plugin's badges. Returns a cleanup.
+     */
+    onPanelBadgesChanged(
+      callback: (payload: {
+        pluginId: string;
+        badges: Record<string, import("../plugin.js").PluginPanelBadge>;
+      }) => void
+    ): () => void;
+    /**
+     * Subscribe to plugin-unload badge clears (#10585). Fires with the unloaded
+     * plugin's id so the renderer drops all of its panel badges. Returns a cleanup.
+     */
+    onPanelBadgesCleared(callback: (payload: { pluginId: string }) => void): () => void;
+    /**
      * Subscribe to `daintree://` deep-link intents (#9559). Fires when the OS
      * hands the app a deep link; the callback opens the Plugin Manager. Returns
      * a cleanup.

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1874,6 +1874,21 @@ export interface IpcEventMap {
     paths?: string[];
   };
 
+  // Plugin panel-badge state changed (main → renderer, #10585). Carries this
+  // plugin's COMPLETE current badge map (panelId → badge) — never a delta — so
+  // the renderer replaces all of `pluginId`'s badges in one shot. An empty
+  // `badges` clears the plugin's badges. Authoritative per plugin, so no
+  // `complete` flag is needed (each event fully describes one plugin's state).
+  "plugin:panel-badges-changed": {
+    pluginId: string;
+    badges: Record<string, import("../plugin.js").PluginPanelBadge>;
+  };
+
+  // Plugin unloaded — drop all of its panel badges (main → renderer, #10585).
+  "plugin:panel-badges-cleared": {
+    pluginId: string;
+  };
+
   // Plugin provenance record changed (main → renderer). Signal-only — the
   // renderer re-pulls via `plugin:list` for the full data.
   "plugin:provenance-changed": Record<string, never>;
@@ -1995,6 +2010,9 @@ export type IpcEventBusMap = Pick<
   | "plugin:agents-changed"
   // Plugin file-decoration invalidation (global broadcast)
   | "plugin:decorations-changed"
+  // Plugin panel-badge state (global broadcast)
+  | "plugin:panel-badges-changed"
+  | "plugin:panel-badges-cleared"
   // Plugin provenance record changed (global broadcast)
   | "plugin:provenance-changed"
   // Run history changed (global broadcast)

--- a/shared/types/plugin-sdk.ts
+++ b/shared/types/plugin-sdk.ts
@@ -57,6 +57,8 @@ export type {
   PluginHostSubscriptionOptions,
   ActionHandler,
   PluginToastOptions,
+  PluginPanelBadge,
+  PluginPanelBadgeColor,
   PluginQuickPickItem,
   PluginQuickPickOptions,
   PluginInputBoxOptions,

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1735,7 +1735,11 @@ export interface PluginHostApi extends PluginActivationApi {
    * becomes a silent no-op once the plugin is unloaded (all of the plugin's
    * badges are cleared on unload). An invalid `panelId` or badge shape (e.g. a
    * `label` longer than {@link PLUGIN_PANEL_BADGE_LABEL_MAX} characters) rejects
-   * so authoring mistakes surface loudly.
+   * so authoring mistakes surface loudly. (For a dev-mode plugin running in the
+   * hot-reload worker this is fire-and-forget like
+   * {@link invalidateFileDecorations}: a malformed badge shape is logged in the
+   * host rather than rejected back to the `await`, though an empty `panelId` is
+   * still rejected synchronously worker-side.)
    */
   setPanelBadge(panelId: string, badge: PluginPanelBadge | null): Promise<void>;
   /**

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -41,6 +41,27 @@ export interface ToolbarButtonContribution {
   priority?: 1 | 2 | 3 | 4 | 5;
 }
 
+/**
+ * Semantic color for a {@link PluginPanelBadge}. Maps to the app's status
+ * palette in the renderer — plugins pick intent, not a raw hex value, so badges
+ * stay theme-consistent. `"default"` is the neutral accent-free tint.
+ */
+export type PluginPanelBadgeColor = "default" | "success" | "warning" | "error";
+
+/**
+ * A small live indicator a plugin overlays on a panel's title chrome via
+ * {@link PluginHostApi.setPanelBadge}, keyed by panel id. Lets per-worktree /
+ * per-agent state (notes present, CI pass/fail, review status) surface without
+ * opening the panel. Two shapes: a bare status `dot`, or a short `label`
+ * (text capped at 6 characters host-side so it can't overflow the header).
+ */
+export type PluginPanelBadge =
+  | { kind: "dot"; color?: PluginPanelBadgeColor; tooltip?: string }
+  | { kind: "label"; text: string; color?: PluginPanelBadgeColor; tooltip?: string };
+
+/** Max length of a {@link PluginPanelBadge} `label` text, enforced host-side. */
+export const PLUGIN_PANEL_BADGE_LABEL_MAX = 6;
+
 export type MenuItemLocation = "terminal" | "file" | "view" | "help";
 // `"panel"` was removed (#10512): no renderer surface ever mounted
 // `usePluginContextMenuItems("panel")`, so a contributed panel context-menu item
@@ -1702,6 +1723,21 @@ export interface PluginHostApi extends PluginActivationApi {
    * unloaded.
    */
   invalidateFileDecorations(scope: string, paths?: string[]): Promise<void>;
+  /**
+   * Set (or clear) a small live badge on the title chrome of the panel with the
+   * given `panelId` — a status `dot` or a short `label` — so per-worktree /
+   * per-agent state surfaces without opening the panel. Pass `null` to clear
+   * this plugin's badge on that panel. Badges are keyed by `(pluginId, panelId)`,
+   * so plugins never clobber each other's badge on the same panel.
+   *
+   * Like {@link invalidateFileDecorations} this is NOT revoke-guarded: plugins
+   * call it from post-activation subscription callbacks and timers, and it
+   * becomes a silent no-op once the plugin is unloaded (all of the plugin's
+   * badges are cleared on unload). An invalid `panelId` or badge shape (e.g. a
+   * `label` longer than {@link PLUGIN_PANEL_BADGE_LABEL_MAX} characters) rejects
+   * so authoring mistakes surface loudly.
+   */
+  setPanelBadge(panelId: string, badge: PluginPanelBadge | null): Promise<void>;
   /**
    * Surface a toast notification. The host namespaces the message as
    * `{pluginId}: {message}` for provenance — a plugin cannot spoof another

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -26,6 +26,7 @@ import type {
   PluginInputBoxOptions,
   PluginConfirmOptions,
   PluginProcessSpawnOptions,
+  PluginPanelBadge,
 } from "./plugin.js";
 
 /** Async host methods the worker proxy relays to main and awaits a reply for. */
@@ -68,6 +69,7 @@ export type PluginHostNotifyMethod =
   | "broadcastToRenderer"
   | "postToPanel"
   | "invalidateFileDecorations"
+  | "setPanelBadge"
   | "registerFileDecorationProvider"
   | "unregisterFileDecorationProvider"
   | "logger.info"
@@ -244,6 +246,12 @@ export interface PostToPanelParams {
 export interface InvalidateFileDecorationsParams {
   scope: string;
   paths?: string[];
+}
+
+/** Params for `setPanelBadge` (`host-notify`). `null` clears the badge. */
+export interface SetPanelBadgeParams {
+  panelId: string;
+  badge: PluginPanelBadge | null;
 }
 
 /**

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -55,6 +55,7 @@ import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { PluginPanelBadges } from "@/components/Panel/PluginPanelBadges";
 import { BellDot, FolderGit2 } from "@/components/icons";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
@@ -849,6 +850,9 @@ function PanelHeaderComponent({
               <BellDot className="w-3 h-3 animate-pulse motion-reduce:animate-none" />
             </span>
           )}
+
+          {/* Live plugin-contributed badges (host.setPanelBadge) for this panel */}
+          <PluginPanelBadges panelId={id} />
 
           {/* Add tab button for single panels */}
           {onAddTab && (

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -57,13 +57,13 @@ export function PluginPanelBadges({ panelId }: { panelId: string }) {
   useEffect(() => init(), [init]);
 
   const badges = usePanelBadges(panelId);
-  const pluginIds = Object.keys(badges).sort();
-  if (pluginIds.length === 0) return null;
+  const entries = Object.entries(badges).sort(([a], [b]) => a.localeCompare(b));
+  if (entries.length === 0) return null;
 
   return (
     <>
-      {pluginIds.map((pluginId) => (
-        <BadgeIndicator key={pluginId} pluginId={pluginId} badge={badges[pluginId]} />
+      {entries.map(([pluginId, badge]) => (
+        <BadgeIndicator key={pluginId} pluginId={pluginId} badge={badge} />
       ))}
     </>
   );

--- a/src/components/Panel/PluginPanelBadges.tsx
+++ b/src/components/Panel/PluginPanelBadges.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import type { PluginPanelBadge, PluginPanelBadgeColor } from "@shared/types/plugin";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { usePanelBadges, usePluginPanelBadgeStore } from "@/store/pluginPanelBadgeStore";
+
+/**
+ * Live badges a plugin set on this panel via `host.setPanelBadge` (#10585),
+ * rendered inline in the panel header's indicator cluster. A `dot` is a small
+ * status circle; a `label` is a short pill. Color maps to the app's status
+ * palette — never the accent (these are secondary, possibly-multiple markers).
+ * Multiple plugins on one panel render in plugin-id order for stability.
+ */
+const DOT_COLOR: Record<PluginPanelBadgeColor, string> = {
+  default: "bg-text-muted",
+  success: "bg-status-success",
+  warning: "bg-status-warning",
+  error: "bg-status-error",
+};
+
+const LABEL_COLOR: Record<PluginPanelBadgeColor, string> = {
+  default: "bg-overlay-subtle text-text-secondary",
+  success: "bg-status-success/15 text-status-success",
+  warning: "bg-status-warning/15 text-status-warning",
+  error: "bg-status-error/15 text-status-error",
+};
+
+function BadgeIndicator({ pluginId, badge }: { pluginId: string; badge: PluginPanelBadge }) {
+  const color = badge.color ?? "default";
+  const indicator =
+    badge.kind === "dot" ? (
+      <span
+        role="status"
+        aria-label={badge.tooltip ?? `${pluginId} status`}
+        className={`w-2 h-2 rounded-full shrink-0 ${DOT_COLOR[color]}`}
+      />
+    ) : (
+      <span
+        role="status"
+        aria-label={badge.tooltip ?? `${pluginId}: ${badge.text}`}
+        className={`shrink-0 rounded px-1 text-[10px] font-medium leading-4 ${LABEL_COLOR[color]}`}
+      >
+        {badge.text}
+      </span>
+    );
+
+  if (!badge.tooltip) return indicator;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{indicator}</TooltipTrigger>
+      <TooltipContent side="bottom">{badge.tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+export function PluginPanelBadges({ panelId }: { panelId: string }) {
+  const init = usePluginPanelBadgeStore((s) => s.init);
+  useEffect(() => init(), [init]);
+
+  const badges = usePanelBadges(panelId);
+  const pluginIds = Object.keys(badges).sort();
+  if (pluginIds.length === 0) return null;
+
+  return (
+    <>
+      {pluginIds.map((pluginId) => (
+        <BadgeIndicator key={pluginId} pluginId={pluginId} badge={badges[pluginId]} />
+      ))}
+    </>
+  );
+}

--- a/src/store/__tests__/pluginPanelBadgeStore.test.ts
+++ b/src/store/__tests__/pluginPanelBadgeStore.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { PluginPanelBadge } from "@shared/types/plugin";
 
@@ -111,20 +112,47 @@ describe("pluginPanelBadgeStore", () => {
     expect(after).toBe(before);
   });
 
-  it("usePanelBadges returns a stable empty object for an unknown panel", async () => {
+  it("usePanelBadges selector returns the same frozen empty object for two unknown panels", async () => {
+    const { renderHook } = await import("@testing-library/react");
     const mod = await load();
-    const a = mod.usePluginPanelBadgeStore.getState().badgesByPanelId.unknown;
-    expect(a).toBeUndefined();
-    // The selector's fallback is exercised through the store's frozen empty.
-    changedCb!({ pluginId: "p1", badges: {} });
-    expect(mod.usePluginPanelBadgeStore.getState().badgesByPanelId).toEqual({});
+    const a = renderHook(() => mod.usePanelBadges("ghost-1"));
+    const b = renderHook(() => mod.usePanelBadges("ghost-2"));
+    expect(a.result.current).toEqual({});
+    // Stable reference across panels and unrelated updates → no churn re-renders.
+    expect(a.result.current).toBe(b.result.current);
+    changedCb!({ pluginId: "p1", badges: { other: dot() } });
+    a.rerender();
+    expect(a.result.current).toBe(b.result.current);
   });
 
-  it("tolerates an absent bridge without throwing", async () => {
-    (globalThis as unknown as { window: { electron: { plugin: object } } }).window.electron.plugin =
-      {};
+  it("usePanelBadges selector reflects a badge set on its panel", async () => {
+    const { renderHook } = await import("@testing-library/react");
+    const { act } = await import("@testing-library/react");
+    const mod = await load();
+    const { result } = renderHook(() => mod.usePanelBadges("panelA"));
+    expect(result.current).toEqual({});
+    act(() => changedCb!({ pluginId: "p1", badges: { panelA: label("CI") } }));
+    expect(result.current).toEqual({ p1: { kind: "label", text: "CI" } });
+  });
+
+  it("tolerates an absent bridge and stays retryable once a real bridge appears", async () => {
+    const win = globalThis as unknown as {
+      window: { electron: { plugin: Record<string, unknown> } };
+    };
+    win.window.electron.plugin = {}; // no badge subscription methods yet
     const mod = await import("../pluginPanelBadgeStore");
     mod._resetPluginPanelBadgeStoreForTest();
     expect(() => mod.usePluginPanelBadgeStore.getState().init()).not.toThrow();
+    expect(onChangedMock).not.toHaveBeenCalled();
+
+    // A later mount with the real bridge present must still subscribe — the
+    // absent-bridge early return did not latch `initialized`.
+    win.window.electron.plugin = {
+      onPanelBadgesChanged: onChangedMock,
+      onPanelBadgesCleared: onClearedMock,
+    };
+    mod.usePluginPanelBadgeStore.getState().init();
+    expect(onChangedMock).toHaveBeenCalledTimes(1);
+    expect(onClearedMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/store/__tests__/pluginPanelBadgeStore.test.ts
+++ b/src/store/__tests__/pluginPanelBadgeStore.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PluginPanelBadge } from "@shared/types/plugin";
+
+type ChangedPayload = { pluginId: string; badges: Record<string, PluginPanelBadge> };
+type ClearedPayload = { pluginId: string };
+
+const { onChangedMock, onClearedMock } = vi.hoisted(() => ({
+  onChangedMock: vi.fn(),
+  onClearedMock: vi.fn(),
+}));
+
+let changedCb: ((p: ChangedPayload) => void) | null = null;
+let clearedCb: ((p: ClearedPayload) => void) | null = null;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  changedCb = null;
+  clearedCb = null;
+  onChangedMock.mockImplementation((cb: (p: ChangedPayload) => void) => {
+    changedCb = cb;
+    return () => {};
+  });
+  onClearedMock.mockImplementation((cb: (p: ClearedPayload) => void) => {
+    clearedCb = cb;
+    return () => {};
+  });
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        onPanelBadgesChanged: onChangedMock,
+        onPanelBadgesCleared: onClearedMock,
+      },
+    },
+  });
+});
+
+async function load() {
+  const mod = await import("../pluginPanelBadgeStore");
+  mod._resetPluginPanelBadgeStoreForTest();
+  mod.usePluginPanelBadgeStore.getState().init();
+  return mod;
+}
+
+const dot = (color?: PluginPanelBadge["color"]): PluginPanelBadge => ({ kind: "dot", color });
+const label = (text: string): PluginPanelBadge => ({ kind: "label", text });
+
+describe("pluginPanelBadgeStore", () => {
+  it("subscribes to both badge events on init", async () => {
+    await load();
+    expect(onChangedMock).toHaveBeenCalledTimes(1);
+    expect(onClearedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("init is idempotent — does not double-subscribe", async () => {
+    const mod = await load();
+    mod.usePluginPanelBadgeStore.getState().init();
+    expect(onChangedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores a badge keyed by panelId then pluginId", async () => {
+    const mod = await load();
+    changedCb!({ pluginId: "p1", badges: { panelA: dot("success") } });
+    expect(mod.usePluginPanelBadgeStore.getState().badgesByPanelId).toEqual({
+      panelA: { p1: { kind: "dot", color: "success" } },
+    });
+  });
+
+  it("keeps two plugins' badges on the same panel independent", async () => {
+    const mod = await load();
+    changedCb!({ pluginId: "p1", badges: { panelA: dot() } });
+    changedCb!({ pluginId: "p2", badges: { panelA: label("CI") } });
+    expect(mod.usePluginPanelBadgeStore.getState().badgesByPanelId.panelA).toEqual({
+      p1: { kind: "dot", color: undefined },
+      p2: { kind: "label", text: "CI" },
+    });
+  });
+
+  it("treats each changed event as the plugin's complete map — drops panels no longer present", async () => {
+    const mod = await load();
+    changedCb!({ pluginId: "p1", badges: { panelA: dot(), panelB: dot() } });
+    // Re-emit with only panelB → panelA's p1 badge must be gone.
+    changedCb!({ pluginId: "p1", badges: { panelB: label("2") } });
+    const state = mod.usePluginPanelBadgeStore.getState().badgesByPanelId;
+    expect(state.panelA).toBeUndefined();
+    expect(state.panelB).toEqual({ p1: { kind: "label", text: "2" } });
+  });
+
+  it("removing one plugin's badge leaves another plugin's badge on the same panel", async () => {
+    const mod = await load();
+    changedCb!({ pluginId: "p1", badges: { panelA: dot() } });
+    changedCb!({ pluginId: "p2", badges: { panelA: dot() } });
+    changedCb!({ pluginId: "p1", badges: {} }); // p1 clears
+    expect(mod.usePluginPanelBadgeStore.getState().badgesByPanelId.panelA).toEqual({
+      p2: { kind: "dot", color: undefined },
+    });
+  });
+
+  it("clears all of a plugin's badges on the cleared event", async () => {
+    const mod = await load();
+    changedCb!({ pluginId: "p1", badges: { panelA: dot(), panelB: dot() } });
+    clearedCb!({ pluginId: "p1" });
+    expect(mod.usePluginPanelBadgeStore.getState().badgesByPanelId).toEqual({});
+  });
+
+  it("preserves the object reference of unaffected panels", async () => {
+    const mod = await load();
+    changedCb!({ pluginId: "p1", badges: { panelA: dot() } });
+    const before = mod.usePluginPanelBadgeStore.getState().badgesByPanelId.panelA;
+    changedCb!({ pluginId: "p2", badges: { panelB: dot() } });
+    const after = mod.usePluginPanelBadgeStore.getState().badgesByPanelId.panelA;
+    expect(after).toBe(before);
+  });
+
+  it("usePanelBadges returns a stable empty object for an unknown panel", async () => {
+    const mod = await load();
+    const a = mod.usePluginPanelBadgeStore.getState().badgesByPanelId.unknown;
+    expect(a).toBeUndefined();
+    // The selector's fallback is exercised through the store's frozen empty.
+    changedCb!({ pluginId: "p1", badges: {} });
+    expect(mod.usePluginPanelBadgeStore.getState().badgesByPanelId).toEqual({});
+  });
+
+  it("tolerates an absent bridge without throwing", async () => {
+    (globalThis as unknown as { window: { electron: { plugin: object } } }).window.electron.plugin =
+      {};
+    const mod = await import("../pluginPanelBadgeStore");
+    mod._resetPluginPanelBadgeStoreForTest();
+    expect(() => mod.usePluginPanelBadgeStore.getState().init()).not.toThrow();
+  });
+});

--- a/src/store/pluginPanelBadgeStore.ts
+++ b/src/store/pluginPanelBadgeStore.ts
@@ -1,0 +1,105 @@
+import { create } from "zustand";
+import type { PluginPanelBadge } from "@shared/types/plugin";
+
+/**
+ * Renderer mirror of the live panel badges plugins set via `host.setPanelBadge`
+ * (#10585), keyed `panelId → pluginId → badge` so a panel header can resolve its
+ * badges in O(1) at render time. Source of truth is `PluginService` in main; we
+ * hydrate from `plugin:panel-badges-changed` (one plugin's COMPLETE current map
+ * per event) and `plugin:panel-badges-cleared` (a plugin unloaded). Cold-restored
+ * views get the current state replayed via `pushSnapshotTo`. Not persisted —
+ * badges are ephemeral runtime state.
+ *
+ * Subscription is module-level (not per-component) so badges survive panel
+ * header unmount/remount (dock/grid toggle, LRU view restore) and no event is
+ * missed between renders.
+ */
+type BadgesByPanelId = Record<string, Record<string, PluginPanelBadge>>;
+
+interface PluginPanelBadgeState {
+  badgesByPanelId: BadgesByPanelId;
+  /** Idempotent: subscribes to live badge updates. */
+  init: () => void;
+}
+
+let initialized = false;
+let unsubscribeChanged: (() => void) | null = null;
+let unsubscribeCleared: (() => void) | null = null;
+
+/**
+ * Recompute `badgesByPanelId` after replacing one plugin's entire badge set.
+ * `badges` is the plugin's COMPLETE current map (`panelId → badge`); an empty
+ * map clears the plugin. Unaffected panels keep their object reference so their
+ * subscribers don't re-render.
+ */
+function applyPluginBadges(
+  current: BadgesByPanelId,
+  pluginId: string,
+  badges: Record<string, PluginPanelBadge>
+): BadgesByPanelId {
+  const affected = new Set<string>(Object.keys(badges));
+  for (const [panelId, byPlugin] of Object.entries(current)) {
+    if (pluginId in byPlugin) affected.add(panelId);
+  }
+  if (affected.size === 0) return current;
+
+  const next: BadgesByPanelId = {};
+  for (const [panelId, byPlugin] of Object.entries(current)) {
+    if (!affected.has(panelId)) next[panelId] = byPlugin;
+  }
+  for (const panelId of affected) {
+    const inner = { ...current[panelId] };
+    delete inner[pluginId];
+    const badge = badges[panelId];
+    if (badge) inner[pluginId] = badge;
+    if (Object.keys(inner).length > 0) next[panelId] = inner;
+  }
+  return next;
+}
+
+export const usePluginPanelBadgeStore = create<PluginPanelBadgeState>((set, get) => ({
+  badgesByPanelId: {},
+  init: () => {
+    if (initialized) return;
+    initialized = true;
+
+    // Rendered from every panel header, so tolerate a partially-stubbed bridge
+    // (component tests that don't mock the plugin namespace) — absent bridge ⇒
+    // no badges, matching prod before the first snapshot.
+    const plugin = window.electron?.plugin;
+    if (
+      typeof plugin?.onPanelBadgesChanged !== "function" ||
+      typeof plugin.onPanelBadgesCleared !== "function"
+    ) {
+      return;
+    }
+
+    unsubscribeChanged = plugin.onPanelBadgesChanged(({ pluginId, badges }) => {
+      set({ badgesByPanelId: applyPluginBadges(get().badgesByPanelId, pluginId, badges) });
+    });
+    unsubscribeCleared = plugin.onPanelBadgesCleared(({ pluginId }) => {
+      set({ badgesByPanelId: applyPluginBadges(get().badgesByPanelId, pluginId, {}) });
+    });
+  },
+}));
+
+/** Stable empty reference so panels with no badges never re-render on identity. */
+const EMPTY_BADGES: Readonly<Record<string, PluginPanelBadge>> = Object.freeze({});
+
+/**
+ * Badges set on `panelId`, keyed by the contributing plugin id (empty when
+ * none). Reference is stable while that panel's badges are unchanged.
+ */
+export function usePanelBadges(panelId: string): Readonly<Record<string, PluginPanelBadge>> {
+  return usePluginPanelBadgeStore((s) => s.badgesByPanelId[panelId] ?? EMPTY_BADGES);
+}
+
+/** Test-only: reset the module-level init guard and state between cases. */
+export function _resetPluginPanelBadgeStoreForTest(): void {
+  unsubscribeChanged?.();
+  unsubscribeCleared?.();
+  unsubscribeChanged = null;
+  unsubscribeCleared = null;
+  initialized = false;
+  usePluginPanelBadgeStore.setState({ badgesByPanelId: {} });
+}

--- a/src/store/pluginPanelBadgeStore.ts
+++ b/src/store/pluginPanelBadgeStore.ts
@@ -61,11 +61,12 @@ export const usePluginPanelBadgeStore = create<PluginPanelBadgeState>((set, get)
   badgesByPanelId: {},
   init: () => {
     if (initialized) return;
-    initialized = true;
 
     // Rendered from every panel header, so tolerate a partially-stubbed bridge
     // (component tests that don't mock the plugin namespace) — absent bridge ⇒
-    // no badges, matching prod before the first snapshot.
+    // no badges, matching prod before the first snapshot. Don't latch
+    // `initialized` until the bridge is actually present, so a no-bridge early
+    // return stays retryable (a later mount with a real bridge can subscribe).
     const plugin = window.electron?.plugin;
     if (
       typeof plugin?.onPanelBadgesChanged !== "function" ||
@@ -73,6 +74,7 @@ export const usePluginPanelBadgeStore = create<PluginPanelBadgeState>((set, get)
     ) {
       return;
     }
+    initialized = true;
 
     unsubscribeChanged = plugin.onPanelBadgesChanged(({ pluginId, badges }) => {
       set({ badgesByPanelId: applyPluginBadges(get().badgesByPanelId, pluginId, badges) });


### PR DESCRIPTION
## Summary

- Adds `host.setPanelBadge(panelId, badge | null)` to `PluginHostApi`, letting plugins attach a small live badge to a panel's title bar — a status dot or a short label (≤6 chars) with semantic colors (`default` / `success` / `warning` / `error`) and an optional tooltip.
- Badges surface per-worktree/per-agent state (CI status, review state, notes present) in panel chrome without requiring the panel to be open. Cleared automatically on plugin unload.
- Part of the pre-1.0 plugin API freeze epic (#10511).

Resolves #10585

## Changes

- `PluginPanelBadge` discriminated-union type + Zod validation in `electron/schemas/plugin.ts` (rejects overlong labels rather than truncating).
- `PluginService` owns a per-plugin badge map; broadcasts `plugin:panel-badges-changed` / `plugin:panel-badges-cleared` over the existing EVENTS_PUSH transport, clears on unload, and replays to cold-restored `WebContentsView`s via `pushSnapshotTo`.
- All four `PluginHostApi` implementer sites wired: real host, `pluginDevWorkerHostProxy`, bridge notify switch + types, public mock host.
- Preload (`electron/preload.cts`), IPC maps (`shared/types/ipc/`), and SDK export (`shared/types/plugin-sdk.ts`) updated.
- New `pluginPanelBadgeStore` (module-level IPC subscription) in `src/store/`; new `PluginPanelBadges` component rendered inside `PanelHeader` — status/neutral tokens only, no accent color.

## Testing

- 11 unit tests for `pluginPanelBadgeStore` (accumulate, clear, multi-plugin merge, unload-clear).
- `createMockHost` recorder test, bridge routing test, SDK surface test.
- 7 `PluginService` integration tests: broadcast, accumulate + clear, validation rejection, unload-clear, post-unload no-op, snapshot replay.
- Full suite (144 unit + 7 integration) passing locally.