### PR TITLE
perf(main): batch host-log writes and coalesce worktree-update bus

### DIFF
--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -681,6 +681,7 @@ export class WorkspaceClient extends EventEmitter {
     if (this.isDisposed) return;
     this.isDisposed = true;
 
+    this.eventRouter.dispose();
     this.copyTree.dispose();
     this.pool.dispose();
     this._statesInflight.clear();

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -7,6 +7,7 @@ import { clearWslGitEntry } from "../../store.js";
 import { gitServiceCache } from "../GitServiceCache.js";
 import { type ProcessEntry, type CopyTreeProgressCallback, sendToEntryWindows } from "./types.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
+import type { WorktreeState } from "../../../shared/types/worktree.js";
 
 export type EmitFn = (event: string | symbol, ...args: unknown[]) => boolean;
 
@@ -19,6 +20,18 @@ export interface WorkspaceHostEventRouterDeps {
 export class WorkspaceHostEventRouter {
   private static readonly RATE_LIMIT_TOKEN_CHANGE_GUARD_MS = 5_000;
 
+  // Coalesce the in-process `sys:worktree:update` bus (#10769). Under
+  // multi-agent load the host streams worktree-update snapshots at 10–50/s;
+  // each synchronously drives `PullRequestService.handleWorktreeUpdate` (branch
+  // diffing, PR-state clears, more log writes) and the MCP session listener,
+  // stalling the main thread and lagging keystroke echo. A 50ms trailing-edge
+  // debounce keyed per worktree collapses bursts (rapid same-worktree snapshots
+  // → one emit with the latest state) while staying imperceptible for these
+  // consumers. The direct per-view MessagePort fan-out (DIRECT_RENDERER_EVENTS)
+  // and the `worktree-update` plugin-bus emit are intentionally NOT debounced —
+  // they drive UI store updates and the PluginService contract.
+  private static readonly SYS_WORKTREE_UPDATE_DEBOUNCE_MS = 50;
+
   private emit: EmitFn;
   private worktreePathToProject: Map<string, string>;
   private copyTreeProgressCallbacks: Map<string, CopyTreeProgressCallback>;
@@ -27,6 +40,10 @@ export class WorkspaceHostEventRouter {
   private inotifyLimitToastSent = false;
   private emfileLimitToastSent = false;
   private cloudTeardownFailureToastKeys = new Set<string>();
+
+  private pendingSysWorktreeUpdates = new Map<string, WorktreeState>();
+  private sysWorktreeUpdateTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
 
   constructor(deps: WorkspaceHostEventRouterDeps) {
     this.emit = deps.emit;
@@ -61,7 +78,7 @@ export class WorkspaceHostEventRouter {
           worktree,
           projectPath: entry.projectPath,
         });
-        events.emit("sys:worktree:update", worktree);
+        this.queueSysWorktreeUpdate(worktree);
 
         // Cloud-side teardown failure: when `phase: "resource-teardown"` ends in
         // `failed` or `timed-out`, the user's cloud resource may still be running
@@ -345,5 +362,46 @@ export class WorkspaceHostEventRouter {
         break;
       }
     }
+  }
+
+  /**
+   * Buffer a `sys:worktree:update` for the trailing-edge debounce window. Keyed
+   * per worktree so rapid snapshots of the same worktree collapse to a single
+   * emit carrying the latest state. Re-arms a single shared timer (#7469: a
+   * pending entry without an armed drain timer would strand until the next
+   * event).
+   */
+  private queueSysWorktreeUpdate(worktree: WorktreeState): void {
+    if (this.disposed) return;
+    const key = worktree.worktreeId || path.resolve(worktree.path ?? "");
+    this.pendingSysWorktreeUpdates.set(key, worktree);
+    if (this.sysWorktreeUpdateTimer === null) {
+      this.sysWorktreeUpdateTimer = setTimeout(
+        () => this.flushSysWorktreeUpdates(),
+        WorkspaceHostEventRouter.SYS_WORKTREE_UPDATE_DEBOUNCE_MS
+      );
+    }
+  }
+
+  private flushSysWorktreeUpdates(): void {
+    this.sysWorktreeUpdateTimer = null;
+    if (this.pendingSysWorktreeUpdates.size === 0) return;
+    const updates = Array.from(this.pendingSysWorktreeUpdates.values());
+    this.pendingSysWorktreeUpdates.clear();
+    // Emit synchronously per worktree so listener ordering (PullRequestService
+    // relies on synchronous reentrancy handling) is preserved.
+    for (const worktree of updates) {
+      events.emit("sys:worktree:update", worktree);
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.sysWorktreeUpdateTimer !== null) {
+      clearTimeout(this.sysWorktreeUpdateTimer);
+      this.sysWorktreeUpdateTimer = null;
+    }
+    this.pendingSysWorktreeUpdates.clear();
   }
 }

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -6,8 +6,7 @@ import { notifyError } from "../../ipc/errorHandlers.js";
 import { clearWslGitEntry } from "../../store.js";
 import { gitServiceCache } from "../GitServiceCache.js";
 import { type ProcessEntry, type CopyTreeProgressCallback, sendToEntryWindows } from "./types.js";
-import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
-import type { WorktreeState } from "../../../shared/types/worktree.js";
+import type { WorkspaceHostEvent, WorktreeSnapshot } from "../../../shared/types/workspace-host.js";
 
 export type EmitFn = (event: string | symbol, ...args: unknown[]) => boolean;
 
@@ -44,7 +43,7 @@ export class WorkspaceHostEventRouter {
   private emfileLimitToastSent = false;
   private cloudTeardownFailureToastKeys = new Set<string>();
 
-  private pendingSysWorktreeUpdates = new Map<string, WorktreeState>();
+  private pendingSysWorktreeUpdates = new Map<string, WorktreeSnapshot>();
   private sysWorktreeUpdateTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed = false;
 
@@ -380,7 +379,7 @@ export class WorkspaceHostEventRouter {
    * pending entry without an armed drain timer would strand until the next
    * event).
    */
-  private queueSysWorktreeUpdate(worktree: WorktreeState): void {
+  private queueSysWorktreeUpdate(worktree: WorktreeSnapshot): void {
     if (this.disposed) return;
     const key = worktree.worktreeId || path.resolve(worktree.path ?? "");
     this.pendingSysWorktreeUpdates.set(key, worktree);

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -24,12 +24,15 @@ export class WorkspaceHostEventRouter {
   // multi-agent load the host streams worktree-update snapshots at 10–50/s;
   // each synchronously drives `PullRequestService.handleWorktreeUpdate` (branch
   // diffing, PR-state clears, more log writes) and the MCP session listener,
-  // stalling the main thread and lagging keystroke echo. A 50ms trailing-edge
-  // debounce keyed per worktree collapses bursts (rapid same-worktree snapshots
-  // → one emit with the latest state) while staying imperceptible for these
-  // consumers. The direct per-view MessagePort fan-out (DIRECT_RENDERER_EVENTS)
-  // and the `worktree-update` plugin-bus emit are intentionally NOT debounced —
-  // they drive UI store updates and the PluginService contract.
+  // stalling the main thread and lagging keystroke echo. A 50ms coalescing
+  // window keyed per worktree collapses bursts (rapid same-worktree snapshots →
+  // one emit with the latest state) while staying imperceptible for these
+  // consumers. The window is bounded from the first pending update (fixed, not
+  // re-armed per update) so an update is delayed at most 50ms and sustained
+  // churn can never starve the flush. The direct per-view MessagePort fan-out
+  // (DIRECT_RENDERER_EVENTS) and the `worktree-update` plugin-bus emit are
+  // intentionally NOT debounced — they drive UI store updates and the
+  // PluginService contract.
   private static readonly SYS_WORKTREE_UPDATE_DEBOUNCE_MS = 50;
 
   private emit: EmitFn;
@@ -130,6 +133,12 @@ export class WorkspaceHostEventRouter {
           worktreeId: event.worktreeId,
           timestamp: Date.now(),
         });
+        // Drop any debounced `sys:worktree:update` still queued for this
+        // worktree so a delayed update can't fire after the removal (#10769).
+        // The update key is `worktreeId || path.resolve(path)`; delete both
+        // possible forms to cover the path-fallback key.
+        this.pendingSysWorktreeUpdates.delete(event.worktreeId);
+        this.pendingSysWorktreeUpdates.delete(path.resolve(event.worktreeId));
         // The resolved worktree path is the map key (set on `worktree-update`).
         // Prune it here so removed paths don't accumulate until `dispose()`.
         this.worktreePathToProject.delete(path.resolve(event.worktreeId));
@@ -365,9 +374,9 @@ export class WorkspaceHostEventRouter {
   }
 
   /**
-   * Buffer a `sys:worktree:update` for the trailing-edge debounce window. Keyed
-   * per worktree so rapid snapshots of the same worktree collapse to a single
-   * emit carrying the latest state. Re-arms a single shared timer (#7469: a
+   * Buffer a `sys:worktree:update` for the coalescing window. Keyed per worktree
+   * so rapid snapshots of the same worktree collapse to a single emit carrying
+   * the latest state. Arms a single shared timer if none is pending (#7469: a
    * pending entry without an armed drain timer would strand until the next
    * event).
    */

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceHostEventRouter } from "../WorkspaceHostEventRouter.js";
 import { CHANNELS } from "../../../ipc/channels.js";
 import type { WorkspaceHostEvent } from "../../../../shared/types/workspace-host.js";
@@ -79,6 +79,10 @@ describe("WorkspaceHostEventRouter", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // `sys:worktree:update` is now coalesced behind a 50ms trailing-edge timer
+    // (#10769). Fake timers let tests advance past the window deterministically;
+    // the forge guard tests override Date.now with their own spies as needed.
+    vi.useFakeTimers();
     copyTreeCallbacks = new Map();
     router = new WorkspaceHostEventRouter({
       emit: vi.fn(),
@@ -86,6 +90,13 @@ describe("WorkspaceHostEventRouter", () => {
       copyTreeProgressCallbacks: copyTreeCallbacks,
     });
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Number of ms past the `sys:worktree:update` debounce window.
+  const SYS_WORKTREE_DEBOUNCE_MS = 50;
 
   describe("inotify-limit-reached dedup", () => {
     it("fires toast on first emit", () => {
@@ -186,13 +197,101 @@ describe("WorkspaceHostEventRouter", () => {
   });
 
   describe("sys:worktree:update", () => {
-    it("emits the full worktree object directly", () => {
+    it("emits the full worktree object after the debounce window", () => {
       const entry = makeEntry();
       const event = makeWorktreeUpdateEvent({ branch: "feature/foo", prTitle: "My PR" });
 
       router.routeHostEvent(entry, event);
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
 
       expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
+    });
+  });
+
+  describe("sys:worktree:update debounce (#10769)", () => {
+    function sysUpdateCalls() {
+      return (events.emit as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c) => c[0] === "sys:worktree:update"
+      );
+    }
+
+    it("does not emit on the sys bus synchronously — it waits for the window", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, makeWorktreeUpdateEvent());
+
+      expect(events.emit).not.toHaveBeenCalledWith("sys:worktree:update", expect.anything());
+
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
+      expect(sysUpdateCalls()).toHaveLength(1);
+    });
+
+    it("still emits worktree-update on the plugin bus synchronously (not debounced)", () => {
+      const entry = makeEntry();
+      const event = makeWorktreeUpdateEvent();
+
+      router.routeHostEvent(entry, event);
+
+      const emit = router as unknown as { emit: ReturnType<typeof vi.fn> };
+      expect(emit.emit).toHaveBeenCalledWith("worktree-update", {
+        worktree: event.worktree,
+        projectPath: entry.projectPath,
+      });
+    });
+
+    it("collapses rapid same-worktree updates into one emit carrying the latest snapshot", () => {
+      const entry = makeEntry();
+      const first = makeWorktreeUpdateEvent({ branch: "old" });
+      const last = makeWorktreeUpdateEvent({ branch: "new" });
+
+      router.routeHostEvent(entry, first);
+      router.routeHostEvent(entry, last);
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
+
+      const calls = sysUpdateCalls();
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toBe(last.worktree);
+    });
+
+    it("emits once per distinct worktree in a burst", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, makeWorktreeUpdateEvent({ id: "wt-1", worktreeId: "wt-1" }));
+      router.routeHostEvent(entry, makeWorktreeUpdateEvent({ id: "wt-2", worktreeId: "wt-2" }));
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
+
+      expect(sysUpdateCalls()).toHaveLength(2);
+    });
+
+    it("keys off the resolved path when worktreeId is missing", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({ worktreeId: undefined, path: "/p/a" })
+      );
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({ worktreeId: undefined, path: "/p/b" })
+      );
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
+
+      expect(sysUpdateCalls()).toHaveLength(2);
+    });
+
+    it("dispose() before the window elapses drops the pending emit", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, makeWorktreeUpdateEvent());
+      router.dispose();
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
+
+      expect(events.emit).not.toHaveBeenCalledWith("sys:worktree:update", expect.anything());
+    });
+
+    it("ignores worktree-update routed after dispose()", () => {
+      const entry = makeEntry();
+      router.dispose();
+      router.routeHostEvent(entry, makeWorktreeUpdateEvent());
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
+
+      expect(events.emit).not.toHaveBeenCalledWith("sys:worktree:update", expect.anything());
     });
   });
 
@@ -434,6 +533,7 @@ describe("WorkspaceHostEventRouter", () => {
       });
 
       router.routeHostEvent(entry, event);
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
 
       expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
     });
