### PR TITLE
refactor(help-session): unify auto-launch into _executeLaunch (#10703)

### DIFF
--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -259,6 +259,15 @@ export interface HelpLaunchOptions {
   replaceExisting?: boolean;
   /** True when called from the controller's auto-launch decision path. */
   isAutoLaunch?: boolean;
+  /**
+   * True when this auto-launch was initiated for the user's explicitly
+   * preferred agent (not the sole-installed-agent fallback). Enables the
+   * stale-agent guards that silently abandon — and re-evaluate — the launch
+   * if `preferredAgentId` changes out from under it mid-flight (version probe
+   * or dispatch). The single-installed-agent path leaves this false so a
+   * preference set mid-launch never aborts it.
+   */
+  preferredAgentLaunch?: boolean;
 }
 
 interface HelpSessionRef {
@@ -1904,14 +1913,16 @@ export class HelpSessionController {
     if (this._hasAutoLaunched) return;
 
     if (inputs.preferredAgentId) {
-      const launchAgentId = inputs.preferredAgentId;
-      const launchProject = inputs.currentProject;
       this._hasAutoLaunched = true;
-      const gen = ++this._launchGen;
-      // Snapshot focus synchronously before the async launch — see launch().
-      const launchContext = actionService.getContext();
-      safeFireAndForget(this._executeAutoLaunch(gen, launchAgentId, launchProject, launchContext), {
-        context: "Auto-launching preferred help agent",
+      // Route through launch() like the sole-installed-agent path below, so the
+      // re-entrancy guard (_isLaunching/_isLaunchingGen) and FSM live in one
+      // place. `preferredAgentLaunch` arms the stale-agent guards that abandon
+      // and re-evaluate if the preference changes mid-flight (#10703).
+      this.launch({
+        agentId: inputs.preferredAgentId,
+        isAutoLaunch: true,
+        preferredAgentLaunch: true,
+        replaceExisting: true,
       });
       return;
     }
@@ -1970,239 +1981,6 @@ export class HelpSessionController {
     return { panelId: newId, resumeKind };
   }
 
-  private async _executeAutoLaunch(
-    gen: number,
-    launchAgentId: string,
-    launchProject: HelpProjectRef,
-    launchContext?: ActionContext
-  ): Promise<void> {
-    let session: HelpSessionRef | null = null;
-    // Tracks whether the launch reached its terminal-bound success state. The
-    // finally resets the phase to idle on any non-success exit (error, bail)
-    // that is still the current generation, so the loading skeleton never
-    // sticks; a superseded generation leaves the phase to its new owner.
-    let reached = false;
-    // Clear any prior failure banner up front so a retry immediately drops the
-    // stale error while the new attempt is in flight.
-    this._patch({ launchError: null });
-    this._armLaunchWatchdog(gen, launchAgentId);
-    try {
-      this._patch({ phase: "version-checking" });
-      const folderPath = await window.electron.help.getFolderPath();
-      if (gen !== this._launchGen) {
-        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
-        return;
-      }
-      if (!folderPath) {
-        this._hasAutoLaunched = false;
-        this._surfaceLaunchError(launchAgentId, "folder-unavailable");
-        return;
-      }
-
-      const launchAgentName = getAgentConfig(launchAgentId)?.name ?? launchAgentId;
-      const versionBlock = await checkAssistantVersion(
-        launchAgentId,
-        launchAgentName,
-        this._hasBlockedThisSession
-      );
-      if (gen !== this._launchGen) {
-        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
-        return;
-      }
-      if (versionBlock) {
-        // Stale-agent guard: skip the block if the user changed
-        // preferredAgentId while the probe was in flight — the new
-        // agent's empty state shouldn't be covered by an "Update Claude"
-        // message that no longer applies.
-        if (useHelpPanelStore.getState().preferredAgentId !== launchAgentId) {
-          this._hasAutoLaunched = false;
-          return;
-        }
-        this._hasAutoLaunched = false;
-        this._hasBlockedThisSession = true;
-        this._patch({ assistantVersionTooOld: versionBlock });
-        return;
-      }
-      this._hasBlockedThisSession = false;
-      this._patch({ assistantVersionTooOld: null, phase: "provisioning" });
-
-      const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
-      if (gen !== this._launchGen) {
-        if (outcome.ok) session = outcome.session;
-        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
-        return;
-      }
-      if (!outcome.ok) {
-        this._hasAutoLaunched = false;
-        this._surfaceLaunchError(launchAgentId, provisionFailureKind(outcome.code));
-        return;
-      }
-      session = outcome.session;
-      this._pendingSessionId = session.sessionId;
-      this._patch({ phase: "launching" });
-      const cwd = session.sessionPath;
-      const env = buildHelpEnv(session, launchProject.id, launchAgentId);
-
-      // Seed hibernate from main's pending-hibernation store BEFORE the
-      // local lookup — this is what carries the conversation across LRU
-      // eviction / window close where the renderer-side hibernate timer
-      // couldn't capture before its view was destroyed. Passing `gen` lets
-      // the helper drop the pulled entry if a discarding action (e.g.
-      // "+ New session") supersedes this launch mid-IPC.
-      await this._seedHibernateFromMain(launchProject.id, gen);
-      if (gen !== this._launchGen) {
-        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
-        return;
-      }
-      const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
-      if (hibernated && hibernated.agentId === launchAgentId) {
-        const resumed = await this._spawnResumed(launchAgentId, hibernated, session, folderPath);
-        if (gen !== this._launchGen) {
-          if (resumed) usePanelStore.getState().removePanel(resumed.panelId);
-          this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
-          return;
-        }
-        if (resumed) {
-          // Stale-launch guard: handleClose may have revoked the pending
-          // session while addPanel was in flight.
-          const expectedSessionId = session.sessionId;
-          if (this._pendingSessionId !== expectedSessionId) {
-            usePanelStore.getState().removePanel(resumed.panelId);
-            this._hasAutoLaunched = false;
-            return;
-          }
-          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
-          useHelpPanelStore
-            .getState()
-            .setTerminal(resumed.panelId, launchAgentId, session.sessionId);
-          this._pendingSessionId = null;
-          window.electron.help.markTerminal(resumed.panelId).catch((err) => {
-            logError("Failed to mark help terminal", err);
-          });
-          reached = true;
-          this._patch({ phase: "live" });
-          // Only claim a specific-session restore when we actually had a
-          // specific session id — the latest-conversation heuristic
-          // (`--continue` / `resume --last`) may or may not have found a
-          // prior session, and the renderer cannot tell from outside.
-          if (resumed.resumeKind === "specific") {
-            this._patch({ showResumeBanner: true });
-            this._armResumeBannerAutoDismiss();
-          }
-          return;
-        }
-        // Resume failed — drop the stale entry so we don't loop, then fall
-        // through to fresh launch using the already-provisioned session.
-        useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
-      }
-
-      const customLaunchFlags = await loadCustomLaunchFlags();
-      if (gen !== this._launchGen) {
-        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
-        return;
-      }
-
-      const result = await actionService.dispatch<{ terminalId: string | null }>(
-        "agent.launch",
-        {
-          agentId: launchAgentId,
-          location: "overlay",
-          cwd,
-          excludeFromPersistence: true,
-          removeOnExit: true,
-          ...(env && { env }),
-          ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
-        },
-        { source: "user" }
-      );
-      if (gen !== this._launchGen) {
-        if (result.ok && result.result?.terminalId) {
-          usePanelStore.getState().removePanel(result.result.terminalId);
-        }
-        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
-        return;
-      }
-
-      // Stale-launch guard: if the user changed preferredAgentId while the
-      // IPC was in flight, drop the result and clean up the spawned panel
-      // rather than reviving a stale terminal.
-      const currentPreferred = useHelpPanelStore.getState().preferredAgentId;
-      if (currentPreferred !== launchAgentId) {
-        if (result.ok && result.result?.terminalId) {
-          usePanelStore.getState().removePanel(result.result.terminalId);
-        }
-        revokeHelpSession(session?.sessionId ?? null);
-        if (this._pendingSessionId === session?.sessionId) {
-          this._pendingSessionId = null;
-        }
-        this._hasAutoLaunched = false;
-        // The preference changed mid-launch, so re-evaluate against the
-        // current inputs rather than waiting on an incidental re-render to
-        // re-fire the effect — the new preferred agent should auto-launch
-        // now. Earlier this was driven solely by the next syncInputs render,
-        // which a transient phase re-render could consume before this reset
-        // landed, swallowing the relaunch. Read `preferredAgentId` straight
-        // from the store (not the possibly-stale `_lastInputs`) so the re-eval
-        // launches the agent that actually superseded this one, never looping
-        // on the old agent.
-        if (this._lastInputs) {
-          this._maybeAutoLaunch({ ...this._lastInputs, preferredAgentId: currentPreferred });
-        }
-        return;
-      }
-
-      if (!result.ok || !result.result?.terminalId) {
-        this._hasAutoLaunched = false;
-        revokeHelpSession(session?.sessionId ?? null);
-        if (this._pendingSessionId === session?.sessionId) {
-          this._pendingSessionId = null;
-        }
-        logError("Help auto-launch failed", { agentId: launchAgentId, result });
-        this._surfaceLaunchError(launchAgentId, "spawn-failed");
-        return;
-      }
-
-      const expectedSessionId = session?.sessionId ?? null;
-      if (expectedSessionId && this._pendingSessionId !== expectedSessionId) {
-        usePanelStore.getState().removePanel(result.result.terminalId);
-        this._hasAutoLaunched = false;
-        return;
-      }
-
-      useHelpPanelStore
-        .getState()
-        .setTerminal(result.result.terminalId, launchAgentId, session?.sessionId ?? null);
-      this._pendingSessionId = null;
-      reached = true;
-      this._patch({ phase: "live" });
-      window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
-        logError("Failed to mark help terminal", err);
-      });
-    } catch (err) {
-      logError("HelpPanel: auto-launch threw", err);
-      this._hasAutoLaunched = false;
-      // Mirror _executeLaunch's catch: an unexpected throw past the
-      // provision step (e.g. agent.launch rejecting) leaves a live session
-      // token with no bound terminal. Revoke it, clear the pending-session
-      // guard, and surface the failure so the panel isn't left silently empty.
-      // A late-rejecting dispatch can reach here AFTER the watchdog (or a
-      // newer launch) bumped the generation — only null `_pendingSessionId`
-      // when it's still ours, so we don't clobber a newer launch's guard.
-      revokeHelpSession(session?.sessionId ?? null);
-      if (this._pendingSessionId === session?.sessionId) {
-        this._pendingSessionId = null;
-      }
-      this._surfaceLaunchError(launchAgentId, "spawn-failed");
-    } finally {
-      // Only the generation that still owns the launch clears the watchdog and
-      // resets the phase — a superseding launch has already armed its own.
-      if (gen === this._launchGen) {
-        this._clearLaunchWatchdog();
-        if (!reached) this._resetPhase();
-      }
-    }
-  }
-
   private async _executeLaunch(
     gen: number,
     options: HelpLaunchOptions,
@@ -2214,8 +1992,8 @@ export class HelpSessionController {
     const reservedId = options.requestedId ?? null;
     const resetAutoLaunch = options.isAutoLaunch === true;
     let session: HelpSessionRef | null = null;
-    // See `_executeAutoLaunch`: the finally drops the phase back to idle on a
-    // non-success exit that's still the current generation.
+    // The finally drops the phase back to idle on a non-success exit that's
+    // still the current generation, so the loading skeleton never sticks.
     let reached = false;
     // Clear any prior failure banner up front so a retry immediately drops the
     // stale error while the new attempt is in flight.
@@ -2258,6 +2036,17 @@ export class HelpSessionController {
           return;
         }
         if (versionBlock) {
+          // Stale-agent guard (preferred-agent auto-launch only): skip the
+          // block if the user changed preferredAgentId while the probe was in
+          // flight — the new agent's empty state shouldn't be covered by an
+          // "Update X" message that no longer applies.
+          if (
+            options.preferredAgentLaunch === true &&
+            useHelpPanelStore.getState().preferredAgentId !== launchAgentId
+          ) {
+            this._hasAutoLaunched = false;
+            return;
+          }
           this._hasAutoLaunched = false;
           this._hasBlockedThisSession = true;
           this._patch({ assistantVersionTooOld: versionBlock });
@@ -2374,6 +2163,31 @@ export class HelpSessionController {
         }
         this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
         return;
+      }
+
+      // Stale-launch guard (preferred-agent auto-launch only): if the user
+      // changed preferredAgentId while the IPC was in flight, drop the result
+      // and clean up the spawned panel rather than reviving a stale terminal,
+      // then re-evaluate against the now-current preference. Read it straight
+      // from the store (not the possibly-stale `_lastInputs`) so the re-eval
+      // launches the agent that actually superseded this one, never looping on
+      // the old agent.
+      if (options.preferredAgentLaunch === true) {
+        const currentPreferred = useHelpPanelStore.getState().preferredAgentId;
+        if (currentPreferred !== launchAgentId) {
+          if (result.ok && result.result?.terminalId) {
+            usePanelStore.getState().removePanel(result.result.terminalId);
+          }
+          revokeHelpSession(session?.sessionId ?? null);
+          if (this._pendingSessionId === session?.sessionId) {
+            this._pendingSessionId = null;
+          }
+          this._hasAutoLaunched = false;
+          if (this._lastInputs) {
+            this._maybeAutoLaunch({ ...this._lastInputs, preferredAgentId: currentPreferred });
+          }
+          return;
+        }
       }
 
       if (!result.ok || !result.result?.terminalId) {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1995,6 +1995,12 @@ export class HelpSessionController {
     // The finally drops the phase back to idle on a non-success exit that's
     // still the current generation, so the loading skeleton never sticks.
     let reached = false;
+    // Set by the preferred-agent stale guard when the preference changed
+    // mid-flight: the re-launch for the now-current agent must run AFTER the
+    // finally releases `_isLaunching`, or launch()'s re-entrancy guard would
+    // see this generation still holding it and silently drop the relaunch
+    // (#10703) — leaving `_hasAutoLaunched` stuck and blocking all auto-launch.
+    let pendingReEval: HelpSessionInputs | null = null;
     // Clear any prior failure banner up front so a retry immediately drops the
     // stale error while the new attempt is in flight.
     this._patch({ launchError: null });
@@ -2183,8 +2189,12 @@ export class HelpSessionController {
             this._pendingSessionId = null;
           }
           this._hasAutoLaunched = false;
+          // Defer the relaunch to the finally so it runs after `_isLaunching`
+          // is released (see `pendingReEval`). Read preferredAgentId straight
+          // from the store so the re-eval targets the agent that superseded
+          // this one, never looping on the old agent.
           if (this._lastInputs) {
-            this._maybeAutoLaunch({ ...this._lastInputs, preferredAgentId: currentPreferred });
+            pendingReEval = { ...this._lastInputs, preferredAgentId: currentPreferred };
           }
           return;
         }
@@ -2267,6 +2277,10 @@ export class HelpSessionController {
         this._clearLaunchWatchdog();
         if (!reached) this._resetPhase();
       }
+      // Preference changed mid-flight: re-evaluate now that the guard is
+      // released so the now-current preferred agent can auto-launch instead of
+      // waiting on an incidental render to re-fire the effect.
+      if (pendingReEval) this._maybeAutoLaunch(pendingReEval);
     }
   }
 }

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -1806,11 +1806,64 @@ describe("HelpSessionController — launch error routing", () => {
     ).takePendingHibernation = vi.fn().mockResolvedValue(null);
     (actionService.dispatch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("boom"));
 
-    await ctrl["_executeAutoLaunch"](7, "claude", { id: "p1", path: "/repo" });
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", isAutoLaunch: true, preferredAgentLaunch: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
 
     expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-x");
     expect(ctrl["_pendingSessionId"]).toBeNull();
     expect(ctrl.getSnapshot().launchError).toEqual({ agentId: "claude", kind: "spawn-failed" });
+    ctrl.stop();
+  });
+
+  it("preferred-agent auto-launch abandons and re-evaluates when preferredAgentId changes mid-dispatch (#10703)", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    primeInputs(ctrl, true);
+    helpPanelState.preferredAgentId = "claude";
+    ctrl["_launchGen"] = 7;
+    provisionMock().mockResolvedValueOnce({
+      sessionId: "sess-stale",
+      sessionPath: "/s/stale",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    (
+      window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
+    ).takePendingHibernation = vi.fn().mockResolvedValue(null);
+    // The user switches preferred agent while the launch IPC is in flight.
+    (actionService.dispatch as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
+      helpPanelState.preferredAgentId = "codex";
+      return { ok: true, result: { terminalId: "term-stale" } };
+    });
+    const reEval = vi.spyOn(
+      ctrl as unknown as { _maybeAutoLaunch: () => void },
+      "_maybeAutoLaunch"
+    );
+    reEval.mockImplementation(() => {});
+
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", isAutoLaunch: true, preferredAgentLaunch: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
+
+    // The orphaned terminal is removed and the stale session token revoked,
+    // rather than binding the panel to the superseded agent.
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-stale");
+    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-stale");
+    expect(ctrl["_pendingSessionId"]).toBeNull();
+    expect(ctrl["_hasAutoLaunched"]).toBe(false);
+    // The launch re-evaluates against the now-current preference so the newly
+    // preferred agent auto-launches instead of waiting on an incidental render.
+    expect(reEval).toHaveBeenCalledWith(expect.objectContaining({ preferredAgentId: "codex" }));
+    // It must not have left the panel bound to the stale agent.
+    expect(ctrl.getSnapshot().phase).not.toBe("live");
     ctrl.stop();
   });
 
@@ -1870,7 +1923,12 @@ describe("HelpSessionController — resume banner gating (#10057)", () => {
       agentId: "claude",
     };
 
-    await ctrl["_executeAutoLaunch"](7, "claude", { id: "p1", path: "/repo" });
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", isAutoLaunch: true, preferredAgentLaunch: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
 
     // The phase still reached live (the spawn succeeded via --continue) but
     // the resume-banner claim is suppressed because we never had a real id.
@@ -1896,7 +1954,12 @@ describe("HelpSessionController — resume banner gating (#10057)", () => {
       agentId: "claude",
     };
 
-    await ctrl["_executeAutoLaunch"](7, "claude", { id: "p1", path: "/repo" });
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", isAutoLaunch: true, preferredAgentLaunch: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
 
     expect(ctrl.getSnapshot().phase).toBe("live");
     expect(ctrl.getSnapshot().showResumeBanner).toBe(true);

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -1819,32 +1819,84 @@ describe("HelpSessionController — launch error routing", () => {
     ctrl.stop();
   });
 
-  it("preferred-agent auto-launch abandons and re-evaluates when preferredAgentId changes mid-dispatch (#10703)", async () => {
+  it("preferred-agent auto-launch abandons and relaunches the new agent when preferredAgentId changes mid-dispatch (#10703)", async () => {
     const ctrl = new HelpSessionController();
     ctrl.start();
-    primeInputs(ctrl, true);
     helpPanelState.preferredAgentId = "claude";
-    ctrl["_launchGen"] = 7;
-    provisionMock().mockResolvedValueOnce({
-      sessionId: "sess-stale",
-      sessionPath: "/s/stale",
-      token: "tok",
-      mcpUrl: null,
-      windowId: 1,
-    });
     (
       window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
     ).takePendingHibernation = vi.fn().mockResolvedValue(null);
-    // The user switches preferred agent while the launch IPC is in flight.
-    (actionService.dispatch as ReturnType<typeof vi.fn>).mockImplementationOnce(async () => {
-      helpPanelState.preferredAgentId = "codex";
-      return { ok: true, result: { terminalId: "term-stale" } };
-    });
-    const reEval = vi.spyOn(
-      ctrl as unknown as { _maybeAutoLaunch: () => void },
-      "_maybeAutoLaunch"
+    provisionMock()
+      .mockResolvedValueOnce({
+        sessionId: "sess-claude",
+        sessionPath: "/s/claude",
+        token: "tok",
+        mcpUrl: null,
+        windowId: 1,
+      })
+      .mockResolvedValueOnce({
+        sessionId: "sess-codex",
+        sessionPath: "/s/codex",
+        token: "tok",
+        mcpUrl: null,
+        windowId: 1,
+      });
+    // The user switches preferred agent while the claude launch IPC is in
+    // flight; the codex relaunch must then succeed.
+    (actionService.dispatch as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_action: string, args: { agentId: string }) => {
+        if (args.agentId === "claude") {
+          helpPanelState.preferredAgentId = "codex";
+          return { ok: true, result: { terminalId: "term-claude" } };
+        }
+        return { ok: true, result: { terminalId: "term-codex" } };
+      }
     );
-    reEval.mockImplementation(() => {});
+
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "p1", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude", "codex"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    });
+
+    // The relaunch must actually reach the codex agent — the bug this guards
+    // against is the re-eval's launch() being swallowed by the still-held
+    // re-entrancy guard, leaving _hasAutoLaunched stuck and codex unlaunched.
+    await vi.waitFor(() => {
+      expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-codex", "codex", "sess-codex");
+    });
+    // The superseded claude attempt is cleaned up: orphan terminal removed,
+    // stale session token revoked.
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-claude");
+    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-claude");
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "codex" }),
+      expect.anything()
+    );
+    expect(ctrl.getSnapshot().phase).toBe("live");
+    ctrl.stop();
+  });
+
+  it("skips the version-too-old banner when preferredAgentId changes during the probe (#10703)", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+    ctrl["_hasAutoLaunched"] = true;
+    ctrl["_launchGen"] = 7;
+    // The probe reports claude as too old, but the user switches to codex
+    // before it resolves — the stale "Update Claude" gate must not apply.
+    (window.electron.system.getAgentVersion as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => {
+        helpPanelState.preferredAgentId = "codex";
+        return { installedVersion: "0.9.0", latestVersion: "1.2.0" };
+      }
+    );
 
     await ctrl["_executeLaunch"](
       7,
@@ -1853,17 +1905,11 @@ describe("HelpSessionController — launch error routing", () => {
       undefined
     );
 
-    // The orphaned terminal is removed and the stale session token revoked,
-    // rather than binding the panel to the superseded agent.
-    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-stale");
-    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-stale");
-    expect(ctrl["_pendingSessionId"]).toBeNull();
+    expect(ctrl.getSnapshot().assistantVersionTooOld).toBeNull();
+    // _hasAutoLaunched is released so codex can auto-launch on the next render.
     expect(ctrl["_hasAutoLaunched"]).toBe(false);
-    // The launch re-evaluates against the now-current preference so the newly
-    // preferred agent auto-launches instead of waiting on an incidental render.
-    expect(reEval).toHaveBeenCalledWith(expect.objectContaining({ preferredAgentId: "codex" }));
-    // It must not have left the panel bound to the stale agent.
-    expect(ctrl.getSnapshot().phase).not.toBe("live");
+    // The abandoned claude launch must never have minted a session.
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
     ctrl.stop();
   });
 


### PR DESCRIPTION
## Summary

- `HelpSessionController` had two ~230-line near-duplicate launch FSM methods (`_executeAutoLaunch` and `_executeLaunch`). Any fix to the launch path had to land twice, and they'd already drifted (the auto path was missing `_isLaunchingGen` ownership release from the `finally` block).
- This unifies them into a single parameterized `_executeLaunch`, routes the preferred-agent auto-launch path through `launch()` so the re-entrancy guard and FSM live in one place, and deletes `_executeAutoLaunch` for a net -126-line reduction.

Resolves #10703

## Changes

- Route `_maybeAutoLaunch`'s preferred-agent branch through `launch()` (the sole-installed-agent path already did this), so `_isLaunching`/`_isLaunchingGen` and the full launch FSM cover both paths.
- Add `preferredAgentLaunch` option to `HelpLaunchOptions` to arm stale-agent guards (version-block-time and post-dispatch) for the preferred-agent path only. The single-installed-agent path has `preferredAgentId === null` and must not run them.
- Port both auto-only stale-agent guards into `_executeLaunch`, then delete `_executeAutoLaunch`.
- Defer the post-dispatch stale-agent relaunch to the `finally` block so it fires after `_isLaunching` releases. Without this, `launch()`'s re-entrancy guard would swallow the relaunch and leave `_hasAutoLaunched` stuck.

## Testing

Updated the 3 direct `_executeAutoLaunch` call sites to the unified signature. Added a full public-path regression test (`syncInputs` → `_maybeAutoLaunch` → `launch()` → `_executeLaunch`) covering mid-dispatch preference change relaunch, plus a version-block stale-agent guard test. 100 controller tests and 306 across all affected HelpPanel suites pass.