### PR TITLE
fix(terminal): stop redundant focus wake from clobbering live TUIs

### DIFF
--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -1207,6 +1207,28 @@ describe("TerminalFocusSlice - setFocused ping gating", () => {
     state.setFocused("term-2", false);
     expect(pingSpy).not.toHaveBeenCalled();
   });
+
+  it("wakes the terminal when focus moves to it", () => {
+    state.setFocused("term-1");
+    expect(terminalInstanceService.wake).toHaveBeenCalledWith("term-1");
+
+    vi.mocked(terminalInstanceService.wake).mockClear();
+    state.setFocused("term-2");
+    expect(terminalInstanceService.wake).toHaveBeenCalledWith("term-2");
+  });
+
+  it("does NOT re-wake when re-focusing the already-focused terminal", () => {
+    // A wake reset()+replays the serialized buffer. Re-focusing a live
+    // foreground terminal (clicking the xterm while the pane hybrid input held
+    // focus) must not trigger that, or the redundant replay clobbers the live
+    // buffer and collapses an alt-screen TUI like OpenCode.
+    state.setFocused("term-1");
+    vi.mocked(terminalInstanceService.wake).mockClear();
+
+    state.setFocused("term-1");
+
+    expect(terminalInstanceService.wake).not.toHaveBeenCalled();
+  });
 });
 
 describe("TerminalFocusSlice - focusAlternate (last-pane toggle)", () => {

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -224,9 +224,18 @@ export const createTerminalFocusSlice =
           if (terminal) {
             stampLastActive(id);
           }
-          // Wake-on-focus: sync terminal state from backend when focused.
-          // Skip wake for non-PTY panels - they don't have backend PTY processes.
-          if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
+          // Wake-on-focus: sync terminal state from backend when focus MOVES to
+          // this terminal. Skip when re-focusing the already-focused terminal
+          // (e.g. clicking the xterm while the pane's hybrid input held focus):
+          // a foreground terminal's xterm is fed by the live PTY stream and is
+          // already current, so a redundant wake's reset()+serialized-replay
+          // clobbers its live buffer. For an alt-screen TUI (OpenCode) the
+          // host buffer is never "unchanged" (it redraws continuously), so the
+          // replay always fires, carries `?1049` frames, flaps the buffer, and
+          // collapses the layout — the "click a settled OpenCode and it goes
+          // weird" corruption. Background→foreground restores run through the
+          // visibility path, not this focus click. Skip wake for non-PTY panels.
+          if (focusActuallyChanged && terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
             terminalInstanceService.wake(id);
           }
           // Only ping when selection actually changes — re-focusing the already


### PR DESCRIPTION
`setFocused` called `terminalInstanceService.wake()` on every focus, including when you re-focus the terminal that already has focus. That re-focus happens constantly in normal use: OpenCode auto-focuses the hybrid input bar, so clicking the terminal is a re-focus.

`wake()` runs `terminal.reset()` and then replays a serialized snapshot of the buffer. It normally skips that when the host reports the buffer hasn't changed, but a full-screen TUI like OpenCode redraws continuously, so the host never reports it unchanged. So every re-focus ran reset + replay and clobbered the live buffer. The layout collapsed: the centered splash input box jumped to the top row with the cursor detached.

It reproduces identically on both the DOM and WebGL renderers, which is how I knew it was a logical buffer clobber and not a render bug. A terminal in the foreground is already current from the live PTY stream, so calling `wake()` on a re-focus was both redundant and destructive.

## Fix

Gate the wake-on-focus in `setFocused` on `focusActuallyChanged`, so re-focusing the already-focused terminal no longer triggers reset + replay. Background to foreground restores run through the separate visibility path, so those are unaffected.

## Test plan

- Adds a regression test: re-focusing the already-focused terminal does not call `wake()`, while moving focus to a different terminal still does.
- Verified end to end against OpenCode: click a settled terminal and the splash stays put instead of collapsing to the top row.
