### PR TITLE
fix(plugins): scrub secrets from plugin log output before buffer and console

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2064,17 +2064,20 @@ export class PluginService {
       const serialized = safeStringify(fields);
       rendered = serialized ? `${rendered} ${serialized}` : rendered;
     }
+    // Scrub before truncation: scrubSecrets replaces each secret with the
+    // shorter "[REDACTED]" sentinel, so the codepoint cap below still bounds the
+    // line — and a secret straddling that boundary is fully redacted instead of
+    // being bisected into a fragment too short for the scrubber to match. Both
+    // sinks below — the log buffer that feeds shareable bug reports and the
+    // console mirror — consume this scrubbed value.
+    rendered = scrubSecrets(rendered);
     // Codepoint-aware cap: spreading splits at codepoint (not UTF-16 code-unit)
-    // boundaries, so the slice can never bisect a surrogate pair.
+    // boundaries, so the slice can never bisect a surrogate pair. (It may clip a
+    // trailing "[REDACTED]" sentinel, which is harmless.)
     const codepoints = Array.from(rendered);
     if (codepoints.length > PLUGIN_LOG_LINE_MAX_CHARS) {
       rendered = `${codepoints.slice(0, PLUGIN_LOG_LINE_MAX_CHARS - 1).join("")}…`;
     }
