### PR TITLE
feat(mcp): native session-scoped automation grants for the assistant

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -625,6 +625,17 @@ export const CHANNELS = {
    */
   MCP_SERVER_REVOKE_SESSION_GRANTS: "mcp-server:revoke-session-grants",
   /**
+   * Approve a native session-scoped automation grant (#10648), addressed by
+   * the public help-session id. Authorizes a bounded set of tools for a
+   * bounded number of uses without a per-call modal. Caller-pin checked.
+   */
+  MCP_SERVER_ISSUE_NATIVE_GRANT: "mcp-server:issue-native-grant",
+  /**
+   * Revoke a single native automation grant by id. Idempotent. Caller-pin
+   * checked against the session the grant belongs to.
+   */
+  MCP_SERVER_REVOKE_NATIVE_GRANT: "mcp-server:revoke-native-grant",
+  /**
    * Reset the per-`(sessionId, toolId)` denial counters for a session without
    * touching its grants. Fired when the user dismisses the tier-mismatch
    * banner so the next out-of-tier call re-arms the banner instead of being

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -307,8 +307,9 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.resetDenialCounts).toHaveBeenCalledWith("sess-7", 77);
   });
 
-  it("cleanup removes all twenty-four registered handlers", () => {
-    expect(ipcHandlers.size).toBe(24);
+  it("cleanup removes all twenty-six registered handlers", () => {
+    // 24 baseline + issueNativeGrant + revokeNativeGrant (#10648).
+    expect(ipcHandlers.size).toBe(26);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.preload.ts
+++ b/electron/ipc/handlers/mcpServer.preload.ts
@@ -21,6 +21,8 @@ export const MCP_SERVER_METHOD_CHANNELS = {
   setSessionTier: "mcp-server:set-session-tier",
   issueGrant: "mcp-server:issue-grant",
   revokeSessionGrants: "mcp-server:revoke-session-grants",
+  issueNativeGrant: "mcp-server:issue-native-grant",
+  revokeNativeGrant: "mcp-server:revoke-native-grant",
   resetDenialCounts: "mcp-server:reset-denial-counts",
   listActiveBearers: "mcp-server:list-active-bearers",
   listHelpSessionBearers: "mcp-server:list-help-session-bearers",

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -16,7 +16,9 @@ import type {
   McpAuditRecord,
   McpAuditStats,
   McpIssueGrantResult,
+  McpIssueNativeGrantResult,
   McpLogRecord,
+  McpRevokeNativeGrantResult,
   McpRevokeSessionGrantsResult,
   McpRuntimeSnapshot,
   McpServerStatusSnapshot,
@@ -259,6 +261,59 @@ export const mcpServerNamespace = defineIpcNamespace({
         }
         const svc = await getMcpServerService();
         return svc.revokeSessionGrants(sessionId, ctx.webContentsId);
+      },
+      { withContext: true }
+    ),
+    issueNativeGrant: op(
+      MCP_SERVER_METHOD_CHANNELS.issueNativeGrant,
+      async (
+        ctx,
+        payload: {
+          helpSessionId: string;
+          allowedTools: string[];
+          maxUses?: number;
+          ttlMs?: number;
+        }
+      ): Promise<McpIssueNativeGrantResult> => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        const { helpSessionId, allowedTools, maxUses, ttlMs } = payload;
+        if (typeof helpSessionId !== "string" || !helpSessionId) {
+          throw new Error("Invalid helpSessionId");
+        }
+        if (!Array.isArray(allowedTools)) {
+          throw new Error("Invalid allowedTools");
+        }
+        if (maxUses !== undefined && typeof maxUses !== "number") {
+          throw new Error("Invalid maxUses");
+        }
+        if (ttlMs !== undefined && typeof ttlMs !== "number") {
+          throw new Error("Invalid ttlMs");
+        }
+        const svc = await getMcpServerService();
+        // Same caller-pin invariant as `issueGrant` — only the renderer that
+        // minted the session can approve native grants for it.
+        return svc.issueNativeGrant(
+          helpSessionId,
+          { allowedTools, maxUses, ttlMs },
+          ctx.webContentsId
+        );
+      },
+      { withContext: true }
+    ),
+    revokeNativeGrant: op(
+      MCP_SERVER_METHOD_CHANNELS.revokeNativeGrant,
+      async (ctx, payload: { grantId: string }): Promise<McpRevokeNativeGrantResult> => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        const { grantId } = payload;
+        if (typeof grantId !== "string" || !grantId) {
+          throw new Error("Invalid grantId");
+        }
+        const svc = await getMcpServerService();
+        return svc.revokeNativeGrant(grantId, ctx.webContentsId);
       },
       { withContext: true }
     ),

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -15,7 +15,9 @@ import type {
   McpAuditStats,
   McpGrantLifecyclePayload,
   McpIssueGrantResult,
+  McpIssueNativeGrantResult,
   McpLogRecord,
+  McpRevokeNativeGrantResult,
   McpRevokeSessionGrantsResult,
   McpRuntimeSnapshot,
   McpRuntimeState,
@@ -541,11 +543,33 @@ export class McpServerService {
   getHelpSessionLiveStatus(
     helpSessionId: string,
     callerWcId: number
-  ): {
-    tier: McpTier;
-    activeGrants: Array<{ toolId: string; expiresAt: number; ttlMs: number }>;
-  } | null {
+  ): ReturnType<SessionStore["getLiveStatusForHelpSession"]> {
     return this.sessionStore.getLiveStatusForHelpSession(helpSessionId, callerWcId);
+  }
+
+  /**
+   * Approve a native session-scoped automation grant (#10648) for the help
+   * session a renderer owns, addressed by its public help-session id. The
+   * grant authorizes the named tools for a bounded number of uses without a
+   * per-call modal. Caller-pinned against the WebContents the session was
+   * pinned to at handshake. Returns the minted grant's id and scope so the
+   * renderer can render its card without polling.
+   */
+  issueNativeGrant(
+    helpSessionId: string,
+    params: { allowedTools: string[]; maxUses?: number; ttlMs?: number },
+    callerWcId?: number
+  ): McpIssueNativeGrantResult {
+    return this.httpLifecycle.issueNativeGrant(helpSessionId, params, callerWcId);
+  }
+
+  /**
+   * Revoke a single native automation grant by id. Caller-pinned against the
+   * session the grant belongs to. Idempotent — a grant already gone (exhausted,
+   * expired, or torn down with its session) reports `revoked: false`.
+   */
+  revokeNativeGrant(grantId: string, callerWcId?: number): McpRevokeNativeGrantResult {
+    return this.httpLifecycle.revokeNativeGrant(grantId, callerWcId);
   }
 
   /**
@@ -620,6 +644,12 @@ export class McpServerService {
         ttlMs: payload.ttlMs,
         expiresAt: payload.expiresAt,
         revokedReason: payload.revokedReason,
+        grantId: payload.grantId,
+        maxUses: payload.maxUses,
+        remainingUses: payload.remainingUses,
+        actorId: payload.actorId,
+        actorType: payload.actorType,
+        allowedTools: payload.allowedTools,
       });
     } catch (err) {
       console.error("[MCP] Failed to append grant audit record:", err);

--- a/electron/services/mcp-server/__tests__/grantCache.test.ts
+++ b/electron/services/mcp-server/__tests__/grantCache.test.ts
@@ -558,3 +558,169 @@ describe("session-level integration assumptions", () => {
 beforeEach(() => {
   // no-op; per-test caches are constructed inside each `it`.
 });
+
+describe("GrantCache native grants (#10648)", () => {
+  function issue(
+    cache: GrantCache,
+    overrides?: { allowedTools?: string[]; maxUses?: number; ttlMs?: number }
+  ) {
+    return cache.issueNativeGrant({
+      sessionId: "s1",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: overrides?.allowedTools ?? ["git.commit", "git.push"],
+      maxUses: overrides?.maxUses ?? 3,
+      ttlMs: overrides?.ttlMs,
+    });
+  }
+
+  it("issueNativeGrant mints an entry and emits grant.issued with native fields", () => {
+    const { cache, emitted } = newCache({ ttlMs: 1000 });
+    const entry = issue(cache);
+    expect(entry.id).toBeTruthy();
+    expect(entry.remainingUses).toBe(3);
+    expect(entry.maxUses).toBe(3);
+    expect([...entry.allowedTools].sort()).toEqual(["git.commit", "git.push"]);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload).toMatchObject({
+      type: "grant.issued",
+      toolId: "*",
+      grantId: entry.id,
+      actorId: "help-1",
+      actorType: "help-session",
+      maxUses: 3,
+      remainingUses: 3,
+    });
+    cache.dispose();
+  });
+
+  it("checkNativeGrant authorizes an allowed tool, consumes one use, emits grant.used", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache);
+    emitted.length = 0;
+    const result = cache.checkNativeGrant("s1", "git.commit");
+    expect(result.granted).toBe(true);
+    if (result.granted) expect(result.grantId).toBe(entry.id);
+    expect(cache._peekNative(entry.id)?.remainingUses).toBe(2);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload).toMatchObject({
+      type: "grant.used",
+      toolId: "git.commit",
+      grantId: entry.id,
+      remainingUses: 2,
+    });
+    cache.dispose();
+  });
+
+  it("denies a tool outside the allowlist without consuming a use", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache, { allowedTools: ["git.commit"] });
+    emitted.length = 0;
+    expect(cache.checkNativeGrant("s1", "git.push").granted).toBe(false);
+    expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
+    expect(emitted).toHaveLength(0);
+    cache.dispose();
+  });
+
+  it("a maxUses:1 grant exhausts after one use and fails closed on the second", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache, { maxUses: 1 });
+    emitted.length = 0;
+    const first = cache.checkNativeGrant("s1", "git.commit");
+    expect(first.granted).toBe(true);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].payload).toMatchObject({
+      type: "grant.exhausted",
+      toolId: "git.commit",
+      remainingUses: 0,
+    });
+    expect(cache._peekNative(entry.id)).toBeUndefined();
+    // Second concurrent-style call sees the grant gone.
+    expect(cache.checkNativeGrant("s1", "git.commit").granted).toBe(false);
+    cache.dispose();
+  });
+
+  it("a grant past its TTL fails closed and emits grant.expired", () => {
+    let clock = 0;
+    const { cache, emitted } = newCache({ ttlMs: 1000, maxLifetimeMs: 100000, now: () => clock });
+    issue(cache, { ttlMs: 1000 });
+    emitted.length = 0;
+    clock = 2000;
+    expect(cache.checkNativeGrant("s1", "git.commit").granted).toBe(false);
+    expect(emitted.some((e) => e.payload.type === "grant.expired")).toBe(true);
+    cache.dispose();
+  });
+
+  it("a grant past the hard ceiling fails closed and emits grant-ceiling revoke", () => {
+    let clock = 0;
+    const { cache, emitted } = newCache({ ttlMs: 100000, maxLifetimeMs: 1000, now: () => clock });
+    issue(cache, { ttlMs: 100000 });
+    emitted.length = 0;
+    clock = 2000;
+    expect(cache.checkNativeGrant("s1", "git.commit").granted).toBe(false);
+    expect(
+      emitted.some(
+        (e) => e.payload.type === "grant.revoked" && e.payload.revokedReason === "grant-ceiling"
+      )
+    ).toBe(true);
+    cache.dispose();
+  });
+
+  it("revokeSession drops native grants for the session and emits grant.revoked", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache);
+    emitted.length = 0;
+    const count = cache.revokeSession("s1", "session-ended");
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(cache._peekNative(entry.id)).toBeUndefined();
+    expect(
+      emitted.some(
+        (e) =>
+          e.payload.type === "grant.revoked" &&
+          e.payload.grantId === entry.id &&
+          e.payload.revokedReason === "session-ended"
+      )
+    ).toBe(true);
+    cache.dispose();
+  });
+
+  it("revokeNativeGrant by id is idempotent", () => {
+    const { cache } = newCache();
+    const entry = issue(cache);
+    expect(cache.revokeNativeGrant(entry.id)).toBe(true);
+    expect(cache.revokeNativeGrant(entry.id)).toBe(false);
+    cache.dispose();
+  });
+
+  it("refreshNativeGrant extends the TTL window; a gone grant is a no-op", () => {
+    let clock = 0;
+    const { cache } = newCache({ ttlMs: 1000, maxLifetimeMs: 100000, now: () => clock });
+    const entry = issue(cache, { ttlMs: 1000 });
+    clock = 500;
+    expect(cache.refreshNativeGrant(entry.id)).toBe(true);
+    expect(cache._peekNative(entry.id)?.expiresAt).toBe(1500);
+    cache.revokeNativeGrant(entry.id);
+    expect(cache.refreshNativeGrant(entry.id)).toBe(false);
+    cache.dispose();
+  });
+
+  it("clearSessionState drops native grants without emitting", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache);
+    emitted.length = 0;
+    cache.clearSessionState("s1");
+    expect(cache._peekNative(entry.id)).toBeUndefined();
+    expect(emitted).toHaveLength(0);
+    cache.dispose();
+  });
+
+  it("getActiveNativeGrants snapshots live grants for the session", () => {
+    const { cache } = newCache();
+    const entry = issue(cache);
+    const snap = cache.getActiveNativeGrants("s1");
+    expect(snap).toHaveLength(1);
+    expect(snap[0].id).toBe(entry.id);
+    expect(cache.getActiveNativeGrants("other")).toHaveLength(0);
+    cache.dispose();
+  });
+});

--- a/electron/services/mcp-server/__tests__/grantCache.test.ts
+++ b/electron/services/mcp-server/__tests__/grantCache.test.ts
@@ -594,13 +594,24 @@ describe("GrantCache native grants (#10648)", () => {
     cache.dispose();
   });
 
-  it("checkNativeGrant authorizes an allowed tool, consumes one use, emits grant.used", () => {
+  it("peekNativeGrant authorizes an allowed tool WITHOUT consuming a use", () => {
     const { cache, emitted } = newCache();
     const entry = issue(cache);
     emitted.length = 0;
-    const result = cache.checkNativeGrant("s1", "git.commit");
+    const result = cache.peekNativeGrant("s1", "git.commit");
     expect(result.granted).toBe(true);
     if (result.granted) expect(result.grantId).toBe(entry.id);
+    // Peek must not decrement or emit — the use is charged by consume.
+    expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
+    expect(emitted).toHaveLength(0);
+    cache.dispose();
+  });
+
+  it("consumeNativeGrantUse charges one use and emits grant.used", () => {
+    const { cache, emitted } = newCache();
+    const entry = issue(cache);
+    emitted.length = 0;
+    expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(true);
     expect(cache._peekNative(entry.id)?.remainingUses).toBe(2);
     expect(emitted).toHaveLength(1);
     expect(emitted[0].payload).toMatchObject({
@@ -612,22 +623,21 @@ describe("GrantCache native grants (#10648)", () => {
     cache.dispose();
   });
 
-  it("denies a tool outside the allowlist without consuming a use", () => {
+  it("peekNativeGrant denies a tool outside the allowlist", () => {
     const { cache, emitted } = newCache();
     const entry = issue(cache, { allowedTools: ["git.commit"] });
     emitted.length = 0;
-    expect(cache.checkNativeGrant("s1", "git.push").granted).toBe(false);
+    expect(cache.peekNativeGrant("s1", "git.push").granted).toBe(false);
     expect(cache._peekNative(entry.id)?.remainingUses).toBe(3);
     expect(emitted).toHaveLength(0);
     cache.dispose();
   });
 
-  it("a maxUses:1 grant exhausts after one use and fails closed on the second", () => {
+  it("a maxUses:1 grant exhausts after one consumed use and fails closed on the second", () => {
     const { cache, emitted } = newCache();
     const entry = issue(cache, { maxUses: 1 });
     emitted.length = 0;
-    const first = cache.checkNativeGrant("s1", "git.commit");
-    expect(first.granted).toBe(true);
+    expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(true);
     expect(emitted).toHaveLength(1);
     expect(emitted[0].payload).toMatchObject({
       type: "grant.exhausted",
@@ -635,34 +645,58 @@ describe("GrantCache native grants (#10648)", () => {
       remainingUses: 0,
     });
     expect(cache._peekNative(entry.id)).toBeUndefined();
-    // Second concurrent-style call sees the grant gone.
-    expect(cache.checkNativeGrant("s1", "git.commit").granted).toBe(false);
+    // Grant is gone — a subsequent peek or consume fails closed.
+    expect(cache.peekNativeGrant("s1", "git.commit").granted).toBe(false);
+    expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(false);
     cache.dispose();
   });
 
-  it("a grant past its TTL fails closed and emits grant.expired", () => {
+  it("a grant past its TTL fails closed (peek) and emits grant.expired", () => {
     let clock = 0;
     const { cache, emitted } = newCache({ ttlMs: 1000, maxLifetimeMs: 100000, now: () => clock });
     issue(cache, { ttlMs: 1000 });
     emitted.length = 0;
     clock = 2000;
-    expect(cache.checkNativeGrant("s1", "git.commit").granted).toBe(false);
+    expect(cache.peekNativeGrant("s1", "git.commit").granted).toBe(false);
     expect(emitted.some((e) => e.payload.type === "grant.expired")).toBe(true);
     cache.dispose();
   });
 
-  it("a grant past the hard ceiling fails closed and emits grant-ceiling revoke", () => {
+  it("consumeNativeGrantUse fails closed when the grant aged past TTL since the peek", () => {
+    let clock = 0;
+    const { cache } = newCache({ ttlMs: 1000, maxLifetimeMs: 100000, now: () => clock });
+    const entry = issue(cache, { ttlMs: 1000 });
+    clock = 2000;
+    expect(cache.consumeNativeGrantUse(entry.id, "git.commit")).toBe(false);
+    expect(cache._peekNative(entry.id)).toBeUndefined();
+    cache.dispose();
+  });
+
+  it("a grant past the hard ceiling fails closed (peek) and emits grant-ceiling revoke", () => {
     let clock = 0;
     const { cache, emitted } = newCache({ ttlMs: 100000, maxLifetimeMs: 1000, now: () => clock });
     issue(cache, { ttlMs: 100000 });
     emitted.length = 0;
     clock = 2000;
-    expect(cache.checkNativeGrant("s1", "git.commit").granted).toBe(false);
+    expect(cache.peekNativeGrant("s1", "git.commit").granted).toBe(false);
     expect(
       emitted.some(
         (e) => e.payload.type === "grant.revoked" && e.payload.revokedReason === "grant-ceiling"
       )
     ).toBe(true);
+    cache.dispose();
+  });
+
+  it("getLiveNativeGrants excludes a grant refreshed past the hard ceiling", () => {
+    let clock = 0;
+    const { cache } = newCache({ ttlMs: 1000, maxLifetimeMs: 5000, now: () => clock });
+    const entry = issue(cache, { ttlMs: 1000 });
+    // Keep refreshing the TTL so `expiresAt` stays in the future, but advance
+    // past the hard ceiling — the live snapshot must drop it.
+    clock = 4000;
+    cache.refreshNativeGrant(entry.id); // expiresAt -> 5000
+    clock = 6000; // past issuedAt + maxLifetimeMs (5000), expiresAt (5000) also passed
+    expect(cache.getLiveNativeGrants("s1")).toHaveLength(0);
     cache.dispose();
   });
 

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -94,10 +94,14 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       revokeSession: vi.fn(() => false),
       registerClientMetadata: vi.fn(),
       listExternalActiveClients: vi.fn(() => []),
+      resolveLiveTransportForHelpSession: vi.fn(() => null),
       grantCache: {
         clearDenialCounts: vi.fn(),
         revokeSession: vi.fn(() => 0),
         issueGrant: vi.fn(),
+        issueNativeGrant: vi.fn(),
+        getNativeGrant: vi.fn(() => undefined),
+        revokeNativeGrant: vi.fn(() => false),
       },
     },
     auditService: {
@@ -514,6 +518,140 @@ describe("HttpLifecycle", () => {
       const deps = fakeDeps();
       const lc = new HttpLifecycle(deps);
       expect(() => lc.resetDenialCounts("")).toThrow(/Invalid sessionId/);
+    });
+  });
+
+  describe("issueNativeGrant / revokeNativeGrant (#10648)", () => {
+    type NativeGrantCache = {
+      issueNativeGrant: ReturnType<typeof vi.fn>;
+      getNativeGrant: ReturnType<typeof vi.fn>;
+      revokeNativeGrant: ReturnType<typeof vi.fn>;
+    };
+    function grantCacheOf(deps: HttpLifecycleDeps) {
+      return (deps.sessionStore as unknown as { grantCache: NativeGrantCache }).grantCache;
+    }
+    function resolverOf(deps: HttpLifecycleDeps) {
+      return deps.sessionStore.resolveLiveTransportForHelpSession as ReturnType<typeof vi.fn>;
+    }
+    function mintEntry(allowedTools: string[], maxUses: number) {
+      return {
+        id: "grant-uuid",
+        sessionId: "transport-1",
+        actorId: "help-1",
+        actorType: "help-session" as const,
+        allowedTools: new Set(allowedTools),
+        maxUses,
+        remainingUses: maxUses,
+        ttlMs: 900_000,
+        expiresAt: 1_000_000,
+      };
+    }
+
+    it("resolves the transport session and mints a grant for valid input", () => {
+      const deps = fakeDeps();
+      resolverOf(deps).mockReturnValue("transport-1");
+      grantCacheOf(deps).issueNativeGrant.mockReturnValue(mintEntry(["git.commit"], 5));
+      const lc = new HttpLifecycle(deps);
+
+      const result = lc.issueNativeGrant(
+        "help-1",
+        { allowedTools: ["git.commit"], maxUses: 5 },
+        42
+      );
+
+      expect(resolverOf(deps)).toHaveBeenCalledWith("help-1", 42);
+      expect(grantCacheOf(deps).issueNativeGrant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "transport-1",
+          actorId: "help-1",
+          actorType: "help-session",
+          allowedTools: ["git.commit"],
+          maxUses: 5,
+        })
+      );
+      expect(result.grantId).toBe("grant-uuid");
+    });
+
+    it("requires a caller WebContents id (fails closed)", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.issueNativeGrant("help-1", { allowedTools: ["git.commit"] })).toThrow(
+        /Caller WebContents id is required/
+      );
+    });
+
+    it("throws when no live pinned session backs the help id", () => {
+      const deps = fakeDeps();
+      resolverOf(deps).mockReturnValue(null);
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.issueNativeGrant("help-gone", { allowedTools: ["git.commit"] }, 42)).toThrow(
+        /No live pinned session/
+      );
+    });
+
+    it("rejects an empty tool allowlist", () => {
+      const deps = fakeDeps();
+      resolverOf(deps).mockReturnValue("transport-1");
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.issueNativeGrant("help-1", { allowedTools: [] }, 42)).toThrow(
+        /at least one tool/
+      );
+      expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unknown / non-grantable tool", () => {
+      const deps = fakeDeps();
+      resolverOf(deps).mockReturnValue("transport-1");
+      const lc = new HttpLifecycle(deps);
+      expect(() =>
+        lc.issueNativeGrant("help-1", { allowedTools: ["totally.notatool"] }, 42)
+      ).toThrow(/non-grantable/);
+      expect(grantCacheOf(deps).issueNativeGrant).not.toHaveBeenCalled();
+    });
+
+    it("rejects an out-of-range maxUses", () => {
+      const deps = fakeDeps();
+      resolverOf(deps).mockReturnValue("transport-1");
+      const lc = new HttpLifecycle(deps);
+      expect(() =>
+        lc.issueNativeGrant("help-1", { allowedTools: ["git.commit"], maxUses: 0 }, 42)
+      ).toThrow(/maxUses/);
+      expect(() =>
+        lc.issueNativeGrant("help-1", { allowedTools: ["git.commit"], maxUses: 9999 }, 42)
+      ).toThrow(/maxUses/);
+    });
+
+    it("revokeNativeGrant enforces caller-pin against the grant's session", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionWebContentsMap.set("transport-1", 42);
+      grantCacheOf(deps).getNativeGrant.mockReturnValue(mintEntry(["git.commit"], 5));
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.revokeNativeGrant("grant-uuid", 99)).toThrow(/not the pinned renderer/);
+      expect(grantCacheOf(deps).revokeNativeGrant).not.toHaveBeenCalled();
+    });
+
+    it("revokeNativeGrant is an idempotent no-op for an already-gone grant", () => {
+      const deps = fakeDeps();
+      grantCacheOf(deps).getNativeGrant.mockReturnValue(undefined);
+      const lc = new HttpLifecycle(deps);
+      expect(lc.revokeNativeGrant("grant-gone", 99)).toEqual({
+        grantId: "grant-gone",
+        revoked: false,
+      });
+      expect(grantCacheOf(deps).revokeNativeGrant).not.toHaveBeenCalled();
+    });
+
+    it("revokeNativeGrant drops the grant when the caller is the pinned renderer", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionWebContentsMap.set("transport-1", 42);
+      grantCacheOf(deps).getNativeGrant.mockReturnValue(mintEntry(["git.commit"], 5));
+      grantCacheOf(deps).revokeNativeGrant.mockReturnValue(true);
+      const lc = new HttpLifecycle(deps);
+      expect(lc.revokeNativeGrant("grant-uuid", 42)).toEqual({
+        grantId: "grant-uuid",
+        revoked: true,
+      });
+      expect(grantCacheOf(deps).revokeNativeGrant).toHaveBeenCalledWith("grant-uuid", "user");
     });
   });
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -1967,6 +1967,103 @@ describe("sessionServer grant cache fallback (#8442)", () => {
     sessionStore.grantCache.dispose();
   });
 
+  it("native grant authorizes a denied tool without a modal and refreshes on success (#10648)", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.sessions.set("s", {
+      transport: {} as never,
+      server: {} as never,
+      idleTimer: setTimeout(() => {}, 1_000_000),
+    });
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 2,
+    });
+    const refreshSpy = vi.spyOn(sessionStore.grantCache, "refreshNativeGrant");
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean };
+
+    expect(result.isError).not.toBe(true);
+    // dispatchConfirmed=true → the native grant bypasses the confirm modal,
+    // unlike a per-tool grant which dispatches with `false`.
+    expect(dispatchAction).toHaveBeenCalledWith("worktree.delete", expect.any(Object), true);
+    expect(refreshSpy).toHaveBeenCalledWith(grant.id);
+    // One use consumed at authorization.
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
+    sessionStore.grantCache.dispose();
+  });
+
+  it("native grant for tool A does not authorize tool B (fails closed on scope) (#10648)", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 5,
+    });
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    // git.push is denied at the workbench floor AND is not in the grant's
+    // allowlist → fail closed with TIER_NOT_PERMITTED, never dispatched.
+    const result = (await callTool(server, {
+      name: "git.push",
+      arguments: {},
+    })) as { isError?: boolean; content?: Array<{ text?: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text ?? "").toContain("TIER_NOT_PERMITTED");
+    expect(dispatchAction).not.toHaveBeenCalled();
+    sessionStore.grantCache.dispose();
+  });
+
+  it("an exhausted native grant fails closed on the next call (#10648)", async () => {
+    const sessionStore = fakeSessionStore("workbench");
+    sessionStore.sessions.set("s", {
+      transport: {} as never,
+      server: {} as never,
+      idleTimer: setTimeout(() => {}, 1_000_000),
+    });
+    sessionStore.grantCache.issueNativeGrant({
+      sessionId: "s",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 1,
+    });
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("s", deps);
+    await server.connect(makeMockTransport());
+
+    const first = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean };
+    expect(first.isError).not.toBe(true);
+
+    const second = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean; content?: Array<{ text?: string }> };
+    expect(second.isError).toBe(true);
+    expect(second.content?.[0]?.text ?? "").toContain("TIER_NOT_PERMITTED");
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    sessionStore.grantCache.dispose();
+  });
+
   it("grant for tool A does not authorize tool B in the same session", async () => {
     const sessionStore = fakeSessionStore("workbench");
     sessionStore.grantCache.issueGrant("s", "worktree.delete");

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2509,6 +2509,38 @@ describe("CallTool rate limiting (handler integration)", () => {
     expect(dispatchAction).not.toHaveBeenCalled();
     sessionStore.grantCache.dispose();
   });
+
+  it("a rate-limited native-grant call does NOT consume a use (#10648)", async () => {
+    // The native grant authorizes worktree.delete, but the rate limiter
+    // rejects. The use must survive — a call that never dispatched can't burn
+    // a grant use (regression guard for the peek/consume split).
+    const sessionStore = fakeSessionStore("workbench");
+    const grant = sessionStore.grantCache.issueNativeGrant({
+      sessionId: "rl-native",
+      actorId: "help-1",
+      actorType: "help-session",
+      allowedTools: ["worktree.delete"],
+      maxUses: 1,
+    });
+    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
+      allowed: false,
+      retryAfter: 4,
+    });
+    const dispatchAction = vi.fn();
+    const deps = fakeDeps({ sessionStore, dispatchAction });
+    const server = createSessionServer("rl-native", deps);
+
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: { worktreeId: "w1" },
+    })) as { content: unknown; isError?: boolean };
+
+    expect(result.isError).toBe(true);
+    expect(parseToolErrorPayload(result).code).toBe(MCP_RATE_LIMITED_CODE);
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
+    sessionStore.grantCache.dispose();
+  });
 });
 
 describe("MCP_DEDUP_ALLOWLIST widening (#8468)", () => {

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -5,6 +5,7 @@ import type {
   McpAuditResult,
   McpAuditStats,
   McpConfirmationDecision,
+  McpGrantActorType,
   McpGrantRecord,
   McpGrantRecordType,
   McpGrantRevokedReason,
@@ -231,6 +232,12 @@ export class AuditService {
     revokedReason?: McpGrantRevokedReason;
     tier?: McpTier;
     previousTier?: McpTier;
+    grantId?: string;
+    maxUses?: number;
+    remainingUses?: number;
+    actorId?: string;
+    actorType?: McpGrantActorType;
+    allowedTools?: string[];
   }): void {
     if (this.readConfig().auditEnabled === false) return;
     this.hydrate();
@@ -247,6 +254,12 @@ export class AuditService {
     if (input.revokedReason !== undefined) record.revokedReason = input.revokedReason;
     if (input.tier !== undefined) record.tier = input.tier;
     if (input.previousTier !== undefined) record.previousTier = input.previousTier;
+    if (input.grantId !== undefined) record.grantId = input.grantId;
+    if (input.maxUses !== undefined) record.maxUses = input.maxUses;
+    if (input.remainingUses !== undefined) record.remainingUses = input.remainingUses;
+    if (input.actorId !== undefined) record.actorId = input.actorId;
+    if (input.actorType !== undefined) record.actorType = input.actorType;
+    if (input.allowedTools !== undefined) record.allowedTools = input.allowedTools;
 
     this.enqueueAndTrim(record);
   }

--- a/electron/services/mcp-server/grantCache.ts
+++ b/electron/services/mcp-server/grantCache.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from "node:crypto";
 import type {
+  McpGrantActorType,
   McpGrantLifecyclePayload,
   McpGrantRecordType,
   McpGrantRevokedReason,
@@ -8,6 +10,7 @@ import {
   MCP_GRANT_MAX_LIFETIME_MS,
   MCP_GRANT_SWEEP_INTERVAL_MS,
   MCP_GRANT_TTL_MS,
+  MCP_NATIVE_GRANT_DEFAULT_MAX_USES,
 } from "./shared.js";
 
 /**
@@ -27,6 +30,47 @@ export interface GrantEntry {
 export type GrantCheckResult =
   | { granted: true; issuedAt: number; expiresAt: number }
   | { granted: false };
+
+/**
+ * A native session-scoped automation grant (#10648). Unlike a {@link GrantEntry}
+ * — which authorizes a single `(sessionId, toolId)` pair with no use ceiling —
+ * a native grant is approved once for a bounded *set* of tools and a bounded
+ * number of uses, then exhausts. It is keyed by its own stable `id` (a UUID)
+ * rather than `${sessionId}:${toolId}` because it spans multiple tools.
+ *
+ * `remainingUses` is the only mutable field after issuance and is decremented
+ * atomically inside {@link GrantCache.checkNativeGrant} — the synchronous
+ * decrement-before-return is what makes the use ceiling race-free against two
+ * concurrent in-flight tool calls (JS is single-threaded; no `await` sits
+ * between the read and the write). `issuedAt` doubles as the hard wall-clock
+ * ceiling anchor, exactly like {@link GrantEntry}.
+ */
+export interface NativeGrantEntry {
+  id: string;
+  sessionId: string;
+  actorId: string;
+  actorType: McpGrantActorType;
+  allowedTools: ReadonlySet<string>;
+  maxUses: number;
+  remainingUses: number;
+  issuedAt: number;
+  expiresAt: number;
+  ttlMs: number;
+}
+
+export type NativeGrantCheckResult = { granted: true; grantId: string } | { granted: false };
+
+/** Parameters for minting a native grant via {@link GrantCache.issueNativeGrant}. */
+export interface IssueNativeGrantParams {
+  sessionId: string;
+  actorId: string;
+  actorType: McpGrantActorType;
+  allowedTools: readonly string[];
+  /** Use ceiling. Defaults to {@link MCP_NATIVE_GRANT_DEFAULT_MAX_USES}. */
+  maxUses?: number;
+  /** Sliding-TTL window. Defaults to the cache's per-tool grant TTL. */
+  ttlMs?: number;
+}
 
 export interface GrantLifecycleEmitter {
   (sessionId: string, payload: McpGrantLifecyclePayload): void;
@@ -81,6 +125,11 @@ function key(sessionId: string, toolId: string): string {
 export class GrantCache {
   private readonly grants = new Map<string, GrantEntry>();
   private readonly denialCounts = new Map<string, number>();
+  // Native session-scoped automation grants (#10648), keyed by their own UUID
+  // (not `${sessionId}:${toolId}`) because each spans a set of tools. Held in
+  // the same cache as the per-tool grants so sweep/revokeSession/clearAll/
+  // dispose cover both stores from one place and can never drift.
+  private readonly nativeGrants = new Map<string, NativeGrantEntry>();
   private readonly ttlMs: number;
   private readonly maxLifetimeMs: number;
   private readonly sweepIntervalMs: number;
@@ -233,6 +282,17 @@ export class GrantCache {
         revokedReason: reason,
       });
     }
+    // Native grants are UUID-keyed, so they can't be prefix-matched — scan by
+    // the `sessionId` field instead. This is the fail-closed teardown path:
+    // when the pinned session ends, every native automation grant it held is
+    // dropped (the `revokeSession(sessionId, "session-ended")` calls in
+    // httpLifecycle on SSE/HTTP close cover native grants through here).
+    for (const entry of [...this.nativeGrants.values()]) {
+      if (entry.sessionId !== sessionId) continue;
+      this.nativeGrants.delete(entry.id);
+      revoked += 1;
+      this.emitSafely(sessionId, this.nativeRevokedPayload(entry, reason));
+    }
     return revoked;
   }
 
@@ -258,6 +318,9 @@ export class GrantCache {
     }
     for (const k of [...this.denialCounts.keys()]) {
       if (k.startsWith(prefix)) this.denialCounts.delete(k);
+    }
+    for (const entry of [...this.nativeGrants.values()]) {
+      if (entry.sessionId === sessionId) this.nativeGrants.delete(entry.id);
     }
   }
 
