### PR TITLE
fix(agent): report crashed agent CLI as exited, not waiting (#10816)

### DIFF
--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -373,3 +373,90 @@ describe("lifecycle spawn — terminal-pid gating and deferred retry (#10787)", 
     expect(getMock(ctx).mock.calls.length).toBeLessThanOrEqual(21);
   });
 });
+
+describe("lifecycle spawn — failed-to-start synthesizes an exit for launched agents (#10816)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function sentEvents(ctx: HostContext) {
+    return (ctx.sendEvent as ReturnType<typeof vi.fn>).mock.calls.map(([event]) => event);
+  }
+
+  it("emits agent-spawned then agent-state(exited) then spawn-result when launchAgentId is set", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("ENOENT: command not found");
+    });
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: { launchAgentId: "claude" } });
+
+    const events = sentEvents(ctx);
+    const spawned = events.find((e) => e.type === "agent-spawned");
+    const state = events.find((e) => e.type === "agent-state");
+    const result = events.find((e) => e.type === "spawn-result");
+
+    expect(spawned).toMatchObject({
+      type: "agent-spawned",
+      payload: { agentId: "claude", terminalId: "t1" },
+    });
+    expect(state).toMatchObject({
+      type: "agent-state",
+      id: "t1",
+      agentId: "claude",
+      state: "exited",
+      previousState: "working",
+      trigger: "exit",
+    });
+    expect(result).toMatchObject({ type: "spawn-result", id: "t1" });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- narrowed by find above
+    expect((result as { result: { success: boolean } }).result.success).toBe(false);
+
+    // Order: agent-spawned resets store state before agent-state writes "exited",
+    // and both precede spawn-result.
+    const order = events
+      .map((e) => e.type)
+      .filter((t) => t === "agent-spawned" || t === "agent-state" || t === "spawn-result");
+    expect(order).toEqual(["agent-spawned", "agent-state", "spawn-result"]);
+  });
+
+  it("emits only spawn-result on a failed plain-shell spawn (no launchAgentId)", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.spawn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: {} });
+
+    const events = sentEvents(ctx);
+    expect(events.find((e) => e.type === "agent-spawned")).toBeUndefined();
+    expect(events.find((e) => e.type === "agent-state")).toBeUndefined();
+    expect(events.find((e) => e.type === "spawn-result")).toMatchObject({
+      type: "spawn-result",
+      id: "t1",
+    });
+  });
+
+  it("does not synthesize exit events on a successful spawn", () => {
+    const ctx = makeCtx();
+    getMockTerminal(ctx).mockReturnValue(termInfo(1234));
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "spawn", id: "t1", options: { launchAgentId: "claude" } });
+
+    const events = sentEvents(ctx);
+    expect(events.find((e) => e.type === "agent-spawned")).toBeUndefined();
+    expect(events.find((e) => e.type === "agent-state")).toBeUndefined();
+  });
+
+  function getMockTerminal(ctx: HostContext) {
+    return ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>;
+  }
+});

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -75,6 +75,33 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
           id: msg.id,
           error: parseSpawnError(error),
         };
+
+        // A failed-to-start spawn never produces a PTY, so no exit event ever
+        // fires and the main-side TerminalProcess never emits agent:spawned.
+        // For a launched agent that means AgentAvailabilityStore retains the
+        // prior session's state and MCP waiters (waitUntilIdle) can't tell the
+        // crash from an idle terminal. Synthesize the spawn + exited transition
+        // so the store records "exited" and consumers see the crash (#10816).
+        // Order matters: agent-spawned resets store state to "working" (and
+        // clears stale exit metadata) before agent-state writes "exited".
+        const launchAgentId = msg.options.launchAgentId;
+        if (launchAgentId) {
+          const timestamp = Date.now();
+          sendEvent({
+            type: "agent-spawned",
+            payload: { agentId: launchAgentId, terminalId: msg.id, timestamp },
+          });
+          sendEvent({
+            type: "agent-state",
+            id: msg.id,
+            agentId: launchAgentId,
+            state: "exited",
+            previousState: "working",
+            timestamp,
+            trigger: "exit",
+            confidence: 1,
+          });
+        }
       }
 
       sendEvent({ type: "spawn-result", id: msg.id, result: spawnResult });

