### PR TITLE
fix(diff-viewer): word-boundary wrap-on and explicit no-wrap reset for add/delete diffs

### DIFF
--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -36,7 +36,12 @@
 
 .diff-viewer[data-wrap="true"] .diff-code {
   white-space: pre-wrap;
-  word-break: break-all;
+  /* Break at whitespace first and only split a token when it alone overflows the
+     column. overflow-wrap: anywhere (not break-word) lets the cell shrink to
+     min-content so the fixed-layout table reflows; word-break: break-all would
+     split mid-token even where a whitespace break point exists. */
+  word-break: normal;
+  overflow-wrap: anywhere;
 }
 
 /* Gutter (line numbers) styling.
@@ -90,11 +95,19 @@
   white-space: nowrap;
 }
 
-/* Code content styling */
+/* Code content styling. white-space: pre alone suppresses wrapping (nowrap
+   leaves no soft-wrap opportunities), but react-diff-view's vendor sheet sets
+   word-break: break-all and word-wrap: break-word on .diff-code — reset all
+   three explicitly so the no-wrap intent on the fallback (add/delete) scroll
+   path survives even if white-space changes on a sub-path. The wrap-on rule
+   above re-enables wrapping via [data-wrap="true"]. */
 .diff-viewer .diff-code {
   background: var(--color-daintree-bg);
   padding: 0 12px;
   white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+  word-wrap: normal;
 }
 
 /* Added lines. The :root values below are the ORIGINAL hardcoded status-based

--- a/src/components/Worktree/DiffViewer.css
+++ b/src/components/Worktree/DiffViewer.css
@@ -37,9 +37,11 @@
 .diff-viewer[data-wrap="true"] .diff-code {
   white-space: pre-wrap;
   /* Break at whitespace first and only split a token when it alone overflows the
-     column. overflow-wrap: anywhere (not break-word) lets the cell shrink to
-     min-content so the fixed-layout table reflows; word-break: break-all would
-     split mid-token even where a whitespace break point exists. */
+     column. word-break: break-all (the react-diff-view default) splits mid-token
+     even where a whitespace break point exists; overflow-wrap: anywhere keeps
+     whole tokens intact until they can't fit. (The columns here are fixed-width
+     so cell content doesn't drive sizing, but anywhere stays correct if the
+     wrap-mode table ever moves back to table-layout: auto.) */
   word-break: normal;
   overflow-wrap: anywhere;
 }

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -665,3 +665,30 @@ describe("DiffViewer gutter CSS contract (#10422)", () => {
     expect(cssText).toMatch(/\.diff-viewer\s+\.diff-line-number\s*\{[^}]*white-space:\s*nowrap/);
   });
 });
