### PR TITLE
feat(agents): wire MCP env contract into daintree-assistant launches

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
@@ -70,6 +70,29 @@ vi.mock("../../../utils.js", () => ({
     });
     return () => ipcMainMock.removeHandler(channel);
   },
+  typedHandleWithContextValidated: (channel: string, schema: SafeParseable, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      async (
+        event: { sender?: { id?: number }; senderWindow?: { id: number } } | null | undefined,
+        ...args: unknown[]
+      ) => {
+        const parsed = schema.safeParse(args[0]);
+        if (!parsed.success) {
+          console.error(`[IPC] Validation failed for ${channel}:`, parsed.error);
+          throw new Error(`IPC validation failed: ${channel}`);
+        }
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: event?.senderWindow ?? null,
+          projectId: null,
+        };
+        return (handler as (ctx: unknown, payload: unknown) => unknown)(ctx, parsed.data);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../../shared/config/agentRegistry.js", () => ({

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -163,12 +163,14 @@ const {
   mockIsRunning,
   mockCurrentPort,
   mockPreparePaneConfig,
+  mockRevokePaneConfig,
   mockEnsureReady,
 } = vi.hoisted(() => ({
   mockValidateToken: vi.fn<(token: string) => "action" | "system" | false>(),
   mockIsRunning: vi.fn<() => boolean>(),
   mockCurrentPort: vi.fn<() => number | null>(),
   mockPreparePaneConfig: vi.fn(),
+  mockRevokePaneConfig: vi.fn<(paneId: string) => Promise<void>>(),
   mockEnsureReady: vi.fn<() => Promise<boolean>>(),
 }));
 
@@ -230,7 +232,7 @@ vi.mock("../../../../services/McpServerService.js", () => ({
 vi.mock("../../../../services/McpPaneConfigService.js", () => ({
   mcpPaneConfigService: {
     preparePaneConfig: (...args: unknown[]) => mockPreparePaneConfig(...args),
-    revokePaneConfig: vi.fn().mockResolvedValue(undefined),
+    revokePaneConfig: (paneId: string) => mockRevokePaneConfig(paneId),
   },
 }));
 
@@ -1716,6 +1718,8 @@ describe("terminal spawn handler - daintree-assistant MCP env injection (#10639)
       configPath: "/tmp/pane-config.json",
       token: "assistant-token",
     });
+    mockRevokePaneConfig.mockReset();
+    mockRevokePaneConfig.mockResolvedValue(undefined);
   });
 
   it("injects MCP url, token, and window id into the env, without --mcp-config", async () => {
@@ -1874,6 +1878,80 @@ describe("terminal spawn handler - daintree-assistant MCP env injection (#10639)
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.command).toBe("daintree-assistant");
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBeUndefined();
+  });
+
+  it('sets DAINTREE_WINDOW_ID to "0" when the window id is 0 (not omitted)', async () => {
+    // The injection guard is `windowId !== null`, so a legitimate window id of
+    // 0 must still be forwarded. A regression to a falsy check (`!windowId`)
+    // would silently drop it.
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      { senderWindow: { id: 0 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_WINDOW_ID).toBe("0");
+  });
+
+  it("revokes the minted pane config when the PTY spawn throws", async () => {
+    ptyClient.spawn.mockImplementation(() => {
+      throw new Error("spawn boom");
+    });
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await expect(
+      handler(
+        { senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+        {
+          id: "assistant-pane",
+          cols: 80,
+          rows: 24,
+          cwd: tmpDir,
+          command: "daintree-assistant",
+          launchAgentId: "daintree-assistant",
+        } as unknown as Parameters<typeof handler>[1]
+      )
+    ).rejects.toThrow(/Failed to spawn terminal/);
+
+    expect(mockPreparePaneConfig).toHaveBeenCalled();
+    expect(mockRevokePaneConfig).toHaveBeenCalledWith("assistant-pane");
+  });
+
+  it("skips MCP injection when no project can be resolved", async () => {
+    mockGetCurrentProject.mockReturnValue(null);
+    mockGetProjectById.mockReturnValue(null);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      { senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBeUndefined();
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -71,6 +71,35 @@ vi.mock("../../../utils.js", () => ({
     });
     return () => ipcMainMock.removeHandler(channel);
   },
+  typedHandleWithContextValidated: (channel: string, schema: SafeParseable, handler: unknown) => {
+    ipcMainMock.handle(
+      channel,
+      async (
+        event:
+          | { sender?: { id?: number }; senderWindow?: { id: number }; projectId?: string }
+          | null
+          | undefined,
+        ...args: unknown[]
+      ) => {
+        const parsed = schema.safeParse(args[0]);
+        if (!parsed.success) {
+          throw new Error(`IPC validation failed: ${channel}`);
+        }
+        // Mirror the real `typedHandleWithContextValidated` ctx shape. Tests
+        // drive `senderWindow` / `projectId` by setting them on the event
+        // object they pass to the handler (the real wrapper derives
+        // `senderWindow` from `BrowserWindow.fromWebContents`).
+        const ctx = {
+          event: event as unknown,
+          webContentsId: event?.sender?.id ?? 0,
+          senderWindow: event?.senderWindow ?? null,
+          projectId: event?.projectId ?? null,
+        };
+        return (handler as (ctx: unknown, payload: unknown) => unknown)(ctx, parsed.data);
+      }
+    );
+    return () => ipcMainMock.removeHandler(channel);
+  },
 }));
 
 vi.mock("../../../../shared/config/agentRegistry.js", () => ({
@@ -1656,6 +1685,196 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.env?.DAINTREE_ASSISTANT_SCRATCH_DIR).toBeUndefined();
     expect(mockGetAssistantScratchEnv).not.toHaveBeenCalled();
+  });
+});
+
+describe("terminal spawn handler - daintree-assistant MCP env injection (#10639)", () => {
+  let ptyClient: {
+    spawn: ReturnType<typeof vi.fn>;
+    hasTerminal: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const os = await import("os");
+    tmpDir = os.tmpdir();
+    ptyClient = {
+      spawn: vi.fn(),
+      hasTerminal: vi.fn(() => false),
+      write: vi.fn(),
+    };
+    mockGetCurrentProject.mockReturnValue({ id: "p1", path: tmpDir, name: "p" });
+    mockGetProjectById.mockReturnValue(null);
+    mockGetProjectSettings.mockResolvedValue({ daintreeMcpTier: "action" });
+    mockValidateToken.mockReturnValue(false);
+    mockIsRunning.mockReturnValue(true);
+    mockCurrentPort.mockReturnValue(45454);
+    mockPreparePaneConfig.mockReset();
+    mockPreparePaneConfig.mockResolvedValue({
+      configPath: "/tmp/pane-config.json",
+      token: "assistant-token",
+    });
+  });
+
+  it("injects MCP url, token, and window id into the env, without --mcp-config", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      { senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        id: "assistant-pane",
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    // Token is minted through the same registered-bearer path as Claude.
+    expect(mockPreparePaneConfig).toHaveBeenCalledWith({
+      paneId: "assistant-pane",
+      port: 45454,
+      tier: "action",
+    });
+    expect(spawnArgs.env?.DAINTREE_MCP_URL).toBe("http://127.0.0.1:45454/mcp");
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBe("assistant-token");
+    expect(spawnArgs.env?.DAINTREE_WINDOW_ID).toBe("7");
+    // env-only: no config flag is appended, and the handler does not set
+    // DAINTREE_PROJECT_ID (injectDaintreeMetadata owns that downstream).
+    expect(spawnArgs.command).toBe("daintree-assistant");
+    expect(spawnArgs.env?.DAINTREE_PROJECT_ID).toBeUndefined();
+  });
+
+  it("omits DAINTREE_WINDOW_ID when no sender window is in scope", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        id: "assistant-pane",
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBe("assistant-token");
+    expect(spawnArgs.env?.DAINTREE_MCP_URL).toBe("http://127.0.0.1:45454/mcp");
+    expect("DAINTREE_WINDOW_ID" in (spawnArgs.env ?? {})).toBe(false);
+  });
+
+  it("starts the MCP server on demand when it is not already running", async () => {
+    mockIsRunning.mockReturnValue(false);
+    mockEnsureReady.mockImplementation(async () => {
+      mockIsRunning.mockReturnValue(true);
+      return true;
+    });
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      { senderWindow: { id: 3 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        id: "assistant-pane",
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(mockEnsureReady).toHaveBeenCalledTimes(1);
+    expect(mockPreparePaneConfig).toHaveBeenCalled();
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBe("assistant-token");
+  });
+
+  it("continues without MCP injection when the server cannot be made ready", async () => {
+    mockIsRunning.mockReturnValue(false);
+    mockCurrentPort.mockReturnValue(null);
+    mockEnsureReady.mockResolvedValue(false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      { senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
+    expect(spawnArgs.command).toBe("daintree-assistant");
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBeUndefined();
+    expect(spawnArgs.env?.DAINTREE_MCP_URL).toBeUndefined();
+  });
+
+  it("skips MCP injection when the resolved tier is off", async () => {
+    mockGetProjectSettings.mockResolvedValue({ daintreeMcpTier: "off" });
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      { senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBeUndefined();
+  });
+
+  it("continues spawning when token minting throws", async () => {
+    mockPreparePaneConfig.mockRejectedValue(new Error("mint failed"));
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      { senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toBe("daintree-assistant");
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBeUndefined();
   });
 });
 

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -12,7 +12,7 @@ import { projectStore } from "../../../services/ProjectStore.js";
 import type * as McpServerServiceModule from "../../../services/McpServerService.js";
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
 import { helpSessionService } from "../../../services/HelpSessionService.js";
-import type { HandlerDependencies } from "../../types.js";
+import type { HandlerDependencies, IpcContext } from "../../types.js";
 import { TerminalSpawnOptionsSchema } from "../../../schemas/ipc.js";
 import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
 import { DEFAULT_DANGEROUS_ARGS } from "../../../../shared/types/agentSettings.js";
@@ -73,8 +73,15 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
   }
 
   const handleTerminalSpawn = async (
+    ctx: IpcContext,
     validatedOptions: ValidatedTerminalSpawnOptions
   ): Promise<string> => {
+    // Capture the sender window id synchronously before any `await` — the
+    // window can be destroyed mid-spawn, after which `ctx.senderWindow` would
+    // be a stale reference. Only the daintree-assistant env-only path consumes
+    // this (as `DAINTREE_WINDOW_ID`); `null` means no window was in scope.
+    const windowId = ctx.senderWindow?.id ?? null;
+
     const bypassedRateLimit = validatedOptions.restore === true && consumeRestoreQuota();
     if (!bypassedRateLimit) {
       await waitForRateLimitSlot("terminalSpawn", 1_000);
@@ -409,6 +416,48 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           mcpErr
         );
       }
+    } else if (launchAgentId === "daintree-assistant" && safeCommand.length > 0 && projectId) {
+      // Daintree Assistant reads its MCP connection details straight from PTY
+      // env (`mcpInjection: "env-only"`) — no .mcp.json, no CLI flags. Mint a
+      // per-pane bearer via the same `preparePaneConfig` path Claude uses so
+      // the token is registered with the MCP server's bearer validator (an
+      // unregistered raw UUID would be rejected on connect) and revoked on PTY
+      // exit; we discard the written config file and use only the token.
+      // The assistant speaks Streamable HTTP at /mcp (not Claude's /sse).
+      // DAINTREE_PROJECT_ID is injected downstream by `injectDaintreeMetadata`
+      // in the pty-host, so it is intentionally not set here.
+      try {
+        const projSettings = await projectStore.getProjectSettings(projectId);
+        const tier = resolveDaintreeMcpTier(projSettings);
+        if (tier !== "off") {
+          const mcpServerService = await getMcpServerService();
+          const ready = mcpServerService.isRunning || (await mcpServerService.ensureReady());
+          if (!ready) {
+            console.warn(
+              "[TerminalSpawn] Daintree MCP requested for assistant launch, but the MCP server is not ready; continuing without MCP injection"
+            );
+          }
+          const port = mcpServerService.currentPort;
+          if (ready && port) {
+            const { token } = await mcpPaneConfigService.preparePaneConfig({
+              paneId: id,
+              port,
+              tier,
+            });
+            spawnEnv = {
+              ...(spawnEnv ?? {}),
+              DAINTREE_MCP_URL: `http://127.0.0.1:${port}/mcp`,
+              DAINTREE_MCP_TOKEN: token,
+              ...(windowId !== null ? { DAINTREE_WINDOW_ID: String(windowId) } : {}),
+            };
+          }
+        }
+      } catch (mcpErr) {
+        console.error(
+          "[TerminalSpawn] Failed to prepare Daintree Assistant MCP env; continuing without MCP injection:",
+          mcpErr
+        );
+      }
     }
 
     // Expand `${settings:*}` templates a plugin agent embedded in its command
@@ -566,7 +615,9 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
   const namespace = defineIpcNamespace({
     name: "terminalLifecycle",
     ops: {
-      spawn: opValidated(CHANNELS.TERMINAL_SPAWN, TerminalSpawnOptionsSchema, handleTerminalSpawn),
+      spawn: opValidated(CHANNELS.TERMINAL_SPAWN, TerminalSpawnOptionsSchema, handleTerminalSpawn, {
+        withContext: true,
+      }),
       kill: op(CHANNELS.TERMINAL_KILL, handleTerminalKill),
       gracefulKill: op(CHANNELS.TERMINAL_GRACEFUL_KILL, handleTerminalGracefulKill),
       trash: op(CHANNELS.TERMINAL_TRASH, handleTerminalTrash),

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -272,7 +272,7 @@ describe("agentRegistry", () => {
       expect(getAssistantWiredAgentIds()).toContain("daintree-assistant");
       expect(getAssistantSupportedAgentIds()).not.toContain("daintree-assistant");
       expect(getAgentConfig("daintree-assistant")?.supports).toMatchObject({
-        mcpInjection: "project-config",
+        mcpInjection: "env-only",
         settingsOverlay: false,
         permissionBypass: false,
         trustDialog: false,

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -298,8 +298,11 @@ export interface AssistantSupports {
    * - `"project-config"`: written to per-session config files (e.g. Claude's
    *   `.mcp.json` plus `.claude/settings.json` overlay).
    * - `"cli-flags"`: passed as `-c key=value` flags at spawn time (e.g. Codex).
+   * - `"env-only"`: connection details are passed purely through PTY env vars
+   *   the agent reads itself (`DAINTREE_MCP_URL`, `DAINTREE_MCP_TOKEN`, …) —
+   *   no config file written, no CLI flags (e.g. Daintree Assistant).
    */
-  mcpInjection: "project-config" | "cli-flags";
+  mcpInjection: "project-config" | "cli-flags" | "env-only";
   /**
    * Whether the agent reads a session-dir settings overlay that bakes in
    * permissions / project-MCP trust (e.g. Claude's `.claude/settings.json`

--- a/shared/config/agents/daintree-assistant.ts
+++ b/shared/config/agents/daintree-assistant.ts
@@ -21,12 +21,12 @@ export const config: AgentConfig = {
     npmPackage: "@daintreehq/daintree-assistant",
   },
   supports: {
-    // Placeholder until the assistant launch path is wired end to end. The
-    // assistant connects over MCP via env vars it reads itself, not a written
-    // config file — `mcpInjection` is a required two-value enum with no
-    // env-only option, so this records the nearest intended mechanism. It is
-    // inert at `experimental` tier (no project-config is written today).
-    mcpInjection: "project-config",
+    // The assistant connects over MCP via env vars it reads itself
+    // (`DAINTREE_MCP_URL`, `DAINTREE_MCP_TOKEN`, `DAINTREE_PROJECT_ID`,
+    // `DAINTREE_WINDOW_ID`) injected at spawn time — no config file is written
+    // and no CLI flags are appended. See the daintree-assistant branch in
+    // `electron/ipc/handlers/terminal/lifecycle.ts`.
+    mcpInjection: "env-only",
     settingsOverlay: false,
     permissionBypass: false,
     trustDialog: false,

--- a/shared/types/userAgentRegistry.ts
+++ b/shared/types/userAgentRegistry.ts
@@ -5,7 +5,7 @@ const RESERVED_KEYS = ["__proto__", "constructor", "prototype"];
 export const SAFE_AGENT_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 export const AssistantSupportsSchema = z.object({
-  mcpInjection: z.enum(["project-config", "cli-flags"]),
+  mcpInjection: z.enum(["project-config", "cli-flags", "env-only"]),
   settingsOverlay: z.boolean(),
   permissionBypass: z.boolean(),
   trustDialog: z.boolean(),


### PR DESCRIPTION
## Summary

- Injects `DAINTREE_MCP_URL` (Streamable HTTP at `/mcp`), `DAINTREE_MCP_TOKEN`, and `DAINTREE_WINDOW_ID` into the PTY spawn environment for daintree-assistant launches. `DAINTREE_PROJECT_ID` is handled downstream by `injectDaintreeMetadata`, so the handler skips it.
- The bearer token is minted via `mcpPaneConfigService.preparePaneConfig` (same registered-token path Claude uses) and revoked on PTY exit. No config files written, no CLI flags — env-only.
- Switched the spawn handler to `withContext` so the sender window id is captured synchronously before any `await`. `null` sender omits `DAINTREE_WINDOW_ID`; `0` is valid and forwarded.

Resolves #10639

## Changes

- `electron/ipc/handlers/terminal/lifecycle.ts` — daintree-assistant branch in the spawn handler; env injection + token revocation; `withContext` migration
- `shared/config/agents/daintree-assistant.ts` — `mcpInjection` set to `"env-only"` (replaces inert `"project-config"`)
- `shared/types/userAgentRegistry.ts` + `shared/config/agentRegistry.ts` — `"env-only"` added to the `AssistantSupports.mcpInjection` TS union and `userAgentRegistry` Zod enum

## Testing

New spawn tests in `lifecycle.spawn.test.ts`: url/token/window injection, window-id `0` forwarded, window-id omitted with no sender, on-demand server start, skip when server unready / tier off / no project, revoke on spawn failure, continue on mint failure. `lifecycle.shellReady.test.ts` and `agentRegistry.test.ts` updated for context-aware handler registration and updated enum. 319 tests passing.