### PR TITLE
test(pty): cover untested Windows kill/shell paths and write-error throttle

### DIFF
--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -1,7 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { spawnSync } from "child_process";
 import type { IPty } from "node-pty";
 import type { ProcessTreeCache } from "../../ProcessTreeCache.js";
 import { ProcessTreeKiller } from "../ProcessTreeKiller.js";
+
+vi.mock("child_process", () => ({ spawnSync: vi.fn() }));
+
+const spawnSyncMock = vi.mocked(spawnSync);
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+function restorePlatform(): void {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
+}
 
 function makePty(pid: number): IPty {
   return {
@@ -30,232 +50,298 @@ function makeErrnoError(code: string, message?: string): NodeJS.ErrnoException {
   return err;
 }
 
-describe("ProcessTreeKiller — kill() error discrimination", () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
-  let killSpy: ReturnType<typeof vi.spyOn>;
+// The POSIX SIGTERM/SIGCONT/SIGKILL escalation is Unix-only (Windows uses
+// taskkill). Skip the whole suite on Windows so it reports as skipped rather
+// than passing vacuously via per-test early-returns.
+describe.skipIf(process.platform === "win32")(
+  "ProcessTreeKiller — kill() error discrimination",
+  () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    let killSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      killSpy?.mockRestore();
+      warnSpy.mockRestore();
+      vi.useRealTimers();
+    });
+
+    it("silently ignores ESRCH from descendant SIGTERM", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, _sig) => {
+        throw makeErrnoError("ESRCH", "kill ESRCH");
+      });
+
+      const killer = new ProcessTreeKiller(makePty(1000), makeTreeCache([1001, 1002]));
+      killer.execute(true);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      // Guard against the loop being silently skipped: both descendants must
+      // have received SIGTERM and the follow-up SIGCONT (ESRCH on SIGTERM is
+      // treated as "process already gone" — SIGCONT still runs and ESRCHs too).
+      expect(killSpy).toHaveBeenCalledWith(1001, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(1001, "SIGCONT");
+      expect(killSpy).toHaveBeenCalledWith(1002, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(1002, "SIGCONT");
+    });
+
+    it("warns once per pid when SIGTERM fails with EPERM", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+        if (sig === "SIGTERM") {
+          throw makeErrnoError("EPERM", "kill EPERM");
+        }
+        // Let SIGKILL succeed silently.
+        return true;
+      });
+
+      const killer = new ProcessTreeKiller(makePty(1000), makeTreeCache([1001, 1002]));
+      killer.execute(true);
+
+      const sigtermWarnings = warnSpy.mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .filter((m: string) => m.includes("SIGTERM"));
+      expect(sigtermWarnings).toHaveLength(2);
+      expect(sigtermWarnings[0]).toContain("[ProcessTreeKiller]");
+      expect(sigtermWarnings[0]).toContain("pid=1001");
+      expect(sigtermWarnings[1]).toContain("pid=1002");
+    });
+
+    it("warns once per pid when SIGKILL sweep fails with EPERM", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+        if (sig === "SIGKILL") {
+          throw makeErrnoError("EPERM", "kill EPERM");
+        }
+        // Let SIGTERM succeed silently.
+        return true;
+      });
+
+      const killer = new ProcessTreeKiller(makePty(2000), makeTreeCache([2001]));
+      killer.execute(true);
+
+      const sigkillWarnings = warnSpy.mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .filter((m: string) => m.includes("SIGKILL"));
+      // sweep iterates [...descendants, shellPid] = [2001, 2000]
+      expect(sigkillWarnings).toHaveLength(2);
+      expect(sigkillWarnings.some((m: string) => m.includes("pid=2001"))).toBe(true);
+      expect(sigkillWarnings.some((m: string) => m.includes("pid=2000"))).toBe(true);
+    });
+
+    it("does not warn on ESRCH during SIGKILL sweep", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+        if (sig === "SIGKILL") {
+          throw makeErrnoError("ESRCH");
+        }
+        return true;
+      });
+
+      const killer = new ProcessTreeKiller(makePty(3000), makeTreeCache([3001]));
+      killer.execute(true);
+
+      const sigkillWarnings = warnSpy.mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .filter((m: string) => m.includes("SIGKILL"));
+      expect(sigkillWarnings).toHaveLength(0);
+      // Guard against the sweep being a no-op: SIGKILL must have been attempted
+      // for both descendant and shell pids.
+      expect(killSpy).toHaveBeenCalledWith(3001, "SIGKILL");
+      expect(killSpy).toHaveBeenCalledWith(3000, "SIGKILL");
+    });
+
+    it("sends SIGCONT after SIGTERM for each descendant, then SIGCONT for shell", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const pty = makePty(4000);
+      const killer = new ProcessTreeKiller(pty, makeTreeCache([4001, 4002]));
+      // Use a deferred escalation so SIGKILL doesn't fire and obscure the
+      // SIGTERM/SIGCONT call sequence we're asserting.
+      killer.execute(false);
+
+      const signals = killSpy.mock.calls.map((c: unknown[]) => [c[0], c[1]]);
+      expect(signals).toEqual([
+        [4001, "SIGTERM"],
+        [4001, "SIGCONT"],
+        [4002, "SIGTERM"],
+        [4002, "SIGCONT"],
+        [4000, "SIGCONT"],
+      ]);
+      expect(pty.kill).toHaveBeenCalledTimes(1);
+
+      killer.abort();
+    });
+
+    it("silently ignores ESRCH from SIGCONT calls", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+        if (sig === "SIGCONT") {
+          throw makeErrnoError("ESRCH");
+        }
+        return true;
+      });
+
+      const killer = new ProcessTreeKiller(makePty(5000), makeTreeCache([5001, 5002]));
+      killer.execute(true);
+
+      const sigcontWarnings = warnSpy.mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .filter((m: string) => m.includes("SIGCONT"));
+      expect(sigcontWarnings).toHaveLength(0);
+      // Guard against SIGCONT being silently skipped: each descendant and the
+      // shell must have received a SIGCONT call.
+      expect(killSpy).toHaveBeenCalledWith(5001, "SIGCONT");
+      expect(killSpy).toHaveBeenCalledWith(5002, "SIGCONT");
+      expect(killSpy).toHaveBeenCalledWith(5000, "SIGCONT");
+    });
+
+    it("warns once per pid when SIGCONT fails with EPERM", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+        if (sig === "SIGCONT") {
+          throw makeErrnoError("EPERM", "kill EPERM");
+        }
+        return true;
+      });
+
+      const killer = new ProcessTreeKiller(makePty(6000), makeTreeCache([6001, 6002]));
+      killer.execute(true);
+
+      const sigcontWarnings = warnSpy.mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .filter((m: string) => m.includes("SIGCONT"));
+      // Two descendants + one shell SIGCONT.
+      expect(sigcontWarnings).toHaveLength(3);
+      expect(sigcontWarnings.some((m: string) => m.includes("pid=6001"))).toBe(true);
+      expect(sigcontWarnings.some((m: string) => m.includes("pid=6002"))).toBe(true);
+      expect(sigcontWarnings.some((m: string) => m.includes("pid=6000"))).toBe(true);
+      sigcontWarnings.forEach((m: string) => {
+        expect(m).toContain("[ProcessTreeKiller]");
+      });
+    });
+
+    it("skips SIGCONT when SIGTERM fails with EPERM", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+        if (sig === "SIGTERM") {
+          throw makeErrnoError("EPERM", "kill EPERM");
+        }
+        return true;
+      });
+
+      const killer = new ProcessTreeKiller(makePty(8000), makeTreeCache([8001, 8002]));
+      killer.execute(true);
+
+      // Descendant SIGCONT must NOT be called when its SIGTERM was rejected.
+      // Waking a process we couldn't signal would let it run freely without
+      // the queued SIGTERM the wake was meant to deliver.
+      expect(killSpy).not.toHaveBeenCalledWith(8001, "SIGCONT");
+      expect(killSpy).not.toHaveBeenCalledWith(8002, "SIGCONT");
+      // Shell SIGCONT is independent of the descendant gate — it's tied to
+      // ptyProcess.kill() (SIGHUP), not the descendant SIGTERM loop.
+      expect(killSpy).toHaveBeenCalledWith(8000, "SIGCONT");
+    });
+
+    it("sends shell SIGCONT even when ptyProcess.kill() throws", () => {
+      killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      const pty = makePty(7000);
+      (pty.kill as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("pty already exited");
+      });
+      const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
+      killer.execute(true);
+
+      const shellSigcont = killSpy.mock.calls.find(
+        (c: unknown[]) => c[0] === 7000 && c[1] === "SIGCONT"
+      );
+      expect(shellSigcont).toBeDefined();
+    });
+  }
+);
+
+// Windows uses `taskkill /T /F /PID` to tear down the whole tree atomically
+// rather than the POSIX signal cascade. This branch had ZERO coverage: the
+// suite above early-returned on win32, so on a Windows dev machine the kill
+// path was never asserted. These tests drive the win32 branch under a mocked
+// platform + mocked spawnSync — no real process is killed.
+describe("ProcessTreeKiller — Windows taskkill", () => {
+  let killSpy: ReturnType<typeof vi.spyOn> | undefined;
 
   beforeEach(() => {
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.useFakeTimers();
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ status: 0 } as never);
+    setPlatform("win32");
   });
 
   afterEach(() => {
     killSpy?.mockRestore();
-    warnSpy.mockRestore();
-    vi.useRealTimers();
+    killSpy = undefined;
+    restorePlatform();
   });
 