@@ -324,6 +387,215 @@ export class GrantCache {
   }
 
   /**
+   * Mint a native session-scoped automation grant (#10648). Authorizes the
+   * given `allowedTools` for the session for up to `maxUses` dispatches within
+   * the sliding TTL (capped by the hard `maxLifetimeMs` ceiling). Returns the
+   * minted entry whose `id` is the revoke/refresh handle.
+   *
+   * Validation of the actor, the tool allowlist, and the bounds is the
+   * caller's responsibility (`httpLifecycle.issueNativeGrant`) — the cache
+   * clamps `maxUses` to at least 1 so an exhausted-on-issue grant can never
+   * exist, and trusts the rest.
+   */
+  issueNativeGrant(params: IssueNativeGrantParams): NativeGrantEntry {
+    if (this.disposed) {
+      throw new Error("GrantCache has been disposed");
+    }
+    const issuedAt = this.now();
+    const ttlMs = params.ttlMs ?? this.ttlMs;
+    const maxUses = Math.max(1, Math.floor(params.maxUses ?? MCP_NATIVE_GRANT_DEFAULT_MAX_USES));
+    const entry: NativeGrantEntry = {
+      id: randomUUID(),
+      sessionId: params.sessionId,
+      actorId: params.actorId,
+      actorType: params.actorType,
+      allowedTools: new Set(params.allowedTools),
+      maxUses,
+      remainingUses: maxUses,
+      issuedAt,
+      expiresAt: issuedAt + ttlMs,
+      ttlMs,
+    };
+    this.nativeGrants.set(entry.id, entry);
+    this.emitSafely(entry.sessionId, this.nativeIssuedPayload(entry));
+    return entry;
+  }
+
+  /**
+   * Authorize `toolId` for the session under a live native grant, consuming
+   * one use. Returns the authorizing grant's id on success. The use decrement
+   * is synchronous and happens before the return, so two concurrent in-flight
+   * calls against a `maxUses: 1` grant can never both succeed — the second
+   * sees `remainingUses: 0` and falls through.
+   *
+   * Picks the first (insertion-order) live grant whose allowlist covers the
+   * tool. Expired / ceiling-past grants are lazily evicted (emitting the same
+   * `grant.expired`/`grant.revoked` signals as the per-tool path) before being
+   * skipped. When the consumed use is the last one the grant is deleted and a
+   * `grant.exhausted` record is emitted — a natural terminal state, distinct
+   * from a forced revoke.
+   */
+  checkNativeGrant(sessionId: string, toolId: string): NativeGrantCheckResult {
+    const now = this.now();
+    for (const entry of this.nativeGrants.values()) {
+      if (entry.sessionId !== sessionId) continue;
+      if (!entry.allowedTools.has(toolId)) continue;
+      const pastCeiling = now > entry.issuedAt + this.maxLifetimeMs;
+      const pastTtl = now > entry.expiresAt;
+      if (pastCeiling || pastTtl) {
+        this.nativeGrants.delete(entry.id);
+        this.emitSafely(
+          entry.sessionId,
+          pastCeiling && !pastTtl
+            ? this.nativeRevokedPayload(entry, "grant-ceiling")
+            : this.nativeExpiredPayload(entry, toolId)
+        );
+        continue;
+      }
+      if (entry.remainingUses <= 0) {
+        // Defensive: an exhausted grant should already have been deleted.
+        this.nativeGrants.delete(entry.id);
+        continue;
+      }
+      entry.remainingUses -= 1;
+      if (entry.remainingUses <= 0) {
+        this.nativeGrants.delete(entry.id);
+        this.emitSafely(entry.sessionId, this.nativeUsedPayload(entry, toolId, "grant.exhausted"));
+      } else {
+        this.emitSafely(entry.sessionId, this.nativeUsedPayload(entry, toolId, "grant.used"));
+      }
+      return { granted: true, grantId: entry.id };
+    }
+    return { granted: false };
+  }
+
+  /**
+   * Extend a native grant's sliding TTL after a successful dispatch. Keyed by
+   * the grant id captured at {@link checkNativeGrant} time, so a grant revoked
+   * or exhausted mid-dispatch (its id already gone) makes this a silent no-op —
+   * the same resurrection-race guard as the per-tool {@link refresh}. Does NOT
+   * refund a use; uses are consumed at authorization and never returned.
+   */
+  refreshNativeGrant(grantId: string): boolean {
+    const entry = this.nativeGrants.get(grantId);
+    if (!entry) return false;
+    const now = this.now();
+    if (now > entry.issuedAt + this.maxLifetimeMs) {
+      this.nativeGrants.delete(grantId);
+      this.emitSafely(entry.sessionId, this.nativeRevokedPayload(entry, "grant-ceiling"));
+      return false;
+    }
+    entry.expiresAt = now + entry.ttlMs;
+    return true;
+  }
+
+  /**
+   * Explicitly revoke a single native grant by id. Emits `grant.revoked` with
+   * the given reason. Returns false when the id was already gone (exhausted,
+   * expired, or torn down with its session) so a renderer dismissal cleanup is
+   * an idempotent no-op.
+   */
+  revokeNativeGrant(grantId: string, reason: McpGrantRevokedReason = "user"): boolean {
+    const entry = this.nativeGrants.get(grantId);
+    if (!entry) return false;
+    this.nativeGrants.delete(grantId);
+    this.emitSafely(entry.sessionId, this.nativeRevokedPayload(entry, reason));
+    return true;
+  }
+
+  /**
+   * Snapshot of live native grants, optionally filtered to one session.
+   * Iteration order is insertion order for deterministic assertions. Does not
+   * evict — callers filter expired entries by `expiresAt` like the per-tool
+   * {@link getActiveGrants} consumers do.
+   */
+  getActiveNativeGrants(sessionId?: string): NativeGrantEntry[] {
+    const out: NativeGrantEntry[] = [];
+    for (const entry of this.nativeGrants.values()) {
+      if (sessionId !== undefined && entry.sessionId !== sessionId) continue;
+      out.push(entry);
+    }
+    return out;
+  }
+
+  /**
+   * Look up a single native grant by id. Returns the live entry (or undefined
+   * when already gone) — used by the revoke path's caller-pin check, which
+   * reads `sessionId` to verify the requester owns the grant's session.
+   */
+  getNativeGrant(grantId: string): NativeGrantEntry | undefined {
+    return this.nativeGrants.get(grantId);
+  }
+
+  private nativeIssuedPayload(entry: NativeGrantEntry): McpGrantLifecyclePayload {
+    return {
+      type: "grant.issued",
+      sessionId: entry.sessionId,
+      toolId: "*",
+      ttlMs: entry.ttlMs,
+      expiresAt: entry.expiresAt,
+      grantId: entry.id,
+      actorId: entry.actorId,
+      actorType: entry.actorType,
+      maxUses: entry.maxUses,
+      remainingUses: entry.remainingUses,
+      allowedTools: [...entry.allowedTools],
+    };
+  }
+
+  private nativeUsedPayload(
+    entry: NativeGrantEntry,
+    toolId: string,
+    type: "grant.used" | "grant.exhausted"
+  ): McpGrantLifecyclePayload {
+    return {
+      type,
+      sessionId: entry.sessionId,
+      toolId,
+      ttlMs: entry.ttlMs,
+      expiresAt: type === "grant.used" ? entry.expiresAt : undefined,
+      grantId: entry.id,
+      actorId: entry.actorId,
+      actorType: entry.actorType,
+      maxUses: entry.maxUses,
+      remainingUses: entry.remainingUses,
+    };
+  }
+
+  private nativeRevokedPayload(
+    entry: NativeGrantEntry,
+    reason: McpGrantRevokedReason
+  ): McpGrantLifecyclePayload {
+    return {
+      type: "grant.revoked",
+      sessionId: entry.sessionId,
+      toolId: "*",
+      ttlMs: entry.ttlMs,
+      revokedReason: reason,
+      grantId: entry.id,
+      actorId: entry.actorId,
+      actorType: entry.actorType,
+      maxUses: entry.maxUses,
+      remainingUses: entry.remainingUses,
+      allowedTools: [...entry.allowedTools],
+    };
+  }
+
+  private nativeExpiredPayload(entry: NativeGrantEntry, toolId: string): McpGrantLifecyclePayload {
+    return {
+      type: "grant.expired",
+      sessionId: entry.sessionId,
+      toolId,
+      ttlMs: entry.ttlMs,
+      grantId: entry.id,
+      actorId: entry.actorId,
+      actorType: entry.actorType,
+      maxUses: entry.maxUses,
+      remainingUses: entry.remainingUses,
+    };
+  }
+
+  /**
    * Periodic sweep — removes expired grants without anyone having to read
    * them. Emits `grant.expired` for each so audit and broadcast match the
    * lazy-eviction path.
@@ -332,6 +604,19 @@ export class GrantCache {
     if (this.disposed) return 0;
     let evicted = 0;
     const now = this.now();
+    for (const [id, entry] of [...this.nativeGrants]) {
+      const pastCeiling = now > entry.issuedAt + this.maxLifetimeMs;
+      const pastTtl = now > entry.expiresAt;
+      if (!pastCeiling && !pastTtl) continue;
+      this.nativeGrants.delete(id);
+      evicted += 1;
+      this.emitSafely(
+        entry.sessionId,
+        pastCeiling && !pastTtl
+          ? this.nativeRevokedPayload(entry, "grant-ceiling")
+          : this.nativeExpiredPayload(entry, "*")
+      );
+    }
     for (const [k, entry] of [...this.grants]) {
       // Ceiling-expired entries can still have a future `expiresAt` (they were
       // refreshed recently), so they survive the TTL skip — evict on either
@@ -379,6 +664,7 @@ export class GrantCache {
     if (this.disposed) return;
     this.grants.clear();
     this.denialCounts.clear();
+    this.nativeGrants.clear();
   }
 
   /**
@@ -396,6 +682,7 @@ export class GrantCache {
     }
     this.grants.clear();
     this.denialCounts.clear();
+    this.nativeGrants.clear();
   }
 
   private emitSafely(sessionId: string, payload: McpGrantLifecyclePayload): void {
@@ -412,6 +699,11 @@ export class GrantCache {
   _peek(sessionId: string, toolId: string): GrantEntry | undefined {
     return this.grants.get(key(sessionId, toolId));
   }
+
+  /** @internal */
+  _peekNative(grantId: string): NativeGrantEntry | undefined {
+    return this.nativeGrants.get(grantId);
+  }
 }
 
