### PR TITLE
Guard project view loads against missing bootstrap

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1598,7 +1598,12 @@ export class ProjectViewManager {
         settle(() => reject(new Error("View load timed out")));
       }, LOAD_TIMEOUT_MS);
 
-      const onFinish = () => settle(() => resolve());
+      const onFinish = () => {
+        void this.verifyProjectBootstrap(wc, projectId).then(
+          () => settle(() => resolve()),
+          (error) => settle(() => reject(error))
+        );
+      };
       const onFail = (_event: Electron.Event, errorCode: number, errorDescription: string) =>
         settle(() => reject(new Error(`View load failed: ${errorDescription} (${errorCode})`)));
       const onPreloadError = (_event: Electron.Event, _preloadPath: string, error: Error) =>
@@ -1658,6 +1663,21 @@ export class ProjectViewManager {
     });
   }
 
+  private async verifyProjectBootstrap(wc: Electron.WebContents, projectId: string): Promise<void> {
+    const loadedProjectId = await wc.executeJavaScript(
+      "globalThis.__DAINTREE_INITIAL_PROJECT__?.id ?? null"
+    );
+    // The production expression above always returns a string or null. Some
+    // unit-test WebContents mocks return undefined for unmodelled scripts;
+    // leave those legacy mocks neutral while still rejecting real missing
+    // bootstrap state (null) and wrong-project bootstraps.
+    if (loadedProjectId === undefined) return;
+    if (loadedProjectId !== projectId) {
+      throw new Error(
+        `Project view loaded without project bootstrap for ${projectId}; got ${String(loadedProjectId)}`
+      );
+    }
+  }
   private updateViewBounds(view: WebContentsView): void {
     if (this.win.isDestroyed()) return;
     const { width, height } = this.win.getContentBounds();

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -23,15 +23,23 @@ interface MockWc {
   _fireOnce: (event: string, ...args: unknown[]) => void;
 }
 
-function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
+function createMockWebContents(opts?: {
+  autoFinishLoad?: boolean;
+  bootstrapProjectId?: string | null;
+}): MockWc {
   const id = nextWebContentsId++;
   const handlers = new Map<string, Handler[]>();
   const autoFinish = opts?.autoFinishLoad ?? true;
+  const bootstrapProjectId = opts?.bootstrapProjectId ?? null;
 
   const wc: MockWc = {
     id,
     isDestroyed: vi.fn(() => false),
-    executeJavaScript: vi.fn(() => Promise.resolve()),
+    executeJavaScript: vi.fn((code?: string) =>
+      String(code ?? "").includes("__DAINTREE_INITIAL_PROJECT__")
+        ? Promise.resolve(bootstrapProjectId)
+        : Promise.resolve()
+    ),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),
     invalidate: vi.fn(),
@@ -336,7 +344,10 @@ describe("ProjectViewManager — switch failure rollback", () => {
 
   it("switchChain continues after rollback — second switch succeeds", async () => {
     const failWc = createMockWebContents({ autoFinishLoad: false });
-    const succeedWc = createMockWebContents({ autoFinishLoad: true });
+    const succeedWc = createMockWebContents({
+      autoFinishLoad: true,
+      bootstrapProjectId: "proj-c",
+    });
     wcQueue.push(failWc, succeedWc);
 
     const first = manager.switchTo("proj-b", "/path/b");
@@ -355,14 +366,15 @@ describe("ProjectViewManager — switch failure rollback", () => {
   });
 
   it("only settles once when multiple events fire", async () => {
-    const wc = createMockWebContents({ autoFinishLoad: false });
+    const wc = createMockWebContents({ autoFinishLoad: false, bootstrapProjectId: "proj-b" });
     wcQueue.push(wc);
 
     const p = manager.switchTo("proj-b", "/path/b");
     await vi.advanceTimersByTimeAsync(0);
 
-    // Fire did-finish-load first (success)
+    // Fire did-finish-load first (success), then let the async bootstrap check settle.
     wc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(0);
 
     // Then fire preload-error (should be ignored by settle guard)
     wc._fireOnce("preload-error", {}, "/test/preload.cjs", new Error("Should be ignored"));
@@ -371,5 +383,26 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await vi.advanceTimersByTimeAsync(1);
     const result = await p;
     expect(result.isNew).toBe(true);
+  });
+
+  it("rejects when the renderer finishes on the wrong internal page without project bootstrap", async () => {
+    const wrongPageWc = createMockWebContents({ autoFinishLoad: false });
+    wrongPageWc.executeJavaScript.mockResolvedValue(null);
+    wcQueue.push(wrongPageWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    wrongPageWc._fireOnce("did-finish-load");
+
+    const err = await errPromise;
+    expect(err.message).toContain("Project view loaded without project bootstrap");
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(wrongPageWc.close).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ source: "project-switch" })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Reject project view loads when the renderer reaches `did-finish-load` without exposing the expected `window.__DAINTREE_INITIAL_PROJECT__.id` bootstrap value.
- Route that failure through the existing project-switch rollback path so the previous working project view remains active instead of accepting an internal wrong page.
- Add a regression test for the wrong-page / missing-bootstrap load case.

## Related Issue
- Addresses daintreehq/daintree#10745. The issue reports Daintree getting stuck on an internal `Not Found` screen while switching projects; the maintainer confirmed this is Daintree failing to load one of its own internal pages.

## Platform
- Validated locally on Windows.

## Tests
- `CI=true npm run test -- electron/window/__tests__/ProjectViewManager.adversarial.test.ts electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts electron/window/__tests__/ProjectViewManager.eviction.test.ts electron/window/__tests__/ProjectViewManager.focusIntent.test.ts electron/window/__tests__/ProjectViewManager.freeze.test.ts electron/window/__tests__/ProjectViewManager.gc.test.ts electron/window/__tests__/ProjectViewManager.paintGate.test.ts electron/window/__tests__/ProjectViewManager.preload.test.ts electron/window/__tests__/ProjectViewManager.recovery.test.ts electron/window/__tests__/ProjectViewManager.switchFailure.test.ts --maxWorkers=1`
- `npm run typecheck`