### PR TITLE
fix(workspace-host): relay dropped worktree lifecycle events

### DIFF
--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -1031,21 +1031,19 @@ export class WorkspaceHostProcess extends EventEmitter {
         );
         break;
 
-      // Spontaneous events - re-emit for the manager to route
+      // Spontaneous events - re-emit for the manager to route. The relay is
+      // dumb: it passes `event` through verbatim (including the `silent` flag)
+      // and lets WorkspaceHostEventRouter own routing/suppression.
+      // `worktree-activated` (router emits to the plugin bus unless silent) and
+      // `lifecycle-setup-error` (router calls notifyError) were both dropped
+      // here before #10778, so their downstream router cases never fired.
       case "worktree-update":
       case "worktree-removed":
-      // Host-originated active-worktree change. The relay is dumb — it must
-      // pass `event` through verbatim (including the `silent` flag); the
-      // WorkspaceHostEventRouter case owns suppression (`if (event.silent)`)
-      // and the plugin-bus emit. Without this case the router never sees the
-      // event and plugin consumers go deaf (#10778).
       case "worktree-activated":
       case "pr-detected":
       case "pr-cleared":
       case "issue-detected":
       case "issue-not-found":
-      // Host-originated lifecycle setup failure — routed to `notifyError` by
-      // the WorkspaceHostEventRouter case. Dropped here before #10778.
       case "lifecycle-setup-error":
       case "copytree:progress":
       case "inotify-limit-reached":

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -1058,6 +1058,16 @@ export class WorkspaceHostProcess extends EventEmitter {
         this.emit("host-event", event);
         break;
 
+      // Renderer-only event: the utility process forwards every event to this
+      // parent port, but `fetch-auth-failure-confirmed` is consumed solely via
+      // the DIRECT_RENDERER_EVENTS MessagePort fan-out (WorktreeStoreContext).
+      // There is no WorkspaceHostEventRouter case for it, so it is intentionally
+      // not relayed as `host-event`. Swallow it here so it does not trip the
+      // `default` "Unknown event" warn — that warn historically flagged a real
+      // dropped event and would cause false-alarm triage (#10778).
+      case "fetch-auth-failure-confirmed":
+        break;
+
       default:
         console.warn(
           `[WorkspaceHost:${this.serviceName}] Unknown event:`,

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -1034,10 +1034,19 @@ export class WorkspaceHostProcess extends EventEmitter {
       // Spontaneous events - re-emit for the manager to route
       case "worktree-update":
       case "worktree-removed":
+      // Host-originated active-worktree change. The relay is dumb — it must
+      // pass `event` through verbatim (including the `silent` flag); the
+      // WorkspaceHostEventRouter case owns suppression (`if (event.silent)`)
+      // and the plugin-bus emit. Without this case the router never sees the
+      // event and plugin consumers go deaf (#10778).
+      case "worktree-activated":
       case "pr-detected":
       case "pr-cleared":
       case "issue-detected":
       case "issue-not-found":
+      // Host-originated lifecycle setup failure — routed to `notifyError` by
+      // the WorkspaceHostEventRouter case. Dropped here before #10778.
+      case "lifecycle-setup-error":
       case "copytree:progress":
       case "inotify-limit-reached":
       case "emfile-limit-reached":

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -276,6 +276,110 @@ describe("WorkspaceHostProcess", () => {
 
     host.dispose();
   });
+
+  it("routes worktree-activated as host-event with payload intact (#10778)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+
+    const event = {
+      type: "worktree-activated",
+      worktreeId: "wt-1",
+      epoch: "epoch-1",
+      seq: 7,
+      silent: false,
+    };
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", event);
+
+    expect(onHostEvent).toHaveBeenCalledWith(event);
+
+    host.dispose();
+  });
+
+  it("relays worktree-activated verbatim when silent — suppression is the router's job (#10778)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+
+    const event = {
+      type: "worktree-activated",
+      worktreeId: "wt-2",
+      epoch: "epoch-2",
+      seq: 8,
+      silent: true,
+    };
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", event);
+
+    // The relay must not interpret or strip `silent`; it passes through so the
+    // WorkspaceHostEventRouter can decide suppression downstream.
+    expect(onHostEvent).toHaveBeenCalledWith(event);
+    expect(onHostEvent.mock.calls[0][0].silent).toBe(true);
+
+    host.dispose();
+  });
+
+  it("routes lifecycle-setup-error as host-event with details (#10778)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+
+    const event = {
+      type: "lifecycle-setup-error",
+      worktreeId: "wt-3",
+      message: "Setup failed",
+      details: "ENOENT: missing hook script",
+    };
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", event);
+
+    expect(onHostEvent).toHaveBeenCalledWith(event);
+
+    host.dispose();
+  });
+
+  it("routes lifecycle-setup-error as host-event with details omitted (#10778)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+
+    const event = {
+      type: "lifecycle-setup-error",
+      worktreeId: "wt-4",
+      message: "Setup failed",
+    };
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", event);
+
+    expect(onHostEvent).toHaveBeenCalledWith(event);
+
+    host.dispose();
+  });
 });
 
 // ── BrokerError contract tests ──

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -380,6 +380,30 @@ describe("WorkspaceHostProcess", () => {
 
     host.dispose();
   });
