### PR TITLE
fix(logger): auto-prune V8 heap snapshots in logs dir

### DIFF
--- a/electron/services/PeriodicCleanupService.ts
+++ b/electron/services/PeriodicCleanupService.ts
@@ -22,7 +22,12 @@
 import { app, powerMonitor } from "electron";
 import { runScratchCleanup } from "./ScratchCleanupService.js";
 import { runAssistantScratchCleanup } from "./AssistantScratchService.js";
-import { pruneOldLogs, logError } from "../utils/logger.js";
+import {
+  pruneOldLogs,
+  pruneHeapSnapshotsAsync,
+  MAX_HEAP_SNAPSHOTS,
+  logError,
+} from "../utils/logger.js";
 import { store } from "../store.js";
 
 const TICK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
@@ -108,6 +113,13 @@ class PeriodicCleanupService {
       }
     } catch (err) {
       logError("[PeriodicCleanup] log prune threw", err);
+    }
+    try {
+      // Count-based prune of V8 heap snapshots in app.getPath("logs") — a
+      // separate dir from userData/logs, bounded by count not retention age.
+      await pruneHeapSnapshotsAsync(app.getPath("logs"), MAX_HEAP_SNAPSHOTS);
+    } catch (err) {
+      logError("[PeriodicCleanup] heap snapshot prune threw", err);
     }
   }
 }

--- a/electron/services/__tests__/PeriodicCleanupService.test.ts
+++ b/electron/services/__tests__/PeriodicCleanupService.test.ts
@@ -5,12 +5,13 @@ const mockPowerMonitor = vi.hoisted(() => ({
 }));
 
 const mockApp = vi.hoisted(() => ({
-  getPath: vi.fn().mockReturnValue("/fake/userData"),
+  getPath: vi.fn((name: string) => `/fake/${name}`),
 }));
 
 const mockRunScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockRunAssistantScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockPruneOldLogs = vi.hoisted(() => vi.fn());
