### PR TITLE
fix(terminal): tone down the failed-session-restore banner (#10823)

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -344,6 +344,9 @@ function TerminalPaneComponent({
   const [justFocusedUntil, setJustFocusedUntil] = useState(0);
   const inputBarRef = useRef<HybridInputBarHandle>(null);
   const [dismissedRestartPrompt, setDismissedRestartPrompt] = useState(false);
+  // Separate from dismissedRestartPrompt so dismissing the lost-session
+  // acknowledgement (issue #10823) never suppresses a later exit-error banner.
+  const [dismissedSessionLost, setDismissedSessionLost] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isUpdateCwdOpen, setIsUpdateCwdOpen] = useState(false);
   const [isAutoRestarting, setIsAutoRestarting] = useState(false);
@@ -372,6 +375,7 @@ function TerminalPaneComponent({
 
   useEffect(() => {
     setDismissedRestartPrompt(false);
+    setDismissedSessionLost(false);
     inputTracker.reset();
     // Track process start time on each restart for backoff stability window
     processStartTimeRef.current = Date.now();
@@ -1174,6 +1178,7 @@ function TerminalPaneComponent({
     spawnError,
     backendStatus,
     sessionLostOnRestore,
+    dismissedSessionLost,
   });
   // Backend-dependent banners (restart / spawn / reconnect) describe failures
   // whose only recovery path runs through the host, so they're hidden while
@@ -1339,7 +1344,11 @@ function TerminalPaneComponent({
         <TerminalRestartStatusBanner
           variant={restartBannerVariant}
           onRestart={handleRestart}
-          onDismiss={() => setDismissedRestartPrompt(true)}
+          onDismiss={() =>
+            restartBannerVariant.type === "session-resume-unavailable"
+              ? setDismissedSessionLost(true)
+              : setDismissedRestartPrompt(true)
+          }
         />
       </BannerSlot>
 

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { XCircle, Loader2, RotateCcw } from "lucide-react";
+import { XCircle, Loader2, RotateCcw, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import type { RestartBannerVariant } from "./restartStatus";
@@ -57,23 +57,22 @@ export function TerminalRestartStatusBanner({
       );
 
     case "session-resume-unavailable":
+      // Toned down per issue #10823: the terminal already relaunched into a
+      // fresh, usable session, so this is a dismissable acknowledgement, not an
+      // assertive error. Warning severity + polite status role + a dismiss
+      // control; no restart action (a restart would be a redundant third
+      // session). The banner still surfaces the lost session so it isn't
+      // dropped silently (issue #9802).
       return (
         <InlineStatusBanner
-          icon={XCircle}
+          icon={AlertTriangle}
           title={RESTART_BANNER_COPY["session-resume-unavailable"].title}
           description={RESTART_BANNER_COPY["session-resume-unavailable"].description}
-          severity="error"
+          severity="warning"
           animated={false}
-          role="alert"
-          action={{
-            id: "start-new-session",
-            label: "Start new session",
-            icon: RotateCcw,
-            variant: "dangerFilled",
-            onClick: onRestart,
-            title: "Start new session",
-            ariaLabel: "Start new session",
-          }}
+          role="status"
+          ariaLive="polite"
+          onClose={onDismiss}
         />
       );
 

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -131,7 +131,7 @@ describe("TerminalRestartStatusBanner", () => {
       expect(description.textContent).not.toMatch(/expired|you lost|agent closed/i);
     });
 
-    it("uses role=alert without aria-live for an assertive interrupt", () => {
+    it("uses role=status with a polite live region (toned down per #10823)", () => {
       render(
         <TerminalRestartStatusBanner
           variant={{ type: "session-resume-unavailable" }}
@@ -139,25 +139,25 @@ describe("TerminalRestartStatusBanner", () => {
           onDismiss={vi.fn()}
         />
       );
-      const region = screen.getByRole("alert");
-      expect(region.hasAttribute("aria-live")).toBe(false);
+      const region = screen.getByRole("status");
+      expect(region.getAttribute("aria-live")).toBe("polite");
+      expect(region.getAttribute("aria-atomic")).toBe("true");
+      // No longer an assertive alert.
+      expect(screen.queryByRole("alert")).toBeNull();
     });
 
-    it("exposes a verb-noun recovery action that calls onRestart", () => {
-      const onRestart = vi.fn();
+    it("has no restart action — the terminal already relaunched fresh (#10823)", () => {
       render(
         <TerminalRestartStatusBanner
           variant={{ type: "session-resume-unavailable" }}
-          onRestart={onRestart}
+          onRestart={vi.fn()}
           onDismiss={vi.fn()}
         />
       );
-      const button = screen.getByRole("button", { name: /start new session/i });
-      fireEvent.click(button);
-      expect(onRestart).toHaveBeenCalledOnce();
+      expect(screen.queryByRole("button", { name: /start new session/i })).toBeNull();
     });
 
-    it("has no dismiss control — the banner is the recovery surface", () => {
+    it("has a dismiss control that calls onDismiss (#10823)", () => {
       const onDismiss = vi.fn();
       render(
         <TerminalRestartStatusBanner
@@ -166,7 +166,9 @@ describe("TerminalRestartStatusBanner", () => {
           onDismiss={onDismiss}
         />
       );
-      expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
+      const button = screen.getByRole("button", { name: "Dismiss" });
+      fireEvent.click(button);
+      expect(onDismiss).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -155,6 +155,9 @@ describe("TerminalRestartStatusBanner", () => {
         />
       );
       expect(screen.queryByRole("button", { name: /start new session/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /restart session/i })).toBeNull();
+      // Dismiss is the only control.
+      expect(screen.getAllByRole("button")).toHaveLength(1);
     });
 
     it("has a dismiss control that calls onDismiss (#10823)", () => {

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -270,9 +270,32 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
     const result = getRestartBannerVariant({
       ...restored,
       sessionLostOnRestore: true,
-      dismissedRestartPrompt: true,
+      dismissedSessionLost: true,
     });
     expect(result).toEqual({ type: "none" });
+  });
+
+  it("stays visible when only dismissedRestartPrompt is set — independent flags (#10823)", () => {
+    // Dismissing an exit-error prompt must not hide a lost-session acknowledgement.
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      dismissedRestartPrompt: true,
+    });
+    expect(result).toEqual({ type: "session-resume-unavailable" });
+  });
+
+  it("surfaces exit-error after the lost-session banner is dismissed (#10823)", () => {
+    // The dedicated dismiss flag means acknowledging the lost session must not
+    // silently suppress a crash banner for the fresh session that followed.
+    const result = getRestartBannerVariant({
+      ...restored,
+      isExited: true,
+      exitCode: 1,
+      sessionLostOnRestore: true,
+      dismissedSessionLost: true,
+    });
+    expect(result).toEqual({ type: "exit-error", exitCode: 1 });
   });
 
   it("ignores backendStatus — the lost session is independent of host connectivity", () => {

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -266,6 +266,15 @@ describe("getRestartBannerVariant — session-resume-unavailable (issue #9802)",
     expect(result).toEqual({ type: "none" });
   });
 
+  it("returns none once dismissed — the banner is dismissable (issue #10823)", () => {
+    const result = getRestartBannerVariant({
+      ...restored,
+      sessionLostOnRestore: true,
+      dismissedRestartPrompt: true,
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
   it("ignores backendStatus — the lost session is independent of host connectivity", () => {
     const result = getRestartBannerVariant({
       ...restored,

--- a/src/components/Terminal/restartBannerCopy.ts
+++ b/src/components/Terminal/restartBannerCopy.ts
@@ -8,12 +8,13 @@ export interface RestartBannerCopyMap {
 export const RESTART_BANNER_COPY: RestartBannerCopyMap = {
   "auto-restarting": { title: "Auto-restarting…" },
   restarting: { title: "Restarting…" },
-  // Neutral, non-accusatory copy per issue #9802 and the CLAUDE.md
-  // Title-Message-Action microcopy rule. Title is a noun phrase; the action
-  // label ("Start new session") lives in the banner component.
+  // Neutral, non-accusatory copy per issue #9802 and the CLAUDE.md microcopy
+  // rule. Title is a period-free noun phrase. The description reassures rather
+  // than prompts an action (issue #10823) — the terminal already relaunched
+  // into a fresh, usable session, so the banner is a dismissable acknowledgement.
   "session-resume-unavailable": {
     title: "Session no longer reachable",
-    description: "The previous conversation couldn't be restored. Start a new session to continue.",
+    description: "The previous session couldn't be restored. A fresh session is ready.",
   },
   "exit-error": ({ exitCode }) => ({ title: `Session exited with code ${exitCode}` }),
 };

--- a/src/components/Terminal/restartBannerCopy.ts
+++ b/src/components/Terminal/restartBannerCopy.ts
@@ -14,7 +14,7 @@ export const RESTART_BANNER_COPY: RestartBannerCopyMap = {
   // into a fresh, usable session, so the banner is a dismissable acknowledgement.
   "session-resume-unavailable": {
     title: "Session no longer reachable",
-    description: "The previous session couldn't be restored. A fresh session is ready.",
+    description: "The previous session couldn't be restored. A fresh session was started.",
   },
   "exit-error": ({ exitCode }) => ({ title: `Session exited with code ${exitCode}` }),
 };

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -43,9 +43,12 @@ export function getRestartBannerVariant(input: RestartBannerInput): RestartBanne
   // fresh launch. Surface it so the user isn't silently dropped into a clean
   // session (issue #9802). Gated below the in-flight restart states (a live
   // restart takes precedence) and above exit-error so a lost session is
-  // acknowledged before any prior exit prompt.
+  // acknowledged before any prior exit prompt. Dismissable (issue #10823): the
+  // user recovers just by carrying on in the fresh session, so once they
+  // acknowledge it the banner stays gone for this session.
   if (
     input.sessionLostOnRestore &&
+    !input.dismissedRestartPrompt &&
     !input.isRestarting &&
     !input.isAutoRestarting &&
     !input.restartError &&

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -22,6 +22,13 @@ export interface RestartBannerInput {
   backendStatus: BackendStatus;
   /** True when restore fell through to a fresh agent launch (issue #9802). */
   sessionLostOnRestore?: boolean;
+  /**
+   * True once the user dismissed the session-resume-unavailable banner
+   * (issue #10823). Tracked separately from `dismissedRestartPrompt` so
+   * acknowledging a lost session never suppresses a later exit-error banner
+   * for a crash of the fresh session.
+   */
+  dismissedSessionLost?: boolean;
 }
 
 export function getRestartBannerVariant(input: RestartBannerInput): RestartBannerVariant {
@@ -45,10 +52,13 @@ export function getRestartBannerVariant(input: RestartBannerInput): RestartBanne
   // restart takes precedence) and above exit-error so a lost session is
   // acknowledged before any prior exit prompt. Dismissable (issue #10823): the
   // user recovers just by carrying on in the fresh session, so once they
-  // acknowledge it the banner stays gone for this session.
+  // acknowledge it the banner stays gone for this session. Uses a dedicated
+  // `dismissedSessionLost` flag — not `dismissedRestartPrompt` — so dismissing
+  // this acknowledgement never suppresses a later exit-error for the fresh
+  // session crashing.
   if (
     input.sessionLostOnRestore &&
-    !input.dismissedRestartPrompt &&
+    !input.dismissedSessionLost &&
     !input.isRestarting &&
     !input.isAutoRestarting &&
     !input.restartError &&


### PR DESCRIPTION
## Summary

- The `session-resume-unavailable` banner was too loud: `severity=error`, `role=alert`, XCircle icon, red "Start new session" button, no dismiss. It fires on every restart for OpenCode (#10822), so it was the first thing users saw on launch, even when nothing actually went wrong.
- The terminal relaunches into a fresh, usable session automatically, so the error severity was unwarranted. Demoted to `severity=warning`, `role=status`, `aria-live=polite`, AlertTriangle icon, and a dismiss control. Dropped the redundant "Start new session" action (a restart would spawn a needless third session). The banner still surfaces the lost session, so nothing is dropped silently.
- Added a dedicated `dismissedSessionLost` flag so acknowledging a lost session never suppresses a later exit-error banner if the fresh session itself crashes.

Resolves #10823

## Changes

- `restartStatus.ts`: new `dismissedSessionLost` flag; resets on PTY restart alongside `dismissedRestartPrompt`
- `restartBannerCopy.ts`: softened session-lost copy to past tense ("The previous session couldn't be restored. A fresh session was started.")
- `TerminalRestartStatusBanner.tsx`: demoted `session-resume-unavailable` variant to warning, `role=status`, `aria-live=polite`, dismiss control, dropped the restart action
- `TerminalPane.tsx`: wired `dismissedSessionLost` and its reset on each PTY restart

## Testing

Updated the three existing `session-resume-unavailable` banner tests (now assert `role=status`/polite, exactly one button, dismiss present and calls `onDismiss`). Added `restartStatus` tests proving the two dismiss flags are independent: dismissing a lost session surfaces a later exit-error, and dismissing an exit-error leaves the lost-session banner visible. 84 targeted tests pass.