### PR TITLE
fix(projectview): prune orphaned views to stop double-rendered toolbar

### DIFF
--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -337,7 +337,13 @@ export class ProjectViewManager {
       // pruneOrphanedChildren detaches it.
       for (const child of win.contentView.children as WebContentsView[]) {
         if (child === view || child === outgoing) continue;
-        if (!child.webContents || child.webContents.isDestroyed()) continue;
+        const childWc = child.webContents;
+        if (!childWc || childWc.isDestroyed()) continue;
+        // Only sync project views. Non-project children (PortalManager parks
+        // hidden portal tabs at OFFSCREEN_BOUNDS while still attached, the
+        // unbound welcome view, devtools) own their own bounds — forcing them
+        // to full-window here would yank a hidden portal onscreen on resize.
+        if (!this.webContentsToProject.has(childWc.id)) continue;
         child.setBounds({ x: 0, y: 0, width, height });
       }
       this.scheduleBackgroundResizeNotify();
@@ -789,6 +795,15 @@ export class ProjectViewManager {
         // welcome view is not a project entry, but IPC helpers still need
         // getAppWebContents() to resolve to it after a failed first switch.
         registerAppView(this.win, unboundOutgoingView);
+      }
+
+      // Sweep any orphan that leaked before this failed switch (#10806). The
+      // rollback above restores the previous view as active; prune removes any
+      // other stray project view still attached behind it. Best-effort.
+      try {
+        this.pruneOrphanedChildren();
+      } catch (pruneError) {
+        console.error("[ProjectViewManager] pruneOrphanedChildren threw:", pruneError);
       }
 
       notifyError(loadError, { source: "project-switch" });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -329,6 +329,17 @@ export class ProjectViewManager {
       if (outgoing && !outgoing.webContents.isDestroyed() && outgoing !== view) {
         outgoing.setBounds({ x: 0, y: 0, width, height });
       }
+      // Defensive (#10806): an orphaned view briefly attached behind the active
+      // one (a cancelled paint gate or a destroyView race outside switchChain)
+      // never receives bounds updates and drifts to a stale x-offset — two
+      // toolbars rendered side by side. Sync every other attached child so any
+      // stray duplicate overlaps the active view exactly until
+      // pruneOrphanedChildren detaches it.
+      for (const child of win.contentView.children as WebContentsView[]) {
+        if (child === view || child === outgoing) continue;
+        if (!child.webContents || child.webContents.isDestroyed()) continue;
+        child.setBounds({ x: 0, y: 0, width, height });
+      }
       this.scheduleBackgroundResizeNotify();
     };
     win.on("resize", this.resizeHandler);
@@ -544,6 +555,13 @@ export class ProjectViewManager {
       const cachedIntent = this.consumePendingFocusIntent(projectId);
       if (cachedIntent) {
         this.deliverFocusIntent(cached.view, cachedIntent);
+      }
+      // Sweep any outgoing view a cancelled gate or destroyView race left
+      // attached behind this one (#10806). Never throws past this point.
+      try {
+        this.pruneOrphanedChildren();
+      } catch (error) {
+        console.error("[ProjectViewManager] pruneOrphanedChildren threw:", error);
       }
       return { view: cached.view, isNew: false };
     }
@@ -790,6 +808,14 @@ export class ProjectViewManager {
         this.evictStaleViews("lru");
       }
     });
+
+    // Sweep any outgoing view a cancelled gate or destroyView race left
+    // attached behind this one (#10806). Never throws past this point.
+    try {
+      this.pruneOrphanedChildren();
+    } catch (error) {
+      console.error("[ProjectViewManager] pruneOrphanedChildren threw:", error);
+    }
 
     return { view, isNew: true };
   }
