### PR TITLE
fix(terminal): converge agent terminals on project switch-back (#10632)

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -340,6 +340,7 @@ class TerminalInstanceService {
       ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
       unhibernate: (id) => this.unhibernate(id),
       forceReflow: (element) => forceXtermReflow(element),
+      reconcileRevealGeometry: (id) => this.reconcileRevealGeometry(id),
       isStoreBackgrounded: (id) => usePanelStore.getState().backgroundedTerminals.has(id),
       isStoreHidden: (id) => usePanelStore.getState().panelsById[id]?.isVisible === false,
       repairStoreVisibility: (id) => usePanelStore.getState().updateVisibility(id, true),
@@ -751,8 +752,21 @@ class TerminalInstanceService {
         this.rendererPolicy.applyRendererPolicy(id, tier);
 
         const termEl = managed.terminal.element;
-        if (termEl) {
+        if (termEl && managed.terminal.modes?.synchronizedOutputMode !== true) {
           forceXtermReflow(termEl);
+        } else if (termEl) {
+          // Defer the unpause reflow while a DEC 2026 synchronized-output block is
+          // open (#10632). forceXtermReflow bypasses xterm's atomic-at-ESU
+          // buffering and would interleave a torn frame — the invariant
+          // TerminalReflowController.maybeReflow enforces at :139. This path IS
+          // reachable on switch-back: the grid IntersectionObserver
+          // (TerminalPane) fires setVisible(id, true) as the pane re-enters the
+          // viewport while an agent is mid-stream. applyDeferredResize above
+          // already synced geometry and applyRendererPolicy still ran; hand the
+          // unpause/repaint to the watchdog's reveal-pending backstop, which
+          // re-runs it once the block closes and the pane is on-screen.
+          managed.revealPendingRepair = true;
+          managed.revealPendingGeneration = managed.attachGeneration;
         }
 
         // Debounced WebGL restore for same-tier transitions. If
@@ -845,22 +859,41 @@ class TerminalInstanceService {
       this.resizeController.lockResize(id, true);
 
       instance.resizeSuppressionTimer = window.setTimeout(() => {
-        instance.isResizeSuppressed = false;
-        instance.resizeSuppressionEndTime = undefined;
-        instance.resizeSuppressionTimer = undefined;
+        // Re-fetch: the instance can be disposed/replaced between arming and
+        // firing. Working off the live map (not the closed-over ref) also lets
+        // the closure drop its `instance` capture for GC.
+        const current = this.instances.get(id);
+        if (!current) return;
+        current.isResizeSuppressed = false;
+        current.resizeSuppressionEndTime = undefined;
+        current.resizeSuppressionTimer = undefined;
         this.resizeController.lockResize(id, false);
         // Guaranteed post-switch redraw. The reveal repaint and its rAF
         // backstops all fire INSIDE this suppression window, where the renderer
         // can still be mid-settle and a stale `isVisible` can no-op the
         // visibility-guarded reveal path. Now that suppression and the resize
-        // lock are gone, the DOM has long settled, and the reconciliation
-        // watchdog (which skips suppressed terminals) re-engages, run the exact
-        // recovery a user gets by clicking "Redraw": resetRenderer has no
-        // isVisible guard and its fit() is no longer lock-gated, so it corrects
-        // both a stale grid (garbled wrapping) and a paused/garbled renderer.
-        // Cheap and idempotent — a no-op when the pane is already correct, and
-        // self-skips a backgrounded/zero-box terminal via its own guards.
-        this.resetRenderer(id);
+        // lock are gone and the reconciliation watchdog (which skips suppressed
+        // terminals) re-engages, run the exact recovery a user gets by clicking
+        // "Redraw": resetRenderer has no isVisible guard and its fit() is no
+        // longer lock-gated, so it corrects both a stale grid (garbled wrapping)
+        // and a paused/garbled renderer.
+        //
+        // Rule #1 (#10632): the obligation must be PRESERVED whenever the redraw
+        // did NOT actually run — not just when the host is detached. On a dwell
+        // longer than the suppression window this timer fires while the outgoing
+        // view is still non-renderable (detached, occluded zero box,
+        // content-visibility:hidden, or a transitional sub-50px box), where
+        // resetRenderer self-skips and the one-shot recovery would be SILENTLY
+        // SPENT. resetRenderer now reports whether it ran; if it didn't (host
+        // not foreground-renderable, OR renderable but below its >=50px floor),
+        // hand the obligation to the reconciliation watchdog, which runs the
+        // closed-loop repair once DOM geometry proves the pane on-screen. Owned
+        // by the current attachGeneration so a later re-attach can supersede it.
+        const ran = this.hostHasRenderableDims(current) ? this.resetRenderer(id) : false;
+        if (!ran) {
+          current.revealPendingRepair = true;
+          current.revealPendingGeneration = current.attachGeneration;
+        }
       }, durationMs);
     });
   }
@@ -1004,8 +1037,24 @@ class TerminalInstanceService {
     // flag (e.g. a prior skip whose deferred re-run we are now satisfying).
     current.pendingVisibilityWake = false;
 
+    // Never interleave the RENDER ops (forceXtermReflow, repairAtlasForReactivation,
+    // the post-wake refresh) into an OPEN DEC 2026 synchronized-output block
+    // (#10632). forceXtermReflow bypasses xterm's atomic-at-ESU buffering and
+    // would paint a partial frame — the exact invariant TerminalReflowController
+    // enforces at maybeReflow. The DATA path stays unconditional: applyDeferredResize
+    // (above), wakeAndRestore (byte-pull/buffer restore), handlePostWake (its only
+    // reflow routes through the guarded maybeReflowTerminal), and the held-byte
+    // flush all still run. Re-checked on BOTH sides of the await — the block can
+    // open or close across the async wakeAndRestore.
+    //
+    // This method has no retry-return like repaintForReveal, so when paint is
+    // deferred hand the obligation to the reconciliation watchdog via
+    // revealPendingRepair: its reveal-pending branch re-runs the atomic repair
+    // (geometry + atlas + unpause) once the block closes and the pane is on-screen.
+    let deferPaintForSync = current.terminal.modes?.synchronizedOutputMode === true;
+
     const termEl = current.terminal.element;
-    if (termEl) {
+    if (termEl && !deferPaintForSync) {
       try {
         forceXtermReflow(termEl);
       } catch (error) {
@@ -1017,8 +1066,10 @@ class TerminalInstanceService {
     // wakeAndRestore IPC and before the view's first composited frame. On warm
     // project-view reactivation the compositor can flash the pre-freeze atlas
     // state; resetting the local model here (no breaker, no shared-atlas churn)
-    // clears it in place. No-op for DOM-renderer terminals.
-    this.webGLManager.repairAtlasForReactivation(id);
+    // clears it in place. No-op for DOM-renderer terminals. Deferred mid-block.
+    if (!deferPaintForSync) {
+      this.webGLManager.repairAtlasForReactivation(id);
+    }
 
     const { ok, replayedMainBuffer } = await this.wakeManager.wakeAndRestore(id);
 
@@ -1028,7 +1079,12 @@ class TerminalInstanceService {
     if (!after || after !== current) return;
     if (after.isHibernated) return;
 
-    after.terminal.refresh(0, after.terminal.rows - 1);
+    // Re-read across the await — a synchronized block may have opened (or closed)
+    // during the buffer restore.
+    if (after.terminal.modes?.synchronizedOutputMode === true) deferPaintForSync = true;
+    if (!deferPaintForSync) {
+      after.terminal.refresh(0, after.terminal.rows - 1);
+    }
 
     if (ok) {
       this.handlePostWake(id);
@@ -1039,6 +1095,15 @@ class TerminalInstanceService {
       this.discardHeldOutput(id);
     } else {
       this.dataBuffer.resumeFlush(id);
+    }
+
+    // Paint was deferred to avoid interleaving an open synchronized-output block.
+    // The watchdog's reveal-pending branch re-runs the full atomic repair once
+    // the block closes and the pane is on-screen — the durable backstop this
+    // retry-less method otherwise lacks.
+    if (deferPaintForSync) {
+      after.revealPendingRepair = true;
+      after.revealPendingGeneration = after.attachGeneration;
     }
   }
 
@@ -1067,19 +1132,43 @@ class TerminalInstanceService {
   repaintForReveal(id: string): boolean {
     const managed = this.instances.get(id);
     if (!managed || managed.isHibernated) return false;
-    if (!managed.isOpened || !managed.isVisible) return false;
+    // Health-check on DOM ground truth (isConnected + checkVisibility + size),
+    // NOT the reactive `managed.isVisible` flag (#10632 item 4). On a warm
+    // WebContentsView resume the attach effect — the one place that force-sets
+    // isVisible=true (XtermAdapter) — does not re-run, and the
+    // IntersectionObserver that would flip it can lag a frame or be culled while
+    // the view un-occludes, so a stale isVisible=false would no-op the exact
+    // repaint the reveal needs. resetRenderer (manual Redraw) already keys off
+    // connected+size for this reason; unify on the same DOM-truth signal here.
+    // The element.isConnected + checkVisibility + >=50px box guards below are the
+    // real preconditions.
+    if (!managed.isOpened) return false;
 
     const element = managed.terminal.element;
     if (!element || !element.isConnected) return false;
 
-    // A not-yet-laid-out grid has no model worth repainting — its first real
-    // resize builds it fresh. Mirrors resetRenderer's size guard. Report "not
-    // paintable yet" (false) so the reveal sweep retries on a later frame once
-    // the foreground view has settled its layout, rather than burning its one
-    // shot against a zero box.
+    // A not-yet-laid-out, content-visibility:hidden, or zero/occluded host has no
+    // model worth repainting — its first real resize builds it fresh. Use the
+    // same hostHasRenderableDims gate (isConnected + checkVisibility + box) that
+    // ensureOpened/fit rely on, then refine with resetRenderer's >=50px floor.
+    // Report "not paintable yet" (false) so the reveal sweep retries on a later
+    // frame once the foreground view has settled its layout, rather than burning
+    // its one shot against a zero box.
+    if (!this.hostHasRenderableDims(managed)) return false;
     if (managed.hostElement.clientWidth < 50 || managed.hostElement.clientHeight < 50) {
       return false;
     }
+
+    // Never repaint into an OPEN DEC 2026 synchronized-output block (#10632). The
+    // atlas repair, forceXtermReflow, and reconcileGeometryFresh below would each
+    // interleave a paint with the buffered range and corrupt a live agent frame.
+    // The watchdog repair path already defers on this; the reveal path must too —
+    // dropping the !isVisible guard above made repaintForReveal more reachable, so
+    // the never-interleave-mid-block guarantee has to hold here as well. Report
+    // "not paintable yet" so the reveal sweep retries on a later frame once the
+    // block closes; the reconciliation watchdog is the backstop if it outlasts
+    // the sweep.
+    if (managed.terminal.modes?.synchronizedOutputMode === true) return false;
 
     // Re-attach a WebGL context the freeze/thaw cycle may have dropped before
     // repairing the local model. Same idiom as the post-reparent restore.
@@ -1139,6 +1228,45 @@ class TerminalInstanceService {
     // immediately rather than being debounced away (mirrors resetRenderer).
     managed.lastReflowAt = 0;
 
+    return true;
+  }
+
+  /**
+   * Watchdog-driven, alt-buffer-safe reveal repair (#10632) — the closed-loop
+   * "is it correct now" correction that the open-loop reveal backstops never
+   * reliably delivered. This is the ATOMIC half of a manual Redraw: re-fit
+   * geometry from a FRESH DOM measurement (xterm + PTY resized together via
+   * {@link TerminalResizeController.reconcileGeometryFresh}) and repair the local
+   * WebGL glyph model (or plain-refresh a DOM-renderer pane).
+   *
+   * Deliberately omits `forceXtermReflow`: a layout reflow mid DEC 2026
+   * synchronized-output block would interleave a paint with the buffered range,
+   * so the watchdog gates the unpause reflow on `synchronizedOutputMode`
+   * separately and only calls this once a block has closed. The atomic resize is
+   * safe for settled-strategy agents (no 500ms xterm/PTY split).
+   *
+   * Returns reconcileGeometryFresh's verdict: false on an unmeasurable /
+   * transitional box (zero/occluded/content-visibility:hidden) so the watchdog
+   * keeps the reveal-pending obligation and retries on a later tick once the
+   * foreground view has settled — the present-ordering guarantee that a repaint
+   * is never issued into an occluded surface.
+   */
+  reconcileRevealGeometry(id: string): boolean {
+    const managed = this.instances.get(id);
+    if (!managed || managed.isHibernated) return false;
+    if (!this.resizeController.reconcileGeometryFresh(id)) return false;
+
+    try {
+      if (!this.webGLManager.repairAtlasForReactivation(id)) {
+        managed.terminal.refresh(0, managed.terminal.rows - 1);
+      }
+    } catch (error) {
+      logWarn(`reconcileRevealGeometry repair failed for ${id}`, { error });
+    }
+
+    // Clear the reflow throttle so a follow-up unpause reflow (the watchdog's
+    // render-pause branch, or the next write/heartbeat) fires immediately.
+    managed.lastReflowAt = 0;
     return true;
   }
 
@@ -2822,20 +2950,27 @@ class TerminalInstanceService {
     }
   }
 
-  resetRenderer(id: string): void {
+  /**
+   * Recover a terminal's renderer the way the manual "Redraw" action does.
+   * Returns whether the repair ACTUALLY ran: false when it self-skipped on its
+   * own guards (gone/hibernated/disconnected/sub-50px box). Callers that must
+   * guarantee a redraw (the project-switch suppression-clear, #10632) use the
+   * return value to know whether the obligation still needs to be carried.
+   */
+  resetRenderer(id: string): boolean {
     const managed = this.instances.get(id);
-    if (!managed || managed.isHibernated) return;
+    if (!managed || managed.isHibernated) return false;
 
     try {
       if (!managed.hostElement.isConnected) {
         logDebug(`resetRenderer skipped for ${id}: not connected`);
-        return;
+        return false;
       }
       if (managed.hostElement.clientWidth < 50 || managed.hostElement.clientHeight < 50) {
         logDebug(
           `resetRenderer skipped for ${id}: too small (${managed.hostElement.clientWidth}x${managed.hostElement.clientHeight})`
         );
-        return;
+        return false;
       }
 
       logDebug(`resetRenderer running for ${id}`);
@@ -2874,6 +3009,7 @@ class TerminalInstanceService {
       }
       managed.lastReflowAt = 0;
     }
+    return true;
   }
 
   handleBackendRecovery(): void {

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -64,6 +64,14 @@ export interface ReconciliationWatchdogDeps {
   ensureWebGL: (id: string, managed: ManagedTerminal) => void;
   unhibernate: (id: string) => void;
   forceReflow: (element: HTMLElement) => void;
+  /**
+   * Repair (#10632): alt-buffer-safe atomic reveal reconcile — a FRESH fit
+   * (xterm + PTY resized together) plus a local WebGL-atlas repair, with NO
+   * mid-block reflow. Returns false on an unmeasurable / occluded box so the
+   * obligation is kept and retried on a later tick (present-ordering: never
+   * repaint into a surface that isn't foreground-presenting).
+   */
+  reconcileRevealGeometry: (id: string) => boolean;
   isStoreBackgrounded: (id: string) => boolean;
   /** Store-side panel.isVisible === false — the one store state DOM geometry can prove wrong. */
   isStoreHidden: (id: string) => boolean;
@@ -191,9 +199,10 @@ export class TerminalReconciliationWatchdog {
    * is rendering its buffer at the wrong width — the exact "garbled line flow"
    * users see after switching back to a project. The watchdog already gated out
    * drags, layout transitions, and resize-suppressed/attaching terminals, so a
-   * divergence reaching here is real, not transient. This does not repair —
-   * the reveal backstops and the suppression-clear redraw own recovery — it
-   * just makes a silently-wrong grid loud during local development.
+   * divergence reaching here is real, not transient. This call itself only
+   * logs (DEV) — the actual repair is the geometry-convergence branch in
+   * {@link reconcile} (#10632) — so a silently-wrong grid is both loud during
+   * local development and reconciled on the same tick.
    */
   private diagnoseGeometryDivergence(id: string, managed: ManagedTerminal): void {
     if (!import.meta.env?.DEV) return;
@@ -331,22 +340,114 @@ export class TerminalReconciliationWatchdog {
       return 0;
     }
 
-    // Mirror TerminalReflowController.maybeReflow's eligibility guards:
-    // alt-buffer TUIs repaint from live PTY data, and a reflow mid
-    // DEC 2026 synchronized-output block would interleave a paint with the
-    // buffered range.
+    // A DEC 2026 synchronized-output block is open: a repaint/reflow now would
+    // interleave a paint with the buffered range, so DEFER every render-level
+    // repair (reveal-pending, geometry, unpause) to a later tick once the block
+    // closes (#10632). Structural repairs above already ran; the synchronized
+    // window is short, so the next 3s tick converges.
+    const inSynchronizedBlock = managed.terminal.modes?.synchronizedOutputMode === true;
     const element = managed.terminal.element;
+
+    // Reveal-pending guaranteed redraw (#10632). The project-switch suppression
+    // window cleared while this host was still detached/occluded, so its one-shot
+    // resetRenderer was deferred to the watchdog rather than spent on a zero-box
+    // host (TerminalInstanceService.suppressResizesDuringProjectSwitch). DOM
+    // geometry now proves the pane on-screen, so run the alt-buffer-safe atomic
+    // repair — this is the closed-loop "is it correct now" recovery the open-loop
+    // rAF/1s/3s/10s backstops never reliably delivered. The obligation is owned
+    // by the attachGeneration it was armed under: a later re-attach that already
+    // re-ran its own reveal supersedes it. Cleared ONLY on a successful reconcile
+    // (false = unmeasurable/occluded box → keep the flag and retry next tick).
+    if (managed.revealPendingRepair && !inSynchronizedBlock) {
+      if (
+        managed.revealPendingGeneration !== undefined &&
+        managed.revealPendingGeneration > managed.attachGeneration
+      ) {
+        // Generation ran backwards (only possible via a fresh instance reusing
+        // the id) — the obligation can't belong to this incarnation; drop it.
+        managed.revealPendingRepair = false;
+        managed.revealPendingGeneration = undefined;
+      } else {
+        if (heavyBudget <= 0) return 0;
+        managed.lastWatchdogRepairAt = now;
+        logWarn(
+          "[TerminalReconciliationWatchdog] reveal-pending redraw for on-screen terminal — reconciling",
+          {
+            id,
+            revealPendingGeneration: managed.revealPendingGeneration,
+            attachGeneration: managed.attachGeneration,
+          }
+        );
+        if (this.deps.reconcileRevealGeometry(id)) {
+          // Full click-equivalent: now that geometry is re-fit AND we are not in
+          // a synchronized block, also unpause so convergence completes in one
+          // tick (resetRenderer reflows too). Safe here — the synchronized guard
+          // above is the only mid-block hazard.
+          this.unpauseIfNeeded(managed, element);
+          managed.revealPendingRepair = false;
+          managed.revealPendingGeneration = undefined;
+        }
+        return 1;
+      }
+    }
+
+    // Geometry convergence (#10632). An on-screen terminal whose xterm grid
+    // (`terminal.cols/rows`) disagrees with what the container can hold
+    // (`fitAddon.proposeDimensions()`) is rendering its buffer at the wrong width
+    // — the exact "garbled line flow" users see after a warm switch-back, and the
+    // failure mode the watchdog previously only DIAGNOSED (DEV log) while
+    // excluding agent TUIs entirely. Now repair it for EVERY on-screen terminal,
+    // alt-buffer/DEC-2026 agents included, with the atomic alt-buffer-safe
+    // reconcile (no mid-block reflow). This is the verifier half: the divergence
+    // IS the proof the pane converged wrong, and the watchdog ticks until it
+    // matches. Bounded by the heavy-repair budget (== REVEAL_CONCURRENCY) so a
+    // grid that all diverges at once never lands as a single long task.
+    if (!inSynchronizedBlock) {
+      const proposal = managed.fitAddon.proposeDimensions?.();
+      if (
+        proposal &&
+        proposal.cols > 1 &&
+        proposal.rows > 1 &&
+        (proposal.cols !== managed.terminal.cols || proposal.rows !== managed.terminal.rows)
+      ) {
+        if (heavyBudget <= 0) return 0;
+        managed.lastWatchdogRepairAt = now;
+        logWarn(
+          "[TerminalReconciliationWatchdog] geometry divergence for on-screen terminal — reconciling",
+          {
+            id,
+            xtermCols: managed.terminal.cols,
+            xtermRows: managed.terminal.rows,
+            proposedCols: proposal.cols,
+            proposedRows: proposal.rows,
+            isAltBuffer: managed.isAltBuffer === true,
+          }
+        );
+        if (this.deps.reconcileRevealGeometry(id)) {
+          this.unpauseIfNeeded(managed, element);
+        }
+        return 1;
+      }
+    }
+
+    // xterm render service paused on an on-screen terminal — force an IO
+    // re-evaluation so a renderer paused while the view was occluded resumes
+    // drawing. This now covers alt-buffer agent TUIs too (#10632): the old
+    // `!managed.isAltBuffer` exclusion was over-broad — the real hazard is
+    // interleaving a paint into an open DEC 2026 synchronized-output block, which
+    // `inSynchronizedBlock` already guards. A paused renderer repaints from
+    // NOTHING until unpaused, so excluding the very agent TUIs that break was the
+    // structural gap behind the recurring switch-back garble.
     if (
       element &&
       element.isConnected &&
-      !managed.isAltBuffer &&
-      managed.terminal.modes?.synchronizedOutputMode !== true &&
+      !inSynchronizedBlock &&
       isXtermRenderPaused(managed.terminal)
     ) {
       managed.lastWatchdogRepairAt = now;
       logWarn(
         "[TerminalReconciliationWatchdog] xterm render service paused for on-screen terminal — reflowing",
-        { id }
+        { id, isAltBuffer: managed.isAltBuffer === true }
       );
       this.deps.forceReflow(element);
       return 0;
@@ -364,6 +465,21 @@ export class TerminalReconciliationWatchdog {
     }
 
     return 0;
+  }
+
+  /**
+   * Unpause a still-paused renderer right after a successful reveal reconcile
+   * (#10632). Only called from the reveal-pending / geometry branches, which
+   * have already established we are NOT inside a DEC 2026 synchronized-output
+   * block — so the reflow can't interleave a paint with a buffered range. This
+   * is what makes the watchdog's reveal recovery single-tick (geometry re-fit +
+   * unpause together), matching a manual Redraw rather than dribbling the two
+   * halves across separate cooldown windows.
+   */
+  private unpauseIfNeeded(managed: ManagedTerminal, element: HTMLElement | undefined): void {
+    if (!element || !element.isConnected) return;
+    if (!isXtermRenderPaused(managed.terminal)) return;
+    this.deps.forceReflow(element);
   }
 
   /**

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -80,11 +80,15 @@ type ManagedTerminalMock = {
     refresh: ReturnType<typeof vi.fn>;
     open?: ReturnType<typeof vi.fn>;
     resize?: ReturnType<typeof vi.fn>;
+    modes?: { synchronizedOutputMode?: boolean };
   };
   hostElement: HTMLElement;
   targetCols?: number;
   targetRows?: number;
   lastAppliedTier?: number;
+  attachGeneration?: number;
+  revealPendingRepair?: boolean;
+  revealPendingGeneration?: number;
 };
 
 type FullWakeTestService = {
@@ -103,6 +107,8 @@ type FullWakeTestService = {
     isActive: (id: string) => boolean;
   };
   handlePostWake: (id: string) => void;
+  setVisible: (id: string, isVisible: boolean, expectedGeneration?: number) => void;
+  rendererPolicy: { applyRendererPolicy: (id: string, tier: number) => void };
   unhibernate: (id: string) => void;
   ensureOpened: (id: string, managed: ManagedTerminalMock) => void;
   ensureDeferredAddons: (id: string, managed: ManagedTerminalMock) => void;
@@ -222,6 +228,53 @@ describe("TerminalInstanceService.fullWakeForVisibilityRestore (#8562)", () => {
     expect(resetForTerminal).toHaveBeenCalledWith(id);
     expect(resumeFlush).not.toHaveBeenCalled();
     expect(terminalClient.discardPortAcks).toHaveBeenCalledWith(id);
+  });
+
+  it("defers paint-interleave ops while a DEC 2026 synchronized-output block is open, but still runs the data restore (#10632)", async () => {
+    // Third unguarded interleave path: the switch-back WAKE path. The paint ops
+    // (forceXtermReflow / repairAtlasForReactivation / refresh) must not fire
+    // mid-block; the data path (applyDeferredResize + wakeAndRestore) must. The
+    // obligation is handed to the watchdog (revealPendingRepair) since this
+    // method has no retry-return. Fails on the pre-fix code, where all three
+    // paint ops ran unconditionally.
+    const id = "fw-sync";
+    const instance = makeInstance({
+      hostElement: renderableHost(),
+      attachGeneration: 3,
+      terminal: {
+        cols: 80,
+        rows: 24,
+        element: document.createElement("div"),
+        refresh: vi.fn(),
+        modes: { synchronizedOutputMode: true },
+      },
+    });
+    service.instances.set(id, instance);
+
+    const applyDeferredResize = vi
+      .spyOn(service.resizeController, "applyDeferredResize")
+      .mockImplementation(() => {});
+    const repairAtlas = vi
+      .spyOn(service.webGLManager, "repairAtlasForReactivation")
+      .mockReturnValue(true);
+    const wakeAndRestore = vi
+      .spyOn(service.wakeManager, "wakeAndRestore")
+      .mockResolvedValue({ ok: true, replayedMainBuffer: false });
+    vi.spyOn(service, "handlePostWake").mockImplementation(() => {});
+    vi.spyOn(service.dataBuffer, "resumeFlush").mockImplementation(() => {});
+
+    await service.fullWakeForVisibilityRestore(id);
+
+    // Data path still runs.
+    expect(applyDeferredResize).toHaveBeenCalledWith(id);
+    expect(wakeAndRestore).toHaveBeenCalledWith(id);
+    // Paint-interleave ops are deferred.
+    expect(forceXtermReflowMock).not.toHaveBeenCalled();
+    expect(repairAtlas).not.toHaveBeenCalled();
+    expect(instance.terminal.refresh).not.toHaveBeenCalled();
+    // Paint obligation handed to the watchdog, owned by the attach generation.
+    expect(instance.revealPendingRepair).toBe(true);
+    expect(instance.revealPendingGeneration).toBe(3);
   });
 
   it("flushes (no discard) when the wake succeeds without a main-buffer replay (alt-buffer)", async () => {
@@ -869,5 +922,84 @@ describe("TerminalInstanceService.repaintForReveal grid reconcile", () => {
     // A false reconcile must propagate so revealUntilStable retries on a later
     // frame rather than spending a confirm paint against an unmeasurable pane.
     expect(service.repaintForReveal(id)).toBe(false);
+  });
+
+  it("setVisible(true) defers its unpause reflow while a synchronized block is open, hands obligation to watchdog (#10632)", () => {
+    // The visibility path (grid IntersectionObserver → setVisible(id, true) on
+    // switch-back) reflows unconditionally; that forceXtermReflow bypasses
+    // xterm's atomic-at-ESU buffering. It must defer mid-block. Geometry sync
+    // (applyDeferredResize) must still run.
+    const id = "sv-sync";
+    const instance = makeInstance({
+      isVisible: false,
+      attachGeneration: 5,
+      hostElement: renderableHost(),
+      terminal: {
+        cols: 80,
+        rows: 24,
+        element: document.createElement("div"),
+        refresh: vi.fn(),
+        modes: { synchronizedOutputMode: true },
+      },
+    });
+    service.instances.set(id, instance);
+    const applyDeferredResize = vi
+      .spyOn(service.resizeController, "applyDeferredResize")
+      .mockImplementation(() => {});
+    vi.spyOn(service.rendererPolicy, "applyRendererPolicy").mockImplementation(() => {});
+
+    service.setVisible(id, true);
+
+    expect(applyDeferredResize).toHaveBeenCalledWith(id); // geometry still synced
+    expect(forceXtermReflowMock).not.toHaveBeenCalled(); // reflow deferred mid-block
+    expect(instance.revealPendingRepair).toBe(true);
+    expect(instance.revealPendingGeneration).toBe(5);
+  });
+
+  it("setVisible(true) reflows immediately on reveal when no synchronized block is open", () => {
+    const id = "sv-nosync";
+    const instance = makeInstance({
+      isVisible: false,
+      attachGeneration: 5,
+      hostElement: renderableHost(),
+      terminal: {
+        cols: 80,
+        rows: 24,
+        element: document.createElement("div"),
+        refresh: vi.fn(),
+        modes: { synchronizedOutputMode: false },
+      },
+    });
+    service.instances.set(id, instance);
+    vi.spyOn(service.resizeController, "applyDeferredResize").mockImplementation(() => {});
+    vi.spyOn(service.rendererPolicy, "applyRendererPolicy").mockImplementation(() => {});
+
+    service.setVisible(id, true);
+
+    expect(forceXtermReflowMock).toHaveBeenCalledWith(instance.terminal.element);
+    expect(instance.revealPendingRepair).toBeUndefined();
+  });
+
+  it("defers (returns false) while a DEC 2026 synchronized-output block is open (#10632)", () => {
+    const id = "repaint-sync";
+    const instance = openedLiveInstance();
+    // Live agent mid-frame: repainting now would interleave a paint with the
+    // buffered range. The reveal path must defer just like the watchdog does.
+    instance.terminal.modes = { synchronizedOutputMode: true };
+    service.instances.set(id, instance);
+
+    vi.spyOn(service.webGLManager, "isActive").mockReturnValue(true);
+    const repairAtlas = vi
+      .spyOn(service.webGLManager, "repairAtlasForReactivation")
+      .mockReturnValue(true);
+    const reconcile = vi
+      .spyOn(service.resizeController, "reconcileGeometryFresh")
+      .mockReturnValue(true);
+
+    expect(service.repaintForReveal(id)).toBe(false);
+    // None of the interleaving operations may run mid-block.
+    expect(reconcile).not.toHaveBeenCalled();
+    expect(repairAtlas).not.toHaveBeenCalled();
+    expect(forceXtermReflowMock).not.toHaveBeenCalled();
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.switchBackObligation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.switchBackObligation.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+//
+// Set-side coverage for #10632 rule #1: the project-switch suppression-clear
+// must PRESERVE the guaranteed-redraw obligation whenever the redraw did not
+// actually run — not only when the host is `isDetached`. This drives the REAL
+// `suppressResizesDuringProjectSwitch` (where the original gap lived) rather
+// than seeding `revealPendingRepair` by hand, so the branch logic at the fire
+// site is exercised. Discharge-on-foreground is covered by the watchdog
+// regression suite (TerminalSwitchBackRedraw.regression.test.ts, path B).
+//
+// The "attached-but-occluded" and "renderable-but-sub-50px" cases FAIL against
+// the pre-fix logic (`else if (instance.isDetached)`): there the obligation was
+// silently spent.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    resize: vi.fn(),
+    onData: vi.fn(() => vi.fn()),
+    onExit: vi.fn(() => vi.fn()),
+    onTierChanged: vi.fn(() => vi.fn()),
+    write: vi.fn(),
+    setActivityTier: vi.fn(),
+    wake: vi.fn(),
+    getSerializedState: vi.fn(),
+    getSharedBuffers: vi.fn(async () => ({ visualBuffers: [], signalBuffer: null })),
+    acknowledgeData: vi.fn(),
+    acknowledgePortData: vi.fn(),
+    discardPortAcks: vi.fn(),
+  },
+  systemClient: { openExternal: vi.fn() },
+  appClient: { getHydrationState: vi.fn() },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@xterm/addon-webgl", () => ({
+  WebglAddon: vi.fn().mockImplementation(() => ({
+    dispose: vi.fn(),
+    onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+  })),
+}));
+
+vi.mock("../TerminalAddonManager", () => ({
+  setupTerminalAddons: vi.fn(() => ({
+    fitAddon: { fit: vi.fn() },
+    serializeAddon: { serialize: vi.fn() },
+    imageAddon: { dispose: vi.fn() },
+    searchAddon: {},
+    fileLinksDisposable: { dispose: vi.fn() },
+    webLinksAddon: { dispose: vi.fn() },
+  })),
+  createImageAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createFileLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+  createWebLinksAddon: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+const SUPPRESSION_MS = 10_000;
+
+type ObligationService = {
+  instances: Map<string, unknown>;
+  suppressResizesDuringProjectSwitch: (ids: string[], durationMs: number) => void;
+  resetRenderer: (id: string) => boolean;
+};
+
+interface HostConfig {
+  connected: boolean;
+  clientWidth: number;
+  clientHeight: number;
+  checkVisibility?: boolean;
+}
+
+function makeHost(cfg: HostConfig): HTMLDivElement {
+  const host = document.createElement("div");
+  if (cfg.connected) document.body.appendChild(host);
+  Object.defineProperty(host, "clientWidth", { configurable: true, get: () => cfg.clientWidth });
+  Object.defineProperty(host, "clientHeight", { configurable: true, get: () => cfg.clientHeight });
+  if (cfg.checkVisibility !== undefined) {
+    (host as unknown as { checkVisibility: () => boolean }).checkVisibility = () =>
+      cfg.checkVisibility === true;
+  }
+  return host;
+}
+
+function makeManaged(id: string, host: HTMLDivElement, isDetached: boolean) {
+  return {
+    id,
+    hostElement: host,
+    terminal: {
+      element: document.createElement("div"),
+      modes: { synchronizedOutputMode: false },
+      rows: 24,
+      refresh: vi.fn(),
+      blur: vi.fn(),
+    },
+    fitAddon: { fit: vi.fn(), proposeDimensions: () => ({ cols: 80, rows: 24 }) },
+    isDetached,
+    isVisible: !isDetached,
+    isHibernated: false,
+    attachGeneration: 7,
+    latestCols: 80,
+    latestRows: 24,
+    resizeSuppressionTimer: undefined as number | undefined,
+    resizeSuppressionEndTime: undefined as number | undefined,
+    isResizeSuppressed: false,
+    revealPendingRepair: undefined as boolean | undefined,
+    revealPendingGeneration: undefined as number | undefined,
+  };
+}
+
+describe("#10632 rule #1 — suppression-clear preserves the redraw obligation", () => {
+  let service: ObligationService;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: ObligationService;
+      });
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    service.instances.clear();
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  it("arms the obligation when the host is detached at fire time", () => {
+    const host = makeHost({ connected: false, clientWidth: 0, clientHeight: 0 });
+    const managed = makeManaged("detached", host, /* isDetached */ true);
+    service.instances.set("detached", managed);
+    const resetSpy = vi.spyOn(service, "resetRenderer");
+
+    service.suppressResizesDuringProjectSwitch(["detached"], SUPPRESSION_MS);
+    vi.advanceTimersByTime(SUPPRESSION_MS);
+
+    expect(resetSpy).not.toHaveBeenCalled(); // not renderable → not spent
+    expect(managed.revealPendingRepair).toBe(true);
+    expect(managed.revealPendingGeneration).toBe(7);
+  });
+
+  it("arms the obligation when the host is ATTACHED-but-occluded (zero box) — the pre-fix dead zone", () => {
+    // isDetached === false, isConnected === true, but zero layout box (occluded
+    // behind the warm bridge). hostHasRenderableDims is false; the old logic's
+    // `else if (instance.isDetached)` would NOT fire here, silently spending the
+    // obligation. This assertion FAILS on the pre-fix branch.
+    const host = makeHost({ connected: true, clientWidth: 0, clientHeight: 0 });
+    const managed = makeManaged("occluded", host, /* isDetached */ false);
+    service.instances.set("occluded", managed);
+    const resetSpy = vi.spyOn(service, "resetRenderer");
+
+    service.suppressResizesDuringProjectSwitch(["occluded"], SUPPRESSION_MS);
+    vi.advanceTimersByTime(SUPPRESSION_MS);
+
+    expect(resetSpy).not.toHaveBeenCalled();
+    expect(managed.revealPendingRepair).toBe(true);
+    expect(managed.revealPendingGeneration).toBe(7);
+  });
+
+  it("arms the obligation when the host is renderable but below the >=50px floor — resetRenderer self-skips", () => {
+    // hostHasRenderableDims is TRUE (nonzero box, visible), so resetRenderer runs
+    // — but self-skips on its >=50px guard and returns false. The obligation must
+    // still be carried. This also FAILS on the pre-fix logic, where resetRenderer
+    // returned void and no flag was set.
+    const host = makeHost({
+      connected: true,
+      clientWidth: 40,
+      clientHeight: 40,
+      checkVisibility: true,
+    });
+    const managed = makeManaged("tiny", host, /* isDetached */ false);
+    service.instances.set("tiny", managed);
+    const resetSpy = vi.spyOn(service, "resetRenderer");
+
+    service.suppressResizesDuringProjectSwitch(["tiny"], SUPPRESSION_MS);
+    vi.advanceTimersByTime(SUPPRESSION_MS);
+
+    expect(resetSpy).toHaveBeenCalledWith("tiny");
+    expect(resetSpy.mock.results[0]?.value).toBe(false); // ran but self-skipped → not spent
+    expect(managed.revealPendingRepair).toBe(true);
+    expect(managed.revealPendingGeneration).toBe(7);
+  });
+
+  it("runs the redraw and does NOT arm an obligation when the host is foreground-renderable", () => {
+    const host = makeHost({
+      connected: true,
+      clientWidth: 800,
+      clientHeight: 600,
+      checkVisibility: true,
+    });
+    const managed = makeManaged("visible", host, /* isDetached */ false);
+    service.instances.set("visible", managed);
+    const resetSpy = vi.spyOn(service, "resetRenderer");
+
+    service.suppressResizesDuringProjectSwitch(["visible"], SUPPRESSION_MS);
+    vi.advanceTimersByTime(SUPPRESSION_MS);
+
+    expect(resetSpy).toHaveBeenCalledWith("visible");
+    expect(resetSpy.mock.results[0]?.value).toBe(true); // redraw actually ran
+    expect(managed.revealPendingRepair).toBeUndefined(); // nothing owed
+  });
+});

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -95,6 +95,23 @@ function setRenderPaused(managed: ManagedTerminal, paused: boolean): void {
   };
 }
 
+/**
+ * Wire the xterm grid and the fit-addon proposal so the watchdog's geometry
+ * convergence check (#10632) has real numbers. A mismatch models the garbled
+ * "wrong column wrapping" a pane shows after a warm switch-back.
+ */
+function setGrid(
+  managed: ManagedTerminal,
+  grid: { cols: number; rows: number },
+  proposal: { cols: number; rows: number }
+): void {
+  (managed.terminal as unknown as { cols: number; rows: number }).cols = grid.cols;
+  (managed.terminal as unknown as { cols: number; rows: number }).rows = grid.rows;
+  (
+    managed.fitAddon as unknown as { proposeDimensions: () => { cols: number; rows: number } }
+  ).proposeDimensions = () => proposal;
+}
+
 function makeDeps(
   instances: Map<string, ManagedTerminal>,
   overrides: Partial<ReconciliationWatchdogDeps> = {}
@@ -115,6 +132,7 @@ function makeDeps(
     ensureWebGL: vi.fn(),
     unhibernate: vi.fn(),
     forceReflow: vi.fn(),
+    reconcileRevealGeometry: vi.fn(() => true),
     isStoreBackgrounded: vi.fn(() => false),
     isStoreHidden: vi.fn(() => false),
     repairStoreVisibility: vi.fn(),
@@ -463,7 +481,11 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
     });
 
-    it("does not reflow a paused alt-buffer (TUI) terminal", () => {
+    it("reflows a paused alt-buffer (agent TUI) terminal when no synchronized block is open (#10632)", () => {
+      // Regression: the watchdog used to EXCLUDE alt-buffer agents from the
+      // render-pause repair (`!managed.isAltBuffer`), so exactly the agent TUIs
+      // that break on switch-back had no closed-loop recovery. The only real
+      // hazard is a mid-synchronized-block paint, which is guarded separately.
       const managed = makeManaged({ isAltBuffer: true });
       setRenderPaused(managed, true);
       instances.set("t1", managed);
@@ -471,11 +493,11 @@ describe("TerminalReconciliationWatchdog", () => {
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      expect(deps.forceReflow).not.toHaveBeenCalled();
+      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
     });
 
-    it("does not reflow while DEC 2026 synchronized output is active", () => {
-      const managed = makeManaged();
+    it("does not reflow while DEC 2026 synchronized output is active (alt-buffer included)", () => {
+      const managed = makeManaged({ isAltBuffer: true });
       (
         managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
       ).modes.synchronizedOutputMode = true;
@@ -486,6 +508,7 @@ describe("TerminalReconciliationWatchdog", () => {
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.forceReflow).not.toHaveBeenCalled();
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
     });
 
     it("reattaches a missing WebGL context for an eligible terminal", () => {
@@ -504,6 +527,7 @@ describe("TerminalReconciliationWatchdog", () => {
     it("issues no repair when the whole chain is consistent", () => {
       const managed = makeManaged();
       setRenderPaused(managed, false);
+      setGrid(managed, { cols: 120, rows: 40 }, { cols: 120, rows: 40 });
       instances.set("t1", managed);
       const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
@@ -514,9 +538,113 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.reassertActiveBackendTier).not.toHaveBeenCalled();
       expect(deps.resumeFlush).not.toHaveBeenCalled();
       expect(deps.forceReflow).not.toHaveBeenCalled();
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
       expect(deps.ensureWebGL).not.toHaveBeenCalled();
       expect(deps.unhibernate).not.toHaveBeenCalled();
       expect(managed.lastWatchdogRepairAt).toBeUndefined();
+    });
+  });
+
+  describe("geometry convergence (#10632)", () => {
+    it("reconciles an on-screen agent TUI whose grid disagrees with the container (garbled wrapping)", () => {
+      // The exact switch-back failure: while backgrounded the container narrowed
+      // (137 → 100 cols) but the alt-buffer agent's xterm grid stayed at the old
+      // width, so its buffer wraps at the wrong column. The watchdog now repairs
+      // this for agent TUIs, which it previously only DIAGNOSED while excluding.
+      const managed = makeManaged({ isAltBuffer: true });
+      setRenderPaused(managed, false);
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("t1");
+      expect(managed.lastWatchdogRepairAt).toBeGreaterThan(0);
+    });
+
+    it("does not reconcile geometry while a synchronized-output block is open", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      (
+        managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
+      ).modes.synchronizedOutputMode = true;
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    });
+
+    it("caps geometry reconciles per tick at the heavy budget (== REVEAL_CONCURRENCY)", () => {
+      for (let i = 0; i < WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1; i++) {
+        const managed = makeManaged({ isAltBuffer: true });
+        setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+        instances.set(`t${i}`, managed);
+      }
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(
+        WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK
+      );
+
+      // The deferred terminal is picked up on the next tick — bounded, not dropped.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(
+        WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1
+      );
+    });
+  });
+
+  describe("reveal-pending guaranteed redraw (#10632)", () => {
+    it("runs the deferred redraw once the host is on-screen and clears the obligation", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      managed.revealPendingRepair = true;
+      managed.revealPendingGeneration = managed.attachGeneration;
+      setGrid(managed, { cols: 100, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("t1");
+      expect(managed.revealPendingRepair).toBe(false);
+      expect(managed.revealPendingGeneration).toBeUndefined();
+    });
+
+    it("keeps the obligation when the reconcile reports an unmeasurable box", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      managed.revealPendingRepair = true;
+      managed.revealPendingGeneration = managed.attachGeneration;
+      setGrid(managed, { cols: 100, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      // reconcile fails (box still occluded) → flag must survive for the retry.
+      const deps = makeDeps(instances, { reconcileRevealGeometry: vi.fn(() => false) });
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("t1");
+      expect(managed.revealPendingRepair).toBe(true);
+    });
+
+    it("defers the reveal-pending redraw while a synchronized-output block is open", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      managed.revealPendingRepair = true;
+      managed.revealPendingGeneration = managed.attachGeneration;
+      (
+        managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
+      ).modes.synchronizedOutputMode = true;
+      setGrid(managed, { cols: 100, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(managed.revealPendingRepair).toBe(true);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
+++ b/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
@@ -1,0 +1,351 @@
+// @vitest-environment jsdom
+//
+// Regression for #10632 — "agent terminals don't auto-redraw on project
+// switch-back". This recreates the BROKEN state the issue describes and proves
+// the closed-loop watchdog recovery converges it WITHOUT a manual Redraw.
+//
+// It drives the REAL TerminalReconciliationWatchdog against a deterministic fake
+// of a live agent TUI (alt-buffer + DEC 2026 synchronized output — the same
+// class of process the deleted `e2e/fixtures/fake-claude-agent.cjs` modelled).
+// The fake's container CHANGES COLUMN COUNT while the project is backgrounded,
+// so on switch-back its xterm grid wraps at the wrong width (the "garbled line
+// flow") and its renderer is left paused — exactly the two halves a manual
+// Redraw fixes.
+//
+// The `reconcileRevealGeometry` / `forceReflow` deps mirror what the real
+// TerminalInstanceService does, INCLUDING the present-ordering guarantee:
+// reconcileGeometryFresh only succeeds against a foreground-renderable host
+// (checkVisibility + non-zero box), so a repaint is never issued into an
+// occluded surface. That is what makes the "dead zone" assertions meaningful.
+//
+// WEBGL-LANE CAVEAT (documented per the issue's hard requirement; ACCEPTED as a
+// follow-up, not part of this fix): E2E runs the DOM renderer with WebGL OFF, so
+// the stale-atlas variant (#9679/#9894) is invisible to it. Here `atlasRepairs`
+// is a STAND-IN for the local glyph-model repair
+// (`TerminalWebGLManager.repairAtlasForReactivation`) and we assert it ran AFTER
+// the host became foreground-presenting — the ordering invariant. A true
+// stale-atlas-recurrence assertion still needs a WebGL-ON pixel lane with
+// framebuffer readback (`gl.readPixels` / Electron `capturePage` of the pane
+// rect) comparing presented glyph cells to expected text; that cannot run in
+// jsdom and is tracked as separate infra work, NOT covered by this test.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalRefreshTier } from "@/types";
+import {
+  TerminalReconciliationWatchdog,
+  WATCHDOG_INTERVAL_MS,
+  type ReconciliationWatchdogDeps,
+} from "../TerminalReconciliationWatchdog";
+import type { ManagedTerminal } from "../types";
+
+vi.mock("@/utils/logger", () => ({
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+}));
+
+interface FakeAgent {
+  /** xterm grid the buffer is currently wrapping at. */
+  cols: number;
+  rows: number;
+  /** What the (now-resized) container can actually hold — proposeDimensions(). */
+  containerCols: number;
+  containerRows: number;
+  /** xterm core render-service paused flag (set while the view was occluded). */
+  paused: boolean;
+  /** Inside an open DEC 2026 synchronized-output block. */
+  synchronized: boolean;
+  /** Foreground-presented (true) vs occluded behind the warm bridge / on another project (false). */
+  onScreen: boolean;
+  /** Count of local atlas repairs (the WebGL stale-glyph-model reset). */
+  atlasRepairs: number;
+}
+
+function newAgent(): FakeAgent {
+  return {
+    cols: 120,
+    rows: 40,
+    containerCols: 120,
+    containerRows: 40,
+    paused: false,
+    synchronized: false,
+    onScreen: true,
+    atlasRepairs: 0,
+  };
+}
+
+function buildManaged(agent: FakeAgent): ManagedTerminal {
+  const hostElement = document.createElement("div");
+  const termEl = document.createElement("div");
+  hostElement.appendChild(termEl);
+  document.body.appendChild(hostElement);
+
+  // Warm path: the host is ALWAYS connected to the live (cached) document — the
+  // renderer/store are never torn down. Only its layout box changes between
+  // foreground (measurable) and occluded (zero box / checkVisibility false).
+  hostElement.getBoundingClientRect = () =>
+    agent.onScreen
+      ? ({ width: 800, height: 600, top: 0, bottom: 600, left: 0, right: 800 } as DOMRect)
+      : ({ width: 0, height: 0, top: 0, bottom: 0, left: 0, right: 0 } as DOMRect);
+  (hostElement as unknown as { checkVisibility: () => boolean }).checkVisibility = () =>
+    agent.onScreen;
+  Object.defineProperty(hostElement, "clientWidth", { get: () => (agent.onScreen ? 800 : 0) });
+  Object.defineProperty(hostElement, "clientHeight", { get: () => (agent.onScreen ? 600 : 0) });
+
+  const terminal = {
+    element: termEl,
+    modes: {
+      get synchronizedOutputMode() {
+        return agent.synchronized;
+      },
+    },
+    get cols() {
+      return agent.cols;
+    },
+    get rows() {
+      return agent.rows;
+    },
+    refresh: vi.fn(),
+    _core: {
+      _renderService: {
+        get _isPaused() {
+          return agent.paused;
+        },
+      },
+    },
+  } as unknown as ManagedTerminal["terminal"];
+
+  const fitAddon = {
+    proposeDimensions: () => ({ cols: agent.containerCols, rows: agent.containerRows }),
+    fit: vi.fn(),
+  } as unknown as ManagedTerminal["fitAddon"];
+
+  return {
+    terminal,
+    fitAddon,
+    hostElement,
+    kind: "terminal",
+    isOpened: true,
+    isVisible: true,
+    isFocused: false,
+    isHibernated: false,
+    isAttaching: false,
+    isDetached: false,
+    isResizeSuppressed: false,
+    isUserScrolledBack: false,
+    // The defining trait of the panes that break: a live agent TUI on the alt
+    // buffer using DEC 2026 synchronized output — exactly what the watchdog used
+    // to exclude from recovery.
+    isAltBuffer: true,
+    lastActiveTime: Date.now(),
+    lastWidth: 0,
+    lastHeight: 0,
+    lastAttachAt: 0,
+    lastDetachAt: 0,
+    latestCols: agent.cols,
+    latestRows: agent.rows,
+    latestWasAtBottom: true,
+    listeners: [],
+    exitSubscribers: new Set(),
+    agentStateSubscribers: new Set(),
+    altBufferListeners: new Set(),
+    writeChain: Promise.resolve(),
+    restoreGeneration: 0,
+    isSerializedRestoreInProgress: false,
+    deferredOutput: [],
+    scrollbackRestoreState: "none",
+    attachGeneration: 0,
+    attachRevealToken: 0,
+    keyHandlerInstalled: false,
+    ipcListenerCount: 0,
+    lastAppliedTier: TerminalRefreshTier.VISIBLE,
+    getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+  } as unknown as ManagedTerminal;
+}
+
+function buildDeps(
+  instances: Map<string, ManagedTerminal>,
+  agents: Map<string, FakeAgent>
+): ReconciliationWatchdogDeps {
+  return {
+    getInstances: () => instances.entries(),
+    setVisible: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    reassertActiveBackendTier: vi.fn(),
+    getBackendTier: vi.fn(() => "active" as const),
+    getStalledBytes: vi.fn(() => 0),
+    getQueuedBytes: vi.fn(() => 0),
+    resumeFlush: vi.fn(),
+    hasInFlightWake: vi.fn(() => false),
+    hasPendingWake: vi.fn(() => false),
+    isWebGLActive: vi.fn(() => true),
+    shouldHaveWebGL: vi.fn(() => false),
+    ensureWebGL: vi.fn(),
+    unhibernate: vi.fn(),
+    forceReflow: vi.fn((_element: HTMLElement) => {
+      // Unpause: the IO re-evaluation resumes the paused renderer. We can't know
+      // which agent the element belongs to cheaply, so unpause any agent whose
+      // host owns it.
+      for (const agent of agents.values()) agent.paused = false;
+    }),
+    // Mirror TerminalInstanceService.reconcileRevealGeometry +
+    // TerminalResizeController.reconcileGeometryFresh: atomic xterm+PTY re-fit to
+    // the FRESH container measurement plus a local atlas repair — but ONLY when
+    // the host is foreground-renderable. Returns false on an occluded box so the
+    // watchdog keeps the obligation and never repaints into a culled surface.
+    reconcileRevealGeometry: vi.fn((id: string) => {
+      const agent = agents.get(id);
+      if (!agent) return false;
+      if (!agent.onScreen) return false; // present-ordering guarantee
+      agent.cols = agent.containerCols;
+      agent.rows = agent.containerRows;
+      agent.atlasRepairs += 1;
+      return true;
+    }),
+    isStoreBackgrounded: vi.fn(() => false),
+    isStoreHidden: vi.fn(() => false),
+    repairStoreVisibility: vi.fn(),
+  };
+}
+
+function setDocumentVisible(): void {
+  Object.defineProperty(document, "visibilityState", { configurable: true, get: () => "visible" });
+}
+
+describe("#10632 switch-back redraw — closed-loop convergence", () => {
+  let watchdog: TerminalReconciliationWatchdog | undefined;
+  let instances: Map<string, ManagedTerminal>;
+  let agents: Map<string, FakeAgent>;
+  let deps: ReconciliationWatchdogDeps;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setDocumentVisible();
+    instances = new Map();
+    agents = new Map();
+  });
+
+  afterEach(() => {
+    watchdog?.dispose();
+    watchdog = undefined;
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function mount(id: string): FakeAgent {
+    const agent = newAgent();
+    agents.set(id, agent);
+    instances.set(id, buildManaged(agent));
+    return agent;
+  }
+
+  it("path A (warm view swap): converges a garbled, paused agent TUI on switch-back with no manual Redraw", () => {
+    const agent = mount("claude");
+    deps = buildDeps(instances, agents);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    // Steady state on project A — nothing to repair.
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(agent.cols).toBe(120);
+
+    // --- Switch A -> B. While A is occluded, its container is reflowed narrower
+    // (a window resize / sidebar change happens against project B) and Chromium
+    // pauses A's culled renderer. A's xterm grid can't follow while occluded.
+    agent.onScreen = false;
+    agent.containerCols = 90; // container now holds fewer columns
+    agent.paused = true;
+
+    // BROKEN STATE — what the user would see on switch-back before this fix:
+    // the grid still wraps at 120 though the container holds 90 (garbled), and
+    // the renderer is paused (stale).
+    expect(agent.cols).toBe(120);
+    expect(agent.cols).not.toBe(agent.containerCols);
+    expect(agent.paused).toBe(true);
+
+    // A tick while still occluded must NOT repair into the culled surface
+    // (present-ordering) — the watchdog only acts on on-screen geometry.
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(agent.cols).toBe(120);
+    expect(agent.paused).toBe(true);
+
+    // --- Switch B -> A. The cached view is foreground-presented (host
+    // measurable). The warm re-attach bumps the attach generation. NO manual
+    // Redraw is issued.
+    agent.onScreen = true;
+    instances.get("claude")!.attachGeneration += 1;
+
+    // One watchdog tick is the closed loop: it sees the grid disagrees with the
+    // container, runs the atomic reconcile, and unpauses — single tick.
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("claude");
+    expect(agent.cols).toBe(90); // grid converged to the container — no garble
+    expect(agent.paused).toBe(false); // renderer resumed
+    expect(agent.atlasRepairs).toBeGreaterThan(0); // local atlas repaired (WebGL path stand-in)
+  });
+
+  it("path B (long dwell): the guaranteed redraw obligation survives the off-screen dead zone and discharges on foreground", () => {
+    const agent = mount("codex");
+    deps = buildDeps(instances, agents);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+    const managed = instances.get("codex")!;
+
+    // Switch away, dwell past the 10s project-switch suppression window. In the
+    // real flow `suppressResizesDuringProjectSwitch`'s timer fires while the
+    // terminal is still detached/occluded, so resetRenderer can't run — the
+    // obligation is handed to the watchdog via the reveal-pending flag instead
+    // of being silently spent on a zero-box host.
+    agent.onScreen = false;
+    agent.containerCols = 100;
+    agent.paused = true;
+    managed.isDetached = true;
+    managed.revealPendingRepair = true;
+    managed.revealPendingGeneration = managed.attachGeneration;
+
+    // Dead zone: while still off-screen the obligation must be PRESERVED, not
+    // spent, and no repair issued into the occluded surface.
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(managed.revealPendingRepair).toBe(true);
+
+    // Switch back: foreground-presented, warm re-attach (generation bump).
+    agent.onScreen = true;
+    managed.isDetached = false;
+    managed.attachGeneration += 1;
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+    expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("codex");
+    expect(agent.cols).toBe(100); // converged
+    expect(agent.paused).toBe(false); // unpaused in the same tick
+    expect(managed.revealPendingRepair).toBe(false); // obligation discharged
+    expect(managed.revealPendingGeneration).toBeUndefined();
+  });
+
+  it("never repaints into an open DEC 2026 synchronized-output block (defers until it closes)", () => {
+    const agent = mount("gemini");
+    deps = buildDeps(instances, agents);
+    watchdog = new TerminalReconciliationWatchdog(deps);
+
+    // On-screen, garbled, paused — but mid synchronized-output block.
+    agent.containerCols = 80;
+    agent.paused = true;
+    agent.synchronized = true;
+
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    // Deferred: a repaint now would interleave with the buffered range.
+    expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+    expect(deps.forceReflow).not.toHaveBeenCalled();
+    expect(agent.cols).toBe(120);
+
+    // Block closes — next tick converges.
+    agent.synchronized = false;
+    vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+    expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("gemini");
+    expect(agent.cols).toBe(80);
+    expect(agent.paused).toBe(false);
+  });
+});

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -92,6 +92,16 @@ export interface ManagedTerminal {
   resizeSuppressionTimer?: number;
   isResizeSuppressed?: boolean;
   resizeSuppressionEndTime?: number;
+  // Reveal-pending guaranteed redraw (#10632). Set true when the project-switch
+  // resize-suppression window clears while the host is NOT foreground-renderable
+  // (still detached/occluded behind the warm anti-flash bridge on a long dwell):
+  // the one-shot `resetRenderer` recovery can't run on a zero-box host without
+  // self-skipping, so the obligation is handed to the reconciliation watchdog,
+  // which runs the alt-buffer-safe atomic repair once DOM geometry proves the
+  // pane on-screen. Owned by `revealPendingGeneration` (the attachGeneration at
+  // arm time); cleared only by a successful reconcile or terminal destruction.
+  revealPendingRepair?: boolean;
+  revealPendingGeneration?: number;
   targetCols?: number;
   targetRows?: number;
   isAttaching?: boolean;


### PR DESCRIPTION
Fixes #10632.

## Root cause

The project switch-back redraw was a pile of **open-loop one-shot repairs** fired at guessed times (rAF, 1s/3s backstops, the 10s `resetRenderer` "guarantee") with **no closed-loop verifier** that the pane actually converged. Worse, the one component that *is* a continuous closed loop — `TerminalReconciliationWatchdog` — deliberately **excluded** alt-buffer / DEC-2026 synchronized-output terminals, i.e. exactly the agent TUIs (Claude/Codex/Gemini) that break. Manual **Redraw** always works because it's an unguarded, late, "is it correct now" action — the human was the missing closed-loop verifier.

Two concrete dead zones made it stick:
- The 10s `resetRenderer` "hard guarantee" is armed on the **outgoing** terminals and immediately followed by `detachForProjectSwitch`. On a dwell longer than the suppression window the timer fires while the host is still detached/occluded, `resetRenderer` self-skips on its `<50px` guard, and the recovery is **silently spent** — no guaranteed repaint left for the eventual switch-back.
- `repaintForReveal` / `fullWakeForVisibilityRestore` / `setVisible` ran `forceXtermReflow` on the live buffer with no `synchronizedOutputMode` check, so a repaint could interleave a torn frame into an open DEC-2026 block — the same invariant `TerminalReflowController.maybeReflow` already enforces, bypassed on the reveal/wake/visibility paths.

## The fix

- **Watchdog: excluder → closed-loop convergence verifier.** It now repairs geometry divergence (`terminal.cols/rows` vs `fitAddon.proposeDimensions()`) and render-pause for **every** on-screen terminal, alt-buffer/DEC-2026 agents included, via an atomic alt-buffer-safe reconcile (fresh fit + local atlas repair, never a mid-block reflow). Bounded by the existing heavy-repair budget (== `REVEAL_CONCURRENCY`).
- **Post-switch redraw obligation is preserved whenever the recovery can't run** — not only when `isDetached`. `resetRenderer` now reports whether it actually ran; if it didn't (host detached, occluded zero-box, content-visibility:hidden, or below the 50px floor) the obligation is handed to the watchdog via `revealPendingRepair`, **owned by `attachGeneration`** so rapid re-entrant A→B→A→B switches cancel stale work. Cleared only on successful convergence or terminal destruction.
- **Never-interleave-mid-DEC-2026-block invariant closed uniformly** by guarding `forceXtermReflow` on every reveal/wake/visibility path — `repaintForReveal`, `fullWakeForVisibilityRestore` (re-checked on both sides of the async wake), and `setVisible`. The data path (geometry sync, byte-pull/buffer restore) always runs; only the paint defers, with the watchdog as the backstop. Plain `terminal.refresh()` is left as-is: it is **xterm-buffered at ESU** — `refreshRows`/`_renderRows` short-circuit to `SyncOutputHandler.bufferRows()` and return without painting while a block is open (`@xterm/xterm` `RenderService.ts:157-160` and `:184-189`), then flush the coalesced range at ESU.
- Unified the reveal health check on DOM ground truth (`isConnected` + `checkVisibility` + box) instead of the reactive `isVisible` flag, which goes stale on warm resume.

## Tests

- A real regression test drives a deterministic **fake alt-buffer + DEC-2026 agent** that changes container column count while backgrounded, reproduces the broken state (stale grid + paused renderer after A→B→A with no manual Redraw), and asserts single-tick convergence — including the present-ordering guarantee that no repaint is issued into an occluded surface.
- Set-side coverage drives the real `suppressResizesDuringProjectSwitch` and asserts the obligation is **set and preserved** (not spent) for detached, attached-but-occluded, and sub-50px hosts.
- Sync-defer tests for `repaintForReveal`, `fullWakeForVisibilityRestore`, and `setVisible` assert the paint-interleave ops are skipped mid-block while the data path still runs.
- Every new assertion was verified to **fail on the pre-fix source**.

## Documented follow-up

E2E runs the DOM renderer with WebGL **off**, so the WebGL stale-atlas variant (#9679/#9894) is structurally invisible to it; the regression test uses an `atlasRepairs` stand-in and asserts repair-after-present ordering. A true stale-atlas-recurrence assertion needs a **WebGL-on pixel-readback E2E lane** (`gl.readPixels` / Electron `capturePage`) that cannot run in jsdom or on GPU-less CI runners — tracked as separate infra work, called out in the regression test header.
