### PR TITLE
fix(github): patch forge cache on bulk worktree self-assign

### DIFF
--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1999,11 +1999,61 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
     viewerHolder.user = { login: "me", avatarUrl: "https://example.com/me.png" };
     mockAssignIssue.mockResolvedValue(undefined);
 
-    // Seed a cached open-issues slot (prefix `${rootPath}:issue:`) holding the
-    // issue being assigned plus a sibling that must stay untouched.
+    // Seed two cached slots (different sort orders) under the same
+    // `${rootPath}:issue:` prefix — mutateCacheEntries must patch every slot.
+    // Each holds the issue being assigned plus a sibling that stays untouched.
+    const keyA = buildCacheKey("/test/root", "issue", "open", "created_at:desc");
+    const keyB = buildCacheKey("/test/root", "issue", "open", "updated_at:desc");
+    // A slot for a different project must NOT be touched.
+    const keyOther = buildCacheKey("/other/root", "issue", "open", "created_at:desc");
+    for (const k of [keyA, keyB, keyOther]) {
+      setCache(k, {
+        items: [makeIssue(1), makeIssue(2)],
+        nextCursor: null,
+        hasMore: false,
+        timestamp: Date.now(),
+      });
+    }
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(mockAssignIssue).toHaveBeenCalledWith("/test/root", 1, "me");
+
+    for (const k of [keyA, keyB]) {
+      const patched = getCache(k);
+      const issue1 = patched?.items.find((i) => i.number === 1) as Issue;
+      expect(issue1.assignees).toContainEqual({
+        login: "me",
+        avatarUrl: "https://example.com/me.png",
+        rawData: null,
+      });
+      // The sibling issue (not assigned) keeps its empty assignees list.
+      const issue2 = patched?.items.find((i) => i.number === 2) as Issue;
+      expect(issue2.assignees).toEqual([]);
+    }
+    // A different project's slot is untouched by the prefix-scoped patch.
+    const otherIssue1 = getCache(keyOther)?.items.find((i) => i.number === 1) as Issue;
+    expect(otherIssue1.assignees).toEqual([]);
+    // The cache patch succeeded, so no cache-error log was emitted.
+    expect(mockLogError).not.toHaveBeenCalled();
+  });
+
+  it("contains a cache-patch throw without failing the assignment", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    viewerHolder.user = { login: "me" };
+    mockAssignIssue.mockResolvedValue(undefined);
+
+    // A malformed entry (items not an array) makes the in-transform map() throw,
+    // exercising the try/catch guard: the assignment already succeeded server
+    // side, so the item must still count as created and the error is only logged.
     const key = buildCacheKey("/test/root", "issue", "open", "created_at:desc");
     setCache(key, {
-      items: [makeIssue(1), makeIssue(2)],
+      items: null as unknown as Issue[],
       nextCursor: null,
       hasMore: false,
       timestamp: Date.now(),
@@ -2017,19 +2067,12 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
     await advanceTimersGradually(5000);
 
     expect(mockAssignIssue).toHaveBeenCalledWith("/test/root", 1, "me");
-
-    const patched = getCache(key);
-    const issue1 = patched?.items.find((i) => i.number === 1) as Issue;
-    expect(issue1.assignees).toContainEqual({
-      login: "me",
-      avatarUrl: "https://example.com/me.png",
-      rawData: null,
-    });
-    // The sibling issue (not assigned) keeps its empty assignees list.
-    const issue2 = patched?.items.find((i) => i.number === 2) as Issue;
-    expect(issue2.assignees).toEqual([]);
-    // The cache patch succeeded, so no cache-error log was emitted.
-    expect(mockLogError).not.toHaveBeenCalled();
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+    expect(screen.queryByText(/failed/)).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      "Failed to patch issue cache after bulk self-assign",
+      expect.any(Error)
+    );
   });
 
   it("does not duplicate the assignee when the cached issue already lists the user", async () => {

--- a/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/plugins/builtin/github/renderer/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -5,6 +5,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, act } from "@testing-library/react";
 import React from "react";
 import type { Issue, PR } from "@shared/types/forge";
+import {
+  setCache,
+  getCache,
+  buildCacheKey,
+  _resetForTests as resetForgeResourceCache,
+} from "@/lib/forgeResourceCache";
 
 vi.stubGlobal(
   "ResizeObserver",
@@ -21,6 +27,7 @@ const mockGetDefaultPath = vi.fn();
 const mockListBranches = vi.fn();
 const mockFetchPRBranch = vi.fn();
 const mockAssignIssue = vi.fn();
+const mockLogError = vi.fn();
 const mockAgentSettingsGet = vi.fn();
 const mockSystemGetTmpDir = vi.fn();
 const mockGetAgentConfig = vi.fn();
@@ -82,6 +89,10 @@ vi.mock("@/utils/textParsing", () => ({
 
 vi.mock("@/lib/notify", () => ({
   notify: vi.fn(),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
 }));
 
 const prefsHolder: { assignWorktreeToSelf: boolean } = { assignWorktreeToSelf: false };
@@ -318,6 +329,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  resetForgeResourceCache();
 });
 
 describe("BulkCreateWorktreeDialog", () => {
@@ -1980,6 +1992,71 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
 
     expect(screen.getByText(/Assignment failed/)).toBeTruthy();
     expect(screen.queryByText(/Missing terminals/)).toBeNull();
+  });
+
+  it("patches the cached issue-list slot so the dropdown reflects the self-assign", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    viewerHolder.user = { login: "me", avatarUrl: "https://example.com/me.png" };
+    mockAssignIssue.mockResolvedValue(undefined);
+
+    // Seed a cached open-issues slot (prefix `${rootPath}:issue:`) holding the
+    // issue being assigned plus a sibling that must stay untouched.
+    const key = buildCacheKey("/test/root", "issue", "open", "created_at:desc");
+    setCache(key, {
+      items: [makeIssue(1), makeIssue(2)],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+    });
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    expect(mockAssignIssue).toHaveBeenCalledWith("/test/root", 1, "me");
+
+    const patched = getCache(key);
+    const issue1 = patched?.items.find((i) => i.number === 1) as Issue;
+    expect(issue1.assignees).toContainEqual({
+      login: "me",
+      avatarUrl: "https://example.com/me.png",
+      rawData: null,
+    });
+    // The sibling issue (not assigned) keeps its empty assignees list.
+    const issue2 = patched?.items.find((i) => i.number === 2) as Issue;
+    expect(issue2.assignees).toEqual([]);
+    // The cache patch succeeded, so no cache-error log was emitted.
+    expect(mockLogError).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate the assignee when the cached issue already lists the user", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    viewerHolder.user = { login: "me" };
+    mockAssignIssue.mockResolvedValue(undefined);
+
+    const key = buildCacheKey("/test/root", "issue", "open", "created_at:desc");
+    const seeded = makeIssue(1);
+    seeded.assignees = [{ login: "me", avatarUrl: undefined, rawData: null }];
+    setCache(key, {
+      items: [seeded],
+      nextCursor: null,
+      hasMore: false,
+      timestamp: Date.now(),
+    });
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+    await advanceTimersGradually(5000);
+
+    const issue1 = getCache(key)?.items.find((i) => i.number === 1) as Issue;
+    expect(issue1.assignees).toHaveLength(1);
+    expect(issue1.assignees.filter((a) => a.login === "me")).toHaveLength(1);
   });
 });
 

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -647,6 +647,10 @@ export function BulkCreateWorktreeDialog({
               // rate limit (~60s) doesn't widen worktree/terminal retry delays.
               if (planned.mode === "issue" && assignWorktreeToSelf && itemNumber) {
                 const username = viewerRef.current?.login;
+                // Snap the avatar alongside the login before any async work so
+                // the optimistic cache entry matches the user we assign to,
+                // mirroring the single-create flow (#10529).
+                const assignAvatarUrl = viewerRef.current?.avatarUrl;
                 if (username) {
                   dispatchProgress({
                     type: "ITEM_ASSIGNING",
@@ -665,7 +669,6 @@ export function BulkCreateWorktreeDialog({
                       // Mirrors the single-create flow (#10529). The dedup guard
                       // inside the transform makes a re-assign a no-op, and the
                       // forge refresh remains the correctness backstop.
-                      const assignAvatarUrl = viewerRef.current?.avatarUrl;
                       try {
                         mutateCacheEntries(rootPath, "issue", (entry) => {
                           let changed = false;

--- a/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
+++ b/plugins/builtin/github/renderer/components/BulkCreateWorktreeDialog.tsx
@@ -15,6 +15,8 @@ import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { cn } from "@/lib/utils";
 import { worktreeClient, forgeClient, agentSettingsClient, systemClient } from "@/clients";
+import { mutateCacheEntries } from "@/lib/forgeResourceCache";
+import { logError } from "@/utils/logger";
 import { resolveIssuePrequeries } from "./bulkCreatePrequery";
 import { notify } from "@/lib/notify";
 import { usePreferencesStore } from "@/store/preferencesStore";
@@ -87,7 +89,7 @@ export function BulkCreateWorktreeDialog({
   // Viewer identity through the forge identity capability — drives the
   // "assign to me" affordance and the run-loop assignment below.
   const [viewer, setViewer] = useState<{ login: string; avatarUrl?: string } | null>(null);
-  const viewerRef = useRef<{ login: string } | null>(null);
+  const viewerRef = useRef<{ login: string; avatarUrl?: string } | null>(null);
   const currentUser = viewer?.login;
   const currentUserAvatar = viewer?.avatarUrl;
 
@@ -657,6 +659,37 @@ export function BulkCreateWorktreeDialog({
                     assignAttempt++;
                     try {
                       await forgeClient.assignIssue(rootPath, itemNumber, username);
+                      // Optimistically patch every cached issue-list slot so the
+                      // open issues dropdown reflects the assignment immediately
+                      // instead of waiting for the next SWR revalidate (#10667).
+                      // Mirrors the single-create flow (#10529). The dedup guard
+                      // inside the transform makes a re-assign a no-op, and the
+                      // forge refresh remains the correctness backstop.
+                      const assignAvatarUrl = viewerRef.current?.avatarUrl;
+                      try {
+                        mutateCacheEntries(rootPath, "issue", (entry) => {
+                          let changed = false;
+                          const items = entry.items.map((item) => {
+                            // `assignees` exists only on Issue, so this `in` check
+                            // narrows the Issue|PR union and skips non-issue slots.
+                            if (!("assignees" in item) || item.number !== itemNumber) return item;
+                            if (item.assignees.some((a) => a.login === username)) return item;
+                            changed = true;
+                            return {
+                              ...item,
+                              assignees: [
+                                ...item.assignees,
+                                { login: username, avatarUrl: assignAvatarUrl, rawData: null },
+                              ],
+                            };
+                          });
+                          return changed ? { ...entry, items } : null;
+                        });
+                      } catch (cacheErr) {
+                        // A cache-layer throw must not masquerade as an assignment
+                        // failure: the server-side assign already succeeded here.
+                        logError("Failed to patch issue cache after bulk self-assign", cacheErr);
+                      }
                       break;
                     } catch (err) {
                       const assignErr = normalizeError(err);


### PR DESCRIPTION
## Summary

- The bulk-create worktree dialog was calling `forgeClient.assignIssue()` per issue but never patching the renderer forge resource cache, so the open-issues dropdown kept showing assigned issues as unassigned until the next SWR revalidate.
- Ports the cache-patch pattern from the single-worktree dialog (#10529) into the bulk path: after each successful assignment, `mutateCacheEntries` patches every cached issue-list slot for the project.
- The patch fires incrementally per issue so a mid-run cancel leaves the cache consistent. A dedup guard prevents double-patching the same assignee, and a `try/catch` ensures a cache-layer throw can't surface as an assignment failure. `viewerRef` type widened to carry `avatarUrl` for the optimistic entry.

Resolves #10667

## Changes

- `BulkCreateWorktreeDialog.tsx`: call `mutateCacheEntries` after each successful `assignIssue()` call, with dedup guard and error containment
- `BulkCreateWorktreeDialog.test.tsx`: new coverage for multi-slot patch, cross-project isolation, dedup no-duplicate, cache-throw containment

## Testing

64 tests pass. New test cases cover: multi-slot patching, patching doesn't cross project boundaries, no duplicate assignee entries added, cache-layer errors don't propagate as assignment failures.