### PR TITLE
fix(assistant): take pending hibernation before provisioning on cold resume (#10819)

### DIFF
--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -892,6 +892,14 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       cwd: "/tmp/help/proj-1",
       panelWasOpen: true,
     });
+    // #10819: the resumeOnly launch gates on the atomic take (hoisted before
+    // provisioning). Whenever the peek surfaces a panelWasOpen entry, main still
+    // holds it, so the take returns the same entry.
+    mockTakePendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
+    });
 
     await act(async () => {
       render(<HelpPanel width={380} />);
@@ -969,6 +977,12 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentSessionId: "abc-123",
       cwd: "/tmp/help/proj-1",
       panelWasOpen: true,
+    });
+    // #10819: take returns the same entry the peek surfaced (gates the resume).
+    mockTakePendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
     });
 
     let view: ReturnType<typeof render> | undefined;
@@ -1148,8 +1162,11 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       expect.anything(),
       expect.anything()
     );
-    // The provisioned session is released, not leaked.
-    expect(mockRevokeSession).toHaveBeenCalledWith("fresh-session");
+    // #10819: the null take aborts BEFORE provisioning, so the loser never mints
+    // a session (nothing to revoke) and — critically — never runs the displacing
+    // provision that would have killed the backend the winning window just resumed.
+    expect(mockProvisionSession).not.toHaveBeenCalled();
+    expect(mockRevokeSession).not.toHaveBeenCalled();
     // No scary launch error — neither a toast nor the inline banner.
     expect(mockNotify).not.toHaveBeenCalled();
     expect(view!.queryByTestId("help-launch-error-banner")).toBeNull();
@@ -1181,6 +1198,12 @@ describe("HelpPanel — cold switch-back auto-resume (#10815)", () => {
       agentSessionId: "abc-123",
       cwd: "/tmp/help/proj-1",
       panelWasOpen: true,
+    });
+    // #10819: take returns the same entry the peek surfaced (gates the resume).
+    mockTakePendingHibernation.mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/tmp/help/proj-1",
     });
 
     let view: ReturnType<typeof render> | undefined;

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -2141,6 +2141,38 @@ export class HelpSessionController {
         this._patch({ assistantVersionTooOld: null, phase: "provisioning" });
       }
 
