### PR TITLE
fix(terminal): eliminate DOM-renderer zebra banding for alt-buffer TUIs (#10768)

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,15 +1,15 @@
 {
-  "count": 1141,
+  "count": 1131,
   "byRule": {
-    "@typescript-eslint/no-explicit-any": 53,
+    "@typescript-eslint/no-explicit-any": 52,
     "@typescript-eslint/no-floating-promises": 90,
-    "@typescript-eslint/no-unsafe-type-assertion": 491,
-    "no-restricted-imports": 8,
-    "no-restricted-syntax": 377,
-    "no-useless-assignment": 20,
-    "preserve-caught-error": 46,
-    "react-compiler/react-compiler": 16,
-    "react-hooks/exhaustive-deps": 40
+    "@typescript-eslint/no-unsafe-type-assertion": 493,
+    "no-restricted-imports": 5,
+    "no-restricted-syntax": 376,
+    "no-useless-assignment": 19,
+    "preserve-caught-error": 43,
+    "react-compiler/react-compiler": 15,
+    "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-06-12T03:07:01.426Z"
+  "updatedAt": "2026-06-25T06:55:07.996Z"
 }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -410,6 +410,7 @@ class TerminalInstanceService {
   private makeListenerInstallDeps(): TerminalListenerInstallDeps {
     return {
       onBufferModeChange: (id, isAltBuffer) => this.handleBufferModeChange(id, isAltBuffer),
+      isWebGLActive: (id) => this.webGLManager.isActive(id),
       notifyParsed: (id) => this.dataBuffer.notifyParsed(id),
       scrollToBottomSafe: (managed) => this.scrollToBottomSafe(managed),
       updateScrollState: (id, isScrolledBack) =>
@@ -597,7 +598,14 @@ class TerminalInstanceService {
    */
   private shouldHaveActiveWebGL(managed: ManagedTerminal): boolean {
     if (!this.shouldRestoreWebGL(managed)) return false;
-    if (this.webGLManager.getMode() === "dom" && managed.id !== this.webGLManager.getPinnedId()) {
+    // In DOM mode the manager only keeps contexts on pinned panes (the focus
+    // pin and alt-buffer pins). A non-pinned pane can never have an active
+    // context, so the watchdog must not treat its absence as a fault.
+    if (
+      this.webGLManager.getMode() === "dom" &&
+      managed.id !== this.webGLManager.getPinnedId() &&
+      !this.webGLManager.isAltBufferPinned(managed.id)
+    ) {
       return false;
     }
     return true;
@@ -2835,6 +2843,17 @@ class TerminalInstanceService {
   private handleBufferModeChange(id: string, isAltBuffer: boolean): void {
     const managed = this.instances.get(id);
     if (!managed) return;
+
+    // Keep alt-buffer TUIs on WebGL through a fleet DOM-mode flip — WebGL has
+    // no fractional-cell-height seam, so this is the primary fix for the DOM
+    // renderer "zebra" banding on HiDPI displays (#10768). The manager treats
+    // an alt-buffer pin like the focus pin: one retained context in DOM mode,
+    // a no-op in WebGL mode and when GPU hardware is unavailable.
+    if (isAltBuffer) {
+      this.webGLManager.pinAltBuffer(id, managed);
+    } else {
+      this.webGLManager.unpinAltBuffer(id);
+    }
 
     for (const callback of managed.altBufferListeners) {
       try {

--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -66,7 +66,10 @@ function snapDomRowHeightsToIntegerPixels(terminal: Terminal): void {
   const base = Math.floor(target / count);
   const extra = target - base * count; // count of rows that get one extra pixel
 
-  let acc = 0;
+  // Midpoint-start Bresenham so the `extra` taller rows are spread evenly across
+  // the viewport rather than bunched at the bottom; the sum is unchanged
+  // (exactly `extra` rows receive base+1 regardless of the start offset).
+  let acc = Math.floor(count / 2);
   for (let i = 0; i < count; i++) {
     acc += extra;
     let h = base;

--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -24,6 +24,64 @@ const OBSERVED_TITLE_DEBOUNCE_MS = 150;
 const WAITING_TITLE_HYSTERESIS_MS = 250;
 
 /**
+ * Snap xterm DOM-renderer row heights to integer pixels that sum exactly to the
+ * canvas height, eliminating HiDPI "zebra" banding (#10768).
+ *
+ * At fractional device-pixel-ratios xterm's DOM renderer stamps every row with
+ * `css.canvas.height / rows` — a fractional CSS px height (DomRenderer
+ * `_updateDimensions`). Chromium then snaps adjacent row boundaries to device
+ * pixels inconsistently and the near-black terminal background bleeds through
+ * the seams as horizontal stripes. The WebGL renderer has no such seam, so the
+ * caller gates this on `!isWebGLActive(id)` — it only runs for DOM panes.
+ *
+ * Rows stack in normal flow, so the snapped heights MUST sum to the original
+ * canvas height; otherwise the rows drift past (or short of) the fixed-height
+ * screen element. A Bresenham distribution gives each row `base` or `base + 1`
+ * px spread evenly, summing exactly to the canvas height: coinciding integer
+ * boundaries snap to the same device pixel (no seam) with zero cumulative
+ * drift. The reconciliation watchdog reads container `getBoundingClientRect`,
+ * not row inline styles, so this does not perturb it.
+ *
+ * Idempotent: xterm only re-stamps fractional heights from `_updateDimensions`
+ * (resize / DPR / font / option change), each followed by a render; once
+ * snapped the first row reads as an integer and this early-returns. Cheap on
+ * the steady-state render path — one inline-style read, no layout flush.
+ */
+function snapDomRowHeightsToIntegerPixels(terminal: Terminal): void {
+  const rowContainer = terminal.element?.querySelector(".xterm-rows");
+  if (!rowContainer) return;
+  const rowEls = rowContainer.children;
+  const count = rowEls.length;
+  if (count === 0) return;
+
+  const cellHeight = parseFloat((rowEls[0] as HTMLElement).style.height);
+  // Nothing stamped yet, a zero-size grid, or already integer — leave it.
+  if (!Number.isFinite(cellHeight) || cellHeight <= 0 || Number.isInteger(cellHeight)) {
+    return;
+  }
+
+  // cellHeight === css.canvas.height / count, so cellHeight * count recovers the
+  // integer canvas height the rows must sum back to.
+  const target = Math.round(cellHeight * count);
+  const base = Math.floor(target / count);
+  const extra = target - base * count; // count of rows that get one extra pixel
+
+  let acc = 0;
+  for (let i = 0; i < count; i++) {
+    acc += extra;
+    let h = base;
+    if (acc >= count) {
+      acc -= count;
+      h = base + 1;
+    }
+    const px = `${h}px`;
+    const row = rowEls[i] as HTMLElement;
+    row.style.height = px;
+    row.style.lineHeight = px;
+  }
+}
+
+/**
  * Callback surface needed by `installTerminalBoundListeners`. Both
  * `TerminalInstanceService.getOrCreate()` (create path) and
  * `TerminalHibernationManager.unhibernate()` (wake path) satisfy this
@@ -33,6 +91,13 @@ const WAITING_TITLE_HYSTERESIS_MS = 250;
 export interface TerminalListenerInstallDeps {
   // Buffer / scroll / selection scrollback
   onBufferModeChange: (id: string, isAltBuffer: boolean) => void;
+  /**
+   * Whether the terminal is currently on the WebGL renderer. Gates the DOM
+   * integer row-height snap (#10768) so it only runs for DOM-rendered panes.
+   * Routed through deps to keep this module import-cycle-free relative to
+   * `TerminalWebGLManager` (same pattern as the reconciliation watchdog).
+   */
+  isWebGLActive: (id: string) => boolean;
   notifyParsed: (id: string) => void;
   scrollToBottomSafe: (managed: ManagedTerminal) => void;
   updateScrollState: (id: string, isScrolledBack: boolean) => void;
@@ -97,6 +162,17 @@ export function installTerminalBoundListeners(
   if (initialIsAltBuffer) {
     deps.onBufferModeChange(id, true);
   }
+
+  // DOM-renderer zebra-banding fix (#10768): after each render on a DOM-rendered
+  // pane, snap fractional row heights to integer pixels. onRender (not onResize)
+  // is the trigger because it also fires when a pane swaps WebGL→DOM on a fleet
+  // mode flip and on DPR changes that re-stamp heights without a cols/rows
+  // resize. The snap is idempotent and bails immediately for WebGL panes.
+  const renderDisposable = terminal.onRender(() => {
+    if (deps.isWebGLActive(id)) return;
+    snapDomRowHeightsToIntegerPixels(terminal);
+  });
+  managed.listeners.push(() => renderDisposable.dispose());
 
   // Suppress xterm's wheel→arrow-key translation for agent terminals that
   // are in the alt-screen buffer with no mouse tracking active. Without

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -216,6 +216,33 @@ export class TerminalWebGLManager {
   // effect when the fleet flips to DOM.
   private pinnedId: string | null = null;
 
+  // Alt-buffer pins: terminals running a full-screen alt-buffer TUI (vim,
+  // opencode, Gemini CLI, …) stay on WebGL even after the fleet flips to DOM,
+  // exactly like the focus pin. On HiDPI/fractional-scaled displays xterm's DOM
+  // renderer divides a rounded canvas height by the row count, yielding a
+  // fractional CSS cell height; Chromium then pixel-snaps adjacent row
+  // boundaries inconsistently and the near-black terminal background bleeds
+  // through the seams as horizontal "zebra" banding (#10768). WebGL has no such
+  // seam, so keeping alt-buffer panes on it is the primary fix; the DOM
+  // integer-snap in TerminalListenerInstaller is the fallback for panes that
+  // genuinely must use DOM (breaker tripped / hardware unavailable).
+  //
+  // Unlike pinnedId (always exactly one, driven by focus), this is a set:
+  // multiple panes can run alt-buffer TUIs at once. Both categories are honored
+  // identically by isPinned() at every DOM-mode exemption site; they are kept
+  // separate only because their lifecycles differ (focus events vs buffer-mode
+  // changes). Each alt-buffer pin still holds one WebGL context against
+  // Chromium's 16-cap, so this is bounded by how many alt-buffer panes are
+  // visible — far below the cap in practice, and the breaker trip clears them
+  // all (see setHardwareAvailable).
+  private altBufferPinnedIds = new Set<string>();
+
+  // A terminal is exempt from DOM-mode context release while it is the focus
+  // pin or an alt-buffer pin. Both keep one WebGL context attached in DOM mode.
+  private isPinned(id: string): boolean {
+    return id === this.pinnedId || this.altBufferPinnedIds.has(id);
+  }
+
   // xterm shares one module-global TextureAtlas across every terminal with a
   // matching font/theme config. A page-merge (TextureAtlas._mergePages) splices
   // pages and rewrites glyph texturePage indices, but each WebGL renderer keeps
@@ -252,6 +279,17 @@ export class TerminalWebGLManager {
       if (pinned !== null && this.pool.has(pinned)) {
         this.dropPoolEntry(pinned);
       }
+      // Alt-buffer pins offer no exemption against a breaker trip either —
+      // clear them (and drop any live contexts) before flipToDom so no WebGL
+      // context outlives the trip. flipToDom only skips still-pinned ids, so
+      // the set must be emptied first.
+      const altPinned = [...this.altBufferPinnedIds];
+      this.altBufferPinnedIds.clear();
+      for (const altId of altPinned) {
+        if (this.pool.has(altId)) {
+          this.dropPoolEntry(altId);
+        }
+      }
       this.flipToDom();
     }
   }
@@ -272,11 +310,11 @@ export class TerminalWebGLManager {
       this.evaluateMode();
     }
     // In WebGL mode, queue an attach for this id if not already pooled. In
-    // DOM mode only the focus-pinned terminal attaches; other wants are
-    // tracked but wait for the next flip back. attachWithLoadedAddon dedups
-    // via pool.has(id), so a repeat ensure on an already-attached terminal is
-    // a cheap no-op.
-    if (!this.pool.has(id) && (this.mode === "webgl" || id === this.pinnedId)) {
+    // DOM mode only pinned terminals (focus pin or alt-buffer pins) attach;
+    // other wants are tracked but wait for the next flip back.
+    // attachWithLoadedAddon dedups via pool.has(id), so a repeat ensure on an
+    // already-attached terminal is a cheap no-op.
+    if (!this.pool.has(id) && (this.mode === "webgl" || this.isPinned(id))) {
       this.queueAttach(id, managed);
     }
   }
@@ -287,6 +325,12 @@ export class TerminalWebGLManager {
       // re-established by the next focus event.
       this.pinnedId = null;
     }
+    // Deliberately NOT clearing altBufferPinnedIds here: a hidden alt-buffer
+    // pane stays "should be on WebGL" even though its context is dropped below.
+    // Unlike the focus pin (re-armed by the next focus event), nothing re-fires
+    // a buffer-mode transition when the pane is revealed, so the pin must
+    // survive hide/show. Dropping the want + context below is enough; the next
+    // ensureContext on reveal re-attaches because isPinned(id) is still true.
     const wasWanted = this.wants.delete(id);
     this.pendingEnsures.delete(id);
     this.pendingReleases.delete(id);
@@ -330,6 +374,46 @@ export class TerminalWebGLManager {
     // ensureContext stays queued-but-skipped until the want exists, and
     // ensureContext re-queues the pinned id in DOM mode.
     this.queueAttach(id, managed);
+  }
+
+  // Pin a terminal that has entered its alt-buffer so it keeps WebGL through a
+  // fleet DOM-mode flip (see altBufferPinnedIds). Idempotent. In WebGL mode the
+  // pin is bookkeeping only — every want already attaches — and it takes effect
+  // when the fleet next flips to DOM. In DOM mode it attaches one context now
+  // through the same rAF-staggered queue the focus pin uses (#7480). A no-op
+  // when hardware is unavailable: queuePinnedAttach bails, mirroring pinFocus.
+  pinAltBuffer(id: string, managed: ManagedTerminal): void {
+    if (this.altBufferPinnedIds.has(id)) {
+      if (this.mode === "dom") this.queuePinnedAttach(id, managed);
+      return;
+    }
+    this.altBufferPinnedIds.add(id);
+    if (this.mode !== "dom") return;
+    // Cancel any in-flight release of this id (it may have been queued by a
+    // mode flip before the alt-buffer transition landed) and attach.
+    this.pendingReleases.delete(id);
+    this.queuePinnedAttach(id, managed);
+  }
+
+  // Release an alt-buffer pin when the terminal returns to its normal buffer.
+  // In DOM mode its WebGL context is scheduled for release through the paced
+  // drain — unless the terminal is also the focus pin, in which case the focus
+  // pin keeps it attached.
+  unpinAltBuffer(id: string): void {
+    if (!this.altBufferPinnedIds.delete(id)) return;
+    if (this.mode !== "dom") return;
+    if (id === this.pinnedId) return;
+    this.pendingEnsures.delete(id);
+    const entry = this.pool.get(id);
+    if (entry) {
+      this.pendingReleases.set(id, entry.managed);
+      this.scheduleReleaseDrain();
+    }
+  }
+
+  // Test/diagnostic introspection and the watchdog's DOM-mode eligibility check.
+  isAltBufferPinned(id: string): boolean {
+    return this.altBufferPinnedIds.has(id);
   }
 
   // External re-evaluation hook. Threshold changes pushed from the main
@@ -397,6 +481,7 @@ export class TerminalWebGLManager {
     if (this.pinnedId === id) {
       this.pinnedId = null;
     }
+    this.altBufferPinnedIds.delete(id);
     const wasWanted = this.wants.delete(id);
     this.pendingEnsures.delete(id);
     this.pendingReleases.delete(id);
@@ -452,6 +537,7 @@ export class TerminalWebGLManager {
     this.pendingReleases.clear();
     this.wants.clear();
     this.pinnedId = null;
+    this.altBufferPinnedIds.clear();
     if (this.atlasResyncRafId !== null) {
       try {
         cancelAnimationFrame(this.atlasResyncRafId);
@@ -498,9 +584,10 @@ export class TerminalWebGLManager {
       );
       this.hasLoggedModeFlip = true;
     }
-    // Cancel pending attaches — only the focus pin is honored in DOM mode.
+    // Cancel pending attaches — only pinned terminals (focus pin or alt-buffer
+    // pins) are honored in DOM mode.
     for (const id of [...this.pendingEnsures.keys()]) {
-      if (id !== this.pinnedId) {
+      if (!this.isPinned(id)) {
         this.pendingEnsures.delete(id);
       }
     }
@@ -516,12 +603,12 @@ export class TerminalWebGLManager {
       this.pendingDrainScheduled = false;
     }
 
-    // Release active contexts progressively, keeping the focus pin attached.
-    // Each released terminal falls back to xterm's DOM renderer on its next
-    // paint. Visible terminals refresh when their release lands so the
-    // renderer swap is not deferred until output.
+    // Release active contexts progressively, keeping pinned terminals (focus
+    // pin and alt-buffer pins) attached. Each released terminal falls back to
+    // xterm's DOM renderer on its next paint. Visible terminals refresh when
+    // their release lands so the renderer swap is not deferred until output.
     for (const [id, entry] of this.pool) {
-      if (id === this.pinnedId) continue;
+      if (this.isPinned(id)) continue;
       this.pendingReleases.set(id, entry.managed);
     }
     this.scheduleReleaseDrain();
@@ -579,10 +666,11 @@ export class TerminalWebGLManager {
       return;
     }
     // A mode flip during an in-flight drain is honored — flipToDom drops the
-    // queued attaches, except the focus pin which stays valid in DOM mode.
+    // queued attaches, except pinned terminals (focus pin and alt-buffer pins)
+    // which stay valid in DOM mode.
     if (this.mode !== "webgl") {
       for (const id of [...this.pendingEnsures.keys()]) {
-        if (id !== this.pinnedId) {
+        if (!this.isPinned(id)) {
           this.pendingEnsures.delete(id);
         }
       }
@@ -644,9 +732,10 @@ export class TerminalWebGLManager {
     const [id, managed] = next.value;
     this.pendingReleases.delete(id);
 
-    // The pin may have moved onto an id queued for release before the focus
-    // change landed — keep its context.
-    if (id === this.pinnedId) {
+    // A pin may have landed on an id queued for release before the focus or
+    // buffer-mode change registered (focus pin or alt-buffer pin) — keep its
+    // context.
+    if (this.isPinned(id)) {
       if (this.pendingReleases.size > 0) {
         this.scheduleReleaseDrain();
       }
@@ -738,7 +827,7 @@ export class TerminalWebGLManager {
     if (this.pool.get(id) !== entry) return;
     const managed = entry.managed;
     this.dropPoolEntry(id);
-    if (managed.isOpened && this.wants.has(id) && (this.mode === "webgl" || id === this.pinnedId)) {
+    if (managed.isOpened && this.wants.has(id) && (this.mode === "webgl" || this.isPinned(id))) {
       this.queueAttach(id, managed);
     }
   }
@@ -755,12 +844,12 @@ export class TerminalWebGLManager {
     // between when this attach was queued and when the rAF drain landed —
     // refreshMode() is best-effort but the queue can already be in flight.
     // Re-evaluating here flips to DOM and clears pendingEnsures, so the next
-    // drain iteration bails immediately. The focus pin is the exception: it
-    // attaches regardless of the count, since DOM mode keeps exactly one
-    // context on the focused terminal.
+    // drain iteration bails immediately. Pinned terminals are the exception:
+    // the focus pin and alt-buffer pins attach regardless of the count, since
+    // DOM mode keeps one context on each of them.
     if (this.wants.size > getWebglUpperThreshold()) {
       this.evaluateMode();
-      if (id !== this.pinnedId || this.mode !== "dom") return;
+      if (!this.isPinned(id) || this.mode !== "dom") return;
     }
 
     let addon: WebglAddonType | null = null;

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -383,8 +383,20 @@ export class TerminalWebGLManager {
   // through the same rAF-staggered queue the focus pin uses (#7480). A no-op
   // when hardware is unavailable: queuePinnedAttach bails, mirroring pinFocus.
   pinAltBuffer(id: string, managed: ManagedTerminal): void {
+    // When hardware is unavailable the breaker has tripped for the session —
+    // WebGL never comes back, so tracking the pin would only make the watchdog
+    // burn repair slots (shouldHaveActiveWebGL gates on it) for a context that
+    // can never attach. Skip entirely; the DOM integer-snap handles the seam.
+    if (!this.hardwareAvailable) return;
     if (this.altBufferPinnedIds.has(id)) {
-      if (this.mode === "dom") this.queuePinnedAttach(id, managed);
+      // Cancel any in-flight release symmetrically with the first-pin branch
+      // below — flipToDom never queues a release for an already-pinned id, but
+      // keeping both branches identical avoids a use-after-free trap if a
+      // future path ever schedules one.
+      if (this.mode === "dom") {
+        this.pendingReleases.delete(id);
+        this.queuePinnedAttach(id, managed);
+      }
       return;
     }
     this.altBufferPinnedIds.add(id);

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -43,6 +43,7 @@ vi.mock("@xterm/xterm", () => ({
     this.onScroll = vi.fn(() => ({ dispose: vi.fn() }));
     this.onWriteParsed = freshTerminalOnWriteParsed;
     this.onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    this.onRender = vi.fn(() => ({ dispose: vi.fn() }));
     this.onTitleChange = freshTerminalOnTitleChange;
     this.getSelection = vi.fn(() => "");
   }),
@@ -115,6 +116,7 @@ function makeMockTerminal() {
     onScroll: vi.fn(() => ({ dispose: vi.fn() })),
     onWriteParsed: vi.fn(() => ({ dispose: vi.fn() })),
     onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
+    onRender: vi.fn(() => ({ dispose: vi.fn() })),
     onTitleChange: vi.fn(() => ({ dispose: vi.fn() })),
     getSelection: vi.fn(() => ""),
   };
@@ -180,6 +182,7 @@ function makeMockDeps(managed?: ManagedTerminal): HibernationManagerDeps {
     onHibernationChanged: vi.fn(),
     getIsBackgrounded: vi.fn(() => false),
     onBufferModeChange: vi.fn(),
+    isWebGLActive: vi.fn(() => false),
     notifyParsed: vi.fn(),
     scrollToBottomSafe: vi.fn(),
     clearUnseen: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -32,6 +32,7 @@ vi.mock("@xterm/xterm", () => ({
     this.onScroll = vi.fn(() => ({ dispose: vi.fn() }));
     this.onWriteParsed = freshTerminalOnWriteParsed;
     this.onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    this.onRender = vi.fn(() => ({ dispose: vi.fn() }));
     this.getSelection = vi.fn(() => "");
     this.hasSelection = vi.fn(() => false);
   }),
@@ -110,6 +111,7 @@ function makeMockTerminal() {
       return { dispose: vi.fn() };
     }),
     onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
+    onRender: vi.fn(() => ({ dispose: vi.fn() })),
     getSelection: vi.fn(() => ""),
     hasSelection: vi.fn(() => false),
   };
@@ -176,6 +178,7 @@ function makeMockDeps(managed?: ManagedTerminal): HibernationManagerDeps {
     onHibernationChanged: vi.fn(),
     getIsBackgrounded: vi.fn(() => false),
     onBufferModeChange: vi.fn(),
+    isWebGLActive: vi.fn(() => false),
     notifyParsed: vi.fn(),
     scrollToBottomSafe: vi.fn(),
     clearUnseen: vi.fn(),

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -63,6 +63,9 @@ type WebGLVisibilityService = {
     getMode: () => "webgl" | "dom";
     getPinnedId: () => string | null;
     getWantsSize: () => number;
+    pinAltBuffer: (id: string, managed: unknown) => void;
+    unpinAltBuffer: (id: string) => void;
+    isAltBufferPinned: (id: string) => boolean;
   };
 };
 
@@ -687,12 +690,56 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
       expect(callShouldHaveActive(managed)).toBe(true);
     });
 
+    it("still repairs an alt-buffer-pinned pane while in DOM-mode fallback (#10768)", () => {
+      vi.spyOn(service.webGLManager, "getMode").mockReturnValue("dom");
+      vi.spyOn(service.webGLManager, "getPinnedId").mockReturnValue("pinned-other");
+      vi.spyOn(service.webGLManager, "isAltBufferPinned").mockReturnValue(true);
+      const managed = makeMockManaged({ id: "t1" });
+
+      // Alt-buffer pins keep a context in DOM mode just like the focus pin, so
+      // the watchdog must treat a missing context as a real fault to repair.
+      expect(callShouldHaveActive(managed)).toBe(true);
+    });
+
     it("does not withhold watchdog repair outside DOM-mode fallback", () => {
       vi.spyOn(service.webGLManager, "getMode").mockReturnValue("webgl");
       vi.spyOn(service.webGLManager, "getPinnedId").mockReturnValue("pinned-other");
       const managed = makeMockManaged({ id: "t1" });
 
       expect(callShouldHaveActive(managed)).toBe(true);
+    });
+  });
+
+  describe("alt-buffer pin wiring (#10768)", () => {
+    function handleBufferModeChange(id: string, isAltBuffer: boolean): void {
+      (
+        service as unknown as {
+          handleBufferModeChange: (id: string, isAltBuffer: boolean) => void;
+        }
+      ).handleBufferModeChange(id, isAltBuffer);
+    }
+
+    it("entering the alt-buffer pins the terminal in the WebGL manager", () => {
+      const managed = makeMockManaged({ id: "t1" });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+      const pinSpy = vi.spyOn(service.webGLManager, "pinAltBuffer");
+
+      handleBufferModeChange("t1", true);
+
+      expect(pinSpy).toHaveBeenCalledWith("t1", managed);
+      expect(service.webGLManager.isAltBufferPinned("t1")).toBe(true);
+    });
+
+    it("returning to the normal buffer unpins the terminal", () => {
+      const managed = makeMockManaged({ id: "t1" });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+      const unpinSpy = vi.spyOn(service.webGLManager, "unpinAltBuffer");
+
+      handleBufferModeChange("t1", true);
+      handleBufferModeChange("t1", false);
+
+      expect(unpinSpy).toHaveBeenCalledWith("t1");
+      expect(service.webGLManager.isAltBufferPinned("t1")).toBe(false);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -762,6 +762,44 @@ describe("installTerminalBoundListeners", () => {
       expect(() => captured.onRender!()).not.toThrow();
     });
 
+    it("starts snapping only after the pane swaps WebGL → DOM (gate flips live)", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const element = makeRowsElement("17.275px", 40);
+      (terminal as { element: HTMLElement }).element = element;
+      // WebGL active at install + first render → no snap (the production state
+      // before a fleet DOM-mode flip / breaker trip).
+      const isWebGLActive = vi.fn(() => true);
+      const deps = makeDeps({ isWebGLActive });
+
+      install(terminal, deps);
+      captured.onRender!();
+      expect(rowHeights(element).every((h) => h === 17.275)).toBe(true);
+
+      // Pane swaps to the DOM renderer — the next render snaps.
+      isWebGLActive.mockReturnValue(false);
+      captured.onRender!();
+      expect(rowHeights(element).every((h) => Number.isInteger(h))).toBe(true);
+    });
+
+    it("assigns one uniform integer height when the canvas rounds to an exact multiple (extra=0)", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      // 17.99px * 40 = 719.6 → round 720 = 18 * 40, so base 18, extra 0: every
+      // row gets the same integer height, with no Bresenham distribution.
+      const element = makeRowsElement("17.99px", 40);
+      (terminal as { element: HTMLElement }).element = element;
+      const deps = makeDeps();
+
+      install(terminal, deps);
+      captured.onRender!();
+
+      const heights = rowHeights(element);
+      expect(new Set(heights).size).toBe(1);
+      expect(heights[0]).toBe(18);
+      expect(heights.reduce((a, b) => a + b, 0)).toBe(720);
+    });
+
     it("no-ops when the row height is unparseable", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -57,8 +57,14 @@ interface CapturedCallbacks {
   wheelHandler?: (event: WheelEvent) => boolean;
 }
 
+// xterm exposes `element` as readonly; the mock keeps it writable and wide-typed
+// (via a function boundary, so it isn't narrowed to `undefined`) so DOM-snap
+// tests can assign a real rows container without a type assertion.
+const emptyMockElement = (): HTMLElement | undefined => undefined;
+
 function makeMockTerminal(captured: CapturedCallbacks) {
   return {
+    element: emptyMockElement(),
     options: { scrollback: 5000 },
     rows: 24,
     cols: 80,
@@ -665,13 +671,9 @@ describe("installTerminalBoundListeners", () => {
       deps: TerminalListenerInstallDeps
     ) {
       const managed = makeMockManaged();
-      managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
-      installTerminalBoundListeners(
-        terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
-        managed,
-        "t1",
-        deps
-      );
+      const asXterm = terminal as unknown as ManagedTerminal["terminal"];
+      managed.terminal = asXterm;
+      installTerminalBoundListeners(asXterm, managed, "t1", deps);
     }
 
     it("snaps fractional row heights to integers that sum exactly to the canvas height", () => {
@@ -679,7 +681,7 @@ describe("installTerminalBoundListeners", () => {
       const terminal = makeMockTerminal(captured);
       // 691px canvas / 40 rows = 17.275px fractional cell height.
       const element = makeRowsElement("17.275px", 40);
-      (terminal as unknown as { element: HTMLElement }).element = element;
+      terminal.element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -704,7 +706,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("17.275px", 40);
-      (terminal as unknown as { element: HTMLElement }).element = element;
+      terminal.element = element;
       const deps = makeDeps({ isWebGLActive: vi.fn(() => true) });
 
       install(terminal, deps);
@@ -717,7 +719,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("18px", 40);
-      (terminal as unknown as { element: HTMLElement }).element = element;
+      terminal.element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -730,7 +732,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("17.275px", 40);
-      (terminal as unknown as { element: HTMLElement }).element = element;
+      terminal.element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -755,7 +757,7 @@ describe("installTerminalBoundListeners", () => {
     it("no-ops on an empty row list", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
-      (terminal as unknown as { element: HTMLElement }).element = makeRowsElement("17.275px", 0);
+      terminal.element = makeRowsElement("17.275px", 0);
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -766,7 +768,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("17.275px", 40);
-      (terminal as unknown as { element: HTMLElement }).element = element;
+      terminal.element = element;
       // WebGL active at install + first render → no snap (the production state
       // before a fleet DOM-mode flip / breaker trip).
       const isWebGLActive = vi.fn(() => true);
@@ -788,7 +790,7 @@ describe("installTerminalBoundListeners", () => {
       // 17.99px * 40 = 719.6 → round 720 = 18 * 40, so base 18, extra 0: every
       // row gets the same integer height, with no Bresenham distribution.
       const element = makeRowsElement("17.99px", 40);
-      (terminal as unknown as { element: HTMLElement }).element = element;
+      terminal.element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -804,7 +806,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("auto", 40);
-      (terminal as unknown as { element: HTMLElement }).element = element;
+      terminal.element = element;
       const deps = makeDeps();
 
       install(terminal, deps);

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -53,6 +53,7 @@ interface CapturedCallbacks {
   onWriteParsed?: () => void;
   onSelectionChange?: () => void;
   onScroll?: () => void;
+  onRender?: () => void;
   wheelHandler?: (event: WheelEvent) => boolean;
 }
 
@@ -91,6 +92,10 @@ function makeMockTerminal(captured: CapturedCallbacks) {
     }),
     onSelectionChange: vi.fn((cb: () => void) => {
       captured.onSelectionChange = cb;
+      return { dispose: vi.fn() };
+    }),
+    onRender: vi.fn((cb: () => void) => {
+      captured.onRender = cb;
       return { dispose: vi.fn() };
     }),
     onTitleChange: vi.fn((cb: (title: string) => void) => {
@@ -150,6 +155,7 @@ function makeDeps(
 ): TerminalListenerInstallDeps {
   return {
     onBufferModeChange: vi.fn(),
+    isWebGLActive: vi.fn(() => false),
     notifyParsed: vi.fn(),
     scrollToBottomSafe: vi.fn(),
     updateScrollState: vi.fn(),
@@ -632,5 +638,143 @@ describe("installTerminalBoundListeners", () => {
     );
 
     expect(managed2.listeners.length).toBe(firstCount);
+  });
+
+  describe("DOM zebra-banding integer row-height snap (#10768)", () => {
+    function makeRowsElement(cellHeightCss: string, rowCount: number): HTMLElement {
+      const element = document.createElement("div");
+      const rows = document.createElement("div");
+      rows.className = "xterm-rows";
+      for (let i = 0; i < rowCount; i++) {
+        const row = document.createElement("div");
+        row.style.height = cellHeightCss;
+        row.style.lineHeight = cellHeightCss;
+        rows.appendChild(row);
+      }
+      element.appendChild(rows);
+      return element;
+    }
+
+    function rowHeights(element: HTMLElement): number[] {
+      const rows = element.querySelector(".xterm-rows")!.children;
+      return Array.from(rows).map((r) => parseFloat((r as HTMLElement).style.height));
+    }
+
+    function install(
+      terminal: ReturnType<typeof makeMockTerminal>,
+      deps: TerminalListenerInstallDeps
+    ) {
+      const managed = makeMockManaged();
+      managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+      installTerminalBoundListeners(
+        terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+        managed,
+        "t1",
+        deps
+      );
+    }
+
+    it("snaps fractional row heights to integers that sum exactly to the canvas height", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      // 691px canvas / 40 rows = 17.275px fractional cell height.
+      const element = makeRowsElement("17.275px", 40);
+      (terminal as { element: HTMLElement }).element = element;
+      const deps = makeDeps();
+
+      install(terminal, deps);
+      captured.onRender!();
+
+      const heights = rowHeights(element);
+      // Every row is an integer pixel value.
+      expect(heights.every((h) => Number.isInteger(h))).toBe(true);
+      // No drift: snapped heights sum back to the integer canvas height.
+      expect(heights.reduce((a, b) => a + b, 0)).toBe(Math.round(17.275 * 40));
+      // Distributed, not uniform: a fractional cell needs a mix of two heights.
+      expect(new Set(heights).size).toBe(2);
+      // lineHeight is snapped in lockstep with height.
+      const rows = element.querySelector(".xterm-rows")!.children;
+      for (const r of Array.from(rows)) {
+        const el = r as HTMLElement;
+        expect(el.style.lineHeight).toBe(el.style.height);
+      }
+    });
+
+    it("does not touch row heights when the pane is on the WebGL renderer", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const element = makeRowsElement("17.275px", 40);
+      (terminal as { element: HTMLElement }).element = element;
+      const deps = makeDeps({ isWebGLActive: vi.fn(() => true) });
+
+      install(terminal, deps);
+      captured.onRender!();
+
+      expect(rowHeights(element).every((h) => h === 17.275)).toBe(true);
+    });
+
+    it("leaves already-integer row heights untouched (idempotent)", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const element = makeRowsElement("18px", 40);
+      (terminal as { element: HTMLElement }).element = element;
+      const deps = makeDeps();
+
+      install(terminal, deps);
+      captured.onRender!();
+
+      expect(rowHeights(element).every((h) => h === 18)).toBe(true);
+    });
+
+    it("is idempotent across repeated renders", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const element = makeRowsElement("17.275px", 40);
+      (terminal as { element: HTMLElement }).element = element;
+      const deps = makeDeps();
+
+      install(terminal, deps);
+      captured.onRender!();
+      const first = rowHeights(element);
+      captured.onRender!();
+      const second = rowHeights(element);
+
+      expect(second).toEqual(first);
+    });
+
+    it("no-ops when the terminal element is not yet attached", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      // No `element` set — terminal.open() hasn't run.
+      const deps = makeDeps();
+
+      install(terminal, deps);
+      expect(() => captured.onRender!()).not.toThrow();
+    });
+
+    it("no-ops on an empty row list", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      (terminal as { element: HTMLElement }).element = makeRowsElement("17.275px", 0);
+      const deps = makeDeps();
+
+      install(terminal, deps);
+      expect(() => captured.onRender!()).not.toThrow();
+    });
+
+    it("no-ops when the row height is unparseable", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const element = makeRowsElement("auto", 40);
+      (terminal as { element: HTMLElement }).element = element;
+      const deps = makeDeps();
+
+      install(terminal, deps);
+      captured.onRender!();
+
+      // "auto" stays as-is (parseFloat → NaN, guarded out).
+      const rows = element.querySelector(".xterm-rows")!.children;
+      expect((rows[0] as HTMLElement).style.height).toBe("auto");
+    });
   });
 });

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -679,7 +679,7 @@ describe("installTerminalBoundListeners", () => {
       const terminal = makeMockTerminal(captured);
       // 691px canvas / 40 rows = 17.275px fractional cell height.
       const element = makeRowsElement("17.275px", 40);
-      (terminal as { element: HTMLElement }).element = element;
+      (terminal as unknown as { element: HTMLElement }).element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -704,7 +704,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("17.275px", 40);
-      (terminal as { element: HTMLElement }).element = element;
+      (terminal as unknown as { element: HTMLElement }).element = element;
       const deps = makeDeps({ isWebGLActive: vi.fn(() => true) });
 
       install(terminal, deps);
@@ -717,7 +717,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("18px", 40);
-      (terminal as { element: HTMLElement }).element = element;
+      (terminal as unknown as { element: HTMLElement }).element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -730,7 +730,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("17.275px", 40);
-      (terminal as { element: HTMLElement }).element = element;
+      (terminal as unknown as { element: HTMLElement }).element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -755,7 +755,7 @@ describe("installTerminalBoundListeners", () => {
     it("no-ops on an empty row list", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
-      (terminal as { element: HTMLElement }).element = makeRowsElement("17.275px", 0);
+      (terminal as unknown as { element: HTMLElement }).element = makeRowsElement("17.275px", 0);
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -766,7 +766,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("17.275px", 40);
-      (terminal as { element: HTMLElement }).element = element;
+      (terminal as unknown as { element: HTMLElement }).element = element;
       // WebGL active at install + first render → no snap (the production state
       // before a fleet DOM-mode flip / breaker trip).
       const isWebGLActive = vi.fn(() => true);
@@ -788,7 +788,7 @@ describe("installTerminalBoundListeners", () => {
       // 17.99px * 40 = 719.6 → round 720 = 18 * 40, so base 18, extra 0: every
       // row gets the same integer height, with no Bresenham distribution.
       const element = makeRowsElement("17.99px", 40);
-      (terminal as { element: HTMLElement }).element = element;
+      (terminal as unknown as { element: HTMLElement }).element = element;
       const deps = makeDeps();
 
       install(terminal, deps);
@@ -804,7 +804,7 @@ describe("installTerminalBoundListeners", () => {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
       const element = makeRowsElement("auto", 40);
-      (terminal as { element: HTMLElement }).element = element;
+      (terminal as unknown as { element: HTMLElement }).element = element;
       const deps = makeDeps();
 
       install(terminal, deps);

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -1669,13 +1669,66 @@ describe("TerminalWebGLManager", () => {
       expect(manager.isActive("t1")).toBe(false);
     });
 
-    it("ignores the pin attach when hardware is unavailable", () => {
+    it("ignores the pin (and records nothing) when hardware is unavailable", () => {
       const terms = fillToDomMode();
       manager.setHardwareAvailable(false);
 
       manager.pinAltBuffer("t1", terms[1]!);
 
       expect(manager.isActive("t1")).toBe(false);
+      // The breaker is a one-way session trip; tracking a pin that can never
+      // attach would only churn the watchdog. Nothing is recorded.
+      expect(manager.isAltBufferPinned("t1")).toBe(false);
+    });
+
+    it("releases the context when the focus pin moves away after the alt-buffer pin was cleared", () => {
+      const terms = fillToDomMode();
+      // t1 is both focus-pinned and alt-buffer-pinned.
+      manager.pinAltBuffer("t1", terms[1]!);
+      manager.pinFocus("t1", terms[1]!);
+      expect(manager.isActive("t1")).toBe(true);
+
+      // Buffer → normal clears the alt pin, but the focus pin still holds it.
+      manager.unpinAltBuffer("t1");
+      expect(manager.isActive("t1")).toBe(true);
+
+      // Focus moves to t2 — t1 now has neither pin, so its context is released.
+      manager.pinFocus("t2", terms[2]!);
+      expect(manager.isActive("t1")).toBe(false);
+      expect(manager.isActive("t2")).toBe(true);
+    });
+
+    it("survives a mode-switch teardown then a hide/show cycle", () => {
+      // Pin before the flip so the alt pane keeps WebGL through the paced
+      // release drain, then hide (releaseContext) and re-reveal (ensureContext).
+      const alt = makeManagedTerminal();
+      manager.ensureContext("alt", alt);
+      manager.pinAltBuffer("alt", alt);
+      manager.ensureContext("a", makeManagedTerminal());
+      manager.ensureContext("b", makeManagedTerminal());
+      manager.ensureContext("c", makeManagedTerminal());
+      expect(manager.getMode()).toBe("dom");
+      expect(manager.isActive("alt")).toBe(true);
+
+      manager.releaseContext("alt"); // hide
+      expect(manager.isActive("alt")).toBe(false);
+      expect(manager.isAltBufferPinned("alt")).toBe(true);
+
+      manager.ensureContext("alt", alt); // reveal
+      expect(manager.isActive("alt")).toBe(true);
+    });
+
+    it("handles a rapid alt→normal→alt toggle without leaking the pin", () => {
+      const terms = fillToDomMode();
+
+      manager.pinAltBuffer("t1", terms[1]!);
+      expect(manager.isAltBufferPinned("t1")).toBe(true);
+      manager.unpinAltBuffer("t1");
+      expect(manager.isAltBufferPinned("t1")).toBe(false);
+      manager.pinAltBuffer("t1", terms[1]!);
+
+      expect(manager.isAltBufferPinned("t1")).toBe(true);
+      expect(manager.isActive("t1")).toBe(true);
     });
 
     it("hardware loss drops every alt-buffer-pinned context — no exemption survives the breaker", () => {

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -1531,6 +1531,220 @@ describe("TerminalWebGLManager", () => {
     });
   });
 
+  describe("alt-buffer pin (keeps alt-screen TUIs on WebGL — #10768)", () => {
+    beforeEach(async () => {
+      const mod = await import("../TerminalWebGLManager");
+      mod.TerminalWebGLManager.setWebglThresholds(3, 2);
+    });
+
+    function fillToDomMode(): ManagedTerminal[] {
+      const terms = Array.from({ length: 4 }, () => makeManagedTerminal());
+      terms.forEach((t, i) => manager.ensureContext(`t${i}`, t));
+      expect(manager.getMode()).toBe("dom");
+      return terms;
+    }
+
+    it("keeps an alt-buffer-pinned terminal's context through a flip to dom mode", () => {
+      const alt = makeManagedTerminal();
+      manager.ensureContext("alt", alt);
+      manager.pinAltBuffer("alt", alt);
+      manager.ensureContext("a", makeManagedTerminal());
+      manager.ensureContext("b", makeManagedTerminal());
+      expect(manager.isActive("alt")).toBe(true);
+
+      // Fourth want crosses upper (3) → dom mode; alt-buffer pin survives.
+      manager.ensureContext("c", makeManagedTerminal());
+      expect(manager.getMode()).toBe("dom");
+      expect(manager.isActive("alt")).toBe(true);
+      expect(manager.isActive("a")).toBe(false);
+      expect(manager.isActive("b")).toBe(false);
+      expect(manager.isAltBufferPinned("alt")).toBe(true);
+    });
+
+    it("attaches a context for a terminal pinned while already in dom mode", () => {
+      const terms = fillToDomMode();
+      expect(manager.isActive("t1")).toBe(false);
+
+      manager.pinAltBuffer("t1", terms[1]!);
+
+      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.getMode()).toBe("dom");
+    });
+
+    it("supports multiple simultaneous alt-buffer pins (unlike the single focus pin)", () => {
+      const terms = fillToDomMode();
+
+      manager.pinAltBuffer("t1", terms[1]!);
+      manager.pinAltBuffer("t2", terms[2]!);
+
+      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.isActive("t2")).toBe(true);
+      expect(manager.isAltBufferPinned("t1")).toBe(true);
+      expect(manager.isAltBufferPinned("t2")).toBe(true);
+    });
+
+    it("unpinAltBuffer releases the context when the terminal returns to its normal buffer", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+      expect(manager.isActive("t1")).toBe(true);
+
+      manager.unpinAltBuffer("t1");
+
+      expect(manager.isActive("t1")).toBe(false);
+      expect(manager.isAltBufferPinned("t1")).toBe(false);
+    });
+
+    it("unpinAltBuffer keeps the context when the terminal is also the focus pin", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+      manager.pinFocus("t1", terms[1]!);
+      expect(manager.isActive("t1")).toBe(true);
+
+      manager.unpinAltBuffer("t1");
+
+      // Focus pin still holds the single dom-mode context.
+      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.getPinnedId()).toBe("t1");
+    });
+
+    it("pinning does not change the wants count or trigger a mode flip", () => {
+      const terms = fillToDomMode();
+      const before = manager.getWantsSize();
+
+      manager.pinAltBuffer("t0", terms[0]!);
+      manager.pinAltBuffer("t1", terms[1]!);
+
+      expect(manager.getWantsSize()).toBe(before);
+      expect(manager.getMode()).toBe("dom");
+    });
+
+    it("is idempotent — re-pinning an already-pinned terminal constructs no second addon", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+      const addonsAfterFirst = WebglAddonMock.mock.calls.length;
+
+      manager.pinAltBuffer("t1", terms[1]!);
+
+      expect(WebglAddonMock.mock.calls.length).toBe(addonsAfterFirst);
+      expect(manager.isActive("t1")).toBe(true);
+    });
+
+    it("alt-buffer pin survives a hide/show cycle so the revealed pane returns to WebGL", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+      expect(manager.isActive("t1")).toBe(true);
+
+      // Hiding the pane (releaseContext) drops its want + context but must KEEP
+      // the pin: no buffer-mode transition re-fires on reveal, so the pin is the
+      // only thing that lets ensureContext re-attach it in dom mode. 4→3 wants
+      // stays above the lower threshold (2), so the fleet stays in dom mode.
+      manager.releaseContext("t1");
+      expect(manager.isActive("t1")).toBe(false);
+      expect(manager.isAltBufferPinned("t1")).toBe(true);
+      expect(manager.getMode()).toBe("dom");
+
+      // Revealing the pane re-ensures WebGL — the intact pin gets it a context.
+      manager.ensureContext("t1", terms[1]!);
+      expect(manager.isActive("t1")).toBe(true);
+    });
+
+    it("unpinAltBuffer is the only visibility-independent way the pin is cleared", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+
+      manager.releaseContext("t1"); // hide — pin survives
+      expect(manager.isAltBufferPinned("t1")).toBe(true);
+
+      manager.unpinAltBuffer("t1"); // buffer → normal — pin cleared
+      expect(manager.isAltBufferPinned("t1")).toBe(false);
+    });
+
+    it("onTerminalDestroyed clears the alt-buffer pin", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+
+      manager.onTerminalDestroyed("t1");
+
+      expect(manager.isAltBufferPinned("t1")).toBe(false);
+      expect(manager.isActive("t1")).toBe(false);
+    });
+
+    it("ignores the pin attach when hardware is unavailable", () => {
+      const terms = fillToDomMode();
+      manager.setHardwareAvailable(false);
+
+      manager.pinAltBuffer("t1", terms[1]!);
+
+      expect(manager.isActive("t1")).toBe(false);
+    });
+
+    it("hardware loss drops every alt-buffer-pinned context — no exemption survives the breaker", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+      manager.pinAltBuffer("t2", terms[2]!);
+      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.isActive("t2")).toBe(true);
+
+      manager.setHardwareAvailable(false);
+
+      expect(manager.isActive("t1")).toBe(false);
+      expect(manager.isActive("t2")).toBe(false);
+      expect(manager.isAltBufferPinned("t1")).toBe(false);
+      expect(manager.isAltBufferPinned("t2")).toBe(false);
+    });
+
+    it("flip back to webgl reattaches every want including alt-buffer pins exactly once", () => {
+      const terms = fillToDomMode();
+      manager.pinAltBuffer("t1", terms[1]!);
+      expect(manager.isActive("t1")).toBe(true);
+
+      manager.releaseContext("t0");
+      manager.releaseContext("t3");
+      expect(manager.getMode()).toBe("webgl");
+
+      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.isActive("t2")).toBe(true);
+    });
+
+    it("alt-buffer pin set before the flip stays out of the paced release queue", () => {
+      const alt = makeManagedTerminal();
+      manager.ensureContext("alt", alt);
+      manager.pinAltBuffer("alt", alt);
+      manager.ensureContext("a", makeManagedTerminal());
+      manager.ensureContext("b", makeManagedTerminal());
+
+      rafMode = "queued";
+      manager.ensureContext("c", makeManagedTerminal());
+      expect(manager.getMode()).toBe("dom");
+
+      // Drain every queued release frame — the alt-buffer pin survives all.
+      while (flushRafFrame()) {
+        // drain
+      }
+      expect(manager.isActive("alt")).toBe(true);
+      expect(manager.isActive("a")).toBe(false);
+      expect(manager.isActive("b")).toBe(false);
+    });
+
+    it("a focus pin and an alt-buffer pin on different terminals both survive dom mode", () => {
+      const focus = makeManagedTerminal();
+      const alt = makeManagedTerminal();
+      manager.ensureContext("focus", focus);
+      manager.ensureContext("alt", alt);
+      manager.pinFocus("focus", focus);
+      manager.pinAltBuffer("alt", alt);
+      manager.ensureContext("a", makeManagedTerminal());
+
+      // Cross the upper threshold (3) → dom mode.
+      manager.ensureContext("b", makeManagedTerminal());
+      expect(manager.getMode()).toBe("dom");
+
+      expect(manager.isActive("focus")).toBe(true);
+      expect(manager.isActive("alt")).toBe(true);
+      expect(manager.isActive("a")).toBe(false);
+    });
+  });
+
   describe("lazy WebglAddon loading", () => {
     // These tests exercise the dynamic-import path. They reset loader state in
     // beforeEach so the queue behavior runs against a real (mocked) import().


### PR DESCRIPTION
## Summary

- On HiDPI/fractional-scaled displays, alt-buffer TUIs (vim, opencode, Gemini CLI) that fall back to xterm's DOM renderer show horizontal zebra stripes. At non-integer DPR, the DOM renderer computes a fractional `css.cell.height` and Chromium pixel-snaps adjacent row boundaries inconsistently, so the terminal background bleeds through the seams. xterm 6.x removed addon-canvas so there's no canvas-renderer escape hatch.
- Fix part 1: `TerminalWebGLManager` gains an `altBufferPinnedIds` set so alt-screen panes stay on WebGL through fleet DOM-mode flips, exactly like the existing focus pin. A shared `isPinned()` helper unifies all 8 exemption sites. The circuit breaker clears alt-buffer pins before `flipToDom`; the reconciliation watchdog's `shouldHaveActiveWebGL` honours them; the pin is visibility-independent so a hidden-then-revealed alt pane returns to WebGL correctly.
- Fix part 2: For panes that genuinely must use DOM (breaker tripped or hardware unavailable), a new `onRender` hook in `TerminalListenerInstaller` snaps fractional row heights to integers using a Bresenham distribution that sums exactly to the canvas height, gated on `!isWebGLActive`. Using `onRender` rather than `onResize` means it also fires on WebGL-to-DOM renderer swaps and DPR changes.

Resolves #10768

## Changes

- `TerminalWebGLManager.ts`: `altBufferPinnedIds` set, `pinAltBuffer`/`unpinAltBuffer` methods, shared `isPinned()`, circuit-breaker clear, watchdog awareness
- `TerminalListenerInstaller.ts`: `onRender` hook with Bresenham integer-snap for DOM-renderer row heights
- `TerminalInstanceService.ts`: wires `handleBufferModeChange` to call `pinAltBuffer`/`unpinAltBuffer`

## Testing

265+ targeted unit tests pass across three new/extended suites:

- `TerminalWebGLManager.test.ts`: alt-buffer pin lifecycle, focus+alt-buffer interaction, circuit-breaker clear, watchdog behaviour
- `TerminalListenerInstaller.test.ts`: DOM integer-snap correctness, Bresenham distribution, WebGL-active guard
- `TerminalInstanceService.webglVisibility.test.ts`: buffer-mode-change wiring

Typecheck clean. Reviewed adversarially before push, no critical findings.