### PR TITLE
fix(logs): make verbose logging toggle session-only (#10774)

### DIFF
--- a/electron/ipc/handlers/__tests__/logs.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/logs.handlers.test.ts
@@ -6,25 +6,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // derived from the same state so a simulated restart (state reset, store never
 // written) reports verbose off.
 const loggerState = vi.hoisted(() => ({ overrides: {} as Record<string, string> }));
-const VALID_LEVELS = ["debug", "info", "warn", "error", "off"];
-const loggerMock = vi.hoisted(() => ({
-  isVerboseLogging: vi.fn(() => loggerState.overrides["*"] === "debug"),
-  logInfo: vi.fn(),
-  logDebug: vi.fn(),
-  logWarn: vi.fn(),
-  logError: vi.fn(),
-  getLogFilePath: vi.fn(() => "/tmp/daintree.log"),
-  getPreviousSessionTail: vi.fn(() => null),
-  getLogLevelOverrides: vi.fn(() => ({ ...loggerState.overrides })),
-  getDefaultLogLevel: vi.fn(() => "info"),
-  setLogLevelOverrides: vi.fn((o: Record<string, string>) => {
-    loggerState.overrides = { ...o };
-  }),
-  getRegisteredLoggerNames: vi.fn(() => []),
-  isValidLogOverrideLevel: vi.fn(
-    (v: unknown) => typeof v === "string" && VALID_LEVELS.includes(v)
-  ),
-}));
+const loggerMock = vi.hoisted(() => {
+  // Mirrors the real isValidLogOverrideLevel in electron/utils/logger.ts.
+  const VALID_LEVELS = ["error", "warn", "info", "debug", "off"];
+  return {
+    isVerboseLogging: vi.fn(() => loggerState.overrides["*"] === "debug"),
+    logInfo: vi.fn(),
+    logDebug: vi.fn(),
+    logWarn: vi.fn(),
+    logError: vi.fn(),
+    getLogFilePath: vi.fn(() => "/tmp/daintree.log"),
+    getPreviousSessionTail: vi.fn(() => null),
+    getLogLevelOverrides: vi.fn(() => ({ ...loggerState.overrides })),
+    getDefaultLogLevel: vi.fn(() => "info"),
+    setLogLevelOverrides: vi.fn((o: Record<string, string>) => {
+      loggerState.overrides = { ...o };
+    }),
+    getRegisteredLoggerNames: vi.fn(() => []),
+    isValidLogOverrideLevel: vi.fn(
+      (v: unknown) => typeof v === "string" && VALID_LEVELS.includes(v)
+    ),
+  };
+});
 
 vi.mock("../../../utils/logger.js", () => loggerMock);
 
@@ -64,22 +67,30 @@ vi.mock("../../../services/LogBuffer.js", () => ({
   },
 }));
 
-class FakeAppError extends Error {
-  code: string;
-  constructor(opts: { code: string; message: string }) {
-    super(opts.message);
-    this.code = opts.code;
-  }
-}
+const FakeAppError = vi.hoisted(
+  () =>
+    class FakeAppError extends Error {
+      code: string;
+      constructor(opts: { code: string; message: string }) {
+        super(opts.message);
+        this.code = opts.code;
+      }
+    }
+);
 
 vi.mock("../../../utils/errorTypes.js", () => ({ AppError: FakeAppError }));
 
 vi.mock("electron", () => ({ shell: { openPath: vi.fn() } }));
 
 import { CHANNELS } from "../../channels.js";
-import { registerLogsHandlers } from "../logs.js";
 
 type Handler = (...args: unknown[]) => unknown;
