### PR TITLE
perf(project): warm project switcher and radix overlay chunks at idle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,6 +94,7 @@ import { AccessibilityAnnouncer } from "./components/Accessibility/Accessibility
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
 import { ConfirmDialog } from "./components/ui/ConfirmDialog";
 import { TooltipProvider } from "./components/ui/tooltip";
+import { primeRadix } from "./components/ui/radix-loader";
 import { UI_TOOLTIP_DELAY_DURATION, UI_TOOLTIP_SKIP_DELAY_DURATION } from "./lib/animationUtils";
 
 // Module-scope loaders: raw import() expressions inside component effects bail
@@ -823,6 +824,7 @@ function AppInner() {
       void preloadNewWorktreeDialog();
       void preloadActionPalette();
       void preloadQuickSwitcher();
+      void preloadProjectSwitcherPalette();
       void preloadWorktreePalette();
       void preloadNewTerminalPalette();
       void preloadPanelPalette();
@@ -841,6 +843,12 @@ function AppInner() {
       // `Worktree/FileDiffModal.tsx`, so an explicit post-paint prefetch keeps
       // it snappy on first use.
       preloadFileViewerModal().catch(() => {});
+      // Warm the shared Radix overlay primitives chunk (`radix-deferred`) so the
+      // ProjectSwitcherPalette popover and context menus are ready on first
+      // interaction in a freshly loaded project view. Otherwise this chunk is
+      // only demand-loaded on the first pointer/focus gesture (#10752). Each
+      // WebContentsView has its own module cache, so this fires per view.
+      primeRadix().catch(() => {});
     };
 
     if (typeof scheduler !== "undefined" && typeof scheduler.postTask === "function") {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -824,7 +824,7 @@ function AppInner() {
       void preloadNewWorktreeDialog();
       void preloadActionPalette();
       void preloadQuickSwitcher();
-      void preloadProjectSwitcherPalette();
+      preloadProjectSwitcherPalette().catch(() => {});
       void preloadWorktreePalette();
       void preloadNewTerminalPalette();
       void preloadPanelPalette();

--- a/src/components/ui/__tests__/radix-loader.test.ts
+++ b/src/components/ui/__tests__/radix-loader.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// These tests exercise the singleton invariants that make `primeRadix()` safe
+// to call repeatedly — once at idle warm-up (per WebContentsView) and again on
+// pointer/focus gestures (#10752). The dynamic `radix-deferred` chunk is mocked
+// so this stays a pure module-logic unit test with no DOM dependency.
+//
+// `vi.resetModules()` before each test discards the module registry so every
+// case gets a fresh `radix-loader` with its `cached`/`inFlight` singletons
+// reset — no state leaks between cases.
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.doUnmock("../radix-deferred");
+});
+
+describe("primeRadix", () => {
+  it("dedupes concurrent priming into a single in-flight promise", async () => {
+    vi.doMock("../radix-deferred", () => ({ marker: "deferred" }));
+    const { primeRadix } = await import("../radix-loader");
+
+    const p1 = primeRadix();
+    const p2 = primeRadix();
+
+    // Same in-flight promise reference — a second call before resolution must
+    // not schedule a second dynamic import.
+    expect(p2).toBe(p1);
+
+    const [m1, m2] = await Promise.all([p1, p2]);
+    expect(m1).toBe(m2);
+  });
+
+  it("caches the resolved module so later calls resolve to the same object", async () => {
+    vi.doMock("../radix-deferred", () => ({ marker: "deferred" }));
+    const { primeRadix, getRadixPrimitives } = await import("../radix-loader");
+
+    const mod = await primeRadix();
+
+    // getRadixPrimitives exposes the cached module synchronously after resolve.
+    expect(getRadixPrimitives()).toBe(mod);
+
+    const again = await primeRadix();
+    expect(again).toBe(mod);
+  });
+
+  it("returns null from getRadixPrimitives before the chunk resolves", async () => {
+    vi.doMock("../radix-deferred", () => ({ marker: "deferred" }));
+    const { primeRadix, getRadixPrimitives } = await import("../radix-loader");
+
+    expect(getRadixPrimitives()).toBeNull();
+    const p = primeRadix();
+    // Still null while the import is in flight.
+    expect(getRadixPrimitives()).toBeNull();
+    await p;
+    expect(getRadixPrimitives()).not.toBeNull();
+  });
+
+  it("clears the in-flight singleton on rejection so the next call retries", async () => {
+    vi.doMock("../radix-deferred", () => {
+      throw new Error("chunk load failed");
+    });
+    const { primeRadix, getRadixPrimitives } = await import("../radix-loader");
+
+    const p1 = primeRadix();
+    await expect(p1).rejects.toThrow();
+
+    // Failure must not be cached as a successful module.
+    expect(getRadixPrimitives()).toBeNull();
+
+    // A subsequent call creates a fresh promise rather than reusing the
+    // rejected one — this is what lets a later gesture retry after a transient
+    // chunk-load failure instead of being permanently broken.
+    const p2 = primeRadix();
+    expect(p2).not.toBe(p1);
+    await expect(p2).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- `ProjectSwitcherPalette` and the shared Radix overlay chunk (`radix-deferred`) both loaded cold on first open. The project selector preload helper already existed but was never called during idle warm-up, and `primeRadix` wasn't wired in at all.
- Both are now added to the existing idle warm-up `useEffect` in `src/App.tsx`, gated on `isStateLoaded` (which resets per `WebContentsView`). This means the warm-up runs fresh for every project switch, not just the first load.
- Added a unit test file for the `primeRadix` singleton covering the four edge cases: in-flight dedup, post-resolve caching, null-before-resolve, and rejection reset.

Fixes #10752

## Changes

- `src/App.tsx`: added `preloadProjectSwitcherPalette().catch()` and `primeRadix().catch()` to the idle warm-up block (background priority via `scheduler.postTask`), plus the `primeRadix` import.
- `src/components/ui/__tests__/radix-loader.test.ts` (new): 4 behavioral unit tests for the `primeRadix` singleton.

## Testing

- `radix-loader.test.ts`: all 4 tests pass.
- Prettier: no changes on modified files.
- ESLint: no errors on modified files.