--- a/electron/services/AgentAvailabilityStore.ts
+++ b/electron/services/AgentAvailabilityStore.ts
@@ -57,6 +57,14 @@ export class AgentAvailabilityStore {
         this.terminalToAgent.set(payload.terminalId, payload.agentId);
         this.agentToTerminal.set(payload.agentId, payload.terminalId);
         this.spawnedAt.set(payload.agentId, payload.timestamp);
+        // A fresh spawn resets the tracked state to "working" so a stale state
+        // from a prior session under the same agentId can't outlive a respawn.
+        // Without this, a previous "waiting" persists and waitUntilIdle settles
+        // immediately as already-idle, dropping its listener before the new
+        // session's crash "exited" event arrives (issue #10816).
+        this.agentStates.set(payload.agentId, "working");
+        this.lastStateChange.set(payload.agentId, payload.timestamp);
+        this.waitingReasons.delete(payload.agentId);
         // A fresh spawn clears any exit metadata from a prior session under the
         // same agentId so a stale exit code can't outlive a respawn.
         this.exitCodes.delete(payload.agentId);

--- a/electron/services/__tests__/AgentAvailabilityStore.test.ts
+++ b/electron/services/__tests__/AgentAvailabilityStore.test.ts
@@ -258,6 +258,81 @@ describe("AgentAvailabilityStore", () => {
     });
   });
 
