### PR TITLE
fix(git): match commit hash prefixes in commit search

### DIFF
--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -930,14 +930,115 @@ describe("listCommits", () => {
     expect(result.hasMore).toBe(true);
   });
 
-  it("passes --grep when search is provided", async () => {
+  it("passes --grep for a non-hex search string", async () => {
     mockGit.raw.mockResolvedValueOnce("0").mockResolvedValueOnce("");
 
     await listCommits({ cwd: "/test", branch: "main", search: "bugfix" });
 
+    // "bugfix" is not hex (u, g, x), so no rev-parse pass: rev-list + log only.
+    expect(mockGit.raw).toHaveBeenCalledTimes(2);
     const logCall = mockGit.raw.mock.calls[1][0] as string[];
     expect(logCall).toContain("--grep=bugfix");
     expect(logCall).toContain("-i");
+  });
+
+  it("resolves a hash prefix and prepends the matched commit on page 0", async () => {
+    const fullHash = "abc1234def567890abc1234def567890abc12345";
+    mockGit.raw
+      .mockResolvedValueOnce("10") // rev-list --count
+      .mockResolvedValueOnce(`${fullHash}\n`) // rev-parse --verify
+      .mockResolvedValueOnce(
+        makeLogOutput([
+          {
+            hash: fullHash,
+            short: "abc1234",
+            msg: "feat: the looked-up commit",
+            body: "",
+            name: "Author",
+            email: "a@b.com",
+            date: "2024-01-15T12:00:00+00:00",
+          },
+        ])
+      ) // log -1 <fullHash>
+      .mockResolvedValueOnce(
+        makeLogOutput([
+          {
+            hash: "ffff999",
+            short: "ffff999",
+            msg: "chore: a message match",
+            body: "",
+            name: "Author",
+            email: "a@b.com",
+            date: "2024-01-14T12:00:00+00:00",
+          },
+        ])
+      ); // log --grep
+
+    const result = await listCommits({ cwd: "/test", branch: "main", search: "abc1234" });
+
+    const revParseCall = mockGit.raw.mock.calls[1][0] as string[];
+    expect(revParseCall).toEqual(["rev-parse", "--verify", "abc1234^{commit}"]);
+    expect(result.items[0].hash).toBe(fullHash);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[1].hash).toBe("ffff999");
+  });
+
+  it("deduplicates a hash prefix match already present in message results", async () => {
+    const fullHash = "abc1234def567890abc1234def567890abc12345";
+    const commit = {
+      hash: fullHash,
+      short: "abc1234",
+      msg: "feat: shared commit",
+      body: "",
+      name: "Author",
+      email: "a@b.com",
+      date: "2024-01-15T12:00:00+00:00",
+    };
+    mockGit.raw
+      .mockResolvedValueOnce("10") // rev-list --count
+      .mockResolvedValueOnce(`${fullHash}\n`) // rev-parse --verify
+      .mockResolvedValueOnce(makeLogOutput([commit])) // log -1 <fullHash>
+      .mockResolvedValueOnce(makeLogOutput([commit])); // log --grep (same commit)
+
+    const result = await listCommits({ cwd: "/test", branch: "main", search: "abc1234" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].hash).toBe(fullHash);
+  });
+
+  it("skips the rev-parse pass when paginating (skip > 0)", async () => {
+    mockGit.raw.mockResolvedValueOnce("10").mockResolvedValueOnce("");
+
+    await listCommits({ cwd: "/test", branch: "main", search: "abc1234", skip: 5 });
+
+    // No rev-parse on paginated pages: rev-list + log only.
+    expect(mockGit.raw).toHaveBeenCalledTimes(2);
+    const secondCall = mockGit.raw.mock.calls[1][0] as string[];
+    expect(secondCall[0]).toBe("log");
+  });
+
+  it("gracefully falls back to message search when the hash prefix matches no commit", async () => {
+    mockGit.raw
+      .mockResolvedValueOnce("10") // rev-list --count
+      .mockRejectedValueOnce(new Error("fatal: Needed a single revision")) // rev-parse fails
+      .mockResolvedValueOnce(
+        makeLogOutput([
+          {
+            hash: "face123",
+            short: "face123",
+            msg: "fix: a face value",
+            body: "",
+            name: "Author",
+            email: "a@b.com",
+            date: "2024-01-15T12:00:00+00:00",
+          },
+        ])
+      ); // log --grep
+
+    const result = await listCommits({ cwd: "/test", branch: "main", search: "face" });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].hash).toBe("face123");
   });
 
   it("returns empty result on git error", async () => {

--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -978,9 +978,45 @@ describe("listCommits", () => {
 
     const revParseCall = mockGit.raw.mock.calls[1][0] as string[];
     expect(revParseCall).toEqual(["rev-parse", "--verify", "abc1234^{commit}"]);
+    // The resolved full hash must be trimmed before it's handed to `log -1`.
+    const logHashCall = mockGit.raw.mock.calls[2][0] as string[];
+    expect(logHashCall).toEqual(["log", expect.stringContaining("--format="), "-1", fullHash]);
+    // The grep pass must still carry the search term and branch.
+    const grepCall = mockGit.raw.mock.calls[3][0] as string[];
+    expect(grepCall).toContain("--grep=abc1234");
+    expect(grepCall).toContain("-i");
+    expect(grepCall).toContain("main");
     expect(result.items[0].hash).toBe(fullHash);
     expect(result.items).toHaveLength(2);
     expect(result.items[1].hash).toBe("ffff999");
+  });
+
+  it("keeps the hash match additive without dropping a full page of message results", async () => {
+    const fullHash = "abc1234def567890abc1234def567890abc12345";
+    const makeCommit = (h: string) => ({
+      hash: h,
+      short: h.slice(0, 7),
+      msg: `msg ${h}`,
+      body: "",
+      name: "A",
+      email: "a@b.com",
+      date: "2024-01-15T12:00:00+00:00",
+    });
+    // limit=1, grep returns 2 distinct message commits (limit+1 = "more exists"),
+    // hash match is not among them. The hash must be pinned AND no message result lost.
+    mockGit.raw
+      .mockResolvedValueOnce("10") // rev-list --count
+      .mockResolvedValueOnce(`${fullHash}\n`) // rev-parse --verify
+      .mockResolvedValueOnce(makeLogOutput([makeCommit(fullHash)])) // log -1 <fullHash>
+      .mockResolvedValueOnce(makeLogOutput([makeCommit("aaa1111"), makeCommit("bbb2222")])); // log --grep
+
+    const result = await listCommits({ cwd: "/test", branch: "main", search: "abc1234", limit: 1 });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].hash).toBe(fullHash);
+    expect(result.items[1].hash).toBe("aaa1111");
+    // bbb2222 was the limit+1 peek entry, so more message results remain.
+    expect(result.hasMore).toBe(true);
   });
 
   it("deduplicates a hash prefix match already present in message results", async () => {
@@ -1004,6 +1040,8 @@ describe("listCommits", () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].hash).toBe(fullHash);
+    // The only message result was the hash match itself, so nothing remains.
+    expect(result.hasMore).toBe(false);
   });
 
   it("skips the rev-parse pass when paginating (skip > 0)", async () => {
@@ -1011,10 +1049,38 @@ describe("listCommits", () => {
 
     await listCommits({ cwd: "/test", branch: "main", search: "abc1234", skip: 5 });
 
-    // No rev-parse on paginated pages: rev-list + log only.
+    // No rev-parse on paginated pages: rev-list + log only. The search term must
+    // still reach the grep call so paginated pages stay filtered.
     expect(mockGit.raw).toHaveBeenCalledTimes(2);
-    const secondCall = mockGit.raw.mock.calls[1][0] as string[];
-    expect(secondCall[0]).toBe("log");
+    const logCall = mockGit.raw.mock.calls[1][0] as string[];
+    expect(logCall[0]).toBe("log");
+    expect(logCall).toContain("--grep=abc1234");
+    expect(logCall).toContain("-i");
+  });
+
+  it("skips the rev-parse pass for sub-4-char and over-40-char hex strings", async () => {
+    mockGit.raw.mockResolvedValue("");
+
+    await listCommits({ cwd: "/test", branch: "main", search: "abc" }); // 3 chars
+    expect(mockGit.raw).toHaveBeenCalledTimes(2);
+
+    vi.clearAllMocks();
+    mockGit.raw.mockResolvedValue("");
+    await listCommits({ cwd: "/test", branch: "main", search: "a".repeat(41) }); // 41 chars
+    expect(mockGit.raw).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips the log -1 call when rev-parse returns only whitespace", async () => {
+    mockGit.raw
+      .mockResolvedValueOnce("10") // rev-list --count
+      .mockResolvedValueOnce("  \n ") // rev-parse --verify → whitespace, trims to ""
+      .mockResolvedValueOnce(""); // log --grep
+
+    const result = await listCommits({ cwd: "/test", branch: "main", search: "abc1234" });
+
+    // rev-list + rev-parse + grep-log only — no log -1 pass.
+    expect(mockGit.raw).toHaveBeenCalledTimes(3);
+    expect(result.items).toEqual([]);
   });
 
   it("gracefully falls back to message search when the hash prefix matches no commit", async () => {
@@ -1039,6 +1105,10 @@ describe("listCommits", () => {
 
     expect(result.items).toHaveLength(1);
     expect(result.items[0].hash).toBe("face123");
+    // Fallback must still pass the search term through to the grep pass.
+    const grepCall = mockGit.raw.mock.calls[2][0] as string[];
+    expect(grepCall).toContain("--grep=face");
+    expect(grepCall).toContain("-i");
   });
 
   it("returns empty result on git error", async () => {

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -319,15 +319,16 @@ export async function listCommits(options: ListCommitsOptions): Promise<ListComm
 
     const output = await git.raw(logOptions);
     const msgCommits = parseCommitOutput(output);
-    const hasMore = msgCommits.length > limit;
 
-    let items: CommitInfo[];
-    if (hashCommit) {
-      const deduped = msgCommits.filter((c) => c.hash !== hashCommit!.hash);
-      items = [hashCommit, ...deduped].slice(0, limit);
-    } else {
-      items = msgCommits.slice(0, limit);
-    }
+    // The hash match is purely additive: it's pinned ahead of a full page of
+    // message results rather than displacing one, so pagination stays aligned to
+    // the message stream and `hasMore` reflects the (deduplicated) message count.
+    const dedupedMsg = hashCommit
+      ? msgCommits.filter((c) => c.hash !== hashCommit!.hash)
+      : msgCommits;
+    const pageMsg = dedupedMsg.slice(0, limit);
+    const items = hashCommit ? [hashCommit, ...pageMsg] : pageMsg;
+    const hasMore = dedupedMsg.length > limit;
 
     return {
       items,

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -245,6 +245,34 @@ export interface ListCommitsResult {
   total: number;
 }
 
+const COMMIT_LOG_FORMAT = "--format=%H%x00%h%x00%s%x00%b%x00%an%x00%ae%x00%aI%x00END";
+
+// Matches a 4–40 char hex string (git's minimum abbreviated SHA is 4 chars).
+// Used to decide whether a search query might be a commit-hash prefix.
+const COMMIT_HASH_PREFIX_RE = /^[0-9a-f]{4,40}$/i;
+
+function parseCommitOutput(output: string): CommitInfo[] {
+  const commits: CommitInfo[] = [];
+  const entries = output.split("\x00END").filter((entry) => entry.trim());
+
+  for (const entry of entries) {
+    const parts = entry.trim().split("\x00");
+    if (parts.length >= 7) {
+      const [hash, shortHash, message, body, authorName, authorEmail, date] = parts;
+      commits.push({
+        hash,
+        shortHash,
+        message,
+        body: body?.trim() || undefined,
+        author: { name: authorName, email: authorEmail },
+        date,
+      });
+    }
+  }
+
+  return commits;
+}
+
 export async function listCommits(options: ListCommitsOptions): Promise<ListCommitsResult> {
   const { cwd, search, branch, skip = 0, limit = 30 } = options;
 
@@ -254,9 +282,28 @@ export async function listCommits(options: ListCommitsOptions): Promise<ListComm
     const totalCountStr = await git.raw(["rev-list", "--count", branch || "HEAD"]);
     const total = parseInt(totalCountStr.trim(), 10);
 
+    // `--grep` only matches commit-message text, so a hash-prefix query returns
+    // nothing. On the first page, additionally resolve hash-like queries directly
+    // and pin the match to the top of the results. Gated to skip === 0 so the
+    // pinned commit doesn't re-appear on every paginated page.
+    let hashCommit: CommitInfo | null = null;
+    if (search && skip === 0 && COMMIT_HASH_PREFIX_RE.test(search)) {
+      try {
+        const fullHash = (await git.raw(["rev-parse", "--verify", `${search}^{commit}`])).trim();
+        if (fullHash) {
+          const hashOutput = await git.raw(["log", COMMIT_LOG_FORMAT, "-1", fullHash]);
+          hashCommit = parseCommitOutput(hashOutput)[0] ?? null;
+        }
+      } catch {
+        // rev-parse/log failed (not found, ambiguous, or < 4 unique chars) —
+        // fall through to the message-grep pass below.
+        hashCommit = null;
+      }
+    }
+
     const logOptions: string[] = [
       "log",
-      "--format=%H%x00%h%x00%s%x00%b%x00%an%x00%ae%x00%aI%x00END",
+      COMMIT_LOG_FORMAT,
       `--skip=${skip}`,
       `-n`,
       `${limit + 1}`,
@@ -271,28 +318,20 @@ export async function listCommits(options: ListCommitsOptions): Promise<ListComm
     }
 
     const output = await git.raw(logOptions);
+    const msgCommits = parseCommitOutput(output);
+    const hasMore = msgCommits.length > limit;
 
-    const commits: CommitInfo[] = [];
-    const entries = output.split("\x00END").filter((entry) => entry.trim());
-
-    for (const entry of entries.slice(0, limit)) {
-      const parts = entry.trim().split("\x00");
-      if (parts.length >= 7) {
-        const [hash, shortHash, message, body, authorName, authorEmail, date] = parts;
-        commits.push({
-          hash,
-          shortHash,
-          message,
-          body: body?.trim() || undefined,
-          author: { name: authorName, email: authorEmail },
-          date,
-        });
-      }
+    let items: CommitInfo[];
+    if (hashCommit) {
+      const deduped = msgCommits.filter((c) => c.hash !== hashCommit!.hash);
+      items = [hashCommit, ...deduped].slice(0, limit);
+    } else {
+      items = msgCommits.slice(0, limit);
     }
 
     return {
-      items: commits,
-      hasMore: entries.length > limit,
+      items,
+      hasMore,
       total,
     };
   } catch (error) {

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -301,13 +301,7 @@ export async function listCommits(options: ListCommitsOptions): Promise<ListComm
       }
     }
 
-    const logOptions: string[] = [
-      "log",
-      COMMIT_LOG_FORMAT,
-      `--skip=${skip}`,
-      `-n`,
-      `${limit + 1}`,
-    ];
+    const logOptions: string[] = ["log", COMMIT_LOG_FORMAT, `--skip=${skip}`, `-n`, `${limit + 1}`];
 
     if (search) {
       logOptions.push(`--grep=${search}`, "-i");


### PR DESCRIPTION
## Summary

- Commit search only matched message text because `listCommits` in `electron/utils/git.ts` used `git log --grep`, which never inspects the hash.
- Added an additive hash-prefix pass: when the query matches `/^[0-9a-f]{4,40}$/i` and `skip === 0`, it resolves the prefix via `git rev-parse --verify <prefix>^{commit}` (try/catch, falls back silently), fetches that commit with `git log -1 <fullHash>` using the shared null-byte format, and pins it to the top of results.
- Extracted a shared `parseCommitOutput` helper and `COMMIT_LOG_FORMAT` constant so both passes use identical parsing.

Resolves #10814

## Changes

- `electron/utils/git.ts`: additive hash-prefix pass in `listCommits`, shared `parseCommitOutput` helper, `COMMIT_LOG_FORMAT` constant.
- The existing `--grep` message search is unchanged. The hash pin is additive, deduplicates by full hash, and `hasMore` is based on the deduplicated message count.

## Testing

47 unit tests pass. Added 6 new hash-prefix tests covering: prefix match, deduplication, additive pagination integrity, `skip > 0` gating, 3/41-char boundary gating, non-hex input, whitespace in `rev-parse` output, and no-match fallback.