### PR TITLE
fix(project): pause background project workspace hosts on switch-away

### DIFF
--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -677,6 +677,8 @@ describe("project:switch worktree-load-status (#8400)", () => {
       loadProject: vi.fn(loadProject),
       attachDirectPort: vi.fn(),
       getHostForProject: vi.fn(() => null),
+      resumeProject: vi.fn(),
+      pauseProject: vi.fn(),
     };
 
     const deps = {
@@ -823,6 +825,8 @@ describe("project:switch PTY port ordering (#10075)", () => {
       loadProject: vi.fn(opts.loadProject),
       attachDirectPort: vi.fn(),
       getHostForProject: vi.fn(() => null),
+      resumeProject: vi.fn(),
+      pauseProject: vi.fn(),
     };
     const windowRegistry = makeWindowRegistry([makeWindowContext(7, 300)]);
     (
@@ -920,5 +924,18 @@ describe("project:switch PTY port ordering (#10075)", () => {
     expect(distributeMock).not.toHaveBeenCalled();
     // onProjectSwitch still fires regardless of new/warm.
     expect(ptyClient.onProjectSwitch).toHaveBeenCalledWith(7, "proj-new", "/projects/new");
+  });
+
+  it("resumes the incoming project's workspace host on switch (#10743)", async () => {
+    const { invoke, worktreeService } = setup({
+      isNew: false,
+      loadProject: async () => undefined,
+    });
+
+    await invoke();
+
+    // Switching TO a project must foreground its host so a previously
+    // backgrounded project resumes full-rate polling for fresh state.
+    expect(worktreeService.resumeProject).toHaveBeenCalledWith("/projects/new");
   });
 });

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -64,12 +64,26 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
       await awaitPendingOutgoingPersist(projectId);
       await activateProjectView(deps, ctx.event, pvm, projectId, project, {
         logPrefix: "[ProjectSwitch]",
+        resumeWorkspace: true,
       });
       await persistOutgoing;
       return project;
     }
 
     await persistOutgoing;
+    // Legacy (non-PVM) path bypasses WorkspaceHostPool.loadProject, so the
+    // pool's switch-away background demotion never fires. Pause the outgoing
+    // project and resume the incoming one explicitly so background projects
+    // stop full-rate polling here too (#10743).
+    if (deps.worktreeService) {
+      if (previousProjectId && previousProjectId !== projectId) {
+        const previousPath = projectStore.getProjectById(previousProjectId)?.path;
+        if (previousPath) {
+          deps.worktreeService.pauseProject(previousPath);
+        }
+      }
+      deps.worktreeService.resumeProject(project.path);
+    }
     return await projectSwitchService.switchProject(projectId);
   };
   handlers.push(typedHandleWithContext(CHANNELS.PROJECT_SWITCH, handleProjectSwitch));

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -259,6 +259,24 @@ describe("WorkspaceClient multi-process manager", () => {
 
       expect(h(0).send).not.toHaveBeenCalledWith({ type: "background" });
     });
