### PR TITLE
fix(commits-dropdown): reflow hard-wrapped commit bodies

### DIFF
--- a/src/components/Layout/LocalCommitsDropdown.tsx
+++ b/src/components/Layout/LocalCommitsDropdown.tsx
@@ -47,6 +47,50 @@ const COMMIT_ROW_HEIGHT_PX = 58;
 const skeletonRowCount = (initialCount: number | null | undefined) =>
   Math.max(1, Math.min(initialCount ?? 3, 8));
 
+// Commit bodies are conventionally hard-wrapped at ~72 columns. In the narrow
+// dropdown panel those hard breaks collide with the panel's own soft wrapping,
+// producing ragged double-wrapped text (issue #10718). Reflow continuation
+// prose lines back into their paragraph so soft-wrapping is the only break,
+// while preserving structure that depends on its own line breaks: blank lines
+// (paragraph separators), list items, indented/code lines, and `Key: value`
+// trailers (Co-authored-by:, Signed-off-by:, Fixes:, …). The <pre> keeps
+// whitespace-pre-wrap + break-words so long unwrapped lines (e.g. pasted URLs)
+// still wrap. Pure, non-throwing, and idempotent.
+export function reflowCommitBody(body: string): string {
+  if (!body) return body;
+
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+
+  const isStructural = (line: string): boolean =>
+    line.trim() === "" || // blank line (paragraph separator)
+    /^\s/.test(line) || // indented / code / continuation line
+    /^\s*[-*+]\s/.test(line) || // bullet list item
+    /^\s*\d+[.)]\s/.test(line) || // numbered list item
+    /^[A-Za-z][A-Za-z0-9-]*:\s/.test(line); // trailer / key: value
+
+  const out: string[] = [];
+  let paragraph: string[] = [];
+
+  const flush = () => {
+    if (paragraph.length > 0) {
+      out.push(paragraph.join(" "));
+      paragraph = [];
+    }
+  };
+
+  for (const line of lines) {
+    if (isStructural(line)) {
+      flush();
+      out.push(line);
+    } else {
+      paragraph.push(line.replace(/\s+$/, ""));
+    }
+  }
+  flush();
+
+  return out.join("\n");
+}
+
 function LocalCommitsSkeleton({ count }: { count: number | null | undefined }) {
   return (
     <div role="status" aria-live="polite" aria-busy="true" aria-label="Loading commits">
@@ -94,7 +138,7 @@ function LocalCommitRow({ commit, optionId, isActive, isExpanded, onToggle }: Lo
     };
   }, []);
 
-  const trimmedBody = commit.body?.trim() ?? "";
+  const trimmedBody = reflowCommitBody(commit.body?.trim() ?? "");
   const hasBody = trimmedBody.length > 0;
 
   const handleCopyHash = async (e: MouseEvent<HTMLButtonElement>) => {

--- a/src/components/Layout/LocalCommitsDropdown.tsx
+++ b/src/components/Layout/LocalCommitsDropdown.tsx
@@ -62,12 +62,13 @@ export function reflowCommitBody(body: string): string {
   const lines = body.replace(/\r\n?/g, "\n").split("\n");
 
   const isBlank = (line: string) => line.trim() === "";
-  // Lines whose own break is meaningful regardless of context.
+  const isFenceDelimiter = (line: string) => line.startsWith("```");
+  // Lines whose own break is meaningful regardless of context. (Fence
+  // delimiters and fenced content are handled separately via inFence below.)
   const isAlwaysStructural = (line: string) =>
     /^\s/.test(line) || // indented / code / continuation line
     /^\s*[-*+]\s/.test(line) || // bullet list item
-    /^\s*\d+[.)]\s/.test(line) || // numbered list item
-    line.startsWith("```"); // fenced code delimiter
+    /^\s*\d+[.)]\s/.test(line); // numbered list item
   // Trailer-shaped line (`Key: value`, incl. `BREAKING CHANGE:`). Only counts
   // as structural inside a trailer block (see below) so a wrapped prose line
   // that merely starts "Word: …" still reflows.
