### PR TITLE
feat(mcp): emit structuredContent for terminal query actions

### DIFF
--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2767,11 +2767,26 @@ describe("help.displayImage short-circuit (#9828)", () => {
 describe("structuredContent for terminal query actions (#10676)", () => {
   // The three high-value query actions carry `mcpOutputSchema: true`, so the real
   // manifest entry the renderer reports back carries an object-typed outputSchema.
-  // Mirror that here so the CallTool path exercises buildStructuredContent.
+  // Mirror that here (per-action, so the fixture shape tracks the real result)
+  // so the CallTool path exercises buildStructuredContent.
+  const OUTPUT_SCHEMAS: Record<string, Record<string, unknown>> = {
+    "terminal.list": { type: "object", properties: { terminals: { type: "array" } } },
+    "terminal.getStatus": { type: "object", properties: { terminals: { type: "array" } } },
+    "terminal.getOutput": {
+      type: "object",
+      properties: {
+        terminalId: { type: "string" },
+        content: { type: ["string", "null"] },
+        lineCount: { type: "number" },
+        truncated: { type: "boolean" },
+      },
+    },
+  };
+
   function entryWithOutputSchema(id: string): ActionManifestEntry {
     return {
       ...makeManifestEntry(id),
-      outputSchema: { type: "object", properties: { terminals: { type: "array" } } },
+      outputSchema: OUTPUT_SCHEMAS[id] ?? { type: "object", properties: {} },
     };
   }
 

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2763,3 +2763,90 @@ describe("help.displayImage short-circuit (#9828)", () => {
     expect(notifyDisplayImage).not.toHaveBeenCalled();
   });
 });
+
+describe("structuredContent for terminal query actions (#10676)", () => {
+  // The three high-value query actions carry `mcpOutputSchema: true`, so the real
+  // manifest entry the renderer reports back carries an object-typed outputSchema.
+  // Mirror that here so the CallTool path exercises buildStructuredContent.
+  function entryWithOutputSchema(id: string): ActionManifestEntry {
+    return {
+      ...makeManifestEntry(id),
+      outputSchema: { type: "object", properties: { terminals: { type: "array" } } },
+    };
+  }
+
+  function structuredOf(result: unknown): Record<string, unknown> | undefined {
+    return (result as { structuredContent?: Record<string, unknown> }).structuredContent;
+  }
+
+  function textOf(result: unknown): string {
+    return (result as { content: { text: string }[] }).content[0].text;
+  }
+
+  // tier "external" + getFullToolSurface bypasses the per-id allowlist, so the
+  // call reaches dispatch regardless of TIER_ALLOWLISTS membership.
+  function deps(id: string, payload: unknown, withSchema = true): SessionServerDeps {
+    return fakeDeps({
+      sessionStore: fakeSessionStore("external"),
+      getFullToolSurface: vi.fn(() => true),
+      requestManifest: vi
+        .fn()
+        .mockResolvedValue([withSchema ? entryWithOutputSchema(id) : makeManifestEntry(id)]),
+      dispatchAction: vi.fn().mockResolvedValue({ result: { ok: true, result: payload } }),
+    });
+  }
+
+  it("emits structuredContent for terminal.list and still emits the JSON text body", async () => {
+    const payload = { terminals: [{ id: "t-1", kind: "terminal", isFocused: true }] };
+    const server = createSessionServer("sc-list", deps("terminal.list", payload));
+    const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
+    expect(structuredOf(result)).toEqual(payload);
+    // Backward compatibility: the text body is preserved for clients that ignore
+    // structuredContent, and it serializes the same data.
+    expect(JSON.parse(textOf(result))).toEqual(payload);
+  });
+
+  it("emits structuredContent for terminal.getStatus", async () => {
+    const payload = {
+      terminals: [{ terminalId: "t-1", agentId: "claude", agentState: "working" }],
+    };
+    const server = createSessionServer("sc-status", deps("terminal.getStatus", payload));
+    const result = await callTool(server, { name: "terminal.getStatus", arguments: {} });
+
+    expect(structuredOf(result)).toEqual(payload);
+  });
+
+  it("emits structuredContent for terminal.getOutput", async () => {
+    const payload = { terminalId: "t-1", content: "hello", lineCount: 1, truncated: false };
+    const server = createSessionServer("sc-output", deps("terminal.getOutput", payload));
+    const result = await callTool(server, {
+      name: "terminal.getOutput",
+      arguments: { terminalId: "t-1" },
+    });
+
+    expect(structuredOf(result)).toEqual(payload);
+  });
+
+  it("emits structuredContent for an empty result set (not just non-empty)", async () => {
+    const payload = { terminals: [] };
+    const server = createSessionServer("sc-empty", deps("terminal.list", payload));
+    const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
+    expect(structuredOf(result)).toEqual(payload);
+  });
+
+  it("omits structuredContent when the manifest entry carries no outputSchema", async () => {
+    // Proves the outputSchema gate is load-bearing: without it, the same object
+    // result falls back to a text-only response (the pre-#10676 behavior).
+    const payload = { terminals: [{ id: "t-1" }] };
+    const server = createSessionServer(
+      "sc-noschema",
+      deps("terminal.list", payload, /* withSchema */ false)
+    );
+    const result = await callTool(server, { name: "terminal.list", arguments: {} });
+
+    expect(structuredOf(result)).toBeUndefined();
+    expect(JSON.parse(textOf(result))).toEqual(payload);
+  });
+});

--- a/src/services/actions/definitions/__tests__/terminalQueryActionsOutputSchema.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalQueryActionsOutputSchema.test.ts
@@ -74,6 +74,17 @@ describe("terminal query actions emit a manifest outputSchema (#10676)", () => {
     expect(props.truncated).toBeDefined();
   });
 
+  it("does not mark terminal.list's `type` as required (runtime emits it undefined)", () => {
+    // terminal.list returns `type: undefined`, which drops on JSON serialization,
+    // so the advertised schema must not require the key — otherwise a strict MCP
+    // client validating structuredContent against outputSchema would reject it.
+    const schema = outputSchema(registerAll(), "terminal.list")!;
+    const items = (schema.properties as { terminals: { items?: Record<string, unknown> } })
+      .terminals.items;
+    const required = (items?.required as string[] | undefined) ?? [];
+    expect(required).not.toContain("type");
+  });
+
   // The watchout from the issue: do not flip the flag on neighbours. waitUntilIdle
   // uses the main-process rawOutputSchema path (no mcpOutputSchema flag), and
   // sendCommand has no resultSchema at all — both must stay schema-less here.

--- a/src/services/actions/definitions/__tests__/terminalQueryActionsOutputSchema.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalQueryActionsOutputSchema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { ActionCallbacks, ActionId, AnyActionDefinition } from "@shared/types/actions";
-import type { ActionRegistry } from "../../actionTypes";
+import type { ActionId } from "@shared/types/actions";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 
 // ActionService pulls in the shortcut-hint store, keybinding service, and notify
 // at module load / dispatch time. Registration only needs the module to import

--- a/src/services/actions/definitions/__tests__/terminalQueryActionsOutputSchema.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalQueryActionsOutputSchema.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionId, AnyActionDefinition } from "@shared/types/actions";
+import type { ActionRegistry } from "../../actionTypes";
+
+// ActionService pulls in the shortcut-hint store, keybinding service, and notify
+// at module load / dispatch time. Registration only needs the module to import
+// cleanly, so stub them out.
+vi.mock("../../../../store/shortcutHintStore", () => ({
+  shortcutHintStore: {
+    getState: vi.fn(() => ({ counts: {}, show: vi.fn(), incrementCount: vi.fn() })),
+  },
+}));
+vi.mock("../../../KeybindingService", () => ({
+  keybindingService: { getEffectiveCombo: vi.fn(() => null), getDisplayCombo: vi.fn(() => "") },
+}));
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+// terminalQueryActions reaches into the renderer-only client/store layer at
+// module load; stub those so the definitions register in a node test.
+vi.mock("@/store/panelStore", () => ({ usePanelStore: { getState: vi.fn() } }));
+vi.mock("@/clients", () => ({ terminalClient: { submit: vi.fn() } }));
+vi.mock("@shared/config/panelKindRegistry", () => ({
+  panelKindHasPty: (kind: string) => kind === "terminal" || kind === "agent",
+}));
+
+import { ActionService } from "../../../ActionService";
+import { registerTerminalQueryActions } from "../terminalQueryActions";
+
+function registerAll(): ActionService {
+  const registry: ActionRegistry = new Map();
+  registerTerminalQueryActions(registry, {} as ActionCallbacks);
+  const service = new ActionService();
+  for (const [, factory] of registry) {
+    service.register(factory() as AnyActionDefinition);
+  }
+  return service;
+}
+
+function outputSchema(service: ActionService, id: string): Record<string, unknown> | undefined {
+  return service.get(id as ActionId)?.outputSchema as Record<string, unknown> | undefined;
+}
+
+// #10676 — the three high-value query actions opt into MCP structuredContent by
+// carrying `mcpOutputSchema: true` alongside a top-level object resultSchema.
+// Registering through the real ActionService exercises the Zod -> JSON Schema
+// conversion, so these assert the *generated* schema, not the literal flag.
+describe("terminal query actions emit a manifest outputSchema (#10676)", () => {
+  const HIGH_VALUE = ["terminal.list", "terminal.getStatus", "terminal.getOutput"];
+
+  it.each(HIGH_VALUE)("%s generates an object-typed outputSchema", (id) => {
+    const schema = outputSchema(registerAll(), id);
+    expect(schema).toBeDefined();
+    expect(schema!.type).toBe("object");
+    // buildToolOutputSchema (tierAuth) only forwards object-typed schemas, and
+    // buildStructuredContent only attaches it when the schema is present — so a
+    // missing or non-object schema would silently drop structuredContent.
+    expect(schema!.properties).toBeDefined();
+  });
+
+  it("terminal.list / terminal.getStatus expose the `terminals` array property", () => {
+    const service = registerAll();
+    for (const id of ["terminal.list", "terminal.getStatus"]) {
+      const props = (outputSchema(service, id)!.properties as Record<string, unknown>) ?? {};
+      expect(props.terminals).toBeDefined();
+    }
+  });
+
+  it("terminal.getOutput exposes content/lineCount/truncated properties", () => {
+    const props =
+      (outputSchema(registerAll(), "terminal.getOutput")!.properties as Record<string, unknown>) ??
+      {};
+    expect(props.content).toBeDefined();
+    expect(props.lineCount).toBeDefined();
+    expect(props.truncated).toBeDefined();
+  });
+
+  // The watchout from the issue: do not flip the flag on neighbours. waitUntilIdle
+  // uses the main-process rawOutputSchema path (no mcpOutputSchema flag), and
+  // sendCommand has no resultSchema at all — both must stay schema-less here.
+  it("does not emit an outputSchema for terminal.waitUntilIdle or terminal.sendCommand", () => {
+    const service = registerAll();
+    expect(outputSchema(service, "terminal.waitUntilIdle")).toBeUndefined();
+    expect(outputSchema(service, "terminal.sendCommand")).toBeUndefined();
+  });
+});

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -144,7 +144,10 @@ export const WorktreeSummarySchema = z.object({
 export const TerminalSummarySchema = z.object({
   id: z.string(),
   kind: z.string(),
-  type: z.unknown().nullable(),
+  // Vestigial: terminal.list always emits this as `undefined`, which drops out
+  // on JSON serialization. Keep it optional so the advertised MCP outputSchema
+  // (#10676) does not mark a key the structuredContent never carries as required.
+  type: z.unknown().nullable().optional(),
   worktreeId: z.string().nullable(),
   title: z.string().nullable(),
   location: z.enum(["grid", "dock", "trash", "background"]),

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -34,6 +34,7 @@ export function registerTerminalQueryActions(
       })
       .optional(),
     resultSchema: z.object({ terminals: z.array(TerminalSummarySchema) }),
+    mcpOutputSchema: true,
     run: async (args: unknown) => {
       const { worktreeId, location } = (args ?? {}) as {
         worktreeId?: string;
@@ -125,6 +126,7 @@ export function registerTerminalQueryActions(
       truncated: z.boolean(),
       error: z.string().optional(),
     }),
+    mcpOutputSchema: true,
     run: async (args: unknown) => {
       const {
         terminalId,
@@ -225,6 +227,7 @@ export function registerTerminalQueryActions(
       })
       .optional(),
     resultSchema: z.object({ terminals: z.array(TerminalStatusEntrySchema) }),
+    mcpOutputSchema: true,
     run: async (args: unknown) => {
       const { terminalIds, worktreeId, location, includeOutput } = (args ?? {}) as {
         terminalIds?: string[];


### PR DESCRIPTION
## Summary

- Adds `mcpOutputSchema: true` to `terminal.list`, `terminal.getOutput`, and `terminal.getStatus` so they emit MCP `structuredContent` alongside the existing `text` body. The mechanism was already wired end-to-end (proven by `agent.launch` and `recipe.run`); these three just needed the flag.
- Fully backward-compatible: the `text` field is preserved for every client that reads it today.
- Fixed a latent schema drift in `terminal.list`: the vestigial `type` field is now optional in `TerminalSummarySchema`, so the advertised `outputSchema` matches what the serialized result actually carries.

Resolves #10676

## Changes

- `src/services/actions/definitions/terminalQueryActions.ts`: set `mcpOutputSchema: true` on `terminal.list`, `terminal.getOutput`, `terminal.getStatus`.
- `src/services/actions/definitions/schemas.ts`: mark `type` optional in `TerminalSummarySchema`.
- `src/__tests__/mcp-server/__tests__/terminalQueryActionsOutputSchema.test.ts`: new test file covering ActionService-pipeline outputSchema shape for the three actions, the `type`-not-required regression, and confirming `terminal.waitUntilIdle`/`terminal.sendCommand` stay schema-less.
- `src/__tests__/mcp-server/__tests__/sessionServer.test.ts`: new describe block covering end-to-end `structuredContent` for all three actions, JSON-text backward-compat, empty result set, and the no-outputSchema gate.

Left `terminal.waitUntilIdle` (rawOutputSchema main-process path) and `terminal.sendCommand` (no resultSchema) untouched.

## Testing

- Unit tests in `terminalQueryActionsOutputSchema.test.ts` assert the three actions generate object-typed `outputSchema`, the `type` field is not required, and the two excluded actions have no outputSchema.
- Integration tests in `sessionServer.test.ts` assert `structuredContent` is populated for all three, the `text` body is still present, empty result sets are handled, and actions without `outputSchema` don't emit `structuredContent`.