### PR TITLE
feat(mcp): expose terminal.restart in MCP tier allowlists

### DIFF
--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2526,6 +2526,11 @@ describe("McpServerService", () => {
         description: "Permanently remove all terminals",
       }),
       createManifestEntry({
+        id: "terminal.restart" as ActionId,
+        title: "Restart Terminal",
+        description: "Restart the terminal process",
+      }),
+      createManifestEntry({
         id: "copyTree.generateAndCopyFile" as ActionId,
         title: "Generate And Copy Context",
         description: "Write generated context to the OS clipboard",

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -75,6 +75,7 @@ export const ACTION_TIER_ADDONS = [
   "terminal.closeAll",
   "terminal.kill",
   "terminal.killAll",
+  "terminal.restart",
   "terminal.moveToDock",
   "terminal.moveToGrid",
   "terminal.toggleDock",


### PR DESCRIPTION
## Summary

- `terminal.restart` was already implemented as a `danger: "confirm"` action with a running-agent guard, but it was missing from the MCP tier allowlists, making it completely unreachable over MCP
- Adds `terminal.restart` to `ACTION_TIER_ADDONS` in `helpAssistantTierAllowlists.ts`, alongside `terminal.kill` and `terminal.killAll` (same blast radius, same confirmation requirement)
- Adds the matching `createManifestEntry` fixture for `terminal.restart` in `McpServerService.test.ts` so the tier-iteration tests pass

Resolves #10681

## Changes

- `shared/config/helpAssistantTierAllowlists.ts`: add `terminal.restart` to `ACTION_TIER_ADDONS`
- `electron/services/__tests__/McpServerService.test.ts`: add `terminal.restart` fixture to `tierManifest`

## Testing

- Prettier and ESLint clean on both changed files
- `McpServerService.test.ts` passes (138 tests)