### PR TITLE
fix(activity): recover agent terminal from waiting during heavy streaming output

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -6,7 +6,7 @@ import {
 } from "./pty/AgentPatternDetector.js";
 import { PatternBuffer } from "./pty/PatternBuffer.js";
 import { InputTracker } from "./pty/InputTracker.js";
-import { OutputVolumeDetector } from "./pty/OutputVolumeDetector.js";
+import { OutputVolumeDetector, type OutputVolumeConfig } from "./pty/OutputVolumeDetector.js";
 import { HighOutputDetector } from "./pty/HighOutputDetector.js";
 import { WorkingSignalDebouncer } from "./pty/WorkingSignalDebouncer.js";
 import { LineRewriteDetector, isStatusLineRewrite } from "./pty/LineRewriteDetector.js";
@@ -124,6 +124,14 @@ export interface ActivityMonitorOptions {
   maxCpuHighEscapeMs?: number;
   maxWaitingSilenceMs?: number;
   simpleOutputState?: boolean;
+  // Leaky-bucket byte-volume detector for the simpleOutputState early-return
+  // path (#10664). Agent terminals short-circuit before the non-simple
+  // first-output-byte recovery guard, so a sustained stream of appended output
+  // (e.g. a long investigation result) never drove waiting→working. This
+  // dedicated detector — kept separate from `outputActivityDetection` so it
+  // can't perturb the polling cycle's `hasRecentOutputActivity` signal —
+  // recovers idle→busy once enough stripped output accumulates.
+  simpleOutputVolumeRecovery?: OutputVolumeConfig;
   // Consecutive watchdog ticks that must all observe a dead-looking probe
   // result before onWaitingTimeout fires. Defaults to 3 (≈15s of sustained
   // consensus at the 5s watchdog cadence) to ride through transient false
@@ -167,6 +175,9 @@ export class ActivityMonitor {
   private readonly inputTracker: InputTracker;
   private readonly patternBuf: PatternBuffer;
   private readonly outputVolumeDetector: OutputVolumeDetector;
+  // Volume-based idle→busy recovery for the simpleOutputState path (#10664).
+  // Undefined unless `simpleOutputVolumeRecovery` is configured.
+  private readonly simpleOutputVolumeDetector?: OutputVolumeDetector;
   private readonly highOutputDetector: HighOutputDetector;
   private readonly workingSignalDebouncer: WorkingSignalDebouncer;
   // Dedicated debouncer for the idle-state cosmetic-redraw recovery path
@@ -288,6 +299,9 @@ export class ActivityMonitor {
     this.patternBuf = new PatternBuffer(options?.patternBufferSize ?? 10000);
 
     this.outputVolumeDetector = new OutputVolumeDetector(options?.outputActivityDetection);
+    this.simpleOutputVolumeDetector = options?.simpleOutputVolumeRecovery
+      ? new OutputVolumeDetector(options.simpleOutputVolumeRecovery)
+      : undefined;
 
     this.highOutputDetector = new HighOutputDetector(options?.highOutputThreshold);
 
@@ -550,6 +564,25 @@ export class ActivityMonitor {
           now,
           isIndicatorRewrite ? "indicator" : "content"
         );
+      }
+      // Byte-volume liveness floor (#10664). The visible-content temperature
+      // model reports changedChars: 0 for appended/scrolled output, so a long
+      // stream of investigation text never recovers waiting→working. Count the
+      // stripped bytes into a dedicated leaky bucket and, once it fires, recover
+      // idle→busy under the same suppression guards the non-simple
+      // first-output-byte path uses (#6388 strip-then-count, #8867 focus gate).
+      if (this.state === "idle" && this.simpleOutputVolumeDetector) {
+        const filteredLength = Buffer.byteLength(stripIdleTerminalSequences(data), "utf8");
+        if (
+          filteredLength > 0 &&
+          this.simpleOutputVolumeDetector.update(filteredLength, now) &&
+          !this.isResizeSuppressed(now) &&
+          !this.isFocusSuppressed(now) &&
+          !this.inputTracker.isRecentUserInput(now) &&
+          this.bootDetector.hasExitedBootState
+        ) {
+          this.becomeBusy({ trigger: "output" }, now);
+        }
       }
       return;
     }

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -178,6 +178,13 @@ export class ActivityMonitor {
   // Volume-based idle→busy recovery for the simpleOutputState path (#10664).
   // Undefined unless `simpleOutputVolumeRecovery` is configured.
   private readonly simpleOutputVolumeDetector?: OutputVolumeDetector;
+  // Wall-clock of the last sustained-volume bucket fire (#10664). Defers both
+  // simpleOutputState waiting-demotion gates (the polling idle gate and the
+  // temperature `stateHint: idle` gate) for the quiet floor after heavy
+  // streaming, since appended output leaves the visible-content diff flat.
+  // Stays 0 — and thus inert — for any monitor whose volume detector never
+  // fires, so non-agent and unconfigured paths are unaffected.
+  private lastSimpleOutputVolumeAt = 0;
   private readonly highOutputDetector: HighOutputDetector;
   private readonly workingSignalDebouncer: WorkingSignalDebouncer;
   // Dedicated debouncer for the idle-state cosmetic-redraw recovery path
@@ -567,11 +574,15 @@ export class ActivityMonitor {
       }
       // Byte-volume liveness floor (#10664). The visible-content temperature
       // model reports changedChars: 0 for appended/scrolled output, so a long
-      // stream of investigation text never recovers waiting→working. Count the
-      // stripped bytes into a dedicated leaky bucket and, once it fires, recover
-      // idle→busy under the same suppression guards the non-simple
-      // first-output-byte path uses (#6388 strip-then-count, #8867 focus gate).
-      if (this.state === "idle" && this.simpleOutputVolumeDetector) {
+      // stream of investigation text never recovers waiting→working and, once
+      // recovered, the simpleOutputState idle gate (which keys off
+      // `lastActivityTimestamp`, only moved by visible-snapshot changes) would
+      // bounce it straight back to waiting. Count the stripped bytes into a
+      // dedicated leaky bucket; when it fires under the same suppression guards
+      // the non-simple first-output-byte path uses (#6388 strip-then-count,
+      // #8867 focus gate), treat that as activity: refresh the activity clock
+      // so heavy streaming keeps the agent working, and recover idle→busy.
+      if (this.simpleOutputVolumeDetector) {
         const filteredLength = Buffer.byteLength(stripIdleTerminalSequences(data), "utf8");
         if (
           filteredLength > 0 &&
@@ -581,7 +592,10 @@ export class ActivityMonitor {
           !this.inputTracker.isRecentUserInput(now) &&
           this.bootDetector.hasExitedBootState
         ) {
-          this.becomeBusy({ trigger: "output" }, now);
+          this.lastSimpleOutputVolumeAt = now;
+          if (this.state === "idle") {
+            this.becomeBusy({ trigger: "output" }, now);
+          }
         }
       }
       return;
@@ -877,7 +891,15 @@ export class ActivityMonitor {
       return;
     }
 
-    if (this.state === "busy" && result.stateHint === "idle" && now >= this.workingHoldUntil) {
+    if (
+      this.state === "busy" &&
+      result.stateHint === "idle" &&
+      now >= this.workingHoldUntil &&
+      // Heavy appended streaming leaves the visible-content diff flat, so the
+      // temperature reports "idle" even while output pours in. Defer demotion
+      // while the byte-volume floor has fired within the quiet window (#10664).
+      !this.hasRecentSimpleOutputVolume(now)
+    ) {
       this.transitionSimpleToIdle(now);
     }
   }
@@ -918,6 +940,7 @@ export class ActivityMonitor {
     this.completionTimer.dispose();
     this.inputTracker.reset();
     this.outputVolumeDetector.reset();
+    this.simpleOutputVolumeDetector?.reset();
     this.highOutputDetector.reset();
     this.workingSignalDebouncer.reset();
     this.cosmeticRecoveryDebouncer.reset();
@@ -937,6 +960,7 @@ export class ActivityMonitor {
     this.cpuTracker.reset();
     this.workingHoldUntil = 0;
     this.lastDataTimestamp = 0;
+    this.lastSimpleOutputVolumeAt = 0;
     this.lastOutputActivityAt = 0;
     this.lastStatusRewriteAt = 0;
     this.lastWorkingIndicatorTimestamp = 0;
@@ -1051,6 +1075,18 @@ export class ActivityMonitor {
       this.state = "busy";
       this.idleSince = now;
     }
+  }
+
+  // True while the simpleOutputState byte-volume floor (#10664) has fired
+  // within the waiting-quiet window. Used to defer waiting-demotion during
+  // heavy appended streaming, which leaves the visible-content diff flat. The
+  // `> 0` guard keeps a never-fired clock (0) from blocking demotion at small
+  // synthetic timestamps, so monitors without a volume detector are inert here.
+  private hasRecentSimpleOutputVolume(now: number): boolean {
+    return (
+      this.lastSimpleOutputVolumeAt > 0 &&
+      now - this.lastSimpleOutputVolumeAt < this.IDLE_DEBOUNCE_MS
+    );
   }
 
   notifyResize(suppressionMs = 500): void {
@@ -1197,6 +1233,7 @@ export class ActivityMonitor {
         this.state === "busy" &&
         !this.completionTimer.emitted &&
         now - this.lastActivityTimestamp >= this.IDLE_DEBOUNCE_MS &&
+        !this.hasRecentSimpleOutputVolume(now) &&
         now >= this.workingHoldUntil
       ) {
         this.transitionSimpleToIdle(now);
@@ -1678,6 +1715,7 @@ export class ActivityMonitor {
         if (
           this.state === "busy" &&
           now - this.lastActivityTimestamp >= this.IDLE_DEBOUNCE_MS &&
+          !this.hasRecentSimpleOutputVolume(now) &&
           now >= this.workingHoldUntil
         ) {
           this.transitionSimpleToIdle(now);

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -1362,6 +1362,94 @@ describe("ActivityMonitor", () => {
 
       monitor.dispose();
     });
+
+    it("recovers waiting→working from sustained byte volume alone (#10664)", () => {
+      const onStateChange = vi.fn();
+      let visible = ["idle prompt"];
+      const monitor = new ActivityMonitor("simple-volume", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => visible,
+        getCursorLine: () => visible[visible.length - 1],
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        simpleOutputVolumeRecovery: {
+          enabled: true,
+          leakRatePerMs: 0.1,
+          activationThreshold: 512,
+          maxBytesPerFrame: 256,
+        },
+      });
+
+      monitor.startPolling();
+      // Drive boot exit + a real work cycle, then let the agent settle back to
+      // waiting with a static screen the polling cycle can't recover from.
+      driveBusyViaOutputChanges(monitor, (text) => {
+        visible = [text];
+      });
+      visible = ["idle prompt"];
+      vi.advanceTimersByTime(8200);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // Heavy streaming output whose visible-content diff registers no change
+      // (pure appended text). Only the byte-volume floor can recover here.
+      const chunk = "investigation result ".repeat(16); // > maxBytesPerFrame
+      monitor.onData(chunk);
+      expect(monitor.getState()).toBe("idle"); // one frame is capped below threshold
+      monitor.onData(chunk);
+
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange).toHaveBeenCalledWith("simple-volume", 1000, "busy", {
+        trigger: "output",
+      });
+
+      monitor.dispose();
+    });
+
+    it("does not recover idle→busy from byte volume during focus suppression (#10664)", () => {
+      const onStateChange = vi.fn();
+      let visible = ["idle prompt"];
+      const monitor = new ActivityMonitor("simple-volume-focus", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => visible,
+        getCursorLine: () => visible[visible.length - 1],
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        simpleOutputVolumeRecovery: {
+          enabled: true,
+          leakRatePerMs: 0.1,
+          activationThreshold: 512,
+          maxBytesPerFrame: 256,
+        },
+      });
+
+      monitor.startPolling();
+      driveBusyViaOutputChanges(monitor, (text) => {
+        visible = [text];
+      });
+      visible = ["idle prompt"];
+      vi.advanceTimersByTime(8200);
+      expect(monitor.getState()).toBe("idle");
+      onStateChange.mockClear();
+
+      // A window-focus repaint suppresses promotion (#8867). Even a volume
+      // burst that crosses the threshold must not flip idle→busy.
+      monitor.notifyFocus(2000);
+      const chunk = "investigation result ".repeat(16);
+      monitor.onData(chunk);
+      monitor.onData(chunk);
+      monitor.onData(chunk);
+
+      expect(monitor.getState()).toBe("idle");
+      expect(onStateChange).not.toHaveBeenCalledWith(
+        "simple-volume-focus",
+        1000,
+        "busy",
+        expect.anything()
+      );
+
+      monitor.dispose();
+    });
   });
 
   describe("notifySubmission (hybrid input bar)", () => {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ActivityMonitor } from "../ActivityMonitor.js";
 import { AGENT_OUTPUT_ACTIVITY_LINE_COUNT } from "../pty/AgentActivityTemperature.js";
+import { buildActivityMonitorOptions } from "../pty/terminalActivityPatterns.js";
 import {
   createVisibleCellContentSnapshot,
   createVisibleContentSnapshot,
@@ -1363,7 +1364,7 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("recovers waiting→working from sustained byte volume alone (#10664)", () => {
+    it("recovers waiting→working from sustained byte volume and stays working through the stream (#10664)", () => {
       const onStateChange = vi.fn();
       let visible = ["idle prompt"];
       const monitor = new ActivityMonitor("simple-volume", 1000, onStateChange, {
@@ -1402,6 +1403,22 @@ describe("ActivityMonitor", () => {
       expect(onStateChange).toHaveBeenCalledWith("simple-volume", 1000, "busy", {
         trigger: "output",
       });
+
+      // The visible screen never changes, so the only thing keeping the agent
+      // working is the volume floor refreshing the activity clock. Keep
+      // streaming for well past WORKING_HOLD_MS (1.5s) and IDLE_DEBOUNCE_MS (8s)
+      // and confirm it does not bounce back to waiting mid-stream.
+      for (let i = 0; i < 60; i += 1) {
+        vi.advanceTimersByTime(500);
+        monitor.onData(chunk);
+      }
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange.mock.calls.filter((call) => call[2] === "idle")).toHaveLength(0);
+
+      // Once the stream stops, the agent settles back to waiting after the gate.
+      visible = ["idle prompt"];
+      vi.advanceTimersByTime(8200);
+      expect(monitor.getState()).toBe("idle");
 
       monitor.dispose();
     });
@@ -1449,6 +1466,19 @@ describe("ActivityMonitor", () => {
       );
 
       monitor.dispose();
+    });
+
+    it("wires simpleOutputVolumeRecovery for agent terminals only (#10664)", () => {
+      const agentOptions = buildActivityMonitorOptions("claude", {});
+      expect(agentOptions.simpleOutputVolumeRecovery?.enabled).toBe(true);
+      // Threshold must exceed the per-frame cap so a single chunk can never fire
+      // the bucket on its own — recovery requires sustained volume.
+      const recovery = agentOptions.simpleOutputVolumeRecovery!;
+      expect(recovery.activationThreshold!).toBeGreaterThan(recovery.maxBytesPerFrame!);
+
+      // Non-agent terminals don't get the recovery detector.
+      const plainOptions = buildActivityMonitorOptions(undefined, {});
+      expect(plainOptions.simpleOutputVolumeRecovery).toBeUndefined();
     });
   });
 

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -206,6 +206,22 @@ export function buildActivityMonitorOptions(
     maxBytesPerFrame: 64,
   };
 
+  // Dedicated byte-volume floor for the simpleOutputState early-return path
+  // (#10664). Deliberately more conservative than outputActivityDetection: it
+  // only recovers waiting→working on a *sustained* stream (>100 B/s for a few
+  // seconds), so it ignores the small inter-tool-call writes that
+  // simpleOutputState was introduced to tolerate, while still escaping the
+  // stuck-waiting state during heavy streaming output. 0.1 B/ms drain means a
+  // ~100 B/s flow never fills the 512-byte bucket; heavier flows fire within a
+  // few seconds. maxBytesPerFrame caps any single status payload so one burst
+  // can't fire alone.
+  const simpleOutputVolumeRecovery = {
+    enabled: true,
+    leakRatePerMs: 0.1,
+    activationThreshold: 512,
+    maxBytesPerFrame: 256,
+  };
+
   const getVisibleLines = effectiveAgentId ? deps.getVisibleLines : undefined;
   const getVisibleContentSnapshot = effectiveAgentId ? deps.getVisibleContentSnapshot : undefined;
   const getCursorLine = effectiveAgentId ? deps.getCursorLine : undefined;
@@ -240,6 +256,8 @@ export function buildActivityMonitorOptions(
     idleDebounceMs,
     promptFastPathMinQuietMs,
     simpleOutputState: effectiveAgentId !== undefined,
+    simpleOutputVolumeRecovery:
+      effectiveAgentId !== undefined ? simpleOutputVolumeRecovery : undefined,
     maxWaitingSilenceMs: 600_000,
     // Background polling (500ms) shortens the recovery debouncer so
     // backgrounded agents can escape "waiting" when output resumes (#6641).


### PR DESCRIPTION
## Summary

- Agent terminals were getting stuck in `waiting` while streaming heavy output. The `simpleOutputState` early-return path in `ActivityMonitor.onData` exits before the byte-volume detectors and the first-output-byte recovery guard, so an agent streaming 30-40s of output had no recovery route: the visible-content diff reports `changedChars:0` for pure append, and OSC 9;4 only fires on explicit agent state transitions.
- Added a dedicated leaky-bucket `OutputVolumeDetector` (`simpleOutputVolumeRecovery`) wired into the `simpleOutputState` path. Stripped byte counts feed the bucket; when it fires under the same resize/focus/user-echo/boot suppression guards the non-simple path uses, the agent recovers `waiting` to `working`. Wired in `buildActivityMonitorOptions` for agent terminals only (512B threshold / 0.1 B/ms drain / 256B/frame cap), kept as a separate detector from `outputActivityDetection` so it can't perturb the polling cycle's signal.
- Recovery alone wasn't enough: the temperature demotion gate and the polling/debounce idle gates would bounce the agent back to `waiting` after `WORKING_HOLD_MS` (1.5s) because the visible-content diff stays flat during appended streaming. Added a `hasRecentSimpleOutputVolume` clock that defers all three `simpleOutputState` waiting-demotion gates while the volume detector has fired within the 8s quiet window. Sustained streaming holds `working`; the agent settles to `waiting` 8 seconds after output stops (preserving the `AGENT_WAITING_QUIET_MS` floor from #3606).

Resolves #10664

## Changes

- `electron/services/ActivityMonitor.ts`: `simpleOutputVolumeRecovery` detector, `hasRecentSimpleOutputVolume` clock, demotion-gate guards
- `electron/services/pty/terminalActivityPatterns.ts`: `buildActivityMonitorOptions` wiring for agent terminals
- `electron/services/__tests__/ActivityMonitor.test.ts`: new tests covering volume-based recovery, sustained hold, focus suppression, and production wiring

## Testing

- New `ActivityMonitor` tests: recovers from sustained byte volume; stays in `working` through a 30s stream then settles; does not recover during focus suppression; `buildActivityMonitorOptions` production-wiring assertion.
- Local pass: `ActivityMonitor` + `SustainedChangeTracker` + `AgentActivityTemperature` + `TerminalProcess.lifecycle` = 294 pass; replay + `terminalActivityPatterns` = 42 pass.
- Guard is inert for any monitor whose volume detector is unconfigured (clock stays 0), so non-agent paths are unchanged. Deliberately left `SustainedChangeTracker.measureVisibleContentDelta`'s `isSuffixOf` branch untouched: changing it would reintroduce false `waiting` to `working` recovery on window resize (#8753).