### PR TITLE
fix(forge-stats): isolate in-flight fetches per project and reuse cached stats on switch-back

### DIFF
--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -546,6 +546,57 @@ describe("useRepositoryStats", () => {
         expect(result.current.error).toBeNull();
       });
     });
+
+    it("evicts the oldest cache entry once the cap is exceeded", async () => {
+      // Cap is 20 entries. Loading 21 distinct projects evicts the oldest
+      // (smallest lastUpdated), so switching back to it can no longer restore
+      // from cache and must refetch with a skeleton.
+      let currentProject = { id: "p0", path: "/repo/p0" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const base = Date.now();
+      let tick = 0;
+      getRepoStatsMock.mockImplementation(async () => {
+        tick += 1;
+        return freshStats({ commitCount: tick, lastUpdated: base + tick });
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(1));
+
+      // Load 20 more distinct projects (p1..p20) → 21 total, evicting p0.
+      for (let i = 1; i <= 20; i++) {
+        currentProject = { id: `p${i}`, path: `/repo/p${i}` };
+        act(() => {
+          switchHandler?.();
+        });
+        await waitFor(() => expect(result.current.stats?.commitCount).toBe(i + 1));
+      }
+
+      // Switch back to p0 — its entry was evicted, so it refetches with a
+      // skeleton instead of restoring instantly.
+      const slowP0 = createDeferred<ForgeRepositoryStats>();
+      getRepoStatsMock.mockImplementationOnce(() => slowP0.promise);
+      currentProject = { id: "p0", path: "/repo/p0" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => {
+        expect(result.current.stats).toBeNull();
+        expect(result.current.loading).toBe(true);
+      });
+
+      await act(async () => {
+        slowP0.resolve(freshStats({ commitCount: 999 }));
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(999));
+    });
   });
 
   describe("onRepoCountsUpdated push (issue #10122)", () => {

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -57,7 +57,11 @@ vi.mock("@/hooks/useResolvedForgeProvider", () => ({
   }),
 }));
 
-import { useRepositoryStats } from "../useRepositoryStats";
+import {
+  useRepositoryStats,
+  FRESH_THRESHOLD_MS,
+  _resetSwitchBackCacheForTests,
+} from "../useRepositoryStats";
 import { _resetPollingLifecycleForTests } from "../usePollingLifecycle";
 import { useSystemWakeStore } from "@/store/systemWakeStore";
 import {
@@ -82,6 +86,7 @@ describe("useRepositoryStats", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetPollingLifecycleForTests();
+    _resetSwitchBackCacheForTests();
     useSystemWakeStore.setState({
       wakeEpoch: 0,
       lastSleepDuration: 0,
@@ -303,6 +308,243 @@ describe("useRepositoryStats", () => {
       expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
       expect(getRepoStatsMock.mock.calls[1]?.[0]).toBe("/repo/b");
       expect(result.current.stats?.commitCount).toBe(77);
+    });
+  });
+
+  describe("cross-project guard + switch-back reuse (issue #10761)", () => {
+    function freshStats(overrides: Partial<ForgeRepositoryStats>): ForgeRepositoryStats {
+      return {
+        commitCount: 0,
+        issueCount: 0,
+        prCount: 0,
+        loading: false,
+        stale: false,
+        lastUpdated: Date.now(),
+        ...overrides,
+      };
+    }
+
+    // The polling lifecycle serializes fetches: a switch while a fetch is in
+    // flight queues the next fetch (rather than running concurrently), so the
+    // previous project's request resolves first and must bail before applying.
+    it("does not leak an in-flight previous-project error onto the new project", async () => {
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const slowA = createDeferred<ForgeRepositoryStats>();
+      const statsB = freshStats({ commitCount: 22, issueCount: 2, prCount: 2 });
+      getRepoStatsMock.mockImplementationOnce(() => slowA.promise).mockResolvedValueOnce(statsB);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      // Switch to B while A's fetch is still pending, then let A fail. A's
+      // error must be discarded; the queued B fetch then loads cleanly.
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await act(async () => {
+        slowA.reject(new Error("Project A network failure"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+        expect(result.current.stats?.commitCount).toBe(22);
+        expect(result.current.error).toBeNull();
+        expect(result.current.freshnessLevel).not.toBe("errored");
+      });
+    });
+
+    it("does not leak an in-flight previous-project success onto the new project", async () => {
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const slowA = createDeferred<ForgeRepositoryStats>();
+      const statsA = freshStats({ commitCount: 11, issueCount: 9, prCount: 9 });
+      const statsB = freshStats({ commitCount: 22, issueCount: 2, prCount: 2 });
+      getRepoStatsMock.mockImplementationOnce(() => slowA.promise).mockResolvedValueOnce(statsB);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(getRepoStatsMock).toHaveBeenCalledTimes(1));
+
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await act(async () => {
+        slowA.resolve(statsA);
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+        expect(result.current.stats?.commitCount).toBe(22);
+      });
+      // A's stale counts never surfaced on B.
+      expect(result.current.stats?.issueCount).toBe(2);
+    });
+
+    it("restores cached stats without a skeleton when switching back within FRESH_THRESHOLD_MS", async () => {
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const now = Date.now();
+      const statsA = freshStats({ commitCount: 7, issueCount: 4, prCount: 3, lastUpdated: now });
+      const statsB = freshStats({ commitCount: 12, issueCount: 1, prCount: 1, lastUpdated: now });
+      const statsARevalidated = freshStats({
+        commitCount: 8,
+        issueCount: 5,
+        prCount: 3,
+        lastUpdated: now + 1,
+      });
+      // Hold the switch-back revalidation so the restored cache value is
+      // observable before fresh data lands over it.
+      const slowRevalidate = createDeferred<ForgeRepositoryStats>();
+
+      getRepoStatsMock
+        .mockResolvedValueOnce(statsA)
+        .mockResolvedValueOnce(statsB)
+        .mockImplementationOnce(() => slowRevalidate.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(12));
+
+      // Switch back to A within the freshness window — cached counts restore
+      // immediately, the skeleton never shows, and a background revalidation
+      // still fires.
+      currentProject = { id: "a", path: "/repo/a" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => {
+        expect(result.current.stats?.commitCount).toBe(7);
+        expect(result.current.loading).toBe(false);
+      });
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(3);
+
+      // The background revalidation converges to fresh data.
+      await act(async () => {
+        slowRevalidate.resolve(statsARevalidated);
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(8));
+    });
+
+    it("does not reuse cached stats when switching back after FRESH_THRESHOLD_MS", async () => {
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      // A's stats are older than the fresh window (but still within aging, so
+      // the entry survives eviction) — switch-back must not restore them.
+      const staleAge = Date.now() - (FRESH_THRESHOLD_MS + 5_000);
+      const statsA = freshStats({ commitCount: 7, lastUpdated: staleAge });
+      const statsB = freshStats({ commitCount: 12 });
+      const slowA2 = createDeferred<ForgeRepositoryStats>();
+
+      getRepoStatsMock
+        .mockResolvedValueOnce(statsA)
+        .mockResolvedValueOnce(statsB)
+        .mockImplementationOnce(() => slowA2.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(12));
+
+      // Switch back to A — its cache entry is past FRESH_THRESHOLD_MS, so the
+      // hook clears to a skeleton and refetches.
+      currentProject = { id: "a", path: "/repo/a" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => {
+        expect(result.current.stats).toBeNull();
+        expect(result.current.loading).toBe(true);
+      });
+
+      await act(async () => {
+        slowA2.resolve(freshStats({ commitCount: 9, issueCount: 4, prCount: 2 }));
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(9));
+    });
+
+    it("never restores a previous error on switch-back (errors are not cached)", async () => {
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const erroredA = freshStats({
+        commitCount: 0,
+        issueCount: null,
+        prCount: null,
+        stale: true,
+        error: "Token expired",
+      });
+      const statsB = freshStats({ commitCount: 12 });
+      const freshA = freshStats({ commitCount: 5, issueCount: 2, prCount: 1 });
+
+      getRepoStatsMock
+        .mockResolvedValueOnce(erroredA)
+        .mockResolvedValueOnce(statsB)
+        .mockResolvedValueOnce(freshA);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.error).toBe("Token expired"));
+
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(12));
+
+      // Switch back to A — the errored result was never cached, so a fresh fetch
+      // runs and the error does not reappear.
+      currentProject = { id: "a", path: "/repo/a" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(3);
+        expect(result.current.stats?.commitCount).toBe(5);
+        expect(result.current.error).toBeNull();
+      });
     });
   });
 

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -43,6 +43,30 @@ const RATE_LIMIT_RESUME_BUFFER_MS = 2_000;
 export const FRESH_THRESHOLD_MS = 90_000;
 export const AGING_THRESHOLD_MS = 300_000;
 
+// Switch-back reuse cache (issue #10761). Keyed by project path, this holds the
+// last genuinely-fresh stats result per project so a rapid switch back to a
+// recently-loaded project restores its counts immediately instead of clearing
+// to a skeleton and forcing a full refetch. Module-level so it survives the
+// hook's per-switch state resets while staying scoped to this `WebContentsView`'s
+// isolated V8 context. Entries are evicted once they age past
+// `AGING_THRESHOLD_MS` (no longer reusable) and capped to bound growth across a
+// session that opens many projects. Only fresh successful results are stored —
+// stale/errored polls and disk bootstrap snapshots are never cached here, so a
+// switch-back never resurrects a previous error.
+interface SwitchBackCacheEntry {
+  stats: ForgeRepositoryStats;
+  lastUpdated: number;
+  providerId: string | null;
+}
+
+const MAX_SWITCHBACK_CACHE_SIZE = 20;
+const switchBackStatsCache = new Map<string, SwitchBackCacheEntry>();
+
+/** Test-only: clear the module-level switch-back cache between cases. */
+export function _resetSwitchBackCacheForTests(): void {
+  switchBackStatsCache.clear();
+}
+
 /**
  * Per-pill freshness tier driving the toolbar's visual encoding. Replaces the
  * old binary `isStale` so a 30-second-old poll, a disk-cache cold start, and a
@@ -131,6 +155,14 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   const mountedRef = useRef(true);
   const lastErrorRef = useRef<string | null>(null);
 
+  // Monotonic fetch epoch (issue #10761). Incremented on every project switch
+  // so an in-flight fetch started before the switch can be detected and
+  // discarded after it resolves — including the A→B→A cyclic case where the
+  // project path alone repeats and a path-based guard would wrongly let the
+  // earlier epoch's result through. Captured locally before the first `await`
+  // in `fetchFn` and re-checked after each await.
+  const fetchGenerationRef = useRef(0);
+
   useEffect(() => {
     mountedRef.current = true;
     return () => {
@@ -211,6 +243,40 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       lastUpdatedRef.current = nextLastUpdated;
       setLastUpdated(nextLastUpdated);
 
+      // Seed the switch-back reuse cache on genuine fresh success only
+      // (issue #10761). `shouldPreserve` covers stale/errored results, and a
+      // missing `lastUpdated` means there's no fetch time to age against — both
+      // are excluded so a switch-back never restores an error or an undatable
+      // snapshot. Evict aged-out entries on write and cap the map size to keep
+      // it bounded across a session that visits many projects.
+      if (!shouldPreserve && nextLastUpdated !== null) {
+        const now = Date.now();
+        for (const [key, entry] of switchBackStatsCache) {
+          if (now - entry.lastUpdated >= AGING_THRESHOLD_MS) {
+            switchBackStatsCache.delete(key);
+          }
+        }
+        if (
+          switchBackStatsCache.size >= MAX_SWITCHBACK_CACHE_SIZE &&
+          !switchBackStatsCache.has(opts.projectPath)
+        ) {
+          let oldestKey: string | null = null;
+          let oldestTs = Infinity;
+          for (const [key, entry] of switchBackStatsCache) {
+            if (entry.lastUpdated < oldestTs) {
+              oldestTs = entry.lastUpdated;
+              oldestKey = key;
+            }
+          }
+          if (oldestKey !== null) switchBackStatsCache.delete(oldestKey);
+        }
+        switchBackStatsCache.set(opts.projectPath, {
+          stats: preservedStats,
+          lastUpdated: nextLastUpdated,
+          providerId: providerIdRef.current,
+        });
+      }
+
       // Carry the probe-derived cadence forward only on successful reads — a
       // stale/errored result has no fresh cadence to offer, so the existing
       // value keeps driving the schedule. On a success that reports no cadence
@@ -259,8 +325,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   const polling = usePollingLifecycle({
     enabled: !isWorkerInstance && currentProjectId !== null && !providerLoading,
     fetchFn: async ({ force, isInvalidated }) => {
+      // Capture the fetch epoch before the first await so a project switch that
+      // fires mid-flight can be detected after each await (issue #10761).
+      const myGeneration = fetchGenerationRef.current;
       try {
         const project = await projectClient.getCurrent();
+        if (fetchGenerationRef.current !== myGeneration) return;
         if (!project) {
           if (mountedRef.current) {
             setStats(null);
@@ -271,6 +341,24 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
             lastErrorRef.current = null;
           }
           return;
+        }
+
+        // Switch-back reuse (issue #10761): if this project's stats were loaded
+        // recently, restore them synchronously before the skeleton would show.
+        // `applyStatsResult` sets `hasAppliedResultRef`, so the `setLoading`
+        // gate below stays off and the poll below revalidates in the
+        // background. Gated on the resolved provider matching the cached one so
+        // a project that now resolves to a different provider doesn't reuse
+        // stale counts. Errors are never cached, so this can't resurrect one.
+        if (mountedRef.current && !hasAppliedResultRef.current) {
+          const cached = switchBackStatsCache.get(project.path);
+          if (
+            cached &&
+            cached.providerId === providerIdRef.current &&
+            Date.now() - cached.lastUpdated < FRESH_THRESHOLD_MS
+          ) {
+            applyStatsResult(cached.stats, { projectPath: project.path });
+          }
         }
 
         if (mountedRef.current) {
@@ -289,13 +377,12 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         if (!mountedRef.current) return;
         if (isInvalidated()) return;
 
-        // Ignore results from previous project (race condition protection)
-        if (
-          lastKnownCountsRef.current.projectPath !== null &&
-          lastKnownCountsRef.current.projectPath !== project.path
-        ) {
-          return;
-        }
+        // Ignore results from a previous project (issue #10761). The fetch
+        // epoch advances on every switch, so a mismatch means this result was
+        // requested before a switch fired — discard it rather than applying the
+        // old project's stats/error to the new one. This supersedes the old
+        // path-based guard, which let A→B→A cyclic switches leak through.
+        if (fetchGenerationRef.current !== myGeneration) return;
 
         applyStatsResult(repoStats, { projectPath: project.path });
       } catch (err) {
@@ -303,6 +390,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
         // error to the new project's state would surface a stale error and
         // push `calculateNextInterval` into ERROR_BACKOFF_INTERVAL.
         if (isInvalidated()) return;
+        if (fetchGenerationRef.current !== myGeneration) return;
         if (mountedRef.current) {
           const errorMessage = formatErrorMessage(err, "Failed to fetch repository stats");
           setError(errorMessage);
@@ -342,6 +430,11 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       return IDLE_POLL_INTERVAL * multiplier;
     },
     onProjectSwitch: () => {
+      // Advance the fetch epoch unconditionally (even while unmounted) so any
+      // in-flight fetch from the previous project is discarded when it resolves
+      // instead of applying its stats/error to the newly-switched project
+      // (issue #10761). This must precede the mounted-guard early return.
+      fetchGenerationRef.current += 1;
       if (!mountedRef.current) return;
       // Clear preserved counts on project switch to prevent cross-contamination
       lastKnownCountsRef.current = { issueCount: null, prCount: null, projectPath: null };

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -149,8 +149,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   const lastKnownCountsRef = useRef<{
     issueCount: number | null;
     prCount: number | null;
-    projectPath: string | null;
-  }>({ issueCount: null, prCount: null, projectPath: null });
+  }>({ issueCount: null, prCount: null });
 
   const mountedRef = useRef(true);
   const lastErrorRef = useRef<string | null>(null);
@@ -179,10 +178,6 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       if (!mountedRef.current) return;
 
       hasAppliedResultRef.current = true;
-
-      // Track current project so a stale callback from a previous project
-      // can be detected by `fetchStats`'s cross-project guard.
-      lastKnownCountsRef.current.projectPath = opts.projectPath;
 
       // Only preserve counts when data is stale or errored (not on successful fresh fetch)
       const shouldPreserve = repoStats.stale === true || repoStats.error !== undefined;
@@ -331,6 +326,10 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       try {
         const project = await projectClient.getCurrent();
         if (fetchGenerationRef.current !== myGeneration) return;
+        // Lifecycle contract: re-check invalidation after every await. A
+        // same-project refresh queued while `getCurrent()` was pending
+        // supersedes this fetch — bail before spending a `getRepoStats` call.
+        if (isInvalidated()) return;
         if (!project) {
           if (mountedRef.current) {
             setStats(null);
@@ -437,7 +436,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       fetchGenerationRef.current += 1;
       if (!mountedRef.current) return;
       // Clear preserved counts on project switch to prevent cross-contamination
-      lastKnownCountsRef.current = { issueCount: null, prCount: null, projectPath: null };
+      lastKnownCountsRef.current = { issueCount: null, prCount: null };
       hasAppliedResultRef.current = false;
 
       setStats(null);


### PR DESCRIPTION
## Summary

- Fixed cross-project fetch contamination in `useRepositoryStats`: a stale in-flight fetch from the previous project could complete after a switch and apply its result (including errors) to the new project. This was the cause of the red error line in `ForgeStatusIndicator` that persisted until a manual click.
- Fixed unconditional stats clear on switch-back: every return to a project flushed stats and triggered a full refetch, flashing a loading skeleton even for projects loaded seconds ago.
- Added a module-level per-project switch-back cache (capped at 20 entries, 90s freshness window) so cached counts restore synchronously on switch-back while the normal poll revalidates in the background.

Resolves #10761.

## Changes

- Replaced the broken `lastKnownCountsRef.projectPath` path guard with a monotonic `fetchGenerationRef` incremented on every project switch and re-checked after each `await` in `fetchFn` (success and catch paths). This is a consumer-owned guard that stays valid across rapid switches.
- Added a module-level `switchBackCache` map: keyed by project path, stores counts, provider, and timestamp. Restored synchronously on switch-back when fresh (under `FRESH_THRESHOLD_MS` / 90s) and matching provider. Only genuine fresh successes are cached (never stale, errored, or disk-bootstrap results). Entries older than `AGING_THRESHOLD_MS` are evicted on read and the map is capped at 20 entries.
- Removed the now-dead `lastKnownCountsRef.projectPath` field.
- Added an `isInvalidated()` re-check after `getCurrent()` per the polling-lifecycle contract.

## Testing

6 new cases in `useRepositoryStats.test.tsx`: cross-project error isolation, cross-project success isolation, switch-back cache reuse within the fresh window, expiry after the fresh window, errors never restored, and cap eviction. All 54 hook tests and 1075 Layout tests pass. ESLint and Prettier clean on changed files.