### PR TITLE
fix(motion): asymmetric Tier-3 timing for assistant slide (#10704)

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -788,7 +788,7 @@ export function HelpPanel({
       }}
       className={cn(
         "relative shrink-0 flex flex-col h-full overflow-hidden outline-hidden",
-        "bg-daintree-bg border-l border-daintree-border transition-colors duration-300",
+        "bg-daintree-bg border-l border-daintree-border transition-[border-left-color,box-shadow] duration-150",
         isHighlighted && "assistant-focused",
         !isVisible && "pointer-events-none"
       )}
@@ -940,7 +940,7 @@ export function HelpPanel({
                     longer available
                   </p>
                   <p className="mt-0.5 text-daintree-text/70">
-                    The agent was removed or is no longer supported as an assistant backend.
+                    The agent was removed or is no longer supported as an assistant backend
                   </p>
                   <button
                     type="button"
@@ -953,7 +953,7 @@ export function HelpPanel({
                 <button
                   type="button"
                   onClick={clearDroppedPreferredAgent}
-                  aria-label="Dismiss"
+                  aria-label="Dismiss agent unavailable notice"
                   className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 >
                   <X className="w-3 h-3" />
@@ -1098,7 +1098,7 @@ export function HelpPanel({
       <ConfirmDialog
         isOpen={showNewSessionConfirm}
         title="Start a new session?"
-        description="The current agent will stop and the conversation will be discarded."
+        description="The current agent will stop and the conversation will be discarded"
         confirmLabel="Start new session"
         onConfirm={handleConfirmNewSession}
         onClose={handleCancelNewSession}
@@ -1109,7 +1109,7 @@ export function HelpPanel({
         title={`Switch to ${
           getAgentConfig(preferredAgentId ?? "")?.name ?? preferredAgentId ?? "agent"
         }?`}
-        description="The current session will end and the conversation will be discarded."
+        description="The current session will end and the conversation will be discarded"
         confirmLabel="Switch agent"
         onConfirm={handleConfirmAgentSwitch}
         onClose={handleCancelAgentSwitch}

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -782,7 +782,9 @@ export function AppLayout({
               "shrink-0 pointer-events-none",
               !reduceAnimations &&
                 !isAssistantResizing &&
-                "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none"
+                (showAssistant
+                  ? "transition-[width] duration-[var(--duration-200)] ease-[var(--ease-out-expo)] motion-reduce:transition-none"
+                  : "transition-[width] duration-[var(--duration-120)] ease-[var(--ease-panel-minimize)] motion-reduce:transition-none")
             )}
             style={{ width: effectiveAssistantWidth }}
             onTransitionStart={handleAssistantSpacerTransitionStart}
@@ -793,7 +795,9 @@ export function AppLayout({
                 "absolute top-0 right-0 h-full overflow-hidden",
                 !reduceAnimations &&
                   !isAssistantResizing &&
-                  "transition-transform duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                  (showAssistant
+                    ? "transition-transform duration-[var(--duration-200)] ease-[var(--ease-out-expo)] motion-reduce:transition-none"
+                    : "transition-transform duration-[var(--duration-120)] ease-[var(--ease-panel-minimize)] motion-reduce:transition-none"),
                 !showAssistant && "pointer-events-none"
               )}
               style={{

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -97,24 +97,23 @@ describe("AppLayout assistant off-canvas slide — issue #10693", () => {
     expect(region).not.toBeNull();
     const slide = region![0];
 
-    // Enter (showAssistant): decelerate, 200ms — on both the width spacer and
-    // the transform wrapper so push and slide stay in lockstep.
-    expect(slide).toContain(
-      "transition-[width] duration-[var(--duration-200)] ease-[var(--ease-out-expo)]"
-    );
-    expect(slide).toContain(
-      "transition-transform duration-[var(--duration-200)] ease-[var(--ease-out-expo)]"
-    );
-    // Exit (!showAssistant): accelerate, 120ms.
-    expect(slide).toContain(
-      "transition-[width] duration-[var(--duration-120)] ease-[var(--ease-panel-minimize)]"
-    );
-    expect(slide).toContain(
-      "transition-transform duration-[var(--duration-120)] ease-[var(--ease-panel-minimize)]"
-    );
-    // The asymmetry is driven by showAssistant, and the old symmetric 250ms is
-    // gone from the assistant slide (it remains correct for the sidebar above).
-    expect(slide).toContain("showAssistant");
+    // Bind direction to branch: the enter (200ms decelerate) class must sit on
+    // the `showAssistant ?` true-arm and the exit (120ms accelerate) class on
+    // the `:` false-arm. A bare toContain would pass even if the branches were
+    // swapped (both strings exist either way), so match the ternary shape.
+    // `transitionClass` is the literal (regex-escaped) transition utility: the
+    // spacer animates width via `transition-[width]`, the wrapper slides via
+    // `transition-transform`.
+    const ternary = (transitionClass: string): RegExp =>
+      new RegExp(
+        `showAssistant\\s*\\?\\s*"${transitionClass} duration-\\[var\\(--duration-200\\)\\] ease-\\[var\\(--ease-out-expo\\)\\][^"]*"\\s*:\\s*"${transitionClass} duration-\\[var\\(--duration-120\\)\\] ease-\\[var\\(--ease-panel-minimize\\)\\]`
+      );
+    // The spacer (width push) and the wrapper (transform slide) must carry
+    // identical timing per direction or the push and slide visibly desync.
+    expect(slide).toMatch(ternary("transition-\\[width\\]"));
+    expect(slide).toMatch(ternary("transition-transform"));
+    // The old symmetric 250ms is gone from the assistant slide (it remains
+    // correct for the sidebar above this region).
     expect(slide).not.toContain("--duration-250");
   });
 

--- a/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts
@@ -85,6 +85,39 @@ describe("AppLayout assistant off-canvas slide — issue #10693", () => {
     expect(source).not.toContain("onTransitionCancel");
   });
 
+  // Issue #10704: the slide must use asymmetric Tier-3 panel-motion timing —
+  // decelerate on enter (200ms ease-out-expo), accelerate on exit (120ms
+  // ease-panel-minimize) — switched on showAssistant, not a symmetric 250ms.
+  it("uses asymmetric panel-motion-tier timing switched on showAssistant", () => {
+    // Anchor to the assistant region (first aria-hidden = the spacer) so the
+    // sidebar's legitimate symmetric 250ms width transition isn't captured.
+    const region = source.match(
+      /aria-hidden[\s\S]*?onTransitionEnd=\{handleAssistantTransitionEnd\}/
+    );
+    expect(region).not.toBeNull();
+    const slide = region![0];
+
+    // Enter (showAssistant): decelerate, 200ms — on both the width spacer and
+    // the transform wrapper so push and slide stay in lockstep.
+    expect(slide).toContain(
+      "transition-[width] duration-[var(--duration-200)] ease-[var(--ease-out-expo)]"
+    );
+    expect(slide).toContain(
+      "transition-transform duration-[var(--duration-200)] ease-[var(--ease-out-expo)]"
+    );
+    // Exit (!showAssistant): accelerate, 120ms.
+    expect(slide).toContain(
+      "transition-[width] duration-[var(--duration-120)] ease-[var(--ease-panel-minimize)]"
+    );
+    expect(slide).toContain(
+      "transition-transform duration-[var(--duration-120)] ease-[var(--ease-panel-minimize)]"
+    );
+    // The asymmetry is driven by showAssistant, and the old symmetric 250ms is
+    // gone from the assistant slide (it remains correct for the sidebar above).
+    expect(slide).toContain("showAssistant");
+    expect(slide).not.toContain("--duration-250");
+  });
+
   it("settles inert/repaint itself for every path that suppresses the transition", () => {
     // reduce-animations, performance mode, OS prefers-reduced-motion, and an
     // in-flight drag-resize all strip the transform transition, so no

--- a/src/index.css
+++ b/src/index.css
@@ -456,6 +456,7 @@
 @theme {
   --duration-75: 75ms;
   --duration-100: 100ms;
+  --duration-120: 120ms;
   --duration-150: 150ms;
   --duration-200: 200ms;
   --duration-250: 250ms;
@@ -479,6 +480,10 @@
   );
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
   --ease-exit: cubic-bezier(0.2, 0, 0.7, 0);
+  /* Tier-3 panel-motion accelerate-exit curve. Mirrors PANEL_MINIMIZE_EASING in
+     src/lib/animationUtils.ts; the parity contract in animationUtils.test.ts
+     enforces this. Pairs with --duration-120 for panel slide-out. */
+  --ease-panel-minimize: cubic-bezier(0.3, 0, 0.8, 0.15);
 }
 
 pre code.hljs {

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -21,6 +21,7 @@ import {
   PANEL_MINIMIZE_DURATION,
   PANEL_MINIMIZE_EASING,
   PANEL_RESTORE_DURATION,
+  PANEL_RESTORE_EASING,
   TERMINAL_ANIMATION_DURATION,
   UI_ANIMATION_DURATION,
   UI_DOHERTY_THRESHOLD,
@@ -340,5 +341,17 @@ describe("panel-motion-tier CSS contract (#10704)", () => {
     const match = css.match(/--ease-panel-minimize\s*:\s*([^;]+);/);
     expect(match).not.toBeNull();
     expect(match?.[1]?.trim()).toBe(PANEL_MINIMIZE_EASING);
+  });
+
+  it("--duration-200 token matches PANEL_RESTORE_DURATION (enter side)", () => {
+    const match = css.match(/--duration-200\s*:\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    expect(match?.[1]?.trim()).toBe(`${PANEL_RESTORE_DURATION}ms`);
+  });
+
+  it("--ease-out-expo token matches PANEL_RESTORE_EASING (enter side)", () => {
+    const match = css.match(/--ease-out-expo\s*:\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    expect(match?.[1]?.trim()).toBe(PANEL_RESTORE_EASING);
   });
 });

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -19,6 +19,7 @@ import {
   getUiAnimationDuration,
   getUiTransitionDuration,
   PANEL_MINIMIZE_DURATION,
+  PANEL_MINIMIZE_EASING,
   PANEL_RESTORE_DURATION,
   TERMINAL_ANIMATION_DURATION,
   UI_ANIMATION_DURATION,
@@ -320,4 +321,24 @@ describe("discrete-feedback easing CSS contract", () => {
       expect(block).not.toMatch(/animation-timing-function\s*:/);
     }
   );
+});
+
+describe("panel-motion-tier CSS contract (#10704)", () => {
+  // The asymmetric assistant slide uses --duration-120 + --ease-panel-minimize
+  // from the @theme block. These cross-check the CSS tokens against the JS
+  // constants in animationUtils.ts (two separate sources of truth), so a silent
+  // drift in either layer fails here rather than shipping a desynced curve.
+  const css = readFileSync(resolve(__dirname, "../../index.css"), "utf8");
+
+  it("--duration-120 token matches PANEL_MINIMIZE_DURATION", () => {
+    const match = css.match(/--duration-120\s*:\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    expect(match?.[1]?.trim()).toBe(`${PANEL_MINIMIZE_DURATION}ms`);
+  });
+
+  it("--ease-panel-minimize token matches PANEL_MINIMIZE_EASING", () => {
+    const match = css.match(/--ease-panel-minimize\s*:\s*([^;]+);/);
+    expect(match).not.toBeNull();
+    expect(match?.[1]?.trim()).toBe(PANEL_MINIMIZE_EASING);
+  });
 });

--- a/src/lib/terminalLayout.ts
+++ b/src/lib/terminalLayout.ts
@@ -72,6 +72,12 @@ export const GRID_TRANSITION_DURATION_MS = 200;
  * doesn't deliver mid-animation fractional dimensions to the host.
  */
 export const SIDEBAR_TRANSITION_MS = 250;
+/**
+ * Dead-man TTL for the resize-suppression lock armed on a sidebar/assistant
+ * width transition. Pegged to the 250ms sidebar transition. The assistant slide
+ * (#10704) is asymmetric — 200ms enter / 120ms exit — so its longest leg (200ms)
+ * is conservatively covered by this 250ms lock; no separate assistant TTL needed.
+ */
 export const SIDEBAR_TOGGLE_LOCK_MS = SIDEBAR_TRANSITION_MS;
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The assistant slide was using symmetric 250ms `ease-out-expo` in both directions. Applying a decelerate curve to an exit is an MD3/HIG anti-pattern: the panel lingers at the screen edge on dismiss instead of clearing fast. Fixed to 200ms enter / 120ms exit, matching Daintree's Tier-3 panel-motion tier (`PANEL_RESTORE_DURATION` / `PANEL_MINIMIZE_DURATION`).
- Adds two `@theme` tokens (`--duration-120`, `--ease-panel-minimize`) to mirror the existing JS constants, keeping CSS and JS in sync. `SIDEBAR_TOGGLE_LOCK_MS` stays 250ms (documented: it conservatively covers the 200ms enter plus the xterm ResizeObserver debounce tail).
- Secondary fixes in the same surface: the focus-lift now transitions `border-color` and `box-shadow` explicitly at 150ms (was `transition-colors duration-300`, which left `box-shadow` snapping while the border faded over double the Tier-1 duration). Microcopy: contextual `aria-label` on the dropped-agent dismiss button, trailing periods removed from a single-clause subtitle and two `ConfirmDialog` descriptions.

Resolves #10704

## Changes

- `src/components/Layout/AppLayout.tsx`: asymmetric slide timing, corrected focus-lift transition, microcopy fixes
- `src/components/HelpPanel/HelpPanel.tsx`: microcopy fix (trailing period, dismiss `aria-label`)
- `src/index.css`: `--duration-120` and `--ease-panel-minimize` `@theme` tokens
- `src/lib/terminalLayout.ts`: `SIDEBAR_TOGGLE_LOCK_MS` inline documentation
- `src/lib/__tests__/animationUtils.test.ts`: CSS-to-JS token parity tests for the new tokens
- `src/components/Layout/__tests__/AppLayout.assistantTransition.test.ts`: direction-bound slide test, enter-side parity assertion

## Testing

- New unit tests cover: `--duration-120` / `--ease-panel-minimize` CSS tokens match `PANEL_MINIMIZE_DURATION` / `PANEL_MINIMIZE_EASING` JS constants; slide applies the enter class on show and the exit class on hide (direction binding).
- Existing motion tests pass.
- `npm run check` clean.