### PR TITLE
chore(mcp-server): remove CallTool tool-call rate limiter (#10764)

### DIFF
--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -12,7 +12,7 @@ vi.mock("electron", () => ({
 import { createSessionServer, validateDisplayImageUrl } from "../sessionServer.js";
 import type { SessionServerDeps } from "../sessionServer.js";
 import type { SessionStore } from "../sessionStore.js";
-import { SessionStore as RealSessionStore, consumeToken } from "../sessionStore.js";
+import { SessionStore as RealSessionStore } from "../sessionStore.js";
 import { GrantCache } from "../grantCache.js";
 import {
   buildToolError,
@@ -26,9 +26,6 @@ import {
   ELICITATION_FAILED_CODE,
   MCP_DEDUP_KEY_COLLISION_CODE,
   MCP_DEDUP_ALLOWLIST,
-  MCP_RATE_LIMITED_CODE,
-  RATE_LIMIT_TIERS,
-  RATE_LIMIT_TOOL_MAP,
   minimumPermittingTier,
   unwrapDispatchResult,
 } from "../shared.js";
@@ -51,7 +48,6 @@ function fakeSessionStore(
     resourceSubscriptions: new Map(),
     dedupInFlight: new Map(),
     dedupResultCache: new Map(),
-    rateLimitBuckets: new Map(),
     grantCache,
     drain: vi.fn(),
     getTier: vi.fn(() => tier),
@@ -60,11 +56,6 @@ function fakeSessionStore(
     resetIdleTimer: vi.fn(),
     resetHttpIdleTimer: vi.fn(),
     clearDedupState: vi.fn(),
-    // Permissive by default so existing suites aren't throttled; the
-    // rate-limit suite overrides this with a counting stub or the real
-    // implementation.
-    consumeRateLimitToken: vi.fn(() => ({ allowed: true })),
-    clearRateLimitState: vi.fn(),
   } as unknown as SessionStore;
   return store;
 }
@@ -1360,28 +1351,6 @@ describe("CallTool live activity notifications (#9759)", () => {
     expect(settled).not.toHaveBeenCalled();
   });
 
-  it("does not emit started/settled for a rate-limited rejection", async () => {
-    const started = vi.fn();
-    const settled = vi.fn();
-    const sessionStore = fakeSessionStore("workbench");
-    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
-      allowed: false,
-      retryAfter: 5,
-    });
-    const deps = fakeDeps({
-      sessionStore,
-      notifyToolCallStarted: started,
-      notifyToolCallSettled: settled,
-    });
-    const server = createSessionServer("session-C", deps);
-    await server.connect(makeMockTransport());
-
-    await callTool(server, { name: "worktree.list", arguments: {} });
-
-    expect(started).not.toHaveBeenCalled();
-    expect(settled).not.toHaveBeenCalled();
-  });
-
   it('flags danger:"confirm" tools on the started event', async () => {
     const started = vi.fn();
     const requestManifest = vi
@@ -2208,344 +2177,6 @@ describe("sessionServer grant cache fallback (#8442)", () => {
   });
 });
 
-function parseToolErrorPayload(result: { content: unknown; isError?: boolean }): {
-  code: string;
-  retriable: boolean;
-  details?: { retryAfter?: number };
-} {
-  const text = (result as { content: Array<{ text: string }> }).content[0].text;
-  return JSON.parse(text);
-}
-
-describe("consumeToken (pure token bucket)", () => {
-  const mutation = RATE_LIMIT_TIERS.mutation; // capacity 10, 10/min
-
-  it("allows up to capacity then rejects with a positive retryAfter", () => {
-    const bucket = { tokens: mutation.capacity, lastRefillMs: 1000 };
-    for (let i = 0; i < mutation.capacity; i++) {
-      expect(consumeToken(bucket, mutation, 1000).allowed).toBe(true);
-    }
-    const rejected = consumeToken(bucket, mutation, 1000);
-    expect(rejected.allowed).toBe(false);
-    if (!rejected.allowed) {
-      expect(rejected.retryAfter).toBeGreaterThanOrEqual(1);
-    }
-  });
-
-  it("refills proportionally to elapsed wall-clock", () => {
-    const bucket = { tokens: 0, lastRefillMs: 0 };
-    // 10/min => one token every 6000ms. After 6000ms exactly one token.
-    const r = consumeToken(bucket, mutation, 6000);
-    expect(r.allowed).toBe(true);
-    expect(bucket.tokens).toBeCloseTo(0, 5);
-  });
-
-  it("caps refill at capacity (no unbounded accrual while idle)", () => {
-    const bucket = { tokens: 0, lastRefillMs: 0 };
-    // A huge idle gap must not let the bucket exceed capacity.
-    consumeToken(bucket, mutation, 60 * 60 * 1000);
-    expect(bucket.tokens).toBeLessThanOrEqual(mutation.capacity);
-  });
-
-  it("never returns a sub-second retryAfter", () => {
-    const bucket = { tokens: 0.99, lastRefillMs: 0 };
-    const r = consumeToken(bucket, RATE_LIMIT_TIERS.highFreqRead, 0);
-    expect(r.allowed).toBe(false);
-    if (!r.allowed) expect(r.retryAfter).toBeGreaterThanOrEqual(1);
-  });
-});
-
-describe("SessionStore.consumeRateLimitToken", () => {
-  it("exhausts the mutation tier (git.commit) after capacity calls", () => {
-    const store = new RealSessionStore(() => {});
-    const cap = RATE_LIMIT_TIERS.mutation.capacity;
-    for (let i = 0; i < cap; i++) {
-      expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(true);
-    }
-    const rejected = store.consumeRateLimitToken("s", "git.commit", 1000);
-    expect(rejected.allowed).toBe(false);
-    store.drain();
-  });
-
-  it("uses the high-frequency tier for read tools (terminal.getStatus)", () => {
-    const store = new RealSessionStore(() => {});
-    const cap = RATE_LIMIT_TIERS.highFreqRead.capacity;
-    for (let i = 0; i < cap; i++) {
-      expect(store.consumeRateLimitToken("s", "terminal.getStatus", 1000).allowed).toBe(true);
-    }
-    expect(store.consumeRateLimitToken("s", "terminal.getStatus", 1000).allowed).toBe(false);
-    store.drain();
-  });
-
-  it("falls back to the standard tier for unmapped tools", () => {
-    const store = new RealSessionStore(() => {});
-    const cap = RATE_LIMIT_TIERS.standard.capacity;
-    for (let i = 0; i < cap; i++) {
-      expect(store.consumeRateLimitToken("s", "files.search", 1000).allowed).toBe(true);
-    }
-    expect(store.consumeRateLimitToken("s", "files.search", 1000).allowed).toBe(false);
-    store.drain();
-  });
-
-  it("isolates buckets per session", () => {
-    const store = new RealSessionStore(() => {});
-    const cap = RATE_LIMIT_TIERS.mutation.capacity;
-    for (let i = 0; i < cap; i++) {
-      store.consumeRateLimitToken("session-a", "git.push", 1000);
-    }
-    expect(store.consumeRateLimitToken("session-a", "git.push", 1000).allowed).toBe(false);
-    // A fresh session is unaffected by session-a's exhausted bucket.
-    expect(store.consumeRateLimitToken("session-b", "git.push", 1000).allowed).toBe(true);
-    store.drain();
-  });
-
-  it("isolates buckets per tool within a session", () => {
-    const store = new RealSessionStore(() => {});
-    const cap = RATE_LIMIT_TIERS.mutation.capacity;
-    for (let i = 0; i < cap; i++) {
-      store.consumeRateLimitToken("s", "git.commit", 1000);
-    }
-    expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(false);
-    expect(store.consumeRateLimitToken("s", "git.push", 1000).allowed).toBe(true);
-    store.drain();
-  });
-
-  it("clearRateLimitState resets the session's buckets", () => {
-    const store = new RealSessionStore(() => {});
-    const cap = RATE_LIMIT_TIERS.mutation.capacity;
-    for (let i = 0; i < cap; i++) {
-      store.consumeRateLimitToken("s", "git.commit", 1000);
-    }
-    expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(false);
-    store.clearRateLimitState("s");
-    // Fresh bucket — full capacity again.
-    expect(store.consumeRateLimitToken("s", "git.commit", 1000).allowed).toBe(true);
-    store.drain();
-  });
-
-  it("drain() tears down all rate-limit buckets", () => {
-    const store = new RealSessionStore(() => {});
-    store.consumeRateLimitToken("s", "git.commit", 1000);
-    expect(store.rateLimitBuckets.has("s")).toBe(true);
-    store.drain();
-    expect(store.rateLimitBuckets.size).toBe(0);
-  });
-
-  it("revokeSession() tears down the rate-limit buckets for a live session", () => {
-    const store = new RealSessionStore(() => {});
-    store.consumeRateLimitToken("live", "git.commit", 1000);
-    expect(store.rateLimitBuckets.has("live")).toBe(true);
-    // Install a minimal HTTP session so revokeSession() has an entry to
-    // tear down (it returns false and no-ops without one).
-    store.httpSessions.set("live", {
-      transport: { close: vi.fn().mockResolvedValue(undefined) },
-      server: {},
-      idleTimer: setTimeout(() => {}, 1_000_000),
-    } as unknown as typeof store.httpSessions extends Map<string, infer V> ? V : never);
-    expect(store.revokeSession("live")).toBe(true);
-    expect(store.rateLimitBuckets.has("live")).toBe(false);
-    store.drain();
-  });
-
-  it("does not advance lastRefillMs backward on a clock step-back", () => {
-    const store = new RealSessionStore(() => {});
-    store.consumeRateLimitToken("s", "git.commit", 10000);
-    store.consumeRateLimitToken("s", "git.commit", 9000); // clock went back
-    const bucket = store.rateLimitBuckets.get("s")!.get("git.commit")!;
-    expect(bucket.lastRefillMs).toBe(10000);
-    store.consumeRateLimitToken("s", "git.commit", 10001);
-    expect(bucket.lastRefillMs).toBe(10001);
-    store.drain();
-  });
-});
-
-describe("CallTool rate limiting (handler integration)", () => {
-  it("rejects with MCP_RATE_LIMITED + retryAfter when the bucket is exhausted", async () => {
-    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
-    const sessionStore = fakeSessionStore("system");
-    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
-      allowed: false,
-      retryAfter: 7,
-    });
-    const appendAuditRecord = vi.fn();
-    const deps = fakeDeps({ sessionStore, dispatchAction, appendAuditRecord });
-    const server = createSessionServer("rl-1", deps);
-
-    const result = (await callTool(server, {
-      name: "git.commit",
-      arguments: { message: "x" },
-    })) as { content: unknown; isError?: boolean };
-
-    expect(result.isError).toBe(true);
-    const payload = parseToolErrorPayload(result);
-    expect(payload.code).toBe(MCP_RATE_LIMITED_CODE);
-    expect(payload.retriable).toBe(true);
-    expect(payload.details?.retryAfter).toBe(7);
-    // Rate limit runs before dispatch — the action never ran.
-    expect(dispatchAction).not.toHaveBeenCalled();
-  });
-
-  it("writes a rate_limited audit record before returning", async () => {
-    const sessionStore = fakeSessionStore("system");
-    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
-      allowed: false,
-      retryAfter: 3,
-    });
-    const appendAuditRecord = vi.fn();
-    const deps = fakeDeps({ sessionStore, appendAuditRecord });
-    const server = createSessionServer("rl-2", deps);
-
-    await callTool(server, { name: "git.push", arguments: {} });
-
-    expect(appendAuditRecord).toHaveBeenCalledTimes(1);
-    const arg = appendAuditRecord.mock.calls[0]![0] as {
-      outcome: { kind: string; retryAfter?: number };
-      toolId: string;
-    };
-    expect(arg.toolId).toBe("git.push");
-    expect(arg.outcome.kind).toBe("rate_limited");
-    expect(arg.outcome.retryAfter).toBe(3);
-  });
-
-  it("runs before dedup — an exhausted bucket short-circuits an allowlisted tool", async () => {
-    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
-    const sessionStore = fakeSessionStore("system");
-    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
-      allowed: false,
-      retryAfter: 1,
-    });
-    const deps = fakeDeps({ sessionStore, dispatchAction });
-    const server = createSessionServer("rl-3", deps);
-
-    // terminal.new is dedup-allowlisted; rate-limit must win the race.
-    const result = (await callTool(server, {
-      name: "terminal.new",
-      arguments: { spawnedBy: { kind: "user" } },
-    })) as { content: unknown; isError?: boolean };
-
-    expect(result.isError).toBe(true);
-    expect(parseToolErrorPayload(result).code).toBe(MCP_RATE_LIMITED_CODE);
-    expect(dispatchAction).not.toHaveBeenCalled();
-    expect(sessionStore.dedupInFlight.size).toBe(0);
-  });
-
-  it("does not consume a token for tier-denied calls (auth precedes rate limit)", async () => {
-    // workbench tier cannot call git.commit; the tier check returns first
-    // and the rate-limit token must not be charged.
-    const sessionStore = fakeSessionStore("workbench");
-    const deps = fakeDeps({ sessionStore });
-    const server = createSessionServer("rl-4", deps);
-
-    const result = (await callTool(server, {
-      name: "git.commit",
-      arguments: { message: "x" },
-    })) as { content: unknown; isError?: boolean };
-
-    expect(result.isError).toBe(true);
-    expect(parseToolErrorPayload(result).code).not.toBe(MCP_RATE_LIMITED_CODE);
-    expect(sessionStore.consumeRateLimitToken).not.toHaveBeenCalled();
-  });
-
-  it("lets allowed calls dispatch normally", async () => {
-    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
-    const sessionStore = fakeSessionStore("system");
-    const deps = fakeDeps({ sessionStore, dispatchAction });
-    const server = createSessionServer("rl-5", deps);
-
-    const result = (await callTool(server, {
-      name: "files.search",
-      arguments: { query: "x" },
-    })) as { isError?: boolean };
-
-    expect(result.isError).not.toBe(true);
-    expect(sessionStore.consumeRateLimitToken).toHaveBeenCalledWith("rl-5", "files.search");
-    expect(dispatchAction).toHaveBeenCalledTimes(1);
-  });
-
-  it("charges a token even when the call is served from the dedup cache", async () => {
-    // Real store so dedup actually caches; spy on the real token bucket to
-    // prove rate-limit runs before dedup for *cached* hits, not just
-    // in-flight ones.
-    const store = new RealSessionStore(() => {});
-    store.sessionTierMap.set("rl-dedup", "system");
-    const consumeSpy = vi.spyOn(store, "consumeRateLimitToken");
-    const dispatchAction = vi
-      .fn()
-      .mockResolvedValue({ result: { ok: true, result: { sha: "abc" } } });
-    const deps = fakeDeps({ sessionStore: store, dispatchAction });
-    const server = createSessionServer("rl-dedup", deps);
-
-    const args = { message: "one" };
-    await callTool(server, { name: "git.commit", arguments: args });
-    await callTool(server, { name: "git.commit", arguments: args });
-
-    // Second call is a dedup cache hit (dispatch ran once) but the token
-    // was still charged on both — runaway loops stay bounded.
-    expect(dispatchAction).toHaveBeenCalledTimes(1);
-    expect(consumeSpy).toHaveBeenCalledTimes(2);
-    store.drain();
-  });
-
-  it("rate-limits a grant-authorized call (auth passes, rate limit fails)", async () => {
-    // Workbench tier can't call worktree.delete; a per-tool grant lifts the
-    // auth gate. The rate limiter must still reject, and the tier-mismatch
-    // banner must NOT fire (this is not an authorization failure).
-    const sessionStore = fakeSessionStore("workbench");
-    sessionStore.grantCache.issueGrant("rl-grant", "worktree.delete");
-    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
-      allowed: false,
-      retryAfter: 4,
-    });
-    const dispatchAction = vi.fn();
-    const notifyTierMismatch = vi.fn();
-    const deps = fakeDeps({ sessionStore, dispatchAction, notifyTierMismatch });
-    const server = createSessionServer("rl-grant", deps);
-
-    const result = (await callTool(server, {
-      name: "worktree.delete",
-      arguments: { worktreeId: "w1" },
-    })) as { content: unknown; isError?: boolean };
-
-    expect(result.isError).toBe(true);
-    expect(parseToolErrorPayload(result).code).toBe(MCP_RATE_LIMITED_CODE);
-    expect(notifyTierMismatch).not.toHaveBeenCalled();
-    expect(dispatchAction).not.toHaveBeenCalled();
-    sessionStore.grantCache.dispose();
-  });
-
-  it("a rate-limited native-grant call does NOT consume a use (#10648)", async () => {
-    // The native grant authorizes worktree.delete, but the rate limiter
-    // rejects. The use must survive — a call that never dispatched can't burn
-    // a grant use (regression guard for the peek/consume split).
-    const sessionStore = fakeSessionStore("workbench");
-    const grant = sessionStore.grantCache.issueNativeGrant({
-      sessionId: "rl-native",
-      actorId: "help-1",
-      actorType: "help-session",
-      allowedTools: ["worktree.delete"],
-      maxUses: 1,
-    });
-    (sessionStore.consumeRateLimitToken as ReturnType<typeof vi.fn>).mockReturnValue({
-      allowed: false,
-      retryAfter: 4,
-    });
-    const dispatchAction = vi.fn();
-    const deps = fakeDeps({ sessionStore, dispatchAction });
-    const server = createSessionServer("rl-native", deps);
-
-    const result = (await callTool(server, {
-      name: "worktree.delete",
-      arguments: { worktreeId: "w1" },
-    })) as { content: unknown; isError?: boolean };
-
-    expect(result.isError).toBe(true);
-    expect(parseToolErrorPayload(result).code).toBe(MCP_RATE_LIMITED_CODE);
-    expect(dispatchAction).not.toHaveBeenCalled();
-    expect(sessionStore.grantCache._peekNative(grant.id)?.remainingUses).toBe(1);
-    sessionStore.grantCache.dispose();
-  });
-});
-
 describe("MCP_DEDUP_ALLOWLIST widening (#8468)", () => {
   it("retains the original creation-tool cohort", () => {
     for (const tool of [
@@ -2570,10 +2201,9 @@ describe("MCP_DEDUP_ALLOWLIST widening (#8468)", () => {
   });
 });
 
-describe("worktree resource lifecycle dedup/rate-limit (#10683)", () => {
-  it("dedups + mutation-rate-limits provision (spins up a remote resource)", () => {
+describe("worktree resource lifecycle dedup (#10683)", () => {
+  it("dedups provision (spins up a remote resource)", () => {
     expect(MCP_DEDUP_ALLOWLIST.has("worktree.resource.provision")).toBe(true);
-    expect(RATE_LIMIT_TOOL_MAP.get("worktree.resource.provision")).toBe(RATE_LIMIT_TIERS.mutation);
   });
 
   it("does not dedup pause/resume/teardown (intentionally re-runnable)", () => {
@@ -2584,15 +2214,6 @@ describe("worktree resource lifecycle dedup/rate-limit (#10683)", () => {
     ]) {
       expect(MCP_DEDUP_ALLOWLIST.has(tool)).toBe(false);
     }
-  });
-
-  it("mutation-rate-limits teardown despite not deduping it (D2 destructive)", () => {
-    expect(RATE_LIMIT_TOOL_MAP.get("worktree.resource.teardown")).toBe(RATE_LIMIT_TIERS.mutation);
-  });
-
-  it("leaves reversible pause/resume at the standard rate-limit tier", () => {
-    expect(RATE_LIMIT_TOOL_MAP.has("worktree.resource.pause")).toBe(false);
-    expect(RATE_LIMIT_TOOL_MAP.has("worktree.resource.resume")).toBe(false);
   });
 
   it("gates each tool at its intended minimum tier", () => {
@@ -2620,15 +2241,8 @@ describe("MCP_DEDUP_ALLOWLIST widening (#9156)", () => {
     }
   });
 
-  it("maps the new cohort to the mutation rate-limit tier", () => {
-    for (const tool of NEW_MUTATIONS) {
-      expect(RATE_LIMIT_TOOL_MAP.get(tool)).toBe(RATE_LIMIT_TIERS.mutation);
-    }
-  });
-
   it("stays bounded — adjacent read-only tools remain excluded", () => {
     expect(MCP_DEDUP_ALLOWLIST.has("git.snapshotGet")).toBe(false);
-    expect(RATE_LIMIT_TOOL_MAP.has("git.snapshotGet")).toBe(false);
   });
 
   it.each(NEW_MUTATIONS)(

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -2265,6 +2265,29 @@ describe("MCP_DEDUP_ALLOWLIST widening (#9156)", () => {
   );
 });
 
+describe("CallTool rate limiter removal (#10764)", () => {
+  it("dispatches a burst of mutation calls without ever rejecting with MCP_RATE_LIMITED", async () => {
+    // The mutation tier used to cap git.commit at 10/min — a burst past the
+    // cap returned MCP_RATE_LIMITED before dispatch. With the limiter gone,
+    // every call must reach dispatch. Distinct args sidestep dedup so each is
+    // a genuine dispatch, not a cached hit.
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: null } });
+    const deps = fakeDeps({ sessionStore: fakeSessionStore("system"), dispatchAction });
+    const server = createSessionServer("rl-removed", deps);
+
+    const BURST = 15; // comfortably past the old mutation cap of 10
+    for (let i = 0; i < BURST; i++) {
+      const result = (await callTool(server, {
+        name: "git.commit",
+        arguments: { message: `commit-${i}` },
+      })) as { isError?: boolean };
+      expect(result.isError).not.toBe(true);
+    }
+
+    expect(dispatchAction).toHaveBeenCalledTimes(BURST);
+  });
+});
+
 describe("validateDisplayImageUrl (#9828)", () => {
   it("accepts an https://daintree.org apex image URL", () => {
     expect(validateDisplayImageUrl("https://daintree.org/docs/img/panel.png")).toEqual({

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -650,6 +650,9 @@ export type AuditOutcome =
   | { kind: "unauthorized" }
   | { kind: "dedup" }
   | { kind: "collision" }
+  // Legacy, dead for writers: nothing constructs this since the CallTool rate
+  // limiter was removed (#10764). Retained so `classifyMcpDispatchResult` can
+  // still map the `rate_limited` outcome carried by historical on-disk records.
   | { kind: "rate_limited"; retryAfter: number };
 
 /**

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -29,10 +29,14 @@ import {
   USER_REJECTED_CODE,
   CONFIRMATION_TIMEOUT_CODE,
   MCP_DEDUP_KEY_COLLISION_CODE,
-  MCP_RATE_LIMITED_CODE,
   minimumPermittingTier,
   PRE_AUTH_FAILED_CODE,
 } from "./shared.js";
+
+// Legacy error code, read-only. The CallTool rate limiter was removed (#10764),
+// so nothing emits this anymore — it survives only to classify `rate_limited`
+// outcomes deserialized from historical on-disk audit records.
+const MCP_RATE_LIMITED_CODE = "MCP_RATE_LIMITED";
 
 const ANOMALY_MIN_RECORDS = 50;
 const LATENCY_SIGMA_THRESHOLD = 3;

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -1026,7 +1026,6 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearFigureCounter(sessionId);
         this.deps.sessionStore.sessionHelpIdMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
-        this.deps.sessionStore.clearRateLimitState(sessionId);
         this.deps.sessionStore.clearClientMetadata(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
         this.detachBearerSession(sessionId);
@@ -1049,7 +1048,6 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearFigureCounter(sessionId);
         this.deps.sessionStore.sessionHelpIdMap.delete(sessionId);
         this.deps.sessionStore.clearDedupState(sessionId);
-        this.deps.sessionStore.clearRateLimitState(sessionId);
         this.deps.sessionStore.clearClientMetadata(sessionId);
         this.deps.abusePolicy.dropSession(sessionId);
         this.detachBearerSession(sessionId);
@@ -1182,7 +1180,6 @@ export class HttpLifecycle {
       this.deps.sessionStore.clearFigureCounter(id);
       this.deps.sessionStore.sessionHelpIdMap.delete(id);
       this.deps.sessionStore.clearDedupState(id);
-      this.deps.sessionStore.clearRateLimitState(id);
       this.deps.sessionStore.clearClientMetadata(id);
       this.deps.abusePolicy.dropSession(id);
       this.detachBearerSession(id);
@@ -1210,7 +1207,6 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearFigureCounter(id);
         this.deps.sessionStore.sessionHelpIdMap.delete(id);
         this.deps.sessionStore.clearDedupState(id);
-        this.deps.sessionStore.clearRateLimitState(id);
         this.deps.sessionStore.clearClientMetadata(id);
         this.deps.abusePolicy.dropSession(id);
         this.detachBearerSession(id);
@@ -1225,7 +1221,6 @@ export class HttpLifecycle {
         this.deps.sessionStore.clearFigureCounter(newSessionId);
         this.deps.sessionStore.sessionHelpIdMap.delete(newSessionId);
         this.deps.sessionStore.clearDedupState(newSessionId);
-        this.deps.sessionStore.clearRateLimitState(newSessionId);
         this.deps.sessionStore.clearClientMetadata(newSessionId);
         this.deps.abusePolicy.dropSession(newSessionId);
         this.detachBearerSession(newSessionId);

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -46,7 +46,6 @@ import {
   MCP_DEDUP_TTL_MS,
   MCP_DEDUP_MAX_ENTRIES_PER_SESSION,
   MCP_DEDUP_KEY_COLLISION_CODE,
-  MCP_RATE_LIMITED_CODE,
   minimumPermittingTier,
   EXECUTION_ERROR_CODE,
   SESSION_BINDING_GONE,
@@ -421,8 +420,8 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         // overrides the static tier floor only because the user explicitly
         // approved this tool's scope — the grant's allowlist gates which tools
         // `peekNativeGrant` authorizes. The use is NOT charged here: it is
-        // consumed only after the rate-limit gate below, so a rate-limited
-        // call (which never dispatches) can't burn a use.
+        // consumed only once the call is committed to dispatching (below), so
+        // an unauthorized call can't burn a use.
         nativeGrantId = native.grantId;
       } else {
         // Increment first, then ask the cache whether to suppress. The
@@ -483,39 +482,10 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
       }
     }
 
-    // Runaway-loop guard (#8468): charge one token against the
-    // per-`(session, toolId)` bucket before dedup or dispatch. Placed
-    // after the tier/grant check (an unauthorized call shouldn't consume
-    // tokens) and before dedup (a tight loop replaying the same dedup key
-    // must still be bounded — dedup is an idempotency guard, not a
-    // rate-limit bypass). Rejection is an explicit retriable tool-error
-    // with a `retryAfter` hint, never a silent skip.
-    const rateLimit = sessionStore.consumeRateLimitToken(sessionId, actionId);
-    if (!rateLimit.allowed) {
-      try {
-        appendAuditRecord({
-          toolId: actionId,
-          sessionId,
-          tier,
-          args,
-          durationMs: Date.now() - startedAt,
-          outcome: { kind: "rate_limited", retryAfter: rateLimit.retryAfter },
-          capturedTurnId,
-        });
-      } catch (err) {
-        console.error("[MCP] Failed to append audit record:", err);
-      }
-      return buildToolError({
-        code: MCP_RATE_LIMITED_CODE,
-        message: `Rate limit exceeded for '${actionId}'. Retry after ${rateLimit.retryAfter}s.`,
-        details: { retryAfter: rateLimit.retryAfter },
-      });
-    }
-
     // Charge the native automation grant's use now that the call has cleared
-    // the rate limiter and is committed to proceeding (#10648). Doing it here —
-    // not at the peek above — means a rate-limited call never burns a use. The
-    // peek→rate-limit→consume path is synchronous (no `await`), so the grant
+    // the tier/grant check and is committed to proceeding (#10648). Doing it
+    // here — not at the peek above — means an unauthorized call never burns a
+    // use. The peek→consume path is synchronous (no `await`), so the grant
     // can't be revoked between peek and consume; a `false` return is purely
     // defensive and fails closed.
     if (nativeGrantId !== undefined) {

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -1,11 +1,7 @@
 import type { ActionContext } from "../../../shared/types/actions.js";
 import type { McpActiveClientInfo } from "../../../shared/types/ipc/mcpServer.js";
-import type { McpTier, McpSseSession, McpHttpSession, RateLimitConfig } from "./shared.js";
-import {
-  MCP_SSE_IDLE_TIMEOUT_MS,
-  MCP_TIER_ELEVATION_TTL_MS,
-  rateLimitConfigForTool,
-} from "./shared.js";
+import type { McpTier, McpSseSession, McpHttpSession } from "./shared.js";
+import { MCP_SSE_IDLE_TIMEOUT_MS, MCP_TIER_ELEVATION_TTL_MS } from "./shared.js";
 import type { DedupCacheEntry, DedupInFlightEntry } from "./sessionDedup.js";
 import { GrantCache, type GrantLifecycleEmitter } from "./grantCache.js";
 import { getSystemSleepService } from "../SystemSleepService.js";
@@ -54,45 +50,6 @@ export interface SessionStoreOptions {
   onTierDecayed?: (sessionId: string, previousTier: McpTier, newTier: McpTier) => void;
 }
 
-/**
- * Mutable token-bucket state for one `(sessionId, toolId)` pair. `tokens`
- * is the current fractional balance; `lastRefillMs` is the wall-clock of
- * the most recent refill so the next call can recompute lazily.
- */
-export interface RateLimitBucket {
-  tokens: number;
-  lastRefillMs: number;
-}
-
-export type ConsumeTokenResult = { allowed: true } | { allowed: false; retryAfter: number };
-
-/**
- * Pure token-bucket step. Refills `bucket` for the time elapsed since its
- * last refill (capped at `config.capacity`), then attempts to consume one
- * token. Mutates `bucket` in place and returns whether the call is allowed;
- * on rejection `retryAfter` is the whole-seconds wait until one token has
- * accrued (always `>= 1`). Exported for direct unit coverage independent
- * of the session-store wiring.
- */
-export function consumeToken(
-  bucket: RateLimitBucket,
-  config: RateLimitConfig,
-  nowMs: number
-): ConsumeTokenResult {
-  const elapsed = Math.max(0, nowMs - bucket.lastRefillMs);
-  bucket.tokens = Math.min(config.capacity, bucket.tokens + elapsed * config.refillPerMs);
-  // Never move the refill anchor backward: a backward `Date.now()` (NTP
-  // step-back, which Electron can see on macOS) would otherwise let the
-  // next call accrue refill it didn't earn.
-  bucket.lastRefillMs = Math.max(bucket.lastRefillMs, nowMs);
-  if (bucket.tokens >= 1) {
-    bucket.tokens -= 1;
-    return { allowed: true };
-  }
-  const retryAfter = Math.max(1, Math.ceil((1 - bucket.tokens) / config.refillPerMs / 1000));
-  return { allowed: false, retryAfter };
-}
-
 export class SessionStore {
   readonly sessions = new Map<string, McpSseSession>();
   readonly httpSessions = new Map<string, McpHttpSession>();
@@ -126,11 +83,6 @@ export class SessionStore {
   // return the original result). Cleared on drain and idle expiry.
   readonly dedupInFlight = new Map<string, Map<string, DedupInFlightEntry>>();
   readonly dedupResultCache = new Map<string, Map<string, DedupCacheEntry>>();
-  // Per-`(sessionId, toolId)` token buckets for the runaway-loop rate
-  // limiter (#8468). Lazily populated on first call to a tool and torn
-  // down in lockstep with the other session-scoped maps on drain, idle
-  // expiry, and explicit revoke.
-  readonly rateLimitBuckets = new Map<string, Map<string, RateLimitBucket>>();
   /**
    * Per-`(sessionId, toolId)` time-bounded grants — replaces the sticky
    * `sessionTierMap` elevation pathway for the "Approve once" flow (#8442).
@@ -255,35 +207,6 @@ export class SessionStore {
   }
 
   /**
-   * Charge one token against the `(sessionId, toolId)` bucket, creating a
-   * full bucket on first use. The tier is resolved from
-   * `rateLimitConfigForTool` so an unmapped tool falls back to `standard`.
-   * Thin wrapper around the pure {@link consumeToken} step.
-   */
-  consumeRateLimitToken(
-    sessionId: string,
-    toolId: string,
-    nowMs: number = Date.now()
-  ): ConsumeTokenResult {
-    const config = rateLimitConfigForTool(toolId);
-    let byTool = this.rateLimitBuckets.get(sessionId);
-    if (!byTool) {
-      byTool = new Map<string, RateLimitBucket>();
-      this.rateLimitBuckets.set(sessionId, byTool);
-    }
-    let bucket = byTool.get(toolId);
-    if (!bucket) {
-      bucket = { tokens: config.capacity, lastRefillMs: nowMs };
-      byTool.set(toolId, bucket);
-    }
-    return consumeToken(bucket, config, nowMs);
-  }
-
-  clearRateLimitState(sessionId: string): void {
-    this.rateLimitBuckets.delete(sessionId);
-  }
-
-  /**
    * Assign the next sequential figure number for a help session and advance
    * the counter (#9828). First call for a session returns 1. Keyed by the
    * public help-session id so the sequence is stable across transport
@@ -325,7 +248,6 @@ export class SessionStore {
     this.clearFigureCounter(sessionId);
     this.sessionHelpIdMap.delete(sessionId);
     this.clearDedupState(sessionId);
-    this.clearRateLimitState(sessionId);
     this.clearClientMetadata(sessionId);
     this.idleStartedAt.delete(sessionId);
     this.clearElevationTimer(sessionId);
@@ -383,7 +305,6 @@ export class SessionStore {
     this.clearFigureCounter(sessionId);
     this.sessionHelpIdMap.delete(sessionId);
     this.clearDedupState(sessionId);
-    this.clearRateLimitState(sessionId);
     this.clearClientMetadata(sessionId);
     this.httpIdleStartedAt.delete(sessionId);
     this.clearElevationTimer(sessionId);
@@ -734,7 +655,6 @@ export class SessionStore {
     this.clearFigureCounter(sessionId);
     this.sessionHelpIdMap.delete(sessionId);
     this.clearDedupState(sessionId);
-    this.clearRateLimitState(sessionId);
     this.clearClientMetadata(sessionId);
     this.clearElevationTimer(sessionId);
     this.dropAbuseStateFn(sessionId);
@@ -749,7 +669,6 @@ export class SessionStore {
     // resurrect a torn-down session's cache.
     this.dedupInFlight.clear();
     this.dedupResultCache.clear();
-    this.rateLimitBuckets.clear();
 
     for (const session of this.sessions.values()) {
       clearTimeout(session.idleTimer);

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -232,7 +232,6 @@ export const BINDING_STALE = "BINDING_STALE";
 export const SESSION_BINDING_GONE = "SESSION_BINDING_GONE";
 export const MCP_DEDUP_KEY_COLLISION_CODE = "MCP_DEDUP_KEY_COLLISION";
 export const PRE_AUTH_FAILED_CODE = "PRE_AUTH_FAILED";
-export const MCP_RATE_LIMITED_CODE = "MCP_RATE_LIMITED";
 export const INVALID_URL_CODE = "INVALID_URL";
 
 /**
@@ -245,7 +244,6 @@ export const INVALID_URL_CODE = "INVALID_URL";
 export const RETRIABLE_ERROR_CODES: ReadonlySet<string> = new Set([
   EXECUTION_ERROR_CODE,
   CONFIRMATION_TIMEOUT_CODE,
-  MCP_RATE_LIMITED_CODE,
 ]);
 
 export interface McpErrorPayload {
@@ -542,90 +540,6 @@ export const MCP_DEDUP_TTL_MS = 120_000;
  * insertion above this cap so memory stays bounded at session lifetime.
  */
 export const MCP_DEDUP_MAX_ENTRIES_PER_SESSION = 256;
-
-/**
- * Token-bucket configuration for the per-`(session, toolId)` rate limiter
- * that bounds runaway agent loops on the MCP CallTool path (#8468).
- *
- * - `capacity`: maximum burst — tokens available when the bucket is full.
- * - `refillPerMs`: tokens regenerated per millisecond. Expressed per-ms so
- *   the bucket can be recomputed lazily from elapsed wall-clock on each call
- *   without a background timer.
- */
-export interface RateLimitConfig {
-  capacity: number;
-  refillPerMs: number;
-}
-
-/**
- * Rate-limit tiers. Intentionally conservative placeholders sized so that no
- * legitimate agent workflow trips them — a runaway loop hits the burst cap,
- * then `retryAfter` forces a minimum gap. Tuned post-ship from audit data.
- *
- * - `highFreqRead` (60/min): cheap read-only polling tools. The
- *   `triage_terminals` recipe explicitly tells agents not to busy-loop;
- *   60/min is generous for legitimate fleet-polling cadences.
- * - `standard` (30/min): the default for any tool not in
- *   {@link RATE_LIMIT_TOOL_MAP}.
- * - `mutation` (10/min): side-effecting tools where a tight loop produces
- *   duplicate resources (commits, pushes, issues, PRs).
- */
-export const RATE_LIMIT_TIERS = {
-  highFreqRead: { capacity: 60, refillPerMs: 60 / 60_000 },
-  standard: { capacity: 30, refillPerMs: 30 / 60_000 },
-  mutation: { capacity: 10, refillPerMs: 10 / 60_000 },
-} as const satisfies Record<string, RateLimitConfig>;
-
-/**
- * Per-tool tier overrides. Tools absent from this map fall back to
- * {@link RATE_LIMIT_TIERS.standard}. Keep the mutation cohort aligned with
- * {@link MCP_DEDUP_ALLOWLIST}'s destructive mutation entries.
- */
-export const RATE_LIMIT_TOOL_MAP: ReadonlyMap<string, RateLimitConfig> = new Map([
-  ["terminal.getOutput", RATE_LIMIT_TIERS.highFreqRead],
-  ["terminal.getStatus", RATE_LIMIT_TIERS.highFreqRead],
-  ["actions.getContext", RATE_LIMIT_TIERS.highFreqRead],
-  ["browser.getConsoleMessages", RATE_LIMIT_TIERS.highFreqRead],
-  ["git.commit", RATE_LIMIT_TIERS.mutation],
-  ["git.push", RATE_LIMIT_TIERS.mutation],
-  ["forge.openIssue", RATE_LIMIT_TIERS.mutation],
-  ["forge.openPR", RATE_LIMIT_TIERS.mutation],
-  ["worktree.delete", RATE_LIMIT_TIERS.mutation],
-  ["worktree.resource.provision", RATE_LIMIT_TIERS.mutation],
-  // Destructive (D2): a tear-down loop against a re-provisioned resource could
-  // destroy the fresh instance. Mutation-tier even though it's not deduped —
-  // each teardown is intentionally re-runnable, but not at 30/min.
-  ["worktree.resource.teardown", RATE_LIMIT_TIERS.mutation],
-  ["git.snapshotRevert", RATE_LIMIT_TIERS.mutation],
-  ["git.snapshotDelete", RATE_LIMIT_TIERS.mutation],
-  ["forge.assignIssue", RATE_LIMIT_TIERS.mutation],
-  ["forge.createPR", RATE_LIMIT_TIERS.mutation],
-  ["forge.closePR", RATE_LIMIT_TIERS.mutation],
-  ["forge.reopenPR", RATE_LIMIT_TIERS.mutation],
-  ["forge.mergePR", RATE_LIMIT_TIERS.mutation],
-  ["forge.convertPRToDraft", RATE_LIMIT_TIERS.mutation],
-  ["forge.markPRReadyForReview", RATE_LIMIT_TIERS.mutation],
-  ["forge.commentOnPR", RATE_LIMIT_TIERS.mutation],
-  ["forge.editPR", RATE_LIMIT_TIERS.mutation],
-  // Not a git mutation, but capped at the mutation tier (10/min) so a runaway
-  // model can't flood the assistant panel's figure rail with images (#9828).
-  ["help.displayImage", RATE_LIMIT_TIERS.mutation],
-  // Fleet-arming mutations (#10695): churning the broadcast set reroutes the
-  // human's keystrokes, so cap at mutation tier rather than 30/min standard.
-  // None carry a per-call confirm gate (all classified danger:"safe"); the
-  // mutation-tier rate limit is the cohort's shared throttle.
-  ["terminal.arm", RATE_LIMIT_TIERS.mutation],
-  ["terminal.disarm", RATE_LIMIT_TIERS.mutation],
-  ["terminal.disarmAll", RATE_LIMIT_TIERS.mutation],
-] as Array<[string, RateLimitConfig]>);
-
-/**
- * Resolve the rate-limit config for a tool — its explicit override or the
- * `standard` fallback.
- */
-export function rateLimitConfigForTool(toolId: string): RateLimitConfig {
-  return RATE_LIMIT_TOOL_MAP.get(toolId) ?? RATE_LIMIT_TIERS.standard;
-}
 
 /**
  * Compute the minimum non-external tier that permits the given tool. Used to

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -14,9 +14,10 @@
  * - `dedup`: a duplicate creation-tool call was suppressed by the
  *   per-session idempotency guard and the cached or in-flight result was
  *   returned. No second dispatch was performed.
- * - `rate_limited`: the per-`(session, toolId)` token bucket was exhausted
- *   and the call was rejected before dispatch with a `retryAfter` hint. No
- *   dispatch was performed — this is a runaway-loop guard, not a failure.
+ * - `rate_limited`: legacy value, no longer emitted. The per-`(session,
+ *   toolId)` token-bucket rate limiter was removed in #10764; this value is
+ *   retained only so historical on-disk audit records (which carry it, with
+ *   the wait in `resultMeta.retryAfter`) still render and classify.
  */
 export type McpAuditResult =
   | "success"


### PR DESCRIPTION
## Summary

- Removes the per-(`sessionId`, `toolId`) token-bucket rate limiter from the MCP server `CallTool` path. The limiter was causing `MCP_RATE_LIMITED` errors when the in-app assistant fired concurrent reads, breaking the assistant with hard `TERMINAL_OUTPUT` errors it couldn't recover from.
- Drops the enforcement code and tier config from `sessionServer.ts`, `shared.ts`, `sessionStore.ts`, and 5 teardown call sites in `httpLifecycle.ts`. Net change is roughly +45/-602 lines.
- Preserves the `rate_limited` audit vocabulary (`McpAuditResult` value, Zod schema, severity map, `classifyMcpDispatchResult` branch) as read-only legacy so historical on-disk audit records still parse correctly. `MCP_RATE_LIMITED_CODE` is now module-local in `auditLog.ts`.

Resolves #10764

## Changes

- `shared.ts`: removed `RATE_LIMIT_TIERS`, `RATE_LIMIT_TOOL_MAP`, `RateLimitConfig`, `rateLimitConfigForTool`, `MCP_RATE_LIMITED_CODE`
- `sessionStore.ts`: removed `rateLimitBuckets`, `consumeToken`, `consumeRateLimitToken`, `clearRateLimitState`
- `sessionServer.ts`: removed enforcement block in `CallTool` handler
- `httpLifecycle.ts`: removed 5 `clearRateLimitState` teardown call sites
- `auditLog.ts`: `MCP_RATE_LIMITED_CODE` moved to module-local const; legacy audit classification path kept intact
- `sessionServer.test.ts`: removed enforcement tests; added regression test asserting a burst of mutation calls dispatches without `MCP_RATE_LIMITED`

Does not touch `PLUGIN_MCP_RATE_LIMITED`, the IPC leaky-bucket (`checkRateLimit`/`waitForRateLimitSlot`), or the GitHub-API `RateLimitBucket` types.

## Testing

- Typecheck: pass
- ESLint (changed files): pass
- Prettier: clean
- Vitest: 316 tests across the full mcp-server suite, 247 across the 3 modified test files