### PR TITLE
fix(assistant): recover stuck launch loader on project switch-back (#10739)

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -378,6 +378,22 @@ export function HelpPanel({
     };
   }, []);
 
+  // Recover a launch stranded by a project switch-back (#10739). When a launch
+  // is interrupted mid-flight, the view is parked in the LRU cache where the
+  // watchdog timer can't fire, leaving the loading skeleton stuck with no
+  // terminal bound. Key off the explicit `app:view-revealed` signal (reliable
+  // for cached-view reveal, unlike DOM `visibilitychange`) so the controller can
+  // reap the stall and re-drive. Gated only on `isOpen` — crucially NOT on
+  // `terminalId`, since the stuck-launch case has no terminal yet, nor on
+  // `isVisible`, so the subscription is live the moment the cached view reveals.
+  useEffect(() => {
+    if (!isOpen) return;
+    const off = window.electron?.app?.onViewRevealed?.(() => {
+      controller.handleViewRevealed();
+    });
+    return () => off?.();
+  }, [controller, isOpen]);
+
   // Revoke the bound help session if the underlying PTY panel disappears
   // from the panel store. The controller's `_pendingNewTerminalId` guard
   // keeps the reservation alive across the brief addPanel/setTerminal gap.

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -366,7 +366,17 @@ vi.mock("../FigureRail", () => ({ FigureRail: () => null }));
 import { HelpPanel } from "../HelpPanel";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
 