+
+// The no-wrap behavior on the fallback (add/delete) scroll path and the
+// word-boundary behavior in wrap-on mode are CSS-only and can't be exercised by
+// jsdom (no layout engine), so guard the load-bearing declarations against an
+// accidental revert to react-diff-view's vendor break-all/break-word defaults
+// (the original #10623 bug). Same readFileSync pattern as the #10422 guard.
+describe("DiffViewer wrap CSS contract (#10623)", () => {
+  it("resets the vendor wrap defaults on the base .diff-code rule", () => {
+    const cssText = readFileSync(join(__dirname, "..", "DiffViewer.css"), "utf8");
+    expect(cssText).toMatch(/\.diff-viewer\s+\.diff-code\s*\{[^}]*white-space:\s*pre[;\s}]/);
+    expect(cssText).toMatch(/\.diff-viewer\s+\.diff-code\s*\{[^}]*word-break:\s*normal/);
+    expect(cssText).toMatch(/\.diff-viewer\s+\.diff-code\s*\{[^}]*overflow-wrap:\s*normal/);
+  });
+
+  it("breaks at word boundaries (not mid-token) in wrap-on mode", () => {
+    const cssText = readFileSync(join(__dirname, "..", "DiffViewer.css"), "utf8");
+    // Strip comments so the negative break-all assertion checks declarations
+    // only — the rule's own comment explains why break-all was dropped.
+    const declarations = cssText
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .match(/\.diff-viewer\[data-wrap="true"\]\s+\.diff-code\s*\{[^}]*\}/)?.[0];
+    expect(declarations).toBeTruthy();
+    expect(declarations).toMatch(/word-break:\s*normal/);
+    expect(declarations).toMatch(/overflow-wrap:\s*anywhere/);
+    expect(declarations).not.toMatch(/word-break:\s*break-all/);
+  });
+});

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -261,6 +261,15 @@ index 0000000..abcdef1
 +line1
 +line2`;
 
+const DELETED_FILE_DIFF = `diff --git a/gone.ts b/gone.ts
+deleted file mode 100644
+index abcdef1..0000000
+--- a/gone.ts
++++ /dev/null
+@@ -1,2 +0,0 @@
+-line1
+-line2`;
+
 describe("DiffViewer centered split", () => {
   it("uses the centered-split scroll system for two-column split diffs", () => {
     const { container } = render(wrap(<DiffViewer diff={SMALL_DIFF} viewType="split" />));
@@ -288,7 +297,18 @@ describe("DiffViewer centered split", () => {
   it("keeps the native scroller for single-side added-file diffs", () => {
     const { container } = render(wrap(<DiffViewer diff={ADDED_FILE_DIFF} viewType="split" />));
 
+    // Add files are single-column ("monotonous") in react-diff-view, so they take
+    // the horizontal-scroll fallback path rather than the two-column centered split.
     expect(container.querySelector(".diff-file-centered")).toBeNull();
+    expect(container.querySelector(".diff-file-scroll")).not.toBeNull();
+    expect(screen.queryByTestId("diff-hscrollbar")).toBeNull();
+  });
+
+  it("keeps the native scroller for single-side deleted-file diffs", () => {
+    const { container } = render(wrap(<DiffViewer diff={DELETED_FILE_DIFF} viewType="split" />));
+
+    expect(container.querySelector(".diff-file-centered")).toBeNull();
+    expect(container.querySelector(".diff-file-scroll")).not.toBeNull();
     expect(screen.queryByTestId("diff-hscrollbar")).toBeNull();
   });
 
@@ -318,6 +338,36 @@ describe("DiffViewer centered split", () => {
     // Predominantly vertical gestures stay with the vertical scroller.
     fireEvent.wheel(region!, { deltaX: 5, deltaY: 50 });
     expect(bar.scrollLeft).toBe(50);
+  });
+});
+
+describe("DiffViewer wrap attribute", () => {
+  // data-wrap drives the [data-wrap="true"] CSS rules (soft-wrap on) versus the
+  // base white-space: pre rule (no-wrap + horizontal scroll). The attribute must
+  // track wrapLines for every diff type, including the single-side add/delete
+  // files that take the fallback scroll path.
+  it("omits data-wrap when wrapLines is unset, for added-file diffs", () => {
+    const { container } = render(wrap(<DiffViewer diff={ADDED_FILE_DIFF} viewType="split" />));
+
+    const root = container.querySelector(".diff-viewer");
+    expect(root).not.toBeNull();
+    expect(root?.hasAttribute("data-wrap")).toBe(false);
+  });
+
+  it("sets data-wrap=true when wrapLines is on, for added-file diffs", () => {
+    const { container } = render(
+      wrap(<DiffViewer diff={ADDED_FILE_DIFF} viewType="split" wrapLines />)
+    );
+
+    expect(container.querySelector(".diff-viewer")?.getAttribute("data-wrap")).toBe("true");
+  });
+
+  it("sets data-wrap=true when wrapLines is on, for deleted-file diffs", () => {
+    const { container } = render(
+      wrap(<DiffViewer diff={DELETED_FILE_DIFF} viewType="split" wrapLines />)
+    );
+
+    expect(container.querySelector(".diff-viewer")?.getAttribute("data-wrap")).toBe("true");
   });
 });
 


### PR DESCRIPTION
## Summary

- Fixes long-line wrapping in new/deleted file diffs when wrap is turned off — these diffs use a fallback scroll path (`diff-file-scroll`) that wasn't getting the full CSS reset.
- Wrap-on mode now breaks at word boundaries (`overflow-wrap: anywhere` + `word-break: normal`) instead of mid-token (`word-break: break-all`), matching VS Code behaviour.
- Base `.diff-viewer .diff-code` rule now explicitly resets react-diff-view's vendor `word-break: break-all` / `word-wrap: break-word` alongside the existing `white-space: pre`.

Resolves #10623.

## Changes

- `DiffViewer.css` — two edits: (1) base `.diff-code` reset now clears `word-break` and `word-wrap` so they can't leak onto the fallback path; (2) wrap-on rule swaps `word-break: break-all` for `overflow-wrap: anywhere` + `word-break: normal`.

## Investigation notes (for reviewers)

Empirically verified in Chromium 148 (Electron 42; Playwright Chromium 148.0.7778.96) that `white-space: pre` already suppresses wrapping on the `add`/`delete` fallback path — horizontal scroll works without the extra reset. So the `word-break`/`word-wrap` reset in the base rule is defensive (belt-and-braces, guards intent if `white-space` ever changes on a sub-path). The substantive user-facing fix is the wrap-on word-boundary improvement.

No `isCenteredSplit` change — `add`/`delete` diffs are single-column in react-diff-view and the centred-split spacer formula assumes two code columns. No layout or `min-width` changes — both real mount chains (`FileViewerModal`, `CrossWorktreeDiff`) are flex-column with no blowout risk.

## Testing

- Added a deleted-file fixture.
- Strengthened the add-file test with a positive `.diff-file-scroll` assertion.
- Added a delete-file equivalent.
- Added `data-wrap` attribute-contract tests.
- Added `#10623` CSS-text guards mirroring the existing `#10422` guard.
- 45 tests pass locally; own files prettier/eslint clean; rebased cleanly onto develop.