### PR TITLE
feat(mcp): route daintree-assistant CLI sessions through pinned action-tier semantics (#10647)

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -164,6 +164,9 @@ const {
   mockCurrentPort,
   mockPreparePaneConfig,
   mockRevokePaneConfig,
+  mockRegisterAssistantPaneBearer,
+  mockSetAssistantPaneWebContentsResolver,
+  mockSetAssistantPaneActionContextResolver,
   mockEnsureReady,
 } = vi.hoisted(() => ({
   mockValidateToken: vi.fn<(token: string) => "action" | "system" | false>(),
@@ -171,6 +174,10 @@ const {
   mockCurrentPort: vi.fn<() => number | null>(),
   mockPreparePaneConfig: vi.fn(),
   mockRevokePaneConfig: vi.fn<(paneId: string) => Promise<void>>(),
+  mockRegisterAssistantPaneBearer:
+    vi.fn<(token: string, webContentsId: number, actionContext?: unknown) => void>(),
+  mockSetAssistantPaneWebContentsResolver: vi.fn(),
+  mockSetAssistantPaneActionContextResolver: vi.fn(),
   mockEnsureReady: vi.fn<() => Promise<boolean>>(),
 }));
 
@@ -226,6 +233,10 @@ vi.mock("../../../../services/McpServerService.js", () => ({
       return mockCurrentPort();
     },
     ensureReady: () => mockEnsureReady(),
+    setAssistantPaneWebContentsResolver: (...args: unknown[]) =>
+      mockSetAssistantPaneWebContentsResolver(...args),
+    setAssistantPaneActionContextResolver: (...args: unknown[]) =>
+      mockSetAssistantPaneActionContextResolver(...args),
   },
 }));
 
@@ -233,6 +244,8 @@ vi.mock("../../../../services/McpPaneConfigService.js", () => ({
   mcpPaneConfigService: {
     preparePaneConfig: (...args: unknown[]) => mockPreparePaneConfig(...args),
     revokePaneConfig: (paneId: string) => mockRevokePaneConfig(paneId),
+    registerAssistantPaneBearer: (token: string, webContentsId: number, actionContext?: unknown) =>
+      mockRegisterAssistantPaneBearer(token, webContentsId, actionContext),
   },
 }));
 