@@ -469,6 +569,7 @@ describe("WorkspaceHostEventRouter", () => {
       });
 
       router.routeHostEvent(entry, event);
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
 
       expect(broadcastToRenderer).not.toHaveBeenCalled();
       // Normal routing must still happen even when the toast is skipped.
@@ -563,6 +664,7 @@ describe("WorkspaceHostEventRouter", () => {
       const event = makeWorktreeUpdateEvent();
 
       expect(() => router.routeHostEvent(entry, event)).not.toThrow();
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
       expect(broadcastToRenderer).not.toHaveBeenCalled();
       expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
     });

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -293,6 +293,25 @@ describe("WorkspaceHostEventRouter", () => {
 
       expect(events.emit).not.toHaveBeenCalledWith("sys:worktree:update", expect.anything());
     });
+
+    it("drops a pending update when the worktree is removed within the window", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, makeWorktreeUpdateEvent({ id: "wt-1", worktreeId: "wt-1" }));
+      router.routeHostEvent(entry, {
+        type: "worktree-removed",
+        worktreeId: "wt-1",
+        epoch: "550e8400-e29b-41d4-a716-446655440000",
+        seq: 2,
+      });
+      vi.advanceTimersByTime(SYS_WORKTREE_DEBOUNCE_MS);
+
+      // The remove fires synchronously; the queued update must NOT fire after it.
+      expect(events.emit).toHaveBeenCalledWith(
+        "sys:worktree:remove",
+        expect.objectContaining({ worktreeId: "wt-1" })
+      );
+      expect(events.emit).not.toHaveBeenCalledWith("sys:worktree:update", expect.anything());
+    });
   });
 
   describe("sys:worktree:remove (#9084)", () => {

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -315,6 +315,26 @@ describe("logger", () => {
       expect(content.indexOf("first buffered")).toBeLessThan(content.indexOf("then error"));
     });
 
+    it("flushes buffered lines via the scheduled setImmediate (not just the test helper)", async () => {
+      initializeLogger(TEST_LOG_DIR);
+      const logFile = getLogFilePath();
+
+      logInfo("scheduled line");
+      // Poll for the write to land without calling the test-only drain — proves
+      // the production setImmediate→drain scheduling path actually writes. The
+      // async appendFile completes off the threadpool, so its arrival isn't
+      // bounded by a fixed number of ticks; poll until it shows up.
+      const deadline = Date.now() + 2000;
+      let content = "";
+      while (Date.now() < deadline) {
+        content = existsSync(logFile) ? readFileSync(logFile, "utf8") : "";
+        if (content.includes("scheduled line")) break;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      expect(content).toContain("scheduled line");
+    });
+
     it("coalesces a burst of lines into the file after a single flush", async () => {
       initializeLogger(TEST_LOG_DIR);
       const logFile = getLogFilePath();

--- a/electron/utils/__tests__/logger.test.ts
+++ b/electron/utils/__tests__/logger.test.ts
@@ -15,6 +15,7 @@ import {
   ROTATION_MAX_SIZE,
   ROTATION_MAX_FILES,
   resetLoggerStateForTesting,
+  flushLogFileWritesForTesting,
   createLogger,
   setLogLevelOverrides,
   getLogLevelOverrides,
@@ -48,7 +49,10 @@ beforeEach(() => {
   process.env.DAINTREE_USER_DATA = TEST_LOG_DIR;
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Drain any buffered async writes to the test dir before tearing it down so a
+  // deferred flush can't race the cleanup and write to a fallback path.
+  await flushLogFileWritesForTesting();
   resetLoggerStateForTesting();
   resetWritesSuppressedForTesting();
   delete process.env.DAINTREE_USER_DATA;
@@ -141,16 +145,17 @@ describe("logger", () => {
   });
 
   describe("rotateLogsIfNeeded", () => {
-    it("does not rotate when file size is below threshold", () => {
+    it("does not rotate when file size is below threshold", async () => {
       initializeLogger(TEST_LOG_DIR);
       logInfo("Small log entry");
+      await flushLogFileWritesForTesting();
 
       const logFile = getLogFilePath();
       expect(existsSync(logFile)).toBe(true);
       expect(existsSync(join(TEST_LOG_DIR, "logs", "daintree.log.1"))).toBe(false);
     });
 
-    it("rotates log file when size exceeds threshold", () => {
+    it("rotates log file when size exceeds threshold", async () => {
       const logFile = join(TEST_LOG_DIR, "logs", "daintree.log");
       mkdirSync(join(TEST_LOG_DIR, "logs"), { recursive: true });
       const largeLine = `[2026-01-01T00:00:00.000Z] [INFO] ${"x".repeat(1024)}`;
@@ -161,6 +166,7 @@ describe("logger", () => {
 
       initializeLogger(TEST_LOG_DIR);
       logInfo("This should trigger rotation");
+      await flushLogFileWritesForTesting();
 
       expect(existsSync(logFile)).toBe(true);
       const rotatedFile = join(TEST_LOG_DIR, "logs", "daintree.log.1");
@@ -173,7 +179,7 @@ describe("logger", () => {
       expect(currentContent).toContain("This should trigger rotation");
     });
 
-    it("shuffles rotated files correctly", () => {
+    it("shuffles rotated files correctly", async () => {
       const logFile = join(TEST_LOG_DIR, "logs", "daintree.log");
       mkdirSync(join(TEST_LOG_DIR, "logs"), { recursive: true });
       const largeLine = `[2026-01-01T00:00:00.000Z] [INFO] ${"x".repeat(1024)}`;
@@ -188,6 +194,7 @@ describe("logger", () => {
 
       initializeLogger(TEST_LOG_DIR);
       logInfo("Trigger rotation");
+      await flushLogFileWritesForTesting();
 
       expect(existsSync(join(TEST_LOG_DIR, "logs", "daintree.log.1"))).toBe(true);
       expect(existsSync(join(TEST_LOG_DIR, "logs", "daintree.log.2"))).toBe(true);
@@ -201,7 +208,7 @@ describe("logger", () => {
       expect(file3Content).toContain("Rotated file 2");
     });
 
-    it("deletes oldest rotated file when max files exceeded", () => {
+    it("deletes oldest rotated file when max files exceeded", async () => {
       const logFile = join(TEST_LOG_DIR, "logs", "daintree.log");
       mkdirSync(join(TEST_LOG_DIR, "logs"), { recursive: true });
       const largeLine = `[2026-01-01T00:00:00.000Z] [INFO] ${"x".repeat(1024)}`;
@@ -216,6 +223,7 @@ describe("logger", () => {
 
       initializeLogger(TEST_LOG_DIR);
       logInfo("Trigger rotation");
+      await flushLogFileWritesForTesting();
 
       expect(existsSync(join(TEST_LOG_DIR, "logs", `daintree.log.${ROTATION_MAX_FILES + 1}`))).toBe(
         false
@@ -233,17 +241,19 @@ describe("logger", () => {
   });
 
   describe("disk pressure suppression", () => {
-    it("does not append to the log file when writes are suppressed", () => {
+    it("does not append to the log file when writes are suppressed", async () => {
       initializeLogger(TEST_LOG_DIR);
       const logFile = getLogFilePath();
 
       logInfo("baseline write before suppression");
+      await flushLogFileWritesForTesting();
       const beforeSize = existsSync(logFile) ? readFileSync(logFile, "utf8").length : 0;
       expect(beforeSize).toBeGreaterThan(0);
 
       setWritesSuppressed(true);
       logInfo("suppressed entry should not reach disk");
       logWarn("another suppressed entry");
+      await flushLogFileWritesForTesting();
 
       const afterSize = readFileSync(logFile, "utf8").length;
       expect(afterSize).toBe(beforeSize);
@@ -252,7 +262,7 @@ describe("logger", () => {
       expect(content).not.toContain("another suppressed entry");
     });
 
-    it("resumes writing once disk pressure clears", () => {
+    it("resumes writing once disk pressure clears", async () => {
       initializeLogger(TEST_LOG_DIR);
       const logFile = getLogFilePath();
 
@@ -261,10 +271,62 @@ describe("logger", () => {
 
       setWritesSuppressed(false);
       logInfo("written after recovery");
+      await flushLogFileWritesForTesting();
 
       const content = readFileSync(logFile, "utf8");
       expect(content).not.toContain("dropped during suppression");
       expect(content).toContain("written after recovery");
+    });
+  });
+
+  describe("async batched file writes (#10769)", () => {
+    it("buffers non-error lines until flushed", async () => {
+      initializeLogger(TEST_LOG_DIR);
+      const logFile = getLogFilePath();
+
+      logInfo("buffered line");
+      // Not yet on disk — the write is deferred off the synchronous hot path.
+      const beforeFlush = existsSync(logFile) ? readFileSync(logFile, "utf8") : "";
+      expect(beforeFlush).not.toContain("buffered line");
+
+      await flushLogFileWritesForTesting();
+      expect(readFileSync(logFile, "utf8")).toContain("buffered line");
+    });
+
+    it("writes error lines synchronously without a flush (crash safety)", () => {
+      initializeLogger(TEST_LOG_DIR);
+      const logFile = getLogFilePath();
+
+      logError("immediate error", new Error("boom"));
+      // Readable right away — errors bypass the async buffer.
+      expect(readFileSync(logFile, "utf8")).toContain("immediate error");
+    });
+
+    it("flushes buffered lines ahead of a synchronous error so on-disk order matches emit order", () => {
+      initializeLogger(TEST_LOG_DIR);
+      const logFile = getLogFilePath();
+
+      logInfo("first buffered");
+      logError("then error", new Error("boom"));
+      // The error path drains the buffer before its own sync write.
+      const content = readFileSync(logFile, "utf8");
+      expect(content).toContain("first buffered");
+      expect(content).toContain("then error");
+      expect(content.indexOf("first buffered")).toBeLessThan(content.indexOf("then error"));
+    });
+
+    it("coalesces a burst of lines into the file after a single flush", async () => {
+      initializeLogger(TEST_LOG_DIR);
+      const logFile = getLogFilePath();
+
+      for (let i = 0; i < 50; i++) {
+        logInfo(`burst line ${i}`);
+      }
+      await flushLogFileWritesForTesting();
+
+      const content = readFileSync(logFile, "utf8");
+      expect(content).toContain("burst line 0");
+      expect(content).toContain("burst line 49");
     });
   });
 
@@ -371,19 +433,21 @@ describe("logger", () => {
     const GITHUB_PAT = `ghp_${"A".repeat(40)}`;
     const ANTHROPIC_KEY = `sk-ant-${"a".repeat(95)}`;
 
-    it("scrubs secrets in the message before writing to the log file", () => {
+    it("scrubs secrets in the message before writing to the log file", async () => {
       initializeLogger(TEST_LOG_DIR);
       logInfo(`auth header set with token ${GITHUB_PAT}`);
+      await flushLogFileWritesForTesting();
 
       const content = readFileSync(getLogFilePath(), "utf8");
       expect(content).toContain("[REDACTED]");
       expect(content).not.toContain(GITHUB_PAT);
     });
 
-    it("scrubs secrets that appear in the context payload", () => {
+    it("scrubs secrets that appear in the context payload", async () => {
       initializeLogger(TEST_LOG_DIR);
       // SENSITIVE_KEYS doesn't catch arbitrary string fields — pattern scrub is the safety net
       logInfo("request received", { traceLine: `Bearer ${"x".repeat(40)}` });
+      await flushLogFileWritesForTesting();
 
       const content = readFileSync(getLogFilePath(), "utf8");
       expect(content).toContain("Bearer [REDACTED]");
@@ -392,6 +456,7 @@ describe("logger", () => {
 
     it("scrubs secrets from error.message when logging via logError", () => {
       initializeLogger(TEST_LOG_DIR);
+      // Errors are written synchronously (crash-safety path) — no flush needed.
       logError("auth failure", new Error(`bad key ${ANTHROPIC_KEY}`));
 
       const content = readFileSync(getLogFilePath(), "utf8");

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -218,6 +218,11 @@ export function resetLoggerStateForTesting(): void {
   trackedLogFile = null;
   trackedLogSize = -1;
   bytesSinceSizeRefresh = 0;
+  // Drop any buffered async writes so a deferred flush can't bleed into the
+  // next test (an already-scheduled setImmediate finds an empty buffer).
+  pendingLogLines = [];
+  pendingLogBytes = 0;
+  asyncFlushScheduled = false;
   loggerRegistry.clear();
   levelOverrides.clear();
   defaultLevel = IS_DEBUG_BOOT ? "debug" : "info";
@@ -655,6 +660,22 @@ let trackedLogFile: string | null = null;
 let trackedLogSize = -1;
 let bytesSinceSizeRefresh = 0;
 
+// Async batched file logging (#10769). A per-line `appendFileSync` on the main
+// thread is the dominant event-loop stall under multi-agent load: a single
+// workspace-host `worktree-update` fans out to several sync writes through the
+// event bus, and a busy session issues hundreds of log lines per second — each
+// 0.2–20ms incl. the periodic rotation `statSync`. Non-error lines are buffered
+// and flushed once per event-loop turn with a single async `appendFile`,
+// collapsing N syscalls into 1 and keeping the write off the synchronous hot
+// path. ERROR lines stay synchronous (see `writeToLogFile`) so they survive a
+// crash, matching the eager-import sync-fs rationale at the top of this file.
+const ASYNC_FLUSH_MAX_PENDING_BYTES = 256 * 1024;
+let pendingLogLines: string[] = [];
+let pendingLogBytes = 0;
+let asyncFlushScheduled = false;
+let asyncFlushInFlight: Promise<void> | null = null;
+let exitFlushRegistered = false;
+
 function rotateIfNeededTracked(logFile: string): boolean {
   if (
     trackedLogSize < 0 ||
@@ -671,33 +692,142 @@ function rotateIfNeededTracked(logFile: string): boolean {
   return true;
 }
 
+/** Ensure the log directory exists; re-stat on the next write if the path moved. */
+function ensureLogDir(logFile: string): void {
+  if (logFile !== trackedLogFile) {
+    mkdirSync(getLogDirectory(), { recursive: true });
+    trackedLogFile = logFile;
+    trackedLogSize = -1;
+  }
+}
+
+function recordWrittenBytes(bytes: number): void {
+  trackedLogSize += bytes;
+  bytesSinceSizeRefresh += bytes;
+}
+
+/** Synchronously append `data` to the active log file, honoring rotation. */
+function appendSync(data: string, bytes: number): void {
+  const logFile = getLogFilePath();
+  ensureLogDir(logFile);
+  if (!rotateIfNeededTracked(logFile)) return;
+  appendFileSync(logFile, data, "utf8");
+  recordWrittenBytes(bytes);
+}
+
+/**
+ * Drain buffered lines synchronously. Used as a memory safety valve when a
+ * synchronous burst never yields to the flush timer, and on process exit for
+ * best-effort durability of buffered non-error lines.
+ */
+function flushPendingLogsSync(): void {
+  if (pendingLogLines.length === 0) return;
+  const data = pendingLogLines.join("");
+  const bytes = pendingLogBytes;
+  pendingLogLines = [];
+  pendingLogBytes = 0;
+  try {
+    appendSync(data, bytes);
+  } catch {
+    trackedLogFile = null;
+  }
+}
+
+function scheduleAsyncFlush(): void {
+  if (!exitFlushRegistered) {
+    exitFlushRegistered = true;
+    process.once("exit", () => {
+      try {
+        flushPendingLogsSync();
+      } catch {
+        // Process is exiting — nothing more we can do.
+      }
+    });
+  }
+  if (asyncFlushScheduled) return;
+  asyncFlushScheduled = true;
+  setImmediate(runAsyncFlush);
+}
+
+function runAsyncFlush(): void {
+  asyncFlushScheduled = false;
+  if (asyncFlushInFlight) return; // the in-flight drain loops until empty
+  asyncFlushInFlight = drainPendingLogs().finally(() => {
+    asyncFlushInFlight = null;
+    // A line buffered after the loop's last check still needs a flush.
+    if (pendingLogLines.length > 0) scheduleAsyncFlush();
+  });
+}
+
+async function drainPendingLogs(): Promise<void> {
+  while (pendingLogLines.length > 0) {
+    const data = pendingLogLines.join("");
+    const bytes = pendingLogBytes;
+    pendingLogLines = [];
+    pendingLogBytes = 0;
+    try {
+      const logFile = getLogFilePath();
+      ensureLogDir(logFile);
+      if (!rotateIfNeededTracked(logFile)) continue;
+      await fsp.appendFile(logFile, data, "utf8");
+      recordWrittenBytes(bytes);
+    } catch {
+      // Re-ensure the directory and re-stat on the next write.
+      trackedLogFile = null;
+    }
+  }
+}
+
+/** Test-only: resolve once all buffered log lines have been written to disk. */
+export async function flushLogFileWritesForTesting(): Promise<void> {
+  if (!asyncFlushInFlight && pendingLogLines.length > 0) {
+    asyncFlushScheduled = false;
+    asyncFlushInFlight = drainPendingLogs().finally(() => {
+      asyncFlushInFlight = null;
+    });
+  }
+  while (asyncFlushInFlight) {
+    await asyncFlushInFlight;
+    if (pendingLogLines.length > 0 && !asyncFlushInFlight) {
+      asyncFlushInFlight = drainPendingLogs().finally(() => {
+        asyncFlushInFlight = null;
+      });
+    }
+  }
+}
+
 function writeToLogFile(level: string, message: string, contextStr: string): void {
   if (!ENABLE_FILE_LOGGING) return;
   if (getWritesSuppressed()) return;
 
-  try {
-    const logFile = getLogFilePath();
-    const timestamp = new Date().toISOString();
-    const logLine = scrubSecrets(
-      `[${timestamp}] [${level}] ${message}${contextStr ? ` ${contextStr}` : ""}\n`
-    );
+  const timestamp = new Date().toISOString();
+  const logLine = scrubSecrets(
+    `[${timestamp}] [${level}] ${message}${contextStr ? ` ${contextStr}` : ""}\n`
+  );
+  const bytes = Buffer.byteLength(logLine, "utf8");
 
-    if (logFile !== trackedLogFile) {
-      mkdirSync(getLogDirectory(), { recursive: true });
-      trackedLogFile = logFile;
-      trackedLogSize = -1;
+  if (level === "ERROR") {
+    // Errors are written synchronously so they survive a crash. Flush any
+    // buffered lines first so the on-disk order matches emit order.
+    try {
+      const data = pendingLogLines.length > 0 ? pendingLogLines.join("") + logLine : logLine;
+      const total = pendingLogBytes + bytes;
+      pendingLogLines = [];
+      pendingLogBytes = 0;
+      appendSync(data, total);
+    } catch {
+      trackedLogFile = null;
     }
+    return;
+  }
 
-    if (!rotateIfNeededTracked(logFile)) {
-      return;
-    }
-    appendFileSync(logFile, logLine, "utf8");
-    const bytes = Buffer.byteLength(logLine, "utf8");
-    trackedLogSize += bytes;
-    bytesSinceSizeRefresh += bytes;
-  } catch (_error) {
-    // Re-ensure the directory and re-stat on the next write.
-    trackedLogFile = null;
+  pendingLogLines.push(logLine);
+  pendingLogBytes += bytes;
+  // Bound memory if a synchronous burst never yields to the flush timer.
+  if (pendingLogBytes >= ASYNC_FLUSH_MAX_PENDING_BYTES) {
+    flushPendingLogsSync();
+  } else {
+    scheduleAsyncFlush();
   }
 }
 

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -808,7 +808,10 @@ function writeToLogFile(level: string, message: string, contextStr: string): voi
 
   if (level === "ERROR") {
     // Errors are written synchronously so they survive a crash. Flush any
-    // buffered lines first so the on-disk order matches emit order.
+    // buffered lines first so the on-disk order matches emit order. Ordering is
+    // best-effort: a batch already handed to an in-flight async flush has left
+    // the buffer and may interleave with this sync write — crash safety for the
+    // error line takes priority over strict ordering in that rare window.
     try {
       const data = pendingLogLines.length > 0 ? pendingLogLines.join("") + logLine : logLine;
       const total = pendingLogBytes + bytes;


### PR DESCRIPTION
## Summary

- Fixes the main-process event-loop stalls (#10769) that caused keystroke echo lag across agent terminals under multi-agent load (telemetry showed 1000-1755ms lag, 73 occurrences in a single session).
- Two independent fixes: async batched log writes in `electron/utils/logger.ts` and a 50ms coalescing window on the worktree-update bus in `WorkspaceHostEventRouter.ts`.

Resolves #10769

## Changes

**Async batched host-log writes (`electron/utils/logger.ts`)**

Replaces the per-line `appendFileSync` calls (running 150-300/s under load, each 0.2-20ms including the periodic rotation `stat`) with a buffered async path. Non-error lines are queued and flushed once per event-loop turn with a single `appendFile`. ERROR lines stay synchronous so they survive a crash, and they flush any pending buffer first to keep on-disk order consistent. A 256KB safety valve flushes synchronously if the buffer gets too large, and there's a best-effort sync flush on process exit. Rotation and size-tracking logic is reused unchanged.

**Coalesce worktree-update bus ingress (`WorkspaceHostEventRouter.ts`)**

Adds a 50ms per-worktree coalescing window on the in-process `sys:worktree:update` bus. Under load, these events burst at 10-50/s and each one synchronously drives `PullRequestService.handleWorktreeUpdate` and the MCP session listener. The direct per-view MessagePort fan-out (`DIRECT_RENDERER_EVENTS`) and the worktree-update plugin bus are intentionally not debounced. `worktree-removed` evicts any queued update for that worktree, and `dispose()` clears the timer (wired from `WorkspaceClient.dispose`).

## Testing

Logger and router suites: 98 tests, all green. Consumer suites (PullRequestService, EventBuffer, workspace-client): 176 tests, all green.

New tests cover: buffer-until-flush, sync-error-bypass, error-flushes-buffer ordering, burst coalescing, real-`setImmediate` scheduling, debounce non-synchronicity, same-worktree collapse, distinct-worktree emits, path-fallback key, dispose, and the removal-evicts-pending regression.