### PR TITLE
perf(pty): coalesce backgrounded terminal output to cut parse cost

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1143,6 +1143,15 @@ export class TerminalProcess {
     const terminal = this.terminalInfo;
     const exitReason: ExitReason = reason === "graceful-shutdown" ? "graceful-shutdown" : "kill";
 
+    // Drain any coalesced background output through the parse pipeline BEFORE
+    // teardown — and before the snapshot flush below — so a backgrounded
+    // terminal's final chunk reaches the headless model, forensics buffer,
+    // semantic buffer, and the session snapshot. teardown's
+    // _cancelBackgroundQueue() would otherwise discard it, dropping the
+    // pre-exit tail a user inspects when foregrounding a finished hidden
+    // project (#10744). emitData fan-out is still live at this call site.
+    this._drainBackgroundQueue();
+
     // Flush session snapshot synchronously BEFORE teardown.
     // Once teardown disposes the writeQueue and processTreeKiller.abort() fires,
     // debounced writes are lost — so this is the last chance.
@@ -1931,7 +1940,11 @@ export class TerminalProcess {
    * Cancel the background drain timer and discard queued output without running
    * the pipeline. Called from teardown (kill / natural exit / dispose) so a
    * timer armed just before teardown can't fire post-teardown and fan deferred
-   * output out to released renderer subscribers / buffers (#10744).
+   * output out to released renderer subscribers / buffers (#10744). On the
+   * kill() and natural-exit paths this is a no-op cleanup: those call sites run
+   * _drainBackgroundQueue() first so the queue is already empty here and the
+   * final chunk reached forensics / snapshot. dispose() (LRU eviction) has no
+   * live exit consumer, so it relies on this to discard.
    */
   private _cancelBackgroundQueue(): void {
     if (this._backgroundDrainTimer) {
@@ -2003,6 +2016,14 @@ export class TerminalProcess {
       }
 
       this.identityWatcher.stop();
+
+      // Drain any coalesced background output through the parse pipeline BEFORE
+      // reading the forensic tail / running teardown, so a backgrounded
+      // terminal's final chunk lands in the forensics buffer and the headless
+      // model rather than being discarded by teardown's _cancelBackgroundQueue().
+      // This keeps the terminal:exited forensic tail complete (#10744).
+      // emitData fan-out is still live here (teardown releases subscribers below).
+      this._drainBackgroundQueue();
 
       // Capture forensic tail before disposeHeadless() clears the buffer.
       // The terminal:exited subscriber reads this via the payload — once

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -190,6 +190,22 @@ export class TerminalProcess {
   }
   private forensicsBuffer = new TerminalForensicsBuffer();
   private _activityTier: "active" | "background" = "active";
+  // Background-tier output coalescing (#10744). When a project is backgrounded
+  // the per-chunk parse pipeline (activityMonitor.onData regex bank, headless
+  // xterm VT write, forensics/semantic buffers, renderer fan-out) stops running
+  // per-chunk and instead drains a coalesced batch on a single self-rearming
+  // timer, so backgrounded terminals stop competing with the foreground project
+  // for CPU. OSC 9;4 + timestamps still run per-chunk in handlePtyData so the
+  // agent-state heartbeat stays accurate (#8753).
+  private _backgroundChunkQueue: string[] = [];
+  private _backgroundQueuedBytes = 0;
+  private _backgroundDrainTimer: NodeJS.Timeout | null = null;
+  private _backgroundDrainDeadline = 0;
+  private _backgroundDrainIntervalMs = 500;
+  // Force a drain if a backgrounded terminal accumulates this much un-parsed
+  // output, bounding queue memory for noisy agents that never pause (mirrors the
+  // renderer-side COALESCE_BATCH_CAP_BYTES from #8371).
+  private readonly COALESCE_MAX_BYTES = 256 * 1024;
   private _restoreBannerStart: IMarker | null = null;
   private _restoreBannerEnd: IMarker | null = null;
   private readonly textDecoder = new TextDecoder();
@@ -1508,6 +1524,18 @@ export class TerminalProcess {
   setActivityMonitorTier(tier: "active" | "background", pollingIntervalMs: number): void {
     // The tier is authoritative; the polling interval is only a cadence hint
     // (issue #8596 — VISIBLE-unfocused panes are "active" at 200ms).
+    if (tier === "background") {
+      // Reuse the polling cadence as the coalescing drain interval so a future
+      // tier never needs a separate constant wired through PtyManager (#10744).
+      this._backgroundDrainIntervalMs = pollingIntervalMs;
+    } else if (this._activityTier === "background") {
+      // Foreground activation: flush any deferred output synchronously so the
+      // headless terminal is current before the renderer's wake/snapshot request
+      // reads getSerializedState() (#10744). Drain before flipping the tier so a
+      // late chunk can't re-enter the background branch mid-flush.
+      this._drainBackgroundQueue();
+    }
+
     this._activityTier = tier;
 
     if (this.activityMonitor) {
@@ -1551,6 +1579,16 @@ export class TerminalProcess {
   dispose(): void {
     const recentOutput = this.forensicsBuffer.getRecentOutput();
     this.identityWatcher.dispose();
+
+    // Drop any deferred background output — the terminal is going away, so
+    // running the parse pipeline on teardown would emit against torn-down
+    // consumers (#10744).
+    if (this._backgroundDrainTimer) {
+      clearTimeout(this._backgroundDrainTimer);
+      this._backgroundDrainTimer = null;
+    }
+    this._backgroundChunkQueue = [];
+    this._backgroundQueuedBytes = 0;
 
     // Best-effort flush before teardown disposes the writeQueue and tears down
     // the buffer. Only attempted on the alive→dispose path — if we already
@@ -1734,6 +1772,45 @@ export class TerminalProcess {
       terminal.firstByteAt = now;
     }
     terminal.lastOutputTime = now;
+
+    // Tap OSC 9;4 progress sequences upstream of the rest of the pipeline so
+    // the agent-state signal is viewport-independent (#8701). The parser is
+    // a read-only side channel; `IdleSequenceFilter.stripIdleTerminalSequences`
+    // still removes the sequence from the ActivityMonitor byte-volume /
+    // activity-gate path, so those detectors stay clean (the renderer keeps
+    // the raw bytes — see TerminalProcess.osc.test.ts). This runs per-chunk for
+    // backgrounded terminals too so the heartbeat never lags (#8753, #10744).
+    this.osc94Parser.feed(data, now);
+
+    // Background tier (#10744): defer the heavy parse pipeline. Coalesce raw
+    // chunks and run the pipeline once per drain cadence so backgrounded
+    // terminals stop competing with the foreground project for CPU. The xterm
+    // VT parser is stateful and chunk-boundary-safe, so feeding the concatenated
+    // batch yields identical headless grid state.
+    if (this._activityTier === "background") {
+      this._backgroundChunkQueue.push(data);
+      this._backgroundQueuedBytes += data.length;
+      if (this._backgroundQueuedBytes >= this.COALESCE_MAX_BYTES) {
+        this._drainBackgroundQueue();
+      } else {
+        this._armBackgroundDrain();
+      }
+      return;
+    }
+
+    this._runPtyPipeline(data);
+  }
+
+  /**
+   * The per-chunk parse pipeline downstream of the OSC 9;4 tap and timestamp
+   * bookkeeping. Runs immediately for foreground terminals and once per drain on
+   * the coalesced batch for backgrounded ones (#10744). `data` is the raw PTY
+   * string (or the joined background batch); the renderer-bound copy is derived
+   * here after OSC color queries are answered.
+   */
+  private _runPtyPipeline(data: string): void {
+    const terminal = this.terminalInfo;
+
     // noteAgentOutputActivity only acts on waiting/idle/completed — skip the
     // full-viewport extraction in other states (it would be computed and
     // discarded on every chunk during "working", the heaviest output phase).
@@ -1745,14 +1822,6 @@ export class TerminalProcess {
       (agentState === "waiting" || agentState === "idle" || agentState === "completed")
         ? this.getAgentOutputContentSnapshot()
         : undefined;
-
-    // Tap OSC 9;4 progress sequences upstream of the rest of the pipeline so
-    // the agent-state signal is viewport-independent (#8701). The parser is
-    // a read-only side channel; `IdleSequenceFilter.stripIdleTerminalSequences`
-    // still removes the sequence from the ActivityMonitor byte-volume /
-    // activity-gate path, so those detectors stay clean (the renderer keeps
-    // the raw bytes — see TerminalProcess.osc.test.ts).
-    this.osc94Parser.feed(data, now);
 
     if (this.activityMonitor) {
       this.activityMonitor.onData(data);
@@ -1810,6 +1879,59 @@ export class TerminalProcess {
         this.queueAgentOutput(liveId, data);
       }
     }
+  }
+
+  /**
+   * Single self-rearming background drain timer (deadline-timestamp pattern from
+   * #8150 — avoids O(N) clear/set churn per chunk). Each incoming chunk pushes
+   * the deadline forward; the timer reschedules itself until output settles, so
+   * a sustained burst drains once it quiets rather than mid-burst. The
+   * COALESCE_MAX_BYTES cap in handlePtyData bounds memory for output that never
+   * pauses.
+   */
+  private _armBackgroundDrain(): void {
+    this._backgroundDrainDeadline = Date.now() + this._backgroundDrainIntervalMs;
+    if (this._backgroundDrainTimer) {
+      return;
+    }
+    this._backgroundDrainTimer = setTimeout(
+      () => this._onBackgroundDrainTimer(),
+      this._backgroundDrainIntervalMs
+    );
+  }
+
+  private _onBackgroundDrainTimer(): void {
+    const remaining = this._backgroundDrainDeadline - Date.now();
+    if (remaining > 0) {
+      // A chunk arrived after this timer was armed and pushed the deadline out;
+      // reschedule for the remaining window so the burst batches optimally.
+      this._backgroundDrainTimer = setTimeout(() => this._onBackgroundDrainTimer(), remaining);
+      return;
+    }
+    this._backgroundDrainTimer = null;
+    this._drainBackgroundQueue();
+  }
+
+  /**
+   * Flush the coalesced background queue through the parse pipeline once. Safe to
+   * call with an empty queue (no-op). Invoked by the drain timer, the
+   * COALESCE_MAX_BYTES cap, and synchronously on foreground activation so the
+   * headless terminal is current before the renderer wakes (#10744).
+   */
+  private _drainBackgroundQueue(): void {
+    if (this._backgroundDrainTimer) {
+      clearTimeout(this._backgroundDrainTimer);
+      this._backgroundDrainTimer = null;
+    }
+    this._backgroundDrainDeadline = 0;
+    if (this._backgroundChunkQueue.length === 0) {
+      this._backgroundQueuedBytes = 0;
+      return;
+    }
+    const coalesced = this._backgroundChunkQueue.join("");
+    this._backgroundChunkQueue = [];
+    this._backgroundQueuedBytes = 0;
+    this._runPtyPipeline(coalesced);
   }
 
   private queueAgentOutput(agentId: string, data: string): void {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -204,7 +204,9 @@ export class TerminalProcess {
   private _backgroundDrainIntervalMs = 500;
   // Force a drain if a backgrounded terminal accumulates this much un-parsed
   // output, bounding queue memory for noisy agents that never pause (mirrors the
-  // renderer-side COALESCE_BATCH_CAP_BYTES from #8371).
+  // renderer-side COALESCE_BATCH_CAP_BYTES from #8371). Measured in UTF-16 code
+  // units (string .length), not bytes — multi-byte output can hold up to ~3× the
+  // nominal cap, which is harmless: draining late only delays, never corrupts.
   private readonly COALESCE_MAX_BYTES = 256 * 1024;
   private _restoreBannerStart: IMarker | null = null;
   private _restoreBannerEnd: IMarker | null = null;
@@ -665,6 +667,7 @@ export class TerminalProcess {
     this.identityWatcher.stop();
     this.semanticBufferManager.flush();
     this.flushAgentOutput();
+    this._cancelBackgroundQueue();
 
     if (this.ptyDataDisposable) {
       try {
@@ -1580,16 +1583,6 @@ export class TerminalProcess {
     const recentOutput = this.forensicsBuffer.getRecentOutput();
     this.identityWatcher.dispose();
 
-    // Drop any deferred background output — the terminal is going away, so
-    // running the parse pipeline on teardown would emit against torn-down
-    // consumers (#10744).
-    if (this._backgroundDrainTimer) {
-      clearTimeout(this._backgroundDrainTimer);
-      this._backgroundDrainTimer = null;
-    }
-    this._backgroundChunkQueue = [];
-    this._backgroundQueuedBytes = 0;
-
     // Best-effort flush before teardown disposes the writeQueue and tears down
     // the buffer. Only attempted on the alive→dispose path — if we already
     // passed through kill / natural exit, persistence has already been handled.
@@ -1932,6 +1925,22 @@ export class TerminalProcess {
     this._backgroundChunkQueue = [];
     this._backgroundQueuedBytes = 0;
     this._runPtyPipeline(coalesced);
+  }
+
+  /**
+   * Cancel the background drain timer and discard queued output without running
+   * the pipeline. Called from teardown (kill / natural exit / dispose) so a
+   * timer armed just before teardown can't fire post-teardown and fan deferred
+   * output out to released renderer subscribers / buffers (#10744).
+   */
+  private _cancelBackgroundQueue(): void {
+    if (this._backgroundDrainTimer) {
+      clearTimeout(this._backgroundDrainTimer);
+      this._backgroundDrainTimer = null;
+    }
+    this._backgroundDrainDeadline = 0;
+    this._backgroundChunkQueue = [];
+    this._backgroundQueuedBytes = 0;
   }
 
   private queueAgentOutput(agentId: string, data: string): void {

--- a/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+let ptyOnDataCallback: ((data: string) => void) | null = null;
+
+function createMockPty(): IPty {
+  const pty: Partial<IPty> = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: (cb: (data: string) => void) => {
+      ptyOnDataCallback = cb;
+      return { dispose: () => {} };
+    },
+    onExit: () => ({ dispose: () => {} }),
+  };
+  const withDestroy = pty as Partial<IPty> & { destroy: () => void };
+  withDestroy.destroy = vi.fn();
+  return pty as IPty;
+}
+
+function defaultSpawnContext(): SpawnContext {
+  return {
+    shell: "/bin/zsh",
+    args: ["-l"],
+    env: {},
+  };
+}
+
+type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
+type TerminalProcessDeps = ConstructorParameters<typeof TerminalProcess>[3];
+
+function createTerminal(
+  emitData: (id: string, data: string | Uint8Array) => void,
+  options?: Partial<TerminalProcessOptions>
+): TerminalProcess {
+  return new TerminalProcess(
+    "t1",
+    {
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      kind: "terminal" as const,
+      ...options,
+    },
+    { emitData, onExit: () => {} },
+    {
+      agentStateService: {
+        handleActivityState: () => {},
+        updateAgentState: () => {},
+        emitAgentKilled: () => {},
+      } as unknown as TerminalProcessDeps["agentStateService"],
+      ptyPool: null,
+      processTreeCache: null,
+    },
+    defaultSpawnContext(),
+    createMockPty()
+  );
+}
+
+// The OSC 9;4 tap must keep running per-chunk even when the rest of the pipeline
+// is deferred, so the agent-state heartbeat never lags (#8753). The parser is a
+// private collaborator; spy on its `feed` to assert it stays per-chunk.
+function osc94FeedSpy(terminal: TerminalProcess) {
+  const internal = terminal as unknown as { osc94Parser: { feed: (d: string, n: number) => void } };
+  return vi.spyOn(internal.osc94Parser, "feed");
+}
+
+describe("TerminalProcess background output coalescing", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ptyOnDataCallback = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  it("runs the parse pipeline per chunk for foreground terminals", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    ptyOnDataCallback!("alpha");
+    ptyOnDataCallback!("beta");
+
+    expect(emitData).toHaveBeenCalledTimes(2);
+    expect(emitData).toHaveBeenNthCalledWith(1, "t1", "alpha");
+    expect(emitData).toHaveBeenNthCalledWith(2, "t1", "beta");
+
+    terminal.dispose();
+  });
+
+  it("defers the parse pipeline for backgrounded terminals and coalesces on drain", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+    const feed = osc94FeedSpy(terminal);
+
+    terminal.setActivityMonitorTier("background", 500);
+
+    ptyOnDataCallback!("chunk-a");
+    ptyOnDataCallback!("chunk-b");
+
+    // OSC 9;4 heartbeat stays per-chunk; the heavy pipeline (emitData fan-out) does not.
+    expect(feed).toHaveBeenCalledTimes(2);
+    expect(emitData).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenCalledWith("t1", "chunk-achunk-b");
+
+    terminal.dispose();
+  });
+
+  it("flushes the deferred queue synchronously when reactivated", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+    ptyOnDataCallback!("pending-1");
+    ptyOnDataCallback!("pending-2");
+    expect(emitData).not.toHaveBeenCalled();
+
+    // No timer advance — activation must drain inline so the headless terminal is
+    // current before the renderer wakes and reads getSerializedState() (#10744).
+    terminal.setActivityMonitorTier("active", 50);
+
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenCalledWith("t1", "pending-1pending-2");
+    expect(terminal.getActivityTier()).toBe("active");
+
+    terminal.dispose();
+  });
+
+  it("drains immediately when the queue exceeds the byte cap", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+    const big = "x".repeat(256 * 1024);
+
+    ptyOnDataCallback!(big);
+
+    // Cap reached → drain inline without waiting for the timer.
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenCalledWith("t1", big);
+
+    terminal.dispose();
+  });
+
+  it("rearms the drain timer while background output continues", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+
+    ptyOnDataCallback!("first");
+    vi.advanceTimersByTime(300);
+    // A later chunk pushes the deadline out; the burst should batch, not drain mid-flight.
+    ptyOnDataCallback!("second");
+    vi.advanceTimersByTime(200);
+    expect(emitData).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(300);
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenCalledWith("t1", "firstsecond");
+
+    terminal.dispose();
+  });
+
+  it("drops queued output on dispose without draining it", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+    ptyOnDataCallback!("orphaned");
+    expect(emitData).not.toHaveBeenCalled();
+
+    terminal.dispose();
+    vi.advanceTimersByTime(1000);
+
+    expect(emitData).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
@@ -8,6 +8,7 @@ vi.mock("node-pty", () => {
 });
 
 let ptyOnDataCallback: ((data: string) => void) | null = null;
+let ptyOnExitCallback: ((e: { exitCode: number; signal?: number }) => void) | null = null;
 
 function createMockPty(): IPty {
   const pty: Partial<IPty> = {
@@ -23,7 +24,10 @@ function createMockPty(): IPty {
       ptyOnDataCallback = cb;
       return { dispose: () => {} };
     },
-    onExit: () => ({ dispose: () => {} }),
+    onExit: (cb: (e: { exitCode: number; signal?: number }) => void) => {
+      ptyOnExitCallback = cb;
+      return { dispose: () => {} };
+    },
   };
   const withDestroy = pty as Partial<IPty> & { destroy: () => void };
   withDestroy.destroy = vi.fn();
@@ -81,6 +85,7 @@ describe("TerminalProcess background output coalescing", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     ptyOnDataCallback = null;
+    ptyOnExitCallback = null;
   });
 
   afterEach(() => {
@@ -176,6 +181,57 @@ describe("TerminalProcess background output coalescing", () => {
     vi.advanceTimersByTime(300);
     expect(emitData).toHaveBeenCalledTimes(1);
     expect(emitData).toHaveBeenCalledWith("t1", "firstsecond");
+
+    terminal.dispose();
+  });
+
+  it("drains while still on the background tier before flipping to active", () => {
+    const seenTierAtDrain: Array<"active" | "background"> = [];
+    let terminal: TerminalProcess;
+    const emitData = vi.fn(() => {
+      seenTierAtDrain.push(terminal.getActivityTier());
+    });
+    terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+    ptyOnDataCallback!("queued");
+
+    terminal.setActivityMonitorTier("active", 50);
+
+    // The flush must run with the tier still "background" so a late chunk can't
+    // re-enter the background branch mid-flush; the tier is "active" afterwards.
+    expect(seenTierAtDrain).toEqual(["background"]);
+    expect(terminal.getActivityTier()).toBe("active");
+
+    terminal.dispose();
+  });
+
+  it("cancels the drain timer on kill without firing the deferred pipeline", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+    ptyOnDataCallback!("pre-kill");
+    expect(emitData).not.toHaveBeenCalled();
+
+    terminal.kill("user requested");
+    vi.advanceTimersByTime(1000);
+
+    expect(emitData).not.toHaveBeenCalled();
+  });
+
+  it("cancels the drain timer on natural exit without firing the deferred pipeline", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+    ptyOnDataCallback!("pre-exit");
+    expect(emitData).not.toHaveBeenCalled();
+
+    ptyOnExitCallback!({ exitCode: 0 });
+    vi.advanceTimersByTime(1000);
+
+    expect(emitData).not.toHaveBeenCalled();
 
     terminal.dispose();
   });

--- a/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
@@ -207,7 +207,7 @@ describe("TerminalProcess background output coalescing", () => {
     terminal.dispose();
   });
 
-  it("cancels the drain timer on kill without firing the deferred pipeline", () => {
+  it("drains the queued output on kill before teardown so the pre-exit tail survives", () => {
     const emitData = vi.fn();
     const terminal = createTerminal(emitData);
 
@@ -215,13 +215,21 @@ describe("TerminalProcess background output coalescing", () => {
     ptyOnDataCallback!("pre-kill");
     expect(emitData).not.toHaveBeenCalled();
 
+    // kill() must flush the coalesced queue through the pipeline BEFORE teardown
+    // releases subscribers, so the final backgrounded chunk reaches forensics /
+    // snapshot and the terminal:exited forensic tail stays complete (#10744).
+    // The drain runs synchronously inside kill() — not on the deferred timer —
+    // and clears the queue, so advancing timers fans nothing else out.
     terminal.kill("user requested");
-    vi.advanceTimersByTime(1000);
 
-    expect(emitData).not.toHaveBeenCalled();
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenCalledWith("t1", "pre-kill");
+
+    vi.advanceTimersByTime(1000);
+    expect(emitData).toHaveBeenCalledTimes(1);
   });
 
-  it("cancels the drain timer on natural exit without firing the deferred pipeline", () => {
+  it("drains the queued output on natural exit before the forensic read", () => {
     const emitData = vi.fn();
     const terminal = createTerminal(emitData);
 
@@ -229,10 +237,17 @@ describe("TerminalProcess background output coalescing", () => {
     ptyOnDataCallback!("pre-exit");
     expect(emitData).not.toHaveBeenCalled();
 
+    // The onExit handler must drain the coalesced queue BEFORE reading the
+    // forensic tail, so a backgrounded terminal's final chunk lands in the
+    // forensics buffer rather than being discarded by teardown (#10744). The
+    // drain is synchronous inside the exit handler and empties the queue.
     ptyOnExitCallback!({ exitCode: 0 });
-    vi.advanceTimersByTime(1000);
 
-    expect(emitData).not.toHaveBeenCalled();
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenCalledWith("t1", "pre-exit");
+
+    vi.advanceTimersByTime(1000);
+    expect(emitData).toHaveBeenCalledTimes(1);
 
     terminal.dispose();
   });

--- a/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
@@ -187,11 +187,12 @@ describe("TerminalProcess background output coalescing", () => {
 
   it("drains while still on the background tier before flipping to active", () => {
     const seenTierAtDrain: Array<"active" | "background"> = [];
-    let terminal: TerminalProcess;
+    // emitData reads `terminal` lazily — only when the pipeline drains, well
+    // after construction — so the const reference is safe.
     const emitData = vi.fn(() => {
       seenTierAtDrain.push(terminal.getActivityTier());
     });
-    terminal = createTerminal(emitData);
+    const terminal = createTerminal(emitData);
 
     terminal.setActivityMonitorTier("background", 500);
     ptyOnDataCallback!("queued");


### PR DESCRIPTION
## Summary

- Backgrounded terminals were running the full per-chunk parse pipeline (ActivityMonitor regex bank, headless xterm VT write, forensics/semantic buffers, renderer fan-out) at the same cost as foreground terminals. Only the poll cadence changed when a project was backgrounded.
- Adds a coalescing queue in `TerminalProcess` so backgrounded terminals defer pipeline work. OSC 9;4 taps and timestamp updates still run per-chunk so the agent-state heartbeat for the worktree dashboard stays current. Everything else is batched onto a single self-rearming drain timer using the deadline-timestamp pattern. On drain, the concatenated batch runs `_runPtyPipeline` once (the xterm VT parser is chunk-boundary-safe, so headless state is identical). The drain interval reuses the polling cadence passed to `setActivityMonitorTier`.
- On foreground activation the queue flushes synchronously before the tier flips, so the renderer wakes to a current `getSerializedState`. Queue is capped at 256KB to bound memory for never-pausing output, and the drain timer is cancelled in `teardown()` covering kill, natural exit, and dispose.

Resolves #10744

## Changes

- `electron/services/pty/TerminalProcess.ts`: background coalescing queue, `_runPtyPipeline` extraction, synchronous flush in `setActivityMonitorTier`, teardown cleanup
- `electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts`: 9 new tests covering queue behaviour, foreground flush, 256KB cap, and timer cancellation on teardown

## Testing

Ran vitest across all TerminalProcess suites: `backgroundCoalescing` (9 tests), `agentOutput`, `osc`, `snapshot`, `kill`, `exit-cleanup`, and `lifecycle`. All green. Prettier and ESLint clean.