### PR TITLE
fix(terminal): warm project switch-back reveal correctness

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -148,6 +148,7 @@ export const CHANNELS = {
   APP_VIEW_PAINTED: "app:view-painted",
   APP_VIEW_WARM_PAINTED: "app:view-warm-painted",
   APP_VIEW_REVEALED: "app:view-revealed",
+  APP_VIEW_CACHED: "app:view-cached",
   APP_DISMISS_ROSETTA_WARNING: "app:dismiss-rosetta-warning",
   MENU_ACTION: "menu:action",
   MENU_SHOW_CONTEXT: "menu:show-context",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1441,6 +1441,7 @@ function buildElectronApi(): ElectronAPI {
       onConfigReloaded: (callback: () => void) => _typedOn(CHANNELS.APP_CONFIG_RELOADED, callback),
 
       onViewRevealed: (callback: () => void) => _typedOn(CHANNELS.APP_VIEW_REVEALED, callback),
+      onViewCached: (callback: () => void) => _typedOn(CHANNELS.APP_VIEW_CACHED, callback),
     },
 
     menu: buildMenuPreloadBindings(_unwrappingInvoke),

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -705,6 +705,10 @@ export class ProjectViewManager {
         }
         previousEntry.state = "active";
         previousEntry.lastUsed = Date.now();
+        // Re-fire the view-ready hook so per-view IPC helpers re-bind to the
+        // rolled-back active view, matching the load/reload path that normally
+        // fires it for the active view.
+        this.onViewReady?.(previousEntry.view.webContents);
       } else if (unboundOutgoingView && !unboundOutgoingView.webContents.isDestroyed()) {
         // Same rollback requirement for first-run/unbound windows: the visible
         // welcome view is not a project entry, but IPC helpers still need
@@ -1184,6 +1188,16 @@ export class ProjectViewManager {
       // Mark cached so visible-only broadcasts (log batches) skip this
       // renderer — pushed messages have no backpressure once throttled/frozen.
       registerCachedViewWebContents(current.view.webContents);
+      // Tell the renderer it's being cached so it cancels any in-flight wake/
+      // repaint rAFs and reveal backstops scheduled for the view it's leaving —
+      // otherwise those fire against a now-occluded/frozen view, or survive to
+      // run stale work on the next reactivation. Sent before the CPU throttle so
+      // the renderer can still process it.
+      try {
+        current.view.webContents.send(CHANNELS.APP_VIEW_CACHED);
+      } catch {
+        // ignore — a destroyed/closing renderer has nothing to cancel
+      }
       // Close live producer ports BEFORE applying CPU throttle. Once throttled,
       // Chromium can freeze the renderer after ~5 min hidden or under memory
       // pressure; any messages still posted by main/utility processes

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -2001,12 +2001,21 @@ export class ProjectViewManager {
 
     const onSpawnResult = () => void seed();
     const onHostCrash = () => void seed();
+    // Drop a terminal from the freeze-seed maps when it exits, so a dead
+    // terminal can't leave a stale project/agent-state entry that keeps
+    // hasActiveAgent() reporting a phantom active agent for its project.
+    const onTerminalExit = (id: string) => {
+      this.projectByTerminal.delete(id);
+      this.agentStateByTerminal.delete(id);
+    };
     ptyClient.on("spawn-result", onSpawnResult);
     ptyClient.on("host-crash", onHostCrash);
+    ptyClient.on("exit", onTerminalExit);
 
     this.agentCacheCleanup.push(offStateChanged);
     this.agentCacheCleanup.push(() => ptyClient.off("spawn-result", onSpawnResult));
     this.agentCacheCleanup.push(() => ptyClient.off("host-crash", onHostCrash));
+    this.agentCacheCleanup.push(() => ptyClient.off("exit", onTerminalExit));
 
     return seed();
   }

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -517,6 +517,37 @@ describe("ProjectViewManager — efficiency freeze", () => {
     expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(initialWc);
     manager.dispose();
   });
+
+  it("drops a terminal from the freeze-seed maps when it exits", async () => {
+    const captured: Record<string, (...a: unknown[]) => void> = {};
+    const ptyClient = {
+      getAllTerminalsAsync: vi.fn(async () => [
+        { id: "t1", projectId: "proj-a", agentState: "working" },
+      ]),
+      on: vi.fn((evt: string, h: (...a: unknown[]) => void) => {
+        captured[evt] = h;
+      }),
+      off: vi.fn(),
+    };
+    await manager.initAgentStateCache(ptyClient as never);
+
+    const priv = manager as unknown as {
+      projectByTerminal: Map<string, string>;
+      agentStateByTerminal: Map<string, string>;
+    };
+    // Seed populates projectByTerminal; set the agent-state entry explicitly so
+    // the test pins the exit handler's cleanup of BOTH maps.
+    priv.agentStateByTerminal.set("t1", "working");
+    expect(priv.projectByTerminal.has("t1")).toBe(true);
+
+    // The terminal exits → its now-stale entries must be dropped so a dead
+    // terminal can't keep hasActiveAgent() reporting a phantom active agent.
+    captured["exit"]?.("t1", 0);
+
+    expect(priv.projectByTerminal.has("t1")).toBe(false);
+    expect(priv.agentStateByTerminal.has("t1")).toBe(false);
+    manager.dispose();
+  });
 });
 
 describe("ProjectViewManager — memory sampler jitter", () => {

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -194,6 +194,7 @@ import { ProjectViewManager } from "../ProjectViewManager.js";
 import { logInfo, logWarn } from "../../utils/logger.js";
 import { registerAppView } from "../webContentsRegistry.js";
 import { unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
+import { CHANNELS } from "../../ipc/channels.js";
 
 function createMockWindow() {
   const children: unknown[] = [];
@@ -831,4 +832,20 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     expect(typeof payload.loadToPaintMs).toBe("number");
     expect(payload.loadToPaintMs).toBeGreaterThanOrEqual(0);
   });
+
+  it("notifies a view it is being cached so the renderer can cancel reveal work", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    // The outgoing project-a view was cached → its renderer is told so it can
+    // cancel any in-flight wake/repaint rAFs before being throttled/frozen.
+    expect(initialWc.send).toHaveBeenCalledWith(CHANNELS.APP_VIEW_CACHED);
+  });
+
 });

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -847,5 +847,4 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     // cancel any in-flight wake/repaint rAFs before being throttled/frozen.
     expect(initialWc.send).toHaveBeenCalledWith(CHANNELS.APP_VIEW_CACHED);
   });
