### PR TITLE
fix(mcp): define assistant action tier and fix headless confirm semantics

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -39,6 +39,12 @@ const PROJECT_HASH_LEN = 16;
 // might grow to ship.
 const TEMPLATE_HASH_FILE = ".template-hash";
 
+// `action` is the deliberate default tier for assistant sessions, including the
+// headless Daintree Assistant CLI (#10640): it covers orchestration, terminal
+// driving, branch setup, recipes, and reads, while leaving irreversible
+// mutations (git.push, worktree.delete) above the floor so they require a
+// human-approved scoped grant rather than running unattended. The tier boundary
+// is locked by the policy guard in `mcp-server/__tests__/tierAuth.test.ts`.
 const DEFAULT_TIER: HelpAssistantTier = "action";
 const DEFAULT_DAINTREE_CONTROL = true;
 const DEFAULT_DOC_SEARCH = true;

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -43,8 +43,10 @@ const TEMPLATE_HASH_FILE = ".template-hash";
 // headless Daintree Assistant CLI (#10640): it covers orchestration, terminal
 // driving, branch setup, recipes, and reads, while leaving irreversible
 // mutations (git.push, worktree.delete) above the floor so they require a
-// human-approved scoped grant rather than running unattended. The tier boundary
-// is locked by the policy guard in `mcp-server/__tests__/tierAuth.test.ts`.
+// human-approved scoped grant rather than running unattended. What that tier
+// permits vs. withholds is locked by the policy guard in
+// `mcp-server/__tests__/tierAuth.test.ts`; this constant selects it as the
+// provisioning default.
 const DEFAULT_TIER: HelpAssistantTier = "action";
 const DEFAULT_DAINTREE_CONTROL = true;
 const DEFAULT_DOC_SEARCH = true;

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -31,7 +31,7 @@ import {
   RATE_LIMIT_TOOL_MAP,
   unwrapDispatchResult,
 } from "../shared.js";
-import { SessionBindingError } from "../rendererBridge.js";
+import { SessionBindingError, RendererBridgeUnavailableError } from "../rendererBridge.js";
 import { getAgentAvailabilityStore } from "../../AgentAvailabilityStore.js";
 import { events } from "../../events.js";
 