-  it("silently ignores ESRCH from descendant SIGTERM", () => {
-    if (process.platform === "win32") {
-      // SIGTERM loop is Unix-only; Windows uses taskkill.
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, _sig) => {
-      throw makeErrnoError("ESRCH", "kill ESRCH");
-    });
+  it("kills the tree with taskkill /T /F /PID and the documented options", () => {
+    const pty = makePty(4321);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([4322, 4323]));
 
-    const killer = new ProcessTreeKiller(makePty(1000), makeTreeCache([1001, 1002]));
     killer.execute(true);
 
-    expect(warnSpy).not.toHaveBeenCalled();
-    // Guard against the loop being silently skipped: both descendants must
-    // have received SIGTERM and the follow-up SIGCONT (ESRCH on SIGTERM is
-    // treated as "process already gone" — SIGCONT still runs and ESRCHs too).
-    expect(killSpy).toHaveBeenCalledWith(1001, "SIGTERM");
-    expect(killSpy).toHaveBeenCalledWith(1001, "SIGCONT");
-    expect(killSpy).toHaveBeenCalledWith(1002, "SIGTERM");
-    expect(killSpy).toHaveBeenCalledWith(1002, "SIGCONT");
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    expect(spawnSyncMock).toHaveBeenCalledWith("taskkill", ["/T", "/F", "/PID", "4321"], {
+      windowsHide: true,
+      stdio: "ignore",
+      timeout: 3000,
+    });
   });
 
