### PR TITLE
feat(assistant): add a model picker to the assistant settings

### DIFF
--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -81,6 +81,7 @@ describe("registerHelpAssistantHandlers", () => {
       tier: "action",
       bypassPermissions: false,
       auditRetention: 7,
+      modelId: "",
       customArgs: "",
       idleHibernateMinutes: 30,
     });
@@ -102,6 +103,7 @@ describe("registerHelpAssistantHandlers", () => {
       tier: "system",
       bypassPermissions: true,
       auditRetention: 30,
+      modelId: "",
       customArgs: "",
       idleHibernateMinutes: 30,
     });
@@ -274,6 +276,7 @@ describe("registerHelpAssistantHandlers", () => {
       tier: "action",
       bypassPermissions: false,
       auditRetention: 7,
+      modelId: "",
       customArgs: "",
       idleHibernateMinutes: 30,
     });
@@ -458,6 +461,104 @@ describe("registerHelpAssistantHandlers", () => {
 
     const result = await handler(null);
     expect(result).toMatchObject({ customArgs: "--model sonnet" });
+  });
+
+  it("persists a valid modelId", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: "claude-sonnet-4-6" });
+
+    expect(storeMock.set).toHaveBeenCalledExactlyOnceWith(
+      "helpAssistant.modelId",
+      "claude-sonnet-4-6"
+    );
+  });
+
+  it("persists an empty modelId so the user can clear back to the CLI default", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: "" });
+
+    expect(storeMock.set).toHaveBeenCalledExactlyOnceWith("helpAssistant.modelId", "");
+  });
+
+  it("trims surrounding whitespace from modelId", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: "  gpt-5.5  " });
+
+    expect(storeMock.set).toHaveBeenCalledExactlyOnceWith("helpAssistant.modelId", "gpt-5.5");
+  });
+
+  it("rejects a modelId with internal whitespace (not a single token)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: "claude sonnet" });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("rejects a modelId that would inject a bare flag (leading dash)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: "--dangerously-skip-permissions" });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("rejects a modelId containing shell metacharacters", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: "sonnet;rm -rf /" });
+    await handler(null, { modelId: "$(whoami)" });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("rejects a modelId that is not a string", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: 42 as unknown as string });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("caps modelId length at 200 characters", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { modelId: "m".repeat(250) });
+
+    const call = storeMock.set.mock.calls[0];
+    expect(call?.[0]).toBe("helpAssistant.modelId");
+    expect((call?.[1] as string).length).toBe(200);
+  });
+
+  it("loads a valid stored modelId from the store", async () => {
+    storeMock.get.mockReturnValue({ modelId: "claude-opus-4-8" });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ modelId: "claude-opus-4-8" });
+  });
+
+  it("sanitizes a corrupted stored modelId back to the empty-string default", async () => {
+    storeMock.get.mockReturnValue({
+      modelId: "sonnet;rm -rf /" as unknown as string,
+    });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ modelId: "" });
   });
 });
 

--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -502,6 +502,27 @@ describe("registerHelpAssistantHandlers", () => {
     expect(storeMock.set).not.toHaveBeenCalled();
   });
 