@@ -1597,6 +1597,79 @@ describe("CallTool error envelope (integration through sessionServer)", () => {
     expect(parsed.retriable).toBe(false);
     expect(parsed.message).toContain("Do not retry");
     expect(parsed.message).toContain("42");
+  });
+
+  it("reclassifies a no-channel confirm dispatch to CONFIRMATION_REQUIRED, not EXECUTION_ERROR (#10640)", async () => {
+    // A confirm-gated tool the session's tier permits, dispatched by a client
+    // without elicitation.form. The unconfirmed dispatch is forwarded to the
+    // renderer bridge, which throws RendererBridgeUnavailableError because no
+    // Daintree window is open. That must surface as a non-retriable
+    // CONFIRMATION_REQUIRED (the human couldn't be asked) rather than a
+    // retriable EXECUTION_ERROR (which would read as a transient failure).
+    const manifest = [
+      {
+        id: "worktree.list",
+        title: "Worktree: list",
+        description: "List worktrees",
+        category: "worktree",
+        danger: "confirm" as const,
+        source: ["agent"] as const,
+      },
+    ] as unknown as import("../../../../shared/types/actions.js").ActionManifestEntry[];
+    const dispatchAction = vi.fn().mockRejectedValue(new RendererBridgeUnavailableError());
+    const deps = fakeDeps({
+      requestManifest: vi.fn().mockResolvedValue(manifest),
+      getCachedManifest: vi.fn(() => manifest),
+      dispatchAction,
+    });
+    const server = createSessionServer("s-no-channel", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "worktree.list",
+      arguments: {},
+    })) as { isError: boolean; content: { type: string; text: string }[] };
+
+    // Dispatch was attempted unconfirmed (the renderer is the confirm gate).
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.list", {}, false);
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.code).toBe("CONFIRMATION_REQUIRED");
+    expect(parsed.retriable).toBe(false);
+    expect(parsed.details).toEqual({ confirmationChannel: "unavailable" });
+  });
+
+  it("keeps EXECUTION_ERROR for a bridge-unavailable failure on a non-confirm tool (#10640)", async () => {
+    // The reclassification is scoped to confirm-gated tools. A safe tool that
+    // hits the same RendererBridgeUnavailableError is a genuine execution
+    // failure (nothing needed confirming) and stays a retriable EXECUTION_ERROR.
+    const manifest = [
+      {
+        id: "files.search",
+        title: "Files: search",
+        description: "Search files",
+        category: "files",
+        danger: "safe" as const,
+        source: ["agent"] as const,
+      },
+    ] as unknown as import("../../../../shared/types/actions.js").ActionManifestEntry[];
+    const deps = fakeDeps({
+      requestManifest: vi.fn().mockResolvedValue(manifest),
+      getCachedManifest: vi.fn(() => manifest),
+      dispatchAction: vi.fn().mockRejectedValue(new RendererBridgeUnavailableError()),
+    });
+    const server = createSessionServer("s-safe-no-channel", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "files.search",
+      arguments: {},
+    })) as { isError: boolean; content: { type: string; text: string }[] };
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.code).toBe(EXECUTION_ERROR_CODE);
+    expect(parsed.retriable).toBe(true);
   });
 });
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1600,24 +1600,26 @@ describe("CallTool error envelope (integration through sessionServer)", () => {
   });
 
   it("reclassifies a no-channel confirm dispatch to CONFIRMATION_REQUIRED, not EXECUTION_ERROR (#10640)", async () => {
-    // A confirm-gated tool the session's tier permits, dispatched by a client
-    // without elicitation.form. The unconfirmed dispatch is forwarded to the
-    // renderer bridge, which throws RendererBridgeUnavailableError because no
-    // Daintree window is open. That must surface as a non-retriable
-    // CONFIRMATION_REQUIRED (the human couldn't be asked) rather than a
-    // retriable EXECUTION_ERROR (which would read as a transient failure).
+    // recipe.run is a real danger:"confirm" action in the action tier. With a
+    // client that lacks elicitation.form, the unconfirmed dispatch is forwarded
+    // to the renderer bridge, which throws RendererBridgeUnavailableError when
+    // no Daintree window is open. Because the manifest entry IS known to be
+    // confirm-gated, that must surface as a non-retriable CONFIRMATION_REQUIRED
+    // (the human couldn't be asked) rather than a retriable EXECUTION_ERROR.
     const manifest = [
       {
-        id: "worktree.list",
-        title: "Worktree: list",
-        description: "List worktrees",
-        category: "worktree",
+        id: "recipe.run",
+        title: "Recipe: run",
+        description: "Run a recipe",
+        category: "recipe",
         danger: "confirm" as const,
         source: ["agent"] as const,
       },
     ] as unknown as import("../../../../shared/types/actions.js").ActionManifestEntry[];
     const dispatchAction = vi.fn().mockRejectedValue(new RendererBridgeUnavailableError());
     const deps = fakeDeps({
+      // action tier so recipe.run clears the tier floor and reaches dispatch.
+      sessionStore: fakeSessionStore("action"),
       requestManifest: vi.fn().mockResolvedValue(manifest),
       getCachedManifest: vi.fn(() => manifest),
       dispatchAction,
@@ -1626,12 +1628,12 @@ describe("CallTool error envelope (integration through sessionServer)", () => {
     await server.connect(makeMockTransport());
 
     const result = (await callTool(server, {
-      name: "worktree.list",
+      name: "recipe.run",
       arguments: {},
     })) as { isError: boolean; content: { type: string; text: string }[] };
 
     // Dispatch was attempted unconfirmed (the renderer is the confirm gate).
-    expect(dispatchAction).toHaveBeenCalledWith("worktree.list", {}, false);
+    expect(dispatchAction).toHaveBeenCalledWith("recipe.run", {}, false);
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.code).toBe("CONFIRMATION_REQUIRED");
@@ -1639,10 +1641,11 @@ describe("CallTool error envelope (integration through sessionServer)", () => {
     expect(parsed.details).toEqual({ confirmationChannel: "unavailable" });
   });
 
-  it("keeps EXECUTION_ERROR for a bridge-unavailable failure on a non-confirm tool (#10640)", async () => {
+  it("keeps a retriable EXECUTION_ERROR for a non-confirm tool when the bridge is unavailable (#10640)", async () => {
     // The reclassification is scoped to confirm-gated tools. A safe tool that
-    // hits the same RendererBridgeUnavailableError is a genuine execution
-    // failure (nothing needed confirming) and stays a retriable EXECUTION_ERROR.
+    // hits the same RendererBridgeUnavailableError is a genuine "no renderer"
+    // failure (nothing needed confirming) and stays a retriable EXECUTION_ERROR
+    // — but with an explicit cause rather than an opaque dispatch failure.
     const manifest = [
       {
         id: "files.search",
@@ -1670,6 +1673,37 @@ describe("CallTool error envelope (integration through sessionServer)", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.code).toBe(EXECUTION_ERROR_CODE);
     expect(parsed.retriable).toBe(true);
+    expect(parsed.message).toContain("No Daintree window is open");
+  });
+
+  it("cold-cache confirm tool with no renderer stays a retriable EXECUTION_ERROR — danger is unknowable without a manifest (#10640)", async () => {
+    // Deliberate boundary: when no window is open AND the manifest cache is cold,
+    // the manifest fetch itself goes through the renderer and throws, so
+    // `lookupManifestEntry` returns undefined and the tool's danger is unknown.
+    // We must NOT claim CONFIRMATION_REQUIRED for an unverified confirm tool, so
+    // this stays a retriable EXECUTION_ERROR (the renderer may return when a
+    // window opens) rather than the non-retriable confirmation signal the
+    // warm-cache path produces.
+    const deps = fakeDeps({
+      sessionStore: fakeSessionStore("action"),
+      // Cold cache + no renderer: both the manifest fetch and the dispatch fail.
+      getCachedManifest: vi.fn(() => null),
+      requestManifest: vi.fn().mockRejectedValue(new RendererBridgeUnavailableError()),
+      dispatchAction: vi.fn().mockRejectedValue(new RendererBridgeUnavailableError()),
+    });
+    const server = createSessionServer("s-cold-cache", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "recipe.run",
+      arguments: {},
+    })) as { isError: boolean; content: { type: string; text: string }[] };
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.code).toBe(EXECUTION_ERROR_CODE);
+    expect(parsed.retriable).toBe(true);
+    expect(parsed.message).toContain("No Daintree window is open");
   });
 });
 

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -17,6 +17,7 @@ import {
   buildAnnotations,
   extractBearerToken,
   isAuthorized,
+  isTierPermitted,
   parseToolArguments,
   precomputeApiKeyBearerHash,
   resolveTokenTier,
@@ -383,5 +384,75 @@ describe("buildAnnotations", () => {
   it("restricted entry bypassing upstream gate → destructiveHint: false (not confirm)", () => {
     const entry = makeEntry({ kind: "command", danger: "restricted" });
     expect(buildAnnotations(entry).destructiveHint).toBe(false);
+  });
+});
+
+// Policy guard for the Daintree Assistant CLI's MCP tier (#10640). The
+// assistant is a headless conductor and runs at the `action` tier (the
+// help-session `DEFAULT_TIER`), NOT the `external` tier an api-key bearer
+// falls into by default. The distinction is load-bearing: `external` auto-
+// permits irreversible mutations (git.push, worktree.delete) subject only to
+// the confirm gate, whereas `action` leaves them TIER_NOT_PERMITTED so they
+// require a human-approved scoped grant to run at all. These assertions lock
+// that invariant against allowlist drift (e.g. someone promoting git.push into
+// the action tier). They test the runtime gate `isTierPermitted`, not the raw
+// allowlist arrays, so they fail closed if the tier wiring itself regresses.
+describe("Daintree Assistant tier policy (#10640)", () => {
+  // The conductor's working tool set — orchestration, terminal driving, branch
+  // setup, recipes, and reads — all resolve under `action`.
+  const ASSISTANT_REQUIRED_TOOLS = [
+    "agent.launch",
+    "agent.terminal",
+    "agent.getState",
+    "workflow.startWorkOnIssue",
+    "terminal.new",
+    "terminal.sendCommand",
+    "terminal.getOutput",
+    "terminal.getStatus",
+    "terminal.waitUntilIdle",
+    "recipe.run",
+    "worktree.createWithRecipe",
+    "worktree.setActive",
+    "worktree.list",
+    "git.getProjectPulse",
+    "files.search",
+    "copyTree.generate",
+  ];
+
+  // Irreversible / shared-state mutations the conductor must NOT be able to
+  // fire unattended at its default tier — they require explicit elevation.
+  const HIGH_BLAST_RADIUS_TOOLS = [
+    "git.commit",
+    "git.push",
+    "git.snapshotRevert",
+    "git.snapshotDelete",
+    "worktree.delete",
+    "forge.assignIssue",
+  ];
+
+  it.each(ASSISTANT_REQUIRED_TOOLS)(
+    "permits the assistant's required tool %s at the action tier",
+    (toolId) => {
+      expect(isTierPermitted("action", toolId, false)).toBe(true);
+    }
+  );
+
+  it.each(HIGH_BLAST_RADIUS_TOOLS)(
+    "withholds high-blast-radius tool %s at the action tier (requires a grant)",
+    (toolId) => {
+      expect(isTierPermitted("action", toolId, false)).toBe(false);
+      // Sanity check: the tool exists in the model and IS reachable one tier up,
+      // so the `false` above is a real tier boundary, not a typo'd action id.
+      expect(isTierPermitted("system", toolId, false)).toBe(true);
+    }
+  );
+
+  it("auto-permits those same mutations under the external tier — the default we are moving the assistant off of", () => {
+    // Documents the security contrast that motivates pinning the assistant to
+    // `action`: on `external` (the api-key fallback) these run subject only to
+    // the confirm gate, with no tier floor in front of them.
+    for (const toolId of ["git.push", "git.commit", "worktree.delete"]) {
+      expect(isTierPermitted("external", toolId, false)).toBe(true);
+    }
   });
 });

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -21,6 +21,20 @@ export class SessionBindingError extends Error {
   }
 }
 
+// Thrown when an unpinned dispatch can't reach any live renderer to route a
+// tool call through. For confirm-gated tools this is the "no confirmation
+// channel reachable" case: a headless conductor with no Daintree window open
+// has nowhere to surface the native ConfirmDialog. The caller reclassifies it
+// to CONFIRMATION_REQUIRED for confirm-gated tools (#10640) so the assistant
+// learns it needs human approval it can't currently obtain, rather than seeing
+// an opaque, retriable EXECUTION_ERROR.
+export class RendererBridgeUnavailableError extends Error {
+  constructor() {
+    super("MCP renderer bridge unavailable");
+    this.name = "RendererBridgeUnavailableError";
+  }
+}
+
 export function createRendererBridge(
   pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>,
   pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>,
@@ -75,7 +89,7 @@ export function createRendererBridge(
       return fallback;
     }
 
-    throw new Error("MCP renderer bridge unavailable");
+    throw new RendererBridgeUnavailableError();
   }
 
   /**

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -38,6 +38,7 @@ import {
   readStringField,
   RESOURCE_BACKING_ACTIONS,
   TIER_NOT_PERMITTED_CODE,
+  CONFIRMATION_REQUIRED_CODE,
   CONFIRMATION_TIMEOUT_CODE,
   USER_REJECTED_CODE,
   ELICITATION_FAILED_CODE,
@@ -57,7 +58,7 @@ import {
   INTERACTIVE_WAIT_UNTIL_IDLE_TIMEOUT_CAP_MS,
   MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
 } from "../../../shared/types/terminalWaitUntilIdle.js";
-import { SessionBindingError } from "./rendererBridge.js";
+import { SessionBindingError, RendererBridgeUnavailableError } from "./rendererBridge.js";
 import {
   buildDedupKey,
   canonicalArgsHash,
@@ -776,6 +777,42 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             return buildToolError({
               code: SESSION_BINDING_GONE,
               message: err.message,
+            });
+          }
+          // No reachable confirmation channel for a confirm-gated tool (#10640).
+          // When a headless client lacks `elicitation.form`, the unconfirmed
+          // dispatch is forwarded to the renderer bridge so the human can
+          // approve it in a native ConfirmDialog. If no Daintree window is open,
+          // `getActiveProjectWebContents` throws `RendererBridgeUnavailableError`
+          // — meaning the action could not be confirmed, not that it failed
+          // mid-execution. Reclassify to CONFIRMATION_REQUIRED (audited as
+          // `confirmation-pending`, never retriable) with a machine-readable
+          // `confirmationChannel: "unavailable"` so an autonomous conductor can
+          // tell "needs a human I can't reach" apart from a transient error.
+          // Scoped to unconfirmed confirm-gated tools so an already-approved
+          // dispatch that fails for any other reason still surfaces as
+          // EXECUTION_ERROR.
+          if (
+            err instanceof RendererBridgeUnavailableError &&
+            entry?.danger === "confirm" &&
+            !dispatchConfirmed
+          ) {
+            const message =
+              `Action '${actionId}' requires confirmation, but no Daintree window is open to surface the ` +
+              `approval dialog. The action was not run — a human must approve it in Daintree.`;
+            const value: import("../../../shared/types/actions.js").ActionDispatchResult = {
+              ok: false,
+              error: {
+                code: CONFIRMATION_REQUIRED_CODE,
+                message,
+                details: { confirmationChannel: "unavailable" },
+              },
+            };
+            outcome = { kind: "result", value };
+            return buildToolError({
+              code: CONFIRMATION_REQUIRED_CODE,
+              message,
+              details: { confirmationChannel: "unavailable" },
             });
           }
           return buildToolError({

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -779,40 +779,51 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
               message: err.message,
             });
           }
-          // No reachable confirmation channel for a confirm-gated tool (#10640).
-          // When a headless client lacks `elicitation.form`, the unconfirmed
-          // dispatch is forwarded to the renderer bridge so the human can
-          // approve it in a native ConfirmDialog. If no Daintree window is open,
-          // `getActiveProjectWebContents` throws `RendererBridgeUnavailableError`
-          // — meaning the action could not be confirmed, not that it failed
-          // mid-execution. Reclassify to CONFIRMATION_REQUIRED (audited as
-          // `confirmation-pending`, never retriable) with a machine-readable
-          // `confirmationChannel: "unavailable"` so an autonomous conductor can
-          // tell "needs a human I can't reach" apart from a transient error.
-          // Scoped to unconfirmed confirm-gated tools so an already-approved
-          // dispatch that fails for any other reason still surfaces as
-          // EXECUTION_ERROR.
-          if (
-            err instanceof RendererBridgeUnavailableError &&
-            entry?.danger === "confirm" &&
-            !dispatchConfirmed
-          ) {
-            const message =
-              `Action '${actionId}' requires confirmation, but no Daintree window is open to surface the ` +
-              `approval dialog. The action was not run — a human must approve it in Daintree.`;
-            const value: import("../../../shared/types/actions.js").ActionDispatchResult = {
-              ok: false,
-              error: {
+          // No live renderer to route the dispatch through (#10640). When a
+          // headless client lacks `elicitation.form`, the unconfirmed dispatch
+          // is forwarded to the renderer bridge so the human can approve it in a
+          // native ConfirmDialog; with no Daintree window open,
+          // `getActiveProjectWebContents` throws `RendererBridgeUnavailableError`.
+          if (err instanceof RendererBridgeUnavailableError) {
+            // Confirm-gated tool we KNOW needs human approval (manifest entry
+            // resolved): the action could not be confirmed, not that it failed
+            // mid-execution. Reclassify to CONFIRMATION_REQUIRED (audited as
+            // `confirmation-pending`, never retriable) with a machine-readable
+            // `confirmationChannel: "unavailable"` so an autonomous conductor
+            // can tell "needs a human I can't reach" apart from a transient
+            // error. Scoped to unconfirmed dispatches so an already-approved
+            // call that fails for any other reason isn't mislabelled.
+            if (entry?.danger === "confirm" && !dispatchConfirmed) {
+              const message =
+                `Action '${actionId}' requires confirmation, but no Daintree window is open to surface the ` +
+                `approval dialog. The action was not run — a human must approve it in Daintree.`;
+              const value: import("../../../shared/types/actions.js").ActionDispatchResult = {
+                ok: false,
+                error: {
+                  code: CONFIRMATION_REQUIRED_CODE,
+                  message,
+                  details: { confirmationChannel: "unavailable" },
+                },
+              };
+              outcome = { kind: "result", value };
+              return buildToolError({
                 code: CONFIRMATION_REQUIRED_CODE,
                 message,
                 details: { confirmationChannel: "unavailable" },
-              },
-            };
-            outcome = { kind: "result", value };
+              });
+            }
+            // Either a non-confirm tool, or a cold-cache call whose manifest
+            // entry couldn't be fetched (the manifest itself comes from the
+            // renderer, so `entry` is undefined here and the tool's danger is
+            // unknowable). We must not claim CONFIRMATION_REQUIRED without
+            // knowing the tool is confirm-gated, so this stays a *retriable*
+            // EXECUTION_ERROR — the renderer may come back when a window opens.
+            // The message names the cause so the caller retries deliberately
+            // rather than treating it as an opaque dispatch failure.
             return buildToolError({
-              code: CONFIRMATION_REQUIRED_CODE,
-              message,
-              details: { confirmationChannel: "unavailable" },
+              code: EXECUTION_ERROR_CODE,
+              message:
+                "No Daintree window is open, so the action surface is unavailable. Retry once a project window is open.",
             });
           }
           return buildToolError({


### PR DESCRIPTION
## Summary

- Headless confirm-gated dispatch now returns `CONFIRMATION_REQUIRED` with `confirmationChannel="unavailable"` (non-retriable) when the tool is known to be confirm-gated, rather than silently auto-running. Cold-cache / no-window cases return a clear retriable `EXECUTION_ERROR`. The existing renderer-modal fallback is preserved.
- The assistant MCP tier is explicitly locked to `action` via `DEFAULT_TIER` in `HelpSessionService`. Required tools (`terminal.*`, `worktree.*`, read tools, `agent.launch`) are all permitted at this tier; `git.push`, `git.commit`, and `worktree.delete` remain above the floor and require an explicit human-approved scoped grant.
- Introduces a typed `RendererBridgeUnavailableError` to distinguish the no-renderer case and adds a regression guard test for tier auth.

Resolves #10640

## Changes

- `electron/services/mcp-server/rendererBridge.ts` -- typed `RendererBridgeUnavailableError` class
- `electron/services/mcp-server/sessionServer.ts` -- split headless confirm path: known confirm-gated returns `CONFIRMATION_REQUIRED` / `confirmationChannel="unavailable"`; unknown-danger returns retriable `EXECUTION_ERROR`
- `electron/services/HelpSessionService.ts` -- `DEFAULT_TIER = "action"` constant pins the assistant tier
- `electron/services/mcp-server/__tests__/sessionServer.test.ts` -- coverage for both headless branches and the renderer-modal fallback
- `electron/services/mcp-server/__tests__/tierAuth.test.ts` -- regression guard asserting required tools resolve and destructive tools stay above the floor

## Notes

The issue's premise that confirm-gated tools silently auto-ran for headless clients wasn't quite right -- the existing `ActionService` + renderer-modal path was already fail-closed. What was missing was a clear, structured response when no renderer is available, and a deliberate tier decision (the `external` tier auto-permits `git.push` etc., which is wrong for the assistant). Both are fixed here.

The launch-provisioning that routes the CLI onto the `action` path is sibling work (#10638, env-contract wiring already landed on develop).

## Testing

349 tests green. New tests cover the headless `CONFIRMATION_REQUIRED` branch, the cold-cache `EXECUTION_ERROR` branch, the renderer-modal fallback, and the tier auth floor.