### PR TITLE
feat(assistant): define native-host protocol contract (#10649)

### DIFF
--- a/docs/architecture/assistant-native-host.md
+++ b/docs/architecture/assistant-native-host.md
@@ -1,0 +1,66 @@
+# Assistant native-host boundary
+
+Status: contract defined, runtime deferred. This doc specifies the boundary between the `daintree-assistant` runtime and Daintree's main/renderer surfaces (#10649). The protocol types live in [`shared/types/ipc/assistantHost.ts`](../../shared/types/ipc/assistantHost.ts); their Zod validators live in the assistant-native-host section of [`electron/schemas/ipc.ts`](../../electron/schemas/ipc.ts). For the broader process topology this plugs into, see [process-and-window-model.md](./process-and-window-model.md); for the MCP event surfaces it reuses, see [mcp-server.md](./mcp-server.md).
+
+## Why this exists
+
+Today the assistant runs as a CLI/Ink child process spawned through `terminal.spawn` and wrapped in an xterm pane (`HelpPanel`). Conversation content — user prompts, model text, tool arguments and results — is only ever terminal bytes; the single structured signals are the MCP-server events in `mcpServer.ts` (tool-call started/settled, turn-outcome alerts, the figure rail), already pushed to the pinned renderer. To render conversation, tool calls, and approvals as native React — and reuse Daintree's own confirmation, grant, audit, and notification surfaces rather than rebuilding them — the runtime needs a structured boundary instead of a terminal. This doc is that boundary.
+
+The boundary is defined now and wired later. Two prerequisites named in #10649 are unbuilt: the workflow ledger, and the `@daintreehq/daintree-assistant` package emitting the structured turn events below. Landing the contract first lets the host plug in without a protocol redesign, and keeps the CLI/Ink path as the default and the fallback throughout.
+
+## Runtime shape (decision)
+
+When the runtime is wired, the host is an Electron `utilityProcess.fork()` child — not a managed CLI, not an in-process embed, not a localhost sidecar. Rationale:
+
+- Three existing precedents (`pty-host`, `workspace-host`, the plugin dev worker) already use `utilityProcess.fork()` with `parentPort` for structured IPC and a `MessageChannelMain` port handed to the renderer. The assistant host follows the same pattern rather than inventing a fourth.
+- A utility process gives a clean Node environment with no Chromium, carries structured JSON over the V8 structured clone (no PTY byte encoding), and is crash-supervised via `utilityProcess.on("exit")`.
+- In-process embedding is rejected — an assistant-SDK crash would take down the main process. A localhost HTTP/WebSocket sidecar is rejected — it adds port binding, collision risk, and socket overhead that a `MessagePort` does not.
+
+The CLI/Ink form stays available for development via the existing `daintree-assistant` agent id and its env-only MCP injection (`tier: "experimental"`). The native host is a separate code branch, never a replacement for that path.
+
+## Message protocol
+
+Two discriminated unions, both versioned by `ASSISTANT_HOST_PROTOCOL_VERSION`. The host announces the version it speaks in `host:ready`; Daintree refuses a mismatch rather than guessing at an unknown shape. The main process validates every inbound host message against `AssistantHostEventSchema` before forwarding to the renderer — a malformed or unknown-`type` message is dropped, never partially applied.
+
+### Host → Daintree (`AssistantHostEvent`)
+
+| Type | Meaning |
+| --- | --- |
+| `host:ready` | Booted, MCP-connected, ready for commands; carries the protocol version and any adopted resume handle. |
+| `turn:start` | A conversation turn began (`user` or `assistant`). |
+| `turn:token` | An incremental text chunk for an in-flight `assistant` turn. |
+| `turn:end` | A turn completed, with an optional audit-aligned `TurnOutcomeClass`. |
+| `tool:started` | A tool dispatch entered the call path; mirrors `McpToolCallStartedPayload` plus a stable `toolCallId`. |
+| `tool:settled` | A tool dispatch settled, with audit-aligned `result`/`severity`. |
+| `approval:requested` | The runtime is awaiting a `danger: "confirm"` decision; Daintree surfaces its own `ConfirmDialog`. |
+| `approval:decided` | A prior approval resolved (`approved`/`rejected`/`timeout`). |
+| `host:error` | A non-fatal error to surface, with a stable `code`. |
+| `host:shutdown` | The host is winding down (`hibernate`/`revoke`/`error`/`exit`), with a resume handle when hibernating. |
+
+### Daintree → host (`AssistantHostCommand`)
+
+| Type              | Meaning                                            |
+| ----------------- | -------------------------------------------------- |
+| `prompt`          | Submit a user prompt to start a turn.              |
+| `approval:decide` | Answer an outstanding `approval:requested`.        |
+| `interrupt`       | Stop the in-flight turn.                           |
+| `hibernate`       | Capture a resume handle and wind the runtime down. |
+| `shutdown`        | Tear the runtime down for good.                    |
+
+The fork-time `AssistantHostSessionDescriptor` is handed over once at spawn, not as a command, so every command is a post-handshake control signal.
+
+## Invariants
+
+These are the load-bearing rules every future wiring step must preserve. They encode hard-won lessons; breaking one reintroduces a known incident class.
+
+1. **Every event and command carries `sessionId`, and delivery is pinned, never broadcast** (#7003). The main process resolves the session's minting `WebContents` and sends only there, failing closed if the view is gone. The schemas reject any message missing `sessionId` so a message that cannot be pinned cannot exist.
+2. **Secrets travel via env, not messages.** The descriptor carries no bearer token and no MCP URL — those reach the host through `DAINTREE_MCP_URL` / `DAINTREE_MCP_TOKEN` / `DAINTREE_WINDOW_ID`, mirroring the existing env-only injection. `AssistantHostSessionDescriptorSchema` is `.strict()` and rejects a descriptor that smuggles a `token` or `mcpUrl` field, so a leaked port message can never carry the secret.
+3. **One backend per project** (#7522). When the runtime is wired, provisioning must displace both PTY-backed and host-backed sessions for the same project inside the existing provision lock, with a `markHostForSession` analog to `markTerminalForToken`, re-checking ownership after every `await` in teardown.
+4. **Outcome vocabularies stay audit-aligned.** `result`/`severity`/`decision`/`outcome` reuse the `mcpServer.ts` vocabularies (`McpAuditResult`, `McpAuditSeverity`, `McpConfirmationDecision`, `TurnOutcomeClass`) so the native timeline and the persisted audit log cannot drift.
+5. **The host bootstrap installs its error guard before any dynamic import** (#8833). The `utilityProcess` entry must call the bootstrap error guard synchronously before `await import(...)`; Electron 42 only warns on unhandled utility-process rejections, so a failed import otherwise hangs the readiness wait silently.
+
+## What is not in scope yet
+
+- No utility process is spawned and no IPC channel is registered — this slice is the contract and its validation only.
+- No conversation transcript renders natively until the `@daintreehq/daintree-assistant` package emits `turn:start`/`turn:token`/`turn:end`. Until then the xterm pane remains the conversation surface.
+- Workflow-ledger events are additive: when the ledger lands, its records layer onto this timeline without changing the event shapes above.

--- a/electron/schemas/__tests__/assistantHostProtocol.test.ts
+++ b/electron/schemas/__tests__/assistantHostProtocol.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from "vitest";
+import {
+  AssistantHostEventSchema,
+  AssistantHostSessionDescriptorSchema,
+  parseAssistantHostEvent,
+  parseAssistantHostCommand,
+  parseAssistantHostSessionDescriptor,
+  ASSISTANT_HOST_PROTOCOL_VERSION,
+} from "../ipc.js";
+import type {
+  AssistantHostEvent,
+  AssistantHostCommand,
+  AssistantHostSessionDescriptor,
+} from "../../../shared/types/ipc/assistantHost.js";
+
+// One valid representative for every event variant — keeps the discriminated
+// union honest: if a variant is added to the type without a schema arm (or
+// vice versa), the round-trip below stops covering it.
+const VALID_EVENTS: AssistantHostEvent[] = [
+  { type: "host:ready", sessionId: "s1", protocolVersion: ASSISTANT_HOST_PROTOCOL_VERSION },
+  { type: "turn:start", sessionId: "s1", turnId: "t1", role: "assistant", startedAt: 100 },
+  { type: "turn:token", sessionId: "s1", turnId: "t1", chunk: "hello" },
+  { type: "turn:end", sessionId: "s1", turnId: "t1", endedAt: 200, outcome: "answered" },
+  {
+    type: "tool:started",
+    sessionId: "s1",
+    toolCallId: "c1",
+    toolId: "fs.read",
+    argsSummary: "<object>",
+    startedAt: 150,
+    danger: false,
+  },
+  {
+    type: "tool:settled",
+    sessionId: "s1",
+    toolCallId: "c1",
+    toolId: "fs.read",
+    durationMs: 12,
+    result: "success",
+    severity: "info",
+  },
+  {
+    type: "approval:requested",
+    sessionId: "s1",
+    approvalId: "a1",
+    toolId: "git.push",
+    summary: "push to origin/main",
+    requestedAt: 300,
+  },
+  {
+    type: "approval:decided",
+    sessionId: "s1",
+    approvalId: "a1",
+    decision: "approved",
+    decidedAt: 320,
+  },
+  { type: "host:error", sessionId: "s1", code: "MCP_UNREACHABLE", message: "no transport" },
+  { type: "host:shutdown", sessionId: "s1", reason: "hibernate", resumeSessionId: "r9" },
+];
+
+const VALID_COMMANDS: AssistantHostCommand[] = [
+  { type: "prompt", sessionId: "s1", text: "how do I rebase?" },
+  { type: "approval:decide", sessionId: "s1", approvalId: "a1", decision: "rejected" },
+  { type: "interrupt", sessionId: "s1" },
+  { type: "hibernate", sessionId: "s1" },
+  { type: "shutdown", sessionId: "s1" },
+];
+
+describe("AssistantHostEventSchema", () => {
+  it.each(VALID_EVENTS)("round-trips the $type event unchanged", (event) => {
+    const parsed = parseAssistantHostEvent(event);
+    expect(parsed).toEqual(event);
+  });
+
+  it("rejects an unknown event type instead of guessing", () => {
+    expect(parseAssistantHostEvent({ type: "turn:middle", sessionId: "s1" })).toBeNull();
+  });
+
+  it("rejects any event missing sessionId (delivery cannot be pinned without it)", () => {
+    for (const event of VALID_EVENTS) {
+      const { sessionId: _omit, ...withoutSession } = event as { sessionId: string };
+      expect(AssistantHostEventSchema.safeParse(withoutSession).success).toBe(false);
+    }
+  });
+
+  it("rejects an empty sessionId", () => {
+    expect(parseAssistantHostEvent({ ...VALID_EVENTS[0], sessionId: "" })).toBeNull();
+  });
+
+  it("rejects a tool:settled result outside the audit vocabulary", () => {
+    const base = VALID_EVENTS.find((e) => e.type === "tool:settled")!;
+    expect(parseAssistantHostEvent({ ...base, result: "maybe" })).toBeNull();
+  });
+
+  it("rejects an approval decision outside the confirmation vocabulary", () => {
+    const base = VALID_EVENTS.find((e) => e.type === "approval:decided")!;
+    expect(parseAssistantHostEvent({ ...base, decision: "later" })).toBeNull();
+  });
+
+  it("drops a turn:end with an out-of-vocabulary outcome", () => {
+    const base = VALID_EVENTS.find((e) => e.type === "turn:end")!;
+    expect(parseAssistantHostEvent({ ...base, outcome: "vibes" })).toBeNull();
+  });
+});
+
+describe("AssistantHostCommandSchema", () => {
+  it.each(VALID_COMMANDS)("round-trips the $type command unchanged", (command) => {
+    expect(parseAssistantHostCommand(command)).toEqual(command);
+  });
+
+  it("rejects an unknown command type", () => {
+    expect(parseAssistantHostCommand({ type: "selfdestruct", sessionId: "s1" })).toBeNull();
+  });
+
+  it("rejects an approval:decide carrying an invalid decision", () => {
+    expect(
+      parseAssistantHostCommand({
+        type: "approval:decide",
+        sessionId: "s1",
+        approvalId: "a1",
+        decision: "perhaps",
+      })
+    ).toBeNull();
+  });
+
+  it("event and command discriminants do not overlap", () => {
+    const eventTypes = new Set(VALID_EVENTS.map((e) => e.type));
+    const commandTypes = VALID_COMMANDS.map((c) => c.type);
+    for (const t of commandTypes) {
+      // approval:decide (command) is distinct from approval:requested/decided (events)
+      expect(eventTypes.has(t as never)).toBe(false);
+    }
+  });
+});
+
+describe("AssistantHostSessionDescriptorSchema", () => {
+  const descriptor: AssistantHostSessionDescriptor = {
+    sessionId: "s1",
+    windowId: 3,
+    projectId: "proj-1",
+    cwd: "/tmp/worktree",
+    tier: "workbench",
+    protocolVersion: ASSISTANT_HOST_PROTOCOL_VERSION,
+  };
+
+  it("accepts a valid descriptor and an optional resume handle", () => {
+    expect(parseAssistantHostSessionDescriptor(descriptor)).toEqual(descriptor);
+    expect(
+      parseAssistantHostSessionDescriptor({ ...descriptor, resumeSessionId: "r1" })
+    ).toMatchObject({ resumeSessionId: "r1" });
+  });
+
+  it("rejects a descriptor that smuggles a bearer token (secrets travel via env, not messages)", () => {
+    expect(
+      parseAssistantHostSessionDescriptor({ ...descriptor, token: "secret-bearer" })
+    ).toBeNull();
+  });
+
+  it("rejects a descriptor that smuggles an mcpUrl field", () => {
+    expect(
+      parseAssistantHostSessionDescriptor({ ...descriptor, mcpUrl: "http://127.0.0.1:9000" })
+    ).toBeNull();
+  });
+
+  it("rejects a non-integer windowId", () => {
+    expect(
+      AssistantHostSessionDescriptorSchema.safeParse({ ...descriptor, windowId: 1.5 }).success
+    ).toBe(false);
+  });
+
+  it("rejects a non-positive protocol version", () => {
+    expect(
+      AssistantHostSessionDescriptorSchema.safeParse({ ...descriptor, protocolVersion: 0 }).success
+    ).toBe(false);
+  });
+});
+
+describe("AssistantHostCommandSchema / EventSchema separation", () => {
+  it("a command does not parse as an event", () => {
+    expect(parseAssistantHostEvent({ type: "prompt", sessionId: "s1", text: "hi" })).toBeNull();
+  });
+
+  it("an event does not parse as a command", () => {
+    expect(
+      parseAssistantHostCommand({ type: "turn:token", sessionId: "s1", turnId: "t1", chunk: "x" })
+    ).toBeNull();
+  });
+});

--- a/electron/schemas/__tests__/assistantHostProtocol.test.ts
+++ b/electron/schemas/__tests__/assistantHostProtocol.test.ts
@@ -173,6 +173,51 @@ describe("AssistantHostSessionDescriptorSchema", () => {
       AssistantHostSessionDescriptorSchema.safeParse({ ...descriptor, protocolVersion: 0 }).success
     ).toBe(false);
   });
+
+  it("rejects a negative windowId (matches the >= 0 invariant the service enforces)", () => {
+    expect(
+      AssistantHostSessionDescriptorSchema.safeParse({ ...descriptor, windowId: -1 }).success
+    ).toBe(false);
+  });
+
+  it("rejects a whitespace-only sessionId (would fail delivery pinning)", () => {
+    expect(parseAssistantHostSessionDescriptor({ ...descriptor, sessionId: "   " })).toBeNull();
+  });
+});
+
+describe("numeric and blank-id bounds on events", () => {
+  const turnEnd = VALID_EVENTS.find((e) => e.type === "turn:end")!;
+  const toolSettled = VALID_EVENTS.find((e) => e.type === "tool:settled")!;
+  const turnStart = VALID_EVENTS.find((e) => e.type === "turn:start")!;
+
+  it("rejects a negative timestamp", () => {
+    expect(parseAssistantHostEvent({ ...turnEnd, endedAt: -1 })).toBeNull();
+  });
+
+  it("rejects a non-finite timestamp", () => {
+    expect(
+      parseAssistantHostEvent({ ...turnStart, startedAt: Number.POSITIVE_INFINITY })
+    ).toBeNull();
+    expect(parseAssistantHostEvent({ ...turnStart, startedAt: Number.NaN })).toBeNull();
+  });
+
+  it("rejects a negative tool durationMs", () => {
+    expect(parseAssistantHostEvent({ ...toolSettled, durationMs: -50 })).toBeNull();
+  });
+
+  it("rejects a whitespace-only turnId", () => {
+    expect(parseAssistantHostEvent({ ...turnEnd, turnId: "  " })).toBeNull();
+  });
+
+  it("strips an extra field rather than forwarding it (secrets never ride an event)", () => {
+    const base = VALID_EVENTS.find((e) => e.type === "host:error")!;
+    const parsed = parseAssistantHostEvent({ ...base, token: "secret-bearer" }) as Record<
+      string,
+      unknown
+    > | null;
+    expect(parsed).not.toBeNull();
+    expect(parsed).not.toHaveProperty("token");
+  });
 });
 
 describe("AssistantHostCommandSchema / EventSchema separation", () => {

--- a/electron/schemas/index.ts
+++ b/electron/schemas/index.ts
@@ -52,6 +52,13 @@ export {
   type WorktreeCreatePayload as ValidatedWorktreeCreatePayload,
   type TabGroupInput,
   type TerminalSnapshotEntry,
+  AssistantHostEventSchema,
+  AssistantHostCommandSchema,
+  AssistantHostSessionDescriptorSchema,
+  parseAssistantHostEvent,
+  parseAssistantHostCommand,
+  parseAssistantHostSessionDescriptor,
+  ASSISTANT_HOST_PROTOCOL_VERSION,
 } from "./ipc.js";
 
 export {

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -11,6 +11,12 @@ import {
   type AssistantHostCommand,
   type AssistantHostSessionDescriptor,
 } from "../../shared/types/ipc/assistantHost.js";
+import type {
+  McpAuditResult,
+  McpAuditSeverity,
+  McpConfirmationDecision,
+  TurnOutcomeClass,
+} from "../../shared/types/ipc/mcpServer.js";
 
 /** Schema for a launch hint — built-in agent id or plugin-provided string. */
 const LaunchAgentIdSchema = z.union([z.enum(BUILT_IN_AGENT_IDS), z.string().min(1)]);
@@ -752,124 +758,160 @@ const AssistantTurnRoleSchema = z.enum(["user", "assistant"]);
 
 const AssistantHostShutdownReasonSchema = z.enum(["hibernate", "revoke", "error", "exit"]);
 
+// Compile-time parity guard. These Zod enums duplicate the audit-aligned string
+// unions from `mcpServer.ts` (Zod has no way to derive an enum from a bare TS
+// union). If a member is added or removed there without a matching change here,
+// one of these assignments fails to typecheck — turning silent runtime drift
+// (valid events rejected, or invalid ones accepted) into a build error.
+type ExactlyEqual<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type AssertTrue<T extends true> = T;
+type _AuditResultParity = AssertTrue<
+  ExactlyEqual<z.infer<typeof McpAuditResultSchema>, McpAuditResult>
+>;
+type _AuditSeverityParity = AssertTrue<
+  ExactlyEqual<z.infer<typeof McpAuditSeveritySchema>, McpAuditSeverity>
+>;
+type _ConfirmationDecisionParity = AssertTrue<
+  ExactlyEqual<z.infer<typeof McpConfirmationDecisionSchema>, McpConfirmationDecision>
+>;
+type _TurnOutcomeParity = AssertTrue<
+  ExactlyEqual<z.infer<typeof TurnOutcomeClassSchema>, TurnOutcomeClass>
+>;
+
+/**
+ * Identifier string carrying at least one non-whitespace character. A blank or
+ * whitespace-only id passes a bare `.min(1)` but fails delivery-pinning
+ * downstream, so it is rejected at the parse boundary instead.
+ */
+const IdString = z.string().refine((s) => s.trim().length > 0, { message: "must not be blank" });
+
+/**
+ * Wall-clock timestamp / duration in milliseconds. Finite and non-negative so
+ * downstream ordering and duration math can never be poisoned by `NaN`,
+ * `Infinity`, or a negative value slipping through the contract.
+ */
+const Timestamp = z.number().finite().nonnegative();
+
 /**
  * Non-secret descriptor handed to the host at fork. The bearer token and MCP
  * URL are intentionally absent — they travel via env vars — so the schema
- * rejects any descriptor that smuggles a `token`/`mcpUrl` field.
+ * rejects any descriptor that smuggles a `token`/`mcpUrl` field. `windowId` is
+ * `.nonnegative()` to match the `>= 0` invariant `HelpSessionService` enforces.
  */
 export const AssistantHostSessionDescriptorSchema = z
   .object({
-    sessionId: z.string().min(1),
-    windowId: z.number().int(),
-    projectId: z.string().min(1),
-    cwd: z.string().min(1),
-    tier: z.string().min(1),
+    sessionId: IdString,
+    windowId: z.number().int().nonnegative(),
+    projectId: IdString,
+    cwd: IdString,
+    tier: IdString,
     protocolVersion: z.number().int().positive(),
-    resumeSessionId: z.string().min(1).optional(),
+    resumeSessionId: IdString.optional(),
   })
   .strict();
 
 export const AssistantHostEventSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("host:ready"),
-    sessionId: z.string().min(1),
+    sessionId: IdString,
     protocolVersion: z.number().int().positive(),
-    resumedSessionId: z.string().min(1).optional(),
+    resumedSessionId: IdString.optional(),
   }),
   z.object({
     type: z.literal("turn:start"),
-    sessionId: z.string().min(1),
-    turnId: z.string().min(1),
+    sessionId: IdString,
+    turnId: IdString,
     role: AssistantTurnRoleSchema,
-    startedAt: z.number(),
+    startedAt: Timestamp,
   }),
   z.object({
     type: z.literal("turn:token"),
-    sessionId: z.string().min(1),
-    turnId: z.string().min(1),
+    sessionId: IdString,
+    turnId: IdString,
     chunk: z.string(),
   }),
   z.object({
     type: z.literal("turn:end"),
-    sessionId: z.string().min(1),
-    turnId: z.string().min(1),
-    endedAt: z.number(),
+    sessionId: IdString,
+    turnId: IdString,
+    endedAt: Timestamp,
     outcome: TurnOutcomeClassSchema.optional(),
   }),
   z.object({
     type: z.literal("tool:started"),
-    sessionId: z.string().min(1),
-    toolCallId: z.string().min(1),
-    toolId: z.string().min(1),
+    sessionId: IdString,
+    toolCallId: IdString,
+    toolId: IdString,
     argsSummary: z.string(),
-    startedAt: z.number(),
-    turnId: z.string().min(1).optional(),
+    startedAt: Timestamp,
+    turnId: IdString.optional(),
     danger: z.boolean(),
   }),
   z.object({
     type: z.literal("tool:settled"),
-    sessionId: z.string().min(1),
-    toolCallId: z.string().min(1),
-    toolId: z.string().min(1),
-    durationMs: z.number(),
+    sessionId: IdString,
+    toolCallId: IdString,
+    toolId: IdString,
+    durationMs: Timestamp,
     result: McpAuditResultSchema,
     severity: McpAuditSeveritySchema,
     errorCode: z.string().optional(),
-    turnId: z.string().min(1).optional(),
+    turnId: IdString.optional(),
   }),
   z.object({
     type: z.literal("approval:requested"),
-    sessionId: z.string().min(1),
-    approvalId: z.string().min(1),
-    toolId: z.string().min(1),
+    sessionId: IdString,
+    approvalId: IdString,
+    toolId: IdString,
     summary: z.string(),
-    requestedAt: z.number(),
-    turnId: z.string().min(1).optional(),
+    requestedAt: Timestamp,
+    turnId: IdString.optional(),
   }),
   z.object({
     type: z.literal("approval:decided"),
-    sessionId: z.string().min(1),
-    approvalId: z.string().min(1),
+    sessionId: IdString,
+    approvalId: IdString,
     decision: McpConfirmationDecisionSchema,
-    decidedAt: z.number(),
+    decidedAt: Timestamp,
   }),
   z.object({
     type: z.literal("host:error"),
-    sessionId: z.string().min(1),
-    code: z.string().min(1),
+    sessionId: IdString,
+    code: IdString,
     message: z.string(),
   }),
   z.object({
     type: z.literal("host:shutdown"),
-    sessionId: z.string().min(1),
+    sessionId: IdString,
     reason: AssistantHostShutdownReasonSchema,
-    resumeSessionId: z.string().min(1).optional(),
+    resumeSessionId: IdString.optional(),
   }),
 ]);
 
 export const AssistantHostCommandSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("prompt"),
