### PR TITLE
feat(project): add "Free memory" to the project switcher

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -204,6 +204,7 @@ export const CHANNELS = {
   PROJECT_DETECT_RUNNERS: "project:detect-runners",
   PROJECT_LIST_REMOTES: "project:list-remotes",
   PROJECT_CLOSE: "project:close",
+  PROJECT_FREE_MEMORY: "project:free-memory",
   PROJECT_REOPEN: "project:reopen",
   PROJECT_GET_STATS: "project:get-stats",
   PROJECT_GET_BULK_STATS: "project:get-bulk-stats",

--- a/electron/ipc/handlers.ts
+++ b/electron/ipc/handlers.ts
@@ -7,6 +7,7 @@ import { registerSystemShellHandlers } from "./handlers/systemShell.js";
 import { registerEditorConfigHandlers } from "./handlers/editorConfig.js";
 import { registerAgentCliHandlers } from "./handlers/agentCli.js";
 import { registerProjectCrudHandlers } from "./handlers/projectCrud/index.js";
+import { registerProjectFreeMemoryHandlers } from "./handlers/projectFreeMemory.js";
 import { registerProjectRecipesHandlers } from "./handlers/projectRecipes.js";
 import { registerProjectPresetsHandlers } from "./handlers/projectPresets.js";
 import { registerGlobalRecipesHandlers } from "./handlers/globalRecipes.js";
@@ -125,6 +126,7 @@ export function registerIpcHandlers(deps: HandlerDependencies): () => void {
     register(() => registerEditorConfigHandlers(deps));
     register(() => registerAgentCliHandlers(deps));
     register(() => registerProjectCrudHandlers(deps));
+    register(() => registerProjectFreeMemoryHandlers(deps));
     register(() => registerProjectRecipesHandlers(deps));
     register(() => registerProjectPresetsHandlers(deps));
     register(() => registerGlobalRecipesHandlers());

--- a/electron/ipc/handlers/__tests__/project.freeMemory.test.ts
+++ b/electron/ipc/handlers/__tests__/project.freeMemory.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import os from "os";
+
+vi.mock("electron", () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+    showErrorBox: vi.fn(),
+  },
+  shell: {
+    openPath: vi.fn(),
+    openExternal: vi.fn(),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue(os.tmpdir()),
+  },
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  getCurrentProjectId: vi.fn<() => string | null>(),
+  getProjectById:
+    vi.fn<
+      (projectId: string) => { id: string; name: string; status?: string; path?: string } | null
+    >(),
+  updateProjectStatus:
+    vi.fn<(projectId: string, status: "active" | "background" | "closed") => unknown>(),
+}));
+
+const evictProjectRendererMock = vi.hoisted(() => vi.fn<(projectId: string) => number>());
+const writeHibernatedMarkerMock = vi.hoisted(() => vi.fn<(terminalId: string) => void>());
+
+vi.mock("../../../services/ProjectStore.js", () => ({
+  projectStore: projectStoreMock,
+}));
+
+vi.mock("../../../services/HibernationService.js", () => ({
+  getHibernationService: () => ({ evictProjectRenderer: evictProjectRendererMock }),
+}));
+
+vi.mock("../../../services/pty/terminalSessionPersistence.js", () => ({
+  writeHibernatedMarker: writeHibernatedMarkerMock,
+}));
+
+vi.mock("../../../services/ProjectSwitchService.js", () => ({
+  ProjectSwitchService: class MockProjectSwitchService {
+    onSwitch = vi.fn();
+  },
+}));
+
+import { ipcMain } from "electron";
+import { CHANNELS } from "../../channels.js";
+import { registerProjectCrudHandlers } from "../projectCrud/index.js";
+import type { HandlerDependencies } from "../../types.js";
+
+type FreeMemoryResult = {
+  terminalsKilled: number;
+  rendererEvicted: boolean;
+  workspaceEvicted: boolean;
+};
+
+type FreeMemoryHandler = (event: unknown, projectId: string) => Promise<FreeMemoryResult>;
+
+function getFreeMemoryHandler(deps: HandlerDependencies): FreeMemoryHandler {
+  registerProjectCrudHandlers(deps);
+  const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+    .calls;
+  const call = calls.find((c) => c[0] === CHANNELS.PROJECT_FREE_MEMORY);
+  expect(call).toBeTruthy();
+  return call?.[1] as unknown as FreeMemoryHandler;
+}
+
+const EVENT = { senderFrame: { url: "http://localhost:5173" } };
+
+describe("project:free-memory handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects freeing memory for the active project", async () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+
+    const ptyClient = { gracefulKillByProject: vi.fn(async () => []) };
+    const worktreeService = { evictProject: vi.fn(() => true) };
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+      worktreeService,
+    } as unknown as HandlerDependencies;
+
+    const handler = getFreeMemoryHandler(deps);
+
+    await expect(handler(EVENT, "project-active")).rejects.toThrow("Switch to another project");
+    expect(ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(worktreeService.evictProject).not.toHaveBeenCalled();
+  });
+
+  it("throws when the project does not exist", async () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+    projectStoreMock.getProjectById.mockReturnValue(null);
+
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient: { gracefulKillByProject: vi.fn(async () => []) },
+      worktreeService: { evictProject: vi.fn(() => false) },
+    } as unknown as HandlerDependencies;
+
+    const handler = getFreeMemoryHandler(deps);
+
+    await expect(handler(EVENT, "missing")).rejects.toThrow("Project not found");
+  });
+
+  it("is idempotent for an already-closed project (no kills)", async () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "project-closed",
+      name: "Closed Project",
+      status: "closed",
+      path: "/test/project-closed",
+    });
+
+    const ptyClient = { gracefulKillByProject: vi.fn(async () => []) };
+    const worktreeService = { evictProject: vi.fn(() => true) };
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+      worktreeService,
+    } as unknown as HandlerDependencies;
+
+    const handler = getFreeMemoryHandler(deps);
+    const result = await handler(EVENT, "project-closed");
+
+    expect(result).toEqual({
+      terminalsKilled: 0,
+      rendererEvicted: false,
+      workspaceEvicted: false,
+    });
+    expect(ptyClient.gracefulKillByProject).not.toHaveBeenCalled();
+    expect(evictProjectRendererMock).not.toHaveBeenCalled();
+    expect(worktreeService.evictProject).not.toHaveBeenCalled();
+    expect(projectStoreMock.updateProjectStatus).not.toHaveBeenCalled();
+  });
+
+  it("frees a background project: graceful kill, markers, renderer + workspace eviction, marks closed", async () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "project-bg",
+      name: "Background Project",
+      status: "background",
+      path: "/test/project-bg",
+    });
+    evictProjectRendererMock.mockReturnValue(1);
+
+    const ptyClient = {
+      gracefulKillByProject: vi.fn(async () => [
+        { id: "term-1", agentSessionId: "sess-1" },
+        { id: "term-2", agentSessionId: null },
+      ]),
+    };
+    const worktreeService = { evictProject: vi.fn(() => true) };
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+      worktreeService,
+    } as unknown as HandlerDependencies;
+
+    const handler = getFreeMemoryHandler(deps);
+    const result = await handler(EVENT, "project-bg");
+
+    // Session-preserving graceful kill — NOT the destructive killByProject.
+    expect(ptyClient.gracefulKillByProject).toHaveBeenCalledWith("project-bg", {
+      preserveSession: true,
+    });
+    // A hibernation marker is written per killed terminal so reopen restores warm.
+    expect(writeHibernatedMarkerMock).toHaveBeenCalledTimes(2);
+    expect(writeHibernatedMarkerMock).toHaveBeenCalledWith("term-1");
+    expect(writeHibernatedMarkerMock).toHaveBeenCalledWith("term-2");
+
+    expect(evictProjectRendererMock).toHaveBeenCalledWith("project-bg");
+    expect(worktreeService.evictProject).toHaveBeenCalledWith("/test/project-bg");
+
+    // Marked closed WITHOUT clearProjectState — layout survives for reopen.
+    expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-bg", "closed");
+
+    expect(result).toEqual({
+      terminalsKilled: 2,
+      rendererEvicted: true,
+      workspaceEvicted: true,
+    });
+  });
+
+  it("reports rendererEvicted=false / workspaceEvicted=false when nothing was resident", async () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-active");
+    projectStoreMock.getProjectById.mockReturnValue({
+      id: "project-bg",
+      name: "Background Project",
+      status: "background",
+      path: "/test/project-bg",
+    });
+    evictProjectRendererMock.mockReturnValue(0);
+
+    const ptyClient = { gracefulKillByProject: vi.fn(async () => []) };
+    // Held by another window (refCount > 0) → eviction skipped.
+    const worktreeService = { evictProject: vi.fn(() => false) };
+    const deps = {
+      mainWindow: {} as unknown,
+      ptyClient,
+      worktreeService,
+    } as unknown as HandlerDependencies;
+
+    const handler = getFreeMemoryHandler(deps);
+    const result = await handler(EVENT, "project-bg");
+
+    expect(result).toEqual({
+      terminalsKilled: 0,
+      rendererEvicted: false,
+      workspaceEvicted: false,
+    });
+    expect(projectStoreMock.updateProjectStatus).toHaveBeenCalledWith("project-bg", "closed");
+  });
+});

