### PR TITLE
fix(pty): gate invalid Windows ConPTY pid 0 from ProcessDetector (#10787)

### DIFF
--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -22,6 +22,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     submit: vi.fn(),
     resize: vi.fn(),
     spawn: vi.fn(),
+    startProcessDetectorForTerminal: vi.fn(),
     kill: vi.fn(),
     trash: vi.fn(),
     restore: vi.fn(),
@@ -134,6 +135,37 @@ describe("lifecycle kill handlers — trackKilledPid", () => {
     expect(ctx.resourceGovernor.trackKilledPid).not.toHaveBeenCalled();
   });
 
+  it("kill does not track when PID is 0 (Windows ConPTY transient, #10787)", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo(0));
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "kill", id: "t1", reason: "test" });
+
+    expect(ctx.ptyManager.kill).toHaveBeenCalledWith("t1", "test");
+    expect(ctx.resourceGovernor.trackKilledPid).not.toHaveBeenCalled();
+  });
+
+  it("kill-by-project skips PID 0 and undefined, tracks only valid PIDs (#10787)", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue([
+      "t1",
+      "t2",
+      "t3",
+    ]);
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(termInfo(0)) // transient ConPTY PID
+      .mockReturnValueOnce(termInfo(500))
+      .mockReturnValueOnce(termInfo()); // no PID
+    (ctx.ptyManager.killByProject as ReturnType<typeof vi.fn>).mockReturnValue(3);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "kill-by-project", projectId: "proj-1", requestId: "r1" });
+
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledTimes(1);
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(500);
+  });
+
   it("kill-by-project tracks all PIDs", () => {
     const ctx = makeCtx();
     (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue([
@@ -243,5 +275,96 @@ describe("lifecycle kill handlers — trackKilledPid", () => {
     await dispatch({ type: "graceful-kill-by-project", projectId: "empty", requestId: "r1" });
 
     expect(ctx.resourceGovernor.trackKilledPid).not.toHaveBeenCalled();
+  });
+});
+
+describe("lifecycle spawn — terminal-pid gating and deferred retry (#10787)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function getMock(ctx: HostContext) {
+    return ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>;
+  }
+
+  it("emits terminal-pid immediately when the PID is valid (no retry)", () => {
+    const ctx = makeCtx();
+    getMock(ctx).mockReturnValue(termInfo(1234));
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+
+    expect(ctx.sendEvent).toHaveBeenCalledWith({ type: "terminal-pid", id: "t1", pid: 1234 });
+    // Detector is started by the spawn path itself, not the deferred retry.
+    expect(ctx.ptyManager.startProcessDetectorForTerminal).not.toHaveBeenCalled();
+  });
+
+  it("does not emit terminal-pid with a transient 0 PID; defers instead", () => {
+    const ctx = makeCtx();
+    getMock(ctx).mockReturnValue(termInfo(0));
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+
+    expect(ctx.sendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "terminal-pid" })
+    );
+  });
+
+  it("recovers the real PID via deferred retry, then emits and starts detection", async () => {
+    vi.useFakeTimers();
+    const ctx = makeCtx();
+    getMock(ctx)
+      .mockReturnValueOnce(termInfo(0)) // synchronous spawn read
+      .mockReturnValueOnce(termInfo(0)) // retry attempt 0 — still resolving
+      .mockReturnValue(termInfo(4321)); // retry attempt 1 — ConPTY resolved
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+    await vi.runAllTimersAsync();
+
+    expect(ctx.sendEvent).toHaveBeenCalledWith({ type: "terminal-pid", id: "t1", pid: 4321 });
+    expect(ctx.ptyManager.startProcessDetectorForTerminal).toHaveBeenCalledTimes(1);
+    expect(ctx.ptyManager.startProcessDetectorForTerminal).toHaveBeenCalledWith("t1");
+  });
+
+  it("abandons the retry if the terminal disappears before the PID resolves", async () => {
+    vi.useFakeTimers();
+    const ctx = makeCtx();
+    getMock(ctx)
+      .mockReturnValueOnce(termInfo(0)) // synchronous spawn read
+      .mockReturnValue(undefined); // killed/trashed before retry fires
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+    await vi.runAllTimersAsync();
+
+    expect(ctx.sendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "terminal-pid" })
+    );
+    expect(ctx.ptyManager.startProcessDetectorForTerminal).not.toHaveBeenCalled();
+  });
+
+  it("gives up after the retry cap when the PID never resolves", async () => {
+    vi.useFakeTimers();
+    const ctx = makeCtx();
+    getMock(ctx).mockReturnValue(termInfo(0)); // never resolves
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+    await vi.runAllTimersAsync();
+
+    expect(ctx.sendEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "terminal-pid" })
+    );
+    expect(ctx.ptyManager.startProcessDetectorForTerminal).not.toHaveBeenCalled();
+    // Bounded: spawn read + at most PID_RETRY_MAX_ATTEMPTS (20) polls.
+    expect(getMock(ctx).mock.calls.length).toBeLessThanOrEqual(21);
   });
 });

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -332,6 +332,11 @@ describe("lifecycle spawn — terminal-pid gating and deferred retry (#10787)", 
     expect(ctx.sendEvent).toHaveBeenCalledWith({ type: "terminal-pid", id: "t1", pid: 4321 });
     expect(ctx.ptyManager.startProcessDetectorForTerminal).toHaveBeenCalledTimes(1);
     expect(ctx.ptyManager.startProcessDetectorForTerminal).toHaveBeenCalledWith("t1");
+    // The transient 0 must never have been emitted at any point.
+    const pidEvents = (ctx.sendEvent as ReturnType<typeof vi.fn>).mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.type === "terminal-pid");
+    expect(pidEvents).toEqual([{ type: "terminal-pid", id: "t1", pid: 4321 }]);
   });
 
   it("abandons the retry if the terminal disappears before the PID resolves", async () => {

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -3,6 +3,17 @@ import type { AgentEvent } from "../../services/AgentStateMachine.js";
 import type { SpawnResult } from "../../../shared/types/pty-host.js";
 import type { HandlerMap, HostContext } from "./types.js";
 
+/** A PTY PID is usable only once it is a positive integer. */
+function isValidPid(pid: number | undefined): pid is number {
+  return typeof pid === "number" && Number.isInteger(pid) && pid > 0;
+}
+
+// On Windows, node-pty reports `pid: 0` during the brief window before the
+// ConPTY `connect()` resolves, and never emits a follow-up event when the real
+// PID lands. We poll the live PTY object across event-loop turns to recover the
+// PID, capped so a terminal that never resolves can't poll forever.
+const PID_RETRY_MAX_ATTEMPTS = 20;
+
 export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
   const {
     ptyManager,
@@ -11,6 +22,25 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
     sendEvent,
     getOrCreatePauseCoordinator,
   } = ctx;
+
+  // Poll the live PTY object across event-loop turns for a terminal that
+  // spawned with an invalid PID (Windows ConPTY). Once a positive PID lands,
+  // emit `terminal-pid` and start the process detector. Stops if the terminal
+  // disappears (killed/trashed) before the PID resolves, or after the cap.
+  function schedulePidRetry(id: string, attempt = 0): void {
+    if (attempt >= PID_RETRY_MAX_ATTEMPTS) return;
+    setImmediate(() => {
+      const terminalInfo = ptyManager.getTerminal(id);
+      if (!terminalInfo) return; // terminal gone — abandon the retry
+      const pid = terminalInfo.ptyProcess?.pid;
+      if (isValidPid(pid)) {
+        sendEvent({ type: "terminal-pid", id, pid });
+        ptyManager.startProcessDetectorForTerminal(id);
+        return;
+      }
+      schedulePidRetry(id, attempt + 1);
+    });
+  }
 
   return {
     spawn: (msg) => {
@@ -31,8 +61,12 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
 
         const terminalInfo = ptyManager.getTerminal(msg.id);
         const pid = terminalInfo?.ptyProcess?.pid;
-        if (pid !== undefined) {
+        if (isValidPid(pid)) {
           sendEvent({ type: "terminal-pid", id: msg.id, pid });
+        } else {
+          // Windows ConPTY: retry until the real PID resolves, then emit the
+          // event and start monitoring (no node-pty event fires on its own).
+          schedulePidRetry(msg.id);
         }
       } catch (error) {
         console.error(`[PtyHost] Spawn failed for terminal ${msg.id}:`, error);
@@ -54,7 +88,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
       } else {
         ptyManager.kill(msg.id, msg.reason);
       }
-      if (killedPid !== undefined) {
+      if (isValidPid(killedPid)) {
         resourceGovernor.trackKilledPid(killedPid);
       }
     },
@@ -72,7 +106,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
       const pids: number[] = [];
       for (const id of terminalIds) {
         const pid = ptyManager.getTerminal(id)?.ptyProcess.pid;
-        if (pid !== undefined) pids.push(pid);
+        if (isValidPid(pid)) pids.push(pid);
       }
       const killed = ptyManager.killByProject(msg.projectId);
       for (const pid of pids) {
@@ -84,7 +118,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
     "graceful-kill": async (msg) => {
       const killedPid = ptyManager.getTerminal(msg.id)?.ptyProcess.pid;
       const agentSessionId = await ptyManager.gracefulKill(msg.id);
-      if (killedPid !== undefined) {
+      if (isValidPid(killedPid)) {
         resourceGovernor.trackKilledPid(killedPid);
       }
       sendEvent({
@@ -100,7 +134,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
       const pids: number[] = [];
       for (const id of terminalIds) {
         const pid = ptyManager.getTerminal(id)?.ptyProcess.pid;
-        if (pid !== undefined) pids.push(pid);
+        if (isValidPid(pid)) pids.push(pid);
       }
       const results = await ptyManager.gracefulKillByProject(msg.projectId, {
         preserveSession: msg.preserveSession,

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -899,6 +899,17 @@ export class PtyManager extends EventEmitter {
   }
 
   /**
+   * Start the process detector for a single terminal.
+   * Used by the pty-host deferred-PID retry: on Windows, node-pty reports
+   * `pid: 0` during the ConPTY connect() window, so detection is skipped at
+   * spawn time and re-triggered here once a real PID resolves. Idempotent —
+   * `startProcessDetector()` no-ops if a detector already exists.
+   */
+  startProcessDetectorForTerminal(id: string): void {
+    this.registry.get(id)?.startProcessDetector();
+  }
+
+  /**
    * Set activity monitoring tier (active vs background).
    */
   setActivityMonitorTier(

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -242,6 +242,12 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       return true;
 
     case "terminal-pid":
+      // Defense-in-depth: the pty-host already gates invalid PIDs, but the
+      // router must never store a non-positive PID (Windows ConPTY `pid: 0`).
+      if (!Number.isInteger(event.pid) || event.pid <= 0) {
+        deps.logWarn(`[PtyClient] Ignoring invalid terminal-pid for ${event.id}: ${event.pid}`);
+        return true;
+      }
       state.terminalPids.set(event.id, event.pid);
       if (callbacks.onTerminalPid) {
         try {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -476,7 +476,11 @@ export class TerminalProcess {
     this.setupPtyHandlers(ptyProcess, dataHandoff);
 
     const ptyPid = ptyProcess.pid;
-    if (ptyPid !== undefined && deps.processTreeCache) {
+    // A PTY PID is usable only once positive — Windows ConPTY reports `pid: 0`
+    // during connect(). Skipping construction here avoids spawning a
+    // ProcessDetector that would spam "Invalid PTY PID" on every refresh tick;
+    // the pty-host re-triggers detection once the real PID resolves.
+    if (Number.isInteger(ptyPid) && ptyPid > 0 && deps.processTreeCache) {
       this.processDetector = new ProcessDetector(
         id,
         spawnedAt,
@@ -1467,7 +1471,12 @@ export class TerminalProcess {
 
   startProcessDetector(): void {
     const ptyPid = this.terminalInfo.ptyProcess.pid;
-    if (ptyPid !== undefined && !this.processDetector && this.deps.processTreeCache) {
+    if (
+      Number.isInteger(ptyPid) &&
+      ptyPid > 0 &&
+      !this.processDetector &&
+      this.deps.processTreeCache
+    ) {
       this.processDetector = new ProcessDetector(
         this.id,
         this.terminalInfo.spawnedAt,

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1398,7 +1398,7 @@ export class TerminalProcess {
 
   private getPtyDescendantCount(): number | undefined {
     const ptyPid = this.terminalInfo.ptyProcess.pid;
-    if (ptyPid === undefined || !this.deps.processTreeCache) {
+    if (!Number.isInteger(ptyPid) || ptyPid <= 0 || !this.deps.processTreeCache) {
       return undefined;
     }
     return this.deps.processTreeCache.getDescendantPids(ptyPid).length;

--- a/electron/services/pty/TerminalRegistry.ts
+++ b/electron/services/pty/TerminalRegistry.ts
@@ -171,7 +171,9 @@ export class TerminalRegistry {
 
     const processIds = projectTerminals
       .map((t) => t.getPtyProcess().pid)
-      .filter((pid): pid is number => pid !== undefined);
+      // Exclude the transient Windows ConPTY `pid: 0` (#10787) so it never
+      // leaks into project stats consumers.
+      .filter((pid): pid is number => Number.isInteger(pid) && pid > 0);
 
     const terminalTypes = projectTerminals.reduce(
       (acc, t) => {

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -295,6 +295,30 @@ describe("routeHostEvent", () => {
     expect(state.terminalPids.get("t1")).toBe(12345);
   });
 
+  it("ignores a non-positive terminal-pid without storing or notifying (#10787)", () => {
+    const logWarn = vi.fn();
+    const { deps, state, callbacks } = makeDeps({ logWarn });
+
+    for (const pid of [0, -1]) {
+      const handled = routeHostEvent({ type: "terminal-pid", id: "t1", pid }, deps);
+      expect(handled).toBe(true);
+    }
+
+    expect(state.terminalPids.has("t1")).toBe(false);
+    expect(callbacks.terminalPidCalls).toEqual([]);
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("invalid terminal-pid"));
+  });
+
+  it("stores a valid terminal-pid arriving after a prior invalid one (#10787)", () => {
+    const { deps, state, callbacks } = makeDeps();
+
+    routeHostEvent({ type: "terminal-pid", id: "t1", pid: 0 }, deps);
+    routeHostEvent({ type: "terminal-pid", id: "t1", pid: 777 }, deps);
+
+    expect(state.terminalPids.get("t1")).toBe(777);
+    expect(callbacks.terminalPidCalls).toEqual([{ id: "t1", pid: 777 }]);
+  });
+
   it("invokes onTerminalPid with id and pid after updating the state map (#7526)", () => {
     const { deps, state, callbacks } = makeDeps();
     routeHostEvent({ type: "terminal-pid", id: "t1", pid: 4242 }, deps);

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -319,6 +319,18 @@ describe("routeHostEvent", () => {
     expect(callbacks.terminalPidCalls).toEqual([{ id: "t1", pid: 777 }]);
   });
 
+  it("retains a stored valid PID when later invalid events arrive (#10787)", () => {
+    const { deps, state, callbacks } = makeDeps();
+
+    routeHostEvent({ type: "terminal-pid", id: "t1", pid: 555 }, deps);
+    for (const pid of [0, -1, NaN, Infinity]) {
+      routeHostEvent({ type: "terminal-pid", id: "t1", pid }, deps);
+    }
+
+    expect(state.terminalPids.get("t1")).toBe(555);
+    expect(callbacks.terminalPidCalls).toEqual([{ id: "t1", pid: 555 }]);
+  });
+
   it("invokes onTerminalPid with id and pid after updating the state map (#7526)", () => {
     const { deps, state, callbacks } = makeDeps();
     routeHostEvent({ type: "terminal-pid", id: "t1", pid: 4242 }, deps);

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -236,7 +236,10 @@ function createPlainTerminalWithCommand(
   );
 }
 
-function createPlainTerminalWithPid(pid: number, deps?: Partial<TerminalProcessDeps>): TerminalProcess {
+function createPlainTerminalWithPid(
+  pid: number,
+  deps?: Partial<TerminalProcessDeps>
+): TerminalProcess {
   const options: TerminalProcessOptions = {
     cwd: process.cwd(),
     cols: 80,

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -236,6 +236,46 @@ function createPlainTerminalWithCommand(
   );
 }
 
+function createPlainTerminalWithPid(pid: number, deps?: Partial<TerminalProcessDeps>): TerminalProcess {
+  const options: TerminalProcessOptions = {
+    cwd: process.cwd(),
+    cols: 80,
+    rows: 24,
+    kind: "terminal",
+  } as TerminalProcessOptions;
+  const ctx: SpawnContext = {
+    shell: "/bin/zsh",
+    args: ["-l"],
+    env: {},
+  };
+  const mockPty = createMockPty();
+  (mockPty as { pid: number }).pid = pid;
+  return installNullForegroundSnapshot(
+    new TerminalProcess(
+      `t-pid-${pid}`,
+      options,
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: {
+          handleActivityState: () => {},
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: () => {},
+        } as unknown as TerminalProcessDeps["agentStateService"],
+        ptyPool: null,
+        processTreeCache: createMockProcessTreeCache(),
+        ...deps,
+      } as TerminalProcessDeps,
+      ctx,
+      mockPty
+    )
+  );
+}
+
+function getProcessDetector(terminal: TerminalProcess): unknown {
+  return terminal.getInfo().processDetector;
+}
+
 function getScrollback(terminal: TerminalProcess): number {
   return (terminal as unknown as { _scrollback: number })._scrollback;
 }
@@ -1393,6 +1433,51 @@ describe("TerminalProcess.handleAgentDetection — unknown/ambiguous hold state 
         getSpawnedAt(terminal)
       );
       expect(terminal.getInfo().detectedAgentId).toBe("claude");
+    } finally {
+      terminal.dispose();
+    }
+  });
+});
+
+describe("TerminalProcess — invalid PTY PID gating (#10787)", () => {
+  it("does not construct a ProcessDetector when the PID is 0 (Windows ConPTY transient)", () => {
+    const terminal = createPlainTerminalWithPid(0);
+    try {
+      expect(getProcessDetector(terminal)).toBeUndefined();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("does not construct a ProcessDetector when the PID is negative", () => {
+    const terminal = createPlainTerminalWithPid(-1);
+    try {
+      expect(getProcessDetector(terminal)).toBeUndefined();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("constructs a ProcessDetector for a valid positive PID", () => {
+    const terminal = createPlainTerminalWithPid(4321);
+    try {
+      expect(getProcessDetector(terminal)).toBeDefined();
+    } finally {
+      terminal.dispose();
+    }
+  });
+
+  it("startProcessDetector() stays a no-op while the PID is 0, then starts once it resolves", () => {
+    const terminal = createPlainTerminalWithPid(0);
+    try {
+      const pty = getMockPty(terminal);
+      (terminal as unknown as { startProcessDetector: () => void }).startProcessDetector();
+      expect(getProcessDetector(terminal)).toBeUndefined();
+
+      // Simulate ConPTY resolving the real PID, then re-trigger detection.
+      (pty as { pid: number }).pid = 9876;
+      (terminal as unknown as { startProcessDetector: () => void }).startProcessDetector();
+      expect(getProcessDetector(terminal)).toBeDefined();
     } finally {
       terminal.dispose();
     }

--- a/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
+++ b/electron/services/pty/__tests__/terminalActivityPatterns.test.ts
@@ -39,6 +39,18 @@ describe("createProcessStateValidator", () => {
     expect(createProcessStateValidator(1, null)).toBeUndefined();
   });
 
+  it("returns undefined for a non-positive PID (Windows ConPTY transient, #10787)", () => {
+    const cache = createMockProcessTreeCache(new Map());
+    expect(createProcessStateValidator(0, cache)).toBeUndefined();
+    expect(createProcessStateValidator(-1, cache)).toBeUndefined();
+  });
+
+  it("returns undefined for a non-integer PID (#10787)", () => {
+    const cache = createMockProcessTreeCache(new Map());
+    expect(createProcessStateValidator(NaN, cache)).toBeUndefined();
+    expect(createProcessStateValidator(12.5, cache)).toBeUndefined();
+  });
+
   it("returns true when descendant CPU activity is present", () => {
     const cache = createMockProcessTreeCache(new Map(), true);
     const validator = createProcessStateValidator(42, cache)!;

--- a/electron/services/pty/terminalActivityPatterns.ts
+++ b/electron/services/pty/terminalActivityPatterns.ts
@@ -138,7 +138,7 @@ export function createProcessStateValidator(
   ptyPid: number | undefined,
   processTreeCache: ProcessTreeCache | null
 ): ProcessStateValidator | undefined {
-  if (ptyPid === undefined || !processTreeCache) {
+  if (ptyPid === undefined || !Number.isInteger(ptyPid) || ptyPid <= 0 || !processTreeCache) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- On Windows, `node-pty` reports `pid: 0` during the ConPTY connect window and fires no follow-up event with the real PID. Producer sites only checked `pid !== undefined`, so `0` slipped through and started `ProcessDetector` with an invalid PID, spamming repeated "Invalid PTY PID" warnings on every refresh tick.
- Fix tightens all producer-side PID gates to require a positive integer: the `terminal-pid` emit in `lifecycle.ts` plus 4 `trackKilledPid` sites, `TerminalProcess` constructor and `startProcessDetector`, `createProcessStateValidator`, `PtyEventRouter` (defense-in-depth), `TerminalRegistry` project stats, and `getPtyDescendantCount`.
- Adds a bounded `setImmediate` retry in the pty-host that re-reads the live PTY pid after ConPTY resolves, then emits `terminal-pid` and starts the process detector via a new `PtyManager.startProcessDetectorForTerminal` method.

Resolves #10787

## Changes

- `electron/pty-host/handlers/lifecycle.ts`: gate `terminal-pid` emit and `trackKilledPid` sites on `pid > 0`
- `electron/services/pty/TerminalProcess.ts`: tighten constructor and `startProcessDetector` to require positive PID
- `electron/services/pty/PtyEventRouter.ts`: defense-in-depth positive-integer guard before storing PID
- `electron/services/pty/TerminalRegistry.ts`: positive PID guard in project stats and `getPtyDescendantCount`
- `electron/services/PtyManager.ts`: new `startProcessDetectorForTerminal` method for the retry path
- `electron/services/pty/terminalActivityPatterns.ts`: positive-integer gate in `createProcessStateValidator`
- `electron/pty-host/handlers/__tests__/lifecycle.test.ts`: 128 unit tests covering the pid-gating and retry logic

## Testing

128 unit tests pass (`npm run test`). Covers: pid 0 rejected at every producer site, valid positive PIDs accepted, bounded retry path resolves and emits correctly, `ProcessDetector` not started until a real PID is available.