-
 });

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -437,6 +437,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * visibilitychange/resume ran while the view was still occluded.
      */
     onViewRevealed(callback: () => void): () => void;
+    onViewCached(callback: () => void): () => void;
   };
   // menu is generated — see GeneratedElectronAPI.
   logs: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1804,6 +1804,7 @@ export interface IpcEventMap {
   // visibilitychange/resume ran while the view was still occluded, where
   // Chromium culls the paint, so it can fail to stick until the user clicks.
   "app:view-revealed": void;
+  "app:view-cached": void;
 
   // Privacy events
   "privacy:telemetry-consent-changed": {

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -840,6 +840,21 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     });
     if (offViewRevealed) cleanups.push(offViewRevealed);
 
+    const offViewCached = window.electron?.app?.onViewCached?.(() => {
+      clearRevealBackstops();
+      if (wakeRafId !== null) {
+        cancelAnimationFrame(wakeRafId);
+        wakeRafId = null;
+        wakePending = false;
+      }
+      if (repaintRafId !== null) {
+        cancelAnimationFrame(repaintRafId);
+        repaintRafId = null;
+        repaintPending = false;
+      }
+    });
+    if (offViewCached) cleanups.push(offViewCached);
+
     // Missed-event guard: if the view is already visible by the time this
     // listener installs (fast cached reactivation), the visibilitychange
     // event has already fired (#4935). Worktree state is fetched via the

--- a/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
 }));
 
 let viewRevealedCb: (() => void) | null = null;
+let viewCachedCb: (() => void) | null = null;
 
 vi.mock("@/lib/notify", () => ({ notify: vi.fn(() => "notif-id") }));
 vi.mock("@/services/ActionService", () => ({ actionService: { dispatch: vi.fn() } }));
