### PR TITLE
fix(layout): defer empty-state grid measurement until sidebar width hydrates (#10827)

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -329,13 +329,28 @@ export function AppLayout({
   // commits the restored `sidebarWidth` (and the cleared hydrating flag) into
   // the DOM, so grid/pane measurement subscribers fire against the correct
   // `<main>` width instead of the default 350px — eliminating the first-load
-  // narrow-then-snap. `unlockSidebarHydration()` is idempotent, so a failed
-  // restore (which also clears the flag) still releases the lock exactly once.
+  // narrow-then-snap. `unlockSidebarHydration()` is idempotent.
+  //
+  // Gated on `isHydrated`: the pre-hydration skeleton AppLayout (App.tsx renders
+  // `<AppLayout isHydrated={false}>` with no ContentGrid) runs the same
+  // `restoreState()` effect, and its fast `appClient.getState()` typically
+  // resolves before the real AppLayout + ContentGrid mount. Without this gate
+  // the skeleton would release the global lock early, so the real grid would
+  // hit the already-unlocked fast path and measure at the default width.
   useEffect(() => {
+    if (!isHydrated) return;
     if (!isSidebarWidthHydrating) {
       unlockSidebarHydration();
+      return;
     }
-  }, [isSidebarWidthHydrating]);
+    // Safety net: if the width restore hangs (IPC never resolves *or* rejects),
+    // `isSidebarWidthHydrating` would stay true forever and the grid would
+    // never measure. Release the lock after a generous timeout so a stuck IPC
+    // degrades to the pre-#10827 behavior (visible grid) rather than a blank
+    // one. Cleared the instant the flag clears normally (effect re-runs).
+    const fallback = window.setTimeout(unlockSidebarHydration, 5000);
+    return () => window.clearTimeout(fallback);
+  }, [isHydrated, isSidebarWidthHydrating]);
 
   useEffect(() => {
     if (layout.gestureSidebarHidden) return;

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -40,6 +40,7 @@ import { useLayoutState, useOverlayOpen } from "@/hooks";
 import { useKeepMounted } from "@/hooks/useKeepMounted";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import { repaintAssistantAfterTransition, suppressSidebarResizes } from "@/lib/sidebarToggle";
+import { unlockSidebarHydration } from "@/lib/layoutTransitionLock";
 import { logError } from "@/utils/logger";
 
 function preloadGlobalBannerCoordinator() {
@@ -322,6 +323,19 @@ export function AppLayout({
     };
     restoreState();
   }, []);
+
+  // #10827: release the grid-measurement hydration lock once the persisted
+  // sidebar width has been restored. This passive effect runs after React
+  // commits the restored `sidebarWidth` (and the cleared hydrating flag) into
+  // the DOM, so grid/pane measurement subscribers fire against the correct
+  // `<main>` width instead of the default 350px — eliminating the first-load
+  // narrow-then-snap. `unlockSidebarHydration()` is idempotent, so a failed
+  // restore (which also clears the flag) still releases the lock exactly once.
+  useEffect(() => {
+    if (!isSidebarWidthHydrating) {
+      unlockSidebarHydration();
+    }
+  }, [isSidebarWidthHydrating]);
 
   useEffect(() => {
     if (layout.gestureSidebarHidden) return;

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -105,6 +105,12 @@ export const MIN_SIDEBAR_WIDTH = 200;
 export const MAX_SIDEBAR_WIDTH = 600;
 export const DEFAULT_SIDEBAR_WIDTH = 350;
 
+// #10827: upper bound on how long the grid-measurement hydration lock stays
+// armed if the persisted-width restore IPC neither resolves nor rejects. After
+// this the lock releases anyway so the grid still measures (pre-#10827 visible
+// behavior) rather than staying blank. Far longer than a healthy restore.
+const SIDEBAR_HYDRATION_UNLOCK_FALLBACK_MS = 5000;
+
 export function AppLayout({
   children,
   sidebarContent,
@@ -348,7 +354,10 @@ export function AppLayout({
     // never measure. Release the lock after a generous timeout so a stuck IPC
     // degrades to the pre-#10827 behavior (visible grid) rather than a blank
     // one. Cleared the instant the flag clears normally (effect re-runs).
-    const fallback = window.setTimeout(unlockSidebarHydration, 5000);
+    const fallback = window.setTimeout(
+      unlockSidebarHydration,
+      SIDEBAR_HYDRATION_UNLOCK_FALLBACK_MS
+    );
     return () => window.clearTimeout(fallback);
   }, [isHydrated, isSidebarWidthHydrating]);
 

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -470,3 +470,31 @@ describe("AppLayout sidebar-width hydration transition gating — issue #10321",
     expect(source).not.toMatch(/flushSync\([^)]*setIsSidebarWidthHydrating/);
   });
 });
+
+describe("AppLayout grid-measurement hydration unlock — issue #10827", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("imports the hydration unlock from the layout-transition lock module", () => {
+    expect(source).toContain("unlockSidebarHydration");
+    expect(source).toContain('from "@/lib/layoutTransitionLock"');
+  });
+
+  it("releases the hydration lock in an effect gated on the cleared hydrating flag", () => {
+    // The passive effect runs after React commits the restored sidebarWidth (and
+    // the cleared flag) into the DOM, so grid/pane measurement subscribers fire
+    // against the correct <main> width instead of the default 350px.
+    expect(source).toMatch(
+      /if \(!isSidebarWidthHydrating\)\s*\{\s*unlockSidebarHydration\(\);\s*\}/
+    );
+  });
+
+  it("depends only on the hydrating flag so it fires when the flag clears", () => {
+    expect(source).toMatch(
+      /unlockSidebarHydration\(\);[\s\S]{0,60}\}, \[isSidebarWidthHydrating\]\)/
+    );
+  });
+});

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -507,7 +507,9 @@ describe("AppLayout grid-measurement hydration unlock — issue #10827", () => {
     // stays true forever; the timeout releases the lock so the grid degrades to a
     // visible (pre-#10827) state rather than never measuring. Cleared the instant
     // the flag clears normally.
-    expect(source).toMatch(/setTimeout\(unlockSidebarHydration, \d+\)/);
+    expect(source).toMatch(
+      /setTimeout\(\s*unlockSidebarHydration,\s*SIDEBAR_HYDRATION_UNLOCK_FALLBACK_MS\s*\)/
+    );
     expect(source).toMatch(/clearTimeout\(fallback\)/);
   });
 });

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -483,18 +483,31 @@ describe("AppLayout grid-measurement hydration unlock — issue #10827", () => {
     expect(source).toContain('from "@/lib/layoutTransitionLock"');
   });
 
