### PR TITLE
feat(plugins): let contributed agents report state via detection patterns

### DIFF
--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -207,6 +207,52 @@ describe("createPtyHostMessageDispatcher", () => {
     }
   });
 
+  it("replaces the plugin-agent registry wholesale on a later sync (#10587)", () => {
+    clearPluginAgentRegistryForTests();
+    try {
+      const ctx = makeCtx();
+      const dispatch = createPtyHostMessageDispatcher(ctx);
+      const entry = (id: string) => ({
+        id,
+        name: id,
+        command: id,
+        color: "#3366ff",
+        iconId: "terminal",
+        supportsContextInjection: false,
+      });
+
+      dispatch({ type: "set-plugin-agent-registry", registry: { "plugin-a": entry("plugin-a") } });
+      expect(getEffectiveAgentConfig("plugin-a")).toBeDefined();
+
+      // A subsequent sync (e.g. plugin A unloaded, plugin B loaded) replaces the
+      // snapshot wholesale — the absent agent is gone.
+      dispatch({ type: "set-plugin-agent-registry", registry: { "plugin-b": entry("plugin-b") } });
+      expect(getEffectiveAgentConfig("plugin-a")).toBeUndefined();
+      expect(getEffectiveAgentConfig("plugin-b")).toBeDefined();
+    } finally {
+      clearPluginAgentRegistryForTests();
+    }
+  });
+
+  it("ignores a malformed plugin-agent registry shape without crashing (#10587)", () => {
+    clearPluginAgentRegistryForTests();
+    try {
+      const ctx = makeCtx();
+      const dispatch = createPtyHostMessageDispatcher(ctx);
+      // null and array are not valid Record shapes — the handler must no-op them
+      // rather than corrupt the snapshot.
+      expect(() =>
+        dispatch({ type: "set-plugin-agent-registry", registry: null as never })
+      ).not.toThrow();
+      expect(() =>
+        dispatch({ type: "set-plugin-agent-registry", registry: [] as never })
+      ).not.toThrow();
+      expect(getEffectiveAgentConfig("anything")).toBeUndefined();
+    } finally {
+      clearPluginAgentRegistryForTests();
+    }
+  });
+
   it("returns a promise for handlers that perform real async work", async () => {
     const ctx = makeCtx();
     ctx.ptyManager.gracefulKill = vi.fn(async () => "session-42");

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createPtyHostMessageDispatcher } from "../index.js";
 import type { HostContext } from "../types.js";
+import { clearPluginAgentRegistryForTests } from "../../../../shared/config/pluginAgentRegistry.js";
+import { getEffectiveAgentConfig } from "../../../../shared/config/agentRegistry.js";
 
 function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   const ptyManager = {
@@ -169,6 +171,40 @@ describe("createPtyHostMessageDispatcher", () => {
       id: "term-1",
       state: "payload",
     });
+  });
+
+  it("mirrors the plugin-agent registry into this process (#10587)", () => {
+    clearPluginAgentRegistryForTests();
+    try {
+      const ctx = makeCtx();
+      const dispatch = createPtyHostMessageDispatcher(ctx);
+
+      // Before the sync, the pty-host process has no knowledge of the agent.
+      expect(getEffectiveAgentConfig("plugin-agent")).toBeUndefined();
+
+      dispatch({
+        type: "set-plugin-agent-registry",
+        registry: {
+          "plugin-agent": {
+            id: "plugin-agent",
+            name: "Plugin Agent",
+            command: "plugin-agent",
+            color: "#3366ff",
+            iconId: "terminal",
+            supportsContextInjection: false,
+            detection: { primaryPatterns: ["thinking"] },
+          },
+        },
+      });
+
+      // After the sync, getEffectiveAgentConfig resolves the agent and its
+      // detection patterns — exactly what the activity monitor needs at spawn.
+      const config = getEffectiveAgentConfig("plugin-agent");
+      expect(config).toBeDefined();
+      expect(config?.detection?.primaryPatterns).toEqual(["thinking"]);
+    } finally {
+      clearPluginAgentRegistryForTests();
+    }
   });
 
   it("returns a promise for handlers that perform real async work", async () => {

--- a/electron/pty-host/handlers/resourceConfig.ts
+++ b/electron/pty-host/handlers/resourceConfig.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../shared/types/resourceProfile.js";
 import { setLogLevelOverrides } from "../../utils/logger.js";
 import { setPortBatchThroughputDelayMs } from "../portBatcher.js";
+import { setPluginAgentRegistry } from "../../../shared/config/pluginAgentRegistry.js";
 import type { HandlerMap, HostContext } from "./types.js";
 
 export function createResourceConfigHandlers(ctx: HostContext): HandlerMap {
@@ -42,6 +43,13 @@ export function createResourceConfigHandlers(ctx: HostContext): HandlerMap {
         }
       }
       setLogLevelOverrides(sanitized);
+    },
+
+    // Mirror main's plugin-agent registry so `getEffectiveAgentConfig` resolves
+    // plugin detection patterns in this process (the one running the activity
+    // monitor). Main is authoritative; the pty-host only ever mirrors (#10587).
+    "set-plugin-agent-registry": (msg) => {
+      setPluginAgentRegistry(msg.registry ?? {});
     },
   };
 }

