### PR TITLE
fix(terminal): stop alt-screen TUIs (OpenCode) garbling on click / reveal

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1028,6 +1028,42 @@ class TerminalInstanceService {
   }
 
   /**
+   * Focus/click-driven wake. The wake-on-focus safety net (51ba86d8d) heals a
+   * frozen/garbled pane on click by running `wakeManager.wake` -> wakeAndRestore
+   * -> restoreFromSerialized = `terminal.reset()` + serialized replay. For a
+   * main-buffer pane that replay is harmless (full-line overwrite) and still
+   * heals background garble. For a LIVE, foreground alt-screen TUI (OpenCode,
+   * any agent with blockAltScreen disabled) it is destructive: reset()+replay
+   * duplicates/collapses the absolutely-positioned frame — the "click a settled
+   * OpenCode and it goes weird" corruption. A co-visible foreground alt-screen
+   * pane is fed by the live PTY stream and is already current, so it needs no
+   * resync at all: leave it untouched. A genuinely stale pane (hibernated,
+   * backgrounded, or armed for wake) still takes the full wake — its replay is
+   * the legitimate background->foreground resync owned by the visibility path.
+   */
+  wakeForFocus(id: string): void {
+    const managed = this.instances.get(id);
+    if (!managed) return;
+
+    const panelState = usePanelStore.getState();
+    const panel = panelState.panelsById[id];
+    const needsRealRestore =
+      managed.isHibernated ||
+      managed.needsWake === true ||
+      panel?.location === "background" ||
+      panelState.backgroundedTerminals.has(id);
+
+    if (needsRealRestore || managed.isAltBuffer !== true) {
+      this.wake(id);
+      return;
+    }
+    // Live foreground alt-screen TUI: already current from the live PTY stream.
+    // No reset+replay (clobbers the frame) and no geometry reconcile (reflows
+    // it). The reflow controller's focus/heartbeat recovery and the
+    // reconciliation watchdog handle any genuine renderer staleness.
+  }
+
+  /**
    * Run the full click-equivalent wake sequence on a visible terminal whose
    * project view just regained visibility (#8562). This method is the complete
    * path: it runs `applyDeferredResize`, `forceXtermReflow`,

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -375,6 +375,19 @@ export class TerminalResizeController {
     const rect = managed.hostElement.getBoundingClientRect();
     if (rect.width < 50 || rect.height < 50) return false;
 
+    // Never reflow a live alt-screen TUI here. A full-screen app (OpenCode, and
+    // any agent with blockAltScreen disabled) paints an absolutely-positioned
+    // frame and emits only cursor-positioned deltas; an out-of-band xterm
+    // resize/reflow at this point mangles that frame and races the app's own
+    // SIGWINCH redraw — the "settled OpenCode goes weird on click / garbles
+    // intermittently" corruption. This one-shot, lock-exempt reconcile was added
+    // (#10632) to re-fit main-buffer scrollback that wrapped at the wrong column
+    // after a project switch-back; it must not touch the alternate buffer. An
+    // alt-screen pane's geometry is reconciled by the ResizeObserver-driven
+    // applyResize path and the app's own redraw. Report success so the reveal
+    // repaint doesn't treat this as "not paintable yet" and spin in a retry loop.
+    if (managed.isAltBuffer) return true;
+
     // Prefer the fit addon's own DOM measurement so the grid matches exactly
     // what a manual Redraw's fit() would compute; fall back to cell-metric math
     // when the renderer hasn't published proposable dimensions yet.

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1276,6 +1276,25 @@ describe("TerminalResizeController", () => {
       expect(managed.fitAddon.fit).not.toHaveBeenCalled();
     });
 
+    it("does NOT reflow a live alt-screen TUI even when the grid drifted (OpenCode clobber regression)", () => {
+      const managed = createManagedTerminal();
+      managed.isAltBuffer = true;
+      // Same stale-grid setup as above (box proposes 100x30, grid is 80x24): a
+      // main-buffer pane gets reflowed, but an alt-screen pane must be left
+      // untouched — an out-of-band xterm resize mangles its absolutely-positioned
+      // frame (the "settled OpenCode goes weird on click" corruption, #10632).
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      // Reports success so the reveal repaint does not retry-loop, but resizes
+      // neither xterm nor the PTY.
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
     it("ignores an active resize lock without clearing it (the reveal exception)", () => {
       const managed = createManagedTerminal();
       managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));

--- a/src/store/__tests__/trashTerminalAgentFocus.test.ts
+++ b/src/store/__tests__/trashTerminalAgentFocus.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     applyRendererPolicy: vi.fn(),
     onPanelBackgrounded: vi.fn(),
     wake: vi.fn(),
+    wakeForFocus: vi.fn(),
   },
 }));
 

--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     applyRendererPolicy: vi.fn(),
     onPanelBackgrounded: vi.fn(),
     wake: vi.fn(),
+    wakeForFocus: vi.fn(),
   },
 }));
 

--- a/src/store/slices/__tests__/terminalFocusSlice.test.ts
+++ b/src/store/slices/__tests__/terminalFocusSlice.test.ts
@@ -5,6 +5,7 @@ import type { PtyPanelData } from "@shared/types/panel";
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     wake: vi.fn(),
+    wakeForFocus: vi.fn(),
   },
 }));
 
@@ -1208,13 +1209,13 @@ describe("TerminalFocusSlice - setFocused ping gating", () => {
     expect(pingSpy).not.toHaveBeenCalled();
   });
 
-  it("wakes the terminal when focus moves to it", () => {
+  it("routes a focus move through wakeForFocus (never a destructive wake on a live grid pane)", () => {
     state.setFocused("term-1");
-    expect(terminalInstanceService.wake).toHaveBeenCalledWith("term-1");
+    expect(terminalInstanceService.wakeForFocus).toHaveBeenCalledWith("term-1");
 
-    vi.mocked(terminalInstanceService.wake).mockClear();
+    vi.mocked(terminalInstanceService.wakeForFocus).mockClear();
     state.setFocused("term-2");
-    expect(terminalInstanceService.wake).toHaveBeenCalledWith("term-2");
+    expect(terminalInstanceService.wakeForFocus).toHaveBeenCalledWith("term-2");
   });
 
   it("does NOT re-wake when re-focusing the already-focused terminal", () => {
@@ -1223,11 +1224,11 @@ describe("TerminalFocusSlice - setFocused ping gating", () => {
     // focus) must not trigger that, or the redundant replay clobbers the live
     // buffer and collapses an alt-screen TUI like OpenCode.
     state.setFocused("term-1");
-    vi.mocked(terminalInstanceService.wake).mockClear();
+    vi.mocked(terminalInstanceService.wakeForFocus).mockClear();
 
     state.setFocused("term-1");
 
-    expect(terminalInstanceService.wake).not.toHaveBeenCalled();
+    expect(terminalInstanceService.wakeForFocus).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/slices/__tests__/worktreeBulkActions.test.ts
+++ b/src/store/slices/__tests__/worktreeBulkActions.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     onPanelBackgrounded: vi.fn(),
     resize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
     wake: vi.fn(),
+    wakeForFocus: vi.fn(),
   },
 }));
 

--- a/src/store/slices/terminalFocusSlice.ts
+++ b/src/store/slices/terminalFocusSlice.ts
@@ -208,6 +208,12 @@ export const createTerminalFocusSlice =
           const previousFocusedId = get().focusedId;
           const focusActuallyChanged = id !== previousFocusedId;
           const terminal = getTerminals().find((t) => t.id === id);
+          // Snapshot BEFORE the set() below flips activeDockTerminalId to `id`: a
+          // dock pane that was already the active dock terminal is live (popover
+          // open), like a grid re-focus; a dock pane that was NOT active is a
+          // first reveal from the parked/offscreen dock and needs a genuine wake.
+          const wasActiveDockTerminal =
+            terminal?.location === "dock" && get().activeDockTerminalId === id;
           if (terminal?.location === "dock") {
             set({
               focusedId: id,
@@ -224,19 +230,23 @@ export const createTerminalFocusSlice =
           if (terminal) {
             stampLastActive(id);
           }
-          // Wake-on-focus: sync terminal state from backend when focus MOVES to
-          // this terminal. Skip when re-focusing the already-focused terminal
-          // (e.g. clicking the xterm while the pane's hybrid input held focus):
-          // a foreground terminal's xterm is fed by the live PTY stream and is
-          // already current, so a redundant wake's reset()+serialized-replay
-          // clobbers its live buffer. For an alt-screen TUI (OpenCode) the
-          // host buffer is never "unchanged" (it redraws continuously), so the
-          // replay always fires, carries `?1049` frames, flaps the buffer, and
-          // collapses the layout — the "click a settled OpenCode and it goes
-          // weird" corruption. Background→foreground restores run through the
-          // visibility path, not this focus click. Skip wake for non-PTY panels.
+          // Wake-on-focus: recover this pane's renderer when focus MOVES to it.
+          // Skip when re-focusing the already-focused terminal (#10800). Use
+          // `wakeForFocus`, NOT `wake`: a live foreground pane is fed by the live
+          // PTY stream and is already current, so the full wake's reset()+replay
+          // is unnecessary and, for an alt-screen TUI (OpenCode), destructive —
+          // it duplicates/collapses the frame (the "click a settled OpenCode and
+          // it goes weird" corruption; the host noChange skip can't catch it
+          // because the TUI redraws continuously). wakeForFocus still full-wakes
+          // main-buffer and genuinely-stale panes. A first reveal of a parked
+          // dock tab keeps the full wake; an already-open dock tab and any grid
+          // pane take wakeForFocus. Skip non-PTY panels.
           if (focusActuallyChanged && terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-            terminalInstanceService.wake(id);
+            if (terminal.location === "dock" && !wasActiveDockTerminal) {
+              terminalInstanceService.wake(id);
+            } else {
+              terminalInstanceService.wakeForFocus(id);
+            }
           }
           // Only ping when selection actually changes — re-focusing the already
           // selected terminal should be a no-op visually (no 1.6s ping loop).
@@ -491,7 +501,14 @@ export const createTerminalFocusSlice =
           return;
         }
         if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
-          terminalInstanceService.wake(id);
+          // Re-focusing the already-open dock pane is live (like a grid click) —
+          // wakeForFocus avoids the alt-screen clobber; a first reveal from the
+          // parked/offscreen dock is a genuine wake.
+          if (get().activeDockTerminalId === id) {
+            terminalInstanceService.wakeForFocus(id);
+          } else {
+            terminalInstanceService.wake(id);
+          }
         }
         if (isPtyPanel(terminal) && terminal.agentState === "waiting") {
           window.electron?.notification?.acknowledgeWaiting(id);
@@ -520,10 +537,19 @@ export const createTerminalFocusSlice =
         const terminal = terminals.find((t) => t.id === id);
         if (!terminal) return;
 
-        // Wake-on-focus: sync terminal state from backend when activated.
-        // Skip wake for non-PTY panels - they don't have backend PTY processes.
+        // Wake-on-focus: recover this pane's renderer when activated. A first
+        // reveal of a parked dock pane takes the full wake; a grid pane and an
+        // already-open dock pane (activeDockTerminalId === id) are live, so they
+        // take wakeForFocus — which never reset+replays a live alt-screen TUI.
+        // Skip non-PTY panels (no backend PTY).
         if (panelKindHasPty(terminal.kind ?? "terminal")) {
-          terminalInstanceService.wake(id);
+          const isFirstDockReveal =
+            terminal.location === "dock" && get().activeDockTerminalId !== id;
+          if (isFirstDockReveal) {
+            terminalInstanceService.wake(id);
+          } else {
+            terminalInstanceService.wakeForFocus(id);
+          }
         }
 
         const previousFocusedId = get().focusedId;


### PR DESCRIPTION
## Summary

Clicking a settled OpenCode pane (or any alt-screen TUI) would garble it — duplicated prompt/status, a collapsed splash, or a diagonal column-shift cascade — and the only cure was a manual window resize or adding another terminal to force a clean reflow. This fixes it at the source.

## Root cause (found by `git bisect`)

`1310f7d6d` "fix(terminal): reflow agent terminal grid on project switch-back" (#10632) is the first bad commit; `v0.19.0` (immediately before it) is clean. It introduced `TerminalResizeController.reconcileGeometryFresh` — a one-shot, lock-exempt xterm+PTY resize driven by `repaintForReveal` and the reconciliation watchdog — to re-fit **main-buffer scrollback** that wrapped at the wrong column after a project switch-back. That out-of-band resize **reflows a live alt-screen TUI** and mangles its absolutely-positioned frame.

Two distinct destructive mechanisms hit a live alt-screen pane:

1. **Reveal / watchdog reflow** — `reconcileGeometryFresh` resizes and reflows the alternate buffer.
2. **Click reset+replay** — a focus click runs `setFocused → wake → wakeAndRestore → restoreFromSerialized` = `terminal.reset()` + serialized replay, which duplicates/collapses the live frame.

(Note: the #10632 Claude switch-back fix it was added for never actually resolved the Claude garble, so this reconcile is pure downside for alt-screen panes.)

## The fix

1. **`reconcileGeometryFresh` skips alt-screen** (`if (managed.isAltBuffer) return true;`). A full-screen app paints its own frame and redraws on `SIGWINCH`; an out-of-band reflow only mangles it. It returns success so `repaintForReveal` / the watchdog's `reconcileRevealGeometry` don't treat it as "not paintable yet" and spin. Genuine box changes still flow through the `ResizeObserver` → `applyResize` path.
2. **`wakeForFocus`** — a focus click on a *live foreground* alt-screen pane now does nothing (it's already current from the live PTY stream). Main-buffer panes keep the full wake (and its background-garble heal); genuinely-stale panes (hibernated / `needsWake` / backgrounded) still take the full wake, owned by the visibility-restore path. Wired into `setFocused`, `activateTerminal`, and `openDockTerminal`, with a first-dock-reveal-vs-already-open distinction.

## Verification

- `git bisect`: `v0.19.0` good → `1310f7d6d` bad (only docs/test/agent-detection commits between them), confirmed manually at each boundary.
- New regression test: `reconcileGeometryFresh` resizes neither xterm nor the PTY for an alt-buffer pane (and still returns `true`).
- Focus-slice routing tests updated to assert `wakeForFocus`.
- `npm run check` green; 153 unit tests pass; manually confirmed in-app that clicking OpenCode no longer garbles.

## Notes / follow-ups

- An alt-screen pane now relies entirely on the `ResizeObserver` `applyResize` path + its own `SIGWINCH` redraw for genuine box changes. A residual scrollbar-width drift (grid a couple of columns wider than the box) is possible but cosmetic — far better than the reflow mangle.
- Non-blocking cleanup: the watchdog's geometry-convergence comment still claims it repairs alt buffers, but `reconcileGeometryFresh` now refuses to resize them — consider skipping `isAltBuffer` in that branch too to avoid noisy periodic "geometry divergence" diagnostics.
