### PR TITLE
fix(workspace): auto-retry forge auth fetch failures with backoff (#10670)

### DIFF
--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -178,26 +178,12 @@ export class RepoFetchCoordinator {
 
     const state = this.getOrCreateState(commonDir);
 
-    if (!opts.force && state.failure) {
-      const failure = state.failure;
-      if (Date.now() < failure.retryAt) {
-        const isAuth = failure.kind === "auth";
-        return {
-          status: "skipped",
-          skipReason: isAuth ? "auth-suspended" : "in-failure-window",
-          reason: failure.reason,
-          lastFetchedAt: state.lastSuccessfulFetch,
-          // Only surface the per-card auth stripe once the failure is
-          // confirmed (several retries exhausted). Pre-confirmation auth
-          // failures show the softer transient "Couldn't reach origin" tooltip
-          // instead, so a single blip doesn't alarm every worktree card.
-          authFailed: isAuth && failure.confirmed === true,
-          networkFailed: isAuth ? failure.confirmed !== true : true,
-        };
-      }
-      // The backoff window elapsed — fall through and re-attempt the fetch.
-      // Auth-class failures auto-retry on a widening schedule rather than
-      // suspending the repo's fetch indefinitely.
+    if (!opts.force) {
+      const skip = this.failureSkipResult(state);
+      // Inside the backoff window we skip; once it elapses, fall through and
+      // re-attempt. Auth-class failures auto-retry on a widening schedule
+      // rather than suspending the repo's fetch indefinitely.
+      if (skip) return skip;
     }
 
     const recent = this.recentSuccessResult(state, opts.force === true);
@@ -293,6 +279,31 @@ export class RepoFetchCoordinator {
     };
   }
 
+  /**
+   * Skip result for a repo still inside its failure backoff window — `null`
+   * once the window elapses (so the caller re-attempts the fetch). Shared by
+   * the pre-queue check and the post-chain re-check so a burst of sibling
+   * fetches that all queue before the first failure lands still collapses to a
+   * single git invocation once that failure is cached.
+   */
+  private failureSkipResult(state: RepoState): FetchResult | null {
+    const failure = state.failure;
+    if (!failure || Date.now() >= failure.retryAt) return null;
+    const isAuth = failure.kind === "auth";
+    return {
+      status: "skipped",
+      skipReason: isAuth ? "auth-suspended" : "in-failure-window",
+      reason: failure.reason,
+      lastFetchedAt: state.lastSuccessfulFetch,
+      // Only surface the per-card auth stripe once the failure is confirmed
+      // (several retries exhausted). Pre-confirmation auth failures show the
+      // softer transient "Couldn't reach origin" tooltip instead, so a single
+      // blip doesn't alarm every worktree card.
+      authFailed: isAuth && failure.confirmed === true,
+      networkFailed: isAuth ? failure.confirmed !== true : true,
+    };
+  }
+
   private getOrCreateState(commonDir: string): RepoState {
     let state = this.states.get(commonDir);
     if (!state) {
@@ -322,6 +333,14 @@ export class RepoFetchCoordinator {
     const recent = this.recentSuccessResult(stateAtStart, opts.force === true);
     if (recent) {
       return recent;
+    }
+    // Same dedup for failures: once the first sibling in a burst caches a
+    // failure, the rest skip instead of each spawning another git fetch (and
+    // re-incrementing the auth retry count). Force fetches still bypass this —
+    // their same-window failures are coalesced in `buildAuthFailureEntry`.
+    if (opts.force !== true) {
+      const skip = this.failureSkipResult(stateAtStart);
+      if (skip) return skip;
     }
 
     const controller = new AbortController();
@@ -457,6 +476,15 @@ export class RepoFetchCoordinator {
     now: number
   ): FetchFailureEntry {
     const prior = state.failure?.kind === "auth" ? state.failure : null;
+    // A failure observed while the prior backoff window is still open belongs
+    // to the SAME retry round — concurrent sibling fetches and force-retries
+    // (which bypass the failure-cache skip) all land here within milliseconds.
+    // Counting each would confirm the failure on a single burst instead of
+    // across retries over time, re-alarming every card. Keep the prior entry
+    // unchanged so the count only advances once per elapsed backoff window.
+    if (prior && now < prior.retryAt) {
+      return prior;
+    }
     const authRetryCount = (prior?.authRetryCount ?? 0) + 1;
     const stepIndex = Math.min(authRetryCount - 1, AUTH_FAILURE_BACKOFF_SCHEDULE_MS.length - 1);
     const confirmed = authRetryCount >= AUTH_FAILURE_CONFIRM_RETRIES;

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -13,7 +13,31 @@ const NETWORK_FAILURE_JITTER_MS = 30_000;
 const REPO_NOT_FOUND_FIRST_FETCH_TTL_MS = 5 * 60_000;
 const TRANSIENT_FAILURE_TTL_MS = 60_000;
 const TRANSIENT_FAILURE_JITTER_MS = 30_000;
-const AUTH_FAILURE_TTL_MS = Number.POSITIVE_INFINITY;
+
+/**
+ * Exponential backoff windows applied to auth-class fetch failures, indexed by
+ * consecutive failure count (clamped to the last entry once exhausted). A bad
+ * token or revoked credential resolves on its own only when the user re-auths,
+ * but a transient credential-helper hiccup or a one-off 401 clears by itself —
+ * so we auto-retry on a widening schedule instead of suspending the repo's
+ * fetch forever. Hourly steady state stays well clear of GitHub's secondary
+ * rate-limit ceiling.
+ */
+const AUTH_FAILURE_BACKOFF_SCHEDULE_MS = [5 * 60_000, 15 * 60_000, 30 * 60_000, 60 * 60_000];
+/**
+ * Consecutive auth failures before the failure is treated as confirmed. Until
+ * then the per-card "Forge authentication failed" stripe stays suppressed (the
+ * card shows the softer transient state) so a single blip doesn't alarm every
+ * worktree. The first three failures span ~20min (5+15) before escalation.
+ */
+const AUTH_FAILURE_CONFIRM_RETRIES = 3;
+/**
+ * Backoff window for forge secondary-rate-limit failures. Long on purpose —
+ * retrying soon extends the limit window — but finite, so fetching resumes
+ * automatically once the throttle clears.
+ */
+const RATE_LIMIT_FAILURE_TTL_MS = 45 * 60_000;
+const RATE_LIMIT_FAILURE_JITTER_MS = 15 * 60_000;
 
 /** Failure categories with distinct retry semantics. */
 type FetchFailureKind = "auth" | "network" | "repo-not-found-first" | "transient";
@@ -22,6 +46,18 @@ interface FetchFailureEntry {
   kind: FetchFailureKind;
   reason: GitOperationReason;
   retryAt: number;
+  /**
+   * Consecutive auth-class failures observed for this repo. Drives the backoff
+   * schedule and the confirmation threshold. Only set on `kind: "auth"` entries;
+   * reset to undefined when a fetch succeeds (the entry is cleared).
+   */
+  authRetryCount?: number;
+  /**
+   * True once an auth-class failure has persisted past
+   * `AUTH_FAILURE_CONFIRM_RETRIES`. Gates the per-card auth stripe and the
+   * one-shot escalation callback. Only meaningful on `kind: "auth"` entries.
+   */
+  confirmed?: boolean;
 }
 
 interface RepoState {
@@ -35,6 +71,14 @@ interface RepoState {
 
 export interface RepoFetchCoordinatorCallbacks {
   onFetchSuccess?: (worktreeId: string) => void;
+  /**
+   * Fired once per repo when an auth-class fetch failure persists past
+   * `AUTH_FAILURE_CONFIRM_RETRIES` — i.e. the credential is genuinely broken,
+   * not a transient blip. Used to surface a single escalation toast instead of
+   * the per-card stripe. Fires only on the unconfirmed→confirmed transition;
+   * `clearAuthFailures()` resets the state so a later re-confirmation re-fires.
+   */
+  onAuthFailureConfirmed?: (commonDir: string, reason: GitOperationReason) => void;
 }
 
 export interface FetchOptions {
@@ -85,10 +129,18 @@ export interface FetchResult {
  *   - `git fetch` has no native timeout. A stalled connection can sit forever
  *     even with the lowSpeedLimit/lowSpeedTime config. Solution: an
  *     AbortController armed with a 60s timeout per fetch.
- *   - Auth failures must NOT auto-retry — repeated bad-token attempts trigger
- *     GitHub secondary rate limits. Solution: indefinite suspension cleared
- *     only by `clearAuthFailures()` (called when the user signs in / rotates
- *     a token).
+ *   - Auth failures auto-retry on a widening exponential backoff
+ *     (`AUTH_FAILURE_BACKOFF_SCHEDULE_MS`) rather than suspending forever — a
+ *     transient 401/credential-helper blip recovers on its own, and a genuinely
+ *     broken token still gets retried hourly. The per-card auth stripe stays
+ *     suppressed until the failure is `confirmed` (past
+ *     `AUTH_FAILURE_CONFIRM_RETRIES`), at which point `onAuthFailureConfirmed`
+ *     fires once so the renderer can show a single escalation toast.
+ *     `clearAuthFailures()` (user sign-in / token rotation / manual retry)
+ *     drops the suspension immediately.
+ *   - Forge secondary rate limits (HTTP 403 with a `secondary rate limit`
+ *     sideband) are classified separately from auth failures and backed off on
+ *     a long but finite window so fetching resumes once the throttle clears.
  *   - Network blips and "repository-not-found-on-first-fetch" should retry
  *     after a short window. After at least one prior success, a 404 is more
  *     likely a permission revocation masked as 404 (GitHub does this) — treat
@@ -128,28 +180,24 @@ export class RepoFetchCoordinator {
 
     if (!opts.force && state.failure) {
       const failure = state.failure;
-      if (failure.kind === "auth") {
-        return {
-          status: "skipped",
-          skipReason: "auth-suspended",
-          reason: failure.reason,
-          lastFetchedAt: state.lastSuccessfulFetch,
-          authFailed: true,
-          networkFailed: false,
-        };
-      }
       if (Date.now() < failure.retryAt) {
+        const isAuth = failure.kind === "auth";
         return {
           status: "skipped",
-          skipReason: "in-failure-window",
+          skipReason: isAuth ? "auth-suspended" : "in-failure-window",
           reason: failure.reason,
           lastFetchedAt: state.lastSuccessfulFetch,
-          authFailed: false,
-          // Skipping inside the retry window means a transient failure is
-          // still cached — keep the "Couldn't reach origin" tooltip up.
-          networkFailed: true,
+          // Only surface the per-card auth stripe once the failure is
+          // confirmed (several retries exhausted). Pre-confirmation auth
+          // failures show the softer transient "Couldn't reach origin" tooltip
+          // instead, so a single blip doesn't alarm every worktree card.
+          authFailed: isAuth && failure.confirmed === true,
+          networkFailed: isAuth ? failure.confirmed !== true : true,
         };
       }
+      // The backoff window elapsed — fall through and re-attempt the fetch.
+      // Auth-class failures auto-retry on a widening schedule rather than
+      // suspending the repo's fetch indefinitely.
     }
 
     const recent = this.recentSuccessResult(state, opts.force === true);
@@ -308,16 +356,18 @@ export class RepoFetchCoordinator {
       if (!state || state.generation !== generationAtStart) {
         return { status: "skipped", skipReason: "stale-generation" };
       }
-      state.failure = this.classifyForCache(reason, state.lastSuccessfulFetch, error);
-      const isAuth = state.failure.kind === "auth";
+      state.failure = this.classifyForCache(reason, commonDir, state, error);
+      const failure = state.failure;
+      const isAuth = failure.kind === "auth";
       return {
         status: "failed",
         reason,
         lastFetchedAt: state.lastSuccessfulFetch,
-        authFailed: isAuth,
-        // Auth-class failures use `authFailed`; everything else surfaces as
-        // a transient "Couldn't reach origin" tooltip line.
-        networkFailed: !isAuth,
+        // Auth-class failures only raise the per-card stripe once confirmed;
+        // until then (and for every non-auth failure) the softer transient
+        // "Couldn't reach origin" tooltip line carries the signal.
+        authFailed: isAuth && failure.confirmed === true,
+        networkFailed: isAuth ? failure.confirmed !== true : true,
       };
     } finally {
       clearTimeout(timeout);
@@ -335,24 +385,36 @@ export class RepoFetchCoordinator {
 
   private classifyForCache(
     reason: GitOperationReason,
-    lastSuccessfulFetch: number | null,
+    commonDir: string,
+    state: RepoState,
     error: unknown
   ): FetchFailureEntry {
     const now = Date.now();
     if (reason === "auth-failed") {
-      return { kind: "auth", reason, retryAt: now + AUTH_FAILURE_TTL_MS };
+      return this.buildAuthFailureEntry(reason, commonDir, state, now);
     }
     if (reason === "repository-not-found") {
       // After at least one prior success, a 404 from origin almost always
-      // indicates GitHub's "404 instead of 403" permission masking. Treat as
-      // auth-failed so we don't hammer with retries.
-      if (lastSuccessfulFetch !== null) {
-        return { kind: "auth", reason, retryAt: now + AUTH_FAILURE_TTL_MS };
+      // indicates GitHub's "404 instead of 403" permission masking. Treat it
+      // on the same auth backoff/confirmation path so we don't hammer retries.
+      if (state.lastSuccessfulFetch !== null) {
+        return this.buildAuthFailureEntry(reason, commonDir, state, now);
       }
       return {
         kind: "repo-not-found-first",
         reason,
         retryAt: now + REPO_NOT_FOUND_FIRST_FETCH_TTL_MS,
+      };
+    }
+    if (reason === "rate-limited") {
+      // Forge secondary rate limits clear on their own; back off a long while
+      // (not the short network window) so retrying doesn't extend the limit.
+      // Bucketed as "transient" so OS-wake / reconnect `clearNetworkFailures()`
+      // also drops it — a fresh session shouldn't stay throttled.
+      return {
+        kind: "transient",
+        reason,
+        retryAt: now + RATE_LIMIT_FAILURE_TTL_MS + Math.random() * RATE_LIMIT_FAILURE_JITTER_MS,
       };
     }
     if (reason === "network-unavailable") {
@@ -378,6 +440,42 @@ export class RepoFetchCoordinator {
       kind: "transient",
       reason,
       retryAt: now + Math.random() * window,
+    };
+  }
+
+  /**
+   * Build (or advance) the auth-class failure entry. Increments the consecutive
+   * retry count off the prior auth entry, schedules the next attempt on the
+   * exponential backoff ladder, and marks the failure `confirmed` once it
+   * persists past the threshold — firing `onAuthFailureConfirmed` exactly once
+   * on the unconfirmed→confirmed transition.
+   */
+  private buildAuthFailureEntry(
+    reason: GitOperationReason,
+    commonDir: string,
+    state: RepoState,
+    now: number
+  ): FetchFailureEntry {
+    const prior = state.failure?.kind === "auth" ? state.failure : null;
+    const authRetryCount = (prior?.authRetryCount ?? 0) + 1;
+    const stepIndex = Math.min(authRetryCount - 1, AUTH_FAILURE_BACKOFF_SCHEDULE_MS.length - 1);
+    const confirmed = authRetryCount >= AUTH_FAILURE_CONFIRM_RETRIES;
+    const wasConfirmed = prior?.confirmed === true;
+    if (confirmed && !wasConfirmed) {
+      // Notify on the transition only. Wrapped defensively — a throwing
+      // observer must not abort building the failure entry below.
+      try {
+        this.callbacks.onAuthFailureConfirmed?.(commonDir, reason);
+      } catch {
+        // Observer threw — swallow; the failure cache must stay consistent.
+      }
+    }
+    return {
+      kind: "auth",
+      reason,
+      retryAt: now + AUTH_FAILURE_BACKOFF_SCHEDULE_MS[stepIndex],
+      authRetryCount,
+      confirmed,
     };
   }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -198,6 +198,11 @@ export class WorkspaceService {
   /** Session-scoped guard so we notify the user about the macOS FSEvents file
    *  descriptor ceiling only once, even if many worktrees hit EMFILE concurrently. */
   private emfileLimitNotified = false;
+  /** Per-commondir guard so a confirmed forge-auth failure raises its single
+   *  escalation toast once, not once per sibling worktree. Cleared by
+   *  `retryAuthFetch()` / credential rotation so a later re-confirmation can
+   *  re-notify. */
+  private readonly authFailureConfirmedNotified = new Set<string>();
 
   /** Per-worktree WSL git opt-in state forwarded from main on load and toggle. */
   private wslGitByWorktree: Record<string, { enabled: boolean; dismissed: boolean }> = {};
@@ -319,6 +324,8 @@ export class WorkspaceService {
         // fire-and-forget; fetch success must never block.
         monitor.triggerRefreshIfUpdating();
       },
+      onAuthFailureConfirmed: (commonDir, reason) =>
+        this.handleAuthFailureConfirmed(commonDir, reason),
     });
     const prCallbacks: PRIntegrationCallbacks = {
       onPRDetected: (worktreeId, data) => {
@@ -1495,6 +1502,24 @@ export class WorkspaceService {
     this.inotifyLimitNotified = false;
     this.emfileLimitNotified = false;
     this.sendEvent({ type: "watcher-recovered" });
+  }
+
+  /**
+   * A repo's background-fetch auth failure persisted past the coordinator's
+   * confirmation threshold. Emit a single escalation event per commondir per
+   * session (the renderer turns it into one toast). The per-commondir guard
+   * dedups the fan-out across sibling worktrees; it's reset by
+   * `retryAuthFetch()` / credential rotation so a re-confirmation re-notifies.
+   * The raw commondir path never leaves the host — only the classified reason
+   * crosses the IPC boundary.
+   */
+  private handleAuthFailureConfirmed(
+    commonDir: string,
+    reason: import("../../shared/types/ipc/errors.js").GitOperationReason
+  ): void {
+    if (this.authFailureConfirmedNotified.has(commonDir)) return;
+    this.authFailureConfirmedNotified.add(commonDir);
+    this.sendEvent({ type: "fetch-auth-failure-confirmed", reason });
   }
 
   /**
@@ -3220,6 +3245,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       // the next scheduled fetch retries. Network/transient entries stay so we
       // don't immediately re-storm an offline remote.
       this.fetchCoordinator.clearAuthFailures();
+      // Re-arm the escalation guard so a credential that's still broken can
+      // surface its toast again after this attempt.
+      this.authFailureConfirmedNotified.clear();
       // Trigger an opportunistic fetch on every worktree so the user sees
       // refreshed counts shortly after sign-in / token rotation.
       for (const monitor of this.monitors.values()) {
@@ -3231,16 +3259,18 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   }
 
   /**
-   * User-triggered retry of auth-suspended fetches. Auth failures suspend a
-   * repo's fetch cache indefinitely (AUTH_FAILURE_TTL_MS = POSITIVE_INFINITY) to
-   * avoid storming GitHub's secondary rate limits with repeated bad-token
-   * attempts. The only safe way out is an explicit user action — e.g. clicking
-   * the auth-failed sync badge — which clears the suspension and re-fetches.
+   * User-triggered retry of auth-suspended fetches. Auth failures back off on a
+   * widening exponential schedule (RepoFetchCoordinator), so an explicit user
+   * action — e.g. clicking the auth-failed sync badge — clears the suspension
+   * and re-fetches immediately rather than waiting for the next backoff window.
    * Mirrors the credential branch of updateForgeCredentials but without a
    * credential update (the user may be retrying after fixing the token elsewhere).
    */
   retryAuthFetch(): void {
     this.fetchCoordinator.clearAuthFailures();
+    // Re-arm the per-commondir escalation guard so a still-broken credential
+    // can re-surface its toast after this retry confirms the failure again.
+    this.authFailureConfirmedNotified.clear();
     for (const monitor of this.monitors.values()) {
       if (monitor.isRunning) {
         void monitor.triggerFetchNow();

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -3322,6 +3322,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // project's monitors get a clean coordinator and stale completions are
     // discarded by the generation guard.
     this.fetchCoordinator.destroy();
+    // Reset the escalation guard so the same broken repo re-opened later can
+    // re-surface its toast instead of being silently suppressed.
+    this.authFailureConfirmedNotified.clear();
     this.pollQueue.clear();
 
     this.activeWorktreeId = null;
@@ -3449,6 +3452,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.monitors.clear();
     this.backgroundGitWatcherLru.clear();
     this.fetchCoordinator.destroy();
+    this.authFailureConfirmedNotified.clear();
     this.pollQueue.clear();
     this.listService.invalidateCache();
   }

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -137,6 +137,64 @@ describe("RepoFetchCoordinator", () => {
     expect(onAuthFailureConfirmed).toHaveBeenCalledTimes(1);
   });
 
+  it("does not confirm an auth failure on a concurrent sibling burst", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
+    );
+
+    const onAuthFailureConfirmed = vi.fn();
+    const coord = new RepoFetchCoordinator({ onAuthFailureConfirmed });
+
+    // Five siblings sharing one commondir all fetch at once (cold start). Only
+    // the first should spawn git; the rest skip on the cached failure. The
+    // single failure must not confirm just because many cards observed it.
+    const results = await Promise.all(
+      ["a", "b", "c", "d", "e"].map((s) =>
+        coord.fetchForWorktree({ worktreeId: `wt-${s}`, worktreePath: `/repo/${s}` })
+      )
+    );
+
+    expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(1);
+    expect(onAuthFailureConfirmed).not.toHaveBeenCalled();
+    // No card shows the alarming auth stripe yet — only the soft transient.
+    expect(results.every((r) => r.authFailed === false)).toBe(true);
+    expect(results.some((r) => r.networkFailed === true)).toBe(true);
+  });
+
+  it("does not re-confirm immediately when force-retries burst inside the backoff window", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
+    );
+
+    const onAuthFailureConfirmed = vi.fn();
+    const coord = new RepoFetchCoordinator({ onAuthFailureConfirmed });
+
+    // Drive the failure to confirmed over time (3 retries across backoff steps).
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    vi.advanceTimersByTime(5 * 60_000 + 1_000);
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    vi.advanceTimersByTime(15 * 60_000 + 1_000);
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(onAuthFailureConfirmed).toHaveBeenCalledTimes(1);
+
+    // Simulate retryAuthFetch: clear failures, then a burst of force fetches
+    // (which bypass the failure-cache skip) from several sibling monitors.
+    coord.clearAuthFailures();
+    const retried = await Promise.all(
+      ["a", "b", "c", "d"].map((s) =>
+        coord.fetchForWorktree({ worktreeId: `wt-${s}`, worktreePath: `/repo/${s}`, force: true })
+      )
+    );
+
+    // The credential is still broken, but a single user-triggered round must
+    // not re-confirm instantly — the failure drops back to the soft state and
+    // the toast does NOT re-fire until retries reconfirm over time.
+    expect(onAuthFailureConfirmed).toHaveBeenCalledTimes(1);
+    expect(retried.every((r) => r.authFailed === false)).toBe(true);
+  });
+
   it("resets the auth retry count after a successful fetch", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
     let mode: "fail" | "ok" = "fail";
@@ -235,8 +293,9 @@ describe("RepoFetchCoordinator", () => {
   it("serializes fetches for sibling worktrees sharing a commondir", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
 
-    // Failing fetches never record a success, so each queued sibling still
-    // runs a real fetch — exercising the per-commondir chain itself.
+    // Force fetches bypass both the recency dedup and the failure-cache skip,
+    // so each queued sibling still runs a real fetch — exercising the
+    // per-commondir chain itself (the failing fetches never record a success).
     let inFlight = 0;
     let maxInFlight = 0;
     mockCreateBackgroundFetchGit.mockReturnValue(
@@ -251,14 +310,35 @@ describe("RepoFetchCoordinator", () => {
     );
 
     const coord = new RepoFetchCoordinator();
-    const a = coord.fetchForWorktree({ worktreeId: "wtA", worktreePath: "/repo/a" });
-    const b = coord.fetchForWorktree({ worktreeId: "wtB", worktreePath: "/repo/b" });
-    const c = coord.fetchForWorktree({ worktreeId: "wtC", worktreePath: "/repo/c" });
+    const a = coord.fetchForWorktree({ worktreeId: "wtA", worktreePath: "/repo/a", force: true });
+    const b = coord.fetchForWorktree({ worktreeId: "wtB", worktreePath: "/repo/b", force: true });
+    const c = coord.fetchForWorktree({ worktreeId: "wtC", worktreePath: "/repo/c", force: true });
 
     await Promise.all([a, b, c]);
 
     expect(maxInFlight).toBe(1);
     expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(3);
+  });
+
+  it("dedups queued sibling fetches once the first one in the chain caches a failure", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("the remote end hung up unexpectedly")))
+    );
+
+    const coord = new RepoFetchCoordinator();
+    // Non-force sibling burst: the first records the transient failure, the
+    // rest skip on it rather than each storming the remote with another fetch.
+    const results = await Promise.all([
+      coord.fetchForWorktree({ worktreeId: "wtA", worktreePath: "/repo/a" }),
+      coord.fetchForWorktree({ worktreeId: "wtB", worktreePath: "/repo/b" }),
+      coord.fetchForWorktree({ worktreeId: "wtC", worktreePath: "/repo/c" }),
+    ]);
+
+    expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(1);
+    // Every sibling still surfaces the transient failure to its card.
+    expect(results.every((r) => r.networkFailed === true)).toBe(true);
+    expect(results.every((r) => r.authFailed === false)).toBe(true);
   });
 
   it("dedups queued sibling fetches once the first one in the chain succeeds", async () => {

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -70,30 +70,130 @@ describe("RepoFetchCoordinator", () => {
     expect(args).toEqual(["fetch", "origin", "--no-auto-gc", "--prune", "--no-write-fetch-head"]);
   });
 
-  it("propagates authFailed=true via FetchResult on auth-class failures and skips", async () => {
+  it("suppresses the per-card auth stripe until an auth failure is confirmed", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
     mockCreateBackgroundFetchGit.mockReturnValue(
       makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
     );
 
     const coord = new RepoFetchCoordinator();
+    // First auth failure is not yet confirmed — surfaces the softer transient
+    // signal (networkFailed) instead of the alarming per-card auth stripe.
     const failed = await coord.fetchForWorktree({
       worktreeId: "wt1",
       worktreePath: "/repo",
     });
     expect(failed.status).toBe("failed");
-    expect(failed.authFailed).toBe(true);
+    expect(failed.reason).toBe("auth-failed");
+    expect(failed.authFailed).toBe(false);
+    expect(failed.networkFailed).toBe(true);
     expect(failed.lastFetchedAt).toBeNull();
 
-    // Subsequent skip from auth suspension also carries authFailed=true so the
-    // renderer keeps the "Sign in to refresh" affordance visible.
+    // A retry inside the backoff window skips with the same unconfirmed
+    // semantics — still no stripe.
     const skipped = await coord.fetchForWorktree({
       worktreeId: "wt1",
       worktreePath: "/repo",
     });
     expect(skipped.status).toBe("skipped");
     expect(skipped.skipReason).toBe("auth-suspended");
+    expect(skipped.authFailed).toBe(false);
+    expect(skipped.networkFailed).toBe(true);
+  });
+
+  it("auto-retries auth failures on backoff and confirms after the threshold, firing once", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
+    );
+
+    const onAuthFailureConfirmed = vi.fn();
+    const coord = new RepoFetchCoordinator({ onAuthFailureConfirmed });
+
+    // Failure 1 — unconfirmed, schedules a retry on the first backoff step.
+    const f1 = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(f1.authFailed).toBe(false);
+    expect(onAuthFailureConfirmed).not.toHaveBeenCalled();
+
+    // Advance past the 5-min step and retry → failure 2, still unconfirmed.
+    vi.advanceTimersByTime(5 * 60_000 + 1_000);
+    const f2 = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(f2.status).toBe("failed");
+    expect(f2.authFailed).toBe(false);
+    expect(onAuthFailureConfirmed).not.toHaveBeenCalled();
+
+    // Advance past the 15-min step and retry → failure 3 confirms the failure.
+    vi.advanceTimersByTime(15 * 60_000 + 1_000);
+    const f3 = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(f3.status).toBe("failed");
+    expect(f3.authFailed).toBe(true);
+    expect(onAuthFailureConfirmed).toHaveBeenCalledTimes(1);
+    expect(onAuthFailureConfirmed).toHaveBeenCalledWith("/repo/.git", "auth-failed");
+
+    // A skip after confirmation keeps the stripe up but does not re-fire.
+    const skipped = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(skipped.status).toBe("skipped");
     expect(skipped.authFailed).toBe(true);
+    expect(onAuthFailureConfirmed).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the auth retry count after a successful fetch", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    let mode: "fail" | "ok" = "fail";
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() =>
+        mode === "fail"
+          ? Promise.reject(new Error("Authentication failed for 'https://x'"))
+          : Promise.resolve()
+      )
+    );
+
+    const onAuthFailureConfirmed = vi.fn();
+    const coord = new RepoFetchCoordinator({ onAuthFailureConfirmed });
+
+    // Two unconfirmed auth failures.
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    vi.advanceTimersByTime(5 * 60_000 + 1_000);
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+
+    // A success clears the failure (and the retry count) before confirmation.
+    mode = "ok";
+    vi.advanceTimersByTime(15 * 60_000 + 1_000);
+    const ok = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(ok.status).toBe("success");
+    expect(coord.hasFailureFor("/repo/.git")).toBe(false);
+
+    // The next auth failure starts fresh — a single failure must not confirm.
+    mode = "fail";
+    vi.advanceTimersByTime(20_000);
+    const again = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    expect(again.authFailed).toBe(false);
+    expect(onAuthFailureConfirmed).not.toHaveBeenCalled();
+  });
+
+  it("does not corrupt failure state when onAuthFailureConfirmed throws", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() => Promise.reject(new Error("Authentication failed for 'https://x'")))
+    );
+
+    const onAuthFailureConfirmed = vi.fn(() => {
+      throw new Error("observer boom");
+    });
+    const coord = new RepoFetchCoordinator({ onAuthFailureConfirmed });
+
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    vi.advanceTimersByTime(5 * 60_000 + 1_000);
+    await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+    vi.advanceTimersByTime(15 * 60_000 + 1_000);
+    const confirmed = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+
+    // The throwing observer was called, but the failure entry is still cached
+    // and reports the confirmed auth state.
+    expect(onAuthFailureConfirmed).toHaveBeenCalledTimes(1);
+    expect(confirmed.status).toBe("failed");
+    expect(confirmed.authFailed).toBe(true);
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
   });
 
   it("preserves the prior lastFetchedAt across a transient failure", async () => {
@@ -286,7 +386,7 @@ describe("RepoFetchCoordinator", () => {
     expect(maxInFlight).toBeGreaterThan(1);
   });
 
-  it("classifies auth failures and suspends future fetches indefinitely", async () => {
+  it("caches auth failures and skips fetches inside the backoff window", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
     mockCreateBackgroundFetchGit.mockReturnValue(
       makeMockGit(() =>
@@ -303,7 +403,7 @@ describe("RepoFetchCoordinator", () => {
     expect(first.reason).toBe("auth-failed");
     expect(coord.hasFailureFor("/repo/.git")).toBe(true);
 
-    // Second attempt should skip without invoking git.
+    // Second attempt inside the first backoff step skips without invoking git.
     mockCreateBackgroundFetchGit.mockClear();
     const second = await coord.fetchForWorktree({
       worktreeId: "wt1",
@@ -312,6 +412,47 @@ describe("RepoFetchCoordinator", () => {
     expect(second.status).toBe("skipped");
     expect(second.skipReason).toBe("auth-suspended");
     expect(mockCreateBackgroundFetchGit).not.toHaveBeenCalled();
+
+    // Once the backoff window elapses, the next attempt actually re-fetches.
+    vi.advanceTimersByTime(5 * 60_000 + 1_000);
+    const retried = await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(retried.status).toBe("failed");
+    expect(mockCreateBackgroundFetchGit).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies forge secondary rate limits as transient, not auth", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    mockCreateBackgroundFetchGit.mockReturnValue(
+      makeMockGit(() =>
+        Promise.reject(
+          new Error(
+            "fatal: unable to access 'https://github.com/x.git/': The requested URL returned error: 403\n" +
+              "remote: You have exceeded a secondary rate limit. Please wait a few minutes before you try again."
+          )
+        )
+      )
+    );
+
+    const onAuthFailureConfirmed = vi.fn();
+    const coord = new RepoFetchCoordinator({ onAuthFailureConfirmed });
+    const result = await coord.fetchForWorktree({ worktreeId: "wt1", worktreePath: "/repo" });
+
+    expect(result.status).toBe("failed");
+    expect(result.reason).toBe("rate-limited");
+    // Rate limits never show the auth stripe, even if repeated.
+    expect(result.authFailed).toBe(false);
+    expect(result.networkFailed).toBe(true);
+    expect(onAuthFailureConfirmed).not.toHaveBeenCalled();
+
+    // Treated as a (long) transient — cleared by the wake/reconnect hook, not
+    // by clearAuthFailures.
+    coord.clearAuthFailures();
+    expect(coord.hasFailureFor("/repo/.git")).toBe(true);
+    coord.clearNetworkFailures();
+    expect(coord.hasFailureFor("/repo/.git")).toBe(false);
   });
 
   it("clears auth suspensions on demand", async () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
@@ -294,4 +294,19 @@ describe("WorkspaceService — handleAuthFailureConfirmed", () => {
     expect(events).toHaveLength(2);
     expect(events.map((e) => e.reason)).toEqual(["auth-failed", "repository-not-found"]);
   });
+
+  it("re-arms the escalation guard on project switch so a re-opened repo can re-notify", async () => {
+    service["handleAuthFailureConfirmed"]("/repoA/.git", "auth-failed");
+    service["handleAuthFailureConfirmed"]("/repoA/.git", "auth-failed");
+    expect(
+      mockSendEvent.mock.calls.filter((c) => c[0]?.type === "fetch-auth-failure-confirmed").length
+    ).toBe(1);
+
+    await service.onProjectSwitch("req-1");
+
+    service["handleAuthFailureConfirmed"]("/repoA/.git", "auth-failed");
+    expect(
+      mockSendEvent.mock.calls.filter((c) => c[0]?.type === "fetch-auth-failure-confirmed").length
+    ).toBe(2);
+  });
 });

--- a/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
@@ -230,4 +230,68 @@ describe("WorkspaceService.retryAuthFetch", () => {
     expect(runningFetch).toHaveBeenCalledTimes(1);
     expect(stoppedFetch).not.toHaveBeenCalled();
   });
+
+  it("re-arms the confirmed-auth escalation guard so a later re-confirmation re-notifies", () => {
+    const confirm = (commonDir: string) =>
+      service["handleAuthFailureConfirmed"](commonDir, "auth-failed");
+
+    // First confirmation emits the escalation event.
+    confirm("/repo/.git");
+    expect(
+      mockSendEvent.mock.calls.filter((c) => c[0]?.type === "fetch-auth-failure-confirmed").length
+    ).toBe(1);
+
+    // A second confirmation for the same repo is suppressed by the guard.
+    confirm("/repo/.git");
+    expect(
+      mockSendEvent.mock.calls.filter((c) => c[0]?.type === "fetch-auth-failure-confirmed").length
+    ).toBe(1);
+
+    // A user retry clears the guard; the next confirmation re-emits.
+    service.retryAuthFetch();
+    confirm("/repo/.git");
+    expect(
+      mockSendEvent.mock.calls.filter((c) => c[0]?.type === "fetch-auth-failure-confirmed").length
+    ).toBe(2);
+  });
+});
+
+describe("WorkspaceService — handleAuthFailureConfirmed", () => {
+  let service: WorkspaceService;
+  let mockSendEvent: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockSendEvent = vi.fn();
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(mockSendEvent as any);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("emits a single escalation event per commondir and carries the reason", () => {
+    service["handleAuthFailureConfirmed"]("/repoA/.git", "auth-failed");
+    service["handleAuthFailureConfirmed"]("/repoA/.git", "auth-failed");
+
+    const events = mockSendEvent.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e?.type === "fetch-auth-failure-confirmed");
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe("auth-failed");
+    // The raw commondir path must never cross the IPC boundary.
+    expect(JSON.stringify(events[0])).not.toContain("/repoA/.git");
+  });
+
+  it("confirms distinct commondirs independently", () => {
+    service["handleAuthFailureConfirmed"]("/repoA/.git", "auth-failed");
+    service["handleAuthFailureConfirmed"]("/repoB/.git", "repository-not-found");
+
+    const events = mockSendEvent.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e?.type === "fetch-auth-failure-confirmed");
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.reason)).toEqual(["auth-failed", "repository-not-found"]);
+  });
 });

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -135,6 +135,7 @@ export type ErrorType =
  */
 export type GitOperationReason =
   | "auth-failed"
+  | "rate-limited"
   | "network-unavailable"
   | "repository-not-found"
   | "not-a-repository"

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -612,6 +612,13 @@ export type WorkspaceHostEvent =
   // Clears the one-shot degradation guards so a later relapse can re-signal,
   // and hides the persistent degraded indicator in the renderer.
   | { type: "watcher-recovered" }
+  // Fired once per repo (guarded host-side) when a background-fetch auth
+  // failure persists past the retry/backoff confirmation threshold — i.e. the
+  // forge credential is genuinely broken, not a transient blip. The renderer
+  // surfaces a single escalation toast instead of the per-card auth stripe.
+  // Re-armed by `retry-auth-fetch` / credential rotation so a later
+  // re-confirmation can re-signal.
+  | { type: "fetch-auth-failure-confirmed"; reason: import("./ipc/errors.js").GitOperationReason }
   // Fired when the topology watcher goes "dark": either the `@parcel/watcher`
   // subscribe() rejected at cold start (no events will ever arrive), or a 5s
   // pending-event safety valve expired without the watcher delivering the

--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -19,12 +19,23 @@ describe("classifyGitError — table-driven", () => {
     ["auth-failed", "Permission denied (publickey)."],
     [
       "auth-failed",
-      "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
-    ],
-    [
-      "auth-failed",
       "fatal: unable to access 'https://github.com/acme/private.git/': The requested URL returned error: 403",
     ],
+    // `could not read Username` is a transient credential-helper hiccup under
+    // GIT_TERMINAL_PROMPT=0, not a durable auth failure — falls through to
+    // unknown (a short transient retry) rather than suspending the repo.
+    [
+      "unknown",
+      "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+    ],
+    // Forge secondary rate limit: same 403 URL line as auth, distinguished by
+    // the sideband message — must NOT bucket into auth-failed.
+    [
+      "rate-limited",
+      "fatal: unable to access 'https://github.com/x.git/': The requested URL returned error: 403\n" +
+        "remote: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.",
+    ],
+    ["rate-limited", "remote: You have triggered an abuse detection mechanism."],
     ["repository-not-found", "remote: ERROR: Repository not found."],
     ["repository-not-found", "fatal: repository 'https://github.com/foo/bar.git/' not found"],
     [
@@ -169,8 +180,18 @@ describe("classifyGitError — ordering and normalization", () => {
   it("prefers auth-failed over repository-not-found when both signals appear", () => {
     const msg =
       "fatal: Could not read from remote repository.\n" +
-      "fatal: could not read Username for 'https://github.com': terminal prompts disabled";
+      "remote: Authentication failed for 'https://github.com/org/repo.git/'";
     expect(classifyGitError(msg)).toBe("auth-failed");
+  });
+
+  it("prefers rate-limited over auth-failed on a secondary-rate-limit 403", () => {
+    // A secondary rate limit and a generic 403 share the same `URL returned
+    // error: 403` line; the rate-limit signal must win so the repo backs off
+    // transiently instead of being treated as a broken credential.
+    const msg =
+      "fatal: unable to access 'https://github.com/acme/repo.git/': The requested URL returned error: 403\n" +
+      "remote: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.";
+    expect(classifyGitError(msg)).toBe("rate-limited");
   });
 
   it("prefers lfs-quota-exceeded over lfs-missing when both signals appear", () => {
@@ -253,6 +274,7 @@ describe("getGitRecoveryHint", () => {
   it("returns a hint for every reason except 'unknown'", () => {
     const reasons: GitOperationReason[] = [
       "auth-failed",
+      "rate-limited",
       "network-unavailable",
       "repository-not-found",
       "not-a-repository",

--- a/shared/utils/errorMessage.ts
+++ b/shared/utils/errorMessage.ts
@@ -72,6 +72,7 @@ const ERROR_TYPE_FALLBACKS = {
  */
 const GIT_REASON_TITLES = {
   "auth-failed": "Git authentication failed",
+  "rate-limited": "Forge rate limit reached",
   "network-unavailable": "Couldn't reach the remote",
   "repository-not-found": "Repository not found",
   "not-a-repository": "Not a git repository",

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -55,9 +55,25 @@ const PATTERNS: ReadonlyArray<readonly [GitOperationReason, RegExp]> = [
     /batch response:.*(?:exceeded.*LFS budget|over.*data quota|LFS budget)|reached.*free storage limit.*(?:Git LFS|git[- ]lfs|LFS)|(?:Git LFS|git[- ]lfs|LFS).*reached.*free storage limit|HTTP 413.*LFS|VS403658:/i,
   ],
   [
+    // MUST run before `auth-failed`: GitHub returns HTTP 403 for a secondary
+    // rate limit on the same `unable to access ...: The requested URL returned
+    // error: 403` line that `auth-failed` matches, but adds a sideband
+    // `remote: You have exceeded a secondary rate limit ...` line (the
+    // `remote: ` prefix is already stripped by `normalizeGitErrorMessage`). A
+    // rate limit is transient — bucketing it as `auth-failed` would suspend the
+    // repo's background fetch on a throttle that clears on its own. Do not
+    // reorder without updating the "prefers rate-limited over auth-failed" test.
+    "rate-limited",
+    /secondary rate limit|You have exceeded a secondary rate limit|abuse detection mechanism/i,
+  ],
+  [
     "auth-failed",
     // HTTPS 401/403/407 (auth/perm/proxy-auth) as well as the direct SSH/HTTPS messages.
-    /Authentication failed|Permission denied \(publickey\)|could not read Username for|unable to access.*: The requested URL returned error: 40[137]/i,
+    // `could not read Username for` is intentionally NOT matched here: background
+    // fetches run with `GIT_TERMINAL_PROMPT=0`, so a credential-helper hiccup
+    // surfaces that message transiently. Leaving it to fall through to `unknown`
+    // (a short transient retry) avoids suspending the repo on a recoverable blip.
+    /Authentication failed|Permission denied \(publickey\)|unable to access.*: The requested URL returned error: 40[137]/i,
   ],
   [
     // Run BEFORE repository-not-found: when both signals appear (network failure plus
@@ -121,6 +137,8 @@ export function classifyGitError(error: unknown): GitOperationReason {
 
 const RECOVERY_HINTS: Record<GitOperationReason, string | undefined> = {
   "auth-failed": "Check your Git credentials or SSH key configuration.",
+  "rate-limited":
+    "The forge is rate-limiting requests. Background fetches will resume automatically once the limit clears.",
   "network-unavailable": "Check your internet connection and try again.",
   "repository-not-found":
     "The remote repository is unreachable — check the URL or your access permissions.",

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -66,6 +66,13 @@ export const PUSH_BANNER_CONFIGS: Record<GitOperationReason, PushBannerConfig> =
     // the active forge provider resolves — no CTA when it can't, since there's
     // no provider-agnostic settings route to send the user to.
   },
+  "rate-limited": {
+    message:
+      getGitRecoveryHint("rate-limited") ??
+      "The forge is rate-limiting requests. Try again shortly.",
+    detailPolicy: "hide",
+    cta: { kind: "retry", label: "Retry" },
+  },
   "network-unavailable": {
     message: getGitRecoveryHint("network-unavailable") ?? "Could not reach the remote.",
     detailPolicy: "hide",

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -632,6 +632,36 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
       })
     );
 
+    // Confirmed forge-auth failure — a background fetch's credential is
+    // genuinely broken (it survived several auto-retries). The host emits this
+    // once per repo instead of flagging every worktree card, so we raise a
+    // single escalation toast pointing at the forge settings. Transient blips
+    // during the retry window never reach here (they show the softer
+    // per-card "couldn't reach origin" tooltip instead).
+    cleanups.push(
+      worktreePort.onEvent("fetch-auth-failure-confirmed", () => {
+        notify({
+          type: "error",
+          title: "Forge authentication failed",
+          message:
+            "Background fetches are paused because your code forge credentials were rejected. Sign in again to resume.",
+          action: {
+            label: "Open settings",
+            actionId: "app.settings.openTab",
+            onClick: () => {
+              void actionService.dispatch(
+                "app.settings.openTab",
+                { tab: "code-forge" },
+                { source: "user" }
+              );
+            },
+          },
+          supersedeKey: "forge-auth-failure-confirmed",
+          context: { eventKind: "git" },
+        });
+      })
+    );
+
     // Topology-watcher-dark/recovered — the worktree list may have silently
     // drifted. The store flag drives the Tier-1 pip; arming/clearing the 30s
     // Tier-3 escalation is shared with the hydration path (#9908).

--- a/src/contexts/__tests__/WorktreeStoreContext.fetchAuth.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.fetchAuth.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+
+import { useProjectStore } from "@/store/projectStore";
+import type { WorktreeSnapshot } from "@shared/types";
+import type { Project } from "@shared/types/project";
+
+const notifyMock = vi.fn<(payload: unknown) => string>(() => "notif-id");
+vi.mock("@/lib/notify", () => ({
+  notify: (payload: unknown) => notifyMock(payload),
+}));
+
+const dispatchMock = vi.fn();
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => dispatchMock(...args),
+  },
+}));
+
+type PortEventName = "fetch-auth-failure-confirmed" | "watcher-recovered";
+
+const listeners = new Map<PortEventName, Set<(data: unknown) => void>>();
+
+function emit(name: PortEventName, data: unknown): void {
+  const set = listeners.get(name);
+  if (!set) return;
+  for (const cb of set) cb(data);
+}
+
+function setCurrentProject(path: string | null): void {
+  const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
+  useProjectStore.setState({ currentProject: project });
+}
+
+beforeEach(() => {
+  listeners.clear();
+  notifyMock.mockClear();
+  dispatchMock.mockClear();
+  setCurrentProject("/repo/proj");
+
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      isReady: () => true,
+      request: (_name: string) =>
+        Promise.resolve({
+          states: [] as WorktreeSnapshot[],
+          watcherDegraded: false,
+          topologyWatcherDark: false,
+        }),
+      onEvent: (name: PortEventName, cb: (data: unknown) => void) => {
+        let set = listeners.get(name);
+        if (!set) {
+          set = new Set();
+          listeners.set(name, set);
+        }
+        set.add(cb);
+        return () => set?.delete(cb);
+      },
+      onReady: (_cb: () => void) => () => {},
+      onDisconnected: (_cb: () => void) => () => {},
+      onFatalDisconnect: (_cb: () => void) => () => {},
+    },
+    worktree: {
+      getAllIssueAssociations: () => Promise.resolve({}),
+      getPRStatus: () => Promise.resolve(null),
+    },
+  } as unknown as typeof window.electron;
+});
+
+afterEach(() => {
+  listeners.clear();
+  setCurrentProject(null);
+  vi.restoreAllMocks();
+});
+
+async function renderProvider() {
+  const { WorktreeStoreProvider, WorktreeStoreContext } = await import("../WorktreeStoreContext");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
+  );
+  const view = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  if (!view.result.current) throw new Error("WorktreeStoreContext is null");
+  return view;
+}
+
+describe("WorktreeStoreProvider — confirmed forge-auth escalation", () => {
+  it("raises a single error toast with a recovery action on fetch-auth-failure-confirmed", async () => {
+    await renderProvider();
+    expect(notifyMock).not.toHaveBeenCalled();
+
+    act(() => {
+      emit("fetch-auth-failure-confirmed", {
+        type: "fetch-auth-failure-confirmed",
+        reason: "auth-failed",
+      });
+    });
+
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    const payload = notifyMock.mock.calls[0]![0] as {
+      type?: string;
+      priority?: string;
+      title?: string;
+      action?: { label?: string };
+      supersedeKey?: string;
+    };
+    expect(payload.type).toBe("error");
+    // An error toast must never be low-priority (silently dropped — lint-banned).
+    expect(payload.priority).not.toBe("low");
+    expect(payload.title).toBeTruthy();
+    expect(payload.action?.label).toBeTruthy();
+    expect(payload.supersedeKey).toBeTruthy();
+  });
+
+  it("dispatches the forge settings action when the recovery button fires", async () => {
+    await renderProvider();
+
+    act(() => {
+      emit("fetch-auth-failure-confirmed", {
+        type: "fetch-auth-failure-confirmed",
+        reason: "auth-failed",
+      });
+    });
+
+    const payload = notifyMock.mock.calls[0]![0] as { action?: { onClick?: () => void } };
+    act(() => {
+      payload.action?.onClick?.();
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      expect.objectContaining({ tab: "code-forge" }),
+      expect.objectContaining({ source: "user" })
+    );
+  });
+
+  it("stops notifying after the provider unmounts", async () => {
+    const view = await renderProvider();
+    view.unmount();
+
+    act(() => {
+      emit("fetch-auth-failure-confirmed", {
+        type: "fetch-auth-failure-confirmed",
+        reason: "auth-failed",
+      });
+    });
+
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #10670.

When a single background `git fetch` failed due to auth, `RepoFetchCoordinator` would set `AUTH_FAILURE_TTL_MS` to `Infinity` and suspend fetching for the whole repo permanently. The Forge auth-failed stripe would appear on every worktree card with no automatic recovery.

## Changes

- Replaces the indefinite suspension with exponential backoff retries at 5, 15, 30, then 60 minute intervals. A transient 401 or credential-helper blip recovers on its own; a genuinely broken token still gets retried hourly.
- Auth failures are only confirmed (and shown on cards) after persisting past 3 retries. Pre-confirmation failures show the softer transient tooltip instead, so a single blip doesn't alarm every card. Concurrent sibling fetches and force-retries that fail inside the same backoff window are coalesced into one retry round, so a cold start or manual retry with multiple worktrees can't confirm instantly.
- Emits a single `fetch-auth-failure-confirmed` host event per repo commondir so the renderer raises one escalation toast pointing at forge settings. The raw commondir path never crosses the IPC boundary.
- Classifies GitHub secondary rate limits as a new `rate-limited` `GitOperationReason` (ordered before `auth-failed`, matching the lfs-quota precedent) with a long transient backoff. A 403 throttle no longer suspends the repo as an auth failure. Drops the transient "could not read Username" message from the auth-failed classifier (falls through to a short transient retry under `GIT_TERMINAL_PROMPT=0`).
- Preserves the PR #9740 manual retry path (`retryAuthFetch` -> `clearAuthFailures`) and re-arms the escalation guard on manual retry, credential rotation, and project switch.

## Testing

New and updated unit tests cover:

- Backoff schedule and confirmation threshold
- Concurrent burst coalescing
- Rate-limit classification
- Tightened auth-failed classifier
- Host event deduplication per commondir
- Renderer escalation toast

245 tests across the changed modules pass locally. Own-file prettier/eslint clean.