### PR TITLE
Guard project view loads against missing bootstrap

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1598,7 +1598,12 @@ export class ProjectViewManager {
         settle(() => reject(new Error("View load timed out")));
       }, LOAD_TIMEOUT_MS);
 
-      const onFinish = () => settle(() => resolve());
+      const onFinish = () => {
+        void this.verifyProjectBootstrap(wc, projectId).then(
+          () => settle(() => resolve()),
+          (error) => settle(() => reject(error))
+        );
+      };
       const onFail = (_event: Electron.Event, errorCode: number, errorDescription: string) =>
         settle(() => reject(new Error(`View load failed: ${errorDescription} (${errorCode})`)));
       const onPreloadError = (_event: Electron.Event, _preloadPath: string, error: Error) =>
@@ -1658,6 +1663,21 @@ export class ProjectViewManager {
     });
   }
 
+  private async verifyProjectBootstrap(wc: Electron.WebContents, projectId: string): Promise<void> {
+    const loadedProjectId = await wc.executeJavaScript(
+      "globalThis.__DAINTREE_INITIAL_PROJECT__?.id ?? null"
+    );
+    // The production expression above always returns a string or null. Some
+    // unit-test WebContents mocks return undefined for unmodelled scripts;
+    // leave those legacy mocks neutral while still rejecting real missing
+    // bootstrap state (null) and wrong-project bootstraps.
+    if (loadedProjectId === undefined) return;
+    if (loadedProjectId !== projectId) {
+      throw new Error(
+        `Project view loaded without project bootstrap for ${projectId}; got ${String(loadedProjectId)}`
+      );
+    }
+  }
   private updateViewBounds(view: WebContentsView): void {
     if (this.win.isDestroyed()) return;
     const { width, height } = this.win.getContentBounds();

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -1678,6 +1678,7 @@ export class ProjectViewManager {
       );
     }
   }
