### PR TITLE
feat(browser): expose browser screenshot over MCP with image bytes

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -71,6 +71,7 @@ const registerMocks = vi.hoisted(() => ({
   registerHelpAssistantHandlers: vi.fn(),
   registerWebviewHandlers: vi.fn(),
   registerWebviewNavigationHandlers: vi.fn(),
+  registerWebviewCaptureHandlers: vi.fn(),
   registerDiagnosticsHandlers: vi.fn(),
 
   registerAccessibilityHandlers: vi.fn(),
@@ -243,6 +244,9 @@ vi.mock("../handlers/webview.js", () => ({
 }));
 vi.mock("../handlers/webviewNavigation.js", () => ({
   registerWebviewNavigationHandlers: registerMocks.registerWebviewNavigationHandlers,
+}));
+vi.mock("../handlers/webviewCapture.js", () => ({
+  registerWebviewCaptureHandlers: registerMocks.registerWebviewCaptureHandlers,
 }));
 vi.mock("../handlers/diagnostics.js", () => ({
   registerDiagnosticsHandlers: registerMocks.registerDiagnosticsHandlers,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -357,6 +357,7 @@ export const CHANNELS = {
   WEBVIEW_GET_CONSOLE_PROPERTIES: "webview:get-console-properties",
   WEBVIEW_RELOAD_IGNORING_CACHE: "webview:reload-ignoring-cache",
   WEBVIEW_GET_SCROLL_POSITION: "webview:get-scroll-position",
+  WEBVIEW_CAPTURE_SCREENSHOT: "webview:capture-screenshot",
   WEBVIEW_CONSOLE_MESSAGE: "webview:console-message",
   WEBVIEW_CONSOLE_CONTEXT_CLEARED: "webview:console-context-cleared",
   WEBVIEW_GET_NAVIGATION_HISTORY: "webview:get-navigation-history",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -55,6 +55,7 @@ import { registerMcpServerHandlers } from "./handlers/mcpServer.js";
 import { registerHelpAssistantHandlers } from "./handlers/helpAssistant.js";
 import { registerWebviewHandlers } from "./handlers/webview.js";
 import { registerWebviewNavigationHandlers } from "./handlers/webviewNavigation.js";
+import { registerWebviewCaptureHandlers } from "./handlers/webviewCapture.js";
 import { registerDiagnosticsHandlers } from "./handlers/diagnostics.js";
 import { registerResourceProfileHandlers } from "./handlers/resourceProfile.js";
 import { registerPerfHandlers } from "./handlers/perf.js";
@@ -173,6 +174,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerHelpAssistantHandlers());
     register(() => registerWebviewHandlers(deps));
     register(() => registerWebviewNavigationHandlers(deps));
+    register(() => registerWebviewCaptureHandlers(deps));
     register(() => registerDiagnosticsHandlers(deps));
     register(() => registerResourceProfileHandlers(deps));
 

--- a/electron/ipc/handlers/__tests__/webviewCapture.test.ts
+++ b/electron/ipc/handlers/__tests__/webviewCapture.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface MockImage {
+  isEmpty: () => boolean;
+  toPNG: () => Buffer;
+  getSize: () => { width: number; height: number };
+}
+
+interface MockGuest {
+  isDestroyed: () => boolean;
+  getURL: () => string;
+  capturePage: () => Promise<MockImage>;
+}
+
+const guestRegistry = vi.hoisted(() => new Map<number, MockGuest>());
+const dialogService = vi.hoisted(() => ({
+  getWebContentsId: vi.fn<(panelId: string) => number | undefined>(),
+}));
+
+vi.mock("electron", () => ({
+  webContents: {
+    fromId: vi.fn((webContentsId: number) => guestRegistry.get(webContentsId)),
+  },
+}));
+
+vi.mock("../../../services/WebviewDialogService.js", () => ({
+  getWebviewDialogService: () => dialogService,
+}));
+
+function makeImage(overrides: Partial<MockImage> = {}): MockImage {
+  return {
+    isEmpty: () => false,
+    toPNG: () => Buffer.from("PNGDATA"),
+    getSize: () => ({ width: 800, height: 600 }),
+    ...overrides,
+  };
+}
+
+function makeGuest(overrides: Partial<MockGuest> = {}): MockGuest {
+  return {
+    isDestroyed: () => false,
+    getURL: () => "https://example.com",
+    capturePage: async () => makeImage(),
+    ...overrides,
+  };
+}
+
+async function getCapture() {
+  const { webviewCaptureNamespace } = await import("../webviewCapture.js");
+  return webviewCaptureNamespace.ops.captureScreenshot.handler as (
+    panelId: string
+  ) => Promise<{ pngBase64: string; width: number; height: number }>;
+}
+
+describe("webviewCapture handler", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    guestRegistry.clear();
+    dialogService.getWebContentsId.mockReset();
+  });
+
+  it("returns base64 PNG bytes and dimensions for a live panel", async () => {
+    dialogService.getWebContentsId.mockReturnValue(7);
+    guestRegistry.set(7, makeGuest());
+
+    const capture = await getCapture();
+    const result = await capture("panel-a");
+
+    expect(result).toEqual({
+      pngBase64: Buffer.from("PNGDATA").toString("base64"),
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it("throws NOT_FOUND when no panel resolves to a webContents", async () => {
+    dialogService.getWebContentsId.mockReturnValue(undefined);
+
+    const capture = await getCapture();
+    await expect(capture("panel-missing")).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws NOT_FOUND when the resolved webContents is destroyed", async () => {
+    dialogService.getWebContentsId.mockReturnValue(7);
+    guestRegistry.set(7, makeGuest({ isDestroyed: () => true }));
+
+    const capture = await getCapture();
+    await expect(capture("panel-a")).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("throws UNSUPPORTED when the page is about:blank", async () => {
+    dialogService.getWebContentsId.mockReturnValue(7);
+    guestRegistry.set(7, makeGuest({ getURL: () => "about:blank" }));
+
+    const capture = await getCapture();
+    await expect(capture("panel-a")).rejects.toMatchObject({ code: "UNSUPPORTED" });
+  });
+
+  it("throws INTERNAL when capturePage returns an empty image", async () => {
+    dialogService.getWebContentsId.mockReturnValue(7);
+    guestRegistry.set(
+      7,
+      makeGuest({ capturePage: async () => makeImage({ isEmpty: () => true }) })
+    );
+
+    const capture = await getCapture();
+    await expect(capture("panel-a")).rejects.toMatchObject({ code: "INTERNAL" });
+  });
+
+  it("normalizes a capturePage rejection (TOCTOU teardown) to NOT_FOUND", async () => {
+    dialogService.getWebContentsId.mockReturnValue(7);
+    guestRegistry.set(
+      7,
+      makeGuest({
+        capturePage: async () => {
+          throw new Error("Object has been destroyed");
+        },
+      })
+    );
+
+    const capture = await getCapture();
+    await expect(capture("panel-a")).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+});

--- a/electron/ipc/handlers/webviewCapture.preload.ts
+++ b/electron/ipc/handlers/webviewCapture.preload.ts
@@ -1,0 +1,24 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const WEBVIEW_CAPTURE_METHOD_CHANNELS = {
+  captureScreenshot: "webview:capture-screenshot",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof WEBVIEW_CAPTURE_METHOD_CHANNELS;
+
+export type WebviewCapturePreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildWebviewCapturePreloadBindings(invoke: Invoker): WebviewCapturePreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(WEBVIEW_CAPTURE_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = WEBVIEW_CAPTURE_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as WebviewCapturePreloadBindings;
+}

--- a/electron/ipc/handlers/webviewCapture.ts
+++ b/electron/ipc/handlers/webviewCapture.ts
@@ -41,7 +41,21 @@ export const webviewCaptureNamespace = defineIpcNamespace({
           });
         }
 
-        const image = await wc.capturePage();
+        let image: Electron.NativeImage;
+        try {
+          image = await wc.capturePage();
+        } catch (err) {
+          // The webContents can be destroyed in the gap between the isDestroyed
+          // check and this await (tab closed / project evicted mid-call), which
+          // surfaces as a raw Electron rejection. Normalize it to the same
+          // AppError the caller and MCP error path expect.
+          throw new AppError({
+            code: "NOT_FOUND",
+            message: "Browser panel became unavailable during capture",
+            context: { panelId, webContentsId },
+            cause: err instanceof Error ? err : undefined,
+          });
+        }
         if (image.isEmpty()) {
           throw new AppError({
             code: "INTERNAL",

--- a/electron/ipc/handlers/webviewCapture.ts
+++ b/electron/ipc/handlers/webviewCapture.ts
@@ -1,0 +1,66 @@
+import { webContents } from "electron";
+import { defineIpcNamespace, op } from "../define.js";
+import { getWebviewDialogService } from "../../services/WebviewDialogService.js";
+import { AppError } from "../../utils/errorTypes.js";
+import type { HandlerDependencies } from "../types.js";
+import { WEBVIEW_CAPTURE_METHOD_CHANNELS } from "./webviewCapture.preload.js";
+
+export const webviewCaptureNamespace = defineIpcNamespace({
+  name: "webviewCapture",
+  ops: {
+    captureScreenshot: op(
+      WEBVIEW_CAPTURE_METHOD_CHANNELS.captureScreenshot,
+      async (panelId: string) => {
+        // The renderer only has the panel id; resolve the live webContentsId
+        // from the panel registry (populated by both browser and dev-preview
+        // webviews) so this works for either panel kind.
+        const webContentsId = getWebviewDialogService().getWebContentsId(panelId);
+        if (webContentsId === undefined) {
+          throw new AppError({
+            code: "NOT_FOUND",
+            message: "No browser panel is available to screenshot",
+            context: { panelId },
+          });
+        }
+
+        const wc = webContents.fromId(webContentsId);
+        if (!wc || wc.isDestroyed()) {
+          throw new AppError({
+            code: "NOT_FOUND",
+            message: "Browser webview is no longer available",
+            context: { panelId, webContentsId },
+          });
+        }
+
+        const url = wc.getURL();
+        if (!url || url === "about:blank") {
+          throw new AppError({
+            code: "UNSUPPORTED",
+            message: "Browser has no page loaded to screenshot",
+            context: { panelId },
+          });
+        }
+
+        const image = await wc.capturePage();
+        if (image.isEmpty()) {
+          throw new AppError({
+            code: "INTERNAL",
+            message: "Screenshot capture returned an empty image",
+            context: { panelId },
+          });
+        }
+
+        const size = image.getSize();
+        return {
+          pngBase64: image.toPNG().toString("base64"),
+          width: size.width,
+          height: size.height,
+        };
+      }
+    ),
+  },
+});
+
+export function registerWebviewCaptureHandlers(_deps: HandlerDependencies): () => void {
+  return webviewCaptureNamespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -71,6 +71,7 @@ import { buildCliPreloadBindings } from "./ipc/handlers/cli.preload.js";
 import { buildGlobalRecipesPreloadBindings } from "./ipc/handlers/globalRecipes.preload.js";
 import { buildEditorConfigPreloadBindings } from "./ipc/handlers/editorConfig.preload.js";
 import { buildWebviewNavigationPreloadBindings } from "./ipc/handlers/webviewNavigation.preload.js";
+import { buildWebviewCapturePreloadBindings } from "./ipc/handlers/webviewCapture.preload.js";
 import { buildWorktreeConfigPreloadBindings } from "./ipc/handlers/worktreeConfig.preload.js";
 import { buildTerminalLayoutPreloadBindings } from "./ipc/handlers/terminalLayout.preload.js";
 import { buildTerminalConfigPreloadBindings } from "./ipc/handlers/terminalConfig.preload.js";
@@ -2009,6 +2010,7 @@ function buildElectronApi(): ElectronAPI {
       getScrollPosition: (webContentsId: number): Promise<number> =>
         _unwrappingInvoke(CHANNELS.WEBVIEW_GET_SCROLL_POSITION, webContentsId),
       ...buildWebviewNavigationPreloadBindings(_unwrappingInvoke),
+      ...buildWebviewCapturePreloadBindings(_unwrappingInvoke),
     },
 
     // Hibernation API

--- a/electron/services/WebviewDialogService.ts
+++ b/electron/services/WebviewDialogService.ts
@@ -35,6 +35,17 @@ class WebviewDialogService {
     }
 
     this.panelMap.set(webContentsId, panelId);
+    // A remount (LRU restore, partition change, dev double-mount) registers a
+    // new webContentsId for the same panelId before the old guest fires
+    // `destroyed`. Drop the stale duplicate now so the reverse lookup
+    // (getWebContentsId) resolves to the live webview rather than the
+    // torn-down one, whose capturePage() would return the old page's pixels.
+    for (const [otherWebContentsId, mappedPanelId] of this.panelMap) {
+      if (mappedPanelId === panelId && otherWebContentsId !== webContentsId) {
+        this.panelMap.delete(otherWebContentsId);
+        this.kindMap.delete(otherWebContentsId);
+      }
+    }
     // Registration happens from multiple effects (dialog + console capture);
     // only some pass a kind. Preserve a previously-set kind when omitted.
     if (kind !== undefined) {

--- a/electron/services/WebviewDialogService.ts
+++ b/electron/services/WebviewDialogService.ts
@@ -64,6 +64,19 @@ class WebviewDialogService {
     return this.kindMap.get(webContentsId);
   }
 
+  /**
+   * Reverse of {@link getPanelId}: resolve a panel's live webContentsId from its
+   * panel id. `panelMap` is keyed by webContentsId, so this is an O(n) scan —
+   * negligible at the handful-of-webview-panels scale it runs at. Returns the
+   * first match; a webContents is rebound to at most one panel at a time.
+   */
+  getWebContentsId(panelId: string): number | undefined {
+    for (const [webContentsId, mappedPanelId] of this.panelMap) {
+      if (mappedPanelId === panelId) return webContentsId;
+    }
+    return undefined;
+  }
+
   registerDialog(
     dialogId: string,
     webContentsId: number,

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -927,6 +927,53 @@ describe("McpServerService", () => {
     );
   });
 
+  it("returns browser.captureScreenshot bytes as an MCP image content block", async () => {
+    const dispatchMock = vi.fn(
+      (): ActionDispatchResult => ({
+        ok: true,
+        result: { pngBase64: "aGVsbG8=", width: 1024, height: 768 },
+      })
+    );
+
+    const { window } = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "browser.captureScreenshot" as ActionId,
+          title: "Capture Browser Screenshot",
+          description:
+            "Capture a screenshot of the focused browser panel and return it as a PNG image",
+        }),
+      ],
+      dispatchAction: dispatchMock,
+    });
+
+    // browser.captureScreenshot lives in the `action` tier — connect with a
+    // token that resolves there so the tool is permitted.
+    paneTokenTiers.set("token-action", "action");
+    await service.start(window);
+    const { client, transport } = await connectClient(service.currentPort!, {
+      Authorization: "Bearer token-action",
+    });
+    transports.push(transport);
+
+    const result = await client.callTool({
+      name: "browser.captureScreenshot",
+      arguments: {},
+    });
+    const content = result.content as Array<Record<string, unknown>>;
+
+    expect(result.isError).toBeFalsy();
+    // The base64 PNG is surfaced as a real image block, not text-serialized.
+    expect(content[0]).toMatchObject({
+      type: "image",
+      mimeType: "image/png",
+      data: "aGVsbG8=",
+    });
+    expect(content[1]).toMatchObject({ type: "text" });
+    expect(String(content[1]!.text)).toContain("1024×768");
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("threads the external bearer's identity through to the renderer dispatch payload (#9157)", async () => {
     // Regression guard: the production `dispatchAction` wrapper in
     // McpServerService must forward the 4th `callerInfo` argument computed by
@@ -2740,6 +2787,12 @@ describe("McpServerService", () => {
         id: "browser.openUrl" as ActionId,
         title: "Open URL in Browser",
         description: "Open a URL in a browser panel, reusing an existing one or creating a new one",
+      }),
+      createManifestEntry({
+        id: "browser.captureScreenshot" as ActionId,
+        title: "Capture Browser Screenshot",
+        description:
+          "Capture a screenshot of the focused browser panel and return it as a PNG image",
       }),
       createManifestEntry({
         id: "panel.focus" as ActionId,

--- a/electron/services/__tests__/WebviewDialogService.adversarial.test.ts
+++ b/electron/services/__tests__/WebviewDialogService.adversarial.test.ts
@@ -208,6 +208,44 @@ describe("WebviewDialogService adversarial", () => {
     expect(survivingCallback).toHaveBeenCalledTimes(1);
   });
 
+  it("GET_WEBCONTENTS_ID_REVERSE_LOOKUP", async () => {
+    guestRegistry.set(1, createGuest());
+    guestRegistry.set(2, createGuest());
+
+    const { getWebviewDialogService } = await import("../WebviewDialogService.js");
+    const service = getWebviewDialogService();
+
+    service.registerPanel(1, "panel-a");
+    service.registerPanel(2, "panel-b");
+
+    expect(service.getWebContentsId("panel-a")).toBe(1);
+    expect(service.getWebContentsId("panel-b")).toBe(2);
+    expect(service.getWebContentsId("panel-missing")).toBeUndefined();
+  });
+
+  it("REMOUNT_DROPS_STALE_REVERSE_LOOKUP_ENTRY", async () => {
+    // A panel remount (LRU restore / partition change) registers a new
+    // webContentsId for the same panelId before the old guest fires
+    // `destroyed`. The reverse lookup must resolve to the live webview.
+    guestRegistry.set(10, createGuest());
+    guestRegistry.set(11, createGuest());
+
+    const { getWebviewDialogService } = await import("../WebviewDialogService.js");
+    const service = getWebviewDialogService();
+
+    service.registerPanel(10, "panel-a", "browser");
+    expect(service.getWebContentsId("panel-a")).toBe(10);
+
+    // Remount: same panelId, new (still-live) webContentsId.
+    service.registerPanel(11, "panel-a", "browser");
+
+    expect(service.getWebContentsId("panel-a")).toBe(11);
+    // The stale forward + kind entries for the old webContents are cleared too.
+    expect(service.getPanelId(10)).toBeUndefined();
+    expect(service.getPanelKind(10)).toBeUndefined();
+    expect(service.getPanelId(11)).toBe("panel-a");
+  });
+
   it("REJECTED_OAUTH_PROMISE_ONE_SHOT", async () => {
     const { getWebviewDialogService } = await import("../WebviewDialogService.js");
     const service = getWebviewDialogService();

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -77,6 +77,28 @@ import {
 
 const TERMINAL_WAIT_UNTIL_IDLE_TOOL = "terminal.waitUntilIdle";
 const HELP_DISPLAY_IMAGE_TOOL = "help.displayImage";
+const BROWSER_CAPTURE_SCREENSHOT_TOOL = "browser.captureScreenshot";
+
+/**
+ * Narrow a `browser.captureScreenshot` result to its base64-PNG payload so the
+ * tool response can carry a real MCP `image` content block (the generic path
+ * only ever text-serializes results). Guarded structurally rather than trusting
+ * the action id alone.
+ */
+function asScreenshotResult(
+  result: unknown
+): { pngBase64: string; width: number; height: number } | null {
+  if (
+    result !== null &&
+    typeof result === "object" &&
+    typeof (result as { pngBase64?: unknown }).pngBase64 === "string" &&
+    typeof (result as { width?: unknown }).width === "number" &&
+    typeof (result as { height?: unknown }).height === "number"
+  ) {
+    return result as { pngBase64: string; width: number; height: number };
+  }
+  return null;
+}
 import type { SessionStore } from "./sessionStore.js";
 
 /**
@@ -892,6 +914,23 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
               sessionStore.resetIdleTimer(sessionId);
             } else if (sessionStore.httpSessions.has(sessionId)) {
               sessionStore.resetHttpIdleTimer(sessionId);
+            }
+          }
+          // browser.captureScreenshot returns PNG bytes — surface them as a real
+          // MCP image content block so the model receives a usable image, not a
+          // base64 blob text-serialized into the transcript.
+          if (actionId === BROWSER_CAPTURE_SCREENSHOT_TOOL) {
+            const shot = asScreenshotResult(outcome.value.result);
+            if (shot) {
+              return {
+                content: [
+                  { type: "image" as const, data: shot.pngBase64, mimeType: "image/png" },
+                  {
+                    type: "text" as const,
+                    text: `Screenshot captured (${shot.width}×${shot.height})`,
+                  },
+                ],
+              };
             }
           }
           const structuredContent = buildStructuredContent(entry, outcome.value.result);

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -115,6 +115,7 @@ export const ACTION_TIER_ADDONS = [
 
   "browser.navigate",
   "browser.openUrl",
+  "browser.captureScreenshot",
 
   "devPreview.reloadPreview",
   "devPreview.restart",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -926,6 +926,10 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     reloadIgnoringCache(webContentsId: number, panelId: string): Promise<void>;
     /** Read the current scroll position from Blink layout — works on frozen pages */
     getScrollPosition(webContentsId: number): Promise<number>;
+    /** Capture the panel's webview viewport as a PNG, returned base64-encoded */
+    captureScreenshot(
+      panelId: string
+    ): Promise<{ pngBase64: string; width: number; height: number }>;
     /** Read Chromium navigation history for the webview */
     getNavigationHistory(
       webContentsId: number

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -619,6 +619,9 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["system-sleep:reset"]["result"]>;
   };
   webview: {
+    captureScreenshot(
+      ...args: IpcInvokeMap["webview:capture-screenshot"]["args"]
+    ): Promise<IpcInvokeMap["webview:capture-screenshot"]["result"]>;
     getNavigationHistory(
       ...args: IpcInvokeMap["webview:get-navigation-history"]["args"]
     ): Promise<IpcInvokeMap["webview:get-navigation-history"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1440,6 +1440,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: void;
   };
+  "webview:capture-screenshot": {
+    args: [panelId: string];
+    result: { pngBase64: string; width: number; height: number };
+  };
   "webview:get-navigation-history": {
     args: [webContentsId: number];
     result: {

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -676,7 +676,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "browser",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Capture a screenshot of the browser viewport and copy to clipboard",
+    "description": "Capture a screenshot of the focused browser panel and return it as a PNG image",
     "examples": undefined,
     "id": "browser.captureScreenshot",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/browserActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/browserActions.adversarial.test.ts
@@ -48,6 +48,9 @@ function setPanelState(state: {
 
 const dispatchSpy = vi.fn<(event: Event) => boolean>(() => true);
 const clipboardSpy = vi.fn<(text: string) => Promise<void>>();
+const captureScreenshotSpy =
+  vi.fn<(panelId: string) => Promise<{ pngBase64: string; width: number; height: number }>>();
+const writeImageSpy = vi.fn<(bytes: Uint8Array) => Promise<void>>();
 
 const getMessagesSpy = vi.fn();
 const getCountsSpy = vi.fn();
@@ -112,6 +115,17 @@ beforeEach(() => {
   consoleCaptureMock.flush.mockReset();
   consoleCaptureMock.getState.mockReset();
   systemClientMock.openExternal.mockResolvedValue(undefined);
+  captureScreenshotSpy
+    .mockReset()
+    .mockResolvedValue({ pngBase64: btoa("png-bytes"), width: 1024, height: 768 });
+  writeImageSpy.mockReset().mockResolvedValue(undefined);
+  Object.defineProperty(globalThis.window, "electron", {
+    value: {
+      webview: { captureScreenshot: captureScreenshotSpy },
+      clipboard: { writeImage: writeImageSpy },
+    },
+    configurable: true,
+  });
   Object.defineProperty(globalThis.window, "dispatchEvent", {
     value: dispatchSpy,
     configurable: true,
@@ -465,5 +479,56 @@ describe("browserActions adversarial", () => {
     await expect(run("browser.getConsoleMessages")).rejects.toThrow(/dev preview panels/);
     expect(consoleCaptureMock.flush).not.toHaveBeenCalled();
     expect(getMessagesSpy).not.toHaveBeenCalled();
+  });
+
+  it("browser.captureScreenshot captures the focused panel and returns PNG bytes", async () => {
+    setPanelState({ focusedId: "b1" });
+    const run = setupActions();
+    const result = await run("browser.captureScreenshot");
+
+    expect(captureScreenshotSpy).toHaveBeenCalledWith("b1");
+    expect(result).toEqual({ pngBase64: btoa("png-bytes"), width: 1024, height: 768 });
+  });
+
+  it("browser.captureScreenshot explicit terminalId overrides focusedId", async () => {
+    setPanelState({ focusedId: "b1" });
+    const run = setupActions();
+    await run("browser.captureScreenshot", { terminalId: "b2" });
+
+    expect(captureScreenshotSpy).toHaveBeenCalledWith("b2");
+  });
+
+  it("browser.captureScreenshot copies to clipboard for non-agent dispatch", async () => {
+    setPanelState({ focusedId: "b1" });
+    const run = setupActions();
+    await run("browser.captureScreenshot");
+
+    expect(writeImageSpy).toHaveBeenCalledTimes(1);
+    const bytes = writeImageSpy.mock.calls[0]![0];
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    // Decoded base64 round-trips back to the original PNG bytes.
+    expect(String.fromCharCode(...bytes)).toBe("png-bytes");
+  });
+
+  it("browser.captureScreenshot does NOT touch the clipboard for agent dispatch", async () => {
+    setPanelState({ focusedId: "b1" });
+    const actions: ActionRegistry = new Map();
+    registerBrowserActions(actions, {} as unknown as ActionCallbacks);
+    const def = actions.get("browser.captureScreenshot")!() as AnyActionDefinition;
+
+    const result = await def.run(undefined, { dispatchSource: "agent" } as never);
+
+    expect(captureScreenshotSpy).toHaveBeenCalledWith("b1");
+    expect(writeImageSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ pngBase64: btoa("png-bytes"), width: 1024, height: 768 });
+  });
+
+  it("browser.captureScreenshot throws when no target panel exists (no silent ok:true)", async () => {
+    setPanelState({ focusedId: null });
+    const run = setupActions();
+
+    await expect(run("browser.captureScreenshot")).rejects.toThrow(/No browser panel/);
+    expect(captureScreenshotSpy).not.toHaveBeenCalled();
+    expect(writeImageSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/services/actions/definitions/browserActions.ts
+++ b/src/services/actions/definitions/browserActions.ts
@@ -258,7 +258,7 @@ export function registerBrowserActions(actions: ActionRegistry, _callbacks: Acti
       // Preserve the user-facing "copy to clipboard" affordance for keybinding /
       // toolbar dispatch; agent (MCP) calls receive the bytes in the result and
       // must not clobber the user's clipboard.
-      if (ctx.dispatchSource !== "agent") {
+      if (ctx?.dispatchSource !== "agent") {
         try {
           const binary = atob(shot.pngBase64);
           const bytes = new Uint8Array(binary.length);

--- a/src/services/actions/definitions/browserActions.ts
+++ b/src/services/actions/definitions/browserActions.ts
@@ -239,19 +239,37 @@ export function registerBrowserActions(actions: ActionRegistry, _callbacks: Acti
     id: "browser.captureScreenshot",
     palette: { mode: "hidden" },
     title: "Capture Browser Screenshot",
-    description: "Capture a screenshot of the browser viewport and copy to clipboard",
+    description: "Capture a screenshot of the focused browser panel and return it as a PNG image",
     category: "browser",
     kind: "command",
     danger: "safe",
     scope: "renderer",
     argsSchema: z.object({ terminalId: z.string().optional() }).optional(),
-    run: async (args: unknown) => {
+    run: async (args: unknown, ctx) => {
       const { terminalId } = (args as { terminalId?: string } | undefined) ?? {};
       const targetId = terminalId ?? usePanelStore.getState().focusedId;
-      if (!targetId) return;
-      window.dispatchEvent(
-        new CustomEvent("daintree:browser-capture-screenshot", { detail: { id: targetId } })
-      );
+      // No silent no-op: returning `undefined` here would make ActionService
+      // report `{ ok: true }` with no image, leaving an MCP caller unable to
+      // tell that nothing was captured. Throw so the failure is explicit.
+      if (!targetId) {
+        throw new Error("No browser panel: pass terminalId or focus a browser panel first");
+      }
+      const shot = await window.electron.webview.captureScreenshot(targetId);
+      // Preserve the user-facing "copy to clipboard" affordance for keybinding /
+      // toolbar dispatch; agent (MCP) calls receive the bytes in the result and
+      // must not clobber the user's clipboard.
+      if (ctx.dispatchSource !== "agent") {
+        try {
+          const binary = atob(shot.pngBase64);
+          const bytes = new Uint8Array(binary.length);
+          for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+          await window.electron.clipboard.writeImage(bytes);
+        } catch {
+          // Clipboard write is a best-effort side-effect — the captured image is
+          // still returned to the caller even if the copy fails.
+        }
+      }
+      return shot;
     },
   }));
 


### PR DESCRIPTION
## Summary

- `browser.captureScreenshot` is now MCP-dispatchable and returns a real MCP image content block (`{ type: "image", mimeType: "image/png", data: <base64> }`) plus a text line with dimensions, instead of returning undefined.
- A new `webview:capture-screenshot` IPC channel captures the focused browser or dev-preview webview as base64 PNG in the main process, using a `panelId` to `webContentsId` reverse lookup on `WebviewDialogService`.
- Clipboard copy is preserved for non-agent dispatch (keybinding, toolbar). Agent calls receive the bytes and don't clobber the clipboard.

Resolves #10679

## Changes

- `browserActions.ts`: wires `browser.captureScreenshot` into the action tier, returns MCP image content block on agent dispatch
- `webviewCapture.ts` + `webviewCapture.preload.ts`: new IPC handler with `NOT_FOUND` (no/destroyed panel), `UNSUPPORTED` (`about:blank`), and `INTERNAL` (empty image) error cases
- `WebviewDialogService.ts`: adds reverse lookup from `panelId` to `webContentsId`, handles remount stale entries
- `sessionServer.ts`: surfaces image content block through the MCP session server
- `channels.ts`, `handlers.ts`, `preload.cts`, `shared/types/ipc/`: registers the new channel through the full IPC codegen pipeline
- `helpAssistantTierAllowlists.ts`: adds `browser.captureScreenshot` to the allowlist

This is the Daintree (producer) side of the rollout. The dependent Assistant wave consumes it.

## Testing

- `browserActions.adversarial.test.ts`: action result and clipboard-gating (agent vs non-agent dispatch)
- `McpServerService.test.ts`: MCP image content block shape
- `webviewCapture.test.ts`: `NOT_FOUND`, `UNSUPPORTED`, `INTERNAL`, and TOCTOU cases
- `WebviewDialogService.adversarial.test.ts`: reverse-lookup and remount stale-entry
- Local checks green: targeted vitest, electron + renderer + preload typecheck, eslint, IPC codegen guards, action snapshot ratchet