### PR TITLE
fix(plugins): tighten plugin manifest and build validation (#10620)

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -46,11 +46,11 @@ Commands are callable actions that appear in the command palette and can be boun
 
 **Handler binding — two ways:**
 
-_Filesystem convention (manifest-declared, lazy import):_ a command with id `plan-from-issue` looks for `src/plan-from-issue.{ts,tsx,js,mjs}` (probed in that order) under your plugin directory. Its default export is the handler. The module is **not** imported until the command is first dispatched — twenty manifest commands cost zero activation time.
+_Filesystem convention (manifest-declared, lazy import):_ a command with id `plan-from-issue` looks for `src/plan-from-issue.{js,mjs}` (probed in that order) under your plugin directory. Its default export is the handler. The module is **not** imported until the command is first dispatched — twenty manifest commands cost zero activation time. The handler must be shipped as JavaScript: `.ts`/`.tsx` files are not probed (a `.ts` handler appears to work under Node's type-stripping but throws at first dispatch on any non-erasable syntax, and `.tsx` never runs) — author in TypeScript and compile to `src/{id}.js`, or register the command imperatively.
 
-```ts
-// src/plan-from-issue.ts
-export default async function planFromIssue(args: { issue: number }) {
+```js
+// src/plan-from-issue.js
+export default async function planFromIssue(args) {
   // handler body
 }
 ```

--- a/docs/plugins/dev-loop.md
+++ b/docs/plugins/dev-loop.md
@@ -31,7 +31,7 @@ Creates `./my-plugin/` with:
 
 Templates:
 
-- **`command`** — single command plugin. `src/index.ts` exports `activate(host)` and registers the command imperatively via `host.registerAction(...)`. (The filesystem-convention handler — `src/{id}.ts` auto-bound on first dispatch — is also supported by the host; the scaffold just shows the imperative path.)
+- **`command`** — single command plugin. `src/index.ts` exports `activate(host)` and registers the command imperatively via `host.registerAction(...)`. (The filesystem-convention handler — compiled `src/{id}.js` auto-bound on first dispatch — is also supported by the host; the scaffold just shows the imperative path.)
 - **`view`** — panel view + React component (`src/index.ts` + `src/panel.tsx`)
 - **`mcp`** — skeleton MCP server plus manifest wiring (`src/index.ts` + `src/server.ts`)
 - **`full`** — command + view + MCP example (largest, for experimenting)
@@ -154,7 +154,7 @@ Check:
 
 Check:
 
-- Handler file exists at `src/{id}.{ts,tsx,js,mjs}` (filesystem convention) OR
+- Compiled handler file exists at `src/{id}.{js,mjs}` (filesystem convention — `.ts`/`.tsx` are not probed; compile to `.js` first) OR
 - `activate()` called `host.registerAction({id: "{id}"}, handler)` (imperative)
 - No import errors in the handler file (these show up as toasts on command invocation)
 

--- a/electron/schemas/__tests__/pluginManifestIntegrity.test.ts
+++ b/electron/schemas/__tests__/pluginManifestIntegrity.test.ts
@@ -38,6 +38,14 @@ function mcpServer(overrides: Record<string, unknown>): Record<string, unknown> 
 function forgeProvider(overrides: Record<string, unknown>): Record<string, unknown> {
   return { id: "prov", name: "Prov", matches: ["github.com"], ...overrides };
 }
+function toolbarButton(id: string): Record<string, unknown> {
+  // actionId in the plugin's own namespace with no declared commands → the
+  // imperative escape hatch, so the actionId gate stays out of the way.
+  return { id, label: "Btn", iconId: "sparkles", actionId: "acme.my-plugin.x" };
+}
+function agent(id: string): Record<string, unknown> {
+  return { id, name: "Agent", command: "claude", color: "#abcdef", iconId: "sparkles" };
+}
 
 function errorCodes(result: ReturnType<typeof schema.safeParse>): string[] {
   if (result.success) return [];
@@ -59,6 +67,7 @@ describe("duplicate contribution ids (#10620)", () => {
   const arrays: Array<[string, (id: string) => Record<string, unknown>, Record<string, unknown>]> =
     [
       ["panels", panel, {}],
+      ["toolbarButtons", toolbarButton, {}],
       ["commands", command, {}],
       ["views", view, {}],
       ["settings", setting, {}],
@@ -99,6 +108,30 @@ describe("duplicate contribution ids (#10620)", () => {
     const result = manifestWith({
       panels: [panel("shared")],
       commands: [command("shared")],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // Agents carry an extra capability gate, so they sit outside the matrix and
+  // declare `agent:register` to isolate the duplicate-id check.
+  it("rejects two agents sharing an id", () => {
+    const result = schema.safeParse({
+      name: "acme.my-plugin",
+      version: "1.0.0",
+      capabilities: ["agent:register"],
+      contributes: { agents: [agent("dup"), agent("dup")] },
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "duplicate_contribution_id");
+    expect(issue?.path).toEqual(["contributes", "agents", 1, "id"]);
+  });
+
+  it("accepts distinct agent ids", () => {
+    const result = schema.safeParse({
+      name: "acme.my-plugin",
+      version: "1.0.0",
+      capabilities: ["agent:register"],
+      contributes: { agents: [agent("a"), agent("b")] },
     });
     expect(result.success).toBe(true);
   });
@@ -209,5 +242,29 @@ describe("MCP server ${settings:*} token references (#10620)", () => {
     });
     const tokenIssues = errorCodes(result).filter((c) => c === "settings_token_unknown");
     expect(tokenIssues).toHaveLength(2);
+  });
+
+  it("rejects a malformed token whose id breaks the safe-id grammar", () => {
+    // `foo/bar` is unmatchable by the supervisor's stricter regex, so the literal
+    // token would reach exec — flag it at parse time instead.
+    const result = manifestWith({
+      mcpServers: [mcpServer({ command: "${settings:foo/bar}" })],
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "settings_token_malformed");
+    expect(issue?.path).toEqual(["contributes", "mcpServers", 0, "command"]);
+  });
+
+  it("reports the token issue at the correct server index with multiple servers", () => {
+    const result = manifestWith({
+      settings: [setting("ok")],
+      mcpServers: [
+        mcpServer({ id: "a", args: ["${settings:ok}"] }),
+        mcpServer({ id: "b", args: ["${settings:bad}"] }),
+      ],
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "settings_token_unknown");
+    expect(issue?.path).toEqual(["contributes", "mcpServers", 1, "args", 0]);
   });
 });

--- a/electron/schemas/__tests__/pluginManifestIntegrity.test.ts
+++ b/electron/schemas/__tests__/pluginManifestIntegrity.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { getPluginManifestSchema } from "../plugin.js";
+
+const schema = getPluginManifestSchema(false);
+
+function manifestWith(contributes: Record<string, unknown>) {
+  return schema.safeParse({
+    name: "acme.my-plugin",
+    version: "1.0.0",
+    contributes,
+  });
+}
+
+// Minimal valid entry factories — only the fields the integrity checks read
+// matter; every other required field is set to a schema-valid stub.
+function panel(id: string): Record<string, unknown> {
+  return { id, name: "Panel", iconId: "sparkles", color: "#fff" };
+}
+function command(id: string): Record<string, unknown> {
+  return {
+    id,
+    title: "Cmd",
+    description: "",
+    category: "general",
+    kind: "command",
+    danger: "safe",
+  };
+}
+function view(id: string): Record<string, unknown> {
+  return { id, name: "View", componentPath: "./view/index.js", location: "panel" };
+}
+function setting(id: string): Record<string, unknown> {
+  return { id, type: "string" };
+}
+function mcpServer(overrides: Record<string, unknown>): Record<string, unknown> {
+  return { id: "srv", name: "Server", command: "node", ...overrides };
+}
+function forgeProvider(overrides: Record<string, unknown>): Record<string, unknown> {
+  return { id: "prov", name: "Prov", matches: ["github.com"], ...overrides };
+}
+
+function errorCodes(result: ReturnType<typeof schema.safeParse>): string[] {
+  if (result.success) return [];
+  return result.error.issues
+    .map((i) => (i as { params?: { errorCode?: string } }).params?.errorCode)
+    .filter((c): c is string => typeof c === "string");
+}
+
+function issueWithCode(result: ReturnType<typeof schema.safeParse>, code: string) {
+  if (result.success) return undefined;
+  return result.error.issues.find(
+    (i) => (i as { params?: { errorCode?: string } }).params?.errorCode === code
+  );
+}
+
+describe("duplicate contribution ids (#10620)", () => {
+  // Each array carries an `id` keying a runtime registry; a duplicate first-wins
+  // silently at load, so the second contribution must be rejected at parse time.
+  const arrays: Array<[string, (id: string) => Record<string, unknown>, Record<string, unknown>]> =
+    [
+      ["panels", panel, {}],
+      ["commands", command, {}],
+      ["views", view, {}],
+      ["settings", setting, {}],
+      ["mcpServers", (id) => mcpServer({ id }), {}],
+      ["forgeProviders", (id) => forgeProvider({ id }), {}],
+      ["fileDecorationProviders", (id) => ({ id, scopes: ["file"] }), {}],
+    ];
+
+  it.each(arrays)("rejects two %s entries sharing an id", (arrayName, make) => {
+    // Views need matching panels to isolate the duplicate check from the
+    // view→panel cross-ref; supply them when testing views.
+    const extra = arrayName === "views" ? { panels: [panel("dup"), panel("other")] } : {};
+    const result = manifestWith({ [arrayName]: [make("dup"), make("dup")], ...extra });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "duplicate_contribution_id");
+    expect(issue).toBeDefined();
+    expect(issue?.path).toEqual(["contributes", arrayName, 1, "id"]);
+  });
+
+  it.each(arrays)("accepts distinct %s ids", (arrayName, make) => {
+    const extra = arrayName === "views" ? { panels: [panel("a"), panel("b")] } : {};
+    const result = manifestWith({ [arrayName]: [make("a"), make("b")], ...extra });
+    expect(result.success).toBe(true);
+  });
+
+  it("reports the duplicate at the second occurrence, not the first", () => {
+    const result = manifestWith({ commands: [command("a"), command("b"), command("a")] });
+    expect(result.success).toBe(false);
+    const dupIssues = (result.success ? [] : result.error.issues).filter(
+      (i) =>
+        (i as { params?: { errorCode?: string } }).params?.errorCode === "duplicate_contribution_id"
+    );
+    expect(dupIssues.map((i) => i.path)).toEqual([["contributes", "commands", 2, "id"]]);
+  });
+
+  it("does not flag the same id used across different arrays", () => {
+    // Cross-array ids are namespaced independently and never collide.
+    const result = manifestWith({
+      panels: [panel("shared")],
+      commands: [command("shared")],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("forgeProvider cross-references (#10620)", () => {
+  it("accepts settingsScopeRef that names a declared setting", () => {
+    const result = manifestWith({
+      settings: [setting("token")],
+      forgeProviders: [forgeProvider({ settingsScopeRef: "token" })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects settingsScopeRef that names no declared setting", () => {
+    const result = manifestWith({
+      forgeProviders: [forgeProvider({ settingsScopeRef: "missing" })],
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "forge_settings_scope_ref_unknown");
+    expect(issue).toBeDefined();
+    expect(issue?.path).toEqual(["contributes", "forgeProviders", 0, "settingsScopeRef"]);
+  });
+
+  it("accepts viewRefs that name declared views", () => {
+    const result = manifestWith({
+      panels: [panel("v1")],
+      views: [view("v1")],
+      forgeProviders: [forgeProvider({ viewRefs: ["v1"] })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a viewRef that names no declared view, at the ref index", () => {
+    const result = manifestWith({
+      panels: [panel("v1")],
+      views: [view("v1")],
+      forgeProviders: [forgeProvider({ viewRefs: ["v1", "ghost"] })],
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "forge_view_ref_unknown");
+    expect(issue).toBeDefined();
+    expect(issue?.path).toEqual(["contributes", "forgeProviders", 0, "viewRefs", 1]);
+  });
+});
+
+describe("view → panel cross-reference (#10620)", () => {
+  it("accepts a view whose id matches a panel", () => {
+    const result = manifestWith({ panels: [panel("rich")], views: [view("rich")] });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a view with no matching panel (was silently ignored before)", () => {
+    const result = manifestWith({ views: [view("orphan")] });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "view_panel_ref_unknown");
+    expect(issue).toBeDefined();
+    expect(issue?.path).toEqual(["contributes", "views", 0, "id"]);
+  });
+});
+
+describe("MCP server ${settings:*} token references (#10620)", () => {
+  it("accepts tokens that name declared settings across command/args/env", () => {
+    const result = manifestWith({
+      settings: [setting("api_key"), setting("base_url"), setting("home")],
+      mcpServers: [
+        mcpServer({
+          command: "${settings:home}/bin/server",
+          args: ["--key", "${settings:api_key}"],
+          env: { BASE_URL: "${settings:base_url}" },
+        }),
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown token in command", () => {
+    const result = manifestWith({
+      mcpServers: [mcpServer({ command: "${settings:nope}" })],
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "settings_token_unknown");
+    expect(issue?.path).toEqual(["contributes", "mcpServers", 0, "command"]);
+  });
+
+  it("rejects an unknown token in an arg, at the arg index", () => {
+    const result = manifestWith({
+      settings: [setting("known")],
+      mcpServers: [mcpServer({ args: ["--a", "${settings:known}", "${settings:bad}"] })],
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "settings_token_unknown");
+    expect(issue?.path).toEqual(["contributes", "mcpServers", 0, "args", 2]);
+  });
+
+  it("rejects an unknown token in an env value, keyed by the env name", () => {
+    const result = manifestWith({
+      mcpServers: [mcpServer({ env: { TOKEN: "${settings:absent}" } })],
+    });
+    expect(result.success).toBe(false);
+    const issue = issueWithCode(result, "settings_token_unknown");
+    expect(issue?.path).toEqual(["contributes", "mcpServers", 0, "env", "TOKEN"]);
+  });
+
+  it("reports every unknown token in one string", () => {
+    const result = manifestWith({
+      mcpServers: [mcpServer({ args: ["${settings:a}-${settings:b}"] })],
+    });
+    const tokenIssues = errorCodes(result).filter((c) => c === "settings_token_unknown");
+    expect(tokenIssues).toHaveLength(2);
+  });
+});

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -171,8 +171,9 @@ function isSafePluginViewComponentPath(componentPath: string): boolean {
 /**
  * View contribution. A view renders into a `contributes.panels` entry with a
  * matching `id`; at plugin load (`PluginService.loadPlugin`) the panels loop
- * attaches the view's `componentPath` to that panel kind. A view with no
- * matching panel entry is ignored. Only `location: "panel"` is supported — it
+ * attaches the view's `componentPath` to that panel kind. A view whose `id`
+ * matches no panel is rejected by the manifest-level `superRefine` (#10620) —
+ * it would otherwise silently never render. Only `location: "panel"` is supported — it
  * sets `showInPalette: true` so the view is spawnable from the panel palette.
  * `"sidebar"` is rejected at the schema boundary: the sidebar host does not
  * exist yet, so accepting it would validate a manifest the runtime cannot
@@ -246,8 +247,11 @@ const CredentialFieldSchema = z
 /**
  * `forgeProviders` manifest entry — wired: the registry populates Preferences
  * and remote-routing before any plugin code runs. See
- * `docs/architecture/forge-provider-abstraction.md`. Two fields are validated
- * for SHAPE only and carry no runtime authority (frozen at 1.0):
+ * `docs/architecture/forge-provider-abstraction.md`. `settingsScopeRef` and
+ * `viewRefs` are cross-validated against `contributes.settings`/`contributes.views`
+ * by the manifest-level `superRefine` (#10620) — a dangling ref is a parse
+ * error. Two fields are validated for SHAPE only and carry no runtime authority
+ * (frozen at 1.0):
  *   - `capabilities` is informational; the host gates behavior on the runtime
  *     `ForgeProviderImpl` field presence, never on these strings.
  *   - `slots` values are opaque renderer view-ids checked for non-emptiness
@@ -1077,6 +1081,122 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
           });
         });
       }
+
+      // Duplicate contribution ids — within each contribution array, the bare
+      // `id` is the lookup key the runtime keys its registries on (panel kind,
+      // command descriptor, MCP server, agent, view, setting, forge provider,
+      // file-decoration provider). A duplicate silently first-wins at load, so
+      // the second contribution vanishes with no diagnostic. Reject it at the
+      // manifest gate instead. The check is per-array (ids in different arrays
+      // are namespaced independently and never collide).
+      const reportDuplicateIds = (arrayName: string, entries: ReadonlyArray<{ id: string }>) => {
+        const seen = new Set<string>();
+        entries.forEach((entry, index) => {
+          if (seen.has(entry.id)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["contributes", arrayName, index, "id"],
+              message: `Duplicate id "${entry.id}" in contributes.${arrayName} — each contribution id must be unique within its array.`,
+              params: { errorCode: "duplicate_contribution_id" },
+            });
+          } else {
+            seen.add(entry.id);
+          }
+        });
+      };
+      reportDuplicateIds("panels", manifest.contributes.panels);
+      reportDuplicateIds("toolbarButtons", manifest.contributes.toolbarButtons);
+      reportDuplicateIds("commands", manifest.contributes.commands);
+      reportDuplicateIds("views", manifest.contributes.views);
+      reportDuplicateIds("mcpServers", manifest.contributes.mcpServers);
+      reportDuplicateIds("forgeProviders", manifest.contributes.forgeProviders);
+      reportDuplicateIds("fileDecorationProviders", manifest.contributes.fileDecorationProviders);
+      reportDuplicateIds("agents", manifest.contributes.agents);
+      reportDuplicateIds("settings", manifest.contributes.settings);
+
+      // Cross-reference integrity — a contribution that names another by id must
+      // point at one that exists in the same manifest, else the reference dangles
+      // and the wiring silently no-ops at runtime.
+      const settingIds = new Set(manifest.contributes.settings.map((setting) => setting.id));
+      const viewIds = new Set(manifest.contributes.views.map((view) => view.id));
+      const panelIds = new Set(manifest.contributes.panels.map((panel) => panel.id));
+
+      // `forgeProvider.settingsScopeRef` → a declared setting; `viewRefs[]` →
+      // declared views. Both were validated for shape only before (#10620).
+      manifest.contributes.forgeProviders.forEach((provider, index) => {
+        if (provider.settingsScopeRef !== undefined && !settingIds.has(provider.settingsScopeRef)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["contributes", "forgeProviders", index, "settingsScopeRef"],
+            message: `forgeProvider settingsScopeRef "${provider.settingsScopeRef}" matches no contributes.settings[].id.`,
+            params: { errorCode: "forge_settings_scope_ref_unknown" },
+          });
+        }
+        provider.viewRefs?.forEach((ref, refIndex) => {
+          if (!viewIds.has(ref)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["contributes", "forgeProviders", index, "viewRefs", refIndex],
+              message: `forgeProvider viewRef "${ref}" matches no contributes.views[].id.`,
+              params: { errorCode: "forge_view_ref_unknown" },
+            });
+          }
+        });
+      });
+
+      // A view renders into a `contributes.panels` entry with a matching id; a
+      // view whose id matches no panel can never be shown (#10620). This is a
+      // hard error now — it previously silently no-op'd at load.
+      manifest.contributes.views.forEach((view, index) => {
+        if (!panelIds.has(view.id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["contributes", "views", index, "id"],
+            message: `View "${view.id}" has no matching contributes.panels[].id — a view renders into a panel of the same id, so it would never be shown.`,
+            params: { errorCode: "view_panel_ref_unknown" },
+          });
+        }
+      });
+
+      // Every `${settings:<id>}` token in an MCP server's command/args/env must
+      // name a declared setting — the supervisor substitutes only declared ids
+      // (`SETTINGS_TEMPLATE_RE` in PluginMcpSupervisor.ts) and an unknown id
+      // resolves to the empty string, silently dropping the value. Agents have
+      // no settings-substitution path, so their args are left untouched.
+      const settingsTokenRe = /\$\{settings:([a-zA-Z0-9._-]+)\}/g;
+      const reportUnknownSettingsTokens = (text: string, path: (string | number)[]) => {
+        for (const match of text.matchAll(settingsTokenRe)) {
+          const key = match[1]!;
+          if (!settingIds.has(key)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path,
+              message: `Reference to undeclared setting "\${settings:${key}}" — no contributes.settings[].id matches "${key}".`,
+              params: { errorCode: "settings_token_unknown" },
+            });
+          }
+        }
+      };
+      manifest.contributes.mcpServers.forEach((server, index) => {
+        reportUnknownSettingsTokens(server.command, [
+          "contributes",
+          "mcpServers",
+          index,
+          "command",
+        ]);
+        server.args?.forEach((arg, argIndex) =>
+          reportUnknownSettingsTokens(arg, ["contributes", "mcpServers", index, "args", argIndex])
+        );
+        for (const [envKey, envValue] of Object.entries(server.env ?? {})) {
+          reportUnknownSettingsTokens(envValue, [
+            "contributes",
+            "mcpServers",
+            index,
+            "env",
+            envKey,
+          ]);
+        }
+      });
     });
 }
 

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -1162,11 +1162,24 @@ export function getPluginManifestSchema(isBuiltin: boolean) {
       // name a declared setting — the supervisor substitutes only declared ids
       // (`SETTINGS_TEMPLATE_RE` in PluginMcpSupervisor.ts) and an unknown id
       // resolves to the empty string, silently dropping the value. Agents have
-      // no settings-substitution path, so their args are left untouched.
-      const settingsTokenRe = /\$\{settings:([a-zA-Z0-9._-]+)\}/g;
+      // no settings-substitution path, so their args are left untouched. The
+      // scan matches any `${settings:...}` shape (broad inner pattern), then
+      // classifies: a key outside the `${SAFE_ID_PATTERN}` grammar is malformed
+      // (the supervisor's stricter regex would skip it, passing the literal
+      // token to exec); a well-formed key naming no setting is unknown.
+      const settingsTokenRe = /\$\{settings:([^}]*)\}/g;
       const reportUnknownSettingsTokens = (text: string, path: (string | number)[]) => {
         for (const match of text.matchAll(settingsTokenRe)) {
           const key = match[1]!;
+          if (!SAFE_ID_PATTERN.test(key)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path,
+              message: `Malformed settings token "${match[0]}" — the setting id must match ${SAFE_ID_PATTERN.source}.`,
+              params: { errorCode: "settings_token_malformed" },
+            });
+            continue;
+          }
           if (!settingIds.has(key)) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -187,13 +187,17 @@ const BUILT_IN_ACTION_ID_SET: ReadonlySet<string> = new Set<string>(BUILT_IN_ACT
 
 /**
  * Filesystem-convention extensions probed for a manifest-declared command's
- * handler module, in precedence order. `.ts`/`.tsx` resolve in Electron 41
- * (Node 24's type-stripping covers `.ts`; `.tsx` needs the plugin author to
- * pre-compile or it'll fail at first dispatch) so a dev-mode plugin can ship
- * source directly. The probe is async file-access only — no module evaluation
- * happens until dispatch time.
+ * handler module, in precedence order. Only shippable JavaScript is probed:
+ * `.ts`/`.tsx` are deliberately excluded (#10620). Node 24's type-stripping
+ * makes a `.ts` handler *appear* to work for erasable syntax but throws a
+ * `SyntaxError` at first dispatch on any non-erasable construct (enum,
+ * parameter properties, decorators), and `.tsx` never runs — a high-confusion
+ * footgun that surfaces only at runtime. A `.ts`/`.tsx` handler in a built-in
+ * or sample plugin's `src/` is caught at build time by
+ * `validateCommandHandlerExtensions` in `scripts/build-main.mjs`. The probe is
+ * async file-access only — no module evaluation happens until dispatch time.
  */
-const COMMAND_HANDLER_EXTENSIONS = [".ts", ".tsx", ".js", ".mjs"] as const;
+const COMMAND_HANDLER_EXTENSIONS = [".js", ".mjs"] as const;
 
 /**
  * Compound-capability lattice (#9247). The flat
@@ -1520,7 +1524,7 @@ export class PluginService {
   }
 
   /**
-   * Probe `{pluginDir}/src/{cmdId}.{ts,tsx,js,mjs}` in precedence order,
+   * Probe `{pluginDir}/src/{cmdId}.{js,mjs}` in precedence order,
    * returning the first existing path or `null` when none match. The result
    * is cached in {@link commandModulePaths} so the probe runs once per
    * command per load — dispatch reads the cached path directly. Path

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -747,6 +747,18 @@ describe("PluginManifestSchema forgeProviders contribution", () => {
     const result = getPluginManifestSchema(false).safeParse({
       ...validBase,
       contributes: {
+        // settingsScopeRef / viewRefs are cross-validated against the manifest's
+        // own settings/views (#10620), and each referenced view needs a matching
+        // panel id — declare them so this stays a positive case.
+        panels: [
+          { id: "github-issues", name: "Issues", iconId: "eye", color: "#abc" },
+          { id: "github-prs", name: "PRs", iconId: "eye", color: "#abc" },
+        ],
+        settings: [{ id: "github", type: "string", label: "GitHub" }],
+        views: [
+          { id: "github-issues", name: "Issues", componentPath: "./issues.js", location: "panel" },
+          { id: "github-prs", name: "PRs", componentPath: "./prs.js", location: "panel" },
+        ],
         forgeProviders: [
           {
             id: "github",
@@ -902,7 +914,11 @@ describe("PluginManifestSchema contributes strict validation", () => {
   it("accepts the stable views key inside contributes (#10466)", () => {
     const result = getPluginManifestSchema(false).safeParse({
       ...validBase,
-      contributes: { views: [{ id: "v", name: "V", componentPath: "./v.js", location: "panel" }] },
+      contributes: {
+        // A view needs a matching panel id (view_panel_ref_unknown, #10620).
+        panels: [{ id: "v", name: "V", iconId: "eye", color: "#abc" }],
+        views: [{ id: "v", name: "V", componentPath: "./v.js", location: "panel" }],
+      },
     });
     expect(result.success).toBe(true);
     if (result.success) {
@@ -925,6 +941,8 @@ describe("PluginManifestSchema contributes strict validation", () => {
     const result = getPluginManifestSchema(false).safeParse({
       ...validBase,
       contributes: {
+        // A view needs a matching panel id (view_panel_ref_unknown, #10620).
+        panels: [{ id: "v", name: "V", iconId: "eye", color: "#abc" }],
         experimental_views: [{ id: "v", name: "V", componentPath: "./v.js", location: "panel" }],
       },
     });
@@ -955,6 +973,8 @@ describe("PluginManifestSchema contributes strict validation", () => {
     const result = getPluginManifestSchema(false).safeParse({
       ...validBase,
       contributes: {
+        // The surviving canonical view needs a matching panel id (#10620).
+        panels: [{ id: "canonical", name: "Canonical", iconId: "eye", color: "#abc" }],
         views: [{ id: "canonical", name: "Canonical", componentPath: "./c.js", location: "panel" }],
         experimental_views: [
           { id: "legacy", name: "Legacy", componentPath: "./l.js", location: "panel" },
@@ -1589,7 +1609,7 @@ describe("PluginService manifest command contributions (#9281)", () => {
         },
       },
       {
-        "plan.ts": `export default async (args) => ({ ok: true, args })`,
+        "plan.js": `export default async (args) => ({ ok: true, args })`,
       }
     );
 
@@ -1659,7 +1679,7 @@ describe("PluginService manifest command contributions (#9281)", () => {
         },
       },
       {
-        "broken.ts": `export const named = 1`,
+        "broken.js": `export const named = 1`,
       }
     );
 
@@ -1671,8 +1691,9 @@ describe("PluginService manifest command contributions (#9281)", () => {
     ).rejects.toThrow(/no callable default export/);
   });
 
-  it("probes extensions in order .ts → .tsx → .js → .mjs", async () => {
-    // When both .ts and .js exist, .ts wins.
+  it("probes extensions in order .js → .mjs and ignores a .ts sibling", async () => {
+    // The resolver now only probes built handler modules (.js, .mjs); a .ts or
+    // .tsx sibling is never picked. When both .js and .mjs exist, .js wins.
     await writePluginWithSrc(
       "cmd-order",
       {
@@ -1692,8 +1713,10 @@ describe("PluginService manifest command contributions (#9281)", () => {
         },
       },
       {
-        "pick.ts": `export default () => "ts-wins"`,
-        "pick.js": `export default () => "js-loses"`,
+        // A .ts sibling must NOT be probed — if it were, it would shadow .js.
+        "pick.ts": `export default () => "ts-not-probed"`,
+        "pick.js": `export default () => "js-wins"`,
+        "pick.mjs": `export default () => "mjs-loses"`,
       }
     );
 
@@ -1706,7 +1729,7 @@ describe("PluginService manifest command contributions (#9281)", () => {
       ctx("acme.cmd-order"),
       []
     );
-    expect(result).toBe("ts-wins");
+    expect(result).toBe("js-wins");
   });
 
   it("surfaces a loadError when a manifest command collides with a built-in id", async () => {
@@ -7397,7 +7420,7 @@ describe("reserved contribution point warnings", () => {
     expect(viewWarnings).toHaveLength(0);
   });
 
-  it("warns and skips an views entry with no matching panel id", async () => {
+  it("rejects the whole manifest when a views entry has no matching panel id (#10620)", async () => {
     await writePlugin("orphan", {
       name: "acme.orphan",
       version: "1.0.0",
@@ -7418,18 +7441,14 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    expect(registerPanelKind).toHaveBeenCalledTimes(1);
-    expect(registerPanelKind).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "acme.orphan.main" })
-    );
-    const panelCall = (registerPanelKind as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
-      componentPath?: string;
-    };
-    expect(panelCall.componentPath).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Plugin "acme.orphan": views entry "ghost" has no matching contributes.panels entry'
-      )
+    // An orphan view (id matches no panel) is now a hard manifest error
+    // (view_panel_ref_unknown superRefine), so the plugin never loads — no
+    // panel kind is registered and the failure surfaces as an invalid manifest.
+    expect(service.listPlugins()).toHaveLength(0);
+    expect(registerPanelKind).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest in orphan"),
+      expect.anything()
     );
   });
 
@@ -7557,7 +7576,7 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
-  it("warns and keeps the first occurrence on duplicate views ids", async () => {
+  it("rejects the whole manifest on duplicate views ids (#10620)", async () => {
     await writePlugin("dup", {
       name: "acme.dup",
       version: "1.0.0",
@@ -7574,13 +7593,14 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
-    expect(registerPanelKind).toHaveBeenCalledTimes(1);
-    const panelCall = (registerPanelKind as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
-      componentPath?: string;
-    };
-    expect(panelCall.componentPath).toBe("plugin://acme.dup/first.js");
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('views has duplicate entries for id "main"')
+    // A duplicate view id is now a hard manifest error
+    // (duplicate_contribution_id superRefine), so the plugin never loads —
+    // no first-wins, no panel kind registered.
+    expect(service.listPlugins()).toHaveLength(0);
+    expect(registerPanelKind).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest in dup"),
+      expect.anything()
     );
   });
 
@@ -7628,6 +7648,19 @@ describe("reserved contribution point warnings", () => {
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
       contributes: {
+        // `settingsScopeRef` / `viewRefs` are cross-validated against the
+        // manifest's own settings/views (#10620), so the referenced ids must
+        // exist; the referenced view in turn needs a matching panel id.
+        panels: [{ id: "github-issues", name: "Issues", iconId: "eye", color: "#abc" }],
+        settings: [{ id: "github", type: "string", label: "GitHub" }],
+        views: [
+          {
+            id: "github-issues",
+            name: "Issues",
+            componentPath: "./issues.js",
+            location: "panel",
+          },
+        ],
         forgeProviders: [
           {
             id: "github",
@@ -7656,8 +7689,6 @@ describe("reserved contribution point warnings", () => {
       },
     ]);
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("contributes.forgeProviders"));
-    // A forge-only manifest does not touch the other registries.
-    expect(registerPanelKind).not.toHaveBeenCalled();
     expect(registerToolbarButton).not.toHaveBeenCalled();
     expect(registerPluginMenuItem).not.toHaveBeenCalled();
   });
@@ -7792,14 +7823,15 @@ describe("reserved contribution point warnings", () => {
     expect(service.findMcpServerContribution("acme.mixed", "svc")).toBeDefined();
   });
 
-  it("logs one warning per orphan view entry", async () => {
+  it("rejects the whole manifest when any view entry is an orphan (#10620)", async () => {
     await writePlugin("many", {
       name: "acme.many",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
       contributes: {
-        // `a` matches a panel and binds; `c` is an orphan with no matching
-        // panel id. The orphan should log exactly one warning naming its id.
+        // `a` matches a panel and would bind; `c` is an orphan with no matching
+        // panel id. A single orphan view now fails the whole manifest
+        // (view_panel_ref_unknown superRefine) rather than logging a warning.
         panels: [{ id: "a", name: "A", iconId: "eye", color: "#000" }],
         views: [
           { id: "a", name: "A", componentPath: "./a.js", location: "panel" },
@@ -7811,10 +7843,16 @@ describe("reserved contribution point warnings", () => {
     const service = new PluginService(tmpDir, "0.7.5");
     await service.initialize();
 
+    expect(service.listPlugins()).toHaveLength(0);
+    expect(registerPanelKind).not.toHaveBeenCalled();
     const orphanWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
       String(call[0]).includes('"c" has no matching contributes.panels')
     );
-    expect(orphanWarnings).toHaveLength(1);
+    expect(orphanWarnings).toHaveLength(0);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid manifest in many"),
+      expect.anything()
+    );
   });
 
   it("rejects a views entry with an invalid location at schema level", () => {

--- a/packages/daintree-plugin/src/__tests__/validate.test.ts
+++ b/packages/daintree-plugin/src/__tests__/validate.test.ts
@@ -131,6 +131,9 @@ describe("runValidate", () => {
       version: "1.0.0",
       engines: { daintree: "^0.11.0" },
       contributes: {
+        // The token must reference a declared setting now (#10620), else the
+        // schema rejects the manifest before --env resolution runs.
+        settings: [{ id: "apiToken", type: "secret" }],
         mcpServers: [
           {
             id: "main",
@@ -201,9 +204,12 @@ describe("runValidate", () => {
     expect(result.errors.join("\n")).toMatch(/settings\.0\.id/);
   });
 
-  it("ignores a ${settings:…} token whose key breaks the safe-id grammar (#10513)", async () => {
-    // The host's substitution gate would never resolve `bad key`, so --env must
-    // not flag it as a missing value — it sees no resolvable tokens at all.
+  it("rejects a ${settings:…} token whose key breaks the safe-id grammar (#10620)", async () => {
+    // #10513 chose to silently ignore a malformed token here; #10620 tightens
+    // the manifest schema so a token the host could never resolve (`bad key`
+    // with a space) is a hard error (settings_token_malformed). The validator
+    // imports the same schema, so it now reports the malformed token rather
+    // than passing the literal through to exec at runtime.
     await writeManifest({
       name: "acme.demo",
       version: "1.0.0",
@@ -213,8 +219,8 @@ describe("runValidate", () => {
       },
     });
     const result = await runValidate({ dir: tmpDir, env: true });
-    expect(result.warnings.join("\n")).toMatch(/no \$\{settings:…\} tokens/);
-    expect(result.errors.join("\n")).not.toMatch(/bad key/);
+    expect(result.ok).toBe(false);
+    expect(result.errors.join("\n")).toMatch(/Malformed settings token/);
   });
 
   it("warns when main points at a missing file whose dir exists (#10513)", async () => {

--- a/scripts/__tests__/plugin-build-assets.test.mjs
+++ b/scripts/__tests__/plugin-build-assets.test.mjs
@@ -7,6 +7,7 @@ import {
   PLUGIN_EXTRA_ASSET_SKIP_DIRS,
   copyPluginExtraAssets,
   findMissingPluginAssets,
+  findTypeScriptCommandHandlers,
 } from "../build-main.mjs";
 
 let workDir;
@@ -244,5 +245,84 @@ describe("findMissingPluginAssets", () => {
 
     expect(missing).toHaveLength(1);
     expect(missing[0]).toContain("sample/bad-json");
+  });
+});
+
+describe("findTypeScriptCommandHandlers", () => {
+  function writeManifest(tier, name, manifest, handlers = {}) {
+    const pluginDir = path.join(workDir, tier, name);
+    writeFile(path.join(pluginDir, "plugin.json"), JSON.stringify(manifest));
+    for (const [relPath, contents] of Object.entries(handlers)) {
+      writeFile(path.join(pluginDir, relPath), contents);
+    }
+  }
+
+  it("flags a command whose handler is authored as src/{id}.ts", () => {
+    writeManifest(
+      "sample",
+      "ts-handler",
+      { contributes: { commands: [{ id: "greet" }] } },
+      { "src/greet.ts": "export default () => {}\n" }
+    );
+
+    const offenders = findTypeScriptCommandHandlers(workDir);
+
+    expect(offenders).toHaveLength(1);
+    expect(offenders[0]).toBe("sample/ts-handler: src/greet.ts");
+  });
+
+  it("flags a .tsx handler", () => {
+    writeManifest(
+      "builtin",
+      "tsx-handler",
+      { contributes: { commands: [{ id: "panel" }] } },
+      { "src/panel.tsx": "export default () => {}\n" }
+    );
+
+    const offenders = findTypeScriptCommandHandlers(workDir);
+
+    expect(offenders).toEqual(["builtin/tsx-handler: src/panel.tsx"]);
+  });
+
+  it("accepts a .js handler", () => {
+    writeManifest(
+      "sample",
+      "js-handler",
+      { contributes: { commands: [{ id: "greet" }] } },
+      { "src/greet.js": "export default () => {}\n" }
+    );
+
+    expect(findTypeScriptCommandHandlers(workDir)).toEqual([]);
+  });
+
+  it("ignores a command with no on-disk handler (imperative registration)", () => {
+    writeManifest("sample", "imperative", { contributes: { commands: [{ id: "greet" }] } });
+
+    expect(findTypeScriptCommandHandlers(workDir)).toEqual([]);
+  });
+
+  it("reports only the offending command when a plugin mixes .ts and .js handlers", () => {
+    writeManifest(
+      "sample",
+      "mixed",
+      { contributes: { commands: [{ id: "ok" }, { id: "bad" }] } },
+      { "src/ok.js": "export default () => {}\n", "src/bad.ts": "export default () => {}\n" }
+    );
+
+    const offenders = findTypeScriptCommandHandlers(workDir);
+
+    expect(offenders).toEqual(["sample/mixed: src/bad.ts"]);
+  });
+
+  it("returns no findings when the plugins root does not exist", () => {
+    expect(findTypeScriptCommandHandlers(path.join(workDir, "never"))).toEqual([]);
+  });
+
+  it("skips an unreadable manifest instead of throwing", () => {
+    const pluginDir = path.join(workDir, "sample", "bad-json");
+    writeFile(path.join(pluginDir, "plugin.json"), "{ not json");
+    writeFile(path.join(pluginDir, "src", "greet.ts"), "x\n");
+
+    expect(findTypeScriptCommandHandlers(workDir)).toEqual([]);
   });
 });

--- a/scripts/__tests__/plugin-build-assets.test.mjs
+++ b/scripts/__tests__/plugin-build-assets.test.mjs
@@ -314,6 +314,32 @@ describe("findTypeScriptCommandHandlers", () => {
     expect(offenders).toEqual(["sample/mixed: src/bad.ts"]);
   });
 
+  it("does not flag a .ts handler when a loadable .js sibling exists", () => {
+    // Mid-migration: the runtime resolves greet.js, so greet.ts is not a footgun.
+    writeManifest(
+      "sample",
+      "migrating",
+      { contributes: { commands: [{ id: "greet" }] } },
+      { "src/greet.ts": "x\n", "src/greet.js": "export default () => {}\n" }
+    );
+
+    expect(findTypeScriptCommandHandlers(workDir)).toEqual([]);
+  });
+
+  it("flags .mts and .cts handlers (also unloadable at runtime)", () => {
+    writeManifest(
+      "builtin",
+      "module-ts",
+      { contributes: { commands: [{ id: "a" }, { id: "b" }] } },
+      { "src/a.mts": "x\n", "src/b.cts": "x\n" }
+    );
+
+    expect(findTypeScriptCommandHandlers(workDir).sort()).toEqual([
+      "builtin/module-ts: src/a.mts",
+      "builtin/module-ts: src/b.cts",
+    ]);
+  });
+
   it("returns no findings when the plugins root does not exist", () => {
     expect(findTypeScriptCommandHandlers(path.join(workDir, "never"))).toEqual([]);
   });

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -393,7 +393,15 @@ export function findTypeScriptCommandHandlers(pluginsSrcRoot) {
       for (const command of commands) {
         const id = command?.id;
         if (typeof id !== "string" || id.length === 0) continue;
-        for (const ext of [".ts", ".tsx"]) {
+        // Mirrors COMMAND_HANDLER_EXTENSIONS in PluginService.ts. A loadable
+        // sibling means the runtime resolves the command (e.g. a plugin
+        // mid-migration keeping the .ts source beside the compiled .js), so the
+        // TypeScript source is not a footgun — skip it.
+        const loadableExts = [".js", ".mjs"];
+        if (loadableExts.some((ext) => fs.existsSync(path.join(pluginDir, "src", `${id}${ext}`)))) {
+          continue;
+        }
+        for (const ext of [".ts", ".tsx", ".mts", ".cts"]) {
           if (fs.existsSync(path.join(pluginDir, "src", `${id}${ext}`))) {
             offenders.push(`${tier}/${entry.name}: src/${id}${ext}`);
           }

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -362,6 +362,93 @@ function validateCopiedPluginAssets() {
   process.exit(1);
 }
 
+/**
+ * Scan each source plugin's declared `contributes.commands` and report any whose
+ * handler module is authored as TypeScript (`src/{id}.ts` / `src/{id}.tsx`).
+ * `COMMAND_HANDLER_EXTENSIONS` in PluginService.ts probes only `.js`/`.mjs` at
+ * runtime (#10620): a `.ts` handler is either never found or throws a
+ * `SyntaxError` at first dispatch under Node's type-stripping (non-erasable
+ * syntax), and `.tsx` never runs. Catching it at build time turns a runtime
+ * footgun into a loud failure. Pure (no exit/logging) and parameterized on the
+ * source plugins root so it is unit testable; a missing root yields `[]`.
+ */
+export function findTypeScriptCommandHandlers(pluginsSrcRoot) {
+  const offenders = [];
+  for (const tier of ["builtin", "sample"]) {
+    const tierRoot = path.join(pluginsSrcRoot, tier);
+    if (!fs.existsSync(tierRoot)) continue;
+    for (const entry of fs.readdirSync(tierRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const pluginDir = path.join(tierRoot, entry.name);
+      const manifestPath = path.join(pluginDir, "plugin.json");
+      if (!fs.existsSync(manifestPath)) continue;
+      let manifest;
+      try {
+        manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+      } catch {
+        // The dedicated manifest validation step reports unreadable manifests.
+        continue;
+      }
+      const commands = manifest?.contributes?.commands ?? [];
+      for (const command of commands) {
+        const id = command?.id;
+        if (typeof id !== "string" || id.length === 0) continue;
+        for (const ext of [".ts", ".tsx"]) {
+          if (fs.existsSync(path.join(pluginDir, "src", `${id}${ext}`))) {
+            offenders.push(`${tier}/${entry.name}: src/${id}${ext}`);
+          }
+        }
+      }
+    }
+  }
+  return offenders;
+}
+
+/**
+ * Fail the build (warn in watch mode) when a plugin ships a TypeScript command
+ * handler the runtime can never load (#10620). Same severity model as
+ * `validateCopiedPluginAssets`: loud-and-fatal for single/production builds, a
+ * warning under watch where the source may still be mid-edit.
+ */
+function validateCommandHandlerExtensions() {
+  const offenders = findTypeScriptCommandHandlers(path.join(root, "plugins"));
+  if (offenders.length === 0) return;
+
+  const detail = offenders.map((o) => `  - ${o}`).join("\n");
+  const message = `[Build] TypeScript command handlers will not load at runtime — the host probes only .js/.mjs (#10620). Compile or rewrite these as .js/.mjs:\n${detail}`;
+  if (isWatch) {
+    console.warn(message);
+    return;
+  }
+  console.error(message);
+  process.exit(1);
+}
+
+/**
+ * Typecheck plugin code (`tsconfig.plugins.json`) before emitting output so a
+ * type error in a built-in/sample plugin's main code fails the build instead of
+ * surfacing at runtime (#10620). Uses `tsc --noEmit` — never `tsc -b`, which
+ * emits `.js` into the source tree and would clobber the esbuild output. Skipped
+ * in watch mode (a full typecheck would stall the watcher); a banner points devs
+ * at `npm run check`.
+ */
+function runPluginTypecheck() {
+  if (isWatch) {
+    console.log("[Build] Plugin types skipped in watch mode — run npm run check to typecheck.");
+    return;
+  }
+  const tscBin = process.platform === "win32" ? "tsc.cmd" : "tsc";
+  const tscPath = path.join(root, "node_modules", ".bin", tscBin);
+  const result = spawnSync(tscPath, ["--noEmit", "-p", "tsconfig.plugins.json"], {
+    stdio: "inherit",
+    cwd: root,
+  });
+  if (result.status !== 0) {
+    console.error("[Build] Plugin typecheck failed.");
+    process.exit(result.status ?? 1);
+  }
+}
+
 function createReadyMarkerPlugin() {
   return {
     name: "build-ready-marker",
@@ -383,6 +470,12 @@ async function run() {
   // output, so an invalid `plugin.json` neither wipes the prior build nor ships
   // a broken plugin (#10564).
   validatePluginManifests();
+
+  // Reject TypeScript command handlers the runtime can never load, and
+  // typecheck plugin code, before any output is emitted (#10620). Both run
+  // ahead of the clean/emit so a failure leaves the prior build intact.
+  validateCommandHandlerExtensions();
+  runPluginTypecheck();
 
   if (isProd && !isWatch) {
     // Clean both the electron host bundles and the built-in plugin outputs


### PR DESCRIPTION
## Summary

- Manifest schema now rejects duplicate contribution ids across all arrays and adds cross-reference validation: `forgeProvider.settingsScopeRef`/`viewRefs` → declared settings/views, `view.id` → declared panels, `${settings:*}` tokens in MCP server `command`/`args`/`env` → declared settings (malformed token ids outside the safe-id grammar get a separate error code)
- Command handler extensions narrowed to `.js`/`.mjs` only — `.ts`/`.tsx` were accepted before but throw at first dispatch on non-erasable syntax under Node 24's type-stripping; a new fatal build-time scan in `scripts/build-main.mjs` catches any TypeScript handlers in built-in/sample plugins before they ship
- `tsc --noEmit -p tsconfig.plugins.json` wired into `build:main` for single/production builds (watch mode skips with a banner); `--noEmit` specifically to avoid clobbering esbuild output

**Behavior change:** views whose `id` matches no declared panel were previously silently ignored at load — they are now a hard manifest parse error (`view_panel_ref_unknown`). No built-in or sample plugin is affected.

Resolves #10620

## Changes

- `electron/schemas/plugin.ts` — `superRefine` additions for duplicate-id checks across all nine contribution arrays and cross-reference validation
- `electron/services/PluginService.ts` — `COMMAND_HANDLER_EXTENSIONS` narrowed to `[".js", ".mjs"]`
- `scripts/build-main.mjs` — `findTypeScriptCommandHandlers` scanner + `runPluginTypecheck` wired into production build
- `electron/schemas/__tests__/pluginManifestIntegrity.test.ts` — new test file covering every new check: cross-array duplicates, indexed error paths, malformed token ids, and all cross-reference cases
- `scripts/__tests__/plugin-build-assets.test.mjs` — scanner tests: `.ts`/`.tsx`/`.mts`/`.cts` flagged, `.js` sibling skips, imperative-only handlers ignored
- `docs/plugins/contribution-points.md` + `dev-loop.md` — handlers must ship as `.js`/`.mjs`

## Testing

Full `electron/schemas` test suite (372 tests) green. `check:plugin-manifests` green. ESLint and Prettier clean on all changed files.