### PR TITLE
fix(terminal): gate WebGL wants on visibility for hidden agents (#10671)

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -294,7 +294,10 @@ class TerminalInstanceService {
 
         if (this.wantsWebGLAtTier(managed, tier)) {
           this.webGLManager.ensureContext(id, managed);
-        } else if (!managed.isVisible || !managed.runtimeAgentId) {
+        } else if (
+          (managed.webGLHideTimer === undefined && !managed.isVisible) ||
+          !managed.runtimeAgentId
+        ) {
           // Agent terminals keep WebGL while visible — releasing causes a
           // one-frame renderer gap, and VISIBLE is an eligible tier for them
           // anyway. Plain terminals release as soon as they stop being
@@ -302,7 +305,13 @@ class TerminalInstanceService {
           // status-quo at VISIBLE, and a lingering want per previously
           // focused shell would accumulate toward the mode-switch threshold.
           // Tier demotion is an authoritative signal — cancel any pending
-          // hide-dwell and release immediately.
+          // hide-dwell and release immediately. The webGLHideTimer guard keeps
+          // the dwell window intact for a hidden agent still streaming at BURST:
+          // wantsWebGLAtTier now returns false for off-screen panes (#10671), so
+          // without it the next write's tier-apply would release on frame 1
+          // instead of after WEBGL_HIDE_DWELL_MS — defeating the hide→show
+          // anti-churn dwell. Once the dwell timer fires (or never armed), the
+          // guard is undefined and the release proceeds.
           this.cancelWebGLHideTimer(managed);
           const hadWebGL = this.webGLManager.isActive(id);
           this.webGLManager.releaseContext(id);
@@ -528,6 +537,13 @@ class TerminalInstanceService {
     tier: TerminalRefreshTier | undefined
   ): boolean {
     if (!isWebGLEligibleTier(tier)) return false;
+    // Visibility gates every case: an off-screen pane never wants WebGL, even
+    // an agent streaming at BURST. The want set is fleet-wide per project view,
+    // so hidden streaming agents would otherwise accumulate wants and trip the
+    // count-based mode switch, dropping the whole visible fleet to DOM
+    // (#10671). The reveal path (setVisible(true) → debounced shouldRestoreWebGL
+    // → ensureContext) re-acquires the want once the pane is on-screen again.
+    if (!managed.isVisible) return false;
     if (managed.runtimeAgentId) return true;
     return (
       tier === TerminalRefreshTier.FOCUSED ||
@@ -3181,7 +3197,10 @@ class TerminalInstanceService {
     // policy now so background promotions don't keep the blink timer alive.
     this.applyCursorBlinkPolicy(managed);
     restoreScrollback(managed);
-    if (managed.isOpened && isWebGLEligibleTier(managed.lastAppliedTier)) {
+    // Route through wantsWebGLAtTier so an off-screen promotion (background
+    // worktree detected mid-stream) doesn't register a fleet-wide want; the
+    // reveal path re-acquires it when the pane comes on-screen (#10671).
+    if (managed.isOpened && this.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);
     }
   }

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -247,6 +247,10 @@ describe("onTierApplied handler — WebGL manager integration", () => {
     ) {
       webGLManager.ensureContext(id, m);
     } else if (!m.isVisible) {
+      // This model intentionally omits the production webGLHideTimer dwell
+      // guard (TerminalInstanceService.onTierApplied) — the lease suite covers
+      // pure tier→WebGL mapping; hide-dwell timing lives in
+      // webglVisibility.test.ts, which drives the real service.
       const hadWebGL = webGLManager.isActive(id);
       webGLManager.releaseContext(id);
       if (hadWebGL && m.terminal.rows > 0) {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts
@@ -237,10 +237,13 @@ describe("onTierApplied handler — WebGL manager integration", () => {
   function simulateOnTierApplied(id: string, tier: TerminalRefreshTier, m: ManagedTerminal) {
     if (!m.runtimeAgentId) return;
 
+    // Mirrors wantsWebGLAtTier: an off-screen pane never wants WebGL, even an
+    // agent at an eligible tier (#10671).
     if (
-      tier === TerminalRefreshTier.FOCUSED ||
-      tier === TerminalRefreshTier.BURST ||
-      tier === TerminalRefreshTier.VISIBLE
+      m.isVisible &&
+      (tier === TerminalRefreshTier.FOCUSED ||
+        tier === TerminalRefreshTier.BURST ||
+        tier === TerminalRefreshTier.VISIBLE)
     ) {
       webGLManager.ensureContext(id, m);
     } else if (!m.isVisible) {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -60,6 +60,8 @@ type WebGLVisibilityService = {
     isActive: (id: string) => boolean;
     ensureContext: (id: string, managed: unknown) => void;
     releaseContext: (id: string) => void;
+    getMode: () => "webgl" | "dom";
+    getWantsSize: () => number;
   };
 };
 
@@ -581,5 +583,65 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     // Dwell elapses — context released, no longer consuming the fleet budget.
     vi.advanceTimersByTime(1);
     expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("hidden streaming agents do not inflate the fleet want count or flip to DOM (#10671)", () => {
+    // The literal #10671 scenario: a handful of visible agents plus many hidden
+    // background-worktree agents all streaming at BURST. Pre-fix, each hidden
+    // agent registered a want; 3 visible + 15 hidden = 18 wants would exceed the
+    // upper threshold and flip the whole fleet to DOM. Post-fix, only the
+    // visible agents contribute wants, so the fleet stays in WebGL.
+    for (let i = 0; i < 3; i++) {
+      const id = `vis-${i}`;
+      service.instances.set(
+        id,
+        makeMockManaged({
+          isVisible: true,
+          lastAppliedTier: TerminalRefreshTier.FOCUSED,
+          getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+        }) as unknown as Record<string, unknown>
+      );
+      service.applyRendererPolicy(id, TerminalRefreshTier.BURST);
+    }
+
+    for (let i = 0; i < 15; i++) {
+      const id = `hid-${i}`;
+      service.instances.set(
+        id,
+        makeMockManaged({
+          isVisible: false,
+          lastAppliedTier: TerminalRefreshTier.VISIBLE,
+          getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+        }) as unknown as Record<string, unknown>
+      );
+      service.applyRendererPolicy(id, TerminalRefreshTier.BURST);
+    }
+
+    expect(service.webGLManager.getWantsSize()).toBe(3);
+    expect(service.webGLManager.getMode()).toBe("webgl");
+    for (let i = 0; i < 3; i++) {
+      expect(service.webGLManager.isActive(`vis-${i}`)).toBe(true);
+    }
+  });
+
+  it("agent promoted while hidden re-acquires WebGL only after reveal (#10671)", () => {
+    const managed = makeMockManaged({
+      isVisible: false,
+      runtimeAgentId: undefined,
+      launchAgentId: undefined,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    // Background detection promotes the off-screen pane — want is withheld.
+    service.applyAgentPromotion("t1", "claude");
+    expect(managed.runtimeAgentId).toBe("claude");
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    // Reveal drives the debounced restore, which now passes the visibility gate.
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(100);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -55,6 +55,7 @@ type WebGLVisibilityService = {
   setVisible: (id: string, visible: boolean, expectedGeneration?: number) => void;
   destroy: (id: string) => void;
   applyRendererPolicy: (id: string, tier: TerminalRefreshTier) => void;
+  applyAgentPromotion: (id: string, agentId: string) => void;
   webGLManager: {
     isActive: (id: string) => boolean;
     ensureContext: (id: string, managed: unknown) => void;
@@ -471,6 +472,114 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     // shouldRestoreWebGL re-checks eligibility in the timer callback,
     // so the deferred restore must not fire after demotion.
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  // #10671: off-screen agent terminals must not register a fleet-wide WebGL
+  // want. The want set is per project view, so enough hidden streaming agents
+  // would trip the count-based mode switch and drop the visible fleet to DOM.
+  it("hidden agent at BURST tier does not acquire WebGL (#10671)", () => {
+    const managed = makeMockManaged({
+      isVisible: false,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    // A PTY write while off-screen drives the pane to BURST. The tier still
+    // applies (backpressure cadence), but the want must not be registered.
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BURST);
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+    expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+  });
+
+  it("visible agent at BURST tier still acquires WebGL (no regression)", () => {
+    const managed = makeMockManaged({
+      isVisible: true,
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BURST);
+
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+  });
+
+  it("applyAgentPromotion on a hidden terminal does not acquire WebGL (#10671)", () => {
+    const managed = makeMockManaged({
+      isVisible: false,
+      runtimeAgentId: undefined,
+      launchAgentId: undefined,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.applyAgentPromotion("t1", "claude");
+
+    expect(managed.runtimeAgentId).toBe("claude");
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("applyAgentPromotion on a visible terminal acquires WebGL", () => {
+    const managed = makeMockManaged({
+      isVisible: true,
+      runtimeAgentId: undefined,
+      launchAgentId: undefined,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    service.applyAgentPromotion("t1", "claude");
+
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+  });
+
+  it("hidden agent revealed via setVisible(true) re-acquires WebGL (#10671)", () => {
+    const managed = makeMockManaged({
+      isVisible: false,
+      lastAppliedTier: TerminalRefreshTier.VISIBLE,
+      getRefreshTier: () => TerminalRefreshTier.VISIBLE,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+    // Off-screen: even at an eligible tier the want is withheld.
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BURST);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+
+    // Reveal re-acquires through the debounced restore path.
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(100);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+  });
+
+  it("hidden agent streaming at BURST keeps WebGL through the hide dwell, then releases (#10671)", () => {
+    // A visible agent that goes off-screen mid-stream must keep its context for
+    // the WEBGL_HIDE_DWELL_MS window (anti-churn for hide→show toggles) even
+    // though wantsWebGLAtTier now returns false off-screen — the webGLHideTimer
+    // guard in onTierApplied preserves the dwell instead of releasing on the
+    // next write's tier apply.
+    const managed = makeMockManaged({
+      isVisible: true,
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      getRefreshTier: () => TerminalRefreshTier.FOCUSED,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    service.setVisible("t1", false);
+
+    // Streaming continues while off-screen — drives BURST during the dwell.
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BURST);
+    vi.advanceTimersByTime(499);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    // Dwell elapses — context released, no longer consuming the fleet budget.
+    vi.advanceTimersByTime(1);
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `wantsWebGLAtTier` in `TerminalInstanceService.ts` had no visibility precondition, so hidden streaming agents (e.g. background worktrees with active Claude sessions) registered WebGL wants and pushed the fleet past the upper threshold (12), dropping every visible terminal to the DOM renderer.
- Added a central `if (!managed.isVisible) return false` guard to `wantsWebGLAtTier` and routed `applyAgentPromotion` through it, so off-screen promotions never acquire a context. The 500ms `WEBGL_HIDE_DWELL_MS` dwell is preserved with a `webGLHideTimer === undefined` guard so an in-flight timer isn't cut short by a streaming write.
- The reveal path is unchanged: `setVisible(true)` triggers the debounced `shouldRestoreWebGL` check and re-acquires the want once the pane is back on screen.

Resolves #10671

## Changes

- `src/services/terminal/TerminalInstanceService.ts`: visibility guard in `wantsWebGLAtTier`, `applyAgentPromotion` routed through it, dwell-preservation guard added
- `src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts`: new test file covering hidden-agent no-acquire, visible-agent acquire, hidden/visible `applyAgentPromotion`, hidden-to-reveal re-acquire, streaming dwell-preservation, promote-while-hidden-then-reveal, and fleet-threshold regression (3 visible + 15 hidden agents keep `wants.size` at 3)
- `src/services/terminal/__tests__/TerminalInstanceService.webglLease.test.ts`: updated simulation to stay faithful to the revised handler

## Testing

164 terminal tests pass. Fleet-threshold regression test confirms that 15 hidden streaming agents cannot push `wants.size` past the visible count. Promote-while-hidden-then-reveal confirms that the want is correctly deferred until `setVisible(true)`.