### PR TITLE
fix(terminal): wake paused-backpressure terminal on user input

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -571,6 +571,23 @@ class TerminalInstanceService {
 
     this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
 
+    // BURST and FOCUSED both map to the "active"/50ms backend tier, so when a
+    // paused-backpressure terminal is already cached at that tier the policy
+    // dedupes and no wake IPC reaches the host — typing leaves the visible
+    // "Paused" state stuck. Fire an explicit wake to resume the coordinator,
+    // mirroring the focus path. Skip backgrounded terminals (the #9906 guard):
+    // waking a hidden pane promotes the host to active streaming. Read both
+    // fields from one snapshot so they can't diverge. resource-governor pauses
+    // are intentionally excluded — wakeExecutor only releases the backpressure
+    // coordinator token, so a wake there is a no-op (#10669).
+    const panelState = usePanelStore.getState();
+    if (
+      panelState.panelsById[id]?.flowStatus === "paused-backpressure" &&
+      !panelState.backgroundedTerminals.has(id)
+    ) {
+      this.wake(id);
+    }
+
     if (managed.inputBurstTimer !== undefined) {
       clearTimeout(managed.inputBurstTimer);
     }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -44,6 +44,7 @@ import {
 import { reduceScrollback, restoreScrollback } from "./TerminalScrollbackController";
 import { DEFAULT_TERMINAL_FONT_FAMILY, onTerminalFontArrivedLate } from "@/config/terminalFont";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import { isPtyPanel } from "@shared/types/panel";
 import { usePanelStore } from "@/store/panelStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { logDebug, logWarn, logError } from "@/utils/logger";
@@ -581,8 +582,11 @@ class TerminalInstanceService {
     // are intentionally excluded — wakeExecutor only releases the backpressure
     // coordinator token, so a wake there is a no-op (#10669).
     const panelState = usePanelStore.getState();
+    const panel = panelState.panelsById[id];
     if (
-      panelState.panelsById[id]?.flowStatus === "paused-backpressure" &&
+      panel &&
+      isPtyPanel(panel) &&
+      panel.flowStatus === "paused-backpressure" &&
       !panelState.backgroundedTerminals.has(id)
     ) {
       this.wake(id);

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -719,7 +719,7 @@ describe("TerminalInstanceService - onUserInput wake for paused-backpressure", (
 
   function setStore(flowStatus: string, backgrounded: boolean) {
     panelStore.setState({
-      panelsById: { t1: { flowStatus } },
+      panelsById: { t1: { kind: "terminal", flowStatus } },
       backgroundedTerminals: backgrounded ? new Map([["t1", {}]]) : new Map(),
     });
   }
@@ -757,6 +757,20 @@ describe("TerminalInstanceService - onUserInput wake for paused-backpressure", (
     // here is a no-op — the exclusion is intentional and locked by this test.
     service.instances.set("t1", makeMockManaged() as unknown as Record<string, unknown>);
     setStore("paused-resource-governor", false);
+
+    service.onUserInput("t1", "a");
+
+    expect(mockTerminalClient.wake).not.toHaveBeenCalled();
+  });
+
+  it("does not wake when the panel is not a PTY panel", () => {
+    // flowStatus is a PtyPanelData field; the isPtyPanel guard keeps the
+    // condition type-safe against the BrowserPanelData branch of the union.
+    service.instances.set("t1", makeMockManaged() as unknown as Record<string, unknown>);
+    panelStore.setState({
+      panelsById: { t1: { kind: "browser", flowStatus: "paused-backpressure" } },
+      backgroundedTerminals: new Map(),
+    });
 
     service.onUserInput("t1", "a");
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -676,3 +676,79 @@ describe("TerminalInstanceService - Activity Tier", () => {
     });
   });
 });
+
+// A separate top-level block: these tests mutate the real panelStore singleton,
+// so each one resets modules to get a fresh store and a fresh service singleton
+// rather than leaking flowStatus/backgroundedTerminals across cases.
+type InputWakeService = {
+  instances: Map<string, Record<string, unknown>>;
+  onUserInput: (id: string, data: string) => void;
+};
+
+type PanelStoreModule = {
+  usePanelStore: {
+    getState: () => Record<string, unknown>;
+    setState: (partial: Record<string, unknown>) => void;
+  };
+};
+
+describe("TerminalInstanceService - onUserInput wake for paused-backpressure", () => {
+  let service: InputWakeService;
+  let panelStore: PanelStoreModule["usePanelStore"];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockTerminalClient.wake.mockResolvedValue({ state: null, noChange: false });
+
+    ({ terminalInstanceService: service } =
+      (await import("../TerminalInstanceService")) as unknown as {
+        terminalInstanceService: InputWakeService;
+      });
+    ({ usePanelStore: panelStore } =
+      (await import("@/store/panelStore")) as unknown as PanelStoreModule);
+
+    service.instances.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    service.instances.clear();
+  });
+
+  function setStore(flowStatus: string, backgrounded: boolean) {
+    panelStore.setState({
+      panelsById: { t1: { flowStatus } },
+      backgroundedTerminals: backgrounded ? new Map([["t1", {}]]) : new Map(),
+    });
+  }
+
+  it("wakes a visible paused-backpressure terminal on user input", () => {
+    service.instances.set("t1", makeMockManaged() as unknown as Record<string, unknown>);
+    setStore("paused-backpressure", false);
+
+    service.onUserInput("t1", "a");
+
+    expect(mockTerminalClient.wake).toHaveBeenCalledTimes(1);
+    expect(mockTerminalClient.wake).toHaveBeenCalledWith("t1", expect.anything());
+  });
+
+  it("does not wake a backgrounded paused-backpressure terminal", () => {
+    service.instances.set("t1", makeMockManaged() as unknown as Record<string, unknown>);
+    setStore("paused-backpressure", true);
+
+    service.onUserInput("t1", "a");
+
+    expect(mockTerminalClient.wake).not.toHaveBeenCalled();
+  });
+
+  it("does not wake a running terminal on user input", () => {
+    service.instances.set("t1", makeMockManaged() as unknown as Record<string, unknown>);
+    setStore("running", false);
+
+    service.onUserInput("t1", "a");
+
+    expect(mockTerminalClient.wake).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -751,4 +751,15 @@ describe("TerminalInstanceService - onUserInput wake for paused-backpressure", (
 
     expect(mockTerminalClient.wake).not.toHaveBeenCalled();
   });
+
+  it("does not wake a paused-resource-governor terminal on user input", () => {
+    // wakeExecutor only releases the backpressure coordinator token, so a wake
+    // here is a no-op — the exclusion is intentional and locked by this test.
+    service.instances.set("t1", makeMockManaged() as unknown as Record<string, unknown>);
+    setStore("paused-resource-governor", false);
+
+    service.onUserInput("t1", "a");
+
+    expect(mockTerminalClient.wake).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes a case where a terminal stuck in `paused-backpressure` stays visually Paused when the user types. The input handler only promoted the renderer tier, which was deduped because the backend cache already showed `active/50ms`, so no wake signal reached the pty host.
- `onUserInput()` now explicitly calls `wake(id)` when `flowStatus === "paused-backpressure"` and the terminal is not backgrounded. The `paused-resource-governor` state is intentionally excluded because `wakeExecutor` only releases the backpressure coordinator token, not the resource governor.
- Both `flowStatus` and the backgrounded flag are read from a single `usePanelStore.getState()` snapshot, preserving the #9906 background guard.

Resolves #10669

## Changes

- `src/services/terminal/TerminalInstanceService.ts`: explicit `wake(id)` call in `onUserInput()` when flow status is `paused-backpressure` and terminal is visible
- `src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts`: four new tests covering the wake path (visible wakes, backgrounded does not wake, running does not wake, `paused-resource-governor` does not wake)

## Testing

All 119 tests across the wake path pass. New tests verify:
- Visible `paused-backpressure` terminal wakes on input
- Backgrounded terminal does not wake on input
- Running terminal does not wake on input
- `paused-resource-governor` terminal does not wake on input