### PR TITLE
fix(git): unblock --continue operations under simple-git 3.36.0

### DIFF
--- a/electron/ipc/handlers/__tests__/git-continue.test.ts
+++ b/electron/ipc/handlers/__tests__/git-continue.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RepoState } from "../../../../shared/types/git.js";
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock }));
+
+vi.mock("../../../store.js", () => ({
+  store: { get: vi.fn().mockReturnValue({ uiFeedbackSoundEnabled: false }) },
+}));
+
+vi.mock("../../../services/SoundService.js", () => ({
+  soundService: { play: vi.fn() },
+}));
+
+vi.mock("../../../services/PreAgentSnapshotService.js", () => ({
+  preAgentSnapshotService: {
+    getSnapshot: vi.fn(),
+    listSnapshots: vi.fn(),
+    revertToSnapshot: vi.fn(),
+    deleteSnapshot: vi.fn(),
+  },
+}));
+
+const createHardenedGitMock = vi.hoisted(() => vi.fn());
+// Sentinel returned by the mocked buildContinueEnv so the test can assert the
+// handler passes its result to .env() rather than raw process.env.
+const CONTINUE_ENV_SENTINEL = { __continueEnv: true } as const;
+const buildContinueEnvMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../utils/hardenedGit.js", () => ({
+  validateCwd: vi.fn(),
+  createHardenedGit: createHardenedGitMock,
+  createAuthenticatedGit: vi.fn(),
+  buildContinueEnv: buildContinueEnvMock,
+}));
+
+const resolveGitDirMock = vi.hoisted(() => vi.fn());
+const detectRepoOperationStateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../services/git/repoOperationState.js", () => ({
+  resolveGitDir: resolveGitDirMock,
+  detectRepoOperationState: detectRepoOperationStateMock,
+}));
+
+import { registerGitWriteHandlers } from "../git-write.js";
+import { _resetRateLimitQueuesForTest } from "../../utils.js";
+
+type FakeGit = {
+  env: ReturnType<typeof vi.fn>;
+  merge: ReturnType<typeof vi.fn>;
+  rebase: ReturnType<typeof vi.fn>;
+  raw: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeGit(): FakeGit {
+  const git: FakeGit = {
+    env: vi.fn(),
+    merge: vi.fn().mockResolvedValue(undefined),
+    rebase: vi.fn().mockResolvedValue(undefined),
+    raw: vi.fn().mockResolvedValue(""),
+  };
+  // .env() is chainable in simple-git — return the same instance.
+  git.env.mockReturnValue(git);
+  return git;
+}
+
+function getHandler(channel: string) {
+  const call = ipcMainMock.handle.mock.calls.find((c: unknown[]) => c[0] === channel);
+  if (!call) throw new Error(`Handler for ${channel} not registered`);
+  return call[1] as (_e: unknown, ...args: unknown[]) => unknown;
+}
+
+const CONTINUE_CHANNEL = "git:continue-repository-operation";
+
+function setup(state: RepoState) {
+  const git = makeFakeGit();
+  createHardenedGitMock.mockReturnValue(git);
+  buildContinueEnvMock.mockReturnValue(CONTINUE_ENV_SENTINEL);
+  resolveGitDirMock.mockResolvedValue("/tmp/repo/.git");
+  detectRepoOperationStateMock.mockResolvedValue({
+    state,
+    rebaseStep: null,
+    rebaseTotalSteps: null,
+    rebaseSequence: null,
+  });
+  registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+  return { git, handler: getHandler(CONTINUE_CHANNEL) };
+}
+
+describe("git:continue-repository-operation handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetRateLimitQueuesForTest();
+  });
+
+  it("applies the hardened continue env via a single .env() call", async () => {
+    const { git, handler } = setup("REBASING");
+
+    await handler(null, "/tmp/repo");
+
+    expect(buildContinueEnvMock).toHaveBeenCalledTimes(1);
+    expect(git.env).toHaveBeenCalledTimes(1);
+    expect(git.env).toHaveBeenCalledWith(CONTINUE_ENV_SENTINEL);
+  });
+
+  it("does not pass raw process.env to .env() (no editor leak)", async () => {
+    const { git, handler } = setup("REBASING");
+
+    await handler(null, "/tmp/repo");
+
+    const envArg = git.env.mock.calls[0][0] as Record<string, unknown>;
+    expect(envArg).toBe(CONTINUE_ENV_SENTINEL);
+    expect(envArg).not.toBe(process.env);
+  });
+
+  it("continues a rebase with --continue (no --no-edit, env suppresses editor)", async () => {
+    const { git, handler } = setup("REBASING");
+
+    await handler(null, "/tmp/repo");
+
+    expect(git.rebase).toHaveBeenCalledWith(["--continue"]);
+  });
+
+  it("continues a merge with --continue --no-edit", async () => {
+    const { git, handler } = setup("MERGING");
+
+    await handler(null, "/tmp/repo");
+
+    expect(git.merge).toHaveBeenCalledWith(["--continue", "--no-edit"]);
+  });
+
+  it("continues a cherry-pick with --continue --no-edit", async () => {
+    const { git, handler } = setup("CHERRY_PICKING");
+
+    await handler(null, "/tmp/repo");
+
+    expect(git.raw).toHaveBeenCalledWith(["cherry-pick", "--continue", "--no-edit"]);
+  });
+
+  it("continues a revert with --continue --no-edit", async () => {
+    const { git, handler } = setup("REVERTING");
+
+    await handler(null, "/tmp/repo");
+
+    expect(git.raw).toHaveBeenCalledWith(["revert", "--continue", "--no-edit"]);
+  });
+
+  it("throws when no operation is in progress", async () => {
+    const { git, handler } = setup("CLEAN");
+
+    await expect(handler(null, "/tmp/repo")).rejects.toThrow(
+      /No merge, rebase, cherry-pick, or revert operation is in progress/
+    );
+    expect(git.rebase).not.toHaveBeenCalled();
+    expect(git.merge).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/__tests__/git-continue.test.ts
+++ b/electron/ipc/handlers/__tests__/git-continue.test.ts
@@ -125,12 +125,14 @@ describe("git:continue-repository-operation handler", () => {
     expect(git.rebase).toHaveBeenCalledWith(["--continue"]);
   });
 
-  it("continues a merge with --continue --no-edit", async () => {
+  it("continues a merge with bare --continue (git rejects extra args)", async () => {
     const { git, handler } = setup("MERGING");
 
     await handler(null, "/tmp/repo");
 
-    expect(git.merge).toHaveBeenCalledWith(["--continue", "--no-edit"]);
+    // `git merge --continue` errors on any extra argument ("--continue expects
+    // no arguments", exit 129); the env overlay handles editor suppression.
+    expect(git.merge).toHaveBeenCalledWith(["--continue"]);
   });
 
   it("continues a cherry-pick with --continue --no-edit", async () => {
@@ -147,6 +149,20 @@ describe("git:continue-repository-operation handler", () => {
     await handler(null, "/tmp/repo");
 
     expect(git.raw).toHaveBeenCalledWith(["revert", "--continue", "--no-edit"]);
+  });
+
+  it("propagates a rebase failure instead of swallowing it", async () => {
+    const { git, handler } = setup("REBASING");
+    git.rebase.mockRejectedValueOnce(new Error("could not apply abc123"));
+
+    await expect(handler(null, "/tmp/repo")).rejects.toThrow(/could not apply abc123/);
+  });
+
+  it("propagates a cherry-pick failure instead of swallowing it", async () => {
+    const { git, handler } = setup("CHERRY_PICKING");
+    git.raw.mockRejectedValueOnce(new Error("cherry-pick failed"));
+
+    await expect(handler(null, "/tmp/repo")).rejects.toThrow(/cherry-pick failed/);
   });
 
   it("throws when no operation is in progress", async () => {

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -4,7 +4,6 @@ import fs from "node:fs";
 import { realpath } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import type { SimpleGit } from "simple-git";
 import { CHANNELS } from "../channels.js";
 import { checkRateLimit, typedHandle, typedHandleWithContext, sendToRenderer } from "../utils.js";
 import type { HandlerDependencies, IpcContext } from "../types.js";
@@ -16,7 +15,12 @@ import type {
   RepoState,
   StagingStatus,
 } from "../../../shared/types/git.js";
-import { validateCwd, createHardenedGit, createAuthenticatedGit } from "../../utils/hardenedGit.js";
+import {
+  validateCwd,
+  createHardenedGit,
+  createAuthenticatedGit,
+  buildContinueEnv,
+} from "../../utils/hardenedGit.js";
 import { getPerFileDiffStats, invalidateStagingDiffStatCache } from "../../utils/git.js";
 import { store } from "../../store.js";
 import { getSoundService } from "../../services/getSoundService.js";
@@ -639,16 +643,6 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
   };
   handlers.push(typedHandle(CHANNELS.GIT_GET_STAGING_STATUS, handleGetStagingStatus));
 
-  const withNonInteractiveEnv = (git: SimpleGit): SimpleGit =>
-    git.env({
-      ...process.env,
-      LC_MESSAGES: "C",
-      LANGUAGE: "",
-      GIT_EDITOR: "true",
-      GIT_MERGE_AUTOEDIT: "no",
-      GIT_TERMINAL_PROMPT: "0",
-    });
-
   const handleAbortRepositoryOperation = async (cwd: string): Promise<void> => {
     checkRateLimit(CHANNELS.GIT_ABORT_REPOSITORY_OPERATION, 5, 10_000);
     validateCwd(cwd);
@@ -682,7 +676,11 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     checkRateLimit(CHANNELS.GIT_CONTINUE_REPOSITORY_OPERATION, 5, 10_000);
     validateCwd(cwd);
 
-    const git = withNonInteractiveEnv(await createHardenedGit(cwd));
+    // One .env() call only: simple-git's .env() replaces the spawn env
+    // wholesale, so re-stating the full hardened env (plus editor suppression)
+    // via buildContinueEnv is the only way to keep createHardenedGit's
+    // hardening intact on the continue path (#7058, #10786).
+    const git = (await createHardenedGit(cwd)).env(buildContinueEnv());
     const gitDir = await resolveGitDir(git, cwd);
     const { state } = await detectRepoOperationState(gitDir, false);
 

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -686,7 +686,10 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
 
     switch (state) {
       case "MERGING":
-        await git.merge(["--continue", "--no-edit"]);
+        // `git merge --continue` rejects extra args ("--continue expects no
+        // arguments", exit 129); the env overlay (GIT_MERGE_AUTOEDIT=no,
+        // GIT_EDITOR=true) suppresses the editor instead of a `--no-edit` flag.
+        await git.merge(["--continue"]);
         return;
       case "REBASING":
         // `git rebase --continue` has no `--no-edit`; the env overlay covers it.

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -22,6 +22,7 @@ import {
   createWslHardenedGit,
   getGitLocaleEnv,
   buildHardenedGitEnv,
+  buildContinueEnv,
   HARDENED_GIT_CONFIG,
   AUTHENTICATED_GIT_CONFIG,
 } from "../hardenedGit.js";
@@ -126,6 +127,7 @@ describe("createHardenedGit", () => {
       allowUnsafeSshCommand: true,
       allowUnsafeGitProxy: true,
       allowUnsafeHooksPath: true,
+      allowUnsafeEditor: true,
     });
   });
 
@@ -511,6 +513,7 @@ describe("createAuthenticatedGit", () => {
       allowUnsafeSshCommand: true,
       allowUnsafeGitProxy: true,
       allowUnsafeHooksPath: true,
+      allowUnsafeEditor: true,
     });
   });
 
@@ -856,6 +859,7 @@ describe("createWslHardenedGit", () => {
       allowUnsafeSshCommand: true,
       allowUnsafeGitProxy: true,
       allowUnsafeHooksPath: true,
+      allowUnsafeEditor: true,
     });
   });
 });
@@ -950,5 +954,60 @@ describe("buildHardenedGitEnv", () => {
   it("uses the platform arg instead of process.platform when supplied", async () => {
     const env = buildHardenedGitEnv("darwin");
     expect(env.LC_CTYPE).toBe("en_US.UTF-8");
+  });
+});
+
+describe("buildContinueEnv", () => {
+  const saved = {
+    EDITOR: process.env.EDITOR,
+    GIT_EDITOR: process.env.GIT_EDITOR,
+    GIT_MERGE_AUTOEDIT: process.env.GIT_MERGE_AUTOEDIT,
+  };
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it("suppresses the editor so continue operations run non-interactively", async () => {
+    const env = buildContinueEnv("linux");
+    expect(env.GIT_EDITOR).toBe("true");
+    expect(env.GIT_MERGE_AUTOEDIT).toBe("no");
+  });
+
+  it("preserves the hardening vars from buildHardenedGitEnv", async () => {
+    const env = buildContinueEnv("linux");
+    expect(env).toEqual(
+      expect.objectContaining({
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_OPTIONAL_LOCKS: "0",
+        GCM_INTERACTIVE: "Never",
+        GIT_ASKPASS: "true",
+        LC_ALL: "",
+        LC_MESSAGES: "C",
+      })
+    );
+  });
+
+  it("strips an inherited EDITOR instead of leaking it into the spawn env", async () => {
+    process.env.EDITOR = "vim";
+    const env = buildContinueEnv("linux");
+    expect(env.EDITOR).toBeUndefined();
+    // The intentional non-interactive value still wins.
+    expect(env.GIT_EDITOR).toBe("true");
+  });
+
+  it("overrides an inherited GIT_EDITOR with the non-interactive value", async () => {
+    process.env.GIT_EDITOR = "code --wait";
+    const env = buildContinueEnv("linux");
+    expect(env.GIT_EDITOR).toBe("true");
+  });
+
+  it("overrides an inherited GIT_MERGE_AUTOEDIT with 'no'", async () => {
+    process.env.GIT_MERGE_AUTOEDIT = "yes";
+    const env = buildContinueEnv("linux");
+    expect(env.GIT_MERGE_AUTOEDIT).toBe("no");
   });
 });

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -1010,4 +1010,31 @@ describe("buildContinueEnv", () => {
     const env = buildContinueEnv("linux");
     expect(env.GIT_MERGE_AUTOEDIT).toBe("no");
   });
+
+  it("strips every blocked inherited key the editor path could ride in on", async () => {
+    const blocked = {
+      GIT_SEQUENCE_EDITOR: "code --wait",
+      GIT_CONFIG_GLOBAL: "/tmp/evil/.gitconfig",
+      GIT_EXTERNAL_DIFF: "/tmp/evil/diff",
+      PAGER: "less",
+      SSH_ASKPASS: "/tmp/evil/askpass",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.editor",
+      GIT_CONFIG_VALUE_0: "/tmp/evil/editor",
+    };
+    Object.assign(process.env, blocked);
+    const env = buildContinueEnv("linux");
+    for (const key of Object.keys(blocked)) {
+      expect(env[key]).toBeUndefined();
+    }
+    // Cleanup beyond the describe-level saved keys.
+    for (const key of Object.keys(blocked)) delete process.env[key];
+  });
+
+  it("does not set GIT_ASKPASS on win32 but still suppresses the editor", async () => {
+    const env = buildContinueEnv("win32");
+    expect(env.GIT_ASKPASS).toBeUndefined();
+    expect(env.GIT_EDITOR).toBe("true");
+    expect(env.GIT_MERGE_AUTOEDIT).toBe("no");
+  });
 });

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -57,6 +57,12 @@ const UNSAFE_FLAGS = {
   allowUnsafeSshCommand: true,
   allowUnsafeGitProxy: true,
   allowUnsafeHooksPath: true,
+  // simple-git 3.36.0 scans the spawn env and rejects any EDITOR / GIT_EDITOR /
+  // GIT_SEQUENCE_EDITOR key unless this flag is set, even when the value is the
+  // non-interactive `true` we set ourselves to suppress the editor on
+  // `git rebase --continue` (see buildContinueEnv). The scanner fires on the
+  // presence of the key, not its origin, so the flag is required.
+  allowUnsafeEditor: true,
 } as const;
 
 const BLOCKED_INHERITED_GIT_ENV_KEYS = new Set([
@@ -69,6 +75,9 @@ const BLOCKED_INHERITED_GIT_ENV_KEYS = new Set([
   "GIT_EDITOR",
   "GIT_EXEC_PATH",
   "GIT_EXTERNAL_DIFF",
+  // Inherited GIT_MERGE_AUTOEDIT=yes would re-open the editor on
+  // `git merge --continue`; strip it so buildContinueEnv's explicit "no" wins.
+  "GIT_MERGE_AUTOEDIT",
   "GIT_PAGER",
   "GIT_PROXY_COMMAND",
   "GIT_SEQUENCE_EDITOR",
@@ -156,6 +165,28 @@ export function buildHardenedGitEnv(
     // dialogs in background processes where no user can interact. No effect
     // on POSIX or on local read operations.
     GCM_INTERACTIVE: "Never",
+  };
+}
+
+/**
+ * Hardened env for continue-style operations (`git rebase/merge/cherry-pick/
+ * revert --continue`). Builds on `buildHardenedGitEnv` and adds the editor
+ * suppression those commands need to run non-interactively — `git rebase
+ * --continue` has no `--no-edit` flag, so `GIT_EDITOR=true` is the only way to
+ * keep it from spawning an editor in the Electron main process.
+ *
+ * Returns a single env object meant to be passed in one `.env()` call:
+ * simple-git's `.env()` replaces the spawn env wholesale, so layering a second
+ * `.env()` over `createHardenedGit` would silently drop all the hardening above
+ * (issue #7058). Set the editor keys AFTER the spread — `buildHardenedGitEnv`
+ * strips inherited `GIT_EDITOR`/`EDITOR` via the block list, and we re-add the
+ * intentional non-interactive value here.
+ */
+export function buildContinueEnv(platform: NodeJS.Platform = process.platform): NodeJS.ProcessEnv {
+  return {
+    ...buildHardenedGitEnv(platform),
+    GIT_EDITOR: "true",
+    GIT_MERGE_AUTOEDIT: "no",
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,7 +158,7 @@
         "safe-regex2": "^5.1.0",
         "semver": "^7.7.3",
         "shell-env": "^4.0.3",
-        "simple-git": "^3.33.0",
+        "simple-git": "3.36.0",
         "stopword": "^3.1.5",
         "stubborn-fs": "^2.0.0",
         "tailwind-merge": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "safe-regex2": "^5.1.0",
     "semver": "^7.7.3",
     "shell-env": "^4.0.3",
-    "simple-git": "^3.33.0",
+    "simple-git": "3.36.0",
     "stopword": "^3.1.5",
     "stubborn-fs": "^2.0.0",
     "tailwind-merge": "^3.4.0",


### PR DESCRIPTION
## Summary

- simple-git 3.36.0 added an env scanner in `@simple-git/argv-parser` that rejects any spawn-env key normalizing to `EDITOR`, `GIT_EDITOR`, or `GIT_SEQUENCE_EDITOR` unless the instance is constructed with `unsafe.allowUnsafeEditor:true`. The continue path was setting `GIT_EDITOR:true` to suppress the editor prompt, which tripped the guard with `Use of EDITOR is not permitted without enabling allowUnsafeEditor`, breaking `git rebase --continue` and all other `--continue` operations.
- The old `withNonInteractiveEnv` helper spread raw `process.env` (leaking the user's `EDITOR` variable into the child process) and its second `.env()` call silently dropped all of `createHardenedGit`'s hardening (the #7058 trap). Replaced it with a single `buildContinueEnv()` that re-states the full hardened env plus `GIT_EDITOR=true` and `GIT_MERGE_AUTOEDIT=no`.
- Caught a pre-existing bug at the same time: `git merge --continue --no-edit` fails with `--continue expects no arguments` (exit 129) on real git 2.54.0. Now uses bare `--continue` and relies on the env to suppress the editor.

Resolves #10786

## Changes

- `electron/utils/hardenedGit.ts`: adds `allowUnsafeEditor:true` to `UNSAFE_FLAGS`; adds `buildContinueEnv()` replacing `withNonInteractiveEnv`; blocks inherited `GIT_MERGE_AUTOEDIT`
- `electron/ipc/handlers/git-write.ts`: switches continue operations to `buildContinueEnv()`, drops `--no-edit` from `merge --continue`
- `package.json` / `package-lock.json`: pins `simple-git` to `3.36.0` exact
- `electron/ipc/handlers/__tests__/git-continue.test.ts`: new suite covering all 4 op states, default throw, single `.env()` call assertion, and error propagation
- `electron/utils/__tests__/hardenedGit.test.ts`: new `buildContinueEnv` unit coverage (editor suppression, hardening preserved, blocked-key stripping, win32 `GIT_ASKPASS` omission)

## Testing

126 targeted tests pass across the new git-continue handler suite and `buildContinueEnv` unit tests. Verified `git merge --continue --no-edit` exit 129 against real git 2.54.0.