### PR TITLE
fix(git): guard polling loops against deleted project path

### DIFF
--- a/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
@@ -33,6 +33,15 @@ vi.mock("../forgeResolution.js", () => ({
   resolveForCwd: resolveForCwdMock,
 }));
 
+// Default to "exists" so the existing stats tests reach the resolution path;
+// the #10663 missing-directory guard test flips this to false explicitly.
+const existsSyncMock = vi.hoisted(() => vi.fn().mockReturnValue(true));
+
+vi.mock("fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("fs")>()),
+  existsSync: existsSyncMock,
+}));
+
 // The handlers transitively import the forge audit singleton, which imports
 // the electron-store. Mock it so the singleton's read/write callbacks hit an
 // in-memory map rather than constructing a real store under a mocked electron.
@@ -239,6 +248,24 @@ describe("registerForgeDataHandlers", () => {
 
     expect(fakeImpl.getRepoMetadata).toHaveBeenCalledWith(repoRef);
     expect(result).toEqual(meta);
+  });
+
+  it("getRepoStats short-circuits to a zero snapshot when the project directory is gone (#10663)", async () => {
+    // The project directory was deleted/moved externally; the renderer keeps
+    // polling this handler. The guard must return a commits-only zero snapshot
+    // without ever touching git resolution — otherwise each poll spams WARN.
+    existsSyncMock.mockReturnValueOnce(false);
+    registerForgeDataHandlers();
+
+    const result = await findHandler("forge:get-repo-stats")(null, { cwd: "/missing/path" });
+
+    expect(resolveForCwdMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      commitCount: 0,
+      issueCount: null,
+      prCount: null,
+      loading: false,
+    });
   });
 
   it("getCurrentUser returns the identity projection when the impl exposes one", async () => {

--- a/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeData.handlers.test.ts
@@ -260,6 +260,8 @@ describe("registerForgeDataHandlers", () => {
     const result = await findHandler("forge:get-repo-stats")(null, { cwd: "/missing/path" });
 
     expect(resolveForCwdMock).not.toHaveBeenCalled();
+    // The guard must check the cwd itself, not a parent or derived path.
+    expect(existsSyncMock).toHaveBeenCalledWith("/missing/path");
     expect(result).toMatchObject({
       commitCount: 0,
       issueCount: null,

--- a/electron/ipc/handlers/forgeData.ts
+++ b/electron/ipc/handlers/forgeData.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises";
+import { existsSync } from "fs";
 import path from "path";
 import { CHANNELS } from "../channels.js";
 import { broadcastToRenderer, checkRateLimit, typedHandle } from "../utils.js";
@@ -327,6 +328,15 @@ async function handleForgeGetRepoStats(payload: {
     throw new Error("Invalid payload");
   }
   const cwd = requireCwd(payload.cwd);
+  // #10663: short-circuit before any git call if the project directory was
+  // deleted or moved externally. The renderer's `useRepositoryStats` loop
+  // keeps polling this handler (every 2min on its error backoff) even after
+  // the path is gone; without this guard each poll runs `getCommitCount` ->
+  // `createHardenedGit` against the dead path and emits a WARN log. Return a
+  // commits-only zero snapshot — the same shape as the no-provider fallback.
+  if (!existsSync(cwd)) {
+    return buildForgeRepositoryStats(0, { issueCount: null, prCount: null });
+  }
   let resolved: Awaited<ReturnType<typeof resolveForCwd>>;
   try {
     resolved = await resolveForCwd(cwd);

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -570,6 +570,16 @@ export class WorkspaceService {
     }
   ): Promise<void> {
     try {
+      // #10663: bail before any state is set if the project root was deleted
+      // or moved externally. Without this guard `createHardenedGit` throws a
+      // GitConstructError on the dead path, but `this.projectRootPath` is
+      // already set — so the renderer's stats/monitor polling loops keep
+      // retrying the dead path and spam WARN logs every tick. Fail fast: the
+      // caller emits a `load-project-result` failure that drives the existing
+      // "Couldn't load worktrees" banner.
+      if (!existsSync(projectRootPath)) {
+        throw new Error(`Project directory does not exist: ${projectRootPath}`);
+      }
       this.projectRootPath = projectRootPath;
       if (wslGitByWorktree && typeof wslGitByWorktree === "object") {
         // Merge instead of replacing: a `set-wsl-opt-in` message arriving

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -143,6 +143,10 @@ describe("WorkspaceService adversarial", () => {
     // The guard must fire before any git instance is constructed for the dead
     // path — otherwise the polling loops keep retrying it and spam WARN logs.
     expect(createHardenedGit).not.toHaveBeenCalled();
+    // `projectRootPath` must stay null: if the guard were moved after the
+    // assignment the failure event would still fire, but the dead path would
+    // be primed and the polling loops would resume. Pin the ordering.
+    expect(service["projectRootPath"]).toBeNull();
   });
 
   it("returns a failure when git worktree add hits index.lock contention", async () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from "events";
+import { existsSync } from "fs";
 import { resolve as pathResolve } from "path";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { createHardenedGit } from "../../utils/hardenedGit.js";
 import type { WorkspaceService } from "../WorkspaceService.js";
 import type { WorkspaceHostEvent } from "../../../shared/types/workspace-host.js";
 
@@ -122,6 +124,25 @@ describe("WorkspaceService adversarial", () => {
         error: "Corrupted worktree metadata",
       })
     );
+  });
+
+  it("fails loadProject before any git call when the project root was deleted (#10663)", async () => {
+    // The project directory was removed/moved externally before this load.
+    vi.mocked(existsSync).mockReturnValueOnce(false);
+
+    await service.loadProject("req-missing", "/missing/path");
+
+    expect(sentEvents).toContainEqual(
+      expect.objectContaining({
+        type: "load-project-result",
+        requestId: "req-missing",
+        success: false,
+        error: "Project directory does not exist: /missing/path",
+      })
+    );
+    // The guard must fire before any git instance is constructed for the dead
+    // path — otherwise the polling loops keep retrying it and spam WARN logs.
+    expect(createHardenedGit).not.toHaveBeenCalled();
   });
 
   it("returns a failure when git worktree add hits index.lock contention", async () => {


### PR DESCRIPTION
## Summary

- When a project directory is deleted or moved externally and Daintree is relaunched, polling loops were retrying the dead git path on every tick and flooding the log with repeated errors.
- This adds two `existsSync` guards: one in `WorkspaceService.loadProject` that fails fast before `projectRootPath` is set (so `createHardenedGit` is never called and the monitor/poll timers never start), and one in `handleForgeGetRepoStats` that short-circuits to a commits-only zero snapshot when the directory no longer exists.
- The renderer already shows the "Couldn't load worktrees" failure banner from the existing error path. `useRepositoryStats` backs off to a 2-minute poll on error but never stops, so the second guard is needed to silence that independent loop too.

Resolves #10663

## Changes

- `electron/workspace-host/WorkspaceService.ts`: `existsSync` guard at the top of `loadProject`, before `projectRootPath` is assigned
- `electron/ipc/handlers/forgeData.ts`: `existsSync` guard in `handleForgeGetRepoStats`, returning a zero snapshot when `cwd` is gone
- `electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts`: tests for the `loadProject` guard
- `electron/ipc/handlers/__tests__/forgeData.handlers.test.ts`: tests for the `handleForgeGetRepoStats` guard

## Testing

Both guards have unit test coverage. `WorkspaceService.loadProject` rejects with a clear message when the path is absent. `handleForgeGetRepoStats` returns a zero-filled snapshot without touching `simple-git` when `cwd` doesn't exist.