### PR TITLE
perf(project): reveal cold switches on the skeleton paint, not React

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -716,14 +716,6 @@ export class ProjectViewManager {
         gateChannel: coldReleaseChannel,
       });
 
-      // Deliver pending focus intent only when the renderer has confirmed
-      // first paint. On hard timeout the renderer may be stuck or
-      // unresponsive — dropping the intent is safer than firing into a
-      // partially-mounted view (the subscriber is registered before
-      // `notifyViewPainted`, but a hard timeout means we have no positive
-      // evidence of that). The intent is always consumed (cleared)
-      // regardless of outcome to prevent a later unrelated switch from
-      // picking up a stale focus.
       // Focus intent is delivered ONLY on the `"painted"` path — the focus-
       // intent switches that armed for the real React paint, where the
       // renderer's focus-on-activate listener is guaranteed mounted. On the fast

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -119,14 +119,19 @@ type PaintGateOutcome = "signal" | "hard-timeout" | "cancelled";
 interface PaintGate {
   webContentsId: number;
   /**
-   * Which renderer signal releases this gate. Cold-start gates wait on the
-   * one-shot `APP_VIEW_PAINTED` (`"painted"`); warm-reactivation gates wait on
-   * the re-fireable `APP_VIEW_WARM_PAINTED` (`"warm-painted"`), because a cached
+   * Which renderer signal releases this gate. Cold-start gates normally wait on
+   * the one-shot `APP_VIEW_PAINTED` (`"painted"`); fast cold switches instead
+   * wait on the earlier one-shot `APP_SKELETON_PARSED` (`"skeleton-painted"`)
+   * so the themed first-paint skeleton reveals in hundreds of ms rather than
+   * after the full React cold boot. Warm-reactivation gates wait on the
+   * re-fireable `APP_VIEW_WARM_PAINTED` (`"warm-painted"`), because a cached
    * view's V8 context already fired its one-shot painted signal on first load
    * and will never re-emit it (#9679). The discriminator keeps a stray signal of
-   * the wrong kind from releasing the bridge early.
+   * the wrong kind from releasing the bridge early; `signalViewPainted` also
+   * releases a `"skeleton-painted"` gate as a fallback (a committed React frame
+   * is a strict superset of the skeleton having parsed).
    */
-  releaseChannel: "painted" | "warm-painted";
+  releaseChannel: "painted" | "warm-painted" | "skeleton-painted";
   /**
    * The view that was visible when the gate opened — still attached during the
    * wait. This may be a registered project view or the unbound welcome view on
@@ -600,6 +605,38 @@ export class ProjectViewManager {
     // a profile push between gate creation and log emission.
     const softMs = this.paintGateTimeoutMs;
     const hardMs = Math.max(this.paintGateHardTimeoutMs, softMs);
+
+    // Reveal the incoming view as soon as its themed first-paint skeleton
+    // (`#startup-skeleton`, injected in createView) is parsed into the DOM —
+    // signalled early by `public/skeleton-ready.js` via APP_SKELETON_PARSED,
+    // well before React mounts — rather than holding the outgoing project on
+    // screen for the entire React cold boot. The skeleton is an opaque themed
+    // cover over the view's themed canvas background (setBackgroundColor in
+    // createView, #9573), so this preserves the anti-flash guarantee while
+    // cutting perceived cold-switch latency from ~1.5–4s to a few hundred ms.
+    //
+    // EXCEPTION: when a focus intent is pending we must keep waiting for the
+    // real React paint. The focus-intent IPC listener isn't mounted until React
+    // commits, so delivering it into a bare pre-React skeleton would be dropped
+    // (#4670). Those (rare) switches keep the legacy `"painted"` gating verbatim.
+    const hasPendingFocusIntent = this.pendingFocusIntent?.projectId === projectId;
+    const coldReleaseChannel: "painted" | "skeleton-painted" = hasPendingFocusIntent
+      ? "painted"
+      : "skeleton-painted";
+    if (coldReleaseChannel === "skeleton-painted") {
+      // Scoped, one-shot receiver for THIS view's skeleton-parsed send. Mirrors
+      // createWindow's initial-window skeleton gate, whose listener is bound to
+      // the main app webContents and never sees a project-switch view. Optional-
+      // chained because the unit-test WebContents mock has no `.ipc`; those
+      // tests drive `signalSkeletonPainted()` directly instead. A superseding
+      // switch cancels the gate, after which this fire is a harmless no-op
+      // (signalSkeletonPainted matches on the pending gate's webContentsId).
+      const skeletonWcId = view.webContents.id;
+      view.webContents.ipc?.once(CHANNELS.APP_SKELETON_PARSED, () => {
+        this.signalSkeletonPainted(skeletonWcId);
+      });
+    }
+
     const paintGatePromise = this.waitForPaint(
       view.webContents.id,
       outgoingView,
@@ -610,8 +647,10 @@ export class ProjectViewManager {
         logWarn("projectview.paintgate.softtimeout", {
           projectId,
           waitedMs: softMs,
+          releaseChannel: coldReleaseChannel,
         });
-      }
+      },
+      { releaseChannel: coldReleaseChannel }
     );
 
     let visibleAt: number;
@@ -633,9 +672,12 @@ export class ProjectViewManager {
       // the CDP session on an uninitialised frame host (Chromium 146).
       void unfreezeWebContents(view.webContents);
 
-      // Wait for the renderer to confirm React has committed its first
-      // structural paint (sent via `APP_VIEW_PAINTED` after a double-rAF in
-      // `notifyViewPainted`). Two-phase: the soft timeout above is observable
+      // Wait for the incoming view to signal readiness. On the fast path that
+      // is APP_SKELETON_PARSED (themed skeleton parsed, channel
+      // `"skeleton-painted"`); on the focus-intent path it is APP_VIEW_PAINTED
+      // (React committed its first structural paint after a double-rAF in
+      // `notifyViewPainted`, channel `"painted"`), and `signalViewPainted` is
+      // the fallback for both. Two-phase: the soft timeout above is observable
       // but never user-visible; only the hard timeout below detaches the
       // outgoing view as a last resort when the renderer is stuck or crashed.
       const gateResult = await paintGatePromise;
@@ -663,6 +705,15 @@ export class ProjectViewManager {
         visibleMs: Math.round(visibleAt - coldStartAt),
         loadToPaintMs: Math.round(visibleAt - loadFinishedAt),
         paintGateOutcome: gateResult,
+        // Which paint-gate channel this cold switch was armed with:
+        // `skeleton-painted` (fast path — revealed on the themed skeleton) vs
+        // `painted` (focus-intent path — held for the full React paint). Lets
+        // telemetry separate fast-path switches from the focus-intent path and
+        // measure each one's `visibleMs` independently. A `skeleton-painted`
+        // gate may still be released by the `signalViewPainted` fallback when
+        // the skeleton signal is missed; this reflects the strategy chosen, not
+        // which signal ultimately fired.
+        gateChannel: coldReleaseChannel,
       });
 
       // Deliver pending focus intent only when the renderer has confirmed
@@ -673,9 +724,23 @@ export class ProjectViewManager {
       // evidence of that). The intent is always consumed (cleared)
       // regardless of outcome to prevent a later unrelated switch from
       // picking up a stale focus.
-      const coldIntent = this.consumePendingFocusIntent(projectId);
-      if (coldIntent && gateResult === "signal") {
-        this.deliverFocusIntent(view, coldIntent);
+      // Focus intent is delivered ONLY on the `"painted"` path — the focus-
+      // intent switches that armed for the real React paint, where the
+      // renderer's focus-on-activate listener is guaranteed mounted. On the fast
+      // skeleton path we never armed for an intent; if one was set mid-flight
+      // (a repeated focusNextWaitingGlobal landing during the switch) we must
+      // NOT consume it here — delivering into a bare pre-React skeleton would
+      // drop it (#4670), and consuming-without-delivering would lose it
+      // entirely. Leaving it pending lets the queued/next same-project switch
+      // deliver it once React is mounted (intents are project-keyed, so an
+      // unrelated switch can't pick it up). On the painted path the intent is
+      // still consumed on every outcome (incl. hard timeout) so a stale focus
+      // can't leak forward.
+      if (coldReleaseChannel === "painted") {
+        const coldIntent = this.consumePendingFocusIntent(projectId);
+        if (coldIntent && gateResult === "signal") {
+          this.deliverFocusIntent(view, coldIntent);
+        }
       }
     } catch (loadError) {
       // Cold-start failed before the swap happened — outgoing view is still
@@ -759,7 +824,7 @@ export class ProjectViewManager {
     outgoingProjectId: string | null,
     onSoftTimeout?: () => void,
     options?: {
-      releaseChannel?: "painted" | "warm-painted";
+      releaseChannel?: "painted" | "warm-painted" | "skeleton-painted";
       softMs?: number;
       hardMs?: number;
     }
@@ -819,14 +884,41 @@ export class ProjectViewManager {
 
   /**
    * Renderer-driven gate release. Called from the `APP_VIEW_PAINTED` IPC
-   * handler with the webContentsId of the renderer that just painted. A
-   * mismatch (e.g. signal arriving after a superseding switch already moved
-   * on) is silently ignored.
+   * handler with the webContentsId of the renderer that just painted. Releases
+   * a cold `"painted"` gate and ALSO a `"skeleton-painted"` early-reveal gate:
+   * React having committed its first frame is a strict superset of the skeleton
+   * having parsed, so this is the fallback that still detaches the bridge if the
+   * one-shot `APP_SKELETON_PARSED` was somehow missed (degrading to today's
+   * behaviour, never worse). Warm gates own a distinct re-fireable channel and
+   * are left for `signalWarmViewPainted`. A mismatch (e.g. a signal arriving
+   * after a superseding switch already moved on) is silently ignored.
    */
   signalViewPainted(webContentsId: number): void {
     const gate = this.pendingPaintGate;
     if (!gate) return;
-    if (gate.releaseChannel !== "painted") return;
+    if (gate.releaseChannel === "warm-painted") return;
+    if (gate.webContentsId !== webContentsId) return;
+    gate.resolve("signal");
+  }
+
+  /**
+   * Early-reveal gate release. Called when an incoming cold-start view's
+   * `APP_SKELETON_PARSED` fires — i.e. its themed first-paint skeleton
+   * (`#startup-skeleton`, injected in `createView`) is in the DOM, well before
+   * React mounts. Releasing here lets the outgoing view detach and the branded
+   * skeleton show in hundreds of ms instead of holding the old project on
+   * screen for the full ~1.5–4s React cold boot. The skeleton is an opaque
+   * themed cover over the view's themed canvas background, so the anti-flash
+   * guarantee (no blank-canvas frame) is preserved. Only releases a gate
+   * explicitly armed for the skeleton channel; a stray signal arriving with a
+   * cold `"painted"` or warm gate pending (or no gate) is ignored, so the
+   * scoped renderer fire is a safe no-op when main isn't bridging an early
+   * reveal.
+   */
+  signalSkeletonPainted(webContentsId: number): void {
+    const gate = this.pendingPaintGate;
+    if (!gate) return;
+    if (gate.releaseChannel !== "skeleton-painted") return;
     if (gate.webContentsId !== webContentsId) return;
     gate.resolve("signal");
   }

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -21,12 +21,22 @@ interface MockWc {
   removeListener: ReturnType<typeof vi.fn>;
   setWindowOpenHandler: ReturnType<typeof vi.fn>;
   setIgnoreMenuShortcuts: ReturnType<typeof vi.fn>;
+  // WebContents-scoped ipc receiver (Electron `webContents.ipc`). Production
+  // registers the cold-start skeleton-parsed listener here; the real renderer
+  // `send` is simulated via `_emitIpcOnce`.
+  ipc: {
+    once: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    removeListener: ReturnType<typeof vi.fn>;
+  };
   _fireOnce: (event: string, ...args: unknown[]) => void;
+  _emitIpcOnce: (channel: string, ...args: unknown[]) => void;
 }
 
 function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
   const id = nextWebContentsId++;
   const handlers = new Map<string, Handler[]>();
+  const ipcHandlers = new Map<string, Handler[]>();
   const autoFinish = opts?.autoFinishLoad ?? true;
 
   const wc: MockWc = {
@@ -58,8 +68,23 @@ function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
     }),
     setWindowOpenHandler: vi.fn(),
     setIgnoreMenuShortcuts: vi.fn(),
