### PR TITLE
fix(recipes): resolve agent preset on recipe launch (#10722)

### DIFF
--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1478,6 +1478,7 @@ describe("ProjectViewManager — telemetry", () => {
     // proj-c is now active; proj-a and proj-b are cached.
     const wcB = manager.getAllViews().find((v) => v.projectId === "proj-b")?.view
       .webContents as unknown as ReturnType<typeof createMockWebContents>;
+    const wcBPid = wcB.getOSProcessId();
 
     // proj-a's getOSProcessId throws — the iteration over proj-a must be skipped,
     // but proj-b must still be sampled.
@@ -1486,7 +1487,7 @@ describe("ProjectViewManager — telemetry", () => {
     });
 
     mockGetAppMetrics.mockReturnValue([
-      { pid: wcB.osPid, memory: { privateBytes: 400 * 1024 } },
+      { pid: wcBPid, memory: { privateBytes: 400 * 1024 } },
     ] as unknown as Electron.ProcessMetric[]);
 
     // Sweep fresh: a background sample timer may have cached empty metrics
@@ -1494,6 +1495,7 @@ describe("ProjectViewManager — telemetry", () => {
     // the mock this test just set.
     resetAppMetricsSnapshotForTesting();
     vi.mocked(logInfo).mockClear();
+    resetAppMetricsSnapshotForTesting();
 
     expect(() =>
       (manager as unknown as { sampleCachedViewMemory(): void }).sampleCachedViewMemory()

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -92,6 +92,27 @@ vi.mock("../panelStore", () => ({
   },
 }));
 
+// Preset sources resolved during recipe agent launches (#10722). Mutable so
+// individual tests can inject CCR/project presets; reset in beforeEach.
+const ccrPresetsState: { ccrPresetsByAgent: Record<string, unknown> } = {
+  ccrPresetsByAgent: {},
+};
+const projectPresetsState: { presetsByAgent: Record<string, unknown> } = {
+  presetsByAgent: {},
+};
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: {
+    getState: vi.fn(() => ccrPresetsState),
+  },
+}));
+
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: {
+    getState: vi.fn(() => projectPresetsState),
+  },
+}));
+
 // runRecipeWithResults records the run via window.electron.runHistory.append
 // (fire-and-forget). Stub it so the call resolves cleanly in tests.
 const runHistoryAppendMock = vi.fn().mockResolvedValue(undefined);