@@ -89,8 +90,29 @@ export function reflowCommitBody(body: string): string {
   // paragraph lines that happen to look like trailers are treated as prose.
   let prevBlank = true;
   let inTrailerBlock = false;
+  // Track whether we're between fence delimiters. Inside a fence every line is
+  // verbatim code — even unindented ones — so it must not join the paragraph
+  // buffer the way a wrapped prose line would.
+  let inFence = false;
 
   for (const line of lines) {
+    if (isFenceDelimiter(line)) {
+      flush();
+      out.push(line);
+      inFence = !inFence;
+      prevBlank = false;
+      inTrailerBlock = false;
+      continue;
+    }
+
+    if (inFence) {
+      flush();
+      out.push(line);
+      prevBlank = false;
+      inTrailerBlock = false;
+      continue;
+    }
+
     if (isBlank(line)) {
       flush();
       out.push(line);

--- a/src/components/Layout/LocalCommitsDropdown.tsx
+++ b/src/components/Layout/LocalCommitsDropdown.tsx
@@ -59,14 +59,20 @@ const skeletonRowCount = (initialCount: number | null | undefined) =>
 export function reflowCommitBody(body: string): string {
   if (!body) return body;
 
-  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  const lines = body.replace(/\r\n?/g, "\n").split("\n");
 
-  const isStructural = (line: string): boolean =>
-    line.trim() === "" || // blank line (paragraph separator)
+  const isBlank = (line: string) => line.trim() === "";
+  // Lines whose own break is meaningful regardless of context.
+  const isAlwaysStructural = (line: string) =>
     /^\s/.test(line) || // indented / code / continuation line
     /^\s*[-*+]\s/.test(line) || // bullet list item
     /^\s*\d+[.)]\s/.test(line) || // numbered list item
-    /^[A-Za-z][A-Za-z0-9-]*:\s/.test(line); // trailer / key: value
+    line.startsWith("```"); // fenced code delimiter
+  // Trailer-shaped line (`Key: value`, incl. `BREAKING CHANGE:`). Only counts
+  // as structural inside a trailer block (see below) so a wrapped prose line
+  // that merely starts "Word: …" still reflows.
+  const isTrailerShaped = (line: string) =>
+    /^[A-Za-z][A-Za-z0-9-]*:\s/.test(line) || /^BREAKING CHANGE:\s/.test(line);
 
   const out: string[] = [];
   let paragraph: string[] = [];
@@ -78,13 +84,31 @@ export function reflowCommitBody(body: string): string {
     }
   };
 
+  // A trailer block is a run of `Key: value` lines that begins after a blank
+  // line (or at the body start) — matching git's own trailer convention. Mid-
+  // paragraph lines that happen to look like trailers are treated as prose.
+  let prevBlank = true;
+  let inTrailerBlock = false;
+
   for (const line of lines) {
-    if (isStructural(line)) {
+    if (isBlank(line)) {
       flush();
       out.push(line);
+      prevBlank = true;
+      inTrailerBlock = false;
+      continue;
+    }
+
+    const isTrailer = isTrailerShaped(line) && (prevBlank || inTrailerBlock);
+    if (isAlwaysStructural(line) || isTrailer) {
+      flush();
+      out.push(line);
+      inTrailerBlock = isTrailer;
     } else {
       paragraph.push(line.replace(/\s+$/, ""));
+      inTrailerBlock = false;
     }
+    prevBlank = false;
   }
   flush();
 

--- a/src/components/Layout/LocalCommitsDropdown.tsx
+++ b/src/components/Layout/LocalCommitsDropdown.tsx
@@ -99,7 +99,7 @@ export function reflowCommitBody(body: string): string {
       continue;
     }
 
-    const isTrailer = isTrailerShaped(line) && (prevBlank || inTrailerBlock);
+    const isTrailer: boolean = isTrailerShaped(line) && (prevBlank || inTrailerBlock);
     if (isAlwaysStructural(line) || isTrailer) {
       flush();
       out.push(line);

--- a/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
+++ b/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, fireEvent, cleanup, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { LocalCommitsDropdown } from "../LocalCommitsDropdown";
+import { LocalCommitsDropdown, reflowCommitBody } from "../LocalCommitsDropdown";
 import type { GitCommit, GitCommitListResponse } from "@shared/types/git";
 
 const listCommitsMock = vi.fn();
@@ -200,6 +200,26 @@ describe("LocalCommitsDropdown", () => {
     expect(bodyAfter?.getAttribute("aria-hidden")).toBe("false");
   });
 
+  it("reflows a hard-wrapped commit body so prose has no mid-paragraph breaks", async () => {
+    const wrappedBody = "This is the first wrapped line of the body\nand this is its continuation line.";
+    listCommitsMock.mockResolvedValue(makeResponse([makeCommit(1, wrappedBody)]));
+
+    const { findAllByText } = render(
+      <LocalCommitsDropdown cwd="/repo" open initialCount={1} />
+    );
+
+    const row = (await findAllByText("commit message 1"))[0]?.closest('[role="option"]');
+    fireEvent.click(row!);
+
+    await waitFor(() => {
+      const pre = document.querySelector("pre");
+      expect(pre?.textContent).toBe(
+        "This is the first wrapped line of the body and this is its continuation line."
+      );
+      expect(pre?.textContent).not.toContain("\n");
+    });
+  });
+
   it("clears rows from the previous repo when cwd changes while open", async () => {
     listCommitsMock.mockResolvedValueOnce(makeResponse([makeCommit(1)]));
 
@@ -257,5 +277,67 @@ describe("LocalCommitsDropdown", () => {
 
     expect((await findAllByText("commit message 30")).length).toBeGreaterThan(0);
     expect(listCommitsMock).toHaveBeenLastCalledWith(expect.objectContaining({ skip: 30 }));
+  });
+});
+
+describe("reflowCommitBody", () => {
+  it("collapses a hard-wrapped prose paragraph into one line", () => {
+    const body = "This sentence was hard wrapped\nat seventy-two columns\nby the author's editor.";
+    expect(reflowCommitBody(body)).toBe(
+      "This sentence was hard wrapped at seventy-two columns by the author's editor."
+    );
+  });
+
+  it("preserves blank-line paragraph separators", () => {
+    const body = "First paragraph line one\nline two\n\nSecond paragraph here";
+    expect(reflowCommitBody(body)).toBe("First paragraph line one line two\n\nSecond paragraph here");
+  });
+
+  it("keeps bullet list items on their own lines", () => {
+    const body = "- first bullet\n- second bullet\n- third bullet";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("keeps numbered list items on their own lines", () => {
+    const body = "1. first step\n2. second step";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("preserves indented continuation lines verbatim", () => {
+    const body = "- a bullet header\n  indented continuation";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("keeps git trailers on their own lines", () => {
+    const body = "Body of the commit.\n\nCo-authored-by: Jane <jane@example.com>\nSigned-off-by: Joe <joe@example.com>\nFixes: #123";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("preserves indented code blocks", () => {
+    const body = "Explanation paragraph.\n\n    const x = 1;\n    const y = 2;";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("leaves a single long URL line untouched", () => {
+    const body = "https://example.com/a/very/long/path/that/exceeds/the/panel/width/and/keeps/going";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("normalizes CRLF line endings without leaving stray carriage returns", () => {
+    const body = "line one\r\nline two";
+    const result = reflowCommitBody(body);
+    expect(result).not.toContain("\r");
+    expect(result).toBe("line one line two");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(reflowCommitBody("")).toBe("");
+  });
+
+  it("is idempotent", () => {
+    const body =
+      "A wrapped prose paragraph\nthat continues here.\n\n- a bullet\n- another\n\nFixes: #1";
+    const once = reflowCommitBody(body);
+    expect(reflowCommitBody(once)).toBe(once);
   });
 });

--- a/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
+++ b/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
@@ -336,6 +336,24 @@ describe("reflowCommitBody", () => {
     expect(reflowCommitBody(body)).toBe(body);
   });
 
+  it("keeps multi-line unindented fenced code on separate lines", () => {
+    const body = "```\nconst x = 1;\nconst y = 2;\n```";
+    const result = reflowCommitBody(body);
+    expect(result).toBe(body);
+    // The two code lines must not be joined into one (the #10718 fence bug).
+    expect(result).not.toContain("const x = 1; const y = 2;");
+    expect(result.split("\n")).toContain("const x = 1;");
+    expect(result.split("\n")).toContain("const y = 2;");
+  });
+
+  it("reflows prose around a fenced block but keeps the fence verbatim", () => {
+    const body =
+      "Intro prose line one\nand its continuation.\n\n```\nfoo();\nbar();\n```\n\nClosing prose line\nand its continuation.";
+    expect(reflowCommitBody(body)).toBe(
+      "Intro prose line one and its continuation.\n\n```\nfoo();\nbar();\n```\n\nClosing prose line and its continuation."
+    );
+  });
+
   it("normalizes a bare carriage return", () => {
     expect(reflowCommitBody("line one\rline two")).toBe("line one line two");
   });

--- a/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
+++ b/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
@@ -212,7 +212,7 @@ describe("LocalCommitsDropdown", () => {
     fireEvent.click(row!);
 
     await waitFor(() => {
-      const pre = document.querySelector("pre");
+      const pre = row!.querySelector("pre");
       expect(pre?.textContent).toBe(
         "This is the first wrapped line of the body and this is its continuation line."
       );
@@ -301,6 +301,38 @@ describe("reflowCommitBody", () => {
   it("keeps numbered list items on their own lines", () => {
     const body = "1. first step\n2. second step";
     expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("keeps parenthesized numbered list items on their own lines", () => {
+    const body = "1) first step\n2) second step";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("reflows a wrapped prose line that merely starts with a word and colon", () => {
+    const body = "This explains the behavior\nNote: it also applies on Windows";
+    expect(reflowCommitBody(body)).toBe("This explains the behavior Note: it also applies on Windows");
+  });
+
+  it("treats a Key: value line as a trailer only after a blank line", () => {
+    const reflowed = "body line\nFixes: a wrapped description that continues";
+    expect(reflowCommitBody(reflowed)).toBe("body line Fixes: a wrapped description that continues");
+
+    const trailer = "body line\n\nFixes: #123";
+    expect(reflowCommitBody(trailer)).toBe(trailer);
+  });
+
+  it("keeps a BREAKING CHANGE footer on its own line", () => {
+    const body = "Reworked the API.\n\nBREAKING CHANGE: the old method is gone";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("keeps fenced code blocks intact", () => {
+    const body = "Example usage:\n\n```ts\nconst x = 1;\n```";
+    expect(reflowCommitBody(body)).toBe(body);
+  });
+
+  it("normalizes a bare carriage return", () => {
+    expect(reflowCommitBody("line one\rline two")).toBe("line one line two");
   });
 
   it("preserves indented continuation lines verbatim", () => {

--- a/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
+++ b/src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx
@@ -201,12 +201,11 @@ describe("LocalCommitsDropdown", () => {
   });
 
   it("reflows a hard-wrapped commit body so prose has no mid-paragraph breaks", async () => {
-    const wrappedBody = "This is the first wrapped line of the body\nand this is its continuation line.";
+    const wrappedBody =
+      "This is the first wrapped line of the body\nand this is its continuation line.";
     listCommitsMock.mockResolvedValue(makeResponse([makeCommit(1, wrappedBody)]));
 
-    const { findAllByText } = render(
-      <LocalCommitsDropdown cwd="/repo" open initialCount={1} />
-    );
+    const { findAllByText } = render(<LocalCommitsDropdown cwd="/repo" open initialCount={1} />);
 
     const row = (await findAllByText("commit message 1"))[0]?.closest('[role="option"]');
     fireEvent.click(row!);
@@ -290,7 +289,9 @@ describe("reflowCommitBody", () => {
 
   it("preserves blank-line paragraph separators", () => {
     const body = "First paragraph line one\nline two\n\nSecond paragraph here";
-    expect(reflowCommitBody(body)).toBe("First paragraph line one line two\n\nSecond paragraph here");
+    expect(reflowCommitBody(body)).toBe(
+      "First paragraph line one line two\n\nSecond paragraph here"
+    );
   });
 
   it("keeps bullet list items on their own lines", () => {
@@ -310,12 +311,16 @@ describe("reflowCommitBody", () => {
 
   it("reflows a wrapped prose line that merely starts with a word and colon", () => {
     const body = "This explains the behavior\nNote: it also applies on Windows";
-    expect(reflowCommitBody(body)).toBe("This explains the behavior Note: it also applies on Windows");
+    expect(reflowCommitBody(body)).toBe(
+      "This explains the behavior Note: it also applies on Windows"
+    );
   });
 
   it("treats a Key: value line as a trailer only after a blank line", () => {
     const reflowed = "body line\nFixes: a wrapped description that continues";
-    expect(reflowCommitBody(reflowed)).toBe("body line Fixes: a wrapped description that continues");
+    expect(reflowCommitBody(reflowed)).toBe(
+      "body line Fixes: a wrapped description that continues"
+    );
 
     const trailer = "body line\n\nFixes: #123";
     expect(reflowCommitBody(trailer)).toBe(trailer);
@@ -341,7 +346,8 @@ describe("reflowCommitBody", () => {
   });
 
   it("keeps git trailers on their own lines", () => {
-    const body = "Body of the commit.\n\nCo-authored-by: Jane <jane@example.com>\nSigned-off-by: Joe <joe@example.com>\nFixes: #123";
+    const body =
+      "Body of the commit.\n\nCo-authored-by: Jane <jane@example.com>\nSigned-off-by: Joe <joe@example.com>\nFixes: #123";
     expect(reflowCommitBody(body)).toBe(body);
   });
 
@@ -351,7 +357,8 @@ describe("reflowCommitBody", () => {
   });
 
   it("leaves a single long URL line untouched", () => {
-    const body = "https://example.com/a/very/long/path/that/exceeds/the/panel/width/and/keeps/going";
+    const body =
+      "https://example.com/a/very/long/path/that/exceeds/the/panel/width/and/keeps/going";
     expect(reflowCommitBody(body)).toBe(body);
   });
 


### PR DESCRIPTION
## Summary

- Git commit bodies are conventionally hard-wrapped at 72 columns, which caused double-wrapping in the narrow `LocalCommitsDropdown` panel, producing ragged text and orphaned continuation lines.
- Adds a pure `reflowCommitBody()` helper in `LocalCommitsDropdown.tsx` that collapses continuation prose lines back into their paragraph, letting the panel's own soft-wrapping take over.
- Structure-preserving: blank-line paragraph separators, bullet/numbered list items, indented/code lines, fenced code blocks, and git trailers (`Co-authored-by:`, `Signed-off-by:`, `Fixes:`, `BREAKING CHANGE:`) are all left intact. Trailer detection is context-aware, so wrapped prose that starts with `Word:` still reflows correctly. The `<pre>` keeps `whitespace-pre-wrap` and `break-words` so long unwrapped lines (e.g. pasted URLs) still wrap at the panel boundary.

Resolves #10718

## Changes

- `src/components/Layout/LocalCommitsDropdown.tsx`: added `reflowCommitBody()` and threaded it through the body render
- `src/components/Layout/__tests__/LocalCommitsDropdown.test.tsx`: 11 new unit tests + 1 integration test (31 total)

## Testing

- 31 unit/integration tests covering plain prose reflow, blank-line paragraph separation, bullet/numbered lists, indented lines, fenced code blocks, trailer detection, context-aware trailer reflow, and the full commit render path.
- All passing.