### PR TITLE
fix(assistant): stop show/hide from orphaning terminal status-line rows

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -74,9 +74,10 @@ interface HelpPanelProps {
    */
   width: number;
   /**
-   * Whether the panel is visible. When false, AppLayout collapses the clipped
-   * right-sidebar slot so the panel grid slides over it. Defaults to width > 0
-   * for backward compatibility.
+   * Whether the panel is visible. When false, AppLayout slides the fixed-width
+   * wrapper off-canvas via transform while a sibling spacer animates the <main>
+   * push, and marks the parked wrapper inert once the slide settles (#10693).
+   * Defaults to width > 0 for backward compatibility.
    */
   isVisible?: boolean;
   /**

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -154,6 +154,14 @@ export function AppLayout({
   const showSidebar = !layout.gestureSidebarHidden && currentProject != null;
   const showAssistant = !layout.gestureAssistantHidden && layout.helpPanelOpen;
   const effectiveAssistantWidth = showAssistant ? layout.helpPanelWidth : 0;
+  // #10693 (off-canvas): the assistant wrapper is always full-width and slides
+  // via transform, so when hidden it still has a real DOM box off-screen. Mark
+  // it inert once it has finished sliding out so keyboard focus and scroll can't
+  // land in the parked panel. Applied only AFTER the slide settles (and removed
+  // immediately on show) so a Radix Presence teardown inside the panel keeps its
+  // transitionend (#6182). pointer-events-none + the panel's own tabIndex gating
+  // already cover the in-flight window.
+  const [assistantInert, setAssistantInert] = useState(!showAssistant);
 
   // Issue #9864: the sidebar wrapper carries overflowClipMargin: 6px so the
   // resize handle's overhang paints outside the contain boundary. But
@@ -216,16 +224,15 @@ export function AppLayout({
     [showSidebar]
   );
 
-  // #10693: the Assistant pane's width animation (0↔full over 250ms) drives a
-  // per-frame ResizeObserver storm that machine-guns SIGWINCH at the hosted CLI
-  // while its own width state lags, orphaning a status-line row into scrollback
-  // each show/hide cycle. Arm the PTY resize lock at the real animation start —
-  // closing the ~16ms gap left by the toggle-time suppressSidebarResizes() call,
-  // which is kept as a reduced-motion/performanceMode fallback (those modes
-  // strip transition-[width], so no transition events fire). Filter on width +
-  // target===currentTarget to ignore other properties and bubbled child
-  // transitions, mirroring the sidebar handler.
-  const handleAssistantTransitionStart = useCallback(
+  // #10693 (off-canvas): the assistant slides via a composited transform on a
+  // fixed-width wrapper, so the terminal box never resizes during show/hide and
+  // the SIGWINCH storm can't form. The PUSH (main grid reclaiming the space) is
+  // driven by a sibling layout spacer that animates its width — that spacer is
+  // the <main> reflow driver, so arm the grid-resize lock when ITS width
+  // transition starts, exactly as the wrapper's width transition used to do.
+  // Filter on width + target===currentTarget to ignore other properties and
+  // bubbled child transitions, mirroring the sidebar handler.
+  const handleAssistantSpacerTransitionStart = useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {
       if (event.propertyName === "width" && event.target === event.currentTarget) {
         suppressSidebarResizes();
@@ -234,18 +241,19 @@ export function AppLayout({
     []
   );
 
-  // Only the settle (transitionend) path issues the corrective repaint. A rapid
-  // hide→show fires transitioncancel at an intermediate animating width, where a
-  // repaint would assert a transient wrong column count — the suppression timer
-  // owns the unlock and the following show's transitionend repaints correctly,
-  // so the cancel needs no handler.
+  // When the wrapper's transform slide settles, issue the one corrective repaint
+  // (reveal) and, on a hide, mark the parked wrapper inert. Filter on transform
+  // because that is the property the wrapper now animates. transitioncancel is
+  // intentionally unwired: a rapid hide→show re-targets the same transform and
+  // the final transitionend resolves the correct state.
   const handleAssistantTransitionEnd = useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {
-      if (event.propertyName === "width" && event.target === event.currentTarget) {
+      if (event.propertyName === "transform" && event.target === event.currentTarget) {
         repaintAssistantAfterTransition();
+        if (!showAssistant) setAssistantInert(true);
       }
     },
-    []
+    [showAssistant]
   );
 
   useEffect(() => {
@@ -539,6 +547,26 @@ export function AppLayout({
     useMacroFocusStore.getState().setVisibility("assistant", showAssistant);
   }, [showAssistant]);
 
+  // #10693 (off-canvas): drive the inert/repaint settle for the paths where no
+  // transform transition fires. On show, clear inert immediately so focus can
+  // enter before the slide finishes. When the slide is animated, the transition
+  // handlers own the settle; when it is suppressed (reduced-motion preference,
+  // OS prefers-reduced-motion, or performance mode) there is no transitionend,
+  // so reconcile geometry and toggle inert synchronously here instead.
+  useEffect(() => {
+    const noTransition =
+      reduceAnimations ||
+      layout.performanceMode ||
+      (typeof window !== "undefined" &&
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true);
+    if (showAssistant) {
+      setAssistantInert(false);
+      if (noTransition) repaintAssistantAfterTransition();
+    } else if (noTransition) {
+      setAssistantInert(true);
+    }
+  }, [showAssistant, reduceAnimations, layout.performanceMode]);
+
   // Clear macro focus on mouse interaction. A click inside the currently-
   // focused region must NOT clear the claim — otherwise a click within the
   // already-focused assistant (or any other claimed region) drops the macro
@@ -723,17 +751,39 @@ export function AppLayout({
               <TerminalDockRegion />
             </main>
           </ErrorBoundary>
+          {/* #10693 (off-canvas): this spacer drives the <main> push by
+              animating its width 0↔helpPanelWidth, while the panel itself slides
+              over the reclaimed space via the wrapper's transform. The spacer is
+              the grid-reflow driver, so it carries the resize-lock arming
+              transition handler the width-wrapper used to own. */}
+          <div
+            aria-hidden
+            className={cn(
+              "shrink-0 pointer-events-none",
+              !reduceAnimations &&
+                !isAssistantResizing &&
+                "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none"
+            )}
+            style={{ width: effectiveAssistantWidth }}
+            onTransitionStart={handleAssistantSpacerTransitionStart}
+          />
           <ErrorBoundary variant="section" componentName="HelpPanel">
             <div
               className={cn(
-                "relative h-full shrink-0 overflow-hidden",
+                "absolute top-0 right-0 h-full overflow-hidden",
                 !reduceAnimations &&
                   !isAssistantResizing &&
-                  "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                  "transition-transform duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
                 !showAssistant && "pointer-events-none"
               )}