--- a/electron/pty-host/handlers/resourceConfig.ts
+++ b/electron/pty-host/handlers/resourceConfig.ts
@@ -48,8 +48,14 @@ export function createResourceConfigHandlers(ctx: HostContext): HandlerMap {
     // Mirror main's plugin-agent registry so `getEffectiveAgentConfig` resolves
     // plugin detection patterns in this process (the one running the activity
     // monitor). Main is authoritative; the pty-host only ever mirrors (#10587).
+    // Guard the shape at the process boundary: only a plain object is a valid
+    // registry — an array (or null) would corrupt the snapshot's spread.
     "set-plugin-agent-registry": (msg) => {
-      setPluginAgentRegistry(msg.registry ?? {});
+      const registry =
+        msg.registry != null && typeof msg.registry === "object" && !Array.isArray(msg.registry)
+          ? msg.registry
+          : {};
+      setPluginAgentRegistry(registry);
     },
   };
 }

--- a/electron/schemas/__tests__/agentContribution.test.ts
+++ b/electron/schemas/__tests__/agentContribution.test.ts
@@ -35,22 +35,71 @@ describe("AgentContributionSchema (issue #9560)", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects a detection block as an unknown key — output detection is cut from the 1.0 schema (#10460)", () => {
+  it("accepts a detection block with valid regex patterns (#10587)", () => {
     const result = AgentContributionSchema.safeParse({
       ...VALID_AGENT,
-      detection: { primaryPatterns: ["thinking"] },
+      detection: {
+        primaryPatterns: ["thinking", "working\\.\\.\\."],
+        completionPatterns: ["completed"],
+        promptPatterns: ["waiting for approval"],
+        scanLineCount: 10,
+        primaryConfidence: 0.9,
+      },
     });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      // Assert the failure is strict unknown-key rejection of `detection`
-      // specifically, not some unrelated validation error — so a future
-      // re-introduction of the field can't silently flip this to a pass.
-      const unknownKeyIssue = result.error.issues.find(
-        (issue) => issue.code === "unrecognized_keys"
-      );
-      expect(unknownKeyIssue).toBeDefined();
-      expect((unknownKeyIssue as { keys?: string[] }).keys).toContain("detection");
-    }
+    expect(result.success).toBe(true);
+  });
+
+  it("requires at least one primaryPattern when a detection block is present (#10587)", () => {
+    expect(
+      AgentContributionSchema.safeParse({ ...VALID_AGENT, detection: { primaryPatterns: [] } })
+        .success
+    ).toBe(false);
+    // Omitting primaryPatterns entirely is also invalid.
+    expect(
+      AgentContributionSchema.safeParse({
+        ...VALID_AGENT,
+        detection: { completionPatterns: ["done"] },
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects a detection pattern that is not a compilable regex (#10587)", () => {
+    expect(
+      AgentContributionSchema.safeParse({
+        ...VALID_AGENT,
+        detection: { primaryPatterns: ["("] },
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects an over-long detection pattern and an oversized pattern array (#10587)", () => {
+    expect(
+      AgentContributionSchema.safeParse({
+        ...VALID_AGENT,
+        detection: { primaryPatterns: ["a".repeat(257)] },
+      }).success
+    ).toBe(false);
+    expect(
+      AgentContributionSchema.safeParse({
+        ...VALID_AGENT,
+        detection: { primaryPatterns: Array.from({ length: 51 }, (_, i) => `p${i}`) },
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects an out-of-range confidence and unknown detection key (strict) (#10587)", () => {
+    expect(
+      AgentContributionSchema.safeParse({
+        ...VALID_AGENT,
+        detection: { primaryPatterns: ["x"], primaryConfidence: 1.5 },
+      }).success
+    ).toBe(false);
+    expect(
+      AgentContributionSchema.safeParse({
+        ...VALID_AGENT,
+        detection: { primaryPatterns: ["x"], bogusField: true },
+      }).success
+    ).toBe(false);
   });
 
   it("rejects unknown top-level fields (strict)", () => {
@@ -170,12 +219,24 @@ describe("manifest-level agent contribution gates (issue #9560)", () => {
     }
   });
 
-  it("rejects the whole manifest when an agent declares a detection block (cut in 1.0, #10460)", () => {
+  it("accepts a manifest whose agent declares a valid detection block (#10587)", () => {
     const result = schema.safeParse(
       manifestWith({
         capabilities: ["agent:register"],
         contributes: {
           agents: [{ ...VALID_AGENT, detection: { primaryPatterns: ["thinking"] } }],
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a manifest whose agent declares a malformed detection regex (#10587)", () => {
+    const result = schema.safeParse(
+      manifestWith({
+        capabilities: ["agent:register"],
+        contributes: {
+          agents: [{ ...VALID_AGENT, detection: { primaryPatterns: ["("] } }],
         },
       })
     );

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -367,6 +367,11 @@ const PluginDetectionConfidenceSchema = z.number().min(0).max(1);
  */
 export const AgentDetectionConfigSchema = z
   .object({
+    // Required and non-empty, mirroring the host-internal `AgentDetectionConfig`
+    // type (where `primaryPatterns` is non-optional): a detection block exists to
+    // describe the working state, and an empty `primaryPatterns` makes
+    // `buildPatternConfig` return undefined anyway. A "prompt/completion only"
+    // agent without a working pattern is out of scope for the declared schema.
     primaryPatterns: PluginDetectionPatternArraySchema.min(1),
     fallbackPatterns: PluginDetectionPatternArraySchema.optional(),
     bootCompletePatterns: PluginDetectionPatternArraySchema.optional(),

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -325,6 +325,72 @@ function isSafePluginAgentCommand(command: string): boolean {
     .every((segment) => segment !== "" && segment !== "." && segment !== "..");
 }
 
+/**
+ * A single output-detection regex pattern (#10587). Compiled with `new RegExp`
+ * by the pty-host activity monitor, so it must be a valid JS regex. Bounded to
+ * 256 chars — the patterns run in the pty-host (a stall is observable, not a
+ * web-server DoS vector), and the length cap plus the activity monitor's
+ * bounded scan window keep catastrophic backtracking a contained risk without
+ * pulling in a new linear-time regex dependency.
+ */
+const PluginDetectionPatternSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .refine(
+    (pattern) => {
+      try {
+        // Call form (not `new`) compiles and validates the pattern without a
+        // constructed-but-unused instance — throws on a malformed regex.
+        RegExp(pattern);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: "Detection pattern must be a valid regular expression" }
+  );
+
+/** A bounded array of detection regex patterns. Capped to keep a manifest from declaring an unbounded matcher set. */
+const PluginDetectionPatternArraySchema = z.array(PluginDetectionPatternSchema).max(50);
+
+/** Confidence weight in [0, 1] for a matched detection tier. */
+const PluginDetectionConfidenceSchema = z.number().min(0).max(1);
+
+/**
+ * Optional output-pattern detection for a contributed agent (#10587). Mirrors
+ * the host-internal `AgentDetectionConfig` (shared/config/agentRegistry.ts) so
+ * a plugin agent can describe its working/waiting/completed states and join the
+ * agent-state UI. Strict so a typo'd field is a loud manifest error. All
+ * pattern arrays validate each entry as a compilable regex; numeric tuning
+ * fields are bounded.
+ */
+export const AgentDetectionConfigSchema = z
+  .object({
+    primaryPatterns: PluginDetectionPatternArraySchema.min(1),
+    fallbackPatterns: PluginDetectionPatternArraySchema.optional(),
+    bootCompletePatterns: PluginDetectionPatternArraySchema.optional(),
+    promptPatterns: PluginDetectionPatternArraySchema.optional(),
+    promptHintPatterns: PluginDetectionPatternArraySchema.optional(),
+    completionPatterns: PluginDetectionPatternArraySchema.optional(),
+    scanLineCount: z.number().int().min(1).max(1000).optional(),
+    promptScanLineCount: z.number().int().min(1).max(1000).optional(),
+    debounceMs: z.number().int().min(0).max(600_000).optional(),
+    promptFastPathMinQuietMs: z.number().int().min(0).max(600_000).optional(),
+    primaryConfidence: PluginDetectionConfidenceSchema.optional(),
+    fallbackConfidence: PluginDetectionConfidenceSchema.optional(),
+    promptConfidence: PluginDetectionConfidenceSchema.optional(),
+    completionConfidence: PluginDetectionConfidenceSchema.optional(),
+    titleStatePatterns: z
+      .object({
+        working: z.array(z.string().min(1).max(256)).max(50),
+        waiting: z.array(z.string().min(1).max(256)).max(50),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
 export const AgentContributionSchema = z
   .object({
     id: z
@@ -354,6 +420,7 @@ export const AgentContributionSchema = z
     color: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
     iconId: z.string().min(1).max(64),
     supportsContextInjection: z.boolean().default(false),
+    detection: AgentDetectionConfigSchema.optional(),
   })
   .strict();
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -1370,6 +1370,11 @@ export class PluginService {
     if (manifest.contributes.agents.length > 0) {
       registerPluginAgents(manifest.name, manifest.contributes.agents, pluginDir);
       this.broadcaster.scheduleAgentsBroadcast(false);
+      // Mirror the updated registry into the pty-host so its activity monitor
+      // resolves this agent's detection patterns at spawn time (#10587). The
+      // renderer is covered by the broadcast above; the pty-host is a separate
+      // process that never registers agents itself.
+      getPtyClient()?.syncPluginAgentRegistry();
     }
 
     // Insert the plugin into the registry BEFORE importing its main module so
@@ -4227,6 +4232,11 @@ export class PluginService {
     runUnloadStep(pluginId, "unregisterPluginAgents", () => unregisterPluginAgents(pluginId));
     runUnloadStep(pluginId, "scheduleAgentsBroadcast", () =>
       this.broadcaster.scheduleAgentsBroadcast(true)
+    );
+    // Re-mirror the (now-smaller) registry to the pty-host so it stops resolving
+    // detection patterns for the unloaded plugin's agents (#10587).
+    runUnloadStep(pluginId, "syncPluginAgentRegistryToPtyHost", () =>
+      getPtyClient()?.syncPluginAgentRegistry()
     );
     // Subscriber disposers already fired in flushPluginEventCleanups() above;
     // this drops any leftover subscriber-set entry and the in-memory settings

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -45,6 +45,7 @@ import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
 import { createLogger, isValidLogOverrideLevel } from "../utils/logger.js";
 import { store } from "../store.js";
+import { getPluginAgentRegistry } from "../../shared/config/pluginAgentRegistry.js";
 
 const logger = createLogger("main:PtyClient");
 const logInfo = (msg: string, ctx?: Record<string, unknown>) =>
@@ -390,6 +391,12 @@ export class PtyClient extends EventEmitter {
       type: "set-log-level-overrides",
       overrides: this.logLevelOverridesCache,
     });
+    // Mirror the current plugin-agent registry to the (re)started host before
+    // any spawn replay below, so respawned plugin-agent terminals resolve their
+    // detection patterns from the first tick (#10587). Reads the authoritative
+    // main-process snapshot directly — no cache needed, and a host restart
+    // re-syncs whatever plugins are loaded now.
+    this.send({ type: "set-plugin-agent-registry", registry: getPluginAgentRegistry() });
     // Re-arm the watchdog on every successful ready — covers both the initial
     // boot and every auto-restart cycle. The original code armed it inside
     // startHost() before ready arrived, but the tick was a no-op until
@@ -544,6 +551,20 @@ export class PtyClient extends EventEmitter {
     this.logLevelOverridesCache = { ...overrides };
     if (this.lifecycle.isInitialized && this.lifecycle.child) {
       this.send({ type: "set-log-level-overrides", overrides: this.logLevelOverridesCache });
+    }
+  }
+
+  /**
+   * Push the current plugin-agent registry to the host so its activity monitor
+   * can resolve plugin detection patterns (#10587). Called by `PluginService`
+   * after a plugin load/unload changes the registry. Reads the authoritative
+   * main snapshot at call time; on a host restart the registry is replayed from
+   * the `ready` handler, so callers don't track restarts themselves. No-op when
+   * the host isn't ready yet — the ready replay covers that window.
+   */
+  syncPluginAgentRegistry(): void {
+    if (this.lifecycle.isInitialized && this.lifecycle.child) {
+      this.send({ type: "set-plugin-agent-registry", registry: getPluginAgentRegistry() });
     }
   }
 

--- a/shared/config/__tests__/pluginAgentRegistry.test.ts
+++ b/shared/config/__tests__/pluginAgentRegistry.test.ts
@@ -51,12 +51,26 @@ describe("pluginAgentRegistry (issue #9560)", () => {
     expect(isBuiltInAgent("acme-agent")).toBe(false);
   });
 
-  it("never carries a detection field onto the resolved config (cut in 1.0, #10460)", () => {
-    // contributionToAgentConfig maps fields explicitly rather than spreading,
-    // so even a stray `detection` on the input must not reach the registry.
+  it("forwards a declared detection block onto the resolved config (#10587)", () => {
+    // contributionToAgentConfig now threads `detection` through so a plugin
+    // agent can drive the working/waiting/completed UI via output patterns.
     registerPluginAgents("acme.plugin", [
-      { ...ACME_AGENT, detection: { primaryPatterns: ["thinking"] } } as PluginAgentContribution,
+      {
+        ...ACME_AGENT,
+        detection: { primaryPatterns: ["thinking"], completionPatterns: ["done"] },
+      },
     ]);
+    const config = getEffectiveAgentConfig("acme-agent");
+    expect(config).toBeDefined();
+    expect(config?.detection?.primaryPatterns).toEqual(["thinking"]);
+    expect(config?.detection?.completionPatterns).toEqual(["done"]);
+  });
+
+  it("omits the detection field entirely for a launch-only contribution (#10587)", () => {
+    // The common case carries no detection block — it must stay absent rather
+    // than land as `detection: undefined`, so output-volume state is the only
+    // path and nothing downstream sees an empty pattern config.
+    registerPluginAgents("acme.plugin", [ACME_AGENT]);
     const config = getEffectiveAgentConfig("acme-agent");
     expect(config).toBeDefined();
     expect("detection" in (config as object)).toBe(false);

--- a/shared/config/__tests__/pluginAgentRegistry.test.ts
+++ b/shared/config/__tests__/pluginAgentRegistry.test.ts
@@ -66,6 +66,30 @@ describe("pluginAgentRegistry (issue #9560)", () => {
     expect(config?.detection?.completionPatterns).toEqual(["done"]);
   });
 
+  it("round-trips every detection field onto the resolved config (#10587)", () => {
+    // Guards against silent truncation if contributionToAgentConfig ever stops
+    // forwarding the detection object wholesale.
+    const detection = {
+      primaryPatterns: ["working"],
+      fallbackPatterns: ["starting"],
+      bootCompletePatterns: ["ready"],
+      promptPatterns: ["waiting"],
+      promptHintPatterns: ["\\[y/n\\]"],
+      completionPatterns: ["done"],
+      scanLineCount: 12,
+      promptScanLineCount: 4,
+      debounceMs: 9000,
+      promptFastPathMinQuietMs: 9000,
+      primaryConfidence: 0.9,
+      fallbackConfidence: 0.7,
+      promptConfidence: 0.8,
+      completionConfidence: 0.85,
+      titleStatePatterns: { working: ["Running"], waiting: ["Idle"] },
+    };
+    registerPluginAgents("acme.plugin", [{ ...ACME_AGENT, detection }]);
+    expect(getEffectiveAgentConfig("acme-agent")?.detection).toEqual(detection);
+  });
+
   it("omits the detection field entirely for a launch-only contribution (#10587)", () => {
     // The common case carries no detection block — it must stay absent rather
     // than land as `detection: undefined`, so output-volume state is the only

--- a/shared/config/pluginAgentRegistry.ts
+++ b/shared/config/pluginAgentRegistry.ts
@@ -86,8 +86,12 @@ function contributionToAgentConfig(
   contribution: PluginAgentContribution,
   pluginDir?: string
 ): AgentConfig {
-  // Surface only the launch-relevant fields. Plugin agents launch as named,
-  // untracked terminals; output-pattern detection is not part of the 1.0 schema.
+  // Surface the launch-relevant fields plus the optional output-pattern
+  // `detection` block (#10587) so a contributed agent can drive the
+  // working/waiting/completed UI. Mapped explicitly (not spread) so no other
+  // contribution field can leak onto the resolved config. `detection` is
+  // forwarded only when present, keeping the field absent for the common
+  // launch-only case.
   return {
     id: contribution.id,
     name: contribution.name,
@@ -96,6 +100,7 @@ function contributionToAgentConfig(
     color: contribution.color,
     iconId: contribution.iconId,
     supportsContextInjection: contribution.supportsContextInjection ?? false,
+    ...(contribution.detection ? { detection: contribution.detection } : {}),
   };
 }
 

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -19,6 +19,7 @@ import type {
   PluginCanDispatchResult,
 } from "./actions.js";
 import type { AgentState, WaitingReason } from "./agent.js";
+import type { AgentDetectionConfig } from "../config/agentRegistry.js";
 import type { z } from "zod";
 
 export interface PanelContribution {
@@ -227,10 +228,15 @@ export interface PluginManifestScopes {
  * at parse time, and built-in entries always shadow plugin entries in
  * `getEffectiveRegistry`. Cross-plugin ID conflicts resolve first-registered-wins.
  *
- * Plugin agents launch as named, untracked terminals: the 1.0 schema surfaces
- * `id`, `name`, `command`, `args`, `color`, `iconId`, and
- * `supportsContextInjection`. Output-pattern detection is not part of the 1.0
- * plugin schema — built-in agents own the live PTY matcher.
+ * Plugin agents launch as named, untracked terminals: the schema surfaces
+ * `id`, `name`, `command`, `args`, `color`, `iconId`,
+ * `supportsContextInjection`, and an optional `detection` block. The
+ * `detection` field (#10587) lets a contributed agent describe its
+ * working/waiting/completed output patterns so it participates in the
+ * agent-state UI like a built-in — output-volume state already works from the
+ * launch hint, and declared patterns add the richer prompt/completion cues.
+ * Threaded onto the resolved {@link AgentConfig} by `contributionToAgentConfig`
+ * and consumed by the pty-host activity monitor.
  */
 export interface PluginAgentContribution {
   id: string;
@@ -240,6 +246,13 @@ export interface PluginAgentContribution {
   color: string;
   iconId: string;
   supportsContextInjection?: boolean;
+  /**
+   * Optional output-pattern detection config (#10587). Passive observation
+   * only — patterns are matched against terminal output to drive the
+   * working/waiting/completed state machine, consistent with the agent-config
+   * boundary (Daintree never modifies the agent's own config).
+   */
+  detection?: AgentDetectionConfig;
 }
 
 /**

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -11,6 +11,7 @@ import type { AgentState, AgentId, WaitingReason } from "./agent.js";
 import type { PanelKind, TerminalFlowStatus, PanelTitleMode } from "./panel.js";
 import type { ResourceProfile } from "./resourceProfile.js";
 import type { BuiltInAgentId } from "../config/agentIds.js";
+import type { AgentConfig } from "../config/agentRegistry.js";
 import type { SemanticSearchMatch, TerminalInfoPayload } from "./ipc/terminal.js";
 
 export type { TerminalFlowStatus };
@@ -193,6 +194,15 @@ export type PtyHostRequest =
   | { type: "set-session-persist-suppressed"; suppressed: boolean }
   | { type: "set-resource-profile"; profile: ResourceProfile }
   | { type: "set-process-tree-poll-interval"; ms: number }
+  /**
+   * Mirror the main-process plugin-agent registry into the pty-host (#10587).
+   * The pty-host runs the activity monitor and resolves `getEffectiveAgentConfig`
+   * for detection patterns, but never registers plugin agents itself — main is
+   * authoritative. Carries the flattened, command-resolved snapshot; the host
+   * applies it via `setPluginAgentRegistry`. Replayed on every host-ready so a
+   * restarted host re-syncs before any spawn replay.
+   */
+  | { type: "set-plugin-agent-registry"; registry: Record<string, AgentConfig> }
   | { type: "get-flow-control-snapshot"; requestId: string };
 
 /** Per-terminal flow-control state in a {@link FlowControlSnapshot}. */


### PR DESCRIPTION
## Summary

Plugin-contributed agents (`PluginAgentContribution`) launched fine but couldn't drive the working/waiting/completed UI with declared output patterns. Two root-cause blockers:

1. `PluginAgentContribution` had no `detection` field, so there was nowhere to declare patterns.
2. The pty-host process — which runs the activity monitor and resolves `getEffectiveAgentConfig` — had no plugin-agent registry sync. `setPluginAgentRegistry` was renderer-only, so any patterns would've been inert there anyway.

Worth noting: launch-hinted plugin agents already get output-volume state + identity chrome via `launchAgentId`. The `isBuiltInAgentId` guard at `TerminalAgentDetection.ts:78` gates process-detector identity promotion, not the activity-monitor state path — so `agentState` itself was never blocked on `detectedAgentId`. These were the only two real blockers.

Resolves #10587

## Changes

- Add optional `detection` block to `PluginAgentContribution` and `AgentContributionSchema`. Each pattern is regex-validated and bounded to 256 chars; arrays capped at 50; `primaryPatterns` required; confidences 0–1. Threaded through `contributionToAgentConfig`.
- Mirror the main-process plugin-agent registry into the pty-host via a new `set-plugin-agent-registry` IPC message. `PtyClient.handleReady` replays it on every host-ready (before spawn replay, so respawned plugin terminals resolve patterns from tick 1). `PluginService` pushes on plugin load/unload. The pty-host handler validates the shape and applies it via the shared `setPluginAgentRegistry`.

## Why this approach

Rejected the broader option of widening `detectedAgentId` everywhere, replacing the line-78 guard, adding spawn-time `agent:detected`, or wiring unload cleanup — none of those were needed. `agentState` is not gated on `detectedAgentId`. Consistent with the agent-config boundary: passive output observation only, no new deps (bounded `RegExp` via stdlib; no re2). `titleStatePatterns` are consumed renderer-side via the existing `plugin:agents-changed` broadcast.

## Testing

- vitest (`pluginAgentRegistry`, `agentContribution` schema, pty-host dispatcher): 59 passed
- `npm run typecheck`: clean across all 7 tsconfigs
- prettier + eslint on changed files: clean