### PR TITLE
fix(assistant-settings): surface dropped agent, version gate, and turn-outcome diagnostics

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -404,6 +404,9 @@ export function DaintreeAssistantSettingsTab() {
       return;
     }
     const agentName = config?.name ?? preferredAgentId;
+    // Drop any prior agent's warning up front so the banner never shows a stale
+    // name/version while this probe is in flight.
+    setVersionWarning(null);
     window.electron.system
       .getAgentVersion(preferredAgentId)
       .then((info) => {

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -12,7 +12,9 @@ import {
   ShieldAlert,
   Sliders,
   Wrench,
+  X,
 } from "lucide-react";
+import * as semver from "semver";
 import { DaintreeIcon, McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { useDeferredLoading, useHelpSessionLiveStatus } from "@/hooks";
@@ -27,6 +29,7 @@ import { SettingsSelect } from "./SettingsSelect";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { McpAuditLogViewer } from "./McpAuditLogViewer";
 import { McpAuditLatencyTable } from "./McpAuditLatencyTable";
+import { TurnOutcomeDiagnostics } from "./TurnOutcomeDiagnostics";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { useSettingsTabFlush } from "./SettingsFlushRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -190,6 +193,18 @@ export function DaintreeAssistantSettingsTab() {
 
   const preferredAgentId = useHelpPanelStore((s) => s.preferredAgentId);
   const setPreferredAgent = useHelpPanelStore((s) => s.setPreferredAgent);
+  const droppedPreferredAgentId = useHelpPanelStore((s) => s.droppedPreferredAgentId);
+  const clearDroppedPreferredAgent = useHelpPanelStore((s) => s.clearDroppedPreferredAgent);
+
+  // Version gate at the configuration point: the launch path already blocks an
+  // outdated CLI (HelpPanelVersionGate), but the user can pick a too-old agent
+  // here with no warning. Probe the selected agent's version (12h cached in
+  // AgentVersionService, so cheap) and surface a non-blocking hint inline.
+  const [versionWarning, setVersionWarning] = useState<{
+    agentName: string;
+    installed: string;
+    required: string;
+  } | null>(null);
 
   const agentOptions = useMemo(() => {
     return getAssistantSupportedAgentIds().map((id) => ({
@@ -370,6 +385,52 @@ export function DaintreeAssistantSettingsTab() {
       if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
     };
   }, []);
+
+  // Isolated version-probe effect (kept separate from the settings-init effect
+  // per past lesson #4958). Mirrors HelpSessionController.probeAssistantVersion:
+  // any non-definitive result (no minimum configured, no installed version, or
+  // a comparison error) clears the warning so we never block on a transient
+  // failure or show a stale hint after switching agents.
+  useEffect(() => {
+    let cancelled = false;
+    if (!preferredAgentId) {
+      setVersionWarning(null);
+      return;
+    }
+    const config = getAgentConfig(preferredAgentId);
+    const required = config?.assistantMinVersion;
+    if (!required) {
+      setVersionWarning(null);
+      return;
+    }
+    const agentName = config?.name ?? preferredAgentId;
+    window.electron.system
+      .getAgentVersion(preferredAgentId)
+      .then((info) => {
+        if (cancelled) return;
+        const installed = info?.installedVersion;
+        if (!installed) {
+          setVersionWarning(null);
+          return;
+        }
+        try {
+          setVersionWarning(
+            semver.lt(installed, required) ? { agentName, installed, required } : null
+          );
+        } catch (err) {
+          setVersionWarning(null);
+          logError("Failed to compare assistant CLI version in settings", err);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setVersionWarning(null);
+        logError("Failed to probe assistant CLI version in settings", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [preferredAgentId]);
 
   const handleCopyAuditAsJson = async (records: McpLogRecord[]) => {
     try {
@@ -561,6 +622,10 @@ export function DaintreeAssistantSettingsTab() {
     void actionService.dispatch("app.settings.openTab", { tab: "mcp" }, { source: "user" });
   };
 
+  const handleGoToAgentSettings = () => {
+    void actionService.dispatch("app.settings.openTab", { tab: "agents" }, { source: "user" });
+  };
+
   const handleCopyConfig = async () => {
     try {
       const snippet = await window.electron.mcpServer.getConfigSnippet();
@@ -611,6 +676,71 @@ export function DaintreeAssistantSettingsTab() {
             options={modelOptions}
             disabled={loading}
           />
+        )}
+        {droppedPreferredAgentId && (
+          <div
+            role="alert"
+            data-testid="assistant-dropped-agent-banner"
+            className={cn(
+              "flex items-start gap-2 p-3 rounded-[var(--radius-md)]",
+              "bg-status-warning/10 border border-status-warning/20"
+            )}
+          >
+            <ShieldAlert
+              className="w-4 h-4 text-status-warning shrink-0 mt-0.5"
+              aria-hidden="true"
+            />
+            <div className="flex-1 text-xs leading-relaxed select-text">
+              <p className="font-medium text-daintree-text">
+                {getAgentConfig(droppedPreferredAgentId)?.name ?? droppedPreferredAgentId} is no
+                longer available
+              </p>
+              <p className="mt-0.5 text-daintree-text/70">
+                The agent was removed or is no longer supported as an assistant backend. Choose
+                another agent above.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={clearDroppedPreferredAgent}
+              aria-label="Dismiss"
+              className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+            >
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        )}
+        {versionWarning && (
+          <div
+            role="alert"
+            data-testid="assistant-version-warning-banner"
+            className={cn(
+              "flex items-start gap-2 p-3 rounded-[var(--radius-md)]",
+              "bg-status-warning/10 border border-status-warning/20"
+            )}
+          >
+            <AlertTriangle
+              className="w-4 h-4 text-status-warning shrink-0 mt-0.5"
+              aria-hidden="true"
+            />
+            <div className="flex-1 text-xs leading-relaxed select-text">
+              <p className="font-medium text-daintree-text">
+                {versionWarning.agentName} needs an update
+              </p>
+              <p className="mt-0.5 text-daintree-text/70">
+                Version {versionWarning.required} or later is required, but{" "}
+                {versionWarning.installed} is installed. Update the CLI to avoid a blocked or
+                degraded session.
+              </p>
+              <button
+                type="button"
+                onClick={handleGoToAgentSettings}
+                className="mt-1 text-daintree-text/70 hover:text-daintree-text underline underline-offset-2 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              >
+                Open agent settings
+              </button>
+            </div>
+          </div>
         )}
         <SettingsInput
           label="Custom CLI args"
@@ -749,7 +879,7 @@ export function DaintreeAssistantSettingsTab() {
       >
         <SettingsSelect
           label="Audit log retention"
-          description="How long help-session logs are kept on this machine. Set to off to skip logging entirely."
+          description="How long MCP audit records are kept on this machine. Turn-outcome diagnostics are recorded separately and aren't affected by this setting."
           value={String(settings.auditRetention)}
           onValueChange={setRetention}
           options={RETENTION_OPTIONS}
@@ -773,6 +903,11 @@ export function DaintreeAssistantSettingsTab() {
         <McpAuditLatencyTable
           records={auditRecords}
           includeRecord={(record) => !isAuditRecord(record) || record.tier !== "external"}
+        />
+        <TurnOutcomeDiagnostics
+          auditRecords={auditRecords}
+          records={turnRecords}
+          onRefresh={refreshAuditRecords}
         />
         {auditStats && auditStats.auth401Count > 0 && (
           <p className="text-xs text-daintree-text/60 select-text">

--- a/src/components/Settings/TurnOutcomeDiagnostics.tsx
+++ b/src/components/Settings/TurnOutcomeDiagnostics.tsx
@@ -106,18 +106,26 @@ export function TurnOutcomeDiagnostics({
   const confirmClearTurnOutcomeLog = async () => {
     if (isClearing) return;
     setIsClearing(true);
+    let cleared = false;
     try {
       await window.electron.mcpServer.clearTurnOutcomeLog();
-      if (isControlled) {
-        await onRefresh?.();
-      } else {
-        setInternalRecords([]);
-      }
+      cleared = true;
+      if (!isControlled) setInternalRecords([]);
       setShowClearConfirm(false);
     } catch (err) {
       logError("Failed to clear turn outcome log", err);
     } finally {
       setIsClearing(false);
+    }
+    // The post-clear refresh is best-effort: the clear already committed, so a
+    // refresh failure must not reopen the dialog or re-surface the destructive
+    // action — log it separately and leave the closed, cleared state intact.
+    if (cleared && isControlled) {
+      try {
+        await onRefresh?.();
+      } catch (err) {
+        logError("Failed to refresh turn outcomes after clearing log", err);
+      }
     }
   };
 
@@ -156,6 +164,9 @@ export function TurnOutcomeDiagnostics({
       });
 
     return () => {
+      // Mark settled so a late-resolving fetch can't write state after unmount
+      // or after a switch into controlled mode.
+      settled = true;
       clearTimeout(timer);
     };
   }, [isControlled]);

--- a/src/components/Settings/TurnOutcomeDiagnostics.tsx
+++ b/src/components/Settings/TurnOutcomeDiagnostics.tsx
@@ -56,11 +56,26 @@ interface PerToolRollup {
 
 interface TurnOutcomeDiagnosticsProps {
   auditRecords?: McpLogRecord[];
+  /**
+   * When provided, the component renders these records instead of self-fetching.
+   * Lets a parent that already holds turn-outcome data (the assistant settings
+   * tab) drive the panel without a redundant IPC round-trip.
+   */
+  records?: AssistantTurnRecord[];
+  /** Refresh handler used in controlled mode; falls back to the internal fetch. */
+  onRefresh?: () => Promise<void> | void;
 }
 
-export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsProps) {
-  const [records, setRecords] = useState<AssistantTurnRecord[]>([]);
-  const [loading, setLoading] = useState(true);
+export function TurnOutcomeDiagnostics({
+  auditRecords,
+  records: controlledRecords,
+  onRefresh,
+}: TurnOutcomeDiagnosticsProps) {
+  const isControlled = controlledRecords !== undefined;
+  const [internalRecords, setInternalRecords] = useState<AssistantTurnRecord[]>([]);
+  const [internalLoading, setInternalLoading] = useState(true);
+  const records = isControlled ? controlledRecords : internalRecords;
+  const loading = isControlled ? false : internalLoading;
   const [outcomeSectionOpen, setOutcomeSectionOpen] = useState(true);
   const [toolErrorOpen, setToolErrorOpen] = useState(true);
   const [tierRejectedOpen, setTierRejectedOpen] = useState(true);
@@ -69,14 +84,22 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
   const [isClearing, setIsClearing] = useState(false);
 
   const fetchRecords = async () => {
-    setLoading(true);
+    setInternalLoading(true);
     try {
       const result = await window.electron.mcpServer.getTurnOutcomeRecords();
-      setRecords(result);
+      setInternalRecords(result);
     } catch (err) {
       logError("Failed to load turn outcome records", err);
     } finally {
-      setLoading(false);
+      setInternalLoading(false);
+    }
+  };
+
+  const handleRefresh = () => {
+    if (isControlled) {
+      void onRefresh?.();
+    } else {
+      void fetchRecords();
     }
   };
 
@@ -85,7 +108,11 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
     setIsClearing(true);
     try {
       await window.electron.mcpServer.clearTurnOutcomeLog();
-      setRecords([]);
+      if (isControlled) {
+        await onRefresh?.();
+      } else {
+        setInternalRecords([]);
+      }
       setShowClearConfirm(false);
     } catch (err) {
       logError("Failed to clear turn outcome log", err);
@@ -100,10 +127,13 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
   };
 
   useEffect(() => {
+    // Controlled mode: the parent owns the records and loading lifecycle.
+    if (isControlled) return;
+
     let settled = false;
     const timer = setTimeout(() => {
       settled = true;
-      setLoading(false);
+      setInternalLoading(false);
       logError("Turn outcome records load timed out");
     }, 10_000);
 
@@ -111,7 +141,7 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
       .getTurnOutcomeRecords()
       .then((result) => {
         if (settled) return;
-        setRecords(result);
+        setInternalRecords(result);
       })
       .catch((err) => {
         if (settled) return;
@@ -121,14 +151,14 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
         if (!settled) {
           settled = true;
           clearTimeout(timer);
-          setLoading(false);
+          setInternalLoading(false);
         }
       });
 
     return () => {
       clearTimeout(timer);
     };
-  }, []);
+  }, [isControlled]);
 
   const outcomeCounts = useMemo(() => {
     const counts = new Map<TurnOutcomeClass, number>();
@@ -486,7 +516,7 @@ export function TurnOutcomeDiagnostics({ auditRecords }: TurnOutcomeDiagnosticsP
           <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={() => void fetchRecords()}
+              onClick={handleRefresh}
               disabled={loading}
               className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
             >

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -902,6 +902,43 @@ describe("DaintreeAssistantSettingsTab", () => {
     expect(screen.queryByTestId("assistant-version-warning-banner")).toBeNull();
   });
 
+  it("clears the version warning when switching to an agent with no minimum", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    installApi(
+      {},
+      {},
+      {
+        getAgentVersion: vi.fn().mockResolvedValue({
+          agentId: "claude",
+          installedVersion: "1.0.0",
+          latestVersion: null,
+          updateAvailable: false,
+          lastChecked: null,
+        }),
+      }
+    );
+
+    const { rerender } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await screen.findByTestId("assistant-version-warning-banner");
+
+    // Codex has no assistantMinVersion in the mock, so the probe effect must
+    // clear the prior agent's warning synchronously on switch.
+    helpPanelState.preferredAgentId = "codex";
+    rerender(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("assistant-version-warning-banner")).toBeNull();
+    });
+  });
+
   it("does not probe versions when no agent is selected", async () => {
     helpPanelState.preferredAgentId = null;
 

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.stubGlobal(
@@ -66,17 +66,20 @@ interface SettingsSelectStubOption {
 vi.mock("../SettingsSelect", () => ({
   SettingsSelect: ({
     label,
+    description,
     value,
     onValueChange,
     options,
   }: {
     label: string;
+    description?: React.ReactNode;
     value: string;
     onValueChange: (v: string) => void;
     options: SettingsSelectStubOption[];
   }) => (
     <label>
       {label}
+      {description != null && <span>{description}</span>}
       <select aria-label={label} value={value} onChange={(e) => onValueChange(e.target.value)}>
         {options.map((o) => (
           <option key={o.value} value={o.value}>
@@ -117,8 +120,10 @@ vi.mock("../SettingsInput", () => ({
 
 const helpPanelState = {
   preferredAgentId: null as string | null,
+  droppedPreferredAgentId: null as string | null,
   sessionId: null as string | null,
   setPreferredAgent: vi.fn(),
+  clearDroppedPreferredAgent: vi.fn(),
 };
 
 vi.mock("@/store/helpPanelStore", () => {
@@ -141,7 +146,7 @@ vi.mock("@/config/agents", () => ({
   getAgentIds: () => ["claude", "codex"],
   getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
   getAgentConfig: (id: string) => {
-    if (id === "claude") return { name: "Claude Code" };
+    if (id === "claude") return { name: "Claude Code", assistantMinVersion: "2.0.0" };
     if (id === "codex") return { name: "Codex" };
     return undefined;
   },
@@ -176,9 +181,14 @@ interface McpServerApi {
   clearAuditLog: ReturnType<typeof vi.fn>;
 }
 
+interface SystemApi {
+  getAgentVersion: ReturnType<typeof vi.fn>;
+}
+
 function installApi(
   helpAssistant: Partial<HelpAssistantApi> = {},
-  mcpServer: Partial<McpServerApi> = {}
+  mcpServer: Partial<McpServerApi> = {},
+  system: Partial<SystemApi> = {}
 ) {
   const helpDefaults: HelpAssistantApi = {
     getSettings: vi.fn().mockResolvedValue({
@@ -223,9 +233,21 @@ function installApi(
     getTurnOutcomeRecords: vi.fn().mockResolvedValue([]),
     clearAuditLog: vi.fn().mockResolvedValue(undefined),
   };
+  const systemDefaults: SystemApi = {
+    // Indeterminate by default (no installed version) so the version probe
+    // never raises a warning unless a test opts in with a concrete version.
+    getAgentVersion: vi.fn().mockResolvedValue({
+      agentId: "claude",
+      installedVersion: null,
+      latestVersion: null,
+      updateAvailable: false,
+      lastChecked: null,
+    }),
+  };
   window.electron = {
     helpAssistant: { ...helpDefaults, ...helpAssistant },
     mcpServer: { ...mcpDefaults, ...mcpServer },
+    system: { ...systemDefaults, ...system },
   } as unknown as typeof window.electron;
 }
 
@@ -233,8 +255,10 @@ describe("DaintreeAssistantSettingsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     helpPanelState.preferredAgentId = null;
+    helpPanelState.droppedPreferredAgentId = null;
     helpPanelState.sessionId = null;
     helpPanelState.setPreferredAgent = vi.fn();
+    helpPanelState.clearDroppedPreferredAgent = vi.fn();
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText },
@@ -776,6 +800,141 @@ describe("DaintreeAssistantSettingsTab", () => {
     fireEvent.change(select, { target: { value: "claude" } });
 
     expect(helpPanelState.setPreferredAgent).toHaveBeenCalledWith("claude");
+  });
+
+  it("shows the dropped-agent banner when a persisted agent was dropped", async () => {
+    helpPanelState.droppedPreferredAgentId = "claude";
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Agent");
+
+    const banner = await screen.findByTestId("assistant-dropped-agent-banner");
+    expect(banner.textContent).toContain("Claude Code is no longer available");
+  });
+
+  it("hides the dropped-agent banner when nothing was dropped", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Agent");
+
+    expect(screen.queryByTestId("assistant-dropped-agent-banner")).toBeNull();
+  });
+
+  it("dismissing the dropped-agent banner calls clearDroppedPreferredAgent", async () => {
+    helpPanelState.droppedPreferredAgentId = "claude";
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Agent");
+
+    const banner = await screen.findByTestId("assistant-dropped-agent-banner");
+    fireEvent.click(within(banner).getByRole("button", { name: "Dismiss" }));
+
+    expect(helpPanelState.clearDroppedPreferredAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when the selected agent's CLI is older than the assistant minimum", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    installApi(
+      {},
+      {},
+      {
+        getAgentVersion: vi.fn().mockResolvedValue({
+          agentId: "claude",
+          installedVersion: "1.0.0",
+          latestVersion: null,
+          updateAvailable: false,
+          lastChecked: null,
+        }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Agent");
+
+    const banner = await screen.findByTestId("assistant-version-warning-banner");
+    expect(banner.textContent).toContain("Claude Code needs an update");
+    expect(banner.textContent).toContain("2.0.0");
+    expect(banner.textContent).toContain("1.0.0");
+    expect(window.electron.system.getAgentVersion).toHaveBeenCalledWith("claude");
+  });
+
+  it("does not warn when the installed CLI meets the assistant minimum", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    installApi(
+      {},
+      {},
+      {
+        getAgentVersion: vi.fn().mockResolvedValue({
+          agentId: "claude",
+          installedVersion: "2.5.0",
+          latestVersion: null,
+          updateAvailable: false,
+          lastChecked: null,
+        }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Agent");
+    await waitFor(() => {
+      expect(window.electron.system.getAgentVersion).toHaveBeenCalledWith("claude");
+    });
+
+    expect(screen.queryByTestId("assistant-version-warning-banner")).toBeNull();
+  });
+
+  it("does not probe versions when no agent is selected", async () => {
+    helpPanelState.preferredAgentId = null;
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Agent");
+
+    expect(screen.queryByTestId("assistant-version-warning-banner")).toBeNull();
+    expect(window.electron.system.getAgentVersion).not.toHaveBeenCalled();
+  });
+
+  it("audit retention description no longer claims logging can be skipped entirely", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Audit log retention");
+
+    expect(container.textContent).not.toContain("skip logging entirely");
+    expect(container.textContent).toContain("recorded separately");
+  });
+
+  it("renders turn-outcome diagnostics in the privacy section", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Turn outcomes by class");
   });
 
   it("loads customArgs from the IPC settings into the input", async () => {

--- a/src/components/Settings/__tests__/TurnOutcomeDiagnostics.test.tsx
+++ b/src/components/Settings/__tests__/TurnOutcomeDiagnostics.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logDebug: vi.fn(),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+import { TurnOutcomeDiagnostics } from "../TurnOutcomeDiagnostics";
+import type { AssistantTurnRecord } from "@shared/types";
+
+const getTurnOutcomeRecords = vi.fn();
+const clearTurnOutcomeLog = vi.fn();
+
+function installApi() {
+  getTurnOutcomeRecords.mockResolvedValue([]);
+  clearTurnOutcomeLog.mockResolvedValue(undefined);
+  window.electron = {
+    mcpServer: { getTurnOutcomeRecords, clearTurnOutcomeLog },
+  } as unknown as typeof window.electron;
+}
+
+const sampleRecord: AssistantTurnRecord = {
+  sessionId: "help-1",
+  outcome: "answered",
+} as unknown as AssistantTurnRecord;
+
+describe("TurnOutcomeDiagnostics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installApi();
+  });
+
+  it("self-fetches turn-outcome records on mount when uncontrolled", async () => {
+    render(<TurnOutcomeDiagnostics />);
+
+    await waitFor(() => {
+      expect(getTurnOutcomeRecords).toHaveBeenCalledTimes(1);
+    });
+    await screen.findByText("Turn outcomes by class");
+  });
+
+  it("does not self-fetch when records are supplied (controlled)", async () => {
+    render(<TurnOutcomeDiagnostics records={[]} />);
+
+    // Controlled mode renders immediately without a loading round-trip.
+    await screen.findByText("Turn outcomes by class");
+    expect(getTurnOutcomeRecords).not.toHaveBeenCalled();
+  });
+
+  it("renders the supplied records in controlled mode", async () => {
+    render(<TurnOutcomeDiagnostics records={[sampleRecord]} />);
+
+    // The turn count reflects the controlled prop, not an internal fetch.
+    await screen.findByText("(1 turns)");
+    expect(getTurnOutcomeRecords).not.toHaveBeenCalled();
+  });
+
+  it("controlled Refresh delegates to onRefresh instead of self-fetching", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(<TurnOutcomeDiagnostics records={[]} onRefresh={onRefresh} />);
+
+    await screen.findByText("Turn outcomes by class");
+    fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(getTurnOutcomeRecords).not.toHaveBeenCalled();
+  });
+
+  it("uncontrolled Refresh re-fetches records", async () => {
+    render(<TurnOutcomeDiagnostics />);
+
+    await waitFor(() => {
+      expect(getTurnOutcomeRecords).toHaveBeenCalledTimes(1);
+    });
+    await screen.findByText("Turn outcomes by class");
+
+    fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+
+    await waitFor(() => {
+      expect(getTurnOutcomeRecords).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/components/Settings/__tests__/TurnOutcomeDiagnostics.test.tsx
+++ b/src/components/Settings/__tests__/TurnOutcomeDiagnostics.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.stubGlobal(
@@ -77,6 +77,46 @@ describe("TurnOutcomeDiagnostics", () => {
 
     expect(onRefresh).toHaveBeenCalledTimes(1);
     expect(getTurnOutcomeRecords).not.toHaveBeenCalled();
+  });
+
+  it("controlled Clear log clears the log then refreshes via onRefresh", async () => {
+    const onRefresh = vi.fn().mockResolvedValue(undefined);
+    render(<TurnOutcomeDiagnostics records={[sampleRecord]} onRefresh={onRefresh} />);
+
+    await screen.findByText("(1 turns)");
+    fireEvent.click(screen.getByRole("button", { name: "Clear log" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Clear log" }));
+
+    await waitFor(() => {
+      expect(clearTurnOutcomeLog).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+    // Controlled mode never touches the internal self-fetch path.
+    expect(getTurnOutcomeRecords).not.toHaveBeenCalled();
+  });
+
+  it("controlled Clear log still closes the dialog when onRefresh rejects", async () => {
+    const onRefresh = vi.fn().mockRejectedValue(new Error("refresh boom"));
+    render(<TurnOutcomeDiagnostics records={[sampleRecord]} onRefresh={onRefresh} />);
+
+    await screen.findByText("(1 turns)");
+    fireEvent.click(screen.getByRole("button", { name: "Clear log" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Clear log" }));
+
+    await waitFor(() => {
+      expect(clearTurnOutcomeLog).toHaveBeenCalledTimes(1);
+    });
+    // Clear committed, so the dialog must not linger or re-surface despite the
+    // post-clear refresh failure.
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+    });
   });
 
   it("uncontrolled Refresh re-fetches records", async () => {


### PR DESCRIPTION
## Summary

- `DaintreeAssistantSettingsTab` silently dropped a preferred agent that wasn't installed (blank select with no explanation) and showed no warning when the selected agent's CLI was below `assistantMinVersion`. Both cases now surface clearly.
- Audit-retention copy was misleading: it implied all diagnostics were gated on that setting, but only MCP audit records are. Copy corrected.
- `TurnOutcomeDiagnostics` now renders in the assistant Privacy section via new controlled `records` and `onRefresh` props, avoiding a double-fetch. Backward-compatible with `McpServerSettingsTab`.

Resolves #10700

## Changes

- Inline banner in `DaintreeAssistantSettingsTab` when the preferred agent is not installed, explaining the drop instead of leaving the select blank
- Version-gate warning when the selected agent's CLI is below `assistantMinVersion`. Version probe is isolated to the selected agent only (per lesson #4958, to avoid side effects from probing unrelated agents)
- Corrected audit-retention section copy: the setting gates MCP audit records, not turn-outcome diagnostics
- `TurnOutcomeDiagnostics` accepts optional `records` and `onRefresh` props so the assistant tab can pass its already-fetched data through, removing the duplicate fetch

## Testing

108 tests passing across `TurnOutcomeDiagnostics`, `DaintreeAssistantSettingsTab`, and `McpServerSettingsTab`. Tests cover the dropped-agent banner, version-gate warning render/hide logic, and the controlled vs. self-fetching `TurnOutcomeDiagnostics` modes.