### PR TITLE
fix(mcp): route fullToolSurface through a fail-closed allowlist (#10701)

### DIFF
--- a/docs/architecture/mcp-server.md
+++ b/docs/architecture/mcp-server.md
@@ -91,7 +91,7 @@ type McpTier = "workbench" | "action" | "system" | "external";
 | `workbench` | `WORKBENCH_TIER_TOOLS` — read-only / low-risk introspection (the help-assistant baseline). |
 | `action` | workbench ∪ `ACTION_TIER_ADDONS` (includes `terminal.waitUntilIdle`). |
 | `system` | workbench ∪ action ∪ `SYSTEM_TIER_ADDONS`. |
-| `external` | `MCP_TOOL_ALLOWLIST` — the full vetted tool set for API-key callers (when `fullToolSurface` is on, `external` may bypass the allowlist entirely). |
+| `external` | `MCP_TOOL_ALLOWLIST` — the full vetted tool set for API-key callers (when `fullToolSurface` is on, `external` uses `MCP_FULL_TOOL_SURFACE_ALLOWLIST` — an explicit, fail-closed superset of `MCP_TOOL_ALLOWLIST`, never a bypass). |
 
 `shouldExposeTool` (used by `tools/list`) and `isTierPermitted` (used by `tools/call`) are the two gates. Both **hard-deny `danger === "restricted"`** and any tool whose `mcpVisibility` is `hidden` or `discoverable` — `restricted` actions are never reachable over MCP regardless of tier.
 
@@ -185,7 +185,7 @@ Three axes are independent — do not infer one from another:
 
 - **`danger`** gates the user-facing confirm. `danger:"confirm"` routes the call through an MCP elicitation prompt before dispatch (see [Risk bands and `danger`](#risk-bands-and-danger)); `danger:"safe"` does not. It says nothing about rate limit. `forge.createIssue` is `safe` while `forge.closeIssue` is `confirm`; `forge.approvePR` is `confirm` yet on the `standard` bucket while `forge.createPR` is `confirm` on `mutation`.
 - **Rate limit** is the token bucket (`standard` 30/min, `mutation` 10/min). It is set per-id in `RATE_LIMIT_TOOL_MAP`, not derived from `danger` or write-intent — the browser-open commands `forge.openIssue`/`forge.openPR` are `safe` but `mutation`-bucketed because an LLM retry would pop a duplicate browser tab.
-- **External** marks whether the action is in `MCP_TOOL_ALLOWLIST` and therefore reachable by `external` (API-key) callers. All writes require the `system` tier; the twelve marked `External: no` are reachable _only_ via a `system`-tier session (the in-app help assistant), not by an external API key (unless `fullToolSurface` is enabled, which lets `external` bypass `MCP_TOOL_ALLOWLIST` entirely — see [Tier model](#tier-model-sharedts)), even though they pass the `system` floor.
+- **External** marks whether the action is in `MCP_TOOL_ALLOWLIST` and therefore reachable by `external` (API-key) callers. All writes require the `system` tier; the twelve marked `External: no` are reachable _only_ via a `system`-tier session (the in-app help assistant), not by an external API key (unless `fullToolSurface` is enabled, which switches `external` to `MCP_FULL_TOOL_SURFACE_ALLOWLIST` — a fail-closed superset of `MCP_TOOL_ALLOWLIST`, not a bypass — see [Tier model](#tier-model-sharedts)), even though they pass the `system` floor.
 
 ### Forge reads (`workbench` tier)
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -694,7 +694,6 @@ describe("McpServerService", () => {
   });
 
   it("applies mcpAnnotations overrides on top of kind/danger defaults", async () => {
-    storeState.mcpServer.fullToolSurface = true;
     const { window } = createMockWindow({
       getManifest: () => [
         // Query that requires UX confirmation but is not destructive.
@@ -709,9 +708,9 @@ describe("McpServerService", () => {
         // Command that is semantically a read-only lookup; both readOnly and
         // idempotent hints are forced on via override.
         createManifestEntry({
-          id: "test.readOnlyCommand" as ActionId,
+          id: "git.stageFile" as ActionId,
           title: "Read Only Command",
-          description: "Synthetic read-only command for override coverage",
+          description: "Allowlisted command used for override coverage",
           kind: "command",
           danger: "safe",
           mcpAnnotations: { readOnlyHint: true, idempotentHint: true },
@@ -719,9 +718,9 @@ describe("McpServerService", () => {
         // Query whose readOnly/idempotent hints are explicitly forced off via
         // override — guards against regressing the merge from `??` to `||`.
         createManifestEntry({
-          id: "test.queryOverriddenFalse" as ActionId,
+          id: "git.listCommits" as ActionId,
           title: "Query With False Overrides",
-          description: "Synthetic query whose hints are explicitly false",
+          description: "Allowlisted query whose hints are explicitly false",
           kind: "query",
           danger: "safe",
           mcpAnnotations: { readOnlyHint: false, idempotentHint: false },
@@ -735,8 +734,8 @@ describe("McpServerService", () => {
 
     const result = await client.listTools();
     const generate = result.tools.find((t) => t.name === "copyTree.generate");
-    const readOnlyCmd = result.tools.find((t) => t.name === "test.readOnlyCommand");
-    const queryFalse = result.tools.find((t) => t.name === "test.queryOverriddenFalse");
+    const readOnlyCmd = result.tools.find((t) => t.name === "git.stageFile");
+    const queryFalse = result.tools.find((t) => t.name === "git.listCommits");
 
     // Override flips destructiveHint off; readOnlyHint/idempotentHint still
     // come from the `kind: "query"` default. openWorldHint now defaults to true.
@@ -772,12 +771,11 @@ describe("McpServerService", () => {
   });
 
   it("allows overriding openWorldHint via mcpAnnotations", async () => {
-    storeState.mcpServer.fullToolSurface = true;
     const { window } = createMockWindow({
       getManifest: () => [
         // openWorldHint defaults to true; explicit false override must win.
         createManifestEntry({
-          id: "keybinding.resetAll" as ActionId,
+          id: "worktree.delete" as ActionId,
           title: "Reset All Keybindings",
           description: "Local-only destructive action",
           category: "settings",
@@ -787,7 +785,7 @@ describe("McpServerService", () => {
         }),
         // No override — must default to true (spec-conservative).
         createManifestEntry({
-          id: "github.someTool" as ActionId,
+          id: "forge.createPR" as ActionId,
           title: "Some GitHub Tool",
           description: "Tool without openWorldHint override",
           category: "github",
@@ -807,15 +805,14 @@ describe("McpServerService", () => {
     transports.push(transport);
 
     const result = await client.listTools();
-    const localTool = result.tools.find((t) => t.name === "keybinding.resetAll");
-    const ghTool = result.tools.find((t) => t.name === "github.someTool");
+    const localTool = result.tools.find((t) => t.name === "worktree.delete");
+    const ghTool = result.tools.find((t) => t.name === "forge.createPR");
 
     expect(localTool?.annotations?.openWorldHint).toBe(false);
     expect(ghTool?.annotations?.openWorldHint).toBe(true);
   });
 
   it("defaults openWorldHint to true for all categories per spec", async () => {
-    storeState.mcpServer.fullToolSurface = true;
     const { window } = createMockWindow({
       getManifest: () => [
         createManifestEntry({
@@ -833,7 +830,7 @@ describe("McpServerService", () => {
           kind: "query",
         }),
         createManifestEntry({
-          id: "worktree.create" as ActionId,
+          id: "worktree.createWithRecipe" as ActionId,
           title: "Create Worktree",
           description: "Create a new worktree",
           category: "worktree",
@@ -849,7 +846,7 @@ describe("McpServerService", () => {
     const result = await client.listTools();
     const ghTool = result.tools.find((t) => t.name === "forge.listPRs");
     const systemTool = result.tools.find((t) => t.name === "system.checkCommand");
-    const wtTool = result.tools.find((t) => t.name === "worktree.create");
+    const wtTool = result.tools.find((t) => t.name === "worktree.createWithRecipe");
 
     expect(ghTool?.annotations?.openWorldHint).toBe(true);
     expect(systemTool?.annotations?.openWorldHint).toBe(true);
@@ -2091,7 +2088,7 @@ describe("McpServerService", () => {
     expect(ids).not.toContain("panel.gridLayout.setStrategy");
   });
 
-  it("exposes the full non-restricted surface when fullToolSurface is enabled", async () => {
+  it("keeps non-allowlisted tools off the surface even when fullToolSurface is enabled (#10701)", async () => {
     storeState.mcpServer.fullToolSurface = true;
     const { window } = createMockWindow({
       getManifest: () => [
@@ -2104,7 +2101,7 @@ describe("McpServerService", () => {
         createManifestEntry({
           id: "panel.gridLayout.setStrategy" as ActionId,
           title: "Set grid layout",
-          description: "Power-user UI plumbing",
+          description: "Sensitive UI plumbing — not in the curated allowlist",
         }),
         createManifestEntry({
           id: "internal.dangerous" as ActionId,
@@ -2122,12 +2119,15 @@ describe("McpServerService", () => {
     const result = await client.listTools();
     const ids = result.tools.map((tool) => tool.name);
 
+    // fullToolSurface lifts the floor through the curated full-surface allowlist;
+    // it does not bypass it. Allowlisted tools stay reachable; non-allowlisted
+    // and restricted tools stay hidden.
     expect(ids).toContain("actions.list");
-    expect(ids).toContain("panel.gridLayout.setStrategy");
+    expect(ids).not.toContain("panel.gridLayout.setStrategy");
     expect(ids).not.toContain("internal.dangerous");
   });
 
-  it("dispatches fullToolSurface external tools that are outside the curated allowlist", async () => {
+  it("denies dispatch of non-allowlisted tools even with fullToolSurface enabled (#10701)", async () => {
     storeState.mcpServer.fullToolSurface = true;
     const dispatchMock = vi.fn(
       (payload: DispatchRequest): ActionDispatchResult => ({
@@ -2140,7 +2140,7 @@ describe("McpServerService", () => {
         createManifestEntry({
           id: "panel.gridLayout.setStrategy" as ActionId,
           title: "Set grid layout",
-          description: "Power-user UI plumbing",
+          description: "Sensitive UI plumbing — not in the curated allowlist",
         }),
       ],
       dispatchAction: dispatchMock,
@@ -2157,11 +2157,10 @@ describe("McpServerService", () => {
       })
     );
 
-    expect(result.isError).not.toBe(true);
-    expect(result.content[0].text).toContain('"dispatched": "panel.gridLayout.setStrategy"');
-    expect(dispatchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ actionId: "panel.gridLayout.setStrategy" })
-    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("TIER_NOT_PERMITTED");
+    expect(result.content[0].text).toContain("panel.gridLayout.setStrategy");
+    expect(dispatchMock).not.toHaveBeenCalled();
   });
 
   it("treats non-true fullToolSurface values as curated (fail-closed)", async () => {
@@ -4187,18 +4186,17 @@ describe("McpServerService", () => {
     };
 
     it("advertises outputSchema in listTools for actions with an object resultSchema", async () => {
-      storeState.mcpServer.fullToolSurface = true;
       const { window } = createMockWindow({
         getManifest: () => [
           createManifestEntry({
-            id: "log.getEntries" as ActionId,
+            id: "git.getProjectPulse" as ActionId,
             title: "Get Log Entries",
             description: "Returns log entries",
             kind: "query",
             outputSchema: objectSchema,
           }),
           createManifestEntry({
-            id: "worktree.create" as ActionId,
+            id: "worktree.createWithRecipe" as ActionId,
             title: "Create Worktree",
             description: "Create a worktree",
             kind: "command",
@@ -4218,8 +4216,8 @@ describe("McpServerService", () => {
       transports.push(transport);
 
       const result = await client.listTools();
-      const objectTool = result.tools.find((t) => t.name === "log.getEntries");
-      const primitiveTool = result.tools.find((t) => t.name === "worktree.create");
+      const objectTool = result.tools.find((t) => t.name === "git.getProjectPulse");
+      const primitiveTool = result.tools.find((t) => t.name === "worktree.createWithRecipe");
       const noSchemaTool = result.tools.find((t) => t.name === "actions.list");
 
       expect(objectTool).toBeDefined();
@@ -4231,12 +4229,11 @@ describe("McpServerService", () => {
     });
 
     it("emits structuredContent on callTool when the action has an object outputSchema and an object result", async () => {
-      storeState.mcpServer.fullToolSurface = true;
       const objectResult = { count: 7, label: "ok" };
       const { window } = createMockWindow({
         getManifest: () => [
           createManifestEntry({
-            id: "log.getEntries" as ActionId,
+            id: "git.getProjectPulse" as ActionId,
             title: "Get Log Entries",
             description: "Returns log entries",
             kind: "query",
@@ -4252,7 +4249,7 @@ describe("McpServerService", () => {
 
       await client.listTools();
       const result = (await client.callTool({
-        name: "log.getEntries",
+        name: "git.getProjectPulse",
         arguments: {},
       })) as {
         content: Array<{ type: string; text: string }>;
@@ -4265,11 +4262,10 @@ describe("McpServerService", () => {
     });
 
     it("omits structuredContent when the action has a primitive resultSchema", async () => {
-      storeState.mcpServer.fullToolSurface = true;
       const { window } = createMockWindow({
         getManifest: () => [
           createManifestEntry({
-            id: "worktree.create" as ActionId,
+            id: "worktree.createWithRecipe" as ActionId,
             title: "Create Worktree",
             description: "Create a worktree",
             kind: "command",
@@ -4285,7 +4281,7 @@ describe("McpServerService", () => {
 
       await client.listTools();
       const result = (await client.callTool({
-        name: "worktree.create",
+        name: "worktree.createWithRecipe",
         arguments: {},
       })) as {
         content: Array<{ type: string; text: string }>;
@@ -4361,11 +4357,10 @@ describe("McpServerService", () => {
     });
 
     it("does not emit structuredContent on failed tool calls", async () => {
-      storeState.mcpServer.fullToolSurface = true;
       const { window } = createMockWindow({
         getManifest: () => [
           createManifestEntry({
-            id: "log.getEntries" as ActionId,
+            id: "git.getProjectPulse" as ActionId,
             title: "Get Log Entries",
             description: "Returns log entries",
             kind: "query",
@@ -4384,7 +4379,7 @@ describe("McpServerService", () => {
 
       await client.listTools();
       const result = (await client.callTool({
-        name: "log.getEntries",
+        name: "git.getProjectPulse",
         arguments: {},
       })) as {
         content: Array<{ type: string; text: string }>;

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -220,9 +220,10 @@ function makeManifestEntry(id: string): ActionManifestEntry {
 }
 
 describe("sessionServer tools/list handler", () => {
-  // tier "external" + fullToolSurface bypasses the per-id allowlist in
-  // shouldExposeTool, so any non-restricted entry surfaces — keeps these tests
-  // decoupled from TIER_ALLOWLISTS membership.
+  // tier "external" + fullToolSurface routes through MCP_FULL_TOOL_SURFACE_ALLOWLIST
+  // (#10701 — it no longer bypasses the allowlist). These manifest-plumbing tests
+  // therefore use allowlisted action ids so the live/cache/fail-closed paths are
+  // exercised independent of exposure gating.
   function fullSurfaceDeps(overrides?: Partial<SessionServerDeps>): SessionServerDeps {
     return fakeDeps({
       sessionStore: fakeSessionStore("external"),
@@ -237,8 +238,8 @@ describe("sessionServer tools/list handler", () => {
 
   it("returns the live manifest when requestManifest succeeds", async () => {
     const deps = fullSurfaceDeps({
-      requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("fresh_tool")]),
-      getCachedManifest: vi.fn(() => [makeManifestEntry("stale_tool")]),
+      requestManifest: vi.fn().mockResolvedValue([makeManifestEntry("actions.list")]),
+      getCachedManifest: vi.fn(() => [makeManifestEntry("terminal.list")]),
     });
     const server = createSessionServer("tools-list-fresh", deps);
     await server.connect(makeMockTransport());
@@ -246,7 +247,7 @@ describe("sessionServer tools/list handler", () => {
     const result = await listTools(server);
 
     // Fresh result wins over the (different) cache, proving the live path is used.
-    expect(result.tools.map((t) => t.name)).toEqual(["fresh_tool"]);
+    expect(result.tools.map((t) => t.name)).toEqual(["actions.list"]);
   });
 
   it("falls back to the cached manifest, warning with the error, when requestManifest rejects", async () => {
@@ -254,14 +255,14 @@ describe("sessionServer tools/list handler", () => {
     const rejection = new Error("Manifest request timed out");
     const deps = fullSurfaceDeps({
       requestManifest: vi.fn().mockRejectedValue(rejection),
-      getCachedManifest: vi.fn(() => [makeManifestEntry("cached_tool")]),
+      getCachedManifest: vi.fn(() => [makeManifestEntry("git.commit")]),
     });
     const server = createSessionServer("tools-list-fallback", deps);
     await server.connect(makeMockTransport());
 
     const result = await listTools(server);
 
-    expect(result.tools.map((t) => t.name)).toEqual(["cached_tool"]);
+    expect(result.tools.map((t) => t.name)).toEqual(["git.commit"]);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     // The rejection must reach the log so operators can diagnose the stale serve.
     expect(warnSpy.mock.calls[0]).toContain(rejection);
@@ -272,7 +273,7 @@ describe("sessionServer tools/list handler", () => {
     const deps = fullSurfaceDeps({
       requestManifest: vi.fn().mockRejectedValue(new Error("Manifest request timed out")),
       getCachedManifest: vi.fn(() => [
-        makeManifestEntry("allowed_tool"),
+        makeManifestEntry("actions.list"),
         { ...makeManifestEntry("restricted_tool"), danger: "restricted" as const },
       ]),
     });
@@ -282,7 +283,7 @@ describe("sessionServer tools/list handler", () => {
     const result = await listTools(server);
 
     // shouldExposeTool drops restricted entries even on the cache path.
-    expect(result.tools.map((t) => t.name)).toEqual(["allowed_tool"]);
+    expect(result.tools.map((t) => t.name)).toEqual(["actions.list"]);
   });
 
   it("fails closed with an McpError when requestManifest rejects and no cache exists", async () => {
@@ -2835,8 +2836,9 @@ describe("structuredContent for terminal query actions (#10676)", () => {
     return (result as { content: { text: string }[] }).content[0].text;
   }
 
-  // tier "external" + getFullToolSurface bypasses the per-id allowlist, so the
-  // call reaches dispatch regardless of TIER_ALLOWLISTS membership.
+  // tier "external" + getFullToolSurface routes through the full-surface allowlist
+  // (#10701); the ids exercised here (terminal.list/getStatus/getOutput) are all
+  // curated-allowlist members, so the call reaches dispatch.
   function deps(id: string, payload: unknown, withSchema = true): SessionServerDeps {
     return fakeDeps({
       sessionStore: fakeSessionStore("external"),

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -339,6 +339,52 @@ describe("shouldExposeTool", () => {
   });
 });
 
+// #10701: fullToolSurface must route through the curated full-surface allowlist
+// (MCP_FULL_TOOL_SURFACE_ALLOWLIST), not bypass the allowlist and trust the
+// author-set `danger` field. Sensitive side-effecting actions that are absent
+// from the allowlist must stay blocked even when fullToolSurface is on, and the
+// gate must agree across exposure (shouldExposeTool) and dispatch
+// (isTierPermitted) — a divergence would advertise a tool the dispatcher then
+// rejects, or vice versa (#7155).
+describe("fullToolSurface allowlist invariants (#10701)", () => {
+  // danger:"safe" actions with real side effects that are deliberately NOT in
+  // the curated external allowlist. fullToolSurface used to expose all of these.
+  const SENSITIVE_NON_ALLOWLISTED = [
+    "system.openExternal",
+    "system.openPath",
+    "env.global.set",
+    "app.quit",
+  ];
+
+  it.each(SENSITIVE_NON_ALLOWLISTED)(
+    "does not expose sensitive non-allowlisted action %s even with fullToolSurface",
+    (actionId) => {
+      const entry = makeEntry({ id: actionId, danger: "safe" });
+      expect(shouldExposeTool(entry, "external", true)).toBe(false);
+    }
+  );
+
+  it.each(SENSITIVE_NON_ALLOWLISTED)(
+    "does not permit dispatch of sensitive non-allowlisted action %s even with fullToolSurface",
+    (actionId) => {
+      expect(isTierPermitted("external", actionId, true)).toBe(false);
+    }
+  );
+
+  it("exposure and dispatch gates agree for a sensitive non-allowlisted action", () => {
+    const entry = makeEntry({ id: "system.openExternal", danger: "safe" });
+    expect(shouldExposeTool(entry, "external", true)).toBe(
+      isTierPermitted("external", "system.openExternal", true)
+    );
+  });
+
+  it("still reaches curated-allowlist tools with fullToolSurface on", () => {
+    const entry = makeEntry({ id: "actions.list" });
+    expect(shouldExposeTool(entry, "external", true)).toBe(true);
+    expect(isTierPermitted("external", "actions.list", true)).toBe(true);
+  });
+});
+
 describe("buildAnnotations", () => {
   it("safe command → destructiveHint: false", () => {
     const entry = makeEntry({ kind: "command", danger: "safe" });

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -23,6 +23,8 @@ import {
   resolveTokenTier,
   shouldExposeTool,
 } from "../tierAuth.js";
+import { MCP_FULL_TOOL_SURFACE_ALLOWLIST, TIER_ALLOWLISTS } from "../shared.js";
+import { BUILT_IN_ACTION_IDS } from "../../../../shared/config/actionIds.js";
 import type { ActionManifestEntry } from "../../../../shared/types/actions.js";
 
 beforeEach(() => {
@@ -347,14 +349,28 @@ describe("shouldExposeTool", () => {
 // (isTierPermitted) — a divergence would advertise a tool the dispatcher then
 // rejects, or vice versa (#7155).
 describe("fullToolSurface allowlist invariants (#10701)", () => {
-  // danger:"safe" actions with real side effects that are deliberately NOT in
-  // the curated external allowlist. fullToolSurface used to expose all of these.
+  const builtInIds = new Set<string>(BUILT_IN_ACTION_IDS);
+
+  // Real, currently-shipping danger:"safe" actions with genuine side effects
+  // (launch a URL/path in the OS, inject env vars, clone an arbitrary repo)
+  // that are deliberately absent from the curated external allowlist.
+  // fullToolSurface used to expose every one of these.
   const SENSITIVE_NON_ALLOWLISTED = [
     "system.openExternal",
     "system.openPath",
     "env.global.set",
-    "app.quit",
+    "project.cloneRepo",
   ];
+
+  // Pin the sentinels to ground truth so the suite below is a real regression
+  // guard, not "unknown strings aren't in a set": each must be an actual
+  // built-in action that is genuinely outside the curated external allowlist.
+  // If one is renamed or promoted into the allowlist, this fails loudly rather
+  // than silently asserting nothing.
+  it.each(SENSITIVE_NON_ALLOWLISTED)("%s is a real built-in action outside the allowlist", (id) => {
+    expect(builtInIds.has(id)).toBe(true);
+    expect(TIER_ALLOWLISTS.external.has(id)).toBe(false);
+  });
 
   it.each(SENSITIVE_NON_ALLOWLISTED)(
     "does not expose sensitive non-allowlisted action %s even with fullToolSurface",
@@ -382,6 +398,29 @@ describe("fullToolSurface allowlist invariants (#10701)", () => {
     const entry = makeEntry({ id: "actions.list" });
     expect(shouldExposeTool(entry, "external", true)).toBe(true);
     expect(isTierPermitted("external", "actions.list", true)).toBe(true);
+  });
+
+  // The full surface is a strict *superset* of the curated external allowlist:
+  // fullToolSurface can only ever widen, never narrow. This guards against a
+  // future edit that makes the opt-in surface smaller than the default
+  // external surface (which would silently revoke tools when the flag is on).
+  it("is a superset of the curated external allowlist", () => {
+    for (const id of TIER_ALLOWLISTS.external) {
+      expect(MCP_FULL_TOOL_SURFACE_ALLOWLIST.has(id)).toBe(true);
+    }
+  });
+
+  // fullToolSurface=false must fall through to the plain external allowlist,
+  // independent of the full-surface set — so the two paths stay distinct even
+  // once the add-on seam is non-empty.
+  it("ignores the full-surface add-ons when fullToolSurface is off", () => {
+    const entry = makeEntry({ id: "actions.list" });
+    expect(shouldExposeTool(entry, "external", false)).toBe(
+      TIER_ALLOWLISTS.external.has("actions.list")
+    );
+    expect(isTierPermitted("external", "actions.list", false)).toBe(
+      TIER_ALLOWLISTS.external.has("actions.list")
+    );
   });
 });
 

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -441,6 +441,34 @@ const MCP_TOOL_ALLOWLIST_ENTRIES = [
 
 const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set(MCP_TOOL_ALLOWLIST_ENTRIES);
 
+/**
+ * Additional tools exposed ONLY to an `external` session that has opted into
+ * `fullToolSurface`, on top of {@link MCP_TOOL_ALLOWLIST}. This is the explicit,
+ * fail-closed seam for widening the api-key surface: `fullToolSurface` is a
+ * *floor-lifting* opt-in, never a bypass. Previously the flag short-circuited
+ * the allowlist entirely and let an external client reach any action that
+ * wasn't `danger: "restricted"` / `mcpVisibility: "hidden"` — trusting the
+ * author-set `danger` field as a security ceiling. The MCP spec is explicit
+ * that tool annotations (and by extension a self-declared danger rating) are
+ * untrusted UX hints, not an access-control boundary; the enforceable boundary
+ * is this server-side allowlist (#10701). Each future addition must be a
+ * deliberate, individually-vetted entry here — empty by default so that newly
+ * added safe-classified actions never silently leak to api-key callers.
+ */
+const MCP_FULL_TOOL_SURFACE_ADDON_ENTRIES = [] as const satisfies readonly BuiltInActionId[];
+
+/**
+ * The complete tool surface reachable by an `external` session with
+ * `fullToolSurface` enabled: the curated external allowlist plus the vetted
+ * add-on set above. Always a *superset* of {@link MCP_TOOL_ALLOWLIST} — the
+ * opt-in can only widen, never narrow, so it can never accidentally make the
+ * full surface smaller than the default external surface.
+ */
+export const MCP_FULL_TOOL_SURFACE_ALLOWLIST: ReadonlySet<string> = unionSet(
+  MCP_TOOL_ALLOWLIST,
+  new Set<string>(MCP_FULL_TOOL_SURFACE_ADDON_ENTRIES)
+);
+
 export const TIER_ALLOWLISTS: Readonly<Record<McpTier, ReadonlySet<string>>> = {
   workbench: WORKBENCH_TOOLS,
   action: unionSet(WORKBENCH_TOOLS, ACTION_TIER_ADDONS),

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -4,7 +4,7 @@ import { deriveBand, BAND_OVERRIDES } from "../../../shared/utils/actionRiskBand
 import type { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
 import { mcpPaneConfigService } from "../McpPaneConfigService.js";
 import type { HelpTokenValidator } from "./shared.js";
-import { type McpTier, TIER_ALLOWLISTS } from "./shared.js";
+import { type McpTier, TIER_ALLOWLISTS, MCP_FULL_TOOL_SURFACE_ALLOWLIST } from "./shared.js";
 
 export { deriveBand, BAND_OVERRIDES };
 
@@ -98,7 +98,7 @@ export function shouldExposeTool(
     return false;
   }
   if (tier === "external" && fullToolSurface) {
-    return true;
+    return MCP_FULL_TOOL_SURFACE_ALLOWLIST.has(entry.id);
   }
   return TIER_ALLOWLISTS[tier].has(entry.id);
 }
@@ -109,7 +109,7 @@ export function isTierPermitted(
   fullToolSurface: boolean
 ): boolean {
   if (tier === "external" && fullToolSurface) {
-    return true;
+    return MCP_FULL_TOOL_SURFACE_ALLOWLIST.has(actionId);
   }
   return TIER_ALLOWLISTS[tier].has(actionId);
 }


### PR DESCRIPTION
## Summary

`fullToolSurface` (the external API-key opt-in) short-circuited both MCP gates -- `shouldExposeTool` and `isTierPermitted` -- to `return true` *before* consulting the curated external allowlist, leaving only `danger:"restricted"` and `mcpVisibility:"hidden"/"discoverable"` as guards. An enumeration of every action definition found **335 of 426 actions leaked** this way: zero actions use `danger:"restricted"` and only 8 are visibility-gated, so the curated allowlist was the *sole* barrier for 335 actions and `fullToolSurface` discarded it. Genuinely sensitive side-effecting actions became reachable to an external client with no allowlist filter and no confirmation: `system.openExternal`, `system.openPath`, `env.global.set`/`env.project.set`, `terminal.kill`, `app.quit`, `project.cloneRepo`, forge writes, and more.

The MCP spec is explicit that tool annotations (and by extension a self-declared `danger` rating) are untrusted UX hints, not an access-control boundary. The enforceable boundary is the server-side allowlist. This is the same bug class as #8331 (plugin self-declared `danger`).

## Fix

`fullToolSurface` now routes through an explicit, fail-closed `MCP_FULL_TOOL_SURFACE_ALLOWLIST` instead of bypassing the allowlist:

- **`shared.ts`** -- new `MCP_FULL_TOOL_SURFACE_ALLOWLIST = unionSet(MCP_TOOL_ALLOWLIST, addons)` with an explicit, currently-empty vetted add-on seam (`MCP_FULL_TOOL_SURFACE_ADDON_ENTRIES`, `as const satisfies readonly BuiltInActionId[]`). It is always a *superset* of the curated external allowlist -- the opt-in can only widen, never narrow or bypass. Each future addition is a deliberate, individually-vetted entry, so newly added safe-classified actions never silently leak to api-key callers.
- **`tierAuth.ts`** -- both gates now gate the external `fullToolSurface` path on `MCP_FULL_TOOL_SURFACE_ALLOWLIST.has(...)`, fixed in lockstep (#7155) so exposure and dispatch never diverge. `danger` remains a floor (confirm/restricted still apply), never a ceiling.

## Tests

- New `fullToolSurface allowlist invariants (#10701)` block in `tierAuth.test.ts`: sentinels tied to `BUILT_IN_ACTION_IDS` + asserted outside the curated allowlist; sensitive actions (`system.openExternal`/`openPath`, `env.global.set`, `project.cloneRepo`) stay hidden **and** non-dispatchable with `fullToolSurface` on; exposure/dispatch gates agree; curated tools still reachable; superset invariant; `fullToolSurface=false` fall-through guard.
- Flipped 2 change-detector tests that asserted the old bypass; migrated 9 annotation/output-schema/manifest-plumbing tests that abused the bypass to surface synthetic ids onto curated-allowlist ids.
- `docs/architecture/mcp-server.md`: stopped describing the bypass as intended behavior.

380 tests pass locally across the affected suites.

## Out of scope

Terminal arming (`terminal.arm`/`disarm`/`disarmAll`) -- intentionally `danger:"safe"` and in the curated allowlist; unchanged.

Closes #10701