### PR TITLE
fix(project-switcher): refresh agent stats on open (#10734)

### DIFF
--- a/src/hooks/__tests__/useProjectSwitcherPalette.hoverPrefetch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.hoverPrefetch.test.tsx
@@ -57,8 +57,9 @@ const { prefetchHydrateMock, useProjectStoreMock, notifyMock, projectState, proj
       locateProject: vi.fn().mockResolvedValue(undefined),
     };
 
-    const useProjectStoreMock = vi.fn((selector: (state: typeof projectState) => unknown) =>
-      selector(projectState)
+    const useProjectStoreMock = Object.assign(
+      vi.fn((selector: (state: typeof projectState) => unknown) => selector(projectState)),
+      { getState: () => projectState }
     );
     const notifyMock = vi.fn().mockReturnValue("");
 
@@ -86,8 +87,16 @@ vi.mock("@/store/projectStore", () => ({
 }));
 
 vi.mock("@/store/projectStatsStore", () => ({
-  useProjectStatsStore: vi.fn((selector: (state: typeof projectStatsState) => unknown) =>
-    selector(projectStatsState)
+  useProjectStatsStore: Object.assign(
+    vi.fn((selector: (state: typeof projectStatsState) => unknown) => selector(projectStatsState)),
+    {
+      getState: () => ({
+        stats: projectStatsState.stats,
+        setStats: (stats: typeof projectStatsState.stats) => {
+          projectStatsState.stats = stats;
+        },
+      }),
+    }
   ),
 }));
 

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -1111,20 +1111,31 @@ describe("useProjectSwitcherPalette", () => {
       }
     });
 
-    it("tolerates a bulk stats fetch rejection without throwing", async () => {
+    it("tolerates a bulk stats fetch rejection without throwing or leaking", async () => {
+      const unhandled = vi.fn();
+      window.addEventListener("unhandledrejection", unhandled);
       getBulkStatsMock.mockRejectedValueOnce(new Error("stats failed"));
 
-      const { result } = renderHook(() => useProjectSwitcherPalette());
+      try {
+        const { result } = renderHook(() => useProjectSwitcherPalette());
 
-      act(() => {
-        result.current.open();
-      });
+        act(() => {
+          result.current.open();
+        });
 
-      await waitFor(() => {
-        expect(result.current.isOpen).toBe(true);
-        expect(getBulkStatsMock).toHaveBeenCalledWith(["project-1"]);
-      });
-      expect(setStatsMock).not.toHaveBeenCalled();
+        await waitFor(() => {
+          expect(result.current.isOpen).toBe(true);
+          expect(getBulkStatsMock).toHaveBeenCalledWith(["project-1"]);
+        });
+        // Let any pending microtask rejection settle.
+        await act(async () => {
+          await Promise.resolve();
+        });
+        expect(setStatsMock).not.toHaveBeenCalled();
+        expect(unhandled).not.toHaveBeenCalled();
+      } finally {
+        window.removeEventListener("unhandledrejection", unhandled);
+      }
     });
   });
 });

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -1,10 +1,12 @@
 // @vitest-environment jsdom
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   getBulkStatsMock,
+  setStatsMock,
   useProjectStoreMock,
+  useProjectStatsStoreMock,
   notifyMock,
   copyMock,
   projectState,
@@ -19,6 +21,10 @@ const {
       { activeAgentCount: number; waitingAgentCount: number; processCount: number }
     >,
   };