-    // Scrub after truncation so the codepoint cap stays a cap on plugin input,
-    // and so a secret sigil near the boundary isn't bisected (a fragment would
-    // slip past the scrubber). Both sinks below — the log buffer that feeds
-    // shareable bug reports and the console mirror — consume this scrubbed value.
-    rendered = scrubSecrets(rendered);
 
     let buffer = this.logBuffers.get(pluginId);
     if (!buffer) {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -141,6 +141,7 @@ import {
 } from "./forgeProviderRegistry.js";
 import { buildStoredCredentials } from "./forge/forgeCredentialUtils.js";
 import { makeForgeProviderId } from "../../shared/utils/forgeProviderIds.js";
+import { scrubSecrets } from "../../shared/utils/secretScrubber.js";
 import {
   registerFileDecorationProviderImpl,
   registerFileDecorationProviders,
@@ -591,9 +592,10 @@ export class PluginService {
    * Per-plugin diagnostic log ring buffer, keyed by `pluginId` (= manifest
    * name). Written by `host.logger.*`, capped at {@link PLUGIN_LOG_BUFFER_MAX}
    * lines (FIFO eviction), and cleared in {@link unloadPlugin} so a reload of
-   * the same plugin starts clean. Lines are stored raw — secret/path scrubbing
-   * happens only at the report-export boundary, never here (mirrors the
-   * action-breadcrumb ring's raw-capture convention).
+   * the same plugin starts clean. Lines are stored scrubbed — this buffer is
+   * itself an outbound boundary (it feeds {@link getDiagnosticsSnapshot} →
+   * shareable bug reports), and the same scrubbed line mirrors to the console,
+   * so {@link recordPluginLog} runs `scrubSecrets` once before either sink.
    */
   private logBuffers = new Map<string, PluginDiagnosticsLogLine[]>();
   /**
@@ -2068,6 +2070,11 @@ export class PluginService {
     if (codepoints.length > PLUGIN_LOG_LINE_MAX_CHARS) {
       rendered = `${codepoints.slice(0, PLUGIN_LOG_LINE_MAX_CHARS - 1).join("")}…`;
     }
+    // Scrub after truncation so the codepoint cap stays a cap on plugin input,
+    // and so a secret sigil near the boundary isn't bisected (a fragment would
+    // slip past the scrubber). Both sinks below — the log buffer that feeds
+    // shareable bug reports and the console mirror — consume this scrubbed value.
+    rendered = scrubSecrets(rendered);
 
     let buffer = this.logBuffers.get(pluginId);
     if (!buffer) {

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -1890,6 +1890,34 @@ describe("PluginService integration — diagnostic logger", () => {
       .plugins.find((p) => p.pluginId === "acme.logger-unload");
     expect(entry).toBeUndefined();
   });
+
+  it("scrubs secrets from buffered lines and the console mirror (#10775)", async () => {
+    // ghp_ + 36 sigil chars trips the github-pat pattern in secretScrubber.
+    const token = `ghp_${"0123456789abcdefghijklmnopqrstuvwxyz"}`;
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      const service = await loadWithLoggerActivate(
+        "acme.logger-secret",
+        "__loggerHost7",
+        `host.logger.info("auth " + ${JSON.stringify(token)});`
+      );
+
+      const entry = service
+        .getDiagnosticsSnapshot()
+        .plugins.find((p) => p.pluginId === "acme.logger-secret");
+      const message = entry?.logLines[0]?.message ?? "";
+      // The buffer feeds shareable bug reports, so the raw token must be gone.
+      expect(message).toContain("[REDACTED]");
+      expect(message).not.toContain(token);
+
+      // The console mirror consumes the same rendered string — also scrubbed.
+      const mirrored = infoSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(mirrored).toContain("[REDACTED]");
+      expect(mirrored).not.toContain(token);
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
 });
 
 describe("PluginService integration — stale temp dir sweep", () => {

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -1918,6 +1918,70 @@ describe("PluginService integration — diagnostic logger", () => {
       infoSpy.mockRestore();
     }
   });
+
+  it("scrubs a secret straddling the truncation boundary (#10775)", async () => {
+    // The token starts just before the codepoint cap. Scrub-before-truncate
+    // redacts the whole token; truncate-first would leave a "ghp_…" fragment.
+    const token = `ghp_${"0123456789abcdefghijklmnopqrstuvwxyz"}`;
+    const service = await loadWithLoggerActivate(
+      "acme.logger-straddle",
+      "__loggerHost8",
+      `host.logger.info("x".repeat(2040) + " " + ${JSON.stringify(token)});`
+    );
+
+    const entry = service
+      .getDiagnosticsSnapshot()
+      .plugins.find((p) => p.pluginId === "acme.logger-straddle");
+    const message = entry?.logLines[0]?.message ?? "";
+    expect(message).not.toContain(token);
+    // No recognizable sigil fragment survives — not even the "ghp_" prefix.
+    expect(message).not.toMatch(/ghp_[A-Za-z0-9_]/);
+  });
+
+  it("scrubs secrets folded in from structured fields (#10775)", async () => {
+    const token = `ghp_${"0123456789abcdefghijklmnopqrstuvwxyz"}`;
+    const service = await loadWithLoggerActivate(
+      "acme.logger-fields",
+      "__loggerHost9",
+      `host.logger.info("request", { authorization: ${JSON.stringify(token)} });`
+    );
+
+    const entry = service
+      .getDiagnosticsSnapshot()
+      .plugins.find((p) => p.pluginId === "acme.logger-fields");
+    const message = entry?.logLines[0]?.message ?? "";
+    expect(message).toContain("[REDACTED]");
+    expect(message).not.toContain(token);
+  });
+
+  it("scrubs the console mirror across all log levels (#10775)", async () => {
+    const token = `ghp_${"0123456789abcdefghijklmnopqrstuvwxyz"}`;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const service = await loadWithLoggerActivate(
+        "acme.logger-levels",
+        "__loggerHost10",
+        `host.logger.warn("w " + ${JSON.stringify(token)});
+         host.logger.error("e " + ${JSON.stringify(token)});`
+      );
+
+      const entry = service
+        .getDiagnosticsSnapshot()
+        .plugins.find((p) => p.pluginId === "acme.logger-levels");
+      expect(entry?.logLines.every((l) => !l.message.includes(token))).toBe(true);
+      expect(entry?.logLines.every((l) => l.message.includes("[REDACTED]"))).toBe(true);
+
+      for (const spy of [warnSpy, errorSpy]) {
+        const mirrored = spy.mock.calls.map((c) => String(c[0])).join("\n");
+        expect(mirrored).toContain("[REDACTED]");
+        expect(mirrored).not.toContain(token);
+      }
+    } finally {
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    }
+  });
 });
 
 describe("PluginService integration — stale temp dir sweep", () => {

--- a/shared/types/ipc/pluginDiagnostics.ts
+++ b/shared/types/ipc/pluginDiagnostics.ts
@@ -5,8 +5,9 @@ import type { PluginInstallSource, PluginLoadError } from "../plugin.js";
  * A single line from a plugin's in-memory log ring buffer, captured via
  * `host.logger.{info,warn,error}`. `message` already folds in any structured
  * `fields` passed to the logger and is capped at the per-line byte budget.
- * Stored raw in the main-process buffer; secret/path scrubbing is applied only
- * at the report-export boundary (`buildReportIssueUrl`), never on this struct.
+ * Stored already scrubbed: `recordPluginLog` runs `scrubSecrets` before the
+ * line enters the buffer, since the buffer is itself an outbound boundary (it
+ * feeds the shareable bug report via `buildReportIssueUrl`).
  */
 export interface PluginDiagnosticsLogLine {
   /** Wall-clock epoch millis the line was logged. */

--- a/shared/utils/secretScrubber.ts
+++ b/shared/utils/secretScrubber.ts
@@ -3,8 +3,10 @@
  * bundles, log files, and IPC error envelopes. Complements the key-based
  * redaction in `TelemetryService.sanitizeEvent` and `DiagnosticsCollector.redactDeep`.
  *
- * Apply at outbound boundaries only — never on the in-memory `logBuffer` path
- * that feeds the diagnostics dock. Approved call sites:
+ * Apply at outbound boundaries only — never on the main-app in-memory
+ * `logBuffer` path that feeds the diagnostics dock. (The plugin log ring is a
+ * separate buffer that is itself an outbound boundary — see call site 12.)
+ * Approved call sites:
  *   1. Sentry `beforeSend` (TelemetryService)
  *   2. DiagnosticsCollector string output
  *   3. Logger file-write (`writeToLogFile`) and console-mirror in `emit`/`emitError`
@@ -16,6 +18,7 @@
  *   9. AgentHelpService command output scrubbing
  *  10. AgentVersionService error-message scrubbing
  *  11. WorktreeLifecycleService full-output teardown log write (writeTeardownLog)
+ *  12. PluginService.recordPluginLog (plugin log ring buffer + console mirror)
  *
  * All patterns use bounded quantifiers for ReDoS safety. See the
  * `secretScrubber.test.ts` sibling for the `safe-regex2` assertion that


### PR DESCRIPTION
## Summary

- `PluginService.recordPluginLog` was writing plugin-supplied log text to `console[level]` and into the per-plugin log ring buffer (which feeds `getDiagnosticsSnapshot`) without calling `scrubSecrets`, leaving an asymmetric redaction gap that every other path in `electron/utils/logger.ts` already closes.
- `scrubSecrets` now runs once in `recordPluginLog` before codepoint truncation, so both the buffer and the console mirror receive the redacted line. A secret straddling the truncation boundary is fully redacted rather than bisected into an unmatched fragment.
- Refreshed two stale "stored raw" JSDoc comments and registered call-site #12 in `secretScrubber`.

Resolves #10775

## Changes

- `electron/services/PluginService.ts`: apply `scrubSecrets` before truncation in `recordPluginLog`
- `shared/utils/secretScrubber.ts`: add approved call-site comment #12
- `shared/types/ipc/pluginDiagnostics.ts`: refresh stale JSDoc on `logBuffer` and `rawLog`
- `electron/services/__tests__/PluginService.integration.test.ts`: regression tests for basic redaction in buffer and console mirror, boundary-straddling secrets, secrets folded from structured fields, and scrubbing across `warn`/`error` levels

## Testing

56 tests pass locally. ESLint and Prettier clean on changed files. Covers: basic redaction, truncation-boundary secrets, structured-field folding, and multi-level log scrubbing.