-    sessionId: z.string().min(1),
+    sessionId: IdString,
     text: z.string(),
   }),
   z.object({
     type: z.literal("approval:decide"),
-    sessionId: z.string().min(1),
-    approvalId: z.string().min(1),
+    sessionId: IdString,
+    approvalId: IdString,
     decision: McpConfirmationDecisionSchema,
   }),
   z.object({
     type: z.literal("interrupt"),
-    sessionId: z.string().min(1),
+    sessionId: IdString,
   }),
   z.object({
     type: z.literal("hibernate"),
-    sessionId: z.string().min(1),
+    sessionId: IdString,
   }),
   z.object({
     type: z.literal("shutdown"),
-    sessionId: z.string().min(1),
+    sessionId: IdString,
   }),
 ]);
 

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -5,6 +5,12 @@
 import { z } from "zod";
 import { BUILT_IN_PANEL_KINDS, panelKindHasPty } from "../../shared/config/panelKindRegistry.js";
 import { BUILT_IN_AGENT_IDS } from "../../shared/config/agentIds.js";
+import {
+  ASSISTANT_HOST_PROTOCOL_VERSION,
+  type AssistantHostEvent,
+  type AssistantHostCommand,
+  type AssistantHostSessionDescriptor,
+} from "../../shared/types/ipc/assistantHost.js";
 
 /** Schema for a launch hint — built-in agent id or plugin-provided string. */
 const LaunchAgentIdSchema = z.union([z.enum(BUILT_IN_AGENT_IDS), z.string().min(1)]);