+    ipc: {
+      once: vi.fn((channel: string, handler: Handler) => {
+        if (!ipcHandlers.has(channel)) ipcHandlers.set(channel, []);
+        ipcHandlers.get(channel)!.push(handler);
+      }),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+    },
     _fireOnce(event: string, ...args: unknown[]) {
       const list = handlers.get(event);
+      if (list && list.length > 0) {
+        const h = list.shift()!;
+        h(...args);
+      }
+    },
+    _emitIpcOnce(channel: string, ...args: unknown[]) {
+      const list = ipcHandlers.get(channel);
       if (list && list.length > 0) {
         const h = list.shift()!;
         h(...args);
@@ -465,6 +490,285 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     // Correct signal — releases.
     manager.signalViewPainted(incomingWc.id);
     await switchPromise;
+    expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+  });
+
+  it("early-reveals on the real skeleton-parsed IPC signal (before React paints)", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The cold path must register a scoped skeleton-parsed listener on the
+    // incoming view's webContents — this is the real production wiring, not the
+    // test calling signalSkeletonPainted() directly.
+    expect(incomingWc.ipc.once).toHaveBeenCalledWith(
+      CHANNELS.APP_SKELETON_PARSED,
+      expect.any(Function)
+    );
+
+    // Bridge armed: incoming behind outgoing, outgoing still attached.
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    // Fire the renderer's skeleton-parsed send (well before any APP_VIEW_PAINTED)
+    // through the real listener — the outgoing view detaches and the branded
+    // skeleton reveals on the fast path.
+    incomingWc._emitIpcOnce(CHANNELS.APP_SKELETON_PARSED);
+    await switchPromise;
+
+    expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+    // Telemetry records the fast-path strategy.
+    const cold = vi.mocked(logInfo).mock.calls.find(([e]) => e === "projectview.coldstart");
+    expect(cold?.[1]).toMatchObject({
+      gateChannel: "skeleton-painted",
+      paintGateOutcome: "signal",
+    });
+    // Released cleanly by the early signal — no timeout warnings.
+    expect(
+      vi
+        .mocked(logWarn)
+        .mock.calls.filter(
+          ([e]) =>
+            e === "projectview.paintgate.softtimeout" || e === "projectview.paintgate.hardtimeout"
+        )
+    ).toHaveLength(0);
+  });
+
+  it("arms the skeleton listener before loadURL so the parse-time send can't be missed", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The listener must be armed before navigation — skeleton-ready.js fires
+    // during HTML parse, so a listener registered after loadURL could miss it.
+    const onceOrder = incomingWc.ipc.once.mock.invocationCallOrder[0];
+    const loadOrder = incomingWc.loadURL.mock.invocationCallOrder[0];
+    expect(onceOrder).toBeDefined();
+    expect(loadOrder).toBeDefined();
+    expect(onceOrder).toBeLessThan(loadOrder);
+
+    incomingWc._emitIpcOnce(CHANNELS.APP_SKELETON_PARSED);
+    await switchPromise;
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+  });
+
+  it("does not arm the skeleton listener (or early-reveal) when a focus intent is pending", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    // A pending focus intent forces the legacy "painted" gating: the focus IPC
+    // listener isn't mounted until React commits, so the gate must wait for the
+    // real paint rather than the bare pre-React skeleton (#4670).
+    manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The focus-intent path must NOT register a skeleton listener at all.
+    expect(incomingWc.ipc.once).not.toHaveBeenCalledWith(
+      CHANNELS.APP_SKELETON_PARSED,
+      expect.anything()
+    );
+
+    // Even a (defensively) injected skeleton signal must NOT release the gate.
+    manager.signalSkeletonPainted(incomingWc.id);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+    expect(incomingWc.send).not.toHaveBeenCalledWith(
+      "project:focus-on-activate",
+      expect.anything()
+    );
+
+    // The real React paint releases the gate AND delivers the focus intent.
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+    expect(incomingWc.send).toHaveBeenCalledWith("project:focus-on-activate", {
+      intent: "focus-next-waiting",
+    });
+    const cold = vi.mocked(logInfo).mock.calls.find(([e]) => e === "projectview.coldstart");
+    expect(cold?.[1]).toMatchObject({ gateChannel: "painted" });
+  });
+
+  it("does NOT consume a focus intent that arrives mid-flight on the fast skeleton path", async () => {
+    // Regression: a repeated focusNextWaitingGlobal can set a focus intent AFTER
+    // a skeleton-gated switch armed (when no intent existed). The fast path must
+    // not consume-and-drop it — it must leave it pending for the next
+    // same-project switch to deliver once React is mounted.
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Intent set mid-flight (after the gate was armed for the skeleton channel).
+    manager.setPendingFocusIntent("proj-b", "focus-next-waiting");
+
+    incomingWc._emitIpcOnce(CHANNELS.APP_SKELETON_PARSED);
+    await switchPromise;
+
+    // Revealed fast; the mid-flight intent was NOT delivered into the bare
+    // pre-React skeleton.
+    expect(incomingWc.send).not.toHaveBeenCalledWith(
+      "project:focus-on-activate",
+      expect.anything()
+    );
+
+    // …and crucially it was NOT consumed/dropped. A follow-up switch to the
+    // (now active) same project takes the active-project path, which consumes
+    // and delivers the surviving intent — proving it outlived the fast reveal.
+    await manager.switchTo("proj-b", "/path/b");
+    expect(incomingWc.send).toHaveBeenCalledWith("project:focus-on-activate", {
+      intent: "focus-next-waiting",
+    });
+  });
+
+  it("captures a skeleton signal that arrives before did-finish-load resolves", async () => {
+    // The gate (and its scoped skeleton listener) is armed BEFORE awaiting
+    // loadView, so a skeleton-ready send firing during parse — possibly before
+    // did-finish-load resolves — is captured, not dropped to the timeout.
+    const incomingWc = createMockWebContents({ autoFinishLoad: false });
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+
+    // Skeleton parses first — captured by the pre-armed listener.
+    incomingWc._emitIpcOnce(CHANNELS.APP_SKELETON_PARSED);
+    // Outgoing stays attached until loadView resolves (the swap runs after the
+    // awaited load, not on the bare signal).
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    // Now let did-finish-load resolve — the captured signal drives a clean swap.
+    incomingWc._fireOnce("did-finish-load");
+    await switchPromise;
+
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+    expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+    expect(
+      vi
+        .mocked(logWarn)
+        .mock.calls.filter(
+          ([e]) =>
+            e === "projectview.paintgate.softtimeout" || e === "projectview.paintgate.hardtimeout"
+        )
+    ).toHaveLength(0);
+  });
+
+  it("treats a later view-painted as an idempotent no-op after the skeleton already revealed", async () => {
+    vi.useFakeTimers();
+    try {
+      const incomingWc = createMockWebContents();
+      wcQueue.push(incomingWc);
+
+      const switchPromise = manager.switchTo("proj-b", "/path/b");
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Fast reveal on the skeleton signal.
+      incomingWc._emitIpcOnce(CHANNELS.APP_SKELETON_PARSED);
+      await switchPromise;
+      expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+
+      // React paints later (the normal real sequence). The gate is already
+      // settled, so this is a no-op — no second detach, one coldstart log, no
+      // timeout warnings.
+      manager.signalViewPainted(incomingWc.id);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+      expect(
+        vi.mocked(logInfo).mock.calls.filter(([e]) => e === "projectview.coldstart")
+      ).toHaveLength(1);
+      expect(
+        vi
+          .mocked(logWarn)
+          .mock.calls.filter(
+            ([e]) =>
+              e === "projectview.paintgate.softtimeout" || e === "projectview.paintgate.hardtimeout"
+          )
+      ).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("releases a skeleton gate via the view-painted fallback when the skeleton signal never arrives", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    // No skeleton signal arrives (e.g. the classic skeleton-ready script raced a
+    // navigation). The later React paint must still detach the bridge, so an
+    // early-reveal switch can never hang worse than the legacy behaviour.
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+    expect(manager.getActiveProjectId()).toBe("proj-b");
+    // Still recorded as the fast-path strategy (the channel reflects the
+    // strategy chosen, not which signal ultimately fired).
+    const cold = vi.mocked(logInfo).mock.calls.find(([e]) => e === "projectview.coldstart");
+    expect(cold?.[1]).toMatchObject({ gateChannel: "skeleton-painted" });
+  });
+
+  it("ignores a skeleton signal from an unknown webContentsId", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Bogus skeleton signal — gate stays open.
+    manager.signalSkeletonPainted(99_999);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    // Correct skeleton signal — releases.
+    manager.signalSkeletonPainted(incomingWc.id);
+    await switchPromise;
+    expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+  });
+
+  it("a skeleton signal does not release a warm bridge gate", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    // Prime B in the cache via the fast skeleton path.
+    const firstSwitch = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalSkeletonPainted(incomingWc.id);
+    await firstSwitch;
+
+    win.contentView.removeChildView.mockClear();
+
+    // Switch back to A (cached) — this opens a WARM gate, not a cold one.
+    const switchBack = manager.switchTo("proj-a", "/path/a");
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+
+    // The cold skeleton channel must not satisfy the warm gate (different
+    // releaseChannel), even with a matching webContentsId.
+    manager.signalSkeletonPainted(initialWc.id);
+    await Promise.resolve();
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    manager.signalWarmViewPainted(initialWc.id);
+    await switchBack;
     expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## What

Switching to a project whose `WebContentsView` was evicted from the small LRU warm set (the common case once 5+ projects are open) felt like the UI locked up. The cold-switch path held the *outgoing* project composited on top as an anti-flash bridge until the incoming renderer fired `APP_VIEW_PAINTED` — React's first structural paint after a full cold renderer boot, ~1.5–4s away. The themed `#startup-skeleton` already injected into the incoming view paints in a few hundred ms, but it sat hidden behind that bridge, so the user stared at the frozen old project for seconds with no feedback.

This reveals the incoming view on the earlier `APP_SKELETON_PARSED` signal instead. The skeleton is an opaque themed cover over the view's themed canvas background (`setBackgroundColor`, #9573), so the anti-flash guarantee holds while perceived cold-switch latency drops to a few hundred ms — an instant swap to the skeleton, with real content streaming in behind it.

## How

- New `"skeleton-painted"` paint-gate release channel. The cold path arms it and registers a scoped one-shot `webContents.ipc` listener for `APP_SKELETON_PARSED` — mirroring how `createWindow` already gates the initial window's `win.show()` on the same signal. Every project view already fires it via `public/skeleton-ready.js`; `ProjectViewManager` simply wasn't listening for it.
- `signalViewPainted` now also releases a `"skeleton-painted"` gate as a fallback, so if the skeleton signal is ever missed the switch degrades to today's behaviour — never worse.
- **Focus-intent switches keep the legacy `"painted"` gating.** The renderer's focus-on-activate listener isn't mounted until React commits, so `focus-next-waiting` switches still wait for the real paint; and the fast path never consumes a mid-flight focus intent — it's left pending for the next same-project switch to deliver once React is up.
- `projectview.coldstart` telemetry gains a `gateChannel` field to separate fast-path switches from the focus-intent path.

Warm reactivation, the switch overlay, and every other path are unchanged. (The warm-reveal path is being worked separately on `fix/warm-project-switch-reveal`.)

## Testing

- `electron/window/__tests__/ProjectViewManager.paintGate.test.ts` — nine new tests covering: early reveal driven through the real scoped IPC listener, listener-registered-before-`loadURL`, focus-intent path neither arms the listener nor early-reveals, a mid-flight focus intent survives the fast reveal (delivered by the next switch), skeleton-before-`did-finish-load` capture, dual-signal idempotency, the `view-painted` fallback, unknown-`webContentsId` rejection, and warm-gate channel discrimination.
- Full `electron/window` suite: 541 passing. Electron + root typecheck, eslint, and prettier all clean.

## Reviewed by Codex

Two-pass Codex review (gpt-5.5). Fixed during review: a mid-flight focus-intent drop on the fast path, telemetry naming (`revealedOn` → `gateChannel`, since a fallback release would otherwise mislabel the signal), and broadened tests to exercise the real `webContents.ipc` wiring rather than calling the release method directly.

## Note for runtime verification

This changes cold-switch reveal *timing* in a heavily-iterated anti-flash area, and was not visually verified. Unit tests cover the gating logic, but the visual result — the first revealed frame is the themed skeleton/canvas, never a white/blank frame — should be confirmed at runtime, and `projectview.coldstart{gateChannel,visibleMs}` checked on a 5+-project session. As with `createWindow`'s initial-window reveal, the very first skeleton frame may show the generic fallback styling for a frame or two before `injectSkeletonCss` (on `dom-ready`) applies the project accent.
