### PR TITLE
fix(hibernation): evict cached project renderer on user-initiated hibernation

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2035,7 +2035,7 @@ function buildElectronApi(): ElectronAPI {
         callback: (payload: {
           projectId: string;
           projectName: string;
-          reason: "scheduled" | "memory-pressure";
+          reason: "scheduled" | "memory-pressure" | "user-initiated";
           terminalsKilled: number;
           timestamp: number;
         }) => void

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -429,25 +429,43 @@ export class HibernationService {
 
   /**
    * Tear down the hibernated project's cached `WebContentsView` across every
-   * open window, skipping the window where the project is the active/foreground
-   * view (each window tracks its own active project). `destroyView` runs the
-   * full `cleanupEntry` teardown — detach, listener removal, port cleanup,
-   * `webContents.close()` — and is a no-op when the project has no cached view.
-   * No-op if the provider has not been wired yet.
+   * open window. `destroyView` runs the full `cleanupEntry` teardown — detach,
+   * listener removal, port cleanup, `webContents.close()` — and is a no-op when
+   * the project has no cached view in that window. No-op if the provider has not
+   * been wired yet.
+   *
+   * Skips any window where the project is on-screen: the active/foreground view,
+   * or the still-visible anti-flash bridge of an open paint gate (during a cold
+   * switch the outgoing project stays painted until the gate settles, even
+   * though `activeProjectId` already points at the incoming project). Destroying
+   * either would expose a blank/unpainted frame. Both guards are per-manager —
+   * each window tracks its own active and outgoing project.
    */
   private evictCachedRenderer(projectId: string): void {
     const provider = this.projectViewManagersProvider;
     if (!provider) return;
 
+    let managers: ProjectViewManager[];
+    try {
+      managers = provider();
+    } catch (error) {
+      // windowRegistry may be tearing down — eviction is best-effort.
+      logError("user-initiated-hibernate-evict-provider-failed", error, { projectId });
+      return;
+    }
+
     let evictedViewCount = 0;
-    for (const manager of provider()) {
-      // Never destroy the foreground view — that would blank the window the
-      // user is looking at. The guard is per-manager because each window has
-      // its own active project.
-      if (manager.getActiveProjectId() === projectId) continue;
+    for (const manager of managers) {
       try {
-        manager.destroyView(projectId);
-        evictedViewCount++;
+        if (
+          manager.getActiveProjectId() === projectId ||
+          manager.getOutgoingBridgeProjectId() === projectId
+        ) {
+          continue;
+        }
+        if (manager.destroyView(projectId)) {
+          evictedViewCount++;
+        }
       } catch (error) {
         // A disposing/closing ProjectViewManager can throw inside cleanupEntry.
         // Isolate per window so one failure doesn't skip the rest (#8607).

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -10,6 +10,7 @@ import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { writeHibernatedMarker } from "./pty/terminalSessionPersistence.js";
 import type { PtyClient } from "./PtyClient.js";
+import type { ProjectViewManager } from "../window/ProjectViewManager.js";
 import { getPtyClient } from "../window/serviceRefs.js";
 
 export interface HibernationConfig {
@@ -65,6 +66,7 @@ export class HibernationService {
   private readonly hibernationCallbacks: Array<(projectId: string) => void | Promise<void>> = [];
   private memoryPressureInactiveMs = DEFAULT_MEMORY_PRESSURE_INACTIVE_MS;
   private ptyClient: PtyClient | null = null;
+  private projectViewManagersProvider: (() => ProjectViewManager[]) | null = null;
 
   /**
    * Inject the live PtyClient so hibernation reads the real terminal registry
@@ -74,6 +76,20 @@ export class HibernationService {
    */
   setPtyClient(client: PtyClient | null): void {
     this.ptyClient = client;
+  }
+
+  /**
+   * Inject a lazy provider over every open window's ProjectViewManager so
+   * user-initiated hibernation can evict the hibernated project's cached
+   * `WebContentsView` renderer (#10668) — the bulk of per-project memory that
+   * killing PTYs alone leaves resident. Mirrors the `getAllProjectViewManagers`
+   * lambda `ResourceProfileService` uses. Must stay lazy: windows open/close
+   * after wiring. NOT cleared in stop(): it's a stateless closure over the
+   * window registry (no stale object pinned), and the user-initiated close path
+   * stays reachable even when scheduled hibernation is toggled off.
+   */
+  setProjectViewManagersProvider(provider: (() => ProjectViewManager[]) | null): void {
+    this.projectViewManagersProvider = provider;
   }
 
   setMemoryPressureThresholdMs(ms: number): void {
@@ -352,11 +368,15 @@ export class HibernationService {
    * and runs the same flow as scheduled hibernation so DevPreview callbacks
    * fire and the renderer sees the standard `hibernation:project-hibernated`
    * event. No-op if the PtyClient has not been injected yet.
+   *
+   * Defaults to `"user-initiated"` — this entry point is only reached through
+   * explicit user actions, which (unlike scheduled/memory-pressure hibernation)
+   * also evict the project's cached renderer (#10668).
    */
   async hibernateProjectOnDemand(
     projectId: string,
     projectName: string,
-    reason: "scheduled" | "memory-pressure" = "scheduled"
+    reason: "scheduled" | "memory-pressure" | "user-initiated" = "user-initiated"
   ): Promise<number> {
     if (!this.ptyClient) return 0;
     return this.hibernateProject(projectId, projectName, reason, this.ptyClient);
@@ -365,7 +385,7 @@ export class HibernationService {
   private async hibernateProject(
     projectId: string,
     projectName: string,
-    reason: "scheduled" | "memory-pressure",
+    reason: "scheduled" | "memory-pressure" | "user-initiated",
     ptyClient: PtyClient
   ): Promise<number> {
     const results = await ptyClient.gracefulKillByProject(projectId, { preserveSession: true });
@@ -393,7 +413,51 @@ export class HibernationService {
       // Window may be closing
     }
 
+    // Only explicit/user-initiated hibernation evicts the cached project
+    // renderer (#10668). Scheduled and memory-pressure hibernation stay
+    // conservative — they silently turn a warm project cold, and renderer
+    // reclaim under pressure is already owned by ResourceProfileService's
+    // setCachedViewLimit(1) path. Killing PTYs alone leaves ~240 MB of
+    // Chromium renderer resident per project, so without this hibernation
+    // appears to free almost nothing.
+    if (reason === "user-initiated") {
+      this.evictCachedRenderer(projectId);
+    }
+
     return terminalsKilled;
+  }
+
+  /**
+   * Tear down the hibernated project's cached `WebContentsView` across every
+   * open window, skipping the window where the project is the active/foreground
+   * view (each window tracks its own active project). `destroyView` runs the
+   * full `cleanupEntry` teardown — detach, listener removal, port cleanup,
+   * `webContents.close()` — and is a no-op when the project has no cached view.
+   * No-op if the provider has not been wired yet.
+   */
+  private evictCachedRenderer(projectId: string): void {
+    const provider = this.projectViewManagersProvider;
+    if (!provider) return;
+
+    let evictedViewCount = 0;
+    for (const manager of provider()) {
+      // Never destroy the foreground view — that would blank the window the
+      // user is looking at. The guard is per-manager because each window has
+      // its own active project.
+      if (manager.getActiveProjectId() === projectId) continue;
+      try {
+        manager.destroyView(projectId);
+        evictedViewCount++;
+      } catch (error) {
+        // A disposing/closing ProjectViewManager can throw inside cleanupEntry.
+        // Isolate per window so one failure doesn't skip the rest (#8607).
+        logError("user-initiated-hibernate-evict-failed", error, { projectId });
+      }
+    }
+
+    if (evictedViewCount > 0) {
+      logInfo("user-initiated-hibernate-renderer-evicted", { projectId, evictedViewCount });
+    }
   }
 
   getConfig(): HibernationConfig {

--- a/electron/services/IdleTerminalNotificationService.ts
+++ b/electron/services/IdleTerminalNotificationService.ts
@@ -232,9 +232,10 @@ export class IdleTerminalNotificationService {
 
   /**
    * "Close Them" action handler. Delegates to HibernationService so that
-   * project-scoped cleanup callbacks (e.g. DevPreview session teardown) run
-   * and the renderer sees the standard hibernation event — same as if the
-   * scheduled hibernation timer had closed the project itself.
+   * project-scoped cleanup callbacks (e.g. DevPreview session teardown) run and
+   * the renderer sees the standard hibernation event. Passes `"user-initiated"`
+   * so this explicit action also evicts the project's cached renderer (#10668) —
+   * unlike the silent scheduled/memory-pressure paths, which leave it warm.
    */
   async closeProject(projectId: string): Promise<number> {
     if (!projectId) return 0;
@@ -247,7 +248,7 @@ export class IdleTerminalNotificationService {
       const terminalsKilled = await getHibernationService().hibernateProjectOnDemand(
         projectId,
         projectName,
-        "scheduled"
+        "user-initiated"
       );
 
       // Only burn a cooldown slot if we actually acted on something — otherwise

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -1101,13 +1101,18 @@ describe("HibernationService", () => {
   describe("user-initiated renderer eviction (#10668)", () => {
     type ProjectViewManagerMock = {
       getActiveProjectId: Mock<() => string | null>;
-      destroyView: Mock<(projectId: string) => void>;
+      getOutgoingBridgeProjectId: Mock<() => string | null>;
+      destroyView: Mock<(projectId: string) => boolean>;
     };
 
-    function makeManager(activeProjectId: string | null = null): ProjectViewManagerMock {
+    function makeManager(
+      activeProjectId: string | null = null,
+      outgoingBridgeProjectId: string | null = null
+    ): ProjectViewManagerMock {
       return {
         getActiveProjectId: vi.fn(() => activeProjectId),
-        destroyView: vi.fn(),
+        getOutgoingBridgeProjectId: vi.fn(() => outgoingBridgeProjectId),
+        destroyView: vi.fn(() => true),
       };
     }
 
@@ -1141,6 +1146,18 @@ describe("HibernationService", () => {
 
       expect(foreground.destroyView).not.toHaveBeenCalled();
       expect(background.destroyView).toHaveBeenCalledWith("proj-1");
+    });
+
+    it("skips the window where the project is the outgoing paint-gate bridge", async () => {
+      // Mid cold-switch: activeProjectId is already the incoming project, but
+      // proj-1 is still painted as the anti-flash bridge. Destroying it would
+      // expose a blank frame — it must be skipped like the active view.
+      const switching = makeManager("incoming-proj", "proj-1");
+      const service = makeServiceWithManagers([switching]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(switching.destroyView).not.toHaveBeenCalled();
     });
 
     it("does not evict renderers for scheduled hibernation", async () => {
@@ -1191,6 +1208,51 @@ describe("HibernationService", () => {
         expect.any(Error),
         { projectId: "proj-1" }
       );
+    });
+
+    it("continues to the next window when a guard accessor throws", async () => {
+      const failing = makeManager(null);
+      failing.getActiveProjectId.mockImplementation(() => {
+        throw new Error("registry torn down");
+      });
+      const healthy = makeManager(null);
+      const service = makeServiceWithManagers([failing, healthy]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(failing.destroyView).not.toHaveBeenCalled();
+      expect(healthy.destroyView).toHaveBeenCalledWith("proj-1");
+    });
+
+    it("does not reject and still kills terminals when the provider throws", async () => {
+      ptyManagerMock.gracefulKillByProject.mockResolvedValue([
+        { id: "t1", agentSessionId: null },
+        { id: "t2", agentSessionId: null },
+      ]);
+      const service = makeService();
+      service.setProjectViewManagersProvider(() => {
+        throw new Error("windowRegistry tearing down");
+      });
+
+      const killed = await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(killed).toBe(2);
+      expect(broadcastToRendererMock).toHaveBeenCalled();
+    });
+
+    it("counts only windows that actually had a cached view", async () => {
+      const withView = makeManager(null);
+      withView.destroyView.mockReturnValue(true);
+      const withoutView = makeManager(null);
+      withoutView.destroyView.mockReturnValue(false);
+      const service = makeServiceWithManagers([withView, withoutView]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(logInfo).toHaveBeenCalledWith("user-initiated-hibernate-renderer-evicted", {
+        projectId: "proj-1",
+        evictedViewCount: 1,
+      });
     });
 
     it("returns the killed-terminal count and does not throw when no provider is wired", async () => {

--- a/electron/services/__tests__/HibernationService.test.ts
+++ b/electron/services/__tests__/HibernationService.test.ts
@@ -71,6 +71,7 @@ vi.mock("../pty/terminalSessionPersistence.js", () => ({
 import { logInfo, logError } from "../../utils/logger.js";
 import { HibernationService } from "../HibernationService.js";
 import type { PtyClient } from "../PtyClient.js";
+import type { ProjectViewManager } from "../../window/ProjectViewManager.js";
 
 /** Construct a service with the PtyClient-shaped mock injected (#10054). */
 function makeService(): HibernationService {
@@ -1094,6 +1095,127 @@ describe("HibernationService", () => {
       expect(successCallback).toHaveBeenCalled();
       // Event should still be emitted
       expect(broadcastToRendererMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("user-initiated renderer eviction (#10668)", () => {
+    type ProjectViewManagerMock = {
+      getActiveProjectId: Mock<() => string | null>;
+      destroyView: Mock<(projectId: string) => void>;
+    };
+
+    function makeManager(activeProjectId: string | null = null): ProjectViewManagerMock {
+      return {
+        getActiveProjectId: vi.fn(() => activeProjectId),
+        destroyView: vi.fn(),
+      };
+    }
+
+    function makeServiceWithManagers(managers: ProjectViewManagerMock[]): HibernationService {
+      const service = makeService();
+      service.setProjectViewManagersProvider(() => managers as unknown as ProjectViewManager[]);
+      return service;
+    }
+
+    beforeEach(() => {
+      ptyManagerMock.gracefulKillByProject.mockResolvedValue([{ id: "t1", agentSessionId: null }]);
+    });
+
+    it("evicts the cached renderer on every window where the project is not active", async () => {
+      const background = makeManager("other-proj");
+      const alsoBackground = makeManager(null);
+      const service = makeServiceWithManagers([background, alsoBackground]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(background.destroyView).toHaveBeenCalledWith("proj-1");
+      expect(alsoBackground.destroyView).toHaveBeenCalledWith("proj-1");
+    });
+
+    it("skips the window where the project is the active/foreground view", async () => {
+      const foreground = makeManager("proj-1");
+      const background = makeManager("other-proj");
+      const service = makeServiceWithManagers([foreground, background]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(foreground.destroyView).not.toHaveBeenCalled();
+      expect(background.destroyView).toHaveBeenCalledWith("proj-1");
+    });
+
+    it("does not evict renderers for scheduled hibernation", async () => {
+      const manager = makeManager(null);
+      const service = makeServiceWithManagers([manager]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "scheduled");
+
+      expect(manager.destroyView).not.toHaveBeenCalled();
+    });
+
+    it("does not evict renderers for memory-pressure hibernation", async () => {
+      (storeMock.get as Mock).mockReturnValue({ enabled: false, inactiveThresholdHours: 24 });
+      projectStoreMock.getCurrentProjectId.mockReturnValue("active-proj");
+      projectStoreMock.getAllProjects.mockReturnValue([
+        {
+          id: "proj-1",
+          name: "Old",
+          path: "/projects/proj-1",
+          lastOpened: Date.now() - 31 * 60 * 1000,
+        },
+      ]);
+      ptyManagerMock.getAllTerminalsAsync.mockResolvedValue([
+        { id: "t1", projectId: "proj-1", agentState: "idle" },
+      ]);
+      const manager = makeManager(null);
+      const service = makeServiceWithManagers([manager]);
+
+      await service.hibernateUnderMemoryPressure();
+
+      expect(manager.destroyView).not.toHaveBeenCalled();
+    });
+
+    it("continues evicting other windows when one destroyView throws", async () => {
+      const failing = makeManager(null);
+      failing.destroyView.mockImplementation(() => {
+        throw new Error("boom");
+      });
+      const healthy = makeManager(null);
+      const service = makeServiceWithManagers([failing, healthy]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(failing.destroyView).toHaveBeenCalledWith("proj-1");
+      expect(healthy.destroyView).toHaveBeenCalledWith("proj-1");
+      expect(logError).toHaveBeenCalledWith(
+        "user-initiated-hibernate-evict-failed",
+        expect.any(Error),
+        { projectId: "proj-1" }
+      );
+    });
+
+    it("returns the killed-terminal count and does not throw when no provider is wired", async () => {
+      ptyManagerMock.gracefulKillByProject.mockResolvedValue([
+        { id: "t1", agentSessionId: null },
+        { id: "t2", agentSessionId: null },
+      ]);
+      const service = makeService();
+
+      const killed = await service.hibernateProjectOnDemand("proj-1", "Proj One", "user-initiated");
+
+      expect(killed).toBe(2);
+    });
+
+    it("defaults to user-initiated when no reason is passed", async () => {
+      const manager = makeManager(null);
+      const service = makeServiceWithManagers([manager]);
+
+      await service.hibernateProjectOnDemand("proj-1", "Proj One");
+
+      expect(manager.destroyView).toHaveBeenCalledWith("proj-1");
+      expect(broadcastToRendererMock).toHaveBeenCalledWith(
+        "hibernation:project-hibernated",
+        expect.objectContaining({ reason: "user-initiated" })
+      );
     });
   });
 });

--- a/electron/services/__tests__/IdleTerminalNotificationService.test.ts
+++ b/electron/services/__tests__/IdleTerminalNotificationService.test.ts
@@ -525,7 +525,7 @@ describe("IdleTerminalNotificationService", () => {
       const killed = await service.closeProject("proj-1");
 
       expect(killed).toBe(2);
-      expect(hibernateProjectOnDemandMock).toHaveBeenCalledWith("proj-1", "Old", "scheduled");
+      expect(hibernateProjectOnDemandMock).toHaveBeenCalledWith("proj-1", "Old", "user-initiated");
       const dismissals = storeBacking.idleTerminalDismissals as Record<string, number>;
       expect(dismissals["proj-1"]).toBeGreaterThan(0);
     });
@@ -540,7 +540,7 @@ describe("IdleTerminalNotificationService", () => {
       expect(hibernateProjectOnDemandMock).toHaveBeenCalledWith(
         "ghost-proj",
         "ghost-proj",
-        "scheduled"
+        "user-initiated"
       );
     });
 

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -960,6 +960,17 @@ export class ProjectViewManager {
     return this.activeProjectId;
   }
 
+  /**
+   * Project whose view is the still-visible anti-flash bridge of an open paint
+   * gate. During a cold switch `activeProjectId` is already the incoming
+   * project, but the outgoing project's view stays on-screen until the gate
+   * settles — so it is non-evictable for the same reason as the active view.
+   * Eviction paths must skip both (mirrors the LRU guard in `evictStaleViews`).
+   */
+  getOutgoingBridgeProjectId(): string | null {
+    return this.pendingPaintGate?.outgoingProjectId ?? null;
+  }
+
   getActiveView(): WebContentsView | null {
     if (!this.activeProjectId) return null;
     return this.views.get(this.activeProjectId)?.view ?? null;
@@ -1188,15 +1199,17 @@ export class ProjectViewManager {
     }
   }
 
-  destroyView(projectId: string): void {
+  /** Returns true if a cached view existed for the project and was torn down. */
+  destroyView(projectId: string): boolean {
     const entry = this.views.get(projectId);
-    if (!entry) return;
+    if (!entry) return false;
 
     if (this.activeProjectId === projectId) {
       this.activeProjectId = null;
     }
 
     this.cleanupEntry(projectId);
+    return true;
   }
 
   dispose(): void {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -143,8 +143,12 @@ vi.mock("../../setup/openFileInstall.js", () => ({
   activateOpenFileInstaller,
 }));
 
+const hibernationServiceMock = vi.hoisted(() => ({
+  setProjectViewManagersProvider: vi.fn(),
+}));
+
 vi.mock("../../services/HibernationService.js", () => ({
-  initializeHibernationService: vi.fn(),
+  initializeHibernationService: vi.fn(() => hibernationServiceMock),
   getHibernationService: () => ({ stop: vi.fn(), hibernateUnderMemoryPressure: vi.fn() }),
 }));
 
@@ -384,6 +388,24 @@ describe("initGlobalServices task ordering", () => {
     run!();
 
     expect(registerCommandsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires a lazy ProjectViewManager provider into HibernationService (#10668)", async () => {
+    hibernationServiceMock.setProjectViewManagersProvider.mockClear();
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const run = registeredTaskRuns.get("hibernation-service");
+    expect(run).toBeDefined();
+    expect(hibernationServiceMock.setProjectViewManagersProvider).not.toHaveBeenCalled();
+
+    run!();
+
+    expect(hibernationServiceMock.setProjectViewManagersProvider).toHaveBeenCalledTimes(1);
+    const provider = hibernationServiceMock.setProjectViewManagersProvider.mock.calls[0][0];
+    expect(typeof provider).toBe("function");
+    // Lazy: re-reads the registry on each call rather than capturing a snapshot.
+    expect(provider()).toEqual([]);
   });
 
   it("registers monitor tasks before resource-profile-service so the profile reads ready data", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -245,7 +245,18 @@ export async function initGlobalServices(
   registerDeferredTask({
     name: "hibernation-service",
     run: () => {
-      initializeHibernationService();
+      const svc = initializeHibernationService();
+      // Let user-initiated hibernation reach every window's cached project
+      // renderers so it can evict them (#10668). Lazy lambda — windows open and
+      // close after this wires, so re-read the registry on each call. Same
+      // pattern ResourceProfileService uses below.
+      svc.setProjectViewManagersProvider(
+        () =>
+          windowRegistry
+            ?.all()
+            .map((wCtx) => wCtx.services.projectViewManager)
+            .filter((pvm): pvm is ProjectViewManager => pvm !== undefined) ?? []
+      );
     },
   });
 

--- a/shared/types/ipc/hibernation.ts
+++ b/shared/types/ipc/hibernation.ts
@@ -9,7 +9,7 @@ export interface HibernationConfig {
 export interface HibernationProjectHibernatedPayload {
   projectId: string;
   projectName: string;
-  reason: "scheduled" | "memory-pressure";
+  reason: "scheduled" | "memory-pressure" | "user-initiated";
   terminalsKilled: number;
   timestamp: number;
 }


### PR DESCRIPTION
## Summary

- Hibernation killed terminal processes but left each project's cached `WebContentsView` renderer (~240 MB each) resident. With 2 cached projects, hibernation freed ~1 MB of 1939 MB total. The renderers are the real memory lever: evicting them freed ~493 MB in the issue repro.
- User-initiated hibernation (the idle-terminal "Close Them" action) now calls `ProjectViewManager.destroyView()` across every window for the hibernated project. Gated strictly to the new `"user-initiated"` reason, so scheduled background hibernation and memory-pressure hibernation are unchanged (no surprise cold restores).
- Eviction skips any window where the project is currently on-screen: the active foreground view and the still-visible outgoing paint-gate bridge during a cold switch (new `getOutgoingBridgeProjectId()`, mirroring the existing LRU eviction guard). Per-manager try/catch isolates a disposing window. Provider wired as a lazy lambda over `windowRegistry`, mirroring `ResourceProfileService`.

Refs #10668 (follow-ups 1 and 3 from the issue remain open: UX copy honesty and an explicit memory-saver action).

## Changes

- `electron/services/HibernationService.ts`: new `ProjectViewManagerProvider` type, `setProjectViewManagerProvider()`, renderer eviction in `hibernateProject()` gated on `"user-initiated"` reason
- `electron/window/ProjectViewManager.ts`: new `getOutgoingBridgeProjectId()` to expose the paint-gate bridge project during cold switches
- `electron/window/globalServicesInit.ts`: wires the lazy provider into `HibernationService`
- `electron/services/IdleTerminalNotificationService.ts`: passes `reason: "user-initiated"` through to `hibernateProjectOnDemand()`
- `electron/preload.cts`: exposes `reason` on the hibernation IPC call
- `shared/types/ipc/hibernation.ts`: adds `"user-initiated"` to the `HibernationReason` union
- `electron/services/__tests__/HibernationService.test.ts`: new suite covering active-view skip, paint-gate-bridge skip, scheduled/memory-pressure no-evict, per-manager and provider fault isolation, accurate eviction count, and default reason
- Updated `IdleTerminalNotificationService.test.ts` and `globalServicesInit.order.test.ts`

## Testing

211 targeted tests pass. Full typecheck, eslint, and prettier clean on all changed files. Test cases cover every skip path (active view, paint-gate bridge), the scheduled/memory-pressure no-evict gate, fault isolation at both the per-manager and provider levels, and that the eviction count matches the number of windows where the project was cached and not on-screen.