+// The real `app:view-revealed` bridge fans out to every registered listener;
+// HelpPanel registers the switch-back recovery effect against it (#10739).
+let viewRevealedCbs: Array<() => void> = [];
+function fireViewRevealed(): void {
+  act(() => {
+    for (const cb of viewRevealedCbs) cb();
+  });
+}
+
 function resetState() {
+  viewRevealedCbs = [];
   helpPanelState.isOpen = true;
   helpPanelState.width = 380;
   helpPanelState.terminalId = null;
@@ -533,6 +543,14 @@ beforeEach(() => {
         project: {
           getSettings: vi.fn().mockResolvedValue({}),
           saveSettings: vi.fn().mockResolvedValue(undefined),
+        },
+        app: {
+          onViewRevealed: (cb: () => void) => {
+            viewRevealedCbs.push(cb);
+            return () => {
+              viewRevealedCbs = viewRevealedCbs.filter((c) => c !== cb);
+            };
+          },
         },
       },
     },
@@ -2489,6 +2507,41 @@ describe("HelpPanel — assistant survives visibility-hidden (project switch per
       { source: "user" }
     );
     expect(mockProvisionSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-drives a launch stranded by a switch-back via app:view-revealed with no terminal bound (#10739)", async () => {
+    // No bound terminal — the stuck-loader case. The existing reveal-repaint
+    // effect is gated on `terminalId`, so it never registers a listener here;
+    // only the new recovery effect (gated on `isOpen`) can re-drive.
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.sessionId = null;
+
+    // getFolderPath never resolves, so the launch parks in `version-checking` —
+    // exactly the stranded loading phase a parked view's frozen watchdog can't
+    // reap.
+    mockGetFolderPath.mockReturnValue(new Promise(() => {}));
+
+    await act(async () => {
+      render(<HelpPanel width={380} isReadyToLaunch />);
+    });
+    await flushAsync();
+
+    // The initial auto-launch fired and hung before reaching dispatch.
+    const folderCallsBefore = mockGetFolderPath.mock.calls.length;
+    expect(folderCallsBefore).toBeGreaterThan(0);
+    expect(mockDispatch).not.toHaveBeenCalled();
+
+    // Switch-back reveal reaps the stall and re-drives, even though terminalId
+    // is still null (the terminalId-gated repaint listener never registered).
+    fireViewRevealed();
+    await flushAsync();
+
+    expect(mockGetFolderPath.mock.calls.length).toBeGreaterThan(folderCallsBefore);
+    // Recovery is silent — no launch-error banner, no toast.
+    expect(screen.queryByTestId("help-launch-error-banner")).toBeNull();
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.revealBackstop.test.tsx
@@ -55,6 +55,7 @@ vi.mock("@/controllers/HelpSessionController", () => ({
     getSnapshot = () => snapshot;
     syncInputs = vi.fn();
     handleTerminalPanelMissing = vi.fn();
+    handleViewRevealed = vi.fn();
     maybeRunPreflightSnapshot = vi.fn(() => undefined);
     selectAgent = vi.fn();
     newSession = vi.fn();
@@ -194,7 +195,10 @@ function flushFrame(): void {
   for (const cb of pending) cb(0);
 }
 
-let viewRevealedCb: (() => void) | null = null;
+// The real `onViewRevealed` supports multiple listeners; HelpPanel registers two
+// (the launch-recovery effect and this repaint effect), so the mock must fan out
+// to all of them rather than keep only the last-registered slot.
+let viewRevealedCbs: Array<() => void> = [];
 
 function setVisibilityState(state: DocumentVisibilityState): void {
   Object.defineProperty(document, "visibilityState", {
@@ -218,7 +222,7 @@ beforeEach(() => {
   rafQueue.clear();
   rafIdCounter = 0;
   repaintForRevealMock.mockClear();
-  viewRevealedCb = null;
+  viewRevealedCbs = [];
 
   globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
     const id = ++rafIdCounter;
@@ -249,9 +253,9 @@ beforeEach(() => {
         help: { getPinnedActionContext: vi.fn().mockResolvedValue({}) },
         app: {
           onViewRevealed: (cb: () => void) => {
-            viewRevealedCb = cb;
+            viewRevealedCbs.push(cb);
             return () => {
-              viewRevealedCb = null;
+              viewRevealedCbs = viewRevealedCbs.filter((c) => c !== cb);
             };
           },
         },
@@ -275,14 +279,16 @@ afterEach(() => {
 // The reveal poll's tick runs on a frame; flush one frame to let the width-gated
 // repaint land.
 function fireReveal(): void {
-  act(() => viewRevealedCb?.());
+  act(() => {
+    for (const cb of viewRevealedCbs) cb();
+  });
   act(() => flushFrame());
 }
 
 describe("HelpPanel — Daintree Assistant reveal redraw backstop", () => {
   it("repaints immediately on reveal, then re-runs on the 1s and 3s backstops", () => {
     render(<HelpPanel width={380} />);
-    expect(viewRevealedCb).not.toBeNull();
+    expect(viewRevealedCbs.length).toBeGreaterThan(0);
     repaintForRevealMock.mockClear();
 
     fireReveal();

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -829,6 +829,54 @@ export class HelpSessionController {
   }
 
   /**
+   * Recover a launch stranded by a project switch-back (#10739). Each project
+   * runs in its own `WebContentsView`; switching away parks it in the LRU cache,
+   * where Chromium throttles/freezes timers and microtasks. A launch caught
+   * mid-flight leaves the FSM in a loading phase, but the dead-man watchdog
+   * (`_armLaunchWatchdog`) is a `setTimeout` that doesn't fire while parked, so
+   * it can't reap the stall — and auto-launch is short-circuited while hidden,
+   * so switching *back* never re-drives it. The loading skeleton then sticks
+   * forever. We key off the same explicit `app:view-revealed` main-process
+   * signal `useResetSwitchOverlayOnReveal` uses (a bare DOM `visibilitychange`
+   * is unreliable for a cached-view reveal).
+   *
+   * On reveal, silently reap a stuck loading-phase launch exactly as the
+   * watchdog would — minus `_surfaceLaunchError`, since we re-drive immediately
+   * and the user should see recovery, not a failure — then re-evaluate
+   * auto-launch. The empty-state launch resumes the hibernated session via the
+   * resume command, so this reconnects and re-drives the existing session
+   * rather than starting a fresh one.
+   *
+   * `hibernating` is excluded: that phase owns a live terminal with a graceful
+   * shutdown in flight, not a stuck loader. A non-null bound `terminalId` is
+   * also excluded — a live terminal (or a synchronously-reserved `newSession`/
+   * `runAnyway` slot) is not a stranded auto-launch and must not be reaped.
+   */
+  handleViewRevealed(): void {
+    const phase = this._snapshot.phase;
+    const isStuckLaunch = phase !== "idle" && phase !== "live" && phase !== "hibernating";
+    if (isStuckLaunch && (this._lastInputs?.terminalId ?? null) === null) {
+      // Supersede the stranded flow so its in-flight awaits bail at their next
+      // gen-check (`_abandonInFlightLaunch`); clear the re-entrancy guard so the
+      // re-drive below isn't dropped; revoke the minted-but-orphaned bearer; and
+      // drop the phase to idle so the loading skeleton clears.
+      this._launchGen++;
+      this._isLaunching = false;
+      this._hasAutoLaunched = false;
+      this._clearLaunchWatchdog();
+      this._revokePendingSession();
+      this._resetPhase();
+    }
+    // Re-drive: auto-launch short-circuits while hidden, so a launch interrupted
+    // by the switch is never restarted on return. Now that the view is the
+    // foreground again, re-evaluate from the last synced inputs. `_maybeAutoLaunch`
+    // guards on `document.hidden`/`isOpen`/`terminalId`/`_hasAutoLaunched`, so a
+    // live or already-bound session is a no-op.
+    const inputs = this._lastInputs;
+    if (inputs) this._maybeAutoLaunch({ ...inputs });
+  }
+
+  /**
    * Auto-snapshot pre-flight: when the project's MCP tier is `system`, take
    * a pre-flight snapshot once per session and surface a Tier-1 ambient
    * banner. The guard is set synchronously to survive React 19 StrictMode

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -855,7 +855,12 @@ export class HelpSessionController {
   handleViewRevealed(): void {
     const phase = this._snapshot.phase;
     const isStuckLaunch = phase !== "idle" && phase !== "live" && phase !== "hibernating";
-    if (isStuckLaunch && (this._lastInputs?.terminalId ?? null) === null) {
+    // Only reap the AUTO-launch path. A manual `selectAgent()` launch doesn't set
+    // `_hasAutoLaunched`, and the re-drive below can't restart it (`_maybeAutoLaunch`
+    // short-circuits on `!autoLaunchEnabled`), so reaping it would silently discard
+    // the user's explicit pick. Leaving it alone lets its own watchdog reap it (with
+    // a retryable error) once the view un-parks, or the thawed IPC complete it.
+    if (isStuckLaunch && this._hasAutoLaunched && (this._lastInputs?.terminalId ?? null) === null) {
       // Supersede the stranded flow so its in-flight awaits bail at their next
       // gen-check (`_abandonInFlightLaunch`); clear the re-entrancy guard so the
       // re-drive below isn't dropped; revoke the minted-but-orphaned bearer; and
@@ -2295,23 +2300,31 @@ export class HelpSessionController {
         logError("Failed to mark help terminal", err);
       });
     } catch (error) {
+      // Revoking the orphaned session token is always safe — it's this flow's
+      // own session regardless of supersession. Everything else mutates shared
+      // launch state and must only run when THIS launch still owns the
+      // generation: a stale rejection (the original hung IPC failing *after* a
+      // reveal-reap, watchdog, or newer launch bumped the gen) would otherwise
+      // clobber the successfully re-driven launch — a false error banner over a
+      // recovered session, or `_hasAutoLaunched` cleared into a duplicate launch.
+      const ownsGen = gen === this._launchGen;
+      revokeHelpSession(session?.sessionId ?? null);
       if (reservedId) {
-        this._pendingNewTerminalId = null;
-        useHelpPanelStore.getState().clearTerminal();
-        revokeHelpSession(session?.sessionId ?? null);
+        if (ownsGen) {
+          this._pendingNewTerminalId = null;
+          useHelpPanelStore.getState().clearTerminal();
+        }
         logError(options.force ? "Help run-anyway failed" : "Help new-session failed", error);
       } else {
-        this._hasAutoLaunched = false;
-        revokeHelpSession(session?.sessionId ?? null);
-        // A late-rejecting dispatch can land here after the watchdog (or a
-        // newer launch) bumped the generation — only clear the guard when the
-        // pending session is still ours, never a newer launch's.
-        if (this._pendingSessionId === session?.sessionId) {
-          this._pendingSessionId = null;
+        if (ownsGen) {
+          this._hasAutoLaunched = false;
+          if (this._pendingSessionId === session?.sessionId) {
+            this._pendingSessionId = null;
+          }
         }
         logError("Help select-agent launch failed", error);
       }
-      this._surfaceLaunchError(launchAgentId, "spawn-failed");
+      if (ownsGen) this._surfaceLaunchError(launchAgentId, "spawn-failed");
     } finally {
       // Release the re-entrancy guard only if THIS launch() still owns it —
       // clearing it unconditionally let a stale unwind drop a newer launch's

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -928,6 +928,130 @@ describe("HelpSessionController — launch phase FSM", () => {
   });
 });
 
+describe("HelpSessionController — handleViewRevealed (switch-back recovery #10739)", () => {
+  // Drives a preferred-agent auto-launch that hangs on the first bridge await,
+  // leaving the FSM stranded in `version-checking` — the parked-view stall the
+  // watchdog can't reap because its setTimeout is frozen in the LRU cache.
+  function startStuckLaunch(ctrl: HelpSessionController): void {
+    helpPanelState.preferredAgentId = "claude";
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise(() => {})
+    );
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    });
+  }
+
+  it("silently reaps a stranded loading-phase launch and re-drives it (no error surfaced)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    startStuckLaunch(ctrl);
+    expect(ctrl.getSnapshot().phase).toBe("version-checking");
+    const genBefore = ctrl["_launchGen"] as number;
+    const folderCallsBefore = (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mock
+      .calls.length;
+
+    ctrl.handleViewRevealed();
+
+    // Re-driven, not left stranded: a fresh launch synchronously re-enters the
+    // loading phase, the auto-launch path ran again, and the generation advanced
+    // (reap + re-drive each bump it).
+    expect(ctrl.getSnapshot().phase).toBe("version-checking");
+    expect(
+      (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>).mock.calls.length
+    ).toBeGreaterThan(folderCallsBefore);
+    expect(ctrl["_launchGen"]).toBeGreaterThan(genBefore);
+    // Recovery is silent — the user must see the resume, not a failure.
+    expect(ctrl.getSnapshot().launchError).toBeNull();
+    expect(notify).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("revokes the minted-but-orphaned pending session token when reaping", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    startStuckLaunch(ctrl);
+    ctrl["_pendingSessionId"] = "sess-orphan";
+
+    ctrl.handleViewRevealed();
+
+    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-orphan");
+    ctrl.stop();
+  });
+
+  it("is a no-op when a session is already live (no reap, no re-drive)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_patch"]({ phase: "live" });
+    const genBefore = ctrl["_launchGen"] as number;
+
+    ctrl.handleViewRevealed();
+
+    expect(ctrl.getSnapshot().phase).toBe("live");
+    expect(ctrl["_launchGen"]).toBe(genBefore);
+    ctrl.stop();
+  });
+
+  it("is a no-op while idle", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    const genBefore = ctrl["_launchGen"] as number;
+
+    ctrl.handleViewRevealed();
+
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    expect(ctrl["_launchGen"]).toBe(genBefore);
+    ctrl.stop();
+  });
+
+  it("does not reap a hibernating phase (it owns a live terminal mid-shutdown)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_patch"]({ phase: "hibernating" });
+    const genBefore = ctrl["_launchGen"] as number;
+
+    ctrl.handleViewRevealed();
+
+    expect(ctrl.getSnapshot().phase).toBe("hibernating");
+    expect(ctrl["_launchGen"]).toBe(genBefore);
+    ctrl.stop();
+  });
+
+  it("does not reap a loading phase when a terminal is already bound (reserved-id guard)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    // A newSession/runAnyway launch reserves its terminal slot synchronously, so
+    // _lastInputs.terminalId is non-null even while the FSM is provisioning —
+    // that is not a stranded auto-launch and must not be reaped.
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: "term-live",
+      preferredAgentId: null,
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    });
+    ctrl["_patch"]({ phase: "provisioning" });
+    const genBefore = ctrl["_launchGen"] as number;
+
+    ctrl.handleViewRevealed();
+
+    expect(ctrl.getSnapshot().phase).toBe("provisioning");
+    expect(ctrl["_launchGen"]).toBe(genBefore);
+    expect(ctrl.getSnapshot().launchError).toBeNull();
+    ctrl.stop();
+  });
+});
+
 describe("HelpSessionController — tier-mismatch handlers", () => {
   it("approveTierOnce() calls issueGrant (per-tool) and clears banner on success", async () => {
     const ctrl = new HelpSessionController();

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -1024,6 +1024,74 @@ describe("HelpSessionController — handleViewRevealed (switch-back recovery #10
     ctrl.stop();
   });
 
+  it("does not reap a manual (non-auto) launch — the _hasAutoLaunched guard protects it", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    // A manual selectAgent() launch never sets `_hasAutoLaunched`; reaping it
+    // would silently discard the user's explicit pick since the re-drive can't
+    // restart it (auto-launch is disabled). Simulate one stranded in provisioning.
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: null,
+      supportedInstalledAgentIds: ["claude", "codex"],
+      autoLaunchEnabled: false,
+      visibilityEpoch: 0,
+    });
+    ctrl["_patch"]({ phase: "provisioning" });
+    ctrl["_hasAutoLaunched"] = false;
+    const genBefore = ctrl["_launchGen"] as number;
+
+    ctrl.handleViewRevealed();
+
+    expect(ctrl.getSnapshot().phase).toBe("provisioning");
+    expect(ctrl["_launchGen"]).toBe(genBefore);
+    ctrl.stop();
+  });
+
+  it("does not surface a launch error when the original hung IPC rejects after the reap", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    helpPanelState.preferredAgentId = "claude";
+    // First getFolderPath (the stranded launch) is rejectable; the re-drive's
+    // call hangs so it stays in version-checking after recovery.
+    let rejectFolder: (err: unknown) => void = () => {};
+    (window.electron.help.getFolderPath as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectFolder = reject;
+        })
+      )
+      .mockReturnValue(new Promise(() => {}));
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    });
+    expect(ctrl.getSnapshot().phase).toBe("version-checking");
+
+    // Switch-back reveal reaps the stall (bumping the gen) and re-drives.
+    ctrl.handleViewRevealed();
+    expect(ctrl.getSnapshot().phase).toBe("version-checking");
+
+    // The original hung IPC now rejects — it belongs to a superseded generation,
+    // so it must NOT paint an error banner over the recovered launch.
+    rejectFolder(new Error("late reject"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctrl.getSnapshot().launchError).toBeNull();
+    expect(notify).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
   it("does not reap a loading phase when a terminal is already bound (reserved-id guard)", () => {
     const ctrl = new HelpSessionController();
     ctrl.start();


### PR DESCRIPTION
## Summary

- Fixes a hang where the Daintree Assistant's launch loader would get stuck permanently when switching back to a project mid-launch
- Root cause: Chromium freezes timers on parked `WebContentsView`s, so the 90s watchdog `setTimeout` in `HelpSessionController` never fires; and auto-launch is short-circuited while hidden, so the interrupted launch never re-drives on return
- Fix keys off the main-process `app:view-revealed` signal (same approach as `useResetSwitchOverlayOnReveal`) to silently reap the stranded launch and re-drive it, resuming the hibernated session without a reset

Resolves #10739

## Changes

- `HelpSessionController.handleViewRevealed()`: reaps a stranded auto-launch by bumping the generation (so the in-flight flow bails), clearing the watchdog, revoking the orphaned session token, resetting the phase, then calling `_maybeAutoLaunch` to re-drive. Guards exclude the hibernating phase, bound-terminal launches (manual `newSession`/`runAnyway` paths), and manual `selectAgent()` picks
- New `HelpPanel` effect gated on `isOpen` (not `terminalId`) that registers the `handleViewRevealed` listener. The pre-existing reveal-repaint effect was `terminalId`-gated, so during a stuck launch (no terminal bound yet) it never fired. That was the gap
- `_executeLaunch` catch block is now generation-aware, so a stale late rejection from the original hung IPC can't paint a false error banner over the recovered launch

## Testing

Covered by unit tests: `HelpSessionController` tests for silent reap and re-drive, session token revocation, and no-op cases (live session, idle, hibernating, manual pick, bound terminal). `HelpPanel` wiring test confirms recovery fires when no terminal is bound. 227 tests pass in the affected suites.

This is a parked-`WebContentsView` timing bug that isn't reproducible in unit tests end-to-end. Manual repro: open the Assistant, trigger a launch, switch projects while the loading skeleton is showing, then switch back. The loader should clear and the session resume.