### PR TITLE
fix(assistant): wire audit log retention to actual pruning (#10776)

### DIFF
--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -52,6 +52,7 @@ vi.mock("../../utils.js", () => utilsMock);
 
 const mcpServiceMock = vi.hoisted(() => ({
   getHelpSessionLiveStatus: vi.fn(),
+  pruneAuditByRetention: vi.fn(),
 }));
 
 vi.mock("../../../services/McpServerService.js", () => ({ mcpServerService: mcpServiceMock }));
@@ -256,6 +257,49 @@ describe("registerHelpAssistantHandlers", () => {
     expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.auditRetention", 0);
     expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.auditRetention", 7);
     expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.auditRetention", 30);
+  });
+
+  it("applies the new retention window to the MCP audit rings on a valid write (#10776)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { auditRetention: 30 });
+    // Pruning is fired-and-forgotten after the await-import resolves — drain
+    // the microtask/timer queue before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mcpServiceMock.pruneAuditByRetention).toHaveBeenCalledWith(30);
+  });
+
+  it("forwards the Off value (0) to the audit rings so pruning is disabled (#10776)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { auditRetention: 0 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mcpServiceMock.pruneAuditByRetention).toHaveBeenCalledWith(0);
+  });
+
+  it("does not prune when the auditRetention value is rejected (#10776)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { auditRetention: 90 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+    expect(mcpServiceMock.pruneAuditByRetention).not.toHaveBeenCalled();
+  });
+
+  it("does not prune when auditRetention is absent from the patch (#10776)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { docSearch: false });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mcpServiceMock.pruneAuditByRetention).not.toHaveBeenCalled();
   });
 
   it("rejects boolean fields that are not actually booleans", async () => {

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -160,6 +160,7 @@ export const helpAssistantNamespace = defineIpcNamespace({
       async (patch: Partial<HelpAssistantSettings>): Promise<void> => {
         if (!patch || typeof patch !== "object") return;
         let daintreeControlTurnedOn = false;
+        let auditRetentionWritten: HelpAssistantAuditRetention | null = null;
         for (const [field, value] of Object.entries(patch)) {
           if (value === undefined) continue;
           if (!KNOWN_KEYS.has(field)) continue;
@@ -190,7 +191,25 @@ export const helpAssistantNamespace = defineIpcNamespace({
             const previous = store.get("helpAssistant")?.daintreeControl ?? true;
             if (previous !== true) daintreeControlTurnedOn = true;
           }
+          if (field === "auditRetention") {
+            auditRetentionWritten = storedValue as HelpAssistantAuditRetention;
+          }
           store.set(`helpAssistant.${field}`, storedValue);
+        }
+
+        // Apply the new retention window to the assistant audit rings
+        // immediately so a shortened (or "Off"→on) setting takes effect now,
+        // not only on the next periodic-cleanup tick. Fire-and-forget with a
+        // logged catch — pruning failures must not block the settings write;
+        // the periodic sweep retries on its own cadence. Mirrors the
+        // daintreeControl auto-couple below.
+        if (auditRetentionWritten !== null) {
+          const days = auditRetentionWritten;
+          void getMcpServerService()
+            .then((svc) => svc.pruneAuditByRetention(days))
+            .catch((err) => {
+              console.warn("[HelpAssistant] auditRetention prune failed:", err);
+            });
         }
 
         // Auto-couple: turning on Daintree control implies the in-process MCP

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -488,6 +488,17 @@ export class McpServerService {
   }
 
   /**
+   * Apply the assistant audit-log retention setting (`helpAssistant.auditRetention`,
+   * in days; 0 = Off) to both assistant audit rings — the MCP dispatch log and
+   * the turn-outcome log. Called when the setting changes and on the periodic
+   * cleanup tick. Synchronous; both sub-services prune in-memory and flush.
+   */
+  pruneAuditByRetention(retentionDays: number): void {
+    this.auditService.pruneByAge(retentionDays);
+    this.turnOutcomeService.pruneByAge(retentionDays);
+  }
+
+  /**
    * Wires the help-session terminal↔session resolver. Called by
    * `HelpSessionService.ensureMcpServerReady()` (and equivalent sites) so
    * the turn-outcome classifier can correlate FSM transitions with the

--- a/electron/services/PeriodicCleanupService.ts
+++ b/electron/services/PeriodicCleanupService.ts
@@ -127,7 +127,11 @@ class PeriodicCleanupService {
       // each pass — the user may change it mid-session. Lazy-import the MCP
       // singleton so this maintenance file never forces it to construct early.
       const retentionDays = store.get("helpAssistant")?.auditRetention ?? 7;
-      if (retentionDays > 0) {
+      if (
+        typeof retentionDays === "number" &&
+        Number.isFinite(retentionDays) &&
+        retentionDays > 0
+      ) {
         const { mcpServerService } = await import("./McpServerService.js");
         mcpServerService.pruneAuditByRetention(retentionDays);
       }

--- a/electron/services/PeriodicCleanupService.ts
+++ b/electron/services/PeriodicCleanupService.ts
@@ -121,6 +121,19 @@ class PeriodicCleanupService {
     } catch (err) {
       logError("[PeriodicCleanup] heap snapshot prune threw", err);
     }
+    try {
+      // Age out assistant audit-log records past the configured retention
+      // window (helpAssistant.auditRetention, in days; 0 = Off → keep). Re-read
+      // each pass — the user may change it mid-session. Lazy-import the MCP
+      // singleton so this maintenance file never forces it to construct early.
+      const retentionDays = store.get("helpAssistant")?.auditRetention ?? 7;
+      if (retentionDays > 0) {
+        const { mcpServerService } = await import("./McpServerService.js");
+        mcpServerService.pruneAuditByRetention(retentionDays);
+      }
+    } catch (err) {
+      logError("[PeriodicCleanup] audit retention prune threw", err);
+    }
   }
 }
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -3380,6 +3380,26 @@ describe("McpServerService", () => {
       return (svc as unknown as { getAuditRecords: () => AuditRecord[] }).getAuditRecords();
     }
 
+    it("pruneAuditByRetention delegates to both audit and turn-outcome services (#10776)", () => {
+      const auditSpy = vi.spyOn(service._auditService, "pruneByAge");
+      const turnSpy = vi.spyOn(service._turnOutcomeService, "pruneByAge");
+
+      service.pruneAuditByRetention(30);
+
+      expect(auditSpy).toHaveBeenCalledWith(30);
+      expect(turnSpy).toHaveBeenCalledWith(30);
+    });
+
+    it("pruneAuditByRetention forwards the Off value (0) to both rings (#10776)", () => {
+      const auditSpy = vi.spyOn(service._auditService, "pruneByAge");
+      const turnSpy = vi.spyOn(service._turnOutcomeService, "pruneByAge");
+
+      service.pruneAuditByRetention(0);
+
+      expect(auditSpy).toHaveBeenCalledWith(0);
+      expect(turnSpy).toHaveBeenCalledWith(0);
+    });
+
     it("records a successful dispatch with redacted args and a non-empty session id", async () => {
       const dispatchMock = vi.fn(
         (): ActionDispatchResult => ({

--- a/electron/services/__tests__/PeriodicCleanupService.test.ts
+++ b/electron/services/__tests__/PeriodicCleanupService.test.ts
@@ -12,7 +12,16 @@ const mockRunScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefin
 const mockRunAssistantScratchCleanup = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const mockPruneOldLogs = vi.hoisted(() => vi.fn());
 const mockPruneHeapSnapshotsAsync = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
-const mockStoreGet = vi.hoisted(() => vi.fn().mockReturnValue({ logRetentionDays: 30 }));
+const mockPruneAuditByRetention = vi.hoisted(() => vi.fn());
+
+// store.get is key-aware: the log-prune routine reads "privacy", the audit-prune
+// routine reads "helpAssistant". A single flat return value would feed the wrong
+// shape to whichever routine didn't expect it.
+function storeGetByKey(key: string): unknown {
+  if (key === "helpAssistant") return { auditRetention: 7 };
+  return { logRetentionDays: 30 };
+}
+const mockStoreGet = vi.hoisted(() => vi.fn());
 
 vi.mock("electron", () => ({
   app: mockApp,
@@ -38,6 +47,10 @@ vi.mock("../../store.js", () => ({
   store: { get: mockStoreGet },
 }));
 
+vi.mock("../McpServerService.js", () => ({
+  mcpServerService: { pruneAuditByRetention: mockPruneAuditByRetention },
+}));
+
 import { PeriodicCleanupService } from "../PeriodicCleanupService.js";
 
 describe("PeriodicCleanupService", () => {
@@ -51,7 +64,7 @@ describe("PeriodicCleanupService", () => {
     mockRunScratchCleanup.mockResolvedValue(undefined);
     mockRunAssistantScratchCleanup.mockResolvedValue(undefined);
     mockPruneHeapSnapshotsAsync.mockResolvedValue(undefined);
-    mockStoreGet.mockReturnValue({ logRetentionDays: 30 });
+    mockStoreGet.mockImplementation(storeGetByKey);
   });
 
   afterEach(() => {
@@ -194,5 +207,50 @@ describe("PeriodicCleanupService", () => {
     // A direct tick after dispose is also a no-op.
     await service.tick();
     expectNoRoutinesRan();
+  });
+
+  it("prunes assistant audit logs using the configured retention (#10776)", async () => {
+    mockStoreGet.mockImplementation((key: string) =>
+      key === "helpAssistant" ? { auditRetention: 30 } : { logRetentionDays: 30 }
+    );
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expect(mockPruneAuditByRetention).toHaveBeenCalledWith(30);
+    service.dispose();
+  });
+
+  it("defaults to a 7-day audit retention when the setting is absent (#10776)", async () => {
+    mockStoreGet.mockImplementation((key: string) =>
+      key === "helpAssistant" ? {} : { logRetentionDays: 30 }
+    );
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expect(mockPruneAuditByRetention).toHaveBeenCalledWith(7);
+    service.dispose();
+  });
+
+  it("skips audit pruning when retention is Off (0) (#10776)", async () => {
+    mockStoreGet.mockImplementation((key: string) =>
+      key === "helpAssistant" ? { auditRetention: 0 } : { logRetentionDays: 30 }
+    );
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    expect(mockPruneAuditByRetention).not.toHaveBeenCalled();
+    service.dispose();
+  });
+
+  it("isolates an audit-prune failure so the other routines still run (#10776)", async () => {
+    mockPruneAuditByRetention.mockImplementation(() => {
+      throw new Error("prune boom");
+    });
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    // The throwing audit prune does not prevent the earlier routines.
+    expectAllRoutinesRan();
+    service.dispose();
   });
 });

--- a/electron/services/__tests__/PeriodicCleanupService.test.ts
+++ b/electron/services/__tests__/PeriodicCleanupService.test.ts
@@ -242,6 +242,21 @@ describe("PeriodicCleanupService", () => {
     service.dispose();
   });
 
+  it("skips audit pruning when the stored retention is a corrupt non-number (#10776)", async () => {
+    mockStoreGet.mockImplementation((key: string) =>
+      key === "helpAssistant"
+        ? ({ auditRetention: "7" } as unknown as { auditRetention: number })
+        : { logRetentionDays: 30 }
+    );
+    const service = new PeriodicCleanupService();
+    await service.tick();
+
+    // A stringly-typed value coerces to `"7" > 0 === true`, so guard on the
+    // type, not just the comparison — otherwise prune is a silent no-op.
+    expect(mockPruneAuditByRetention).not.toHaveBeenCalled();
+    service.dispose();
+  });
+
   it("isolates an audit-prune failure so the other routines still run (#10776)", async () => {
     mockPruneAuditByRetention.mockImplementation(() => {
       throw new Error("prune boom");

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -1215,18 +1215,36 @@ describe("AuditService.pruneByAge (#10776)", () => {
     expect(logStore.write).not.toHaveBeenCalled();
   });
 
-  it("retains records with a non-numeric timestamp rather than dropping them", () => {
+  it("retains records with a non-finite timestamp rather than dropping them", () => {
     const now = Date.now();
     const { service } = makeFixture({}, [
       seedRecord(undefined),
+      seedRecord(-Infinity),
+      seedRecord(NaN),
       seedRecord(now - 30 * DAY),
       seedRecord(now - 1 * DAY),
     ]);
     service.pruneByAge(7);
     const ids = service.getRecords().map((r) => r.id);
-    // The malformed-timestamp record is kept; only the genuinely-old one drops.
+    // Malformed-timestamp records are kept (even -Infinity, which is typeof
+    // "number" but not finite); only the genuinely-old one drops.
     expect(ids).toContain("r-undefined");
+    expect(ids).toContain("r--Infinity"); // seedRecord(-Infinity) → `r-${String(-Infinity)}`
+    expect(ids).toContain("r-NaN");
     expect(ids).toContain(`r-${now - 1 * DAY}`);
     expect(ids).not.toContain(`r-${now - 30 * DAY}`);
+  });
+
+  it("flushes the pruned ring to the log store, not just the in-memory view", () => {
+    const now = Date.now();
+    const { service, getPersistedLog } = makeFixture({}, [
+      seedRecord(now - 40 * DAY),
+      seedRecord(now - 1 * DAY),
+    ]);
+    service.pruneByAge(7);
+    const persistedIds = getPersistedLog().map((r) => (r as { id: string }).id);
+    // The flushed payload reflects the prune, so a reload won't resurrect the
+    // dropped record.
+    expect(persistedIds).toEqual([`r-${now - 1 * DAY}`]);
   });
 });

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -1139,3 +1139,94 @@ describe("AuditService.getLogRecords — union preservation (#10027)", () => {
     expect(isAuditRecord(log[1]!)).toBe(true);
   });
 });
+
+describe("AuditService.pruneByAge (#10776)", () => {
+  const DAY = 86_400_000;
+
+  function seedRecord(timestamp: unknown): Record<string, unknown> {
+    return {
+      id: `r-${String(timestamp)}`,
+      timestamp,
+      toolId: "files.search",
+      sessionId: "sess-1",
+      tier: "action",
+      argsSummary: "{}",
+      result: "success" as McpAuditResult,
+      durationMs: 1,
+    };
+  }
+
+  it("drops records older than the retention window and keeps newer ones", () => {
+    const now = Date.now();
+    const { service, logStore } = makeFixture({}, [
+      seedRecord(now - 8 * DAY),
+      seedRecord(now - 6 * DAY),
+      seedRecord(now - 1 * DAY),
+    ]);
+    service.pruneByAge(7);
+    const ids = service.getRecords().map((r) => r.id);
+    // getRecords is newest-first; the 8-day-old record is gone.
+    expect(ids).toEqual([`r-${now - 1 * DAY}`, `r-${now - 6 * DAY}`]);
+    expect(logStore.write).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a record exactly at the cutoff boundary (>= cutoff retained)", () => {
+    vi.useFakeTimers();
+    try {
+      const now = 1_000_000_000_000;
+      vi.setSystemTime(now);
+      const cutoff = now - 7 * DAY;
+      const { service } = makeFixture({}, [seedRecord(cutoff), seedRecord(cutoff - 1)]);
+      service.pruneByAge(7);
+      const ids = service.getRecords().map((r) => r.id);
+      // The record at exactly the cutoff survives; the one 1ms older is dropped.
+      expect(ids).toEqual([`r-${cutoff}`]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("is a no-op when retentionDays <= 0 (Off keeps everything)", () => {
+    const now = Date.now();
+    const { service, logStore } = makeFixture({}, [
+      seedRecord(now - 90 * DAY),
+      seedRecord(now - 1 * DAY),
+    ]);
+    service.pruneByAge(0);
+    expect(service.getRecords()).toHaveLength(2);
+    expect(logStore.write).not.toHaveBeenCalled();
+  });
+
+  it("does not flush when nothing falls outside the window", () => {
+    const now = Date.now();
+    const { service, logStore } = makeFixture({}, [
+      seedRecord(now - 2 * DAY),
+      seedRecord(now - 1 * DAY),
+    ]);
+    service.pruneByAge(7);
+    expect(service.getRecords()).toHaveLength(2);
+    expect(logStore.write).not.toHaveBeenCalled();
+  });
+
+  it("no-ops silently on an empty ring", () => {
+    const { service, logStore } = makeFixture({}, []);
+    service.pruneByAge(7);
+    expect(service.getRecords()).toHaveLength(0);
+    expect(logStore.write).not.toHaveBeenCalled();
+  });
+
+  it("retains records with a non-numeric timestamp rather than dropping them", () => {
+    const now = Date.now();
+    const { service } = makeFixture({}, [
+      seedRecord(undefined),
+      seedRecord(now - 30 * DAY),
+      seedRecord(now - 1 * DAY),
+    ]);
+    service.pruneByAge(7);
+    const ids = service.getRecords().map((r) => r.id);
+    // The malformed-timestamp record is kept; only the genuinely-old one drops.
+    expect(ids).toContain("r-undefined");
+    expect(ids).toContain(`r-${now - 1 * DAY}`);
+    expect(ids).not.toContain(`r-${now - 30 * DAY}`);
+  });
+});

--- a/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
+++ b/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
@@ -834,3 +834,65 @@ describe("TurnOutcomeService turnId lifecycle", () => {
     expect(f.service.getCurrentTurnIdForSession("session-1")).toBeNull();
   });
 });
+
+describe("TurnOutcomeService.pruneByAge (#10776)", () => {
+  const DAY = 86_400_000;
+
+  function seedRecord(timestamp: unknown): Record<string, unknown> {
+    return {
+      id: `r-${String(timestamp)}`,
+      timestamp,
+      terminalId: "term-1",
+      sessionId: "session-1",
+      outcome: "answered",
+    };
+  }
+
+  it("drops records older than the retention window and keeps newer ones", () => {
+    const now = Date.now();
+    const f = makeFixture({
+      initialLog: [
+        seedRecord(now - 40 * DAY),
+        seedRecord(now - 20 * DAY),
+        seedRecord(now - 1 * DAY),
+      ],
+    });
+    f.service.pruneByAge(30);
+    const ids = f.service.getRecords().map((r) => r.id);
+    // getRecords is newest-first; the 40-day-old record is gone.
+    expect(ids).toEqual([`r-${now - 1 * DAY}`, `r-${now - 20 * DAY}`]);
+    expect(f.logStore.write).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a no-op when retentionDays <= 0 (Off keeps everything)", () => {
+    const now = Date.now();
+    const f = makeFixture({
+      initialLog: [seedRecord(now - 365 * DAY), seedRecord(now - 1 * DAY)],
+    });
+    f.service.pruneByAge(0);
+    expect(f.service.getRecords()).toHaveLength(2);
+    expect(f.logStore.write).not.toHaveBeenCalled();
+  });
+
+  it("does not flush when nothing falls outside the window", () => {
+    const now = Date.now();
+    const f = makeFixture({
+      initialLog: [seedRecord(now - 2 * DAY), seedRecord(now - 1 * DAY)],
+    });
+    f.service.pruneByAge(30);
+    expect(f.service.getRecords()).toHaveLength(2);
+    expect(f.logStore.write).not.toHaveBeenCalled();
+  });
+
+  it("retains records with a non-numeric timestamp rather than dropping them", () => {
+    const now = Date.now();
+    const f = makeFixture({
+      initialLog: [seedRecord(undefined), seedRecord(now - 90 * DAY), seedRecord(now - 1 * DAY)],
+    });
+    f.service.pruneByAge(30);
+    const ids = f.service.getRecords().map((r) => r.id);
+    expect(ids).toContain("r-undefined");
+    expect(ids).toContain(`r-${now - 1 * DAY}`);
+    expect(ids).not.toContain(`r-${now - 90 * DAY}`);
+  });
+});

--- a/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
+++ b/electron/services/mcp-server/__tests__/turnOutcomeLog.test.ts
@@ -884,14 +884,20 @@ describe("TurnOutcomeService.pruneByAge (#10776)", () => {
     expect(f.logStore.write).not.toHaveBeenCalled();
   });
 
-  it("retains records with a non-numeric timestamp rather than dropping them", () => {
+  it("retains records with a non-finite timestamp rather than dropping them", () => {
     const now = Date.now();
     const f = makeFixture({
-      initialLog: [seedRecord(undefined), seedRecord(now - 90 * DAY), seedRecord(now - 1 * DAY)],
+      initialLog: [
+        seedRecord(undefined),
+        seedRecord(-Infinity),
+        seedRecord(now - 90 * DAY),
+        seedRecord(now - 1 * DAY),
+      ],
     });
     f.service.pruneByAge(30);
     const ids = f.service.getRecords().map((r) => r.id);
     expect(ids).toContain("r-undefined");
+    expect(ids).toContain("r--Infinity");
     expect(ids).toContain(`r-${now - 1 * DAY}`);
     expect(ids).not.toContain(`r-${now - 90 * DAY}`);
   });

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -659,9 +659,19 @@ export class AuditService {
     const cutoff = Date.now() - retentionDays * 86_400_000;
     const before = this.records.length;
     this.records = this.records.filter(
-      (r) => !(typeof r.timestamp === "number" && r.timestamp < cutoff)
+      (r) => !(Number.isFinite(r.timestamp) && r.timestamp < cutoff)
     );
     if (this.records.length !== before) {
+      // If the pre-auth coalesce target was pruned, reset the coalesce state so
+      // the next 401 writes a fresh record rather than mutating a vanished one —
+      // mirrors the eviction reset in `enqueueAndTrim`.
+      if (
+        this.lastPreAuthRecordId !== null &&
+        !this.records.some((r) => r.id === this.lastPreAuthRecordId)
+      ) {
+        this.lastPreAuthRecordId = null;
+        this.lastPreAuthRecordAt = 0;
+      }
       this.flushNow();
     }
   }

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -642,6 +642,29 @@ export class AuditService {
     this.flushNow();
     return this.getAuditConfig();
   }
+
+  /**
+   * Drop audit records older than `retentionDays`, then flush if anything was
+   * removed. `retentionDays <= 0` is the "Off" setting — keep everything,
+   * bounded only by the count cap. Filters on each record's own `.timestamp`
+   * (event time, `Date.now()` at append), NOT the SQLite `created_at` column:
+   * `writeAll` re-stamps `created_at` to the flush time on every flush, so it
+   * cannot distinguish record ages. Records whose `timestamp` is not a finite
+   * number are retained rather than dropped — a corrupt timestamp shouldn't
+   * silently evict privacy-sensitive history.
+   */
+  pruneByAge(retentionDays: number): void {
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return;
+    this.hydrate();
+    const cutoff = Date.now() - retentionDays * 86_400_000;
+    const before = this.records.length;
+    this.records = this.records.filter(
+      (r) => !(typeof r.timestamp === "number" && r.timestamp < cutoff)
+    );
+    if (this.records.length !== before) {
+      this.flushNow();
+    }
+  }
 }
 
 export type AuditOutcome =

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -533,4 +533,24 @@ export class TurnOutcomeService {
     this.records = [];
     this.flushNow();
   }
+
+  /**
+   * Drop turn-outcome records older than `retentionDays`, then flush if
+   * anything was removed. Mirrors {@link AuditService.pruneByAge}:
+   * `retentionDays <= 0` is "Off" (keep everything, count cap only), filtering
+   * is on each record's own `.timestamp` (event time) not SQLite `created_at`,
+   * and records with a non-finite timestamp are retained rather than dropped.
+   */
+  pruneByAge(retentionDays: number): void {
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) return;
+    this.hydrate();
+    const cutoff = Date.now() - retentionDays * 86_400_000;
+    const before = this.records.length;
+    this.records = this.records.filter(
+      (r) => !(typeof r.timestamp === "number" && r.timestamp < cutoff)
+    );
+    if (this.records.length !== before) {
+      this.flushNow();
+    }
+  }
 }

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -547,7 +547,7 @@ export class TurnOutcomeService {
     const cutoff = Date.now() - retentionDays * 86_400_000;
     const before = this.records.length;
     this.records = this.records.filter(
-      (r) => !(typeof r.timestamp === "number" && r.timestamp < cutoff)
+      (r) => !(Number.isFinite(r.timestamp) && r.timestamp < cutoff)
     );
     if (this.records.length !== before) {
       this.flushNow();


### PR DESCRIPTION
## Summary

- The audit log retention setting in Settings (Daintree Assistant, Privacy) was persisting a value but nothing ever acted on it. The `mcpAuditLog` and `mcpTurnOutcomeLog` SQLite rings were trimmed by record count only, never by age.
- Adds `pruneByAge(retentionDays)` to `AuditService` and `TurnOutcomeService`, using each record's embedded `.timestamp` (event time) rather than the `created_at` column, which gets re-stamped on every flush and can't distinguish record ages.
- Pruning fires immediately when the setting changes and on every 4-hour `PeriodicCleanupService` tick.

Resolves #10776

## Changes

- `AuditService.pruneByAge` / `TurnOutcomeService.pruneByAge`: filter in-memory records by embedded timestamp. Off (0) keeps everything (count cap only); non-finite timestamps are retained.
- `McpServerService.pruneAuditByRetention`: delegates to both rings.
- `helpAssistant.setSettings` handler: fires `pruneAuditByRetention` immediately on setting change (fire-and-forget with logged catch).
- `PeriodicCleanupService.runAll`: re-applies on the 4-hour tick and startup sweep, reading the setting fresh each pass.
- Count cap (500) and `auditEnabled` kill-switch are unchanged. No schema migration needed (`created_at` column and index already existed).

## Testing

- `pruneByAge` boundary, Off, no-op, non-finite timestamp, and flushed-payload cases for both rings.
- Handler trigger forwarding, service delegation, periodic prune (configured/default/Off/corrupt-value/failure-isolation).
- 327 tests green across the affected suites.