### PR TITLE
perf(project): freeze cached views instead of destroying them under efficiency (#10742)

### DIFF
--- a/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/terminalConfig.handlers.test.ts
@@ -136,7 +136,7 @@ describe("terminalConfig handlers", () => {
     expect(result).toEqual(
       expect.objectContaining(storeState.data.terminalConfig as Record<string, unknown>)
     );
-    expect(result.cachedProjectViews).toBe(1);
+    expect(result.cachedProjectViews).toBe(2);
   });
 
   describe("get derives cachedProjectViews", () => {
@@ -160,67 +160,67 @@ describe("terminalConfig handlers", () => {
       expect(result.cachedProjectViews).toBe(2);
     });
 
-    it("returns 1 for an 8 GiB machine with no preference", async () => {
+    it("returns 2 for an 8 GiB machine with no preference", async () => {
       osState.totalmem = 8 * 1024 ** 3;
       registerTerminalConfigHandlers();
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(1);
+      expect(result.cachedProjectViews).toBe(2);
     });
 
-    it("returns 1 for a 16 GiB machine with no preference", async () => {
+    it("returns 2 for a 16 GiB machine with no preference", async () => {
       osState.totalmem = 16 * 1024 ** 3;
       registerTerminalConfigHandlers();
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(1);
+      expect(result.cachedProjectViews).toBe(2);
     });
 
-    it("returns 1 for a 24 GiB machine (below the 32 GiB threshold)", async () => {
+    it("returns 2 for a 24 GiB machine (below the 32 GiB threshold)", async () => {
       osState.totalmem = 24 * 1024 ** 3;
       registerTerminalConfigHandlers();
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(1);
+      expect(result.cachedProjectViews).toBe(2);
     });
 
-    it("returns 2 at the 32 GiB threshold", async () => {
+    it("returns 3 at the 32 GiB threshold", async () => {
       osState.totalmem = 32 * 1024 ** 3;
       registerTerminalConfigHandlers();
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(2);
+      expect(result.cachedProjectViews).toBe(3);
     });
 
-    it("returns 2 for a 48 GiB machine", async () => {
+    it("returns 3 for a 48 GiB machine", async () => {
       osState.totalmem = 48 * 1024 ** 3;
       registerTerminalConfigHandlers();
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(2);
+      expect(result.cachedProjectViews).toBe(3);
     });
 
-    it("returns 3 at the 64 GiB threshold", async () => {
+    it("returns 4 at the 64 GiB threshold", async () => {
       osState.totalmem = 64 * 1024 ** 3;
       registerTerminalConfigHandlers();
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(3);
+      expect(result.cachedProjectViews).toBe(4);
     });
 
-    it("returns 3 for a 128 GiB machine", async () => {
+    it("returns 4 for a 128 GiB machine", async () => {
       osState.totalmem = 128 * 1024 ** 3;
       registerTerminalConfigHandlers();
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(3);
+      expect(result.cachedProjectViews).toBe(4);
     });
 
     it("returns 4 in E2E mode when no preference is stored, regardless of RAM", async () => {
@@ -240,7 +240,7 @@ describe("terminalConfig handlers", () => {
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(3);
+      expect(result.cachedProjectViews).toBe(4);
     });
 
     it("treats out-of-range stored values as absent and falls back to the RAM default", async () => {
@@ -250,7 +250,7 @@ describe("terminalConfig handlers", () => {
       const handler = getHandler(CHANNELS.TERMINAL_CONFIG_GET);
 
       const result = (await handler({}, undefined)) as Record<string, unknown>;
-      expect(result.cachedProjectViews).toBe(2);
+      expect(result.cachedProjectViews).toBe(3);
     });
   });
 

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -160,12 +160,6 @@ export class ResourceProfileService {
   private lagEnterTicks = 0;
   private lagExitWindow: boolean[] = [];
   private lagPressureStartedAt: number | null = null;
-  // Memory sub-score captured from the most recent computeTargetProfile() run.
-  // Gates the setCachedViewLimit(1) clamp on efficiency entry so non-memory
-  // efficiency triggers (battery + thermal/CPU + worktrees) don't pay the
-  // cost of destroying cached WebContentsViews. sampleLag() bypasses
-  // computeTargetProfile() and must zero this before calling applyProfile().
-  private lastMemoryScore = 0;
 
   constructor(private deps: ResourceProfileDeps) {
     const totalRamMb = os.totalmem() / 1024 / 1024;
@@ -325,15 +319,10 @@ export class ResourceProfileService {
   applyCurrentProfileTo(pvm: ProjectViewManager): void {
     const config = RESOURCE_PROFILE_CONFIGS[this.currentProfile];
     if (this.currentProfile === "efficiency") {
-      // Same gating as applyProfile: only clamp cached views when memory
-      // contributed to entering efficiency.
-      if (this.lastMemoryScore > 0) {
-        try {
-          pvm.setCachedViewLimit(1);
-        } catch {
-          // non-critical
-        }
-      }
+      // Efficiency freezes cached views (CPU/timer suppression) but never
+      // destroys them. RAM is reclaimed only by evictStaleViews()'s own
+      // lowMemoryFreeThresholdMb floor when free RAM is genuinely low, keeping
+      // the user's working set warm under battery/thermal/CPU-only pressure.
       try {
         pvm.setEfficiencyFreeze(true);
       } catch {
@@ -520,11 +509,6 @@ export class ResourceProfileService {
         utilization: Math.round(utilization * 100) / 100,
       });
       if (this.currentProfile !== "efficiency") {
-        // Severe-spike lag entry bypasses computeTargetProfile(), so
-        // lastMemoryScore holds whatever the previous eval recorded (stale).
-        // The trigger here is CPU/event-loop, not memory — zero it so the
-        // setCachedViewLimit(1) clamp in applyProfile() stays off.
-        this.lastMemoryScore = 0;
         this.applyProfile("efficiency");
       }
       return;
@@ -543,11 +527,6 @@ export class ResourceProfileService {
           utilization: Math.round(utilization * 100) / 100,
         });
         if (this.currentProfile !== "efficiency") {
-          // Lag-triggered efficiency entry bypasses computeTargetProfile(), so
-          // lastMemoryScore holds whatever the previous eval recorded (stale).
-          // The trigger here is CPU/event-loop, not memory — zero it so the
-          // setCachedViewLimit(1) clamp in applyProfile() stays off.
-          this.lastMemoryScore = 0;
           this.applyProfile("efficiency");
         }
       }
@@ -658,7 +637,6 @@ export class ResourceProfileService {
     }
     this.lagPreviousElu = null;
     this.clearLagPressure();
-    this.lastMemoryScore = 0;
     this.thermalState = "unknown";
     this.isOnBattery = false;
     this.speedLimit = 100;
@@ -725,7 +703,6 @@ export class ResourceProfileService {
       // Skip memory signal on error — memoryScore stays 0 (correct: no measurement, no clamp)
     }
     pressureScore += memoryScore;
-    this.lastMemoryScore = memoryScore;
 
     // Battery signal (cached from startup + transition events)
     if (this.isOnBattery) {
@@ -860,9 +837,12 @@ export class ResourceProfileService {
       }
     }
 
-    // Adjust cached project view limit under memory pressure.
-    // Cached WebContentsViews cost ~100–500 MB RSS each (full Chromium renderer),
-    // so clamping to 1 on efficiency reclaims the largest memory chunk available.
+    // Freeze cached project views under efficiency to reclaim CPU, but never
+    // destroy them to reclaim RAM. Destruction is owned exclusively by
+    // evictStaleViews()'s lowMemoryFreeThresholdMb floor, which clamps to 1
+    // only when free RAM is genuinely low (independent of profile). This keeps
+    // the user's working set warm under battery/thermal/CPU-only pressure,
+    // avoiding cold-start storms when switching among many open projects.
     // Fan out across every open window's PVM so multi-window sessions all
     // honor the profile change, not just the most-recently-created window.
     for (const pvm of this.deps.getAllProjectViewManagers()) {
@@ -873,18 +853,6 @@ export class ResourceProfileService {
       // isolation applies per-PVM: a failure on one window must not skip the
       // remaining windows in the iteration.
       if (profile === "efficiency") {
-        // Only destroy cached WebContentsViews when memory actually contributed
-        // to entering efficiency. Battery + thermal/CPU-only triggers are
-        // handled by setEfficiencyFreeze(true) alone, and evictStaleViews()
-        // has its own lowMemoryFreeThresholdMb floor that clamps to 1 when
-        // free RAM really is low (independent of profile).
-        if (this.lastMemoryScore > 0) {
-          try {
-            pvm.setCachedViewLimit(1);
-          } catch {
-            // non-critical
-          }
-        }
         try {
           // Freeze cached project views' renderers via CDP under efficiency to
           // suppress timer wake-ups on top of background throttling. PVM

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -440,10 +440,9 @@ describe("ResourceProfileService adversarial", () => {
 
     it("lag-triggered efficiency entry does not clamp cached view limit", () => {
       // Lag triggers efficiency directly from sampleLag(), bypassing
-      // computeTargetProfile(). Memory is not the trigger, so the
-      // setCachedViewLimit(1) clamp must NOT fire — only setEfficiencyFreeze(true)
-      // should run (freezing the renderers suppresses the CPU wake-ups that
-      // lag pressure is actually about).
+      // computeTargetProfile(). Efficiency entry never clamps cached views
+      // regardless of trigger — only setEfficiencyFreeze(true) runs (freezing
+      // the renderers suppresses the CPU wake-ups that lag pressure is about).
       const pvm = {
         setCachedViewLimit: vi.fn(),
         setLowMemoryFreeThresholdMb: vi.fn(),
@@ -470,12 +469,11 @@ describe("ResourceProfileService adversarial", () => {
       service.stop();
     });
 
-    it("lag-triggered efficiency entry clears stale memory score from prior eval", () => {
-      // A prior memory-pressure eval may have set lastMemoryScore to 2. If lag
-      // then triggers a fresh efficiency entry (the prior entry was reset by an
-      // intervening recovery), the lag path must zero the stale score so the
-      // clamp does NOT fire. Without the zero, the lag path would inherit the
-      // last memory measurement (up to 30s old) and clamp incorrectly.
+    it("memory-pressure efficiency entry freezes but never destroys cached views", () => {
+      // Even when memory pressure drives efficiency, entry must not clamp the
+      // cached-view limit — destruction is owned solely by PVM's evictStaleViews
+      // floor under genuine low free RAM. This keeps the working set warm and
+      // avoids cold-start storms on rapid project switching (#10742).
       const pvm = {
         setCachedViewLimit: vi.fn(),
         setLowMemoryFreeThresholdMb: vi.fn(),
@@ -490,29 +488,11 @@ describe("ResourceProfileService adversarial", () => {
       mockIsOnBatteryPower.mockReturnValue(true);
       service.start();
 
-      // Drive into efficiency via memory + battery — sets lastMemoryScore = 2.
+      // Drive into efficiency via memory + battery (high memory contribution).
       mockGetAppMetrics.mockReturnValue([makeMetric(1300)]);
       vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
       expect(service.getProfile()).toBe("efficiency");
-      expect(pvm.setCachedViewLimit).toHaveBeenLastCalledWith(1);
 
-      // Recover to balanced. Memory drops, battery off.
-      const onAcHandler = mockPowerMonitorOn.mock.calls.find(
-        (call: string[]) => call[0] === "on-ac"
-      )?.[1] as (() => void) | undefined;
-      mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
-      onAcHandler!();
-      vi.advanceTimersByTime(30_000 * 4);
-      expect(service.getProfile()).not.toBe("efficiency");
-      pvm.setCachedViewLimit.mockClear();
-
-      // Now drive efficiency via lag only. Memory is still low (no contribution).
-      setLag(300, 0.85);
-      vi.advanceTimersByTime(5_000);
-      vi.advanceTimersByTime(5_000);
-      expect(service.getProfile()).toBe("efficiency");
-
-      // The lag entry must not have reused the stale memory score.
       expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
       expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(true);
 

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -173,7 +173,8 @@ function createDeps(overrides?: Partial<ResourceProfileDeps>): {
       getHibernationService: () => hibernation as unknown as HibernationService,
       getAllProjectViewManagers: () => [],
       getProjectStatsService: () => stats as unknown as ProjectStatsService,
-      getUserCachedViewLimit: () => 1,
+      // Models the RAM-tier default (effectiveCachedProjectViews never returns 1).
+      getUserCachedViewLimit: () => 2,
       ...overrides,
     },
     workspace,

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -407,7 +407,12 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
-  it("clamps cached project views to 1 when transitioning to efficiency", () => {
+  it("freezes but never destroys cached views on memory-pressure efficiency entry", () => {
+    // Even under HIGH memory pressure, efficiency entry must NOT clamp cached
+    // views to 1 — destruction is owned solely by PVM's evictStaleViews()
+    // lowMemoryFreeThresholdMb floor (genuine low free RAM). Entry only freezes
+    // (CPU/timer suppression) so the user's working set stays warm and rapid
+    // project switching doesn't trigger cold-start storms (#10742).
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
     mockIsOnBatteryPower.mockReturnValue(true);
@@ -419,8 +424,7 @@ describe("ResourceProfileService", () => {
     expect(service.getProfile()).toBe("efficiency");
 
     const pvm = deps.getAllProjectViewManagers()[0] as unknown as MockProjectViewManager;
-    expect(pvm.setCachedViewLimit).toHaveBeenCalledWith(1);
-    expect(pvm.setCachedViewLimit).toHaveBeenCalledTimes(1);
+    expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
     expect(pvm.setEfficiencyFreeze).toHaveBeenCalledWith(true);
 
     service.stop();
@@ -428,10 +432,9 @@ describe("ResourceProfileService", () => {
 
   it("does not clamp cached view limit when efficiency is triggered by non-memory signals", () => {
     // Battery (+1) + thermal critical (+2) + zero memory = score 3 → efficiency.
-    // No memory contribution, so setCachedViewLimit(1) MUST NOT fire — it would
-    // destroy cached WebContentsViews (each 100–500 MB) for no memory benefit.
-    // setEfficiencyFreeze(true) still fires because freeze suppresses CPU/timer
-    // wake-ups, which IS what the thermal+battery trigger needs.
+    // setCachedViewLimit(1) MUST NOT fire — it would destroy cached
+    // WebContentsViews (each 100–500 MB). setEfficiencyFreeze(true) still fires
+    // because freeze suppresses CPU/timer wake-ups.
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
     mockIsOnBatteryPower.mockReturnValue(true);
@@ -450,9 +453,10 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
-  it("clamps cached view limit when efficiency is triggered with LOW memory pressure", () => {
+  it("does not clamp cached view limit even when memory contributes to efficiency entry", () => {
     // Battery (+1) + thermal serious (+1) + LOW memory (+1) = score 3 → efficiency.
-    // Memory contributed (+1), so the clamp DOES fire even at LOW tier.
+    // Memory contributed, but the clamp is gone regardless of the memory score —
+    // only setEfficiencyFreeze(true) fires on entry.
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
     mockIsOnBatteryPower.mockReturnValue(true);
@@ -465,16 +469,16 @@ describe("ResourceProfileService", () => {
     expect(service.getProfile()).toBe("efficiency");
 
     const pvm = deps.getAllProjectViewManagers()[0] as unknown as MockProjectViewManager;
-    expect(pvm.setCachedViewLimit).toHaveBeenCalledWith(1);
+    expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
+    expect(pvm.setEfficiencyFreeze).toHaveBeenCalledWith(true);
 
     service.stop();
   });
 
-  it("still restores user cached view limit on exit after a non-memory efficiency entry", () => {
-    // Enter efficiency via battery + thermal critical (no memory), so entry does
-    // NOT clamp. On exit, the restore call must still fire — the user-configured
-    // limit might have changed mid-efficiency, and PVM's own evictStaleViews
-    // floor could have clamped while we were inside.
+  it("still restores user cached view limit on exit from efficiency", () => {
+    // Entry never clamps. On exit, the restore call must still fire — the
+    // user-configured limit might have changed mid-efficiency, and PVM's own
+    // evictStaleViews floor could have clamped while we were inside.
     const deps = createDeps({ getUserCachedViewLimit: () => 3 });
     const service = new ResourceProfileService(deps);
     mockIsOnBatteryPower.mockReturnValue(true);
@@ -531,30 +535,6 @@ describe("ResourceProfileService", () => {
     expect(service.getProfile()).toBe("balanced");
     expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(false);
     expect(pvm.setEfficiencyFreeze).toHaveBeenCalledTimes(2);
-
-    service.stop();
-  });
-
-  it("still freezes when setCachedViewLimit throws on the entry path", () => {
-    // Split try/catch on entry mirrors the exit path: a throw from
-    // setCachedViewLimit(1) (e.g. an onViewEvicted callback failing inside
-    // evictStaleViews) must not block setEfficiencyFreeze(true) — leaving
-    // efficiency unfrozen defeats the CPU/timer-wake suppression that
-    // efficiency is supposed to provide.
-    const deps = createDeps();
-    const pvm = deps.getAllProjectViewManagers()[0] as unknown as MockProjectViewManager;
-    const service = new ResourceProfileService(deps);
-    mockIsOnBatteryPower.mockReturnValue(true);
-    service.start();
-
-    pvm.setCachedViewLimit.mockImplementationOnce(() => {
-      throw new Error("simulated eviction failure");
-    });
-
-    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
-    expect(service.getProfile()).toBe("efficiency");
-    expect(pvm.setEfficiencyFreeze).toHaveBeenCalledWith(true);
 
     service.stop();
   });
@@ -624,7 +604,8 @@ describe("ResourceProfileService", () => {
     expect(service.getProfile()).toBe("efficiency");
 
     const pvm = deps.getAllProjectViewManagers()[0] as unknown as MockProjectViewManager;
-    expect(pvm.setCachedViewLimit).toHaveBeenLastCalledWith(1);
+    // Entry no longer clamps cached views.
+    expect(pvm.setCachedViewLimit).not.toHaveBeenCalled();
 
     // Relieve to moderate pressure (score 1 = balanced)
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
@@ -637,8 +618,9 @@ describe("ResourceProfileService", () => {
     vi.advanceTimersByTime(30_000);
 
     expect(service.getProfile()).toBe("balanced");
+    // Only the exit restore touches the limit now.
     expect(pvm.setCachedViewLimit).toHaveBeenLastCalledWith(3);
-    expect(pvm.setCachedViewLimit).toHaveBeenCalledTimes(2);
+    expect(pvm.setCachedViewLimit).toHaveBeenCalledTimes(1);
 
     service.stop();
   });
@@ -670,8 +652,9 @@ describe("ResourceProfileService", () => {
 
     expect(service.getProfile()).toBe("performance");
     const pvm = deps.getAllProjectViewManagers()[0] as unknown as MockProjectViewManager;
+    // Entry never clamped, so only the exit restore touches the limit.
     expect(pvm.setCachedViewLimit).toHaveBeenLastCalledWith(2);
-    expect(pvm.setCachedViewLimit).toHaveBeenCalledTimes(2);
+    expect(pvm.setCachedViewLimit).toHaveBeenCalledTimes(1);
 
     service.stop();
   });
@@ -730,8 +713,7 @@ describe("ResourceProfileService", () => {
       expect(latePvm.setWarmPaintGateHardTimeoutMs).toHaveBeenCalledWith(
         RESOURCE_PROFILE_CONFIGS.efficiency.warmPaintGateHardTimeoutMs
       );
-      // Forced transition carries no memory score — the cached-view clamp
-      // must stay off, matching applyProfile's gating.
+      // Efficiency entry never clamps cached views — it only freezes them.
       expect(latePvm.setCachedViewLimit).not.toHaveBeenCalled();
 
       service.stop();
@@ -1764,9 +1746,9 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
-  it("efficiency transition fans out setCachedViewLimit and setEfficiencyFreeze to every PVM", () => {
+  it("efficiency transition fans out setEfficiencyFreeze to every PVM", () => {
     // Regression for #8605: profile transitions must reach every open window's
-    // PVM so the memory controls aren't silently scoped to one window.
+    // PVM so the controls aren't silently scoped to one window.
     const pvmA = makeMockPvm();
     const pvmB = makeMockPvm();
     const deps = createDeps({
@@ -1783,12 +1765,13 @@ describe("ResourceProfileService", () => {
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
 
-    expect(pvmA.setCachedViewLimit).toHaveBeenCalledWith(1);
+    // Entry freezes both windows' cached views but destroys neither.
+    expect(pvmA.setCachedViewLimit).not.toHaveBeenCalled();
     expect(pvmA.setEfficiencyFreeze).toHaveBeenCalledWith(true);
     expect(pvmA.setLowMemoryFreeThresholdMb).toHaveBeenLastCalledWith(
       RESOURCE_PROFILE_CONFIGS.efficiency.lowMemoryFreeThresholdMb
     );
-    expect(pvmB.setCachedViewLimit).toHaveBeenCalledWith(1);
+    expect(pvmB.setCachedViewLimit).not.toHaveBeenCalled();
     expect(pvmB.setEfficiencyFreeze).toHaveBeenCalledWith(true);
     expect(pvmB.setLowMemoryFreeThresholdMb).toHaveBeenLastCalledWith(
       RESOURCE_PROFILE_CONFIGS.efficiency.lowMemoryFreeThresholdMb
@@ -1799,10 +1782,10 @@ describe("ResourceProfileService", () => {
 
   it("one failing PVM does not block the remaining PVMs", () => {
     // Per-operation try/catch isolation must extend across PVMs: a throw on
-    // one window's setCachedViewLimit must not skip the next window's calls.
+    // one window's setEfficiencyFreeze must not skip the next window's calls.
     const pvmA = makeMockPvm();
     const pvmB = makeMockPvm();
-    pvmA.setCachedViewLimit.mockImplementation(() => {
+    pvmA.setEfficiencyFreeze.mockImplementation(() => {
       throw new Error("simulated PVM A failure");
     });
     const deps = createDeps({
@@ -1819,11 +1802,9 @@ describe("ResourceProfileService", () => {
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
 
-    // PVM A's setEfficiencyFreeze must still run even though
-    // setCachedViewLimit threw — split try/catch per call.
+    // PVM A's setEfficiencyFreeze threw, but PVM B must receive the full
+    // sequence, unblocked by A's failure — split try/catch per call/per PVM.
     expect(pvmA.setEfficiencyFreeze).toHaveBeenCalledWith(true);
-    // And PVM B must receive the full sequence, unblocked by A's failure.
-    expect(pvmB.setCachedViewLimit).toHaveBeenCalledWith(1);
     expect(pvmB.setEfficiencyFreeze).toHaveBeenCalledWith(true);
     expect(pvmB.setLowMemoryFreeThresholdMb).toHaveBeenLastCalledWith(
       RESOURCE_PROFILE_CONFIGS.efficiency.lowMemoryFreeThresholdMb

--- a/electron/utils/__tests__/cachedProjectViews.test.ts
+++ b/electron/utils/__tests__/cachedProjectViews.test.ts
@@ -9,34 +9,42 @@ import {
 const GIB = 1024 ** 3;
 
 describe("computeDefaultCachedViews", () => {
-  it("returns 1 for machines with 16 GiB or less", () => {
-    expect(computeDefaultCachedViews(4 * GIB)).toBe(1);
-    expect(computeDefaultCachedViews(8 * GIB)).toBe(1);
-    expect(computeDefaultCachedViews(16 * GIB)).toBe(1);
+  it("returns 2 for machines with 16 GiB or less", () => {
+    expect(computeDefaultCachedViews(4 * GIB)).toBe(2);
+    expect(computeDefaultCachedViews(8 * GIB)).toBe(2);
+    expect(computeDefaultCachedViews(16 * GIB)).toBe(2);
   });
 
-  it("returns 1 for machines between 16 and 32 GiB", () => {
-    expect(computeDefaultCachedViews(24 * GIB)).toBe(1);
-    expect(computeDefaultCachedViews(32 * GIB - 1)).toBe(1);
+  it("returns 2 for machines between 16 and 32 GiB", () => {
+    expect(computeDefaultCachedViews(24 * GIB)).toBe(2);
+    expect(computeDefaultCachedViews(32 * GIB - 1)).toBe(2);
   });
 
-  it("returns 2 at the 32 GiB threshold and up to just below 64 GiB", () => {
-    expect(computeDefaultCachedViews(32 * GIB)).toBe(2);
-    expect(computeDefaultCachedViews(48 * GIB)).toBe(2);
-    expect(computeDefaultCachedViews(64 * GIB - 1)).toBe(2);
+  it("returns 3 at the 32 GiB threshold and up to just below 64 GiB", () => {
+    expect(computeDefaultCachedViews(32 * GIB)).toBe(3);
+    expect(computeDefaultCachedViews(48 * GIB)).toBe(3);
+    expect(computeDefaultCachedViews(64 * GIB - 1)).toBe(3);
   });
 
-  it("returns 3 at the 64 GiB threshold and above", () => {
-    expect(computeDefaultCachedViews(64 * GIB)).toBe(3);
-    expect(computeDefaultCachedViews(96 * GIB)).toBe(3);
-    expect(computeDefaultCachedViews(128 * GIB)).toBe(3);
+  it("returns 4 at the 64 GiB threshold and above", () => {
+    expect(computeDefaultCachedViews(64 * GIB)).toBe(4);
+    expect(computeDefaultCachedViews(96 * GIB)).toBe(4);
+    expect(computeDefaultCachedViews(128 * GIB)).toBe(4);
   });
 
-  it("falls back to 1 for invalid or non-positive inputs", () => {
-    expect(computeDefaultCachedViews(0)).toBe(1);
-    expect(computeDefaultCachedViews(-1)).toBe(1);
-    expect(computeDefaultCachedViews(Number.NaN)).toBe(1);
-    expect(computeDefaultCachedViews(Number.POSITIVE_INFINITY)).toBe(1);
+  it("falls back to 2 for invalid or non-positive inputs", () => {
+    expect(computeDefaultCachedViews(0)).toBe(2);
+    expect(computeDefaultCachedViews(-1)).toBe(2);
+    expect(computeDefaultCachedViews(Number.NaN)).toBe(2);
+    expect(computeDefaultCachedViews(Number.POSITIVE_INFINITY)).toBe(2);
+  });
+
+  it("returns strictly increasing caps across the RAM tiers", () => {
+    const low = computeDefaultCachedViews(8 * GIB);
+    const mid = computeDefaultCachedViews(48 * GIB);
+    const high = computeDefaultCachedViews(96 * GIB);
+    expect(low).toBeLessThan(mid);
+    expect(mid).toBeLessThan(high);
   });
 });
 
@@ -78,24 +86,24 @@ describe("effectiveCachedProjectViews", () => {
   });
 
   it("derives from RAM when no preference and not in E2E mode", () => {
-    expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: false })).toBe(1);
+    expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: false })).toBe(2);
     expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(32), isE2E: false })).toBe(
-      2
+      3
     );
     expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(64), isE2E: false })).toBe(
-      3
+      4
     );
   });
 
   it("treats corrupted stored values as absent and falls back", () => {
     const ramDefault64 = { totalMemBytes: mem(64), isE2E: false };
-    expect(effectiveCachedProjectViews("bogus", ramDefault64)).toBe(3);
-    expect(effectiveCachedProjectViews(99, ramDefault64)).toBe(3);
-    expect(effectiveCachedProjectViews(0, ramDefault64)).toBe(3);
-    expect(effectiveCachedProjectViews(-1, ramDefault64)).toBe(3);
-    expect(effectiveCachedProjectViews(2.5, ramDefault64)).toBe(3);
-    expect(effectiveCachedProjectViews(Number.NaN, ramDefault64)).toBe(3);
-    expect(effectiveCachedProjectViews({ v: 2 }, ramDefault64)).toBe(3);
+    expect(effectiveCachedProjectViews("bogus", ramDefault64)).toBe(4);
+    expect(effectiveCachedProjectViews(99, ramDefault64)).toBe(4);
+    expect(effectiveCachedProjectViews(0, ramDefault64)).toBe(4);
+    expect(effectiveCachedProjectViews(-1, ramDefault64)).toBe(4);
+    expect(effectiveCachedProjectViews(2.5, ramDefault64)).toBe(4);
+    expect(effectiveCachedProjectViews(Number.NaN, ramDefault64)).toBe(4);
+    expect(effectiveCachedProjectViews({ v: 2 }, ramDefault64)).toBe(4);
   });
 
   it("honors the E2E override when stored value is invalid", () => {
@@ -109,7 +117,7 @@ describe("effectiveCachedProjectViews", () => {
     try {
       process.env.DAINTREE_E2E_MODE = "1";
       expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: false })).toBe(
-        1
+        2
       );
       delete process.env.DAINTREE_E2E_MODE;
       expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8), isE2E: true })).toBe(
@@ -130,11 +138,11 @@ describe("effectiveCachedProjectViews", () => {
       process.env.DAINTREE_E2E_MODE = "1";
       expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(4);
       process.env.DAINTREE_E2E_MODE = "0";
-      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(1);
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(2);
       process.env.DAINTREE_E2E_MODE = "false";
-      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(1);
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(2);
       delete process.env.DAINTREE_E2E_MODE;
-      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(1);
+      expect(effectiveCachedProjectViews(undefined, { totalMemBytes: mem(8) })).toBe(2);
     } finally {
       if (prev === undefined) {
         delete process.env.DAINTREE_E2E_MODE;

--- a/electron/utils/cachedProjectViews.ts
+++ b/electron/utils/cachedProjectViews.ts
@@ -4,10 +4,15 @@ import { getIsE2EMode } from "../setup/runtimeFlags.js";
 const GIB = 1024 ** 3;
 
 export function computeDefaultCachedViews(totalMemBytes: number): number {
-  if (!Number.isFinite(totalMemBytes) || totalMemBytes <= 0) return 1;
-  if (totalMemBytes >= 64 * GIB) return 3;
-  if (totalMemBytes >= 32 * GIB) return 2;
-  return 1;
+  // The cap counts the active view, so N means N-1 warm background views.
+  // Frozen+invisible cached renderers (setVisible(false) releases their GPU
+  // tile textures) are cheap enough to keep more around, and evictStaleViews()
+  // still drops to 1 when free RAM is genuinely low — so a higher default keeps
+  // rapid project switching warm without unbounded memory growth.
+  if (!Number.isFinite(totalMemBytes) || totalMemBytes <= 0) return 2;
+  if (totalMemBytes >= 64 * GIB) return 4;
+  if (totalMemBytes >= 32 * GIB) return 3;
+  return 2;
 }
 
 export function isValidCachedProjectViews(value: unknown): value is number {

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -695,6 +695,14 @@ export class ProjectViewManager {
         // to the still-visible previous project view instead of falling
         // through to the bare BrowserWindow's webContents.
         registerAppView(this.win, previousEntry.view);
+        // If the failure landed after the outgoing view was already
+        // deactivated (which now marks it invisible), restore its visibility
+        // so the rolled-back active view is composited again.
+        try {
+          previousEntry.view.setVisible(true);
+        } catch {
+          // non-critical
+        }
         previousEntry.state = "active";
         previousEntry.lastUsed = Date.now();
       } else if (unboundOutgoingView && !unboundOutgoingView.webContents.isDestroyed()) {
@@ -1157,6 +1165,16 @@ export class ProjectViewManager {
     } catch {
       // View may not be attached
     }
+    // Mark the parked view invisible so Chromium's compositor releases its GPU
+    // tile textures (VRAM) and macOS WindowServer stops compositing it. Removal
+    // from the hierarchy alone leaves stacked offscreen views being composited;
+    // setVisible(false) is what actually makes a frozen-but-alive cached view
+    // cheap to retain. Reactivation restores visibility in activateView().
+    try {
+      current.view.setVisible(false);
+    } catch {
+      // non-critical
+    }
     current.state = "cached";
     current.lastUsed = Date.now();
 
@@ -1247,6 +1265,17 @@ export class ProjectViewManager {
 
   private activateView(entry: ViewEntry, insertBehind = false): void {
     registerAppView(this.win, entry.view);
+
+    // Restore visibility BEFORE unfreezing: deactivateEntry() called
+    // setVisible(false) to release this view's GPU tile textures while cached.
+    // The compositor must know the view is visible again before the "active"
+    // CDP lifecycle command lands, so first paint after wake targets a live
+    // layer rather than a discarded one.
+    try {
+      entry.view.setVisible(true);
+    } catch {
+      // non-critical
+    }
 
     if (!entry.view.webContents.isDestroyed()) {
       unregisterCachedViewWebContents(entry.view.webContents.id);

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -76,7 +76,12 @@ function createMockWebContents(options?: { autoFinishLoad?: boolean }): MockWebC
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
 
   return {

--- a/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
@@ -31,7 +31,12 @@ function createMockWebContents() {
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -52,7 +52,12 @@ const mockGetAllWebContents = vi.fn<() => unknown[]>(() => []);
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: {

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -74,7 +74,12 @@ let wcQueue: MockWc[] = [];
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() }, getAppMetrics: () => [] },

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -31,7 +31,12 @@ function createMockWebContents() {
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: {
@@ -355,6 +360,54 @@ describe("ProjectViewManager — efficiency freeze", () => {
 
     const cachedCalls = vi.mocked(registerCachedViewWebContents).mock.calls;
     expect(cachedCalls.every((call) => (call[0] as unknown) !== initialWc)).toBe(true);
+  });
+
+  type VisibleSpy = { setVisible: ReturnType<typeof vi.fn> };
+
+  it("parks the deactivated view invisible AFTER removing it from the hierarchy", async () => {
+    // proj-b is a factory-created view (its setVisible is a real spy); proj-a is
+    // the initial view. Switch a→b→c so proj-b is deactivated and parked.
+    await manager.switchTo("proj-b", "/path/b");
+    const viewB = manager.getActiveView()! as unknown as VisibleSpy;
+    await manager.switchTo("proj-c", "/path/c");
+
+    expect(viewB.setVisible).toHaveBeenCalledWith(false);
+
+    // setVisible(false) must fire after the view is detached, so the compositor
+    // releases the parked view's tile textures rather than a still-attached one.
+    const removeIdx = win.contentView.removeChildView.mock.calls.findIndex(
+      (call) => (call[0] as unknown) === viewB
+    );
+    expect(removeIdx).toBeGreaterThanOrEqual(0);
+    const removeOrder = win.contentView.removeChildView.mock.invocationCallOrder[removeIdx];
+    const visibleOrder = viewB.setVisible.mock.invocationCallOrder[0];
+    expect(removeOrder).toBeLessThan(visibleOrder);
+  });
+
+  it("restores visibility BEFORE unfreezing on warm reactivation", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    const viewB = manager.getActiveView()! as unknown as VisibleSpy & {
+      webContents: ReturnType<typeof createMockWebContents>;
+    };
+    const viewBWc = viewB.webContents;
+    await manager.switchTo("proj-c", "/path/c");
+
+    viewB.setVisible.mockClear();
+    vi.mocked(unfreezeWebContents).mockClear();
+
+    // Warm reactivation: proj-b is cached (within the cap of 3), so this wakes
+    // the existing view rather than cold-starting.
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(viewB.setVisible).toHaveBeenCalledWith(true);
+
+    const unfreezeIdx = vi
+      .mocked(unfreezeWebContents)
+      .mock.calls.findIndex((call) => (call[0] as unknown) === viewBWc);
+    expect(unfreezeIdx).toBeGreaterThanOrEqual(0);
+    const unfreezeOrder = vi.mocked(unfreezeWebContents).mock.invocationCallOrder[unfreezeIdx];
+    const visibleOrder = viewB.setVisible.mock.invocationCallOrder[0];
+    expect(visibleOrder).toBeLessThan(unfreezeOrder);
   });
 
   function seedActiveAgent(terminalId: string, projectId: string) {

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -32,7 +32,12 @@ function createMockWebContents() {
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -74,7 +74,12 @@ let wcQueue: MockWc[] = [];
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: {

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -51,7 +51,12 @@ const mockGetAppMetrics = vi.fn<() => Electron.ProcessMetric[]>(() => []);
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = createMockWebContents();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: {

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -72,7 +72,12 @@ let wcQueue: MockWc[] = [];
 vi.mock("electron", () => {
   function MockWebContentsView() {
     const wc = wcQueue.shift();
-    return { webContents: wc, setBounds: vi.fn(), setBackgroundColor: vi.fn() };
+    return {
+      webContents: wc,
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      setVisible: vi.fn(),
+    };
   }
   return {
     app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -52,6 +52,7 @@ import {
   MAX_HEAP_SNAPSHOTS,
   logError,
 } from "../utils/logger.js";
+import { effectiveCachedProjectViews } from "../utils/cachedProjectViews.js";
 import { SCROLLBACK_BACKGROUND } from "../../shared/config/scrollback.js";
 import { PERF_MARKS } from "../../shared/perf/marks.js";
 import { CHANNELS } from "../ipc/channels.js";
@@ -64,7 +65,7 @@ import { getProjectStatsService } from "../ipc/handlers/projectCrud/index.js";
 import { registerDeferredTask } from "./deferredInitQueue.js";
 import { isSmokeTest } from "../setup/environment.js";
 import { setPluginDirResolver } from "../setup/protocols.js";
-import { isE2EFaultMode, isE2EMode } from "../setup/runtimeFlags.js";
+import { isE2EFaultMode } from "../setup/runtimeFlags.js";
 import { activateOpenFileInstaller } from "../setup/openFileInstall.js";
 import { projectStore } from "../services/ProjectStore.js";
 import { registerCommands } from "../services/commands/index.js";
@@ -674,7 +675,7 @@ export async function initGlobalServices(
             .filter((pvm): pvm is ProjectViewManager => pvm !== undefined) ?? [],
         getProjectStatsService: () => getProjectStatsService(),
         getUserCachedViewLimit: () =>
-          store.get("terminalConfig")?.cachedProjectViews ?? (isE2EMode ? 4 : 1),
+          effectiveCachedProjectViews(store.get("terminalConfig")?.cachedProjectViews),
         hasSustainedRendererSaturation: () => hasSustainedRendererSaturation(),
       });
       setResourceProfileService(svc);


### PR DESCRIPTION
## Summary

- Rapid project switching was triggering cold-start storms (~1.5-4s per switch) because the efficiency profile destroyed cached `WebContentsView` renderers based on a proportional RSS threshold, even when free RAM was plentiful.
- The efficiency profile now only freezes cached views (CPU/timer suppression). Destruction is owned exclusively by `evictStaleViews()`, which clamps to 1 only under genuine memory pressure (free+purgeable based).
- `ProjectViewManager` parks deactivated views with `setVisible(false)` to release GPU tile textures, restores visibility before unfreezing on warm reactivation, and re-shows a deactivated `previousEntry` on cold-start rollback.

Resolves #10742

## Changes

- **`ResourceProfileService`:** efficiency entry no longer sets a `setCachedViewLimit` clamp. Removed the RSS-proportional clamp and the dead `lastMemoryScore` field.
- **`ProjectViewManager`:** `setVisible(false)` on deactivation; restore visibility before CDP unfreeze on warm reactivation; re-show deactivated `previousEntry` on cold-start rollback.
- **`cachedProjectViews`:** default caps raised from 1/2/3 to 2/3/4 across RAM tiers. Frozen+invisible views are cheap; pressure eviction is the safety net.
- **`globalServicesInit`:** efficiency-exit cap restore now uses `effectiveCachedProjectViews` (RAM-tiered, E2E-aware) instead of a hardcoded fallback of 1 that would re-clamp on machines without a stored preference.

## Testing

- Added `setVisible` to `ProjectViewManager` mock factories.
- New ordering tests for park/unpark sequence.
- Retargeted profile clamp and cap-tier expectations to match the new logic.
- All affected suites pass (332 tests). Prettier and ESLint clean on changed files.