### PR TITLE
fix(agent): return MCP error on agent.launch with unknown worktreeId

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -430,6 +430,7 @@ import type { BuiltInPanelKind } from "./types";
 import { actionService, installE2EActionDispatchBridge } from "./services/ActionService";
 import { voiceRecordingService } from "./services/VoiceRecordingService";
 import { useRenderProfiler } from "./utils/renderProfiler";
+import { logError } from "./utils/logger";
 
 import { SidebarContent, preloadNewWorktreeDialog, E2EFaultInjector } from "./components/Sidebar";
 import { ensureHydrationBootstrap } from "./utils/stateHydration/bootstrapGuard";
@@ -870,7 +871,15 @@ function AppInner() {
 
   const handleLaunchAgent = useCallback(
     async (type: string) => {
-      await launchAgent(type);
+      // launchAgent now throws on an unresolvable worktreeId (#10812). UI surfaces
+      // pass no explicit worktreeId (they fall back to the active one), so this is
+      // only reachable via a stale activeWorktreeId race — keep it a quiet no-op,
+      // matching the pre-fix silent behavior, rather than an unhandled rejection.
+      try {
+        await launchAgent(type);
+      } catch (error) {
+        logError("Failed to launch agent", error);
+      }
     },
     [launchAgent]
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1242,7 +1242,7 @@ function AppInner() {
                       } else if (result.id.startsWith("agent:")) {
                         const agentId = result.id.slice("agent:".length);
                         if (agentId) {
-                          launchAgent(agentId);
+                          void handleLaunchAgent(agentId);
                         }
                       } else {
                         addPanel({
@@ -1278,7 +1278,7 @@ function AppInner() {
                       } else if (selected.id.startsWith("agent:")) {
                         const agentId = selected.id.slice("agent:".length);
                         if (agentId) {
-                          launchAgent(agentId);
+                          void handleLaunchAgent(agentId);
                         }
                       } else {
                         addPanel({

--- a/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
+++ b/src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+/**
+ * Tests resolveLaunchWorktree from useAgentLauncher.ts — the pure worktree
+ * lookup that gates agent launches. Extracted so the throw-on-unknown-id
+ * contract (#10812) is guarded at the source: reverting it to a silent null
+ * return must fail a test here, not just at the ActionService boundary.
+ */
+import { describe, expect, it } from "vitest";
+import { resolveLaunchWorktree } from "../useAgentLauncher";
+
+function map(ids: string[]): Map<string, { path: string }> {
+  return new Map(ids.map((id) => [id, { path: `/repo/${id}` }]));
+}
+
+describe("resolveLaunchWorktree", () => {
+  it("returns the matching worktree when the id resolves", () => {
+    const worktrees = map(["wt-1", "wt-2"]);
+    expect(resolveLaunchWorktree("wt-2", worktrees, true)).toEqual({ path: "/repo/wt-2" });
+  });
+
+  it("returns null when no target id is supplied (active-worktree fallback)", () => {
+    expect(resolveLaunchWorktree(null, map(["wt-1"]), true)).toBeNull();
+    expect(resolveLaunchWorktree(undefined, map(["wt-1"]), true)).toBeNull();
+  });
+
+  it("throws on an unknown id once the worktree map is initialized (#10812)", () => {
+    expect(() => resolveLaunchWorktree("main", map(["wt-1", "wt-2"]), true)).toThrow(
+      "Worktree 'main' not found"
+    );
+  });
+
+  it("lists the available worktree ids in the thrown message so clients can self-correct", () => {
+    expect(() => resolveLaunchWorktree("main", map(["wt-1", "wt-2"]), true)).toThrow(
+      "Available worktree IDs: wt-1, wt-2"
+    );
+  });
+
+  it("reports 'none' when an unknown id is launched against an empty (but initialized) map", () => {
+    expect(() => resolveLaunchWorktree("main", map([]), true)).toThrow(
+      "Available worktree IDs: none"
+    );
+  });
+
+  it("does NOT throw before the map is initialized — can't assert not-found yet", () => {
+    // Pre-init we cannot distinguish "missing" from "not loaded"; fall through to
+    // the caller's cwd fallbacks rather than failing a launch spuriously.
+    expect(resolveLaunchWorktree("main", map([]), false)).toBeNull();
+    expect(resolveLaunchWorktree("main", map(["wt-1"]), false)).toBeNull();
+  });
+});

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -281,8 +281,11 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         const targetWorktree = targetWorktreeId ? worktreeMap.get(targetWorktreeId) : null;
 
         if (targetWorktreeId && !targetWorktree && isInitialized) {
-          console.warn(`Worktree ${targetWorktreeId} not found, cannot launch agent`);
-          return null;
+          throw new Error(
+            `Worktree '${targetWorktreeId}' not found. Available worktree IDs: ${
+              [...worktreeMap.keys()].join(", ") || "none"
+            }`
+          );
         }
 
         const cwd =

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -62,6 +62,32 @@ function sanitizeTerminalName(raw: string): string {
   return out.replace(/\s+/g, " ").trim();
 }
 
+/**
+ * Resolve the worktree a launch should target. When a `targetWorktreeId` is
+ * supplied but matches no known worktree (and the worktree map has finished
+ * loading), this throws instead of returning null so the failure surfaces as a
+ * real error to callers — notably the MCP `agent.launch` path, where a silent
+ * null was serialized as a terminal-less success and triggered client retry
+ * loops (#10812). The thrown message lists the available IDs so a model client
+ * can self-correct. Before the map is initialized we cannot assert "not found",
+ * so we fall through and let the caller use its cwd fallbacks.
+ */
+export function resolveLaunchWorktree<T>(
+  targetWorktreeId: string | null | undefined,
+  worktreeMap: Map<string, T>,
+  isInitialized: boolean
+): T | null {
+  const targetWorktree = targetWorktreeId ? worktreeMap.get(targetWorktreeId) : undefined;
+  if (targetWorktreeId && !targetWorktree && isInitialized) {
+    throw new Error(
+      `Worktree '${targetWorktreeId}' not found. Available worktree IDs: ${
+        [...worktreeMap.keys()].join(", ") || "none"
+      }`
+    );
+  }
+  return targetWorktree ?? null;
+}
+
 export interface LaunchAgentOptions {
   location?: AddPanelOptions["location"];
   cwd?: string;
@@ -278,15 +304,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
 
       try {
         const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
-        const targetWorktree = targetWorktreeId ? worktreeMap.get(targetWorktreeId) : null;
-
-        if (targetWorktreeId && !targetWorktree && isInitialized) {
-          throw new Error(
-            `Worktree '${targetWorktreeId}' not found. Available worktree IDs: ${
-              [...worktreeMap.keys()].join(", ") || "none"
-            }`
-          );
-        }
+        const targetWorktree = resolveLaunchWorktree(targetWorktreeId, worktreeMap, isInitialized);
 
         const cwd =
           launchOptions?.cwd ??

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -343,6 +343,36 @@ describe("agentActions adversarial", () => {
     );
   });
 
+  it("agent.launch surfaces a worktree-not-found launcher error as ok:false through ActionService (#10812)", async () => {
+    // Regression guard: a worktree-not-found launch must reach the MCP layer as a
+    // dispatch failure (ok:false), NOT as a terminal-less success ({ok:true,result:null}).
+    // The hook throws on an unknown worktreeId; ActionService converts the throw to
+    // an EXECUTION_ERROR result, which sessionServer serializes with isError:true.
+    const { ActionService } = await import("../../../ActionService");
+    const service = new ActionService();
+
+    const callbacks = makeCallbacks();
+    callbacks.onLaunchAgent.mockRejectedValueOnce(
+      new Error("Worktree 'main' not found. Available worktree IDs: wt-1, wt-2")
+    );
+    const registry: ActionRegistry = new Map();
+    registerAgentActions(registry, callbacks);
+    for (const [, factory] of registry) service.register(factory());
+
+    const result = await service.dispatch(
+      "agent.launch",
+      { agentId: "claude", worktreeId: "main" },
+      { source: "agent" }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe("EXECUTION_ERROR");
+      expect(result.error.message).toContain("Worktree 'main' not found");
+      expect(result.error.message).toContain("wt-1, wt-2");
+    }
+  });
+
   it("onLaunchAgent rejection propagates out of generated agent.<id>", async () => {
     const callbacks = makeCallbacks();
     callbacks.onLaunchAgent.mockRejectedValueOnce(new Error("generator boom"));


### PR DESCRIPTION
## Summary

- `agent.launch` was returning `{ok:true, result:null}` on an unknown `worktreeId`, which the MCP serialized as a terminal-less success with no `isError`. Clients had no signal to distinguish "launch failed" from "launch succeeded", so they retry-looped. One real session cascaded into 34 no-op tool calls from a single bad worktree ID.
- Fixed by extracting a pure helper `resolveLaunchWorktree` that throws when the ID can't be resolved. ActionService catches the throw and converts it to `{ok:false, error:{code:"EXECUTION_ERROR", message}}`, which the session server serializes as `isError:true` on the wire. The error message lists available worktree IDs so a model client can self-correct without manual intervention.
- Hardened `handleLaunchAgent` in `App.tsx` with a catch so a stale `activeWorktreeId` race stays a quiet no-op rather than an unhandled rejection.

Resolves #10812

## Changes

- `src/hooks/useAgentLauncher.ts`: extract `resolveLaunchWorktree` pure helper, throw on unknown worktree ID
- `src/hooks/__tests__/useAgentLauncher.worktreeResolution.test.ts`: 6 new unit tests covering the helper directly
- `src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts`: ActionService dispatch regression test asserting `ok:false` on bad `worktreeId`
- `src/App.tsx`: catch `launchAgent` rejection in `handleLaunchAgent`

## Testing

83 targeted tests across 5 files, all passing. Own files prettier-clean, no new lint errors against the ratchet baseline. Rebased clean onto `origin/develop`.