### PR TITLE
fix(help-session): revoke orphaned MCP bearer on hung launch

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -60,7 +60,10 @@ const DEFAULT_BYPASS_PERMISSIONS = false;
 // mid-launch), the record can outlive the launch with a live token but no bound
 // terminal. The periodic sweep revokes any such unbound record older than this
 // ceiling. Bound sessions are never swept regardless of age — they're healthy
-// long-lived assistants. 30 min mirrors the MCP idle-reaper horizon.
+// long-lived assistants. 30 min mirrors the MCP idle-reaper horizon; an orphan
+// is reaped between 30 and ~35 min old (this floor plus up to one sweep
+// interval). The 90s launch watchdog is the primary fix — this is the
+// renderer-crash backstop, so the coarse timing is intentional.
 const ORPHAN_SESSION_MAX_AGE_MS = 30 * 60 * 1000;
 const ORPHAN_SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -53,6 +53,17 @@ const DEFAULT_DAINTREE_CONTROL = true;
 const DEFAULT_DOC_SEARCH = true;
 const DEFAULT_BYPASS_PERMISSIONS = false;
 
+// Belt-and-suspenders bound for orphaned provisional bearers (#10698). A
+// session record is minted at provision time, then bound to a PTY terminal once
+// the agent spawns. If the launch hangs past the renderer watchdog AND the
+// watchdog's revoke somehow didn't run (renderer crash, view torn down
+// mid-launch), the record can outlive the launch with a live token but no bound
+// terminal. The periodic sweep revokes any such unbound record older than this
+// ceiling. Bound sessions are never swept regardless of age — they're healthy
+// long-lived assistants. 30 min mirrors the MCP idle-reaper horizon.
+const ORPHAN_SESSION_MAX_AGE_MS = 30 * 60 * 1000;
+const ORPHAN_SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
 function isHelpAssistantTier(value: unknown): value is HelpAssistantTier {
   return value === "workbench" || value === "action" || value === "system";
 }
@@ -266,6 +277,7 @@ export class HelpSessionService {
   private readonly pendingCapturesByProject = new Map<string, string>();
   private onMcpSessionRevokedFn: ((token: string) => void) | null = null;
   private disposed = false;
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
 
   setMcpRegistry(registry: WindowRegistry): void {
     this.mcpRegistry = registry;
@@ -1184,8 +1196,51 @@ export class HelpSessionService {
     );
   }
 
+  /**
+   * Arm the periodic orphan-bearer sweep (#10698). Wired once at app boot from
+   * `globalServicesInit`. Idempotent and a no-op after `dispose`. The timer is
+   * `unref`'d so it never keeps the process alive on its own.
+   */
+  startOrphanSweep(): void {
+    if (this.disposed || this.sweepTimer) return;
+    this.sweepTimer = setInterval(() => {
+      try {
+        this.sweepOrphanSessions(ORPHAN_SESSION_MAX_AGE_MS);
+      } catch (err) {
+        console.warn("[HelpSessionService] Orphan-bearer sweep failed:", err);
+      }
+    }, ORPHAN_SESSION_SWEEP_INTERVAL_MS);
+    this.sweepTimer.unref?.();
+  }
+
+  /**
+   * Revoke every unrevoked session record that was minted more than `maxAgeMs`
+   * ago but never bound to a PTY terminal — an orphaned provisional bearer
+   * whose launch was abandoned without the renderer revoking its token. Bound
+   * sessions (present in `terminalBySessionId`) are skipped regardless of age:
+   * a healthy long-running assistant must never be swept. Snapshots the target
+   * list before mutating so the `revokeSession` map deletes don't disturb the
+   * iteration.
+   */
+  sweepOrphanSessions(maxAgeMs: number): void {
+    const cutoff = Date.now() - maxAgeMs;
+    const orphans = [...this.sessionsById.values()].filter(
+      (record) =>
+        !record.revoked &&
+        !this.terminalBySessionId.has(record.sessionId) &&
+        record.createdAt <= cutoff
+    );
+    for (const record of orphans) {
+      void this.revokeSession(record.sessionId);
+    }
+  }
+
   dispose(): void {
     this.disposed = true;
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
     void this.revokeAll();
   }
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1056,6 +1056,94 @@ describe("HelpSessionService", () => {
     });
   });
 