@@ -1370,6 +1396,53 @@ export class ProjectViewManager {
         !this.hasActiveAgent(capturedProjectId)
       ) {
         void freezeWebContents(webContents);
+      }
+    }
+  }
+
+  /**
+   * Defensive sweep for orphaned project views still attached to
+   * `contentView.children` (#10806). The warm/cold anti-flash bridge skips
+   * `deactivateEntry(previousEntry)` whenever the paint gate resolves
+   * `"cancelled"` or `activeProjectId` no longer matches the switch target —
+   * the latter happens when `HibernationService.destroyView` runs outside
+   * `switchChain` and nulls `activeProjectId` mid-gate. A superseding switch
+   * only tears down its own `previousEntry`, so an earlier outgoing view can
+   * stay attached behind the newly active one, compositing two renderers at
+   * once (the duplicated forge toolbar). Called on each switch's success path —
+   * after the gate has settled and `pendingPaintGate` is already null — so it
+   * detaches any project view that is neither the active view nor an in-flight
+   * gate's outgoing bridge. Known live entries are parked as reusable cached
+   * views via `deactivateEntry` (preserving cleanup handlers, #6085); stray
+   * children the registry no longer tracks are simply removed.
+   */
+  private pruneOrphanedChildren(): void {
+    if (this.win.isDestroyed()) return;
+    const activeView = this.getActiveView();
+    const gateOutgoing = this.pendingPaintGate?.outgoingView ?? null;
+    // Snapshot — removeChildView/deactivateEntry mutate contentView.children.
+    const children = [...this.win.contentView.children] as WebContentsView[];
+    for (const child of children) {
+      if (child === activeView || child === gateOutgoing) continue;
+      const wc = child.webContents;
+      // Unbound/welcome views (not in webContentsToProject) own their own
+      // teardown via detachUnboundOutgoingView — never prune them here.
+      if (!wc || wc.isDestroyed() || !this.webContentsToProject.has(wc.id)) continue;
+      const projectId = this.webContentsToProject.get(wc.id) ?? null;
+      // Belt-and-suspenders: never detach the active project's view even if
+      // getActiveView() returned null (e.g. a destroyView race nulled
+      // activeProjectId but left the entry mid-teardown).
+      if (projectId !== null && projectId === this.activeProjectId) continue;
+      const entry = projectId ? this.views.get(projectId) : undefined;
+      try {
+        if (entry && entry.state !== "cached") {
+          this.deactivateEntry(entry);
+        } else {
+          this.win.contentView.removeChildView(child);
+        }
+        logWarn("projectview.orphan-pruned", { projectId });
+      } catch (error) {
+        console.error("[ProjectViewManager] pruneOrphanedChildren failed:", error);
       }
     }
   }

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -175,6 +175,11 @@ import { ProjectViewManager } from "../ProjectViewManager.js";
 const flushImmediates = () => new Promise<void>((resolve) => setImmediate(resolve));
 
 function createMockWindow() {
+  // Track children so contentView.children reflects real attach/detach order —
+  // required to assert orphaned-view pruning (#10806). The old no-op mock left
+  // children empty regardless of addChildView/removeChildView, hiding the
+  // double-attach the orphan bug produces.
+  const children: unknown[] = [];
   return {
     id: 1,
     isDestroyed: vi.fn(() => false),
@@ -183,12 +188,28 @@ function createMockWindow() {
     destroy: vi.fn(),
     getContentBounds: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
     contentView: {
-      children: [] as unknown[],
-      addChildView: vi.fn(),
-      removeChildView: vi.fn(),
+      children,
+      addChildView: vi.fn((view: unknown, index?: number) => {
+        if (typeof index === "number") {
+          children.splice(index, 0, view);
+        } else {
+          children.push(view);
+        }
+      }),
+      removeChildView: vi.fn((view: unknown) => {
+        const idx = children.indexOf(view);
+        if (idx >= 0) children.splice(idx, 1);
+      }),
     },
     webContents: createMockWebContents(),
   };
+}
+
+function getResizeHandler(win: ReturnType<typeof createMockWindow>): (() => void) | undefined {
+  const call = (win.on as ReturnType<typeof vi.fn>).mock.calls.find(
+    ([event]) => event === "resize"
+  );
+  return call?.[1] as (() => void) | undefined;
 }
 
 describe("ProjectViewManager adversarial", () => {
@@ -379,5 +400,119 @@ describe("ProjectViewManager adversarial", () => {
       setBackgroundColor: ReturnType<typeof vi.fn>;
     };
     expect(replacementView.setBackgroundColor).toHaveBeenCalledWith("#1f1b16");
+  });
+
+  // #10806 — Under rapid switching + backgrounding, a cancelled paint gate or a
+  // destroyView race (HibernationService runs outside switchChain) can skip
+  // deactivateEntry(previousEntry), leaving an outgoing view attached behind the
+  // active one. Two renderers composite at once → the forge toolbar renders
+  // twice. pruneOrphanedChildren on each switch's success path sweeps the leak.
+
+  it("detaches an orphaned outgoing view left attached behind the active view (#10806)", async () => {
+    const win = createMockWindow();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 3,
+    });
+
+    const aWc = createMockWebContents();
+    const aView = { webContents: aWc, setBounds: vi.fn(), setVisible: vi.fn() };
+    win.contentView.addChildView(aView);
+    manager.registerInitialView(aView as never, "proj-a", "/a");
+
+    // A→B deactivates A (cached) and detaches it from contentView.
+    wcQueue.push(createMockWebContents());
+    await manager.switchTo("proj-b", "/b");
+    expect(win.contentView.children).not.toContain(aView);
+
+    // Reproduce the leaked state: the cached A view is attached behind the
+    // active B view, as a cancelled gate / destroyView race would leave it.
+    win.contentView.addChildView(aView);
+    expect(win.contentView.children).toContain(aView);
+
+    // The next switch must sweep the orphan so only the active view remains.
+    wcQueue.push(createMockWebContents());
+    const result = await manager.switchTo("proj-c", "/c");
+
+    expect(win.contentView.children).not.toContain(aView);
+    expect(win.contentView.children).toEqual([result.view]);
+    expect(manager.getActiveProjectId()).toBe("proj-c");
+  });
+
+  it("parks a still-active orphaned view as cached rather than evicting it (#10806)", async () => {
+    const win = createMockWindow();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 3,
+    });
+
+    const aWc = createMockWebContents();
+    const aView = { webContents: aWc, setBounds: vi.fn(), setVisible: vi.fn() };
+    win.contentView.addChildView(aView);
+    manager.registerInitialView(aView as never, "proj-a", "/a");
+
+    wcQueue.push(createMockWebContents());
+    await manager.switchTo("proj-b", "/b");
+
+    // Reproduce the precise race: deactivateEntry(A) was skipped, so A is still
+    // marked active and still attached behind the active B view.
+    const aEntry = manager.getAllViews().find((entry) => entry.projectId === "proj-a");
+    expect(aEntry).toBeDefined();
+    aEntry!.state = "active";
+    win.contentView.addChildView(aView);
+
+    wcQueue.push(createMockWebContents());
+    await manager.switchTo("proj-c", "/c");
+
+    // Orphan detached and parked as cached (setVisible(false)) — never evicted,
+    // so its reusable cached renderer and cleanup handlers survive (#6085).
+    expect(win.contentView.children).not.toContain(aView);
+    expect(aView.setVisible).toHaveBeenCalledWith(false);
+    expect(
+      manager
+        .getAllViews()
+        .map((entry) => entry.projectId)
+        .sort()
+    ).toEqual(["proj-a", "proj-b", "proj-c"]);
+  });
+
+  it("resizes orphaned attached views so a stray duplicate overlaps the active view (#10806)", async () => {
+    const win = createMockWindow();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 3,
+    });
+
+    const aWc = createMockWebContents();
+    const aView = { webContents: aWc, setBounds: vi.fn(), setVisible: vi.fn() };
+    win.contentView.addChildView(aView);
+    manager.registerInitialView(aView as never, "proj-a", "/a");
+
+    wcQueue.push(createMockWebContents());
+    await manager.switchTo("proj-b", "/b");
+
+    // Orphan A attached behind active B with no in-flight paint gate.
+    win.contentView.addChildView(aView);
+
+    const resize = getResizeHandler(win);
+    expect(resize).toBeTypeOf("function");
+    aView.setBounds.mockClear();
+    resize!();
+
+    // The orphan gets the full window bounds, so it overlaps the active view
+    // exactly instead of drifting to a stale x-offset (side-by-side toolbars).
+    expect(aView.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 800, height: 600 });
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -515,4 +515,34 @@ describe("ProjectViewManager adversarial", () => {
     // exactly instead of drifting to a stale x-offset (side-by-side toolbars).
     expect(aView.setBounds).toHaveBeenCalledWith({ x: 0, y: 0, width: 800, height: 600 });
   });
