### PR TITLE
feat(settings): add audit recording toggle to Assistant Privacy, collapse diagnostics

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -175,6 +175,7 @@ export function DaintreeAssistantSettingsTab() {
   // Recording stays on by default — the audit trail is a privacy/safety feature.
   // The authoritative value loads from getAuditConfig in the audit fetch effect.
   const [auditEnabled, setAuditEnabled] = useState(true);
+  const [isTogglingAudit, setIsTogglingAudit] = useState(false);
   // Diagnostics (audit viewer, latency table, turn outcomes) collapse by default
   // so the Privacy section doesn't surface telemetry on load. Local-only state —
   // no persistence precedent for section collapse in Settings.
@@ -452,14 +453,22 @@ export function DaintreeAssistantSettingsTab() {
 
   // Proxies the same mcpServer.setAuditEnabled endpoint as the MCP Server tab's
   // "Capture audit log" toggle. Server response is authoritative — no optimistic
-  // flip. On failure, leave the last known-good value (the IPC error is logged).
+  // flip. The in-flight guard prevents a double-click from computing `next` twice
+  // off the same pre-await state. On failure, surface the error and leave the
+  // last known-good value (matches McpServerSettingsTab's toggle).
   const handleAuditEnabledToggle = async () => {
+    if (isTogglingAudit) return;
+    setIsTogglingAudit(true);
     try {
+      setError(null);
       const next = !auditEnabled;
       const cfg = await window.electron.mcpServer.setAuditEnabled(next);
       setAuditEnabled(cfg.enabled);
     } catch (err) {
+      setError(formatErrorMessage(err, "Couldn't update audit recording"));
       logError("Failed to toggle MCP audit log from assistant tab", err);
+    } finally {
+      setIsTogglingAudit(false);
     }
   };
 
@@ -933,7 +942,10 @@ export function DaintreeAssistantSettingsTab() {
           isEnabled={auditEnabled}
           onChange={handleAuditEnabledToggle}
           ariaLabel="Capture audit log"
-          disabled={loading}
+          // Gate on auditLoading too: until getAuditConfig resolves, auditEnabled
+          // is still the optimistic default and a late fulfillment would clobber
+          // a user toggle made in that window.
+          disabled={loading || auditLoading || isTogglingAudit}
         />
         <SettingsSelect
           label="Audit log retention"

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -172,6 +172,13 @@ export function DaintreeAssistantSettingsTab() {
   const [isExportingAudit, setIsExportingAudit] = useState(false);
   const [showClearAuditConfirm, setShowClearAuditConfirm] = useState(false);
   const [isClearingAudit, setIsClearingAudit] = useState(false);
+  // Recording stays on by default — the audit trail is a privacy/safety feature.
+  // The authoritative value loads from getAuditConfig in the audit fetch effect.
+  const [auditEnabled, setAuditEnabled] = useState(true);
+  // Diagnostics (audit viewer, latency table, turn outcomes) collapse by default
+  // so the Privacy section doesn't surface telemetry on load. Local-only state —
+  // no persistence precedent for section collapse in Settings.
+  const [advancedDiagnosticsOpen, setAdvancedDiagnosticsOpen] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const auditExportTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -358,8 +365,9 @@ export function DaintreeAssistantSettingsTab() {
         window.electron.mcpServer.getLogRecords(),
         window.electron.mcpServer.getAuditStats(),
         window.electron.mcpServer.getTurnOutcomeRecords(),
+        window.electron.mcpServer.getAuditConfig(),
       ])
-        .then(([recordsResult, statsResult, turnsResult]) => {
+        .then(([recordsResult, statsResult, turnsResult, configResult]) => {
           if (cancelled) return;
           if (recordsResult.status === "fulfilled") {
             setAuditRecords(recordsResult.value);
@@ -375,6 +383,11 @@ export function DaintreeAssistantSettingsTab() {
             setTurnRecords(turnsResult.value);
           } else {
             logError("Failed initial turn outcomes load for assistant tab", turnsResult.reason);
+          }
+          if (configResult.status === "fulfilled") {
+            setAuditEnabled(configResult.value.enabled);
+          } else {
+            logError("Failed initial audit config load for assistant tab", configResult.reason);
           }
         })
         .finally(() => {
@@ -436,6 +449,19 @@ export function DaintreeAssistantSettingsTab() {
       cancelled = true;
     };
   }, [preferredAgentId]);
+
+  // Proxies the same mcpServer.setAuditEnabled endpoint as the MCP Server tab's
+  // "Capture audit log" toggle. Server response is authoritative — no optimistic
+  // flip. On failure, leave the last known-good value (the IPC error is logged).
+  const handleAuditEnabledToggle = async () => {
+    try {
+      const next = !auditEnabled;
+      const cfg = await window.electron.mcpServer.setAuditEnabled(next);
+      setAuditEnabled(cfg.enabled);
+    } catch (err) {
+      logError("Failed to toggle MCP audit log from assistant tab", err);
+    }
+  };
 
   const handleCopyAuditAsJson = async (records: McpLogRecord[]) => {
     try {
@@ -898,6 +924,17 @@ export function DaintreeAssistantSettingsTab() {
         title="Privacy"
         description="Help-session activity is logged locally so you can review what the assistant did."
       >
+        <SettingsSwitchCard
+          variant="compact"
+          title="Capture audit log"
+          subtitle={
+            auditEnabled ? "Recording every dispatch" : "New dispatches will not be recorded"
+          }
+          isEnabled={auditEnabled}
+          onChange={handleAuditEnabledToggle}
+          ariaLabel="Capture audit log"
+          disabled={loading}
+        />
         <SettingsSelect
           label="Audit log retention"
           description="How long MCP audit records are kept on this machine. Turn-outcome diagnostics are recorded separately and aren't affected by this setting."
@@ -906,37 +943,61 @@ export function DaintreeAssistantSettingsTab() {
           options={RETENTION_OPTIONS}
           disabled={loading}
         />
-        <McpAuditLogViewer
-          records={auditRecords}
-          turnRecords={turnRecords}
-          loading={auditLoading}
-          onRefresh={refreshAuditRecords}
-          onCopy={handleCopyAuditAsJson}
-          onClear={() => setShowClearAuditConfirm(true)}
-          copyFlashActive={auditCopied}
-          // Privacy section hides external MCP traffic. Grant-lifecycle
-          // events stay visible — they're tied to this Daintree's own
-          // help-session bearers, not external API-key clients.
-          includeRecord={(record) => !isAuditRecord(record) || record.tier !== "external"}
-          onExport={handleExportAuditAsNdjson}
-          exportFlashActive={auditExported}
-        />
-        <McpAuditLatencyTable
-          records={auditRecords}
-          includeRecord={(record) => !isAuditRecord(record) || record.tier !== "external"}
-        />
-        <TurnOutcomeDiagnostics
-          auditRecords={auditRecords}
-          records={turnRecords}
-          onRefresh={refreshAuditRecords}
-        />
-        {auditStats && auditStats.auth401Count > 0 && (
-          <p className="text-xs text-daintree-text/60 select-text">
-            <span className="font-mono text-daintree-text/80">{auditStats.auth401Count}</span>{" "}
-            bearer rejection{auditStats.auth401Count === 1 ? "" : "s"} since last launch — an
-            external client is connecting with a stale or missing API key.
-          </p>
-        )}
+        <div className="rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle/40">
+          <button
+            type="button"
+            onClick={() => setAdvancedDiagnosticsOpen((v) => !v)}
+            aria-expanded={advancedDiagnosticsOpen}
+            className={cn(
+              "w-full flex items-center gap-2 px-3 py-2 text-xs",
+              "text-daintree-text/80 hover:text-daintree-text transition-colors"
+            )}
+          >
+            <ChevronRight
+              data-animated-chevron
+              className={cn(
+                "w-3.5 h-3.5 transition-transform duration-150",
+                advancedDiagnosticsOpen ? "rotate-90" : "rotate-0"
+              )}
+            />
+            Advanced diagnostics
+          </button>
+          {advancedDiagnosticsOpen && (
+            <div className="flex flex-col gap-4 px-3 pb-3 pt-1">
+              <McpAuditLogViewer
+                records={auditRecords}
+                turnRecords={turnRecords}
+                loading={auditLoading}
+                onRefresh={refreshAuditRecords}
+                onCopy={handleCopyAuditAsJson}
+                onClear={() => setShowClearAuditConfirm(true)}
+                copyFlashActive={auditCopied}
+                // Privacy section hides external MCP traffic. Grant-lifecycle
+                // events stay visible — they're tied to this Daintree's own
+                // help-session bearers, not external API-key clients.
+                includeRecord={(record) => !isAuditRecord(record) || record.tier !== "external"}
+                onExport={handleExportAuditAsNdjson}
+                exportFlashActive={auditExported}
+              />
+              <McpAuditLatencyTable
+                records={auditRecords}
+                includeRecord={(record) => !isAuditRecord(record) || record.tier !== "external"}
+              />
+              <TurnOutcomeDiagnostics
+                auditRecords={auditRecords}
+                records={turnRecords}
+                onRefresh={refreshAuditRecords}
+              />
+              {auditStats && auditStats.auth401Count > 0 && (
+                <p className="text-xs text-daintree-text/60 select-text">
+                  <span className="font-mono text-daintree-text/80">{auditStats.auth401Count}</span>{" "}
+                  bearer rejection{auditStats.auth401Count === 1 ? "" : "s"} since last launch — an
+                  external client is connecting with a stale or missing API key.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
       </SettingsSection>
 
       {/* Connection */}

--- a/src/components/Settings/TurnOutcomeDiagnostics.tsx
+++ b/src/components/Settings/TurnOutcomeDiagnostics.tsx
@@ -76,9 +76,9 @@ export function TurnOutcomeDiagnostics({
   const [internalLoading, setInternalLoading] = useState(true);
   const records = isControlled ? controlledRecords : internalRecords;
   const loading = isControlled ? false : internalLoading;
-  const [outcomeSectionOpen, setOutcomeSectionOpen] = useState(true);
-  const [toolErrorOpen, setToolErrorOpen] = useState(true);
-  const [tierRejectedOpen, setTierRejectedOpen] = useState(true);
+  const [outcomeSectionOpen, setOutcomeSectionOpen] = useState(false);
+  const [toolErrorOpen, setToolErrorOpen] = useState(false);
+  const [tierRejectedOpen, setTierRejectedOpen] = useState(false);
   const [agentStuckOpen, setAgentStuckOpen] = useState(false);
   const [showClearConfirm, setShowClearConfirm] = useState(false);
   const [isClearing, setIsClearing] = useState(false);

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -178,6 +178,8 @@ interface McpServerApi {
   getLogRecords: ReturnType<typeof vi.fn>;
   getAuditStats: ReturnType<typeof vi.fn>;
   getTurnOutcomeRecords: ReturnType<typeof vi.fn>;
+  getAuditConfig: ReturnType<typeof vi.fn>;
+  setAuditEnabled: ReturnType<typeof vi.fn>;
   clearAuditLog: ReturnType<typeof vi.fn>;
 }
 
@@ -231,6 +233,10 @@ function installApi(
     getLogRecords: vi.fn().mockResolvedValue([]),
     getAuditStats: vi.fn().mockResolvedValue({ auth401Count: 0 }),
     getTurnOutcomeRecords: vi.fn().mockResolvedValue([]),
+    getAuditConfig: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
+    setAuditEnabled: vi
+      .fn()
+      .mockImplementation((next: boolean) => Promise.resolve({ enabled: next, maxRecords: 500 })),
     clearAuditLog: vi.fn().mockResolvedValue(undefined),
   };
   const systemDefaults: SystemApi = {
@@ -1003,13 +1009,72 @@ describe("DaintreeAssistantSettingsTab", () => {
     expect(container.textContent).toContain("recorded separately");
   });
 
-  it("renders turn-outcome diagnostics in the privacy section", async () => {
+  it("renders turn-outcome diagnostics in the privacy section after expanding advanced diagnostics", async () => {
     const { container } = render(
       <SettingsValidationProvider>
         <DaintreeAssistantSettingsTab />
       </SettingsValidationProvider>
     );
+    await waitForContent(container, "Advanced diagnostics");
+
+    // Diagnostics are collapsed by default — the turn-outcome block is unmounted
+    // until the disclosure is opened.
+    expect(container.textContent).not.toContain("Turn outcomes by class");
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced diagnostics" }));
+
     await waitForContent(container, "Turn outcomes by class");
+  });
+
+  it("renders the recording toggle in the privacy section, on by default", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capture audit log");
+
+    expect(window.electron.mcpServer.getAuditConfig).toHaveBeenCalledTimes(1);
+    const toggle = screen.getByLabelText("Capture audit log");
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(container.textContent).toContain("Recording every dispatch");
+  });
+
+  it("toggling the recording switch off calls setAuditEnabled(false) and updates the subtitle", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capture audit log");
+
+    const toggle = screen.getByLabelText("Capture audit log");
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(window.electron.mcpServer.setAuditEnabled).toHaveBeenCalledWith(false);
+    });
+    await waitForContent(container, "New dispatches will not be recorded");
+    expect(screen.getByLabelText("Capture audit log").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("reflects recording-off state loaded from getAuditConfig", async () => {
+    installApi(
+      {},
+      {
+        getAuditConfig: vi.fn().mockResolvedValue({ enabled: false, maxRecords: 500 }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capture audit log");
+
+    await waitForContent(container, "New dispatches will not be recorded");
+    expect(screen.getByLabelText("Capture audit log").getAttribute("aria-checked")).toBe("false");
   });
 
   it("loads customArgs from the IPC settings into the input", async () => {

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -1048,7 +1048,12 @@ describe("DaintreeAssistantSettingsTab", () => {
     );
     await waitForContent(container, "Capture audit log");
 
+    // The toggle is disabled until getAuditConfig resolves (auditLoading) so the
+    // late config fulfillment can't clobber a user toggle — wait for it to enable.
     const toggle = screen.getByLabelText("Capture audit log");
+    await waitFor(() => {
+      expect(toggle.hasAttribute("disabled")).toBe(false);
+    });
     fireEvent.click(toggle);
 
     await waitFor(() => {
@@ -1056,6 +1061,32 @@ describe("DaintreeAssistantSettingsTab", () => {
     });
     await waitForContent(container, "New dispatches will not be recorded");
     expect(screen.getByLabelText("Capture audit log").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("surfaces an inline error when setAuditEnabled rejects, leaving recording on", async () => {
+    installApi(
+      {},
+      {
+        setAuditEnabled: vi.fn().mockRejectedValue(new Error("audit ipc failed")),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capture audit log");
+
+    const toggle = screen.getByLabelText("Capture audit log");
+    await waitFor(() => {
+      expect(toggle.hasAttribute("disabled")).toBe(false);
+    });
+    fireEvent.click(toggle);
+
+    await waitForContent(container, "audit ipc failed");
+    // Recording state holds at the last known-good value on failure.
+    expect(screen.getByLabelText("Capture audit log").getAttribute("aria-checked")).toBe("true");
   });
 
   it("reflects recording-off state loaded from getAuditConfig", async () => {


### PR DESCRIPTION
## Summary

- Adds a "Capture audit log" toggle to the Assistant Privacy settings tab, proxying `mcpServer.setAuditEnabled`. Recording stays on by default; initial state loads via `getAuditConfig` in the existing audit-fetch effect.
- Collapses the audit log viewer, latency table, and turn-outcome diagnostics behind an "Advanced diagnostics" disclosure that is collapsed by default, so users aren't shown telemetry on load.
- Defaults the three `TurnOutcomeDiagnostics` inner sections to collapsed.

Resolves #10777

## Changes

- `DaintreeAssistantSettingsTab.tsx`: recording toggle wired to `mcpServer.setAuditEnabled`, gated on `auditLoading` and an in-flight guard to prevent load-race or double-click clobber; diagnostics block wrapped in an "Advanced diagnostics" `<details>` collapsed by default; IPC failures surface via inline error banner.
- `TurnOutcomeDiagnostics.tsx`: defaults all three inner section states to collapsed.
- `DaintreeAssistantSettingsTab.test.tsx`: 58 tests covering toggle render, initial state load, enable/disable flow, in-flight guard, error banner, and diagnostics collapse state.

## Testing

- 58 vitest tests pass across both Settings test files.
- prettier and eslint clean on changed files.