+
+    it("foregrounds a warm host when a window re-attaches after switch-away (#10743)", async () => {
+      const load1 = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load1;
+
+      // Switch away: project-a is demoted to background (refCount 0).
+      const load2 = client.loadProject("/project-b", 1);
+      await readyAndResolveLoad(1);
+      await load2;
+      expect(h(0).send).toHaveBeenCalledWith({ type: "background" });
+
+      // Re-attach to the still-warm project-a — the pool must resume it so it
+      // doesn't stay paused (covers menu open / reopen / switch-back paths).
+      const load3 = client.loadProject("/project-a", 1);
+      await load3;
+      expect(h(0).send).toHaveBeenCalledWith({ type: "foreground" });
+    });
   });
 
   describe("getAllStatesAsync", () => {

--- a/electron/services/__tests__/WorkspaceClient.resilience.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.resilience.test.ts
@@ -228,6 +228,37 @@ describe("WorkspaceClient multi-process manager", () => {
       await readyAndResolveLoad(1);
       await load2;
     });
+
+    it("demotes the old host to background when the last window switches away (#10743)", async () => {
+      const load1 = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load1;
+
+      const load2 = client.loadProject("/project-b", 1);
+      await readyAndResolveLoad(1);
+      await load2;
+
+      // refCount on project-a dropped to 0 — its host should be paused so it
+      // stops full-rate polling while dormant.
+      expect(h(0).send).toHaveBeenCalledWith({ type: "background" });
+    });
+
+    it("does NOT background the old host while another window still holds it (#10743)", async () => {
+      const load1 = client.loadProject("/project-a", 1);
+      await readyAndResolveLoad(0);
+      await load1;
+
+      // A second window also holds project-a (refCount = 2).
+      const load1b = client.loadProject("/project-a", 2);
+      await load1b;
+
+      // Window 1 switches to project-b; project-a still has window 2.
+      const load2 = client.loadProject("/project-b", 1);
+      await readyAndResolveLoad(1);
+      await load2;
+
+      expect(h(0).send).not.toHaveBeenCalledWith({ type: "background" });
+    });
   });
 
   describe("getAllStatesAsync", () => {

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -213,6 +213,13 @@ export class WorkspaceHostPool {
           clearTimeout(existingEntry.cleanupTimeout);
           existingEntry.cleanupTimeout = null;
         }
+        // Resume a warm host that may have been demoted to background by an
+        // earlier switch-away (#10743). Symmetric with the `background` send in
+        // `releaseOldProject`: the pool pauses on release, so it resumes on
+        // re-attach — covering every caller (menu open, IPC switch/reopen)
+        // without each having to remember to foreground first. `resume()` is
+        // idempotent, so this is harmless when the host was never paused.
+        existingEntry.host.send({ type: "foreground" });
         this.windowToProject.set(windowId, normalizedPath);
 
         if (isSwitching) {

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -317,6 +317,14 @@ export class WorkspaceHostPool {
     oldEntry.refCount--;
 
     if (oldEntry.refCount <= 0) {
+      // No window holds this project anymore — demote its host to background so
+      // it stops full-rate git status / fetch / PR polling while it sits dormant
+      // (#10743). Switching back resumes it via `resumeProject` (foreground).
+      // Gated on refCount: a project still visible in another window must keep
+      // polling. Sent before scheduling cleanup so the grace-period host is
+      // already quiesced. Resume on switch-back is driven by the IPC handler's
+      // `resumeWorkspace` flag, not here.
+      oldEntry.host.send({ type: "background" });
       this.scheduleDormantCleanup(oldProjectPath, oldEntry);
     }
   }


### PR DESCRIPTION
## Summary

- Background projects kept polling git status, fetches, and pull requests at full rate after switching away, because `pauseProject` was only wired to the close path, not the switch path.
- `WorkspaceHostPool.releaseOldProject` now sends a `{type:"background"}` message to the outgoing host when its ref count drops to 0. A multi-window guard prevents demotion when another window still holds a ref on the same project. `loadProject` sends `{type:"foreground"}` on warm re-attach, so a backgrounded project resumes immediately when the user switches back.
- The legacy non-pool IPC switch path in `switch.ts` gets the same treatment: it explicitly pauses the outgoing project and passes `resumeWorkspace:true` for the incoming one.

Resolves #10743

## Changes

- `electron/services/workspace-client/WorkspaceHostPool.ts`: demote outgoing host to background on last-window switch-away; resume on warm re-attach via `loadProject`.
- `electron/ipc/handlers/projectCrud/switch.ts`: pass `resumeWorkspace:true` on the PVM path; explicit pause/resume on the legacy fallback path.
- `electron/services/workspace-client/__tests__/WorkspaceClient.resilience.test.ts`: pool-level demotion, multi-window guard (no demotion when another window holds the ref), resume on re-attach.
- `electron/ipc/handlers/__tests__/project.switch.test.ts`: IPC handler resumes the incoming workspace on switch.

## Testing

79 targeted tests pass. Own-file prettier and eslint clean. Rebased onto `origin/develop`.