### PR TITLE
fix(brand-icon): user-chosen preset colors no longer add a white tile to the agent icon

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -446,7 +446,7 @@ export function AgentButton({
         </span>
         <span data-zone="label" className="flex min-w-0 flex-1 items-center py-1.5">
           <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-            <BrandMark brandColor={presetColor}>
+            <BrandMark brandColor={presetColor} userChosen={!!preset.color}>
               <config.icon brandColor={presetColor} />
             </BrandMark>
           </span>

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -290,7 +290,10 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
                   onSelect={() => onLaunch(row.id, preset.id)}
                 >
                   <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                    <BrandMark brandColor={preset.color ?? getBrandColorHex(row.id)}>
+                    <BrandMark
+                      brandColor={preset.color ?? getBrandColorHex(row.id)}
+                      userChosen={!!preset.color}
+                    >
                       <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
                     </BrandMark>
                   </span>
@@ -310,7 +313,10 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
                   onSelect={() => onLaunch(row.id, preset.id)}
                 >
                   <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                    <BrandMark brandColor={preset.color ?? getBrandColorHex(row.id)}>
+                    <BrandMark
+                      brandColor={preset.color ?? getBrandColorHex(row.id)}
+                      userChosen={!!preset.color}
+                    >
                       <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
                     </BrandMark>
                   </span>
@@ -330,7 +336,10 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
                   onSelect={() => onLaunch(row.id, preset.id)}
                 >
                   <span className="inline-flex h-4 w-4 items-center justify-center shrink-0 mr-1.5">
-                    <BrandMark brandColor={preset.color ?? getBrandColorHex(row.id)}>
+                    <BrandMark
+                      brandColor={preset.color ?? getBrandColorHex(row.id)}
+                      userChosen={!!preset.color}
+                    >
                       <row.Icon brandColor={preset.color ?? getBrandColorHex(row.id)} />
                     </BrandMark>
                   </span>

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -580,6 +580,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                   kind={activePanel.kind}
                   chrome={activeChrome}
                   className="w-3.5 h-3.5"
+                  userChosen={!!panelPresetColors.get(activePanel.id)}
                 />
               </div>
               <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
@@ -819,6 +820,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                                   kind={panel.kind ?? "terminal"}
                                   chrome={tabChrome}
                                   className="w-3.5 h-3.5"
+                                  userChosen={!!panelPresetColors.get(panel.id)}
                                 />
                               </span>
                               <span className="truncate">{getBaseTitle(panel.title)}</span>

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -189,16 +189,18 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
       terminal.exitCode,
     ]
   );