+const mockPruneHeapSnapshotsAsync = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockStoreGet = vi.hoisted(() => vi.fn().mockReturnValue({ logRetentionDays: 30 }));
 
 vi.mock("electron", () => ({
@@ -28,6 +29,8 @@ vi.mock("../AssistantScratchService.js", () => ({
 
 vi.mock("../../utils/logger.js", () => ({
   pruneOldLogs: mockPruneOldLogs,
+  pruneHeapSnapshotsAsync: mockPruneHeapSnapshotsAsync,
+  MAX_HEAP_SNAPSHOTS: 10,
   logError: vi.fn(),
 }));
 
@@ -44,9 +47,10 @@ describe("PeriodicCleanupService", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.clearAllMocks();
     mockPowerMonitor.getSystemIdleTime.mockReturnValue(120);
-    mockApp.getPath.mockReturnValue("/fake/userData");
+    mockApp.getPath.mockImplementation((name: string) => `/fake/${name}`);
     mockRunScratchCleanup.mockResolvedValue(undefined);
     mockRunAssistantScratchCleanup.mockResolvedValue(undefined);
+    mockPruneHeapSnapshotsAsync.mockResolvedValue(undefined);
     mockStoreGet.mockReturnValue({ logRetentionDays: 30 });
   });
 
@@ -59,20 +63,23 @@ describe("PeriodicCleanupService", () => {
     expect(mockRunScratchCleanup).not.toHaveBeenCalled();
     expect(mockRunAssistantScratchCleanup).not.toHaveBeenCalled();
     expect(mockPruneOldLogs).not.toHaveBeenCalled();
+    expect(mockPruneHeapSnapshotsAsync).not.toHaveBeenCalled();
   }
 
   function expectAllRoutinesRan() {
     expect(mockRunScratchCleanup).toHaveBeenCalledTimes(1);
     expect(mockRunAssistantScratchCleanup).toHaveBeenCalledTimes(1);
     expect(mockPruneOldLogs).toHaveBeenCalledTimes(1);
+    expect(mockPruneHeapSnapshotsAsync).toHaveBeenCalledTimes(1);
   }
 
-  it("runs all three routines when the system is idle", async () => {
+  it("runs all routines when the system is idle", async () => {
     const service = new PeriodicCleanupService();
     await service.tick();
 
     expectAllRoutinesRan();
     expect(mockPruneOldLogs).toHaveBeenCalledWith("/fake/userData", 30);
+    expect(mockPruneHeapSnapshotsAsync).toHaveBeenCalledWith("/fake/logs", 10);
     service.dispose();
   });
 
@@ -138,12 +145,14 @@ describe("PeriodicCleanupService", () => {
     service.dispose();
   });
 
-  it("skips log pruning when retention is zero", async () => {
+  it("skips log pruning when retention is zero but still prunes heap snapshots", async () => {
     mockStoreGet.mockReturnValue({ logRetentionDays: 0 });
     const service = new PeriodicCleanupService();
     await service.tick();
 
+    // Heap snapshot pruning is count-based, not gated on log retention.
     expect(mockPruneOldLogs).not.toHaveBeenCalled();
+    expect(mockPruneHeapSnapshotsAsync).toHaveBeenCalledWith("/fake/logs", 10);
     service.dispose();
   });
 

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -5,6 +5,9 @@ import {
   initializeLogger,
   getLogFilePath,
   pruneOldLogsAsync,
+  pruneHeapSnapshots,
+  pruneHeapSnapshotsAsync,
+  MAX_HEAP_SNAPSHOTS,
   logInfo,
   logWarn,
   logError,
@@ -446,6 +449,121 @@ describe("logger", () => {
       await expect(pruneOldLogsAsync(TEST_LOG_DIR, 30)).resolves.toBeUndefined();
 
       expect(existsSync(nestedDir)).toBe(true);
+    });
+  });
+
+  describe.each([
+    [
+      "pruneHeapSnapshots (sync)",
+      (dir: string, max: number) => Promise.resolve(pruneHeapSnapshots(dir, max)),
+    ],
+    ["pruneHeapSnapshotsAsync", (dir: string, max: number) => pruneHeapSnapshotsAsync(dir, max)],
+  ])("%s", (_label, prune) => {
+    // Heap snapshots land directly in app.getPath("logs"), so the prune target
+    // is the dir itself — not a userData base with logs/ + debug/ subdirs.
+    const snapDir = join(TEST_LOG_DIR, "heap");
+    const MINUTE_MS = 60 * 1000;
+
+    function seedSnapshot(name: string, ageMinutes: number): string {
+      mkdirSync(snapDir, { recursive: true });
+      const filePath = join(snapDir, name);
+      writeFileSync(filePath, "x");
+      const mtimeSeconds = (Date.now() - ageMinutes * MINUTE_MS) / 1000;
+      utimesSync(filePath, mtimeSeconds, mtimeSeconds);
+      return filePath;
+    }
+
+    it("keeps the newest maxCount snapshots and deletes the rest", async () => {
+      // Ages 1..6 minutes — older = larger ageMinutes.
+      const files = Array.from({ length: 6 }, (_, i) =>
+        seedSnapshot(`Heap.2026.${i}.heapsnapshot`, i + 1)
+      );
+
+      await prune(snapDir, 3);
+
+      // Newest 3 (ages 1,2,3 → indices 0,1,2) survive; oldest 3 deleted.
+      expect(existsSync(files[0])).toBe(true);
+      expect(existsSync(files[1])).toBe(true);
+      expect(existsSync(files[2])).toBe(true);
+      expect(existsSync(files[3])).toBe(false);
+      expect(existsSync(files[4])).toBe(false);
+      expect(existsSync(files[5])).toBe(false);
+    });
+
+    it("is a no-op when the snapshot count is at or below maxCount", async () => {
+      const a = seedSnapshot("Heap.a.heapsnapshot", 1);
+      const b = seedSnapshot("Heap.b.heapsnapshot", 2);
+
+      await prune(snapDir, 3);
+
+      expect(existsSync(a)).toBe(true);
+      expect(existsSync(b)).toBe(true);
+    });
+
+    it("never touches files without the .heapsnapshot extension", async () => {
+      const log = seedSnapshot("daintree.log", 100);
+      const looksClose = seedSnapshot("heap.heapsnapshot.log", 100);
+      const txt = seedSnapshot("notes.txt", 100);
+      // Enough real snapshots to force deletion past maxCount.
+      const snaps = Array.from({ length: 4 }, (_, i) =>
+        seedSnapshot(`Heap.${i}.heapsnapshot`, i + 1)
+      );
+
+      await prune(snapDir, 1);
+
+      // Non-snapshot siblings always survive regardless of age/count.
+      expect(existsSync(log)).toBe(true);
+      expect(existsSync(looksClose)).toBe(true);
+      expect(existsSync(txt)).toBe(true);
+      // Only the single newest snapshot remains.
+      expect(existsSync(snaps[0])).toBe(true);
+      expect(existsSync(snaps[1])).toBe(false);
+      expect(existsSync(snaps[2])).toBe(false);
+      expect(existsSync(snaps[3])).toBe(false);
+    });
+
+    it("ignores subdirectories that end in .heapsnapshot", async () => {
+      mkdirSync(snapDir, { recursive: true });
+      const dirNamedLikeSnapshot = join(snapDir, "weird.heapsnapshot");
+      mkdirSync(dirNamedLikeSnapshot, { recursive: true });
+      const realSnaps = Array.from({ length: 3 }, (_, i) =>
+        seedSnapshot(`Heap.${i}.heapsnapshot`, i + 1)
+      );
+
+      await prune(snapDir, 1);
+
+      expect(existsSync(dirNamedLikeSnapshot)).toBe(true);
+      expect(existsSync(realSnaps[0])).toBe(true);
+      expect(existsSync(realSnaps[1])).toBe(false);
+      expect(existsSync(realSnaps[2])).toBe(false);
+    });
+
+    it("is idempotent across repeated runs", async () => {
+      const files = Array.from({ length: 5 }, (_, i) =>
+        seedSnapshot(`Heap.${i}.heapsnapshot`, i + 1)
+      );
+
+      await prune(snapDir, 2);
+      await prune(snapDir, 2);
+
+      expect(existsSync(files[0])).toBe(true);
+      expect(existsSync(files[1])).toBe(true);
+      expect(existsSync(files[2])).toBe(false);
+    });
+
+    it("resolves without throwing when the directory does not exist", async () => {
+      const missing = join(TEST_LOG_DIR, "no-such-dir");
+      await expect(prune(missing, MAX_HEAP_SNAPSHOTS)).resolves.toBeUndefined();
+    });
+
+    it("does not delete anything when maxCount is negative", async () => {
+      const a = seedSnapshot("Heap.a.heapsnapshot", 1);
+      const b = seedSnapshot("Heap.b.heapsnapshot", 2);
+
+      await prune(snapDir, -1);
+
+      expect(existsSync(a)).toBe(true);
+      expect(existsSync(b)).toBe(true);
     });
   });
 });

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -289,6 +289,101 @@ export async function pruneOldLogsAsync(
   }
 }
 
+/**
+ * Cap on retained `*.heapsnapshot` files in `app.getPath("logs")`. V8's
+ * `setHeapSnapshotNearHeapLimit` (main, pty-host, workspace-host, watchdog) dumps
+ * 55–60 MB snapshots there on near-OOM; with frequent OOM restarts they accumulate
+ * unbounded (#10728). 10 ≈ 600 MB and leaves room for all processes to each emit a
+ * full set without dropping the freshest diagnostics.
+ */
+export const MAX_HEAP_SNAPSHOTS = 10;
+
+const HEAP_SNAPSHOT_EXT = ".heapsnapshot";
+
+/**
+ * Count-based prune of V8 heap snapshots in `logsDir` (= `app.getPath("logs")`).
+ * Keeps the `maxCount` newest `*.heapsnapshot` files by mtime and deletes the
+ * rest. Time-based pruning (like {@link pruneOldLogs}) is the wrong model here —
+ * each snapshot is ~55 MB and old dumps have no diagnostic value once superseded.
+ * Strictly filters by extension so sibling logs (daintree.log, crash reports) are
+ * never touched. Missing/unreadable dir and per-file unlink failures are no-ops.
+ */
+export function pruneHeapSnapshots(logsDir: string, maxCount: number): void {
+  if (maxCount < 0) return;
+  if (!existsSync(logsDir)) return;
+
+  try {
+    const snapshots: { path: string; mtimeMs: number }[] = [];
+    for (const file of readdirSync(logsDir)) {
+      if (!file.endsWith(HEAP_SNAPSHOT_EXT)) continue;
+      try {
+        const filePath = join(logsDir, file);
+        const stats = statSync(filePath);
+        if (stats.isFile()) {
+          snapshots.push({ path: filePath, mtimeMs: stats.mtimeMs });
+        }
+      } catch {
+        // Skip locked or inaccessible files
+      }
+    }
+
+    if (snapshots.length <= maxCount) return;
+
+    snapshots.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    for (const { path } of snapshots.slice(maxCount)) {
+      try {
+        unlinkSync(path);
+      } catch {
+        // Skip locked or inaccessible files
+      }
+    }
+  } catch {
+    // Directory read failed — non-fatal
+  }
+}
+
+/**
+ * Async twin of {@link pruneHeapSnapshots}. Uses `fs/promises` so the scan/delete
+ * pass yields to the event loop instead of blocking it. Use this from async
+ * contexts (deferred-init queue, periodic cleanup); keep the sync version for the
+ * synchronous DiskSpaceMonitor critical-edge handler.
+ */
+export async function pruneHeapSnapshotsAsync(logsDir: string, maxCount: number): Promise<void> {
+  if (maxCount < 0) return;
+
+  const snapshots: { path: string; mtimeMs: number }[] = [];
+  try {
+    const handle = await fsp.opendir(logsDir);
+    for await (const dirent of handle) {
+      // dirent.isFile() does not follow symlinks; the logs dir never contains
+      // symlinks, so this matches the sync twin while avoiding an extra stat.
+      if (!dirent.isFile()) continue;
+      if (!dirent.name.endsWith(HEAP_SNAPSHOT_EXT)) continue;
+      try {
+        const filePath = join(logsDir, dirent.name);
+        const stats = await fsp.stat(filePath);
+        snapshots.push({ path: filePath, mtimeMs: stats.mtimeMs });
+      } catch {
+        // Skip locked or inaccessible files
+      }
+    }
+  } catch {
+    // Directory read failed or doesn't exist — non-fatal
+    return;
+  }
+
+  if (snapshots.length <= maxCount) return;
+
+  snapshots.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  for (const { path } of snapshots.slice(maxCount)) {
+    try {
+      await fsp.unlink(path);
+    } catch {
+      // Skip locked or inaccessible files
+    }
+  }
+}
+
 export function getLogDirectory(): string {
   // Priority 1: Environment variable (Utility Processes)
   if (process.env.DAINTREE_USER_DATA) {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -11,10 +11,14 @@ const setMcpRegistry = vi.hoisted(() => vi.fn());
 let migrationCurrentVersion = 1;
 let migrationShouldThrow = false;
 let mockLogRetentionDays: number | undefined = 30;
-const { pruneOldLogs, pruneOldLogsAsync } = vi.hoisted(() => ({
-  pruneOldLogs: vi.fn(),
-  pruneOldLogsAsync: vi.fn(),
-}));
+const { pruneOldLogs, pruneOldLogsAsync, pruneHeapSnapshots, pruneHeapSnapshotsAsync } = vi.hoisted(
+  () => ({
+    pruneOldLogs: vi.fn(),
+    pruneOldLogsAsync: vi.fn(),
+    pruneHeapSnapshots: vi.fn(),
+    pruneHeapSnapshotsAsync: vi.fn(),
+  })
+);
 const {
   pluginMcpHydrate,
   getPluginMcpAuditService,
@@ -79,6 +83,9 @@ vi.mock("../../store.js", () => ({
 vi.mock("../../utils/logger.js", () => ({
   pruneOldLogs,
   pruneOldLogsAsync,
+  pruneHeapSnapshots,
+  pruneHeapSnapshotsAsync,
+  MAX_HEAP_SNAPSHOTS: 10,
   logError: vi.fn(),
   logWarn: vi.fn(),
   logInfo: vi.fn(),
@@ -264,7 +271,7 @@ vi.mock("../deferredInitQueue.js", () => ({
 }));
 
 vi.mock("electron", () => ({
-  app: { exit: vi.fn(), getPath: vi.fn(() => "/tmp/userData") },
+  app: { exit: vi.fn(), getPath: vi.fn((name: string) => `/tmp/${name}`) },
   dialog: { showErrorBox: vi.fn() },
   session: { defaultSession: { clearCache: vi.fn(), clearStorageData: vi.fn() } },
 }));
@@ -283,6 +290,8 @@ describe("initGlobalServices task ordering", () => {
     setMcpRegistry.mockReset();
     pruneOldLogs.mockReset();
     pruneOldLogsAsync.mockReset();
+    pruneHeapSnapshots.mockReset();
+    pruneHeapSnapshotsAsync.mockReset();
     pluginMcpHydrate.mockClear();
     getPluginMcpAuditService.mockClear();
     getPluginMcpConsentService.mockClear();
@@ -650,6 +659,9 @@ describe("initGlobalServices task ordering", () => {
     // The async twin replaces the sync version in the deferred drain so the
     // fs scan no longer blocks the main-process event loop (#10325).
     expect(pruneOldLogs).not.toHaveBeenCalled();
+    // Heap snapshots live in app.getPath("logs"), a different dir from
+    // userData/logs, and are bounded by count (#10728).
+    expect(pruneHeapSnapshotsAsync).toHaveBeenCalledWith("/tmp/logs", 10);
   });
 
   it("prune-old-logs task delegates retentionDays 0 to pruneOldLogsAsync (which skips internally)", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -44,7 +44,14 @@ import { startDiskSpaceMonitor } from "../services/DiskSpaceMonitor.js";
 import { runScratchCleanup } from "../services/ScratchCleanupService.js";
 import { runAssistantScratchCleanup } from "../services/AssistantScratchService.js";
 import { getPeriodicCleanupService } from "../services/PeriodicCleanupService.js";
-import { pruneOldLogs, pruneOldLogsAsync, logError } from "../utils/logger.js";
+import {
+  pruneOldLogs,
+  pruneOldLogsAsync,
+  pruneHeapSnapshots,
+  pruneHeapSnapshotsAsync,
+  MAX_HEAP_SNAPSHOTS,
+  logError,
+} from "../utils/logger.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -317,6 +324,7 @@ export async function initGlobalServices(
                 if (retentionDays > 0) {
                   pruneOldLogs(app.getPath("userData"), retentionDays);
                 }
+                pruneHeapSnapshots(app.getPath("logs"), MAX_HEAP_SNAPSHOTS);
               } catch (err) {
                 logError("[DiskSpaceMonitor] log prune threw", err);
               }
@@ -875,6 +883,9 @@ export async function initGlobalServices(
       // because its files are appended-to, not truncated.
       const retentionDays = store.get("privacy")?.logRetentionDays ?? 30;
       await pruneOldLogsAsync(app.getPath("userData"), retentionDays);
+      // Heap snapshots land in app.getPath("logs") (a separate dir from
+      // userData/logs) and are bounded by count, not age — see pruneHeapSnapshots.
+      await pruneHeapSnapshotsAsync(app.getPath("logs"), MAX_HEAP_SNAPSHOTS);
     },
   });
 


### PR DESCRIPTION
## Summary

- V8 heap snapshots from `setHeapSnapshotNearHeapLimit` (main, pty-host, workspace-host, watchdog) were written to `app.getPath("logs")` and never pruned. A real machine accumulated 103 files totalling 5.6 GB.
- Adds `pruneHeapSnapshots` and `pruneHeapSnapshotsAsync` to `electron/utils/logger.ts`. Both keep the 10 newest `*.heapsnapshot` files by mtime and strictly filter by extension so sibling logs and crash reports are never touched.
- Wired into the three existing cleanup call sites: deferred boot prune and `DiskSpaceMonitor` critical-edge in `globalServicesInit.ts`, and `PeriodicCleanupService.runAll()`. Existing backlog is cleared on next launch for current users.

Resolves #10728

## Changes

- `electron/utils/logger.ts`: `pruneHeapSnapshots` (sync) + `pruneHeapSnapshotsAsync` with `MAX_HEAP_SNAPSHOTS = 10`
- `electron/window/globalServicesInit.ts`: call both variants at boot prune + critical disk edge
- `electron/services/PeriodicCleanupService.ts`: call async variant in `runAll()`
- Tests: new `electron/utils/__tests__/logger.test.ts` (7 cases, both variants); updated `PeriodicCleanupService.test.ts` and `globalServicesInit.order.test.ts` mocks and assertions

## Testing

78 tests pass across the 3 affected test files. Both sync and async code paths covered. Extension filter verified to leave non-snapshot files untouched.