--- a/electron/ipc/handlers/__tests__/project.freeMemory.test.ts
+++ b/electron/ipc/handlers/__tests__/project.freeMemory.test.ts
@@ -55,7 +55,7 @@ vi.mock("../../../services/ProjectSwitchService.js", () => ({
 
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
-import { registerProjectCrudHandlers } from "../projectCrud/index.js";
+import { registerProjectFreeMemoryHandlers } from "../projectFreeMemory.js";
 import type { HandlerDependencies } from "../../types.js";
 
 type FreeMemoryResult = {
@@ -67,7 +67,7 @@ type FreeMemoryResult = {
 type FreeMemoryHandler = (event: unknown, projectId: string) => Promise<FreeMemoryResult>;
 
 function getFreeMemoryHandler(deps: HandlerDependencies): FreeMemoryHandler {
-  registerProjectCrudHandlers(deps);
+  registerProjectFreeMemoryHandlers(deps);
   const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
     .calls;
   const call = calls.find((c) => c[0] === CHANNELS.PROJECT_FREE_MEMORY);

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -3,6 +3,8 @@ import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { projectStore } from "../../../services/ProjectStore.js";
+import { getHibernationService } from "../../../services/HibernationService.js";
+import { writeHibernatedMarker } from "../../../services/pty/terminalSessionPersistence.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -208,6 +210,82 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_CLOSE, handleProjectClose));
+
+  const handleProjectFreeMemory = async (projectId: string) => {
+    if (typeof projectId !== "string" || !projectId) {
+      throw new Error("Invalid project ID");
+    }
+
+    // The active project owns the visible renderer and the live workspace host
+    // for this window — tearing them down would blank the window and sever the
+    // worktree feed. Match project:close's guard: switch away first.
+    if (projectId === projectStore.getCurrentProjectId()) {
+      throw new Error(
+        "Cannot free memory for the active project. Switch to another project first."
+      );
+    }
+
+    const project = projectStore.getProjectById(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+
+    // Already reclaimed — nothing resident to free. Idempotent so repeated
+    // menu clicks (or a re-broadcast) don't double-kill or throw.
+    if (project.status === "closed") {
+      return { terminalsKilled: 0, rendererEvicted: false, workspaceEvicted: false };
+    }
+
+    try {
+      // Graceful, session-preserving kill — NOT killByProject. The shell
+      // scrollback survives via the hibernation markers below so a later
+      // reopen restores the panels instead of starting cold.
+      const results = await deps.ptyClient!.gracefulKillByProject(projectId, {
+        preserveSession: true,
+      });
+      for (const result of results) {
+        writeHibernatedMarker(result.id);
+      }
+
+      // Tear down the cached WebContentsView across every window (no-ops where
+      // the project is on-screen — guarded inside evictProjectRenderer).
+      const evictedViewCount = getHibernationService().evictProjectRenderer(projectId);
+
+      // Drop the workspace-host utility process. Skips when another window
+      // still holds the project (refCount > 0).
+      const workspaceEvicted = deps.worktreeService?.evictProject(project.path) ?? false;
+
+      // Keep the project in the list as `closed` WITHOUT clearProjectState, so
+      // its panel/terminal layout survives for a non-destructive reopen.
+      projectStore.updateProjectStatus(projectId, "closed");
+      const updated = projectStore.getProjectById(projectId);
+      if (updated) {
+        broadcastToRenderer(CHANNELS.PROJECT_UPDATED, updated);
+      }
+
+      console.log(
+        `[IPC] project:free-memory: ${projectId} — killed ${results.length} terminal(s), ` +
+          `evicted ${evictedViewCount} renderer view(s), workspace host ${
+            workspaceEvicted ? "evicted" : "retained"
+          }`
+      );
+
+      return {
+        terminalsKilled: results.length,
+        rendererEvicted: evictedViewCount > 0,
+        workspaceEvicted,
+      };
+    } catch (error) {
+      console.error(`[IPC] project:free-memory: Failed for ${projectId}:`, error);
+      throw new AppError({
+        code: "INTERNAL",
+        message: formatErrorMessage(error, "Failed to free memory"),
+        context: { projectId },
+        cause: error instanceof Error ? error : undefined,
+      });
+    }
+  };
+  handlers.push(typedHandle(CHANNELS.PROJECT_FREE_MEMORY, handleProjectFreeMemory));
 
   const handleProjectCheckMissing = async (): Promise<string[]> => {
     return projectStore.checkMissingProjects();

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -3,8 +3,6 @@ import path from "path";
 import { CHANNELS } from "../../channels.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { projectStore } from "../../../services/ProjectStore.js";
-import { getHibernationService } from "../../../services/HibernationService.js";
-import { writeHibernatedMarker } from "../../../services/pty/terminalSessionPersistence.js";
 import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
 import { resolveScopedProjectForIpcContext } from "../../projectContext.js";
 import type { HandlerDependencies } from "../../types.js";
@@ -210,82 +208,6 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_CLOSE, handleProjectClose));
-
-  const handleProjectFreeMemory = async (projectId: string) => {
-    if (typeof projectId !== "string" || !projectId) {
-      throw new Error("Invalid project ID");
-    }
-
-    // The active project owns the visible renderer and the live workspace host
-    // for this window — tearing them down would blank the window and sever the
-    // worktree feed. Match project:close's guard: switch away first.
-    if (projectId === projectStore.getCurrentProjectId()) {
-      throw new Error(
-        "Cannot free memory for the active project. Switch to another project first."
-      );
-    }
-
-    const project = projectStore.getProjectById(projectId);
-    if (!project) {
-      throw new Error(`Project not found: ${projectId}`);
-    }
-
-    // Already reclaimed — nothing resident to free. Idempotent so repeated
-    // menu clicks (or a re-broadcast) don't double-kill or throw.
-    if (project.status === "closed") {
-      return { terminalsKilled: 0, rendererEvicted: false, workspaceEvicted: false };
-    }
-
-    try {
-      // Graceful, session-preserving kill — NOT killByProject. The shell
-      // scrollback survives via the hibernation markers below so a later
-      // reopen restores the panels instead of starting cold.
-      const results = await deps.ptyClient!.gracefulKillByProject(projectId, {
-        preserveSession: true,
-      });
-      for (const result of results) {
-        writeHibernatedMarker(result.id);
-      }
-
-      // Tear down the cached WebContentsView across every window (no-ops where
-      // the project is on-screen — guarded inside evictProjectRenderer).
-      const evictedViewCount = getHibernationService().evictProjectRenderer(projectId);
-
-      // Drop the workspace-host utility process. Skips when another window
-      // still holds the project (refCount > 0).
-      const workspaceEvicted = deps.worktreeService?.evictProject(project.path) ?? false;
-
-      // Keep the project in the list as `closed` WITHOUT clearProjectState, so
-      // its panel/terminal layout survives for a non-destructive reopen.
-      projectStore.updateProjectStatus(projectId, "closed");
-      const updated = projectStore.getProjectById(projectId);
-      if (updated) {
-        broadcastToRenderer(CHANNELS.PROJECT_UPDATED, updated);
-      }
-
-      console.log(
-        `[IPC] project:free-memory: ${projectId} — killed ${results.length} terminal(s), ` +
-          `evicted ${evictedViewCount} renderer view(s), workspace host ${
-            workspaceEvicted ? "evicted" : "retained"
-          }`
-      );
-
-      return {
-        terminalsKilled: results.length,
-        rendererEvicted: evictedViewCount > 0,
-        workspaceEvicted,
-      };
-    } catch (error) {
-      console.error(`[IPC] project:free-memory: Failed for ${projectId}:`, error);
-      throw new AppError({
-        code: "INTERNAL",
-        message: formatErrorMessage(error, "Failed to free memory"),
-        context: { projectId },
-        cause: error instanceof Error ? error : undefined,
-      });
-    }
-  };
-  handlers.push(typedHandle(CHANNELS.PROJECT_FREE_MEMORY, handleProjectFreeMemory));
 
   const handleProjectCheckMissing = async (): Promise<string[]> => {
     return projectStore.checkMissingProjects();

--- a/electron/ipc/handlers/projectFreeMemory.ts
+++ b/electron/ipc/handlers/projectFreeMemory.ts
@@ -1,0 +1,109 @@
+import { CHANNELS } from "../channels.js";
+import { broadcastToRenderer } from "../utils.js";
+import { projectStore } from "../../services/ProjectStore.js";
+import { getHibernationService } from "../../services/HibernationService.js";
+import { writeHibernatedMarker } from "../../services/pty/terminalSessionPersistence.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import { AppError } from "../../utils/errorTypes.js";
+import { defineIpcNamespace, op } from "../define.js";
+import type { HandlerDependencies } from "../types.js";
+import type { ProjectFreeMemoryResult } from "../../../shared/types/ipc/project.js";
+
+/**
+ * `project:free-memory` — reclaim a background project's resident memory while
+ * keeping it in the list as `closed` for a non-destructive reopen. Tears down
+ * all three reclaimable tiers: graceful (session-preserving) PTY kill, cached
+ * renderer WebContentsView, and the workspace-host process. Deliberately does
+ * NOT call `clearProjectState` (layout survives), `killByProject` (destructive),
+ * or route through `HibernationService.hibernateProject` (experiment-gated).
+ *
+ * Lives in its own `defineIpcNamespace` block rather than the hand-written
+ * `project` namespace so its `IpcInvokeMap` entry is codegen-generated — new
+ * channels must not grow the hand-written ratchet (`check:ipc-handwritten`).
+ */
+export function registerProjectFreeMemoryHandlers(deps: HandlerDependencies): () => void {
+  const namespace = defineIpcNamespace({
+    name: "projectFreeMemory",
+    ops: {
+      freeMemory: op(
+        CHANNELS.PROJECT_FREE_MEMORY,
+        async (projectId: string): Promise<ProjectFreeMemoryResult> => {
+          if (typeof projectId !== "string" || !projectId) {
+            throw new Error("Invalid project ID");
+          }
+
+          // The active project owns the visible renderer and the live workspace
+          // host for this window — tearing them down would blank the window and
+          // sever the worktree feed. Match project:close's guard: switch away.
+          if (projectId === projectStore.getCurrentProjectId()) {
+            throw new Error(
+              "Cannot free memory for the active project. Switch to another project first."
+            );
+          }
+
+          const project = projectStore.getProjectById(projectId);
+          if (!project) {
+            throw new Error(`Project not found: ${projectId}`);
+          }
+
+          // Already reclaimed — nothing resident to free. Idempotent so repeated
+          // menu clicks (or a re-broadcast) don't double-kill or throw.
+          if (project.status === "closed") {
+            return { terminalsKilled: 0, rendererEvicted: false, workspaceEvicted: false };
+          }
+
+          try {
+            // Graceful, session-preserving kill — NOT killByProject. The shell
+            // scrollback survives via the hibernation markers below so a later
+            // reopen restores the panels instead of starting cold.
+            const results = await deps.ptyClient!.gracefulKillByProject(projectId, {
+              preserveSession: true,
+            });
+            for (const result of results) {
+              writeHibernatedMarker(result.id);
+            }
+
+            // Tear down the cached WebContentsView across every window (no-ops
+            // where the project is on-screen — guarded inside the service).
+            const evictedViewCount = getHibernationService().evictProjectRenderer(projectId);
+
+            // Drop the workspace-host utility process. Skips when another window
+            // still holds the project (refCount > 0).
+            const workspaceEvicted = deps.worktreeService?.evictProject(project.path) ?? false;
+
+            // Keep the project in the list as `closed` WITHOUT clearProjectState,
+            // so its panel/terminal layout survives for a non-destructive reopen.
+            projectStore.updateProjectStatus(projectId, "closed");
+            const updated = projectStore.getProjectById(projectId);
+            if (updated) {
+              broadcastToRenderer(CHANNELS.PROJECT_UPDATED, updated);
+            }
+
+            console.log(
+              `[IPC] project:free-memory: ${projectId} — killed ${results.length} terminal(s), ` +
+                `evicted ${evictedViewCount} renderer view(s), workspace host ${
+                  workspaceEvicted ? "evicted" : "retained"
+                }`
+            );
+
+            return {
+              terminalsKilled: results.length,
+              rendererEvicted: evictedViewCount > 0,
+              workspaceEvicted,
+            };
+          } catch (error) {
+            console.error(`[IPC] project:free-memory: Failed for ${projectId}:`, error);
+            throw new AppError({
+              code: "INTERNAL",
+              message: formatErrorMessage(error, "Failed to free memory"),
+              context: { projectId },
+              cause: error instanceof Error ? error : undefined,
+            });
+          }
+        }
+      ),
+    },
+  });
+
+  return namespace.register();
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1599,6 +1599,8 @@ function buildElectronApi(): ElectronAPI {
       close: (projectId: string, options?: { killTerminals?: boolean }) =>
         _unwrappingInvoke(CHANNELS.PROJECT_CLOSE, projectId, options),
 
+      freeMemory: (projectId: string) => _unwrappingInvoke(CHANNELS.PROJECT_FREE_MEMORY, projectId),
+
       reopen: (
         projectId: string,
         outgoingState?: import("../shared/types/ipc/project.js").ProjectSwitchOutgoingState

--- a/electron/services/HibernationService.ts
+++ b/electron/services/HibernationService.ts
@@ -437,7 +437,7 @@ export class HibernationService {
     // Chromium renderer resident per project, so without this hibernation
     // appears to free almost nothing.
     if (reason === "user-initiated") {
-      this.evictCachedRenderer(projectId);
+      this.evictProjectRenderer(projectId);
     }
 
     return terminalsKilled;
@@ -456,10 +456,15 @@ export class HibernationService {
    * though `activeProjectId` already points at the incoming project). Destroying
    * either would expose a blank/unpainted frame. Both guards are per-manager —
    * each window tracks its own active and outgoing project.
+   *
+   * Public so the user-initiated `project:free-memory` IPC handler can reclaim
+   * the renderer directly without routing through the (experiment-gated)
+   * `hibernateProject` PTY-kill path. Returns the number of windows whose
+   * cached view was torn down.
    */
-  private evictCachedRenderer(projectId: string): void {
+  evictProjectRenderer(projectId: string): number {
     const provider = this.projectViewManagersProvider;
-    if (!provider) return;
+    if (!provider) return 0;
 
     let managers: ProjectViewManager[];
     try {
@@ -467,7 +472,7 @@ export class HibernationService {
     } catch (error) {
       // windowRegistry may be tearing down — eviction is best-effort.
       logError("user-initiated-hibernate-evict-provider-failed", error, { projectId });
-      return;
+      return 0;
     }
 
     let evictedViewCount = 0;
@@ -492,6 +497,8 @@ export class HibernationService {
     if (evictedViewCount > 0) {
       logInfo("user-initiated-hibernate-renderer-evicted", { projectId, evictedViewCount });
     }
+
+    return evictedViewCount;
   }
 
   getConfig(): HibernationConfig {

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -297,6 +297,17 @@ export class WorkspaceClient extends EventEmitter {
     }
   }
 
+  /**
+   * Force-evict the workspace host for `projectPath` (user-initiated "free
+   * memory"). No-op when the client is disposed. Returns false when no host is
+   * loaded or the project is still held by a window (see
+   * {@link WorkspaceHostPool.evictProject}).
+   */
+  evictProject(projectPath: string): boolean {
+    if (this.isDisposed) return false;
+    return this.pool.evictProject(projectPath);
+  }
+
   pauseHealthCheck(): void {
     for (const entry of this.pool.entries.values()) {
       entry.host.pauseHealthCheck();

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -414,6 +414,22 @@ export class WorkspaceHostPool {
 
   // ── Eviction / dormant management ──
 
+  /**
+   * Force-evict the workspace host for `projectPath` on demand (user-initiated
+   * "free memory"). Disposes the utility process and drops the entry. Returns
+   * false — without evicting — when no host is loaded, or when the project is
+   * still held by a window (`refCount > 0`): another open window may be using
+   * the same host, and severing it mid-use would break that window's worktree
+   * monitoring. Unlike `scheduleDormantCleanup`, this skips the grace period.
+   */
+  evictProject(projectPath: string): boolean {
+    const normalized = this.normalizeProjectPath(projectPath);
+    const entry = this.entries.get(normalized);
+    if (!entry || entry.refCount > 0) return false;
+    this.evictEntry(normalized, entry);
+    return true;
+  }
+
   private evictEntry(projectPath: string, entry: ProcessEntry): void {
     if (entry.cleanupTimeout) {
       clearTimeout(entry.cleanupTimeout);

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -165,6 +165,7 @@ export type {
   IssueNotFoundPayload,
   // Project close IPC types
   ProjectCloseResult,
+  ProjectFreeMemoryResult,
   ProjectStats,
   BulkProjectStatsEntry,
   BulkProjectStats,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -111,6 +111,7 @@ import type { RetryAction, ErrorRecord, RetryProgressPayload } from "./errors.js
 import type { EventRecord } from "./events.js";
 import type {
   ProjectCloseResult,
+  ProjectFreeMemoryResult,
   ProjectStats,
   ProjectStatusMap,
   BulkProjectStats,
@@ -537,6 +538,14 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * @param options - Optional: { killTerminals: true } to kill running terminals (default: false, just backgrounds)
      */
     close(projectId: string, options?: { killTerminals?: boolean }): Promise<ProjectCloseResult>;
+    /**
+     * Reclaim a background project's resident memory — tears down its cached
+     * renderer, gracefully kills its PTYs (sessions preserved), and evicts its
+     * workspace host — while keeping the project in the list as `closed` and
+     * preserving its layout for a non-destructive reopen. Rejects if the
+     * project is currently active (switch away first).
+     */
+    freeMemory(projectId: string): Promise<ProjectFreeMemoryResult>;
     /**
      * Reopen a background project, making it the active project.
      * Terminals that were running in the background will be reconnected.

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1099,6 +1099,10 @@ export interface GeneratedIpcInvokeMap {
     args: [options: import("./gitClone.js").CloneRepoOptions];
     result: import("./gitClone.js").CloneRepoResult;
   };
+  "project:free-memory": {
+    args: [projectId: string];
+    result: import("./project.js").ProjectFreeMemoryResult;
+  };
   "project:get-draft-inputs": {
     args: [projectId: string];
     result: Record<string, string>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -71,7 +71,6 @@ import type { RetryAction, ErrorRecord, RetryProgressPayload } from "./errors.js
 import type { EventRecord } from "./events.js";
 import type {
   ProjectCloseResult,
-  ProjectFreeMemoryResult,
   ProjectStats,
   ProjectStatusMap,
   ProjectSwitchPayload,
@@ -629,10 +628,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   "project:close": {
     args: [projectId: string, options?: { killTerminals?: boolean }];
     result: ProjectCloseResult;
-  };
-  "project:free-memory": {
-    args: [projectId: string];
-    result: ProjectFreeMemoryResult;
   };
   "project:reopen": {
     args: [projectId: string, outgoingState?: ProjectSwitchOutgoingState];

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -71,6 +71,7 @@ import type { RetryAction, ErrorRecord, RetryProgressPayload } from "./errors.js
 import type { EventRecord } from "./events.js";
 import type {
   ProjectCloseResult,
+  ProjectFreeMemoryResult,
   ProjectStats,
   ProjectStatusMap,
   ProjectSwitchPayload,
@@ -628,6 +629,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
   "project:close": {
     args: [projectId: string, options?: { killTerminals?: boolean }];
     result: ProjectCloseResult;
+  };
+  "project:free-memory": {
+    args: [projectId: string];
+    result: ProjectFreeMemoryResult;
   };
   "project:reopen": {
     args: [projectId: string, outgoingState?: ProjectSwitchOutgoingState];

--- a/shared/types/ipc/project.ts
+++ b/shared/types/ipc/project.ts
@@ -50,6 +50,21 @@ export interface ProjectCloseResult {
   terminalsKilled: number;
 }
 
+/**
+ * Result from the project:free-memory operation. Reclaims a background
+ * project's resident memory (renderer + PTYs + workspace host) while keeping
+ * the project in the list as `closed` and preserving its layout for a
+ * non-destructive reopen. Failures throw `AppError`.
+ */
+export interface ProjectFreeMemoryResult {
+  /** Number of terminals gracefully killed (sessions preserved for restore). */
+  terminalsKilled: number;
+  /** True when a cached renderer WebContentsView was torn down. */
+  rendererEvicted: boolean;
+  /** True when the project's workspace-host process was evicted. */
+  workspaceEvicted: boolean;
+}
+
 /** Project resource statistics */
 export interface ProjectStats {
   /** Total number of running processes */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1319,6 +1319,9 @@ function AppInner() {
                     onCloseProject={(projectId) =>
                       void projectSwitcherPalette.removeProject(projectId)
                     }
+                    onFreeMemoryProject={(projectId) =>
+                      void projectSwitcherPalette.freeMemoryProject(projectId)
+                    }
                     onLocateProject={(projectId) =>
                       void projectSwitcherPalette.locateProject(projectId)
                     }
@@ -1332,6 +1335,12 @@ function AppInner() {
                     }
                     onConfirmRemove={projectSwitcherPalette.confirmRemoveProject}
                     isRemovingProject={projectSwitcherPalette.isRemovingProject}
+                    freeMemoryConfirmProject={projectSwitcherPalette.freeMemoryConfirmProject}
+                    onFreeMemoryConfirmClose={() =>
+                      projectSwitcherPalette.setFreeMemoryConfirmProject(null)
+                    }
+                    onConfirmFreeMemory={projectSwitcherPalette.confirmFreeMemory}
+                    isFreeingMemory={projectSwitcherPalette.isFreeingMemory}
                     onSelectNewWindow={(project) => {
                       projectSwitcherPalette.close();
                       void actionService.dispatch(

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -3,6 +3,7 @@ import type {
   ProjectSettings,
   RunCommand,
   ProjectCloseResult,
+  ProjectFreeMemoryResult,
   ProjectStats,
   BulkProjectStats,
   TerminalRecipe,
@@ -210,6 +211,11 @@ export const projectClient = {
   ): Promise<ProjectCloseResult> => {
     invalidateCurrentCache();
     return window.electron.project.close(projectId, options);
+  },
+
+  freeMemory: (projectId: string): Promise<ProjectFreeMemoryResult> => {
+    invalidateCurrentCache();
+    return window.electron.project.freeMemory(projectId);
   },
 
   reopen: (projectId: string, outgoingState?: ProjectSwitchOutgoingState): Promise<Project> => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -609,6 +609,13 @@ export function Toolbar({
     [projectSwitcher]
   );
 
+  const handleFreeMemoryProject = useCallback(
+    (projectId: string) => {
+      void projectSwitcher.freeMemoryProject(projectId);
+    },
+    [projectSwitcher]
+  );
+
   const handleLocateProject = useCallback(
     (projectId: string) => {
       void projectSwitcher.locateProject(projectId);
@@ -1466,6 +1473,7 @@ export function Toolbar({
                 onCloneRepo={projectSwitcher.cloneRepo}
                 onStopProject={handleStopProject}
                 onCloseProject={handleCloseProject}
+                onFreeMemoryProject={handleFreeMemoryProject}
                 onLocateProject={handleLocateProject}
                 onTogglePinProject={projectSwitcher.togglePinProject}
                 onCopyPath={projectSwitcher.copyPath}
@@ -1476,6 +1484,10 @@ export function Toolbar({
                 onRemoveConfirmClose={handleRemoveConfirmClose}
                 onConfirmRemove={projectSwitcher.confirmRemoveProject}
                 isRemovingProject={projectSwitcher.isRemovingProject}
+                freeMemoryConfirmProject={projectSwitcher.freeMemoryConfirmProject}
+                onFreeMemoryConfirmClose={() => projectSwitcher.setFreeMemoryConfirmProject(null)}
+                onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
+                isFreeingMemory={projectSwitcher.isFreeingMemory}
                 scratchResults={projectSwitcher.scratchResults}
                 onCreateScratch={() => void projectSwitcher.createScratch()}
                 onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -97,6 +97,13 @@ export function ProjectSwitcher() {
     [projectSwitcher]
   );
 
+  const handleFreeMemoryProject = useCallback(
+    (projectId: string) => {
+      void projectSwitcher.freeMemoryProject(projectId);
+    },
+    [projectSwitcher]
+  );
+
   const handleLocateProject = useCallback(
     (projectId: string) => {
       void projectSwitcher.locateProject(projectId);
@@ -172,6 +179,7 @@ export function ProjectSwitcher() {
             onCreateFolder={handleCreateFolder}
             onStopProject={handleStopProject}
             onCloseProject={handleCloseProject}
+            onFreeMemoryProject={handleFreeMemoryProject}
             onLocateProject={handleLocateProject}
             onTogglePinProject={handleTogglePinProject}
             onCopyPath={projectSwitcher.copyPath}
@@ -182,6 +190,10 @@ export function ProjectSwitcher() {
             onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
             onConfirmRemove={projectSwitcher.confirmRemoveProject}
             isRemovingProject={projectSwitcher.isRemovingProject}
+            freeMemoryConfirmProject={projectSwitcher.freeMemoryConfirmProject}
+            onFreeMemoryConfirmClose={() => projectSwitcher.setFreeMemoryConfirmProject(null)}
+            onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
+            isFreeingMemory={projectSwitcher.isFreeingMemory}
             scratchResults={projectSwitcher.scratchResults}
             onCreateScratch={() => void projectSwitcher.createScratch()}
             onSelectScratch={(scratch) => void projectSwitcher.selectScratch(scratch)}
@@ -240,6 +252,7 @@ export function ProjectSwitcher() {
         onCreateFolder={handleCreateFolder}
         onStopProject={handleStopProject}
         onCloseProject={handleCloseProject}
+        onFreeMemoryProject={handleFreeMemoryProject}
         onLocateProject={handleLocateProject}
         onTogglePinProject={handleTogglePinProject}
         onOpenProjectSettings={handleOpenSettings}
@@ -250,6 +263,10 @@ export function ProjectSwitcher() {
         onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
         onConfirmRemove={projectSwitcher.confirmRemoveProject}
         isRemovingProject={projectSwitcher.isRemovingProject}
+        freeMemoryConfirmProject={projectSwitcher.freeMemoryConfirmProject}
+        onFreeMemoryConfirmClose={() => projectSwitcher.setFreeMemoryConfirmProject(null)}
+        onConfirmFreeMemory={projectSwitcher.confirmFreeMemory}
+        isFreeingMemory={projectSwitcher.isFreeingMemory}
         onDropdownCloseAutoFocus={suppressTooltipDuringFocusRestore}
       >
         <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -184,9 +184,10 @@ function ProjectListItem({
 }: ProjectListItemProps) {
   const showStop = project.processCount > 0 && !project.isMissing;
   // "Free memory" reclaims a backgrounded project's resident RAM. Only
-  // meaningful for non-active, non-missing projects (the active project owns
-  // the live renderer; a missing one has nothing loaded).
-  const showFreeMemory = !project.isActive && !project.isMissing;
+  // meaningful for non-active, non-missing projects that still hold resources
+  // (the active project owns the live renderer; a missing one has nothing
+  // loaded; an already-closed one was reclaimed, so the action would no-op).
+  const showFreeMemory = !project.isActive && !project.isMissing && project.status !== "closed";
 
   const notificationOverrides = useProjectSettingsStore(
     (state) => state.notificationOverridesByProjectId[project.id]
@@ -1115,6 +1116,7 @@ function DropdownContent({
           onOpenProjectSettings={innerProps.onOpenProjectSettings}
           onStopProject={innerProps.onStopProject}
           onCloseProject={innerProps.onCloseProject}
+          onFreeMemoryProject={innerProps.onFreeMemoryProject}
           onLocateProject={innerProps.onLocateProject}
           onTogglePinProject={innerProps.onTogglePinProject}
           onCopyPath={innerProps.onCopyPath}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useEffect, useRef, useState, useCallback } from "react";
 import {
+  ArchiveX,
   BellOff,
   ChevronDown,
   ChevronRight,
@@ -65,6 +66,7 @@ export interface ProjectSwitcherPaletteProps {
   onCreateFolder?: () => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
+  onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
@@ -86,6 +88,11 @@ export interface ProjectSwitcherPaletteProps {
   onRemoveConfirmClose?: () => void;
   onConfirmRemove?: () => void;
   isRemovingProject?: boolean;
+  /** Frozen snapshot of the project pending a "Free memory" confirm, or null. */
+  freeMemoryConfirmProject?: SearchableProject | null;
+  onFreeMemoryConfirmClose?: () => void;
+  onConfirmFreeMemory?: () => void;
+  isFreeingMemory?: boolean;
   /** Scratch (one-off agent workspace) results — rendered in their own collapsible section. */
   scratchResults?: SearchableScratch[];
   /** Callback to create and switch to a new scratch. */
@@ -115,6 +122,7 @@ interface ProjectListItemProps {
   onSelect: (project: SearchableProject) => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
+  onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
@@ -166,6 +174,7 @@ function ProjectListItem({
   onSelect,
   onStopProject,
   onCloseProject,
+  onFreeMemoryProject,
   onLocateProject,
   onTogglePinProject,
   onCopyPath,
@@ -174,6 +183,10 @@ function ProjectListItem({
   onHoverProjectEnd,
 }: ProjectListItemProps) {
   const showStop = project.processCount > 0 && !project.isMissing;
+  // "Free memory" reclaims a backgrounded project's resident RAM. Only
+  // meaningful for non-active, non-missing projects (the active project owns
+  // the live renderer; a missing one has nothing loaded).
+  const showFreeMemory = !project.isActive && !project.isMissing;
 
   const notificationOverrides = useProjectSettingsStore(
     (state) => state.notificationOverridesByProjectId[project.id]
@@ -264,7 +277,12 @@ function ProjectListItem({
   );
 
   const hasContextActions =
-    onTogglePinProject || onStopProject || onCloseProject || onCopyPath || onSelectNewWindow;
+    onTogglePinProject ||
+    onStopProject ||
+    onCloseProject ||
+    onFreeMemoryProject ||
+    onCopyPath ||
+    onSelectNewWindow;
   if (!hasContextActions) return row;
 
   return (
@@ -298,13 +316,18 @@ function ProjectListItem({
             Copy path
           </ContextMenuItem>
         )}
-        {(onTogglePinProject || onCopyPath) && (onStopProject || onCloseProject) && (
-          <ContextMenuSeparator />
-        )}
+        {(onTogglePinProject || onCopyPath) &&
+          (onStopProject || onFreeMemoryProject || onCloseProject) && <ContextMenuSeparator />}
         {showStop && onStopProject && (
           <ContextMenuItem destructive onSelect={() => onStopProject(project.id)}>
             <Square className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
             Stop all agents
+          </ContextMenuItem>
+        )}
+        {showFreeMemory && onFreeMemoryProject && (
+          <ContextMenuItem onSelect={() => onFreeMemoryProject(project.id)}>
+            <ArchiveX className="w-3.5 h-3.5 mr-2" aria-hidden="true" />
+            Free memory
           </ContextMenuItem>
         )}
         {onCloseProject && project.isActive && (
@@ -354,6 +377,7 @@ interface ProjectListContentProps {
   mode?: ProjectSwitcherMode;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
+  onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
@@ -371,6 +395,7 @@ function ProjectListContent({
   mode,
   onStopProject,
   onCloseProject,
+  onFreeMemoryProject,
   onLocateProject,
   onTogglePinProject,
   onCopyPath,
@@ -440,6 +465,7 @@ function ProjectListContent({
           onSelect={onSelect}
           onStopProject={onStopProject}
           onCloseProject={onCloseProject}
+          onFreeMemoryProject={onFreeMemoryProject}
           onLocateProject={onLocateProject}
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
@@ -716,6 +742,7 @@ interface ProjectPaletteInnerProps {
   onOpenProjectSettings?: () => void;
   onStopProject?: (projectId: string) => void;
   onCloseProject?: (projectId: string) => void;
+  onFreeMemoryProject?: (projectId: string) => void;
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
@@ -747,6 +774,7 @@ function ProjectPaletteInner({
   onOpenProjectSettings,
   onStopProject,
   onCloseProject,
+  onFreeMemoryProject,
   onLocateProject,
   onTogglePinProject,
   onCopyPath,
@@ -868,6 +896,7 @@ function ProjectPaletteInner({
           mode={mode}
           onStopProject={onStopProject}
           onCloseProject={onCloseProject}
+          onFreeMemoryProject={onFreeMemoryProject}
           onLocateProject={onLocateProject}
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
@@ -991,6 +1020,7 @@ function ModalContent({
         onOpenProjectSettings={innerProps.onOpenProjectSettings}
         onStopProject={innerProps.onStopProject}
         onCloseProject={innerProps.onCloseProject}
+        onFreeMemoryProject={innerProps.onFreeMemoryProject}
         onLocateProject={innerProps.onLocateProject}
         onTogglePinProject={innerProps.onTogglePinProject}
         onCopyPath={innerProps.onCopyPath}
@@ -1118,6 +1148,7 @@ export function ProjectSwitcherPalette({
   onCreateFolder,
   onStopProject,
   onCloseProject,
+  onFreeMemoryProject,
   onLocateProject,
   onTogglePinProject,
   onCopyPath,
@@ -1132,6 +1163,10 @@ export function ProjectSwitcherPalette({
   onRemoveConfirmClose,
   onConfirmRemove,
   isRemovingProject = false,
+  freeMemoryConfirmProject,
+  onFreeMemoryConfirmClose,
+  onConfirmFreeMemory,
+  isFreeingMemory = false,
   scratchResults,
   onCreateScratch,
   onSelectScratch,
@@ -1166,6 +1201,7 @@ export function ProjectSwitcherPalette({
         onCreateFolder={onCreateFolder}
         onStopProject={onStopProject}
         onCloseProject={onCloseProject}
+        onFreeMemoryProject={onFreeMemoryProject}
         onLocateProject={onLocateProject}
         onTogglePinProject={onTogglePinProject}
         onCopyPath={onCopyPath}
@@ -1200,6 +1236,7 @@ export function ProjectSwitcherPalette({
         onCreateFolder={onCreateFolder}
         onStopProject={onStopProject}
         onCloseProject={onCloseProject}
+        onFreeMemoryProject={onFreeMemoryProject}
         onLocateProject={onLocateProject}
         onTogglePinProject={onTogglePinProject}
         onCopyPath={onCopyPath}
@@ -1276,6 +1313,49 @@ export function ProjectSwitcherPalette({
               {removeConfirmProject.isActive
                 ? "The project will remain in your list and can be reopened at any time."
                 : "This project will be removed from your list. You can add it back later, but any running terminals or processes will need to be restarted."}
+            </div>
+          </div>
+        </ConfirmDialog>
+      )}
+      {freeMemoryConfirmProject && onFreeMemoryConfirmClose && onConfirmFreeMemory && (
+        <ConfirmDialog
+          isOpen={true}
+          onClose={isFreeingMemory ? undefined : onFreeMemoryConfirmClose}
+          title={`Free memory for '${freeMemoryConfirmProject.name}'?`}
+          zIndex="nested"
+          confirmLabel="Free memory"
+          cancelLabel="Cancel"
+          onConfirm={onConfirmFreeMemory}
+          isConfirmLoading={isFreeingMemory}
+          variant="default"
+        >
+          <div className="space-y-3">
+            <div>
+              <div className="font-medium text-sm">{freeMemoryConfirmProject.name}</div>
+              <div className="text-xs text-daintree-text/50 font-mono mt-1">
+                {freeMemoryConfirmProject.path}
+              </div>
+            </div>
+            {(freeMemoryConfirmProject.processCount > 0 ||
+              freeMemoryConfirmProject.activeAgentCount > 0 ||
+              freeMemoryConfirmProject.waitingAgentCount > 0) && (
+              <div className="rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20 px-3 py-2 text-xs text-status-warning">
+                <div className="font-medium">Running processes will be stopped</div>
+                <div className="mt-1 text-status-warning/80">
+                  {freeMemoryConfirmProject.processCount > 0 && (
+                    <div>• {freeMemoryConfirmProject.processCount} running process(es)</div>
+                  )}
+                  {freeMemoryConfirmProject.activeAgentCount > 0 && (
+                    <div>• {freeMemoryConfirmProject.activeAgentCount} active agent(s)</div>
+                  )}
+                  {freeMemoryConfirmProject.waitingAgentCount > 0 && (
+                    <div>• {freeMemoryConfirmProject.waitingAgentCount} waiting agent(s)</div>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="text-xs text-daintree-text/60">
+              Sessions are preserved and restored when you reopen the project.
             </div>
           </div>
         </ConfirmDialog>

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   getBulkStatsMock,
+  freeMemoryMock,
   setStatsMock,
   useProjectStoreMock,
   useProjectStatsStoreMock,
@@ -13,6 +14,7 @@ const {
   projectStatsState,
 } = vi.hoisted(() => {
   const getBulkStatsMock = vi.fn();
+  const freeMemoryMock = vi.fn();
   const copyMock = vi.fn().mockResolvedValue(true);
 
   const projectStatsState = {
@@ -62,6 +64,7 @@ const {
 
   return {
     getBulkStatsMock,
+    freeMemoryMock,
     setStatsMock,
     useProjectStoreMock,
     useProjectStatsStoreMock,
@@ -75,6 +78,7 @@ const {
 vi.mock("@/clients", () => ({
   projectClient: {
     getBulkStats: getBulkStatsMock,
+    freeMemory: freeMemoryMock,
   },
 }));
 
@@ -130,6 +134,11 @@ describe("useProjectSwitcherPalette", () => {
     projectState.currentProject = null;
     projectStatsState.stats = {};
     getBulkStatsMock.mockResolvedValue(emptyBulkStats(["project-1"]));
+    freeMemoryMock.mockResolvedValue({
+      terminalsKilled: 0,
+      rendererEvicted: false,
+      workspaceEvicted: false,
+    });
     setStatsMock.mockImplementation((stats: typeof projectStatsState.stats) => {
       projectStatsState.stats = stats;
     });
@@ -570,6 +579,140 @@ describe("useProjectSwitcherPalette", () => {
           type: "error",
           title: "Couldn't close project",
         })
+      );
+    });
+  });
+
+  describe("free memory", () => {
+    beforeEach(() => {
+      // Pin a single, non-active project so ordering with describes that mutate
+      // the shared projects array can't change result counts.
+      projectState.projects = [
+        {
+          id: "project-1",
+          name: "Project One",
+          path: "/repo/one",
+          emoji: "🌲",
+          color: "#00aa00",
+          lastOpened: 123,
+          frecencyScore: 3.0,
+          status: "active" as const,
+        },
+      ];
+      projectState.currentProject = null;
+    });
+
+    const bulkStats = (
+      counts: { processCount?: number; activeAgentCount?: number; waitingAgentCount?: number } = {}
+    ) => ({
+      "project-1": {
+        processCount: counts.processCount ?? 0,
+        terminalCount: counts.processCount ?? 0,
+        estimatedMemoryMB: 0,
+        terminalTypes: {},
+        processIds: [],
+        activeAgentCount: counts.activeAgentCount ?? 0,
+        waitingAgentCount: counts.waitingAgentCount ?? 0,
+      },
+    });
+
+    it("D0: a project with no live processes frees immediately, no confirm dialog", async () => {
+      getBulkStatsMock.mockResolvedValue(bulkStats());
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(1);
+      });
+
+      await act(async () => {
+        await result.current.freeMemoryProject("project-1");
+      });
+
+      expect(freeMemoryMock).toHaveBeenCalledWith("project-1");
+      expect(result.current.freeMemoryConfirmProject).toBeNull();
+    });
+
+    it("D1: a project with live processes opens a confirm dialog before freeing", async () => {
+      getBulkStatsMock.mockResolvedValue(bulkStats({ processCount: 2, activeAgentCount: 1 }));
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results[0]?.processCount).toBe(2);
+      });
+
+      await act(async () => {
+        await result.current.freeMemoryProject("project-1");
+      });
+
+      // Snapshot captured, nothing freed yet.
+      expect(result.current.freeMemoryConfirmProject?.id).toBe("project-1");
+      expect(result.current.freeMemoryConfirmProject?.processCount).toBe(2);
+      expect(freeMemoryMock).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await result.current.confirmFreeMemory();
+      });
+
+      expect(freeMemoryMock).toHaveBeenCalledWith("project-1");
+      expect(result.current.freeMemoryConfirmProject).toBeNull();
+    });
+
+    it("refuses to free the active project and surfaces guidance instead", async () => {
+      projectState.currentProject = { id: "project-1" };
+      getBulkStatsMock.mockResolvedValue(bulkStats());
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(1);
+      });
+
+      await act(async () => {
+        await result.current.freeMemoryProject("project-1");
+      });
+
+      expect(freeMemoryMock).not.toHaveBeenCalled();
+      expect(result.current.freeMemoryConfirmProject).toBeNull();
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Switch away first" })
+      );
+    });
+
+    it("shows an error notification when freeing fails", async () => {
+      notifyMock.mockClear();
+      freeMemoryMock.mockRejectedValueOnce(new Error("free failed"));
+      getBulkStatsMock.mockResolvedValue(bulkStats());
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      act(() => {
+        result.current.open();
+      });
+
+      await waitFor(() => {
+        expect(result.current.results).toHaveLength(1);
+      });
+
+      await act(async () => {
+        await result.current.freeMemoryProject("project-1");
+      });
+
+      expect(notifyMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Couldn't free memory" })
       );
     });
   });

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -624,6 +624,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
               title: "Couldn't free memory",
               message: formatErrorMessage(retryError, "Couldn't free the project's memory"),
               actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+              context: { eventKind: "uiFeedback" },
             });
           }
         };
@@ -632,6 +633,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           title: "Couldn't free memory",
           message: formatErrorMessage(error, "Couldn't free the project's memory"),
           actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+          context: { eventKind: "uiFeedback" },
         });
       }
     },
@@ -651,6 +653,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
           type: "info",
           title: "Switch away first",
           message: "Switch to another project to free this one's memory.",
+          context: { eventKind: "uiFeedback" },
         });
         return;
       }

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -80,6 +80,13 @@ export interface UseProjectSwitcherPaletteReturn {
   cloneRepo: () => void;
   stopProject: (projectId: string) => Promise<void>;
   removeProject: (projectId: string) => Promise<void>;
+  /**
+   * Reclaim a background project's resident memory (renderer + PTYs + workspace
+   * host) while keeping it in the list as `closed` for a non-destructive
+   * reopen. Shows a confirm dialog when the project has live processes, runs
+   * silently otherwise. No-op (with a toast) for the active project.
+   */
+  freeMemoryProject: (projectId: string) => Promise<void>;
   locateProject: (projectId: string) => Promise<void>;
   togglePinProject: (projectId: string) => Promise<void>;
   /**
@@ -96,6 +103,16 @@ export interface UseProjectSwitcherPaletteReturn {
   setRemoveConfirmProject: (project: SearchableProject | null) => void;
   confirmRemoveProject: () => Promise<void>;
   isRemovingProject: boolean;
+  /**
+   * Frozen snapshot of the project pending a "Free memory" confirmation —
+   * captured at menu-select time so the dialog's process/agent counts don't
+   * drift if agents finish while the dialog is open (lesson #8725). Null when
+   * no confirm is pending (D0 path runs without it).
+   */
+  freeMemoryConfirmProject: SearchableProject | null;
+  setFreeMemoryConfirmProject: (project: SearchableProject | null) => void;
+  confirmFreeMemory: () => Promise<void>;
+  isFreeingMemory: boolean;
   backgroundWaitingCount: number;
   /** Scratch (one-off agent workspace) view-models, sorted by lastOpened desc. */
   scratchResults: SearchableScratch[];
@@ -154,6 +171,9 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const [isStoppingProject, setIsStoppingProject] = useState(false);
   const [removeConfirmProject, setRemoveConfirmProject] = useState<SearchableProject | null>(null);
   const [isRemovingProject, setIsRemovingProject] = useState(false);
+  const [freeMemoryConfirmProject, setFreeMemoryConfirmProject] =
+    useState<SearchableProject | null>(null);
+  const [isFreeingMemory, setIsFreeingMemory] = useState(false);
   const [saveAsProjectConfirm, setSaveAsProjectConfirm] = useState<{
     scratch: SearchableScratch;
     project: Project;
@@ -321,6 +341,14 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       setRemoveConfirmProject(null);
     }
   }, [removeConfirmProject, searchableProjects]);
+
+  useEffect(() => {
+    if (!freeMemoryConfirmProject) return;
+    const stillExists = searchableProjects.some((p) => p.id === freeMemoryConfirmProject.id);
+    if (!stillExists) {
+      setFreeMemoryConfirmProject(null);
+    }
+  }, [freeMemoryConfirmProject, searchableProjects]);
 
   const open = useCallback(
     (nextMode: ProjectSwitcherMode = "modal") => {
@@ -581,6 +609,80 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     [searchableProjects, removeConfirmProject]
   );
 
+  const doFreeMemory = useCallback(
+    async (projectId: string) => {
+      const run = () => projectClient.freeMemory(projectId).then(() => loadProjects());
+      try {
+        await run();
+      } catch (error) {
+        const retry = async () => {
+          try {
+            await run();
+          } catch (retryError) {
+            notify({
+              type: "error",
+              title: "Couldn't free memory",
+              message: formatErrorMessage(retryError, "Couldn't free the project's memory"),
+              actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+            });
+          }
+        };
+        notify({
+          type: "error",
+          title: "Couldn't free memory",
+          message: formatErrorMessage(error, "Couldn't free the project's memory"),
+          actions: [{ label: "Try again", variant: "primary", onClick: retry }],
+        });
+      }
+    },
+    [loadProjects]
+  );
+
+  const freeMemoryProject = useCallback(
+    async (projectId: string) => {
+      const project = searchableProjects.find((p) => p.id === projectId);
+      if (!project) return;
+
+      // The active project can't free its own renderer/host — surface the
+      // same guidance the backend guard enforces instead of a silent no-op.
+      if (project.isActive) {
+        // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
+        notify({
+          type: "info",
+          title: "Switch away first",
+          message: "Switch to another project to free this one's memory.",
+        });
+        return;
+      }
+
+      close();
+
+      const hasProcesses =
+        project.processCount > 0 || project.activeAgentCount > 0 || project.waitingAgentCount > 0;
+
+      // D1 (confirm) when live processes would be stopped; D0 (immediate) when
+      // there's nothing running to interrupt. The snapshot freezes the counts.
+      if (hasProcesses) {
+        setFreeMemoryConfirmProject(project);
+      } else {
+        await doFreeMemory(projectId);
+      }
+    },
+    [searchableProjects, close, doFreeMemory]
+  );
+
+  const confirmFreeMemory = useCallback(async () => {
+    if (!freeMemoryConfirmProject || isFreeingMemory) return;
+    setIsFreeingMemory(true);
+    const capturedId = freeMemoryConfirmProject.id;
+    try {
+      await doFreeMemory(capturedId);
+      setFreeMemoryConfirmProject(null);
+    } finally {
+      setIsFreeingMemory(false);
+    }
+  }, [freeMemoryConfirmProject, isFreeingMemory, doFreeMemory]);
+
   const scratchResults = useMemo<SearchableScratch[]>(() => {
     const list: SearchableScratch[] = scratches.map((s: Scratch) => ({
       id: s.id,
@@ -774,6 +876,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     cloneRepo,
     stopProject,
     removeProject: removeProjectFromList,
+    freeMemoryProject,
     locateProject,
     togglePinProject,
     copyPath,
@@ -785,6 +888,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     setRemoveConfirmProject,
     confirmRemoveProject,
     isRemovingProject,
+    freeMemoryConfirmProject,
+    setFreeMemoryConfirmProject,
+    confirmFreeMemory,
+    isFreeingMemory,
     backgroundWaitingCount,
     scratchResults,
     createScratch,

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -30,6 +30,9 @@ const createMockProjectClient = () => ({
   saveSettings: vi.fn().mockResolvedValue(undefined),
   detectRunners: vi.fn().mockResolvedValue([]),
   close: vi.fn().mockResolvedValue({ success: true }),
+  freeMemory: vi
+    .fn()
+    .mockResolvedValue({ terminalsKilled: 0, rendererEvicted: false, workspaceEvicted: false }),
   reopen: vi.fn().mockResolvedValue({}),
   getStats: vi.fn().mockResolvedValue({}),
   getBulkStats: vi.fn().mockResolvedValue({}),

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -22,6 +22,9 @@ const createMockProjectClient = () => ({
   saveSettings: vi.fn().mockResolvedValue(undefined),
   detectRunners: vi.fn().mockResolvedValue([]),
   close: vi.fn().mockResolvedValue({ success: true }),
+  freeMemory: vi
+    .fn()
+    .mockResolvedValue({ terminalsKilled: 0, rendererEvicted: false, workspaceEvicted: false }),
   reopen: vi.fn().mockResolvedValue({}),
   getStats: vi.fn().mockResolvedValue({}),
   getBulkStats: vi.fn().mockResolvedValue({}),


### PR DESCRIPTION
## Summary

Adds a "Free memory" action to the project switcher's context menu for background and inactive projects. It gracefully kills the project's PTYs (with session preservation), evicts the cached renderer `WebContentsView`, and evicts the workspace-host process. The project stays in the list as `closed` and can be reopened without losing layout.

Resolves #10829.

## Changes

- New `project:free-memory` IPC channel, hand-typed across `channels.ts`, `maps.ts`, `api.ts`, preload, and a `ProjectFreeMemoryResult` type in `shared/types/ipc/project.ts`.
- `WorkspaceHostPool.evictProject`: refCount-guarded, multi-window safe. `WorkspaceClient` pass-through wired.
- `HibernationService.evictCachedRenderer` promoted to public as `evictProjectRenderer` (returns evicted-view count).
- Handler rejects the active project with a "Switch away first" toast, is idempotent for already-closed projects, and never touches `clearProjectState` or `killByProject`.
- D1 confirm dialog with a request-time stats snapshot of running processes and agents when the project has live work. D0 immediate free when idle.
- `ArchiveX` icon in the context menu; action hidden for already-closed projects.

## Testing

- IPC handler: reject/idempotent/full-free/nothing-resident paths.
- Hook: D0/D1/active/error paths.
- Updated sibling persistence-test client mocks for the new interface method.
- `npm run typecheck` PASS, eslint on changed files PASS, prettier clean, 130 targeted tests PASS.