### PR TITLE
fix(recipe): suppress unresolved badges during authoring without worktree context

### DIFF
--- a/src/components/TerminalRecipe/RecipeVariablePreview.tsx
+++ b/src/components/TerminalRecipe/RecipeVariablePreview.tsx
@@ -57,7 +57,7 @@ export function RecipeVariablePreview({ initialPrompt, worktreeId }: RecipeVaria
             )}
       </div>
       {!hasContext && <p className="text-[10px] text-text-muted mt-1">Resolving at run time</p>}
-      {unresolvedVars.length > 0 && (
+      {hasContext && unresolvedVars.length > 0 && (
         <div className="mt-1 flex flex-wrap gap-1">
           {unresolvedVars.map((name) => (
             <span

--- a/src/components/TerminalRecipe/__tests__/RecipeVariablePreview.test.tsx
+++ b/src/components/TerminalRecipe/__tests__/RecipeVariablePreview.test.tsx
@@ -80,11 +80,10 @@ describe("RecipeVariablePreview", () => {
     expect(screen.getByText("Resolving at run time")).toBeTruthy();
   });
 
-  it("shows rose unresolved badges in fallback mode for missing context", () => {
+  it("does not show unresolved badges in fallback mode without worktree context", () => {
     renderPreview("Fix {{issue_number}} on {{branch_name}}", undefined);
 
-    const badges = screen.getAllByText(/unresolved/);
-    expect(badges.length).toBe(2);
+    expect(screen.queryByText(/unresolved/)).toBeNull();
   });
 
   it("treats unknown {{var}} as literal text, not as unresolved", () => {

--- a/src/components/TerminalRecipe/__tests__/RecipeVariablePreview.test.tsx
+++ b/src/components/TerminalRecipe/__tests__/RecipeVariablePreview.test.tsx
@@ -86,6 +86,15 @@ describe("RecipeVariablePreview", () => {
     expect(screen.queryByText(/unresolved/)).toBeNull();
   });
 
+  it("does not flag {{number}} as unresolved during authoring without worktree", () => {
+    const { container } = renderPreview("See {{number}}", undefined);
+
+    expect(screen.queryByText(/unresolved/)).toBeNull();
+    expect(container.querySelector(".bg-category-rose-subtle")).toBeNull();
+    expect(container.querySelector(".bg-category-amber-subtle")).toBeTruthy();
+    expect(screen.getByText("Resolving at run time")).toBeTruthy();
+  });
+
   it("treats unknown {{var}} as literal text, not as unresolved", () => {
     mockSnapshot = { path: "/tmp/test", branch: "main" };
 
@@ -101,6 +110,7 @@ describe("RecipeVariablePreview", () => {
     const { container } = renderPreview("See {{number}}", "wt-1");
 
     expect(container.textContent).toContain("#7");
+    expect(screen.queryByText(/unresolved/)).toBeNull();
   });
 
   it("resolves {{number}} to prNumber when issueNumber is absent", () => {


### PR DESCRIPTION
## Summary

- The recipe editor was showing rose unresolved-variable warning badges for context-dependent variables (`{{number}}`, `{{issue_number}}`, `{{branch_name}}`, `{{worktree_path}}`) during authoring, even with no worktree selected. The preview already shows "Resolving at run time" for these -- the badge was contradictory.
- Root cause: `RecipeVariablePreview` rendered the unresolved-badge block unconditionally, regardless of whether `hasContext` was true.
- Fix: guard the badge block on `hasContext` in `src/components/TerminalRecipe/RecipeVariablePreview.tsx`. The shared `detectUnresolvedVariables` utility is intentionally untouched -- five call sites across fleet execution, the recipe runner, and tests depend on its current behaviour.

Resolves #10643

## Changes

- `src/components/TerminalRecipe/RecipeVariablePreview.tsx` -- wrap the unresolved-badge render block in `hasContext`
- `src/components/TerminalRecipe/__tests__/RecipeVariablePreview.test.tsx` -- inverted the test that previously asserted the buggy authoring-mode badges; added regression coverage for the `{{number}}`-during-authoring case and for resolved-state badge absence

## Testing

11 tests passing in `RecipeVariablePreview.test.tsx`. Prettier clean, ESLint 0 errors on changed files.