+      // #10819: resume-only intent must claim the pending-hibernation entry
+      // BEFORE provisioning. `provisionHelpSession` calls `displacePriorSessions`
+      // in main, which revokes/kills the project's existing assistant backend. In
+      // a multi-window cold-restore race, both windows would provision (and so
+      // displace each other) before reaching the `resumeOnly` abort below, leaving
+      // both with no live backend. The atomic `takePendingHibernation` is the
+      // single-winner gate: a null take (lost the race, or nothing captured) or an
+      // agentId mismatch aborts before any displacement. The seeded local-store
+      // entry then drives the normal resume block; `_seedHibernateFromMain` is
+      // skipped for this path since the take already happened.
+      if (options.resumeOnly && !reservedId && !options.seedPrompt) {
+        let earlyPending: { agentId: string; agentSessionId: string; cwd: string } | null = null;
+        try {
+          earlyPending = await window.electron.help.takePendingHibernation(launchProject.id);
+        } catch (err) {
+          logError("HelpPanel: resumeOnly early hibernation take failed", err);
+        }
+        if (gen !== this._launchGen) {
+          this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
+          return;
+        }
+        if (!earlyPending || earlyPending.agentId !== launchAgentId) {
+          this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
+          return;
+        }
+        useHelpPanelStore.getState().setHibernateSession(launchProject.id, {
+          sessionId: earlyPending.agentSessionId,
+          cwd: earlyPending.cwd,
+          agentId: earlyPending.agentId,
+        });
+      }
+
       const outcome = await provisionHelpSession(launchProject, launchAgentId, launchContext);
       if (gen !== this._launchGen) {
         if (outcome.ok) session = outcome.session;
@@ -2181,10 +2213,18 @@ export class HelpSessionController {
         // eviction-captured entry is available to the lookup below. The
         // helper checks `gen` after its IPC await so a superseded launch
         // doesn't write a stale entry back into helpPanelStore.
-        await this._seedHibernateFromMain(launchProject.id, gen);
-        if (gen !== this._launchGen) {
-          this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
-          return;
+        //
+        // #10819: the `resumeOnly` path already performed the atomic
+        // `takePendingHibernation` before provisioning and seeded the local
+        // store from it, so re-seeding here is skipped — a second take would
+        // return null (the entry is consumed) and clear nothing, but running it
+        // is wasteful and misleading.
+        if (!options.resumeOnly) {
+          await this._seedHibernateFromMain(launchProject.id, gen);
+          if (gen !== this._launchGen) {
+            this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
+            return;
+          }
         }
         const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
         if (hibernated && hibernated.agentId === launchAgentId && folderPath) {

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -2312,12 +2312,23 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
   const provisionMock = () =>
     window.electron.help.provisionSession as unknown as ReturnType<typeof vi.fn>;
 
-  it("aborts a resumeOnly launch without fresh-launching when there is nothing to resume", async () => {
-    // Cold switch-back / cross-window auto-resume: the renderer peeks
-    // non-consumingly, then launches resumeOnly. If the atomic take finds nothing
-    // (another window already won it, or a stale peek), the launch must NOT fall
-    // through to a fresh agent.launch — that would displace the backend the other
-    // window just resumed. It must release the provisioned session and bail.
+  // #10819: a state-mutating setHibernateSession so the resume block below can
+  // read the entry the early atomic take seeded. The global resetState() leaves
+  // it a pure spy; this writes through to helpPanelState.hibernateSessions.
+  const seedThroughSetHibernate = () => {
+    helpPanelState.setHibernateSession = vi.fn(
+      (projectId: string, entry: { sessionId: string; cwd: string; agentId: string }) => {
+        helpPanelState.hibernateSessions[projectId] = entry;
+      }
+    );
+  };
+
+  it("aborts a resumeOnly launch without provisioning when the atomic take returns null", async () => {
+    // Cold switch-back / cross-window auto-resume. #10819: the atomic take is
+    // hoisted BEFORE provisioning. A null take (another window already won it, or
+    // nothing was captured) must abort before provisionHelpSession runs — that
+    // call displaces the project's existing backend, which is exactly what would
+    // strand the window that legitimately resumed.
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl["_launchGen"] = 7;
@@ -2325,13 +2336,6 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
       window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
     ).takePendingHibernation = vi.fn().mockResolvedValue(null);
     helpPanelState.hibernateSessions = {};
-    provisionMock().mockResolvedValueOnce({
-      sessionId: "sess-ro",
-      sessionPath: "/help",
-      token: "tok",
-      mcpUrl: null,
-      windowId: 1,
-    });
 
     await ctrl["_executeLaunch"](
       7,
@@ -2340,8 +2344,9 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
       undefined
     );
 
-    // The provisioned session is released — no orphaned token leaks.
-    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-ro");
+    // Never provisions, so nothing to displace and no session to revoke.
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
+    expect(window.electron.help.revokeSession).not.toHaveBeenCalled();
     expect(ctrl["_pendingSessionId"]).toBeNull();
     // NEVER fresh-launches, and never spawns a panel.
     expect(actionService.dispatch).not.toHaveBeenCalledWith(
@@ -2357,7 +2362,11 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     ctrl.stop();
   });
 
-  it("resumes (never fresh-launches) on a resumeOnly launch when a matching entry exists", async () => {
+  it("does not provision when the take returns null even if a stale local hibernate entry exists (#10819 secondary race)", async () => {
+    // The resume decision must gate on the main-side atomic take, NOT on the
+    // local persisted hibernateSessions entry. A losing window can still carry a
+    // stale local entry from before; without the take gate it would provision
+    // (and displace the winner) on the strength of that stale entry alone.
     const ctrl = new HelpSessionController();
     ctrl.start();
     ctrl["_launchGen"] = 7;
@@ -2365,10 +2374,39 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
       window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
     ).takePendingHibernation = vi.fn().mockResolvedValue(null);
     helpPanelState.hibernateSessions["p1"] = {
-      sessionId: "abc-123",
+      sessionId: "stale-123",
       cwd: "/repo",
       agentId: "claude",
     };
+
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", replaceExisting: true, resumeOnly: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
+
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
+    expect(window.electron.help.revokeSession).not.toHaveBeenCalled();
+    expect(panelStoreState.addPanel).not.toHaveBeenCalled();
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    ctrl.stop();
+  });
+
+  it("resumes (never fresh-launches) on a resumeOnly launch when the atomic take returns a matching entry", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_launchGen"] = 7;
+    seedThroughSetHibernate();
+    helpPanelState.hibernateSessions = {};
+    const takeMock = vi.fn().mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-123",
+      cwd: "/repo",
+    });
+    (
+      window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
+    ).takePendingHibernation = takeMock;
     provisionMock().mockResolvedValueOnce({
       sessionId: "sess-ro2",
       sessionPath: "/help",
@@ -2385,6 +2423,17 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
       undefined
     );
 
+    // The take is the gate, and it runs before provisioning displaces anything.
+    expect(takeMock).toHaveBeenCalledWith("p1");
+    expect(takeMock.mock.invocationCallOrder[0]).toBeLessThan(
+      provisionMock().mock.invocationCallOrder[0]
+    );
+    // The taken entry seeds the local store the resume block reads.
+    expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("p1", {
+      sessionId: "abc-123",
+      cwd: "/repo",
+      agentId: "claude",
+    });
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
       expect.objectContaining({ kind: "terminal" })
     );
@@ -2395,6 +2444,65 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     );
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1");
     expect(ctrl.getSnapshot().phase).toBe("live");
+    ctrl.stop();
+  });
+
+  it("aborts before provisioning when the early take's agentId mismatches the launch agent (#10819)", async () => {
+    // The entry was captured for a different agent (the user switched the
+    // preferred agent before the cold restore). The mismatched entry can't be
+    // resumed, so abort before provisioning rather than displace a live backend.
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_launchGen"] = 7;
+    helpPanelState.hibernateSessions = {};
+    (
+      window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
+    ).takePendingHibernation = vi.fn().mockResolvedValue({
+      agentId: "codex",
+      agentSessionId: "codex-1",
+      cwd: "/repo",
+    });
+
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", replaceExisting: true, resumeOnly: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
+
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
+    expect(window.electron.help.revokeSession).not.toHaveBeenCalled();
+    expect(panelStoreState.addPanel).not.toHaveBeenCalled();
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    ctrl.stop();
+  });
+
+  it("drops the early take and does not provision when the generation is superseded mid-take (#10819)", async () => {
+    // A competing launch bumps _launchGen while the atomic take IPC is in flight.
+    // The stale result must not seed the store or provision — the gen guard after
+    // the take await abandons the launch.
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_launchGen"] = 7;
+    seedThroughSetHibernate();
+    helpPanelState.hibernateSessions = {};
+    (
+      window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
+    ).takePendingHibernation = vi.fn().mockImplementation(async () => {
+      ctrl["_launchGen"] = 8; // superseded mid-await
+      return { agentId: "claude", agentSessionId: "abc-123", cwd: "/repo" };
+    });
+
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", replaceExisting: true, resumeOnly: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
+
+    expect(helpPanelState.setHibernateSession).not.toHaveBeenCalled();
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
+    expect(panelStoreState.addPanel).not.toHaveBeenCalled();
     ctrl.stop();
   });
 });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -2561,12 +2561,7 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     });
     panelStoreState.addPanel = vi.fn().mockResolvedValue("term-normal");
 