+  describe("respawn state reset (#10816)", () => {
+    it("resets a stale 'waiting' state to 'working' on respawn", () => {
+      store.registerAgent("agent-1", "working");
+      events.emit("agent:state-changed", {
+        agentId: "agent-1",
+        state: "waiting",
+        previousState: "working",
+        timestamp: Date.now(),
+        trigger: "output",
+        confidence: 1.0,
+        waitingReason: "prompt",
+      });
+      expect(store.getState("agent-1")).toBe("waiting");
+      expect(store.getWaitingReason("agent-1")).toBe("prompt");
+
+      // A fresh spawn under the same agentId must not inherit "waiting"; it
+      // would otherwise let waitUntilIdle settle as already-idle before the new
+      // session's exit event arrives.
+      events.emit("agent:spawned", {
+        agentId: "agent-1",
+        terminalId: "term-1",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState("agent-1")).toBe("working");
+      expect(store.getWaitingReason("agent-1")).toBeUndefined();
+      expect(store.isAvailable("agent-1")).toBe(false);
+    });
+
+    it("excludes a freshly respawned agent from getAvailableAgents", () => {
+      store.registerAgent("agent-1", "waiting");
+      events.emit("agent:spawned", {
+        agentId: "agent-1",
+        terminalId: "term-1",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getAvailableAgents().find((a) => a.agentId === "agent-1")).toBeUndefined();
+    });
+
+    it("clears a stale 'exited' state on respawn", () => {
+      store.registerAgent("agent-1", "working");
+      events.emit("agent:state-changed", {
+        agentId: "agent-1",
+        state: "exited",
+        previousState: "working",
+        timestamp: Date.now(),
+        trigger: "exit",
+        confidence: 1.0,
+        exitCode: 1,
+      });
+      expect(store.getState("agent-1")).toBe("exited");
+
+      events.emit("agent:spawned", {
+        agentId: "agent-1",
+        terminalId: "term-1",
+        timestamp: Date.now(),
+      });
+
+      expect(store.getState("agent-1")).toBe("working");
+      expect(store.getExitCode("agent-1")).toBeUndefined();
+    });
+
+    it("records the spawn timestamp as the lastStateChange on respawn", () => {
+      store.registerAgent("agent-1", "waiting");
+      events.emit("agent:spawned", {
+        agentId: "agent-1",
+        terminalId: "term-1",
+        timestamp: 9999,
+      });
+
+      expect(store.getLastStateChange("agent-1")).toBe(9999);
+    });
+  });
+
   describe("getAgentsByAvailability", () => {
     it("returns all agents with availability info", () => {
       store.registerAgent("agent-1", "idle");

--- a/electron/services/mcp-server/__tests__/waitUntilIdle.test.ts
+++ b/electron/services/mcp-server/__tests__/waitUntilIdle.test.ts
@@ -182,6 +182,58 @@ describe("handleWaitUntilIdle exit metadata", () => {
   });
 });
 
+describe("handleWaitUntilIdle stale-state crash race (#10816)", () => {
+  it("does not settle as already-idle on a prior session's stale 'waiting' after respawn", async () => {
+    const store = getAgentAvailabilityStore();
+    const agentId = `wt-agent-stale-${(counter += 1)}`;
+    const oldTerminal = `wt-term-stale-old-${counter}`;
+    const newTerminal = `wt-term-stale-new-${counter}`;
+
+    // Prior session under the same agentId ended in "waiting".
+    events.emit("agent:spawned", { agentId, terminalId: oldTerminal, timestamp: Date.now() });
+    events.emit("agent:state-changed", {
+      agentId,
+      terminalId: oldTerminal,
+      state: "waiting",
+      previousState: "working",
+      trigger: "output",
+      confidence: 1,
+      timestamp: Date.now(),
+      waitingReason: "prompt",
+    });
+    expect(store.getState(agentId)).toBe("waiting");
+
+    // New session spawns under the same agentId (e.g. another "claude" launch).
+    events.emit("agent:spawned", { agentId, terminalId: newTerminal, timestamp: Date.now() });
+
+    const p = handleWaitUntilIdle(
+      { terminalId: newTerminal, timeoutMs: 10_000 },
+      new AbortController().signal,
+      { maxTimeoutMs: 5_000 }
+    );
+
+    // Must block on the live subscription rather than short-circuit on the stale
+    // "waiting". Then the crash arrives and is reported as the exit, not idle.
+    await new Promise((r) => setTimeout(r, 10));
+    events.emit("agent:state-changed", {
+      agentId,
+      terminalId: newTerminal,
+      state: "exited",
+      previousState: "working",
+      trigger: "exit",
+      confidence: 1,
+      timestamp: Date.now(),
+      exitCode: 1,
+    });
+
+    const result = await p;
+    expect(result.timedOut).toBe(false);
+    expect(result.busyState).toBe("idle");
+    expect(result.idleReason).toBe("exited");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
 describe("handleWaitUntilIdleBatch", () => {
   it("mode 'first' resolves as soon as any terminal leaves working", async () => {
     const a = nextIds();
@@ -303,25 +355,44 @@ describe("handleWaitUntilIdleBatch", () => {
     expect(res.results[0]!.terminalId).toBe("batch-dup");
   });
 
-  it("settles a mapped-but-stateless terminal immediately instead of waiting (mode 'all')", async () => {
-    // agent:spawned with no following state-changed leaves getState() undefined.
-    // The batch must treat that as already-idle (mirrors the single handler), or
-    // 'all' mode would hang on it until timeout.
+  it("treats a freshly spawned terminal as working, not already-idle (mode 'all', #10816)", async () => {
+    // agent:spawned now resets the tracked state to "working", so a brand-new
+    // session must NOT settle immediately — that stale "already-idle" short
+    // circuit is exactly what let a crash be missed. The batch blocks until the
+    // session actually transitions.
     const { terminalId, agentId } = nextIds();
     getAgentAvailabilityStore();
     events.emit("agent:spawned", { agentId, terminalId, timestamp: Date.now() });
 
-    const started = Date.now();
-    const res = await handleWaitUntilIdleBatch(
-      { terminalIds: [terminalId], mode: "all" },
+    const p = handleWaitUntilIdleBatch(
+      { terminalIds: [terminalId], mode: "all", timeoutMs: 10_000 },
       new AbortController().signal,
       { maxTimeoutMs: 5_000 }
     );
-    expect(Date.now() - started).toBeLessThan(1_000);
+    // It must still be pending after a beat — proves it didn't short-circuit.
+    const stillPending = await Promise.race([
+      p.then(() => "resolved" as const),
+      new Promise<"pending">((r) => setTimeout(() => r("pending"), 60)),
+    ]);
+    expect(stillPending).toBe("pending");
+
+    // The crash exit then settles it with the exit metadata intact.
+    events.emit("agent:state-changed", {
+      agentId,
+      terminalId,
+      state: "exited",
+      previousState: "working",
+      trigger: "exit",
+      confidence: 1,
+      timestamp: Date.now(),
+      exitCode: 1,
+    });
+    const res = await p;
     expect(res.timedOut).toBe(false);
     expect(res.settledTerminalIds).toEqual([terminalId]);
     expect(res.results[0]!.busyState).toBe("idle");
-    expect(res.results[0]!.settled).toBe(true);
+    expect(res.results[0]!.idleReason).toBe("exited");
+    expect(res.results[0]!.exitCode).toBe(1);
   });
 
   it("rejects an empty terminalIds array", async () => {

--- a/electron/services/mcp-server/__tests__/waitUntilIdle.test.ts
+++ b/electron/services/mcp-server/__tests__/waitUntilIdle.test.ts
@@ -232,6 +232,37 @@ describe("handleWaitUntilIdle stale-state crash race (#10816)", () => {
     expect(result.idleReason).toBe("exited");
     expect(result.exitCode).toBe(1);
   });
+
+  it("reports a failed-to-start agent as exited (no exitCode) on the already-idle path (#10816 mode 3)", async () => {
+    // Mode 3: the pty-host synthesizes agent-spawned + agent-state(exited) with
+    // NO exitCode before the consumer calls waitUntilIdle. The store is already
+    // "exited", so this exercises the already-idle snapshot path — it must
+    // report idleReason "exited" (not "unknown"/working) and omit exitCode,
+    // since no process ever ran.
+    const store = getAgentAvailabilityStore();
+    const agentId = `wt-agent-mode3-${(counter += 1)}`;
+    const terminalId = `wt-term-mode3-${counter}`;
+
+    events.emit("agent:spawned", { agentId, terminalId, timestamp: Date.now() });
+    events.emit("agent:state-changed", {
+      agentId,
+      terminalId,
+      state: "exited",
+      previousState: "working",
+      trigger: "exit",
+      confidence: 1,
+      timestamp: Date.now(),
+      // No exitCode — failed-to-start, process never ran.
+    });
+    expect(store.getState(agentId)).toBe("exited");
+    expect(store.getExitCode(agentId)).toBeUndefined();
+
+    const result = await handleWaitUntilIdle({ terminalId }, new AbortController().signal);
+    expect(result.timedOut).toBe(false);
+    expect(result.busyState).toBe("idle");
+    expect(result.idleReason).toBe("exited");
+    expect(result).not.toHaveProperty("exitCode");
+  });
 });
 
 describe("handleWaitUntilIdleBatch", () => {

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -257,6 +257,35 @@ describe("optimistic panel spawn (#5789)", () => {
     expect(failed?.spawnError?.code).toBe("UNKNOWN");
     expect(failed?.spawnError?.message).toBe("spawn boom");
     expect(failed?.runtimeStatus).toBe("error");
+    // A launched agent that fails to start never produces a PTY exit, so mark it
+    // "exited" so terminal.list / terminal.getStatus report the crash rather
+    // than a phantom running agent (#10816).
+    expect(failed?.agentState).toBe("exited");
+  });
+
+  it("leaves agentState undefined when a plain-shell spawn fails (#10816)", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockImplementationOnce(async () => {
+      throw new Error("shell boom");
+    });
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      command: "bash",
+      requestedId: "shell-fail",
+      cwd: "/",
+      bypassLimits: true,
+    });
+
+    await drainMicrotasks();
+
+    const failed = usePanelStore.getState().panelsById["shell-fail"] as PtyPanelData | undefined;
+    expect(failed?.spawnStatus).toBe("failed");
+    // No launchAgentId — it was never an agent, so it must not gain an agent state.
+    expect(failed?.agentState).toBeUndefined();
   });
 
   it("marks reconnect panels as 'ready' without calling spawn", async () => {

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -211,6 +211,29 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
     expect(payload.agentLaunchFlags).toEqual(["--persisted-flag"]);
   });
 
+  it("restarts as agent terminal when a failed-to-start spawn is retried (#10816)", async () => {
+    // A failed-to-start agent spawn carries agentState "exited" (so MCP read
+    // paths report the crash) but no exitCode — it never ran. Retrying it must
+    // relaunch the agent rather than demote to a shell.
+    const failedToStart = {
+      ...agentPanelBase,
+      agentState: "exited" as const,
+      spawnStatus: "failed" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [failedToStart.id]: failedToStart },
+      panelIds: [failedToStart.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.kind).toBe("terminal");
+    expect(payload.launchAgentId).toBe("claude");
+    expect(payload.agentLaunchFlags).toEqual(["--persisted-flag"]);
+  });
+
   it("reapplies preset env, color, IDs, and args when restarting an active agent terminal", async () => {
     const { agentSettingsClient, projectClient } = await import("@/clients");
     (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -234,6 +234,30 @@ describe("restartTerminal agent-exited demotion (#5764)", () => {
     expect(payload.agentLaunchFlags).toEqual(["--persisted-flag"]);
   });
 
+  it("does not re-promote a demoted shell whose restart later fails to spawn (#10816 / #5764)", async () => {
+    // A demoted shell (agent quit to its shell) keeps launchAgentId but has its
+    // command cleared. If a subsequent restart fails to spawn, spawnStatus
+    // becomes "failed" — but command is still undefined, so it must stay a shell
+    // and NOT be reclassified as an agent.
+    const demotedFailed = {
+      ...agentPanelBase,
+      command: undefined,
+      agentState: "exited" as const,
+      spawnStatus: "failed" as const,
+    };
+    usePanelStore.setState({
+      panelsById: { [demotedFailed.id]: demotedFailed },
+      panelIds: [demotedFailed.id],
+    });
+
+    await usePanelStore.getState().restartTerminal("test-1");
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const payload = mockSpawn.mock.calls[0]![0];
+    expect(payload.kind).toBe("terminal");
+    expect(payload.launchAgentId).toBeUndefined();
+  });
+
   it("reapplies preset env, color, IDs, and args when restarting an active agent terminal", async () => {
     const { agentSettingsClient, projectClient } = await import("@/clients");
     (agentSettingsClient.get as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -753,10 +753,24 @@ export const createAddPanelActions = (
           const _current = state.panelsById[id];
           if (!_current || !isPtyPanel(_current) || _current.spawnStatus !== "spawning")
             return state;
+          // A launched agent that fails to start never produces a PTY exit, so
+          // its optimistic agentState would stay stuck (e.g. "working"). Mark it
+          // "exited" so terminal.list / terminal.getStatus report the crash
+          // instead of a phantom running agent (#10816). Plain shells have no
+          // launchAgentId and keep agentState undefined.
+          const agentPatch = _current.launchAgentId
+            ? { agentState: "exited" as const, lastStateChange: Date.now() }
+            : {};
           return {
             panelsById: {
               ...state.panelsById,
-              [id]: { ..._current, spawnStatus: "failed", spawnError, runtimeStatus: "error" },
+              [id]: {
+                ..._current,
+                spawnStatus: "failed",
+                spawnError,
+                runtimeStatus: "error",
+                ...agentPatch,
+              },
             },
           };
         });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -329,11 +329,14 @@ export const createRestartActions = (
     // read paths surface the crash (#10816), but it never actually ran and must
     // relaunch as the agent rather than demote to a shell. `wasFailed`
     // (captured above before spawnStatus is cleared for the restart) means
-    // "never started" (vs a real run that quit to shell), so treat it as still
-    // an agent despite the "exited" state.
+    // "never started". Gate it on a surviving `command`: a failed *agent* launch
+    // keeps its agent command, whereas a demoted shell (an agent that quit to
+    // its shell) has `command` cleared — without this, a demoted shell whose
+    // restart then fails to spawn would wrongly re-promote to an agent (#5764).
+    const failedAgentLaunch = wasFailed && currentTerminal.command !== undefined;
     const isAgent =
       !!effectiveAgentId &&
-      (currentTerminal.agentState !== "exited" || wasFailed) &&
+      (currentTerminal.agentState !== "exited" || failedAgentLaunch) &&
       currentTerminal.exitCode === undefined;
     const isDemotedAgent = !!effectiveAgentId && !isAgent;
     let loadedRuntimeSettings: LoadedAgentRuntimeSettings | undefined;

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -325,9 +325,15 @@ export const createRestartActions = (
     // `panelStoreListeners.onAgentExited` must NOT clear `agentId` — if it
     // did, a cold-launched agent that `/quit`s into its shell would lose its
     // launch identity and relaunch decisions would misclassify. #5807
+    // A failed-to-start agent spawn now carries `agentState === "exited"` so MCP
+    // read paths surface the crash (#10816), but it never actually ran and must
+    // relaunch as the agent rather than demote to a shell. `wasFailed`
+    // (captured above before spawnStatus is cleared for the restart) means
+    // "never started" (vs a real run that quit to shell), so treat it as still
+    // an agent despite the "exited" state.
     const isAgent =
       !!effectiveAgentId &&
-      currentTerminal.agentState !== "exited" &&
+      (currentTerminal.agentState !== "exited" || wasFailed) &&
       currentTerminal.exitCode === undefined;
     const isDemotedAgent = !!effectiveAgentId && !isAgent;
     let loadedRuntimeSettings: LoadedAgentRuntimeSettings | undefined;


### PR DESCRIPTION
## Summary

Fixes a bug where a crashed agent CLI would get stuck reporting `agentState` as `waiting` instead of `exited`. Most visible when an agent process crashed on launch with zero or minimal output. MCP consumers couldn't distinguish a crashed agent from an idle one, so `terminal.awaitAll` / `waitUntilIdle` misclassified the crash as finished work and tried to read output that never existed.

Resolves #10816.

## Root cause

`AgentAvailabilityStore`'s `agent:spawned` handler reset exit metadata but never reset `agentStates`, so a prior session's stale `waiting` survived a respawn. `handleWaitUntilIdle` reads authoritative store state right after subscribing; if it isn't `working` it settles immediately as already-idle and drops its listener. The crash's `agent:state-changed{exited}` arrived after the listener was already gone.

## Changes

- **`AgentAvailabilityStore`:** `agent:spawned` now resets `agentStates` to `working` (plus clears `waitingReason`, sets `lastStateChange`), so `waitUntilIdle` blocks until the new session actually transitions. Fixes the nonzero-exit and signal-kill crash modes.
- **`pty-host` lifecycle:** a failed-to-start spawn never produces a PTY exit, so for a launched agent the host now synthesizes `agent-spawned` + `agent-state(exited)` wire events before `spawn-result`. Fixes the failed-to-start mode.
- **Renderer panel store (`addPanel`):** a failed agent spawn marks the panel `agentState` as `exited` so `terminal.list` / `getStatus` report the crash accurately. Plain shells stay untouched.
- **Renderer restart guard:** a failed-to-start agent panel relaunches as the agent (not demoted to a shell), gated on a surviving `command` so a demoted shell whose restart later fails can't wrongly re-promote (#5764).

## Testing

Regression tests across `AgentAvailabilityStore`, `waitUntilIdle` (stale-waiting crash race + failed-to-start mode-3 already-idle path), `pty-host` lifecycle (synthetic event ordering), and the panel store (failed-spawn `agentState` + restart classification). 109 targeted tests pass locally; lint and format clean.