### PR TITLE
feat(assistant): gate auto-launch behind explicit consent (#10699)

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -9,8 +9,9 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { ExternalLink, Settings2, ShieldAlert, X } from "lucide-react";
+import { ExternalLink, MessageCircle, Settings2, ShieldAlert, Sparkles, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
 import { shouldShowHybridInputBar } from "@/components/Terminal/terminalFocus";
@@ -65,6 +66,16 @@ const RESIZE_PAGE_STEP = 50;
 
 const ASSISTANT_DOCS_URL = "https://daintree.org/assistant";
 const ASSISTANT_INSTALLER_URL = "https://daintree.org/download";
+
+// First-run starter prompts. Clicking one starts the assistant AND seeds the
+// agent with the question, so the very first session is an explicit, useful
+// action rather than a bare empty terminal. Shown only before the user has
+// ever launched an agent (#10699).
+const STARTER_PROMPTS = [
+  "How do I set up a new worktree?",
+  "Explain Daintree's panel system",
+  "Help me configure my first agent",
+] as const;
 
 interface HelpPanelProps {
   /**
@@ -152,6 +163,7 @@ export function HelpPanel({
     sessionId,
     agentId,
     preferredAgentId,
+    autoLaunchEnabled,
     droppedPreferredAgentId,
     introDismissed,
     conversationTouched,
@@ -160,6 +172,7 @@ export function HelpPanel({
     markConversationStarted,
     setWidth,
     setOpen,
+    setAutoLaunchEnabled,
     dismissIntro,
     clearDroppedPreferredAgent,
   } = useHelpPanelStore(
@@ -170,6 +183,7 @@ export function HelpPanel({
       sessionId: s.sessionId,
       agentId: s.agentId,
       preferredAgentId: s.preferredAgentId,
+      autoLaunchEnabled: s.autoLaunchEnabled,
       droppedPreferredAgentId: s.droppedPreferredAgentId,
       introDismissed: s.introDismissed,
       conversationTouched: s.conversationTouched,
@@ -178,6 +192,7 @@ export function HelpPanel({
       markConversationStarted: s.markConversationStarted,
       setWidth: s.setWidth,
       setOpen: s.setOpen,
+      setAutoLaunchEnabled: s.setAutoLaunchEnabled,
       dismissIntro: s.dismissIntro,
       clearDroppedPreferredAgent: s.clearDroppedPreferredAgent,
     }))
@@ -323,6 +338,7 @@ export function HelpPanel({
       terminalId,
       preferredAgentId,
       supportedInstalledAgentIds,
+      autoLaunchEnabled,
       visibilityEpoch,
     });
   }, [
@@ -334,6 +350,7 @@ export function HelpPanel({
     preferredAgentId,
     supportedInstalledAgentIdsKey,
     supportedInstalledAgentIds,
+    autoLaunchEnabled,
     visibilityEpoch,
   ]);
 
@@ -734,6 +751,31 @@ export function HelpPanel({
     controller.runAnyway();
   }, [controller]);
 
+  // The agent the idle empty state's "Start assistant" CTA would launch — the
+  // user's preference, or the sole installed assistant backend. Mirrors the
+  // controller's own auto-launch eligibility so the CTA is shown only when a
+  // single unambiguous target exists; otherwise the user is sent to settings.
+  const launchableAgentId =
+    preferredAgentId ??
+    (supportedInstalledAgentIds.length === 1 ? (supportedInstalledAgentIds[0] ?? null) : null);
+
+  // Explicit, billed start (#10699). Records consent so future opens may
+  // auto-launch, then launches directly — relying on syncInputs re-evaluation
+  // would leave a render-cycle gap. An optional starter prompt seeds the first
+  // turn (skips the resume path by design).
+  const handleStartAssistant = useCallback(
+    (seedPrompt?: string) => {
+      if (!launchableAgentId) return;
+      setAutoLaunchEnabled(true);
+      controller.launch({
+        agentId: launchableAgentId,
+        replaceExisting: true,
+        ...(seedPrompt ? { seedPrompt } : {}),
+      });
+    },
+    [controller, launchableAgentId, setAutoLaunchEnabled]
+  );
+
   const dismissResume = useCallback(() => controller.dismissResumeBanner(), [controller]);
   const dismissSnapshot = useCallback(() => controller.dismissPreflightSnapshot(), [controller]);
   const dismissTierMismatch = useCallback(() => controller.dismissTierMismatch(), [controller]);
@@ -991,11 +1033,46 @@ export function HelpPanel({
               <p className="text-sm text-daintree-text/70 max-w-[30ch]">
                 Use Daintree Assistant to configure and navigate Daintree.
               </p>
+              {launchableAgentId ? (
+                <div className="flex flex-col items-center gap-4 w-full max-w-[34ch]">
+                  {/* Explicit start — opening the panel no longer auto-bills a
+                      session (#10699); the user kicks it off here. This is the
+                      single load-bearing accent in the idle focus region. */}
+                  <Button
+                    type="button"
+                    onClick={() => handleStartAssistant()}
+                    data-testid="help-start-assistant"
+                  >
+                    <Sparkles />
+                    Start assistant
+                  </Button>
+                  {!hasEverLaunchedAgent && (
+                    <div className="flex flex-col gap-1.5 w-full">
+                      <p className="text-[11px] text-daintree-text/60">Or start with a question</p>
+                      {STARTER_PROMPTS.map((prompt) => (
+                        <button
+                          key={prompt}
+                          type="button"
+                          onClick={() => handleStartAssistant(prompt)}
+                          className="flex items-center gap-2 w-full text-left px-3 py-2 text-xs rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/80 hover:text-daintree-text hover:bg-overlay-soft transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                        >
+                          <MessageCircle className="w-3.5 h-3.5 shrink-0 text-daintree-text/50" />
+                          <span>{prompt}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <p className="text-xs text-daintree-text/70 max-w-[32ch]">
+                  Configure an assistant agent in settings to get started.
+                </p>
+              )}
               <div className="flex flex-col gap-2">
                 <button
                   type="button"
                   onClick={handleOpenSettings}
-                  className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  className="flex items-center gap-1 text-[11px] text-daintree-text/70 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 >
                   <Settings2 className="w-3.5 h-3.5" />
                   Assistant settings
@@ -1003,7 +1080,7 @@ export function HelpPanel({
                 <button
                   type="button"
                   onClick={handleOpenAssistantDocs}
-                  className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  className="flex items-center gap-1 text-[11px] text-daintree-text/70 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 >
                   <ExternalLink className="w-3.5 h-3.5" />
                   Daintree Assistant guide

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1459,6 +1459,75 @@ describe("HelpPanel — empty state hero (Daintree-relevant entry points)", () =
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 
+  it("'Start assistant' CTA records consent and launches, with no auto-launch beforehand (#10699)", async () => {
+    // Consent off: opening the panel must show the CTA and start nothing.
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.preferredAgentId = "claude";
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "cta-term" } });
+
+    render(<HelpPanel width={380} />);
+
+    expect(mockProvisionSession).not.toHaveBeenCalled();
+
+    const cta = await screen.findByTestId("help-start-assistant");
+    await act(async () => {
+      fireEvent.click(cta);
+    });
+
+    expect(helpPanelState.setAutoLaunchEnabled).toHaveBeenCalledWith(true);
+    expect(mockProvisionSession).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "claude" })
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+  });
+
+  it("first-run starter-prompt chip records consent and launches (#10699)", async () => {
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.preferredAgentId = "claude";
+    // No prior agent launches → the first-run starter chips render.
+    panelStoreState.panelIds = [];
+    panelStoreState.panelsById = {};
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "chip-term" } });
+
+    render(<HelpPanel width={380} />);
+
+    const chip = await screen.findByRole("button", {
+      name: /How do I set up a new worktree\?/i,
+    });
+    await act(async () => {
+      fireEvent.click(chip);
+    });
+
+    expect(helpPanelState.setAutoLaunchEnabled).toHaveBeenCalledWith(true);
+    expect(mockProvisionSession).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "claude" })
+    );
+  });
+
+  it("renders the configure-in-settings fallback and no Start CTA when no single launchable agent (#10699)", () => {
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+
+    render(<HelpPanel width={380} />);
+
+    expect(
+      screen.getByText(/Configure an assistant agent in settings to get started/i)
+    ).toBeTruthy();
+    expect(screen.queryByTestId("help-start-assistant")).toBeNull();
+  });
+
   it("dispatches app.settings.openTab with tab='assistant' when the empty-state settings link is clicked", async () => {
     helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "ready", codex: "ready" };

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -71,6 +71,10 @@ const {
     terminalId: null as string | null,
     agentId: null as string | null,
     preferredAgentId: null as string | null,
+    // Consent granted by default (#10699) so the existing auto-launch coverage
+    // exercises the downstream launch wiring; the consent gate itself is
+    // unit-tested in HelpSessionController.test.ts.
+    autoLaunchEnabled: true,
     sessionId: null as string | null,
     introDismissed: true,
     conversationTouched: false,
@@ -79,6 +83,7 @@ const {
     markConversationStarted: vi.fn(),
     setWidth: vi.fn(),
     setOpen: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
     clearTerminal: vi.fn(),
     setPreferredAgent: vi.fn(),
     setTerminal: vi.fn(),
@@ -367,6 +372,7 @@ function resetState() {
   helpPanelState.terminalId = null;
   helpPanelState.agentId = null;
   helpPanelState.preferredAgentId = null;
+  helpPanelState.autoLaunchEnabled = true;
   helpPanelState.sessionId = null;
   helpPanelState.introDismissed = true;
   helpPanelState.conversationTouched = false;
@@ -375,6 +381,7 @@ function resetState() {
   helpPanelState.markConversationStarted = vi.fn();
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.setOpen = vi.fn();
+  helpPanelState.setAutoLaunchEnabled = vi.fn();
   helpPanelState.setWidth = vi.fn();
   helpPanelState.clearTerminal = vi.fn();
   helpPanelState.setPreferredAgent = vi.fn();

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -517,6 +517,28 @@ describe("HelpPanel — resume from hibernated session", () => {
     );
   });
 
+  it("does NOT resume a matching hibernated session when autoLaunchEnabled is false (#10699)", async () => {
+    // Consent gates the resume path too — a returning user post-migration must
+    // not silently spend tokens re-launching a hibernated agent on panel open.
+    helpPanelState.autoLaunchEnabled = false;
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("resumed-term-1");
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockBuildResumeCommand).not.toHaveBeenCalled();
+    expect(panelStoreState.addPanel).not.toHaveBeenCalled();
+    expect(mockProvisionSession).not.toHaveBeenCalled();
+    expect(helpPanelState.clearHibernateSession).not.toHaveBeenCalled();
+  });
+
   it("renders the resume banner after a successful resume", async () => {
     helpPanelState.preferredAgentId = "claude";
     helpPanelState.hibernateSessions = {

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -68,6 +68,9 @@ const {
     terminalId: null as string | null,
     agentId: null as string | null,
     preferredAgentId: null as string | null,
+    // Consent granted by default (#10699) so the resume/auto-launch coverage
+    // runs; the consent gate is unit-tested in HelpSessionController.test.ts.
+    autoLaunchEnabled: true,
     sessionId: null as string | null,
     introDismissed: true,
     conversationTouched: false,
@@ -76,6 +79,7 @@ const {
     markConversationStarted: vi.fn(),
     setWidth: vi.fn(),
     setOpen: vi.fn(),
+    setAutoLaunchEnabled: vi.fn(),
     clearTerminal: vi.fn(),
     setPreferredAgent: vi.fn(),
     setTerminal: vi.fn(),
@@ -321,6 +325,7 @@ function resetState() {
   helpPanelState.terminalId = null;
   helpPanelState.agentId = null;
   helpPanelState.preferredAgentId = null;
+  helpPanelState.autoLaunchEnabled = true;
   helpPanelState.sessionId = null;
   helpPanelState.introDismissed = true;
   helpPanelState.conversationTouched = false;
@@ -329,6 +334,7 @@ function resetState() {
   helpPanelState.markConversationStarted = vi.fn();
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.setOpen = vi.fn();
+  helpPanelState.setAutoLaunchEnabled = vi.fn();
   helpPanelState.setWidth = vi.fn();
   helpPanelState.clearTerminal = vi.fn();
   helpPanelState.setPreferredAgent = vi.fn();

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -230,6 +230,12 @@ export interface HelpSessionInputs {
   terminalId: string | null;
   preferredAgentId: string | null;
   supportedInstalledAgentIds: readonly string[];
+  /**
+   * User consent to auto-launch a billed session when the panel opens (#10699).
+   * False until the user explicitly starts the assistant once; auto-launch is
+   * fully suppressed while false, so revealing the panel never bills a session.
+   */
+  autoLaunchEnabled: boolean;
   /** Bumped each time the panel becomes visible — re-evaluates auto-launch. */
   visibilityEpoch: number;
 }
@@ -1886,6 +1892,10 @@ export class HelpSessionController {
   }
 
   private _maybeAutoLaunch(inputs: HelpSessionInputs): void {
+    // Consent gate first (#10699): with no explicit opt-in, opening the panel
+    // must never start a billed session. Placed ahead of the visibility check
+    // so a visibilityEpoch re-arm can't bypass consent on a restore.
+    if (!inputs.autoLaunchEnabled) return;
     if (typeof document !== "undefined" && document.hidden) return;
     if (!inputs.isOpen) return;
     if (!inputs.isReadyToLaunch) return;

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -848,6 +848,7 @@ describe("HelpSessionController — launch phase FSM", () => {
         terminalId: null,
         preferredAgentId: "claude",
         supportedInstalledAgentIds: ["claude"],
+        autoLaunchEnabled: true,
         visibilityEpoch: 0,
       });
 
@@ -905,6 +906,7 @@ describe("HelpSessionController — launch phase FSM", () => {
       terminalId: null,
       preferredAgentId: "claude",
       supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
     await vi.waitFor(() => {

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -498,6 +498,7 @@ describe("HelpSessionController — syncInputs", () => {
       terminalId: null,
       preferredAgentId: "claude",
       supportedInstalledAgentIds: [],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
     expect(ctrl.getSnapshot().assistantVersionTooOld).not.toBeNull();
@@ -509,6 +510,7 @@ describe("HelpSessionController — syncInputs", () => {
       terminalId: null,
       preferredAgentId: "codex",
       supportedInstalledAgentIds: [],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
     expect(ctrl.getSnapshot().assistantVersionTooOld).toBeNull();
@@ -548,6 +550,7 @@ describe("HelpSessionController — launch phase FSM", () => {
         terminalId: null,
         preferredAgentId: "claude",
         supportedInstalledAgentIds: ["claude"],
+        autoLaunchEnabled: true,
         visibilityEpoch: 0,
       });
       expect(ctrl.getSnapshot().phase).toBe("version-checking");
@@ -584,6 +587,7 @@ describe("HelpSessionController — launch phase FSM", () => {
       terminalId: null,
       preferredAgentId: null,
       supportedInstalledAgentIds: [],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
 
@@ -628,6 +632,7 @@ describe("HelpSessionController — launch phase FSM", () => {
       terminalId: null,
       preferredAgentId: "claude",
       supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
 
@@ -667,12 +672,71 @@ describe("HelpSessionController — launch phase FSM", () => {
       terminalId: null,
       preferredAgentId: "claude",
       supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
 
     await vi.waitFor(() => {
       expect(ctrl.getSnapshot().phase).toBe("idle");
     });
+    expect(vi.mocked(actionService.dispatch)).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("does NOT auto-launch when autoLaunchEnabled is false, despite a preferred agent + open ready panel (#10699)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: false,
+      visibilityEpoch: 0,
+    });
+
+    // The auto-launch path writes phase synchronously before its first await,
+    // so an idle phase here proves the consent gate short-circuited it.
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    expect(ctrl["_hasAutoLaunched"]).toBe(false);
+
+    // A visibility-restore epoch bump must not bypass consent either.
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: false,
+      visibilityEpoch: 1,
+    });
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    expect(vi.mocked(actionService.dispatch)).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("does NOT auto-launch a sole installed agent when autoLaunchEnabled is false (#10699)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: null,
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: false,
+      visibilityEpoch: 0,
+    });
+
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    expect(ctrl["_hasAutoLaunched"]).toBe(false);
     expect(vi.mocked(actionService.dispatch)).not.toHaveBeenCalled();
     ctrl.stop();
   });
@@ -745,6 +809,7 @@ describe("HelpSessionController — launch phase FSM", () => {
       terminalId: null,
       preferredAgentId: "claude",
       supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
 
@@ -1016,6 +1081,7 @@ describe("HelpSessionController — session revoked (#10017)", () => {
       terminalId: null,
       preferredAgentId: "claude",
       supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     };
     ctrl["_patch"]({ sessionRevoked: { sessionId: "sess-old", denialKind: "tierMismatch" } });
@@ -1541,6 +1607,7 @@ describe("HelpSessionController — launch error routing", () => {
       terminalId: null,
       preferredAgentId: "claude",
       supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     };
   }
@@ -1753,6 +1820,7 @@ describe("HelpSessionController — launch error routing", () => {
       terminalId: null,
       preferredAgentId,
       supportedInstalledAgentIds: ["claude", "codex"],
+      autoLaunchEnabled: true,
       visibilityEpoch: 0,
     });
     ctrl.syncInputs(inputs("claude"));

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -717,6 +717,9 @@ describe("HelpSessionController — launch phase FSM", () => {
     });
     expect(ctrl.getSnapshot().phase).toBe("idle");
     expect(vi.mocked(actionService.dispatch)).not.toHaveBeenCalled();
+    // No billed work may even begin — the gate must short-circuit before the
+    // session is provisioned, not merely before the terminal is dispatched.
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
     ctrl.stop();
   });
 
@@ -738,6 +741,7 @@ describe("HelpSessionController — launch phase FSM", () => {
     expect(ctrl.getSnapshot().phase).toBe("idle");
     expect(ctrl["_hasAutoLaunched"]).toBe(false);
     expect(vi.mocked(actionService.dispatch)).not.toHaveBeenCalled();
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
     ctrl.stop();
   });
 

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -227,7 +227,7 @@ describe("helpPanelStore persistence migration", () => {
           introDismissed: boolean;
         };
       };
-      expect(parsed.version).toBe(4);
+      expect(parsed.version).toBe(5);
       expect(parsed.state.width).toBe(450);
       expect(parsed.state.preferredAgentId).toBeNull();
     } finally {
@@ -295,7 +295,7 @@ describe("helpPanelStore persistence migration", () => {
       expect(written).toBeDefined();
       const parsed: unknown = JSON.parse(written!);
       expect(parsed).toMatchObject({
-        version: 4,
+        version: 5,
         state: { introDismissed: true },
       });
     } finally {
@@ -357,7 +357,7 @@ describe("helpPanelStore persistence migration", () => {
         version: number;
         state: Record<string, unknown>;
       };
-      expect(parsed.version).toBe(4);
+      expect(parsed.version).toBe(5);
       expect(parsed.state).not.toHaveProperty("isOpen");
     } finally {
       vi.useRealTimers();
@@ -604,7 +604,7 @@ describe("helpPanelStore persistence migration", () => {
           version: number;
           state: { hibernateSessions: Record<string, unknown> };
         };
-        expect(parsed.version).toBe(4);
+        expect(parsed.version).toBe(5);
         expect(parsed.state.hibernateSessions).toEqual({
           "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
         });
@@ -707,6 +707,92 @@ describe("helpPanelStore persistence migration", () => {
       // Other fields still load correctly
       expect(store.getState().preferredAgentId).toBe("claude");
       expect(store.getState().introDismissed).toBe(true);
+    });
+  });
+
+  describe("autoLaunchEnabled (#10699)", () => {
+    it("starts false on a fresh install so opening the panel never auto-bills a session", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().autoLaunchEnabled).toBe(false);
+    });
+
+    it("defaults to false for a returning v4 user with a preferredAgentId set (no carve-out)", async () => {
+      // The whole point of #10699: existing installs must NOT keep silently
+      // auto-launching. A v4 blob has no autoLaunchEnabled field at all.
+      const v4Blob = JSON.stringify({
+        version: 4,
+        state: { width: 400, preferredAgentId: "claude", introDismissed: true },
+      });
+      installLocalStorage({ [STORAGE_KEY]: v4Blob });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().preferredAgentId).toBe("claude");
+      expect(store.getState().autoLaunchEnabled).toBe(false);
+    });
+
+    it("preserves autoLaunchEnabled: true from a persisted blob across rehydration", async () => {
+      const blob = JSON.stringify({
+        version: 5,
+        state: { width: 400, preferredAgentId: "claude", autoLaunchEnabled: true },
+      });
+      installLocalStorage({ [STORAGE_KEY]: blob });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().autoLaunchEnabled).toBe(true);
+    });
+
+    it("falls back to false when persisted autoLaunchEnabled has a non-boolean type", async () => {
+      const malformed = JSON.stringify({
+        version: 5,
+        state: { width: 400, preferredAgentId: null, autoLaunchEnabled: "true" },
+      });
+      installLocalStorage({ [STORAGE_KEY]: malformed });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().autoLaunchEnabled).toBe(false);
+    });
+
+    it("setAutoLaunchEnabled(true) records consent and persists it", async () => {
+      vi.useFakeTimers();
+      try {
+        const backing = installLocalStorage({});
+
+        const { useHelpPanelStore: store } = await import("../helpPanelStore");
+        store.getState().setAutoLaunchEnabled(true);
+        expect(store.getState().autoLaunchEnabled).toBe(true);
+        vi.advanceTimersByTime(400);
+
+        const written = backing.get(STORAGE_KEY);
+        expect(written).toBeDefined();
+        const parsed = JSON.parse(written!) as {
+          version: number;
+          state: Record<string, unknown>;
+        };
+        expect(parsed.version).toBe(5);
+        expect(parsed.state.autoLaunchEnabled).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("setAutoLaunchEnabled(false) flips consent back off", async () => {
+      const blob = JSON.stringify({
+        version: 5,
+        state: { width: 400, preferredAgentId: "claude", autoLaunchEnabled: true },
+      });
+      installLocalStorage({ [STORAGE_KEY]: blob });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      expect(store.getState().autoLaunchEnabled).toBe(true);
+
+      store.getState().setAutoLaunchEnabled(false);
+      expect(store.getState().autoLaunchEnabled).toBe(false);
     });
   });
 

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -51,6 +51,14 @@ interface HelpPanelState {
   agentId: string | null;
   preferredAgentId: string | null;
   /**
+   * User consent to auto-launch a billed agent session when the panel opens.
+   * Defaults to false so opening the panel never starts (and bills) a session
+   * without an explicit user action (#10699). The first-run "Start assistant"
+   * CTA and starter-prompt chips flip this true, so subsequent opens resume the
+   * auto-launch convenience the user has now opted into.
+   */
+  autoLaunchEnabled: boolean;
+  /**
    * Set at rehydration when a persisted preferredAgentId was dropped because the
    * agent is no longer an assistant backend (CLI uninstalled or demoted from
    * tier:"stable"). Transient (never persisted) — drives a one-shot banner so
@@ -89,6 +97,7 @@ interface HelpPanelActions {
   setTerminal: (terminalId: string, agentId: string, sessionId: string | null) => void;
   clearTerminal: () => void;
   setPreferredAgent: (agentId: string | null) => void;
+  setAutoLaunchEnabled: (enabled: boolean) => void;
   clearDroppedPreferredAgent: () => void;
   dismissIntro: () => void;
   markConversationStarted: () => void;
@@ -112,6 +121,7 @@ const initialState: HelpPanelState = {
   terminalId: null,
   agentId: null,
   preferredAgentId: null,
+  autoLaunchEnabled: false,
   droppedPreferredAgentId: null,
   sessionId: null,
   introDismissed: false,
@@ -190,6 +200,8 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       setPreferredAgent: (agentId) =>
         set({ preferredAgentId: agentId, droppedPreferredAgentId: null }),
 
+      setAutoLaunchEnabled: (enabled) => set({ autoLaunchEnabled: enabled }),
+
       clearDroppedPreferredAgent: () => set({ droppedPreferredAgentId: null }),
 
       dismissIntro: () => set({ introDismissed: true }),
@@ -242,11 +254,12 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
     {
       name: "help-panel-storage",
       storage: createDebouncedSafeJSONStorage(300),
-      version: 4,
+      version: 5,
       migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state) => ({
         width: state.width,
         preferredAgentId: state.preferredAgentId,
+        autoLaunchEnabled: state.autoLaunchEnabled,
         introDismissed: state.introDismissed,
         hibernateSessions: state.hibernateSessions,
       }),
@@ -277,6 +290,11 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
           preferredAgentId: isAssistantSupportedAgentId(persisted.preferredAgentId)
             ? persisted.preferredAgentId
             : null,
+          // Default false for everyone, including returning users (v4 had no
+          // such field) — the issue is surprise billing, so preserving the old
+          // auto-launch for existing installs would preserve the reported bug.
+          // A malformed (non-boolean) stored value normalizes to false too.
+          autoLaunchEnabled: persisted.autoLaunchEnabled === true,
           droppedPreferredAgentId,
           introDismissed:
             typeof persisted.introDismissed === "boolean"
@@ -293,5 +311,5 @@ registerPersistedStore({
   storeId: "helpPanelStore",
   store: useHelpPanelStore,
   persistedStateType:
-    "Pick<HelpPanelState, 'width' | 'preferredAgentId' | 'introDismissed' | 'hibernateSessions'>",
+    "Pick<HelpPanelState, 'width' | 'preferredAgentId' | 'autoLaunchEnabled' | 'introDismissed' | 'hibernateSessions'>",
 });


### PR DESCRIPTION
## Summary

Opening the assistant panel was silently starting a billed agent session. This PR gates auto-launch behind explicit user consent and replaces the bare idle empty state with a proper first-run experience.

Resolves #10699.

## Changes

**Consent gate.** New persisted flag `autoLaunchEnabled` (default `false`) on `helpPanelStore`. `HelpSessionController._maybeAutoLaunch` returns early unless consent is granted. The check is placed before the `document.hidden` guard so a visibility-restore epoch bump can't bypass it.

**Migration v4 to v5.** Defaults `autoLaunchEnabled=false` for everyone, including returning users with a `preferredAgentId`. The issue is surprise billing, so preserving auto-launch for existing installs would preserve the bug. A single "Start assistant" click re-enables the convenience.

**First-run empty state.** Replaced the low-contrast idle links with a primary "Start assistant" CTA and three starter-prompt chips. Both record consent (`setAutoLaunchEnabled(true)`) and launch directly. The CTA shows when a single launchable agent exists (preferred or sole-installed). Chips are gated on `!hasEverLaunchedAgent`. When no single launchable agent is available, a "Configure an assistant agent in settings" fallback shows instead.

**Contrast.** Secondary settings and guide links raised from `text-daintree-text/40` to `/70` for WCAG AA.

## Testing

- Store: default false, v4 returning-user migration defaults false, preserves true, non-boolean coerced to false, version bumped to 5.
- Controller: consent gate blocks auto-launch for both preferred-agent and sole-installed-agent paths, survives a visibility-restore epoch bump, never provisions a session when off.
- Component: CTA and starter-chip each record consent and launch; configure-fallback renders with no CTA; hibernated session does not resume when consent is off.