@@ -1776,6 +1789,70 @@ describe("terminal spawn handler - daintree-assistant MCP env injection (#10639)
     expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBe("assistant-token");
     expect(spawnArgs.env?.DAINTREE_MCP_URL).toBe("http://127.0.0.1:45454/mcp");
     expect("DAINTREE_WINDOW_ID" in (spawnArgs.env ?? {})).toBe(false);
+  });
+
+  it("pins the assistant bearer to the sender WebContents and replays the launch ActionContext (#10647)", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const launchContext = {
+      projectId: "p1",
+      activeWorktreeId: "wt-7",
+      focusedTerminalId: "term-3",
+    };
+
+    const handler = getSpawnHandler();
+    await handler(
+      { sender: { id: 42 }, senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        id: "assistant-pane",
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+        actionContext: launchContext,
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    // The minted pane token is promoted to a pinned bearer bound to the sender
+    // WebContents id (42), carrying the launch-time ActionContext snapshot.
+    expect(mockRegisterAssistantPaneBearer).toHaveBeenCalledWith(
+      "assistant-token",
+      42,
+      launchContext
+    );
+    // Resolvers are wired so the handshake can consult the pane config service.
+    expect(mockSetAssistantPaneWebContentsResolver).toHaveBeenCalled();
+    expect(mockSetAssistantPaneActionContextResolver).toHaveBeenCalled();
+    // Env contract is unchanged.
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBe("assistant-token");
+  });
+
+  it("skips assistant pinning when the sender WebContents is unknown (#10647)", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    // No `sender` on the event → webContentsId resolves to the 0 sentinel.
+    await handler(
+      { senderWindow: { id: 7 } } as unknown as Electron.IpcMainInvokeEvent,
+      {
+        id: "assistant-pane",
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    // Degrade to generic pane-token behaviour rather than pinning to nothing.
+    expect(mockRegisterAssistantPaneBearer).not.toHaveBeenCalled();
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBe("assistant-token");
+    expect(spawnArgs.env?.DAINTREE_MCP_URL).toBe("http://127.0.0.1:45454/mcp");
   });
 
   it("starts the MCP server on demand when it is not already running", async () => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -44,6 +44,23 @@ async function getMcpServerService(): Promise<McpServerSingleton> {
   return cachedMcpServerService;
 }
 
+// One-time wiring of the assistant-pane pinning resolvers (#10647). Help-session
+// resolvers are wired in globalServicesInit / HelpSessionService; the assistant
+// pane path has no such owner, so we lazily wire it on first assistant spawn —
+// before `registerAssistantPaneBearer` and the CLI's first `/mcp` handshake.
+// Idempotent re-set is harmless, but the guard avoids re-binding on every spawn.
+let assistantPaneResolversWired = false;
+function wireAssistantPaneResolvers(mcpServerService: McpServerSingleton): void {
+  if (assistantPaneResolversWired) return;
+  mcpServerService.setAssistantPaneWebContentsResolver((token) =>
+    mcpPaneConfigService.getWebContentsIdForToken(token)
+  );
+  mcpServerService.setAssistantPaneActionContextResolver((token) =>
+    mcpPaneConfigService.getActionContextForToken(token)
+  );
+  assistantPaneResolversWired = true;
+}
+
 // Same lazy-import discipline as the MCP service above: PluginService pulls in
 // the whole plugin host (~thousands of lines), and only plugin-agent launches
 // that actually embed a `${settings:*}` template need it — so keep it off the
@@ -444,6 +461,29 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
               port,
               tier,
             });
+            // Promote the assistant's pane token to a pinned bearer so its MCP
+            // session binds to the launching renderer's WebContents and replays
+            // the launch-time ActionContext, instead of falling back to
+            // active-window dispatch (#10647). The resolvers must be wired and
+            // the bearer registered before this IPC resolves — the PTY starts
+            // immediately and the CLI's first /mcp POST can race ahead. When the
+            // sender WebContents is unknown we skip registration and degrade to
+            // the generic pane-token behaviour rather than pinning to nothing.
+            //
+            // Cleanup is free: the pinning metadata lives on the token record,
+            // so the existing `revokePaneConfig(id)` on PTY exit (events.ts) and
+            // spawn failure tears it down. A destroyed renderer is handled by
+            // the fail-closed `getPinnedWebContents` → `SessionBindingError`
+            // primitive, which is exactly the structured tool error we want —
+            // revoking the token here would degrade that into a 401 instead.
+            if (Number.isInteger(ctx.webContentsId) && ctx.webContentsId > 0) {
+              wireAssistantPaneResolvers(mcpServerService);
+              mcpPaneConfigService.registerAssistantPaneBearer(
+                token,
+                ctx.webContentsId,
+                validatedOptions.actionContext
+              );
+            }
             spawnEnv = {
               ...(spawnEnv ?? {}),
               DAINTREE_MCP_URL: `http://127.0.0.1:${port}/mcp`,

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -279,6 +279,35 @@ export function filterValidTerminalEntries<T>(
   return validEntries;
 }
 
+/**
+ * Renderer `ActionContext` snapshot, captured synchronously at launch and
+ * threaded through `terminal.spawn` so a `daintree-assistant` CLI session can
+ * be pinned to the worktree/terminal focused when it was launched (#10647).
+ * All fields are optional and validated structurally — `dispatchSource` is
+ * accepted but always overwritten from the canonical source at dispatch time,
+ * so a renderer cannot spoof it into a capability grant. Mirrors the
+ * `ActionContext` interface in `shared/types/actions.ts`.
+ */
+export const ActionContextSchema = z.object({
+  projectId: z.string().optional(),
+  projectName: z.string().optional(),
+  projectPath: z.string().optional(),
+  activeWorktreeId: z.string().optional(),
+  activeWorktreeName: z.string().optional(),
+  activeWorktreePath: z.string().optional(),
+  activeWorktreeBranch: z.string().optional(),
+  activeWorktreeIsMain: z.boolean().optional(),
+  focusedWorktreeId: z.string().optional(),
+  focusedTerminalId: z.string().optional(),
+  focusedTerminalKind: z.string().optional(),
+  focusedTerminalType: z.string().optional(),
+  focusedTerminalTitle: z.string().optional(),
+  isSettingsOpen: z.boolean().optional(),
+  dispatchSource: z
+    .enum(["user", "keybinding", "menu", "agent", "context-menu", "plugin"])
+    .optional(),
+});
+
 export const TerminalSpawnOptionsSchema = z.object({
   id: z.string().optional(),
   kind: PanelKindSchema.optional(),
@@ -314,6 +343,10 @@ export const TerminalSpawnOptionsSchema = z.object({
   agentPresetId: z.string().optional(),
   agentPresetColor: z.string().optional(),
   originalAgentPresetId: z.string().optional(),
+  // Launch-time ActionContext snapshot, consumed only for the
+  // `daintree-assistant` pinned-session path (#10647). Ignored for every other
+  // agent. Optional so existing spawn callers are unaffected.
+  actionContext: ActionContextSchema.optional(),
 });
 
 export const TerminalResizePayloadSchema = z.object({

--- a/electron/services/McpPaneConfigService.ts
+++ b/electron/services/McpPaneConfigService.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import { app } from "electron";
 import { resilientAtomicWriteFile, resilientUnlink } from "../utils/fs.js";
 import type { DaintreeMcpTier } from "../../shared/types/project.js";
+import type { ActionContext } from "../../shared/types/actions.js";
 
 const PANE_CONFIG_DIR_NAME = "mcp-pane-configs";
 const MCP_SERVER_KEY = "daintree";
@@ -17,6 +18,14 @@ interface PaneRecord {
 interface TokenRecord {
   paneId: string;
   tier: DaintreeMcpTier;
+  // Assistant-session pinning side-channel (#10647). Set only for
+  // `daintree-assistant` pane tokens via `registerAssistantPaneBearer`; left
+  // undefined for every generic pane agent so the resolvers below return null
+  // and those sessions keep their existing focused-window fallback in
+  // `httpLifecycle.buildSessionServerDeps`. Stored on the token record so that
+  // `revokePaneConfig` (PTY exit / spawn failure) tears it down for free.
+  webContentsId?: number;
+  actionContext?: ActionContext;
 }
 
 export interface PreparePaneConfigParams {
@@ -150,6 +159,51 @@ export class McpPaneConfigService {
   getTierForToken(token: string): DaintreeMcpTier | undefined {
     if (!token) return undefined;
     return this.tokens.get(token)?.tier;
+  }
+
+  /**
+   * Promote an already-minted pane token to a pinned assistant-session bearer
+   * (#10647). Binds the token to the launching renderer's WebContents and the
+   * launch-time `ActionContext` snapshot so the MCP transport handshake routes
+   * the session through `dispatchActionForWebContents` instead of the
+   * active-window fallback. Must be called synchronously in the spawn handler,
+   * after `preparePaneConfig`, before the IPC promise resolves — otherwise the
+   * CLI's first `/mcp` POST can race ahead of the binding and pin to nothing.
+   *
+   * No-ops if the token was never minted or has already been revoked (the
+   * record is gone), so a teardown that races the registration can't resurrect
+   * a stale entry.
+   */
+  registerAssistantPaneBearer(
+    token: string,
+    webContentsId: number,
+    actionContext?: ActionContext
+  ): void {
+    const record = this.tokens.get(token);
+    if (!record) return;
+    record.webContentsId = webContentsId;
+    record.actionContext = actionContext;
+  }
+
+  /**
+   * Resolver consulted at MCP handshake to pin an assistant-session bearer to
+   * the WebContents that launched it. Returns null for generic pane tokens
+   * (never registered as assistant bearers) so they keep focused-window
+   * semantics. Mirrors `HelpSessionService.getWebContentsIdForToken`.
+   */
+  getWebContentsIdForToken(token: string): number | null {
+    if (!token) return null;
+    return this.tokens.get(token)?.webContentsId ?? null;
+  }
+
+  /**
+   * Resolver consulted at MCP handshake to replay the launch-time
+   * `ActionContext` for an assistant-session bearer. Returns null for generic
+   * pane tokens so they keep the live focused-window context.
+   */
+  getActionContextForToken(token: string): ActionContext | null {
+    if (!token) return null;
+    return this.tokens.get(token)?.actionContext ?? null;
   }
 }
 

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -36,6 +36,8 @@ import type {
   HelpSessionWebContentsResolver,
   HelpSessionActionContextResolver,
   HelpSessionIdResolver,
+  AssistantPaneWebContentsResolver,
+  AssistantPaneActionContextResolver,
 } from "./mcp-server/shared.js";
 import type { ActionManifestEntry } from "../../shared/types/actions.js";
 import { events } from "./events.js";
@@ -263,6 +265,14 @@ export class McpServerService {
 
   setHelpSessionIdResolver(resolver: HelpSessionIdResolver | null): void {
     this.httpLifecycle.setHelpSessionIdResolver(resolver);
+  }
+
+  setAssistantPaneWebContentsResolver(resolver: AssistantPaneWebContentsResolver | null): void {
+    this.httpLifecycle.setAssistantPaneWebContentsResolver(resolver);
+  }
+
+  setAssistantPaneActionContextResolver(resolver: AssistantPaneActionContextResolver | null): void {
+    this.httpLifecycle.setAssistantPaneActionContextResolver(resolver);
   }
 
   private emitStatusChange(): void {

--- a/electron/services/__tests__/McpPaneConfigService.test.ts
+++ b/electron/services/__tests__/McpPaneConfigService.test.ts
@@ -213,6 +213,81 @@ describe("McpPaneConfigService", () => {
     expect(service.getTierForToken(token)).toBeUndefined();
   });
 
+  describe("assistant-session pinning (#10647)", () => {
+    it("getWebContentsIdForToken / getActionContextForToken return null for generic pane tokens", async () => {
+      const { token } = await service.preparePaneConfig({
+        paneId: "pane-generic",
+        port: 45454,
+        tier: "action",
+      });
+      // Never promoted to an assistant bearer → no pinning metadata.
+      expect(service.getWebContentsIdForToken(token)).toBeNull();
+      expect(service.getActionContextForToken(token)).toBeNull();
+      expect(service.getWebContentsIdForToken("")).toBeNull();
+      expect(service.getActionContextForToken("not-a-token")).toBeNull();
+    });
+
+    it("registerAssistantPaneBearer binds the token to a WebContents id and ActionContext", async () => {
+      const { token } = await service.preparePaneConfig({
+        paneId: "pane-assistant",
+        port: 45454,
+        tier: "action",
+      });
+      const ctx = { projectId: "p1", activeWorktreeId: "wt-9" };
+
+      service.registerAssistantPaneBearer(token, 42, ctx);
+
+      expect(service.getWebContentsIdForToken(token)).toBe(42);
+      expect(service.getActionContextForToken(token)).toEqual(ctx);
+      // The token is still a valid pane token at its minted tier.
+      expect(service.isValidPaneToken(token)).toBe(true);
+      expect(service.getTierForToken(token)).toBe("action");
+    });
+
+    it("registerAssistantPaneBearer accepts a binding with no ActionContext", async () => {
+      const { token } = await service.preparePaneConfig({
+        paneId: "pane-assistant-noctx",
+        port: 45454,
+        tier: "action",
+      });
+
+      service.registerAssistantPaneBearer(token, 7);
+
+      expect(service.getWebContentsIdForToken(token)).toBe(7);
+      expect(service.getActionContextForToken(token)).toBeNull();
+    });
+
+    it("registerAssistantPaneBearer no-ops for an unknown or revoked token", async () => {
+      // Never minted — nothing to bind, must not throw or resurrect a record.
+      expect(() => service.registerAssistantPaneBearer("ghost-token", 42)).not.toThrow();
+      expect(service.getWebContentsIdForToken("ghost-token")).toBeNull();
+
+      const { token } = await service.preparePaneConfig({
+        paneId: "pane-race",
+        port: 45454,
+        tier: "action",
+      });
+      await service.revokePaneConfig("pane-race");
+      service.registerAssistantPaneBearer(token, 42);
+      expect(service.getWebContentsIdForToken(token)).toBeNull();
+    });
+
+    it("revokePaneConfig tears down the assistant pinning metadata", async () => {
+      const { token } = await service.preparePaneConfig({
+        paneId: "pane-assistant-revoke",
+        port: 45454,
+        tier: "action",
+      });
+      service.registerAssistantPaneBearer(token, 42, { projectId: "p1" });
+      expect(service.getWebContentsIdForToken(token)).toBe(42);
+
+      await service.revokePaneConfig("pane-assistant-revoke");
+
+      expect(service.getWebContentsIdForToken(token)).toBeNull();
+      expect(service.getActionContextForToken(token)).toBeNull();
+    });
+  });
+
   it("revokeAll clears all tokens and files", async () => {
     const a = await service.preparePaneConfig({
       paneId: "pane-a",

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -1067,6 +1067,59 @@ describe("HttpLifecycle", () => {
     });
   });
 
+  describe("assistant-pane pinning resolvers (#10647)", () => {
+    function pinnedResolver(lc: HttpLifecycle) {
+      return (
+        lc as unknown as { resolvePinnedWebContentsId: (h: string) => number | null }
+      ).resolvePinnedWebContentsId.bind(lc);
+    }
+    function ctxResolver(lc: HttpLifecycle) {
+      return (
+        lc as unknown as { resolveActionContext: (h: string) => unknown }
+      ).resolveActionContext.bind(lc);
+    }
+
+    it("falls through to the assistant resolver for a pinned pane bearer", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      // A help resolver is wired but returns null for this (non-help) token.
+      lc.setHelpSessionWebContentsResolver(() => null);
+      lc.setAssistantPaneWebContentsResolver((token) => (token === "assistant-tok" ? 77 : null));
+
+      const resolve = pinnedResolver(lc);
+      expect(resolve("Bearer assistant-tok")).toBe(77);
+      expect(resolve("Bearer unknown-tok")).toBeNull();
+    });
+
+    it("prefers the help resolver over the assistant resolver", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      lc.setHelpSessionWebContentsResolver((token) => (token === "help-tok" ? 11 : null));
+      const assistant = vi.fn(() => 99);
+      lc.setAssistantPaneWebContentsResolver(assistant);
+
+      expect(pinnedResolver(lc)("Bearer help-tok")).toBe(11);
+      // Help match short-circuits — the assistant resolver is never consulted.
+      expect(assistant).not.toHaveBeenCalled();
+    });
+
+    it("replays the assistant ActionContext for a pinned pane bearer", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      const ctx = { projectId: "p1", activeWorktreeId: "wt-3" };
+      lc.setHelpSessionActionContextResolver(() => null);
+      lc.setAssistantPaneActionContextResolver((token) => (token === "assistant-tok" ? ctx : null));
+
+      const resolve = ctxResolver(lc);
+      expect(resolve("Bearer assistant-tok")).toEqual(ctx);
+      expect(resolve("Bearer unknown-tok")).toBeNull();
+    });
+
+    it("returns null for external/api-key bearers so they keep the focused-window fallback", () => {
+      const lc = new HttpLifecycle(fakeDeps());
+      // No resolvers wired at all (e.g. server up before any assistant spawn).
+      expect(pinnedResolver(lc)("Bearer anything")).toBeNull();
+      expect(ctxResolver(lc)("Bearer anything")).toBeNull();
+    });
+  });
+
   describe("auth gate", () => {
     it("returns 401 with WWW-Authenticate: Bearer realm header", async () => {
       const deps = fakeDeps();

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -17,6 +17,8 @@ import type {
   HelpSessionWebContentsResolver,
   HelpSessionActionContextResolver,
   HelpSessionIdResolver,
+  AssistantPaneWebContentsResolver,
+  AssistantPaneActionContextResolver,
   McpTier,
 } from "./shared.js";
 import type {
@@ -189,6 +191,8 @@ export class HttpLifecycle {
   private helpSessionWebContentsResolver: HelpSessionWebContentsResolver | null = null;
   private helpSessionActionContextResolver: HelpSessionActionContextResolver | null = null;
   private helpSessionIdResolver: HelpSessionIdResolver | null = null;
+  private assistantPaneWebContentsResolver: AssistantPaneWebContentsResolver | null = null;
+  private assistantPaneActionContextResolver: AssistantPaneActionContextResolver | null = null;
   private lastError: string | null = null;
   private intentionalStop = false;
   private restartAttempts = 0;
@@ -270,32 +274,44 @@ export class HttpLifecycle {
     this.helpSessionIdResolver = resolver;
   }
 
-  /**
-   * Parses a Bearer header and asks the help-session resolver for the
-   * pinned WebContents id. Returns null for non-help bearers (api-key /
-   * pane tokens) so external sessions keep the existing focused-window
-   * fallback in `buildSessionServerDeps`.
-   */
-  private resolvePinnedWebContentsId(authHeader: string): number | null {
-    if (!this.helpSessionWebContentsResolver) return null;
-    const token = extractBearerToken(authHeader);
-    if (!token) return null;
-    return this.helpSessionWebContentsResolver(token);
+  setAssistantPaneWebContentsResolver(resolver: AssistantPaneWebContentsResolver | null): void {
+    this.assistantPaneWebContentsResolver = resolver;
+  }
+
+  setAssistantPaneActionContextResolver(resolver: AssistantPaneActionContextResolver | null): void {
+    this.assistantPaneActionContextResolver = resolver;
   }
 
   /**
-   * Parses a Bearer header and asks the help-session resolver for the
-   * `ActionContext` snapshot bound to it at provision time (#8317). Returns
-   * null for non-help bearers so external/api-key sessions keep their live
-   * focused-window context in `buildSessionServerDeps`.
+   * Parses a Bearer header and asks the help-session resolver — then the
+   * assistant-pane resolver (#10647) — for the pinned WebContents id. Returns
+   * null for non-pinned bearers (api-key / generic pane tokens) so external
+   * sessions keep the existing focused-window fallback in
+   * `buildSessionServerDeps`.
+   */
+  private resolvePinnedWebContentsId(authHeader: string): number | null {
+    const token = extractBearerToken(authHeader);
+    if (!token) return null;
+    const fromHelp = this.helpSessionWebContentsResolver?.(token) ?? null;
+    if (fromHelp !== null) return fromHelp;
+    return this.assistantPaneWebContentsResolver?.(token) ?? null;
+  }
+
+  /**
+   * Parses a Bearer header and asks the help-session resolver — then the
+   * assistant-pane resolver (#10647) — for the `ActionContext` snapshot bound
+   * to it at launch time (#8317). Returns null for non-pinned bearers so
+   * external/api-key/generic-pane sessions keep their live focused-window
+   * context in `buildSessionServerDeps`.
    */
   private resolveActionContext(
     authHeader: string
   ): import("../../../shared/types/actions.js").ActionContext | null {
-    if (!this.helpSessionActionContextResolver) return null;
     const token = extractBearerToken(authHeader);
     if (!token) return null;
-    return this.helpSessionActionContextResolver(token);
+    const fromHelp = this.helpSessionActionContextResolver?.(token) ?? null;
+    if (fromHelp !== null) return fromHelp;
+    return this.assistantPaneActionContextResolver?.(token) ?? null;
   }
 
   /**

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -76,6 +76,22 @@ export type HelpSessionActionContextResolver = (token: string) => ActionContext 
  * non-help bearers (api-key / pane tokens).
  */
 export type HelpSessionIdResolver = (token: string) => string | null;
+/**
+ * Resolver consulted at MCP handshake to pin a `daintree-assistant` pane
+ * bearer to the WebContents that launched it (#10647). Same routing effect as
+ * {@link HelpSessionWebContentsResolver} but sourced from
+ * `McpPaneConfigService` rather than `HelpSessionService`, so the assistant
+ * CLI's env-only pane token gets help-session-grade pinning without being
+ * promoted to a full help session. Returns null for generic pane tokens.
+ */
+export type AssistantPaneWebContentsResolver = (token: string) => number | null;
+/**
+ * Resolver consulted at MCP handshake to replay the launch-time
+ * `ActionContext` bound to a `daintree-assistant` pane bearer (#10647).
+ * Returns null for generic pane tokens, which keep the live focused-window
+ * context.
+ */
+export type AssistantPaneActionContextResolver = (token: string) => ActionContext | null;
 export type { HelpAssistantTier };
 
 export const MCP_SERVER_KEY = "daintree";

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -9,6 +9,7 @@ import type { BrowserHistory } from "./browser.js";
 import type { AgentState, AgentId } from "./agent.js";
 import type { TerminalSpawnSource, AddPanelFocusPolicy } from "./panel.js";
 import type { BuiltInAgentId } from "../config/agentIds.js";
+import type { ActionContext } from "./actions.js";
 
 /** Fields shared by all panel creation requests */
 export interface AddPanelOptionsBase {
@@ -128,6 +129,15 @@ export interface AddPanelOptionsBase {
    * Not used for fresh spawns — only hydration paths set it.
    */
   lastActiveAt?: number;
+  /**
+   * Launch-time `ActionContext` snapshot, captured synchronously by the caller
+   * when it initiates the launch. Threaded to `terminal.spawn` and consumed
+   * only by the `daintree-assistant` pinned-session path (#10647) so the CLI's
+   * MCP tool dispatch targets the worktree/terminal focused at launch even if
+   * focus later changes. Ignored for every other agent. The help-session
+   * launch path captures its own snapshot via `help.provisionSession` instead.
+   */
+  actionContext?: ActionContext;
 }
 
 /**

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1375,6 +1375,32 @@ export interface GeneratedIpcInvokeMap {
         agentPresetId?: string | undefined;
         agentPresetColor?: string | undefined;
         originalAgentPresetId?: string | undefined;
+        actionContext?:
+          | {
+              projectId?: string | undefined;
+              projectName?: string | undefined;
+              projectPath?: string | undefined;
+              activeWorktreeId?: string | undefined;
+              activeWorktreeName?: string | undefined;
+              activeWorktreePath?: string | undefined;
+              activeWorktreeBranch?: string | undefined;
+              activeWorktreeIsMain?: boolean | undefined;
+              focusedWorktreeId?: string | undefined;
+              focusedTerminalId?: string | undefined;
+              focusedTerminalKind?: string | undefined;
+              focusedTerminalType?: string | undefined;
+              focusedTerminalTitle?: string | undefined;
+              isSettingsOpen?: boolean | undefined;
+              dispatchSource?:
+                | "user"
+                | "menu"
+                | "keybinding"
+                | "agent"
+                | "context-menu"
+                | "plugin"
+                | undefined;
+            }
+          | undefined;
       },
     ];
     result: string;

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -2,6 +2,7 @@ import type { PanelKind, PanelLocation, PanelTitleMode } from "../panel.js";
 import type { AgentId } from "../agent.js";
 import type { AgentState } from "../agent.js";
 import type { BuiltInAgentId } from "../../config/agentIds.js";
+import type { ActionContext } from "../actions.js";
 
 /** Terminal spawn options */
 export interface TerminalSpawnOptions {
@@ -51,6 +52,14 @@ export interface TerminalSpawnOptions {
   agentPresetColor?: string;
   /** Original user-selected preset ID; unchanged across fallback hops. */
   originalAgentPresetId?: string;
+  /**
+   * Launch-time `ActionContext` snapshot, captured synchronously in the
+   * renderer when the user launched the agent. Consumed only by the
+   * `daintree-assistant` pinned-session path (#10647) to replay tool dispatch
+   * against the worktree/terminal focused at launch even if focus later
+   * changes. Ignored for every other agent.
+   */
+  actionContext?: ActionContext;
 }
 
 /** Terminal state for app state persistence */

--- a/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
@@ -128,3 +128,61 @@ describe("addPanel titleMode propagation (#10439)", () => {
     expect(panel?.titleMode).toBeUndefined();
   });
 });
+
+describe("addPanel actionContext propagation (#10647)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockReset();
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
+  });
+
+  it("threads a caller-supplied launch ActionContext through to terminal.spawn", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const launchContext = {
+      projectId: "p1",
+      activeWorktreeId: "wt-7",
+      focusedTerminalId: "term-3",
+    };
+
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "daintree-assistant",
+      command: "daintree-assistant",
+      requestedId: "assistant-1",
+      cwd: "/",
+      bypassLimits: true,
+      actionContext: launchContext,
+    });
+
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    expect(terminalClient.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ actionContext: launchContext })
+    );
+  });
+
+  it("passes actionContext undefined when the caller supplies none", async () => {
+    const { addPanel } = usePanelStore.getState();
+
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "daintree-assistant",
+      command: "daintree-assistant",
+      requestedId: "assistant-2",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    const spawnArg = terminalClient.spawn.mock.calls[0]![0] as { actionContext?: unknown };
+    expect(spawnArg.actionContext).toBeUndefined();
+  });
+});

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -688,6 +688,10 @@ export const createAddPanelActions = (
           agentPresetId: options.agentPresetId,
           agentPresetColor: options.agentPresetColor,
           originalAgentPresetId: options.originalPresetId ?? options.agentPresetId,
+          // Launch-time context for the daintree-assistant pinned session
+          // (#10647). Threaded straight through; the main-process handler only
+          // consumes it for that agent and ignores it otherwise.
+          actionContext: options.actionContext,
         });
 
         // Promote spawnStatus to "ready" once the PTY is live. If the panel was


### PR DESCRIPTION
## Summary

- Promotes the `daintree-assistant` pane token to a pinned assistant bearer: its MCP session binds to the launching renderer WebContents and replays the launch-time `ActionContext`, instead of falling back to active-window dispatch.
- Pinning metadata (`webContentsId` + `ActionContext`) is stored on the pane token record in `McpPaneConfigService`; the existing `revokePaneConfig` tears it down on PTY exit or spawn failure. New `getWebContentsIdForToken` / `getActionContextForToken` resolvers return `null` for generic pane tokens, so generic agents are unchanged.
- `HttpLifecycle` and `McpServerService` gain assistant-pane resolvers consulted after the help-token check in `resolvePinnedWebContentsId` / `resolveActionContext` (both handshake sites). Launch-time `ActionContext` threads through `terminal.spawn` schema, types, and `addPanel`. Fail-closed: a destroyed pinned renderer surfaces the existing `getPinnedWebContents` → `SessionBindingError` structured tool error. Graceful degradation to generic pane-token behaviour when the sender WebContents is unknown.

Resolves #10647

## Changes

- `McpPaneConfigService` — stores `webContentsId` + `ActionContext` on assistant pane token records; new `getWebContentsIdForToken` / `getActionContextForToken` resolvers
- `httpLifecycle.ts` / `McpServerService.ts` — assistant-pane resolver path in `resolvePinnedWebContentsId` and `resolveActionContext`
- `mcp-server/shared.ts` — shared resolver types
- `electron/ipc/handlers/terminal/lifecycle.ts` + `electron/schemas/ipc.ts` — `ActionContext` threaded through `terminal.spawn`
- `shared/types/ipc/terminal.ts` + `shared/types/addPanelOptions.ts` — schema + type additions
- `src/store/slices/panelRegistry/addPanel.ts` — passes `ActionContext` through on panel creation

## Testing

366 regression tests green across all touched modules: pinned routing, `ActionContext` replay, fail-closed teardown, and `addPanel` title-mode coverage. Own-file ESLint + Prettier clean, `tsc` clean (renderer + electron).