### PR TITLE
fix(pty): bound background coalesce deferral so backgrounded agents don't show 'waiting'

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -201,6 +201,10 @@ export class TerminalProcess {
   private _backgroundQueuedBytes = 0;
   private _backgroundDrainTimer: NodeJS.Timeout | null = null;
   private _backgroundDrainDeadline = 0;
+  // Wall-clock time the current batch started accumulating (queue empty→nonempty);
+  // 0 while the queue is empty. Drives the COALESCE_MAX_DEFER_MS hard ceiling,
+  // independent of the self-rearming soft deadline above.
+  private _backgroundOldestQueuedAt = 0;
   private _backgroundDrainIntervalMs = 500;
   // Force a drain if a backgrounded terminal accumulates this much un-parsed
   // output, bounding queue memory for noisy agents that never pause (mirrors the
@@ -208,6 +212,19 @@ export class TerminalProcess {
   // units (string .length), not bytes — multi-byte output can hold up to ~3× the
   // nominal cap, which is harmless: draining late only delays, never corrupts.
   private readonly COALESCE_MAX_BYTES = 256 * 1024;
+  // Hard ceiling on how long output may sit un-parsed during SUSTAINED background
+  // output. The soft drain deadline (_armBackgroundDrain) is pushed forward by
+  // every chunk, so an agent emitting faster than the drain interval would never
+  // drain — starving activityMonitor.onData and the headless VT write. That
+  // freezes the ActivityMonitor's lastActivityTimestamp (refreshed only when the
+  // polled headless viewport changes) and trips its 8s idle gate, misclassifying
+  // a working backgrounded agent as "waiting" (#10744 regression). This bound
+  // forces a drain every ≤1s so the same change-detection path that keeps
+  // foreground agents "working" keeps running for backgrounded ones — well under
+  // the 8s gate, while still cutting parse frequency ~20× vs the 50ms foreground
+  // cadence. It bounds demotion starvation; it is not meant to preserve every
+  // sub-second idle→busy recovery nuance (recovery runs on the drain itself).
+  private readonly COALESCE_MAX_DEFER_MS = 1000;
   private _restoreBannerStart: IMarker | null = null;
   private _restoreBannerEnd: IMarker | null = null;
   private readonly textDecoder = new TextDecoder();
@@ -1790,6 +1807,9 @@ export class TerminalProcess {
     // VT parser is stateful and chunk-boundary-safe, so feeding the concatenated
     // batch yields identical headless grid state.
     if (this._activityTier === "background") {
+      if (this._backgroundChunkQueue.length === 0) {
+        this._backgroundOldestQueuedAt = now;
+      }
       this._backgroundChunkQueue.push(data);
       this._backgroundQueuedBytes += data.length;
       if (this._backgroundQueuedBytes >= this.COALESCE_MAX_BYTES) {
@@ -1886,28 +1906,34 @@ export class TerminalProcess {
   /**
    * Single self-rearming background drain timer (deadline-timestamp pattern from
    * #8150 — avoids O(N) clear/set churn per chunk). Each incoming chunk pushes
-   * the deadline forward; the timer reschedules itself until output settles, so
-   * a sustained burst drains once it quiets rather than mid-burst. The
-   * COALESCE_MAX_BYTES cap in handlePtyData bounds memory for output that never
-   * pauses.
+   * the soft deadline forward; the timer reschedules itself until output settles,
+   * so a sustained burst drains once it quiets rather than mid-burst. Two caps
+   * bound that deferral: COALESCE_MAX_BYTES (memory) in handlePtyData, and
+   * COALESCE_MAX_DEFER_MS (latency) in _onBackgroundDrainTimer, so output that
+   * never pauses still drains — keeping the agent-state clock fresh (#10744).
    */
   private _armBackgroundDrain(): void {
     this._backgroundDrainDeadline = Date.now() + this._backgroundDrainIntervalMs;
     if (this._backgroundDrainTimer) {
       return;
     }
-    this._backgroundDrainTimer = setTimeout(
-      () => this._onBackgroundDrainTimer(),
-      this._backgroundDrainIntervalMs
-    );
+    // Never let the first fire wait past the hard ceiling, so the cap holds even
+    // if a future tier sets a drain interval larger than COALESCE_MAX_DEFER_MS.
+    const wait = Math.min(this._backgroundDrainIntervalMs, this.COALESCE_MAX_DEFER_MS);
+    this._backgroundDrainTimer = setTimeout(() => this._onBackgroundDrainTimer(), wait);
   }
 
   private _onBackgroundDrainTimer(): void {
-    const remaining = this._backgroundDrainDeadline - Date.now();
-    if (remaining > 0) {
-      // A chunk arrived after this timer was armed and pushed the deadline out;
-      // reschedule for the remaining window so the burst batches optimally.
-      this._backgroundDrainTimer = setTimeout(() => this._onBackgroundDrainTimer(), remaining);
+    const now = Date.now();
+    const remaining = this._backgroundDrainDeadline - now;
+    const deferredFor = now - this._backgroundOldestQueuedAt;
+    if (remaining > 0 && deferredFor < this.COALESCE_MAX_DEFER_MS) {
+      // A chunk arrived after this timer was armed and pushed the soft deadline
+      // out; reschedule for the remaining window so the burst batches optimally —
+      // but never wait past the hard ceiling, so sustained output can't starve
+      // the parse pipeline (and the agent-state clock riding on it) (#10744).
+      const wait = Math.min(remaining, this.COALESCE_MAX_DEFER_MS - deferredFor);
+      this._backgroundDrainTimer = setTimeout(() => this._onBackgroundDrainTimer(), wait);
       return;
     }
     this._backgroundDrainTimer = null;
@@ -1926,6 +1952,7 @@ export class TerminalProcess {
       this._backgroundDrainTimer = null;
     }
     this._backgroundDrainDeadline = 0;
+    this._backgroundOldestQueuedAt = 0;
     if (this._backgroundChunkQueue.length === 0) {
       this._backgroundQueuedBytes = 0;
       return;
@@ -1952,6 +1979,7 @@ export class TerminalProcess {
       this._backgroundDrainTimer = null;
     }
     this._backgroundDrainDeadline = 0;
+    this._backgroundOldestQueuedAt = 0;
     this._backgroundChunkQueue = [];
     this._backgroundQueuedBytes = 0;
   }

--- a/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.backgroundCoalescing.test.ts
@@ -185,6 +185,70 @@ describe("TerminalProcess background output coalescing", () => {
     terminal.dispose();
   });
 
+  it("forces a drain within the latency ceiling during sustained background output, every cycle (#10744)", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    terminal.setActivityMonitorTier("background", 500);
+
+    // Cycle 1 — chunks every 200ms, faster than the 500ms soft drain interval, so
+    // each chunk pushes the self-rearming deadline forward and the queue would
+    // never drain while output flows. That starved activityMonitor.onData and the
+    // headless VT write, freezing the ActivityMonitor's lastActivityTimestamp
+    // until its 8s idle gate flipped a working backgrounded agent to "waiting"
+    // (#10744 regression). COALESCE_MAX_DEFER_MS (1000ms) must force a drain.
+    ptyOnDataCallback!("c0");
+    for (let i = 1; i <= 4; i++) {
+      vi.advanceTimersByTime(200);
+      ptyOnDataCallback!(`c${i}`);
+    }
+    // ~800ms in, still under the ceiling: no forced drain yet.
+    expect(emitData).not.toHaveBeenCalled();
+
+    // Crossing the 1000ms ceiling must drain MID-BURST — pre-fix "drain only once
+    // output quiets" would never fire while chunks keep arriving sub-interval.
+    vi.advanceTimersByTime(200);
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenLastCalledWith("t1", "c0c1c2c3c4");
+
+    // Cycle 2 — the window must RESET after the drain (_backgroundOldestQueuedAt
+    // back to 0, timer re-armed), so a fresh sustained burst drains within its OWN
+    // ceiling rather than riding the previous window or never re-arming.
+    ptyOnDataCallback!("c5");
+    for (let i = 6; i <= 9; i++) {
+      vi.advanceTimersByTime(200);
+      ptyOnDataCallback!(`c${i}`);
+    }
+    expect(emitData).toHaveBeenCalledTimes(1); // still only cycle 1's drain
+
+    vi.advanceTimersByTime(200);
+    expect(emitData).toHaveBeenCalledTimes(2);
+    expect(emitData).toHaveBeenLastCalledWith("t1", "c5c6c7c8c9");
+
+    terminal.dispose();
+  });
+
+  it("keeps the latency ceiling hard when the background poll interval exceeds it", () => {
+    const emitData = vi.fn();
+    const terminal = createTerminal(emitData);
+
+    // A future tier could pass a drain interval larger than the 1000ms ceiling.
+    // The min(interval, cap) on both the initial arm and the reschedule must still
+    // force a drain by ~1000ms instead of waiting out the 2500ms soft interval.
+    terminal.setActivityMonitorTier("background", 2500);
+
+    ptyOnDataCallback!("a");
+    vi.advanceTimersByTime(400);
+    ptyOnDataCallback!("b"); // output still flowing; soft deadline pushed to ~2900ms
+    expect(emitData).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(700); // reach ~1100ms, past the 1000ms ceiling
+    expect(emitData).toHaveBeenCalledTimes(1);
+    expect(emitData).toHaveBeenCalledWith("t1", "ab");
+
+    terminal.dispose();
+  });
+
   it("drains while still on the background tier before flipping to active", () => {
     const seenTierAtDrain: Array<"active" | "background"> = [];
     // emitData reads `terminal` lazily — only when the pipeline drains, well


### PR DESCRIPTION
## Problem

After the 2026-06-23 perf merges, every agent terminal in a **backgrounded** project/worktree showed up as **"waiting"** within ~8s — even while the agent was actively working. It looked like background monitoring had stopped.

## Root cause

The background output coalescing from #10744 (`bfcdb0c1b`) defers the parse pipeline (`activityMonitor.onData` + the headless xterm VT write + renderer fan-out) for backgrounded terminals into a self-rearming drain timer. That timer pushes its deadline forward on **every** chunk, so it only fires once output goes quiet (~500ms) or 256KB accumulates.

An agent producing **continuous** output (chunks closer together than the drain interval) therefore never drains. `activityMonitor.onData` and the headless write get starved, so the ActivityMonitor's `lastActivityTimestamp` — which for agent terminals is refreshed only when the polled headless viewport content changes — goes stale. After 8s the idle gate (`now - lastActivityTimestamp >= IDLE_DEBOUNCE_MS`) flips `busy → idle`, and the FSM maps that to `working → waiting`.

The per-chunk OSC 9;4 heartbeat the commit kept only covers Claude Code v2.0.56+ (state 1/3); Gemini, Codex, older Claude, and plain shells emit none — so the universal liveness signal (output → `onData`) was the one left behind the timer. Hence *all* backgrounded agents.

## Fix

Bound the deferral with a hard latency ceiling, `COALESCE_MAX_DEFER_MS = 1000`. The queue now drains at least every ~1s during sustained output regardless of incoming-chunk cadence (tracked via `_backgroundOldestQueuedAt`), so the same change-detection path that keeps foreground agents "working" keeps running for backgrounded ones — well under the 8s gate, while still cutting parse frequency ~20× vs the 50ms foreground cadence.

This reuses the existing detection pipeline rather than adding a parallel liveness clock. Two alternatives — a per-chunk liveness refresh and backing the idle gate with `terminal.lastOutputTime` — were deliberately **not** taken: both refresh on unfiltered bytes (cosmetic redraws, CPR/DSR, OSC titles) that `stripIdleTerminalSequences` exists to drop, which would pin agents falsely "working" — the inverse bug.

Details:
- New `_backgroundOldestQueuedAt`, set when the queue goes empty → non-empty, reset in both `_drainBackgroundQueue` and `_cancelBackgroundQueue`.
- `_onBackgroundDrainTimer` reschedules only while `remaining > 0 && deferredFor < cap`, waiting `min(remaining, cap - deferredFor)`; otherwise it drains.
- `min(interval, cap)` on the initial arm so the ceiling stays hard even if a future tier passes a drain interval larger than the cap.
- The 256KB byte cap still drains inline; foreground activation and teardown paths are unchanged.

## Testing

- New regression test: sustained sub-interval background output drains mid-burst within the ceiling, across two cycles (proves the window resets and the timer re-arms). Fails on the pre-fix code.
- New test: the ceiling holds even when the background poll interval (2500ms) exceeds it.
- Local: electron typecheck, lint, format clean; 1267 PTY + agent-state unit tests pass.