+  describe("orphan-bearer sweep (#10698)", () => {
+    it("revokes an unbound bearer older than the ceiling and tears down its MCP session", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.validateToken(result.token)).toBe("action");
+      // Wire the teardown spy AFTER provisioning — `ensureMcpServerReady` (run
+      // during provision) re-sets `onMcpSessionRevoked`, so an earlier spy
+      // would be overwritten before the sweep fires.
+      const onRevoked = vi.fn();
+      service.setOnMcpSessionRevoked(onRevoked);
+
+      // maxAge 0 → cutoff is now, so the just-minted record (createdAt <= now)
+      // counts as past-ceiling. It was never bound to a terminal → orphan.
+      service.sweepOrphanSessions(0);
+      await Promise.resolve();
+
+      expect(service.validateToken(result.token)).toBe(false);
+      expect(onRevoked).toHaveBeenCalledWith(result.token);
+      // No terminal was ever bound, so there's nothing to kill.
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("leaves a freshly provisioned bearer alone (younger than the ceiling)", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      // A generous ceiling means the just-minted record is well within it.
+      service.sweepOrphanSessions(60 * 60 * 1000);
+      await Promise.resolve();
+
+      expect(service.validateToken(result.token)).toBe("action");
+    });
+
+    it("never sweeps a bound session regardless of age", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
+
+      // Even with maxAge 0 (sweep everything past now), the bound session is
+      // a healthy live assistant and must survive.
+      service.sweepOrphanSessions(0);
+      await Promise.resolve();
+
+      expect(service.validateToken(result.token)).toBe("action");
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("does not re-revoke an already-revoked session", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      // Wire the spy after provision (see note above) so it's the active
+      // teardown hook when revokeSession and the sweep run.
+      const onRevoked = vi.fn();
+      service.setOnMcpSessionRevoked(onRevoked);
+      await service.revokeSession(result.sessionId);
+      expect(onRevoked).toHaveBeenCalledTimes(1);
+
+      // The revoked record was already dropped from the index, so the sweep
+      // can't see it and the teardown callback never fires a second time.
+      service.sweepOrphanSessions(0);
+      await Promise.resolve();
+
+      expect(onRevoked).toHaveBeenCalledTimes(1);
+    });
+
+    it("startOrphanSweep arms a periodic sweep that dispose tears down", () => {
+      vi.useFakeTimers();
+      const svc = new HelpSessionService();
+      svc.setMcpRegistry({} as never);
+      const sweepSpy = vi.spyOn(svc, "sweepOrphanSessions").mockImplementation(() => {});
+      try {
+        svc.startOrphanSweep();
+        svc.startOrphanSweep(); // idempotent — must not arm a second timer
+
+        vi.advanceTimersByTime(5 * 60 * 1000);
+        expect(sweepSpy).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(5 * 60 * 1000);
+        expect(sweepSpy).toHaveBeenCalledTimes(2);
+
+        svc.dispose();
+        vi.advanceTimersByTime(15 * 60 * 1000);
+        expect(sweepSpy).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("hibernation capture on eviction (project-switch persistence)", () => {
     let hibernationStore: {
       get: ReturnType<typeof vi.fn>;

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -233,6 +233,7 @@ vi.mock("../../services/HelpSessionService.js", () => ({
     setMcpRegistry,
     setPendingHibernationStore: vi.fn(),
     setPtyClient: vi.fn(),
+    startOrphanSweep: vi.fn(),
     validateToken: vi.fn(),
     gcStaleSessions: vi.fn(async () => {}),
   },

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -759,6 +759,13 @@ export async function initGlobalServices(
     // reference store — no MCP SDK loaded.
     helpSessionService.setMcpRegistry(registryRef);
 
+    // Arm the periodic orphan-bearer sweep (#10698): a defense-in-depth bound
+    // that revokes provisional session tokens minted by a launch that hung and
+    // was abandoned without the renderer revoking. The renderer watchdog is the
+    // primary fix; this catches the residual case (renderer crash / view torn
+    // down mid-launch). The timer is unref'd, so it never holds the process up.
+    helpSessionService.startOrphanSweep();
+
     // Load the pending-hibernation file and wire it into HelpSessionService.
     // Floated, not awaited: the deadline is the user's first project switch
     // (project-view eviction fires inside `pvm.switchTo()`, possibly before

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1259,6 +1259,10 @@ export class HelpSessionController {
       this._launchGen++;
       this._hasAutoLaunched = false;
       this._isLaunching = false;
+      // The gen-check above proves we still own `_pendingSessionId`, so a
+      // post-provision hang doesn't strand the minted bearer. Revoke it
+      // before resetting — otherwise the token outlives the launch forever.
+      this._revokePendingSession();
       this._resetPhase();
       this._surfaceLaunchError(agentId, "spawn-failed");
     }, this.LAUNCH_WATCHDOG_MS);
@@ -2118,7 +2122,9 @@ export class HelpSessionController {
           usePanelStore.getState().removePanel(result.result.terminalId);
         }
         revokeHelpSession(session?.sessionId ?? null);
-        this._pendingSessionId = null;
+        if (this._pendingSessionId === session?.sessionId) {
+          this._pendingSessionId = null;
+        }
         this._hasAutoLaunched = false;
         // The preference changed mid-launch, so re-evaluate against the
         // current inputs rather than waiting on an incidental re-render to
@@ -2138,7 +2144,9 @@ export class HelpSessionController {
       if (!result.ok || !result.result?.terminalId) {
         this._hasAutoLaunched = false;
         revokeHelpSession(session?.sessionId ?? null);
-        this._pendingSessionId = null;
+        if (this._pendingSessionId === session?.sessionId) {
+          this._pendingSessionId = null;
+        }
         logError("Help auto-launch failed", { agentId: launchAgentId, result });
         this._surfaceLaunchError(launchAgentId, "spawn-failed");
         return;
@@ -2167,8 +2175,13 @@ export class HelpSessionController {
       // provision step (e.g. agent.launch rejecting) leaves a live session
       // token with no bound terminal. Revoke it, clear the pending-session
       // guard, and surface the failure so the panel isn't left silently empty.
+      // A late-rejecting dispatch can reach here AFTER the watchdog (or a
+      // newer launch) bumped the generation — only null `_pendingSessionId`
+      // when it's still ours, so we don't clobber a newer launch's guard.
       revokeHelpSession(session?.sessionId ?? null);
-      this._pendingSessionId = null;
+      if (this._pendingSessionId === session?.sessionId) {
+        this._pendingSessionId = null;
+      }
       this._surfaceLaunchError(launchAgentId, "spawn-failed");
     } finally {
       // Only the generation that still owns the launch clears the watchdog and
@@ -2408,7 +2421,12 @@ export class HelpSessionController {
       } else {
         this._hasAutoLaunched = false;
         revokeHelpSession(session?.sessionId ?? null);
-        this._pendingSessionId = null;
+        // A late-rejecting dispatch can land here after the watchdog (or a
+        // newer launch) bumped the generation — only clear the guard when the
+        // pending session is still ours, never a newer launch's.
+        if (this._pendingSessionId === session?.sessionId) {
+          this._pendingSessionId = null;
+        }
         logError("Help select-agent launch failed", error);
       }
       this._surfaceLaunchError(launchAgentId, "spawn-failed");

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -754,6 +754,99 @@ describe("HelpSessionController — launch phase FSM", () => {
     expect(ctrl.getSnapshot().phase).toBe("idle");
     ctrl.stop();
   });
+
+  it("watchdog revokes the provisioned session when agent.launch hangs after provisioning (#10698)", async () => {
+    vi.useFakeTimers();
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+    (window.electron.help.provisionSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: "sess-hang",
+      sessionPath: "/help",
+      token: "tok-hang",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    // Provisioning succeeds (the bearer is minted), then agent.launch never
+    // settles — the post-provision stall the watchdog must reclaim. Without the
+    // fix the watchdog reset the phase but left the live token orphaned forever.
+    vi.mocked(actionService.dispatch).mockReturnValue(new Promise(() => {}) as never);
+    try {
+      ctrl.syncInputs({
+        isOpen: true,
+        isReadyToLaunch: true,
+        currentProject: { id: "proj", path: "/repo" },
+        terminalId: null,
+        preferredAgentId: "claude",
+        supportedInstalledAgentIds: ["claude"],
+        visibilityEpoch: 0,
+      });
+
+      // Let the provision microtask chain settle so the bearer is minted and
+      // agent.launch has been dispatched (and is now hanging).
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(ctrl["_pendingSessionId"]).toBe("sess-hang");
+      expect(window.electron.help.revokeSession).not.toHaveBeenCalled();
+
+      // Past the 90s ceiling the dead-man timer reclaims the stranded FSM and
+      // revokes the orphaned bearer so the token can't outlive the launch.
+      await vi.advanceTimersByTimeAsync(90_000);
+      expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-hang");
+      expect(ctrl["_pendingSessionId"]).toBeNull();
+      expect(ctrl.getSnapshot().phase).toBe("idle");
+      expect(ctrl.getSnapshot().launchError).toEqual(
+        expect.objectContaining({ agentId: "claude", kind: "spawn-failed" })
+      );
+    } finally {
+      ctrl.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it("a late-rejecting stale launch revokes its own token but spares a newer launch's pending session (#10698)", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+    (window.electron.help.provisionSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessionId: "sess-stale",
+      sessionPath: "/help",
+      token: "tok-stale",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    let rejectDispatch: (err: unknown) => void = () => {};
+    vi.mocked(actionService.dispatch).mockReturnValueOnce(
+      new Promise((_, reject) => {
+        rejectDispatch = reject;
+      }) as never
+    );
+
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      visibilityEpoch: 0,
+    });
+    await vi.waitFor(() => {
+      expect(ctrl["_pendingSessionId"]).toBe("sess-stale");
+    });
+
+    // A newer launch wins the race and takes ownership of the pending-session
+    // slot while the stale launch's dispatch is still in flight.
+    ctrl["_pendingSessionId"] = "sess-new";
+
+    // The stale launch's dispatch finally rejects. Its catch must revoke ITS
+    // own bearer but must NOT null the newer launch's pending-session guard.
+    rejectDispatch(new Error("late boom"));
+    await vi.waitFor(() => {
+      expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-stale");
+    });
+    expect(ctrl["_pendingSessionId"]).toBe("sess-new");
+    ctrl.stop();
+  });
 });
 
 describe("HelpSessionController — tier-mismatch handlers", () => {

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -786,6 +786,14 @@ describe("HelpSessionController — launch phase FSM", () => {
       // agent.launch has been dispatched (and is now hanging).
       await vi.advanceTimersByTimeAsync(1_000);
       expect(ctrl["_pendingSessionId"]).toBe("sess-hang");
+      // Prove the flow actually reached (and is now hung on) agent.launch, so
+      // the revoke below is exercising the post-provision stall, not an earlier
+      // bail before the bearer was put at risk.
+      expect(vi.mocked(actionService.dispatch)).toHaveBeenCalledWith(
+        "agent.launch",
+        expect.anything(),
+        expect.anything()
+      );
       expect(window.electron.help.revokeSession).not.toHaveBeenCalled();
 
       // Past the 90s ceiling the dead-man timer reclaims the stranded FSM and


### PR DESCRIPTION
## Summary

- When the 90s launch watchdog fires on a hung launch, it resets the FSM but never revokes the already-minted MCP bearer token. `_armLaunchWatchdog` now calls `_revokePendingSession` after its gen-check so a post-provision hang cleans up the credential it minted.
- Four `_pendingSessionId = null` assignments in `_executeAutoLaunch` and `_executeLaunch` catch/bail paths were unconditional. They now guard on session-id ownership, so a late-rejecting stale launch can't clobber a newer launch's pending-session guard.
- `HelpSessionService` gains `sweepOrphanSessions(maxAgeMs)` plus an unref'd 5-min periodic timer (wired at boot in `globalServicesInit`, torn down in `dispose`) that revokes any unrevoked bearer older than 30 min never bound to a terminal.

Resolves #10698

## Changes

- `src/controllers/HelpSessionController.ts`: watchdog revoke after gen-check; ownership guards on four null-assignment sites
- `electron/services/HelpSessionService.ts`: `sweepOrphanSessions` + `startOrphanSweep` / `stopOrphanSweep`
- `electron/window/globalServicesInit.ts`: wire `startOrphanSweep` at boot
- Tests: watchdog revoke on post-provision stall, ownership guard on late-rejecting stale launch, full orphan-sweep coverage (orphan revoked, fresh bearer preserved, bound session not swept, no double-revoke, interval lifecycle)

## Testing

255 unit tests pass across `HelpSessionController.test.ts`, `HelpSessionService.test.ts`, and `globalServicesInit.order.test.ts`. Own files prettier-clean, eslint 0 errors.