### PR TITLE
fix(sidebar): stop reconnecting badge wrapping the Worktrees header

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1551,13 +1551,26 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           {showReconnecting && (
             <span
               aria-hidden="true"
-              className="flex items-center gap-1 text-daintree-text/60 text-xs"
               data-reconnect-escalated={showReconnectingEscalated ? "true" : undefined}
             >
-              <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
-              {showReconnectingEscalated && reconnectingAt !== null
-                ? `Reconnecting… last updated ${formatRelativeTime(reconnectingAt)}`
-                : "Reconnecting…"}
+              {showReconnectingEscalated && reconnectingAt !== null ? (
+                <Tooltip autoDismiss={false}>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-status-warning text-xs">
+                      <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
+                      Reconnecting…
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    Last updated {formatRelativeTime(reconnectingAt)}
+                  </TooltipContent>
+                </Tooltip>
+              ) : (
+                <span className="inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-daintree-text/60 text-xs">
+                  <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
+                  Reconnecting…
+                </span>
+              )}
             </span>
           )}
         </div>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1551,6 +1551,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           {showReconnecting && (
             <span
               aria-hidden="true"
+              className="shrink-0"
               data-reconnect-escalated={showReconnectingEscalated ? "true" : undefined}
             >
               {showReconnectingEscalated && reconnectingAt !== null ? (

--- a/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
@@ -44,9 +44,15 @@ describe("SidebarContent reconnecting indicator — issue #8074", () => {
   it("keeps the reconnecting badge on one line and moves the relative time into a tooltip — issue #10727", () => {
     // The escalated string "Reconnecting… last updated X ago" used to render
     // inline with no width constraint, wrapping and breaking the header layout.
-    // The badge spans must now stay single-line.
-    expect(source).toMatch(/whitespace-nowrap/);
-    expect(source).toMatch(/shrink-0/);
+    // Both badge branches must now stay single-line (whitespace-nowrap) and the
+    // text size must match across them (text-xs parity), scoped to the badge so
+    // an unrelated element keeping these classes can't mask a regression.
+    expect(source).toMatch(
+      /inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-status-warning text-xs/
+    );
+    expect(source).toMatch(
+      /inline-flex items-center gap-1 whitespace-nowrap shrink-0 text-daintree-text\/60 text-xs/
+    );
     // The relative-time detail moved off the visible badge into hover tooltip
     // content; the old inline combined template literal must be gone (the
     // explanatory comment at the tick may still mention the phrasing).

--- a/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
@@ -40,4 +40,28 @@ describe("SidebarContent reconnecting indicator — issue #8074", () => {
     // The old ungated reconnect interval must be gone.
     expect(source).not.toMatch(/setInterval\(\(\) => setReconnectTick/);
   });
+
+  it("keeps the reconnecting badge on one line and moves the relative time into a tooltip — issue #10727", () => {
+    // The escalated string "Reconnecting… last updated X ago" used to render
+    // inline with no width constraint, wrapping and breaking the header layout.
+    // The badge spans must now stay single-line.
+    expect(source).toMatch(/whitespace-nowrap/);
+    expect(source).toMatch(/shrink-0/);
+    // The relative-time detail moved off the visible badge into hover tooltip
+    // content; the old inline combined template literal must be gone (the
+    // explanatory comment at the tick may still mention the phrasing).
+    expect(source).not.toMatch(/`Reconnecting… last updated \$\{/);
+    expect(source).toMatch(
+      /<TooltipContent[\s\S]*?Last updated \{formatRelativeTime\(reconnectingAt\)\}/
+    );
+    // The tooltip must not auto-dismiss — the relative time is the substance and
+    // has to stay readable while the user hovers.
+    expect(source).toMatch(/<Tooltip autoDismiss=\{false\}>/);
+  });
+
+  it("renders the stalled (escalated) state with the warning status color — issue #10727", () => {
+    // Past 10s the reconnect reads as "action needed", not a perpetual ambient
+    // spinner — driven by the theme-aware warning token, not the muted default.
+    expect(source).toMatch(/text-status-warning/);
+  });
 });


### PR DESCRIPTION
## Summary

- The reconnecting badge in the Worktrees sidebar header escalated after 10s to an inline string with the relative timestamp, which had no width constraint and wrapped to multiple lines inside the `items-baseline` flex container, breaking the header height.
- Both badge branches are now kept single-line: `whitespace-nowrap` on the inner spans and `shrink-0` on the outer flex child so it resists compression at the 200px minimum sidebar width.
- The relative time ("last updated X ago") moves out of the inline badge into a hover `Tooltip` with `autoDismiss=false`, and the stalled (>10s) state renders in `text-status-warning` so it reads as action-needed rather than a perpetual ambient spinner.

Resolves #10727

## Changes

- `src/components/Sidebar/SidebarContent.tsx`: `shrink-0` + `whitespace-nowrap` on both badge branches; timestamp relocated to `Tooltip`; stalled state styled with `text-status-warning`.
- `src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts`: source-regex regression guards for single-line layout, tooltip relocation, `autoDismiss=false`, and warning state.

State logic, hooks (`useDohertyGate`, `useVisibilityAwareInterval`), and the worktree store are unchanged. The underlying workspace-host crash loop is out of scope (#10729).

## Testing

- All 5 tests in `SidebarContent.reconnecting.test.ts` pass.
- Regression guards cover: single-line constraint, timestamp in tooltip, `autoDismiss=false`, and the warning-state styling branch.