### PR TITLE
fix(plugin): time out abandoned plugin consent prompts

### DIFF
--- a/electron/ipc/handlers/__tests__/pluginCapability.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginCapability.test.ts
@@ -38,11 +38,16 @@ vi.mock("../../../window/windowRef.js", () => ({
   getMainWindow: () => focusedWindow,
 }));
 
-import { handleResolveConsent, _resetCapabilityConsentBridgeForTest } from "../pluginCapability.js";
+import {
+  handleResolveConsent,
+  registerPluginCapabilityHandlers,
+  _resetCapabilityConsentBridgeForTest,
+} from "../pluginCapability.js";
 import {
   getPluginCapabilityConsentService,
   _resetPluginCapabilityServicesForTest,
 } from "../../../services/plugin-capability/instances.js";
+import { PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS } from "../../../../shared/types/pluginCapabilityConsent.js";
 import type { IpcContext } from "../../types.js";
 
 function ctx(webContentsId: number): IpcContext {
@@ -99,5 +104,49 @@ describe("pluginCapability consent bridge", () => {
     await expect(
       handleResolveConsent(ctx(7), { requestId: "does-not-exist", decision: "rejected" })
     ).resolves.toBeUndefined();
+  });
+
+  it("settles an abandoned prompt as a timeout denial and ignores a late reply (#10841)", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+
+      const decisionPromise = getPluginCapabilityConsentService().ensureAllowed(
+        "acme.x",
+        "Acme",
+        "shell:exec",
+        ["shell:exec"]
+      );
+      // Surface the rejection synchronously so an unhandled rejection isn't
+      // flagged while we advance the fake clock.
+      const settled = decisionPromise.then(
+        () => ({ ok: true }) as const,
+        (err: Error) => ({ ok: false, err }) as const
+      );
+
+      const requestId = (
+        focusedWindow!.webContents.send.mock.calls[0][1] as {
+          payload: { requestId: string };
+        }
+      ).payload.requestId;
+
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
+
+      // The gating call fails closed (PERMISSION_REQUIRED) rather than hanging.
+      const outcome = await settled;
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.err.message).toContain("PERMISSION_REQUIRED");
+      }
+      // The destroyed listener was torn down on settle.
+      expect(focusedWindow!.webContents.removeListener).toHaveBeenCalled();
+
+      // A late reply for the timed-out request is a no-op (pending entry gone).
+      await handleResolveConsent(ctx(7), { requestId, decision: "approved-and-pin" });
+
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/electron/ipc/handlers/__tests__/pluginCapability.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginCapability.test.ts
@@ -149,4 +149,44 @@ describe("pluginCapability consent bridge", () => {
       vi.useRealTimers();
     }
   });