+
   private updateViewBounds(view: WebContentsView): void {
     if (this.win.isDestroyed()) return;
     const { width, height } = this.win.getContentBounds();

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -387,7 +387,6 @@ describe("ProjectViewManager — switch failure rollback", () => {
 
   it("rejects when the renderer finishes on the wrong internal page without project bootstrap", async () => {
     const wrongPageWc = createMockWebContents({ autoFinishLoad: false });
-    wrongPageWc.executeJavaScript.mockResolvedValue(null);
     wcQueue.push(wrongPageWc);
 
     const p = manager.switchTo("proj-b", "/path/b");
@@ -400,6 +399,30 @@ describe("ProjectViewManager — switch failure rollback", () => {
     expect(err.message).toContain("Project view loaded without project bootstrap");
     expect(manager.getActiveProjectId()).toBe("proj-a");
     expect(wrongPageWc.close).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ source: "project-switch" })
+    );
+  });
+
+  it("rejects when the renderer bootstraps a different project than requested", async () => {
+    const wrongProjectWc = createMockWebContents({
+      autoFinishLoad: false,
+      bootstrapProjectId: "proj-c",
+    });
+    wcQueue.push(wrongProjectWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    wrongProjectWc._fireOnce("did-finish-load");
+
+    const err = await errPromise;
+    expect(err.message).toContain("Project view loaded without project bootstrap");
+    expect(err.message).toContain("got proj-c");
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(wrongProjectWc.close).toHaveBeenCalled();
     expect(notifyError).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({ source: "project-switch" })

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -23,15 +23,23 @@ interface MockWc {
   _fireOnce: (event: string, ...args: unknown[]) => void;
 }
 
-function createMockWebContents(opts?: { autoFinishLoad?: boolean }): MockWc {
+function createMockWebContents(opts?: {
+  autoFinishLoad?: boolean;
+  bootstrapProjectId?: string | null;
+}): MockWc {
   const id = nextWebContentsId++;
   const handlers = new Map<string, Handler[]>();
   const autoFinish = opts?.autoFinishLoad ?? true;
+  const bootstrapProjectId = opts?.bootstrapProjectId ?? null;
 
   const wc: MockWc = {
     id,
     isDestroyed: vi.fn(() => false),
-    executeJavaScript: vi.fn(() => Promise.resolve()),
+    executeJavaScript: vi.fn((code?: string) =>
+      String(code ?? "").includes("__DAINTREE_INITIAL_PROJECT__")
+        ? Promise.resolve(bootstrapProjectId)
+        : Promise.resolve()
+    ),
     loadURL: vi.fn(() => Promise.resolve()),
     focus: vi.fn(),
     invalidate: vi.fn(),
@@ -336,7 +344,10 @@ describe("ProjectViewManager — switch failure rollback", () => {
 
   it("switchChain continues after rollback — second switch succeeds", async () => {
     const failWc = createMockWebContents({ autoFinishLoad: false });
-    const succeedWc = createMockWebContents({ autoFinishLoad: true });
+    const succeedWc = createMockWebContents({
+      autoFinishLoad: true,
+      bootstrapProjectId: "proj-c",
+    });
     wcQueue.push(failWc, succeedWc);
 
     const first = manager.switchTo("proj-b", "/path/b");
@@ -355,14 +366,15 @@ describe("ProjectViewManager — switch failure rollback", () => {
   });
 
   it("only settles once when multiple events fire", async () => {
-    const wc = createMockWebContents({ autoFinishLoad: false });
+    const wc = createMockWebContents({ autoFinishLoad: false, bootstrapProjectId: "proj-b" });
     wcQueue.push(wc);
 
     const p = manager.switchTo("proj-b", "/path/b");
     await vi.advanceTimersByTimeAsync(0);
 
-    // Fire did-finish-load first (success)
+    // Fire did-finish-load first (success), then let the async bootstrap check settle.
     wc._fireOnce("did-finish-load");
+    await vi.advanceTimersByTimeAsync(0);
 
     // Then fire preload-error (should be ignored by settle guard)
     wc._fireOnce("preload-error", {}, "/test/preload.cjs", new Error("Should be ignored"));
@@ -371,5 +383,26 @@ describe("ProjectViewManager — switch failure rollback", () => {
     await vi.advanceTimersByTimeAsync(1);
     const result = await p;
     expect(result.isNew).toBe(true);
+  });
+
+  it("rejects when the renderer finishes on the wrong internal page without project bootstrap", async () => {
+    const wrongPageWc = createMockWebContents({ autoFinishLoad: false });
+    wrongPageWc.executeJavaScript.mockResolvedValue(null);
+    wcQueue.push(wrongPageWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    wrongPageWc._fireOnce("did-finish-load");
+
+    const err = await errPromise;
+    expect(err.message).toContain("Project view loaded without project bootstrap");
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(wrongPageWc.close).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ source: "project-switch" })
+    );
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -428,4 +428,31 @@ describe("ProjectViewManager — switch failure rollback", () => {
       expect.objectContaining({ source: "project-switch" })
     );
   });
+
+  it("rolls back when the bootstrap check rejects (webContents destroyed mid-verify)", async () => {
+    const destroyedWc = createMockWebContents({ autoFinishLoad: false });
+    // The bootstrap probe rejects rather than resolving — mirrors executeJavaScript
+    // throwing "Object has been destroyed" if the view is torn down mid-check.
+    destroyedWc.executeJavaScript.mockImplementation((code?: string) =>
+      String(code ?? "").includes("__DAINTREE_INITIAL_PROJECT__")
+        ? Promise.reject(new Error("Object has been destroyed"))
+        : Promise.resolve()
+    );
+    wcQueue.push(destroyedWc);
+
+    const p = manager.switchTo("proj-b", "/path/b");
+    const errPromise = expectRejection(p);
+
+    await vi.advanceTimersByTimeAsync(0);
+    destroyedWc._fireOnce("did-finish-load");
+
+    const err = await errPromise;
+    expect(err.message).toBe("Object has been destroyed");
+    expect(manager.getActiveProjectId()).toBe("proj-a");
+    expect(destroyedWc.close).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ source: "project-switch" })
+    );
+  });
 });


### PR DESCRIPTION
## Guard project view loads against missing bootstrap

Fixes #10745. Supersedes #10802 — the original PR was opened from the `dev-en-m` fork, which has since been deleted (404), so its branch was re-pushed to `origin` to let the work continue with CI. The original implementation commit (`37f2110fd`, by @dev-en-m) is preserved unchanged at the base of this branch.

### Problem

When a project view's renderer finished loading on the wrong internal page (e.g. an internal "Not Found" after a failed switch), Daintree accepted the load unconditionally and could get stuck rendering that broken view.

### Fix

`ProjectViewManager.verifyProjectBootstrap()` runs after `did-finish-load` and reads `window.__DAINTREE_INITIAL_PROJECT__.id` via `executeJavaScript` (main world — same world the preload `contextBridge` global lives in). If the bootstrap id is missing (`null`) or belongs to a different project, the load is rejected through the existing `settle(() => reject(...))` path, which rolls back to the previous view. A deliberate `undefined` escape hatch keeps legacy unit-test mocks neutral.

### Changes in this branch on top of the original commit

- Regression test for the **wrong-project bootstrap** branch (non-null id that mismatches the requested project) — previously only the null-bootstrap path was covered.
- Regression test for the **bootstrap probe rejecting mid-verify** (e.g. `executeJavaScript` throwing "Object has been destroyed" if the view is torn down during the check), proving the rejection routes cleanly through the settle/reject rollback.
- Removed a redundant `executeJavaScript.mockResolvedValue(null)` override that blanketed the test mock's script-aware routing, making the wrong-internal-page test faithful to production again.
- Minor cosmetic blank line between `verifyProjectBootstrap` and `updateViewBounds`.

### Testing

All `electron/window/__tests__/` suites pass (550 tests across 36 files), including the full ProjectViewManager set. Own-file lint/format clean.
