### PR TITLE
fix(worktree): recover from stuck blocking git operations on the card (#10715)

### DIFF
--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1538,11 +1538,27 @@ export class WorktreeMonitor {
     }
 
     if (gitDir && opState !== undefined) {
+      const wasInitialStatus = this._hasInitialStatus;
       // If we're skipping the very first poll (e.g. app started mid-rebase),
       // emit a default snapshot so the renderer can still display the worktree.
       // Mirrors startWithoutGitStatus()'s contract.
       if (!this._hasInitialStatus) {
         this._hasInitialStatus = true;
+        this.emitUpdate();
+      }
+      // Stamp the completion timestamp even though git status was skipped: the
+      // sentinel state was freshly observed above, so the freshness signal is
+      // accurate, and the heartbeat-gap detector (which reads this field) won't
+      // false-positive on a long blocking operation. Without this, a
+      // user-triggered refresh during a stuck blocking operation never advances
+      // lastGitStatusCompletedAt, leaving the freshness pill permanently stale
+      // and its Refresh button a no-op (#10715).
+      this.lastGitStatusCompletedAt = Date.now();
+      // On a forced refresh (the user clicked Refresh on a stale card), emit so
+      // the renderer actually receives the advanced timestamp and the freshness
+      // pill resets — otherwise the click is silently dropped. Background polls
+      // stamp silently; the watcher emits a real status once sentinels clear.
+      if (forceRefresh && wasInitialStatus) {
         this.emitUpdate();
       }
       return;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1538,27 +1538,26 @@ export class WorktreeMonitor {
     }
 
     if (gitDir && opState !== undefined) {
-      const wasInitialStatus = this._hasInitialStatus;
-      // If we're skipping the very first poll (e.g. app started mid-rebase),
-      // emit a default snapshot so the renderer can still display the worktree.
-      // Mirrors startWithoutGitStatus()'s contract.
-      if (!this._hasInitialStatus) {
-        this._hasInitialStatus = true;
-        this.emitUpdate();
-      }
-      // Stamp the completion timestamp even though git status was skipped: the
-      // sentinel state was freshly observed above, so the freshness signal is
-      // accurate, and the heartbeat-gap detector (which reads this field) won't
+      // Stamp the completion timestamp before any emit so every snapshot below
+      // carries the advanced value. Git status was skipped, but the sentinel
+      // state was freshly observed above, so the freshness signal is accurate
+      // and the heartbeat-gap detector (which reads this field) won't
       // false-positive on a long blocking operation. Without this, a
       // user-triggered refresh during a stuck blocking operation never advances
       // lastGitStatusCompletedAt, leaving the freshness pill permanently stale
       // and its Refresh button a no-op (#10715).
       this.lastGitStatusCompletedAt = Date.now();
-      // On a forced refresh (the user clicked Refresh on a stale card), emit so
-      // the renderer actually receives the advanced timestamp and the freshness
-      // pill resets — otherwise the click is silently dropped. Background polls
-      // stamp silently; the watcher emits a real status once sentinels clear.
-      if (forceRefresh && wasInitialStatus) {
+      if (!this._hasInitialStatus) {
+        // First poll started mid-operation (e.g. app started mid-rebase) — emit
+        // a default snapshot so the renderer can still display the worktree.
+        // Mirrors startWithoutGitStatus()'s contract.
+        this._hasInitialStatus = true;
+        this.emitUpdate();
+      } else if (forceRefresh) {
+        // The user clicked Refresh on a stale card. Emit so the renderer
+        // receives the advanced timestamp and the freshness pill resets —
+        // otherwise the click is silently dropped. Background polls stamp
+        // silently; the watcher emits a real status once sentinels clear.
         this.emitUpdate();
       }
       return;

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -2705,6 +2705,56 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
+    it("forced refresh during a blocking operation stamps freshness and re-emits (#10715)", async () => {
+      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      mockGetRepoOperationStateSync.mockReturnValue("REVERTING");
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      await flushInitialStatus();
+      // Initial snapshot emitted once; the git status fork itself was skipped.
+      expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+
+      callbacks.onUpdate.mockClear();
+      // The user clicks Refresh on the stale card → forced refresh. The op is
+      // still in progress so git status stays skipped, but the renderer must
+      // receive a fresh snapshot whose freshness timestamp has advanced —
+      // otherwise the Refresh button is a permanent no-op (the bug).
+      await monitor.updateGitStatus(true);
+
+      expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+      expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
+      const snapshot = callbacks.onUpdate.mock.calls.at(-1)?.[0] as {
+        lastGitStatusCheckedAt: number;
+      };
+      expect(snapshot.lastGitStatusCheckedAt).toBeGreaterThan(0);
+
+      monitor.stop();
+    });
+
+    it("background poll during a blocking operation stamps silently without re-emitting", async () => {
+      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      mockGetRepoOperationStateSync.mockReturnValue("REBASING");
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      await flushInitialStatus();
+      expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
+
+      callbacks.onUpdate.mockClear();
+      // A non-forced (background) poll advances the freshness stamp but must not
+      // emit a redundant snapshot — only the user-driven forced refresh does.
+      await monitor.updateGitStatus(false);
+      expect(callbacks.onUpdate).not.toHaveBeenCalled();
+
+      monitor.stop();
+    });
+
     it("does not check operation sentinels when getGitDir returns null", async () => {
       vi.mocked(getGitDir).mockReturnValue(null);
       mockGetWorktreeChangesWithStats.mockResolvedValue({

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -2718,7 +2718,7 @@ describe("WorktreeMonitor", () => {
       expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
 
-      callbacks.onUpdate.mockClear();
+      vi.mocked(callbacks.onUpdate).mockClear();
       // The user clicks Refresh on the stale card → forced refresh. The op is
       // still in progress so git status stays skipped, but the renderer must
       // receive a fresh snapshot whose freshness timestamp has advanced —
@@ -2727,10 +2727,8 @@ describe("WorktreeMonitor", () => {
 
       expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
       expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
-      const snapshot = callbacks.onUpdate.mock.calls.at(-1)?.[0] as {
-        lastGitStatusCheckedAt: number;
-      };
-      expect(snapshot.lastGitStatusCheckedAt).toBeGreaterThan(0);
+      const snapshot = vi.mocked(callbacks.onUpdate).mock.calls.at(-1)?.[0];
+      expect(snapshot?.lastGitStatusCheckedAt).toBeGreaterThan(0);
 
       monitor.stop();
     });
@@ -2746,7 +2744,7 @@ describe("WorktreeMonitor", () => {
       await flushInitialStatus();
       expect(callbacks.onUpdate).toHaveBeenCalledTimes(1);
 
-      callbacks.onUpdate.mockClear();
+      vi.mocked(callbacks.onUpdate).mockClear();
       // A non-forced (background) poll advances the freshness stamp but must not
       // emit a redundant snapshot — only the user-driven forced refresh does.
       await monitor.updateGitStatus(false);

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -677,8 +677,8 @@ export function WorktreeCard({
   const handleAbortRepositoryOperation = useCallback(async () => {
     try {
       await window.electron.git.abortRepositoryOperation(worktree.path);
-      await worktreeClient.refresh(worktree.id);
     } catch (err) {
+      // The git abort itself failed — the operation is still in progress.
       notify({
         type: "error",
         title: "Abort failed",
@@ -690,12 +690,14 @@ export function WorktreeCard({
       });
       throw err;
     }
+    // Abort succeeded; a refresh failure is non-fatal (the watcher will pick up
+    // the cleared sentinel), so swallow it rather than report a false "failed".
+    await worktreeClient.refresh(worktree.id).catch(() => {});
   }, [worktree.path, worktree.id]);
 
   const handleContinueRepositoryOperation = useCallback(async () => {
     try {
       await window.electron.git.continueRepositoryOperation(worktree.path);
-      await worktreeClient.refresh(worktree.id);
     } catch (err) {
       notify({
         type: "error",
@@ -708,6 +710,7 @@ export function WorktreeCard({
       });
       throw err;
     }
+    await worktreeClient.refresh(worktree.id).catch(() => {});
   }, [worktree.path, worktree.id]);
 
   const handlePointerEnter = useCallback(() => {

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -687,6 +687,7 @@ export function WorktreeCard({
           "Couldn't abort the operation. The working tree is unchanged."
         ),
         action: { label: "Retry", onClick: () => void handleAbortRepositoryOperation() },
+        context: { eventKind: "git" },
       });
       throw err;
     }
@@ -707,6 +708,7 @@ export function WorktreeCard({
           "Couldn't continue the operation. Resolve any remaining conflicts and try again."
         ),
         action: { label: "Retry", onClick: () => void handleContinueRepositoryOperation() },
+        context: { eventKind: "git" },
       });
       throw err;
     }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -22,6 +22,8 @@ import {
 } from "../../store/projectSettingsStore";
 import { useWorktreeFilterStore } from "../../store/worktreeFilterStore";
 import { errorsClient, worktreeClient } from "@/clients";
+import { notify } from "@/lib/notify";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { actionService } from "@/services/ActionService";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -666,6 +668,48 @@ export function WorktreeCard({
       .catch(() => {});
   }, [isActive, worktree.lastGitStatusCheckedAt]);
 
+  // Abort/continue a stuck blocking git operation (revert/rebase/merge/
+  // cherry-pick) directly from the card. The IPC handlers live in
+  // git-write.ts; this mirrors ReviewHubContent's wiring. After the call we
+  // refresh the worktree directly (not via handleRevalidate, which has a 10s
+  // freshness gate that would suppress this user-driven refresh) so the card
+  // recovers immediately instead of waiting for the filesystem watcher.
+  const handleAbortRepositoryOperation = useCallback(async () => {
+    try {
+      await window.electron.git.abortRepositoryOperation(worktree.path);
+      await worktreeClient.refresh(worktree.id);
+    } catch (err) {
+      notify({
+        type: "error",
+        title: "Abort failed",
+        message: formatErrorMessage(
+          err,
+          "Couldn't abort the operation. The working tree is unchanged."
+        ),
+        action: { label: "Retry", onClick: () => void handleAbortRepositoryOperation() },
+      });
+      throw err;
+    }
+  }, [worktree.path, worktree.id]);
+
+  const handleContinueRepositoryOperation = useCallback(async () => {
+    try {
+      await window.electron.git.continueRepositoryOperation(worktree.path);
+      await worktreeClient.refresh(worktree.id);
+    } catch (err) {
+      notify({
+        type: "error",
+        title: "Continue failed",
+        message: formatErrorMessage(
+          err,
+          "Couldn't continue the operation. Resolve any remaining conflicts and try again."
+        ),
+        action: { label: "Retry", onClick: () => void handleContinueRepositoryOperation() },
+      });
+      throw err;
+    }
+  }, [worktree.path, worktree.id]);
+
   const handlePointerEnter = useCallback(() => {
     if (isActive || !worktree.lastGitStatusCheckedAt) return;
     if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
@@ -951,6 +995,8 @@ export function WorktreeCard({
                   onOpenPlan: worktree.hasPlanFile ? () => setShowPlanViewer(true) : undefined,
                 }}
                 gitStateIndicator={gitStateIndicator}
+                onAbortRepositoryOperation={handleAbortRepositoryOperation}
+                onContinueRepositoryOperation={handleContinueRepositoryOperation}
                 menu={{
                   launchAgents,
                   recipes,

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AgentState, TerminalRecipe, WorktreeState } from "@/types";
-import type { GitStateIndicator } from "./hooks/useWorktreeStatus";
+import type { GitStateIndicator, GitStateKind } from "./hooks/useWorktreeStatus";
 import { cn } from "@/lib/utils";
 import { STATE_LABELS, STATE_PRIORITY } from "../terminalStateConfig";
 import { BranchLabel } from "../BranchLabel";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
-import { Sprout, Pin, BellOff, RefreshCw } from "lucide-react";
+import { Sprout, Pin, BellOff, RefreshCw, Play, Ban } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 import { IssueBadge } from "./IssueBadge";
 import { PRBadge } from "./PRBadge";
@@ -58,6 +60,8 @@ export interface WorktreeHeaderProps {
   };
 
   gitStateIndicator: GitStateIndicator | null;
+  onAbortRepositoryOperation?: () => Promise<void>;
+  onContinueRepositoryOperation?: () => Promise<void>;
 
   menu: {
     launchAgents: import("../WorktreeMenuItems").WorktreeLaunchAgentItem[];
@@ -214,6 +218,128 @@ function GitStatusFreshnessPill({
   );
 }
 
+// Blocking git operations the card can recover from inline. Excludes
+// "conflicted" (defer to ReviewHub) and "detached" (not an in-progress op).
+const BLOCKING_OP_KINDS = ["reverting", "rebasing", "merging", "cherry-picking"] as const;
+type BlockingOpKind = (typeof BLOCKING_OP_KINDS)[number];
+
+function isBlockingOpKind(kind: GitStateKind): kind is BlockingOpKind {
+  return (BLOCKING_OP_KINDS as readonly GitStateKind[]).includes(kind);
+}
+
+// User-facing operation noun (lowercase, for inline button/dialog copy).
+const BLOCKING_OP_LABEL: Record<BlockingOpKind, string> = {
+  reverting: "revert",
+  rebasing: "rebase",
+  merging: "merge",
+  "cherry-picking": "cherry-pick",
+};
+
+// Abort consequence copy, mirrored from ConflictPanel's ABORT_RESTORE_SUFFIX so
+// the dialog states the specific outcome rather than generic irreversibility.
+const BLOCKING_OP_ABORT_DESCRIPTION: Record<BlockingOpKind, string> = {
+  reverting:
+    "Discards the in-progress revert and restores the working tree to the state before it started.",
+  rebasing: "Discards the in-progress rebase and returns HEAD to the original branch tip.",
+  merging: "Discards the in-progress merge and restores the working tree to its pre-merge state.",
+  "cherry-picking":
+    "Discards the in-progress cherry-pick and restores the working tree to the state before it started.",
+};
+
+/**
+ * Inline recovery row for a stuck blocking git operation (revert/rebase/merge/
+ * cherry-pick) — surfaced on the card so the user isn't left with a permanent
+ * state badge and no way out (#10715). Continue is disabled while conflicts
+ * remain unresolved; Abort is a D1 destructive action gated by a ConfirmDialog.
+ */
+function BlockingOpRow({
+  kind,
+  hasUnresolvedConflicts,
+  onAbort,
+  onContinue,
+}: {
+  kind: BlockingOpKind;
+  hasUnresolvedConflicts: boolean;
+  onAbort: () => Promise<void>;
+  onContinue: () => Promise<void>;
+}) {
+  const [isAbortOpen, setIsAbortOpen] = useState(false);
+  const [isAborting, setIsAborting] = useState(false);
+  const [isContinuing, setIsContinuing] = useState(false);
+  const label = BLOCKING_OP_LABEL[kind];
+
+  const handleAbort = useCallback(async () => {
+    setIsAborting(true);
+    try {
+      await onAbort();
+      setIsAbortOpen(false);
+    } catch {
+      // Error surfaced via notify() in the parent; keep the dialog open to retry.
+    } finally {
+      setIsAborting(false);
+    }
+  }, [onAbort]);
+
+  const handleContinue = useCallback(async () => {
+    setIsContinuing(true);
+    try {
+      await onContinue();
+    } catch {
+      // Error surfaced via notify() in the parent.
+    } finally {
+      setIsContinuing(false);
+    }
+  }, [onContinue]);
+
+  return (
+    <div className="mt-1.5 flex items-center gap-1.5">
+      <Button
+        type="button"
+        size="xs"
+        variant="outline"
+        loading={isContinuing}
+        disabled={hasUnresolvedConflicts}
+        title={
+          hasUnresolvedConflicts ? "Resolve the remaining conflicts before continuing" : undefined
+        }
+        onClick={(e) => {
+          e.stopPropagation();
+          void handleContinue();
+        }}
+      >
+        <Play aria-hidden="true" />
+        Continue {label}
+      </Button>
+      <Button
+        type="button"
+        size="xs"
+        variant="ghost-danger"
+        onClick={(e) => {
+          e.stopPropagation();
+          setIsAbortOpen(true);
+        }}
+      >
+        <Ban aria-hidden="true" />
+        Abort {label}
+      </Button>
+
+      <ConfirmDialog
+        isOpen={isAbortOpen}
+        onClose={() => {
+          if (!isAborting) setIsAbortOpen(false);
+        }}
+        title={`Abort ${label}?`}
+        description={BLOCKING_OP_ABORT_DESCRIPTION[kind]}
+        confirmLabel={`Abort ${label}`}
+        cancelLabel="Keep working"
+        onConfirm={() => void handleAbort()}
+        isConfirmLoading={isAborting}
+        variant="destructive"
+      />
+    </div>
+  );
+}
+
 export function WorktreeHeader({
   worktree,
   isActive,
@@ -245,6 +371,8 @@ export function WorktreeHeader({
   onCleanupWorktree,
   badges,
   gitStateIndicator,
+  onAbortRepositoryOperation,
+  onContinueRepositoryOperation,
   menu,
 }: WorktreeHeaderProps) {
   const recipeOptions = useMemo(
@@ -291,6 +419,18 @@ export function WorktreeHeader({
     (worktree.matchedForgeProviderId != null || worktree.linked?.providerId != null)
   );
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasDisplayTitle);
+
+  // Inline recovery for a stuck blocking git operation. Only mounts when the
+  // indicator resolves to one of the in-progress operation kinds (not
+  // "conflicted" — that defers to ReviewHub — nor "detached"). Continue is
+  // gated on there being no unresolved conflicts, the same source the indicator
+  // uses, so a half-resolved revert can't be advanced prematurely.
+  const blockingOpKind =
+    gitStateIndicator && isBlockingOpKind(gitStateIndicator.kind) ? gitStateIndicator.kind : null;
+  const hasUnresolvedConflicts = !!worktree.worktreeChanges?.changes?.some(
+    (c) => c.status === "conflicted"
+  );
+  const showBlockingOpRow = !isCollapsed && blockingOpKind !== null;
 
   const prState = worktree.linked?.pr?.state;
   const isPrLive = prState !== undefined && prState !== "closed" && prState !== "declined";
@@ -458,6 +598,18 @@ export function WorktreeHeader({
           handleLaunchAgent={handleLaunchAgent}
         />
       </div>
+
+      {showBlockingOpRow &&
+        blockingOpKind &&
+        onAbortRepositoryOperation &&
+        onContinueRepositoryOperation && (
+          <BlockingOpRow
+            kind={blockingOpKind}
+            hasUnresolvedConflicts={hasUnresolvedConflicts}
+            onAbort={onAbortRepositoryOperation}
+            onContinue={onContinueRepositoryOperation}
+          />
+        )}
 
       {!isCollapsed && isMainStandardLayout && (
         <MainWorktreeSecondaryRow

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AgentState, TerminalRecipe, WorktreeState } from "@/types";
-import type { GitStateIndicator, GitStateKind } from "./hooks/useWorktreeStatus";
+import type { RepoState } from "@shared/types";
+import type { GitStateIndicator } from "./hooks/useWorktreeStatus";
 import { cn } from "@/lib/utils";
 import { STATE_LABELS, STATE_PRIORITY } from "../terminalStateConfig";
 import { BranchLabel } from "../BranchLabel";
@@ -218,14 +219,20 @@ function GitStatusFreshnessPill({
   );
 }
 
-// Blocking git operations the card can recover from inline. Excludes
-// "conflicted" (defer to ReviewHub) and "detached" (not an in-progress op).
-const BLOCKING_OP_KINDS = ["reverting", "rebasing", "merging", "cherry-picking"] as const;
-type BlockingOpKind = (typeof BLOCKING_OP_KINDS)[number];
+// Blocking git operations the card can recover from inline.
+type BlockingOpKind = "reverting" | "rebasing" | "merging" | "cherry-picking";
 
-function isBlockingOpKind(kind: GitStateKind): kind is BlockingOpKind {
-  return (BLOCKING_OP_KINDS as readonly GitStateKind[]).includes(kind);
-}
+// Derived from worktree.repoState (the raw in-progress operation), NOT from
+// gitStateIndicator: the indicator gives "conflicted" priority over the
+// operation, so a revert/rebase/merge/cherry-pick that hit conflicts — the
+// canonical stuck case — would otherwise never surface the recovery row
+// (#10715). The Continue button stays disabled while conflicts remain.
+const REPO_STATE_TO_BLOCKING_KIND: Partial<Record<RepoState, BlockingOpKind>> = {
+  REVERTING: "reverting",
+  REBASING: "rebasing",
+  MERGING: "merging",
+  CHERRY_PICKING: "cherry-picking",
+};
 
 // User-facing operation noun (lowercase, for inline button/dialog copy).
 const BLOCKING_OP_LABEL: Record<BlockingOpKind, string> = {
@@ -298,7 +305,7 @@ function BlockingOpRow({
         size="xs"
         variant="outline"
         loading={isContinuing}
-        disabled={hasUnresolvedConflicts}
+        disabled={hasUnresolvedConflicts || isAborting || isAbortOpen}
         title={
           hasUnresolvedConflicts ? "Resolve the remaining conflicts before continuing" : undefined
         }
@@ -314,6 +321,7 @@ function BlockingOpRow({
         type="button"
         size="xs"
         variant="ghost-danger"
+        disabled={isContinuing}
         onClick={(e) => {
           e.stopPropagation();
           setIsAbortOpen(true);
@@ -420,13 +428,14 @@ export function WorktreeHeader({
   );
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasDisplayTitle);
 
-  // Inline recovery for a stuck blocking git operation. Only mounts when the
-  // indicator resolves to one of the in-progress operation kinds (not
-  // "conflicted" — that defers to ReviewHub — nor "detached"). Continue is
-  // gated on there being no unresolved conflicts, the same source the indicator
-  // uses, so a half-resolved revert can't be advanced prematurely.
-  const blockingOpKind =
-    gitStateIndicator && isBlockingOpKind(gitStateIndicator.kind) ? gitStateIndicator.kind : null;
+  // Inline recovery for a stuck blocking git operation (revert/rebase/merge/
+  // cherry-pick). Mounts whenever an operation is in progress, even when it has
+  // conflicts (the badge then reads "conflicted" but the op is still abortable).
+  // Continue is gated on there being no unresolved conflicts so a half-resolved
+  // operation can't be advanced prematurely.
+  const blockingOpKind = worktree.repoState
+    ? (REPO_STATE_TO_BLOCKING_KIND[worktree.repoState] ?? null)
+    : null;
   const hasUnresolvedConflicts = !!worktree.worktreeChanges?.changes?.some(
     (c) => c.status === "conflicted"
   );

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1520,12 +1520,9 @@ describe("WorktreeHeader upstream sync indicator", () => {
 });
 
 describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
-  type Kind = NonNullable<WorktreeHeaderProps["gitStateIndicator"]>["kind"];
-
-  function indicator(kind: Kind): WorktreeHeaderProps["gitStateIndicator"] {
-    return { kind, label: kind, tone: kind === "conflicted" ? "error" : "warning" };
-  }
-
+  // The row mounts off worktree.repoState (the raw in-progress operation), NOT
+  // gitStateIndicator — so it surfaces even when conflicts make the badge read
+  // "conflicted". gitStateIndicator only drives the inert badge label.
   function conflictedChanges(): WorktreeState["worktreeChanges"] {
     return {
       changedFileCount: 1,
@@ -1533,67 +1530,64 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
     } as WorktreeState["worktreeChanges"];
   }
 
-  const BLOCKING: { kind: Kind; label: string }[] = [
-    { kind: "reverting", label: "revert" },
-    { kind: "rebasing", label: "rebase" },
-    { kind: "merging", label: "merge" },
-    { kind: "cherry-picking", label: "cherry-pick" },
-  ];
-
-  it.each(BLOCKING)("renders Continue + Abort for $kind", ({ kind, label }) => {
-    renderHeader({
-      gitStateIndicator: indicator(kind),
+  function blockingHeader(
+    repoState: WorktreeState["repoState"],
+    overrides: Partial<WorktreeHeaderProps> = {}
+  ) {
+    const { worktree: worktreeOverride, ...rest } = overrides;
+    return renderHeader({
+      worktree: { ...baseWorktree, repoState, ...(worktreeOverride ?? {}) },
       onAbortRepositoryOperation: vi.fn().mockResolvedValue(undefined),
       onContinueRepositoryOperation: vi.fn().mockResolvedValue(undefined),
+      ...rest,
     });
+  }
+
+  const BLOCKING = [
+    { repoState: "REVERTING", label: "revert" },
+    { repoState: "REBASING", label: "rebase" },
+    { repoState: "MERGING", label: "merge" },
+    { repoState: "CHERRY_PICKING", label: "cherry-pick" },
+  ] as const;
+
+  it.each(BLOCKING)("renders Continue + Abort for $repoState", ({ repoState, label }) => {
+    blockingHeader(repoState);
     expect(screen.getByRole("button", { name: `Continue ${label}` })).toBeTruthy();
     expect(screen.getByRole("button", { name: `Abort ${label}` })).toBeTruthy();
   });
 
-  it.each(["conflicted", "detached"] as Kind[])(
-    "does not render the row for %s (defers to ReviewHub / not an op)",
-    (kind) => {
-      renderHeader({
-        gitStateIndicator: indicator(kind),
-        onAbortRepositoryOperation: vi.fn(),
-        onContinueRepositoryOperation: vi.fn(),
-      });
-      expect(screen.queryByRole("button", { name: /^Continue / })).toBeNull();
-      expect(screen.queryByRole("button", { name: /^Abort / })).toBeNull();
-    }
-  );
+  it("renders the row for an in-progress operation that has conflicts (the canonical stuck case)", () => {
+    blockingHeader("REVERTING", { worktree: { worktreeChanges: conflictedChanges() } });
+    // Row still mounts even though the badge would read "conflicted"...
+    expect(screen.getByRole("button", { name: "Abort revert" })).toBeTruthy();
+    // ...and Continue is disabled until the conflicts are resolved.
+    const cont = screen.getByRole("button", { name: "Continue revert" });
+    expect(cont.hasAttribute("disabled")).toBe(true);
+  });
 
-  it("does not render the row when gitStateIndicator is null", () => {
+  it("does not render the row when no operation is in progress", () => {
     renderHeader({
-      gitStateIndicator: null,
+      worktree: { ...baseWorktree, repoState: undefined, isDetached: true },
       onAbortRepositoryOperation: vi.fn(),
       onContinueRepositoryOperation: vi.fn(),
     });
     expect(screen.queryByRole("button", { name: /^Continue / })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Abort / })).toBeNull();
   });
 
   it("does not render the row when collapsed", () => {
-    renderHeader({
-      isCollapsed: true,
-      gitStateIndicator: indicator("reverting"),
-      onAbortRepositoryOperation: vi.fn(),
-      onContinueRepositoryOperation: vi.fn(),
-    });
+    blockingHeader("REVERTING", { isCollapsed: true });
     expect(screen.queryByRole("button", { name: "Continue revert" })).toBeNull();
   });
 
   it("does not render the row when callbacks are absent", () => {
-    renderHeader({ gitStateIndicator: indicator("reverting") });
+    renderHeader({ worktree: { ...baseWorktree, repoState: "REVERTING" } });
     expect(screen.queryByRole("button", { name: "Continue revert" })).toBeNull();
   });
 
   it("Abort opens a destructive ConfirmDialog and confirming invokes onAbort", async () => {
     const onAbort = vi.fn().mockResolvedValue(undefined);
-    renderHeader({
-      gitStateIndicator: indicator("reverting"),
-      onAbortRepositoryOperation: onAbort,
-      onContinueRepositoryOperation: vi.fn(),
-    });
+    blockingHeader("REVERTING", { onAbortRepositoryOperation: onAbort });
     // The inline Abort button only opens the dialog — it must not call IPC directly.
     const triggers = screen.getAllByRole("button", { name: "Abort revert" });
     fireEvent.click(triggers[0]);
@@ -1608,15 +1602,24 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
     expect(onAbort).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the abort dialog open when the abort fails so the user can retry", async () => {
+    const onAbort = vi.fn().mockRejectedValue(new Error("nope"));
+    blockingHeader("REVERTING", { onAbortRepositoryOperation: onAbort });
+    fireEvent.click(screen.getAllByRole("button", { name: "Abort revert" })[0]);
+    const confirmButtons = screen.getAllByRole("button", { name: "Abort revert" });
+    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    await Promise.resolve();
+    await Promise.resolve();
+    // Dialog still mounted (both trigger + confirm present) and not stuck loading.
+    expect(screen.getAllByRole("button", { name: "Abort revert" }).length).toBeGreaterThan(1);
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
   it("Continue invokes onContinue when there are no unresolved conflicts", async () => {
     const onContinue = vi.fn().mockResolvedValue(undefined);
-    renderHeader({
-      gitStateIndicator: indicator("rebasing"),
-      onAbortRepositoryOperation: vi.fn(),
-      onContinueRepositoryOperation: onContinue,
-    });
+    blockingHeader("REBASING", { onContinueRepositoryOperation: onContinue });
     const btn = screen.getByRole("button", { name: "Continue rebase" });
-    expect(btn.getAttribute("aria-disabled")).not.toBe("true");
+    expect(btn.hasAttribute("disabled")).toBe(false);
     fireEvent.click(btn);
     await Promise.resolve();
     expect(onContinue).toHaveBeenCalledTimes(1);
@@ -1624,10 +1627,8 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
 
   it("Continue is disabled while unresolved conflicts remain", () => {
     const onContinue = vi.fn();
-    renderHeader({
-      worktree: { ...baseWorktree, repoState: "REBASING", worktreeChanges: conflictedChanges() },
-      gitStateIndicator: indicator("rebasing"),
-      onAbortRepositoryOperation: vi.fn(),
+    blockingHeader("REBASING", {
+      worktree: { worktreeChanges: conflictedChanges() },
       onContinueRepositoryOperation: onContinue,
     });
     const btn = screen.getByRole("button", { name: "Continue rebase" });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1525,9 +1525,11 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
   // "conflicted". gitStateIndicator only drives the inert badge label.
   function conflictedChanges(): WorktreeState["worktreeChanges"] {
     return {
+      worktreeId: "test-wt",
+      rootPath: "/tmp/test-wt",
       changedFileCount: 1,
       changes: [{ path: "a.ts", status: "conflicted", insertions: null, deletions: null }],
-    } as WorktreeState["worktreeChanges"];
+    };
   }
 
   function blockingHeader(

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { WorktreeHeader, type WorktreeHeaderProps } from "../WorktreeHeader";
@@ -13,6 +13,18 @@ import { actionService } from "@/services/ActionService";
 vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
   return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
 });
 
 let mockMissingCredential = false;
@@ -1504,5 +1516,123 @@ describe("WorktreeHeader upstream sync indicator", () => {
     expect(indicator.getAttribute("data-fetch-auth-failed")).toBe("true");
     expect(indicator.getAttribute("data-fetch-network-failed")).toBeNull();
     expect(indicator.className).not.toContain("opacity-75");
+  });
+});
+
+describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
+  type Kind = NonNullable<WorktreeHeaderProps["gitStateIndicator"]>["kind"];
+
+  function indicator(kind: Kind): WorktreeHeaderProps["gitStateIndicator"] {
+    return { kind, label: kind, tone: kind === "conflicted" ? "error" : "warning" };
+  }
+
+  function conflictedChanges(): WorktreeState["worktreeChanges"] {
+    return {
+      changedFileCount: 1,
+      changes: [{ path: "a.ts", status: "conflicted", insertions: null, deletions: null }],
+    } as WorktreeState["worktreeChanges"];
+  }
+
+  const BLOCKING: { kind: Kind; label: string }[] = [
+    { kind: "reverting", label: "revert" },
+    { kind: "rebasing", label: "rebase" },
+    { kind: "merging", label: "merge" },
+    { kind: "cherry-picking", label: "cherry-pick" },
+  ];
+
+  it.each(BLOCKING)("renders Continue + Abort for $kind", ({ kind, label }) => {
+    renderHeader({
+      gitStateIndicator: indicator(kind),
+      onAbortRepositoryOperation: vi.fn().mockResolvedValue(undefined),
+      onContinueRepositoryOperation: vi.fn().mockResolvedValue(undefined),
+    });
+    expect(screen.getByRole("button", { name: `Continue ${label}` })).toBeTruthy();
+    expect(screen.getByRole("button", { name: `Abort ${label}` })).toBeTruthy();
+  });
+
+  it.each(["conflicted", "detached"] as Kind[])(
+    "does not render the row for %s (defers to ReviewHub / not an op)",
+    (kind) => {
+      renderHeader({
+        gitStateIndicator: indicator(kind),
+        onAbortRepositoryOperation: vi.fn(),
+        onContinueRepositoryOperation: vi.fn(),
+      });
+      expect(screen.queryByRole("button", { name: /^Continue / })).toBeNull();
+      expect(screen.queryByRole("button", { name: /^Abort / })).toBeNull();
+    }
+  );
+
+  it("does not render the row when gitStateIndicator is null", () => {
+    renderHeader({
+      gitStateIndicator: null,
+      onAbortRepositoryOperation: vi.fn(),
+      onContinueRepositoryOperation: vi.fn(),
+    });
+    expect(screen.queryByRole("button", { name: /^Continue / })).toBeNull();
+  });
+
+  it("does not render the row when collapsed", () => {
+    renderHeader({
+      isCollapsed: true,
+      gitStateIndicator: indicator("reverting"),
+      onAbortRepositoryOperation: vi.fn(),
+      onContinueRepositoryOperation: vi.fn(),
+    });
+    expect(screen.queryByRole("button", { name: "Continue revert" })).toBeNull();
+  });
+
+  it("does not render the row when callbacks are absent", () => {
+    renderHeader({ gitStateIndicator: indicator("reverting") });
+    expect(screen.queryByRole("button", { name: "Continue revert" })).toBeNull();
+  });
+
+  it("Abort opens a destructive ConfirmDialog and confirming invokes onAbort", async () => {
+    const onAbort = vi.fn().mockResolvedValue(undefined);
+    renderHeader({
+      gitStateIndicator: indicator("reverting"),
+      onAbortRepositoryOperation: onAbort,
+      onContinueRepositoryOperation: vi.fn(),
+    });
+    // The inline Abort button only opens the dialog — it must not call IPC directly.
+    const triggers = screen.getAllByRole("button", { name: "Abort revert" });
+    fireEvent.click(triggers[0]);
+    expect(onAbort).not.toHaveBeenCalled();
+
+    // The dialog's confirm button carries the same verb-noun label; it's the
+    // last "Abort revert" button now that the dialog has opened.
+    const confirmButtons = screen.getAllByRole("button", { name: "Abort revert" });
+    const dialogConfirm = confirmButtons[confirmButtons.length - 1];
+    fireEvent.click(dialogConfirm);
+    await Promise.resolve();
+    expect(onAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it("Continue invokes onContinue when there are no unresolved conflicts", async () => {
+    const onContinue = vi.fn().mockResolvedValue(undefined);
+    renderHeader({
+      gitStateIndicator: indicator("rebasing"),
+      onAbortRepositoryOperation: vi.fn(),
+      onContinueRepositoryOperation: onContinue,
+    });
+    const btn = screen.getByRole("button", { name: "Continue rebase" });
+    expect(btn.getAttribute("aria-disabled")).not.toBe("true");
+    fireEvent.click(btn);
+    await Promise.resolve();
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("Continue is disabled while unresolved conflicts remain", () => {
+    const onContinue = vi.fn();
+    renderHeader({
+      worktree: { ...baseWorktree, repoState: "REBASING", worktreeChanges: conflictedChanges() },
+      gitStateIndicator: indicator("rebasing"),
+      onAbortRepositoryOperation: vi.fn(),
+      onContinueRepositoryOperation: onContinue,
+    });
+    const btn = screen.getByRole("button", { name: "Continue rebase" });
+    expect(btn.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(btn);
+    expect(onContinue).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1534,7 +1534,9 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
 
   function blockingHeader(
     repoState: WorktreeState["repoState"],
-    overrides: Partial<WorktreeHeaderProps> = {}
+    overrides: Partial<Omit<WorktreeHeaderProps, "worktree">> & {
+      worktree?: Partial<WorktreeState>;
+    } = {}
   ) {
     const { worktree: worktreeOverride, ...rest } = overrides;
     return renderHeader({
@@ -1543,6 +1545,14 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
       onContinueRepositoryOperation: vi.fn().mockResolvedValue(undefined),
       ...rest,
     });
+  }
+
+  // getAllByRole(...)[i] is `HTMLElement | undefined` under noUncheckedIndexedAccess.
+  function nthButton(name: string, index: number): HTMLElement {
+    const els = screen.getAllByRole("button", { name });
+    const el = index < 0 ? els[els.length + index] : els[index];
+    if (!el) throw new Error(`button "${name}" at index ${index} not found`);
+    return el;
   }
 
   const BLOCKING = [
@@ -1591,15 +1601,12 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
     const onAbort = vi.fn().mockResolvedValue(undefined);
     blockingHeader("REVERTING", { onAbortRepositoryOperation: onAbort });
     // The inline Abort button only opens the dialog — it must not call IPC directly.
-    const triggers = screen.getAllByRole("button", { name: "Abort revert" });
-    fireEvent.click(triggers[0]);
+    fireEvent.click(nthButton("Abort revert", 0));
     expect(onAbort).not.toHaveBeenCalled();
 
     // The dialog's confirm button carries the same verb-noun label; it's the
     // last "Abort revert" button now that the dialog has opened.
-    const confirmButtons = screen.getAllByRole("button", { name: "Abort revert" });
-    const dialogConfirm = confirmButtons[confirmButtons.length - 1];
-    fireEvent.click(dialogConfirm);
+    fireEvent.click(nthButton("Abort revert", -1));
     await Promise.resolve();
     expect(onAbort).toHaveBeenCalledTimes(1);
   });
@@ -1607,9 +1614,8 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
   it("keeps the abort dialog open when the abort fails so the user can retry", async () => {
     const onAbort = vi.fn().mockRejectedValue(new Error("nope"));
     blockingHeader("REVERTING", { onAbortRepositoryOperation: onAbort });
-    fireEvent.click(screen.getAllByRole("button", { name: "Abort revert" })[0]);
-    const confirmButtons = screen.getAllByRole("button", { name: "Abort revert" });
-    fireEvent.click(confirmButtons[confirmButtons.length - 1]);
+    fireEvent.click(nthButton("Abort revert", 0));
+    fireEvent.click(nthButton("Abort revert", -1));
     await Promise.resolve();
     await Promise.resolve();
     // Dialog still mounted (both trigger + confirm present) and not stuck loading.


### PR DESCRIPTION
## Summary

- A worktree left mid-revert, rebase, merge, or cherry-pick showed a permanent state badge with a Refresh button that was a guaranteed no-op, and no way out.
- `WorktreeMonitor.ts` now stamps `lastGitStatusCompletedAt` on the blocking-operation path and re-emits a snapshot on forced refresh, so the `GitStatusFreshnessPill` Refresh button actually resets rather than doing nothing. Background polls stamp silently.
- A new inline abort/continue recovery row appears in the worktree card header for the four blocking-operation states, wired to the existing `git.abortRepositoryOperation` / `continueRepositoryOperation` IPC handlers. Continue is disabled until conflicts are resolved; Abort is a D1 destructive action behind a `ConfirmDialog` with operation-specific copy. Errors surface via `notify()` with a Retry action.

Resolves #10715

## Changes

- `electron/workspace-host/WorktreeMonitor.ts`: stamp timestamp and re-emit on forced refresh while a sentinel file is present
- `electron/workspace-host/__tests__/WorktreeMonitor.test.ts`: regression tests for forced-refresh re-emit and silent background poll
- `src/components/Worktree/WorktreeCard.tsx`: thread `repoState` into `WorktreeHeader`
- `src/components/Worktree/WorktreeCard/WorktreeHeader.tsx`: blocking-op recovery row (abort/continue, confirm dialog, conflict-gated continue)
- `src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx`: row visibility per state, conflict-gated continue, abort confirm flow

## Testing

230 targeted tests pass. New `WorktreeMonitor` tests cover the forced-refresh and silent-poll paths. New `WorktreeHeader` tests cover row visibility for each blocking state, continue disabled when conflicts are present, and the abort confirm flow. Own files lint-clean and formatted.