### PR TITLE
fix(pty): silence spurious stack trace for disposed non-preserved terminals

### DIFF
--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -266,8 +266,17 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
       expect(terminal.getInfo().headlessTerminal).toBeUndefined();
     });
     expect(terminal.getInfo().preservedSnapshot).toBeUndefined();
-    expect(terminal.getSerializedState()).toBeNull();
-    await expect(terminal.getSerializedStateAsync()).resolves.toBeNull();
+
+    // Serializing a disposed non-preserved terminal must return null silently —
+    // not throw, get caught, and log a spurious "Failed to serialize" error.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(terminal.getSerializedState()).toBeNull();
+      await expect(terminal.getSerializedStateAsync()).resolves.toBeNull();
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 
   it("keeps the live headless terminal when serialization fails", async () => {

--- a/electron/services/pty/__tests__/terminalSerialization.test.ts
+++ b/electron/services/pty/__tests__/terminalSerialization.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { serializeTerminal, serializeTerminalAsync } from "../terminalSerialization.js";
+import { disposeTerminalSerializerService } from "../TerminalSerializerService.js";
+import type { TerminalInfo } from "../types.js";
+
+type AddonStub = { serialize: ReturnType<typeof vi.fn> };
+
+function makeTerminalInfo(overrides: Partial<TerminalInfo>): TerminalInfo {
+  return overrides as unknown as TerminalInfo;
+}
+
+function makeAddon(impl: () => string = () => "snapshot"): AddonStub {
+  return { serialize: vi.fn(impl) };
+}
+
+describe("terminalSerialization guards", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+    disposeTerminalSerializerService();
+  });
+
+  it("serializeTerminal returns null without logging when the addon is gone", () => {
+    const info = makeTerminalInfo({ serializeAddon: undefined, preservedSnapshot: undefined });
+    expect(serializeTerminal("t1", info)).toBeNull();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("serializeTerminalAsync returns null without logging when the headless terminal is gone", async () => {
+    const info = makeTerminalInfo({
+      headlessTerminal: undefined,
+      serializeAddon: undefined,
+      preservedSnapshot: undefined,
+    });
+    await expect(serializeTerminalAsync("t1", info)).resolves.toBeNull();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it("serializeTerminalAsync still logs genuine serialize failures on a live terminal", async () => {
+    const addon = makeAddon(() => {
+      throw new Error("serialize boom");
+    });
+    const info = makeTerminalInfo({
+      headlessTerminal: { buffer: { active: { length: 10 } } } as unknown as TerminalInfo["headlessTerminal"],
+      serializeAddon: addon as unknown as TerminalInfo["serializeAddon"],
+      preservedSnapshot: undefined,
+    });
+    await expect(serializeTerminalAsync("t1", info)).resolves.toBeNull();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializeTerminalAsync yields null without logging when disposal clears the addon mid-flight", async () => {
+    const addon = makeAddon();
+    // Large buffer forces the async (deferred) serialize path.
+    const info = makeTerminalInfo({
+      headlessTerminal: {
+        buffer: { active: { length: 2000 } },
+      } as unknown as TerminalInfo["headlessTerminal"],
+      serializeAddon: addon as unknown as TerminalInfo["serializeAddon"],
+      preservedSnapshot: undefined,
+    });
+
+    const pending = serializeTerminalAsync("t1", info);
+    // Simulate disposeHeadless() running before the deferred callback fires.
+    info.serializeAddon = undefined;
+    info.headlessTerminal = undefined;
+
+    await expect(pending).resolves.toBeNull();
+    expect(addon.serialize).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/pty/__tests__/terminalSerialization.test.ts
+++ b/electron/services/pty/__tests__/terminalSerialization.test.ts
@@ -46,7 +46,9 @@ describe("terminalSerialization guards", () => {
       throw new Error("serialize boom");
     });
     const info = makeTerminalInfo({
-      headlessTerminal: { buffer: { active: { length: 10 } } } as unknown as TerminalInfo["headlessTerminal"],
+      headlessTerminal: {
+        buffer: { active: { length: 10 } },
+      } as unknown as TerminalInfo["headlessTerminal"],
       serializeAddon: addon as unknown as TerminalInfo["serializeAddon"],
       preservedSnapshot: undefined,
     });

--- a/electron/services/pty/terminalSerialization.ts
+++ b/electron/services/pty/terminalSerialization.ts
@@ -38,7 +38,12 @@ export async function serializeTerminalAsync(
     const serializerService = getTerminalSerializerService();
 
     if (serializerService.shouldUseAsync(lineCount)) {
-      return await serializerService.serializeAsync(id, () => addon.serialize());
+      // The serialize callback runs on a later tick; disposeHeadless() may clear
+      // the addon in between. Re-check identity so a disposed terminal yields
+      // null instead of throwing (which would re-log a spurious failure).
+      return await serializerService.serializeAsync(id, () =>
+        terminalInfo.serializeAddon === addon ? addon.serialize() : null
+      );
     }
 
     return addon.serialize();

--- a/electron/services/pty/terminalSerialization.ts
+++ b/electron/services/pty/terminalSerialization.ts
@@ -8,8 +8,12 @@ export function serializeTerminal(id: string, terminalInfo: TerminalInfo): strin
   if (terminalInfo.preservedSnapshot !== undefined) {
     return terminalInfo.preservedSnapshot;
   }
+  // Non-preserved disposed terminal — disposeHeadless() clears the addon. No
+  // snapshot to produce; return null without logging a spurious error.
+  const addon = terminalInfo.serializeAddon;
+  if (!addon) return null;
   try {
-    return terminalInfo.serializeAddon!.serialize();
+    return addon.serialize();
   } catch (error) {
     console.error(`[TerminalProcess] Failed to serialize terminal ${id}:`, error);
     return null;
@@ -23,17 +27,21 @@ export async function serializeTerminalAsync(
   if (terminalInfo.preservedSnapshot !== undefined) {
     return terminalInfo.preservedSnapshot;
   }
+  // Non-preserved disposed terminal — disposeHeadless() clears both fields
+  // together. No snapshot to produce; return null without logging a spurious
+  // error. Snap to locals so the guard and every dereference stay consistent.
+  const headless = terminalInfo.headlessTerminal;
+  const addon = terminalInfo.serializeAddon;
+  if (!headless || !addon) return null;
   try {
-    const lineCount = terminalInfo.headlessTerminal!.buffer.active.length;
+    const lineCount = headless.buffer.active.length;
     const serializerService = getTerminalSerializerService();
 
     if (serializerService.shouldUseAsync(lineCount)) {
-      return await serializerService.serializeAsync(id, () =>
-        terminalInfo.serializeAddon!.serialize()
-      );
+      return await serializerService.serializeAsync(id, () => addon.serialize());
     }
 
-    return terminalInfo.serializeAddon!.serialize();
+    return addon.serialize();
   } catch (error) {
     console.error(`[TerminalProcess] Failed to serialize terminal ${id}:`, error);
     return null;


### PR DESCRIPTION
## Summary

- `serializeTerminal()` and `serializeTerminalAsync()` in `terminalSerialization.ts` had no null guard for disposed non-preserved terminals. When `headlessTerminal`/`serializeAddon` were cleared by `disposeHeadless()`, the missing guard caused a caught `TypeError` that logged `[TerminalProcess] Failed to serialize terminal` with a full stack trace, even though returning `null` is the correct expected result for this state.
- Added null guards matching the existing pattern in `serializeForPersistence()`, so disposed non-preserved terminals return `null` silently.
- Closed a residual async race: the deferred `serializeAsync` callback now re-checks `serializeAddon` identity, so a terminal disposed between scheduling and execution also returns `null` without re-logging under `[TerminalSerializerService]`.

Resolves #10785

## Changes

- `electron/services/pty/terminalSerialization.ts`: null guards in `serializeTerminal()` and `serializeTerminalAsync()`, plus identity re-check in the deferred callback
- `electron/services/pty/__tests__/terminalSerialization.test.ts`: new unit tests covering both guards and the mid-flight disposal race (live serialize failure still logs as expected)
- `electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts`: extended the existing non-preserved-exit test with a `console.error` spy asserting no spurious log on `getSerializedStateAsync()`

## Testing

23 targeted unit tests pass. Prettier and ESLint clean on all changed files.