+  it("rejects a modelId with an internal tab rather than collapsing it", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    // A tab is a control char; stripping-before-checking would silently coerce
+    // this to "claudesonnet". It must be rejected as a non-single-token value.
+    await handler(null, { modelId: "claude\tsonnet" });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("accepts a modelId exactly at the 200-char cap unchanged", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    const exact = "m".repeat(200);
+    await handler(null, { modelId: exact });
+
+    expect(storeMock.set).toHaveBeenCalledExactlyOnceWith("helpAssistant.modelId", exact);
+  });
+
   it("rejects a modelId that would inject a bare flag (leading dash)", async () => {
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -75,19 +75,21 @@ function sanitizeCustomArgs(value: unknown): string | undefined {
 }
 
 // A valid model ID is a single shell-safe token. The empty string is valid and
-// means "use the CLI default" (no `--model` injected). Anything with
-// whitespace, a leading `-` (would inject a bare flag), or shell metacharacters
-// is rejected outright rather than coerced — the picker only ever emits clean
-// IDs, so a dirty value is corruption, not a near-miss to salvage.
+// means "use the CLI default" (no `--model` injected). Anything with internal
+// whitespace, control characters, a leading `-` (would inject a bare flag), or
+// shell metacharacters is rejected outright rather than coerced — the picker
+// only ever emits clean IDs, so a dirty value is corruption, not a near-miss to
+// salvage. Whitespace/control chars are checked, not stripped, so a tab or
+// newline can't be silently collapsed into a bogus token.
 function sanitizeModelId(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed === "") return "";
   // eslint-disable-next-line no-control-regex
-  const cleaned = value.replace(/[\x00-\x1f\x7f]/g, "").trim();
-  if (cleaned === "") return "";
-  if (/\s/.test(cleaned)) return undefined;
-  if (cleaned.startsWith("-")) return undefined;
-  if (hasShellMetachar(cleaned)) return undefined;
-  return cleaned.slice(0, MODEL_ID_MAX_LEN);
+  if (/[\s\x00-\x1f\x7f]/.test(trimmed)) return undefined;
+  if (trimmed.startsWith("-")) return undefined;
+  if (hasShellMetachar(trimmed)) return undefined;
+  return trimmed.slice(0, MODEL_ID_MAX_LEN);
 }
 
 function sanitizeStored(stored: unknown): Partial<HelpAssistantSettings> {

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -26,6 +26,9 @@ async function getMcpServerService(): Promise<McpServerSingleton> {
 }
 
 const CUSTOM_ARGS_MAX_LEN = 10000;
+// A model ID is a single CLI token (e.g. "claude-sonnet-4-6"); cap well above
+// any realistic ID so a corrupted store value can't bloat the launch command.
+const MODEL_ID_MAX_LEN = 200;
 
 const HELP_ASSISTANT_DEFAULTS: HelpAssistantSettings = {
   docSearch: true,
@@ -33,6 +36,7 @@ const HELP_ASSISTANT_DEFAULTS: HelpAssistantSettings = {
   tier: "action",
   bypassPermissions: false,
   auditRetention: 7,
+  modelId: "",
   customArgs: "",
   idleHibernateMinutes: 30,
 };
@@ -43,6 +47,7 @@ const HELP_ASSISTANT_KEYS = [
   "tier",
   "bypassPermissions",
   "auditRetention",
+  "modelId",
   "customArgs",
   "idleHibernateMinutes",
 ] as const satisfies ReadonlyArray<keyof HelpAssistantSettings>;
@@ -69,6 +74,22 @@ function sanitizeCustomArgs(value: unknown): string | undefined {
   return collapsed.slice(0, CUSTOM_ARGS_MAX_LEN);
 }
 
+// A valid model ID is a single shell-safe token. The empty string is valid and
+// means "use the CLI default" (no `--model` injected). Anything with
+// whitespace, a leading `-` (would inject a bare flag), or shell metacharacters
+// is rejected outright rather than coerced — the picker only ever emits clean
+// IDs, so a dirty value is corruption, not a near-miss to salvage.
+function sanitizeModelId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  // eslint-disable-next-line no-control-regex
+  const cleaned = value.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  if (cleaned === "") return "";
+  if (/\s/.test(cleaned)) return undefined;
+  if (cleaned.startsWith("-")) return undefined;
+  if (hasShellMetachar(cleaned)) return undefined;
+  return cleaned.slice(0, MODEL_ID_MAX_LEN);
+}
+
 function sanitizeStored(stored: unknown): Partial<HelpAssistantSettings> {
   if (!stored || typeof stored !== "object") return {};
   const out: Partial<HelpAssistantSettings> = {};
@@ -93,6 +114,8 @@ function sanitizeStored(stored: unknown): Partial<HelpAssistantSettings> {
   if (isValidIdleHibernateMinutes(record.idleHibernateMinutes)) {
     out.idleHibernateMinutes = record.idleHibernateMinutes;
   }
+  const sanitizedModelId = sanitizeModelId(record.modelId);
+  if (sanitizedModelId !== undefined) out.modelId = sanitizedModelId;
   const sanitizedArgs = sanitizeCustomArgs(record.customArgs);
   if (sanitizedArgs !== undefined) out.customArgs = sanitizedArgs;
   return out;
@@ -149,6 +172,11 @@ export const helpAssistantNamespace = defineIpcNamespace({
           let storedValue: unknown = value;
           if (field === "customArgs") {
             const sanitized = sanitizeCustomArgs(value);
+            if (sanitized === undefined) continue;
+            storedValue = sanitized;
+          }
+          if (field === "modelId") {
+            const sanitized = sanitizeModelId(value);
             if (sanitized === undefined) continue;
             storedValue = sanitized;
           }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -2015,7 +2015,15 @@ export interface HelpAssistantSettings {
   bypassPermissions: boolean;
   /** How long to retain help-session audit logs. 7 = 7 days, 30 = 30 days, 0 = off. Defaults to 7. */
   auditRetention: HelpAssistantAuditRetention;
-  /** Whitespace-separated CLI flags appended at assistant launch (e.g. "--model sonnet"). Defaults to "". */
+  /**
+   * Model the assistant launches with, injected as `--model <id>` ahead of
+   * {@link customArgs} so a `--model` in custom args still wins as the advanced
+   * override. Empty string means "use the CLI's default model" (no flag).
+   * Model IDs are agent-specific, so this is reset whenever the agent changes.
+   * Defaults to "".
+   */
+  modelId: string;
+  /** Whitespace-separated CLI flags appended at assistant launch (advanced override). Defaults to "". */
   customArgs: string;
   /**
    * Minutes the assistant panel must be continuously hidden before its PTY is

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -260,6 +260,19 @@ export function HelpPanel({
     pinnedContext.worktreeId !== focusedWorktreeId;
 
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
+  // The model the live session actually launched with, read from its persisted
+  // launch flags (not current settings — those can drift after the session
+  // starts). `lastIndexOf` so a custom-args `--model` override wins, matching the
+  // CLI's last-flag semantics. Resolved to the catalog short label when known.
+  const launchedModelLabel = useMemo(() => {
+    const flags = terminalPty?.agentLaunchFlags;
+    if (!flags || !agentId) return null;
+    const idx = flags.lastIndexOf("--model");
+    if (idx === -1 || idx + 1 >= flags.length) return null;
+    const modelId = flags[idx + 1];
+    if (!modelId) return null;
+    return getAgentConfig(agentId)?.models?.find((m) => m.id === modelId)?.shortLabel ?? modelId;
+  }, [terminalPty?.agentLaunchFlags, agentId]);
   const effectiveAgentId = isBuiltInAgentId(agentId) ? agentId : undefined;
   const showHybridInputBar = shouldShowHybridInputBar({
     hasAgentIdentity: effectiveAgentId !== undefined,
@@ -1078,18 +1091,32 @@ export function HelpPanel({
               // and frees up the tight footer width.
               <span
                 className="flex items-center gap-1 shrink-0"
-                title={`Assistant agent: ${agentConfig.name}`}
+                title={
+                  launchedModelLabel
+                    ? `Assistant agent: ${agentConfig.name} · ${launchedModelLabel}`
+                    : `Assistant agent: ${agentConfig.name}`
+                }
               >
                 <DaintreeIcon className="w-3.5 h-3.5" />
                 Assistant
+                {launchedModelLabel && (
+                  <span className="text-daintree-text/50">· {launchedModelLabel}</span>
+                )}
               </span>
             ) : (
               <span
                 className="flex items-center gap-1 shrink-0"
-                title={`Assistant agent: ${agentConfig.name}`}
+                title={
+                  launchedModelLabel
+                    ? `Assistant agent: ${agentConfig.name} · ${launchedModelLabel}`
+                    : `Assistant agent: ${agentConfig.name}`
+                }
               >
                 <agentConfig.icon className="w-3.5 h-3.5" />
                 {agentConfig.name}
+                {launchedModelLabel && (
+                  <span className="text-daintree-text/50">· {launchedModelLabel}</span>
+                )}
               </span>
             )}
           </span>

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -267,9 +267,21 @@ export function HelpPanel({
   const launchedModelLabel = useMemo(() => {
     const flags = terminalPty?.agentLaunchFlags;
     if (!flags || !agentId) return null;
-    const idx = flags.lastIndexOf("--model");
-    if (idx === -1 || idx + 1 >= flags.length) return null;
-    const modelId = flags[idx + 1];
+    // Scan from the end so a later (custom-args) --model override wins, matching
+    // the CLI's last-flag semantics. Handles both "--model X" and "--model=X",
+    // and ignores a dangling "--model" or one followed by another flag.
+    let modelId: string | null = null;
+    for (let i = flags.length - 1; i >= 0; i--) {
+      const flag = flags[i];
+      if (flag.startsWith("--model=")) {
+        modelId = flag.slice("--model=".length);
+        break;
+      }
+      if (flag === "--model" && i + 1 < flags.length && !flags[i + 1].startsWith("-")) {
+        modelId = flags[i + 1];
+        break;
+      }
+    }
     if (!modelId) return null;
     return getAgentConfig(agentId)?.models?.find((m) => m.id === modelId)?.shortLabel ?? modelId;
   }, [terminalPty?.agentLaunchFlags, agentId]);

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -273,12 +273,14 @@ export function HelpPanel({
     let modelId: string | null = null;
     for (let i = flags.length - 1; i >= 0; i--) {
       const flag = flags[i];
+      if (!flag) continue;
       if (flag.startsWith("--model=")) {
         modelId = flag.slice("--model=".length);
         break;
       }
-      if (flag === "--model" && i + 1 < flags.length && !flags[i + 1].startsWith("-")) {
-        modelId = flags[i + 1];
+      const next = flags[i + 1];
+      if (flag === "--model" && next && !next.startsWith("-")) {
+        modelId = next;
         break;
       }
     }

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -35,6 +35,8 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
+import { agentCapabilitiesClient } from "@/clients/agentCapabilitiesClient";
+import type { AgentModelConfig } from "@shared/config/agentRegistry";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import type {
   HelpAssistantSettings,
@@ -60,9 +62,14 @@ const DEFAULT_SETTINGS: HelpAssistantSettings = {
   tier: "action",
   bypassPermissions: false,
   auditRetention: 7,
+  modelId: "",
   customArgs: "",
   idleHibernateMinutes: 30,
 };
+
+// Radix Select rejects an empty-string item value, so the "use the CLI default"
+// choice carries a sentinel in the dropdown and maps back to "" on persist.
+const MODEL_DEFAULT_SENTINEL = "__default__";
 
 const TIER_OPTIONS = [
   { value: "workbench", label: "Workbench — read-only" },
@@ -194,6 +201,52 @@ export function DaintreeAssistantSettingsTab() {
   // suggest a value is set when it isn't, leaving onChange unfired and the help
   // panel still in its empty state. The placeholder makes "no selection" explicit.
   const agentSelectValue = preferredAgentId ?? "";
+
+  // Resolved model catalog for the currently-preferred agent. `null` means "not
+  // loaded / unavailable" (we render nothing); an empty array means "agent has
+  // no models" (also nothing). The model picker only appears once a non-empty
+  // catalog resolves for the selected agent.
+  const [resolvedModels, setResolvedModels] = useState<AgentModelConfig[] | null>(null);
+
+  useEffect(() => {
+    if (!preferredAgentId) {
+      setResolvedModels(null);
+      return;
+    }
+    let cancelled = false;
+    setResolvedModels(null);
+    agentCapabilitiesClient
+      .getResolvedModelList(preferredAgentId)
+      .then((catalog) => {
+        if (cancelled) return;
+        setResolvedModels(catalog?.models ?? []);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setResolvedModels([]);
+        logError("Failed to load model catalog for assistant tab", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [preferredAgentId]);
+
+  const modelOptions = useMemo(() => {
+    const models = resolvedModels ?? [];
+    const options = [
+      { value: MODEL_DEFAULT_SENTINEL, label: "Default (CLI default)" },
+      ...models.map((m) => ({ value: m.id, label: m.name })),
+    ];
+    // A persisted model that's no longer in the catalog (custom CLI, renamed
+    // model) still needs a matching option or Radix shows a blank trigger.
+    if (settings.modelId && !models.some((m) => m.id === settings.modelId)) {
+      options.push({ value: settings.modelId, label: settings.modelId });
+    }
+    return options;
+  }, [resolvedModels, settings.modelId]);
+
+  const modelSelectValue = settings.modelId || MODEL_DEFAULT_SENTINEL;
+  const showModelPicker = Boolean(resolvedModels && resolvedModels.length > 0);
 
   useEffect(() => {
     let cancelled = false;
@@ -432,6 +485,13 @@ export function DaintreeAssistantSettingsTab() {
 
   const handleAgentChange = (value: string) => {
     setPreferredAgent(value || null);
+    // Model IDs are agent-specific — a Claude model passed to Gemini's --model
+    // would break the launch — so clear any stale selection on agent change.
+    if (settings.modelId) void persist({ modelId: "" });
+  };
+
+  const handleModelChange = (value: string) => {
+    void persist({ modelId: value === MODEL_DEFAULT_SENTINEL ? "" : value });
   };
 
   const handleCustomArgsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -542,13 +602,23 @@ export function DaintreeAssistantSettingsTab() {
           placeholder="Choose an agent"
           disabled={loading || agentOptions.length === 0}
         />
+        {showModelPicker && (
+          <SettingsSelect
+            label="Model"
+            description="The model the assistant launches with. Custom CLI args override this."
+            value={modelSelectValue}
+            onValueChange={handleModelChange}
+            options={modelOptions}
+            disabled={loading}
+          />
+        )}
         <SettingsInput
           label="Custom CLI args"
           description={
             <>
-              Whitespace-separated flags appended to the launch command — e.g.{" "}
-              <code className="font-mono text-[11px]">--model sonnet</code>. Applies to new
-              assistant sessions.
+              Advanced — whitespace-separated flags appended to the launch command. Use the Model
+              picker above for the model; a <code className="font-mono text-[11px]">--model</code>{" "}
+              flag here overrides it. Applies to new assistant sessions.
             </>
           }
           type="text"
@@ -556,7 +626,7 @@ export function DaintreeAssistantSettingsTab() {
           autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"
-          placeholder="--model sonnet"
+          placeholder="--verbose"
           value={displayedCustomArgs}
           onChange={handleCustomArgsChange}
           disabled={loading}

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -407,14 +407,21 @@ async function checkAssistantVersion(
   return result.status === "too-old" ? result.block : null;
 }
 
-async function loadCustomLaunchFlags(): Promise<string[]> {
+// Exported for unit coverage of the model/customArgs flag composition.
+export async function loadCustomLaunchFlags(): Promise<string[]> {
   try {
     const settings = await window.electron.helpAssistant.getSettings();
+    const flags: string[] = [];
+    // The model picker injects `--model <id>` first so a `--model` typed into
+    // custom args still wins (CLIs are last-flag-wins on repeated `--model`),
+    // keeping custom args the advanced override.
+    const modelId = settings.modelId?.trim();
+    if (modelId) flags.push("--model", modelId);
     const raw = settings.customArgs?.trim();
-    if (!raw) return [];
-    return raw.split(/\s+/).filter(Boolean);
+    if (raw) flags.push(...raw.split(/\s+/).filter(Boolean));
+    return flags;
   } catch (err) {
-    logError("Failed to load helpAssistant customArgs", err);
+    logError("Failed to load helpAssistant launch flags", err);
     return [];
   }
 }

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -120,7 +120,7 @@ vi.mock("@/utils/safeFireAndForget", () => ({
   safeFireAndForget: (p: Promise<unknown>) => p,
 }));
 
-import { HelpSessionController } from "../HelpSessionController";
+import { HelpSessionController, loadCustomLaunchFlags } from "../HelpSessionController";
 import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
 
@@ -2014,5 +2014,45 @@ describe("HelpSessionController — MCP tool activity strip (#9759)", () => {
     expect(a?.toolId).toBe("b");
     expect(a?.durationMs).toBe(25);
     ctrl.stop();
+  });
+});
+
+describe("loadCustomLaunchFlags — model + custom args composition", () => {
+  const getSettings = () => window.electron.helpAssistant.getSettings as ReturnType<typeof vi.fn>;
+
+  it("returns no flags when neither modelId nor customArgs is set", async () => {
+    getSettings().mockResolvedValue({ modelId: "", customArgs: "" });
+    expect(await loadCustomLaunchFlags()).toEqual([]);
+  });
+
+  it("injects --model when modelId is set", async () => {
+    getSettings().mockResolvedValue({ modelId: "claude-sonnet-4-6", customArgs: "" });
+    expect(await loadCustomLaunchFlags()).toEqual(["--model", "claude-sonnet-4-6"]);
+  });
+
+  it("prepends the model flag before custom args so a custom --model wins (last-flag semantics)", async () => {
+    getSettings().mockResolvedValue({ modelId: "sonnet", customArgs: "--model opus --verbose" });
+    expect(await loadCustomLaunchFlags()).toEqual([
+      "--model",
+      "sonnet",
+      "--model",
+      "opus",
+      "--verbose",
+    ]);
+  });
+
+  it("returns only custom args when no model is selected", async () => {
+    getSettings().mockResolvedValue({ modelId: "", customArgs: "--verbose --foo bar" });
+    expect(await loadCustomLaunchFlags()).toEqual(["--verbose", "--foo", "bar"]);
+  });
+
+  it("tolerates absent modelId (legacy settings) and falls back to custom args only", async () => {
+    getSettings().mockResolvedValue({ customArgs: "--verbose" });
+    expect(await loadCustomLaunchFlags()).toEqual(["--verbose"]);
+  });
+
+  it("returns [] when reading settings throws", async () => {
+    getSettings().mockRejectedValue(new Error("ipc down"));
+    expect(await loadCustomLaunchFlags()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a first-class Model select to the assistant settings tab, replacing raw `--model` flag entry as the way to set the model per agent.
- A new `modelId` field on `HelpAssistantSettings` is sanitized, persisted, and injected via `loadCustomLaunchFlags` ahead of custom args, so a `--model` typed into Custom CLI args still wins as the advanced override.
- The selected model is surfaced in the HelpPanel footer identity pill (reads persisted launch flags, supports both `--model X` and `--model=X`, last-flag-wins).

Resolves #10702

## Changes

- `shared/types/ipc/api.ts`: `modelId` field added to `HelpAssistantSettings` (empty string = CLI default).
- `electron/ipc/handlers/helpAssistant.ts`: sanitization rejects internal whitespace, control chars, leading `-`, and shell metacharacters; capped at 200 chars. `loadCustomLaunchFlags` injects `--model <id>` before custom args.
- `src/components/Settings/DaintreeAssistantSettingsTab.tsx`: Model select populated from `agentCapabilities.getResolvedModelList`, shown only when the agent has a model catalog, reset on agent change.
- `src/components/HelpPanel/HelpPanel.tsx`: footer identity pill parses and displays the launched model from the session's persisted launch flags.
- `src/controllers/HelpSessionController.ts`: passes `modelId` through to launch flag composition.

## Testing

- `helpAssistant` handler tests: sanitize/persist/load coverage for `modelId`.
- `loadCustomLaunchFlags` tests: model-only, model+customArgs override ordering, customArgs-only, legacy-absent, ipc-throws.
- `HelpSessionController` tests: `modelId` forwarded correctly.
- 141 targeted tests pass; eslint/prettier clean on changed files.