### PR TITLE
feat(mcp): expose fleet arming actions to system tier

### DIFF
--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -2577,6 +2577,21 @@ describe("McpServerService", () => {
         description: "Restart the terminal process",
       }),
       createManifestEntry({
+        id: "terminal.arm" as ActionId,
+        title: "Arm Terminal",
+        description: "Add a terminal to the fleet broadcast set",
+      }),
+      createManifestEntry({
+        id: "terminal.disarm" as ActionId,
+        title: "Disarm Terminal",
+        description: "Remove a terminal from the fleet broadcast set",
+      }),
+      createManifestEntry({
+        id: "terminal.disarmAll" as ActionId,
+        title: "Disarm All Terminals",
+        description: "Clear the fleet broadcast set",
+      }),
+      createManifestEntry({
         id: "copyTree.generateAndCopyFile" as ActionId,
         title: "Generate And Copy Context",
         description: "Write generated context to the OS clipboard",
@@ -3041,9 +3056,11 @@ describe("McpServerService", () => {
       WORKBENCH_TIER_TOOLS_LIST.find((id) => id === "hibernation.getConfig")!,
     ] as const;
 
-    // Fleet-broadcast primitives are renderer-only — they remain available
-    // via keybindings, palette, and menus, but are NOT exposed through the
-    // MCP control plane on any tier.
+    // terminal.bulkCommand (the one-shot broadcast-send) is renderer-only — it
+    // remains available via keybindings, palette, and menus, but is NOT exposed
+    // through the MCP control plane on any tier. (Distinct from the arming
+    // primitives terminal.arm/disarm/disarmAll, which only edit the broadcast
+    // membership set and ARE exposed at the system tier.)
     const NEVER_EXPOSED_VIA_MCP = ["terminal.bulkCommand"] as const;
 
     // External tier (apiKey) curates MCP_TOOL_ALLOWLIST independently from the

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -611,8 +611,8 @@ export const RATE_LIMIT_TOOL_MAP: ReadonlyMap<string, RateLimitConfig> = new Map
   ["help.displayImage", RATE_LIMIT_TIERS.mutation],
   // Fleet-arming mutations (#10695): churning the broadcast set reroutes the
   // human's keystrokes, so cap at mutation tier rather than 30/min standard.
-  // disarm/disarmAll have no per-call confirm gate; arm is confirm-gated but
-  // tiered alongside them for a consistent cohort.
+  // None carry a per-call confirm gate (all classified danger:"safe"); the
+  // mutation-tier rate limit is the cohort's shared throttle.
   ["terminal.arm", RATE_LIMIT_TIERS.mutation],
   ["terminal.disarm", RATE_LIMIT_TIERS.mutation],
   ["terminal.disarmAll", RATE_LIMIT_TIERS.mutation],

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -139,6 +139,10 @@ export const SYSTEM_TIER_ADDONS = [
   "worktree.delete",
   "worktree.resource.teardown",
 
+  "terminal.arm",
+  "terminal.disarm",
+  "terminal.disarmAll",
+
   "copyTree.generateAndCopyFile",
 
   "git.stageFile",


### PR DESCRIPTION
## Problem

The Daintree Assistant couldn't see `terminal.arm`, `terminal.disarm`, or `terminal.disarmAll` over MCP — its drift check flagged them as "documented but missing from the live server."

Root cause: those three fleet-arming tools were only in `MCP_TOOL_ALLOWLIST` (the `external`/api-key tier), not in any help-assistant tier set. But the Daintree Assistant doesn't connect on `external` — it's provisioned at help-tier `system` (`HelpSessionService.ts:507-510`). Since the arming tools were absent from `WORKBENCH_TIER_TOOLS` / `ACTION_TIER_ADDONS` / `SYSTEM_TIER_ADDONS`, `shouldExposeTool` never advertised them to the assistant. The two allowlist sources (external vs help-tier) are curated independently and had drifted.

## Fix

Add `terminal.arm` / `terminal.disarm` / `terminal.disarmAll` to `SYSTEM_TIER_ADDONS`. This is the correct tier:

- The Daintree Assistant (our own first-class conductor, in `ASSISTANT_ONLY_AGENT_IDS`) runs at `system` and now sees them in its default surface.
- Third-party Claude/Codex help overlays stay at the `action` floor and do **not** get fleet arming — matching the "support multiple assistants, but this one is ours" boundary.
- `external` (api-key) clients keep their existing access via `MCP_TOOL_ALLOWLIST` (a separate curation, not inherited by `system`).

No assistant-repo changes needed — it already documents, wraps, tests, and expects these tools.

## Notes

- `danger:"safe"` (all three) doesn't affect tier gating; mutation-tier rate limiting still applies (`shared.ts`). Arming only edits the broadcast membership set — reversible, no-ops for ineligible terminals — so `system` is an appropriate bar alongside the git/worktree mutations already there.
- Added matching `createManifestEntry` fixtures to the synthetic `tierManifest()` so the existing system-tier `listTools` assertion (which iterates `SYSTEM_TIER_ADDONS`) covers them.
- Drive-by comment cleanups surfaced during review: corrected the stale "arm is confirm-gated" note in `shared.ts` (now `danger:"safe"`), and clarified the `NEVER_EXPOSED_VIA_MCP` comment now that the arming primitives *are* exposed (only `terminal.bulkCommand` remains renderer-only).

## Testing

- `npm run typecheck` ✅
- `McpServerService.test.ts` + `tierAuth.test.ts` (225 tests) ✅
- lint + format ✅
- Codex review (2 passes: tier correctness + consistency sweep) confirmed placement and completeness; `npm run check` passed.

## Follow-up (not in this PR)

There's no build-time guard diffing `MCP_TOOL_ALLOWLIST` against the help-tier sets, which is why this drift went unnoticed. A cross-set guard (or a shared/generated manifest both repos import) would prevent the next one.