-export type { McpGrantRecordType, McpGrantRevokedReason };
+export type { McpGrantActorType, McpGrantRecordType, McpGrantRevokedReason };

--- a/electron/services/mcp-server/grantCache.ts
+++ b/electron/services/mcp-server/grantCache.ts
@@ -422,20 +422,18 @@ export class GrantCache {
   }
 
   /**
-   * Authorize `toolId` for the session under a live native grant, consuming
-   * one use. Returns the authorizing grant's id on success. The use decrement
-   * is synchronous and happens before the return, so two concurrent in-flight
-   * calls against a `maxUses: 1` grant can never both succeed — the second
-   * sees `remainingUses: 0` and falls through.
+   * Authorize `toolId` for the session under a live native grant WITHOUT
+   * consuming a use — the use is charged separately by {@link consumeNativeGrantUse}
+   * once the call clears the rate limiter and is committed to dispatch, so a
+   * call that authorizes but is then rate-limited can't burn a use it never
+   * spent (#10648 review). Returns the authorizing grant's id on success.
    *
    * Picks the first (insertion-order) live grant whose allowlist covers the
    * tool. Expired / ceiling-past grants are lazily evicted (emitting the same
    * `grant.expired`/`grant.revoked` signals as the per-tool path) before being
-   * skipped. When the consumed use is the last one the grant is deleted and a
-   * `grant.exhausted` record is emitted — a natural terminal state, distinct
-   * from a forced revoke.
+   * skipped — eviction is hygiene, not use-consumption, so it is safe here.
    */
