### PR TITLE
feat(project): show busy overlay while switching projects (#10736)

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -140,6 +140,12 @@ export function AppLayout({
   // paint (the new width arrives with the class already gone — no animation).
   const [isSidebarWidthHydrating, setIsSidebarWidthHydrating] = useState(true);
   const currentProject = useProjectStore((state) => state.currentProject);
+  const isSwitchingProject = useProjectStore((state) => state.isSwitching);
+  const switchingToProjectName = useProjectStore((state) =>
+    state.switchingToProjectId
+      ? state.projects.find((p) => p.id === state.switchingToProjectId)?.name
+      : undefined
+  );
   const layout = useLayoutState();
   const diagnosticsMounted = useKeepMounted(layout.diagnosticsOpen);
   const isThemeBrowserOpen = useOverlayOpen("theme-browser");
@@ -837,7 +843,7 @@ export function AppLayout({
         )}
       </div>
 
-      <ProjectSwitchOverlay isSwitching={false} projectName={undefined} />
+      <ProjectSwitchOverlay isSwitching={isSwitchingProject} projectName={switchingToProjectName} />
       <ChordIndicator />
 
       <AllClearOverlay />

--- a/src/components/Project/ProjectSwitchOverlay.tsx
+++ b/src/components/Project/ProjectSwitchOverlay.tsx
@@ -1,12 +1,48 @@
+import { createPortal } from "react-dom";
+
+import { Spinner } from "@/components/ui/Spinner";
+import { useDohertyGate } from "@/hooks/useDeferredLoading";
+
 export interface ProjectSwitchOverlayProps {
   isSwitching: boolean;
   projectName?: string;
 }
 
-export const CANCEL_BUTTON_DELAY_MS = 5_000;
+/**
+ * Busy indication shown over the main content area while a project switch is in
+ * flight (#10736). During a switch the outgoing project's `WebContentsView`
+ * stays composited on top until the incoming view paints (or the main-process
+ * hard timeout fires), so the user otherwise stares at a frozen UI with no
+ * feedback for up to several seconds on a cold switch. This portal scrim sits
+ * above that frozen content and signals the transition.
+ *
+ * Gated through the 400ms Doherty threshold so it never flashes on fast warm
+ * switches (cached view reactivation resolves in ~16-500ms). A centered
+ * `Spinner` — not a skeleton — because the incoming project's layout shape is
+ * unknown to this renderer.
+ */
+export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitchOverlayProps) {
+  const showOverlay = useDohertyGate(isSwitching);
 
-export function ProjectSwitchOverlay(_props: ProjectSwitchOverlayProps) {
-  // In multi-view mode each project gets its own WebContentsView,
-  // so renderer-side project switching no longer occurs.
-  return null;
+  if (!showOverlay || typeof document === "undefined") {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      role="status"
+      aria-live="polite"
+      // Above the toolbar (z-60) so the whole outgoing surface reads as busy,
+      // below the panel-transition (z-100) and all-clear (z-200) overlays.
+      // Opacity-only scrim — no backdrop-filter: a viewport blur re-rasterizes
+      // every frame while the incoming WebContentsView is painting beneath.
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-scrim-soft/60"
+    >
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <Spinner size="md" />
+        <span>{projectName ? `Switching to ${projectName}…` : "Switching project…"}</span>
+      </div>
+    </div>,
+    document.body
+  );
 }

--- a/src/components/Project/ProjectSwitchOverlay.tsx
+++ b/src/components/Project/ProjectSwitchOverlay.tsx
@@ -38,9 +38,11 @@ export function ProjectSwitchOverlay({ isSwitching, projectName }: ProjectSwitch
       // every frame while the incoming WebContentsView is painting beneath.
       className="fixed inset-0 z-[80] flex items-center justify-center bg-scrim-soft/60"
     >
-      <div className="flex items-center gap-2 text-sm text-text-secondary">
+      <div className="flex max-w-[80vw] items-center gap-2 text-sm text-text-secondary">
         <Spinner size="md" />
-        <span>{projectName ? `Switching to ${projectName}…` : "Switching project…"}</span>
+        <span className="truncate">
+          {projectName ? `Switching to ${projectName}…` : "Switching project…"}
+        </span>
       </div>
     </div>,
     document.body

--- a/src/components/Project/__tests__/ProjectSwitchOverlay.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitchOverlay.test.tsx
@@ -1,17 +1,74 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
-import { ProjectSwitchOverlay, CANCEL_BUTTON_DELAY_MS } from "../ProjectSwitchOverlay";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+import { ProjectSwitchOverlay } from "../ProjectSwitchOverlay";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+
+function advance(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+function overlay(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('[role="status"]');
+}
 
 describe("ProjectSwitchOverlay", () => {
-  it("exports the cancel button delay constant", () => {
-    expect(CANCEL_BUTTON_DELAY_MS).toBe(5_000);
+  beforeEach(() => {
+    vi.useFakeTimers();
   });
 
-  it("renders nothing (multi-view mode replaced renderer-side switching)", () => {
-    const { container } = render(<ProjectSwitchOverlay isSwitching={true} projectName="Test" />);
-    expect(container.innerHTML).toBe("");
+  afterEach(() => {
+    // Unmount (and tear down the portal) before swapping back to real timers,
+    // so React removes its own nodes instead of a manual document.body wipe
+    // racing the unmount.
+    cleanup();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("renders nothing while not switching", () => {
+    render(<ProjectSwitchOverlay isSwitching={false} projectName="Acme" />);
+    advance(UI_DOHERTY_THRESHOLD + 50);
+    expect(overlay()).toBeNull();
+  });
+
+  it("stays hidden until the Doherty gate elapses, then appears", () => {
+    render(<ProjectSwitchOverlay isSwitching={true} projectName="Acme" />);
+    // Before the gate: no overlay — anti-flicker for fast warm switches.
+    advance(UI_DOHERTY_THRESHOLD - 50);
+    expect(overlay()).toBeNull();
+    // Crossing the gate reveals the overlay.
+    advance(100);
+    expect(overlay()).not.toBeNull();
+  });
+
+  it("shows a spinner and the target project name once gated on", () => {
+    render(<ProjectSwitchOverlay isSwitching={true} projectName="Acme" />);
+    advance(UI_DOHERTY_THRESHOLD + 50);
+    const el = overlay();
+    expect(el).not.toBeNull();
+    expect(el?.querySelector(".animate-spin")).not.toBeNull();
+    expect(el?.textContent).toContain("Switching to Acme");
+  });
+
+  it("falls back to a generic label when no project name is provided", () => {
+    render(<ProjectSwitchOverlay isSwitching={true} />);
+    advance(UI_DOHERTY_THRESHOLD + 50);
+    const el = overlay();
+    expect(el?.textContent).toContain("Switching project");
+    expect(el?.textContent).not.toContain("Switching to");
+  });
+
+  it("tears down the overlay when switching ends", () => {
+    const { rerender } = render(<ProjectSwitchOverlay isSwitching={true} projectName="Acme" />);
+    advance(UI_DOHERTY_THRESHOLD + 50);
+    expect(overlay()).not.toBeNull();
+
+    rerender(<ProjectSwitchOverlay isSwitching={false} projectName="Acme" />);
+    expect(overlay()).toBeNull();
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitchOverlay.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitchOverlay.test.tsx
@@ -63,6 +63,16 @@ describe("ProjectSwitchOverlay", () => {
     expect(el?.textContent).not.toContain("Switching to");
   });
 
+  it("never paints when switching ends before the Doherty gate elapses", () => {
+    const { rerender } = render(<ProjectSwitchOverlay isSwitching={true} projectName="Acme" />);
+    // Switch completes just before the gate would fire — the fast-warm case.
+    advance(UI_DOHERTY_THRESHOLD - 1);
+    rerender(<ProjectSwitchOverlay isSwitching={false} projectName="Acme" />);
+    // Advancing well past the original threshold must not resurrect the overlay.
+    advance(500);
+    expect(overlay()).toBeNull();
+  });
+
   it("tears down the overlay when switching ends", () => {
     const { rerender } = render(<ProjectSwitchOverlay isSwitching={true} projectName="Acme" />);
     advance(UI_DOHERTY_THRESHOLD + 50);

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -609,3 +609,55 @@ describe("worktreeLoadError surfacing (#8400)", () => {
     expect(useProjectStore.getState().worktreeLoadError).toBeNull();
   });
 });
+
+describe("switch busy indication (#10736)", () => {
+  it("flags isSwitching and the target project id when a switch starts", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    expect(useProjectStore.getState().isSwitching).toBe(false);
+    expect(useProjectStore.getState().switchingToProjectId).toBeNull();
+
+    await useProjectStore.getState().switchProject(projectB.id);
+
+    expect(useProjectStore.getState().isSwitching).toBe(true);
+    expect(useProjectStore.getState().switchingToProjectId).toBe(projectB.id);
+  });
+
+  it("keeps isSwitching set after the fire-and-forget IPC resolves (view is replaced)", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The happy path never re-enters this renderer, so the flag is not cleared.
+    expect(useProjectStore.getState().isSwitching).toBe(true);
+  });
+
+  it("clears isSwitching when the switch IPC rejects (outgoing view stays visible)", async () => {
+    projectClientMock.switch.mockRejectedValueOnce(new Error("boom"));
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    // Let the rejected promise's .catch() run.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useProjectStore.getState().isSwitching).toBe(false);
+    expect(useProjectStore.getState().switchingToProjectId).toBeNull();
+    expect(useProjectStore.getState().isLoading).toBe(false);
+  });
+
+  it("does not flag isSwitching when switching to the current project (early return)", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectA.id);
+
+    expect(useProjectStore.getState().isSwitching).toBe(false);
+    expect(useProjectStore.getState().switchingToProjectId).toBeNull();
+  });
+});

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -660,4 +660,45 @@ describe("switch busy indication (#10736)", () => {
     expect(useProjectStore.getState().isSwitching).toBe(false);
     expect(useProjectStore.getState().switchingToProjectId).toBeNull();
   });
+
+  it("flags isSwitching for reopenProject (background-project switch path)", async () => {
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().reopenProject(projectB.id);
+
+    expect(useProjectStore.getState().isSwitching).toBe(true);
+    expect(useProjectStore.getState().switchingToProjectId).toBe(projectB.id);
+  });
+
+  it("clears isSwitching when the reopen IPC rejects", async () => {
+    projectClientMock.reopen.mockRejectedValueOnce(new Error("boom"));
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().reopenProject(projectB.id);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useProjectStore.getState().isSwitching).toBe(false);
+    expect(useProjectStore.getState().switchingToProjectId).toBeNull();
+  });
+
+  it("a superseded switch's rejection does not clobber the newer transition's busy state", async () => {
+    // Switch A→B (requestId N), then A→C supersedes it (requestId N+1). When B's
+    // IPC later rejects, the staleness guard must keep C's busy state intact so
+    // the overlay keeps tracking the live switch rather than clearing early.
+    projectClientMock.switch.mockRejectedValueOnce(new Error("B failed")); // first call (B)
+    const { useProjectStore } = await import("../projectStore");
+    useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
+
+    await useProjectStore.getState().switchProject(projectB.id);
+    await useProjectStore.getState().switchProject("project-c");
+    // Let B's rejected promise's .catch() run (it should short-circuit).
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useProjectStore.getState().isSwitching).toBe(true);
+    expect(useProjectStore.getState().switchingToProjectId).toBe("project-c");
+  });
 });

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -93,6 +93,21 @@ interface ProjectState {
   projects: Project[];
   currentProject: Project | null;
   isLoading: boolean;
+  /**
+   * True while a project switch is in flight (#10736). Distinct from the shared
+   * `isLoading`, which also fires for load/add/remove — this is scoped to the
+   * switch so the main-content busy overlay only appears during a switch. Set
+   * synchronously in `switchProject` before the fire-and-forget IPC; never
+   * cleared on the happy path (the outgoing renderer is detached and replaced),
+   * only in the `.catch()` where the outgoing view stays visible. Transient,
+   * never persisted.
+   */
+  isSwitching: boolean;
+  /**
+   * Id of the project being switched to while `isSwitching` is true, used to
+   * label the busy overlay. Set/cleared atomically with `isSwitching`.
+   */
+  switchingToProjectId: string | null;
   error: string | null;
   /**
    * True once the batched boot payload has seeded `projects` + `currentProject`
@@ -327,6 +342,8 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
   projects: [],
   currentProject: null,
   isLoading: false,
+  isSwitching: false,
+  switchingToProjectId: null,
   isBootstrapped: false,
   gitInitDialogOpen: false,
   gitInitDirectoryPath: null,
@@ -533,7 +550,13 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     // Clear any stale worktree-load banner atomically with the switch start so
     // the previous project's failure never coexists with the new project (#8400,
     // mirrors the #4451 atomic-swap fix).
-    set({ isLoading: true, error: null, worktreeLoadError: null });
+    set({
+      isLoading: true,
+      isSwitching: true,
+      switchingToProjectId: projectId,
+      error: null,
+      worktreeLoadError: null,
+    });
     // Fire-and-forget: the main process swaps WebContentsViews, so this
     // renderer gets detached. Don't write the response into stores — the
     // new view handles its own state independently.
@@ -561,7 +584,10 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
           },
         ],
       });
-      set({ error: message, isLoading: false });
+      // The switch failed before the view swap, so this outgoing renderer stays
+      // visible — clear the busy flag here (the happy path never reaches this
+      // renderer again, so it needs no clear).
+      set({ error: message, isLoading: false, isSwitching: false, switchingToProjectId: null });
     });
   },
 

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -749,7 +749,13 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     const currentProjectId = get().currentProject?.id;
     const outgoingState = currentProjectId ? buildOutgoingState(currentProjectId) : undefined;
 
-    set({ isLoading: true, error: null, worktreeLoadError: null });
+    set({
+      isLoading: true,
+      isSwitching: true,
+      switchingToProjectId: projectId,
+      error: null,
+      worktreeLoadError: null,
+    });
     projectClient.reopen(projectId, outgoingState).catch((error) => {
       if (requestId !== projectTransitionRequestId) {
         return;
@@ -774,7 +780,11 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
           },
         ],
       });
-      set({ error: message, isLoading: false });
+      // The reopen failed before the view swap, so this outgoing renderer stays
+      // visible — clear the busy flag (mirrors switchProject). Guarded by the
+      // requestId check above so a superseded reopen never clobbers a newer
+      // transition's state.
+      set({ error: message, isLoading: false, isSwitching: false, switchingToProjectId: null });
     });
   },
 


### PR DESCRIPTION
## Summary

- Cold project switches left the outgoing content area frozen with no feedback for up to ~4s while the incoming `WebContentsView` painted or the hard timeout fired.
- Adds a Doherty-gated busy overlay (400ms) so fast warm switches stay flash-free while cold switches get clear visual feedback.
- Covers both `switchProject` and `reopenProject` code paths.

Resolves #10736

## Changes

- `projectStore`: new `isSwitching` and `switchingToProjectId` flags scoped to `switchProject` and `reopenProject`. Set on start, cleared only in `.catch()` (the happy path detaches the outgoing renderer). Not persisted.
- `AppLayout`: wires the live flags into the previously-stubbed `ProjectSwitchOverlay`.
- `ProjectSwitchOverlay`: implemented as a portal scrim (`fixed inset-0 z-[80] bg-scrim-soft/60`, `role=status`) with a centered `Spinner` and target-project label. No backdrop-blur, no accent tokens. Long names truncate. Removed the dead `CANCEL_BUTTON_DELAY_MS` export.

## Testing

- Behavioral overlay tests: gated-off below 400ms, gated-on after, gate-cancel on fast switch.
- `projectStore` flag transition tests including the superseded-switch staleness guard.