### PR TITLE
perf(plugins): centralize context-menu items into a shared store

### DIFF
--- a/src/hooks/__tests__/usePluginContextMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginContextMenuItems.test.ts
@@ -248,4 +248,79 @@ describe("usePluginContextMenuItems", () => {
     // consumer must not unsubscribe, or remaining/future consumers go stale.
     expect(cleanupMock).not.toHaveBeenCalled();
   });
+
+  it("each mounted consumer independently filters one shared push", async () => {
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onContextMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const term = renderHook(() => usePluginContextMenuItems("terminal"));
+    const wt = renderHook(() => usePluginContextMenuItems("worktree"));
+    const file = renderHook(() => usePluginContextMenuItems("file"));
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    act(() => {
+      emit!({
+        items: [
+          entry("acme", "T", "terminal"),
+          entry("acme", "W", "worktree"),
+          entry("acme", "F", "file"),
+        ],
+        complete: true,
+      });
+    });
+
+    expect(term.result.current.map((e) => e.item.label)).toEqual(["T"]);
+    expect(wt.result.current.map((e) => e.item.label)).toEqual(["W"]);
+    expect(file.result.current.map((e) => e.item.label)).toEqual(["F"]);
+  });
+
+  it("a remounted consumer sees current data without a second subscription", async () => {
+    let emit:
+      | ((p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void)
+      | null = null;
+    onContextMenuItemsChangedMock.mockImplementation(
+      (
+        cb: (p: {
+          items: Array<{ pluginId: string; item: ContextMenuContribution }>;
+          complete: boolean;
+        }) => void
+      ) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    const first = renderHook(() => usePluginContextMenuItems("terminal"));
+    await waitFor(() => expect(emit).not.toBeNull());
+    first.unmount();
+
+    // A push lands through the retained listener while no consumer is mounted —
+    // mirrors an LRU-evicted view's state advancing before it restores.
+    act(() => {
+      emit!({ items: [entry("acme", "Live", "terminal")], complete: true });
+    });
+
+    const second = renderHook(() => usePluginContextMenuItems("terminal"));
+    expect(second.result.current.map((e) => e.item.label)).toEqual(["Live"]);
+    // No re-subscription: the module-level listener was never torn down.
+    expect(onContextMenuItemsChangedMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/hooks/__tests__/usePluginContextMenuItems.test.ts
+++ b/src/hooks/__tests__/usePluginContextMenuItems.test.ts
@@ -226,13 +226,26 @@ describe("usePluginContextMenuItems", () => {
     expect(result.current.map((e) => e.item.label)).toEqual(["ForB"]);
   });
 
-  it("cleans up the push subscription on unmount", async () => {
+  it("shares one pull and one subscription across multiple mounted instances", async () => {
+    const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
+    renderHook(() => usePluginContextMenuItems("terminal"));
+    renderHook(() => usePluginContextMenuItems("worktree"));
+    renderHook(() => usePluginContextMenuItems("file"));
+
+    await waitFor(() => expect(onContextMenuItemsChangedMock).toHaveBeenCalledTimes(1));
+    expect(contextMenuItemsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not tear down the shared subscription when an instance unmounts", async () => {
     const cleanupMock = vi.fn();
     onContextMenuItemsChangedMock.mockReturnValue(cleanupMock);
     const { usePluginContextMenuItems } = await import("../usePluginContextMenuItems");
-    const { unmount } = renderHook(() => usePluginContextMenuItems("terminal"));
+    const a = renderHook(() => usePluginContextMenuItems("terminal"));
+    renderHook(() => usePluginContextMenuItems("worktree"));
 
-    unmount();
-    expect(cleanupMock).toHaveBeenCalled();
+    a.unmount();
+    // The store owns the subscription for the renderer's lifetime — unmounting a
+    // consumer must not unsubscribe, or remaining/future consumers go stale.
+    expect(cleanupMock).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/usePluginContextMenuItems.ts
+++ b/src/hooks/usePluginContextMenuItems.ts
@@ -1,69 +1,39 @@
-import { useState, useEffect, useMemo } from "react";
-import type { ContextMenuContribution, ContextMenuLocation } from "@shared/types/plugin";
+import { useEffect, useMemo } from "react";
+import type { ContextMenuLocation } from "@shared/types/plugin";
 import type { WhenClauseContext } from "@shared/utils/whenClause";
 import { parse, evaluate } from "@shared/utils/whenClause";
-import { logWarn } from "@/utils/logger";
+import {
+  usePluginContextMenuItemsStore,
+  type PluginContextMenuItemEntry,
+} from "@/store/pluginContextMenuItemsStore";
 
-export interface PluginContextMenuItemEntry {
-  pluginId: string;
-  item: ContextMenuContribution;
-}
+export type { PluginContextMenuItemEntry };
 
 const EMPTY_CONTEXT: WhenClauseContext = {};
 
 /**
- * Pull plugin-contributed context-menu items on mount and keep them in sync
- * with main's authoritative set via push. Same pull-on-mount + push-authoritative
- * shape as `usePluginToolbarButtons` — see that hook for the `pushReceived` race
- * rationale.
+ * Plugin-contributed context-menu items for `location`, filtered to the caller's
+ * surface. The pull-on-mount + push-authoritative shared state lives in
+ * `pluginContextMenuItemsStore` (one IPC round-trip, one listener for the whole
+ * renderer); this hook only initializes that store and derives a filtered view.
  *
- * Unlike `usePluginToolbarButtons`, callers pass a `ctx` map captured at
- * menu-open time (e.g. `{ worktreeId }`, `{ panelId, panelKind }`) so `when` clauses that
- * reference the surface's context keys evaluate correctly. An item that
- * references unset keys evaluates to `false` and is hidden — fail-closed. Parse
- * errors are also fail-closed.
- *
- * The `complete` flag on the broadcast is received but has no side effect here
- * (no renderer-local persisted state to sweep); it is plumbed for symmetry with
- * the broadcast contract.
+ * Callers pass a `ctx` map captured at menu-open time (e.g. `{ worktreeId }`,
+ * `{ panelId, panelKind }`) so `when` clauses that reference the surface's
+ * context keys evaluate correctly. An item that references unset keys evaluates
+ * to `false` and is hidden — fail-closed. Parse errors are also fail-closed.
+ * Because the context is consumer-specific, the `when`-clause evaluation stays
+ * here rather than in the shared store.
  */
 export function usePluginContextMenuItems(
   location: ContextMenuLocation,
   ctx?: WhenClauseContext
 ): PluginContextMenuItemEntry[] {
-  const [entries, setEntries] = useState<PluginContextMenuItemEntry[]>([]);
+  const entries = usePluginContextMenuItemsStore((s) => s.entries);
+  const init = usePluginContextMenuItemsStore((s) => s.init);
 
   useEffect(() => {
-    let disposed = false;
-    let pushReceived = false;
-
-    const electron = typeof window !== "undefined" ? window.electron : undefined;
-    if (!electron?.plugin) return;
-
-    void electron.plugin
-      .contextMenuItems()
-      .then((items) => {
-        if (disposed) return;
-        if (pushReceived) return;
-        setEntries(items);
-      })
-      .catch((err: unknown) => {
-        logWarn("[PluginContextMenuItems] Failed to fetch initial plugin context menu items", {
-          error: err,
-        });
-      });
-
-    const cleanup = electron.plugin.onContextMenuItemsChanged((payload) => {
-      if (disposed) return;
-      pushReceived = true;
-      setEntries(payload.items);
-    });
-
-    return () => {
-      disposed = true;
-      cleanup();
-    };
-  }, []);
+    init();
+  }, [init]);
 
   return useMemo(() => {
     const context = ctx ?? EMPTY_CONTEXT;

--- a/src/store/__tests__/pluginContextMenuItemsStore.test.ts
+++ b/src/store/__tests__/pluginContextMenuItemsStore.test.ts
@@ -105,6 +105,19 @@ describe("pluginContextMenuItemsStore", () => {
     });
   });
 
+  it("a failed initial pull does not block later pushes", async () => {
+    contextMenuItemsMock.mockRejectedValue(new Error("ipc down"));
+    const mod = await load();
+    await vi.waitFor(() => expect(onChangedMock).toHaveBeenCalledTimes(1));
+    expect(mod.usePluginContextMenuItemsStore.getState().entries).toEqual([]);
+
+    // The permanent listener rescues the empty set on the next broadcast.
+    changedCb!({ items: [entry("Rescued", "terminal")], complete: true });
+    expect(mod.usePluginContextMenuItemsStore.getState().entries.map((e) => e.item.label)).toEqual([
+      "Rescued",
+    ]);
+  });
+
   it("tolerates an absent bridge and stays retryable once a real bridge appears", async () => {
     const win = globalThis as unknown as {
       window: { electron: { plugin: Record<string, unknown> } };

--- a/src/store/__tests__/pluginContextMenuItemsStore.test.ts
+++ b/src/store/__tests__/pluginContextMenuItemsStore.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { ContextMenuContribution, ContextMenuLocation } from "@shared/types/plugin";
+
+type Entry = { pluginId: string; item: ContextMenuContribution };
+type ChangedPayload = { items: Entry[]; complete: boolean };
+
+const { contextMenuItemsMock, onChangedMock } = vi.hoisted(() => ({
+  contextMenuItemsMock: vi.fn(),
+  onChangedMock: vi.fn(),
+}));
+
+let changedCb: ((p: ChangedPayload) => void) | null = null;
+
+function entry(label: string, location: ContextMenuLocation): Entry {
+  return { pluginId: "acme", item: { label, actionId: `acme.${label}`, location } };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  changedCb = null;
+  contextMenuItemsMock.mockResolvedValue([]);
+  onChangedMock.mockImplementation((cb: (p: ChangedPayload) => void) => {
+    changedCb = cb;
+    return () => {};
+  });
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        contextMenuItems: contextMenuItemsMock,
+        onContextMenuItemsChanged: onChangedMock,
+      },
+    },
+  });
+});
+
+async function load() {
+  const mod = await import("../pluginContextMenuItemsStore");
+  mod._resetPluginContextMenuItemsStoreForTest();
+  mod.usePluginContextMenuItemsStore.getState().init();
+  return mod;
+}
+
+describe("pluginContextMenuItemsStore", () => {
+  it("pulls once and subscribes once on init", async () => {
+    await load();
+    expect(contextMenuItemsMock).toHaveBeenCalledTimes(1);
+    expect(onChangedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("init is idempotent — does not double-pull or double-subscribe", async () => {
+    const mod = await load();
+    mod.usePluginContextMenuItemsStore.getState().init();
+    mod.usePluginContextMenuItemsStore.getState().init();
+    expect(contextMenuItemsMock).toHaveBeenCalledTimes(1);
+    expect(onChangedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("populates entries from the mount-time pull", async () => {
+    contextMenuItemsMock.mockResolvedValue([entry("Foo", "terminal")]);
+    const mod = await load();
+    await vi.waitFor(() => {
+      expect(mod.usePluginContextMenuItemsStore.getState().entries).toHaveLength(1);
+    });
+    expect(mod.usePluginContextMenuItemsStore.getState().entries[0]?.item.label).toBe("Foo");
+  });
+
+  it("updates entries when a push arrives", async () => {
+    const mod = await load();
+    changedCb!({ items: [entry("Pushed", "worktree")], complete: false });
+    expect(mod.usePluginContextMenuItemsStore.getState().entries.map((e) => e.item.label)).toEqual([
+      "Pushed",
+    ]);
+  });
+
+  it("a push received before the pull resolves wins (stale pull is dropped)", async () => {
+    let resolvePull: ((v: Entry[]) => void) | null = null;
+    contextMenuItemsMock.mockImplementation(
+      () =>
+        new Promise<Entry[]>((res) => {
+          resolvePull = res;
+        })
+    );
+    const mod = await load();
+
+    // Push lands first while the pull is still in flight.
+    changedCb!({ items: [entry("PushWins", "terminal")], complete: true });
+    // Now the older pull resolves with different data — it must be ignored.
+    resolvePull!([entry("StalePull", "terminal")]);
+
+    await vi.waitFor(() => {
+      expect(
+        mod.usePluginContextMenuItemsStore.getState().entries.map((e) => e.item.label)
+      ).toEqual(["PushWins"]);
+    });
+  });
+
+  it("a pull that resolves before any push populates entries", async () => {
+    contextMenuItemsMock.mockResolvedValue([entry("FromPull", "terminal")]);
+    const mod = await load();
+    await vi.waitFor(() => {
+      expect(
+        mod.usePluginContextMenuItemsStore.getState().entries.map((e) => e.item.label)
+      ).toEqual(["FromPull"]);
+    });
+  });
+
+  it("tolerates an absent bridge and stays retryable once a real bridge appears", async () => {
+    const win = globalThis as unknown as {
+      window: { electron: { plugin: Record<string, unknown> } };
+    };
+    win.window.electron.plugin = {}; // no plugin context-menu methods yet
+    const mod = await import("../pluginContextMenuItemsStore");
+    mod._resetPluginContextMenuItemsStoreForTest();
+    expect(() => mod.usePluginContextMenuItemsStore.getState().init()).not.toThrow();
+    expect(contextMenuItemsMock).not.toHaveBeenCalled();
+    expect(onChangedMock).not.toHaveBeenCalled();
+
+    // A later init with the real bridge present must still subscribe — the
+    // absent-bridge early return did not latch `initialized`.
+    win.window.electron.plugin = {
+      contextMenuItems: contextMenuItemsMock,
+      onContextMenuItemsChanged: onChangedMock,
+    };
+    mod.usePluginContextMenuItemsStore.getState().init();
+    expect(contextMenuItemsMock).toHaveBeenCalledTimes(1);
+    expect(onChangedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset unsubscribes, clears entries, and resets the init guard", async () => {
+    const cleanup = vi.fn();
+    onChangedMock.mockImplementation((cb: (p: ChangedPayload) => void) => {
+      changedCb = cb;
+      return cleanup;
+    });
+    const mod = await load();
+    changedCb!({ items: [entry("Foo", "terminal")], complete: false });
+    expect(mod.usePluginContextMenuItemsStore.getState().entries).toHaveLength(1);
+
+    mod._resetPluginContextMenuItemsStoreForTest();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(mod.usePluginContextMenuItemsStore.getState().entries).toEqual([]);
+
+    // Guard reset ⇒ a fresh init subscribes again.
+    mod.usePluginContextMenuItemsStore.getState().init();
+    expect(onChangedMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/store/pluginContextMenuItemsStore.ts
+++ b/src/store/pluginContextMenuItemsStore.ts
@@ -1,0 +1,89 @@
+import { create } from "zustand";
+import type { ContextMenuContribution } from "@shared/types/plugin";
+import { logWarn } from "@/utils/logger";
+
+export interface PluginContextMenuItemEntry {
+  pluginId: string;
+  item: ContextMenuContribution;
+}
+
+/**
+ * Renderer mirror of the plugin-contributed context-menu items. Source of truth
+ * is `PluginService` in main; we pull the current set once and keep it in sync
+ * via the authoritative `plugin:context-menu-items-changed` push.
+ *
+ * The pull + subscription live here (one IPC round-trip, one listener) instead
+ * of in every `usePluginContextMenuItems` caller — the hook is rendered once per
+ * worktree card, file-change row, and terminal menu, so a per-instance pull
+ * scaled the IPC traffic and listener count with the surface count (#10753). The
+ * subscription is module-level (not per-component) so it survives consumer
+ * unmount/remount (list churn, dock/grid toggle, LRU view restore) and no push
+ * is missed between renders — it is never torn down for the renderer's lifetime.
+ *
+ * The `complete` flag on the broadcast is received but has no side effect (no
+ * renderer-local persisted state to sweep); it is plumbed for symmetry with the
+ * broadcast contract.
+ */
+interface PluginContextMenuItemsState {
+  entries: PluginContextMenuItemEntry[];
+  /** Idempotent: pulls the current set once and subscribes to live updates. */
+  init: () => void;
+}
+
+let initialized = false;
+let unsubscribe: (() => void) | null = null;
+// Monotonic pull sequence: the one-shot mount pull must never overwrite a push
+// that arrived while it was in flight. A push bumps this before applying its
+// payload, so the older pull bails on resolution (push is authoritative).
+let pullSeq = 0;
+
+export const usePluginContextMenuItemsStore = create<PluginContextMenuItemsState>((set) => ({
+  entries: [],
+  init: () => {
+    if (initialized) return;
+
+    // Consumed from many leaf components (every worktree card, file-change row,
+    // terminal menu), so tolerate a partially-stubbed bridge instead of pushing
+    // a plugin-namespace mock into every component test. Absent bridge ⇒ empty
+    // set, matching prod before the first pull. Don't latch `initialized` until
+    // the bridge is present, so a no-bridge early return stays retryable.
+    const plugin = window.electron?.plugin;
+    if (
+      typeof plugin?.contextMenuItems !== "function" ||
+      typeof plugin.onContextMenuItemsChanged !== "function"
+    ) {
+      return;
+    }
+    initialized = true;
+
+    // Capture the pull's sequence and start it BEFORE registering the listener:
+    // a push that arrives while the pull is in flight bumps `pullSeq`, so the
+    // stale pull bails on resolution.
+    const seq = ++pullSeq;
+    void plugin
+      .contextMenuItems()
+      .then((items) => {
+        if (seq !== pullSeq) return;
+        set({ entries: items });
+      })
+      .catch((err: unknown) => {
+        logWarn("[pluginContextMenuItemsStore] Failed to fetch initial plugin context menu items", {
+          error: err,
+        });
+      });
+
+    unsubscribe = plugin.onContextMenuItemsChanged((payload) => {
+      pullSeq++;
+      set({ entries: payload.items });
+    });
+  },
+}));
+
+/** Test-only: reset the module-level init guard, pull sequence, and state. */
+export function _resetPluginContextMenuItemsStoreForTest(): void {
+  unsubscribe?.();
+  unsubscribe = null;
+  initialized = false;
+  pullSeq = 0;
+  usePluginContextMenuItemsStore.setState({ entries: [] });
+}

--- a/src/store/pluginContextMenuItemsStore.ts
+++ b/src/store/pluginContextMenuItemsStore.ts
@@ -54,7 +54,6 @@ export const usePluginContextMenuItemsStore = create<PluginContextMenuItemsState
     ) {
       return;
     }
-    initialized = true;
 
     // Capture the pull's sequence and start it BEFORE registering the listener:
     // a push that arrives while the pull is in flight bumps `pullSeq`, so the
@@ -67,6 +66,8 @@ export const usePluginContextMenuItemsStore = create<PluginContextMenuItemsState
         set({ entries: items });
       })
       .catch((err: unknown) => {
+        // A transient pull failure leaves entries empty; the permanent push
+        // listener below corrects the set on the next plugin load/unload.
         logWarn("[pluginContextMenuItemsStore] Failed to fetch initial plugin context menu items", {
           error: err,
         });
@@ -76,6 +77,11 @@ export const usePluginContextMenuItemsStore = create<PluginContextMenuItemsState
       pullSeq++;
       set({ entries: payload.items });
     });
+
+    // Latch only after the pull is dispatched and the listener is registered, so
+    // a throw from either path leaves the store retryable rather than wedged
+    // with no subscription. A retry's fresh `pullSeq` voids any earlier pull.
+    initialized = true;
   },
 }));
 


### PR DESCRIPTION
## Summary

- `usePluginContextMenuItems` previously made a separate IPC call and registered a separate push listener per mounting instance (once per worktree card, file-change row, and terminal context menu), so both IPC traffic and live-listener count scaled with the number of rendered surfaces.
- Moves the pull and subscription into a new Zustand store (`src/store/pluginContextMenuItemsStore.ts`) so the whole renderer shares exactly one IPC call and one listener. The hook becomes a thin wrapper that initializes the store idempotently and returns a per-consumer filtered view.
- No call-site changes. `PluginContextMenuItemEntry` is re-exported from the hook so `PluginContextMenuSection.tsx` is untouched.

Resolves #10753

## Changes

- `src/store/pluginContextMenuItemsStore.ts` (new): Zustand store owning the single IPC pull and module-level push subscription. Monotonic `pullSeq` guard ensures an authoritative push beats an in-flight pull. Subscription is never torn down so LRU-evicted views continue receiving updates on restore (per #9490). Absent-bridge init stays retryable.
- `src/hooks/usePluginContextMenuItems.ts`: simplified to a thin store wrapper. Initializes the store on first call, derives the filtered view. `when`-clause evaluation stays in the hook because context is captured at menu-open time.
- `src/store/__tests__/pluginContextMenuItemsStore.test.ts` (new): 10 store tests covering init, push, pull/push race via `pullSeq`, and absent-bridge retry.
- `src/hooks/__tests__/usePluginContextMenuItems.test.ts`: 11 hook tests (broadened from the original coverage).

## Testing

21 targeted tests pass: 10 store, 11 hook. `npm run check` clean.