-  it("warns once per pid when SIGTERM fails with EPERM", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
-      if (sig === "SIGTERM") {
-        throw makeErrnoError("EPERM", "kill EPERM");
-      }
-      // Let SIGKILL succeed silently.
-      return true;
-    });
+  it("calls ptyProcess.kill() after taskkill", () => {
+    const pty = makePty(4321);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
 
-    const killer = new ProcessTreeKiller(makePty(1000), makeTreeCache([1001, 1002]));
     killer.execute(true);
 
-    const sigtermWarnings = warnSpy.mock.calls
-      .map((c: unknown[]) => String(c[0]))
-      .filter((m: string) => m.includes("SIGTERM"));
-    expect(sigtermWarnings).toHaveLength(2);
-    expect(sigtermWarnings[0]).toContain("[ProcessTreeKiller]");
-    expect(sigtermWarnings[0]).toContain("pid=1001");
-    expect(sigtermWarnings[1]).toContain("pid=1002");
-  });
-
-  it("warns once per pid when SIGKILL sweep fails with EPERM", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
-      if (sig === "SIGKILL") {
-        throw makeErrnoError("EPERM", "kill EPERM");
-      }
-      // Let SIGTERM succeed silently.
-      return true;
-    });
-
-    const killer = new ProcessTreeKiller(makePty(2000), makeTreeCache([2001]));
-    killer.execute(true);
-
-    const sigkillWarnings = warnSpy.mock.calls
-      .map((c: unknown[]) => String(c[0]))
-      .filter((m: string) => m.includes("SIGKILL"));
-    // sweep iterates [...descendants, shellPid] = [2001, 2000]
-    expect(sigkillWarnings).toHaveLength(2);
-    expect(sigkillWarnings.some((m: string) => m.includes("pid=2001"))).toBe(true);
-    expect(sigkillWarnings.some((m: string) => m.includes("pid=2000"))).toBe(true);
-  });
-
-  it("does not warn on ESRCH during SIGKILL sweep", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
-      if (sig === "SIGKILL") {
-        throw makeErrnoError("ESRCH");
-      }
-      return true;
-    });
-
-    const killer = new ProcessTreeKiller(makePty(3000), makeTreeCache([3001]));
-    killer.execute(true);
-
-    const sigkillWarnings = warnSpy.mock.calls
-      .map((c: unknown[]) => String(c[0]))
-      .filter((m: string) => m.includes("SIGKILL"));
-    expect(sigkillWarnings).toHaveLength(0);
-    // Guard against the sweep being a no-op: SIGKILL must have been attempted
-    // for both descendant and shell pids.
-    expect(killSpy).toHaveBeenCalledWith(3001, "SIGKILL");
-    expect(killSpy).toHaveBeenCalledWith(3000, "SIGKILL");
-  });
-
-  it("sends SIGCONT after SIGTERM for each descendant, then SIGCONT for shell", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
-    const pty = makePty(4000);
-    const killer = new ProcessTreeKiller(pty, makeTreeCache([4001, 4002]));
-    // Use a deferred escalation so SIGKILL doesn't fire and obscure the
-    // SIGTERM/SIGCONT call sequence we're asserting.
-    killer.execute(false);
-
-    const signals = killSpy.mock.calls.map((c: unknown[]) => [c[0], c[1]]);
-    expect(signals).toEqual([
-      [4001, "SIGTERM"],
-      [4001, "SIGCONT"],
-      [4002, "SIGTERM"],
-      [4002, "SIGCONT"],
-      [4000, "SIGCONT"],
-    ]);
     expect(pty.kill).toHaveBeenCalledTimes(1);
-
-    killer.abort();
   });
 