+
+  it("times out even when only a wrong-sender reply ever arrives (#10841)", async () => {
+    vi.useFakeTimers();
+    try {
+      const dispose = registerPluginCapabilityHandlers();
+
+      const decisionPromise = getPluginCapabilityConsentService().ensureAllowed(
+        "acme.x",
+        "Acme",
+        "shell:exec",
+        ["shell:exec"]
+      );
+      const settled = decisionPromise.then(
+        () => ({ ok: true }) as const,
+        (err: Error) => ({ ok: false, err }) as const
+      );
+
+      const requestId = (
+        focusedWindow!.webContents.send.mock.calls[0][1] as {
+          payload: { requestId: string };
+        }
+      ).payload.requestId;
+
+      // A reply from the wrong WebContents is ignored and must NOT settle or
+      // disarm the timer — otherwise the prompt would hang forever.
+      await handleResolveConsent(ctx(999), { requestId, decision: "approved-and-pin" });
+
+      await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
+
+      const outcome = await settled;
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.err.message).toContain("PERMISSION_REQUIRED");
+      }
+
+      dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/electron/ipc/handlers/__tests__/pluginMcpCallTool.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginMcpCallTool.test.ts
@@ -308,13 +308,18 @@ describe("handleCallTool pipeline", () => {
       expect(h.fakeWc.send).toHaveBeenCalledTimes(1);
       expect(h.supervisor.callTool).not.toHaveBeenCalled();
 
+      // Just before the deadline the prompt is still live — guards against a
+      // mis-set (e.g. 1ms) timeout silently passing the full-advance assertions.
+      await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS - 1);
+      const audit = h.audit as { append: ReturnType<typeof vi.fn> };
+      expect(audit.append).not.toHaveBeenCalled();
+
       // No reply ever arrives — the bridge timer fires and settles "timeout".
-      await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(1);
 
       const result = await pending;
       expect(result).toEqual({ kind: "denied", errorCode: PLUGIN_MCP_CONSENT_TIMEOUT_CODE });
       expect(h.supervisor.callTool).not.toHaveBeenCalled();
-      const audit = h.audit as { append: ReturnType<typeof vi.fn> };
       expect(audit.append.mock.calls[0][0]).toMatchObject({
         result: "timeout",
         consentDecision: "timeout",

--- a/electron/ipc/handlers/__tests__/pluginMcpCallTool.test.ts
+++ b/electron/ipc/handlers/__tests__/pluginMcpCallTool.test.ts
@@ -72,11 +72,19 @@ import { PluginMcpConsentStore } from "../../../services/plugin-mcp/PluginMcpCon
 import { PluginMcpRateLimiter } from "../../../services/plugin-mcp/PluginMcpRateLimiter.js";
 import {
   PLUGIN_MCP_CAPABILITY_CAP_EXCEEDED_CODE,
+  PLUGIN_MCP_CONSENT_TIMEOUT_CODE,
   PLUGIN_MCP_RATE_LIMITED_CODE,
   PLUGIN_MCP_USER_REJECTED_CODE,
 } from "../../../../shared/types/ipc/pluginMcpAudit.js";
+import { PLUGIN_MCP_CONSENT_TIMEOUT_MS } from "../../../../shared/types/pluginMcpConsent.js";
 import type { IpcContext } from "../../types.js";
 import type { PluginMcpCallToolInput } from "../../../../shared/types/ipc/pluginMcp.js";
+
+/** Flush the awaited resolution chain (dynamic imports + mocked async) so the
+ * consent-request push fires under fake timers without relying on wall-clock. */
+async function flushMicrotasks(turns = 30): Promise<void> {
+  for (let i = 0; i < turns; i++) await Promise.resolve();
+}
 
 function makeConsentStore(): PluginMcpConsentStore {
   let cfg: Record<string, unknown> = {};
@@ -278,6 +286,49 @@ describe("handleCallTool pipeline", () => {
     expect(h.supervisor.callTool).not.toHaveBeenCalled();
     const audit = h.audit as { append: ReturnType<typeof vi.fn> };
     expect(audit.append.mock.calls[0][0]).toMatchObject({ result: "rejected" });
+  });
+
+  it("settles consent as a timeout denial when the prompt is abandoned (#10841)", async () => {
+    vi.useFakeTimers();
+    try {
+      setSchema({
+        found: true,
+        tool: {
+          name: "do_thing",
+          description: "Maybe mutate.",
+          inputSchema: { type: "object" },
+          annotations: { destructiveHint: false },
+        },
+      });
+
+      const pending = handleCallTool(ctx, input);
+      // Resolve the await chain so the consent-request is pushed and the bridge
+      // timer is armed.
+      await flushMicrotasks();
+      expect(h.fakeWc.send).toHaveBeenCalledTimes(1);
+      expect(h.supervisor.callTool).not.toHaveBeenCalled();
+
+      // No reply ever arrives — the bridge timer fires and settles "timeout".
+      await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS);
+
+      const result = await pending;
+      expect(result).toEqual({ kind: "denied", errorCode: PLUGIN_MCP_CONSENT_TIMEOUT_CODE });
+      expect(h.supervisor.callTool).not.toHaveBeenCalled();
+      const audit = h.audit as { append: ReturnType<typeof vi.fn> };
+      expect(audit.append.mock.calls[0][0]).toMatchObject({
+        result: "timeout",
+        consentDecision: "timeout",
+        errorCode: PLUGIN_MCP_CONSENT_TIMEOUT_CODE,
+      });
+
+      // A late reply for the timed-out request is a no-op.
+      const requestId = (h.fakeWc.send.mock.calls[0][1] as { payload: { requestId: string } })
+        .payload.requestId;
+      await handleResolveConsent(ctx, { requestId, decision: "approved-once" });
+      expect(h.supervisor.callTool).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("pins on approve-and-pin so the next call skips the prompt", async () => {

--- a/electron/ipc/handlers/pluginCapability.ts
+++ b/electron/ipc/handlers/pluginCapability.ts
@@ -10,9 +10,10 @@ import type {
   PluginCapabilityConsentRequest,
 } from "../../services/plugin-capability/PluginCapabilityConsentService.js";
 import { getMainWindow } from "../../window/windowRef.js";
-import type {
-  PluginCapabilityConsentDecision,
-  PluginCapabilityResolveConsentInput,
+import {
+  PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS,
+  type PluginCapabilityConsentDecision,
+  type PluginCapabilityResolveConsentInput,
 } from "../../../shared/types/pluginCapabilityConsent.js";
 
 // --- Consent bridge (main → renderer prompt, renderer → main decision) --------
@@ -28,6 +29,7 @@ interface PendingConsent {
   resolve: (decision: PluginCapabilityConsentDecision) => void;
   webContentsId: number;
   cleanup: () => void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 const pendingConsents = new Map<string, PendingConsent>();
@@ -46,6 +48,7 @@ function settleConsent(requestId: string, decision: PluginCapabilityConsentDecis
   const pending = pendingConsents.get(requestId);
   if (!pending) return;
   pendingConsents.delete(requestId);
+  clearTimeout(pending.timer);
   pending.cleanup();
   pending.resolve(decision);
 }
@@ -67,7 +70,13 @@ const consentBridge: PluginCapabilityConsentBridge = (request: PluginCapabilityC
         // best-effort — the WebContents may already be torn down
       }
     };
-    pendingConsents.set(requestId, { resolve, webContentsId: wc.id, cleanup });
+    // Safety net: an abandoned prompt settles itself as "timeout" so the gating
+    // promise never hangs and the pending entry is freed (#10841).
+    const timer = setTimeout(
+      () => settleConsent(requestId, "timeout"),
+      PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS
+    );
+    pendingConsents.set(requestId, { resolve, webContentsId: wc.id, cleanup, timer });
     wc.once("destroyed", onDestroyed);
     try {
       wc.send(CHANNELS.EVENTS_PUSH, {

--- a/electron/ipc/handlers/pluginMcp.ts
+++ b/electron/ipc/handlers/pluginMcp.ts
@@ -23,9 +23,10 @@ import type {
 } from "../../services/plugin-mcp/PluginMcpConsentService.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { PLUGIN_MCP_RATE_LIMITED_CODE } from "../../../shared/types/ipc/pluginMcpAudit.js";
-import type {
-  PluginMcpConsentDecision,
-  PluginMcpDangerTier,
+import {
+  PLUGIN_MCP_CONSENT_TIMEOUT_MS,
+  type PluginMcpConsentDecision,
+  type PluginMcpDangerTier,
 } from "../../../shared/types/pluginMcpConsent.js";
 import {
   PLUGIN_MCP_DEFAULT_MAX_TOOLS_PER_SESSION,
@@ -191,6 +192,7 @@ interface PendingConsent {
   resolve: (decision: PluginMcpConsentDecision) => void;
   webContentsId: number;
   cleanup: () => void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
 const pendingConsents = new Map<string, PendingConsent>();
@@ -201,6 +203,7 @@ function settleConsent(requestId: string, decision: PluginMcpConsentDecision): v
   const pending = pendingConsents.get(requestId);
   if (!pending) return;
   pendingConsents.delete(requestId);
+  clearTimeout(pending.timer);
   pending.cleanup();
   pending.resolve(decision);
 }
@@ -224,7 +227,13 @@ function pushConsentRequest(
         // best-effort — the WebContents may already be torn down
       }
     };
-    pendingConsents.set(requestId, { resolve, webContentsId, cleanup });
+    // Safety net: an abandoned prompt settles itself as "timeout" so the gating
+    // promise never hangs and the pending entry is freed (#10841).
+    const timer = setTimeout(
+      () => settleConsent(requestId, "timeout"),
+      PLUGIN_MCP_CONSENT_TIMEOUT_MS
+    );
+    pendingConsents.set(requestId, { resolve, webContentsId, cleanup, timer });
     wc.once("destroyed", onDestroyed);
     try {
       wc.send(CHANNELS.EVENTS_PUSH, {

--- a/electron/services/plugin-capability/PluginCapabilityConsentService.ts
+++ b/electron/services/plugin-capability/PluginCapabilityConsentService.ts
@@ -95,6 +95,15 @@ export class PluginCapabilityConsentService {
     }
     if (decision === "approved-once") return;
 
+    if (decision === "timeout") {
+      // Fail closed exactly like "rejected", but log distinctly so an abandoned
+      // dialog is diagnosable in the operator logs rather than reading as a
+      // deliberate refusal (#10841).
+      console.warn(
+        `[PluginCapabilityConsentService] consent prompt timed out for plugin "${pluginId}" capability "${capability}"`
+      );
+    }
+
     throw new Error(
       `${PLUGIN_CAPABILITY_DENIED_PREFIX}: plugin "${pluginId}" was denied use of the "${capability}" capability`
     );

--- a/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
+++ b/electron/services/plugin-capability/__tests__/PluginCapabilityConsentService.test.ts
@@ -74,6 +74,23 @@ describe("PluginCapabilityConsentService", () => {
     ).rejects.toThrow(/PERMISSION_REQUIRED.*git:write/);
   });
 
+  it("treats a timeout decision as a fail-closed denial without persisting a grant (#10841)", async () => {
+    const { service, store } = makeService();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      service.setConsentBridge(async () => "timeout");
+      await expect(service.ensureAllowed("acme.x", "Acme", "shell:exec", CAPS)).rejects.toThrow(
+        /PERMISSION_REQUIRED.*shell:exec/
+      );
+      // A timed-out prompt must not leave a grant behind.
+      expect(store.hasGrant({ pluginId: "acme.x", capability: "shell:exec" })).toBe(false);
+      // Logged distinctly so an abandoned dialog is diagnosable.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("timed out"));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("treats a thrown bridge as a rejection (fail-closed)", async () => {
     const { service } = makeService();
     service.setConsentBridge(async () => {

--- a/shared/types/pluginCapabilityConsent.ts
+++ b/shared/types/pluginCapabilityConsent.ts
@@ -48,9 +48,28 @@ export interface PluginCapabilityConsentRecord {
  * User decision returned by the consent dialog. `rejected` aborts the gated
  * host call (the closure throws a `PERMISSION_REQUIRED:` error); `approved-once`
  * runs the call without persisting; `approved-and-pin` runs it and writes the
- * grant so future calls skip the prompt.
+ * grant so future calls skip the prompt. `timeout` is settled by the consent
+ * bridge when an abandoned prompt outlives
+ * {@link PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS}; it fails closed exactly like
+ * `rejected` (the gated call still throws `PERMISSION_REQUIRED:`) but is
+ * distinguished for diagnostics so a walked-away dialog reads differently from a
+ * deliberate refusal in the logs.
  */
-export type PluginCapabilityConsentDecision = "approved-once" | "approved-and-pin" | "rejected";
+export type PluginCapabilityConsentDecision =
+  | "approved-once"
+  | "approved-and-pin"
+  | "rejected"
+  | "timeout";
+
+/**
+ * How long a pushed plugin-capability consent prompt may stay unanswered before
+ * the bridge settles it as `"timeout"` and frees the pending entry. Mirrors the
+ * plugin-MCP timeout: a five-minute safety net for an abandoned dialog so the
+ * gating promise (and the renderer dialog) never hangs forever. Both the
+ * main-process bridge and the renderer confirm store arm an independent timer at
+ * this duration.
+ */
+export const PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * Display-safe consent prompt pushed from main to the renderer over the typed

--- a/shared/types/pluginCapabilityConsent.ts
+++ b/shared/types/pluginCapabilityConsent.ts
@@ -68,6 +68,11 @@ export type PluginCapabilityConsentDecision =
  * gating promise (and the renderer dialog) never hangs forever. Both the
  * main-process bridge and the renderer confirm store arm an independent timer at
  * this duration.
+ *
+ * As with the MCP timeout, the clock starts when the prompt is raised, not when
+ * the dialog becomes visible — a queued prompt shares this window rather than
+ * getting its own per-display clock. The timeout is an abandonment backstop, and
+ * the rare queued-then-expired case fails closed (denied), the safe direction.
  */
 export const PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS = 5 * 60 * 1000;
 

--- a/shared/types/pluginMcpConsent.ts
+++ b/shared/types/pluginMcpConsent.ts
@@ -113,14 +113,26 @@ export type PluginMcpConsentLookup =
  * User decision returned by the consent dialog and consumed by the dispatch
  * chain. `rejected` aborts the tool call; `approved-once` runs without
  * pinning; `approved-and-pin` runs and writes the fingerprint into the TOFU
- * store. `timeout` is reserved for a future deadline-bound prompt — today the
- * dialog stays open until the user decides.
+ * store. `timeout` is settled by the consent bridge when an abandoned prompt
+ * outlives {@link PLUGIN_MCP_CONSENT_TIMEOUT_MS} — it fails closed exactly like
+ * `rejected`, but is recorded distinctly on the audit row so an operator can
+ * tell a deliberate refusal from a walked-away dialog.
  */
 export type PluginMcpConsentDecision =
   | "approved-once"
   | "approved-and-pin"
   | "rejected"
   | "timeout";
+
+/**
+ * How long a pushed plugin-MCP consent prompt may stay unanswered before the
+ * bridge settles it as `"timeout"` and frees the pending entry. Five minutes is
+ * a deliberate safety net for an abandoned dialog — long enough for a human to
+ * read the tool surface and decide, short enough that the gating promise (and
+ * the renderer dialog) never hangs forever. Both the main-process bridge and the
+ * renderer confirm store arm an independent timer at this duration.
+ */
+export const PLUGIN_MCP_CONSENT_TIMEOUT_MS = 5 * 60 * 1000;
 
 /**
  * Reason a consent prompt was raised. Surfaces to the dialog title/copy and

--- a/shared/types/pluginMcpConsent.ts
+++ b/shared/types/pluginMcpConsent.ts
@@ -131,6 +131,15 @@ export type PluginMcpConsentDecision =
  * read the tool surface and decide, short enough that the gating promise (and
  * the renderer dialog) never hangs forever. Both the main-process bridge and the
  * renderer confirm store arm an independent timer at this duration.
+ *
+ * The clock starts when the prompt is *raised* (the request is pushed / enqueued),
+ * not when the dialog becomes visible. The renderer FIFO shows one prompt at a
+ * time, so a prompt sitting behind others in the queue shares this same window —
+ * a deliberate simplification (no per-dialog clock, no suspend/resume drift) on
+ * the principle that the timeout is an abandonment backstop, not a precise
+ * read-time budget. Concurrent batched tool calls are the only case where a
+ * queued prompt could expire before display, and they fail closed (denied),
+ * which is the safe direction.
  */
 export const PLUGIN_MCP_CONSENT_TIMEOUT_MS = 5 * 60 * 1000;
 

--- a/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
+++ b/src/store/__tests__/pluginCapabilityConfirmStore.test.ts
@@ -1,10 +1,13 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __resetPluginCapabilityConfirmStoreForTesting,
   requestPluginCapabilityConsent,
   usePluginCapabilityConfirmStore,
 } from "../pluginCapabilityConfirmStore";
-import type { PluginCapabilityConsentRequestEvent } from "@shared/types/pluginCapabilityConsent";
+import {
+  PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS,
+  type PluginCapabilityConsentRequestEvent,
+} from "@shared/types/pluginCapabilityConsent";
 
 function req(id: string): Omit<PluginCapabilityConsentRequestEvent, never> {
   return {
@@ -69,5 +72,72 @@ describe("pluginCapabilityConfirmStore", () => {
     expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("r1");
     usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-once");
     await expect(p1).resolves.toBe("approved-once");
+  });
+
+  describe("consent timeout safety net (#10841)", () => {
+    it("settles an abandoned prompt as 'timeout' and evicts it from the store", async () => {
+      vi.useFakeTimers();
+      try {
+        const p = requestPluginCapabilityConsent(req("r1"));
+        expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("r1");
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
+
+        await expect(p).resolves.toBe("timeout");
+        expect(usePluginCapabilityConfirmStore.getState().current).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not fire after a user decision clears the timer", async () => {
+      vi.useFakeTimers();
+      try {
+        const p = requestPluginCapabilityConsent(req("r1"));
+        usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-and-pin");
+        await expect(p).resolves.toBe("approved-and-pin");
+
+        // Advancing past the deadline must not re-settle the already-decided promise.
+        await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS * 2);
+        await expect(p).resolves.toBe("approved-and-pin");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("advances the FIFO queue when a queued prompt times out", async () => {
+      vi.useFakeTimers();
+      try {
+        const p1 = requestPluginCapabilityConsent(req("r1"));
+        const p2 = requestPluginCapabilityConsent(req("r2"));
+
+        usePluginCapabilityConfirmStore.getState().resolveCurrent("approved-once");
+        await expect(p1).resolves.toBe("approved-once");
+        expect(usePluginCapabilityConfirmStore.getState().current?.requestId).toBe("r2");
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
+        await expect(p2).resolves.toBe("timeout");
+        expect(usePluginCapabilityConfirmStore.getState().current).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("reset clears pending timers so they never fire into a cleared store", async () => {
+      vi.useFakeTimers();
+      try {
+        const p = requestPluginCapabilityConsent(req("r1"));
+        __resetPluginCapabilityConfirmStoreForTesting();
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS * 2);
+        // The promise stays unsettled (the timer was cleared); no leaked timer
+        // re-enqueued or re-settled anything.
+        expect(usePluginCapabilityConfirmStore.getState().current).toBeNull();
+        expect(vi.getTimerCount()).toBe(0);
+        void p;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/src/store/__tests__/pluginMcpConfirmStore.test.ts
+++ b/src/store/__tests__/pluginMcpConfirmStore.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetPluginMcpConfirmStoreForTesting,
+  requestPluginMcpConsent,
+  usePluginMcpConfirmStore,
+} from "../pluginMcpConfirmStore";
+import {
+  PLUGIN_MCP_CONSENT_TIMEOUT_MS,
+  type PluginMcpConsentRequestEvent,
+} from "@shared/types/pluginMcpConsent";
+
+function req(id: string): PluginMcpConsentRequestEvent {
+  return {
+    requestId: id,
+    pluginId: "acme.x",
+    serverId: "srv",
+    toolName: "do_thing",
+    pluginDisplayName: "Acme",
+    descriptionDisplay: "Does a thing",
+    argsSummary: "",
+    dangerTier: "D1",
+    declaredCapabilities: [],
+    reason: "first-use",
+  };
+}
+
+afterEach(() => {
+  __resetPluginMcpConfirmStoreForTesting();
+});
+
+describe("pluginMcpConfirmStore", () => {
+  it("surfaces the first request immediately and resolves its promise on decision", async () => {
+    const p = requestPluginMcpConsent(req("r1"));
+    expect(usePluginMcpConfirmStore.getState().current?.requestId).toBe("r1");
+
+    usePluginMcpConfirmStore.getState().resolveCurrent("approved-and-pin");
+    await expect(p).resolves.toBe("approved-and-pin");
+    expect(usePluginMcpConfirmStore.getState().current).toBeNull();
+  });
+
+  it("queues concurrent requests and advances in FIFO order", async () => {
+    const p1 = requestPluginMcpConsent(req("r1"));
+    const p2 = requestPluginMcpConsent(req("r2"));
+
+    const state = usePluginMcpConfirmStore.getState();
+    expect(state.current?.requestId).toBe("r1");
+    expect(state.queue.map((q) => q.requestId)).toEqual(["r2"]);
+
+    usePluginMcpConfirmStore.getState().resolveCurrent("approved-once");
+    await expect(p1).resolves.toBe("approved-once");
+    expect(usePluginMcpConfirmStore.getState().current?.requestId).toBe("r2");
+
+    usePluginMcpConfirmStore.getState().resolveCurrent("rejected");
+    await expect(p2).resolves.toBe("rejected");
+  });
+
+  it("rejects a duplicate requestId without disturbing the live prompt", async () => {
+    const p1 = requestPluginMcpConsent(req("dup"));
+    const dup = requestPluginMcpConsent(req("dup"));
+    await expect(dup).resolves.toBe("rejected");
+    expect(usePluginMcpConfirmStore.getState().current?.requestId).toBe("dup");
+
+    usePluginMcpConfirmStore.getState().resolveCurrent("approved-and-pin");
+    await expect(p1).resolves.toBe("approved-and-pin");
+  });
+
+  it("drop rejects a queued request and removes it from the queue", async () => {
+    const p1 = requestPluginMcpConsent(req("r1"));
+    const p2 = requestPluginMcpConsent(req("r2"));
+
+    usePluginMcpConfirmStore.getState().drop("r2");
+    await expect(p2).resolves.toBe("rejected");
+    expect(usePluginMcpConfirmStore.getState().queue).toHaveLength(0);
+    expect(usePluginMcpConfirmStore.getState().current?.requestId).toBe("r1");
+    usePluginMcpConfirmStore.getState().resolveCurrent("approved-once");
+    await expect(p1).resolves.toBe("approved-once");
+  });
+
+  describe("consent timeout safety net (#10841)", () => {
+    it("settles an abandoned prompt as 'timeout' and evicts it from the store", async () => {
+      vi.useFakeTimers();
+      try {
+        const p = requestPluginMcpConsent(req("r1"));
+        expect(usePluginMcpConfirmStore.getState().current?.requestId).toBe("r1");
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS);
+
+        await expect(p).resolves.toBe("timeout");
+        expect(usePluginMcpConfirmStore.getState().current).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not fire after a user decision clears the timer", async () => {
+      vi.useFakeTimers();
+      try {
+        const p = requestPluginMcpConsent(req("r1"));
+        usePluginMcpConfirmStore.getState().resolveCurrent("approved-and-pin");
+        await expect(p).resolves.toBe("approved-and-pin");
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS * 2);
+        await expect(p).resolves.toBe("approved-and-pin");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not fire after drop clears the timer", async () => {
+      vi.useFakeTimers();
+      try {
+        const p = requestPluginMcpConsent(req("r1"));
+        usePluginMcpConfirmStore.getState().drop("r1");
+        await expect(p).resolves.toBe("rejected");
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS * 2);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("advances the FIFO queue when a queued prompt times out", async () => {
+      vi.useFakeTimers();
+      try {
+        const p1 = requestPluginMcpConsent(req("r1"));
+        const p2 = requestPluginMcpConsent(req("r2"));
+
+        usePluginMcpConfirmStore.getState().resolveCurrent("approved-once");
+        await expect(p1).resolves.toBe("approved-once");
+        expect(usePluginMcpConfirmStore.getState().current?.requestId).toBe("r2");
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS);
+        await expect(p2).resolves.toBe("timeout");
+        expect(usePluginMcpConfirmStore.getState().current).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("reset clears pending timers so they never fire into a cleared store", async () => {
+      vi.useFakeTimers();
+      try {
+        const p = requestPluginMcpConsent(req("r1"));
+        __resetPluginMcpConfirmStoreForTesting();
+
+        await vi.advanceTimersByTimeAsync(PLUGIN_MCP_CONSENT_TIMEOUT_MS * 2);
+        expect(usePluginMcpConfirmStore.getState().current).toBeNull();
+        expect(vi.getTimerCount()).toBe(0);
+        void p;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/src/store/pluginCapabilityConfirmStore.ts
+++ b/src/store/pluginCapabilityConfirmStore.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
-import type {
-  PluginCapabilityConsentDecision,
-  PluginCapabilityConsentRequestEvent,
+import {
+  PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS,
+  type PluginCapabilityConsentDecision,
+  type PluginCapabilityConsentRequestEvent,
 } from "@shared/types/pluginCapabilityConsent";
 
 /**
@@ -26,7 +27,12 @@ interface PluginCapabilityConfirmActions {
   reset: () => void;
 }
 
-const resolvers = new Map<string, (decision: PluginCapabilityConsentDecision) => void>();
+interface PendingResolver {
+  resolve: (decision: PluginCapabilityConsentDecision) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const resolvers = new Map<string, PendingResolver>();
 
 function advance(
   set: (partial: Partial<PluginCapabilityConfirmState>) => void,
@@ -58,17 +64,23 @@ export const usePluginCapabilityConfirmStore = create<
   resolveCurrent: (decision) => {
     const { current, queue } = get();
     if (current === null) return;
-    const resolve = resolvers.get(current.requestId);
+    const entry = resolvers.get(current.requestId);
     resolvers.delete(current.requestId);
-    resolve?.(decision);
+    if (entry) {
+      clearTimeout(entry.timer);
+      entry.resolve(decision);
+    }
     advance(set, queue);
   },
 
   drop: (requestId) => {
     const { current, queue } = get();
-    const resolve = resolvers.get(requestId);
-    resolvers.delete(requestId);
-    resolve?.("rejected");
+    const entry = resolvers.get(requestId);
+    if (entry) {
+      resolvers.delete(requestId);
+      clearTimeout(entry.timer);
+      entry.resolve("rejected");
+    }
     if (current?.requestId === requestId) {
       advance(set, queue);
       return;
@@ -80,6 +92,7 @@ export const usePluginCapabilityConfirmStore = create<
   },
 
   reset: () => {
+    for (const { timer } of resolvers.values()) clearTimeout(timer);
     resolvers.clear();
     set({ queue: [], current: null });
   },
@@ -101,7 +114,19 @@ export function requestPluginCapabilityConsent(
       resolve("rejected");
       return;
     }
-    resolvers.set(item.requestId, resolve);
+    const { requestId } = item;
+    // Safety net: an abandoned dialog settles itself as "timeout" so the gating
+    // promise never hangs and the stale prompt is evicted from the store. The
+    // resolver is pre-deleted before delegating state cleanup to drop(), which
+    // then finds no resolver and only advances the queue (#10841).
+    const timer = setTimeout(() => {
+      const entry = resolvers.get(requestId);
+      if (!entry) return;
+      resolvers.delete(requestId);
+      entry.resolve("timeout");
+      usePluginCapabilityConfirmStore.getState().drop(requestId);
+    }, PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS);
+    resolvers.set(requestId, { resolve, timer });
     usePluginCapabilityConfirmStore.getState().enqueue({ ...item, enqueuedAt: Date.now() });
   });
 }

--- a/src/store/pluginMcpConfirmStore.ts
+++ b/src/store/pluginMcpConfirmStore.ts
@@ -1,7 +1,8 @@
 import { create } from "zustand";
-import type {
-  PluginMcpConsentDecision,
-  PluginMcpConsentRequestEvent,
+import {
+  PLUGIN_MCP_CONSENT_TIMEOUT_MS,
+  type PluginMcpConsentDecision,
+  type PluginMcpConsentRequestEvent,
 } from "@shared/types/pluginMcpConsent";
 
 /**
@@ -31,7 +32,12 @@ interface PluginMcpConfirmActions {
   reset: () => void;
 }
 
-const resolvers = new Map<string, (decision: PluginMcpConsentDecision) => void>();
+interface PendingResolver {
+  resolve: (decision: PluginMcpConsentDecision) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const resolvers = new Map<string, PendingResolver>();
 
 function advance(
   set: (partial: Partial<PluginMcpConfirmState>) => void,
@@ -62,17 +68,23 @@ export const usePluginMcpConfirmStore = create<PluginMcpConfirmState & PluginMcp
     resolveCurrent: (decision) => {
       const { current, queue } = get();
       if (current === null) return;
-      const resolve = resolvers.get(current.requestId);
+      const entry = resolvers.get(current.requestId);
       resolvers.delete(current.requestId);
-      resolve?.(decision);
+      if (entry) {
+        clearTimeout(entry.timer);
+        entry.resolve(decision);
+      }
       advance(set, queue);
     },
 
     drop: (requestId) => {
       const { current, queue } = get();
-      const resolve = resolvers.get(requestId);
-      resolvers.delete(requestId);
-      resolve?.("rejected");
+      const entry = resolvers.get(requestId);
+      if (entry) {
+        resolvers.delete(requestId);
+        clearTimeout(entry.timer);
+        entry.resolve("rejected");
+      }
       if (current?.requestId === requestId) {
         advance(set, queue);
         return;
@@ -84,6 +96,7 @@ export const usePluginMcpConfirmStore = create<PluginMcpConfirmState & PluginMcp
     },
 
     reset: () => {
+      for (const { timer } of resolvers.values()) clearTimeout(timer);
       resolvers.clear();
       set({ queue: [], current: null });
     },
@@ -104,7 +117,19 @@ export function requestPluginMcpConsent(
       resolve("rejected");
       return;
     }
-    resolvers.set(item.requestId, resolve);
+    const { requestId } = item;
+    // Safety net: an abandoned dialog settles itself as "timeout" so the gating
+    // promise never hangs and the stale prompt is evicted from the store. The
+    // resolver is pre-deleted before delegating state cleanup to drop(), which
+    // then finds no resolver and only advances the queue (#10841).
+    const timer = setTimeout(() => {
+      const entry = resolvers.get(requestId);
+      if (!entry) return;
+      resolvers.delete(requestId);
+      entry.resolve("timeout");
+      usePluginMcpConfirmStore.getState().drop(requestId);
+    }, PLUGIN_MCP_CONSENT_TIMEOUT_MS);
+    resolvers.set(requestId, { resolve, timer });
     usePluginMcpConfirmStore.getState().enqueue({ ...item, enqueuedAt: Date.now() });
   });
 }


### PR DESCRIPTION
## Summary

- Both main-process consent bridges (`pluginMcp.ts` and `pluginCapability.ts`) held pending promises with no timeout, settling only on user reply or window destruction. An abandoned dialog would leak the pending entry indefinitely.
- Adds a 5-minute safety-net timer on both bridges and mirrors it in the renderer-side Zustand confirm stores. Timeout fails closed (denied), which is the safe direction.
- Adds `"timeout"` to `PluginCapabilityConsentDecision` so the capability path has a distinct outcome rather than mis-reporting as `"rejected"`. `PluginCapabilityConsentService` throws `PERMISSION_REQUIRED` on timeout and logs a `console.warn` for diagnosability.

Resolves #10841

## Changes

- `electron/ipc/handlers/pluginMcp.ts` / `pluginCapability.ts`: arm a `setTimeout` on each pending entry; clear it on every normal settle path (reply, window-destroyed, send-failure).
- `src/store/pluginMcpConfirmStore.ts` / `pluginCapabilityConfirmStore.ts`: same timer mirrored in the renderer; cleared on decision/drop, iterate-cleared on reset.
- `shared/types/pluginCapabilityConsent.ts`: add `"timeout"` to `PluginCapabilityConsentDecision`.
- `shared/types/pluginMcpConsent.ts`: export `PLUGIN_MCP_CONSENT_TIMEOUT_MS` (5 minutes).
- Export `PLUGIN_CAPABILITY_CONSENT_TIMEOUT_MS` (5 minutes) alongside the MCP constant.
- `electron/services/PluginCapabilityConsentService.ts`: fail-closed on `"timeout"`.

## Testing

40 targeted tests cover: timeout fires and evicts the pending entry; timer cleared on decision/drop/reset (no double-settle); FIFO queue advances on queued timeout; pre-deadline still-pending boundary; main-bridge timeout denial with late/wrong-sender reply no-ops and listener teardown; capability service timeout fails closed with grant not persisted. New file: `src/store/__tests__/pluginMcpConfirmStore.test.ts`.