### PR TITLE
fix(terminal): prevent duplicate agent spawn on Enter at trust prompt

### DIFF
--- a/e2e/full/platform/core-hybrid-input-bar.spec.ts
+++ b/e2e/full/platform/core-hybrid-input-bar.spec.ts
@@ -333,8 +333,10 @@ test.describe.serial("Core: HybridInputBar trust-prompt focus (#10541)", () => {
     // only after it receives a carriage return.
     await waitForTerminalText(regPanel, "FAKE_CLAUDE_READY", T_LONG);
 
-    // Invariant 3: exactly one agent panel exists — no duplicate spawn.
-    const idsAfter = (await getGridPanelIds(window)).filter((id) => !beforeIds.has(id));
-    expect(idsAfter).toEqual([panelId]);
+    // Invariant 3: exactly one agent panel exists — no duplicate spawn. Re-check
+    // after a settle window since the buggy second spawn was an async addPanel.
+    expect((await getGridPanelIds(window)).filter((id) => !beforeIds.has(id))).toEqual([panelId]);
+    await window.waitForTimeout(T_SETTLE);
+    expect((await getGridPanelIds(window)).filter((id) => !beforeIds.has(id))).toEqual([panelId]);
   });
 });

--- a/e2e/full/platform/core-hybrid-input-bar.spec.ts
+++ b/e2e/full/platform/core-hybrid-input-bar.spec.ts
@@ -270,3 +270,71 @@ test.describe.serial("Core: HybridInputBar", () => {
     await expect(restoredEditor).toHaveText(new RegExp(draftText), { timeout: T_MEDIUM });
   });
 });