@@ -110,6 +131,8 @@ describe("recipeStore", () => {
     useRecipeStore.getState().reset();
     panelStoreState.panelIds = [];
     panelStoreState.panelsById = {};
+    ccrPresetsState.ccrPresetsByAgent = {};
+    projectPresetsState.presetsByAgent = {};
   });
 
   it("rejects malformed recipe json", async () => {
@@ -1073,6 +1096,184 @@ describe("recipeStore", () => {
         expect.arrayContaining(["--dangerously-skip-permissions"])
       );
       expect(call.agentLaunchFlags?.every((f) => f.trim().length > 0)).toBe(true);
+    });
+
+    describe("preset resolution (#10722)", () => {
+      type AgentSpawnCall = {
+        command?: string;
+        env?: Record<string, string>;
+        agentLaunchFlags?: string[];
+        agentPresetId?: string;
+        agentPresetColor?: string;
+      };
+
+      const runSingleAgentRecipe = async (
+        terminal: Record<string, unknown>,
+        worktreeId = "worktree-1"
+      ): Promise<AgentSpawnCall> => {
+        addTerminalMock.mockResolvedValue("terminal-1");
+        useRecipeStore.setState({
+          recipes: [
+            {
+              id: "recipe-1",
+              name: "Agent Recipe",
+              projectId: "project-1",
+              terminals: [terminal as never],
+              createdAt: Date.now(),
+            },
+          ],
+          isLoading: false,
+          currentProjectId: "project-1",
+        });
+        await useRecipeStore
+          .getState()
+          .runRecipeWithResults("recipe-1", "/tmp/worktree", worktreeId);
+        return addTerminalMock.mock.calls[0]?.[0] as AgentSpawnCall;
+      };
+
+      it("folds the agent-wide default preset's args and env into the launch", async () => {
+        getAgentSettingsMock.mockResolvedValue({
+          agents: {
+            claude: {
+              presetId: "fast",
+              customPresets: [
+                { id: "fast", name: "Fast", args: ["--fast"], env: { PRESET_KEY: "preset" } },
+              ],
+            },
+          },
+        });
+
+        const call = await runSingleAgentRecipe({ type: "claude", title: "Claude", env: {} });
+
+        expect(call.command).toContain("--fast");
+        expect(call.env).toMatchObject({ PRESET_KEY: "preset" });
+        expect(call.agentPresetId).toBe("fast");
+        expect(call.agentLaunchFlags).toEqual(expect.arrayContaining(["--fast"]));
+      });
+
+      it("prefers the worktree-scoped preset over the agent-wide default", async () => {
+        getAgentSettingsMock.mockResolvedValue({
+          agents: {
+            claude: {
+              presetId: "fast",
+              worktreePresets: { "worktree-1": "careful" },
+              customPresets: [
+                { id: "fast", name: "Fast", args: ["--fast"] },
+                { id: "careful", name: "Careful", args: ["--careful"], color: "#abcdef" },
+              ],
+            },
+          },
+        });
+
+        const call = await runSingleAgentRecipe({ type: "claude", title: "Claude", env: {} });
+
+        expect(call.command).toContain("--careful");
+        expect(call.command).not.toContain("--fast");
+        expect(call.agentPresetId).toBe("careful");
+        expect(call.agentPresetColor).toBe("#abcdef");
+      });
+
+      it("lets recipe-defined env win over preset env on key conflicts", async () => {
+        getAgentSettingsMock.mockResolvedValue({
+          agents: {
+            claude: {
+              presetId: "fast",
+              customPresets: [
+                {
+                  id: "fast",
+                  name: "Fast",
+                  env: { SHARED: "from-preset", PRESET_ONLY: "preset" },
+                },
+              ],
+            },
+          },
+        });
+
+        const call = await runSingleAgentRecipe({
+          type: "claude",
+          title: "Claude",
+          env: { SHARED: "from-recipe" },
+        });
+
+        expect(call.env).toMatchObject({ SHARED: "from-recipe", PRESET_ONLY: "preset" });
+      });
+
+      it("applies preset behavioral overrides to the generated command", async () => {
+        getAgentSettingsMock.mockResolvedValue({
+          agents: {
+            claude: {
+              presetId: "danger",
+              customPresets: [
+                { id: "danger", name: "Danger", dangerousMode: "on", customFlags: "--verbose" },
+              ],
+            },
+          },
+        });
+
+        const call = await runSingleAgentRecipe({ type: "claude", title: "Claude", env: {} });
+
+        expect(call.command).toContain("--dangerously-skip-permissions");
+        expect(call.command).toContain("--verbose");
+      });
+
+      it("falls back to the agent-wide default when the worktree preset is stale", async () => {
+        getAgentSettingsMock.mockResolvedValue({
+          agents: {
+            claude: {
+              presetId: "fast",
+              worktreePresets: { "worktree-1": "deleted" },
+              customPresets: [{ id: "fast", name: "Fast", args: ["--fast"] }],
+            },
+          },
+        });
+
+        const call = await runSingleAgentRecipe({ type: "claude", title: "Claude", env: {} });
+
+        expect(call.command).toContain("--fast");
+        expect(call.agentPresetId).toBe("fast");
+      });
+
+      it("resolves presets discovered from the CCR source", async () => {
+        getAgentSettingsMock.mockResolvedValue({
+          agents: { claude: { presetId: "ccr-preset" } },
+        });
+        ccrPresetsState.ccrPresetsByAgent = {
+          claude: [{ id: "ccr-preset", name: "CCR", args: ["--ccr"] }],
+        };
+
+        const call = await runSingleAgentRecipe({ type: "claude", title: "Claude", env: {} });
+
+        expect(call.command).toContain("--ccr");
+        expect(call.agentPresetId).toBe("ccr-preset");
+      });
+
+      it("resolves presets shared via the project source", async () => {
+        getAgentSettingsMock.mockResolvedValue({
+          agents: { claude: { presetId: "project-preset" } },
+        });
+        projectPresetsState.presetsByAgent = {
+          claude: [{ id: "project-preset", name: "Project", args: ["--project"] }],
+        };
+
+        const call = await runSingleAgentRecipe({ type: "claude", title: "Claude", env: {} });
+
+        expect(call.command).toContain("--project");
+        expect(call.agentPresetId).toBe("project-preset");
+      });
+
+      it("does not attach preset metadata to non-agent terminals", async () => {
+        getAgentSettingsMock.mockResolvedValue({ agents: {} });
+
+        const call = await runSingleAgentRecipe({
+          type: "terminal",
+          title: "Shell",
+          command: "npm test",
+          env: {},
+        });
+
+        expect(call.agentPresetId).toBeUndefined();
+        expect(call.agentPresetColor).toBeUndefined();
+      });
     });
   });
 

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -133,6 +133,10 @@ describe("recipeStore", () => {
     panelStoreState.panelsById = {};
     ccrPresetsState.ccrPresetsByAgent = {};
     projectPresetsState.presetsByAgent = {};
+    // clearAllMocks resets call counts but not implementations — restore the
+    // hoisted default so each test starts from an empty agent-settings shape
+    // instead of inheriting a prior test's mockResolvedValue.
+    getAgentSettingsMock.mockResolvedValue({ agents: {} });
   });
 
   it("rejects malformed recipe json", async () => {
@@ -1171,6 +1175,9 @@ describe("recipeStore", () => {
         expect(call.command).not.toContain("--fast");
         expect(call.agentPresetId).toBe("careful");
         expect(call.agentPresetColor).toBe("#abcdef");
+        // Restart/resume must reproduce the scoped preset, so its args have to
+        // land in the persisted launch flags too — not just the live command.
+        expect(call.agentLaunchFlags).toEqual(expect.arrayContaining(["--careful"]));
       });
 
       it("lets recipe-defined env win over preset env on key conflicts", async () => {
@@ -1214,6 +1221,11 @@ describe("recipeStore", () => {
 
         expect(call.command).toContain("--dangerously-skip-permissions");
         expect(call.command).toContain("--verbose");
+        // effectiveEntry (not the raw entry) must reach buildAgentLaunchFlags so
+        // the bypass override survives a restart.
+        expect(call.agentLaunchFlags).toEqual(
+          expect.arrayContaining(["--dangerously-skip-permissions"])
+        );
       });
 
       it("falls back to the agent-wide default when the worktree preset is stale", async () => {
@@ -1259,6 +1271,23 @@ describe("recipeStore", () => {
 
         expect(call.command).toContain("--project");
         expect(call.agentPresetId).toBe("project-preset");
+      });
+
+      it("does not auto-apply a CCR/registry default when no preset is selected", async () => {
+        // Boundary of the #10722 fix: recipe launches honor an explicitly
+        // selected preset (agent-level or worktree-scoped) but, unlike manual
+        // launches, deliberately do not auto-select a registry/CCR default when
+        // the user never picked one — recipe launches stay conservative and
+        // never apply a preset the user didn't choose.
+        getAgentSettingsMock.mockResolvedValue({ agents: { claude: {} } });
+        ccrPresetsState.ccrPresetsByAgent = {
+          claude: [{ id: "ccr-default", name: "CCR Default", args: ["--ccr"] }],
+        };
+
+        const call = await runSingleAgentRecipe({ type: "claude", title: "Claude", env: {} });
+
+        expect(call.command).not.toContain("--ccr");
+        expect(call.agentPresetId).toBeUndefined();
       });
 
       it("does not attach preset metadata to non-agent terminals", async () => {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -11,8 +11,19 @@ import {
   type PtyPanelData,
 } from "@shared/types/panel";
 import { projectClient, agentSettingsClient, systemClient, globalRecipesClient } from "@/clients";
-import { getAgentConfig } from "@/config/agents";
-import { generateAgentCommand, buildAgentLaunchFlags } from "@shared/types";
+import { getAgentConfig, getMergedPreset } from "@/config/agents";
+import {
+  generateAgentCommand,
+  buildAgentLaunchFlags,
+  resolveEffectivePresetId,
+} from "@shared/types";
+import {
+  applyPresetBehaviorOverrides,
+  mergeAgentRuntimeEnv,
+  resolveAgentRuntimeSettings,
+} from "@/utils/agentRuntimeSettings";
+import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
+import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import { sanitizeRecipeTerminals, MAX_TERMINALS_PER_RECIPE } from "@shared/utils/recipeSanitizer";
 import type { ActionSource } from "@shared/types/actions";
@@ -810,11 +821,65 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               : undefined;
             const entry = agentSettings?.agents?.[agentId] ?? {};
             const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
-            const command = generateAgentCommand(baseCommand, entry, agentId, {
+
+            // Resolve the selected preset to parity with manual launches
+            // (useAgentLauncher): the worktree-scoped pick wins over the
+            // agent-level default, and the preset's args/env/behavioral
+            // overrides must fold into the spawn. Without this, recipe
+            // launches silently ignored the chosen preset (#10722).
+            const resolvedPresetId = resolveEffectivePresetId(entry, worktreeId);
+            const ccrPresets = useCcrPresetsStore.getState().ccrPresetsByAgent[agentId];
+            const projectPresets = useProjectPresetsStore.getState().presetsByAgent[agentId];
+            const resolution = resolveAgentRuntimeSettings({
+              agentId,
+              presetId: resolvedPresetId,
+              entry,
+              ccrPresets,
+              projectPresets,
+            });
+            let preset = resolution.preset;
+            let effectiveEntry = resolution.effectiveEntry;
+            // Stale worktree-scoped preset: fall back to the agent-level
+            // default if it still resolves. Unlike useAgentLauncher we never
+            // clear the vanished slot here — recipe launches must not mutate
+            // persisted agent settings (the recipe path deliberately avoids
+            // useAgentSettingsStore).
+            const scopedId =
+              worktreeId && entry.worktreePresets ? entry.worktreePresets[worktreeId] : undefined;
+            if (
+              resolution.presetWasStale &&
+              scopedId &&
+              scopedId === resolvedPresetId &&
+              entry.presetId &&
+              entry.presetId !== scopedId
+            ) {
+              const fallbackPreset = getMergedPreset(
+                agentId,
+                entry.presetId,
+                entry.customPresets,
+                ccrPresets,
+                projectPresets
+              );
+              if (fallbackPreset) {
+                preset = fallbackPreset;
+                effectiveEntry = applyPresetBehaviorOverrides(entry, fallbackPreset);
+              }
+            }
+
+            // Layer env: global env (base) < preset env < recipe-defined env.
+            // The recipe's own `terminal.env` is caller-supplied and must win.
+            const baseEnv = mergeAgentRuntimeEnv(entry, preset);
+            const finalEnv =
+              baseEnv || terminal.env
+                ? { ...baseEnv, ...terminal.env }
+                : terminal.env;
+
+            const command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
               initialPrompt,
               clipboardDirectory,
               modelId: terminal.agentModelId,
               recipeArgs: terminal.args?.trim() || undefined,
+              presetArgs: preset?.args?.join(" "),
               globalSkipPermissions,
             });
             // Persist the process-level launch flags so restart/resume/continue
@@ -828,8 +893,9 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             // raw tokens since the restart command builder applies its own
             // escaping.
             const agentLaunchFlags = terminal.agentLaunchFlags ?? [
-              ...buildAgentLaunchFlags(entry, agentId, {
+              ...buildAgentLaunchFlags(effectiveEntry, agentId, {
                 modelId: terminal.agentModelId,
+                presetArgs: preset?.args,
                 globalSkipPermissions,
               }),
               ...(terminal.args?.trim().split(/\s+/).filter(Boolean) ?? []),
@@ -843,7 +909,9 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               worktreeId: worktreeId,
               agentLaunchFlags,
               agentModelId: terminal.agentModelId,
-              env: terminal.env,
+              agentPresetId: preset?.id,
+              agentPresetColor: preset?.color,
+              env: finalEnv,
               exitBehavior: terminal.exitBehavior,
               spawnedBy,
               focusPolicy,

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -870,9 +870,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             // The recipe's own `terminal.env` is caller-supplied and must win.
             const baseEnv = mergeAgentRuntimeEnv(entry, preset);
             const finalEnv =
-              baseEnv || terminal.env
-                ? { ...baseEnv, ...terminal.env }
-                : terminal.env;
+              baseEnv || terminal.env ? { ...baseEnv, ...terminal.env } : terminal.env;
 
             const command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
               initialPrompt,


### PR DESCRIPTION
## Summary

- Recipe launches were calling `generateAgentCommand` with the raw agent settings entry, skipping the preset resolution that manual launches (`useAgentLauncher`) perform — so the selected preset's args, env, and behavioral overrides were silently ignored.
- Brings `recipeStore.runRecipeWithResults` to parity: resolves the effective preset (worktree-scoped over agent-wide default), layers env as global < preset < recipe-defined (recipe env still wins), passes `agentPresetId`/`agentPresetColor` to `addPanel`, and includes preset args in `agentLaunchFlags` for restart/resume (#9650).
- Falls back to the agent-wide default on a stale worktree preset without mutating persisted settings.

Closes #10722

## Changes

- `src/store/recipeStore.ts` — resolve effective preset before spawn; fold preset args/env/behavior into the call; pass preset identity to `addPanel`
- `src/store/__tests__/recipeStore.test.ts` — 9 new preset-resolution tests (95 pass total)

## Testing

- Unit tests cover: preset args/env merged correctly, env layering order, `agentPresetId`/`agentPresetColor` forwarded to `addPanel`, preset args in `agentLaunchFlags`, stale-preset fallback, no-preset path unchanged.
- Confirmed existing 86 recipe store tests still pass.