-    await ctrl["_executeLaunch"](
-      7,
-      { agentId: "claude" },
-      { id: "p1", path: "/repo" },
-      undefined
-    );
+    await ctrl["_executeLaunch"](7, { agentId: "claude" }, { id: "p1", path: "/repo" }, undefined);
 
     // _seedHibernateFromMain ran (the take is its only caller on this path).
     expect(takeMock).toHaveBeenCalledWith("p1");

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -2425,9 +2425,11 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
 
     // The take is the gate, and it runs before provisioning displaces anything.
     expect(takeMock).toHaveBeenCalledWith("p1");
-    expect(takeMock.mock.invocationCallOrder[0]).toBeLessThan(
-      provisionMock().mock.invocationCallOrder[0]
-    );
+    const takeOrder = takeMock.mock.invocationCallOrder[0];
+    const provisionOrder = provisionMock().mock.invocationCallOrder[0];
+    expect(takeOrder).toBeDefined();
+    expect(provisionOrder).toBeDefined();
+    expect(takeOrder!).toBeLessThan(provisionOrder!);
     // The taken entry seeds the local store the resume block reads.
     expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("p1", {
       sessionId: "abc-123",

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -2505,6 +2505,76 @@ describe("HelpSessionController — resume-only auto-resume (#10815)", () => {
     expect(panelStoreState.addPanel).not.toHaveBeenCalled();
     ctrl.stop();
   });
+
+  it("aborts silently before provisioning when the early take IPC throws (#10819)", async () => {
+    // The early take is a recovery-path credential check; an IPC failure means
+    // "can't prove we won the race", so abort WITHOUT displacing — and without a
+    // scary error banner, mirroring how _seedHibernateFromMain swallows its own
+    // IPC failure.
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_launchGen"] = 7;
+    helpPanelState.hibernateSessions = {};
+    (
+      window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
+    ).takePendingHibernation = vi.fn().mockRejectedValue(new Error("ipc down"));
+
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude", replaceExisting: true, resumeOnly: true },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
+
+    expect(window.electron.help.provisionSession).not.toHaveBeenCalled();
+    expect(window.electron.help.revokeSession).not.toHaveBeenCalled();
+    expect(panelStoreState.addPanel).not.toHaveBeenCalled();
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    expect(ctrl.getSnapshot().launchError).toBeNull();
+    expect(notify).not.toHaveBeenCalled();
+    ctrl.stop();
+  });
+
+  it("still seeds via _seedHibernateFromMain on a non-resumeOnly launch (#10819 invariant)", async () => {
+    // The early-take guard must NOT swallow the normal empty-state launch: a
+    // non-resumeOnly launch still pulls main's pending entry post-provision via
+    // _seedHibernateFromMain and resumes from it.
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_launchGen"] = 7;
+    seedThroughSetHibernate();
+    helpPanelState.hibernateSessions = {};
+    const takeMock = vi.fn().mockResolvedValue({
+      agentId: "claude",
+      agentSessionId: "abc-9",
+      cwd: "/repo",
+    });
+    (
+      window.electron.help as unknown as { takePendingHibernation: ReturnType<typeof vi.fn> }
+    ).takePendingHibernation = takeMock;
+    provisionMock().mockResolvedValueOnce({
+      sessionId: "sess-normal",
+      sessionPath: "/help",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("term-normal");
+
+    await ctrl["_executeLaunch"](
+      7,
+      { agentId: "claude" },
+      { id: "p1", path: "/repo" },
+      undefined
+    );
+
+    // _seedHibernateFromMain ran (the take is its only caller on this path).
+    expect(takeMock).toHaveBeenCalledWith("p1");
+    expect(panelStoreState.addPanel).toHaveBeenCalled();
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("p1");
+    expect(ctrl.getSnapshot().phase).toBe("live");
+    ctrl.stop();
+  });
 });
 
 describe("HelpSessionController — MCP tool activity strip (#9759)", () => {


### PR DESCRIPTION
## Summary

- In a multi-window cold-restore scenario, both windows were calling `provisionHelpSession` (which runs `displacePriorSessions`) before reaching the atomic `takePendingHibernation` check. The losing window displaced the winning window's backend before aborting, leaving both windows with no live assistant and the hibernation token already consumed.
- The fix hoists `takePendingHibernation` before provisioning on the `resumeOnly` path. A null take or `agentId` mismatch now aborts before any displacement occurs.
- The resume decision gates on the main-side atomic take rather than the local `helpPanelStore` entry, closing the stale-local-entry secondary race. `_seedHibernateFromMain` is skipped on the `resumeOnly` path since the take has already run.

Resolves #10819

## Changes

- `src/controllers/HelpSessionController.ts`: hoists `takePendingHibernation` before `provisionHelpSession` on the `resumeOnly` path; null-take and `agentId`-mismatch aborts prevent displacement before they happen; `_seedHibernateFromMain` skipped on `resumeOnly`; gen stale-check preserved after the new early-take await (#6951)
- `src/controllers/__tests__/HelpSessionController.test.ts`: new tests for the multi-window race, `agentId` mismatch, superseded generation, early-take IPC failure, and non-`resumeOnly` seed path

## Testing

117 tests pass in `HelpSessionController.test.ts`. Single-window path (#10815) and non-`resumeOnly` launches are unaffected.