@@ -701,3 +707,191 @@ export type TerminalReplayHistoryPayload = z.infer<typeof TerminalReplayHistoryP
 export type DevPreviewStartPayload = z.infer<typeof DevPreviewStartPayloadSchema>;
 export type WorktreeSetActivePayload = z.infer<typeof WorktreeSetActivePayloadSchema>;
 export type WorktreeCreatePayload = z.infer<typeof WorktreeCreatePayloadSchema>;
+
+// ============================================================================
+// Assistant Native-Host Protocol Schemas (#10649)
+// ============================================================================
+//
+// Validation for the typed boundary between a future `daintree-assistant`
+// runtime hosted as a utility process and Daintree's main/renderer surfaces.
+// The main process parses every inbound host message before forwarding to the
+// pinned renderer — a malformed or unknown-`type` message is rejected, never
+// guessed at. Vocabularies mirror the audit-aligned types in
+// `shared/types/ipc/mcpServer.ts` so the native timeline and the audit log
+// cannot drift. See `shared/types/ipc/assistantHost.ts` for the source types.
+
+const McpAuditResultSchema = z.enum([
+  "success",
+  "error",
+  "confirmation-pending",
+  "unauthorized",
+  "dedup",
+  "collision",
+  "rate_limited",
+]);
+
+const McpAuditSeveritySchema = z.enum(["info", "notice", "warning", "error", "critical"]);
+
+const McpConfirmationDecisionSchema = z.enum(["approved", "rejected", "timeout"]);
+
+const TurnOutcomeClassSchema = z.enum([
+  "answered",
+  "hedged",
+  "refused",
+  "docs-empty",
+  "tier-rejected",
+  "mcp-not-ready",
+  "agent-stuck",
+  "tool-error",
+  "reasoning-loop",
+  "hibernate-resume-stale",
+  "unknown",
+]);
+
+const AssistantTurnRoleSchema = z.enum(["user", "assistant"]);
+
+const AssistantHostShutdownReasonSchema = z.enum(["hibernate", "revoke", "error", "exit"]);
+
+/**
+ * Non-secret descriptor handed to the host at fork. The bearer token and MCP
+ * URL are intentionally absent — they travel via env vars — so the schema
+ * rejects any descriptor that smuggles a `token`/`mcpUrl` field.
+ */
+export const AssistantHostSessionDescriptorSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    windowId: z.number().int(),
+    projectId: z.string().min(1),
+    cwd: z.string().min(1),
+    tier: z.string().min(1),
+    protocolVersion: z.number().int().positive(),
+    resumeSessionId: z.string().min(1).optional(),
+  })
+  .strict();
+
+export const AssistantHostEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("host:ready"),
+    sessionId: z.string().min(1),
+    protocolVersion: z.number().int().positive(),
+    resumedSessionId: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("turn:start"),
+    sessionId: z.string().min(1),
+    turnId: z.string().min(1),
+    role: AssistantTurnRoleSchema,
+    startedAt: z.number(),
+  }),
+  z.object({
+    type: z.literal("turn:token"),
+    sessionId: z.string().min(1),
+    turnId: z.string().min(1),
+    chunk: z.string(),
+  }),
+  z.object({
+    type: z.literal("turn:end"),
+    sessionId: z.string().min(1),
+    turnId: z.string().min(1),
+    endedAt: z.number(),
+    outcome: TurnOutcomeClassSchema.optional(),
+  }),
+  z.object({
+    type: z.literal("tool:started"),
+    sessionId: z.string().min(1),
+    toolCallId: z.string().min(1),
+    toolId: z.string().min(1),
+    argsSummary: z.string(),
+    startedAt: z.number(),
+    turnId: z.string().min(1).optional(),
+    danger: z.boolean(),
+  }),
+  z.object({
+    type: z.literal("tool:settled"),
+    sessionId: z.string().min(1),
+    toolCallId: z.string().min(1),
+    toolId: z.string().min(1),
+    durationMs: z.number(),
+    result: McpAuditResultSchema,
+    severity: McpAuditSeveritySchema,
+    errorCode: z.string().optional(),
+    turnId: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("approval:requested"),
+    sessionId: z.string().min(1),
+    approvalId: z.string().min(1),
+    toolId: z.string().min(1),
+    summary: z.string(),
+    requestedAt: z.number(),
+    turnId: z.string().min(1).optional(),
+  }),
+  z.object({
+    type: z.literal("approval:decided"),
+    sessionId: z.string().min(1),
+    approvalId: z.string().min(1),
+    decision: McpConfirmationDecisionSchema,
+    decidedAt: z.number(),
+  }),
+  z.object({
+    type: z.literal("host:error"),
+    sessionId: z.string().min(1),
+    code: z.string().min(1),
+    message: z.string(),
+  }),
+  z.object({
+    type: z.literal("host:shutdown"),
+    sessionId: z.string().min(1),
+    reason: AssistantHostShutdownReasonSchema,
+    resumeSessionId: z.string().min(1).optional(),
+  }),
+]);
+
+export const AssistantHostCommandSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("prompt"),
+    sessionId: z.string().min(1),
+    text: z.string(),
+  }),
+  z.object({
+    type: z.literal("approval:decide"),
+    sessionId: z.string().min(1),
+    approvalId: z.string().min(1),
+    decision: McpConfirmationDecisionSchema,
+  }),
+  z.object({
+    type: z.literal("interrupt"),
+    sessionId: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("hibernate"),
+    sessionId: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("shutdown"),
+    sessionId: z.string().min(1),
+  }),
+]);
+
+/** Parse an inbound host event, returning `null` for any invalid message. */
+export function parseAssistantHostEvent(value: unknown): AssistantHostEvent | null {
+  const result = AssistantHostEventSchema.safeParse(value);
+  return result.success ? (result.data as AssistantHostEvent) : null;
+}
+
+/** Parse an outbound host command, returning `null` for any invalid message. */
+export function parseAssistantHostCommand(value: unknown): AssistantHostCommand | null {
+  const result = AssistantHostCommandSchema.safeParse(value);
+  return result.success ? (result.data as AssistantHostCommand) : null;
+}
+
+/** Parse a fork-time descriptor, returning `null` if it is malformed. */
+export function parseAssistantHostSessionDescriptor(
+  value: unknown
+): AssistantHostSessionDescriptor | null {
+  const result = AssistantHostSessionDescriptorSchema.safeParse(value);
+  return result.success ? (result.data as AssistantHostSessionDescriptor) : null;
+}
+
+/** Re-exported so callers validating a handshake don't import two modules. */
+export { ASSISTANT_HOST_PROTOCOL_VERSION };

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -766,18 +766,17 @@ const AssistantHostShutdownReasonSchema = z.enum(["hibernate", "revoke", "error"
 type ExactlyEqual<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 type AssertTrue<T extends true> = T;
-type _AuditResultParity = AssertTrue<
-  ExactlyEqual<z.infer<typeof McpAuditResultSchema>, McpAuditResult>
->;
-type _AuditSeverityParity = AssertTrue<
-  ExactlyEqual<z.infer<typeof McpAuditSeveritySchema>, McpAuditSeverity>
->;
-type _ConfirmationDecisionParity = AssertTrue<
-  ExactlyEqual<z.infer<typeof McpConfirmationDecisionSchema>, McpConfirmationDecision>
->;
-type _TurnOutcomeParity = AssertTrue<
-  ExactlyEqual<z.infer<typeof TurnOutcomeClassSchema>, TurnOutcomeClass>
->;
+/**
+ * Exported (so it counts as used under `noUnusedLocals`) purely to host the
+ * parity assertions — each tuple member fails to compile if the matching Zod
+ * enum drifts from its `mcpServer.ts` union. Never imported at runtime.
+ */
+export type AssistantHostVocabularyParity = [
+  AssertTrue<ExactlyEqual<z.infer<typeof McpAuditResultSchema>, McpAuditResult>>,
+  AssertTrue<ExactlyEqual<z.infer<typeof McpAuditSeveritySchema>, McpAuditSeverity>>,
+  AssertTrue<ExactlyEqual<z.infer<typeof McpConfirmationDecisionSchema>, McpConfirmationDecision>>,
+  AssertTrue<ExactlyEqual<z.infer<typeof TurnOutcomeClassSchema>, TurnOutcomeClass>>,
+];
 
 /**
  * Identifier string carrying at least one non-whitespace character. A blank or

--- a/shared/types/ipc/assistantHost.ts
+++ b/shared/types/ipc/assistantHost.ts
@@ -1,0 +1,264 @@
+/**
+ * Native assistant-host protocol (#10649).
+ *
+ * Defines the typed boundary between a future `daintree-assistant` runtime
+ * hosted as an Electron utility process and Daintree's main/renderer surfaces.
+ * Today the assistant runs as a CLI/Ink child wrapped in an xterm pane, with
+ * the only structured signals being the MCP-server events in `mcpServer.ts`
+ * (tool-call started/settled, turn-outcome alerts, figure rail). This module
+ * is the *contract* the native host will speak so conversation turns, tool
+ * calls, and approvals can be rendered natively instead of scraped from
+ * terminal bytes — without rebuilding Daintree's confirmation/audit surfaces.
+ *
+ * This file is intentionally runtime-free: it declares the message shapes and
+ * the descriptor handed to the host at fork time. The CLI/Ink path stays the
+ * default and fallback; nothing here wires a process. Runtime wiring is gated
+ * on two unbuilt prerequisites called out in the issue — the workflow ledger
+ * and the `@daintreehq/daintree-assistant` package emitting these structured
+ * turn events — so the protocol lands first and the host plugs in later.
+ *
+ * Design rules baked into the shapes below:
+ * - Every event and command carries `sessionId` so the main process can pin
+ *   delivery to the WebContents that minted the session, never broadcast
+ *   (lesson #7003).
+ * - The descriptor handed to the host over `parentPort` carries no bearer
+ *   token. The MCP URL and token reach the host through env vars
+ *   (`DAINTREE_MCP_URL` / `DAINTREE_MCP_TOKEN` / `DAINTREE_WINDOW_ID`), mirroring
+ *   the existing `daintree-assistant` env-only injection — so a leaked port
+ *   message can never carry the secret.
+ * - Outcome/result/decision fields reuse the audit-aligned vocabularies from
+ *   `mcpServer.ts` so the native timeline and the audit log can never drift.
+ */
+
+import type {
+  McpAuditResult,
+  McpAuditSeverity,
+  McpConfirmationDecision,
+  TurnOutcomeClass,
+} from "./mcpServer.js";
+
+/**
+ * Wire-format version for the host↔Daintree protocol. Bumped on any breaking
+ * change to {@link AssistantHostEvent} or {@link AssistantHostCommand}. The
+ * host announces the version it speaks in `host:ready`; Daintree refuses a
+ * mismatch rather than guessing at an unknown shape.
+ */
+export const ASSISTANT_HOST_PROTOCOL_VERSION = 1;
+
+/** Author of a conversation turn in the native timeline. */
+export type AssistantTurnRole = "user" | "assistant";
+
+/**
+ * Non-secret session descriptor handed to the assistant host process at fork
+ * time over `parentPort`. Deliberately excludes the bearer token and MCP URL —
+ * those reach the host through environment variables, never a structured
+ * message, so the descriptor stays safe to log and forward.
+ */
+export interface AssistantHostSessionDescriptor {
+  /** Stable help-session id minted by `HelpSessionService` at provision. */
+  sessionId: string;
+  /** Owning window; correlates to the pinned `WebContents` for delivery. */
+  windowId: number;
+  /** Project the assistant is bound to for this session. */
+  projectId: string;
+  /** Working directory the runtime starts in (the bound worktree path). */
+  cwd: string;
+  /** Source-tier classification of the session's MCP connection. */
+  tier: string;
+  /** Protocol version Daintree expects the host to speak. */
+  protocolVersion: number;
+  /**
+   * Resume handle captured at the prior hibernation, if this descriptor is
+   * re-spawning a hibernated session. Absent for a cold start.
+   */
+  resumeSessionId?: string;
+}
+
+// ============================================================================
+// Host → Daintree events
+// ============================================================================
+
+/** Host has booted, connected to the MCP server, and is ready for commands. */
+export interface AssistantHostReadyEvent {
+  type: "host:ready";
+  sessionId: string;
+  /** Protocol version the host actually speaks. */
+  protocolVersion: number;
+  /** Resume handle the runtime adopted, echoed back for correlation. */
+  resumedSessionId?: string;
+}
+
+/** A new conversation turn began. */
+export interface AssistantTurnStartEvent {
+  type: "turn:start";
+  sessionId: string;
+  turnId: string;
+  role: AssistantTurnRole;
+  startedAt: number;
+}
+
+/**
+ * An incremental text chunk for an in-flight `assistant` turn. Streamed
+ * frequently; consumers should accumulate into the active turn's buffer and
+ * avoid placing per-token state in a global store (re-render cost).
+ */
+export interface AssistantTurnTokenEvent {
+  type: "turn:token";
+  sessionId: string;
+  turnId: string;
+  chunk: string;
+}
+
+/** A conversation turn completed. */
+export interface AssistantTurnEndEvent {
+  type: "turn:end";
+  sessionId: string;
+  turnId: string;
+  endedAt: number;
+  /** Audit-aligned classification of how the turn resolved, when known. */
+  outcome?: TurnOutcomeClass;
+}
+
+/**
+ * A tool dispatch entered the call path. Shape mirrors
+ * `McpToolCallStartedPayload` plus a stable `toolCallId` so the native
+ * timeline can correlate the matching settle event without racing on `toolId`.
+ */
+export interface AssistantToolStartedEvent {
+  type: "tool:started";
+  sessionId: string;
+  toolCallId: string;
+  toolId: string;
+  argsSummary: string;
+  startedAt: number;
+  turnId?: string;
+  danger: boolean;
+}
+
+/** A tool dispatch settled. Carries audit-aligned outcome fields. */
+export interface AssistantToolSettledEvent {
+  type: "tool:settled";
+  sessionId: string;
+  toolCallId: string;
+  toolId: string;
+  durationMs: number;
+  result: McpAuditResult;
+  severity: McpAuditSeverity;
+  errorCode?: string;
+  turnId?: string;
+}
+
+/**
+ * The runtime is awaiting a user decision for a `danger: "confirm"` dispatch.
+ * Daintree surfaces this through its existing `ConfirmDialog`, then answers
+ * with an `approval:decide` command — the host never renders its own modal.
+ */
+export interface AssistantApprovalRequestedEvent {
+  type: "approval:requested";
+  sessionId: string;
+  approvalId: string;
+  toolId: string;
+  /** Redacted, single-level summary of what the tool will do. */
+  summary: string;
+  requestedAt: number;
+  turnId?: string;
+}
+
+/** A previously requested approval was resolved (by user or timeout). */
+export interface AssistantApprovalDecidedEvent {
+  type: "approval:decided";
+  sessionId: string;
+  approvalId: string;
+  decision: McpConfirmationDecision;
+  decidedAt: number;
+}
+
+/** The host hit a non-fatal error it wants surfaced to the user. */
+export interface AssistantHostErrorEvent {
+  type: "host:error";
+  sessionId: string;
+  /** Stable, machine-readable failure code. */
+  code: string;
+  message: string;
+}
+
+/** The host is shutting down (graceful hibernate, revoke, or crash drain). */
+export interface AssistantHostShutdownEvent {
+  type: "host:shutdown";
+  sessionId: string;
+  reason: AssistantHostShutdownReason;
+  /** Resume handle captured for a later cold re-spawn, when hibernating. */
+  resumeSessionId?: string;
+}
+
+export type AssistantHostShutdownReason = "hibernate" | "revoke" | "error" | "exit";
+
+/**
+ * Discriminated union of every message the host pushes to Daintree. The main
+ * process validates each against the Zod schema before forwarding to the
+ * pinned renderer.
+ */
+export type AssistantHostEvent =
+  | AssistantHostReadyEvent
+  | AssistantTurnStartEvent
+  | AssistantTurnTokenEvent
+  | AssistantTurnEndEvent
+  | AssistantToolStartedEvent
+  | AssistantToolSettledEvent
+  | AssistantApprovalRequestedEvent
+  | AssistantApprovalDecidedEvent
+  | AssistantHostErrorEvent
+  | AssistantHostShutdownEvent;
+
+export type AssistantHostEventType = AssistantHostEvent["type"];
+
+// ============================================================================
+// Daintree → host commands
+// ============================================================================
+
+/** Submit a user prompt to start a new turn. */
+export interface AssistantPromptCommand {
+  type: "prompt";
+  sessionId: string;
+  text: string;
+}
+
+/** Answer an outstanding `approval:requested` event. */
+export interface AssistantApprovalDecideCommand {
+  type: "approval:decide";
+  sessionId: string;
+  approvalId: string;
+  decision: McpConfirmationDecision;
+}
+
+/** Interrupt the in-flight turn (user pressed stop). */
+export interface AssistantInterruptCommand {
+  type: "interrupt";
+  sessionId: string;
+}
+
+/** Capture a resume handle and wind the runtime down for hibernation. */
+export interface AssistantHibernateCommand {
+  type: "hibernate";
+  sessionId: string;
+}
+
+/** Tear the runtime down for good (session revoked / project closed). */
+export interface AssistantShutdownCommand {
+  type: "shutdown";
+  sessionId: string;
+}
+
+/**
+ * Discriminated union of every control message Daintree sends the host. The
+ * session descriptor is handed over at fork time, not as a command, so these
+ * are all post-handshake control signals.
+ */
+export type AssistantHostCommand =
+  | AssistantPromptCommand
+  | AssistantApprovalDecideCommand
+  | AssistantInterruptCommand
+  | AssistantHibernateCommand
+  | AssistantShutdownCommand;
+
+export type AssistantHostCommandType = AssistantHostCommand["type"];

--- a/shared/types/ipc/index.ts
+++ b/shared/types/ipc/index.ts
@@ -27,3 +27,4 @@ export * from "./webviewConsole.js";
 export * from "./demo.js";
 export * from "./telemetryPreview.js";
 export * from "./help.js";
+export * from "./assistantHost.js";


### PR DESCRIPTION
## Summary

Defines and documents the native-host boundary for the Daintree Assistant (#10649): the typed protocol Daintree and a future `daintree-assistant` utility-process runtime will speak so conversation turns, tool calls, and approvals can render as native React instead of being scraped from terminal bytes. This is a contract-only slice. It lands the protocol, its validation, and the documented boundary, and leaves runtime wiring for when its prerequisites exist. The CLI/Ink PTY path is untouched and stays the default and fallback.

### Why contract-only

Two prerequisites the issue names are genuinely unbuilt: the workflow ledger does not exist anywhere in the codebase, and the `@daintreehq/daintree-assistant` package emits no structured turn events. The structured MCP signals a native host would show (tool-call started/settled, turn-outcome, figure rail) already render natively today. Standing up the full utility process now would produce a host entrypoint that is a dead stub, shelling out to the CLI and re-creating the existing PTY byte stream for zero gain. This PR establishes the boundary the issue asks to "define" and "document". The host plugs in later without a protocol redesign.

## What's in this PR

- `shared/types/ipc/assistantHost.ts` — `AssistantHostEvent` and `AssistantHostCommand` discriminated unions, the non-secret fork-time `AssistantHostSessionDescriptor`, and `ASSISTANT_HOST_PROTOCOL_VERSION`. Outcome/result/decision fields reuse the audit-aligned vocabularies from `mcpServer.ts`.
- `electron/schemas/ipc.ts` — Zod validators (`parseAssistantHostEvent` / `parseAssistantHostCommand` / `parseAssistantHostSessionDescriptor`) that reject unknown-`type` messages, blank/whitespace ids, non-finite/negative timestamps and durations, off-vocabulary outcomes, and descriptors smuggling a `token`/`mcpUrl` (secrets travel via env, never a port message). A compile-time parity guard fails the build if the Zod enums drift from the `mcpServer.ts` unions.
- `docs/architecture/assistant-native-host.md` — the boundary spec: the `utilityProcess.fork()` runtime-shape decision and rationale, the message protocol, and the five invariants any future wiring must preserve (per-WebContents pin #7003, secrets-via-env, one-backend-per-project #7522, audit-aligned vocabularies, bootstrap-guard-before-import #8833).
- `electron/schemas/__tests__/assistantHostProtocol.test.ts` — 38 tests covering round-trips, rejection paths, the numeric/blank-id bounds, and the secret-exclusion invariant.

## Scope explicitly deferred

- No utility process is spawned and no IPC channel is registered.
- No native conversation transcript until `@daintreehq/daintree-assistant` emits `turn:start`/`turn:token`/`turn:end`.
- Workflow-ledger events are additive and layer onto this protocol unchanged once the ledger lands.

## Testing

- `vitest electron/schemas/__tests__/assistantHostProtocol.test.ts` — 38 pass
- `eslint` + `prettier` clean on all changed files
- `tsc -b electron/tsconfig.json` clean (validates the compile-time parity guard)

Refs #10649 — this slice defines the contract; the runtime wiring remains, so the issue stays open.