### PR TITLE
fix(forge): skip redundant stats revalidation on fresh reactivation (#10765)

### DIFF
--- a/src/hooks/__tests__/usePollingLifecycle.test.tsx
+++ b/src/hooks/__tests__/usePollingLifecycle.test.tsx
@@ -12,7 +12,18 @@ vi.mock("@/clients", () => ({
   },
 }));
 
-import { usePollingLifecycle, _resetPollingLifecycleForTests } from "../usePollingLifecycle";
+import {
+  usePollingLifecycle,
+  _resetPollingLifecycleForTests,
+  type PollingLifecycleFetchReason,
+} from "../usePollingLifecycle";
+
+type TestFetchContext = {
+  force: boolean;
+  fetchId: number;
+  isInvalidated: () => boolean;
+  reason: PollingLifecycleFetchReason;
+};
 
 function createDeferred<T>() {
   let resolve: (value: T) => void;
@@ -25,11 +36,7 @@ function createDeferred<T>() {
 }
 
 function setupHook(opts: {
-  fetchFn?: (ctx: {
-    force: boolean;
-    fetchId: number;
-    isInvalidated: () => boolean;
-  }) => Promise<void>;
+  fetchFn?: (ctx: TestFetchContext) => Promise<void>;
   calculateNextInterval?: (ctx: { isVisible: boolean }) => number;
   onProjectSwitch?: () => void;
 }) {
@@ -324,6 +331,191 @@ describe("usePollingLifecycle", () => {
     });
   });
 