+
+  it("swallows fetch-auth-failure-confirmed — no host-event, no Unknown-event warn (#10778)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "fetch-auth-failure-confirmed", reason: "fetch" });
+
+    // Renderer-only event (delivered via DIRECT_RENDERER_EVENTS): it must not be
+    // relayed as host-event, and must not trip the default "Unknown event" warn.
+    expect(onHostEvent).not.toHaveBeenCalled();
+    const unknownWarns = warnSpy.mock.calls.filter((c) => String(c[0]).includes("Unknown event"));
+    expect(unknownWarns).toHaveLength(0);
+
+    host.dispose();
+  });
 });
 
 // ── BrokerError contract tests ──

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -87,6 +87,11 @@ const DIRECT_RENDERER_EVENTS = new Set([
   // the renderer (the get-all-states handshake only covers mount-time state).
   "topology-watcher-dark",
   "topology-watcher-recovered",
+  // Confirmed fetch-auth failure — delivered direct so the per-view
+  // `WorktreeStoreContext` listener (`fetch-auth-failure-confirmed`) fires.
+  // Renderer-only: there is no WorkspaceHostEventRouter case for this event,
+  // so the main-process relay never carries it (#10778).
+  "fetch-auth-failure-confirmed",
 ]);
 
 function sendToWorktreePorts(event: WorkspaceHostEvent): void {


### PR DESCRIPTION
## Summary

Three worktree lifecycle events were silently dropped in `WorkspaceHostProcess.processHostEvent()` before they could reach the plugin bus or per-view listeners. This fixes all three gaps with a purely additive change.

Resolves #10778

## Changes

- `worktree-activated` was missing from the spontaneous-event fallthrough in `WorkspaceHostProcess.ts`, so `WorkspaceHostEventRouter` never emitted it on the plugin bus. Plugin consumers were effectively deaf to activation events.
- `lifecycle-setup-error` was also missing from the fallthrough, so host-originated lifecycle failures never reached `notifyError`.
- `fetch-auth-failure-confirmed` was absent from `DIRECT_RENDERER_EVENTS` in `workspace-host.ts`, so per-view `WorktreeStoreContext` listeners never fired. A no-op case was also added to `WorkspaceHostProcess` so the parent-port copy no longer trips the misleading "Unknown event" warning.
- 5 regression tests added covering: relay-with-payload, silent-flag passthrough (relay must not strip `silent`), `lifecycle-setup-error` with and without details, and the renderer-only swallow path.

## Testing

45 tests pass in `electron/services/__tests__/WorkspaceHostProcess.test.ts`. ESLint and Prettier clean on changed files.