+
+// Regression for issue #10541: launching Claude from the primary toolbar button
+// left DOM focus stranded on that button (the lazy HybridInputBar chunk hadn't
+// resolved when TerminalPane's focus RAF fired, so the RAF no-opped). Pressing
+// Enter at the trust prompt then re-fired the focused button's click handler,
+// spawning a SECOND agent panel instead of confirming the prompt. The fix has
+// HybridInputBar self-claim focus on mount and AgentButton blur on launch.
+test.describe.serial("Core: HybridInputBar trust-prompt focus (#10541)", () => {
+  let regCtx: AppContext;
+  let regPanel: Locator;
+
+  test.beforeAll(async () => {
+    // Fresh app instance so the HybridInputBar chunk is cold on first launch —
+    // that cold load is the exact window the focus race lived in.
+    prepareFixture();
+    regCtx = await launchApp({
+      env: {
+        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        DAINTREE_CLI_PATH_PREPEND: fakeBinDir,
+        ANTHROPIC_API_KEY: "e2e-fake-key",
+      },
+    });
+    regCtx.window = await openAndOnboardProject(
+      regCtx.app,
+      regCtx.window,
+      fixtureDir,
+      "HybridInputBar #10541"
+    );
+  });
+
+  test.afterAll(async () => {
+    if (regCtx?.app) await closeApp(regCtx.app);
+    fixtureCleanup?.();
+  });
+
+  test("Enter at trust prompt confirms it without spawning a second panel", async () => {
+    const window = regCtx.window;
+    await dismissBlockingPalette(window);
+
+    // Launch via the PRIMARY Start button (not the tray) — this is the surface
+    // that used to retain DOM focus after a fire-and-forget launch.
+    const beforeIds = new Set(await getGridPanelIds(window));
+    await window.locator(SEL.agent.startButton).click();
+
+    const panelId = await newestPanelId(window, beforeIds);
+    regPanel = window.locator(`[data-panel-id="${panelId}"]`);
+    await expect(regPanel).toHaveAttribute("data-launch-agent-id", "claude", { timeout: T_LONG });
+
+    // Wait for the trust prompt to render in the PTY.
+    await waitForTerminalText(regPanel, "Enter to confirm", T_LONG);
+
+    // Invariant 1: focus landed in the input bar on mount — no click needed.
+    // This is what proves the AgentButton no longer holds focus.
+    await expectInputBarFocused(regPanel);
+
+    // Press Enter WITHOUT clicking into the editor first. Pre-fix this either
+    // re-fired the focused button (second panel) or did nothing.
+    await window.keyboard.press("Enter");
+
+    // Invariant 2: the keystroke reached the PTY — the fake CLI flips to READY
+    // only after it receives a carriage return.
+    await waitForTerminalText(regPanel, "FAKE_CLAUDE_READY", T_LONG);
+
+    // Invariant 3: exactly one agent panel exists — no duplicate spawn.
+    const idsAfter = (await getGridPanelIds(window)).filter((id) => !beforeIds.has(id));
+    expect(idsAfter).toEqual([panelId]);
+  });
+});

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,4 +1,9 @@
-import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import {
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -342,9 +347,14 @@ export function AgentButton({
         ? `Configure ${config.name}`
         : `Install ${config.name} CLI`;
 
-  const handleClick = () => {
+  const handleClick = (e?: ReactMouseEvent<HTMLElement>) => {
     if (isLoading) return;
     if (isLaunchable) {
+      // Drop DOM focus on launch so a CLI prompt's Enter can't bounce back to
+      // this still-focused button and spawn a duplicate agent before the input
+      // bar claims focus. Native buttons synthesize a click on Enter, so a
+      // launch that doesn't hand off focus is a footgun. See issue #10541.
+      e?.currentTarget?.blur();
       // Defer all preset resolution to useAgentLauncher. Forwarding the
       // resolved savedPresetId explicitly would block the launcher's
       // stale-fallback path: when a worktree-scoped pick references a

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -350,10 +350,8 @@ export function AgentButton({
   const handleClick = (e?: ReactMouseEvent<HTMLElement>) => {
     if (isLoading) return;
     if (isLaunchable) {
-      // Drop DOM focus on launch so a CLI prompt's Enter can't bounce back to
-      // this still-focused button and spawn a duplicate agent before the input
-      // bar claims focus. Native buttons synthesize a click on Enter, so a
-      // launch that doesn't hand off focus is a footgun. See issue #10541.
+      // Drop focus on launch so Enter at a CLI prompt can't re-fire this button
+      // and spawn a duplicate agent before the input bar claims focus. See #10541.
       e?.currentTarget?.blur();
       // Defer all preset resolution to useAgentLauncher. Forwarding the
       // resolved savedPresetId explicitly would block the launcher's

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -502,20 +502,14 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       });
     };
 
-    // On first mount (e.g. after the React.lazy chunk resolves), the one-shot
-    // focus RAF in TerminalPane may have already fired against a null ref and
-    // no-opped — leaving DOM focus stranded on whatever launched us (the toolbar
-    // AgentButton). Claim focus here so Enter at a CLI prompt can't re-trigger
-    // that button and spawn a duplicate agent. The editor view is created in a
-    // useLayoutEffect (useEditorFactory), which flushes before this useEffect,
-    // so focusEditor() finds a live view. See issue #10541.
+    // Claim focus on mount: TerminalPane's one-shot focus RAF may have no-opped
+    // against a null ref if this lazy chunk wasn't loaded yet, leaving focus on
+    // the launching AgentButton where Enter spawns a duplicate agent. See #10541.
     useEffect(() => {
       if (!isFocusedTerminal) return;
       if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
       focusEditor();
-      // Mount-only: read focus intent once. Later focus changes go through
-      // TerminalPane's RAF path, which by then has a live ref to drive.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-only focus claim
     }, []);
 
     const handleHistoryNavigation = (direction: "up" | "down"): boolean => {

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -502,6 +502,22 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       });
     };
 
+    // On first mount (e.g. after the React.lazy chunk resolves), the one-shot
+    // focus RAF in TerminalPane may have already fired against a null ref and
+    // no-opped — leaving DOM focus stranded on whatever launched us (the toolbar
+    // AgentButton). Claim focus here so Enter at a CLI prompt can't re-trigger
+    // that button and spawn a duplicate agent. The editor view is created in a
+    // useLayoutEffect (useEditorFactory), which flushes before this useEffect,
+    // so focusEditor() finds a live view. See issue #10541.
+    useEffect(() => {
+      if (!isFocusedTerminal) return;
+      if (usePanelStore.getState().preferredTerminalFocusTarget !== "hybridInput") return;
+      focusEditor();
+      // Mount-only: read focus intent once. Later focus changes go through
+      // TerminalPane's RAF path, which by then has a live ref to drive.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     const handleHistoryNavigation = (direction: "up" | "down"): boolean => {
       const latest = latestRef.current;
       if (!latest) return false;


### PR DESCRIPTION
## Summary

Fixes #10541 — launching a Claude agent from the toolbar, then pressing **Enter** at Claude's workspace-trust prompt, spawned a **second** agent panel instead of confirming the prompt.

## Root cause

A focus-steal race, not the keymap path the issue originally suspected (`sendKey` already writes `\r` correctly — the proposed `"\r"` change would have *broken* Enter, per the thread discussion):

1. `AgentButton.handleClick` dispatches `agent.launch` fire-and-forget with **no DOM focus handoff** — the toolbar `<button>` keeps focus.
2. The new `TerminalPane` mounts focused and schedules a one-shot RAF to focus the input bar. But `HybridInputBar` is `React.lazy()` inside `<Suspense>`; on a cold chunk load the RAF fires while `inputBarRef.current` is still `null`, so it silently no-ops.
3. DOM focus never leaves the button. At the trust prompt, the focused native `<button>` synthesizes a `click` on Enter (HTML spec) → `agent.launch` again → second panel.

The existing per-agentId reentrancy guard in `useAgentLauncher` doesn't help: it releases when the first launch completes, long before the trust-prompt Enter.

## Fix (defense-in-depth)

- **`HybridInputBar`** self-claims focus on mount when its panel is focused, so focus lands correctly even when the focus RAF lost the race. The `EditorView` is created in `useEditorFactory`'s `useLayoutEffect`, which flushes before this `useEffect`, so `focusEditor()` always finds a live view.
- **`AgentButton`** blurs the button on launch so a stranded-focus Enter can never bounce back into a duplicate launch — closing the same class of bug from any other focus-stranding path.

## Tests

Adds a `full-platform` E2E regression test (`core-hybrid-input-bar.spec.ts`): launch via the primary Start button, press Enter at the trust prompt **without** clicking the editor, and assert (1) focus landed in the input bar, (2) the carriage return reached the PTY (fake CLI flips to `FAKE_CLAUDE_READY`), and (3) exactly one agent panel exists.

## Verification

- ✅ `npm run check` — typecheck, all IPC/channel/confirm-wiring/plugin guards, lint ratchet (warnings decreased), Prettier — all green.
- ✅ New spec typechecks and lints clean; renderer build emits the fix.
- ⚠️ Runtime E2E could not be run locally (the author's Windows machine blocks the unsigned dev `electron.exe` via WDAC/Device Guard — an OS policy unrelated to this change). The regression test will run in CI's `full-platform` bucket.