### PR TITLE
fix(workspace-host): detect slow OOM crash-loops and raise heap cap

### DIFF
--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -787,8 +787,8 @@ export class WorkspaceHostProcess extends EventEmitter {
           this.restartTimer.unref?.();
         } else {
           const cause = slowOomLoop
-            ? `slow crash-loop (${this.consecutiveShortCrashIntervals + 1} crashes under ${OOM_LOOP_INTERVAL_MS}ms apart — likely OOM)`
-            : `${CRASH_THRESHOLD} crashes in ${CRASH_WINDOW_MS}ms`;
+            ? `slow crash-loop (${this.consecutiveShortCrashIntervals + 1} crashes under ${OOM_LOOP_INTERVAL_MS / 60_000}min apart — likely OOM)`
+            : `${CRASH_THRESHOLD} crashes in ${CRASH_WINDOW_MS / 60_000}min`;
           console.error(
             `[WorkspaceHost:${this.serviceName}] Max restart attempts reached (${cause}), giving up`
           );

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -43,6 +43,29 @@ const RESTART_CAP_MAX_MS = 10_000;
 const CRASH_THRESHOLD = 3;
 export const CRASH_WINDOW_MS = 30 * 60 * 1000;
 
+// Slow-OOM crash-loop detector. The burst guard above only trips when three
+// crashes land inside a single *fixed* 30-minute window. A host that OOMs every
+// 6-11 minutes restarts cleanly between crashes, and because the OOM cadence is
+// jittery (each crash writes a ~55 MB near-heap-limit snapshot, and GC during
+// the dump buys irregular extra time) the oldest timestamp routinely decays out
+// of the window before the third crash lands — so the burst guard never trips
+// and the host loops in "Reconnecting…" forever (#10729).
+//
+// This secondary detector keys on the *interval between consecutive crashes*
+// instead of a fixed window, which is robust to that jitter: when two
+// consecutive crashes are each less than `OOM_LOOP_INTERVAL_MS` apart, the
+// process is in a slow loop and we give up (emit `host-crash`) instead of
+// restarting again. 20 minutes is deliberately wider than the burst guard's
+// effective reach (~15-min cadence — at wider spacing the 30-min/3 window can no
+// longer hold three entries) so this strictly extends detection to the slow
+// loops the burst guard misses, while still covering the reported 6-11 min band.
+//
+// Intentionally NOT part of the `crashGuardAlignment.test.ts` triad — it tracks
+// a distinct concept (inter-crash cadence, not a fixed window) and is named so
+// it cannot be confused with the aligned CRASH_WINDOW_MS/CRASH_THRESHOLD pair.
+const OOM_LOOP_INTERVAL_MS = 20 * 60 * 1000;
+const OOM_LOOP_THRESHOLD = 2;
+
 export class WorkspaceHostProcess extends EventEmitter {
   private child: UtilityProcess | null = null;
   private config: Required<WorkspaceClientConfig>;
@@ -60,6 +83,18 @@ export class WorkspaceHostProcess extends EventEmitter {
    * Three crashes within the window trip the cap and emit `host-crash`.
    */
   private crashTimestamps: number[] = [];
+  /**
+   * Timestamp of the previous crash, used by the slow-OOM detector to measure
+   * the interval between consecutive crashes. `null` until the first crash.
+   */
+  private previousCrashAt: number | null = null;
+  /**
+   * Count of consecutive crashes whose interval from the prior crash was under
+   * `OOM_LOOP_INTERVAL_MS`. Reset whenever a crash follows a longer gap. Tripping
+   * `OOM_LOOP_THRESHOLD` signals a slow OOM crash-loop (#10729). In-memory only —
+   * the loop persists within a single session, so it needs no disk backing.
+   */
+  private consecutiveShortCrashIntervals = 0;
   /**
    * Authoritative crash reason captured from `app.on("child-process-gone")`.
    * Consumed by the next `exit` handler via `setImmediate` deferral, since the
@@ -373,6 +408,8 @@ export class WorkspaceHostProcess extends EventEmitter {
     }
 
     this.crashTimestamps = [];
+    this.previousCrashAt = null;
+    this.consecutiveShortCrashIntervals = 0;
 
     console.log(`[WorkspaceHost:${this.serviceName}] Manual restart initiated`);
     this.startHost();
@@ -597,7 +634,10 @@ export class WorkspaceHostProcess extends EventEmitter {
         // Redirect v8.setHeapSnapshotNearHeapLimit dumps (set in
         // workspace-host.ts) into the app's logs directory.
         execArgv: [
-          "--max-old-space-size=256",
+          // 256 MB was marginal for large multi-worktree projects and let the
+          // host OOM-loop (#10729). 512 MB raises the headroom while the slow-OOM
+          // detector above surfaces any genuine leak instead of looping silently.
+          "--max-old-space-size=512",
           `--diagnostic-dir=${app.getPath("logs")}`,
           "--report-exclude-env",
         ],
@@ -711,7 +751,19 @@ export class WorkspaceHostProcess extends EventEmitter {
         this.crashTimestamps = this.crashTimestamps.filter((t) => crashAt - t < CRASH_WINDOW_MS);
         this.crashTimestamps.push(crashAt);
 
-        if (this.crashTimestamps.length < CRASH_THRESHOLD) {
+        // Slow-OOM detector: track consecutive crashes that land close together
+        // even when they never accumulate three inside the burst window. A short
+        // gap from the prior crash increments the counter; a long gap resets it.
+        const interCrashGap = this.previousCrashAt !== null ? crashAt - this.previousCrashAt : null;
+        if (interCrashGap !== null && interCrashGap < OOM_LOOP_INTERVAL_MS) {
+          this.consecutiveShortCrashIntervals++;
+        } else {
+          this.consecutiveShortCrashIntervals = 0;
+        }
+        this.previousCrashAt = crashAt;
+        const slowOomLoop = this.consecutiveShortCrashIntervals >= OOM_LOOP_THRESHOLD;
+
+        if (this.crashTimestamps.length < CRASH_THRESHOLD && !slowOomLoop) {
           const windowAttempt = this.crashTimestamps.length;
           const cap = Math.min(
             RESTART_CAP_BASE_MS * Math.pow(2, windowAttempt),
@@ -734,8 +786,11 @@ export class WorkspaceHostProcess extends EventEmitter {
           }, delay);
           this.restartTimer.unref?.();
         } else {
+          const cause = slowOomLoop
+            ? `slow crash-loop (${this.consecutiveShortCrashIntervals + 1} crashes under ${OOM_LOOP_INTERVAL_MS}ms apart — likely OOM)`
+            : `${CRASH_THRESHOLD} crashes in ${CRASH_WINDOW_MS}ms`;
           console.error(
-            `[WorkspaceHost:${this.serviceName}] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${CRASH_WINDOW_MS}ms), giving up`
+            `[WorkspaceHost:${this.serviceName}] Max restart attempts reached (${cause}), giving up`
           );
           this.emit("host-crash", reportedCode);
         }

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -110,7 +110,12 @@ describe("WorkspaceHostProcess", () => {
     host.waitForReady().catch(() => {});
 
     const execArgv: string[] = forkMock.mock.calls[0][2].execArgv;
-    expect(execArgv.some((arg) => /^--max-old-space-size=\d+$/.test(arg))).toBe(true);
+    const heapCapArg = execArgv.find((arg) => /^--max-old-space-size=\d+$/.test(arg));
+    expect(heapCapArg).toBeDefined();
+    // The cap must stay at or above the OOM-mitigation floor (#10729) — 256 MB
+    // was too tight for large multi-worktree projects and let the host OOM-loop.
+    const heapCapMb = Number(heapCapArg!.split("=")[1]);
+    expect(heapCapMb).toBeGreaterThanOrEqual(512);
     expect(execArgv.some((arg) => arg.startsWith("--diagnostic-dir="))).toBe(true);
     expect(execArgv).toContain("--report-exclude-env");
 
@@ -771,6 +776,153 @@ describe("WorkspaceHostProcess crash window", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect((host as any).crashTimestamps).toHaveLength(3);
     expect(crashSpy).toHaveBeenCalledWith(1);
+
+    host.dispose();
+  });
+
+  it("slow OOM loop trips host-crash even when the burst window never holds 3 crashes (#10729)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const crashSpy = vi.fn();
+    host.on("host-crash", crashSpy);
+
+    // Crash 1 at t=0
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Crash 2 at t=12min (gap 12min < 20min interval → consecutive short #1)
+    await vi.advanceTimersByTimeAsync(12 * 60_000);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(crashSpy).not.toHaveBeenCalled();
+
+    // Crash 3 at t=30min (gap 18min < 20min → consecutive short #2 → trips).
+    // The burst window has decayed crash 1 out (30min ≥ 30min window) so it
+    // holds only 2 timestamps and would NOT trip — the interval detector does.
+    await vi.advanceTimersByTimeAsync(18 * 60_000);
+    const child3 = mockChildren[2] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child3.emit("message", { type: "ready" });
+    child3.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect((host as any).crashTimestamps).toHaveLength(2); // burst guard alone would not trip
+    expect((host as any).consecutiveShortCrashIntervals).toBeGreaterThanOrEqual(2);
+    expect(crashSpy).toHaveBeenCalledWith(1);
+
+    host.dispose();
+  });
+
+  it("a long gap between crashes resets the slow-OOM interval counter", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const crashSpy = vi.fn();
+    host.on("host-crash", crashSpy);
+
+    // Crash 1 at t=0
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Crash 2 at t=12min (gap 12min < 20min → counter goes to 1)
+    await vi.advanceTimersByTimeAsync(12 * 60_000);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).consecutiveShortCrashIntervals).toBe(1);
+
+    // Crash 3 at t=37min (gap 25min > 20min → counter resets to 0, no trip)
+    await vi.advanceTimersByTimeAsync(25 * 60_000);
+    const child3 = mockChildren[2] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child3.emit("message", { type: "ready" });
+    child3.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect((host as any).consecutiveShortCrashIntervals).toBe(0);
+    expect(crashSpy).not.toHaveBeenCalled();
+
+    host.dispose();
+  });
+
+  it("ready does NOT reset the slow-OOM interval state", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Crash 1 at t=0
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Crash 2 at t=6min (gap 6min < 20min → counter goes to 1)
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).consecutiveShortCrashIntervals).toBe(1);
+
+    // Restart comes up clean — `ready` must NOT wipe the interval state, or a
+    // crash-ready-crash-ready loop would never accumulate (mirrors #8553).
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+    const child3 = mockChildren[2] as MockUtilityChild;
+    child3.emit("message", { type: "ready" });
+
+    expect((host as any).consecutiveShortCrashIntervals).toBe(1);
+    expect((host as any).previousCrashAt).not.toBeNull();
+
+    host.dispose();
+  });
+
+  it("manualRestart clears the slow-OOM interval state", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Two short-interval crashes → counter at 1, child null (restart pending)
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(2_001);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect((host as any).consecutiveShortCrashIntervals).toBe(1);
+    expect((host as any).child).toBeNull();
+
+    host.manualRestart();
+    expect((host as any).consecutiveShortCrashIntervals).toBe(0);
+    expect((host as any).previousCrashAt).toBeNull();
 
     host.dispose();
   });

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -820,6 +820,43 @@ describe("WorkspaceHostProcess crash window", () => {
     expect((host as any).consecutiveShortCrashIntervals).toBeGreaterThanOrEqual(2);
     expect(crashSpy).toHaveBeenCalledWith(1);
 
+    // Behavioral guard: once the slow loop trips host-crash, the host must give
+    // up — no further auto-restart fork is scheduled (otherwise it would keep
+    // looping in "Reconnecting…", the exact #10729 symptom).
+    const forksAtTrip = forkMock.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(11_000); // past RESTART_CAP_MAX_MS
+    expect(forkMock.mock.calls.length).toBe(forksAtTrip);
+
+    host.dispose();
+  });
+
+  it("exactly OOM_LOOP_INTERVAL_MS apart does not increment the counter (boundary contract)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Crash 1 at t=0
+    const child1 = mockChildren[0] as MockUtilityChild;
+    child1.emit("message", { type: "ready" });
+    child1.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Crash 2 exactly 20min later. The detector uses strict `<`, so a gap equal
+    // to the interval is treated as "not a short interval" and resets the
+    // counter. Documenting the boundary so a future `<`→`<=` change is a
+    // deliberate, test-visible decision rather than a silent surprise.
+    await vi.advanceTimersByTimeAsync(20 * 60_000);
+    const child2 = mockChildren[1] as MockUtilityChild;
+    host.waitForReady().catch(() => {});
+    child2.emit("message", { type: "ready" });
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect((host as any).consecutiveShortCrashIntervals).toBe(0);
+
     host.dispose();
   });
 


### PR DESCRIPTION
## Summary

- The workspace-host was looping forever in "Reconnecting..." when it hit the 256 MB heap cap. OOM crashes are spaced minutes apart (jitter from the ~55 MB near-heap-limit snapshot each crash writes), so the burst guard (3 crashes in 30 minutes) never tripped. The host just kept restarting silently.
- Added an inter-crash-interval detector in `WorkspaceHostProcess`: two consecutive crashes less than 20 minutes apart (`OOM_LOOP_INTERVAL_MS` / `OOM_LOOP_THRESHOLD`) now surface the failure and stop the silent restart loop. The 20-minute window extends past the burst guard's effective reach so the two detectors don't overlap. State resets on `manualRestart`, never on `ready` (mirrors the pattern from #8553).
- Raised `--max-old-space-size` from 256 to 512 MB. 256 was marginal for large multi-worktree projects and is what's causing the OOM in the first place for most users.

Resolves #10729

## Changes

- `electron/services/WorkspaceHostProcess.ts`: `OOM_LOOP_INTERVAL_MS` and `OOM_LOOP_THRESHOLD` constants, `previousCrashAt` and `consecutiveShortCrashIntervals` state, interval check on each crash, reset on `manualRestart`. `--max-old-space-size` raised to 512.
- `electron/services/__tests__/WorkspaceHostProcess.test.ts`: 6 new/strengthened tests covering the slow-loop trip, long-gap reset, `ready`-preservation, `manualRestart` reset, no-restart-after-trip behavioral guard, and the raised heap-cap floor.

## Testing

All 41 tests in `WorkspaceHostProcess.test.ts` pass, including the existing `crashGuardAlignment` suite. The new constants sit outside the crash-guard triad on purpose so that alignment test stays green.

Note: the specific heap retainer driving the OOM requires a runtime heap snapshot to identify (not statically knowable). That's out of scope here. This PR makes the slow loop detectable and surfaced, and raises the ceiling to reduce how often users hit it in the first place.