### PR TITLE
fix(panel): show 'Claude [Preset]' title and pin against detection overwrite

### DIFF
--- a/e2e/full/presets/preset-panel-behavior.spec.ts
+++ b/e2e/full/presets/preset-panel-behavior.spec.ts
@@ -199,9 +199,9 @@ test.describe.serial("Presets: Panel Behavior (107–112)", () => {
     const { id, panel } = await launchPresetPanel(ctx.window);
     presetPanelId = id;
 
-    // The panel header shows the agent's display name ("Claude"), not the preset
-    // name — the preset's load-bearing signal is the icon color, which mirrors
-    // core-agent-preset-icon-color.spec.ts.
+    // The panel is titled "Claude [<Preset>]" (verified via the dock chip in
+    // 111) and the preset's load-bearing signal is the icon color, which
+    // mirrors core-agent-preset-icon-color.spec.ts.
     await expect(panel).toHaveAttribute("data-chrome-agent-id", "claude", { timeout: T_LONG });
     const icon = panel.locator('[data-terminal-icon-id="claude"]').first();
     await expect(icon).toHaveAttribute("data-terminal-icon-color", PRESET_COLOR, {
@@ -264,7 +264,7 @@ test.describe.serial("Presets: Panel Behavior (107–112)", () => {
     expect(result.ok, result.error?.message).toBe(true);
 
     // The moved panel leaves the grid tab list and surfaces as a dock chip
-    // titled with the agent name ("Claude").
+    // titled "Claude [<Preset>]".
     await expect(tabFor(ctx.window, presetPanelId)).toHaveCount(0, { timeout: T_MEDIUM });
 
     const dock = ctx.window.locator(SEL.dock.container);
@@ -274,10 +274,14 @@ test.describe.serial("Presets: Panel Behavior (107–112)", () => {
     });
   });
 
-  test("111. Dock chip for the paneled panel carries the preset color", async () => {
+  test("111. Dock chip for the paneled panel carries the preset title and color", async () => {
     const dock = ctx.window.locator(SEL.dock.container);
     const chip = dock.locator(SEL.dock.chipByTitle("Claude")).first();
     await expect(chip).toBeVisible({ timeout: T_MEDIUM });
+
+    // The preset name is composed into the title ("Claude [<Preset>]") and
+    // survives agent detection via the titleMode pin — the #10738 regression.
+    await expect(chip).toContainText(PRESET_NAME, { timeout: T_MEDIUM });
 
     const icon = chip.locator('[data-terminal-icon-id="claude"]').first();
     await expect(icon).toHaveAttribute("data-terminal-icon-color", PRESET_COLOR, {

--- a/src/hooks/__tests__/useAgentLauncher.titleResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.titleResolution.test.ts
@@ -1,19 +1,20 @@
 // @vitest-environment node
 /**
- * Tests the assistant-supplied `name` → title / titleMode resolution from
- * useAgentLauncher.ts (issue #10439).
+ * Tests the title / titleMode resolution from useAgentLauncher.ts
+ * (issues #10439, #10738).
  *
  * The full hook has deep React/Electron dependencies that make direct rendering
  * costly here, so we mirror the pure branching logic that builds the
- * `AddPanelOptions.title` / `titleMode` pair — see `trimmedName` / `customTitle`
- * in useAgentLauncher.ts. Any change to those lines should require a
- * corresponding update here.
+ * `AddPanelOptions.title` / `titleMode` pair — see `presetTitle` /
+ * `hasPresetTitle` / `trimmedName` / `customTitle` in useAgentLauncher.ts. Any
+ * change to those lines should require a corresponding update here.
  */
 import { describe, it, expect } from "vitest";
 
 // ── mirror of the hook's title-resolution block ──────────────────────────────
-// Mirrors `sanitizeTerminalName` + the trimmedName/customTitle branch in
-// useAgentLauncher.ts. Any change to that logic should update this mirror.
+// Mirrors `sanitizeTerminalName` + the presetTitle/trimmedName/customTitle
+// resolution in useAgentLauncher.ts. Any change to that logic should update
+// this mirror.
 function sanitizeTerminalName(raw: string): string {
   let out = "";
   for (const ch of raw) {
@@ -23,107 +24,133 @@ function sanitizeTerminalName(raw: string): string {
   return out.replace(/\s+/g, " ").trim();
 }
 
-function resolveTitle(
+function resolvePanelTitle(
   computedTitle: string,
+  preset: { name?: string; displayTitle?: string } | undefined,
   name: string | undefined
 ): { title: string; titleMode?: "custom" } {
+  // Preset title: explicit displayTitle wins verbatim; otherwise compose the
+  // agent name with the preset in brackets. Pinned as "custom" so the
+  // agent-detected title sync can't overwrite it with the bare agent name.
+  let presetTitle = computedTitle;
+  let hasPresetTitle = false;
+  if (preset) {
+    const presetName = preset.name?.trim();
+    if (presetName) {
+      hasPresetTitle = true;
+      presetTitle = preset.displayTitle?.trim()
+        ? preset.displayTitle
+        : `${computedTitle} [${presetName}]`;
+    }
+  }
   const trimmedName = name ? sanitizeTerminalName(name) : undefined;
-  const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
-  return { title: trimmedName || computedTitle, ...customTitle };
+  // Pin when either a caller name or a preset title is in effect.
+  const customTitle = trimmedName || hasPresetTitle ? { titleMode: "custom" as const } : {};
+  return { title: trimmedName || presetTitle, ...customTitle };
 }
 
-const DEFAULT_TITLE = "Claude";
+const AGENT_TITLE = "Claude";
 
 describe("assistant-supplied name → title / titleMode", () => {
   it("uses the name as the title and pins it with titleMode 'custom'", () => {
-    expect(resolveTitle(DEFAULT_TITLE, "Claude: auth refactor")).toEqual({
+    expect(resolvePanelTitle(AGENT_TITLE, undefined, "Claude: auth refactor")).toEqual({
       title: "Claude: auth refactor",
       titleMode: "custom",
     });
   });
 
   it("trims surrounding whitespace from a non-empty name", () => {
-    expect(resolveTitle(DEFAULT_TITLE, "  research work  ")).toEqual({
+    expect(resolvePanelTitle(AGENT_TITLE, undefined, "  research work  ")).toEqual({
       title: "research work",
       titleMode: "custom",
     });
   });
 
   it("strips control characters and collapses whitespace from the name", () => {
-    expect(resolveTitle(DEFAULT_TITLE, "Claude:\tauth\n\nrefactor")).toEqual({
+    expect(resolvePanelTitle(AGENT_TITLE, undefined, "Claude:\tauth\n\nrefactor")).toEqual({
       title: "Claude: auth refactor",
       titleMode: "custom",
     });
   });
 
-  it("falls back to the default when the name is only control characters", () => {
-    const result = resolveTitle(DEFAULT_TITLE, "\t\n\r");
-    expect(result.title).toBe(DEFAULT_TITLE);
+  it("falls back to the computed title when the name is only control characters", () => {
+    const result = resolvePanelTitle(AGENT_TITLE, undefined, "\t\n\r");
+    expect(result.title).toBe(AGENT_TITLE);
     expect(result.titleMode).toBeUndefined();
   });
 
   it("falls back to the computed title and sets no titleMode when name is undefined", () => {
-    const result = resolveTitle(DEFAULT_TITLE, undefined);
-    expect(result.title).toBe(DEFAULT_TITLE);
+    const result = resolvePanelTitle(AGENT_TITLE, undefined, undefined);
+    expect(result.title).toBe(AGENT_TITLE);
     expect(result.titleMode).toBeUndefined();
   });
 
   it("falls back to the computed title and sets no titleMode when name is empty", () => {
-    const result = resolveTitle(DEFAULT_TITLE, "");
-    expect(result.title).toBe(DEFAULT_TITLE);
+    const result = resolvePanelTitle(AGENT_TITLE, undefined, "");
+    expect(result.title).toBe(AGENT_TITLE);
     expect(result.titleMode).toBeUndefined();
   });
 
   it("falls back to the computed title and sets no titleMode when name is whitespace only", () => {
-    const result = resolveTitle(DEFAULT_TITLE, "   ");
-    expect(result.title).toBe(DEFAULT_TITLE);
-    expect(result.titleMode).toBeUndefined();
-  });
-
-  it("does not pin (titleMode) merely because a computed title exists", () => {
-    // The pin is owned by the caller's name, never by the default title — so a
-    // default-titled launch stays free for agent detection to relabel.
-    const result = resolveTitle(DEFAULT_TITLE, undefined);
+    const result = resolvePanelTitle(AGENT_TITLE, undefined, "   ");
+    expect(result.title).toBe(AGENT_TITLE);
     expect(result.titleMode).toBeUndefined();
   });
 });
 
-// ── mirror of the hook's preset-title resolution (issue #10738) ──────────────
-// Mirrors `presetTitle` + the `trimmedName || presetTitle` selection in
-// useAgentLauncher.ts. A preset's optional displayTitle overrides its name,
-// but an explicit caller-supplied name still wins over both.
-function resolveLaunchTitle(
-  computedTitle: string,
-  preset: { name: string; displayTitle?: string } | undefined,
-  name: string | undefined
-): string {
-  const presetTitle = preset ? (preset.displayTitle ?? preset.name) : computedTitle;
-  const trimmedName = name ? sanitizeTerminalName(name) : undefined;
-  return trimmedName || presetTitle;
-}
-
-describe("preset displayTitle → panel title", () => {
-  it("prefers displayTitle over the preset name", () => {
-    expect(
-      resolveLaunchTitle(
-        DEFAULT_TITLE,
-        { name: "Claude", displayTitle: "Claude [Z.ai]" },
-        undefined
-      )
-    ).toBe("Claude [Z.ai]");
+describe("preset → panel title and titleMode pin", () => {
+  it("composes '<Agent> [<Preset>]' and pins it when displayTitle is absent", () => {
+    // The bracketed preset name must be pinned so agent detection can't
+    // overwrite it with the bare agent name (the #10738 regression).
+    expect(resolvePanelTitle(AGENT_TITLE, { name: "Z.ai" }, undefined)).toEqual({
+      title: "Claude [Z.ai]",
+      titleMode: "custom",
+    });
   });
 
-  it("falls back to the preset name when displayTitle is absent", () => {
-    expect(resolveLaunchTitle(DEFAULT_TITLE, { name: "Claude" }, undefined)).toBe("Claude");
+  it("uses displayTitle verbatim and pins it when set", () => {
+    // Distinct from the composed "Claude [Z.ai]" so this proves displayTitle
+    // wins verbatim rather than the bracket fallback happening to match.
+    expect(
+      resolvePanelTitle(AGENT_TITLE, { name: "Z.ai", displayTitle: "Pinned Route" }, undefined)
+    ).toEqual({
+      title: "Pinned Route",
+      titleMode: "custom",
+    });
   });
 
-  it("lets an explicit caller-supplied name override displayTitle", () => {
+  it("treats a whitespace-only displayTitle as absent and composes the bracket form", () => {
     expect(
-      resolveLaunchTitle(
-        DEFAULT_TITLE,
-        { name: "Claude", displayTitle: "Claude [Z.ai]" },
+      resolvePanelTitle(AGENT_TITLE, { name: "Z.ai", displayTitle: "   " }, undefined)
+    ).toEqual({
+      title: "Claude [Z.ai]",
+      titleMode: "custom",
+    });
+  });
+
+  it("ignores a preset whose name is empty/whitespace (no compose, no pin)", () => {
+    expect(resolvePanelTitle(AGENT_TITLE, { name: "   " }, undefined)).toEqual({
+      title: AGENT_TITLE,
+    });
+  });
+
+  it("lets an explicit caller-supplied name override the preset title", () => {
+    expect(
+      resolvePanelTitle(
+        AGENT_TITLE,
+        { name: "Z.ai", displayTitle: "Claude [Z.ai]" },
         "auth refactor"
       )
-    ).toBe("auth refactor");
+    ).toEqual({
+      title: "auth refactor",
+      titleMode: "custom",
+    });
+  });
+
+  it("does not pin when there is no preset and no caller name", () => {
+    // A default-titled launch stays free for agent detection to relabel.
+    expect(resolvePanelTitle(AGENT_TITLE, undefined, undefined)).toEqual({
+      title: AGENT_TITLE,
+    });
   });
 });

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -506,7 +506,22 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
           return null;
         }
 
-        const presetTitle = isAgent && preset ? (preset.displayTitle ?? preset.name) : title;
+        // Preset title: an explicit `displayTitle` wins verbatim; otherwise
+        // compose the agent name with the preset in brackets ("Claude [Z.ai]")
+        // so the active preset is visible next to the agent name. Pinned as
+        // "custom" below so the agent-detected title sync can't overwrite it
+        // with the bare agent name.
+        let presetTitle = title;
+        let hasPresetTitle = false;
+        if (isAgent && preset) {
+          const presetName = preset.name?.trim();
+          if (presetName) {
+            hasPresetTitle = true;
+            presetTitle = preset.displayTitle?.trim()
+              ? preset.displayTitle
+              : `${title} [${presetName}]`;
+          }
+        }
         // A caller-supplied name overrides the computed title and pins it so
         // agent detection can't rewrite it. Strip control characters (an LLM
         // assistant could emit newlines/ANSI/tabs) and collapse whitespace so
@@ -516,7 +531,9 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         const trimmedName = launchOptions?.name
           ? sanitizeTerminalName(launchOptions.name)
           : undefined;
-        const customTitle = trimmedName ? { titleMode: "custom" as const } : {};
+        // Pin any non-default title (caller name OR preset) as "custom" so the
+        // agent-detected title sync (computeDefaultTitle) can't clobber it.
+        const customTitle = trimmedName || hasPresetTitle ? { titleMode: "custom" as const } : {};
         const spawnedBy = launchOptions?.spawnedBy;
         const focusPolicy =
           launchOptions?.focusPolicy ?? (isMcpSpawnFocusSuppressed() ? "preserve" : undefined);


### PR DESCRIPTION
## What
Launching an agent with a preset now titles the panel `Claude [Z.ai]` (agent name + bracketed preset name). An explicit `displayTitle` still wins verbatim.

## Why
The preset title was set correctly at launch but overwritten to the bare agent name (`Claude`) the moment agent detection fired — `computeDefaultTitle` rewrites any `titleMode: "default"` panel, and preset titles weren't pinned. The icon color survived because detection never touches `agentPresetColor`, which is why a preset launch showed color-but-not-name.

The earlier `Claude (Preset)` parens format was dropped in `b9b168973`; this restores preset visibility, as brackets.

## Change
- `useAgentLauncher.ts`: compose `${title} [${presetName}]` when `displayTitle` is blank; pin `titleMode: "custom"` for both preset and caller-supplied titles so the detection title-sync can't clobber them.
- `useAgentLauncher.titleResolution.test.ts`: mirror the new resolution; assert the pin (the regression).
- `preset-panel-behavior.spec.ts`: assert the bracketed title on the dock chip; correct stale comments.

Follow-up to #10738 (customizable display titles).

## Known limitation (not addressed here)
`titleMode` isn't persisted (`panelToSnapshot` / `statePatcher`), so a preset title survives launch but reverts to the bare agent name after an app restart once detection re-fires. Pre-existing — it also affects caller-renamed terminals — and left for a separate change rather than expanding this PR into the terminal-restoration path.