### PR TITLE
perf(logger): gate and batch renderer log IPC before it crosses to main

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -162,9 +162,11 @@ export const CHANNELS = {
   LOGS_SET_VERBOSE: "logs:set-verbose",
   LOGS_GET_VERBOSE: "logs:get-verbose",
   LOGS_WRITE: "logs:write",
+  LOGS_WRITE_BATCH: "logs:write-batch",
   LOGS_GET_LEVEL_OVERRIDES: "logs:get-level-overrides",
   LOGS_SET_LEVEL_OVERRIDES: "logs:set-level-overrides",
   LOGS_CLEAR_LEVEL_OVERRIDES: "logs:clear-level-overrides",
+  LOGS_LEVEL_OVERRIDES_CHANGED: "logs:level-overrides-changed",
   LOGS_GET_REGISTRY: "logs:get-registry",
 
   ERROR_NOTIFY: "error:notify",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -163,6 +163,7 @@ export const CHANNELS = {
   LOGS_GET_VERBOSE: "logs:get-verbose",
   LOGS_WRITE: "logs:write",
   LOGS_WRITE_BATCH: "logs:write-batch",
+  LOGS_GET_DEFAULT_LEVEL: "logs:get-default-level",
   LOGS_GET_LEVEL_OVERRIDES: "logs:get-level-overrides",
   LOGS_SET_LEVEL_OVERRIDES: "logs:set-level-overrides",
   LOGS_CLEAR_LEVEL_OVERRIDES: "logs:clear-level-overrides",

--- a/electron/ipc/handlers/__tests__/logs.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/logs.handlers.test.ts
@@ -9,6 +9,7 @@ const loggerMock = vi.hoisted(() => ({
   getLogFilePath: vi.fn(() => "/tmp/daintree.log"),
   getPreviousSessionTail: vi.fn(() => null),
   getLogLevelOverrides: vi.fn(() => ({ "*": "warn" })),
+  getDefaultLogLevel: vi.fn(() => "info"),
   setLogLevelOverrides: vi.fn(),
   getRegisteredLoggerNames: vi.fn(() => []),
   isValidLogOverrideLevel: vi.fn(
@@ -119,6 +120,29 @@ describe("logs:write-batch handler", () => {
     const handler = getHandler(CHANNELS.LOGS_WRITE_BATCH);
     await handler([]);
     expect(loggerMock.logDebug).not.toHaveBeenCalled();
+  });
+
+  it("skips a malformed entry without aborting later entries", async () => {
+    const handler = getHandler(CHANNELS.LOGS_WRITE_BATCH);
+    await handler([
+      { level: "info", message: "ok" },
+      null,
+      { level: "error", message: "must land" },
+    ]);
+
+    expect(loggerMock.logInfo).toHaveBeenCalledWith("ok", { source: "Renderer" });
+    expect(loggerMock.logError).toHaveBeenCalledWith("must land", undefined, {
+      source: "Renderer",
+    });
+  });
+});
+
+describe("logs:get-default-level handler", () => {
+  it("returns the main-process effective default level", async () => {
+    const handler = getHandler(CHANNELS.LOGS_GET_DEFAULT_LEVEL);
+    const result = await handler();
+    expect(result).toBe("info");
+    expect(loggerMock.getDefaultLogLevel).toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/__tests__/logs.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/logs.handlers.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const loggerMock = vi.hoisted(() => ({
+  isVerboseLogging: vi.fn(() => false),
+  logInfo: vi.fn(),
+  logDebug: vi.fn(),
+  logWarn: vi.fn(),
+  logError: vi.fn(),
+  getLogFilePath: vi.fn(() => "/tmp/daintree.log"),
+  getPreviousSessionTail: vi.fn(() => null),
+  getLogLevelOverrides: vi.fn(() => ({ "*": "warn" })),
+  setLogLevelOverrides: vi.fn(),
+  getRegisteredLoggerNames: vi.fn(() => []),
+  isValidLogOverrideLevel: vi.fn(
+    (v: unknown) => typeof v === "string" && ["debug", "info", "warn", "error", "off"].includes(v)
+  ),
+}));
+
+vi.mock("../../../utils/logger.js", () => loggerMock);
+
+const utilsMock = vi.hoisted(() => {
+  const registered: Array<{ channel: string; handler: (...a: unknown[]) => unknown }> = [];
+  return {
+    registered,
+    typedHandle: vi.fn((channel: string, handler: (...a: unknown[]) => unknown) => {
+      registered.push({ channel, handler });
+      return () => {};
+    }),
+    broadcastToRenderer: vi.fn(),
+  };
+});
+
+vi.mock("../../utils.js", () => ({
+  typedHandle: utilsMock.typedHandle,
+  broadcastToRenderer: utilsMock.broadcastToRenderer,
+}));
+
+const storeMock = vi.hoisted(() => {
+  const data = new Map<string, unknown>();
+  return {
+    get: vi.fn((key: string) => data.get(key)),
+    set: vi.fn((key: string, value: unknown) => data.set(key, value)),
+  };
+});
+
+vi.mock("../../../store.js", () => ({ store: storeMock }));
+
+vi.mock("../../../services/LogBuffer.js", () => ({
+  logBuffer: {
+    getAll: vi.fn(() => []),
+    getFiltered: vi.fn(() => []),
+    getSources: vi.fn(() => []),
+    clear: vi.fn(),
+  },
+}));
+
+vi.mock("electron", () => ({ shell: { openPath: vi.fn() } }));
+
+import { CHANNELS } from "../../channels.js";
+import { registerLogsHandlers } from "../logs.js";
+
+type Handler = (...args: unknown[]) => unknown;
+
+function getHandler(channel: string): Handler {
+  const match = utilsMock.registered.find((r) => r.channel === channel);
+  if (!match) throw new Error(`No handler registered for ${channel}`);
+  return match.handler;
+}
+
+let cleanup: () => void;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  utilsMock.registered.length = 0;
+  cleanup = registerLogsHandlers();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("logs:write-batch handler", () => {
+  it("registers the batch channel", () => {
+    expect(utilsMock.registered.some((r) => r.channel === CHANNELS.LOGS_WRITE_BATCH)).toBe(true);
+  });
+
+  it("dispatches every entry to its level-specific main logger, tagging the source", async () => {
+    const handler = getHandler(CHANNELS.LOGS_WRITE_BATCH);
+    await handler([
+      { level: "info", message: "one" },
+      { level: "warn", message: "two" },
+      { level: "debug", message: "three" },
+    ]);
+
+    expect(loggerMock.logInfo).toHaveBeenCalledWith("one", { source: "Renderer" });
+    expect(loggerMock.logWarn).toHaveBeenCalledWith("two", { source: "Renderer" });
+    expect(loggerMock.logDebug).toHaveBeenCalledWith("three", { source: "Renderer" });
+  });
+
+  it("routes error entries through logError with the serialized error context", async () => {
+    const handler = getHandler(CHANNELS.LOGS_WRITE_BATCH);
+    const serializedError = { name: "Error", message: "kaboom" };
+    await handler([{ level: "error", message: "boom", context: { error: serializedError } }]);
+
+    expect(loggerMock.logError).toHaveBeenCalledWith("boom", serializedError, {
+      error: serializedError,
+      source: "Renderer",
+    });
+  });
+
+  it("is a no-op for a non-array payload", async () => {
+    const handler = getHandler(CHANNELS.LOGS_WRITE_BATCH);
+    await handler(undefined as unknown);
+    expect(loggerMock.logInfo).not.toHaveBeenCalled();
+    expect(loggerMock.logWarn).not.toHaveBeenCalled();
+  });
+
+  it("handles an empty batch without dispatching", async () => {
+    const handler = getHandler(CHANNELS.LOGS_WRITE_BATCH);
+    await handler([]);
+    expect(loggerMock.logDebug).not.toHaveBeenCalled();
+  });
+});
+
+describe("logs override-change broadcast", () => {
+  it("broadcasts the resolved overrides when set-level-overrides runs", async () => {
+    const handler = getHandler(CHANNELS.LOGS_SET_LEVEL_OVERRIDES);
+    await handler({ "*": "debug" });
+
+    expect(utilsMock.broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED,
+      { "*": "warn" } // value comes from getLogLevelOverrides() — the sanitized in-memory map
+    );
+  });
+
+  it("broadcasts when clear-level-overrides runs", async () => {
+    const handler = getHandler(CHANNELS.LOGS_CLEAR_LEVEL_OVERRIDES);
+    await handler();
+
+    expect(utilsMock.broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED,
+      expect.any(Object)
+    );
+  });
+
+  it("broadcasts when verbose is toggled", async () => {
+    const handler = getHandler(CHANNELS.LOGS_SET_VERBOSE);
+    await handler(true);
+
+    expect(utilsMock.broadcastToRenderer).toHaveBeenCalledWith(
+      CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED,
+      expect.any(Object)
+    );
+  });
+
+  it("does not broadcast on a plain write", async () => {
+    const handler = getHandler(CHANNELS.LOGS_WRITE);
+    await handler({ level: "info", message: "hi" });
+    expect(utilsMock.broadcastToRenderer).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -11,6 +11,7 @@ import {
   getLogFilePath,
   getPreviousSessionTail,
   getLogLevelOverrides,
+  getDefaultLogLevel,
   setLogLevelOverrides,
   getRegisteredLoggerNames,
   isValidLogOverrideLevel,
@@ -203,10 +204,22 @@ export function registerLogsHandlers(
   ) => {
     if (!Array.isArray(entries)) return;
     for (const entry of entries) {
-      dispatchRendererLog(entry);
+      // Isolate each entry: a malformed one must not abort dispatch of the
+      // entries that follow it (e.g. a trailing error-level log).
+      if (!entry || typeof entry !== "object") continue;
+      try {
+        dispatchRendererLog(entry);
+      } catch {
+        // Drop the bad entry; keep draining the batch.
+      }
     }
   };
   handlers.push(typedHandle(CHANNELS.LOGS_WRITE_BATCH, handleLogsWriteBatch));
+
+  const handleGetDefaultLevel = async (): Promise<string> => {
+    return getDefaultLogLevel();
+  };
+  handlers.push(typedHandle(CHANNELS.LOGS_GET_DEFAULT_LEVEL, handleGetDefaultLevel));
 
   const handleGetLevelOverrides = async (): Promise<Record<string, string>> => {
     // Return the in-memory sanitized map (not the raw store value) so the UI

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -19,6 +19,7 @@ import {
 } from "../../utils/logger.js";
 import type { FilterOptions as LogFilterOptions } from "../../services/LogBuffer.js";
 import { typedHandle, broadcastToRenderer } from "../utils.js";
+import { defineIpcNamespace, op } from "../define.js";
 import { store } from "../../store.js";
 import { AppError } from "../../utils/errorTypes.js";
 import type { HandlerDependencies } from "../types.js";
@@ -191,35 +192,42 @@ export function registerLogsHandlers(
   };
   handlers.push(typedHandle(CHANNELS.LOGS_WRITE, handleLogsWrite));
 
-  // Renderer coalesces below-warn writes into a single batched invoke (one IPC
-  // round-trip per tick) instead of one invoke per log call. Each entry is
-  // dispatched through the same path as a single write; the main-process
-  // `shouldLog` gate still applies per entry.
-  const handleLogsWriteBatch = async (
-    entries: Array<{
-      level: LogLevel;
-      message: string;
-      context?: Record<string, unknown>;
-    }>
-  ) => {
-    if (!Array.isArray(entries)) return;
-    for (const entry of entries) {
-      // Isolate each entry: a malformed one must not abort dispatch of the
-      // entries that follow it (e.g. a trailing error-level log).
-      if (!entry || typeof entry !== "object") continue;
-      try {
-        dispatchRendererLog(entry);
-      } catch {
-        // Drop the bad entry; keep draining the batch.
-      }
-    }
-  };
-  handlers.push(typedHandle(CHANNELS.LOGS_WRITE_BATCH, handleLogsWriteBatch));
-
-  const handleGetDefaultLevel = async (): Promise<string> => {
-    return getDefaultLogLevel();
-  };
-  handlers.push(typedHandle(CHANNELS.LOGS_GET_DEFAULT_LEVEL, handleGetDefaultLevel));
+  // Renderer-perf channels are codegen'd via defineIpcNamespace (new IPC
+  // entries must not be hand-written into IpcInvokeMap — see the ratchet in
+  // scripts/ipc-handwritten-ratchet.mjs). `writeBatch` coalesces below-warn
+  // writes into one round-trip per tick; `getDefaultLevel` lets the renderer
+  // mirror main's effective default floor for its pre-IPC gate.
+  const rendererPerfNamespace = defineIpcNamespace({
+    name: "logsRendererPerf",
+    ops: {
+      writeBatch: op(
+        CHANNELS.LOGS_WRITE_BATCH,
+        async (
+          entries: Array<{
+            level: "debug" | "info" | "warn" | "error";
+            message: string;
+            context?: Record<string, unknown>;
+          }>
+        ): Promise<void> => {
+          if (!Array.isArray(entries)) return;
+          for (const entry of entries) {
+            // Isolate each entry: a malformed one must not abort dispatch of
+            // the entries that follow it (e.g. a trailing error-level log).
+            if (!entry || typeof entry !== "object") continue;
+            try {
+              dispatchRendererLog(entry);
+            } catch {
+              // Drop the bad entry; keep draining the batch.
+            }
+          }
+        }
+      ),
+      getDefaultLevel: op(CHANNELS.LOGS_GET_DEFAULT_LEVEL, async (): Promise<string> => {
+        return getDefaultLogLevel();
+      }),
+    },
+  });
+  handlers.push(rendererPerfNamespace.register());
 
   const handleGetLevelOverrides = async (): Promise<Record<string, string>> => {
     // Return the in-memory sanitized map (not the raw store value) so the UI

--- a/electron/ipc/handlers/logs.ts
+++ b/electron/ipc/handlers/logs.ts
@@ -17,7 +17,7 @@ import {
   type LogLevel,
 } from "../../utils/logger.js";
 import type { FilterOptions as LogFilterOptions } from "../../services/LogBuffer.js";
-import { typedHandle } from "../utils.js";
+import { typedHandle, broadcastToRenderer } from "../utils.js";
 import { store } from "../../store.js";
 import { AppError } from "../../utils/errorTypes.js";
 import type { HandlerDependencies } from "../types.js";
@@ -148,6 +148,7 @@ export function registerLogsHandlers(
     store.set("logLevelOverrides", current);
     setLogLevelOverrides(current);
     fanOut(current, deps);
+    broadcastToRenderer(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, getLogLevelOverrides());
     logInfo(`Verbose logging ${enabled ? "enabled" : "disabled"} by user`);
   };
   handlers.push(typedHandle(CHANNELS.LOGS_SET_VERBOSE, handleLogsSetVerbose));
@@ -157,12 +158,12 @@ export function registerLogsHandlers(
   };
   handlers.push(typedHandle(CHANNELS.LOGS_GET_VERBOSE, handleLogsGetVerbose));
 
-  const handleLogsWrite = async (payload: {
+  const dispatchRendererLog = (entry: {
     level: LogLevel;
     message: string;
     context?: Record<string, unknown>;
-  }) => {
-    const { level, message, context } = payload;
+  }): void => {
+    const { level, message, context } = entry;
     const contextWithSource = { ...context, source: "Renderer" };
     switch (level) {
       case "debug":
@@ -179,7 +180,33 @@ export function registerLogsHandlers(
         break;
     }
   };
+
+  const handleLogsWrite = async (payload: {
+    level: LogLevel;
+    message: string;
+    context?: Record<string, unknown>;
+  }) => {
+    dispatchRendererLog(payload);
+  };
   handlers.push(typedHandle(CHANNELS.LOGS_WRITE, handleLogsWrite));
+
+  // Renderer coalesces below-warn writes into a single batched invoke (one IPC
+  // round-trip per tick) instead of one invoke per log call. Each entry is
+  // dispatched through the same path as a single write; the main-process
+  // `shouldLog` gate still applies per entry.
+  const handleLogsWriteBatch = async (
+    entries: Array<{
+      level: LogLevel;
+      message: string;
+      context?: Record<string, unknown>;
+    }>
+  ) => {
+    if (!Array.isArray(entries)) return;
+    for (const entry of entries) {
+      dispatchRendererLog(entry);
+    }
+  };
+  handlers.push(typedHandle(CHANNELS.LOGS_WRITE_BATCH, handleLogsWriteBatch));
 
   const handleGetLevelOverrides = async (): Promise<Record<string, string>> => {
     // Return the in-memory sanitized map (not the raw store value) so the UI
@@ -193,6 +220,7 @@ export function registerLogsHandlers(
     store.set("logLevelOverrides", clean);
     setLogLevelOverrides(clean);
     fanOut(clean, deps);
+    broadcastToRenderer(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, getLogLevelOverrides());
     logInfo("Log level overrides updated", { count: Object.keys(clean).length });
     return { success: true };
   };
@@ -207,6 +235,7 @@ export function registerLogsHandlers(
     store.set("logLevelOverrides", {});
     setLogLevelOverrides({});
     fanOut({}, deps);
+    broadcastToRenderer(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, getLogLevelOverrides());
     logInfo("Log level overrides cleared");
     return { success: true };
   };

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1479,12 +1479,23 @@ function buildElectronApi(): ElectronAPI {
         context?: Record<string, unknown>
       ) => _unwrappingInvoke(CHANNELS.LOGS_WRITE, { level, message, context }),
 
+      writeBatch: (
+        entries: Array<{
+          level: "debug" | "info" | "warn" | "error";
+          message: string;
+          context?: Record<string, unknown>;
+        }>
+      ) => _unwrappingInvoke(CHANNELS.LOGS_WRITE_BATCH, entries),
+
       getLevelOverrides: () => _unwrappingInvoke(CHANNELS.LOGS_GET_LEVEL_OVERRIDES),
 
       setLevelOverrides: (overrides: Record<string, string>) =>
         _unwrappingInvoke(CHANNELS.LOGS_SET_LEVEL_OVERRIDES, overrides),
 
       clearLevelOverrides: () => _unwrappingInvoke(CHANNELS.LOGS_CLEAR_LEVEL_OVERRIDES),
+
+      onLevelOverridesChanged: (callback: (overrides: Record<string, string>) => void) =>
+        _typedOn(CHANNELS.LOGS_LEVEL_OVERRIDES_CHANGED, callback),
 
       getRegistry: () => _unwrappingInvoke(CHANNELS.LOGS_GET_REGISTRY),
     },

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1487,6 +1487,8 @@ function buildElectronApi(): ElectronAPI {
         }>
       ) => _unwrappingInvoke(CHANNELS.LOGS_WRITE_BATCH, entries),
 
+      getDefaultLevel: () => _unwrappingInvoke(CHANNELS.LOGS_GET_DEFAULT_LEVEL),
+
       getLevelOverrides: () => _unwrappingInvoke(CHANNELS.LOGS_GET_LEVEL_OVERRIDES),
 
       setLevelOverrides: (overrides: Record<string, string>) =>

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -504,6 +504,16 @@ export function getLogLevelOverrides(): Record<string, LogOverrideLevel> {
   return Object.fromEntries(levelOverrides.entries());
 }
 
+/**
+ * The effective floor applied when no override matches — `"debug"` under
+ * debug-boot (`NODE_ENV=development` / `DAINTREE_DEBUG`), else `"info"`. The
+ * renderer mirrors this so its pre-IPC gate matches what main would accept for
+ * an unmatched logger (`resolveEffectiveLevel`'s final fallback).
+ */
+export function getDefaultLogLevel(): LogOverrideLevel {
+  return defaultLevel;
+}
+
 export function isValidLogOverrideLevel(value: unknown): value is LogOverrideLevel {
   return (
     value === "debug" ||

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -461,6 +461,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
         context?: Record<string, unknown>;
       }>
     ): Promise<void>;
+    getDefaultLevel(): Promise<string>;
     getLevelOverrides(): Promise<Record<string, string>>;
     setLevelOverrides(overrides: Record<string, string>): Promise<{ success: boolean }>;
     clearLevelOverrides(): Promise<{ success: boolean }>;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -454,9 +454,17 @@ export interface ElectronAPI extends GeneratedElectronAPI {
       message: string,
       context?: Record<string, unknown>
     ): Promise<void>;
+    writeBatch(
+      entries: Array<{
+        level: "debug" | "info" | "warn" | "error";
+        message: string;
+        context?: Record<string, unknown>;
+      }>
+    ): Promise<void>;
     getLevelOverrides(): Promise<Record<string, string>>;
     setLevelOverrides(overrides: Record<string, string>): Promise<{ success: boolean }>;
     clearLevelOverrides(): Promise<{ success: boolean }>;
+    onLevelOverridesChanged(callback: (overrides: Record<string, string>) => void): () => void;
     getRegistry(): Promise<string[]>;
   };
   errors: {

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -618,6 +618,20 @@ export interface GeneratedIpcInvokeMap {
     args: [config: Partial<import("./idleTerminals.js").IdleTerminalNotifyConfig>];
     result: import("./idleTerminals.js").IdleTerminalNotifyConfig;
   };
+  "logs:get-default-level": {
+    args: [];
+    result: string;
+  };
+  "logs:write-batch": {
+    args: [
+      entries: {
+        level: "error" | "debug" | "info" | "warn";
+        message: string;
+        context?: Record<string, unknown> | undefined;
+      }[],
+    ];
+    result: void;
+  };
   "mcp-server:clear-audit-log": {
     args: [];
     result: void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -539,6 +539,16 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     ];
     result: void;
   };
+  "logs:write-batch": {
+    args: [
+      entries: Array<{
+        level: "debug" | "info" | "warn" | "error";
+        message: string;
+        context?: Record<string, unknown>;
+      }>,
+    ];
+    result: void;
+  };
   "logs:get-level-overrides": {
     args: [];
     result: Record<string, string>;
@@ -1618,6 +1628,7 @@ export interface IpcEventMap {
   // Log events
   "logs:entry": LogEntry;
   "logs:batch": LogEntry[];
+  "logs:level-overrides-changed": Record<string, string>;
 
   // Event inspector events
   "event-inspector:event-batch": EventRecord[];

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -539,20 +539,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     ];
     result: void;
   };
-  "logs:write-batch": {
-    args: [
-      entries: Array<{
-        level: "debug" | "info" | "warn" | "error";
-        message: string;
-        context?: Record<string, unknown>;
-      }>,
-    ];
-    result: void;
-  };
-  "logs:get-default-level": {
-    args: [];
-    result: string;
-  };
   "logs:get-level-overrides": {
     args: [];
     result: Record<string, string>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -549,6 +549,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     ];
     result: void;
   };
+  "logs:get-default-level": {
+    args: [];
+    result: string;
+  };
   "logs:get-level-overrides": {
     args: [];
     result: Record<string, string>;

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -36,6 +36,26 @@ function removeElectron(): void {
   delete (globalThis as unknown as { window?: unknown }).window;
 }
 
+interface SentEntry {
+  level: string;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+/** The entries array passed to the Nth writeBatch invoke, guarded for tsc. */
+function sentBatch(callIndex = 0): SentEntry[] {
+  const call = logsApi.writeBatch.mock.calls[callIndex];
+  if (!call) throw new Error(`expected a writeBatch call at index ${callIndex}`);
+  return call[0] as SentEntry[];
+}
+
+/** A single entry from a writeBatch invoke, guarded for tsc. */
+function sentEntry(callIndex = 0, entryIndex = 0): SentEntry {
+  const entry = sentBatch(callIndex)[entryIndex];
+  if (!entry) throw new Error(`expected entry ${entryIndex} in writeBatch call ${callIndex}`);
+  return entry;
+}
+
 /** Let the init's getLevelOverrides().then() microtask settle. */
 async function flushMicrotasks(): Promise<void> {
   await Promise.resolve();
@@ -170,8 +190,7 @@ describe("renderer logger batching", () => {
 
     vi.advanceTimersByTime(LOG_BATCH_MS);
     expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
-    const entries = logsApi.writeBatch.mock.calls[0][0];
-    expect(entries.map((e: { message: string }) => e.message)).toEqual(["a", "b", "c"]);
+    expect(sentBatch().map((e) => e.message)).toEqual(["a", "b", "c"]);
   });
 
   it("only opens one timer window per burst", () => {
@@ -202,9 +221,9 @@ describe("renderer logger warn/error bypass", () => {
   it("flushes error synchronously and serializes the Error", () => {
     logError("boom", new Error("kaboom"));
     expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
-    const entry = logsApi.writeBatch.mock.calls[0][0][0];
+    const entry = sentEntry();
     expect(entry.level).toBe("error");
-    expect(entry.context.error).toMatchObject({ name: "Error", message: "kaboom" });
+    expect(entry.context?.error).toMatchObject({ name: "Error", message: "kaboom" });
   });
 
   it("flushes pending info ahead of an error, preserving order, in one batch", () => {
@@ -213,9 +232,8 @@ describe("renderer logger warn/error bypass", () => {
 
     logError("after");
     expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
-    const entries = logsApi.writeBatch.mock.calls[0][0];
-    expect(entries.map((e: { message: string }) => e.message)).toEqual(["before", "after"]);
-    expect(entries.map((e: { level: string }) => e.level)).toEqual(["info", "error"]);
+    expect(sentBatch().map((e) => e.message)).toEqual(["before", "after"]);
+    expect(sentBatch().map((e) => e.level)).toEqual(["info", "error"]);
   });
 
   it("does not re-send the flushed entries when the timer later fires", () => {

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetRendererLoggerForTesting, logDebug, logError, logInfo, logWarn } from "../logger";
+
+const LOG_BATCH_MS = 16;
+
+type LevelOverridesCallback = (overrides: Record<string, string>) => void;
+
+interface MockLogsApi {
+  writeBatch: ReturnType<typeof vi.fn>;
+  getLevelOverrides: ReturnType<typeof vi.fn>;
+  onLevelOverridesChanged: ReturnType<typeof vi.fn>;
+}
+
+let logsApi: MockLogsApi;
+let overridesCallback: LevelOverridesCallback | null;
+
+function installElectron(initialOverrides: Record<string, string> = {}): void {
+  overridesCallback = null;
+  logsApi = {
+    writeBatch: vi.fn().mockResolvedValue(undefined),
+    getLevelOverrides: vi.fn().mockResolvedValue(initialOverrides),
+    onLevelOverridesChanged: vi.fn((cb: LevelOverridesCallback) => {
+      overridesCallback = cb;
+      return () => {};
+    }),
+  };
+  (globalThis as unknown as { window: unknown }).window = { electron: { logs: logsApi } };
+}
+
+function removeElectron(): void {
+  delete (globalThis as unknown as { window?: unknown }).window;
+}
+
+/** Let the init's getLevelOverrides().then() microtask settle. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/**
+ * First electron-backed call wires the subscription/fetch. Drain its queued
+ * entry + timer and reset the writeBatch spy so subsequent assertions start
+ * from a clean slate.
+ */
+async function triggerInitAndDrain(): Promise<void> {
+  logInfo("trigger init");
+  await flushMicrotasks();
+  vi.advanceTimersByTime(LOG_BATCH_MS);
+  logsApi.writeBatch.mockClear();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  installElectron();
+  _resetRendererLoggerForTesting();
+});
+
+afterEach(() => {
+  _resetRendererLoggerForTesting();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  removeElectron();
+});
+
+describe("renderer logger gating", () => {
+  it("drops below-floor debug calls before any IPC at the default info floor", () => {
+    logDebug("noise");
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).not.toHaveBeenCalled();
+  });
+
+  it("lets info and above cross at the default floor", () => {
+    logInfo("hello");
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("raises the floor when a '*' override arrives via the push subscription", async () => {
+    await triggerInitAndDrain();
+    expect(overridesCallback).toBeTypeOf("function");
+
+    overridesCallback?.({ "*": "warn" });
+
+    logInfo("now gated");
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).not.toHaveBeenCalled();
+
+    logWarn("still delivered");
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("lowers the floor to debug when overrides resolve from the initial fetch", async () => {
+    removeElectron();
+    installElectron({ "*": "debug" });
+    _resetRendererLoggerForTesting();
+
+    await triggerInitAndDrain();
+
+    logDebug("now allowed");
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("renderer logger batching", () => {
+  it("coalesces multiple same-tick info writes into one batched invoke", () => {
+    logInfo("a");
+    logInfo("b");
+    logInfo("c");
+    expect(logsApi.writeBatch).not.toHaveBeenCalled(); // nothing before the timer fires
+
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+    const entries = logsApi.writeBatch.mock.calls[0][0];
+    expect(entries.map((e: { message: string }) => e.message)).toEqual(["a", "b", "c"]);
+  });
+
+  it("only opens one timer window per burst", () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    logInfo("a");
+    logInfo("b");
+    logInfo("c");
+    const timerCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === LOG_BATCH_MS);
+    expect(timerCalls).toHaveLength(1);
+  });
+
+  it("splits oversized batches into <=60-entry chunks", () => {
+    for (let i = 0; i < 130; i++) logInfo(`m${i}`);
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(3);
+    const sizes = logsApi.writeBatch.mock.calls.map((c) => c[0].length);
+    expect(sizes).toEqual([60, 60, 10]);
+  });
+});
+
+describe("renderer logger warn/error bypass", () => {
+  it("flushes warn synchronously without waiting for the timer", () => {
+    logWarn("urgent");
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes error synchronously and serializes the Error", () => {
+    logError("boom", new Error("kaboom"));
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+    const entry = logsApi.writeBatch.mock.calls[0][0][0];
+    expect(entry.level).toBe("error");
+    expect(entry.context.error).toMatchObject({ name: "Error", message: "kaboom" });
+  });
+
+  it("flushes pending info ahead of an error, preserving order, in one batch", () => {
+    logInfo("before");
+    expect(logsApi.writeBatch).not.toHaveBeenCalled();
+
+    logError("after");
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+    const entries = logsApi.writeBatch.mock.calls[0][0];
+    expect(entries.map((e: { message: string }) => e.message)).toEqual(["before", "after"]);
+    expect(entries.map((e: { level: string }) => e.level)).toEqual(["info", "error"]);
+  });
+
+  it("does not re-send the flushed entries when the timer later fires", () => {
+    logInfo("queued");
+    logError("flush-now");
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1); // no duplicate flush
+  });
+});
+
+describe("renderer logger fallback", () => {
+  it("logs to console (without gating) when electron is unavailable", () => {
+    removeElectron();
+    _resetRendererLoggerForTesting();
+    const debugSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    logDebug("d");
+    logError("e");
+
+    expect(debugSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -7,6 +7,7 @@ type LevelOverridesCallback = (overrides: Record<string, string>) => void;
 
 interface MockLogsApi {
   writeBatch: ReturnType<typeof vi.fn>;
+  getDefaultLevel: ReturnType<typeof vi.fn>;
   getLevelOverrides: ReturnType<typeof vi.fn>;
   onLevelOverridesChanged: ReturnType<typeof vi.fn>;
 }
@@ -14,10 +15,14 @@ interface MockLogsApi {
 let logsApi: MockLogsApi;
 let overridesCallback: LevelOverridesCallback | null;
 
-function installElectron(initialOverrides: Record<string, string> = {}): void {
+function installElectron(
+  initialOverrides: Record<string, string> = {},
+  defaultLevel = "info"
+): void {
   overridesCallback = null;
   logsApi = {
     writeBatch: vi.fn().mockResolvedValue(undefined),
+    getDefaultLevel: vi.fn().mockResolvedValue(defaultLevel),
     getLevelOverrides: vi.fn().mockResolvedValue(initialOverrides),
     onLevelOverridesChanged: vi.fn((cb: LevelOverridesCallback) => {
       overridesCallback = cb;
@@ -98,6 +103,60 @@ describe("renderer logger gating", () => {
 
     logDebug("now allowed");
     vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("mirrors main's debug-boot default so renderer debug crosses when main would accept it", async () => {
+    removeElectron();
+    installElectron({}, "debug"); // no '*' override, but main's default is debug
+    _resetRendererLoggerForTesting();
+
+    await triggerInitAndDrain();
+
+    logDebug("dev debug");
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the newer pushed override when the initial fetch resolves afterward (stale-fetch race)", async () => {
+    removeElectron();
+    let resolveFetch: (v: Record<string, string>) => void = () => {};
+    const fetchPromise = new Promise<Record<string, string>>((r) => {
+      resolveFetch = r;
+    });
+    installElectron();
+    logsApi.getLevelOverrides.mockReturnValue(fetchPromise);
+    _resetRendererLoggerForTesting();
+
+    logInfo("trigger init"); // starts the (still-pending) fetch + wires the push
+    await flushMicrotasks();
+
+    // A push raises the floor to warn before the fetch resolves.
+    overridesCallback?.({ "*": "warn" });
+    // The stale fetch now resolves with the older (empty) state.
+    resolveFetch({});
+    await flushMicrotasks();
+    // Drain the "trigger init" entry (queued while the floor was still info).
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    logsApi.writeBatch.mockClear();
+
+    logInfo("should be gated by the pushed warn floor");
+    vi.advanceTimersByTime(LOG_BATCH_MS);
+    expect(logsApi.writeBatch).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when the preload lacks onLevelOverridesChanged (version skew)", () => {
+    removeElectron();
+    logsApi = {
+      writeBatch: vi.fn().mockResolvedValue(undefined),
+      getDefaultLevel: vi.fn().mockResolvedValue("info"),
+      getLevelOverrides: vi.fn().mockResolvedValue({}),
+      onLevelOverridesChanged: undefined as unknown as ReturnType<typeof vi.fn>,
+    };
+    (globalThis as unknown as { window: unknown }).window = { electron: { logs: logsApi } };
+    _resetRendererLoggerForTesting();
+
+    expect(() => logWarn("urgent")).not.toThrow();
     expect(logsApi.writeBatch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -4,23 +4,141 @@ interface LogContext {
   [key: string]: unknown;
 }
 
+interface BatchEntry {
+  level: LogLevel;
+  message: string;
+  context?: LogContext;
+}
+
+/**
+ * Numeric level ordering mirrored from the main-process logger
+ * (`electron/utils/logger.ts`). A message at level X is suppressed when
+ * `LEVELS[X] < floor`. `"off"` is highest — anything below `Infinity` passes
+ * only when the floor is a real level. The renderer cannot import from
+ * `electron/`, so this is an intentional local copy of a shared concept.
+ */
+const LEVELS: Record<LogLevel | "off", number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+  off: Number.POSITIVE_INFINITY,
+};
+
+/**
+ * Renderer log writes are coalesced into a single batched IPC invoke per
+ * ~tick instead of one round-trip per call. 16ms mirrors the main-process
+ * outbound `LOG_THROTTLE_MS`; the 60-entry cap mirrors `MAX_LOGS_PER_FLUSH`
+ * and bounds a single `writeBatch` payload.
+ */
+const LOG_BATCH_MS = 16;
+const MAX_BATCH_ENTRIES = 60;
+
+/**
+ * Effective floor the renderer gates against before touching IPC. The renderer
+ * logger has no named loggers — every call funnels through the bare
+ * `logDebug`/`logInfo`/`logWarn`/`logError` exports — so only the global `"*"`
+ * wildcard override is relevant (no per-name or process-wildcard resolution).
+ * Defaults to `info` synchronously; refreshed once the async override fetch and
+ * the push subscription land. The main-process `shouldLog` remains the
+ * authoritative gate, so a stale floor only ever lets a below-threshold call
+ * cross the wire (it is then dropped in main) — it never drops a log that
+ * should be delivered.
+ */
+const DEFAULT_FLOOR = LEVELS.info;
+let rendererFloor: number = DEFAULT_FLOOR;
+
+let batchQueue: BatchEntry[] = [];
+let batchTimer: ReturnType<typeof setTimeout> | null = null;
+let mirrorInitialized = false;
+
 function isElectronAvailable(): boolean {
-  return typeof window !== "undefined" && !!window.electron?.logs?.write;
+  return typeof window !== "undefined" && !!window.electron?.logs?.writeBatch;
+}
+
+function consoleFallback(level: LogLevel, message: string, context?: LogContext): void {
+  const consoleFn =
+    level === "error" ? console.error : level === "warn" ? console.warn : console.log;
+  consoleFn(`[${level.toUpperCase()}] ${message}`, context ?? "");
+}
+
+function isValidFloorLevel(value: unknown): value is LogLevel | "off" {
+  return typeof value === "string" && value in LEVELS;
+}
+
+function applyOverrides(overrides: Record<string, string> | undefined): void {
+  const wildcard = overrides?.["*"];
+  rendererFloor = isValidFloorLevel(wildcard) ? LEVELS[wildcard] : DEFAULT_FLOOR;
+}
+
+function initLevelMirror(): void {
+  if (mirrorInitialized) return;
+  if (typeof window === "undefined" || !window.electron?.logs) return;
+  mirrorInitialized = true;
+  // First few calls may fire before this resolves; they default to the `info`
+  // floor, and main re-gates anyway, so no log that should appear is lost.
+  window.electron.logs
+    .getLevelOverrides()
+    .then(applyOverrides)
+    .catch(() => {});
+  window.electron.logs.onLevelOverridesChanged(applyOverrides);
+}
+
+function shouldRendererLog(level: LogLevel): boolean {
+  return LEVELS[level] >= rendererFloor;
+}
+
+function flushBatch(): void {
+  if (batchTimer !== null) {
+    clearTimeout(batchTimer);
+    batchTimer = null;
+  }
+  if (batchQueue.length === 0) return;
+  // Snapshot-and-clear before the send so any re-entrant enqueue lands in the
+  // next batch instead of being dropped or double-sent.
+  const snapshot = batchQueue;
+  batchQueue = [];
+
+  if (!isElectronAvailable()) {
+    // Window torn down between enqueue and flush — don't lose the entries.
+    for (const entry of snapshot) consoleFallback(entry.level, entry.message, entry.context);
+    return;
+  }
+
+  for (let i = 0; i < snapshot.length; i += MAX_BATCH_ENTRIES) {
+    const chunk = snapshot.slice(i, i + MAX_BATCH_ENTRIES);
+    window.electron.logs.writeBatch(chunk).catch(() => {
+      for (const entry of chunk) consoleFallback(entry.level, entry.message, entry.context);
+    });
+  }
 }
 
 function writeLog(level: LogLevel, message: string, context?: LogContext): void {
-  if (isElectronAvailable()) {
-    window.electron.logs.write(level, message, context).catch(() => {
-      // Fallback to console if IPC fails
-      const consoleFn =
-        level === "error" ? console.error : level === "warn" ? console.warn : console.log;
-      consoleFn(`[${level.toUpperCase()}] ${message}`, context ?? "");
-    });
-  } else {
-    // No electron API (e.g., in tests or non-electron context)
-    const consoleFn =
-      level === "error" ? console.error : level === "warn" ? console.warn : console.log;
-    consoleFn(`[${level.toUpperCase()}] ${message}`, context ?? "");
+  if (!isElectronAvailable()) {
+    // No electron API (tests / non-electron context) — there's no IPC cost to
+    // save, so log everything to console without gating.
+    consoleFallback(level, message, context);
+    return;
+  }
+
+  initLevelMirror();
+
+  if (!shouldRendererLog(level)) return;
+
+  const entry: BatchEntry = { level, message, context };
+  batchQueue.push(entry);
+
+  // warn/error must never be deferred beyond the current tick: flush the queue
+  // (including any debug/info enqueued before them, preserving order) right
+  // now instead of waiting for the batch timer.
+  if (level === "warn" || level === "error") {
+    flushBatch();
+    return;
+  }
+
+  // debug/info: coalesce into the next batch window.
+  if (batchTimer === null) {
+    batchTimer = setTimeout(flushBatch, LOG_BATCH_MS);
   }
 }
 
@@ -50,4 +168,19 @@ export function logError(message: string, error?: unknown, context?: LogContext)
     }
   }
   writeLog("error", message, errorContext);
+}
+
+/**
+ * Test-only reset of module-level state (queue, timer, floor, init flag),
+ * mirroring `resetLoggerStateForTesting` in the main-process logger so suites
+ * can isolate batching/gating behavior.
+ */
+export function _resetRendererLoggerForTesting(): void {
+  if (batchTimer !== null) {
+    clearTimeout(batchTimer);
+    batchTimer = null;
+  }
+  batchQueue = [];
+  rendererFloor = DEFAULT_FLOOR;
+  mirrorInitialized = false;
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -35,22 +35,31 @@ const LOG_BATCH_MS = 16;
 const MAX_BATCH_ENTRIES = 60;
 
 /**
- * Effective floor the renderer gates against before touching IPC. The renderer
- * logger has no named loggers — every call funnels through the bare
- * `logDebug`/`logInfo`/`logWarn`/`logError` exports — so only the global `"*"`
- * wildcard override is relevant (no per-name or process-wildcard resolution).
- * Defaults to `info` synchronously; refreshed once the async override fetch and
- * the push subscription land. The main-process `shouldLog` remains the
- * authoritative gate, so a stale floor only ever lets a below-threshold call
- * cross the wire (it is then dropped in main) — it never drops a log that
- * should be delivered.
+ * The renderer gate mirrors main's `resolveEffectiveLevel` for an unmatched
+ * logger: a global `"*"` override if one is set, otherwise main's process
+ * default (`"debug"` under debug-boot, else `"info"`). The renderer logger has
+ * no named loggers — every call funnels through the bare
+ * `logDebug`/`logInfo`/`logWarn`/`logError` exports — so per-name and
+ * process-wildcard keys never apply, only `"*"`.
+ *
+ * Both inputs start at the conservative `info` default and are refreshed
+ * asynchronously (a one-time default fetch + the override fetch/subscription).
+ * Until they resolve, a stale floor only ever lets a below-threshold call cross
+ * the wire (main then drops it) — it never drops a log main would deliver. The
+ * one window where the renderer could under-send is debug-boot before the
+ * default fetch lands; those few early `debug` calls are gated, which is
+ * acceptable for a startup-only race.
  */
-const DEFAULT_FLOOR = LEVELS.info;
-let rendererFloor: number = DEFAULT_FLOOR;
+const FALLBACK_FLOOR = LEVELS.info;
+let defaultFloor: number = FALLBACK_FLOOR;
+let wildcardFloor: number | null = null;
+let mirrorInitialized = false;
+// Once an override push lands, the initial (possibly slower) override fetch is
+// stale and must not overwrite it.
+let overridePushReceived = false;
 
 let batchQueue: BatchEntry[] = [];
 let batchTimer: ReturnType<typeof setTimeout> | null = null;
-let mirrorInitialized = false;
 
 function isElectronAvailable(): boolean {
   return typeof window !== "undefined" && !!window.electron?.logs?.writeBatch;
@@ -66,26 +75,42 @@ function isValidFloorLevel(value: unknown): value is LogLevel | "off" {
   return typeof value === "string" && value in LEVELS;
 }
 
+function setDefaultFloor(level: string | undefined): void {
+  defaultFloor = isValidFloorLevel(level) ? LEVELS[level] : FALLBACK_FLOOR;
+}
+
 function applyOverrides(overrides: Record<string, string> | undefined): void {
   const wildcard = overrides?.["*"];
-  rendererFloor = isValidFloorLevel(wildcard) ? LEVELS[wildcard] : DEFAULT_FLOOR;
+  wildcardFloor = isValidFloorLevel(wildcard) ? LEVELS[wildcard] : null;
 }
 
 function initLevelMirror(): void {
   if (mirrorInitialized) return;
   if (typeof window === "undefined" || !window.electron?.logs) return;
   mirrorInitialized = true;
-  // First few calls may fire before this resolves; they default to the `info`
-  // floor, and main re-gates anyway, so no log that should appear is lost.
-  window.electron.logs
-    .getLevelOverrides()
-    .then(applyOverrides)
+  const logs = window.electron.logs;
+  // The default is static per process (set at boot), so a one-time fetch is
+  // enough — no push channel needed for it.
+  logs
+    .getDefaultLevel?.()
+    ?.then(setDefaultFloor)
     .catch(() => {});
-  window.electron.logs.onLevelOverridesChanged(applyOverrides);
+  logs
+    .getLevelOverrides?.()
+    ?.then((overrides) => {
+      // A push that arrived first reflects newer state than this fetch.
+      if (!overridePushReceived) applyOverrides(overrides);
+    })
+    .catch(() => {});
+  logs.onLevelOverridesChanged?.((overrides) => {
+    overridePushReceived = true;
+    applyOverrides(overrides);
+  });
 }
 
 function shouldRendererLog(level: LogLevel): boolean {
-  return LEVELS[level] >= rendererFloor;
+  const floor = wildcardFloor ?? defaultFloor;
+  return LEVELS[level] >= floor;
 }
 
 function flushBatch(): void {
@@ -181,6 +206,8 @@ export function _resetRendererLoggerForTesting(): void {
     batchTimer = null;
   }
   batchQueue = [];
-  rendererFloor = DEFAULT_FLOOR;
+  defaultFloor = FALLBACK_FLOOR;
+  wildcardFloor = null;
   mirrorInitialized = false;
+  overridePushReceived = false;
 }


### PR DESCRIPTION
## Summary

- The renderer logger had no client-side level filter, so every `logger.debug()` and `logger.info()` call made a separate `ipcRenderer.invoke(LOGS_WRITE)` round-trip even when main would immediately discard it at the `info` floor. Around 99 call sites were paying that wasted crossing in a production build.
- This PR mirrors the effective level floor into the renderer so sub-threshold calls are dropped before touching IPC, and coalesces renderer-to-main writes into a single batched invoke on a 16ms self-expiring timer (matching the existing main-to-renderer flush). `warn` and `error` bypass the timer and flush synchronously to preserve delivery order.
- The renderer floor refreshes via a new `LOGS_LEVEL_OVERRIDES_CHANGED` push channel broadcast from all three override-mutating handlers, with a stale-fetch race guard so a late-arriving initial fetch can't overwrite a more recent push.

Resolves #10773

## Changes

- `src/utils/logger.ts`: renderer-side level gate (`resolveEffectiveLevel` mirror), 16ms coalescing queue with single self-expiring timer, synchronous `warn`/`error` flush, optional-chained IPC calls for preload version skew
- `electron/ipc/channels.ts` + `shared/types/ipc/`: three new channels (`LOGS_WRITE_BATCH`, `LOGS_GET_DEFAULT_LEVEL`, `LOGS_LEVEL_OVERRIDES_CHANGED`)
- `electron/ipc/handlers/logs.ts`: `LOGS_WRITE_BATCH` handler (per-entry guard, 60-entry chunk limit), `LOGS_GET_DEFAULT_LEVEL` handler, override-change broadcast wired to all three mutators
- `electron/preload.cts`: expose `getDefaultLevel` and `onLevelOverridesChanged` on the `logs` bridge
- `electron/utils/logger.ts`: re-export `resolveEffectiveLevel` for renderer parity

## Testing

New test files: `src/utils/__tests__/logger.test.ts` and `electron/ipc/handlers/__tests__/logs.handlers.test.ts`. Coverage includes level gating, coalescing, single-timer-per-burst, 60-entry chunking, `warn`/`error` sync bypass and ordering, debug-boot default mirror, stale-fetch race, preload version skew, console fallback, batch dispatch, error serialization, malformed-entry resilience, `getDefaultLevel`, and override-change broadcast on all three mutators. 76 tests pass; changed files lint and format clean.