+type RegisterLogsHandlers = typeof import("../logs.js").registerLogsHandlers;
+
+// Re-imported per test so the module-scoped verbose session state
+// (`verboseSessionActive` / `savedWildcardBeforeVerbose`) starts fresh and
+// can't leak across cases.
+let registerLogsHandlers: RegisterLogsHandlers;
 
 function getHandler(channel: string): Handler {
   const match = utilsMock.registered.find((r) => r.channel === channel);
@@ -87,18 +98,20 @@ function getHandler(channel: string): Handler {
   return match.handler;
 }
 
-function resetMocks() {
+async function resetMocks() {
   vi.clearAllMocks();
+  vi.resetModules();
   utilsMock.registered.length = 0;
   loggerState.overrides = {};
   storeMock.get.mockReturnValue(undefined as unknown);
+  ({ registerLogsHandlers } = await import("../logs.js"));
 }
 
 describe("logs:write-batch handler", () => {
   let cleanup: () => void;
 
-  beforeEach(() => {
-    resetMocks();
+  beforeEach(async () => {
+    await resetMocks();
     cleanup = registerLogsHandlers();
   });
 
@@ -165,8 +178,8 @@ describe("logs:write-batch handler", () => {
 describe("logs:get-default-level handler", () => {
   let cleanup: () => void;
 
-  beforeEach(() => {
-    resetMocks();
+  beforeEach(async () => {
+    await resetMocks();
     cleanup = registerLogsHandlers();
   });
 
@@ -185,8 +198,8 @@ describe("logs:get-default-level handler", () => {
 describe("logs override-change broadcast", () => {
   let cleanup: () => void;
 
-  beforeEach(() => {
-    resetMocks();
+  beforeEach(async () => {
+    await resetMocks();
     cleanup = registerLogsHandlers();
   });
 
@@ -245,8 +258,8 @@ describe("registerLogsHandlers — verbose toggle is session-only", () => {
     });
   }
 
-  beforeEach(() => {
-    resetMocks();
+  beforeEach(async () => {
+    await resetMocks();
     ptyClient = { setLogLevelOverrides: vi.fn() };
     worktreeService = { setLogLevelOverrides: vi.fn() };
   });
@@ -363,5 +376,92 @@ describe("registerLogsHandlers — verbose toggle is session-only", () => {
       "*": "debug",
     });
     expect(loggerState.overrides).toEqual({ "main:Foo": "warn", "*": "debug" });
+  });
+
+  it("disable fans out a map with no verbose wildcard", async () => {
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    ptyClient.setLogLevelOverrides.mockClear();
+    worktreeService.setLogLevelOverrides.mockClear();
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(false);
+
+    expect(ptyClient.setLogLevelOverrides).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ "*": "debug" })
+    );
+    expect(worktreeService.setLogLevelOverrides).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ "*": "debug" })
+    );
+  });
+
+  // Critical regression: the LogLevelPalette fetches the override map on open and
+  // writes it back when the user edits any logger. If verbose is active, the
+  // fetched map must not carry "*":"debug", or the round-trip re-persists verbose.
+  it("hides the verbose overlay from get-level-overrides while verbose is active", async () => {
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+
+    const result = (await getHandler(CHANNELS.LOGS_GET_LEVEL_OVERRIDES)()) as Record<
+      string,
+      string
+    >;
+
+    expect(result["*"]).toBeUndefined();
+  });
+
+  it("exposes the underlying explicit wildcard (not debug) while verbose is active", async () => {
+    storeMock.get.mockReturnValue({ "*": "warn" });
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+
+    const result = (await getHandler(CHANNELS.LOGS_GET_LEVEL_OVERRIDES)()) as Record<
+      string,
+      string
+    >;
+
+    expect(result["*"]).toBe("warn");
+  });
+
+  it("does not persist the verbose wildcard when a per-module override is set while verbose is active", async () => {
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    storeMock.set.mockClear();
+
+    // Simulate the palette writing back the full map it fetched plus a new edit.
+    await getHandler(CHANNELS.LOGS_SET_LEVEL_OVERRIDES)({ "*": "debug", "main:Foo": "warn" });
+
+    // Store must never receive the session-only verbose wildcard.
+    const persisted = storeMock.set.mock.calls.at(-1)?.[1] as Record<string, string>;
+    expect(persisted).toEqual({ "main:Foo": "warn" });
+    // ...but verbose stays live in memory for the rest of the session.
+    expect(loggerState.overrides["*"]).toBe("debug");
+    expect(loggerState.overrides["main:Foo"]).toBe("warn");
+  });
+
+  it("keeps an explicit non-debug wildcard set while verbose is active and restores it on disable", async () => {
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+
+    // User explicitly sets "*":"error" via the palette while verbose is on.
+    await getHandler(CHANNELS.LOGS_SET_LEVEL_OVERRIDES)({ "*": "error" });
+    expect(loggerState.overrides["*"]).toBe("debug"); // overlay still active in memory
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(false);
+    expect(loggerState.overrides["*"]).toBe("error"); // user's wildcard restored
+  });
+
+  it("clearing overrides while verbose is active keeps verbose live and resets the saved wildcard", async () => {
+    storeMock.get.mockReturnValue({ "*": "warn" });
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    storeMock.set.mockClear();
+
+    await getHandler(CHANNELS.LOGS_CLEAR_LEVEL_OVERRIDES)();
+    expect(storeMock.set).toHaveBeenCalledWith("logLevelOverrides", {});
+    expect(loggerState.overrides).toEqual({ "*": "debug" });
+
+    // With nothing persisted to restore, disabling verbose clears the wildcard.
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(false);
+    expect(loggerState.overrides["*"]).toBeUndefined();
   });
 });

--- a/electron/ipc/handlers/__tests__/logs.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/logs.handlers.test.ts
@@ -1,19 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Stateful logger mock: setLogLevelOverrides mutates `loggerState.overrides`
+// and getLogLevelOverrides reflects it, so the verbose-session-only suite can
+// assert the in-memory override map directly (no disk involved). isVerbose is
+// derived from the same state so a simulated restart (state reset, store never
+// written) reports verbose off.
+const loggerState = vi.hoisted(() => ({ overrides: {} as Record<string, string> }));
+const VALID_LEVELS = ["debug", "info", "warn", "error", "off"];
 const loggerMock = vi.hoisted(() => ({
-  isVerboseLogging: vi.fn(() => false),
+  isVerboseLogging: vi.fn(() => loggerState.overrides["*"] === "debug"),
   logInfo: vi.fn(),
   logDebug: vi.fn(),
   logWarn: vi.fn(),
   logError: vi.fn(),
   getLogFilePath: vi.fn(() => "/tmp/daintree.log"),
   getPreviousSessionTail: vi.fn(() => null),
-  getLogLevelOverrides: vi.fn(() => ({ "*": "warn" })),
+  getLogLevelOverrides: vi.fn(() => ({ ...loggerState.overrides })),
   getDefaultLogLevel: vi.fn(() => "info"),
-  setLogLevelOverrides: vi.fn(),
+  setLogLevelOverrides: vi.fn((o: Record<string, string>) => {
+    loggerState.overrides = { ...o };
+  }),
   getRegisteredLoggerNames: vi.fn(() => []),
   isValidLogOverrideLevel: vi.fn(
-    (v: unknown) => typeof v === "string" && ["debug", "info", "warn", "error", "off"].includes(v)
+    (v: unknown) => typeof v === "string" && VALID_LEVELS.includes(v)
   ),
 }));
 
@@ -55,6 +64,16 @@ vi.mock("../../../services/LogBuffer.js", () => ({
   },
 }));
 
+class FakeAppError extends Error {
+  code: string;
+  constructor(opts: { code: string; message: string }) {
+    super(opts.message);
+    this.code = opts.code;
+  }
+}
+
+vi.mock("../../../utils/errorTypes.js", () => ({ AppError: FakeAppError }));
+
 vi.mock("electron", () => ({ shell: { openPath: vi.fn() } }));
 
 import { CHANNELS } from "../../channels.js";
@@ -68,19 +87,25 @@ function getHandler(channel: string): Handler {
   return match.handler;
 }
 
-let cleanup: () => void;
-
-beforeEach(() => {
+function resetMocks() {
   vi.clearAllMocks();
   utilsMock.registered.length = 0;
-  cleanup = registerLogsHandlers();
-});
-
-afterEach(() => {
-  cleanup();
-});
+  loggerState.overrides = {};
+  storeMock.get.mockReturnValue(undefined as unknown);
+}
 
 describe("logs:write-batch handler", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    resetMocks();
+    cleanup = registerLogsHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   it("registers the batch channel", () => {
     expect(utilsMock.registered.some((r) => r.channel === CHANNELS.LOGS_WRITE_BATCH)).toBe(true);
   });
@@ -138,6 +163,17 @@ describe("logs:write-batch handler", () => {
 });
 
 describe("logs:get-default-level handler", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    resetMocks();
+    cleanup = registerLogsHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
   it("returns the main-process effective default level", async () => {
     const handler = getHandler(CHANNELS.LOGS_GET_DEFAULT_LEVEL);
     const result = await handler();
@@ -147,13 +183,26 @@ describe("logs:get-default-level handler", () => {
 });
 
 describe("logs override-change broadcast", () => {
-  it("broadcasts the resolved overrides when set-level-overrides runs", async () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    resetMocks();
+    cleanup = registerLogsHandlers();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("broadcasts the resolved in-memory overrides when set-level-overrides runs", async () => {
     const handler = getHandler(CHANNELS.LOGS_SET_LEVEL_OVERRIDES);
     await handler({ "*": "debug" });
 
+    // Broadcast payload comes from getLogLevelOverrides() — the sanitized
+    // in-memory map after the set, not the raw request.
     expect(utilsMock.broadcastToRenderer).toHaveBeenCalledWith(
       CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED,
-      { "*": "warn" } // value comes from getLogLevelOverrides() — the sanitized in-memory map
+      { "*": "debug" }
     );
   });
 
@@ -181,5 +230,138 @@ describe("logs override-change broadcast", () => {
     const handler = getHandler(CHANNELS.LOGS_WRITE);
     await handler({ level: "info", message: "hi" });
     expect(utilsMock.broadcastToRenderer).not.toHaveBeenCalled();
+  });
+});
+
+describe("registerLogsHandlers — verbose toggle is session-only", () => {
+  let cleanup: () => void;
+  let ptyClient: { setLogLevelOverrides: ReturnType<typeof vi.fn> };
+  let worktreeService: { setLogLevelOverrides: ReturnType<typeof vi.fn> };
+
+  function register() {
+    cleanup = registerLogsHandlers({
+      ptyClient: ptyClient as never,
+      worktreeService: worktreeService as never,
+    });
+  }
+
+  beforeEach(() => {
+    resetMocks();
+    ptyClient = { setLogLevelOverrides: vi.fn() };
+    worktreeService = { setLogLevelOverrides: vi.fn() };
+  });
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  it("enabling verbose updates the in-memory map without writing to the store", async () => {
+    register();
+    storeMock.set.mockClear();
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+
+    expect(loggerState.overrides["*"]).toBe("debug");
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("enabling verbose fans out the override to utility processes", async () => {
+    register();
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+
+    expect(ptyClient.setLogLevelOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({ "*": "debug" })
+    );
+    expect(worktreeService.setLogLevelOverrides).toHaveBeenCalledWith(
+      expect.objectContaining({ "*": "debug" })
+    );
+  });
+
+  it("disabling verbose updates memory without writing to the store", async () => {
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    storeMock.set.mockClear();
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(false);
+
+    expect(loggerState.overrides["*"]).toBeUndefined();
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("an on/off cycle preserves a pre-existing explicit wildcard override", async () => {
+    // Persisted explicit "*":"warn" (e.g. from the per-module overrides UI).
+    storeMock.get.mockReturnValue({ "*": "warn" });
+    register();
+    expect(loggerState.overrides["*"]).toBe("warn");
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    expect(loggerState.overrides["*"]).toBe("debug");
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(false);
+    expect(loggerState.overrides["*"]).toBe("warn");
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("double-enable does not clobber the saved prior wildcard", async () => {
+    storeMock.get.mockReturnValue({ "*": "warn" });
+    register();
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(false);
+
+    // The "warn" stashed on first enable must survive the redundant enable.
+    expect(loggerState.overrides["*"]).toBe("warn");
+  });
+
+  it("preserves non-wildcard per-module overrides through a verbose cycle", async () => {
+    storeMock.get.mockReturnValue({ "main:Foo": "warn" });
+    register();
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    expect(loggerState.overrides).toEqual({ "main:Foo": "warn", "*": "debug" });
+
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(false);
+    expect(loggerState.overrides).toEqual({ "main:Foo": "warn" });
+  });
+
+  it("verbose does not survive a simulated restart", async () => {
+    register();
+    await getHandler(CHANNELS.LOGS_SET_VERBOSE)(true);
+    expect(loggerState.overrides["*"]).toBe("debug");
+
+    // Restart: a fresh process re-hydrates from disk, which was never written.
+    cleanup?.();
+    loggerState.overrides = {};
+    utilsMock.registered.length = 0;
+    storeMock.get.mockReturnValue({});
+    register();
+
+    const verbose = await getHandler(CHANNELS.LOGS_GET_VERBOSE)();
+    expect(verbose).toBe(false);
+    expect(loggerState.overrides["*"]).toBeUndefined();
+  });
+
+  it("rejects a non-boolean payload without mutating state or store", async () => {
+    register();
+    storeMock.set.mockClear();
+
+    await expect(getHandler(CHANNELS.LOGS_SET_VERBOSE)("yes")).rejects.toBeInstanceOf(FakeAppError);
+    expect(loggerState.overrides["*"]).toBeUndefined();
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("explicit per-module overrides still persist to the store", async () => {
+    register();
+    storeMock.set.mockClear();
+
+    await getHandler(CHANNELS.LOGS_SET_LEVEL_OVERRIDES)({ "main:Foo": "warn", "*": "debug" });
+
+    expect(storeMock.set).toHaveBeenCalledWith("logLevelOverrides", {
+      "main:Foo": "warn",
+      "*": "debug",
+    });
+    expect(loggerState.overrides).toEqual({ "main:Foo": "warn", "*": "debug" });
   });
 });

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -127,13 +127,15 @@ export function registerLogsHandlers(
         message: "logs:set-verbose requires a boolean",
       });
     }
-    // Verbose toggle maps to the `"*"` wildcard override so it flows through
-    // the same persistence + utility-process propagation as explicit per-module
-    // overrides. Enabling unconditionally sets `"*": "debug"`; disabling
-    // restores whatever wildcard existed before the user turned verbose on
-    // (tracked in `savedWildcardBeforeVerbose`) so a pre-existing explicit
-    // `"*": "warn"` isn't wiped by a verbose on/off cycle.
-    const current = sanitizeOverrides(store.get("logLevelOverrides") ?? {});
+    // Verbose toggle maps to the `"*"` wildcard override, but is session-only:
+    // it mutates the in-memory override map and propagates to utility processes
+    // without ever writing to disk, so the toggle genuinely "resets on app
+    // restart" (matching its subtitle). Enabling unconditionally sets
+    // `"*": "debug"`; disabling restores whatever wildcard existed before the
+    // user turned verbose on (tracked in `savedWildcardBeforeVerbose`) so a
+    // pre-existing explicit `"*": "warn"` isn't wiped by a verbose on/off cycle.
+    // Explicit per-module overrides (handleSetLevelOverrides) still persist.
+    const current = sanitizeOverrides(getLogLevelOverrides());
     if (enabled) {
       if (current["*"] !== "debug") {
         savedWildcardBeforeVerbose = current["*"] ?? null;
@@ -147,7 +149,6 @@ export function registerLogsHandlers(
       }
       savedWildcardBeforeVerbose = null;
     }
-    store.set("logLevelOverrides", current);
     setLogLevelOverrides(current);
     fanOut(current, deps);
     broadcastToRenderer(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, getLogLevelOverrides());

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -32,6 +32,15 @@ import type { HandlerDependencies } from "../types.js";
  */
 let savedWildcardBeforeVerbose: string | null = null;
 
+/**
+ * True while the user has verbose logging toggled on this session. The verbose
+ * `"*": "debug"` wildcard lives only in the in-memory override map as a
+ * session-only overlay — it is never persisted. This flag lets the per-module
+ * override handlers strip that overlay before writing to disk (so the palette
+ * can't round-trip it back into the store) while keeping verbose live in memory.
+ */
+let verboseSessionActive = false;
+
 function sanitizeOverrides(raw: unknown): Record<string, string> {
   if (!raw || typeof raw !== "object") return {};
   const clean: Record<string, string> = {};
@@ -149,6 +158,7 @@ export function registerLogsHandlers(
       }
       savedWildcardBeforeVerbose = null;
     }
+    verboseSessionActive = enabled;
     setLogLevelOverrides(current);
     fanOut(current, deps);
     broadcastToRenderer(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, getLogLevelOverrides());
@@ -232,16 +242,40 @@ export function registerLogsHandlers(
 
   const handleGetLevelOverrides = async (): Promise<Record<string, string>> => {
     // Return the in-memory sanitized map (not the raw store value) so the UI
-    // never shows overrides that the logger silently dropped as invalid.
-    return getLogLevelOverrides();
+    // never shows overrides that the logger silently dropped as invalid. While
+    // verbose is active this session, hide the `"*": "debug"` overlay (showing
+    // the user's underlying wildcard instead) so the palette never displays or
+    // round-trips the session-only verbose flag back into the persisted store.
+    const overrides: Record<string, string> = { ...getLogLevelOverrides() };
+    if (verboseSessionActive && overrides["*"] === "debug") {
+      if (savedWildcardBeforeVerbose) {
+        overrides["*"] = savedWildcardBeforeVerbose;
+      } else {
+        delete overrides["*"];
+      }
+    }
+    return overrides;
   };
   handlers.push(typedHandle(CHANNELS.LOGS_GET_LEVEL_OVERRIDES, handleGetLevelOverrides));
 
   const handleSetLevelOverrides = async (overrides: Record<string, string>) => {
     const clean = sanitizeOverrides(overrides);
+    // The session-only verbose overlay maps to `"*": "debug"` and must never be
+    // persisted. While verbose is active, drop a `"*": "debug"` entry before
+    // writing to disk; any other wildcard the user sets is a real override that
+    // persists and is tracked so a later verbose toggle-off restores it. The
+    // overlay is then re-applied to the in-memory map so verbose stays on.
+    if (verboseSessionActive && clean["*"] === "debug") {
+      delete clean["*"];
+    }
     store.set("logLevelOverrides", clean);
-    setLogLevelOverrides(clean);
-    fanOut(clean, deps);
+    const effective = { ...clean };
+    if (verboseSessionActive) {
+      savedWildcardBeforeVerbose = clean["*"] ?? null;
+      effective["*"] = "debug";
+    }
+    setLogLevelOverrides(effective);
+    fanOut(effective, deps);
     broadcastToRenderer(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, getLogLevelOverrides());
     logInfo("Log level overrides updated", { count: Object.keys(clean).length });
     return { success: true };
@@ -253,10 +287,17 @@ export function registerLogsHandlers(
 
   const handleClearLevelOverrides = async () => {
     // electron-store v11: `set(..., undefined)` throws. Clear by writing the
-    // default empty object explicitly.
+    // default empty object explicitly. Preserve the session-only verbose overlay
+    // in memory so clearing persisted per-module overrides doesn't silently turn
+    // verbose off (and drop the saved wildcard, since nothing persists to restore).
     store.set("logLevelOverrides", {});
-    setLogLevelOverrides({});
-    fanOut({}, deps);
+    const effective: Record<string, string> = {};
+    if (verboseSessionActive) {
+      savedWildcardBeforeVerbose = null;
+      effective["*"] = "debug";
+    }
+    setLogLevelOverrides(effective);
+    fanOut(effective, deps);
     broadcastToRenderer(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, getLogLevelOverrides());
     logInfo("Log level overrides cleared");
     return { success: true };


### PR DESCRIPTION
## Summary

- The Settings > Troubleshooting \"Verbose logging\" toggle is subtitled \"Resets on app restart.\" but it wasn't. `handleLogsSetVerbose` was writing `\"*\":\"debug\"` into the electron-store `logLevelOverrides` map, which `electron/main.ts` re-hydrates on every boot. So a quick debug session silently kept the whole app at debug level across every subsequent restart.
- Verbose is now a genuine session-only in-memory overlay. `handleLogsSetVerbose` sources its override map from `getLogLevelOverrides()` without writing to the store. A `verboseSessionActive` flag makes `getLevelOverrides` hide the wildcard (so the `LogLevelPalette` can't round-trip it to disk), `setLevelOverrides` strip it before persisting while keeping verbose live in memory, and `clearLevelOverrides` preserve it in memory.
- Per-module log level overrides continue to persist across restarts unchanged.

Resolves #10774

## Changes

- `electron/ipc/handlers/logs.ts`: in-memory verbose overlay, `verboseSessionActive` flag, updated `getLevelOverrides`/`setLevelOverrides`/`clearLevelOverrides` to guard the wildcard
- `electron/ipc/handlers/__tests__/logs.handlers.test.ts`: 15 new tests covering session isolation, toggle on/off with a pre-existing explicit wildcard, double-enable, restart simulation, palette write-back regression, clear-while-verbose, and that per-module overrides still persist

## Testing

New test file at `electron/ipc/handlers/__tests__/logs.handlers.test.ts` covers the key scenarios. Legacy users who already have `\"*\":\"debug\"` persisted from the old build will see verbose re-hydrate on their first boot after updating since the provenance can't be distinguished from a deliberately user-set wildcard. No destructive boot migration is performed.