@@ -41,6 +42,7 @@ beforeEach(() => {
   wakeMock.mockClear();
   repaintMock.mockClear();
   viewRevealedCb = null;
+  viewCachedCb = null;
   globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
     const id = ++rafIdCounter;
     rafQueue.set(id, cb);
@@ -72,6 +74,12 @@ beforeEach(() => {
         viewRevealedCb = cb;
         return () => {
           viewRevealedCb = null;
+        };
+      },
+      onViewCached: (cb: () => void) => {
+        viewCachedCb = cb;
+        return () => {
+          viewCachedCb = null;
         };
       },
     },
@@ -152,6 +160,27 @@ describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
     act(() => viewRevealedCb?.());
     act(() => flushFrame());
     setVisibilityState("hidden");
+    act(() => flushFrame());
+
+    expect(repaintMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending post-reveal repaint when the view is cached (switched away)", async () => {
+    await renderProvider();
+    act(() => flushFrame());
+    act(() => flushFrame());
+    repaintMock.mockClear();
+    expect(viewCachedCb).not.toBeNull();
+
+    // Schedule a repaint; it parks on the gate's second frame.
+    act(() => viewRevealedCb?.());
+    act(() => flushFrame());
+    expect(repaintMock).not.toHaveBeenCalled();
+
+    // The view is cached (project switched away) before the second frame — the
+    // pending repaint rAF must be cancelled so it can't fire against the now
+    // occluded/about-to-freeze view.
+    act(() => viewCachedCb?.());
     act(() => flushFrame());
 
     expect(repaintMock).not.toHaveBeenCalled();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -346,7 +346,7 @@ class TerminalInstanceService {
       hasInFlightWake: (id) => this.wakeManager.hasInFlightWake(id),
       hasPendingWake: (id) => this.wakeManager.hasPendingWake(id),
       isWebGLActive: (id) => this.webGLManager.isActive(id),
-      shouldHaveWebGL: (managed) => this.shouldRestoreWebGL(managed),
+      shouldHaveWebGL: (managed) => this.shouldHaveActiveWebGL(managed),
       ensureWebGL: (id, managed) => this.webGLManager.ensureContext(id, managed),
       unhibernate: (id) => this.unhibernate(id),
       forceReflow: (element) => forceXtermReflow(element),
@@ -564,6 +564,26 @@ class TerminalInstanceService {
     if (managed.isAttaching) return false;
     if (managed.isHibernated) return false;
     return this.wantsWebGLAtTier(managed, managed.lastAppliedTier ?? managed.getRefreshTier?.());
+  }
+
+  /**
+   * Watchdog-only WebGL eligibility. Identical to {@link shouldRestoreWebGL} but
+   * additionally false for a non-pinned pane in DOM-mode fallback: in DOM mode
+   * the manager only ever attaches the single focus-pinned context, so a
+   * non-pinned pane's context can never become active. Without this the
+   * watchdog's `shouldHaveWebGL && !isWebGLActive` stays permanently true for
+   * every non-pinned agent pane and burns a heavy-repair slot every tick (plus a
+   * spurious "context missing" warning). The reveal / visibility restore paths
+   * deliberately keep using {@link shouldRestoreWebGL} so they still call
+   * `ensureContext` and keep the pane in the manager's `wants` set — which is
+   * what lets a later focus change pin and attach it immediately.
+   */
+  private shouldHaveActiveWebGL(managed: ManagedTerminal): boolean {
+    if (!this.shouldRestoreWebGL(managed)) return false;
+    if (this.webGLManager.getMode() === "dom" && managed.id !== this.webGLManager.getPinnedId()) {
+      return false;
+    }
+    return true;
   }
 
   private onUserInput(id: string, data: string): void {
@@ -1505,6 +1525,7 @@ class TerminalInstanceService {
     const kind = "terminal" as const;
 
     const managed: ManagedTerminal = {
+      id,
       terminal,
       kind,
       launchAgentId,

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -899,7 +899,7 @@ class TerminalInstanceService {
 
       instance.isResizeSuppressed = true;
       instance.resizeSuppressionEndTime = Date.now() + durationMs;
-      this.resizeController.lockResize(id, true);
+      this.resizeController.lockResize(id, true, durationMs);
 
       instance.resizeSuppressionTimer = window.setTimeout(() => {
         // Re-fetch: the instance can be disposed/replaced between arming and

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -535,7 +535,8 @@ class TerminalInstanceService {
    */
   private wantsWebGLAtTier(
     managed: ManagedTerminal,
-    tier: TerminalRefreshTier | undefined
+    tier: TerminalRefreshTier | undefined,
+    opts?: { trustDomVisibility?: boolean }
   ): boolean {
     if (!isWebGLEligibleTier(tier)) return false;
     // Visibility gates every case: an off-screen pane never wants WebGL, even
@@ -543,8 +544,11 @@ class TerminalInstanceService {
     // so hidden streaming agents would otherwise accumulate wants and trip the
     // count-based mode switch, dropping the whole visible fleet to DOM
     // (#10671). The reveal path (setVisible(true) → debounced shouldRestoreWebGL
-    // → ensureContext) re-acquires the want once the pane is on-screen again.
-    if (!managed.isVisible) return false;
+    // → ensureContext) re-acquires the want once the pane is on-screen again —
+    // and on a warm WebContentsView resume it passes trustDomVisibility because
+    // it has already proven the pane on-screen from DOM truth, so the stale
+    // reactive isVisible flag must not veto the want there.
+    if (!opts?.trustDomVisibility && !managed.isVisible) return false;
     if (managed.runtimeAgentId) return true;
     return (
       tier === TerminalRefreshTier.FOCUSED ||
@@ -558,12 +562,25 @@ class TerminalInstanceService {
    * (opened, not attaching, not hibernated). Used by the debounced timer in
    * setVisible() before re-acquiring a context.
    */
-  private shouldRestoreWebGL(managed: ManagedTerminal): boolean {
+  private shouldRestoreWebGL(
+    managed: ManagedTerminal,
+    opts?: { trustDomVisibility?: boolean }
+  ): boolean {
     if (!managed.isOpened) return false;
-    if (!managed.isVisible) return false;
+    // The reveal path proves visibility from DOM ground truth (isConnected +
+    // checkVisibility + box) before calling, because the reactive isVisible flag
+    // can be stale-false on a warm WebContentsView resume (#10632 item 4). Trust
+    // that here so a dropped WebGL context is reattached on reveal instead of
+    // leaving the pane on the DOM renderer until the ~3s watchdog (which is
+    // itself suppressed for the first ~5s by the project-switch resize lock).
+    if (!opts?.trustDomVisibility && !managed.isVisible) return false;
     if (managed.isAttaching) return false;
     if (managed.isHibernated) return false;
-    return this.wantsWebGLAtTier(managed, managed.lastAppliedTier ?? managed.getRefreshTier?.());
+    return this.wantsWebGLAtTier(
+      managed,
+      managed.lastAppliedTier ?? managed.getRefreshTier?.(),
+      opts
+    );
   }
 
   /**
@@ -1192,7 +1209,7 @@ class TerminalInstanceService {
    * mirror sync already ran behind the bridge (IPC data is not culled like a
    * paint is), so only the repaint needs replaying.
    */
-  repaintForReveal(id: string): boolean {
+  repaintForReveal(id: string, opts?: { trustDomVisibility?: boolean }): boolean {
     const managed = this.instances.get(id);
     if (!managed || managed.isHibernated) return false;
     // Health-check on DOM ground truth (isConnected + checkVisibility + size),
@@ -1234,8 +1251,13 @@ class TerminalInstanceService {
     if (managed.terminal.modes?.synchronizedOutputMode === true) return false;
 
     // Re-attach a WebGL context the freeze/thaw cycle may have dropped before
-    // repairing the local model. Same idiom as the post-reparent restore.
-    if (!this.webGLManager.isActive(id) && this.shouldRestoreWebGL(managed)) {
+    // repairing the local model. The warm view-reveal caller (revealTerminal)
+    // passes trustDomVisibility so a stale reactive isVisible=false on warm
+    // WebContentsView resume doesn't skip the reattach and strand non-focused
+    // agent panes on the DOM renderer. Assistant show/hide-transition callers
+    // pass nothing, so they keep the isVisible gate — a transform-hidden pane
+    // must not accumulate a fleet-wide WebGL want (#10671).
+    if (!this.webGLManager.isActive(id) && this.shouldRestoreWebGL(managed, opts)) {
       this.webGLManager.ensureContext(id, managed);
     }
 
@@ -1385,7 +1407,11 @@ class TerminalInstanceService {
           after.pendingVisibilityWake !== true)
       );
     }
-    return this.repaintForReveal(id);
+    // The warm view-reveal sweep has confirmed the foreground view is presented,
+    // so trust DOM-truth visibility for the WebGL reattach — the reactive
+    // isVisible flag is stale-false on a warm resume. Assistant-transition
+    // callers of repaintForReveal deliberately do NOT trust it.
+    return this.repaintForReveal(id, { trustDomVisibility: true });
   }
 
   /**

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -80,6 +80,12 @@ export class TerminalResizeController {
       this.resizeLocks.set(id, Date.now() + ttl);
     } else {
       this.resizeLocks.delete(id);
+      const managed = this.deps.getInstance(id);
+      if (managed && managed.pendingBackgroundResize) {
+        const { width, height } = managed.pendingBackgroundResize;
+        managed.pendingBackgroundResize = undefined;
+        this.resizePtyOnly(id, width, height);
+      }
     }
   }
 
@@ -264,7 +270,10 @@ export class TerminalResizeController {
     }
     const managed = this.deps.getInstance(id);
     if (!managed) return null;
-    if (this.isResizeLocked(id)) return null;
+    if (this.isResizeLocked(id)) {
+      managed.pendingBackgroundResize = { width, height };
+      return null;
+    }
     if (Math.abs(managed.lastWidth - width) < 1 && Math.abs(managed.lastHeight - height) < 1) {
       return null;
     }

--- a/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.batchResize.test.ts
@@ -95,6 +95,7 @@ function makeManaged(fixture: ManagedFixture): ManagedTerminal {
   }
 
   return {
+    id: fixture.id,
     terminal: {
       element: termEl,
       modes: { synchronizedOutputMode: false },

--- a/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fullWake.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -105,6 +106,8 @@ type FullWakeTestService = {
   webGLManager: {
     repairAtlasForReactivation: (id: string) => boolean;
     isActive: (id: string) => boolean;
+    getMode: () => "webgl" | "dom";
+    ensureContext: (id: string, managed: ManagedTerminalMock) => void;
   };
   handlePostWake: (id: string) => void;
   setVisible: (id: string, isVisible: boolean, expectedGeneration?: number) => void;
@@ -114,7 +117,7 @@ type FullWakeTestService = {
   ensureDeferredAddons: (id: string, managed: ManagedTerminalMock) => void;
   wantsWebGLAtTier: (managed: ManagedTerminalMock, tier: number | undefined) => boolean;
   fullWakeForVisibilityRestore: (id: string) => Promise<void>;
-  repaintForReveal: (id: string) => boolean;
+  repaintForReveal: (id: string, opts?: { trustDomVisibility?: boolean }) => boolean;
   revealTerminal: (id: string) => Promise<boolean>;
   notifyAttachSettledWaiters: (id: string) => void;
 };
@@ -775,7 +778,7 @@ describe("TerminalInstanceService.revealTerminal (foreground reveal routing)", (
 
     await expect(service.revealTerminal(id)).resolves.toBe(true);
 
-    expect(repaint).toHaveBeenCalledWith(id);
+    expect(repaint).toHaveBeenCalledWith(id, { trustDomVisibility: true });
     expect(fullWake).not.toHaveBeenCalled();
   });
 
@@ -909,6 +912,52 @@ describe("TerminalInstanceService.repaintForReveal grid reconcile", () => {
     // that fixes garbled wrapping and that the old handlePostWake path could not
     // perform under the project-switch resize lock.
     expect(reconcile).toHaveBeenCalledWith(id);
+  });
+
+  function staleVisibleAgentInstance(): ManagedTerminalMock {
+    const element = document.createElement("div");
+    document.body.appendChild(element);
+    return makeInstance({
+      isOpened: true,
+      isHibernated: false,
+      isVisible: false, // stale on a warm WebContentsView resume (#10632 item 4)
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      hostElement: renderableHost(), // DOM truth: the pane IS on-screen
+      terminal: { cols: 80, rows: 24, element, refresh: vi.fn() },
+    });
+  }
+
+  it("reattaches a dropped WebGL context on a warm reveal even when isVisible is stale-false (W1)", () => {
+    const id = "repaint-w1";
+    service.instances.set(id, staleVisibleAgentInstance());
+
+    vi.spyOn(service.webGLManager, "isActive").mockReturnValue(false); // context dropped on freeze
+    vi.spyOn(service.webGLManager, "getMode").mockReturnValue("webgl");
+    const ensure = vi.spyOn(service.webGLManager, "ensureContext").mockImplementation(() => {});
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    vi.spyOn(service.resizeController, "reconcileGeometryFresh").mockReturnValue(true);
+
+    // The warm reveal path trusts DOM truth → reattaches despite the stale flag,
+    // instead of stranding the pane on the DOM renderer until the watchdog.
+    expect(service.repaintForReveal(id, { trustDomVisibility: true })).toBe(true);
+    expect(ensure).toHaveBeenCalledWith(id, service.instances.get(id));
+  });
+
+  it("does NOT reattach WebGL on a non-reveal repaint with a stale isVisible=false (assistant transition)", () => {
+    const id = "repaint-noassist";
+    service.instances.set(id, staleVisibleAgentInstance());
+
+    vi.spyOn(service.webGLManager, "isActive").mockReturnValue(false);
+    vi.spyOn(service.webGLManager, "getMode").mockReturnValue("webgl");
+    const ensure = vi.spyOn(service.webGLManager, "ensureContext").mockImplementation(() => {});
+    vi.spyOn(service.webGLManager, "repairAtlasForReactivation").mockReturnValue(true);
+    vi.spyOn(service.resizeController, "reconcileGeometryFresh").mockReturnValue(true);
+
+    // No trust (the assistant show/hide-transition callers): the isVisible gate
+    // holds, so a transform-hidden pane can't accumulate a fleet-wide WebGL want
+    // and trip the count-based DOM flip (#10671 / Codex review of W1).
+    expect(service.repaintForReveal(id)).toBe(true);
+    expect(ensure).not.toHaveBeenCalled();
   });
 
   it("reports not-paintable (retry) when the fresh reconcile finds no measurable box", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.resizePass.test.ts
@@ -64,7 +64,7 @@ type PanelStoreModule = {
   };
 };
 
-function makeManaged(visible = true): ManagedTerminal {
+function makeManaged(visible = true, id = "term"): ManagedTerminal {
   const hostElement = document.createElement("div");
   const termEl = document.createElement("div");
   hostElement.appendChild(termEl);
@@ -84,6 +84,7 @@ function makeManaged(visible = true): ManagedTerminal {
   document.body.appendChild(hostElement);
 
   return {
+    id,
     terminal: {
       element: termEl,
       modes: { synchronizedOutputMode: false },

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -695,4 +695,29 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
       expect(callShouldHaveActive(managed)).toBe(true);
     });
   });
+
+  describe("shouldRestoreWebGL — trust DOM visibility on reveal (W1)", () => {
+    function callShouldRestore(managed: unknown, opts?: { trustDomVisibility?: boolean }): boolean {
+      return (
+        service as unknown as {
+          shouldRestoreWebGL: (m: unknown, o?: { trustDomVisibility?: boolean }) => boolean;
+        }
+      ).shouldRestoreWebGL(managed, opts);
+    }
+
+    it("withholds restore for a stale isVisible=false pane by default", () => {
+      const managed = makeMockManaged({ id: "t1", isVisible: false });
+      expect(callShouldRestore(managed)).toBe(false);
+    });
+
+    it("restores a stale isVisible=false pane when DOM truth is trusted (reveal path)", () => {
+      const managed = makeMockManaged({ id: "t1", isVisible: false });
+      // repaintForReveal proves the pane on-screen from DOM truth before it
+      // reattaches WebGL, so a stale reactive isVisible=false must not veto the
+      // want — otherwise non-focused agent panes sit on the DOM renderer (mangled
+      // block glyphs) until the watchdog heals (#10632 item 4 / W1). The guard is
+      // threaded through wantsWebGLAtTier, which gates on isVisible too.
+      expect(callShouldRestore(managed, { trustDomVisibility: true })).toBe(true);
+    });
+  });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -61,6 +61,7 @@ type WebGLVisibilityService = {
     ensureContext: (id: string, managed: unknown) => void;
     releaseContext: (id: string) => void;
     getMode: () => "webgl" | "dom";
+    getPinnedId: () => string | null;
     getWantsSize: () => number;
   };
 };
@@ -643,5 +644,55 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     service.setVisible("t1", true);
     vi.advanceTimersByTime(100);
     expect(service.webGLManager.isActive("t1")).toBe(true);
+  });
+
+  describe("WebGL DOM-mode fallback eligibility (W3)", () => {
+    function callShouldRestore(managed: unknown): boolean {
+      return (
+        service as unknown as { shouldRestoreWebGL: (m: unknown) => boolean }
+      ).shouldRestoreWebGL(managed);
+    }
+    function callShouldHaveActive(managed: unknown): boolean {
+      return (
+        service as unknown as { shouldHaveActiveWebGL: (m: unknown) => boolean }
+      ).shouldHaveActiveWebGL(managed);
+    }
+
+    it("keeps a non-pinned DOM pane RESTORE-eligible so it stays in the manager's wants set", () => {
+      vi.spyOn(service.webGLManager, "getMode").mockReturnValue("dom");
+      vi.spyOn(service.webGLManager, "getPinnedId").mockReturnValue("pinned-other");
+      const managed = makeMockManaged({ id: "t1" });
+
+      // The reveal/visibility restore path must still call ensureContext for this
+      // pane — that keeps it in `wants`, so a later focus change can pin+attach it
+      // immediately instead of waiting on the watchdog.
+      expect(callShouldRestore(managed)).toBe(true);
+    });
+
+    it("withholds WATCHDOG repair for a non-pinned pane while in DOM-mode fallback", () => {
+      vi.spyOn(service.webGLManager, "getMode").mockReturnValue("dom");
+      vi.spyOn(service.webGLManager, "getPinnedId").mockReturnValue("pinned-other");
+      const managed = makeMockManaged({ id: "t1" });
+
+      // In DOM mode the manager only ever attaches the pinned pane; the watchdog
+      // must not burn a heavy-repair slot retrying a context it will never get.
+      expect(callShouldHaveActive(managed)).toBe(false);
+    });
+
+    it("still repairs the focus-pinned pane while in DOM-mode fallback", () => {
+      vi.spyOn(service.webGLManager, "getMode").mockReturnValue("dom");
+      vi.spyOn(service.webGLManager, "getPinnedId").mockReturnValue("t1");
+      const managed = makeMockManaged({ id: "t1" });
+
+      expect(callShouldHaveActive(managed)).toBe(true);
+    });
+
+    it("does not withhold watchdog repair outside DOM-mode fallback", () => {
+      vi.spyOn(service.webGLManager, "getMode").mockReturnValue("webgl");
+      vi.spyOn(service.webGLManager, "getPinnedId").mockReturnValue("pinned-other");
+      const managed = makeMockManaged({ id: "t1" });
+
+      expect(callShouldHaveActive(managed)).toBe(true);
+    });
   });
 });

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1413,4 +1413,79 @@ describe("TerminalResizeController", () => {
       expect(resizeMock).not.toHaveBeenCalled();
     });
   });
+
+  describe("background resize lock replay + custom TTL", () => {
+    function makeManagedWithMetrics() {
+      const managed = createManagedTerminal();
+      managed.isFocused = false;
+      managed.isVisible = false;
+      managed.lastAppliedTier = TerminalRefreshTier.BACKGROUND;
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      return managed;
+    }
+
+    function makeCtl(managed: ReturnType<typeof createManagedTerminal>) {
+      return new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: { flushForTerminal: vi.fn(), resetForTerminal: vi.fn() } as any,
+      });
+    }
+
+    it("stashes a background resize that lands while the resize lock is held instead of dropping it", () => {
+      const managed = makeManagedWithMetrics();
+      const controller = makeCtl(managed);
+
+      controller.lockResize("term-1", true);
+      const result = controller.resizePtyOnly("term-1", 1600, 800);
+
+      // Locked: the PTY is not resized now, but the geometry is preserved.
+      expect(result).toBeNull();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.pendingBackgroundResize).toEqual({ width: 1600, height: 800 });
+    });
+
+    it("replays the stashed background resize when the lock releases", () => {
+      const managed = makeManagedWithMetrics();
+      const controller = makeCtl(managed);
+
+      controller.lockResize("term-1", true);
+      controller.resizePtyOnly("term-1", 1600, 800);
+      expect(resizeMock).not.toHaveBeenCalled();
+
+      controller.lockResize("term-1", false);
+
+      // The held geometry is delivered to the PTY once on unlock, stash cleared.
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 160, 40);
+      expect(managed.pendingBackgroundResize).toBeUndefined();
+    });
+
+    it("releasing the lock with no stashed resize is a no-op", () => {
+      const managed = makeManagedWithMetrics();
+      const controller = makeCtl(managed);
+
+      controller.lockResize("term-1", true);
+      controller.lockResize("term-1", false);
+
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.pendingBackgroundResize).toBeUndefined();
+    });
+
+    it("honors a custom lock TTL longer than the default", () => {
+      const managed = makeManagedWithMetrics();
+      const controller = makeCtl(managed);
+
+      // 10s custom TTL — the project-switch suppression window.
+      controller.lockResize("term-1", true, 10_000);
+
+      // Past the 5s default lock TTL, a custom-TTL lock is still held.
+      vi.advanceTimersByTime(6_000);
+      expect(controller.isResizeLocked("term-1")).toBe(true);
+
+      // Past the 10s custom TTL, the lock has expired.
+      vi.advanceTimersByTime(4_001);
+      expect(controller.isResizeLocked("term-1")).toBe(false);
+    });
+  });
 });

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -15,6 +15,8 @@ export type AgentStateCallback = (state: AgentState) => void;
 export type PostCompleteHook = (output: string) => void | Promise<void>;
 
 export interface ManagedTerminal {
+  /** Stable terminal id — the key this instance is registered under. */
+  id: string;
   terminal: Terminal;
   kind?: PanelKind;
   /** Launch hint — agent this terminal was launched to run. Not identity. */

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -92,6 +92,10 @@ export interface ManagedTerminal {
   resizeSuppressionTimer?: number;
   isResizeSuppressed?: boolean;
   resizeSuppressionEndTime?: number;
+  // A background resize that arrived while the resize lock was held (e.g. during
+  // the project-switch suppression window). Stashed here and replayed when the
+  // lock releases, so a window resize that lands mid-suppression isn't dropped.
+  pendingBackgroundResize?: { width: number; height: number };
   // Reveal-pending guaranteed redraw (#10632). Set true when the project-switch
   // resize-suppression window clears while the host is NOT foreground-renderable
   // (still detached/occluded behind the warm anti-flash bridge on a long dwell):

--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -570,6 +570,74 @@ describe("repaintActiveWorktreeTerminals (#10362)", () => {
     expect(revealedIds()).toEqual(["a"]);
   });
 
+  it("aborts the whole reveal sweep when the view is switched away (hidden) mid-sweep", async () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    const b = panel("b", { worktreeId: "wt-1" });
+    const c = panel("c", { worktreeId: "wt-1" });
+    const d = panel("d", { worktreeId: "wt-1" });
+    mockPanelIds = ["a", "b", "c", "d"];
+    mockPanelsById = { a, b, c, d };
+
+    let visibility: "visible" | "hidden" = "visible";
+    let visibilityHandler: (() => void) | null = null;
+    vi.stubGlobal("document", {
+      get visibilityState() {
+        return visibility;
+      },
+      addEventListener: (evt: string, h: () => void) => {
+        if (evt === "visibilitychange") visibilityHandler = h;
+      },
+      removeEventListener: () => {},
+    });
+    // rAF fires synchronously; the timeout fallback is a no-op for this test.
+    vi.stubGlobal("requestAnimationFrame", (cb: (time: number) => void) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal("setTimeout", () => 1);
+
+    revealTerminalMock.mockImplementation((id: string) => {
+      // The project is switched away during the first terminal's first attempt.
+      if (id === "a") {
+        visibility = "hidden";
+        visibilityHandler?.();
+      }
+      return Promise.resolve(false); // never paintable → would otherwise retry
+    });
+
+    await repaintActiveWorktreeTerminals();
+
+    // The hidden event latches sweep-wide: the next worker sees it before taking
+    // another target, so the rest of the grid ("b"/"c"/"d") is skipped entirely
+    // rather than each getting one hidden reveal.
+    expect(revealedIds()).toEqual(["a"]);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("does not hang the sweep when requestAnimationFrame never fires (paused view)", async () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    mockPanelIds = ["a"];
+    mockPanelsById = { a };
+
+    // Paused rAF: registered but its callback is never invoked (backgrounded
+    // WebContentsView). Without the timeout fallback the worker would hang here.
+    vi.stubGlobal("requestAnimationFrame", () => 1);
+    // The timeout fallback (fired synchronously for the test) unblocks the frame.
+    vi.stubGlobal("setTimeout", (cb: () => void) => {
+      cb();
+      return 1;
+    });
+    revealTerminalMock.mockResolvedValue(true);
+
+    await expect(repaintActiveWorktreeTerminals()).resolves.toBeUndefined();
+    expect(revealTerminalMock).toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
   it("isolates a per-terminal reveal rejection so the sweep continues", async () => {
     mockActiveWorktreeId = "wt-1";
     const a = panel("a", { worktreeId: "wt-1" });

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -175,9 +175,29 @@ const REVEAL_CONCURRENCY = 2;
 // intermittent reveal into a reliable one.
 const REVEAL_CONFIRM_PAINTS = 2;
 
+// rAF is paused for a backgrounded/occluded WebContentsView, so its callback can
+// never fire there. Race it against a timeout so a worker awaiting a frame can't
+// hang the reveal sweep forever (and later resume stale to interleave with the
+// next reveal). In the normal foreground case the real frame (~16ms) always wins
+// well before the fallback.
+const NEXT_FRAME_FALLBACK_MS = 250;
+
 function nextFrame(): Promise<void> {
   if (typeof requestAnimationFrame !== "function") return Promise.resolve();
-  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    requestAnimationFrame(done);
+    if (typeof setTimeout === "function") setTimeout(done, NEXT_FRAME_FALLBACK_MS);
+  });
+}
+
+function isDocumentHidden(): boolean {
+  return typeof document !== "undefined" && document.visibilityState === "hidden";
 }
 
 /**
@@ -186,9 +206,15 @@ function nextFrame(): Promise<void> {
  * across separate frames to defeat the compositor/observer present-race that
  * otherwise leaves the first paint un-stuck. Bounded by {@link MAX_REVEAL_FRAMES}.
  */
-async function revealUntilStable(id: string): Promise<void> {
+async function revealUntilStable(id: string, isAborted: () => boolean): Promise<void> {
   let painted = 0;
   for (let frame = 0; frame < MAX_REVEAL_FRAMES && painted < REVEAL_CONFIRM_PAINTS; frame++) {
+    // The view may have been switched away (detached → hidden) since the sweep
+    // started or during a frame yield. Stop before touching a hidden view — the
+    // switch-back starts a fresh sweep. The caller latches the same flag for the
+    // worker pool, so a single hidden event abandons the WHOLE sweep, not just
+    // this terminal.
+    if (isAborted()) return;
     let paintable: boolean;
     try {
       paintable = await terminalInstanceService.revealTerminal(id);
@@ -241,17 +267,35 @@ export async function repaintActiveWorktreeTerminals(): Promise<void> {
   // Reveal the pane the user is reading first — the rest stagger in behind it.
   prioritizeFocusedFirst(targets);
 
-  let cursor = 0;
-  const worker = async (): Promise<void> => {
-    while (cursor < targets.length) {
-      const id = targets[cursor++];
-      if (id) await revealUntilStable(id);
-    }
+  // Abort the whole sweep if the view is switched away (detached → hidden) at any
+  // point: continuing would repaint a now-hidden view, and the switch-back starts
+  // a fresh sweep. Latched on the first hidden event, so a rapid hidden→visible
+  // flip still abandons this (now superseded) sweep rather than letting a
+  // post-await visibility sample miss the transition.
+  let aborted = isDocumentHidden();
+  const onVisibilityChange = (): void => {
+    if (isDocumentHidden()) aborted = true;
   };
-  const workerCount = Math.min(REVEAL_CONCURRENCY, targets.length);
-  const workers: Promise<void>[] = [];
-  for (let i = 0; i < workerCount; i++) {
-    workers.push(worker());
+  const canListen =
+    typeof document !== "undefined" && typeof document.addEventListener === "function";
+  if (canListen) document.addEventListener("visibilitychange", onVisibilityChange);
+
+  try {
+    let cursor = 0;
+    const worker = async (): Promise<void> => {
+      while (cursor < targets.length) {
+        if (aborted) return;
+        const id = targets[cursor++];
+        if (id) await revealUntilStable(id, () => aborted);
+      }
+    };
+    const workerCount = Math.min(REVEAL_CONCURRENCY, targets.length);
+    const workers: Promise<void>[] = [];
+    for (let i = 0; i < workerCount; i++) {
+      workers.push(worker());
+    }
+    await Promise.all(workers);
+  } finally {
+    if (canListen) document.removeEventListener("visibilitychange", onVisibilityChange);
   }
-  await Promise.all(workers);
 }


### PR DESCRIPTION
## What

A batch of correctness fixes for the "switch back to a project and the terminals look strange" problem, found during a deep multi-agent investigation of the warm `WebContentsView` reactivation path. These are the verified, well-scoped fixes from that investigation; the riskier structural items are deferred (see below).

Root cause across all of them: when a project's `WebContentsView` is backgrounded it freezes, and its terminals' geometry / output / WebGL atlas drift out of sync. On return, the reveal machinery has to reconcile that — and several paths were either dropping work, gating on a stale signal, or able to hang/over-run.

## Fixes (each commit is independently reviewed and tested)

- **`fix(pty)` bound background coalesce deferral** — caps how long backgrounded coalesced output is deferred so agent-state detection stays fresh and the switch-back drain stays small (already landed; the #10744 lineage).
- **`fix(terminal)` replay background resize dropped during the project-switch lock** — `resizePtyOnly` now stashes a window resize that lands while the resize lock is held and replays it on unlock instead of dropping it; the lock TTL now matches the 10s suppression window instead of expiring at 5s.
- **`fix(projectview)` cancel in-flight reveal work when a view is cached** — a new `app:view-cached` IPC tells the renderer to cancel any pending wake/repaint rAFs before the view is throttled/frozen, so timers scheduled for the view being left can't fire against a now-hidden view or survive to run stale on the next reactivation. Also re-fires `onViewReady` on a failed-switch rollback.
- **`fix(terminal)` stop the watchdog retrying WebGL for non-pinned DOM-mode panes** — adds a watchdog-only eligibility predicate so the reconciliation watchdog stops burning a heavy-repair slot every tick on panes the manager will never attach in DOM-mode fallback, while the reveal/visibility paths still keep those panes in the manager's `wants` set.
- **`fix(terminal)` reattach WebGL on warm reveal despite a stale isVisible flag (W1)** — the headline one. On a warm resume the reactive `isVisible` flag is stale-false, so `repaintForReveal` was skipping the WebGL reattach and leaving non-focused agent panes on the DOM renderer (mangled block glyphs) for seconds after switch-back. The reveal path already proves the pane on-screen from DOM ground truth; it now trusts that for the reattach too, scoped so only the warm-reveal sweep gets the bypass (assistant transitions keep the gate, so a transform-hidden pane can't accumulate a fleet-wide want).
- **`fix(terminal)` bound and cancel the reveal sweep on a paused or switched-away view** — `nextFrame()` now races rAF against a 250ms fallback so a worker can't hang forever when a backgrounded view pauses rAF, and the sweep latches a sweep-wide abort on the first `visibilitychange → hidden` so it stops repainting across all remaining terminals (not just the current one).

## Deferred follow-ups (intentionally out of scope here)

These came out of the same investigation but are riskier structural changes that deserve standalone design + review:

- **Warm-gate generation nonce** — the stale-warm-painted-signal-releases-the-current-gate race. A correct fix needs a main↔renderer generation handshake in the paint-gate protocol (the renderer currently fires `notifyWarmViewPainted` unconditionally with no generation).
- **Superseding switch chain / head-of-line blocking** — clearing the paint gate at `switchTo` start was attempted and reverted: it corrupts the view stack on rapid A→B→C and prematurely detaches the cold bridge. Needs real view-stack reconciliation on cancellation.
- **Proper resize-on-thaw reveal reconcile** — the WIP `force`-applied a PTY-only resize while foreground, which risks PTY/xterm divergence; reverted. The right fix is an authoritative reveal-time reconcile.
- Lower-priority: theme/font cross-view propagation (stale-until-remount), DPR/monitor-change-while-frozen, atlas-repair private-xterm-internals fragility (no test coverage since E2E runs WebGL off), search-highlight/marker loss on restore.

## Testing

- New unit tests for every fix (lock replay + TTL, view-cached cancellation, paint-gate cache notify, WebGL DOM-mode + reveal eligibility, reveal-sweep abort + no-hang).
- 4442 tests pass across the touched areas (terminal services, store, contexts, window); full `npm run check` clean.
- Each fix commit was run past Codex review before landing — five of the six reviews caught a real bug (a regression-introducing resize hunk, a view-stack-corrupting supersession, a watchdog guard that stranded the focused pane, an assistant-transition want leak, and a per-terminal-vs-sweep-wide cancellation gap), all fixed before commit.