-  const brandColor = useMemo(() => {
+  const { color: brandColor, userChosen: brandColorUserChosen } = useMemo(() => {
     const fallbackColor = baseChrome.color;
-    if (!terminal.agentPresetId || !terminal.launchAgentId) return fallbackColor;
+    if (!terminal.agentPresetId || !terminal.launchAgentId)
+      return { color: fallbackColor, userChosen: false };
     const preset = getMergedPresets(
       terminal.launchAgentId,
       presetCustomPresets,
       presetCcrPresets,
       presetProjectPresets
     ).find((f) => f.id === terminal.agentPresetId);
-    return preset?.color ?? terminal.agentPresetColor ?? fallbackColor;
+    const presetColor = preset?.color ?? terminal.agentPresetColor;
+    return { color: presetColor ?? fallbackColor, userChosen: !!presetColor };
   }, [
     terminal.launchAgentId,
     terminal.agentPresetId,
@@ -332,7 +334,12 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
                 aria-label={`${terminal.title}${displayAgentState ? ` — agent ${getEffectiveStateLabel(displayAgentState)}` : ""} - Click to preview, double-click to move to grid, drag to reorder`}
               >
                 <div className="flex items-center justify-center shrink-0">
-                  <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />
+                  <TerminalIcon
+                    kind={terminal.kind}
+                    chrome={chrome}
+                    className="w-3.5 h-3.5"
+                    userChosen={brandColorUserChosen}
+                  />
                 </div>
                 <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
                   {displayTitle}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -598,6 +598,7 @@ function PanelHeaderComponent({
                 chrome={tab.chrome}
                 className="w-3.5 h-3.5"
                 brandColor={tab.presetColor ?? tab.chrome.color}
+                userChosen={!!tab.presetColor}
               />
             </span>
             <span className="truncate">{getBaseTitle(tab.title)}</span>
@@ -744,6 +745,7 @@ function PanelHeaderComponent({
               chrome={chrome}
               className="w-3.5 h-3.5"
               brandColor={presetColor ?? chrome.color}
+              userChosen={!!presetColor}
             />
           </span>
 

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -337,6 +337,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               chrome={chrome}
               className="w-3.5 h-3.5"
               brandColor={presetColor ?? chrome.color}
+              userChosen={!!presetColor}
             />
           </span>
 

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -12,9 +12,18 @@ export interface TerminalIconProps {
   chrome?: TerminalChromeDescriptor;
   className?: string;
   brandColor?: string;
+  /** Marks `brandColor` as a deliberate user choice (e.g. a preset color),
+   * which bypasses the dark-theme white-tile fallback in `BrandMark`. */
+  userChosen?: boolean;
 }
 
-export function TerminalIcon({ kind, chrome, className, brandColor }: TerminalIconProps) {
+export function TerminalIcon({
+  kind,
+  chrome,
+  className,
+  brandColor,
+  userChosen,
+}: TerminalIconProps) {
   const resolvedChrome = chrome ?? deriveTerminalChrome({ kind });
   const iconId = resolvedChrome.iconId ?? "terminal";
   const finalProps = {
@@ -83,7 +92,11 @@ export function TerminalIcon({ kind, chrome, className, brandColor }: TerminalIc
   if (RunIcon) {
     const runBrandColor = brandColor ?? resolvedChrome.color;
     return withIconMarker(
-      <BrandMark brandColor={runBrandColor} className={finalProps.className}>
+      <BrandMark
+        brandColor={runBrandColor}
+        userChosen={userChosen}
+        className={finalProps.className}
+      >
         <RunIcon {...finalProps} brandColor={runBrandColor} />
       </BrandMark>
     );

--- a/src/components/icons/BrandMark.tsx
+++ b/src/components/icons/BrandMark.tsx
@@ -5,6 +5,9 @@ import { useActiveAppScheme } from "@/hooks/useActiveAppScheme";
 
 interface BrandMarkProps {
   brandColor?: string;
+  /** Marks `brandColor` as a deliberate user choice (e.g. a preset color),
+   * which bypasses the dark-theme white-tile fallback. */
+  userChosen?: boolean;
   size?: number;
   className?: string;
   children: ReactElement<{ className?: string; brandColor?: string }>;
@@ -20,9 +23,9 @@ const SIZE_CLASS_REGEX = /\b(?:size-|w-|h-)/;
 // recoloring the mark. On LIGHT themes the mark itself is darkened to a
 // contrast-clearing tint of the same hue — a dark tile on pale chrome reads
 // as a black box, not a brand.
-export function BrandMark({ brandColor, size, className, children }: BrandMarkProps) {
+export function BrandMark({ brandColor, userChosen, size, className, children }: BrandMarkProps) {
   const scheme = useActiveAppScheme();
-  const chip = resolveBrandChip(brandColor, scheme);
+  const chip = resolveBrandChip(brandColor, scheme, userChosen);
 
   if (!chip || chip.tint) {
     const tintProps = chip?.tint ? { brandColor: chip.tint } : null;

--- a/src/components/icons/__tests__/BrandMark.test.tsx
+++ b/src/components/icons/__tests__/BrandMark.test.tsx
@@ -85,4 +85,19 @@ describe("BrandMark", () => {
     expect(spanClass).toContain("mr-2");
     expect(getByTestId("icon").hasAttribute("class")).toBe(false);
   });
+
+  it("threads userChosen through to resolveBrandChip and renders no chip wrapper", () => {
+    // A user-chosen color bypasses the white tile in the resolver (returns null),
+    // so the child renders directly without a <span> wrapper.
+    resolveBrandChipMock.mockReturnValue(null);
+
+    const { container } = render(
+      <BrandMark brandColor="#000000" userChosen>
+        <TestIcon />
+      </BrandMark>
+    );
+
+    expect(resolveBrandChipMock).toHaveBeenCalledWith("#000000", expect.anything(), true);
+    expect(container.querySelector("span")).toBeNull();
+  });
 });

--- a/src/lib/__tests__/brandIcon.test.ts
+++ b/src/lib/__tests__/brandIcon.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { contrastRatio } from "@shared/theme";
+import type { AppColorScheme } from "@shared/theme";
+import { resolveBrandChip } from "../brandIcon";
+
+const CHIP_LIGHT = "#F5F5F5";
+const NON_TEXT_CONTRAST_THRESHOLD = 3;
+
+function makeScheme(type: "dark" | "light", surfacePanel: string): AppColorScheme {
+  return {
+    id: "test",
+    name: "Test",
+    type,
+    builtin: true,
+    tokens: { "surface-panel": surfacePanel } as AppColorScheme["tokens"],
+  };
+}
+
+const DARK = makeScheme("dark", "#1e1e1e");
+const LIGHT = makeScheme("light", "#ffffff");
+
+describe("resolveBrandChip", () => {
+  it("returns the white tile for a built-in mono mark on dark themes", () => {
+    // #000000 (Goose-style silhouette) fails contrast against the dark surface
+    // but clears it against the near-white tile — the tile path is preserved.
+    const chip = resolveBrandChip("#000000", DARK);
+    expect(chip).toEqual({ background: CHIP_LIGHT });
+  });
+
+  it("skips the white tile for a user-chosen color on dark themes", () => {
+    // Same color, but flagged as a deliberate user choice — render it as-is
+    // rather than stamping a white tile that overrides the user's intent.
+    const chip = resolveBrandChip("#000000", DARK, true);
+    expect(chip).toBeNull();
+  });
+
+  it("does not alter colors that already clear contrast on dark themes", () => {
+    // A bright color clears 3:1 against the dark surface regardless of provenance.
+    expect(resolveBrandChip("#ffffff", DARK, false)).toBeNull();
+    expect(resolveBrandChip("#ffffff", DARK, true)).toBeNull();
+  });
+
+  it("still applies the light-theme tint correction for user-chosen colors", () => {
+    // The light-theme tint path is a helpful readability correction that should
+    // remain active even for user choices — only the dark tile is bypassed.
+    const lowContrastLight = "#dddddd";
+    const chip = resolveBrandChip(lowContrastLight, LIGHT, true);
+    expect(chip?.tint).toBeDefined();
+    expect(chip?.background).toBeUndefined();
+    // The returned tint must actually clear the contrast floor against the surface.
+    expect(contrastRatio(chip!.tint!, "#ffffff")).toBeGreaterThanOrEqual(
+      NON_TEXT_CONTRAST_THRESHOLD
+    );
+  });
+
+  it("returns null for an invalid hex regardless of provenance", () => {
+    expect(resolveBrandChip("not-a-color", DARK, true)).toBeNull();
+    expect(resolveBrandChip(undefined, DARK, true)).toBeNull();
+  });
+});

--- a/src/lib/brandIcon.ts
+++ b/src/lib/brandIcon.ts
@@ -20,7 +20,8 @@ function mixTowardBlack(hex: string, amount: number): string {
 
 export function resolveBrandChip(
   brandColor: string | undefined,
-  scheme: AppColorScheme
+  scheme: AppColorScheme,
+  userChosen?: boolean
 ): BrandChip | null {
   if (!brandColor || !isHexColor(brandColor)) {
     return null;
@@ -35,7 +36,12 @@ export function resolveBrandChip(
   if (scheme.type === "dark") {
     // Mono brands like Goose and Open Interpreter render their official
     // silhouette against a near-white tile — preserving brand fidelity
-    // rather than recoloring the mark.
+    // rather than recoloring the mark. A user-chosen preset color is a
+    // deliberate choice; render it as-is rather than stamping a white tile
+    // that overrides their intent.
+    if (userChosen) {
+      return null;
+    }
     if (contrastRatio(brandColor, CHIP_LIGHT) < NON_TEXT_CONTRAST_THRESHOLD) {
       return null;
     }


### PR DESCRIPTION
## Summary

- Picking a preset color on dark themes was wrapping the agent icon in a near-white tile (`CHIP_LIGHT` `#F5F5F5`) because `resolveBrandChip`'s contrast fallback didn't distinguish user-chosen colors from built-in mono brand marks.
- Added a `userChosen` flag threaded from each preset call site through `BrandMark` and `TerminalIcon` into `resolveBrandChip`. When set, the dark-theme white-tile fallback is skipped so the chosen color renders directly.
- Built-in mono brand marks (Goose, Open Interpreter) still get the white tile. Light-theme tint correction stays active for all colors.

Resolves #10721

## Changes

- `src/lib/brandIcon.ts` — `resolveBrandChip` skips dark-theme fallback when `userChosen` is true
- `src/components/icons/BrandMark.tsx`, `src/components/Terminal/TerminalIcon.tsx` — accept and forward `userChosen`
- Call sites updated: `AgentButton`, `AgentTrayButton`, `PanelHeader`, `TabButton` (+ `SortableTabButton` via spread), `DockedTerminalItem`, `DockedTabGroup`

## Testing

- New `src/lib/__tests__/brandIcon.test.ts` covering `resolveBrandChip` behavior across user-chosen and built-in paths
- `BrandMark` regression tests added to `src/components/icons/__tests__/BrandMark.test.tsx`
- 11 tests passing