+
+  it("does not resize non-project children such as parked portal views (#10806)", async () => {
+    const win = createMockWindow();
+    const manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+      warmPaintGateTimeoutMs: 0,
+      warmPaintGateHardTimeoutMs: 0,
+      cachedProjectViews: 3,
+    });
+
+    const aView = { webContents: createMockWebContents(), setBounds: vi.fn(), setVisible: vi.fn() };
+    win.contentView.addChildView(aView);
+    manager.registerInitialView(aView as never, "proj-a", "/a");
+
+    // A hidden portal tab: attached to contentView but never registered as a
+    // project view, parked far offscreen by PortalManager.
+    const portalView = { webContents: createMockWebContents(), setBounds: vi.fn() };
+    win.contentView.addChildView(portalView);
+
+    const resize = getResizeHandler(win);
+    expect(resize).toBeTypeOf("function");
+    portalView.setBounds.mockClear();
+    resize!();
+
+    // The portal view must keep its own (offscreen) bounds — yanking it to the
+    // full window would surface a hidden tab over the active project view.
+    expect(portalView.setBounds).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- Rapid project-view switching combined with app backgrounding could leave two `WebContentsView`s simultaneously attached to `win.contentView`. The renderer composited both side-by-side (offset, because the orphan never got bounds updates), which is why the forge/GitHub status toolbar appeared twice.
- Root cause: a cancelled paint gate or a `destroyView` race (HibernationService runs outside `switchChain` and can null `activeProjectId` mid-gate) could skip `deactivateEntry(previousEntry)`, leaving the previous view attached.
- Fix adds a `pruneOrphanedChildren()` sweep in `ProjectViewManager.ts` called on every switch success path and on the cold-switch rollback path.

Resolves #10806

## Changes

- `pruneOrphanedChildren()` detaches any project view that is neither the active view nor an in-flight paint gate's outgoing bridge. Still-active orphans are parked via `deactivateEntry` (preserving cleanup handlers, not evicting them from the cache). Non-project children like portal tabs and the welcome view are skipped via the `webContentsToProject` filter.
- `resizeHandler` now syncs bounds for every attached project child using the same filter, so a stray duplicate overlaps the active view exactly instead of drifting to a stale x-offset.

## Testing

Upgraded `ProjectViewManager.adversarial.test.ts` to use a children-tracking mock and added 4 targeted regression tests:

- Cached-orphan detach
- Still-active orphan parked, not evicted
- Resize syncs orphan bounds
- Resize skips non-project portal views

All 110 tests across adversarial, paintGate, and eviction suites pass.