### PR TITLE
feat(assistant): wire Daintree Assistant compatibility for help sessions

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -849,6 +849,60 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
+  it("injects DAINTREE_ASSISTANT_AUTO_APPROVE=1 when the Daintree Assistant launches with bypassPermissions on", async () => {
+    mockValidateToken.mockImplementation((token) =>
+      token === "assistant-bypass" ? "system" : false
+    );
+    mockGetBypassPermissions.mockImplementation((token) => token === "assistant-bypass");
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+        env: { DAINTREE_MCP_TOKEN: "assistant-bypass" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_ASSISTANT_AUTO_APPROVE).toBe("1");
+    // The assistant is not Claude Code — no CLI permission flag is appended.
+    expect(spawnArgs.command).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("does NOT inject DAINTREE_ASSISTANT_AUTO_APPROVE when the assistant launches with bypassPermissions off", async () => {
+    mockValidateToken.mockImplementation((token) =>
+      token === "assistant-nobypass" ? "system" : false
+    );
+    mockGetBypassPermissions.mockImplementation(() => false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "daintree-assistant",
+        launchAgentId: "daintree-assistant",
+        env: { DAINTREE_MCP_TOKEN: "assistant-nobypass" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_ASSISTANT_AUTO_APPROVE).toBeUndefined();
+  });
+
   it("appends --dangerously-skip-permissions even at action tier when bypassPermissions is on", async () => {
     // Tier and bypassPermissions are decoupled (#7532): an action-tier
     // session with bypass on should still skip the CLI confirmation gate.

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -256,6 +256,14 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     if (isHelpLaunch && launchAgentId) {
       const dangerous = DEFAULT_DANGEROUS_ARGS[launchAgentId];
       const bypassPermissions = helpSessionService.getBypassPermissions(helpToken);
+      // The Daintree Assistant is not Claude Code — it has no
+      // `--dangerously-skip-permissions` flag (no DEFAULT_DANGEROUS_ARGS entry).
+      // For it, the user's "bypass permissions" preference maps to skipping the
+      // assistant's OWN per-action confirm sheet, which the CLI reads from this
+      // env var at startup. The capability tier remains the only safeguard.
+      if (launchAgentId === "daintree-assistant" && bypassPermissions) {
+        spawnEnv = { ...(spawnEnv ?? {}), DAINTREE_ASSISTANT_AUTO_APPROVE: "1" };
+      }
       // Honor the agent's `supports.permissionBypass` declaration: only
       // append the dangerous flag when the agent has opted in. Gemini help
       // sessions sit at `permissionBypass: false` (Phase 1 stays in plan

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -10,6 +10,7 @@ import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { probeMcpServer, probeMcpSseServer } from "./mcp-server/readinessProbe.js";
 import { getAssistantWiredAgentIds } from "../../shared/config/agentRegistry.js";
+import { ASSISTANT_ONLY_AGENT_IDS } from "../../shared/config/agentIds.js";
 import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
 import type { ActionContext } from "../../shared/types/actions.js";
 import type { PtyClient } from "./PtyClient.js";
@@ -495,7 +496,18 @@ export class HelpSessionService {
     pathHash: string
   ): Promise<ProvisionResult | null> {
     const settings = this.readSettings();
-    const tier = settings.tier;
+    // The Daintree Assistant is the workspace's first-class conductor: when the
+    // user explicitly selects it, it runs at the top `system` tier so the full
+    // action surface — forge writes, git mutations, worktree.delete — is reachable
+    // (still behind the per-action confirm gate; the tier opens the door, it does
+    // not skip confirmation). Other help-overlay agents (Claude/Codex) keep the
+    // deliberate `action` floor from settings, where irreversible mutations need a
+    // human-approved scoped grant. Policy locks live in
+    // `mcp-server/__tests__/tierAuth.test.ts`.
+    const isDaintreeAssistant = (ASSISTANT_ONLY_AGENT_IDS as readonly string[]).includes(
+      input.agentId
+    );
+    const tier: HelpAssistantTier = isDaintreeAssistant ? "system" : settings.tier;
     const sessionId = randomUUID();
     const token = randomBytes(SESSION_TOKEN_BYTES).toString("hex");
     const sessionsRoot = this.getSessionsRoot();

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -387,6 +387,33 @@ describe("HelpSessionService", () => {
     expect(settings.defaultMode).toBeUndefined();
   });
 
+  it("provisions the Daintree Assistant at the system tier regardless of the stored setting", async () => {
+    // Selecting the Daintree Assistant grants full capability (system tier),
+    // overriding the action-tier floor that governs the Claude/Codex help
+    // overlays. The stored setting here says `action`; the agent identity wins.
+    mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: false });
+
+    const result = await service.provisionSession({
+      ...provisionInput(),
+      agentId: "daintree-assistant",
+    });
+    if (!result) throw new Error("expected result");
+    expect(result.tier).toBe("system");
+  });
+
+  it("leaves non-assistant help agents on the stored action tier", async () => {
+    // Contrast with the Daintree Assistant override above: a Claude help overlay
+    // keeps the deliberate action floor so irreversible mutations still need a grant.
+    mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: false });
+
+    const result = await service.provisionSession({
+      ...provisionInput(),
+      agentId: "claude",
+    });
+    if (!result) throw new Error("expected result");
+    expect(result.tier).toBe("action");
+  });
+
   it("getBypassPermissions returns the snapshot taken at provision time", async () => {
     mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: true });
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2703,6 +2703,11 @@ describe("McpServerService", () => {
         title: "Open URL in Browser",
         description: "Open a URL in a browser panel, reusing an existing one or creating a new one",
       }),
+      createManifestEntry({
+        id: "panel.focus" as ActionId,
+        title: "Focus Panel",
+        description: "Focus a specific panel by id",
+      }),
       // Additional entries needed for full SYSTEM_TIER_ADDONS coverage.
       createManifestEntry({
         id: "git.stageFile" as ActionId,

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -387,17 +387,19 @@ describe("buildAnnotations", () => {
   });
 });
 
-// Policy guard for the Daintree Assistant CLI's MCP tier (#10640). The
-// assistant is a headless conductor and runs at the `action` tier (the
-// help-session `DEFAULT_TIER`), NOT the `external` tier an api-key bearer
-// falls into by default. The distinction is load-bearing: `external` auto-
-// permits irreversible mutations (git.push, worktree.delete) subject only to
-// the confirm gate, whereas `action` leaves them TIER_NOT_PERMITTED so they
-// require a human-approved scoped grant to run at all. These assertions lock
-// that invariant against allowlist drift (e.g. someone promoting git.push into
-// the action tier). They test the runtime gate `isTierPermitted`, not the raw
+// Policy guard for the help-session MCP tiers (#10640). NOTE: the Daintree
+// Assistant itself is now provisioned at the `system` tier (see
+// HelpSessionService.doProvision — selecting it grants full capability), so the
+// assertions below lock the `action` tier that still governs the Claude/Codex
+// help OVERLAYS, plus the system/external boundaries the assistant relies on.
+// The distinction is load-bearing: `action` leaves irreversible mutations
+// (git.push, worktree.delete) TIER_NOT_PERMITTED so the overlays need a
+// human-approved scoped grant, while `system` (the assistant) and `external`
+// permit them subject only to the confirm gate. These assertions lock those
+// invariants against allowlist drift (e.g. someone promoting git.push into the
+// action tier). They test the runtime gate `isTierPermitted`, not the raw
 // allowlist arrays, so they fail closed if the tier wiring itself regresses.
-describe("Daintree Assistant tier policy (#10640)", () => {
+describe("help-session tier policy (#10640)", () => {
   // The conductor's working tool set — orchestration, terminal driving, branch
   // setup, recipes, and reads — all resolve under `action`.
   const ASSISTANT_REQUIRED_TOOLS = [

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -302,6 +302,65 @@ describe("openDb (integration)", () => {
     }
   });
 
+  it("applies a later migration to a DB already migrated through an earlier one (regression: audit_rings skip)", async () => {
+    // Reproduces the journal-timestamp bug: drizzle only applies a migration when
+    // its folderMillis (the journal `when`) is greater than the newest recorded
+    // `created_at`. A migration stamped with a `when` that predates an already-
+    // applied one is silently skipped on every existing DB. Here we seed a DB that
+    // has run through every migration EXCEPT the last and assert openDb closes the
+    // gap — i.e. the final migration's table actually gets created.
+    const dbPath = path.join(tmpDir, "mid-history.db");
+
+    const journal = JSON.parse(
+      fs.readFileSync(path.join(migrationsFolder, "meta", "_journal.json"), "utf8")
+    ).entries as Array<{ when: number; tag: string }>;
+    // Everything except the most recent migration is "already applied".
+    const applied = journal.slice(0, -1);
+    const latest = journal[journal.length - 1];
+
+    const Database = (await import("better-sqlite3")).default;
+    const seed = new Database(dbPath);
+    // Mirror drizzle's own bookkeeping table + a projects table for openDb's backfill.
+    seed.exec(`
+      CREATE TABLE __drizzle_migrations (
+        id SERIAL PRIMARY KEY,
+        hash text NOT NULL,
+        created_at numeric
+      );
+      CREATE TABLE projects (
+        id TEXT PRIMARY KEY,
+        path TEXT NOT NULL,
+        name TEXT NOT NULL,
+        emoji TEXT NOT NULL,
+        last_opened INTEGER NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0,
+        frecency_score REAL NOT NULL DEFAULT 3.0,
+        last_accessed_at INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    const ins = seed.prepare("INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)");
+    for (const entry of applied) ins.run(entry.tag, entry.when);
+    seed.close();
+
+    // The migration's table must be absent before the upgrade for the test to mean
+    // anything — guards against the seed accidentally creating it.
+    expect(latest.tag).toContain("audit_rings");
+
+    const { sqlite } = openDb(dbPath, migrationsFolder);
+    try {
+      const hasAuditRings = sqlite
+        .prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name='audit_rings'")
+        .get();
+      expect(hasAuditRings).toBeTruthy();
+
+      // The skipped migration is now recorded — total equals the full journal.
+      const migrations = sqlite.prepare("SELECT id FROM __drizzle_migrations").all();
+      expect(migrations).toHaveLength(EXPECTED_MIGRATION_COUNT);
+    } finally {
+      sqlite.close();
+    }
+  });
+
   it("closes the underlying SQLite handle if migrate() throws", () => {
     const dbPath = path.join(tmpDir, "leak.db");
     const bogusFolder = path.join(tmpDir, "does-not-exist");

--- a/electron/services/persistence/migrations/meta/_journal.json
+++ b/electron/services/persistence/migrations/meta/_journal.json
@@ -33,7 +33,7 @@
     {
       "idx": 4,
       "version": "6",
-      "when": 1749686400000,
+      "when": 1781277645000,
       "tag": "0004_audit_rings",
       "breakpoints": true
     }

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -95,6 +95,8 @@ export const ACTION_TIER_ADDONS = [
   "agent.focusNextAgent",
   "agent.focusPreviousAgent",
 
+  "panel.focus",
+
   "workflow.startWorkOnIssue",
   "workflow.focusNextAttention",
 

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -26,6 +26,7 @@ import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import { HelpLaunchingState } from "./HelpLaunchingState";
 import { McpActivityStrip } from "./McpActivityStrip";
 import { McpAnomalyFooterLink } from "./McpAnomalyFooterLink";
+import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { TurnOutcomePip } from "./TurnOutcomePip";
 import { FigureRail } from "./FigureRail";
 import {
@@ -1051,13 +1052,27 @@ export function HelpPanel({
                 Start new session
               </button>
             )}
-            <span
-              className="flex items-center gap-1 shrink-0"
-              title={`Assistant agent: ${agentConfig.name}`}
-            >
-              <agentConfig.icon className="w-3.5 h-3.5" />
-              {agentConfig.name}
-            </span>
+            {agentId === "daintree-assistant" ? (
+              // The Daintree Assistant is the workspace's own conductor, so the
+              // brand mark already says "Daintree" — pairing it with just
+              // "assistant" keeps this status row from repeating the word twice
+              // and frees up the tight footer width.
+              <span
+                className="flex items-center gap-1 shrink-0"
+                title={`Assistant agent: ${agentConfig.name}`}
+              >
+                <DaintreeIcon className="w-3.5 h-3.5" />
+                Assistant
+              </span>
+            ) : (
+              <span
+                className="flex items-center gap-1 shrink-0"
+                title={`Assistant agent: ${agentConfig.name}`}
+              >
+                <agentConfig.icon className="w-3.5 h-3.5" />
+                {agentConfig.name}
+              </span>
+            )}
           </span>
         </div>
       )}


### PR DESCRIPTION
## Summary

Wires first-class support for the **Daintree Assistant** as a help-session agent, distinct from the external CLI agents (Claude Code, Codex, Gemini) that also run in the help overlay.

- **Top-tier by selection** — when the user explicitly picks the Daintree Assistant, the help session runs at the `system` tier so the full action surface (forge writes, git mutations, `worktree.delete`) is reachable. The tier opens the door; the per-action confirm gate is unchanged, so irreversible mutations still require human approval. Other help-overlay agents keep the deliberate `action` floor from settings.
- **Bypass-permissions mapping** — the Assistant is not Claude Code and has no `--dangerously-skip-permissions` flag. The user's "bypass permissions" preference instead maps to `DAINTREE_ASSISTANT_AUTO_APPROVE=1`, which skips the assistant's own per-action confirm sheet at startup. The capability tier remains the only safeguard.
- **Allowlist** — adds `panel.focus` to `ACTION_TIER_ADDONS`.
- **Footer chrome** — the Assistant renders with the Daintree brand mark + "Assistant" instead of repeating the word twice in the tight status row.

## Changes

- `electron/services/HelpSessionService.ts` — `system` tier for `ASSISTANT_ONLY_AGENT_IDS`.
- `electron/ipc/handlers/terminal/lifecycle.ts` — `DAINTREE_ASSISTANT_AUTO_APPROVE` env wiring under bypass-permissions.
- `shared/config/helpAssistantTierAllowlists.ts` — add `panel.focus` addon.
- `src/components/HelpPanel/HelpPanel.tsx` — brand-mark footer for the Assistant.
- Tests: `HelpSessionService.test.ts`, `tierAuth.test.ts`, `lifecycle.spawn.test.ts`, `db.openDb.test.ts`; migration journal bump.

## Testing

- `npm run test` (unit) covers tier policy locks (`tierAuth.test.ts`), session tier assignment, spawn-env wiring, and migration open.
