### PR TITLE
fix(agent): resume latest OpenCode session on restart

### DIFF
--- a/shared/config/agents/opencode.ts
+++ b/shared/config/agents/opencode.ts
@@ -136,6 +136,7 @@ export const config: AgentConfig = {
     args: (sessionId: string) => ["-s", sessionId],
     quitCommand: "/quit",
     sessionIdPattern: "opencode -s ([\\w-]+)",
+    resumeLatestArgs: ["--continue"],
   },
   authCheck: {
     // OpenCode v1.4.6+ uses XDG-compliant config paths on all platforms

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -153,13 +153,19 @@ describe("buildResumeLatestCommand", () => {
   });
 
   it("returns undefined for session-id agents that don't declare resumeLatestArgs", () => {
-    // Copilot/Goose/Qwen/Mistral/OpenCode are session-id agents that didn't
-    // ship a resume-latest fallback in this issue; should return undefined.
+    // Copilot/Goose/Qwen/Mistral are session-id agents that didn't ship a
+    // resume-latest fallback; should return undefined.
     expect(buildResumeLatestCommand("copilot")).toBeUndefined();
     expect(buildResumeLatestCommand("goose")).toBeUndefined();
     expect(buildResumeLatestCommand("qwen")).toBeUndefined();
     expect(buildResumeLatestCommand("mistral")).toBeUndefined();
-    expect(buildResumeLatestCommand("opencode")).toBeUndefined();
+  });
+
+  it("returns opencode --continue for opencode without flags", () => {
+    // OpenCode declares resumeLatestArgs: ["--continue"] so a previously-open
+    // terminal can resume the latest session on restart even when no session id
+    // was captured (issue #10822).
+    expect(buildResumeLatestCommand("opencode")).toBe("opencode --continue");
   });
 
   it("prepends launch flags before resume-latest args for claude", () => {

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -168,6 +168,11 @@ describe("buildResumeLatestCommand", () => {
     expect(buildResumeLatestCommand("opencode")).toBe("opencode --continue");
   });
 
+  it("prepends launch flags before resume-latest args for opencode", () => {
+    const cmd = buildResumeLatestCommand("opencode", ["--dangerously-skip-permissions"]);
+    expect(cmd).toBe("opencode --dangerously-skip-permissions --continue");
+  });
+
   it("prepends launch flags before resume-latest args for claude", () => {
     const cmd = buildResumeLatestCommand("claude", ["--dangerously-skip-permissions"]);
     expect(cmd).toBe("claude --dangerously-skip-permissions --continue");


### PR DESCRIPTION
## Summary

- OpenCode was missing `resumeLatestArgs` in its resume config, so `buildResumeLatestCommand` returned `undefined` on every restart. That set `sessionLostOnRestore = true` and fired the "session couldn't be restored" banner every time, even when there was a perfectly good session to pick up.
- Adds `resumeLatestArgs: ["--continue"]` to `shared/config/agents/opencode.ts`, matching the pattern already in `claude.ts`.

Resolves #10822

## Changes

- `shared/config/agents/opencode.ts`: added `resumeLatestArgs: ["--continue"]` to the resume config
- `shared/types/__tests__/agentSettings.test.ts`: dropped opencode from the undefined-group assertion, added a positive test for `opencode --continue`, and added a flag-prepend ordering test

## Testing

All 112 targeted tests pass. The `resumeLatestArgs` path in `buildResumeLatestCommand` and the `sessionLostOnRestore` fallback in `buildArgsForRespawn` are covered by the updated suite.