-              style={{ width: effectiveAssistantWidth, contain: "layout paint" }}
-              onTransitionStart={handleAssistantTransitionStart}
+              style={{
+                width: layout.helpPanelWidth,
+                transform: showAssistant
+                  ? "translateX(0)"
+                  : `translateX(${layout.helpPanelWidth}px)`,
+                contain: "layout paint",
+              }}
+              inert={assistantInert}
               onTransitionEnd={handleAssistantTransitionEnd}
             >
               <div

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -39,7 +39,7 @@ import type { CliAvailability, AgentSettings } from "@shared/types";
 import { useLayoutState, useOverlayOpen } from "@/hooks";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
-import { suppressSidebarResizes } from "@/lib/sidebarToggle";
+import { releaseAssistantResizeLock, suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { logError } from "@/utils/logger";
 
 function preloadGlobalBannerCoordinator() {
@@ -214,6 +214,36 @@ export function AppLayout({
       }
     },
     [showSidebar]
+  );
+
+  // #10693: the Assistant pane's width animation (0↔full over 250ms) drives a
+  // per-frame ResizeObserver storm that machine-guns SIGWINCH at the hosted CLI
+  // while its own width state lags, orphaning a status-line row into scrollback
+  // each show/hide cycle. Arm the PTY resize lock at the real animation start —
+  // closing the ~16ms gap left by the toggle-time suppressSidebarResizes() call
+  // — and release it, with one corrective repaint, the instant the transition
+  // settles. Filter on width + target===currentTarget to ignore other
+  // properties and bubbled child transitions, mirroring the sidebar handler.
+  const handleAssistantTransitionStart = useCallback(
+    (event: React.TransitionEvent<HTMLDivElement>) => {
+      if (event.propertyName === "width" && event.target === event.currentTarget) {
+        suppressSidebarResizes();
+      }
+    },
+    []
+  );
+
+  // transitioncancel is mandatory, not redundant: a rapid hide→show reverses the
+  // animation mid-flight and fires transitioncancel (never transitionend), so
+  // wiring only transitionend would strand the lock and silence every later PTY
+  // resize for that terminal session.
+  const handleAssistantTransitionSettled = useCallback(
+    (event: React.TransitionEvent<HTMLDivElement>) => {
+      if (event.propertyName === "width" && event.target === event.currentTarget) {
+        releaseAssistantResizeLock();
+      }
+    },
+    []
   );
 
   useEffect(() => {
@@ -701,6 +731,9 @@ export function AppLayout({
                 !showAssistant && "pointer-events-none"
               )}
               style={{ width: effectiveAssistantWidth, contain: "layout paint" }}
+              onTransitionStart={handleAssistantTransitionStart}
+              onTransitionEnd={handleAssistantTransitionSettled}
+              onTransitionCancel={handleAssistantTransitionSettled}
             >
               <div
                 className="absolute top-0 right-0 h-full"

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -550,22 +550,31 @@ export function AppLayout({
   // #10693 (off-canvas): drive the inert/repaint settle for the paths where no
   // transform transition fires. On show, clear inert immediately so focus can
   // enter before the slide finishes. When the slide is animated, the transition
-  // handlers own the settle; when it is suppressed (reduced-motion preference,
-  // OS prefers-reduced-motion, or performance mode) there is no transitionend,
-  // so reconcile geometry and toggle inert synchronously here instead.
+  // handlers own the settle; when it is suppressed there is no transitionend, so
+  // reconcile geometry and toggle inert synchronously here instead. A slide is
+  // suppressed by the reduce-animations preference, performance mode, an OS
+  // prefers-reduced-motion match, OR an in-flight drag-resize (which strips the
+  // transition so the handle tracks the cursor 1:1). The media query is also
+  // subscribed so flipping the OS setting mid-hide still parks the wrapper inert.
   useEffect(() => {
-    const noTransition =
-      reduceAnimations ||
-      layout.performanceMode ||
-      (typeof window !== "undefined" &&
-        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches === true);
-    if (showAssistant) {
-      setAssistantInert(false);
-      if (noTransition) repaintAssistantAfterTransition();
-    } else if (noTransition) {
-      setAssistantInert(true);
-    }
-  }, [showAssistant, reduceAnimations, layout.performanceMode]);
+    const mql =
+      typeof window !== "undefined"
+        ? window.matchMedia?.("(prefers-reduced-motion: reduce)")
+        : undefined;
+    const settle = () => {
+      const noTransition =
+        reduceAnimations || layout.performanceMode || isAssistantResizing || mql?.matches === true;
+      if (showAssistant) {
+        setAssistantInert(false);
+        if (noTransition) repaintAssistantAfterTransition();
+      } else if (noTransition) {
+        setAssistantInert(true);
+      }
+    };
+    settle();
+    mql?.addEventListener("change", settle);
+    return () => mql?.removeEventListener("change", settle);
+  }, [showAssistant, reduceAnimations, layout.performanceMode, isAssistantResizing]);
 
   // Clear macro focus on mouse interaction. A click inside the currently-
   // focused region must NOT clear the claim — otherwise a click within the

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -39,7 +39,7 @@ import type { CliAvailability, AgentSettings } from "@shared/types";
 import { useLayoutState, useOverlayOpen } from "@/hooks";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
-import { releaseAssistantResizeLock, suppressSidebarResizes } from "@/lib/sidebarToggle";
+import { repaintAssistantAfterTransition, suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { logError } from "@/utils/logger";
 
 function preloadGlobalBannerCoordinator() {
@@ -220,10 +220,11 @@ export function AppLayout({
   // per-frame ResizeObserver storm that machine-guns SIGWINCH at the hosted CLI
   // while its own width state lags, orphaning a status-line row into scrollback
   // each show/hide cycle. Arm the PTY resize lock at the real animation start —
-  // closing the ~16ms gap left by the toggle-time suppressSidebarResizes() call
-  // — and release it, with one corrective repaint, the instant the transition
-  // settles. Filter on width + target===currentTarget to ignore other
-  // properties and bubbled child transitions, mirroring the sidebar handler.
+  // closing the ~16ms gap left by the toggle-time suppressSidebarResizes() call,
+  // which is kept as a reduced-motion/performanceMode fallback (those modes
+  // strip transition-[width], so no transition events fire). Filter on width +
+  // target===currentTarget to ignore other properties and bubbled child
+  // transitions, mirroring the sidebar handler.
   const handleAssistantTransitionStart = useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {
       if (event.propertyName === "width" && event.target === event.currentTarget) {
@@ -233,14 +234,15 @@ export function AppLayout({
     []
   );
 
-  // transitioncancel is mandatory, not redundant: a rapid hide→show reverses the
-  // animation mid-flight and fires transitioncancel (never transitionend), so
-  // wiring only transitionend would strand the lock and silence every later PTY
-  // resize for that terminal session.
-  const handleAssistantTransitionSettled = useCallback(
+  // Only the settle (transitionend) path issues the corrective repaint. A rapid
+  // hide→show fires transitioncancel at an intermediate animating width, where a
+  // repaint would assert a transient wrong column count — the suppression timer
+  // owns the unlock and the following show's transitionend repaints correctly,
+  // so the cancel needs no handler.
+  const handleAssistantTransitionEnd = useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {
       if (event.propertyName === "width" && event.target === event.currentTarget) {
-        releaseAssistantResizeLock();
+        repaintAssistantAfterTransition();
       }
     },
     []
@@ -732,8 +734,7 @@ export function AppLayout({
               )}
               style={{ width: effectiveAssistantWidth, contain: "layout paint" }}
               onTransitionStart={handleAssistantTransitionStart}
-              onTransitionEnd={handleAssistantTransitionSettled}
-              onTransitionCancel={handleAssistantTransitionSettled}
+              onTransitionEnd={handleAssistantTransitionEnd}
             >
               <div
                 className="absolute top-0 right-0 h-full"

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -4,13 +4,13 @@ import path from "path";
 
 const APP_LAYOUT_PATH = path.resolve(__dirname, "../AppLayout.tsx");
 
-// Issue #10693: showing/hiding the Assistant pane animates its wrapper width
-// 0↔full over 250ms. The per-frame ResizeObserver storm that drives a SIGWINCH
-// to the hosted CLI orphans a status-line row into scrollback each cycle.
-// AppLayout must arm the PTY resize lock at the real animation start and issue a
-// single corrective repaint when the transition settles — wired to the
-// wrapper's transition events, mirroring the existing sidebar handler.
-describe("AppLayout assistant transition resize suppression — issue #10693", () => {
+// Issue #10693: the assistant pane is shown/hidden with an off-canvas slide. A
+// fixed-width wrapper animates `transform: translateX` (composited — no layout,
+// no ResizeObserver, terminal geometry stable) while a sibling layout spacer
+// animates its width 0↔helpPanelWidth to drive the <main> push. The spacer is
+// the grid-reflow driver, so it arms the resize lock; the wrapper's transform
+// settle issues the corrective repaint and parks the wrapper inert on hide.
+describe("AppLayout assistant off-canvas slide — issue #10693", () => {
   let source: string;
 
   beforeEach(async () => {
@@ -27,43 +27,61 @@ describe("AppLayout assistant transition resize suppression — issue #10693", (
     );
   });
 
-  it("arms the lock on transitionstart via suppressSidebarResizes", () => {
+  it("arms the grid-resize lock on the spacer's width-transition start", () => {
     const handler = source.match(
-      /const handleAssistantTransitionStart = useCallback\(([\s\S]*?)\n {2}\);/
+      /const handleAssistantSpacerTransitionStart = useCallback\(([\s\S]*?)\n {2}\);/
     );
     expect(handler).not.toBeNull();
+    expect(handler![1]).toContain('event.propertyName === "width"');
+    expect(handler![1]).toContain("event.target === event.currentTarget");
     expect(handler![1]).toContain("suppressSidebarResizes()");
   });
 
-  it("repaints on transition settle via repaintAssistantAfterTransition", () => {
+  it("repaints and parks inert when the wrapper's transform slide settles", () => {
     const handler = source.match(
       /const handleAssistantTransitionEnd = useCallback\(([\s\S]*?)\n {2}\);/
     );
     expect(handler).not.toBeNull();
+    // Filters on transform (the property the wrapper now animates), not width.
+    expect(handler![1]).toContain('event.propertyName === "transform"');
+    expect(handler![1]).toContain("event.target === event.currentTarget");
     expect(handler![1]).toContain("repaintAssistantAfterTransition()");
+    // Inert is only set on a hide (slide-out), never on reveal.
+    expect(handler![1]).toContain("if (!showAssistant) setAssistantInert(true)");
   });
 
-  it("filters both handlers to the wrapper's own width transition", () => {
-    // propertyName === "width" ignores other transitioned props; target ===
-    // currentTarget blocks bubbled child transitions — same guard the sidebar
-    // handler uses.
-    for (const name of ["handleAssistantTransitionStart", "handleAssistantTransitionEnd"]) {
-      const handler = source.match(
-        new RegExp(`const ${name} = useCallback\\(([\\s\\S]*?)\\n {2}\\);`)
-      );
-      expect(handler, `${name} should exist`).not.toBeNull();
-      expect(handler![1]).toContain('event.propertyName === "width"');
-      expect(handler![1]).toContain("event.target === event.currentTarget");
-    }
+  it("tracks the parked-inert state for the off-canvas wrapper", () => {
+    expect(source).toMatch(/const \[assistantInert, setAssistantInert\] = useState\(/);
   });
 
-  it("wires only transitionstart and transitionend on the assistant wrapper", () => {
-    // transitioncancel is deliberately NOT wired: a rapid hide→show fires cancel
-    // at an intermediate animating width, where a repaint would assert a wrong
-    // column count. The suppression timer owns the unlock and the following
-    // show's transitionend repaints correctly.
-    expect(source).toContain("onTransitionStart={handleAssistantTransitionStart}");
+  it("drives the push with a width-animated spacer that arms the lock", () => {
+    expect(source).toContain("onTransitionStart={handleAssistantSpacerTransitionStart}");
+    // The spacer is the element that animates width now.
+    expect(source).toMatch(
+      /aria-hidden[\s\S]*?transition-\[width\][\s\S]*?style=\{\{ width: effectiveAssistantWidth \}\}/
+    );
+  });
+
+  it("slides the fixed-width wrapper with a composited transform", () => {
+    // The wrapper animates transform, not width: its width is the constant
+    // helpPanelWidth and it translateX-es off-canvas when hidden.
+    expect(source).toContain("transition-transform");
+    expect(source).toMatch(/transform: showAssistant\s*\n?\s*\?\s*"translateX\(0\)"/);
+    expect(source).toMatch(/translateX\(\$\{layout\.helpPanelWidth\}px\)/);
     expect(source).toContain("onTransitionEnd={handleAssistantTransitionEnd}");
+    expect(source).toContain("inert={assistantInert}");
+  });
+
+  it("gates both the spacer width and wrapper transform transitions during drag-resize", () => {
+    // Both animated properties must be suppressed while isAssistantResizing so a
+    // drag tracks the cursor 1:1 (#7642/#7627). Each gated block pairs the
+    // reduce-animations and resizing guards.
+    const gatedBlocks = source.match(/!reduceAnimations &&\s*\n\s*!isAssistantResizing &&/g);
+    expect(gatedBlocks).not.toBeNull();
+    expect(gatedBlocks!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not wire transitioncancel (the final transitionend resolves rapid toggles)", () => {
     expect(source).not.toContain("onTransitionCancel");
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const APP_LAYOUT_PATH = path.resolve(__dirname, "../AppLayout.tsx");
+
+// Issue #10693: showing/hiding the Assistant pane animates its wrapper width
+// 0↔full over 250ms. The per-frame ResizeObserver storm that drives forwards a
+// SIGWINCH to the hosted CLI orphans a status-line row into scrollback each
+// cycle. AppLayout must arm the PTY resize lock at the real animation start and
+// release it (with a corrective repaint) when the transition settles — wired to
+// the wrapper's transition events, mirroring the existing sidebar handler.
+describe("AppLayout assistant transition resize suppression — issue #10693", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("imports both the arm and release helpers from sidebarToggle", () => {
+    expect(source).toContain('from "@/lib/sidebarToggle"');
+    expect(source).toMatch(
+      /import \{[^}]*releaseAssistantResizeLock[^}]*\} from "@\/lib\/sidebarToggle"/
+    );
+    expect(source).toMatch(
+      /import \{[^}]*suppressSidebarResizes[^}]*\} from "@\/lib\/sidebarToggle"/
+    );
+  });
+
+  it("arms the lock on transitionstart via suppressSidebarResizes", () => {
+    const handler = source.match(
+      /const handleAssistantTransitionStart = useCallback\(([\s\S]*?)\n {2}\);/
+    );
+    expect(handler).not.toBeNull();
+    expect(handler![1]).toContain("suppressSidebarResizes()");
+  });
+
+  it("releases the lock on transition settle via releaseAssistantResizeLock", () => {
+    const handler = source.match(
+      /const handleAssistantTransitionSettled = useCallback\(([\s\S]*?)\n {2}\);/
+    );
+    expect(handler).not.toBeNull();
+    expect(handler![1]).toContain("releaseAssistantResizeLock()");
+  });
+
+  it("filters both handlers to the wrapper's own width transition", () => {
+    // propertyName === "width" ignores other transitioned props; target ===
+    // currentTarget blocks bubbled child transitions — same guard the sidebar
+    // handler uses.
+    for (const name of ["handleAssistantTransitionStart", "handleAssistantTransitionSettled"]) {
+      const handler = source.match(
+        new RegExp(`const ${name} = useCallback\\(([\\s\\S]*?)\\n {2}\\);`)
+      );
+      expect(handler, `${name} should exist`).not.toBeNull();
+      expect(handler![1]).toContain('event.propertyName === "width"');
+      expect(handler![1]).toContain("event.target === event.currentTarget");
+    }
+  });
+
+  it("wires transitionstart, transitionend, and transitioncancel on the assistant wrapper", () => {
+    // transitioncancel is mandatory: a rapid hide→show reverses the animation
+    // and fires transitioncancel (never transitionend), so it must route to the
+    // same release handler or the lock is stranded.
+    expect(source).toContain("onTransitionStart={handleAssistantTransitionStart}");
+    expect(source).toContain("onTransitionEnd={handleAssistantTransitionSettled}");
+    expect(source).toContain("onTransitionCancel={handleAssistantTransitionSettled}");
+  });
+});

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -5,11 +5,11 @@ import path from "path";
 const APP_LAYOUT_PATH = path.resolve(__dirname, "../AppLayout.tsx");
 
 // Issue #10693: showing/hiding the Assistant pane animates its wrapper width
-// 0↔full over 250ms. The per-frame ResizeObserver storm that drives forwards a
-// SIGWINCH to the hosted CLI orphans a status-line row into scrollback each
-// cycle. AppLayout must arm the PTY resize lock at the real animation start and
-// release it (with a corrective repaint) when the transition settles — wired to
-// the wrapper's transition events, mirroring the existing sidebar handler.
+// 0↔full over 250ms. The per-frame ResizeObserver storm that drives a SIGWINCH
+// to the hosted CLI orphans a status-line row into scrollback each cycle.
+// AppLayout must arm the PTY resize lock at the real animation start and issue a
+// single corrective repaint when the transition settles — wired to the
+// wrapper's transition events, mirroring the existing sidebar handler.
 describe("AppLayout assistant transition resize suppression — issue #10693", () => {
   let source: string;
 
@@ -17,10 +17,10 @@ describe("AppLayout assistant transition resize suppression — issue #10693", (
     source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
   });
 
-  it("imports both the arm and release helpers from sidebarToggle", () => {
+  it("imports both the arm and repaint helpers from sidebarToggle", () => {
     expect(source).toContain('from "@/lib/sidebarToggle"');
     expect(source).toMatch(
-      /import \{[^}]*releaseAssistantResizeLock[^}]*\} from "@\/lib\/sidebarToggle"/
+      /import \{[^}]*repaintAssistantAfterTransition[^}]*\} from "@\/lib\/sidebarToggle"/
     );
     expect(source).toMatch(
       /import \{[^}]*suppressSidebarResizes[^}]*\} from "@\/lib\/sidebarToggle"/
@@ -35,19 +35,19 @@ describe("AppLayout assistant transition resize suppression — issue #10693", (
     expect(handler![1]).toContain("suppressSidebarResizes()");
   });
 
-  it("releases the lock on transition settle via releaseAssistantResizeLock", () => {
+  it("repaints on transition settle via repaintAssistantAfterTransition", () => {
     const handler = source.match(
-      /const handleAssistantTransitionSettled = useCallback\(([\s\S]*?)\n {2}\);/
+      /const handleAssistantTransitionEnd = useCallback\(([\s\S]*?)\n {2}\);/
     );
     expect(handler).not.toBeNull();
-    expect(handler![1]).toContain("releaseAssistantResizeLock()");
+    expect(handler![1]).toContain("repaintAssistantAfterTransition()");
   });
 
   it("filters both handlers to the wrapper's own width transition", () => {
     // propertyName === "width" ignores other transitioned props; target ===
     // currentTarget blocks bubbled child transitions — same guard the sidebar
     // handler uses.
-    for (const name of ["handleAssistantTransitionStart", "handleAssistantTransitionSettled"]) {
+    for (const name of ["handleAssistantTransitionStart", "handleAssistantTransitionEnd"]) {
       const handler = source.match(
         new RegExp(`const ${name} = useCallback\\(([\\s\\S]*?)\\n {2}\\);`)
       );
@@ -57,12 +57,13 @@ describe("AppLayout assistant transition resize suppression — issue #10693", (
     }
   });
 
-  it("wires transitionstart, transitionend, and transitioncancel on the assistant wrapper", () => {
-    // transitioncancel is mandatory: a rapid hide→show reverses the animation
-    // and fires transitioncancel (never transitionend), so it must route to the
-    // same release handler or the lock is stranded.
+  it("wires only transitionstart and transitionend on the assistant wrapper", () => {
+    // transitioncancel is deliberately NOT wired: a rapid hide→show fires cancel
+    // at an intermediate animating width, where a repaint would assert a wrong
+    // column count. The suppression timer owns the unlock and the following
+    // show's transitionend repaints correctly.
     expect(source).toContain("onTransitionStart={handleAssistantTransitionStart}");
-    expect(source).toContain("onTransitionEnd={handleAssistantTransitionSettled}");
-    expect(source).toContain("onTransitionCancel={handleAssistantTransitionSettled}");
+    expect(source).toContain("onTransitionEnd={handleAssistantTransitionEnd}");
+    expect(source).not.toContain("onTransitionCancel");
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -84,4 +84,20 @@ describe("AppLayout assistant off-canvas slide — issue #10693", () => {
   it("does not wire transitioncancel (the final transitionend resolves rapid toggles)", () => {
     expect(source).not.toContain("onTransitionCancel");
   });
+
+  it("settles inert/repaint itself for every path that suppresses the transition", () => {
+    // reduce-animations, performance mode, OS prefers-reduced-motion, and an
+    // in-flight drag-resize all strip the transform transition, so no
+    // transitionend arrives — the effect must settle inert + repaint on its own.
+    const settle = source.match(/const settle = \(\) => \{([\s\S]*?)\n {4}\};/);
+    expect(settle).not.toBeNull();
+    expect(settle![1]).toContain("reduceAnimations");
+    expect(settle![1]).toContain("layout.performanceMode");
+    expect(settle![1]).toContain("isAssistantResizing");
+    expect(settle![1]).toContain("mql?.matches === true");
+    // The media query is subscribed so an OS reduced-motion flip mid-slide still
+    // parks the wrapper inert (the read alone would not re-run).
+    expect(source).toContain('mql?.addEventListener("change", settle)');
+    expect(source).toContain('mql?.removeEventListener("change", settle)');
+  });
 });

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -68,17 +68,21 @@ describe("AppLayout assistant push sidebar — issue #6619", () => {
     expect(source).not.toContain("assistantSlotReserved");
   });
 
-  it("mounts HelpPanel unconditionally inside a flex-reserved sidebar slot (issue #6619, #6816)", () => {
+  it("mounts HelpPanel unconditionally and reserves its space with a layout spacer (issue #6619, #6816)", () => {
     // The old conditional-render guard (which destroyed the PTY on every
     // toggle) must not be reintroduced.
     expect(source).not.toMatch(/\{layout\.helpPanelOpen && \(\s*\n\s*<ErrorBoundary[^>]*HelpPanel/);
     expect(source).toMatch(
       /<HelpPanel\s+width=\{layout\.helpPanelWidth\}\s+isVisible=\{showAssistant\}\s+isReadyToLaunch=\{isHydrated\}/
     );
-    // The Assistant must remain a structural flex sibling that reserves
-    // horizontal space instead of reverting to an overlay on top of terminals.
-    expect(source).toContain('"relative h-full shrink-0 overflow-hidden"');
-    expect(source).toContain("width: effectiveAssistantWidth");
+    // The Assistant must reserve horizontal space (push the grid) rather than
+    // float over terminals. Under the off-canvas model (#10693) a sibling layout
+    // spacer is the structural flex element reserving the slot width; the panel
+    // slides over that reserved space via transform, never over the grid. The
+    // old z-30 floating-overlay form must not return.
+    expect(source).toMatch(
+      /aria-hidden[\s\S]*?shrink-0[\s\S]*?style=\{\{ width: effectiveAssistantWidth \}\}/
+    );
     expect(source).not.toMatch(/"absolute top-0 right-0 bottom-0 z-30"/);
   });
 
@@ -93,16 +97,17 @@ describe("AppLayout assistant push sidebar — issue #6619", () => {
     expect(source).toContain("void preloadHelpPanel();");
   });
 
-  it("clips a full-width Assistant while the right sidebar slot animates like the worktree sidebar", () => {
-    // The Assistant content stays full width and pinned to the viewport edge.
-    // The flex slot width animates underneath it, so the panel grid slides
-    // over the Assistant instead of the Assistant floating over terminals.
+  it("keeps the Assistant content full width while the slot animates (issue #10693 off-canvas)", () => {
+    // The Assistant content stays full width and pinned to the viewport edge;
+    // the wrapper slides off-canvas via transform while the spacer's width
+    // animates the <main> push. The content must never be resized to the slot
+    // width — that would reflow the terminal, which is the orphaned-row bug.
     expect(source).toContain("isReadyToLaunch={isHydrated}");
     expect(source).toContain("transition-[width]");
     expect(source).toContain('className="absolute top-0 right-0 h-full"');
+    // The slot must not be hidden with a Tailwind translate utility (which would
+    // animate via class swap rather than the gated inline transform).
     expect(source).not.toContain("translate-x-full");
-    // The effective slot width must not be passed as the content width; that
-    // would resize the Assistant contents instead of clipping/revealing them.
     expect(source).not.toContain("<HelpPanel width={effectiveAssistantWidth}");
   });
 
@@ -346,8 +351,11 @@ describe("AppLayout CSS layout containment — issue #9014", () => {
     );
   });
 
-  it("applies contain: layout paint to the resizable assistant wrapper", () => {
-    expect(source).toMatch(/width:\s*effectiveAssistantWidth,\s*contain:\s*"layout paint"/);
+  it("applies contain: layout paint to the off-canvas assistant wrapper", () => {
+    // The wrapper now animates transform (off-canvas slide, #10693) at a
+    // constant width; containment stays on it to isolate the slide's layout and
+    // paint from the rest of the row. Issue #9014.
+    expect(source).toMatch(/transform: showAssistant[\s\S]{0,300}contain:\s*"layout paint"/);
   });
 });
 

--- a/src/lib/__tests__/sidebarToggle.test.ts
+++ b/src/lib/__tests__/sidebarToggle.test.ts
@@ -35,7 +35,7 @@ vi.mock("../layoutTransitionLock", () => ({
   lockSidebarLayoutTransition: lockMock,
 }));
 
-import { releaseAssistantResizeLock, suppressSidebarResizes } from "../sidebarToggle";
+import { repaintAssistantAfterTransition, suppressSidebarResizes } from "../sidebarToggle";
 import { SIDEBAR_TOGGLE_LOCK_MS } from "../terminalLayout";
 
 type PanelFixture = {
@@ -130,40 +130,64 @@ describe("suppressSidebarResizes", () => {
     expect(lockMock).toHaveBeenCalledTimes(1);
     expect(lockMock).toHaveBeenCalledWith(SIDEBAR_TOGGLE_LOCK_MS);
   });
+
+  it("includes the assistant terminal when it is a live panel", () => {
+    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+    setup(
+      [
+        { id: "p-grid", location: "grid", worktreeId: "wt-a" },
+        { id: "assistant-1", location: "dock", worktreeId: "wt-a" },
+      ],
+      "wt-a"
+    );
+
+    suppressSidebarResizes();
+
+    // The dock-located assistant terminal is suppressed even though dock panels
+    // are otherwise excluded — it animates alongside the sidebar gesture.
+    expect(suppressMock).toHaveBeenCalledWith(["p-grid", "assistant-1"], SIDEBAR_TOGGLE_LOCK_MS);
+  });
+
+  it("omits the assistant terminal when it is not yet a registered panel", () => {
+    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+    setup([{ id: "p-grid", location: "grid", worktreeId: "wt-a" }], "wt-a");
+
+    suppressSidebarResizes();
+
+    expect(suppressMock).toHaveBeenCalledWith(["p-grid"], SIDEBAR_TOGGLE_LOCK_MS);
+  });
 });
 
-describe("releaseAssistantResizeLock", () => {
+describe("repaintAssistantAfterTransition", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getHelpPanelStateMock.mockReturnValue({ terminalId: null });
   });
 
-  it("unlocks the assistant terminal and fires one corrective repaint", () => {
+  it("fires one corrective repaint for the assistant terminal", () => {
     getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
 
-    releaseAssistantResizeLock();
+    repaintAssistantAfterTransition();
 
-    expect(lockResizeMock).toHaveBeenCalledWith("assistant-1", false);
+    expect(repaintForRevealMock).toHaveBeenCalledTimes(1);
     expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
   });
 
-  it("unlocks before repainting so the corrective resize isn't swallowed by the lock", () => {
+  it("does not clear the resize lock — the suppression timer owns the unlock", () => {
+    // reconcileGeometryFresh inside repaintForReveal is lock-exempt, so the
+    // corrective resize lands while the lock stays armed. Clearing it here would
+    // defeat the dead-man TTL that gates the ResizeObserver debounce tail.
     getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
 
-    releaseAssistantResizeLock();
+    repaintAssistantAfterTransition();
 
-    // repaintForReveal's geometry reconciliation is gated by the resize lock,
-    // so the unlock must be ordered strictly before the repaint.
-    const unlockOrder = lockResizeMock.mock.invocationCallOrder[0];
-    const repaintOrder = repaintForRevealMock.mock.invocationCallOrder[0];
-    expect(unlockOrder).toBeLessThan(repaintOrder);
+    expect(lockResizeMock).not.toHaveBeenCalled();
   });
 
   it("is a no-op when no assistant terminal is present", () => {
     getHelpPanelStateMock.mockReturnValue({ terminalId: null });
 
-    expect(() => releaseAssistantResizeLock()).not.toThrow();
-    expect(lockResizeMock).not.toHaveBeenCalled();
+    expect(() => repaintAssistantAfterTransition()).not.toThrow();
     expect(repaintForRevealMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/__tests__/sidebarToggle.test.ts
+++ b/src/lib/__tests__/sidebarToggle.test.ts
@@ -2,13 +2,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const suppressMock = vi.hoisted(() => vi.fn());
+const lockResizeMock = vi.hoisted(() => vi.fn());
+const repaintForRevealMock = vi.hoisted(() => vi.fn());
 const lockMock = vi.hoisted(() => vi.fn());
 const getPanelStateMock = vi.hoisted(() => vi.fn());
 const getWorktreeSelectionStateMock = vi.hoisted(() => vi.fn());
+const getHelpPanelStateMock = vi.hoisted(() =>
+  vi.fn(() => ({ terminalId: null }) as { terminalId: string | null })
+);
 
 vi.mock("@/services/terminal/TerminalInstanceService", () => ({
   terminalInstanceService: {
     suppressResizesDuringLayoutTransition: suppressMock,
+    lockResize: lockResizeMock,
+    repaintForReveal: repaintForRevealMock,
   },
 }));
 
@@ -20,11 +27,15 @@ vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: { getState: getWorktreeSelectionStateMock },
 }));
 
+vi.mock("@/store/helpPanelStore", () => ({
+  useHelpPanelStore: { getState: getHelpPanelStateMock },
+}));
+
 vi.mock("../layoutTransitionLock", () => ({
   lockSidebarLayoutTransition: lockMock,
 }));
 
-import { suppressSidebarResizes } from "../sidebarToggle";
+import { releaseAssistantResizeLock, suppressSidebarResizes } from "../sidebarToggle";
 import { SIDEBAR_TOGGLE_LOCK_MS } from "../terminalLayout";
 
 type PanelFixture = {
@@ -118,5 +129,41 @@ describe("suppressSidebarResizes", () => {
 
     expect(lockMock).toHaveBeenCalledTimes(1);
     expect(lockMock).toHaveBeenCalledWith(SIDEBAR_TOGGLE_LOCK_MS);
+  });
+});
+
+describe("releaseAssistantResizeLock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getHelpPanelStateMock.mockReturnValue({ terminalId: null });
+  });
+
+  it("unlocks the assistant terminal and fires one corrective repaint", () => {
+    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+
+    releaseAssistantResizeLock();
+
+    expect(lockResizeMock).toHaveBeenCalledWith("assistant-1", false);
+    expect(repaintForRevealMock).toHaveBeenCalledWith("assistant-1");
+  });
+
+  it("unlocks before repainting so the corrective resize isn't swallowed by the lock", () => {
+    getHelpPanelStateMock.mockReturnValue({ terminalId: "assistant-1" });
+
+    releaseAssistantResizeLock();
+
+    // repaintForReveal's geometry reconciliation is gated by the resize lock,
+    // so the unlock must be ordered strictly before the repaint.
+    const unlockOrder = lockResizeMock.mock.invocationCallOrder[0];
+    const repaintOrder = repaintForRevealMock.mock.invocationCallOrder[0];
+    expect(unlockOrder).toBeLessThan(repaintOrder);
+  });
+
+  it("is a no-op when no assistant terminal is present", () => {
+    getHelpPanelStateMock.mockReturnValue({ terminalId: null });
+
+    expect(() => releaseAssistantResizeLock()).not.toThrow();
+    expect(lockResizeMock).not.toHaveBeenCalled();
+    expect(repaintForRevealMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -40,22 +40,26 @@ export function suppressSidebarResizes(): void {
 }
 
 /**
- * Release the Assistant terminal's resize lock the instant its width
- * transition settles, then issue one corrective repaint. Wired to the wrapper's
- * transitionend/transitioncancel in AppLayout so the lock clears at the real
- * animation boundary instead of waiting out the dead-man TTL.
+ * Issue one corrective repaint to the Assistant terminal once its width
+ * transition has settled. Wired to the wrapper's transitionend in AppLayout so
+ * the single authoritative geometry pass fires the instant the animation ends,
+ * after the per-frame ResizeObserver storm has been suppressed (#10693).
  *
- * transitioncancel is the load-bearing caller: a rapid hide→show reverses the
- * width animation mid-flight and fires transitioncancel (never transitionend),
- * so routing only transitionend here would strand the lock and silence every
- * later PTY resize for that terminal session (#10693).
+ * Deliberately does NOT clear the resize lock: repaintForReveal's
+ * reconcileGeometryFresh is lock-exempt (it asserts the final cols/rows whether
+ * or not the lock is armed), and the suppression lock must stay live so the
+ * layout-transition timer's dead-man TTL keeps gating the ResizeObserver
+ * debounce tail that fires up to ~50ms after the animation settles. The lock is
+ * released on its own schedule by suppressResizesDuringLayoutTransition.
+ *
+ * Only the settle (transitionend) path repaints — never transitioncancel: a
+ * rapid hide→show fires cancel at an intermediate animating width, and
+ * repainting there would assert a transient wrong column count. The cancel is
+ * harmlessly ignored because the suppression timer still owns the unlock and
+ * the subsequent show's transitionend issues the correct repaint.
  */
-export function releaseAssistantResizeLock(): void {
+export function repaintAssistantAfterTransition(): void {
   const assistantTerminalId = useHelpPanelStore.getState().terminalId;
   if (!assistantTerminalId) return;
-  // Unlock BEFORE repainting: repaintForReveal's geometry reconciliation is
-  // itself gated by the resize lock, so the single authoritative SIGWINCH it
-  // sends would be swallowed if the lock were still armed.
-  terminalInstanceService.lockResize(assistantTerminalId, false);
   terminalInstanceService.repaintForReveal(assistantTerminalId);
 }

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -38,3 +38,24 @@ export function suppressSidebarResizes(): void {
   // reflows every frame against the animating sidebar slot (see #6979).
   lockSidebarLayoutTransition(SIDEBAR_TOGGLE_LOCK_MS);
 }
+
+/**
+ * Release the Assistant terminal's resize lock the instant its width
+ * transition settles, then issue one corrective repaint. Wired to the wrapper's
+ * transitionend/transitioncancel in AppLayout so the lock clears at the real
+ * animation boundary instead of waiting out the dead-man TTL.
+ *
+ * transitioncancel is the load-bearing caller: a rapid hide→show reverses the
+ * width animation mid-flight and fires transitioncancel (never transitionend),
+ * so routing only transitionend here would strand the lock and silence every
+ * later PTY resize for that terminal session (#10693).
+ */
+export function releaseAssistantResizeLock(): void {
+  const assistantTerminalId = useHelpPanelStore.getState().terminalId;
+  if (!assistantTerminalId) return;
+  // Unlock BEFORE repainting: repaintForReveal's geometry reconciliation is
+  // itself gated by the resize lock, so the single authoritative SIGWINCH it
+  // sends would be swallowed if the lock were still armed.
+  terminalInstanceService.lockResize(assistantTerminalId, false);
+  terminalInstanceService.repaintForReveal(assistantTerminalId);
+}

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -839,7 +839,13 @@ class TerminalInstanceService {
       clearTimeout(this.layoutTransitionTimer);
     }
 
-    const safetyTtl = durationMs + 100;
+    // Dead-man fallback that outlives the timer-driven unlock below. The +150
+    // margin (vs the +100 it covered before) spans XtermAdapter's ~50ms
+    // ResizeObserver debounce plus its rAF: an observer entry queued a frame
+    // before the transition settles fires its resize() ~50ms later, which must
+    // still land inside the lock window — otherwise it slips through as a
+    // post-transition SIGWINCH (#10693).
+    const safetyTtl = durationMs + 150;
     for (const id of panelIds) {
       this.resizeController.lockResize(id, true, safetyTtl);
     }


### PR DESCRIPTION
## Summary

- Fixes #10693: toggling the assistant pane was orphaning terminal status-line rows. Two complementary approaches ship together in this PR, per the request in the issue.
- Approach 1 coalesces PTY resize events across the show/hide transition: arms the suppress lock at the real width-transition start, issues one corrective lock-exempt repaint on settle, and bumps the `TerminalInstanceService` layout-transition safety TTL from `durationMs+100` to `+150`.
- Approach 2 is the root-cause fix: moves the assistant pane to an off-canvas wrapper that slides via composited `transform: translateX`. Terminal geometry stays constant through the animation (never clipped, no `IntersectionObserver` pause, no reveal-time `SIGWINCH`). A sibling `aria-hidden` layout spacer drives the `<main>` push and arms the suppress lock on its own width-transition start.

Resolves #10693

## How they coexist

The resize suppression lock still gates the `<main>` grid reflow triggered by the spacer. The transform keeps the terminal stable during that same reflow. They are complementary, not redundant.

The off-canvas approach also covers every no-transition path: `prefers-reduced-motion`, `data-performance-mode`, a subscribed media query, and in-flight drag-resize (via `flushSync`). The wrapper parks `inert` after settle so focus and scroll can't reach it while hidden. `HelpPanel`'s existing 1s/3s `repaintForReveal` backstops from #10362 and #5092 are kept.

Stayed a flex-sibling layout (spacer + fixed wrapper), not a viewport overlay, to preserve #6800 (`--portal-right-offset`) and #6645 (containing-block). `--right-obstruction-offset` is unchanged.

## Changes

- `src/components/Layout/AppLayout.tsx`: off-canvas wrapper + layout spacer, `inert` lifecycle, drag-resize transition gating, integer-px `translateX`
- `src/components/HelpPanel/HelpPanel.tsx`: minor wiring to cooperate with the off-canvas settle
- `src/lib/sidebarToggle.ts`: `repaintAssistantAfterTransition()` helper, lock armed at width-transition start
- `src/services/terminal/TerminalInstanceService.ts`: layout-transition TTL `+100` to `+150`
- `src/lib/__tests__/sidebarToggle.test.ts`, `src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts`, `src/components/Layout/__tests__/AppLayout.sidebar.test.ts`: new and updated tests

## Testing

Vitest: 146 tests across 29 files pass, including `AppLayout.sidebar`, `AppLayout.focusAssistant`, `AppLayout.assistantTransition`, `TerminalResizeController`, and `TerminalInstanceService.*`. Prettier clean, eslint 0 errors on changed files. Codex review: 0 critical findings; 2 minor inert-lifecycle findings fixed (`isAssistantResizing` in the no-transition guard, reactive `prefers-reduced-motion` subscription).