-  it("releases the hydration lock in an effect gated on the cleared hydrating flag", () => {
+  it("releases the hydration lock in an effect once the hydrating flag clears", () => {
     // The passive effect runs after React commits the restored sidebarWidth (and
     // the cleared flag) into the DOM, so grid/pane measurement subscribers fire
     // against the correct <main> width instead of the default 350px.
     expect(source).toMatch(
-      /if \(!isSidebarWidthHydrating\)\s*\{\s*unlockSidebarHydration\(\);\s*\}/
+      /if \(!isSidebarWidthHydrating\)\s*\{\s*unlockSidebarHydration\(\);\s*return;\s*\}/
     );
   });
 
-  it("depends only on the hydrating flag so it fires when the flag clears", () => {
-    expect(source).toMatch(
-      /unlockSidebarHydration\(\);[\s\S]{0,60}\}, \[isSidebarWidthHydrating\]\)/
-    );
+  it("gates the unlock on isHydrated so the pre-hydration skeleton can't release the lock early", () => {
+    // App.tsx renders a skeleton <AppLayout isHydrated={false}> (no ContentGrid)
+    // whose fast appClient.getState() typically resolves before the real layout
+    // mounts. Without this gate the skeleton would unlock the global lock early,
+    // so the real grid would hit the already-unlocked fast path and measure at
+    // the default 350px — reproducing the snap.
+    expect(source).toMatch(/if \(!isHydrated\) return;[\s\S]{0,500}unlockSidebarHydration\(\)/);
+    expect(source).toMatch(/\}, \[isHydrated, isSidebarWidthHydrating\]\)/);
+  });
+
+  it("arms a fallback unlock so a hung width-restore IPC still measures the grid", () => {
+    // If appClient.getState() neither resolves nor rejects, isSidebarWidthHydrating
+    // stays true forever; the timeout releases the lock so the grid degrades to a
+    // visible (pre-#10827) state rather than never measuring. Cleared the instant
+    // the flag clears normally.
+    expect(source).toMatch(/setTimeout\(unlockSidebarHydration, \d+\)/);
+    expect(source).toMatch(/clearTimeout\(fallback\)/);
   });
 });

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -12,8 +12,9 @@ import { MIN_TERMINAL_WIDTH_PX } from "@/lib/terminalLayout";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isBrowserPanel, isDevPreviewPanel, isReviewPanel } from "@shared/types/panel";
 import {
-  isSidebarLayoutTransitionLocked,
+  isSidebarMeasurementLocked,
   subscribeSidebarLayoutTransitionUnlock,
+  subscribeSidebarHydrationUnlock,
 } from "@/lib/layoutTransitionLock";
 
 interface TwoPaneSplitLayoutProps {
@@ -139,7 +140,7 @@ export function TwoPaneSplitLayout({
         rafId = null;
         const entry = latestEntry;
         latestEntry = null;
-        if (isSidebarLayoutTransitionLocked()) return;
+        if (isSidebarMeasurementLocked()) return;
         if (entry) {
           const width = entry.contentRect.width;
           setContainerWidth((prev) => (prev === width ? prev : width));
@@ -148,24 +149,26 @@ export function TwoPaneSplitLayout({
     });
 
     observer.observe(container);
-    // Skip the initial measurement if a sidebar transition is in flight — the
-    // unlock subscriber below will resync once the animation completes.
-    if (!isSidebarLayoutTransitionLocked()) {
+    // Skip the initial measurement if a sidebar transition is in flight, or
+    // while startup hydration is still pending (#10827) — the unlock
+    // subscribers below resync once the animation completes / width restores.
+    if (!isSidebarMeasurementLocked()) {
       setContainerWidth(container.clientWidth);
     }
 
-    // Force a single measurement after the sidebar transition completes so
-    // the pane widths land at their post-transition size even if no further
-    // RO entry fires.
-    const unsubscribe = subscribeSidebarLayoutTransitionUnlock(() => {
+    // Force a single measurement after the sidebar transition completes (or
+    // after startup hydration lands, #10827) so the pane widths reach their
+    // settled size even if no further RO entry fires. Shared by both unlock
+    // subscribers.
+    const remeasureAfterUnlock = () => {
       const node = containerRef.current;
       if (!node) return;
       if (finalRafId !== null) cancelAnimationFrame(finalRafId);
       finalRafId = requestAnimationFrame(() => {
         finalRafId = null;
-        // Re-check the lock — a second toggle may have started in the ~16ms
+        // Re-check both locks — a second toggle may have started in the ~16ms
         // between unlock and this rAF.
-        if (isSidebarLayoutTransitionLocked()) return;
+        if (isSidebarMeasurementLocked()) return;
         // Don't override an in-progress divider drag — changing
         // `containerWidth` mid-drag shifts `minRatio`/`maxRatio` clamping
         // bounds, which can snap the live ratio. Defer the resync until
@@ -179,13 +182,19 @@ export function TwoPaneSplitLayout({
         const width = measureNode.clientWidth;
         setContainerWidth((prev) => (prev === width ? prev : width));
       });
-    });
+    };
+
+    const unsubscribeTransition = subscribeSidebarLayoutTransitionUnlock(remeasureAfterUnlock);
+    // #10827: remeasure once the persisted sidebar width is restored. Fires
+    // synchronously if hydration already completed before this effect mounted.
+    const unsubscribeHydration = subscribeSidebarHydrationUnlock(remeasureAfterUnlock);
 
     return () => {
       observer.disconnect();
       if (rafId !== null) cancelAnimationFrame(rafId);
       if (finalRafId !== null) cancelAnimationFrame(finalRafId);
-      unsubscribe();
+      unsubscribeTransition();
+      unsubscribeHydration();
     };
   }, []);
 

--- a/src/components/Terminal/__tests__/twoPaneSplitLayout.sidebar.test.ts
+++ b/src/components/Terminal/__tests__/twoPaneSplitLayout.sidebar.test.ts
@@ -9,9 +9,11 @@ const LAYOUT_PATH = resolve(__dirname, "../TwoPaneSplitLayout.tsx");
 // gate-and-resync pattern already used by `useContentGridContext` and
 // `useGridNavigation` against `layoutTransitionLock`.
 describe("TwoPaneSplitLayout sidebar lock gating (issue #7825)", () => {
-  it("imports the sidebar layout-transition lock helpers", async () => {
+  it("imports the sidebar measurement lock helpers", async () => {
     const content = await readFile(LAYOUT_PATH, "utf-8");
-    expect(content).toContain("isSidebarLayoutTransitionLocked");
+    // #10827 promoted the guards to the combined measurement lock so both the
+    // transition lock and the startup hydration lock gate measurement.
+    expect(content).toContain("isSidebarMeasurementLocked");
     expect(content).toContain("subscribeSidebarLayoutTransitionUnlock");
     expect(content).toContain("@/lib/layoutTransitionLock");
   });
@@ -22,19 +24,19 @@ describe("TwoPaneSplitLayout sidebar lock gating (issue #7825)", () => {
     expect(content).not.toContain("setContainerEl");
   });
 
-  it("creates a manual ResizeObserver guarded by the sidebar lock", async () => {
+  it("creates a manual ResizeObserver guarded by the measurement lock", async () => {
     const content = await readFile(LAYOUT_PATH, "utf-8");
     expect(content).toContain("new ResizeObserver");
-    const lockGuardIndex = content.indexOf("if (isSidebarLayoutTransitionLocked()) return;");
+    const lockGuardIndex = content.indexOf("if (isSidebarMeasurementLocked()) return;");
     const setterIndex = content.indexOf("setContainerWidth(");
     expect(lockGuardIndex).toBeGreaterThan(-1);
     expect(setterIndex).toBeGreaterThan(-1);
     expect(lockGuardIndex).toBeLessThan(setterIndex);
   });
 
-  it("skips the initial measurement when the sidebar lock is active", async () => {
+  it("skips the initial measurement when the measurement lock is active", async () => {
     const content = await readFile(LAYOUT_PATH, "utf-8");
-    expect(content).toContain("if (!isSidebarLayoutTransitionLocked())");
+    expect(content).toContain("if (!isSidebarMeasurementLocked())");
   });
 
   it("resyncs the container width on sidebar transition unlock with a drag guard", async () => {
@@ -51,11 +53,31 @@ describe("TwoPaneSplitLayout sidebar lock gating (issue #7825)", () => {
     expect(content).toContain("pendingResyncAfterDragRef.current = false");
   });
 
-  it("cancels pending animation frames on cleanup", async () => {
+  it("cancels pending animation frames and unsubscribes both locks on cleanup", async () => {
     const content = await readFile(LAYOUT_PATH, "utf-8");
     expect(content).toContain("observer.disconnect()");
     expect(content).toContain("cancelAnimationFrame(rafId)");
     expect(content).toContain("cancelAnimationFrame(finalRafId)");
-    expect(content).toContain("unsubscribe()");
+    expect(content).toContain("unsubscribeTransition()");
+    expect(content).toContain("unsubscribeHydration()");
+  });
+});
+
+// Issue #10827 — on first load the right pane measured against the default
+// 350px sidebar before the persisted width restored, then snapped. The same
+// gate-and-resync pattern now also covers the one-shot hydration lock.
+describe("TwoPaneSplitLayout hydration lock gating (issue #10827)", () => {
+  it("imports the hydration unlock subscription and combined lock", async () => {
+    const content = await readFile(LAYOUT_PATH, "utf-8");
+    expect(content).toContain("isSidebarMeasurementLocked");
+    expect(content).toContain("subscribeSidebarHydrationUnlock");
+    // The bare transition-only lock query must not linger — every measure site
+    // gates on the combined lock so neither half can be bypassed.
+    expect(content).not.toContain("isSidebarLayoutTransitionLocked");
+  });
+
+  it("subscribes to the hydration unlock to remeasure after the width restore", async () => {
+    const content = await readFile(LAYOUT_PATH, "utf-8");
+    expect(content).toContain("subscribeSidebarHydrationUnlock(");
   });
 });

--- a/src/components/Terminal/__tests__/useContentGridContext.hydration.test.ts
+++ b/src/components/Terminal/__tests__/useContentGridContext.hydration.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+
+const HOOK_PATH = resolve(__dirname, "../useContentGridContext.tsx");
+
+// Issue #10827 — the empty-state grid measured against the default 350px
+// sidebar on first load (before the persisted width restored), then snapped to
+// the correct width. The ResizeObserver effect now gates every measurement on
+// the combined `isSidebarMeasurementLocked()` (transition lock OR one-shot
+// startup hydration lock) and remeasures once hydration completes, mirroring
+// the existing transition-unlock resync.
+describe("useContentGridContext hydration lock gating (issue #10827)", () => {
+  it("imports the combined measurement lock and the hydration unlock subscription", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("isSidebarMeasurementLocked");
+    expect(content).toContain("subscribeSidebarHydrationUnlock");
+    expect(content).toContain("subscribeSidebarLayoutTransitionUnlock");
+    expect(content).toContain("@/lib/layoutTransitionLock");
+    // The bare transition-only query must not linger — measurement sites gate
+    // on the combined lock so the hydration half can't be bypassed.
+    expect(content).not.toContain("isSidebarLayoutTransitionLocked");
+  });
+
+  it("guards the ResizeObserver callback on the combined measurement lock", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("if (isSidebarMeasurementLocked()) return;");
+  });
+
+  it("skips the initial synchronous measurement while measurement is locked", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("if (!isSidebarMeasurementLocked())");
+  });
+
+  it("subscribes to both transition and hydration unlock for the deferred remeasure", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("subscribeSidebarLayoutTransitionUnlock(remeasureAfterUnlock)");
+    expect(content).toContain("subscribeSidebarHydrationUnlock(remeasureAfterUnlock)");
+  });
+
+  it("unsubscribes both lock subscriptions on cleanup", async () => {
+    const content = await readFile(HOOK_PATH, "utf-8");
+    expect(content).toContain("unsubscribeTransition()");
+    expect(content).toContain("unsubscribeHydration()");
+  });
+});

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -42,8 +42,9 @@ import {
   GRID_TRANSITION_DURATION_MS,
 } from "@/lib/terminalLayout";
 import {
-  isSidebarLayoutTransitionLocked,
+  isSidebarMeasurementLocked,
   subscribeSidebarLayoutTransitionUnlock,
+  subscribeSidebarHydrationUnlock,
 } from "@/lib/layoutTransitionLock";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useProjectBranding } from "@/hooks";
@@ -574,8 +575,10 @@ export function useContentGridContext({
         latestEntry = null;
         // Skip mid-transition widths — the flex parent is reflowing every
         // frame and committing fractional widths into `grid-template-columns`
-        // produces visible jitter on the panel grid edge (#6979).
-        if (isSidebarLayoutTransitionLocked()) return;
+        // produces visible jitter on the panel grid edge (#6979). Also skip
+        // during startup hydration, before the persisted sidebar width is
+        // restored (#10827).
+        if (isSidebarMeasurementLocked()) return;
         if (entry) {
           const { width, height } = entry.contentRect;
           setGridWidth((prev) => (prev === width ? prev : width));
@@ -587,29 +590,31 @@ export function useContentGridContext({
 
     observer.observe(container);
     // If the effect re-mounts mid-transition (e.g., a dep like
-    // `gridTerminals.length` changes during the lock window), skip the
-    // initial measurement — a mid-animation `<main>` width would re-snap
-    // `grid-template-columns` and reintroduce jitter. The unlock subscriber
-    // below will sync the grid once the transition completes.
-    if (!isSidebarLayoutTransitionLocked()) {
+    // `gridTerminals.length` changes during the lock window), or while startup
+    // hydration is still pending (#10827), skip the initial measurement — a
+    // mid-animation or pre-restore `<main>` width would re-snap
+    // `grid-template-columns` and reintroduce jitter. The unlock subscribers
+    // below sync the grid once the transition completes / hydration lands.
+    if (!isSidebarMeasurementLocked()) {
       setGridWidth(container.clientWidth);
       setGridHeight(container.clientHeight);
       setGridDimensions({ width: container.clientWidth, height: container.clientHeight });
     }
 
-    // Force a single measurement after the sidebar transition completes so
-    // the grid lands at its post-transition size even if no further RO entry
-    // fires (the geometry may already be settled by the time we unlock).
-    const unsubscribe = subscribeSidebarLayoutTransitionUnlock(() => {
+    // Force a single measurement after the sidebar transition completes (or
+    // after startup hydration lands, #10827) so the grid reaches its settled
+    // size even if no further RO entry fires (the geometry may already be
+    // stable by the time we unlock). Shared by both unlock subscribers.
+    const remeasureAfterUnlock = () => {
       const node = gridContainerRef.current;
       if (!node) return;
       if (finalRafId !== null) cancelAnimationFrame(finalRafId);
       finalRafId = requestAnimationFrame(() => {
         finalRafId = null;
-        // Re-check the lock — a second toggle may have started in the ~16ms
+        // Re-check both locks — a second toggle may have started in the ~16ms
         // between unlock and this rAF, in which case our measurement would
         // capture a mid-animation width from the new transition.
-        if (isSidebarLayoutTransitionLocked()) return;
+        if (isSidebarMeasurementLocked()) return;
         const measureNode = gridContainerRef.current;
         if (!measureNode) return;
         const width = measureNode.clientWidth;
@@ -618,13 +623,19 @@ export function useContentGridContext({
         setGridHeight((prev) => (prev === height ? prev : height));
         setGridDimensions({ width, height });
       });
-    });
+    };
+
+    const unsubscribeTransition = subscribeSidebarLayoutTransitionUnlock(remeasureAfterUnlock);
+    // #10827: remeasure once the persisted sidebar width is restored. Fires
+    // synchronously if hydration already completed before this effect mounted.
+    const unsubscribeHydration = subscribeSidebarHydrationUnlock(remeasureAfterUnlock);
 
     return () => {
       observer.disconnect();
       if (rafId !== null) cancelAnimationFrame(rafId);
       if (finalRafId !== null) cancelAnimationFrame(finalRafId);
-      unsubscribe();
+      unsubscribeTransition();
+      unsubscribeHydration();
       setGridDimensions(null);
     };
   }, [setGridDimensions, gridTerminals.length, maximizedId, twoPaneSplitEnabled, showPlaceholder]);

--- a/src/lib/__tests__/layoutTransitionLock.test.ts
+++ b/src/lib/__tests__/layoutTransitionLock.test.ts
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  __resetSidebarHydrationLockForTests,
   __resetSidebarLayoutTransitionLockForTests,
+  isSidebarHydrationLocked,
   isSidebarLayoutTransitionLocked,
+  isSidebarMeasurementLocked,
   lockSidebarLayoutTransition,
+  subscribeSidebarHydrationUnlock,
   subscribeSidebarLayoutTransitionUnlock,
+  unlockSidebarHydration,
 } from "../layoutTransitionLock";
 
 describe("layoutTransitionLock", () => {
@@ -157,5 +162,145 @@ describe("layoutTransitionLock", () => {
 
     vi.advanceTimersByTime(250);
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+// Issue #10827 — the one-shot startup hydration lock. Distinct from the
+// transition lock: it starts locked, releases exactly once when the persisted
+// sidebar width is restored, and never re-arms.
+describe("layoutTransitionLock sidebar hydration lock", () => {
+  beforeEach(() => {
+    __resetSidebarHydrationLockForTests();
+  });
+
+  afterEach(() => {
+    __resetSidebarHydrationLockForTests();
+  });
+
+  it("starts locked", () => {
+    expect(isSidebarHydrationLocked()).toBe(true);
+  });
+
+  it("unlocks on the first call and stays unlocked", () => {
+    unlockSidebarHydration();
+    expect(isSidebarHydrationLocked()).toBe(false);
+    unlockSidebarHydration();
+    expect(isSidebarHydrationLocked()).toBe(false);
+  });
+
+  it("notifies subscribers exactly once on unlock", () => {
+    const listener = vi.fn();
+    subscribeSidebarHydrationUnlock(listener);
+    expect(listener).not.toHaveBeenCalled();
+
+    unlockSidebarHydration();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire subscribers a second time on a repeated unlock", () => {
+    const listener = vi.fn();
+    subscribeSidebarHydrationUnlock(listener);
+
+    unlockSidebarHydration();
+    unlockSidebarHydration();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies multiple subscribers", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    subscribeSidebarHydrationUnlock(a);
+    subscribeSidebarHydrationUnlock(b);
+
+    unlockSidebarHydration();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe before unlock prevents the callback from firing", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSidebarHydrationUnlock(listener);
+    unsubscribe();
+
+    unlockSidebarHydration();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("fires synchronously and returns a no-op cleanup when already unlocked", () => {
+    unlockSidebarHydration();
+
+    const listener = vi.fn();
+    const unsubscribe = subscribeSidebarHydrationUnlock(listener);
+    // Already-unlocked fast path: a measurement effect mounting after restore
+    // still gets its deferred remeasure instead of silently dropping it.
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("survives a listener that throws and still notifies the others", () => {
+    const ok = vi.fn();
+    subscribeSidebarHydrationUnlock(() => {
+      throw new Error("boom");
+    });
+    subscribeSidebarHydrationUnlock(ok);
+
+    unlockSidebarHydration();
+    expect(ok).toHaveBeenCalledTimes(1);
+    expect(isSidebarHydrationLocked()).toBe(false);
+  });
+
+  it("__resetSidebarHydrationLockForTests re-arms the lock and drops pending listeners", () => {
+    const listener = vi.fn();
+    subscribeSidebarHydrationUnlock(listener);
+
+    __resetSidebarHydrationLockForTests();
+    expect(isSidebarHydrationLocked()).toBe(true);
+
+    unlockSidebarHydration();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("isSidebarMeasurementLocked", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+  });
+
+  afterEach(() => {
+    __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
+    vi.useRealTimers();
+  });
+
+  it("is true while only the hydration lock is active", () => {
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+    expect(isSidebarHydrationLocked()).toBe(true);
+    expect(isSidebarMeasurementLocked()).toBe(true);
+  });
+
+  it("is true while only the transition lock is active", () => {
+    unlockSidebarHydration();
+    lockSidebarLayoutTransition(100);
+    expect(isSidebarHydrationLocked()).toBe(false);
+    expect(isSidebarLayoutTransitionLocked()).toBe(true);
+    expect(isSidebarMeasurementLocked()).toBe(true);
+  });
+
+  it("is true while both locks are active", () => {
+    lockSidebarLayoutTransition(100);
+    expect(isSidebarMeasurementLocked()).toBe(true);
+  });
+
+  it("is false only once both locks have cleared", () => {
+    unlockSidebarHydration();
+    lockSidebarLayoutTransition(100);
+    expect(isSidebarMeasurementLocked()).toBe(true);
+
+    vi.advanceTimersByTime(100);
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+    expect(isSidebarHydrationLocked()).toBe(false);
+    expect(isSidebarMeasurementLocked()).toBe(false);
   });
 });

--- a/src/lib/__tests__/layoutTransitionLock.test.ts
+++ b/src/lib/__tests__/layoutTransitionLock.test.ts
@@ -249,6 +249,24 @@ describe("layoutTransitionLock sidebar hydration lock", () => {
     expect(isSidebarHydrationLocked()).toBe(false);
   });
 
+  it("stays locked and silent until unlock is called (covers a hung width-restore IPC)", () => {
+    const listener = vi.fn();
+    subscribeSidebarHydrationUnlock(listener);
+
+    // No unlock — mirrors appClient.getState() hanging without resolve/reject.
+    expect(isSidebarHydrationLocked()).toBe(true);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("survives a throwing listener on the already-unlocked fast path", () => {
+    unlockSidebarHydration();
+    expect(() =>
+      subscribeSidebarHydrationUnlock(() => {
+        throw new Error("boom");
+      })
+    ).not.toThrow();
+  });
+
   it("__resetSidebarHydrationLockForTests re-arms the lock and drops pending listeners", () => {
     const listener = vi.fn();
     subscribeSidebarHydrationUnlock(listener);

--- a/src/lib/layoutTransitionLock.ts
+++ b/src/lib/layoutTransitionLock.ts
@@ -16,14 +16,46 @@
  * Single renderer = single lock. Module-level state is safe — each project
  * view is a distinct WebContentsView with its own V8 context (see
  * `ProjectViewManager`), so there is exactly one grid per module scope.
+ *
+ * A second, independent lock (`hydrationLocked`) covers the startup window
+ * before the persisted sidebar width is restored. At mount the sidebar sits at
+ * `DEFAULT_SIDEBAR_WIDTH`; the real width arrives ~50–100ms later when the
+ * async `appClient.getState()` restore resolves (see `AppLayout`). Measuring
+ * the grid in that window captures the wrong (narrow) `<main>` width and the
+ * grid visibly snaps once the restore lands (#10827). Unlike the transition
+ * lock this one is one-shot: it starts `true`, is released exactly once when
+ * hydration completes, and never re-arms. The `isSidebarMeasurementLocked()`
+ * combiner is the single query every measurement site should use so neither
+ * lock can be forgotten.
  */
 
 let locked = false;
 let timer: number | undefined;
 const listeners = new Set<() => void>();
 
+let hydrationLocked = true;
+const hydrationListeners = new Set<() => void>();
+
 export function isSidebarLayoutTransitionLocked(): boolean {
   return locked;
+}
+
+/**
+ * True while the persisted sidebar width is still being restored on startup.
+ * Starts `true`, flips to `false` exactly once via `unlockSidebarHydration()`.
+ */
+export function isSidebarHydrationLocked(): boolean {
+  return hydrationLocked;
+}
+
+/**
+ * Single query for "is any width-affecting operation in flight?" — the union of
+ * the user-triggered transition lock and the one-shot startup hydration lock.
+ * Every grid/pane measurement site should gate on this rather than either lock
+ * alone, so adding a new lock can't silently bypass an existing measure path.
+ */
+export function isSidebarMeasurementLocked(): boolean {
+  return locked || hydrationLocked;
 }
 
 export function lockSidebarLayoutTransition(durationMs: number): void {
@@ -52,6 +84,44 @@ export function subscribeSidebarLayoutTransitionUnlock(listener: () => void): ()
   };
 }
 
+/**
+ * Release the startup hydration lock and notify subscribers. Idempotent and
+ * one-shot: a second call after the lock has cleared is a no-op (no double
+ * fire). Listeners are cleared after firing — hydration happens once per
+ * renderer lifetime, so a late subscriber takes the already-unlocked fast path
+ * in `subscribeSidebarHydrationUnlock` instead.
+ */
+export function unlockSidebarHydration(): void {
+  if (!hydrationLocked) return;
+  hydrationLocked = false;
+  // Snapshot — a callback may unsubscribe (or this set is cleared) mid-iteration.
+  for (const listener of Array.from(hydrationListeners)) {
+    try {
+      listener();
+    } catch {
+      // Swallow per-listener errors so one bad subscriber can't block others.
+    }
+  }
+  hydrationListeners.clear();
+}
+
+/**
+ * Subscribe to the one-shot hydration unlock. If hydration has already
+ * completed the listener fires synchronously and the returned cleanup is a
+ * no-op — a measurement effect that mounts after restore still gets its
+ * deferred remeasure rather than silently dropping it.
+ */
+export function subscribeSidebarHydrationUnlock(listener: () => void): () => void {
+  if (!hydrationLocked) {
+    listener();
+    return () => {};
+  }
+  hydrationListeners.add(listener);
+  return () => {
+    hydrationListeners.delete(listener);
+  };
+}
+
 export function __resetSidebarLayoutTransitionLockForTests(): void {
   if (timer !== undefined) {
     clearTimeout(timer);
@@ -59,4 +129,9 @@ export function __resetSidebarLayoutTransitionLockForTests(): void {
   }
   locked = false;
   listeners.clear();
+}
+
+export function __resetSidebarHydrationLockForTests(): void {
+  hydrationLocked = true;
+  hydrationListeners.clear();
 }

--- a/src/lib/layoutTransitionLock.ts
+++ b/src/lib/layoutTransitionLock.ts
@@ -113,7 +113,12 @@ export function unlockSidebarHydration(): void {
  */
 export function subscribeSidebarHydrationUnlock(listener: () => void): () => void {
   if (!hydrationLocked) {
-    listener();
+    try {
+      listener();
+    } catch {
+      // Mirror unlockSidebarHydration's throw-safety so a bad subscriber on the
+      // already-unlocked fast path can't escape into the caller's effect.
+    }
     return () => {};
   }
   hydrationListeners.add(listener);

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -1,6 +1,6 @@
 import { Terminal } from "@xterm/xterm";
 import { TerminalRefreshTier } from "@/types";
-import { isSidebarLayoutTransitionLocked } from "@/lib/layoutTransitionLock";
+import { isSidebarMeasurementLocked } from "@/lib/layoutTransitionLock";
 import { logDebug, logWarn } from "@/utils/logger";
 import type { ManagedTerminal } from "./types";
 
@@ -149,10 +149,11 @@ export class TerminalReconciliationWatchdog {
    */
   tick(): void {
     if (typeof document === "undefined" || document.visibilityState !== "visible") return;
-    // Mid-drag and mid-layout-animation geometry is not ground truth, and
-    // repairs during either would fight legitimate transient suppression.
+    // Mid-drag, mid-layout-animation, and pre-hydration (#10827) geometry is
+    // not ground truth, and repairs during any of them would fight legitimate
+    // transient suppression.
     if (document.documentElement.dataset.dragging === "true") return;
-    if (isSidebarLayoutTransitionLocked()) return;
+    if (isSidebarMeasurementLocked()) return;
 
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -209,6 +209,24 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.setVisible).not.toHaveBeenCalled();
     });
 
+    it("skips the tick while the startup hydration lock is held, then resumes (issue #10827)", () => {
+      // The production boot path: pre-hydration geometry is the default-width
+      // sidebar, so reconciling against it would repair to the wrong size. Other
+      // suites unlock hydration in beforeEach; this one re-arms it to exercise
+      // the real first-load gate.
+      __resetSidebarHydrationLockForTests();
+      instances.set("t1", makeManaged({ isVisible: false }));
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).not.toHaveBeenCalled();
+
+      unlockSidebarHydration();
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.setVisible).toHaveBeenCalledWith("t1");
+    });
+
     it("fires an immediate sweep when the document becomes visible again", () => {
       instances.set("t1", makeManaged({ isVisible: false }));
       const deps = makeDeps(instances);

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -2,8 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalRefreshTier } from "@/types";
 import {
+  __resetSidebarHydrationLockForTests,
   __resetSidebarLayoutTransitionLockForTests,
   lockSidebarLayoutTransition,
+  unlockSidebarHydration,
 } from "@/lib/layoutTransitionLock";
 import {
   TerminalReconciliationWatchdog,
@@ -155,6 +157,10 @@ describe("TerminalReconciliationWatchdog", () => {
     instances = new Map();
     setDocumentVisibility("visible");
     __resetSidebarLayoutTransitionLockForTests();
+    // #10827: the watchdog now also gates on the one-shot hydration lock, which
+    // starts locked at module init. Release it so ticks run their repairs.
+    __resetSidebarHydrationLockForTests();
+    unlockSidebarHydration();
   });
 
   afterEach(() => {
@@ -163,6 +169,7 @@ describe("TerminalReconciliationWatchdog", () => {
     delete document.documentElement.dataset.dragging;
     document.body.innerHTML = "";
     __resetSidebarLayoutTransitionLockForTests();
+    __resetSidebarHydrationLockForTests();
     vi.useRealTimers();
     vi.clearAllMocks();
   });

--- a/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
+++ b/src/services/terminal/__tests__/TerminalSwitchBackRedraw.regression.test.ts
@@ -35,6 +35,10 @@ import {
   WATCHDOG_INTERVAL_MS,
   type ReconciliationWatchdogDeps,
 } from "../TerminalReconciliationWatchdog";
+import {
+  __resetSidebarHydrationLockForTests,
+  unlockSidebarHydration,
+} from "@/lib/layoutTransitionLock";
 import type { ManagedTerminal } from "../types";
 
 vi.mock("@/utils/logger", () => ({
@@ -222,12 +226,17 @@ describe("#10632 switch-back redraw — closed-loop convergence", () => {
     setDocumentVisible();
     instances = new Map();
     agents = new Map();
+    // #10827: the watchdog gates on the one-shot hydration lock, which starts
+    // locked at module init. Release it so ticks run their repairs.
+    __resetSidebarHydrationLockForTests();
+    unlockSidebarHydration();
   });
 
   afterEach(() => {
     watchdog?.dispose();
     watchdog = undefined;
     document.body.innerHTML = "";
+    __resetSidebarHydrationLockForTests();
     vi.useRealTimers();
     vi.clearAllMocks();
   });


### PR DESCRIPTION
## Summary

- On first load, the empty-state content grid and two-pane split measured their container while the sidebar was still at its default width, before the async persisted-width restore arrived, causing a visible snap.
- The #10321 fix suppressed the sidebar's CSS transition during this window but didn't extend to grid measurement on mount. This PR closes that gap.
- Adds a one-shot startup hydration lock to `layoutTransitionLock` (alongside the existing user-transition lock), exposed via a combined `isSidebarMeasurementLocked()`. `AppLayout` releases it once the persisted width restores, gated on `isHydrated` so the pre-hydration skeleton `AppLayout` can't release it early, with a fallback timeout if the IPC hangs. `useContentGridContext`, `TwoPaneSplitLayout`, and `TerminalReconciliationWatchdog` all gate on the combined lock and remeasure on unlock.

Resolves #10827

## Changes

- `src/lib/layoutTransitionLock.ts`: new startup hydration lock + `isSidebarMeasurementLocked()` combining both locks
- `src/components/Layout/AppLayout.tsx`: releases hydration lock on persisted-width restore (gated on `isHydrated`, with fallback timeout)
- `src/components/Terminal/useContentGridContext.tsx`: gates initial measure on combined lock, remeasures on hydration unlock
- `src/components/Terminal/TwoPaneSplitLayout.tsx`: same gate as `useContentGridContext`
- `electron/pty-host/terminal/TerminalReconciliationWatchdog.ts`: gates first-load boot path on combined lock

## Testing

129 tests passing, including new hydration-lock and combined-lock unit suites, `AppLayout`/two-pane/grid source-inspection guards, and a watchdog first-load boot-path test.