### PR TITLE
fix(dock): restore drag handles on docked panel chips

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -21,6 +21,7 @@ import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modi
 import { LayoutGroup, AnimatePresence, m } from "framer-motion";
 import { ChevronDown, CopyPlus } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -77,6 +78,12 @@ interface DockedTabGroupProps {
 }
 
 export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
+  // Consume the drag listeners SortableDockItem publishes via DragHandleProvider
+  // so the group chip button is a real drag source (pointer reorder + keyboard
+  // drag). setActivatorNodeRef must land on the focusable button itself or
+  // KeyboardSensor's Space/Enter activation silently fails. Called before the
+  // early return below to satisfy the Rules of Hooks.
+  const dragHandle = useDragHandle();
   const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
   const openDockTerminal = usePanelStore((s) => s.openDockTerminal);
   const closeDockTerminal = usePanelStore((s) => s.closeDockTerminal);
@@ -542,6 +549,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         <TerminalContextMenu terminalId={activePanel.id} forceLocation="dock">
           <PopoverTrigger asChild>
             <button
+              ref={dragHandle?.setActivatorNodeRef}
+              {...dragHandle?.listeners}
               data-dock-item=""
               className={cn(
                 "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -9,6 +9,7 @@ import {
   PointerSensor,
   TouchSensor,
   type DragEndEvent,
+  type DraggableSyntheticListeners,
   type UniqueIdentifier,
 } from "@dnd-kit/core";
 import {
@@ -78,12 +79,22 @@ interface DockedTabGroupProps {
 }
 
 export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
-  // Consume the drag listeners SortableDockItem publishes via DragHandleProvider
-  // so the group chip button is a real drag source (pointer reorder + keyboard
-  // drag). setActivatorNodeRef must land on the focusable button itself or
-  // KeyboardSensor's Space/Enter activation silently fails. Called before the
-  // early return below to satisfy the Rules of Hooks.
+  // Forward only the pointer/touch drag listeners SortableDockItem publishes via
+  // DragHandleProvider, so the group chip becomes a real drag source instead of
+  // just grab-cursor styling. The KeyboardSensor's onKeyDown is dropped on
+  // purpose: the chip is its own preview trigger, and dnd-kit's Space/Enter
+  // handler calls preventDefault() to start a keyboard drag, which would
+  // suppress this native <button>'s activation click — the sole keyboard path to
+  // the chip's primary action. (Grid PanelHeader has no such conflict: its drag
+  // surface is a non-interactive <div>.) Keyboard-driven reordering of dock
+  // chips is intentionally out of scope. Computed before the early return below
+  // to satisfy the Rules of Hooks.
   const dragHandle = useDragHandle();
+  const dragPointerListeners: DraggableSyntheticListeners = dragHandle?.listeners
+    ? Object.fromEntries(
+        Object.entries(dragHandle.listeners).filter(([name]) => name !== "onKeyDown")
+      )
+    : undefined;
   const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
   const openDockTerminal = usePanelStore((s) => s.openDockTerminal);
   const closeDockTerminal = usePanelStore((s) => s.closeDockTerminal);
@@ -549,8 +560,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         <TerminalContextMenu terminalId={activePanel.id} forceLocation="dock">
           <PopoverTrigger asChild>
             <button
-              ref={dragHandle?.setActivatorNodeRef}
-              {...dragHandle?.listeners}
+              {...dragPointerListeners}
               data-dock-item=""
               className={cn(
                 "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDndMonitor } from "@dnd-kit/core";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { cn, getBaseTitle } from "@/lib/utils";
 import { useTerminalInputStore, usePanelStore, useFocusStore } from "@/store";
 import type { PtyPanelData } from "@shared/types/panel";
@@ -42,6 +43,11 @@ interface DockedTerminalItemProps {
 }
 
 export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
+  // Consume the drag listeners SortableDockItem publishes via DragHandleProvider
+  // so the chip button is a real drag source (pointer reorder + keyboard drag),
+  // not just grab-cursor styling. setActivatorNodeRef must land on the focusable
+  // button itself or KeyboardSensor's Space/Enter activation silently fails.
+  const dragHandle = useDragHandle();
   const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
   const openDockTerminal = usePanelStore((s) => s.openDockTerminal);
   const closeDockTerminal = usePanelStore((s) => s.closeDockTerminal);
@@ -301,6 +307,8 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
             <PopoverTrigger asChild>
               <button
+                ref={dragHandle?.setActivatorNodeRef}
+                {...dragHandle?.listeners}
                 data-dock-item=""
                 className={cn(
                   "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDndMonitor } from "@dnd-kit/core";
+import type { DraggableSyntheticListeners } from "@dnd-kit/core";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { cn, getBaseTitle } from "@/lib/utils";
@@ -43,11 +44,21 @@ interface DockedTerminalItemProps {
 }
 
 export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
-  // Consume the drag listeners SortableDockItem publishes via DragHandleProvider
-  // so the chip button is a real drag source (pointer reorder + keyboard drag),
-  // not just grab-cursor styling. setActivatorNodeRef must land on the focusable
-  // button itself or KeyboardSensor's Space/Enter activation silently fails.
+  // Forward only the pointer/touch drag listeners SortableDockItem publishes via
+  // DragHandleProvider, so the chip becomes a real drag source (reorder/eject)
+  // instead of just grab-cursor styling. The KeyboardSensor's onKeyDown is
+  // dropped on purpose: the chip is its own preview trigger, and dnd-kit's
+  // Space/Enter handler calls preventDefault() to start a keyboard drag, which
+  // would suppress this native <button>'s activation click — the sole keyboard
+  // path to the chip's primary action. (Grid PanelHeader has no such conflict:
+  // its drag surface is a non-interactive <div>.) Keyboard-driven reordering of
+  // dock chips is intentionally out of scope.
   const dragHandle = useDragHandle();
+  const dragPointerListeners: DraggableSyntheticListeners = dragHandle?.listeners
+    ? Object.fromEntries(
+        Object.entries(dragHandle.listeners).filter(([name]) => name !== "onKeyDown")
+      )
+    : undefined;
   const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
   const openDockTerminal = usePanelStore((s) => s.openDockTerminal);
   const closeDockTerminal = usePanelStore((s) => s.closeDockTerminal);
@@ -307,8 +318,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
             <PopoverTrigger asChild>
               <button
-                ref={dragHandle?.setActivatorNodeRef}
-                {...dragHandle?.listeners}
+                {...dragPointerListeners}
                 data-dock-item=""
                 className={cn(
                   "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -246,6 +246,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 }));
 
 import { DockedTabGroup } from "../DockedTabGroup";
+import { DragHandleProvider } from "@/components/DragDrop/DragHandleContext";
 import { handleDockFocusOutside } from "../dockPopoverGuard";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
@@ -775,5 +776,62 @@ describe("DockedTabGroup add-tab orphan cleanup (#10441)", () => {
 
     expect(trashPanelMock).not.toHaveBeenCalled();
     expect(setActiveTabMock).toHaveBeenCalledWith("g-1", "t-new");
+  });
+});
+
+// #10797 — the group chip showed grab-cursor styling but never consumed the
+// drag listeners SortableDockItem publishes via DragHandleProvider, so it
+// wasn't a functional drag source. These tests verify the chip now registers
+// the activator node (KeyboardSensor's focusable surface) and forwards pointer
+// drag events.
+describe("DockedTabGroup drag wiring (#10797)", () => {
+  beforeEach(() => {
+    mockActiveDockTerminalId = null;
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
+  });
+
+  function renderInProvider(value: {
+    listeners: Record<string, unknown>;
+    setActivatorNodeRef: (node: HTMLElement | null) => void;
+  }) {
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+    return render(
+      <DragHandleProvider value={value}>
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      </DragHandleProvider>
+    );
+  }
+
+  it("registers the group chip button as the drag activator node", () => {
+    const setActivatorNodeRef = vi.fn();
+    const { container } = renderInProvider({ listeners: {}, setActivatorNodeRef });
+
+    const chip = container.querySelector(
+      'button[aria-label*="drag to reorder"]'
+    ) as HTMLButtonElement | null;
+    expect(chip).not.toBeNull();
+    expect(setActivatorNodeRef).toHaveBeenCalledWith(chip);
+  });
+
+  it("forwards pointer drag events from the group chip to the dnd listeners", () => {
+    const onPointerDown = vi.fn();
+    const { container } = renderInProvider({
+      listeners: { onPointerDown },
+      setActivatorNodeRef: vi.fn(),
+    });
+
+    const chip = container.querySelector(
+      'button[aria-label*="drag to reorder"]'
+    ) as HTMLButtonElement;
+    fireEvent.pointerDown(chip);
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders without a drag-handle provider (no listeners) without throwing", () => {
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+    expect(() =>
+      render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />)
+    ).not.toThrow();
   });
 });

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -781,9 +781,10 @@ describe("DockedTabGroup add-tab orphan cleanup (#10441)", () => {
 
 // #10797 — the group chip showed grab-cursor styling but never consumed the
 // drag listeners SortableDockItem publishes via DragHandleProvider, so it
-// wasn't a functional drag source. These tests verify the chip now registers
-// the activator node (KeyboardSensor's focusable surface) and forwards pointer
-// drag events.
+// wasn't a functional drag source. The fix forwards the pointer/touch listeners
+// but deliberately drops the KeyboardSensor's onKeyDown: the chip is its own
+// preview trigger, so Space/Enter must keep opening the preview rather than
+// being hijacked into a keyboard drag pickup.
 describe("DockedTabGroup drag wiring (#10797)", () => {
   beforeEach(() => {
     mockActiveDockTerminalId = null;
@@ -803,29 +804,36 @@ describe("DockedTabGroup drag wiring (#10797)", () => {
     );
   }
 
-  it("registers the group chip button as the drag activator node", () => {
-    const setActivatorNodeRef = vi.fn();
-    const { container } = renderInProvider({ listeners: {}, setActivatorNodeRef });
-
-    const chip = container.querySelector(
-      'button[aria-label*="drag to reorder"]'
-    ) as HTMLButtonElement | null;
-    expect(chip).not.toBeNull();
-    expect(setActivatorNodeRef).toHaveBeenCalledWith(chip);
-  });
-
   it("forwards pointer drag events from the group chip to the dnd listeners", () => {
-    const onPointerDown = vi.fn();
+    const onMouseDown = vi.fn();
     const { container } = renderInProvider({
-      listeners: { onPointerDown },
+      listeners: { onMouseDown },
       setActivatorNodeRef: vi.fn(),
     });
 
     const chip = container.querySelector(
       'button[aria-label*="drag to reorder"]'
     ) as HTMLButtonElement;
-    fireEvent.pointerDown(chip);
-    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    fireEvent.mouseDown(chip);
+    expect(onMouseDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not wire the keyboard-drag listener onto the group chip (Space/Enter stays for preview)", () => {
+    const onKeyDown = vi.fn();
+    const { container } = renderInProvider({
+      listeners: { onKeyDown },
+      setActivatorNodeRef: vi.fn(),
+    });
+
+    const chip = container.querySelector(
+      'button[aria-label*="drag to reorder"]'
+    ) as HTMLButtonElement;
+    fireEvent.keyDown(chip, { key: "Enter" });
+    fireEvent.keyDown(chip, { key: " " });
+    // The KeyboardSensor's onKeyDown would call preventDefault() and start a drag
+    // pickup, suppressing the native button click that opens the preview. It must
+    // not be forwarded onto the chip.
+    expect(onKeyDown).not.toHaveBeenCalled();
   });
 
   it("renders without a drag-handle provider (no listeners) without throwing", () => {

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -246,7 +246,10 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 }));
 
 import { DockedTabGroup } from "../DockedTabGroup";
-import { DragHandleProvider } from "@/components/DragDrop/DragHandleContext";
+import {
+  DragHandleProvider,
+  type DragHandleContextValue,
+} from "@/components/DragDrop/DragHandleContext";
 import { handleDockFocusOutside } from "../dockPopoverGuard";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
@@ -792,10 +795,7 @@ describe("DockedTabGroup drag wiring (#10797)", () => {
     mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
   });
 
-  function renderInProvider(value: {
-    listeners: Record<string, unknown>;
-    setActivatorNodeRef: (node: HTMLElement | null) => void;
-  }) {
+  function renderInProvider(value: DragHandleContextValue) {
     const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
     return render(
       <DragHandleProvider value={value}>

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -123,6 +123,7 @@ vi.mock("@dnd-kit/core", () => ({
 }));
 
 import { DockedTerminalItem } from "../DockedTerminalItem";
+import { DragHandleProvider } from "@/components/DragDrop/DragHandleContext";
 
 function makeTerminal(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
@@ -185,5 +186,49 @@ describe("DockedTerminalItem move-to-grid gesture", () => {
 
     expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
     expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+});
+
+// #10797 — the chip showed grab-cursor styling but never consumed the drag
+// listeners SortableDockItem publishes via DragHandleProvider, so it wasn't a
+// functional drag source. These tests verify the chip now registers the
+// activator node (KeyboardSensor's focusable surface) and forwards pointer
+// drag events.
+describe("DockedTerminalItem drag wiring", () => {
+  beforeEach(() => {
+    mockActiveDockTerminalId = null;
+    mockDockAgentState = undefined;
+  });
+
+  it("registers the chip button as the drag activator node", () => {
+    const setActivatorNodeRef = vi.fn();
+    render(
+      <DragHandleProvider value={{ listeners: {}, setActivatorNodeRef }}>
+        <DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />
+      </DragHandleProvider>
+    );
+
+    const chip = screen.getByRole("button", { name: /drag to reorder/i });
+    expect(setActivatorNodeRef).toHaveBeenCalledWith(chip);
+  });
+
+  it("forwards pointer drag events from the chip to the dnd listeners", () => {
+    const onPointerDown = vi.fn();
+    render(
+      <DragHandleProvider value={{ listeners: { onPointerDown }, setActivatorNodeRef: vi.fn() }}>
+        <DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />
+      </DragHandleProvider>
+    );
+
+    const chip = screen.getByRole("button", { name: /drag to reorder/i });
+    fireEvent.pointerDown(chip);
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders without a drag-handle provider (no listeners) without throwing", () => {
+    expect(() =>
+      render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />)
+    ).not.toThrow();
+    expect(screen.getByRole("button", { name: /drag to reorder/i })).not.toBeNull();
   });
 });

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -191,38 +191,44 @@ describe("DockedTerminalItem move-to-grid gesture", () => {
 
 // #10797 — the chip showed grab-cursor styling but never consumed the drag
 // listeners SortableDockItem publishes via DragHandleProvider, so it wasn't a
-// functional drag source. These tests verify the chip now registers the
-// activator node (KeyboardSensor's focusable surface) and forwards pointer
-// drag events.
+// functional drag source. The fix forwards the pointer/touch listeners but
+// deliberately drops the KeyboardSensor's onKeyDown: the chip is its own preview
+// trigger, so Space/Enter must keep opening the preview rather than being
+// hijacked into a keyboard drag pickup.
 describe("DockedTerminalItem drag wiring", () => {
   beforeEach(() => {
     mockActiveDockTerminalId = null;
     mockDockAgentState = undefined;
   });
 
-  it("registers the chip button as the drag activator node", () => {
-    const setActivatorNodeRef = vi.fn();
+  it("forwards pointer drag events from the chip to the dnd listeners", () => {
+    const onMouseDown = vi.fn();
     render(
-      <DragHandleProvider value={{ listeners: {}, setActivatorNodeRef }}>
+      <DragHandleProvider value={{ listeners: { onMouseDown }, setActivatorNodeRef: vi.fn() }}>
         <DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />
       </DragHandleProvider>
     );
 
     const chip = screen.getByRole("button", { name: /drag to reorder/i });
-    expect(setActivatorNodeRef).toHaveBeenCalledWith(chip);
+    fireEvent.mouseDown(chip);
+    expect(onMouseDown).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards pointer drag events from the chip to the dnd listeners", () => {
-    const onPointerDown = vi.fn();
+  it("does not wire the keyboard-drag listener onto the chip (Space/Enter stays for preview)", () => {
+    const onKeyDown = vi.fn();
     render(
-      <DragHandleProvider value={{ listeners: { onPointerDown }, setActivatorNodeRef: vi.fn() }}>
+      <DragHandleProvider value={{ listeners: { onKeyDown }, setActivatorNodeRef: vi.fn() }}>
         <DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />
       </DragHandleProvider>
     );
 
     const chip = screen.getByRole("button", { name: /drag to reorder/i });
-    fireEvent.pointerDown(chip);
-    expect(onPointerDown).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(chip, { key: "Enter" });
+    fireEvent.keyDown(chip, { key: " " });
+    // The KeyboardSensor's onKeyDown would call preventDefault() and start a drag
+    // pickup, suppressing the native button click that opens the preview. It must
+    // not be forwarded onto the chip.
+    expect(onKeyDown).not.toHaveBeenCalled();
   });
 
   it("renders without a drag-handle provider (no listeners) without throwing", () => {


### PR DESCRIPTION
## Summary

- Docked panel chips (`DockedTerminalItem`, `DockedTabGroup`) had grab-cursor styling but no drag listeners attached, so they were visually draggable but non-functional.
- Both components now call `useDragHandle()` and forward the pointer and touch listeners onto the chip `<button>`, restoring drag-to-grid, drag-to-worktree, and dock reordering.
- The keyboard sensor `onKeyDown` is deliberately not forwarded: dnd-kit's Space/Enter handler calls `preventDefault()` to start a keyboard drag, which would swallow the chip button's click (the only path to opening the panel preview). Pointer/touch only is the right scope here.

Resolves #10797

## Changes

- `src/components/Layout/DockedTerminalItem.tsx`: consume `useDragHandle()`, spread pointer/touch listeners onto chip button.
- `src/components/Layout/DockedTabGroup.tsx`: same.
- `src/components/Layout/__tests__/DockedTerminalItem.test.tsx`: drag-wiring assertions (pointer forwards, keyboard does not).
- `src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx`: same.

## Testing

42 tests pass across `DockedTerminalItem.test.tsx`, `DockedTabGroup.mountGuard.test.tsx`, and `SortableDockItem.test.tsx`. New tests assert that pointer drag listeners are forwarded onto the chip button and that the keyboard drag listener is not.