-  checkNativeGrant(sessionId: string, toolId: string): NativeGrantCheckResult {
+  peekNativeGrant(sessionId: string, toolId: string): NativeGrantCheckResult {
     const now = this.now();
     for (const entry of this.nativeGrants.values()) {
       if (entry.sessionId !== sessionId) continue;
@@ -457,16 +455,49 @@ export class GrantCache {
         this.nativeGrants.delete(entry.id);
         continue;
       }
-      entry.remainingUses -= 1;
-      if (entry.remainingUses <= 0) {
-        this.nativeGrants.delete(entry.id);
-        this.emitSafely(entry.sessionId, this.nativeUsedPayload(entry, toolId, "grant.exhausted"));
-      } else {
-        this.emitSafely(entry.sessionId, this.nativeUsedPayload(entry, toolId, "grant.used"));
-      }
       return { granted: true, grantId: entry.id };
     }
     return { granted: false };
+  }
+
+  /**
+   * Charge one use against a native grant previously authorized by
+   * {@link peekNativeGrant}. Synchronous decrement — paired with a peek that
+   * ran with no intervening `await`, two concurrent in-flight calls against a
+   * `maxUses: 1` grant can never both consume it. When the consumed use is the
+   * last one the grant is deleted and a `grant.exhausted` record is emitted (a
+   * natural terminal state, distinct from a forced revoke). Returns false and
+   * fails closed when the grant is gone or has aged past its TTL/ceiling since
+   * the peek — the caller must reject the dispatch in that case.
+   */
+  consumeNativeGrantUse(grantId: string, toolId: string): boolean {
+    const entry = this.nativeGrants.get(grantId);
+    if (!entry) return false;
+    const now = this.now();
+    const pastCeiling = now > entry.issuedAt + this.maxLifetimeMs;
+    const pastTtl = now > entry.expiresAt;
+    if (pastCeiling || pastTtl) {
+      this.nativeGrants.delete(grantId);
+      this.emitSafely(
+        entry.sessionId,
+        pastCeiling && !pastTtl
+          ? this.nativeRevokedPayload(entry, "grant-ceiling")
+          : this.nativeExpiredPayload(entry, toolId)
+      );
+      return false;
+    }
+    if (entry.remainingUses <= 0) {
+      this.nativeGrants.delete(grantId);
+      return false;
+    }
+    entry.remainingUses -= 1;
+    if (entry.remainingUses <= 0) {
+      this.nativeGrants.delete(grantId);
+      this.emitSafely(entry.sessionId, this.nativeUsedPayload(entry, toolId, "grant.exhausted"));
+    } else {
+      this.emitSafely(entry.sessionId, this.nativeUsedPayload(entry, toolId, "grant.used"));
+    }
+    return true;
   }
 
   /**
@@ -513,6 +544,26 @@ export class GrantCache {
     const out: NativeGrantEntry[] = [];
     for (const entry of this.nativeGrants.values()) {
       if (sessionId !== undefined && entry.sessionId !== sessionId) continue;
+      out.push(entry);
+    }
+    return out;
+  }
+
+  /**
+   * Like {@link getActiveNativeGrants} but returns only grants that are live by
+   * every condition — uses remaining, not past TTL, and not past the hard
+   * wall-clock ceiling. Used for the settings live-status snapshot so a grant
+   * that is logically dead (but not yet swept) never shows as active with a
+   * misleading countdown. Read-only: does not evict.
+   */
+  getLiveNativeGrants(sessionId?: string): NativeGrantEntry[] {
+    const now = this.now();
+    const out: NativeGrantEntry[] = [];
+    for (const entry of this.nativeGrants.values()) {
+      if (sessionId !== undefined && entry.sessionId !== sessionId) continue;
+      if (entry.remainingUses <= 0) continue;
+      if (now > entry.expiresAt) continue;
+      if (now > entry.issuedAt + this.maxLifetimeMs) continue;
       out.push(entry);
     }
     return out;

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -27,6 +27,8 @@ import type {
   McpActiveClientInfo,
   McpBearerIdentity,
   McpIssueGrantResult,
+  McpIssueNativeGrantResult,
+  McpRevokeNativeGrantResult,
   McpRevokeSessionGrantsResult,
   McpTurnOutcomeAlertPayload,
 } from "../../../shared/types/ipc/mcpServer.js";
@@ -54,6 +56,13 @@ import {
   MCP_STOP_DRAIN_TIMEOUT_MS,
   MCP_SERVER_KEY,
   MCP_TIER_ELEVATION_TTL_MS,
+  MCP_GRANT_MAX_LIFETIME_MS,
+  MCP_NATIVE_GRANT_DEFAULT_MAX_USES,
+  MCP_NATIVE_GRANT_MIN_MAX_USES,
+  MCP_NATIVE_GRANT_MAX_MAX_USES,
+  MCP_NATIVE_GRANT_MAX_ALLOWED_TOOLS,
+  MCP_NATIVE_GRANT_MIN_TTL_MS,
+  minimumPermittingTier,
 } from "./shared.js";
 
 export interface HttpLifecycleDeps {
@@ -1631,6 +1640,124 @@ export class HttpLifecycle {
     }
     const revokedCount = this.deps.sessionStore.grantCache.revokeSession(sessionId, "user");
     return { sessionId, revokedCount };
+  }
+
+  /**
+   * Approve a native session-scoped automation grant (#10648), addressed by
+   * the *public* help-session id the renderer holds. Resolves the live
+   * transport session behind it (caller-pinned, so only the renderer that
+   * minted the session can approve grants for it), validates the scope and
+   * limits, then mints the grant. Unlike {@link issueGrant} a native grant
+   * authorizes a *set* of tools for a bounded number of uses without a
+   * per-call modal — so the allowlist, use ceiling, and TTL are all validated
+   * here before the cache mints anything.
+   */
+  issueNativeGrant(
+    helpSessionId: string,
+    params: { allowedTools: string[]; maxUses?: number; ttlMs?: number },
+    callerWcId?: number
+  ): McpIssueNativeGrantResult {
+    if (!helpSessionId || typeof helpSessionId !== "string") {
+      throw new Error("Invalid helpSessionId");
+    }
+    if (callerWcId === undefined) {
+      throw new Error("Caller WebContents id is required to issue a native grant");
+    }
+    const transportSessionId = this.deps.sessionStore.resolveLiveTransportForHelpSession(
+      helpSessionId,
+      callerWcId
+    );
+    if (transportSessionId === null) {
+      throw new Error("No live pinned session for this help session");
+    }
+
+    const requested = Array.isArray(params?.allowedTools) ? params.allowedTools : [];
+    const allowedTools = [
+      ...new Set(requested.filter((t): t is string => typeof t === "string" && t.length > 0)),
+    ];
+    if (allowedTools.length === 0) {
+      throw new Error("A native grant must authorize at least one tool");
+    }
+    if (allowedTools.length > MCP_NATIVE_GRANT_MAX_ALLOWED_TOOLS) {
+      throw new Error(
+        `A native grant may authorize at most ${MCP_NATIVE_GRANT_MAX_ALLOWED_TOOLS} tools`
+      );
+    }
+    // Reject tools no non-external help tier permits — a grant must name a real,
+    // scope-bounded tool. This is also what keeps grants additive: they can
+    // only ever authorize tools that exist in the help-tier universe, never
+    // elevate the session to the api-key-only `external` surface.
+    const ungrantable = allowedTools.filter((t) => minimumPermittingTier(t) === null);
+    if (ungrantable.length > 0) {
+      throw new Error(`Unknown or non-grantable tool(s): ${ungrantable.join(", ")}`);
+    }
+
+    const maxUses = params.maxUses ?? MCP_NATIVE_GRANT_DEFAULT_MAX_USES;
+    if (
+      !Number.isInteger(maxUses) ||
+      maxUses < MCP_NATIVE_GRANT_MIN_MAX_USES ||
+      maxUses > MCP_NATIVE_GRANT_MAX_MAX_USES
+    ) {
+      throw new Error(
+        `maxUses must be an integer in [${MCP_NATIVE_GRANT_MIN_MAX_USES}, ${MCP_NATIVE_GRANT_MAX_MAX_USES}]`
+      );
+    }
+
+    const ttlMs = params.ttlMs;
+    if (
+      ttlMs !== undefined &&
+      (!Number.isFinite(ttlMs) ||
+        ttlMs < MCP_NATIVE_GRANT_MIN_TTL_MS ||
+        ttlMs > MCP_GRANT_MAX_LIFETIME_MS)
+    ) {
+      throw new Error(
+        `ttlMs must be in [${MCP_NATIVE_GRANT_MIN_TTL_MS}, ${MCP_GRANT_MAX_LIFETIME_MS}]`
+      );
+    }
+
+    const entry = this.deps.sessionStore.grantCache.issueNativeGrant({
+      sessionId: transportSessionId,
+      actorId: helpSessionId,
+      actorType: "help-session",
+      allowedTools,
+      maxUses,
+      ttlMs,
+    });
+    return {
+      grantId: entry.id,
+      sessionId: entry.sessionId,
+      actorId: entry.actorId,
+      actorType: entry.actorType,
+      allowedTools: [...entry.allowedTools],
+      maxUses: entry.maxUses,
+      remainingUses: entry.remainingUses,
+      ttlMs: entry.ttlMs,
+      expiresAt: entry.expiresAt,
+    };
+  }
+
+  /**
+   * Revoke a single native grant by id. Caller-pinned against the session the
+   * grant belongs to so a renderer can only revoke its own session's grants.
+   * Idempotent: a grant already gone (exhausted, expired, or torn down with
+   * its session) reports `revoked: false` so a dismissal cleanup never throws.
+   */
+  revokeNativeGrant(grantId: string, callerWcId?: number): McpRevokeNativeGrantResult {
+    if (!grantId || typeof grantId !== "string") {
+      throw new Error("Invalid grantId");
+    }
+    const entry = this.deps.sessionStore.grantCache.getNativeGrant(grantId);
+    if (!entry) {
+      // Already gone — idempotent no-op. No pin to check (the session may have
+      // drained), so this is safe to report as a non-revoke.
+      return { grantId, revoked: false };
+    }
+    const pinnedWcId = this.deps.sessionStore.sessionWebContentsMap.get(entry.sessionId);
+    if (pinnedWcId !== undefined && callerWcId !== undefined && callerWcId !== pinnedWcId) {
+      throw new Error("Caller is not the pinned renderer for this grant's session");
+    }
+    const revoked = this.deps.sessionStore.grantCache.revokeNativeGrant(grantId, "user");
+    return { grantId, revoked };
   }
 
   /**

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -381,17 +381,19 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
       const grant = sessionStore.grantCache.check(sessionId, actionId);
       const native = grant.granted
         ? null
-        : sessionStore.grantCache.checkNativeGrant(sessionId, actionId);
+        : sessionStore.grantCache.peekNativeGrant(sessionId, actionId);
       if (grant.granted) {
         // Grant authorised the call. Capture the `issuedAt` token so the
         // post-dispatch refresh can verify the entry wasn't revoked and
         // re-issued under us (race guard, lesson #2243).
         grantIssuedAt = grant.issuedAt;
       } else if (native?.granted) {
-        // A native automation grant covers this tool and had a use left (one
-        // was just consumed atomically). It overrides the static tier floor
-        // only because the user explicitly approved this tool's scope — the
-        // grant's allowlist gates which tools `checkNativeGrant` will authorize.
+        // A native automation grant covers this tool and has a use left. It
+        // overrides the static tier floor only because the user explicitly
+        // approved this tool's scope — the grant's allowlist gates which tools
+        // `peekNativeGrant` authorizes. The use is NOT charged here: it is
+        // consumed only after the rate-limit gate below, so a rate-limited
+        // call (which never dispatches) can't burn a use.
         nativeGrantId = native.grantId;
       } else {
         // Increment first, then ask the cache whether to suppress. The
@@ -479,6 +481,22 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         message: `Rate limit exceeded for '${actionId}'. Retry after ${rateLimit.retryAfter}s.`,
         details: { retryAfter: rateLimit.retryAfter },
       });
+    }
+
+    // Charge the native automation grant's use now that the call has cleared
+    // the rate limiter and is committed to proceeding (#10648). Doing it here —
+    // not at the peek above — means a rate-limited call never burns a use. The
+    // peek→rate-limit→consume path is synchronous (no `await`), so the grant
+    // can't be revoked between peek and consume; a `false` return is purely
+    // defensive and fails closed.
+    if (nativeGrantId !== undefined) {
+      const consumed = sessionStore.grantCache.consumeNativeGrantUse(nativeGrantId, actionId);
+      if (!consumed) {
+        return buildToolError({
+          code: TIER_NOT_PERMITTED_CODE,
+          message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
+        });
+      }
     }
 
     // Idempotency dedup for the creation-tool allowlist. Same-moment duplicates

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -372,9 +372,28 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     // action never consults the grant cache — grants are an additive layer,
     // never required when the floor already grants access.
     let grantIssuedAt: number | undefined;
+    // Set when a native session-scoped automation grant (#10648) authorized
+    // this call. Captured here so the post-dispatch path can refresh the
+    // grant's TTL window, and so the `danger: "confirm"` modal is bypassed —
+    // a native grant is an explicit user approval of the tool's scope.
+    let nativeGrantId: string | undefined;
     if (!isTierPermitted(tier, actionId, fullToolSurface)) {
       const grant = sessionStore.grantCache.check(sessionId, actionId);
-      if (!grant.granted) {
+      const native = grant.granted
+        ? null
+        : sessionStore.grantCache.checkNativeGrant(sessionId, actionId);
+      if (grant.granted) {
+        // Grant authorised the call. Capture the `issuedAt` token so the
+        // post-dispatch refresh can verify the entry wasn't revoked and
+        // re-issued under us (race guard, lesson #2243).
+        grantIssuedAt = grant.issuedAt;
+      } else if (native?.granted) {
+        // A native automation grant covers this tool and had a use left (one
+        // was just consumed atomically). It overrides the static tier floor
+        // only because the user explicitly approved this tool's scope — the
+        // grant's allowlist gates which tools `checkNativeGrant` will authorize.
+        nativeGrantId = native.grantId;
+      } else {
         // Increment first, then ask the cache whether to suppress. The
         // post-increment count reflects "this denial counted"; the cache's
         // threshold compares against that. With threshold=2 the 1st and
@@ -431,10 +450,6 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           message: `action '${actionId}' is not permitted for the '${tier}' tier.`,
         });
       }
-      // Grant authorised the call. Capture the `issuedAt` token so the
-      // post-dispatch refresh can verify the entry wasn't revoked and
-      // re-issued under us (race guard, lesson #2243).
-      grantIssuedAt = grant.issuedAt;
     }
 
     // Runaway-loop guard (#8468): charge one token against the
@@ -567,7 +582,10 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     let confirmationDecision:
       | import("../../../shared/types/ipc/mcpServer.js").McpConfirmationDecision
       | undefined;
-    let dispatchConfirmed = false;
+    // A native automation grant is an explicit user approval of the tool's
+    // scope, so it authorizes a `danger: "confirm"` dispatch without surfacing
+    // a per-call modal — exactly as if the user had just approved it.
+    let dispatchConfirmed = nativeGrantId !== undefined;
     // Tracks whether a live "tool-call-started" push fired for this dispatch so
     // the shared `finally` only emits the matching "settled" push for calls the
     // activity strip is actually showing (#9759). Pre-dispatch rejections never
@@ -623,8 +641,13 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
             // can run up to 2 hours on external sessions (longer than the
             // 15-min grant window), so this is the only block that prevents
             // the grant from silently aging out during a long wait (#8442).
-            if (grantIssuedAt !== undefined) {
-              sessionStore.grantCache.refresh(sessionId, actionId, grantIssuedAt);
+            if (grantIssuedAt !== undefined || nativeGrantId !== undefined) {
+              if (grantIssuedAt !== undefined) {
+                sessionStore.grantCache.refresh(sessionId, actionId, grantIssuedAt);
+              }
+              if (nativeGrantId !== undefined) {
+                sessionStore.grantCache.refreshNativeGrant(nativeGrantId);
+              }
               if (sessionStore.sessions.has(sessionId)) {
                 sessionStore.resetIdleTimer(sessionId);
               } else if (sessionStore.httpSessions.has(sessionId)) {
@@ -840,8 +863,13 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
           // grant was issued (#8442). The `grantIssuedAt` token guards
           // against a revoke-and-reissue race (#2243): if the entry was
           // replaced mid-dispatch, `refresh` is a silent no-op.
-          if (grantIssuedAt !== undefined) {
-            sessionStore.grantCache.refresh(sessionId, actionId, grantIssuedAt);
+          if (grantIssuedAt !== undefined || nativeGrantId !== undefined) {
+            if (grantIssuedAt !== undefined) {
+              sessionStore.grantCache.refresh(sessionId, actionId, grantIssuedAt);
+            }
+            if (nativeGrantId !== undefined) {
+              sessionStore.grantCache.refreshNativeGrant(nativeGrantId);
+            }
             if (sessionStore.sessions.has(sessionId)) {
               sessionStore.resetIdleTimer(sessionId);
             } else if (sessionStore.httpSessions.has(sessionId)) {

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -663,19 +663,16 @@ export class SessionStore {
       // transport sessionId in the cache; merge them into the same snapshot so
       // the settings surface shows the full grant lifecycle. Lazy-eviction
       // semantics match the per-tool grants — drop logically-expired entries.
-      const nativeGrants = this.grantCache
-        .getActiveNativeGrants(transportSessionId)
-        .filter((g) => g.expiresAt > now && g.remainingUses > 0)
-        .map((g) => ({
-          toolId: "*",
-          expiresAt: g.expiresAt,
-          ttlMs: g.ttlMs,
-          kind: "native" as const,
-          grantId: g.id,
-          allowedTools: [...g.allowedTools],
-          maxUses: g.maxUses,
-          remainingUses: g.remainingUses,
-        }));
+      const nativeGrants = this.grantCache.getLiveNativeGrants(transportSessionId).map((g) => ({
+        toolId: "*",
+        expiresAt: g.expiresAt,
+        ttlMs: g.ttlMs,
+        kind: "native" as const,
+        grantId: g.id,
+        allowedTools: [...g.allowedTools],
+        maxUses: g.maxUses,
+        remainingUses: g.remainingUses,
+      }));
       return {
         tier: this.getTier(transportSessionId),
         activeGrants: [...activeGrants, ...nativeGrants],

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -624,7 +624,16 @@ export class SessionStore {
     callerWebContentsId: number
   ): {
     tier: McpTier;
-    activeGrants: Array<{ toolId: string; expiresAt: number; ttlMs: number }>;
+    activeGrants: Array<{
+      toolId: string;
+      expiresAt: number;
+      ttlMs: number;
+      kind?: "per-tool" | "native";
+      grantId?: string;
+      allowedTools?: string[];
+      maxUses?: number;
+      remainingUses?: number;
+    }>;
   } | null {
     if (!helpSessionId) return null;
     for (const [transportSessionId, mappedHelpId] of this.sessionHelpIdMap) {
@@ -650,7 +659,51 @@ export class SessionStore {
         .getActiveGrants(transportSessionId)
         .filter((g) => g.expiresAt > now)
         .map((g) => ({ toolId: g.toolId, expiresAt: g.expiresAt, ttlMs: g.ttlMs }));
-      return { tier: this.getTier(transportSessionId), activeGrants };
+      // Native session-scoped automation grants (#10648) are addressed by the
+      // transport sessionId in the cache; merge them into the same snapshot so
+      // the settings surface shows the full grant lifecycle. Lazy-eviction
+      // semantics match the per-tool grants — drop logically-expired entries.
+      const nativeGrants = this.grantCache
+        .getActiveNativeGrants(transportSessionId)
+        .filter((g) => g.expiresAt > now && g.remainingUses > 0)
+        .map((g) => ({
+          toolId: "*",
+          expiresAt: g.expiresAt,
+          ttlMs: g.ttlMs,
+          kind: "native" as const,
+          grantId: g.id,
+          allowedTools: [...g.allowedTools],
+          maxUses: g.maxUses,
+          remainingUses: g.remainingUses,
+        }));
+      return {
+        tier: this.getTier(transportSessionId),
+        activeGrants: [...activeGrants, ...nativeGrants],
+      };
+    }
+    return null;
+  }
+
+  /**
+   * Resolve the live transport sessionId backing a public help-session id,
+   * caller-pinned. Mirrors {@link getLiveStatusForHelpSession}'s scan: returns
+   * the transport sessionId only when a live transport exists for the help id
+   * AND it is pinned to `callerWebContentsId`, else null. Used by the native
+   * grant issuance path (#10648) so the renderer can approve a grant addressed
+   * by the public help id it already holds, never a transport id it can't see.
+   */
+  resolveLiveTransportForHelpSession(
+    helpSessionId: string,
+    callerWebContentsId: number
+  ): string | null {
+    if (!helpSessionId) return null;
+    for (const [transportSessionId, mappedHelpId] of this.sessionHelpIdMap) {
+      if (mappedHelpId !== helpSessionId) continue;
+      if (this.sessionWebContentsMap.get(transportSessionId) !== callerWebContentsId) continue;
+      if (!this.sessions.has(transportSessionId) && !this.httpSessions.has(transportSessionId)) {
+        continue;
+      }
+      return transportSessionId;
     }
     return null;
   }

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -146,6 +146,37 @@ export const MCP_GRANT_MAX_LIFETIME_MS = 30 * 60 * 1000;
 export const MCP_GRANT_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
+ * Default use ceiling for a native session-scoped automation grant (#10648)
+ * when the renderer issues one without specifying `maxUses`. A native grant
+ * authorizes its allowed tools for at most this many dispatches before it
+ * exhausts and the user must re-approve.
+ */
+export const MCP_NATIVE_GRANT_DEFAULT_MAX_USES = 10;
+
+/**
+ * Hard bounds on the use ceiling a renderer may request when issuing a native
+ * grant. Keeps a single approval from authorizing an unbounded run of
+ * automated tool calls — past the ceiling the grant must be re-approved.
+ */
+export const MCP_NATIVE_GRANT_MIN_MAX_USES = 1;
+export const MCP_NATIVE_GRANT_MAX_MAX_USES = 100;
+
+/**
+ * Maximum number of tools a single native grant may authorize. A grant is a
+ * deliberate, inspectable scope — an unbounded allowlist would defeat the
+ * point. Issuance rejects an allowlist larger than this.
+ */
+export const MCP_NATIVE_GRANT_MAX_ALLOWED_TOOLS = 20;
+
+/**
+ * Lower bound on a native grant's requested TTL. Below a minute a grant would
+ * expire before the assistant could meaningfully use it; the upper bound is
+ * {@link MCP_GRANT_MAX_LIFETIME_MS} so a native grant can never outlive its
+ * SSE session, matching the per-tool grant ceiling.
+ */
+export const MCP_NATIVE_GRANT_MIN_TTL_MS = 60 * 1000;
+
+/**
  * Number of consecutive `(sessionId, toolId)` denials before the renderer
  * banner is silenced. The audit record is always written. The counter
  * resets when a grant is issued for the pair or when the session ends.

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -2021,14 +2021,34 @@ export interface HelpAssistantSettings {
   idleHibernateMinutes: HelpAssistantIdleHibernateMinutes;
 }
 
-/** One per-tool grant currently active for the pinned help session. */
+/**
+ * One grant currently active for the pinned help session. Covers both the
+ * per-tool "Approve once" grants (`kind: "per-tool"`) and the native
+ * session-scoped automation grants (`kind: "native"`, #10648). Native grants
+ * carry a multi-tool allowlist and a use ceiling; the native-only fields are
+ * absent on per-tool grants.
+ */
 export interface HelpSessionActiveGrant {
-  /** Dotted `BuiltInActionId` the grant authorizes (e.g. `terminal.kill`). */
+  /**
+   * For per-tool grants, the dotted `BuiltInActionId` authorized (e.g.
+   * `terminal.kill`). For native grants, `"*"` — the authorized tools are
+   * listed in {@link allowedTools}.
+   */
   toolId: string;
   /** Absolute epoch millis when the grant expires without refresh. */
   expiresAt: number;
   /** TTL the grant was minted with, in milliseconds. */
   ttlMs: number;
+  /** Discriminates the grant kind. Defaults to `"per-tool"` when absent. */
+  kind?: "per-tool" | "native";
+  /** Stable UUID of a native grant — the revoke target. Native grants only. */
+  grantId?: string;
+  /** Dotted `BuiltInActionId`s a native grant authorizes. Native grants only. */
+  allowedTools?: string[];
+  /** Use ceiling a native grant was minted with. Native grants only. */
+  maxUses?: number;
+  /** Uses left on a native grant. Native grants only. */
+  remainingUses?: number;
 }
 
 /**

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -264,6 +264,9 @@ export interface GeneratedElectronAPI {
     issueGrant(
       ...args: IpcInvokeMap["mcp-server:issue-grant"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:issue-grant"]["result"]>;
+    issueNativeGrant(
+      ...args: IpcInvokeMap["mcp-server:issue-native-grant"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:issue-native-grant"]["result"]>;
     listActiveBearers(
       ...args: IpcInvokeMap["mcp-server:list-active-bearers"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:list-active-bearers"]["result"]>;
@@ -276,6 +279,9 @@ export interface GeneratedElectronAPI {
     resetDenialCounts(
       ...args: IpcInvokeMap["mcp-server:reset-denial-counts"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:reset-denial-counts"]["result"]>;
+    revokeNativeGrant(
+      ...args: IpcInvokeMap["mcp-server:revoke-native-grant"]["args"]
+    ): Promise<IpcInvokeMap["mcp-server:revoke-native-grant"]["result"]>;
     revokeSessionGrants(
       ...args: IpcInvokeMap["mcp-server:revoke-session-grants"]["args"]
     ): Promise<IpcInvokeMap["mcp-server:revoke-session-grants"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -666,6 +666,17 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: { sessionId: string; toolId: string }];
     result: import("./mcpServer.js").McpIssueGrantResult;
   };
+  "mcp-server:issue-native-grant": {
+    args: [
+      payload: {
+        helpSessionId: string;
+        allowedTools: string[];
+        maxUses?: number | undefined;
+        ttlMs?: number | undefined;
+      },
+    ];
+    result: import("./mcpServer.js").McpIssueNativeGrantResult;
+  };
   "mcp-server:list-active-bearers": {
     args: [];
     result: import("./mcpServer.js").ActiveBearerRecord[];
@@ -681,6 +692,10 @@ export interface GeneratedIpcInvokeMap {
   "mcp-server:reset-denial-counts": {
     args: [payload: { sessionId: string }];
     result: void;
+  };
+  "mcp-server:revoke-native-grant": {
+    args: [payload: { grantId: string }];
+    result: import("./mcpServer.js").McpRevokeNativeGrantResult;
   };
   "mcp-server:revoke-session-grants": {
     args: [payload: { sessionId: string }];

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -194,13 +194,34 @@ export interface McpAuditRecord {
  * - `tier.decayed`: a bounded elevation aged out (`SessionStore.decayTier`)
  *   and the session silently fell back to its baseline. `tier` is the
  *   baseline it decayed to, `previousTier` the elevated tier it left.
+ * - `grant.used`: a native session-scoped automation grant (#10648)
+ *   authorized one tool dispatch and one use was consumed. `toolId` is the
+ *   specific tool that consumed the use; `remainingUses` is the count left
+ *   *after* the decrement. Distinct from a per-tool TTL grant, which has no
+ *   use ceiling and emits no per-use record.
+ * - `grant.exhausted`: a native grant's last use was consumed — a natural
+ *   terminal lifecycle state, NOT a forced revocation (so it is deliberately
+ *   a distinct record type rather than a {@link McpGrantRevokedReason}). The
+ *   grant is deleted by record-write time; `toolId` is the tool whose call
+ *   exhausted it.
  */
 export type McpGrantRecordType =
   | "grant.issued"
   | "grant.expired"
   | "grant.revoked"
+  | "grant.used"
+  | "grant.exhausted"
   | "tier.elevated"
   | "tier.decayed";
+
+/**
+ * Identity class of the actor a native automation grant (#10648) was issued
+ * to. Both are renderer-pinned internal bearers:
+ * - `help-session`: the help-chat assistant panel (a full help session).
+ * - `assistant-pane`: a `daintree-assistant` CLI pane bearer (#10647) pinned
+ *   to its launching WebContents without being promoted to a help session.
+ */
+export type McpGrantActorType = "help-session" | "assistant-pane";
 
 /**
  * Source of a `grant.revoked` transition.
@@ -240,6 +261,31 @@ export interface McpGrantRecord {
    */
   tier?: string;
   previousTier?: string;
+  /**
+   * Stable UUID of the native automation grant (#10648) this record belongs
+   * to. Set on `grant.issued`/`grant.used`/`grant.exhausted`/`grant.revoked`
+   * for native grants; absent on per-tool "Approve once" grants and tier
+   * records, so existing on-disk rows deserialize unchanged.
+   */
+  grantId?: string;
+  /** Use ceiling a native grant was minted with. Native grants only. */
+  maxUses?: number;
+  /**
+   * Uses left after this record's transition. On `grant.issued` it equals
+   * `maxUses`; on `grant.used` it is the post-decrement count; on
+   * `grant.exhausted` it is `0`. Native grants only.
+   */
+  remainingUses?: number;
+  /** Public id of the actor the native grant was issued to. Native grants only. */
+  actorId?: string;
+  /** Actor identity class for a native grant. Native grants only. */
+  actorType?: McpGrantActorType;
+  /**
+   * Dotted `BuiltInActionId`s a native grant authorizes. Carried on
+   * `grant.issued`/`grant.revoked` (where `toolId` is `"*"`) so the audit
+   * trail records the full approved scope. Native grants only.
+   */
+  allowedTools?: string[];
 }
 
 /**
@@ -267,6 +313,8 @@ const GRANT_RECORD_TYPES: ReadonlySet<McpGrantRecordType> = new Set([
   "grant.issued",
   "grant.expired",
   "grant.revoked",
+  "grant.used",
+  "grant.exhausted",
   "tier.elevated",
   "tier.decayed",
 ]);
@@ -304,6 +352,13 @@ export interface McpGrantLifecyclePayload {
   ttlMs: number;
   expiresAt?: number;
   revokedReason?: McpGrantRevokedReason;
+  /** Native automation grant fields (#10648); absent for per-tool grants. */
+  grantId?: string;
+  maxUses?: number;
+  remainingUses?: number;
+  actorId?: string;
+  actorType?: McpGrantActorType;
+  allowedTools?: string[];
 }
 
 /**
@@ -407,6 +462,37 @@ export interface McpIssueGrantResult {
   toolId: string;
   ttlMs: number;
   expiresAt: number;
+}
+
+/**
+ * Result of a renderer-driven `issueNativeGrant` IPC (#10648). A native
+ * session-scoped automation grant authorizes a bounded set of tools for the
+ * pinned assistant session for a limited number of uses, without a per-call
+ * modal. Returns the minted grant id and its scope/limit fields so the
+ * renderer can render the grant card (allowed tools, remaining uses,
+ * countdown) without polling.
+ */
+export interface McpIssueNativeGrantResult {
+  grantId: string;
+  sessionId: string;
+  actorId: string;
+  actorType: McpGrantActorType;
+  allowedTools: string[];
+  maxUses: number;
+  remainingUses: number;
+  ttlMs: number;
+  expiresAt: number;
+}
+
+/**
+ * Result of a renderer-driven `revokeNativeGrant` IPC (#10648). `revoked` is
+ * true when a matching native grant existed for the caller's session and was
+ * dropped; false when the grant id was already gone (exhausted, expired, or
+ * torn down with the session) so a dismissal cleanup is an idempotent no-op.
+ */
+export interface McpRevokeNativeGrantResult {
+  grantId: string;
+  revoked: boolean;
 }
 
 /** Minimum and maximum values accepted for the configurable ring-buffer cap. */

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -39,6 +39,7 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import type {
   HelpAssistantSettings,
   HelpAssistantTier,
+  HelpSessionActiveGrant,
   McpAuditStats,
   McpLogRecord,
   AssistantTurnRecord,
@@ -939,6 +940,135 @@ function GrantCountdown({ expiresAt }: { expiresAt: number }) {
   );
 }
 
+// Native session-scoped automation grants (#10648): approve a bounded set of
+// tools for a limited number of uses, then inspect and revoke them. Distinct
+// from the per-tool "Approve once" grants above — these authorize follow-up
+// automation across the session without a per-call modal. The grant lifecycle
+// (issue/use/exhaust/expire/revoke) is mirrored in the audit log below.
+function NativeGrantsSection({
+  helpSessionId,
+  grants,
+}: {
+  helpSessionId: string;
+  grants: HelpSessionActiveGrant[];
+}) {
+  const [toolsInput, setToolsInput] = useState("");
+  const [usesInput, setUsesInput] = useState("5");
+  const [issuing, setIssuing] = useState(false);
+  const [issueError, setIssueError] = useState<string | null>(null);
+
+  const approve = useCallback(() => {
+    const allowedTools = toolsInput
+      .split(/[\s,]+/)
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+    if (allowedTools.length === 0) {
+      setIssueError("Enter at least one tool id");
+      return;
+    }
+    const maxUses = Number.parseInt(usesInput, 10);
+    setIssuing(true);
+    setIssueError(null);
+    safeFireAndForget(
+      window.electron.mcpServer
+        .issueNativeGrant({
+          helpSessionId,
+          allowedTools,
+          maxUses: Number.isFinite(maxUses) ? maxUses : undefined,
+        })
+        .then(() => {
+          setToolsInput("");
+        })
+        .catch((err: unknown) => {
+          setIssueError(formatErrorMessage(err, "Couldn't approve grant"));
+        })
+        .finally(() => {
+          setIssuing(false);
+        }),
+      { context: "DaintreeAssistant:issueNativeGrant" }
+    );
+  }, [helpSessionId, toolsInput, usesInput]);
+
+  const revoke = useCallback((grantId: string) => {
+    safeFireAndForget(
+      window.electron.mcpServer
+        .revokeNativeGrant({ grantId })
+        .then(() => undefined)
+        .catch((err: unknown) => {
+          logError("DaintreeAssistant: revokeNativeGrant failed", err);
+        }),
+      { context: "DaintreeAssistant:revokeNativeGrant" }
+    );
+  }, []);
+
+  return (
+    <div className="space-y-2 pt-1">
+      <div className="text-[10px] uppercase tracking-wide text-daintree-text/50 font-mono">
+        Automation grants{grants.length > 0 ? ` (${grants.length})` : ""}
+      </div>
+      {grants.length > 0 ? (
+        <div className="space-y-1.5">
+          {grants.map((grant) => (
+            <div
+              key={grant.grantId}
+              className="rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg/40 px-2 py-1.5 space-y-1"
+            >
+              <div className="flex items-center justify-between gap-2 text-[11px]">
+                <span className="font-mono text-daintree-text/70 truncate">
+                  {(grant.allowedTools ?? []).join(", ") || "no tools"}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => grant.grantId && revoke(grant.grantId)}
+                  className="shrink-0 text-[10px] text-daintree-text/60 hover:text-status-danger transition-colors"
+                >
+                  Revoke
+                </button>
+              </div>
+              <div className="flex items-center justify-between gap-2 text-[10px] text-daintree-text/50">
+                <span className="tabular-nums">
+                  {grant.remainingUses ?? 0} of {grant.maxUses ?? 0} uses left
+                </span>
+                <GrantCountdown expiresAt={grant.expiresAt} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-[11px] text-daintree-text/50">No automation grants active</div>
+      )}
+
+      <div className="flex items-end gap-1.5 pt-0.5">
+        <input
+          type="text"
+          value={toolsInput}
+          onChange={(e) => setToolsInput(e.target.value)}
+          placeholder="git.commit terminal.new"
+          className="flex-1 min-w-0 rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg px-2 py-1 text-[11px] font-mono text-daintree-text placeholder:text-daintree-text/30 focus-visible:outline-2 focus-visible:outline-daintree-accent"
+        />
+        <input
+          type="number"
+          min={1}
+          max={100}
+          value={usesInput}
+          onChange={(e) => setUsesInput(e.target.value)}
+          aria-label="Maximum uses"
+          className="w-12 rounded-[var(--radius-sm)] border border-daintree-border bg-daintree-bg px-1.5 py-1 text-[11px] tabular-nums text-daintree-text focus-visible:outline-2 focus-visible:outline-daintree-accent"
+        />
+        <button
+          type="button"
+          onClick={approve}
+          disabled={issuing}
+          className="shrink-0 rounded-[var(--radius-sm)] border border-daintree-border bg-overlay-subtle px-2 py-1 text-[11px] text-daintree-text/80 hover:text-daintree-text disabled:opacity-50 transition-colors"
+        >
+          Approve grant
+        </button>
+      </div>
+      {issueError && <div className="text-[10px] text-status-danger">{issueError}</div>}
+    </div>
+  );
+}
+
 interface SessionLiveStatusCardProps {
   configuredTier: HelpAssistantTier;
 }
@@ -953,6 +1083,8 @@ interface SessionLiveStatusCardProps {
 function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
   const sessionId = useHelpPanelStore((s) => s.sessionId);
   const { connected, tier, activeGrants } = useHelpSessionLiveStatus(sessionId);
+  const perToolGrants = activeGrants.filter((g) => g.kind !== "native");
+  const nativeGrants = activeGrants.filter((g) => g.kind === "native");
   // Three-way relation to the configured default: a renderer-approved elevation
   // raises the live tier above it, but a session can also sit *below* it (e.g.
   // a per-session choice or a decayed elevation) — both must read truthfully,
@@ -994,13 +1126,13 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
             <span className="text-daintree-text">{TIER_SHORT_LABEL[tier].toLowerCase()}</span>
             {tierComparisonCopy}
           </div>
-          {activeGrants.length > 0 ? (
+          {perToolGrants.length > 0 ? (
             <div className="space-y-1">
               <div className="text-[10px] uppercase tracking-wide text-daintree-text/50 font-mono">
-                Active grants ({activeGrants.length})
+                Active grants ({perToolGrants.length})
               </div>
               <div className="space-y-1">
-                {activeGrants.map((grant) => (
+                {perToolGrants.map((grant) => (
                   <div
                     key={grant.toolId}
                     className="flex items-center justify-between gap-2 text-[11px]"
@@ -1014,6 +1146,7 @@ function SessionLiveStatusCard({ configuredTier }: SessionLiveStatusCardProps) {
           ) : (
             <div className="text-[11px] text-daintree-text/50">No per-tool grants active</div>
           )}
+          {sessionId && <NativeGrantsSection helpSessionId={sessionId} grants={nativeGrants} />}
         </>
       ) : (
         <div className="text-xs text-daintree-text/60 leading-relaxed">

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -47,6 +47,8 @@ const GRANT_TYPE_LABEL: Record<McpGrantRecordType, string> = {
   "grant.issued": "Grant issued",
   "grant.expired": "Grant expired",
   "grant.revoked": "Grant revoked",
+  "grant.used": "Grant used",
+  "grant.exhausted": "Grant exhausted",
   "tier.elevated": "Tier elevated",
   "tier.decayed": "Tier decayed",
 };
@@ -55,6 +57,8 @@ const GRANT_TYPE_DOT_CLASS: Record<McpGrantRecordType, string> = {
   "grant.issued": "bg-status-info",
   "grant.expired": "bg-status-warning",
   "grant.revoked": "bg-status-danger",
+  "grant.used": "bg-status-info",
+  "grant.exhausted": "bg-status-warning",
   "tier.elevated": "bg-status-warning",
   "tier.decayed": "bg-status-info",
 };
@@ -262,6 +266,12 @@ function GrantRow({
             Reason: {record.revokedReason}
           </div>
         )}
+        {record.maxUses !== undefined &&
+          (record.type === "grant.used" || record.type === "grant.exhausted") && (
+            <div className="mt-0.5 text-[10px] text-daintree-text/50">
+              {record.remainingUses ?? 0} of {record.maxUses} uses left
+            </div>
+          )}
         {record.expiresAt !== undefined && record.type === "grant.issued" && (
           <div className="mt-0.5 text-[10px] text-daintree-text/50">
             Expires{" "}


### PR DESCRIPTION
## Summary

- Adds native session-scoped automation grants to the Daintree Assistant. A grant covers a bounded set of tools for a limited number of uses, bypassing per-call confirmation modals for the duration of the session.
- The authorization check is additive: native grants are consulted only when the static tier floor and the per-tool grant both deny, and they only override for tools the user explicitly approved. Fails closed on teardown.
- Two new IPC channels (`mcp-server:issue-native-grant` and `mcp-server:revoke-native-grant`) wired through the settings UI, which shows active grants with remaining uses, a countdown, and a revoke button.

Resolves #10648

## Changes

- `grantCache.ts`: new `NativeGrantEntry` type (UUID-keyed), `peekNativeGrant` / `consumeNativeGrantUse` split so rate-limited calls don't burn a use, hard wall-clock ceiling plus sliding TTL, `grant.used` / `grant.exhausted` lifecycle events. `sweep`, `revokeSession`, `clearSessionState`, `clearAll`, and `dispose` all cover native grants.
- `sessionServer.ts`: additive native-grant check after the static tier floor and per-tool grant both deny. Native grants bypass the `danger:"confirm"` modal; out-of-scope, expired, exhausted, and revoked grants fail closed.
- `httpLifecycle.ts`: `issueNativeGrant` (addressed by public help-session id, caller-pinned, validates allowlist / `maxUses` / TTL) and `revokeNativeGrant` (by id, caller-pinned, idempotent). Existing `revokeSession` teardown covers native grants automatically.
- `electron/ipc/channels.ts` + `mcpServer.ts` + preload + shared IPC types: two new channels, codegen regenerated.
- `DaintreeAssistantSettingsTab.tsx`: live-status card extended with active native grants (allowed tools, remaining uses, countdown, revoke button).
- `McpAuditLogViewer.tsx`: labels the new grant-lifecycle record types.

## Testing

351 targeted unit tests pass across `grantCache`, `sessionServer`, `sessionStore`, `httpLifecycle`, and the `mcpServer` + `helpAssistant` IPC handlers. Typecheck clean. Lint clean on changed files (one pre-existing unrelated warning at `McpServerService.ts:690`).