### PR TITLE
fix(plugins): harden host-API contract — async rejection, lazy-handler docs, mock parity

### DIFF
--- a/docs/plugins/contribution-points.md
+++ b/docs/plugins/contribution-points.md
@@ -55,7 +55,9 @@ export default async function planFromIssue(args: { issue: number }) {
 }
 ```
 
-_Imperative registration (escape hatch for dynamic commands):_
+> **Lazy handlers receive `args` only — no `host`.** A filesystem-convention handler's single parameter is the dispatched `args` payload. There is no second `host` argument, so a lazy handler **cannot** call `host.showQuickPick`, `host.sendToActiveAgent`, `host.settings.get`, or any other host API. This is structural, not an oversight: the host is scoped to `activate()` and is revoked once activation returns, long before a command is first dispatched, so there is no live host to hand a lazily-imported handler. **If your command needs host APIs, register it imperatively in `activate()`** (next section) — that handler closes over the live `host`. An imperative `registerAction` for the same id supersedes the lazy file, so you can start with a manifest-declared stub and graduate to `registerAction` the moment you need host access.
+
+_Imperative registration (escape hatch for dynamic commands — and the only way to reach host APIs from a command handler):_
 
 > `@daintreehq/plugin-sdk` is the forward-looking published name for the SDK types/runtime (reserved in `shared/types/plugin-sdk.ts`, scaffolded as a dependency by the `daintree-plugin` CLI). It's distinct from the in-repo `daintree-plugin` CLI package — don't conflate the two.
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2180,8 +2180,14 @@ export class PluginService {
       postToPanel: (channel, payload) => {
         if (!isBound()) return Promise.resolve();
         if (typeof channel !== "string" || channel.length === 0 || channel.includes(":")) {
-          throw new Error(
-            `Plugin "${pluginId}" postToPanel: channel must be a non-empty string without colons: ${String(channel)}`
+          // Reject (not sync throw): this is a post-activation runtime-surface
+          // method returning a Promise, so a validation error must stay inside
+          // the Promise contract a plugin can `.catch()` (#10617). The liveness
+          // no-op above stays a silent resolve.
+          return Promise.reject(
+            new Error(
+              `Plugin "${pluginId}" postToPanel: channel must be a non-empty string without colons: ${String(channel)}`
+            )
           );
         }
         broadcastToRenderer(`plugin:${pluginId}:${channel}`, payload);
@@ -2546,8 +2552,11 @@ export class PluginService {
       invalidateFileDecorations: (scope, paths) => {
         if (!this.plugins.has(pluginId)) return Promise.resolve();
         if (typeof scope !== "string" || scope.length === 0) {
-          throw new Error(
-            `Plugin "${pluginId}" invalidateFileDecorations: scope must be a non-empty string`
+          // Reject (not sync throw): runtime-surface Promise method (#10617).
+          return Promise.reject(
+            new Error(
+              `Plugin "${pluginId}" invalidateFileDecorations: scope must be a non-empty string`
+            )
           );
         }
         // A plugin may only invalidate scopes it actually declared in
@@ -2562,8 +2571,11 @@ export class PluginService {
           !declaredScopes ||
           !declaredScopes.some((pattern) => scopeMatchesPattern(scope, pattern))
         ) {
-          throw new Error(
-            `Plugin "${pluginId}" invalidateFileDecorations: scope "${scope}" is not covered by any declared contributes.fileDecorationProviders[].scopes`
+          // Reject (not sync throw): runtime-surface Promise method (#10617).
+          return Promise.reject(
+            new Error(
+              `Plugin "${pluginId}" invalidateFileDecorations: scope "${scope}" is not covered by any declared contributes.fileDecorationProviders[].scopes`
+            )
           );
         }
         let narrowed =
@@ -2595,16 +2607,22 @@ export class PluginService {
       setPanelBadge: (panelId, badge) => {
         if (!this.plugins.has(pluginId)) return Promise.resolve();
         if (typeof panelId !== "string" || panelId.length === 0) {
-          throw new Error(`Plugin "${pluginId}" setPanelBadge: panelId must be a non-empty string`);
+          // Reject (not sync throw): runtime-surface Promise method (#10617).
+          return Promise.reject(
+            new Error(`Plugin "${pluginId}" setPanelBadge: panelId must be a non-empty string`)
+          );
         }
         let validated: PluginPanelBadge | null = null;
         if (badge !== null && badge !== undefined) {
           const parsed = PluginPanelBadgeSchema.safeParse(badge);
           if (!parsed.success) {
-            throw new Error(
-              `Plugin "${pluginId}" setPanelBadge: invalid badge — ${parsed.error.issues
-                .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
-                .join("; ")}`
+            // Reject (not sync throw): runtime-surface Promise method (#10617).
+            return Promise.reject(
+              new Error(
+                `Plugin "${pluginId}" setPanelBadge: invalid badge — ${parsed.error.issues
+                  .map((i) => `${i.path.join(".") || "(root)"}: ${i.message}`)
+                  .join("; ")}`
+              )
             );
           }
           validated = parsed.data;

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -820,9 +820,11 @@ describe("PluginService integration — file decoration provider contributions",
     const mainFile = `decor-${randomUUID()}.mjs`;
     await fs.writeFile(
       path.join(pluginDir, mainFile),
-      `export function activate(host) {
+      `export async function activate(host) {
   try {
-    host.invalidateFileDecorations("other:/x");
+    // invalidateFileDecorations now REJECTS (not sync-throws) a disallowed
+    // scope, so the handler must await it to observe the error (#10617).
+    await host.invalidateFileDecorations("other:/x");
   } catch (err) {
     globalThis[${JSON.stringify(markerKey)}] = String(err && err.message);
   }
@@ -925,7 +927,7 @@ describe("PluginService integration — panel badges (#10585)", () => {
     setPanelBadge: (
       panelId: string,
       badge: { kind: string; text?: string; color?: string } | null
-    ) => void;
+    ) => Promise<void>;
   }
 
   async function loadBadgeHost(name: string): Promise<{ service: PluginService; host: BadgeHost }> {
@@ -987,10 +989,12 @@ describe("PluginService integration — panel badges (#10585)", () => {
 
   it("rejects an invalid badge shape (label over the length cap) and a bad panelId", async () => {
     const { host } = await loadBadgeHost("acme.badge3");
-    expect(() => host.setPanelBadge("p1", { kind: "label", text: "TOOLONG" })).toThrow(
+    // Validation errors now REJECT (not sync-throw) — the runtime-surface
+    // Promise contract a plugin can `.catch()` (#10617).
+    await expect(host.setPanelBadge("p1", { kind: "label", text: "TOOLONG" })).rejects.toThrow(
       /invalid badge/
     );
-    expect(() => host.setPanelBadge("", { kind: "dot" })).toThrow(/non-empty string/);
+    await expect(host.setPanelBadge("", { kind: "dot" })).rejects.toThrow(/non-empty string/);
   });
 
   it("broadcasts panel-badges-cleared on unload only when the plugin had badges", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -4043,6 +4043,8 @@ describe("createHost (plugin activation API)", () => {
       caught = err;
     });
     expect(caught).toBeInstanceOf(Error);
+    // A rejected setPanelBadge has no side effect: no badge-changed broadcast.
+    expect(broadcastToRendererMock).not.toHaveBeenCalled();
   });
 
   it("host.setPanelBadge silently no-ops once the plugin is unloaded (#10617)", async () => {
@@ -4072,6 +4074,11 @@ describe("createHost (plugin activation API)", () => {
     // through the Promise, not a sync throw (#10617).
     await expect(host.invalidateFileDecorations("")).rejects.toThrow(
       /invalidateFileDecorations: scope/
+    );
+    // A non-empty but undeclared scope rejects at the second guard, also through
+    // the Promise (this plugin declares no fileDecorationProviders).
+    await expect(host.invalidateFileDecorations("acme.deco-reject:*")).rejects.toThrow(
+      /is not covered by any declared/
     );
   });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -3839,7 +3839,9 @@ type CreateHostShape = (pluginId: string) => {
       typedHandler?: (...args: unknown[]) => unknown
     ) => void;
     broadcastToRenderer: (channel: string, payload: unknown) => void;
-    postToPanel: (channel: string, payload: unknown) => void;
+    postToPanel: (channel: string, payload: unknown) => Promise<void>;
+    setPanelBadge: (panelId: string, badge: unknown) => Promise<void>;
+    invalidateFileDecorations: (scope: string, paths?: string[]) => Promise<void>;
     registerForgeProvider: (descriptor: { id: string }, impl: unknown) => () => void;
   };
   revoke: () => void;
@@ -3987,8 +3989,19 @@ describe("createHost (plugin activation API)", () => {
     );
 
     broadcastToRendererMock.mockClear();
-    expect(() => host.postToPanel("bad:channel", null)).toThrow(/postToPanel: channel/);
-    expect(() => host.postToPanel("", null)).toThrow(/postToPanel: channel/);
+    // Validation errors must REJECT (not throw synchronously) so a plugin can
+    // `.catch()` a non-awaited call — the promise-based error contract (#10617).
+    // A sync throw would escape the Promise and force a try/catch wrapper.
+    await expect(host.postToPanel("bad:channel", null)).rejects.toThrow(/postToPanel: channel/);
+    await expect(host.postToPanel("", null)).rejects.toThrow(/postToPanel: channel/);
+    // Calling without awaiting must not throw synchronously — the rejection is
+    // delivered through the returned promise, catchable via `.catch()`.
+    let caught: unknown;
+    const pending = host.postToPanel("also:bad", null).catch((err) => {
+      caught = err;
+    });
+    await pending;
+    expect(caught).toBeInstanceOf(Error);
     expect(broadcastToRendererMock).not.toHaveBeenCalled();
   });
 
@@ -4006,6 +4019,73 @@ describe("createHost (plugin activation API)", () => {
     broadcastToRendererMock.mockClear();
     expect(() => host.postToPanel("tick", { n: 1 })).not.toThrow();
     expect(broadcastToRendererMock).not.toHaveBeenCalled();
+  });
+
+  it("host.setPanelBadge rejects an invalid panelId or badge shape (#10617)", async () => {
+    await writePlugin("badge-reject", { name: "acme.badge-reject", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.badge-reject"
+    );
+
+    broadcastToRendererMock.mockClear();
+    // Empty panelId and a malformed badge must reject through the Promise, not
+    // throw synchronously — the runtime-surface error contract (#10617).
+    await expect(host.setPanelBadge("", { kind: "dot" })).rejects.toThrow(/setPanelBadge: panelId/);
+    await expect(host.setPanelBadge("panel-1", { kind: "bogus" })).rejects.toThrow(
+      /setPanelBadge: invalid badge/
+    );
+    // Non-awaited call is catchable, never a sync throw.
+    let caught: unknown;
+    await host.setPanelBadge("", null).catch((err) => {
+      caught = err;
+    });
+    expect(caught).toBeInstanceOf(Error);
+  });
+
+  it("host.setPanelBadge silently no-ops once the plugin is unloaded (#10617)", async () => {
+    await writePlugin("badge-unloaded", { name: "acme.badge-unloaded", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.badge-unloaded"
+    );
+    service.unloadPlugin("acme.badge-unloaded");
+
+    // Liveness no-op stays a silent resolve even with an otherwise-invalid badge.
+    await expect(host.setPanelBadge("", { kind: "bogus" })).resolves.toBeUndefined();
+  });
+
+  it("host.invalidateFileDecorations rejects an empty scope (#10617)", async () => {
+    await writePlugin("deco-reject", { name: "acme.deco-reject", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.deco-reject"
+    );
+
+    // Empty scope rejects at the first guard, before the declared-scope check —
+    // through the Promise, not a sync throw (#10617).
+    await expect(host.invalidateFileDecorations("")).rejects.toThrow(
+      /invalidateFileDecorations: scope/
+    );
+  });
+
+  it("host.invalidateFileDecorations silently no-ops once the plugin is unloaded (#10617)", async () => {
+    await writePlugin("deco-unloaded", { name: "acme.deco-unloaded", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.deco-unloaded"
+    );
+    service.unloadPlugin("acme.deco-unloaded");
+
+    await expect(host.invalidateFileDecorations("")).resolves.toBeUndefined();
   });
 });
 

--- a/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
+++ b/electron/services/plugin/__tests__/pluginDevWorkerHostProxy.test.ts
@@ -356,3 +356,45 @@ describe("PluginDevWorkerHostProxy host-call post failure (#10526)", () => {
     expect(post).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("PluginDevWorkerHostProxy runtime-surface validation rejects, never throws (#10617)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("postToPanel rejects an empty or colon-bearing channel without notifying main", async () => {
+    const { proxy, sent } = makeProxy();
+    await expect(proxy.host.postToPanel("bad:channel", null)).rejects.toThrow(
+      /postToPanel: channel/
+    );
+    await expect(proxy.host.postToPanel("", null)).rejects.toThrow(/postToPanel: channel/);
+    // No host-notify for postToPanel was sent — the call rejected before forwarding.
+    expect(sent.some((m) => m.type === "host-notify" && m.method === "postToPanel")).toBe(false);
+  });
+
+  it("postToPanel rejection is catchable on a non-awaited call (no sync throw)", async () => {
+    const { proxy } = makeProxy();
+    let caught: unknown;
+    const pending = proxy.host.postToPanel("also:bad", null).catch((err) => {
+      caught = err;
+    });
+    await pending;
+    expect(caught).toBeInstanceOf(Error);
+  });
+
+  it("setPanelBadge rejects a non-string panelId without notifying main", async () => {
+    const { proxy, sent } = makeProxy();
+    await expect(proxy.host.setPanelBadge("", { kind: "dot" })).rejects.toThrow(
+      /setPanelBadge: panelId/
+    );
+    expect(sent.some((m) => m.type === "host-notify" && m.method === "setPanelBadge")).toBe(false);
+  });
+
+  it("invalidateFileDecorations rejects an empty scope without notifying main", async () => {
+    const { proxy, sent } = makeProxy();
+    await expect(proxy.host.invalidateFileDecorations("", undefined)).rejects.toThrow(
+      /invalidateFileDecorations: scope/
+    );
+    expect(
+      sent.some((m) => m.type === "host-notify" && m.method === "invalidateFileDecorations")
+    ).toBe(false);
+  });
+});

--- a/electron/services/plugin/pluginDevWorkerHostProxy.ts
+++ b/electron/services/plugin/pluginDevWorkerHostProxy.ts
@@ -408,8 +408,14 @@ export class PluginDevWorkerHostProxy {
       // to their panels from timers and subscription callbacks.
       postToPanel: (channel, payload) => {
         if (typeof channel !== "string" || channel.length === 0 || channel.includes(":")) {
-          throw new Error(
-            `Plugin "${this.pluginId}" postToPanel: channel must be a non-empty string without colons: ${String(channel)}`
+          // Reject (not sync throw): runtime-surface Promise method must keep
+          // validation errors inside the Promise contract, mirroring the
+          // main-side host (#10617). notify() is fire-and-forget/sync, so this
+          // method can't simply be `async`.
+          return Promise.reject(
+            new Error(
+              `Plugin "${this.pluginId}" postToPanel: channel must be a non-empty string without colons: ${String(channel)}`
+            )
           );
         }
         this.notify("postToPanel", { channel, payload });
@@ -511,8 +517,11 @@ export class PluginDevWorkerHostProxy {
       },
       invalidateFileDecorations: (scope, paths) => {
         if (typeof scope !== "string" || scope.length === 0) {
-          throw new Error(
-            `Plugin "${this.pluginId}" invalidateFileDecorations: scope must be a non-empty string`
+          // Reject (not sync throw): runtime-surface Promise method (#10617).
+          return Promise.reject(
+            new Error(
+              `Plugin "${this.pluginId}" invalidateFileDecorations: scope must be a non-empty string`
+            )
           );
         }
         this.notify("invalidateFileDecorations", { scope, paths });
@@ -522,8 +531,9 @@ export class PluginDevWorkerHostProxy {
       // badge fire-and-forget; the real host re-validates the badge shape.
       setPanelBadge: (panelId, badge) => {
         if (typeof panelId !== "string" || panelId.length === 0) {
-          throw new Error(
-            `Plugin "${this.pluginId}" setPanelBadge: panelId must be a non-empty string`
+          // Reject (not sync throw): runtime-surface Promise method (#10617).
+          return Promise.reject(
+            new Error(`Plugin "${this.pluginId}" setPanelBadge: panelId must be a non-empty string`)
           );
         }
         this.notify("setPanelBadge", { panelId, badge: badge ?? null });

--- a/packages/plugin-testing/src/index.ts
+++ b/packages/plugin-testing/src/index.ts
@@ -11,6 +11,9 @@ export type {
   RegisteredForgeProviderRecord,
   RegisteredFileDecorationProviderRecord,
   InvalidationRecord,
+  ShowQuickPickRecord,
+  ShowInputBoxRecord,
+  ShowConfirmRecord,
 } from "../../../shared/testing/createMockHost.js";
 
 // Re-exported so plugin authors can type `seedActionCatalog` entries without a

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -278,6 +278,26 @@ describe("createMockHost", () => {
     await expect(host.showToast({ message: "" })).rejects.toThrow(/non-empty/);
   });
 
+  it("rejects toast options the production schema would reject (#10617)", async () => {
+    const host = createMockHost();
+    // Message past the 2000-char cap.
+    await expect(host.showToast({ message: "x".repeat(2001) })).rejects.toThrow(
+      /showToast: invalid options/
+    );
+    // Unknown toast type.
+    await expect(host.showToast({ message: "hi", type: "fatal" as never })).rejects.toThrow(
+      /type:/
+    );
+    // durationMs out of bounds / non-integer.
+    await expect(host.showToast({ message: "hi", durationMs: 0 })).rejects.toThrow(/durationMs:/);
+    await expect(host.showToast({ message: "hi", durationMs: 60_001 })).rejects.toThrow(
+      /durationMs:/
+    );
+    await expect(host.showToast({ message: "hi", durationMs: 1.5 })).rejects.toThrow(/durationMs:/);
+    // Nothing recorded for any rejected call.
+    expect(host.shownToasts).toEqual([]);
+  });
+
   it("records invalidateFileDecorations calls", async () => {
     const host = createMockHost();
     await host.invalidateFileDecorations("hello:*");
@@ -890,6 +910,130 @@ describe("createMockHost", () => {
         throw new Error("watcher boom");
       });
       expect(() => host.simulateFsWatch("/tmp/file.ts")).toThrow(/watcher boom/);
+    });
+  });
+});
+
+describe("createMockHost production-parity validation (#10617)", () => {
+  it("setPanelBadge rejects an invalid panelId or badge shape", async () => {
+    const host = createMockHost();
+    await expect(host.setPanelBadge("", { kind: "dot" })).rejects.toThrow(/setPanelBadge: panelId/);
+    await expect(host.setPanelBadge("p1", { kind: "bogus" } as never)).rejects.toThrow(
+      /invalid badge/
+    );
+    // Label text past the 6-char cap is rejected (not truncated), matching prod.
+    await expect(host.setPanelBadge("p1", { kind: "label", text: "TOOLONG" })).rejects.toThrow(
+      /text:/
+    );
+    // A valid badge still records.
+    await host.setPanelBadge("p1", { kind: "label", text: "CI" });
+    expect(host.setPanelBadgeCalls).toEqual([
+      { panelId: "p1", badge: { kind: "label", text: "CI" } },
+    ]);
+  });
+
+  it("postToPanel and broadcastToRenderer reject colon-bearing channels", async () => {
+    const host = createMockHost();
+    await expect(host.postToPanel("bad:channel", null)).rejects.toThrow(/postToPanel: channel/);
+    await expect(host.postToPanel("", null)).rejects.toThrow(/postToPanel: channel/);
+    await expect(host.broadcastToRenderer("bad:channel", null)).rejects.toThrow(
+      /broadcastToRenderer: channel/
+    );
+    // No invalid call was recorded.
+    expect(host.postToPanelCalls).toEqual([]);
+    expect(host.broadcastCalls).toEqual([]);
+  });
+
+  it("getAgentState rejects PERMISSION_REQUIRED without the agent:read capability", async () => {
+    const host = createMockHost({ capabilities: [] });
+    await expect(host.getAgentState()).rejects.toThrow(/PERMISSION_REQUIRED/);
+  });
+
+  it("getAgentState resolves when agent:read is declared", async () => {
+    const host = createMockHost({ capabilities: ["agent:read"] });
+    expect(await host.getAgentState()).toBeNull();
+  });
+
+  it("sendToActiveAgent rejects PERMISSION_REQUIRED without the agent:input capability", async () => {
+    const host = createMockHost({ capabilities: ["agent:read"] });
+    await expect(host.sendToActiveAgent("hello")).rejects.toThrow(/PERMISSION_REQUIRED/);
+  });
+
+  it("sendToActiveAgent rejects NO_ACTIVE_AGENT when no agent is active", async () => {
+    const host = createMockHost({ hasActiveAgent: false });
+    await expect(host.sendToActiveAgent("hello")).rejects.toThrow(/NO_ACTIVE_AGENT/);
+  });
+
+  it("sendToActiveAgent records a valid call with the default permissive capabilities", async () => {
+    const host = createMockHost();
+    await host.sendToActiveAgent("run it", { submit: true });
+    expect(host.sentToActiveAgentCalls).toEqual([{ text: "run it", submit: true }]);
+  });
+
+  describe("imperative UI prompts", () => {
+    it("showQuickPick validates items, records the call, and returns the configured response", async () => {
+      const host = createMockHost();
+      // Duplicate ids are rejected like production.
+      await expect(
+        host.showQuickPick([
+          { id: "a", label: "A" },
+          { id: "a", label: "A2" },
+        ])
+      ).rejects.toThrow(/duplicate item id/);
+
+      host.simulateQuickPickResponse({ id: "a", label: "A" });
+      const picked = await host.showQuickPick([{ id: "a", label: "A" }], { title: "Pick" });
+      expect(picked).toEqual({ id: "a", label: "A" });
+      expect(host.showQuickPickCalls).toEqual([
+        { items: [{ id: "a", label: "A" }], options: { title: "Pick" } },
+      ]);
+    });
+
+    it("showQuickPick defaults to undefined (the dismiss value)", async () => {
+      const host = createMockHost();
+      expect(await host.showQuickPick([{ id: "a", label: "A" }])).toBeUndefined();
+    });
+
+    it("showInputBox records the call and returns the configured response", async () => {
+      const host = createMockHost();
+      expect(await host.showInputBox({ title: "Name" })).toBeUndefined();
+      host.simulateInputBoxResponse("typed value");
+      expect(await host.showInputBox({ title: "Name" })).toBe("typed value");
+      expect(host.showInputBoxCalls).toEqual([
+        { options: { title: "Name" } },
+        { options: { title: "Name" } },
+      ]);
+    });
+
+    it("showConfirm validates options, records the call, and returns the configured response", async () => {
+      const host = createMockHost();
+      await expect(host.showConfirm({} as never)).rejects.toThrow(/options.title/);
+      expect(await host.showConfirm({ title: "Sure?" })).toBe(false);
+      host.simulateConfirmResponse(true);
+      expect(await host.showConfirm({ title: "Sure?" })).toBe(true);
+      expect(host.showConfirmCalls).toEqual([
+        { options: { title: "Sure?" } },
+        { options: { title: "Sure?" } },
+      ]);
+    });
+  });
+
+  describe("fs.readdir", () => {
+    it("lists files and subdirectories previously written under the directory", async () => {
+      const host = createMockHost();
+      await host.fs.writeFile("/repo/a.ts", "1");
+      await host.fs.writeFile("/repo/b.ts", "2");
+      await host.fs.writeFile("/repo/sub/c.ts", "3");
+      const entries = await host.fs.readdir("/repo");
+      const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+      expect(Object.keys(byName).sort()).toEqual(["a.ts", "b.ts", "sub"]);
+      expect(byName["a.ts"]).toMatchObject({ isFile: true, isDirectory: false });
+      expect(byName.sub).toMatchObject({ isFile: false, isDirectory: true });
+    });
+
+    it("returns an empty list for a directory with no written files", async () => {
+      const host = createMockHost();
+      expect(await host.fs.readdir("/empty")).toEqual([]);
     });
   });
 });

--- a/shared/testing/__tests__/createMockHost.test.ts
+++ b/shared/testing/__tests__/createMockHost.test.ts
@@ -932,6 +932,28 @@ describe("createMockHost production-parity validation (#10617)", () => {
     ]);
   });
 
+  it("invalidateFileDecorations rejects an empty scope", async () => {
+    const host = createMockHost();
+    await expect(host.invalidateFileDecorations("")).rejects.toThrow(
+      /invalidateFileDecorations: scope/
+    );
+    // A non-empty scope still records (the mock has no manifest model to gate on).
+    await host.invalidateFileDecorations("hello:*");
+    expect(host.invalidationCalls).toEqual([{ scope: "hello:*", paths: undefined }]);
+  });
+
+  it("rejects unknown keys on toast and badge options (production schemas are strict)", async () => {
+    const host = createMockHost();
+    await expect(host.showToast({ message: "hi", priority: "low" } as never)).rejects.toThrow(
+      /unrecognized option/
+    );
+    await expect(host.setPanelBadge("p1", { kind: "dot", extra: true } as never)).rejects.toThrow(
+      /unrecognized key/
+    );
+    expect(host.shownToasts).toEqual([]);
+    expect(host.setPanelBadgeCalls).toEqual([]);
+  });
+
   it("postToPanel and broadcastToRenderer reject colon-bearing channels", async () => {
     const host = createMockHost();
     await expect(host.postToPanel("bad:channel", null)).rejects.toThrow(/postToPanel: channel/);

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -284,15 +284,27 @@ const PLUGIN_ACTION_DANGERS = new Set(["safe", "confirm"]);
 const MOCK_PANEL_BADGE_LABEL_MAX = 6;
 const MOCK_TOAST_TYPES = new Set(["info", "success", "warning", "error"]);
 const MOCK_BADGE_COLORS = new Set(["default", "success", "warning", "error"]);
+// Allowed-key sets mirroring the production `.strict()` schemas — unknown keys
+// are rejected, not silently dropped.
+const TOAST_OPTION_KEYS = new Set(["message", "type", "durationMs"]);
+const BADGE_DOT_KEYS = new Set(["kind", "color", "tooltip"]);
+const BADGE_LABEL_KEYS = new Set(["kind", "text", "color", "tooltip"]);
 
 /**
  * Validate `showToast` options against the same constraints as production's
- * `PluginToastOptionsSchema` (message length, type enum, durationMs bounds).
- * Throws a parity-style aggregated error so a plugin tested against the mock
- * fails on a shape the real host would reject (#10617).
+ * `PluginToastOptionsSchema` (message length, type enum, durationMs bounds,
+ * strict unknown-key rejection). Throws a parity-style aggregated error so a
+ * plugin tested against the mock fails on a shape the real host would reject
+ * (#10617).
  */
 function validateToastOptions(opts: PluginToastOptions): void {
   const issues: string[] = [];
+  // Production's schema is `.strict()` — unknown keys are rejected, not dropped.
+  if (opts && typeof opts === "object") {
+    for (const key of Object.keys(opts)) {
+      if (!TOAST_OPTION_KEYS.has(key)) issues.push(`${key}: unrecognized option`);
+    }
+  }
   const message = opts?.message;
   if (typeof message !== "string" || message.trim().length < 1) {
     issues.push("message: must be a non-empty string");
@@ -337,6 +349,7 @@ function validatePanelBadge(badge: PluginPanelBadge): void {
     );
   }
   if (badge.kind === "dot") {
+    rejectUnknownBadgeKeys(badge, BADGE_DOT_KEYS);
     return;
   }
   if (badge.kind === "label") {
@@ -349,9 +362,19 @@ function validatePanelBadge(badge: PluginPanelBadge): void {
         `setPanelBadge: invalid badge — text: must be at most ${MOCK_PANEL_BADGE_LABEL_MAX} characters`
       );
     }
+    rejectUnknownBadgeKeys(badge, BADGE_LABEL_KEYS);
     return;
   }
   throw new Error('setPanelBadge: invalid badge — kind: must be "dot" or "label"');
+}
+
+/** Production badge schemas are `.strict()`: reject any key outside the variant's set. */
+function rejectUnknownBadgeKeys(badge: object, allowed: ReadonlySet<string>): void {
+  for (const key of Object.keys(badge)) {
+    if (!allowed.has(key)) {
+      throw new Error(`setPanelBadge: invalid badge — ${key}: unrecognized key`);
+    }
+  }
 }
 
 /**
@@ -924,6 +947,15 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       return Promise.resolve(dispose);
     },
     invalidateFileDecorations(scope, paths) {
+      // Mirror production's non-empty-scope guard (#10617): reject (not throw),
+      // matching the host's Promise contract. The declared-scope gate production
+      // also applies is intentionally skipped — the mock has no manifest model
+      // (#9878), so it can't know which scopes a plugin declared.
+      if (typeof scope !== "string" || scope.length === 0) {
+        return Promise.reject(
+          new Error("invalidateFileDecorations: scope must be a non-empty string")
+        );
+      }
       invalidationCalls.push({ scope, paths });
       return Promise.resolve();
     },

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -970,7 +970,9 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         try {
           validatePanelBadge(badge);
         } catch (err) {
-          return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+          // validatePanelBadge only throws Error; re-reject it so the validation
+          // error stays inside the Promise contract (not a sync throw).
+          return Promise.reject(err);
         }
       }
       setPanelBadgeCalls.push({ panelId, badge: badge ?? null });

--- a/shared/testing/createMockHost.ts
+++ b/shared/testing/createMockHost.ts
@@ -26,10 +26,14 @@ import type {
   ActionHandler,
   PluginActionContribution,
   PluginChannelSchema,
+  PluginConfirmOptions,
   PluginHostApi,
+  PluginInputBoxOptions,
   PluginIpcHandler,
   PluginProcessHandle,
   PluginProcessSpawnOptions,
+  PluginQuickPickItem,
+  PluginQuickPickOptions,
   PluginSettingsScope,
   PluginStorageScope,
   PluginToastOptions,
@@ -108,6 +112,22 @@ export interface SetPanelBadgeRecord {
   badge: PluginPanelBadge | null;
 }
 
+/** Captured `host.showQuickPick(items, options)` calls. */
+export interface ShowQuickPickRecord {
+  items: PluginQuickPickItem[];
+  options: PluginQuickPickOptions | undefined;
+}
+
+/** Captured `host.showInputBox(options)` calls. */
+export interface ShowInputBoxRecord {
+  options: PluginInputBoxOptions | undefined;
+}
+
+/** Captured `host.showConfirm(options)` calls. */
+export interface ShowConfirmRecord {
+  options: PluginConfirmOptions;
+}
+
 /** Captured `host.fs.writeFile(path, contents)` calls. */
 export interface FsWriteRecord {
   path: string;
@@ -132,6 +152,9 @@ export interface MockHostState {
   readonly registeredFileDecorationProviders: ReadonlyArray<RegisteredFileDecorationProviderRecord>;
   readonly invalidationCalls: ReadonlyArray<InvalidationRecord>;
   readonly setPanelBadgeCalls: ReadonlyArray<SetPanelBadgeRecord>;
+  readonly showQuickPickCalls: ReadonlyArray<ShowQuickPickRecord>;
+  readonly showInputBoxCalls: ReadonlyArray<ShowInputBoxRecord>;
+  readonly showConfirmCalls: ReadonlyArray<ShowConfirmRecord>;
   readonly spawnCalls: ReadonlyArray<SpawnRecord>;
   readonly fsWriteCalls: ReadonlyArray<FsWriteRecord>;
   readonly gitCommitCalls: ReadonlyArray<GitCommitRecord>;
@@ -178,6 +201,18 @@ export interface MockHostState {
    * errors propagate so a test sees them.
    */
   simulateFsWatch(changedPath: string): void;
+
+  /**
+   * Configure what `showQuickPick` resolves to. Default is `undefined` (the
+   * dismiss value a user-cancel produces). Pass a single item or an array for a
+   * `canSelectMany` pick. Lets a test drive a plugin's handling of a real
+   * selection without wrapping the host.
+   */
+  simulateQuickPickResponse(result: PluginQuickPickItem | PluginQuickPickItem[] | undefined): void;
+  /** Configure what `showInputBox` resolves to (default `undefined` = dismissed). */
+  simulateInputBoxResponse(result: string | undefined): void;
+  /** Configure what `showConfirm` resolves to (default `false` = cancelled). */
+  simulateConfirmResponse(result: boolean): void;
 }
 
 export interface CreateMockHostOptions {
@@ -209,6 +244,22 @@ export interface CreateMockHostOptions {
    * mirrors `ActionService.dispatch` closely enough for activation-time tests.
    */
   dispatch?: (actionId: ActionId, args?: unknown) => Promise<ActionDispatchResult>;
+  /**
+   * Declared plugin capabilities (`manifest.capabilities`), gating the agent
+   * APIs the way production does (#10617). `getAgentState` requires `agent:read`
+   * and `sendToActiveAgent` requires `agent:input`; without the capability the
+   * call rejects with `PERMISSION_REQUIRED`, exactly as the real host. Defaults
+   * to a permissive set (`agent:read` + `agent:input`) so existing manifest-free
+   * tests keep working — pass a restricted list (or `[]`) to assert the
+   * rejection a plugin missing the capability would hit.
+   */
+  capabilities?: readonly string[];
+  /**
+   * Whether an agent terminal is currently active. When `false`,
+   * `sendToActiveAgent` rejects `NO_ACTIVE_AGENT`, mirroring production's "no
+   * resolvable active agent" path. Defaults to `true`.
+   */
+  hasActiveAgent?: boolean;
 }
 
 /**
@@ -222,6 +273,126 @@ export interface CreateMockHostOptions {
 const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
 const PLUGIN_ACTION_KINDS = new Set(["command", "query"]);
 const PLUGIN_ACTION_DANGERS = new Set(["safe", "confirm"]);
+
+/**
+ * Mirrors `PLUGIN_PANEL_BADGE_LABEL_MAX` in `shared/types/plugin.ts` and the
+ * toast/badge enums in `electron/schemas/plugin.ts`. Duplicated (not imported)
+ * for the same reason as the action constants above — the mock validates with
+ * plain JS rather than pulling the cross-process Zod schemas — and the
+ * production definitions remain the source of truth. Mirror any change here.
+ */
+const MOCK_PANEL_BADGE_LABEL_MAX = 6;
+const MOCK_TOAST_TYPES = new Set(["info", "success", "warning", "error"]);
+const MOCK_BADGE_COLORS = new Set(["default", "success", "warning", "error"]);
+
+/**
+ * Validate `showToast` options against the same constraints as production's
+ * `PluginToastOptionsSchema` (message length, type enum, durationMs bounds).
+ * Throws a parity-style aggregated error so a plugin tested against the mock
+ * fails on a shape the real host would reject (#10617).
+ */
+function validateToastOptions(opts: PluginToastOptions): void {
+  const issues: string[] = [];
+  const message = opts?.message;
+  if (typeof message !== "string" || message.trim().length < 1) {
+    issues.push("message: must be a non-empty string");
+  } else if (message.trim().length > 2000) {
+    issues.push("message: must be at most 2000 characters");
+  }
+  if (opts?.type !== undefined && !MOCK_TOAST_TYPES.has(opts.type)) {
+    issues.push("type: must be one of info, success, warning, error");
+  }
+  if (opts?.durationMs !== undefined) {
+    const d = opts.durationMs;
+    if (typeof d !== "number" || !Number.isInteger(d) || d <= 0 || d > 60_000) {
+      issues.push("durationMs: must be a positive integer at most 60000");
+    }
+  }
+  if (issues.length > 0) {
+    throw new Error(`showToast: invalid options — ${issues.join("; ")}`);
+  }
+}
+
+/**
+ * Validate a `setPanelBadge` badge against the same constraints as production's
+ * `PluginPanelBadgeSchema` (discriminated on `kind`; label `text` rejected past
+ * the length cap rather than truncated). `null` (clear) is handled at the call
+ * site. Throws on an invalid shape (#10617).
+ */
+function validatePanelBadge(badge: PluginPanelBadge): void {
+  if (!badge || typeof badge !== "object") {
+    throw new Error("setPanelBadge: invalid badge — badge must be an object");
+  }
+  const color = (badge as { color?: unknown }).color;
+  if (color !== undefined && !MOCK_BADGE_COLORS.has(color as string)) {
+    throw new Error("setPanelBadge: invalid badge — color: must be a known badge color");
+  }
+  const tooltip = (badge as { tooltip?: unknown }).tooltip;
+  if (
+    tooltip !== undefined &&
+    (typeof tooltip !== "string" || tooltip.trim().length < 1 || tooltip.trim().length > 200)
+  ) {
+    throw new Error(
+      "setPanelBadge: invalid badge — tooltip: must be a non-empty string at most 200 characters"
+    );
+  }
+  if (badge.kind === "dot") {
+    return;
+  }
+  if (badge.kind === "label") {
+    const text = (badge as { text?: unknown }).text;
+    if (typeof text !== "string" || text.trim().length < 1) {
+      throw new Error("setPanelBadge: invalid badge — text: must be a non-empty string");
+    }
+    if (text.trim().length > MOCK_PANEL_BADGE_LABEL_MAX) {
+      throw new Error(
+        `setPanelBadge: invalid badge — text: must be at most ${MOCK_PANEL_BADGE_LABEL_MAX} characters`
+      );
+    }
+    return;
+  }
+  throw new Error('setPanelBadge: invalid badge — kind: must be "dot" or "label"');
+}
+
+/**
+ * Mirror production's `validateQuickPickItems`: items must be an array of objects
+ * with a non-empty string `id` (unique) and a string `label`. Returns the
+ * normalized items. Throws on a violation (#10617).
+ */
+function validateQuickPickItems(items: PluginQuickPickItem[]): PluginQuickPickItem[] {
+  if (!Array.isArray(items)) {
+    throw new Error("showQuickPick: items must be an array");
+  }
+  const seen = new Set<string>();
+  return items.map((item, index) => {
+    if (!item || typeof item !== "object") {
+      throw new Error(`showQuickPick: items[${index}] must be an object`);
+    }
+    if (typeof item.id !== "string" || item.id.length === 0) {
+      throw new Error(`showQuickPick: items[${index}].id must be a non-empty string`);
+    }
+    if (typeof item.label !== "string") {
+      throw new Error(`showQuickPick: items[${index}].label must be a string`);
+    }
+    if (seen.has(item.id)) {
+      throw new Error(`showQuickPick: duplicate item id "${item.id}" (ids must be unique)`);
+    }
+    seen.add(item.id);
+    return {
+      id: item.id,
+      label: item.label,
+      ...(item.description !== undefined ? { description: String(item.description) } : {}),
+      ...(item.detail !== undefined ? { detail: String(item.detail) } : {}),
+    };
+  });
+}
+
+/** Reject a postToPanel/broadcastToRenderer channel the way production does. */
+function isInvalidChannel(channel: unknown, allowEmpty: boolean): boolean {
+  if (typeof channel !== "string") return true;
+  if (!allowEmpty && channel.length === 0) return true;
+  return channel.includes(":");
+}
 
 export function createMockHost(options: CreateMockHostOptions = {}): PluginHostApi & MockHostState {
   const pluginId = options.pluginId ?? "test.mock";
@@ -239,6 +410,9 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
   const registeredFileDecorationProviders: RegisteredFileDecorationProviderRecord[] = [];
   const invalidationCalls: InvalidationRecord[] = [];
   const setPanelBadgeCalls: SetPanelBadgeRecord[] = [];
+  const showQuickPickCalls: ShowQuickPickRecord[] = [];
+  const showInputBoxCalls: ShowInputBoxRecord[] = [];
+  const showConfirmCalls: ShowConfirmRecord[] = [];
   const spawnCalls: SpawnRecord[] = [];
   const fsFiles = new Map<string, string>();
   const fsWriteCalls: FsWriteRecord[] = [];
@@ -251,6 +425,18 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
 
   let lastAgentSnapshot: PluginAgentSnapshot | null = null;
   const agentStateSubs = new Set<(snapshot: PluginAgentSnapshot) => void>();
+
+  // Capability gating + active-agent presence for the agent APIs (#10617).
+  // Default permissive so manifest-free tests are unaffected; restrict to assert
+  // the PERMISSION_REQUIRED / NO_ACTIVE_AGENT rejections production enforces.
+  const capabilities = new Set<string>(options.capabilities ?? ["agent:read", "agent:input"]);
+  const hasActiveAgent = options.hasActiveAgent ?? true;
+
+  // Configurable answers for the imperative UI prompts. Default to the dismiss
+  // value (cancel) a user produces; `simulate*Response` overrides per test.
+  let quickPickResponse: PluginQuickPickItem | PluginQuickPickItem[] | undefined;
+  let inputBoxResponse: string | undefined;
+  let confirmResponse = false;
 
   const settingsStore: Record<PluginSettingsScope, Map<string, unknown>> = {
     user: new Map(Object.entries(options.settings?.user ?? {})),
@@ -553,10 +739,28 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       return Promise.resolve();
     },
     broadcastToRenderer(channel, payload) {
+      // Mirror production's channel-format guard (#10617): a colon would collide
+      // with the `plugin:{id}:{channel}` transport. Reject (not throw) so the
+      // mock matches the host's Promise contract. Production allows an empty
+      // broadcast channel, so only the colon/non-string checks apply here.
+      if (isInvalidChannel(channel, true)) {
+        return Promise.reject(
+          new Error(
+            `broadcastToRenderer: channel must be a string without colons: ${String(channel)}`
+          )
+        );
+      }
       broadcastCalls.push({ channel, payload });
       return Promise.resolve();
     },
     postToPanel(channel, payload) {
+      if (isInvalidChannel(channel, false)) {
+        return Promise.reject(
+          new Error(
+            `postToPanel: channel must be a non-empty string without colons: ${String(channel)}`
+          )
+        );
+      }
       postToPanelCalls.push({ channel, payload });
       return Promise.resolve();
     },
@@ -597,15 +801,31 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       return Promise.resolve(dispose);
     },
     async getAgentState() {
+      // Capability gating mirrors production (#10617): without "agent:read" the
+      // call rejects PERMISSION_REQUIRED, so a plugin that forgot to declare the
+      // capability fails the mock the same way the real host fails it.
+      if (!capabilities.has("agent:read")) {
+        throw new Error(
+          'PERMISSION_REQUIRED: getAgentState requires "agent:read", which is not declared in manifest.capabilities'
+        );
+      }
       return lastAgentSnapshot;
     },
     async sendToActiveAgent(text, options) {
-      // Mirrors PluginService.createHost: reject whitespace-only text (the
-      // production host rejects it so a no-op stage can't bank consent and
-      // submit:true can't fire a bare Enter). The mock has no PTY, so a valid
-      // call just records its intent for assertions.
+      // Capability first, then text validation, then active-agent resolution —
+      // the same order production enforces (#10617). Whitespace-only text is
+      // rejected (a no-op stage can't bank consent, and submit:true can't fire a
+      // bare Enter). The mock has no PTY, so a valid call just records its intent.
+      if (!capabilities.has("agent:input")) {
+        throw new Error(
+          'PERMISSION_REQUIRED: sendToActiveAgent requires "agent:input", which is not declared in manifest.capabilities'
+        );
+      }
       if (typeof text !== "string" || text.trim().length === 0) {
         throw new Error("sendToActiveAgent: text must be a non-empty, non-whitespace string");
+      }
+      if (!hasActiveAgent) {
+        throw new Error("NO_ACTIVE_AGENT: no active agent terminal to receive input");
       }
       sentToActiveAgentCalls.push({ text, submit: options?.submit === true });
     },
@@ -708,13 +928,27 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       return Promise.resolve();
     },
     setPanelBadge(panelId, badge) {
+      // Validate to production parity (#10617): non-empty panelId, and a badge
+      // shape the real host's Zod schema would accept. Reject (not throw) so the
+      // mock matches the host's Promise contract. `null`/`undefined` clears.
+      if (typeof panelId !== "string" || panelId.length === 0) {
+        return Promise.reject(new Error("setPanelBadge: panelId must be a non-empty string"));
+      }
+      if (badge !== null && badge !== undefined) {
+        try {
+          validatePanelBadge(badge);
+        } catch (err) {
+          return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      }
       setPanelBadgeCalls.push({ panelId, badge: badge ?? null });
       return Promise.resolve();
     },
     async showToast(opts: PluginToastOptions) {
-      if (!opts.message) {
-        throw new Error("showToast: message must be a non-empty string");
-      }
+      // Full production parity (#10617): message length, type enum, durationMs
+      // bounds — not just a truthy-message check. A shape the real host rejects
+      // now fails the mock too.
+      validateToastOptions(opts);
       shownToasts.push({
         message: opts.message,
         type: opts.type,
@@ -752,16 +986,26 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         };
       }
     },
-    // Imperative UI prompts (#10522). The mock has no renderer to drive a
-    // dialog, so it resolves the dismiss value (undefined / false) — the same
-    // outcome a plugin sees when the user cancels. Tests that need a concrete
-    // answer can wrap the host and override these.
-    showQuickPick: (async () => undefined) as PluginHostApi["showQuickPick"],
-    async showInputBox() {
-      return undefined;
+    // Imperative UI prompts (#10522, hardened in #10617). The mock has no
+    // renderer to drive a dialog, so each prompt validates its arguments to
+    // production parity, records the call for assertions, then resolves the
+    // configured `simulate*Response` value (default = the user-cancel dismiss
+    // value). A shape the real host rejects now fails the mock too.
+    showQuickPick: (async (items: PluginQuickPickItem[], options?: PluginQuickPickOptions) => {
+      const validItems = validateQuickPickItems(items);
+      showQuickPickCalls.push({ items: validItems, options });
+      return quickPickResponse;
+    }) as PluginHostApi["showQuickPick"],
+    async showInputBox(options) {
+      showInputBoxCalls.push({ options });
+      return inputBoxResponse;
     },
-    async showConfirm() {
-      return false;
+    async showConfirm(options) {
+      if (!options || typeof options !== "object" || typeof options.title !== "string") {
+        throw new Error("showConfirm: options.title must be a string");
+      }
+      showConfirmCalls.push({ options });
+      return confirmResponse;
     },
     actions: {
       // Backed by the catalog seeded via `seedActionCatalog`. With no seed the
@@ -817,9 +1061,32 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
         fsFiles.set(filePath, contents);
         fsWriteCalls.push({ path: filePath, contents });
       },
-      async readdir(_dirPath, options) {
+      async readdir(dirPath, options) {
         options?.signal?.throwIfAborted();
-        return [];
+        // Derive entries from files written via writeFile whose parent directory
+        // is `dirPath` (#10617). Previously always returned [], so a plugin that
+        // wrote files then listed the dir saw nothing — a false-green gap. Each
+        // immediate child name is reported once: a name with a deeper path
+        // segment is a directory, a name that is itself a written file is a file
+        // (basename only, like a real readdir).
+        const prefix = dirPath.endsWith("/") ? dirPath : `${dirPath}/`;
+        const isDir = new Map<string, boolean>();
+        for (const filePath of fsFiles.keys()) {
+          if (!filePath.startsWith(prefix)) continue;
+          const rest = filePath.slice(prefix.length);
+          const slash = rest.indexOf("/");
+          if (slash === -1) {
+            if (rest.length > 0 && !isDir.has(rest)) isDir.set(rest, false);
+          } else {
+            isDir.set(rest.slice(0, slash), true);
+          }
+        }
+        return [...isDir.entries()].map(([name, directory]) => ({
+          name,
+          isDirectory: directory,
+          isFile: !directory,
+          isSymbolicLink: false,
+        }));
       },
       async stat(targetPath, options) {
         options?.signal?.throwIfAborted();
@@ -914,6 +1181,9 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
     registeredFileDecorationProviders,
     invalidationCalls,
     setPanelBadgeCalls,
+    showQuickPickCalls,
+    showInputBoxCalls,
+    showConfirmCalls,
     spawnCalls,
     fsWriteCalls,
     gitCommitCalls,
@@ -942,6 +1212,15 @@ export function createMockHost(options: CreateMockHostOptions = {}): PluginHostA
       // Snapshot before firing so a callback that registers/disposes a watcher
       // doesn't mutate the set mid-iteration.
       for (const { callback } of [...fsWatchers]) callback(changedPath);
+    },
+    simulateQuickPickResponse(result) {
+      quickPickResponse = result;
+    },
+    simulateInputBoxResponse(result) {
+      inputBoxResponse = result;
+    },
+    simulateConfirmResponse(result) {
+      confirmResponse = result;
     },
   };
 


### PR DESCRIPTION
## Summary

- Runtime-surface host methods (`postToPanel`, `invalidateFileDecorations`, `setPanelBadge`) now reject via `Promise.reject()` after their liveness guard instead of throwing synchronously, in both `PluginService.ts` and `pluginDevWorkerHostProxy.ts`. Plugins can reliably `.catch()` validation and capability errors.
- Lazy manifest-declared command handlers get a prominent callout in `docs/plugins/contribution-points.md` — they receive only `args` (no `host`) because the host is revoked after `activate()`, and the workaround is `host.registerAction()` in `activate()`.
- `createMockHost` now mirrors production validation without pulling in `zod` or Electron: `showToast` bounds, `setPanelBadge` shape, `postToPanel`/`broadcastToRenderer` channel format, `invalidateFileDecorations` empty-scope, `agent:read`/`agent:input` capability gating with configurable `NO_ACTIVE_AGENT`, UI-prompt recording arrays with `simulate*Response` helpers, and `fs.readdir` derived from written files.

Resolves #10617

## Changes

- `electron/services/PluginService.ts` — convert sync throws to `Promise.reject()` on runtime-surface methods after liveness check; leave `broadcastToRenderer` (registration surface) and already-async methods unchanged
- `electron/services/plugin/pluginDevWorkerHostProxy.ts` — same async-rejection fix on the dev-worker side
- `shared/testing/createMockHost.ts` — significant parity expansion; new record types exported from `packages/plugin-testing`
- `docs/plugins/contribution-points.md` — lazy-handler limitation callout

## Testing

Targeted unit suites all pass: `createMockHost` (91 tests), `pluginDevWorkerHostProxy` (25), `PluginService` (536), bridge (40). `plugin-testing` typecheck and `tsup` dts build pass. One pre-existing integration test failure (`logger` per-plugin buffer isolation) confirmed against clean `develop` — unrelated to this change and excluded from CI.