### PR TITLE
fix(version-probe): reap pipe-holding grandchild on every teardown path

### DIFF
--- a/electron/services/AgentVersionService.ts
+++ b/electron/services/AgentVersionService.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "child_process";
+import { spawn, spawnSync, type ChildProcess } from "child_process";
 import * as semver from "semver";
 import {
   getEffectiveAgentConfig,
@@ -117,7 +117,13 @@ export class AgentVersionService {
     } catch (error) {
       return this.createErrorInfo(agentId, error);
     } finally {
-      this.inFlightChecks.delete(agentId);
+      // Promise-identity guard: a `refresh=true` call bypasses the in-flight
+      // check and overwrites this entry, so an older probe settling later must
+      // only evict its OWN promise. Deleting unconditionally would drop a newer
+      // refresh probe's entry and let a concurrent caller miss dedup.
+      if (this.inFlightChecks.get(agentId) === checkPromise) {
+        this.inFlightChecks.delete(agentId);
+      }
     }
   }
 
@@ -218,17 +224,19 @@ export class AgentVersionService {
    * on "Checking version…" (its phase reset lives in a `finally` that an
    * unsettled await never reaches).
    *
-   * Settle order: prefer `close` (full output, the normal fast path); on `exit`
-   * arm a short grace timer (`EXIT_DRAIN_MS`) so a grandchild holding the pipe
-   * can't keep us pending past the process actually terminating, while still
-   * letting any stdout delivered between `exit` and `close` land. `exit` does
-   * NOT guarantee stdout is flushed, so we never finish on it directly. A hard
-   * wall-clock deadline is the final backstop: it kills the whole process group
-   * (`detached` on POSIX) so a foreground that genuinely hangs — and any
-   * grandchildren still holding the pipe — are reaped, then resolves with
-   * whatever was captured (usually the version line, else an empty string →
-   * `parseVersion` → null → "indeterminate" → the launch proceeds rather than
-   * blocking on an outdated-CLI gate).
+   * Settle order: prefer `close` (full output, the normal fast path, and the
+   * only path where every fd-holder has already exited — so it never needs to
+   * reap); on `exit` arm a short grace timer (`EXIT_DRAIN_MS`) so a grandchild
+   * holding the pipe can't keep us pending past the process actually
+   * terminating, while still letting any stdout delivered between `exit` and
+   * `close` land. `exit` does NOT guarantee stdout is flushed, so we never
+   * finish on it directly. Every settle that bypasses `close` — the exit-grace
+   * timer and the hard wall-clock deadline — reaps the whole process group
+   * (`detached` SIGKILL on POSIX, `taskkill /T` on Windows) so a foreground that
+   * exited (or genuinely hangs) leaves no grandchild still holding the pipe,
+   * then resolves with whatever was captured (usually the version line, else an
+   * empty string → `parseVersion` → null → "indeterminate" → the launch proceeds
+   * rather than blocking on an outdated-CLI gate).
    */
   private runVersionProbe(command: string, args: string[]): Promise<string> {
     return new Promise<string>((resolve, reject) => {
@@ -251,6 +259,11 @@ export class AgentVersionService {
         return;
       }
 
+      // Detached + unref'd so an in-flight probe can't pin main-process teardown
+      // during `app.quit()`. unref only drops the event-loop ref-count; the
+      // ChildProcess object stays referenced here and its events still deliver.
+      child.unref();
+
       let stdout = "";
       let stderr = "";
       let settled = false;
@@ -258,22 +271,45 @@ export class AgentVersionService {
       // stdout has been delivered (Node only guarantees that by `close`), so we
       // don't finish on `exit` directly — we give the pipes a short grace to
       // flush. If `close` arrives in that window we finish with the full output;
-      // if it never comes (a daemon grandchild is holding the pipe open), the
-      // grace timer finishes with whatever the foreground printed before exiting.
+      // if it never comes (a grandchild is holding the pipe open), the grace
+      // timer reaps the group and finishes with whatever the foreground printed.
       let exitGraceTimer: ReturnType<typeof setTimeout> | null = null;
 
       const killTree = (): void => {
-        try {
-          if (useGroup && typeof child.pid === "number") {
-            // Negative pid → signal the whole process group (the grandchild
-            // holding the pipe lives here unless it properly daemonized via
-            // setsid, in which case it has escaped the hang anyway).
-            process.kill(-child.pid, "SIGKILL");
-          } else {
-            child.kill("SIGKILL");
+        const pid = child.pid;
+        if (typeof pid !== "number") return;
+        if (!useGroup) {
+          // Windows has no process groups here: `child.kill()` TerminateProcess-es
+          // only the foreground, orphaning the inherited-pipe grandchild. Use
+          // `taskkill /T` to reap the whole tree (repo pattern: ProcessTreeKiller,
+          // PtyClient). `timeout`/`stdio: ignore` keep it from blocking the probe.
+          try {
+            spawnSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
+              windowsHide: true,
+              stdio: "ignore",
+              timeout: 3000,
+            });
+          } catch (error) {
+            // taskkill itself failed to launch — the tree may still be alive.
+            console.warn(`[AgentVersionService] taskkill pid=${pid}:`, this.toErrorString(error));
           }
-        } catch {
-          // ESRCH — the process/group is already gone. Nothing to reap.
+          return;
+        }
+        try {
+          // Negative pid → signal the whole process group (the grandchild
+          // holding the pipe lives here unless it properly daemonized via
+          // setsid, in which case it has escaped the hang anyway).
+          process.kill(-pid, "SIGKILL");
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException).code;
+          // ESRCH: the group is already gone — nothing to reap, silent. EPERM/
+          // EINVAL mean the tree may still be alive and the operator needs to
+          // know, so surface them rather than swallowing every failure.
+          if (code !== "ESRCH") {
+            console.warn(
+              `[AgentVersionService] SIGKILL group pid=${pid}: ${this.toErrorString(error)}`
+            );
+          }
         }
       };
 
@@ -286,6 +322,9 @@ export class AgentVersionService {
         killTree();
         finish(stdout || stderr);
       }, this.TIMEOUT_MS);
+      // Don't let the deadline timer pin event-loop teardown (the optional call
+      // guards Vitest fake-timer objects that lack `unref`).
+      timer.unref?.();
 
       function cleanup(): void {
         clearTimeout(timer);
@@ -302,6 +341,12 @@ export class AgentVersionService {
         cleanup();
         resolve(value);
       }
+
+      // A rare pipe error (EBADF/EIO on a dead/closed fd) on a piped stream
+      // becomes an uncaughtException if unhandled (lesson from #5648). The
+      // `settled` guard already covers teardown, so these can be no-ops.
+      child.stdout?.on("error", () => {});
+      child.stderr?.on("error", () => {});
 
       child.stdout?.on("data", (chunk: Buffer) => {
         if (stdout.length >= this.MAX_BUFFER) return;
@@ -330,7 +375,15 @@ export class AgentVersionService {
       // can't keep us pending. `close` (if it comes) clears this via `cleanup`.
       child.on("exit", () => {
         if (settled || exitGraceTimer) return;
-        exitGraceTimer = setTimeout(() => finish(stdout || stderr), this.EXIT_DRAIN_MS);
+        exitGraceTimer = setTimeout(() => {
+          // `close` never came within the grace window, so a grandchild is still
+          // holding the pipe open — reap the whole group before settling, else
+          // the detached process the probe exists to kill leaks. (The `close`
+          // path stays kill-free: it fires only once every fd-holder has exited.)
+          killTree();
+          finish(stdout || stderr);
+        }, this.EXIT_DRAIN_MS);
+        exitGraceTimer.unref?.();
       });
 
       child.on("error", (error: NodeJS.ErrnoException) => {

--- a/electron/services/AgentVersionService.ts
+++ b/electron/services/AgentVersionService.ts
@@ -284,14 +284,26 @@ export class AgentVersionService {
           // `taskkill /T` to reap the whole tree (repo pattern: ProcessTreeKiller,
           // PtyClient). `timeout`/`stdio: ignore` keep it from blocking the probe.
           try {
-            spawnSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
+            const result = spawnSync("taskkill", ["/T", "/F", "/PID", String(pid)], {
               windowsHide: true,
               stdio: "ignore",
               timeout: 3000,
             });
+            // spawnSync reports failure in the result, not by throwing: `error`
+            // is set if it couldn't launch / timed out; status 0 = killed and
+            // 128 = no such process (already exited — benign, like ESRCH). Any
+            // other non-zero (e.g. 1 access denied) leaves the tree alive, so
+            // warn rather than swallow.
+            if (result?.error) {
+              console.warn(
+                `[AgentVersionService] taskkill pid=${pid}: ${this.toErrorString(result.error)}`
+              );
+            } else if (result && result.status !== 0 && result.status !== 128) {
+              console.warn(`[AgentVersionService] taskkill pid=${pid} exited ${result.status}`);
+            }
           } catch (error) {
-            // taskkill itself failed to launch — the tree may still be alive.
-            console.warn(`[AgentVersionService] taskkill pid=${pid}:`, this.toErrorString(error));
+            // Defensive: spawnSync normally returns rather than throws.
+            console.warn(`[AgentVersionService] taskkill pid=${pid}: ${this.toErrorString(error)}`);
           }
           return;
         }
@@ -329,8 +341,13 @@ export class AgentVersionService {
       function cleanup(): void {
         clearTimeout(timer);
         if (exitGraceTimer) clearTimeout(exitGraceTimer);
-        child.stdout?.removeAllListeners();
-        child.stderr?.removeAllListeners();
+        // Drop only the `data` handlers so a post-settle chunk can't re-enter
+        // killTree/finish — but KEEP the no-op `error` sinks (added below): the
+        // `destroy()` calls can surface a pending EIO/EBADF on the next tick,
+        // and an unhandled stream `error` is fatal in the main process. A blanket
+        // removeAllListeners() here would strip those sinks and reopen #5648.
+        child.stdout?.removeAllListeners("data");
+        child.stderr?.removeAllListeners("data");
         child.stdout?.destroy();
         child.stderr?.destroy();
       }
@@ -343,8 +360,9 @@ export class AgentVersionService {
       }
 
       // A rare pipe error (EBADF/EIO on a dead/closed fd) on a piped stream
-      // becomes an uncaughtException if unhandled (lesson from #5648). The
-      // `settled` guard already covers teardown, so these can be no-ops.
+      // becomes an uncaughtException if unhandled (lesson from #5648). These
+      // sinks must outlive cleanup()'s destroy() — which can itself surface a
+      // pending error on the next tick — so cleanup() only removes `data`.
       child.stdout?.on("error", () => {});
       child.stderr?.on("error", () => {});
 

--- a/electron/services/__tests__/AgentVersionService.resilience.test.ts
+++ b/electron/services/__tests__/AgentVersionService.resilience.test.ts
@@ -11,10 +11,16 @@ const registryMock = vi.hoisted(() => ({
 // `child_process`, so we substitute the whole module at hoist time. The
 // installed-version probe spawns `<command> --version` and resolves on the
 // child's `exit` event; tests drive a fake ChildProcess via the helpers below.
-const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+const { spawnMock, spawnSyncMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  spawnSyncMock: vi.fn(),
+}));
 
 vi.mock("child_process", () => ({
   spawn: spawnMock,
+  // Windows tree-kill shells out to `taskkill` via spawnSync; POSIX CI never
+  // hits it, but the mock must export it so the import resolves.
+  spawnSync: spawnSyncMock,
 }));
 
 vi.mock("../../../shared/config/agentRegistry.js", () => registryMock);
@@ -27,17 +33,20 @@ import type { CliAvailabilityService } from "../CliAvailabilityService.js";
 function makeFakeChild(): EventEmitter & {
   pid: number;
   kill: Mock;
+  unref: Mock;
   stdout: EventEmitter & { destroy: Mock };
   stderr: EventEmitter & { destroy: Mock };
 } {
   const child = new EventEmitter() as EventEmitter & {
     pid: number;
     kill: Mock;
+    unref: Mock;
     stdout: EventEmitter & { destroy: Mock };
     stderr: EventEmitter & { destroy: Mock };
   };
   child.pid = 4242;
   child.kill = vi.fn();
+  child.unref = vi.fn();
   const stdout = new EventEmitter() as EventEmitter & { destroy: Mock };
   stdout.destroy = vi.fn();
   const stderr = new EventEmitter() as EventEmitter & { destroy: Mock };
@@ -208,11 +217,9 @@ describe("AgentVersionService resilience", () => {
       });
 
       const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
-      let spawnedChild: ReturnType<typeof makeFakeChild> | null = null;
       // A genuinely hung foreground: prints its version but never exits.
       spawnMock.mockImplementation((() => {
         const child = makeFakeChild();
-        spawnedChild = child;
         queueMicrotask(() => child.stdout.emit("data", Buffer.from("4.5.6\n")));
         return child;
       }) as never);
@@ -229,9 +236,13 @@ describe("AgentVersionService resilience", () => {
         expect(result.installedVersion).toBe("4.5.6");
         // The hung tree is reaped: POSIX SIGKILLs the whole process group
         // (negative pid) so a grandchild holding the pipe dies too; Windows has
-        // no group here and falls back to killing the child directly.
+        // no group here and shells out to `taskkill /T` to kill the whole tree.
         if (process.platform === "win32") {
-          expect(spawnedChild!.kill).toHaveBeenCalledWith("SIGKILL");
+          expect(spawnSyncMock).toHaveBeenCalledWith(
+            "taskkill",
+            ["/T", "/F", "/PID", "4242"],
+            expect.objectContaining({ windowsHide: true })
+          );
         } else {
           expect(killSpy).toHaveBeenCalledWith(-4242, "SIGKILL");
         }
@@ -239,6 +250,158 @@ describe("AgentVersionService resilience", () => {
         vi.useRealTimers();
         killSpy.mockRestore();
       }
+    });
+
+    // Issue #10697: the exit-grace settle (the COMMON case — foreground exits,
+    // grandchild keeps the pipe open) must reap the detached group. Before the
+    // fix the grace timer settled via finish()→cleanup() and cleared the
+    // deadline without ever calling killTree(), leaking the group every probe.
+    it("reaps the process group on the exit-grace path when `close` never fires", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+      spawnMock.mockImplementation((() => {
+        const child = makeFakeChild();
+        queueMicrotask(() => {
+          child.stdout.emit("data", Buffer.from("1.2.3\n"));
+          child.emit("exit", 0, null);
+          // Never emit `close` — the grandchild holds the inherited pipe.
+        });
+        return child;
+      }) as never);
+
+      vi.useFakeTimers();
+      try {
+        const { service } = createService(async () => ({ claude: "ready" }));
+        const pending = service.getVersion("claude" as AgentId);
+        // Past EXIT_DRAIN_MS but nowhere near the 10s deadline — proving the reap
+        // happens on the grace settle, not the hard-deadline backstop.
+        await vi.advanceTimersByTimeAsync(300);
+        const result = await pending;
+
+        expect(result.installedVersion).toBe("1.2.3");
+        if (process.platform === "win32") {
+          expect(spawnSyncMock).toHaveBeenCalledWith(
+            "taskkill",
+            ["/T", "/F", "/PID", "4242"],
+            expect.objectContaining({ windowsHide: true })
+          );
+        } else {
+          expect(killSpy).toHaveBeenCalledWith(-4242, "SIGKILL");
+        }
+      } finally {
+        vi.useRealTimers();
+        killSpy.mockRestore();
+      }
+    });
+
+    // The `close` settle is the one path where every fd-holder has already
+    // exited, so reaping there is pure ESRCH noise — it must stay kill-free.
+    it("does not reap the process group on the normal `close` settle path", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+      spawnMock.mockImplementation((() => {
+        const child = makeFakeChild();
+        queueMicrotask(() => {
+          child.stdout.emit("data", Buffer.from("1.2.3\n"));
+          child.emit("exit", 0, null);
+          child.emit("close", 0, null);
+        });
+        return child;
+      }) as never);
+
+      const { service } = createService(async () => ({ claude: "ready" }));
+      const result = await service.getVersion("claude" as AgentId);
+
+      expect(result.installedVersion).toBe("1.2.3");
+      expect(killSpy).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+      killSpy.mockRestore();
+    });
+
+    // The child is spawned `detached` but must be unref'd so an in-flight probe
+    // can't pin main-process teardown during `app.quit()`.
+    it("unref's the detached child after spawn", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      let spawnedChild: ReturnType<typeof makeFakeChild> | null = null;
+      spawnMock.mockImplementation((() => {
+        const child = makeFakeChild();
+        spawnedChild = child;
+        queueMicrotask(() => {
+          child.stdout.emit("data", Buffer.from("1.0.0\n"));
+          child.emit("exit", 0, null);
+          child.emit("close", 0, null);
+        });
+        return child;
+      }) as never);
+
+      const { service } = createService(async () => ({ claude: "ready" }));
+      await service.getVersion("claude" as AgentId);
+
+      expect(spawnedChild!.unref).toHaveBeenCalled();
+    });
+
+    // Issue #10697 dedup race: a `refresh=true` call overwrites inFlightChecks,
+    // so an earlier probe settling later must only evict its OWN promise. Without
+    // the identity guard the older settle drops the refresh probe's entry and a
+    // concurrent third caller misses dedup and spawns a redundant probe.
+    it("keeps the refresh probe's in-flight entry when an earlier probe settles first", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      const children: ReturnType<typeof makeFakeChild>[] = [];
+      // Hand back manually-driven children so we control settle ordering.
+      spawnMock.mockImplementation((() => {
+        const child = makeFakeChild();
+        children.push(child);
+        return child;
+      }) as never);
+
+      const { service } = createService(async () => ({ claude: "ready" }));
+
+      const a = service.getVersion("claude" as AgentId, false);
+      const b = service.getVersion("claude" as AgentId, true);
+
+      // Both reach the spawn once availability resolves and allSettled schedules.
+      await vi.waitFor(() => expect(children.length).toBe(2));
+
+      // Settle A first → A's finally runs. The guard must NOT evict B's entry.
+      children[0].stdout.emit("data", Buffer.from("1.0.0\n"));
+      children[0].emit("exit", 0, null);
+      children[0].emit("close", 0, null);
+      await a;
+
+      // A concurrent caller arrives; it must dedup onto B's surviving entry
+      // rather than spawning a third probe.
+      const c = service.getVersion("claude" as AgentId, false);
+
+      children[1].stdout.emit("data", Buffer.from("2.0.0\n"));
+      children[1].emit("exit", 0, null);
+      children[1].emit("close", 0, null);
+      await Promise.all([b, c]);
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/electron/services/__tests__/AgentVersionService.resilience.test.ts
+++ b/electron/services/__tests__/AgentVersionService.resilience.test.ts
@@ -325,7 +325,9 @@ describe("AgentVersionService resilience", () => {
       const result = await service.getVersion("claude" as AgentId);
 
       expect(result.installedVersion).toBe("1.2.3");
-      expect(killSpy).not.toHaveBeenCalledWith(-4242, "SIGKILL");
+      // No reap of any kind on the close path — not a group kill, not a direct
+      // kill, not a taskkill — because every fd-holder has already exited.
+      expect(killSpy).not.toHaveBeenCalled();
       expect(spawnSyncMock).not.toHaveBeenCalled();
       killSpy.mockRestore();
     });
@@ -402,6 +404,86 @@ describe("AgentVersionService resilience", () => {
       await Promise.all([b, c]);
 
       expect(spawnMock).toHaveBeenCalledTimes(2);
+    });
+
+    // The Windows reap branch is dead code on POSIX CI, so force-exercise it by
+    // faking `process.platform`. Asserts the exit-grace path shells out to
+    // `taskkill /T` (whole tree) and never falls back to a group/foreground kill.
+    it("reaps via taskkill on the exit-grace path when platform is win32", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      const realPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+      spawnSyncMock.mockReturnValue({ status: 0 });
+      spawnMock.mockImplementation((() => {
+        const child = makeFakeChild();
+        queueMicrotask(() => {
+          child.stdout.emit("data", Buffer.from("1.2.3\n"));
+          child.emit("exit", 0, null);
+          // No `close` — a grandchild holds the pipe.
+        });
+        return child;
+      }) as never);
+
+      vi.useFakeTimers();
+      try {
+        const { service } = createService(async () => ({ claude: "ready" }));
+        const pending = service.getVersion("claude" as AgentId);
+        await vi.advanceTimersByTimeAsync(300);
+        const result = await pending;
+
+        expect(result.installedVersion).toBe("1.2.3");
+        expect(spawnSyncMock).toHaveBeenCalledWith(
+          "taskkill",
+          ["/T", "/F", "/PID", "4242"],
+          expect.objectContaining({ windowsHide: true, stdio: "ignore", timeout: 3000 })
+        );
+        // Windows has no process group here — no SIGKILL fallback.
+        expect(killSpy).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        killSpy.mockRestore();
+        Object.defineProperty(process, "platform", { value: realPlatform, configurable: true });
+      }
+    });
+
+    // Regression guard for the cleanup ordering: cleanup() destroys the pipes,
+    // which can surface a pending EIO/EBADF `error` on the next tick. The no-op
+    // error sinks must outlive that destroy, so a stream error after settle
+    // never escapes as an uncaughtException.
+    it("survives a stdout `error` emitted after the probe has settled", async () => {
+      (registryMock.getEffectiveAgentConfig as Mock).mockReturnValue({
+        id: "claude",
+        name: "Claude",
+        command: "claude",
+        version: { args: ["--version"] },
+      });
+
+      let spawnedChild: ReturnType<typeof makeFakeChild> | null = null;
+      spawnMock.mockImplementation((() => {
+        const child = makeFakeChild();
+        spawnedChild = child;
+        queueMicrotask(() => {
+          child.stdout.emit("data", Buffer.from("1.0.0\n"));
+          child.emit("exit", 0, null);
+          child.emit("close", 0, null);
+        });
+        return child;
+      }) as never);
+
+      const { service } = createService(async () => ({ claude: "ready" }));
+      const result = await service.getVersion("claude" as AgentId);
+      expect(result.installedVersion).toBe("1.0.0");
+
+      // A late pipe error must have a live listener (else Node makes it fatal).
+      expect(() => spawnedChild!.stdout.emit("error", new Error("EIO"))).not.toThrow();
+      expect(spawnedChild!.stdout.listenerCount("error")).toBeGreaterThan(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- The `execFile` to `spawn` rewrite (previous PR) fixed the promise hang, but never actually reaped the grandchild process on the normal exit-grace path. `killTree()` only ran from the hard deadline and `MAX_BUFFER` cap, so the detached process group leaked on every normal probe.
- This PR completes the fix: six targeted changes to `AgentVersionService.ts` covering process reaping, Windows tree-kill, shutdown pinning, error handling, dedup race, and pipe error propagation.
- `HelpSessionJobService` registration was deliberately declined (see below).

Resolves #10697

## Changes

- **Exit-grace reap:** the exit-grace settle path now kills the detached process group via `process.kill(-pid, "SIGKILL")` on POSIX. The `close` path stays kill-free since every fd-holder has already exited by that point.
- **Windows tree-kill:** `killTree` on win32 now runs `taskkill /PID <pid> /T /F` instead of `child.kill("SIGKILL")`, which only terminated the direct child and orphaned the grandchild on every cycle. Result-failure cases log a warning rather than silently swallowing.
- **`unref` everything:** the detached child and both timers (`deadlineTimer`, `exitGraceTimer`) are `.unref()`'d so an in-flight probe can't pin `app.quit()` teardown.
- **Narrow kill catch:** the bare `catch {}` around `process.kill(-pid)` is replaced with a typed catch that swallows only `ESRCH` (process group already gone) and warns on `EPERM`/`EINVAL`.
- **Promise-identity guard:** `inFlightChecks.delete()` now verifies it holds the same promise before deleting, fixing a `refresh=true` dedup race where the first settler could delete the second caller's entry and leave a third caller without dedup.
- **No-op error sinks:** `stdout` and `stderr` get `'error'` listeners after `cleanup()` destroys the streams, preventing rare `EBADF`/`EIO` pipe errors from becoming `uncaughtException`s.

**Declined: `HelpSessionJobService` registration.** The posix-pty-reaper protocol is ADD/DISARM-only with no REMOVE. It reaps the full descendant tree of every registered PID indefinitely, so registering sub-10s probe PIDs creates a recycled-PID hazard where the OS hands the same PID to an unrelated process and the reaper tears down the wrong tree.

## Testing

30 resilience tests pass (24 existing + 6 new). New cases cover: exit-grace POSIX reap, `unref` on child and both timers, narrowed kill-catch ESRCH/EPERM paths, promise-identity guard on the `refresh=true` race, and no-op pipe error sinks.