-  it("silently ignores ESRCH from SIGCONT calls", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
-      if (sig === "SIGCONT") {
-        throw makeErrnoError("ESRCH");
-      }
-      return true;
-    });
+  it("never sends POSIX signals on Windows", () => {
+    killSpy = vi.spyOn(process, "kill");
+    const pty = makePty(4321);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([4322, 4323]));
 
-    const killer = new ProcessTreeKiller(makePty(5000), makeTreeCache([5001, 5002]));
     killer.execute(true);
 
-    const sigcontWarnings = warnSpy.mock.calls
-      .map((c: unknown[]) => String(c[0]))
-      .filter((m: string) => m.includes("SIGCONT"));
-    expect(sigcontWarnings).toHaveLength(0);
-    // Guard against SIGCONT being silently skipped: each descendant and the
-    // shell must have received a SIGCONT call.
-    expect(killSpy).toHaveBeenCalledWith(5001, "SIGCONT");
-    expect(killSpy).toHaveBeenCalledWith(5002, "SIGCONT");
-    expect(killSpy).toHaveBeenCalledWith(5000, "SIGCONT");
+    // The Unix SIGTERM/SIGCONT/SIGKILL cascade must not run on Windows.
+    expect(killSpy).not.toHaveBeenCalled();
   });
 