+
+  const setStatsMock = vi.fn((stats: typeof projectStatsState.stats) => {
+    projectStatsState.stats = stats;
+  });
 
   const projectState = {
     projects: [
@@ -48,11 +54,17 @@ const {
     vi.fn((selector: (state: typeof projectState) => unknown) => selector(projectState)),
     { getState: () => projectState }
   );
+  const useProjectStatsStoreMock = Object.assign(
+    vi.fn((selector: (state: typeof projectStatsState) => unknown) => selector(projectStatsState)),
+    { getState: () => ({ stats: projectStatsState.stats, setStats: setStatsMock }) }
+  );
   const notifyMock = vi.fn().mockReturnValue("");
 
   return {
     getBulkStatsMock,
+    setStatsMock,
     useProjectStoreMock,
+    useProjectStatsStoreMock,
     notifyMock,
     copyMock,
     projectState,
@@ -71,9 +83,7 @@ vi.mock("@/store/projectStore", () => ({
 }));
 
 vi.mock("@/store/projectStatsStore", () => ({
-  useProjectStatsStore: vi.fn((selector: (state: typeof projectStatsState) => unknown) =>
-    selector(projectStatsState)
-  ),
+  useProjectStatsStore: useProjectStatsStoreMock,
 }));
 
 vi.mock("@/lib/notify", () => ({
@@ -119,6 +129,10 @@ describe("useProjectSwitcherPalette", () => {
     vi.clearAllMocks();
     projectState.currentProject = null;
     projectStatsState.stats = {};
+    getBulkStatsMock.mockResolvedValue(emptyBulkStats(["project-1"]));
+    setStatsMock.mockImplementation((stats: typeof projectStatsState.stats) => {
+      projectStatsState.stats = stats;
+    });
     usePaletteStore.setState({ activePaletteId: null });
   });
 
@@ -1012,6 +1026,105 @@ describe("useProjectSwitcherPalette", () => {
 
       expect(copyMock).toHaveBeenCalledWith("/repo/one");
       expect(notifyMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stats refresh on open", () => {
+    let savedProjects: typeof projectState.projects;
+
+    beforeEach(() => {
+      savedProjects = projectState.projects;
+      projectState.projects = [
+        {
+          id: "project-1",
+          name: "Project One",
+          path: "/repo/one",
+          emoji: "🌲",
+          color: "#00aa00",
+          lastOpened: 123,
+          frecencyScore: 3.0,
+          status: "active" as const,
+        },
+      ];
+    });
+
+    afterEach(() => {
+      projectState.projects = savedProjects;
+    });
+
+    it("pulls fresh bulk stats for loaded project IDs when opened", async () => {
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(getBulkStatsMock).toHaveBeenCalledWith(["project-1"]);
+      });
+    });
+
+    it("updates the stats store with mapped agent counts from the bulk response", async () => {
+      getBulkStatsMock.mockResolvedValue({
+        "project-1": {
+          processCount: 2,
+          terminalCount: 2,
+          estimatedMemoryMB: 10,
+          terminalTypes: {},
+          processIds: [1, 2],
+          activeAgentCount: 1,
+          waitingAgentCount: 3,
+        },
+      });
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(setStatsMock).toHaveBeenCalledWith({
+          "project-1": { activeAgentCount: 1, waitingAgentCount: 3, processCount: 2 },
+        });
+      });
+    });
+
+    it("does not request stats when no projects are loaded", async () => {
+      const originalProjects = projectState.projects;
+      projectState.projects = [];
+
+      try {
+        const { result } = renderHook(() => useProjectSwitcherPalette());
+
+        act(() => {
+          result.current.open();
+        });
+
+        await waitFor(() => {
+          expect(result.current.isOpen).toBe(true);
+        });
+        expect(getBulkStatsMock).not.toHaveBeenCalled();
+        expect(setStatsMock).not.toHaveBeenCalled();
+      } finally {
+        projectState.projects = originalProjects;
+      }
+    });
+
+    it("tolerates a bulk stats fetch rejection without throwing", async () => {
+      getBulkStatsMock.mockRejectedValueOnce(new Error("stats failed"));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isOpen).toBe(true);
+        expect(getBulkStatsMock).toHaveBeenCalledWith(["project-1"]);
+      });
+      expect(setStatsMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -8,6 +8,7 @@ import { usePaletteStore } from "@/store/paletteStore";
 import { notify } from "@/lib/notify";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import type { Project, Scratch } from "@shared/types";
+import type { ProjectStatusMap } from "@shared/types/ipc/project";
 import { projectClient, scratchClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
@@ -187,8 +188,25 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
 
   useEffect(() => {
     if (!isOpen) return;
-    void loadProjects();
     void loadScratches();
+    // Pull a fresh agent-status snapshot on open so rows show live status
+    // immediately instead of waiting for the next passive broadcast, which
+    // would otherwise leave them falling back to a stale relative timestamp.
+    void loadProjects().then(() => {
+      const ids = useProjectStore.getState().projects.map((p) => p.id);
+      if (ids.length === 0) return;
+      void projectClient.getBulkStats(ids).then((bulk) => {
+        const map: ProjectStatusMap = {};
+        for (const [id, entry] of Object.entries(bulk)) {
+          map[id] = {
+            activeAgentCount: entry.activeAgentCount,
+            waitingAgentCount: entry.waitingAgentCount,
+            processCount: entry.processCount,
+          };
+        }
+        useProjectStatsStore.getState().setStats(map);
+      });
+    });
   }, [isOpen, loadProjects, loadScratches]);
 
   const searchableProjects = useMemo<SearchableProject[]>(() => {

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -192,12 +192,11 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     // Pull a fresh agent-status snapshot on open so rows show live status
     // immediately instead of waiting for the next passive broadcast, which
     // would otherwise leave them falling back to a stale relative timestamp.
-    void loadProjects().then(() => {
-      const ids = useProjectStore.getState().projects.map((p) => p.id);
-      if (ids.length === 0) return;
-      void projectClient
-        .getBulkStats(ids)
-        .then((bulk) => {
+    void loadProjects()
+      .then(() => {
+        const ids = useProjectStore.getState().projects.map((p) => p.id);
+        if (ids.length === 0) return;
+        return projectClient.getBulkStats(ids).then((bulk) => {
           const map: ProjectStatusMap = {};
           for (const [id, entry] of Object.entries(bulk)) {
             map[id] = {
@@ -207,12 +206,12 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
             };
           }
           useProjectStatsStore.getState().setStats(map);
-        })
-        .catch(() => {
-          // Stats refresh failed; rows fall back to the relative timestamp.
-          // A background freshness pull should never surface an error.
         });
-    });
+      })
+      .catch(() => {
+        // Project load or stats refresh failed; rows fall back to the relative
+        // timestamp. This background freshness pull must never surface an error.
+      });
   }, [isOpen, loadProjects, loadScratches]);
 
   const searchableProjects = useMemo<SearchableProject[]>(() => {

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -195,17 +195,23 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     void loadProjects().then(() => {
       const ids = useProjectStore.getState().projects.map((p) => p.id);
       if (ids.length === 0) return;
-      void projectClient.getBulkStats(ids).then((bulk) => {
-        const map: ProjectStatusMap = {};
-        for (const [id, entry] of Object.entries(bulk)) {
-          map[id] = {
-            activeAgentCount: entry.activeAgentCount,
-            waitingAgentCount: entry.waitingAgentCount,
-            processCount: entry.processCount,
-          };
-        }
-        useProjectStatsStore.getState().setStats(map);
-      });
+      void projectClient
+        .getBulkStats(ids)
+        .then((bulk) => {
+          const map: ProjectStatusMap = {};
+          for (const [id, entry] of Object.entries(bulk)) {
+            map[id] = {
+              activeAgentCount: entry.activeAgentCount,
+              waitingAgentCount: entry.waitingAgentCount,
+              processCount: entry.processCount,
+            };
+          }
+          useProjectStatsStore.getState().setStats(map);
+        })
+        .catch(() => {
+          // Stats refresh failed; rows fall back to the relative timestamp.
+          // A background freshness pull should never surface an error.
+        });
     });
   }, [isOpen, loadProjects, loadScratches]);
 


### PR DESCRIPTION
## Summary

- Opening the project switcher showed stale relative timestamps ("a few minutes ago") instead of live agent status. The `projectStatsStore` is populated only by passive IPC broadcasts from `ProjectStatsService`, so the first open always fell back to cached data until the next background tick.
- Fix chains a `getBulkStats()` call in the `isOpen` `useEffect` of `useProjectSwitcherPalette.ts`, after `loadProjects()` resolves. Project IDs come from `useProjectStore.getState().projects` and results are pushed through the existing `setStats()`. No new IPC channel or store action needed.
- The fetch is fire-and-forget with a `.catch`: a failed refresh degrades to the stale timestamp rather than surfacing an error or leaking an unhandled rejection.

Resolves #10734

## Changes

- `src/hooks/useProjectSwitcherPalette.ts`: chain `getBulkStats()` after `loadProjects()` in the `isOpen` effect, map response to `ProjectStatusMap`, push through `setStats()`
- `src/hooks/__tests__/useProjectSwitcherPalette.test.tsx`: extend mocks with `getState`/`setStats` and `getBulkStats`; add "stats refresh on open" suite covering fetch fires with loaded IDs, store updated with mapped counts, skip when no projects, rejection tolerated

## Testing

34 tests pass. The new suite covers the four main cases: fetch fires on open, store is updated correctly, fetch is skipped when no projects are loaded, and rejection is caught cleanly without leaking an unhandled rejection.