+  describe("fetch reason (#10765)", () => {
+    it("tags the initial mount fetch with reason 'initial'", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+      expect(fetchFn.mock.calls[0]?.[0]?.reason).toBe("initial");
+    });
+
+    it("tags a visibilitychange-visible reactivation with reason 'reactivate'", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+      expect(fetchFn.mock.calls[1]?.[0]?.reason).toBe("reactivate");
+    });
+
+    it("tags a project switch with reason 'reactivate'", async () => {
+      let captured: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb) => {
+        captured = cb;
+        return () => {};
+      });
+
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        captured?.();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+      expect(fetchFn.mock.calls[1]?.[0]?.reason).toBe("reactivate");
+    });
+
+    it("tags a sidebar refresh with reason 'manual'", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+      expect(fetchFn.mock.calls[1]?.[0]?.reason).toBe("manual");
+    });
+
+    it("tags an explicit refresh() with reason 'manual'", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      const { hook } = setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await hook.result.current.refresh();
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+      expect(fetchFn.mock.calls[1]?.[0]?.reason).toBe("manual");
+    });
+
+    it("tags a scheduled poll with reason 'scheduled'", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      // First reschedule fires quickly (one scheduled poll); the second pushes
+      // the next poll far out so the count settles at 2 under real timers
+      // instead of looping a tight interval.
+      let intervalCalls = 0;
+      setupHook({
+        fetchFn,
+        calculateNextInterval: () => (intervalCalls++ === 0 ? 5 : 10_000_000),
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+      expect(fetchFn.mock.calls[1]?.[0]?.reason).toBe("scheduled");
+    });
+
+    it("coalesces a queued reactivate up to a stronger manual when both arrive in flight", async () => {
+      const deferred = createDeferred<void>();
+      let callCount = 0;
+      const fetchFn = vi.fn().mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) await deferred.promise;
+      });
+
+      const { hook } = setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      // While the initial fetch is in flight, queue a manual (sidebar) then a
+      // reactivate (visibility). The reactivate must NOT downgrade the queued
+      // reason — strongest-wins keeps it 'manual'.
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        deferred.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+      // Single coalesced drain, tagged with the strongest queued reason.
+      expect(fetchFn.mock.calls[1]?.[0]?.reason).toBe("manual");
+      expect(fetchFn.mock.calls[1]?.[0]?.force).toBe(true);
+
+      hook.unmount();
+    });
+
+    it("keeps a queued manual when a later reactivate arrives (order-independent)", async () => {
+      const deferred = createDeferred<void>();
+      let callCount = 0;
+      const fetchFn = vi.fn().mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) await deferred.promise;
+      });
+
+      const { hook } = setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      // Reverse order vs the previous test: reactivate first, then manual.
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        deferred.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+      });
+      expect(fetchFn.mock.calls[1]?.[0]?.reason).toBe("manual");
+
+      hook.unmount();
+    });
+  });
+
   describe("control object", () => {
     it("returns a stable scheduleNextPoll / refresh control across renders", () => {
       const { hook } = setupHook({});
@@ -427,11 +619,7 @@ describe("usePollingLifecycle", () => {
   describe("enabled gate (#10123)", () => {
     function setupGatedHook(opts: {
       enabled: boolean;
-      fetchFn?: (ctx: {
-        force: boolean;
-        fetchId: number;
-        isInvalidated: () => boolean;
-      }) => Promise<void>;
+      fetchFn?: (ctx: TestFetchContext) => Promise<void>;
       calculateNextInterval?: (ctx: { isVisible: boolean }) => number;
     }) {
       const fetchFn = opts.fetchFn ?? vi.fn().mockResolvedValue(undefined);

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -396,7 +396,7 @@ describe("useRepositoryStats", () => {
       expect(result.current.stats?.issueCount).toBe(2);
     });
 
-    it("restores cached stats without a skeleton when switching back within FRESH_THRESHOLD_MS", async () => {
+    it("restores cached stats and skips the network revalidation when switching back within FRESH_THRESHOLD_MS (#10765)", async () => {
       let currentProject = { id: "a", path: "/repo/a" };
       getCurrentMock.mockImplementation(async () => currentProject);
       let switchHandler: (() => void) | undefined;
@@ -408,20 +408,8 @@ describe("useRepositoryStats", () => {
       const now = Date.now();
       const statsA = freshStats({ commitCount: 7, issueCount: 4, prCount: 3, lastUpdated: now });
       const statsB = freshStats({ commitCount: 12, issueCount: 1, prCount: 1, lastUpdated: now });
-      const statsARevalidated = freshStats({
-        commitCount: 8,
-        issueCount: 5,
-        prCount: 3,
-        lastUpdated: now + 1,
-      });
-      // Hold the switch-back revalidation so the restored cache value is
-      // observable before fresh data lands over it.
-      const slowRevalidate = createDeferred<ForgeRepositoryStats>();
 
-      getRepoStatsMock
-        .mockResolvedValueOnce(statsA)
-        .mockResolvedValueOnce(statsB)
-        .mockImplementationOnce(() => slowRevalidate.promise);
+      getRepoStatsMock.mockResolvedValueOnce(statsA).mockResolvedValueOnce(statsB);
 
       const { result } = renderHook(() => useRepositoryStats());
       await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
@@ -433,8 +421,11 @@ describe("useRepositoryStats", () => {
       await waitFor(() => expect(result.current.stats?.commitCount).toBe(12));
 
       // Switch back to A within the freshness window — cached counts restore
-      // immediately, the skeleton never shows, and a background revalidation
-      // still fires.
+      // immediately, the skeleton never shows. Before #10765 a reactivation
+      // here fired a third getRepoStats call (the redundant revalidation that,
+      // under rapid switching, bursts past the IPC rate limiter and paints the
+      // red toolbar error). Now the fresh cache short-circuits the network:
+      // getRepoStats stays at 2 total.
       currentProject = { id: "a", path: "/repo/a" };
       act(() => {
         switchHandler?.();
@@ -443,14 +434,104 @@ describe("useRepositoryStats", () => {
         expect(result.current.stats?.commitCount).toBe(7);
         expect(result.current.loading).toBe(false);
       });
-      expect(getRepoStatsMock).toHaveBeenCalledTimes(3);
-
-      // The background revalidation converges to fresh data.
+      // Flush any queued/drained reactivation fetch to prove none fires.
       await act(async () => {
-        slowRevalidate.resolve(statsARevalidated);
         await Promise.resolve();
       });
-      await waitFor(() => expect(result.current.stats?.commitCount).toBe(8));
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("skips the network even when both project-switch and visibility reactivations fire (#10765)", async () => {
+      // Production per-view reality: reactivating a backgrounded WebContentsView
+      // fires BOTH onProjectSwitch and visibilitychange, each a reactivation
+      // fetch. With fresh cached data neither should hit the network — this is
+      // the exact double-trigger that bursts the rate limiter on rapid switching.
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const now = Date.now();
+      const statsA = freshStats({ commitCount: 7, issueCount: 4, prCount: 3, lastUpdated: now });
+      const statsB = freshStats({ commitCount: 12, issueCount: 1, prCount: 1, lastUpdated: now });
+      getRepoStatsMock.mockResolvedValueOnce(statsA).mockResolvedValueOnce(statsB);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(12));
+
+      // Switch back to A and fire both reactivation triggers in one tick.
+      currentProject = { id: "a", path: "/repo/a" };
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      await act(async () => {
+        switchHandler?.();
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("still force-fetches on a manual refresh after a fresh reactivation (#10765)", async () => {
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const now = Date.now();
+      const statsA = freshStats({ commitCount: 7, issueCount: 4, prCount: 3, lastUpdated: now });
+      const statsB = freshStats({ commitCount: 12, issueCount: 1, prCount: 1, lastUpdated: now });
+      const statsARefreshed = freshStats({
+        commitCount: 9,
+        issueCount: 6,
+        prCount: 4,
+        lastUpdated: now + 1,
+      });
+      getRepoStatsMock
+        .mockResolvedValueOnce(statsA)
+        .mockResolvedValueOnce(statsB)
+        .mockResolvedValueOnce(statsARefreshed);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(12));
+
+      // Fresh reactivation back to A — restores cache, no network.
+      currentProject = { id: "a", path: "/repo/a" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+
+      // A manual refresh is forced and reason 'manual' — it must always hit the
+      // network, never short-circuit on freshness.
+      await act(async () => {
+        await result.current.refresh({ force: true });
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(9));
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(3);
+      expect(getRepoStatsMock.mock.calls[2]?.[1]).toBe(true);
     });
 
     it("does not reuse cached stats when switching back after FRESH_THRESHOLD_MS", async () => {

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -534,6 +534,96 @@ describe("useRepositoryStats", () => {
       expect(getRepoStatsMock.mock.calls[2]?.[1]).toBe(true);
     });
 
+    it("never paints an error under rapid dual-trigger switching once data is cached (#10765)", async () => {
+      // Closest reproduction of the production failure: each switch fires both
+      // onProjectSwitch and visibilitychange, and the IPC layer rejects once a
+      // burst exceeds the 10-calls/10s limiter. With freshness short-circuiting,
+      // only the two cold loads reach the network, so the burst never trips it.
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const now = Date.now();
+      let callCount = 0;
+      getRepoStatsMock.mockImplementation(async (path: string) => {
+        callCount += 1;
+        if (callCount > 10) throw new Error("RATE_LIMITED: too many requests");
+        return freshStats({ commitCount: path === "/repo/a" ? 7 : 12, lastUpdated: now });
+      });
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      const sequence = ["/repo/b", "/repo/a", "/repo/b", "/repo/a", "/repo/b", "/repo/a"];
+      for (const path of sequence) {
+        currentProject = { id: path, path };
+        // eslint-disable-next-line no-await-in-loop -- sequential switches model rapid user toggling
+        await act(async () => {
+          switchHandler?.();
+          document.dispatchEvent(new Event("visibilitychange"));
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+      }
+
+      await waitFor(() => expect(result.current.stats).not.toBeNull());
+      // Only the two cold loads (A, then B) hit the network; every subsequent
+      // reactivation restores fresh cache and short-circuits.
+      expect(callCount).toBeLessThanOrEqual(3);
+      expect(result.current.error).toBeNull();
+      expect(result.current.freshnessLevel).not.toBe("errored");
+    });
+
+    it("skips the network when reactivation triggers arrive in separate ticks (#10765)", async () => {
+      // The same-tick dual-trigger test guarantees queue coalescing; this one
+      // proves the short-circuit also holds when onProjectSwitch and
+      // visibilitychange land in distinct macrotasks (no coalescing).
+      let currentProject = { id: "a", path: "/repo/a" };
+      getCurrentMock.mockImplementation(async () => currentProject);
+      let switchHandler: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb: () => void) => {
+        switchHandler = cb;
+        return () => {};
+      });
+
+      const now = Date.now();
+      const statsA = freshStats({ commitCount: 7, issueCount: 4, prCount: 3, lastUpdated: now });
+      const statsB = freshStats({ commitCount: 12, issueCount: 1, prCount: 1, lastUpdated: now });
+      getRepoStatsMock.mockResolvedValueOnce(statsA).mockResolvedValueOnce(statsB);
+
+      const { result } = renderHook(() => useRepositoryStats());
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+
+      currentProject = { id: "b", path: "/repo/b" };
+      act(() => {
+        switchHandler?.();
+      });
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(12));
+
+      // Switch back to A — fire the two triggers in separate act() ticks.
+      currentProject = { id: "a", path: "/repo/a" };
+      await act(async () => {
+        switchHandler?.();
+        await Promise.resolve();
+      });
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => expect(result.current.stats?.commitCount).toBe(7));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+    });
+
     it("does not reuse cached stats when switching back after FRESH_THRESHOLD_MS", async () => {
       let currentProject = { id: "a", path: "/repo/a" };
       getCurrentMock.mockImplementation(async () => currentProject);

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -562,7 +562,6 @@ describe("useRepositoryStats", () => {
       const sequence = ["/repo/b", "/repo/a", "/repo/b", "/repo/a", "/repo/b", "/repo/a"];
       for (const path of sequence) {
         currentProject = { id: path, path };
-        // eslint-disable-next-line no-await-in-loop -- sequential switches model rapid user toggling
         await act(async () => {
           switchHandler?.();
           document.dispatchEvent(new Event("visibilitychange"));

--- a/src/hooks/usePollingLifecycle.ts
+++ b/src/hooks/usePollingLifecycle.ts
@@ -1,10 +1,37 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { projectClient } from "@/clients";
 
+/**
+ * Why a fetch fired. Lets a consumer treat a cheap reactivation (tab focus /
+ * project switch back) differently from a scheduled poll, manual refresh, or
+ * cold start — e.g. skip a redundant network revalidation when cached data is
+ * still fresh. Strength ordering (weakest→strongest):
+ * `initial < reactivate < scheduled < manual` — see `REASON_RANK`.
+ */
+export type PollingLifecycleFetchReason = "initial" | "reactivate" | "scheduled" | "manual";
+
 export interface PollingLifecycleFetchContext {
   force: boolean;
   fetchId: number;
   isInvalidated: () => boolean;
+  reason: PollingLifecycleFetchReason;
+}
+
+// Strongest-wins coalescing rank. When a second trigger arrives while a fetch
+// is in flight, the queued reason is promoted to the stronger of the two so a
+// pending `manual`/`scheduled` is never downgraded by a later `reactivate`.
+const REASON_RANK: Record<PollingLifecycleFetchReason, number> = {
+  initial: 0,
+  reactivate: 1,
+  scheduled: 2,
+  manual: 3,
+};
+
+function strongerReason(
+  a: PollingLifecycleFetchReason,
+  b: PollingLifecycleFetchReason
+): PollingLifecycleFetchReason {
+  return REASON_RANK[b] > REASON_RANK[a] ? b : a;
 }
 
 export interface PollingLifecycleConfig {
@@ -163,9 +190,14 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
   const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isVisibleRef = useRef(!document.hidden);
   const inFlightRef = useRef(false);
-  const queuedFetchRef = useRef<{ pending: boolean; force: boolean }>({
+  const queuedFetchRef = useRef<{
+    pending: boolean;
+    force: boolean;
+    reason: PollingLifecycleFetchReason;
+  }>({
     pending: false,
     force: false,
+    reason: "initial",
   });
   const activeFetchIdRef = useRef(0);
   const invalidatedFetchIdRef = useRef<number | null>(null);
@@ -185,10 +217,14 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
     configRef.current = config;
   });
 
-  const callFetchFn = useCallback(async function callFetchFnImpl(force: boolean): Promise<void> {
+  const callFetchFn = useCallback(async function callFetchFnImpl(
+    force: boolean,
+    reason: PollingLifecycleFetchReason
+  ): Promise<void> {
     if (inFlightRef.current) {
       queuedFetchRef.current.pending = true;
       queuedFetchRef.current.force = queuedFetchRef.current.force || force;
+      queuedFetchRef.current.reason = strongerReason(queuedFetchRef.current.reason, reason);
       invalidatedFetchIdRef.current = activeFetchIdRef.current;
       return;
     }
@@ -199,7 +235,7 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
       const fetchId = activeFetchIdRef.current;
       const isInvalidated = () => invalidatedFetchIdRef.current === fetchId;
       try {
-        await configRef.current.fetchFn({ force, fetchId, isInvalidated });
+        await configRef.current.fetchFn({ force, fetchId, isInvalidated, reason });
       } catch (err) {
         // The consumer's fetchFn is responsible for surfacing its own errors
         // (setError, lastErrorRef). The primitive catches here so a throw —
@@ -214,11 +250,12 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
       inFlightRef.current = false;
       if (aliveRef.current && queuedFetchRef.current.pending) {
         const queuedForce = queuedFetchRef.current.force;
-        queuedFetchRef.current = { pending: false, force: false };
+        const queuedReason = queuedFetchRef.current.reason;
+        queuedFetchRef.current = { pending: false, force: false, reason: "initial" };
         // Named-function self-recursion — avoids referencing the outer
         // `callFetchFn` variable, which would close over a potentially
         // stale binding before useCallback returns.
-        void callFetchFnImpl(queuedForce);
+        void callFetchFnImpl(queuedForce, queuedReason);
       }
     }
   }, []);
@@ -237,7 +274,7 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
         isVisible: isVisibleRef.current,
       });
       pollTimerRef.current = setTimeout(() => {
-        void callFetchFn(false).then(() => {
+        void callFetchFn(false, "scheduled").then(() => {
           if (aliveRef.current) scheduleNextPollImpl();
         });
       }, interval);
@@ -252,7 +289,7 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
         clearTimeout(pollTimerRef.current);
         pollTimerRef.current = null;
       }
-      await callFetchFn(options?.force ?? false);
+      await callFetchFn(options?.force ?? false, "manual");
       if (aliveRef.current) scheduleNextPoll();
     },
     [callFetchFn, scheduleNextPoll]
@@ -287,7 +324,7 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
           clearTimeout(pollTimerRef.current);
           pollTimerRef.current = null;
         }
-        void callFetchFn(false).then(() => {
+        void callFetchFn(false, "reactivate").then(() => {
           if (aliveRef.current) scheduleNextPoll();
         });
       },
@@ -308,7 +345,7 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
           pollTimerRef.current = null;
         }
         configRef.current.onProjectSwitch?.();
-        void callFetchFn(false).then(() => {
+        void callFetchFn(false, "reactivate").then(() => {
           if (aliveRef.current) scheduleNextPoll();
         });
       },
@@ -317,14 +354,14 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
     subscribers.add(subscriber);
     ensureGlobalListenersInstalled();
 
-    void callFetchFn(false).then(() => {
+    void callFetchFn(false, "initial").then(() => {
       if (aliveRef.current) scheduleNextPoll();
     });
 
     return () => {
       aliveRef.current = false;
       subscribers.delete(subscriber);
-      queuedFetchRef.current = { pending: false, force: false };
+      queuedFetchRef.current = { pending: false, force: false, reason: "initial" };
       invalidatedFetchIdRef.current = null;
       if (pollTimerRef.current) {
         clearTimeout(pollTimerRef.current);

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -319,7 +319,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
   const polling = usePollingLifecycle({
     enabled: !isWorkerInstance && currentProjectId !== null && !providerLoading,
-    fetchFn: async ({ force, isInvalidated }) => {
+    fetchFn: async ({ force, isInvalidated, reason }) => {
       // Capture the fetch epoch before the first await so a project switch that
       // fires mid-flight can be detected after each await (issue #10761).
       const myGeneration = fetchGenerationRef.current;
@@ -358,6 +358,29 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
           ) {
             applyStatsResult(cached.stats, { projectPath: project.path });
           }
+        }
+
+        // Skip the network revalidation on a cheap reactivation (tab focus /
+        // project switch back) when fresh data is already in hand (issue
+        // #10765). Each project runs in its own WebContentsView, so a single
+        // reactivation fires both `onVisibilityVisible` and `onProjectSwitch`
+        // — two `getRepoStats` calls per switch. Rapid switching bursts past
+        // the IPC rate limiter (10 calls / 10s), which throws `RATE_LIMITED`
+        // and paints the toolbar's red error line until a manual refresh. A
+        // reactivation never needs to revalidate when the switch-back cache (or
+        // a prior poll) left `lastUpdatedRef` within the freshness window;
+        // scheduled polls, manual refresh, and cold starts (`lastUpdatedRef`
+        // still null) all fall through to the network. Placed after the
+        // switch-back restore (which repopulates `lastUpdatedRef`) and before
+        // `setIsValidating(true)` so a skipped reactivation never flashes a
+        // validating affordance.
+        if (
+          reason === "reactivate" &&
+          !force &&
+          lastUpdatedRef.current !== null &&
+          Date.now() - lastUpdatedRef.current < FRESH_THRESHOLD_MS
+        ) {
+          return;
         }
 
         if (mountedRef.current) {


### PR DESCRIPTION
## Summary

- Rapid project switching was painting a persistent red error line on the forge issues/PRs stats toolbar. Each reactivation fired two `FORGE_GET_REPO_STATS` IPC calls (`visibilitychange` and `onProjectSwitch`), which burst past the 10 calls / 10s rate limiter, set `statsError`, and kept the indicator red until a manual interaction cleared it.
- Threads a `reason` field (`initial` | `reactivate` | `scheduled` | `manual`) through `usePollingLifecycle`'s fetch context with strongest-wins queue coalescing, so a queued `manual` or `scheduled` fetch is never downgraded by a later `reactivate`.
- Short-circuits the `getRepoStats` network call in `useRepositoryStats` when `reason === 'reactivate'`, the fetch is not forced, and `lastUpdated` is within `FRESH_THRESHOLD_MS` (90s). Scheduled polling, manual refresh, and cold starts still hit the network.

Resolves #10765

## Changes

- `src/hooks/usePollingLifecycle.ts`: reason field + strongest-wins queue coalescing (`manual > scheduled > reactivate > initial`).
- `src/hooks/useRepositoryStats.ts`: fresh-reactivation short-circuit placed after the switch-back cache restore and before `setIsValidating`.
- `src/hooks/__tests__/usePollingLifecycle.test.tsx` and `src/hooks/__tests__/useRepositoryStats.test.tsx`: rebased onto per-view reality; added dual-trigger (same-tick and separate-tick), coalescing (both orderings), rapid-switching with simulated rate limiter, and manual-after-reactivation coverage. All 103 affected hook tests pass.

## Testing

Ran the full `usePollingLifecycle` and `useRepositoryStats` test suites locally. Manually reproduced the red-line bug before the fix by switching rapidly between two GitHub-backed projects, then confirmed it no longer appears after the fix.