-  it("warns once per pid when SIGCONT fails with EPERM", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
-      if (sig === "SIGCONT") {
-        throw makeErrnoError("EPERM", "kill EPERM");
-      }
-      return true;
+  it("swallows a thrown taskkill and still calls ptyProcess.kill()", () => {
+    spawnSyncMock.mockImplementation(() => {
+      throw new Error("taskkill: process already exited");
     });
+    const pty = makePty(4321);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
 
-    const killer = new ProcessTreeKiller(makePty(6000), makeTreeCache([6001, 6002]));
-    killer.execute(true);
-
-    const sigcontWarnings = warnSpy.mock.calls
-      .map((c: unknown[]) => String(c[0]))
-      .filter((m: string) => m.includes("SIGCONT"));
-    // Two descendants + one shell SIGCONT.
-    expect(sigcontWarnings).toHaveLength(3);
-    expect(sigcontWarnings.some((m: string) => m.includes("pid=6001"))).toBe(true);
-    expect(sigcontWarnings.some((m: string) => m.includes("pid=6002"))).toBe(true);
-    expect(sigcontWarnings.some((m: string) => m.includes("pid=6000"))).toBe(true);
-    sigcontWarnings.forEach((m: string) => {
-      expect(m).toContain("[ProcessTreeKiller]");
-    });
+    expect(() => killer.execute(true)).not.toThrow();
+    expect(pty.kill).toHaveBeenCalledTimes(1);
   });
 
-  it("skips SIGCONT when SIGTERM fails with EPERM", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
-      if (sig === "SIGTERM") {
-        throw makeErrnoError("EPERM", "kill EPERM");
-      }
-      return true;
-    });
-
-    const killer = new ProcessTreeKiller(makePty(8000), makeTreeCache([8001, 8002]));
-    killer.execute(true);
-
-    // Descendant SIGCONT must NOT be called when its SIGTERM was rejected.
-    // Waking a process we couldn't signal would let it run freely without
-    // the queued SIGTERM the wake was meant to deliver.
-    expect(killSpy).not.toHaveBeenCalledWith(8001, "SIGCONT");
-    expect(killSpy).not.toHaveBeenCalledWith(8002, "SIGCONT");
-    // Shell SIGCONT is independent of the descendant gate — it's tied to
-    // ptyProcess.kill() (SIGHUP), not the descendant SIGTERM loop.
-    expect(killSpy).toHaveBeenCalledWith(8000, "SIGCONT");
-  });
-
-  it("sends shell SIGCONT even when ptyProcess.kill() throws", () => {
-    if (process.platform === "win32") {
-      return;
-    }
-    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
-
-    const pty = makePty(7000);
+  it("swallows a thrown ptyProcess.kill() after taskkill", () => {
+    const pty = makePty(4321);
     (pty.kill as ReturnType<typeof vi.fn>).mockImplementation(() => {
       throw new Error("pty already exited");
     });
     const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
+
+    expect(() => killer.execute(true)).not.toThrow();
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("short-circuits to ptyProcess.kill() without taskkill when shellPid is invalid", () => {
+    const pty = makePty(0);
+    const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
+
     killer.execute(true);
 
-    const shellSigcont = killSpy.mock.calls.find(
-      (c: unknown[]) => c[0] === 7000 && c[1] === "SIGCONT"
-    );
-    expect(shellSigcont).toBeDefined();
+    // shellPid <= 0 returns before the platform branch — no taskkill.
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(pty.kill).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -334,13 +334,27 @@ describe("ProcessTreeKiller — Windows taskkill", () => {
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it("short-circuits to ptyProcess.kill() without taskkill when shellPid is invalid", () => {
-    const pty = makePty(0);
+  it.each([0, -1])(
+    "short-circuits to ptyProcess.kill() without taskkill when shellPid is %i",
+    (pid) => {
+      const pty = makePty(pid);
+      const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
+
+      killer.execute(true);
+
+      // shellPid <= 0 returns before the platform branch — no taskkill.
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+      expect(pty.kill).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("short-circuits to ptyProcess.kill() without taskkill when shellPid is undefined", () => {
+    const pty = makePty(undefined as unknown as number);
     const killer = new ProcessTreeKiller(pty, makeTreeCache([]));
 
     killer.execute(true);
 
-    // shellPid <= 0 returns before the platform branch — no taskkill.
+    // The `shellPid === undefined` guard returns before the platform branch.
     expect(spawnSyncMock).not.toHaveBeenCalled();
     expect(pty.kill).toHaveBeenCalledTimes(1);
   });

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -299,10 +299,16 @@ describe("ProcessTreeKiller — Windows taskkill", () => {
     killer.execute(true);
 
     expect(pty.kill).toHaveBeenCalledTimes(1);
+    // Ordering matters: taskkill (tree teardown) must run before pty.kill()
+    // closes the session leader, else the descendant tree can be orphaned.
+    const killMock = pty.kill as ReturnType<typeof vi.fn>;
+    expect(spawnSyncMock.mock.invocationCallOrder[0]).toBeLessThan(
+      killMock.mock.invocationCallOrder[0]
+    );
   });
 
   it("never sends POSIX signals on Windows", () => {
-    killSpy = vi.spyOn(process, "kill");
+    killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     const pty = makePty(4321);
     const killer = new ProcessTreeKiller(pty, makeTreeCache([4322, 4323]));
 

--- a/electron/services/pty/__tests__/TerminalProcess.writeErrorThrottle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.writeErrorThrottle.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+interface MockPtyHandles {
+  pty: IPty;
+  writeMock: ReturnType<typeof vi.fn<(data: string) => void>>;
+}
+
+function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
+  const writeMock = vi.fn<(data: string) => void>();
+
+  const pty: Partial<IPty> = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: (data: string) => {
+      writeMock(data);
+      if (writeOverride) writeOverride(data);
+    },
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: () => ({ dispose: () => {} }),
+    onExit: () => ({ dispose: () => {} }),
+  };
+
+  return { pty: pty as IPty, writeMock };
+}
+
+function defaultSpawnContext(overrides?: Partial<SpawnContext>): SpawnContext {
+  return {
+    shell: "/bin/zsh",
+    args: ["-l"],
+    env: {},
+    ...overrides,
+  };
+}
+
+type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
+
+function createTerminal(handles: MockPtyHandles): TerminalProcess {
+  const opts: TerminalProcessOptions = {
+    cwd: process.cwd(),
+    cols: 80,
+    rows: 24,
+    kind: "terminal",
+  };
+  return new TerminalProcess(
+    "t1",
+    opts,
+    { emitData: () => {}, onExit: () => {} },
+    {
+      agentStateService: {
+        handleActivityState: () => {},
+        updateAgentState: () => {},
+        emitAgentKilled: () => {},
+      } as never,
+      ptyPool: null,
+      processTreeCache: null,
+    },
+    defaultSpawnContext(),
+    handles.pty
+  );
+}
+
+// A throwing pty surfaces a write error on every keystroke, exercising
+// logWriteError's 5s throttle + suppression-summary path. On Windows the
+// triggering errno differs (NTSTATUS vs EPIPE/EIO), but the throttle is
+// error-code-agnostic, so the platform is irrelevant to this behavior.
+const THROTTLE_MS = 5000;
+
+describe("TerminalProcess write-error throttle", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let base: number;
+
+  function errorLogs(): string[] {
+    return errSpy.mock.calls.map((c: unknown[]) => String(c[0]));
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    base = Date.now();
+    vi.setSystemTime(base);
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("logs the first write error immediately", () => {
+    const handles = createMockPty(() => {
+      throw new Error("EBADF");
+    });
+    const terminal = createTerminal(handles);
+
+    terminal.write("a");
+
+    const logs = errorLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs[0]).toContain("PTY write(fast-path) failed for t1");
+    // The error object is forwarded as the second arg.
+    expect(errSpy.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+  });
+
+  it("suppresses subsequent errors within the 5000ms window", () => {
+    const handles = createMockPty(() => {
+      throw new Error("EBADF");
+    });
+    const terminal = createTerminal(handles);
+
+    terminal.write("a"); // logs
+    vi.setSystemTime(base + 1000);
+    terminal.write("b"); // suppressed
+    vi.setSystemTime(base + 2000);
+    terminal.write("c"); // suppressed
+
+    expect(errorLogs()).toHaveLength(1);
+  });
+
+  it("logs a suppression summary once the window elapses", () => {
+    const handles = createMockPty(() => {
+      throw new Error("EBADF");
+    });
+    const terminal = createTerminal(handles);
+
+    terminal.write("a"); // logs
+    vi.setSystemTime(base + 1000);
+    terminal.write("b"); // suppressed (1)
+    vi.setSystemTime(base + 2000);
+    terminal.write("c"); // suppressed (2)
+    vi.setSystemTime(base + 3000);
+    terminal.write("d"); // suppressed (3)
+
+    vi.setSystemTime(base + THROTTLE_MS + 1);
+    terminal.write("e"); // logs again + emits suppression summary
+
+    const summary = errorLogs().find((m) => m.includes("Suppressed"));
+    expect(summary).toBeDefined();
+    expect(summary).toContain("Suppressed 3 additional PTY write errors for t1");
+    expect(summary).toContain(`${THROTTLE_MS}ms`);
+  });
+
+  it("resets the suppression counter after reporting it", () => {
+    const handles = createMockPty(() => {
+      throw new Error("EBADF");
+    });
+    const terminal = createTerminal(handles);
+
+    terminal.write("a"); // logs
+    vi.setSystemTime(base + 1000);
+    terminal.write("b"); // suppressed (1)
+
+    vi.setSystemTime(base + THROTTLE_MS + 1);
+    terminal.write("c"); // logs + "Suppressed 1" summary
+
+    // Advance another full window with NO intervening suppressed errors, then
+    // trigger one more error: the counter was reset to 0, so no stale summary.
+    vi.setSystemTime(base + 2 * THROTTLE_MS + 2);
+    errSpy.mockClear();
+    terminal.write("d"); // logs, but must NOT emit a "Suppressed" line
+
+    const logs = errorLogs();
+    expect(logs).toHaveLength(1);
+    expect(logs.some((m) => m.includes("Suppressed"))).toBe(false);
+  });
+
+  it("includes traceId in the error log when provided", () => {
+    const handles = createMockPty(() => {
+      throw new Error("EBADF");
+    });
+    const terminal = createTerminal(handles);
+
+    terminal.write("a", "trace-42");
+
+    expect(errorLogs()[0]).toContain("traceId=trace-42");
+  });
+});

--- a/electron/services/pty/__tests__/terminalShell.test.ts
+++ b/electron/services/pty/__tests__/terminalShell.test.ts
@@ -149,8 +149,11 @@ describe("findWindowsShell (Windows shell discovery)", () => {
     process.env.COMSPEC = "C:\\custom\\cmd.exe";
 
     expect(findWindowsShell()).toBe("C:\\custom\\cmd.exe");
-    // Both `where pwsh.exe` and `where powershell.exe` must be probed first.
+    // Both `where pwsh.exe` and `where powershell.exe` must be probed, in order,
+    // before falling back to COMSPEC.
     expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock.mock.calls[0]?.[1]).toEqual(["pwsh.exe"]);
+    expect(execFileSyncMock.mock.calls[1]?.[1]).toEqual(["powershell.exe"]);
   });
 
   it("falls back to cmd.exe when both PowerShell probes fail and COMSPEC is unset", () => {
@@ -158,8 +161,11 @@ describe("findWindowsShell (Windows shell discovery)", () => {
     delete process.env.COMSPEC;
 
     expect(findWindowsShell()).toBe("cmd.exe");
-    // Both `where pwsh.exe` and `where powershell.exe` must be probed first.
+    // Both `where pwsh.exe` and `where powershell.exe` must be probed, in order,
+    // before falling back to the hardcoded cmd.exe.
     expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock.mock.calls[0]?.[1]).toEqual(["pwsh.exe"]);
+    expect(execFileSyncMock.mock.calls[1]?.[1]).toEqual(["powershell.exe"]);
   });
 });
 

--- a/electron/services/pty/__tests__/terminalShell.test.ts
+++ b/electron/services/pty/__tests__/terminalShell.test.ts
@@ -149,6 +149,8 @@ describe("findWindowsShell (Windows shell discovery)", () => {
     process.env.COMSPEC = "C:\\custom\\cmd.exe";
 
     expect(findWindowsShell()).toBe("C:\\custom\\cmd.exe");
+    // Both `where pwsh.exe` and `where powershell.exe` must be probed first.
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
   });
 
   it("falls back to cmd.exe when both PowerShell probes fail and COMSPEC is unset", () => {
@@ -156,6 +158,8 @@ describe("findWindowsShell (Windows shell discovery)", () => {
     delete process.env.COMSPEC;
 
     expect(findWindowsShell()).toBe("cmd.exe");
+    // Both `where pwsh.exe` and `where powershell.exe` must be probed first.
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/electron/services/pty/__tests__/terminalShell.test.ts
+++ b/electron/services/pty/__tests__/terminalShell.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { getDefaultShellArgs } from "../terminalShell.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execFileSync } from "child_process";
+import { findWindowsShell, getDefaultShell, getDefaultShellArgs } from "../terminalShell.js";
+
+vi.mock("child_process", () => ({ execFileSync: vi.fn() }));
+
+const execFileSyncMock = vi.mocked(execFileSync);
 
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
 
@@ -94,5 +99,98 @@ describe("getDefaultShellArgs", () => {
       expect(getDefaultShellArgs("C:\\tools\\nushell\\nu.exe")).toEqual([]);
       expect(getDefaultShellArgs("C:\\Program Files\\Git\\bin\\bash.exe")).toEqual([]);
     });
+  });
+});
+
+function throwOnce(): never {
+  throw new Error("where: not found");
+}
+
+// Shell DISCOVERY (which shell to spawn) was untested — only getDefaultShellArgs
+// (args for an already-resolved shell) had coverage. These tests drive the
+// Windows fallback chain `where pwsh.exe` → `where powershell.exe` → COMSPEC →
+// cmd.exe under a mocked execFileSync, so no real `where.exe` runs.
+describe("findWindowsShell (Windows shell discovery)", () => {
+  const originalComspec = process.env.COMSPEC;
+
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalComspec === undefined) {
+      delete process.env.COMSPEC;
+    } else {
+      process.env.COMSPEC = originalComspec;
+    }
+  });
+
+  it("returns pwsh.exe when 'where pwsh.exe' succeeds", () => {
+    execFileSyncMock.mockReturnValue(Buffer.from("") as never);
+
+    expect(findWindowsShell()).toBe("pwsh.exe");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    expect(execFileSyncMock).toHaveBeenCalledWith("where", ["pwsh.exe"], {
+      stdio: "ignore",
+      timeout: 3000,
+    });
+  });
+
+  it("falls back to powershell.exe when pwsh.exe is not on PATH", () => {
+    execFileSyncMock.mockImplementationOnce(throwOnce).mockReturnValue(Buffer.from("") as never);
+
+    expect(findWindowsShell()).toBe("powershell.exe");
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
+    expect(execFileSyncMock.mock.calls[1]?.[1]).toEqual(["powershell.exe"]);
+  });
+
+  it("falls back to COMSPEC when neither PowerShell is on PATH", () => {
+    execFileSyncMock.mockImplementation(throwOnce);
+    process.env.COMSPEC = "C:\\custom\\cmd.exe";
+
+    expect(findWindowsShell()).toBe("C:\\custom\\cmd.exe");
+  });
+
+  it("falls back to cmd.exe when both PowerShell probes fail and COMSPEC is unset", () => {
+    execFileSyncMock.mockImplementation(throwOnce);
+    delete process.env.COMSPEC;
+
+    expect(findWindowsShell()).toBe("cmd.exe");
+  });
+});
+
+describe("getDefaultShell", () => {
+  const originalShell = process.env.SHELL;
+
+  beforeEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+    if (originalShell === undefined) {
+      delete process.env.SHELL;
+    } else {
+      process.env.SHELL = originalShell;
+    }
+  });
+
+  it("delegates to findWindowsShell on win32 (no POSIX shell resolution)", () => {
+    setPlatform("win32");
+    process.env.SHELL = "/bin/zsh"; // must be ignored on Windows
+    execFileSyncMock.mockReturnValue(Buffer.from("") as never);
+
+    expect(getDefaultShell()).toBe("pwsh.exe");
+    // Proves the win32 short-circuit: the POSIX $SHELL branch never runs.
+    expect(execFileSyncMock).toHaveBeenCalledWith("where", ["pwsh.exe"], expect.anything());
+  });
+
+  it("returns process.env.SHELL when set on POSIX", () => {
+    setPlatform("linux");
+    process.env.SHELL = "/usr/bin/fish";
+
+    expect(getDefaultShell()).toBe("/usr/bin/fish");
   });
 });


### PR DESCRIPTION
﻿## Summary

Closes three test-coverage gaps in the Windows node-pty surface. Tests only — no production changes.

### 1. ProcessTreeKiller — Windows `taskkill` path (false-green fix)

Every test in `ProcessTreeKiller.test.ts` began with `if (process.platform === "win32") { return; }`, so on Windows the suite passed **vacuously** — the actual Windows kill path (`taskkill /T /F /PID`, which tears down the entire agent process tree) was never asserted.

- Wrapped the POSIX SIGTERM/SIGCONT/SIGKILL cascade suite in `describe.skipIf(win32)` so it now reports as **skipped** on Windows instead of a misleading pass.
- Added a `Windows taskkill` suite that exercises the win32 branch under a mocked platform + mocked `spawnSync` (no real process killed): exact args/options, post-kill `ptyProcess.kill()`, absence of POSIX signals, error swallowing for thrown `taskkill`/`kill`, and the `shellPid <= 0` short-circuit.

### 2. terminalShell — Windows shell discovery

`findWindowsShell()` and `getDefaultShell()`'s win32 delegation were untested (only `getDefaultShellArgs` had coverage). Added tests for the fallback chain `pwsh.exe → powershell.exe → COMSPEC → cmd.exe` via mocked `execFileSync`.

### 3. TerminalProcess — write-error throttle

`logWriteError`'s 5s throttle window, the "Suppressed N…" summary, the counter reset, and `traceId` passthrough had no coverage. Added a dedicated suite driving the public `write()` fast path with a throwing pty.

## Verification

- Full PTY suite: 1213 passed / 17 skipped (no regressions)
- `ProcessTreeKiller.test.ts`: 6 Windows tests pass, 9 Unix tests skipped on Windows
- `npm run check` (typecheck + IPC/channel/confirm-wiring guards + lint ratchet + format): exit 0
- Anti-vacuous check: dropping `/T` from the expected taskkill args makes the test fail, confirming the assertion is load-bearing
