### PR TITLE
fix(crash-recovery): clear pending crash after resolve (#10809)

### DIFF
--- a/electron/ipc/__tests__/app.state.test.ts
+++ b/electron/ipc/__tests__/app.state.test.ts
@@ -40,6 +40,7 @@ const crashService = {
   resetToFresh: vi.fn(),
   restoreBackup: vi.fn(() => false),
   setPanelFilter: vi.fn(),
+  clearPendingCrash: vi.fn(),
   getPendingCrash: vi.fn() as any,
   getConfig: vi.fn(() => ({ autoRestoreOnCrash: false })),
 };

--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -56,6 +56,7 @@ vi.mock("../../../utils/performance.js", () => ({
 vi.mock("../../../services/CrashRecoveryService.js", () => ({
   getCrashRecoveryService: vi.fn(() => ({
     resetToFresh: vi.fn(),
+    clearPendingCrash: vi.fn(),
   })),
 }));
 
@@ -278,12 +279,14 @@ describe("registerRecoveryHandlers", () => {
       expect(win.loadURL).not.toHaveBeenCalled();
     });
 
-    it("resets state then reloads the app when sender is the recovery page", async () => {
+    it("resets state, clears the pending crash, then reloads the app when sender is the recovery page", async () => {
       const { getCrashRecoveryService: getCrash } =
         await import("../../../services/CrashRecoveryService.js");
       const resetMock = vi.fn();
+      const clearMock = vi.fn();
       vi.mocked(getCrash).mockReturnValue({
         resetToFresh: resetMock,
+        clearPendingCrash: clearMock,
       } as unknown as ReturnType<typeof getCrash>);
 
       const win = buildWindow();
@@ -294,9 +297,15 @@ describe("registerRecoveryHandlers", () => {
       await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(resetMock).toHaveBeenCalledTimes(1);
+      // Without clearing the in-memory record, the reload's app:boot re-reads
+      // it and re-presents the dialog with the backup already gone (#10809).
+      expect(clearMock).toHaveBeenCalledTimes(1);
       expect(win.loadURL).toHaveBeenCalledTimes(1);
       expect(win.loadURL).toHaveBeenCalledWith("http://localhost:5173");
       expect(resetMock.mock.invocationCallOrder[0]).toBeLessThan(
+        clearMock.mock.invocationCallOrder[0]
+      );
+      expect(clearMock.mock.invocationCallOrder[0]).toBeLessThan(
         win.loadURL.mock.invocationCallOrder[0]
       );
     });

--- a/electron/ipc/handlers/app/__tests__/crashRecovery.test.ts
+++ b/electron/ipc/handlers/app/__tests__/crashRecovery.test.ts
@@ -9,6 +9,7 @@ const crashServiceMock = vi.hoisted(() => ({
   restoreBackup: vi.fn(() => false),
   setPanelFilter: vi.fn(),
   resetToFresh: vi.fn(),
+  clearPendingCrash: vi.fn(),
   getPendingCrash: vi.fn(),
   getConfig: vi.fn(() => ({ autoRestoreOnCrash: false })),
   setConfig: vi.fn(),
@@ -91,6 +92,10 @@ describe("registerCrashRecoveryHandlers", () => {
         expect(crashServiceMock.restoreBackup).toHaveBeenCalledWith(["p1", "p2"]);
         expect(crashServiceMock.setPanelFilter).toHaveBeenCalledWith(["p1", "p2"]);
         expect(crashServiceMock.resetToFresh).not.toHaveBeenCalled();
+        // Clears the in-memory pending-crash record so a cold-rebooted
+        // WebContentsView on project switch-back does not re-present the
+        // dialog (#10809).
+        expect(crashServiceMock.clearPendingCrash).toHaveBeenCalledTimes(1);
       });
 
       it("rejects with 'Crash recovery restore failed' when restoreBackup returns false", async () => {
@@ -124,6 +129,20 @@ describe("registerCrashRecoveryHandlers", () => {
 
         expect(crashServiceMock.setPanelFilter).not.toHaveBeenCalled();
       });
+
+      it("does NOT clear the pending crash when restoreBackup returns false", async () => {
+        crashServiceMock.restoreBackup.mockReturnValue(false);
+        registerCrashRecoveryHandlers();
+        const handler = getHandlerFn("crash-recovery:resolve");
+
+        // Recovery has not succeeded, so the record must persist — a later
+        // LRU eviction should re-present the dialog so the user can retry.
+        await expect(
+          Promise.resolve().then(() => handler(FAKE_EVENT, { kind: "restore", panelIds: ["p1"] }))
+        ).rejects.toThrow("Crash recovery restore failed");
+
+        expect(crashServiceMock.clearPendingCrash).not.toHaveBeenCalled();
+      });
     });
 
     describe("fresh action", () => {
@@ -137,6 +156,7 @@ describe("registerCrashRecoveryHandlers", () => {
         expect(crashServiceMock.resetToFresh).toHaveBeenCalledTimes(1);
         expect(crashServiceMock.restoreBackup).not.toHaveBeenCalled();
         expect(crashServiceMock.setPanelFilter).not.toHaveBeenCalled();
+        expect(crashServiceMock.clearPendingCrash).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/electron/ipc/handlers/app/crashRecovery.ts
+++ b/electron/ipc/handlers/app/crashRecovery.ts
@@ -28,6 +28,7 @@ export function registerCrashRecoveryHandlers(): () => void {
         const ok = service.restoreBackup(action.panelIds);
         if (ok) {
           service.setPanelFilter(action.panelIds);
+          service.clearPendingCrash();
         } else {
           // Propagate the failure to the renderer. `restoreBackup` returns
           // false for: no parseable snapshot, zero-match panel filter, no
@@ -41,6 +42,7 @@ export function registerCrashRecoveryHandlers(): () => void {
         }
       } else {
         service.resetToFresh();
+        service.clearPendingCrash();
       }
     })
   );

--- a/electron/ipc/handlers/recovery.ts
+++ b/electron/ipc/handlers/recovery.ts
@@ -55,7 +55,13 @@ export function registerRecoveryHandlers(deps: HandlerDependencies): () => void 
       const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
       if (win && !win.isDestroyed()) {
         console.log("[MAIN] Recovery: resetting state and reloading app");
-        getCrashRecoveryService().resetToFresh();
+        const service = getCrashRecoveryService();
+        service.resetToFresh();
+        // Drop the in-memory pending-crash record too — the reload below
+        // fires app:boot, which re-reads getPendingCrash(); without this the
+        // recovery dialog reappears immediately with the backup already
+        // deleted from disk (#10809, same surface as LRU switch-back).
+        service.clearPendingCrash();
         win.loadURL(getAppUrl());
       }
     })

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -108,6 +108,16 @@ export class CrashRecoveryService {
     return this.pendingCrash;
   }
 
+  // Drop the in-memory pending-crash record once the user has resolved the
+  // recovery dialog. Without this, an LRU-evicted WebContentsView that
+  // cold-reboots re-reads the stale record via app:boot and re-presents the
+  // dialog on project switch-back (#10809). Disk cleanup is already done by
+  // restoreBackup()/resetToFresh(); this only clears the cache, so it is safe
+  // to call after those complete. Idempotent.
+  clearPendingCrash(): void {
+    this.pendingCrash = null;
+  }
+
   getLastBackupTimestamp(): number | null {
     const info = this.readBackupInfo();
     return info.exists && typeof info.timestamp === "number" ? info.timestamp : null;

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -145,6 +145,29 @@ describe("CrashRecoveryService", () => {
       expect(pending!.entry.appVersion).toBe("1.0.0");
     });
 
+    it("clearPendingCrash() zeroes the pending record so cold reboots see no crash (#10809)", () => {
+      const markerPath = path.join(userData, "running.lock");
+      fs.writeFileSync(
+        markerPath,
+        JSON.stringify({
+          sessionStartMs: Date.now() - 5000,
+          appVersion: "1.0.0",
+          platform: "darwin",
+        })
+      );
+
+      const svc = makeService();
+      svc.initialize();
+      expect(svc.getPendingCrash()).not.toBeNull();
+
+      svc.clearPendingCrash();
+      expect(svc.getPendingCrash()).toBeNull();
+
+      // Idempotent — a second call must not throw and stays null.
+      svc.clearPendingCrash();
+      expect(svc.getPendingCrash()).toBeNull();
+    });
+
     it("consumes marker on detection — marker deleted before new one written", () => {
       const markerPath = path.join(userData, "running.lock");
       fs.writeFileSync(


### PR DESCRIPTION
## Summary

Fixes a bug where the crash-recovery dialog reappears after the user has already resolved it and switched back to the project.

After dismissal, `pendingCrash` stayed set in the `CrashRecoveryService` main-process singleton. When `ProjectViewManager` LRU-evicts a `WebContentsView` and the user returns to that project, the fresh V8 context re-fires `app:boot`, picks up the stale `pendingCrash`, and re-presents the dialog. That's dangerous: declining at that point kills live terminals.

Resolves #10809

## Changes

- Added `clearPendingCrash()` to `CrashRecoveryService` (idempotent; disk cleanup is already handled by `restoreBackup()`/`resetToFresh()`).
- Called from `crash-recovery:resolve` on both success paths. Deliberately not called on the restore-failure path so the dialog stays up for retry.
- Also called from `recovery:reset-and-reload` after `resetToFresh()`, covering the same bug via the static recovery page surface.

## Testing

- Service unit test: `clearPendingCrash()` zeroes `getPendingCrash()` and is idempotent.
- `crash-recovery:resolve` handler: clears once on restore-success, once on fresh, never on restore-failure.
- `recovery:reset-and-reload` handler: asserts reset, clear, and reload ordering.
- Defensive stub added to the `app.state` handler test.

229 tests passing, ESLint clean on changed files.