### PR TITLE
fix(pty): bound in-memory preserved agent-terminal snapshots (#10839)

### DIFF
--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -291,15 +291,16 @@ export class PtyManager extends EventEmitter {
             this.emit("exit", termId, exitCode, signal);
             if (!terminalProcess.shouldPreserveOnExit(exitCode)) {
               this.registry.delete(termId);
-            } else {
-              // Preserved terminals retain their full scrollback snapshot in
-              // memory and aren't otherwise removed until trash/kill or project
-              // close. Bound the in-memory count so long-lived projects don't
-              // accumulate snapshots without limit (issue #10839). skipId
-              // protects the just-exited terminal, whose snapshot write callback
-              // runs after this handler.
-              this.registry.evictPreservedSnapshots(MAX_PRESERVED_TERMINAL_SNAPSHOTS, termId);
             }
+          },
+          onPreserved: (termId) => {
+            // Preserved terminals retain their full scrollback snapshot in
+            // memory and aren't otherwise removed until trash/kill or project
+            // close. Bound the in-memory count so long-lived projects don't
+            // accumulate snapshots without limit (issue #10839). Fires after the
+            // snapshot is captured, so this terminal is already counted; skipId
+            // keeps it (the newest entry) out of the eviction set defensively.
+            this.registry.evictPreservedSnapshots(MAX_PRESERVED_TERMINAL_SNAPSHOTS, termId);
           },
         },
         {

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -27,6 +27,7 @@ import {
   type TerminalInfo,
   TerminalSnapshot,
   type PtyManagerEvents,
+  MAX_PRESERVED_TERMINAL_SNAPSHOTS,
 } from "./pty/index.js";
 import { computeSpawnContext, acquirePtyProcess } from "./pty/terminalSpawn.js";
 import { disposeTerminalSerializerService } from "./pty/TerminalSerializerService.js";
@@ -290,6 +291,14 @@ export class PtyManager extends EventEmitter {
             this.emit("exit", termId, exitCode, signal);
             if (!terminalProcess.shouldPreserveOnExit(exitCode)) {
               this.registry.delete(termId);
+            } else {
+              // Preserved terminals retain their full scrollback snapshot in
+              // memory and aren't otherwise removed until trash/kill or project
+              // close. Bound the in-memory count so long-lived projects don't
+              // accumulate snapshots without limit (issue #10839). skipId
+              // protects the just-exited terminal, whose snapshot write callback
+              // runs after this handler.
+              this.registry.evictPreservedSnapshots(MAX_PRESERVED_TERMINAL_SNAPSHOTS, termId);
             }
           },
         },

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -115,6 +115,14 @@ type CursorBuffer = {
 export interface TerminalProcessCallbacks {
   emitData: (id: string, data: string | Uint8Array) => void;
   onExit: (id: string, exitCode: number, signal?: number) => void;
+  /**
+   * Fired once the preserved-exit snapshot has actually been captured (after
+   * the deferred headless write callback runs). The owner uses this to bound
+   * the number of in-memory preserved snapshots (issue #10839); triggering here
+   * — rather than in `onExit` — means the just-preserved terminal is already
+   * counted, so a burst of exits can't slip past the cap.
+   */
+  onPreserved?: (id: string) => void;
 }
 
 export interface TerminalProcessDependencies {
@@ -615,18 +623,22 @@ export class TerminalProcess {
         }
       }
       terminal.preservedSnapshot = snapshot;
-      // Stamp capture + initial access time so eviction (issue #10839) sorts
-      // oldest-first and a just-preserved snapshot keeps a grace window before
-      // a later exit can evict it.
-      const preservedAt = Date.now();
-      terminal.preservedAt = preservedAt;
-      terminal.preservedSnapshotLastAccessedAt = preservedAt;
+      // Stamp capture time so eviction (issue #10839) sorts oldest-first. Do
+      // NOT seed preservedSnapshotLastAccessedAt here: a freshly-captured
+      // snapshot has not been viewed, and treating it as recently-accessed
+      // would shield a burst of just-exited terminals from the cap. The access
+      // stamp is set only on a real serialize request.
+      terminal.preservedAt = Date.now();
       // The buffer is final from here on: bump the epoch so the next wake
       // serves the preserved snapshot, and zero the parse counter (disposed
       // headless write callbacks never fire) so that serve can serve-mark.
       terminal.contentEpoch++;
       terminal.pendingHeadlessWrites = 0;
       this.disposeHeadless();
+      // Bound the in-memory preserved-snapshot count now that this terminal's
+      // snapshot is actually present — counting it (unlike an onExit-time sweep)
+      // keeps the cap accurate under bursts of simultaneous exits.
+      this.callbacks.onPreserved?.(this.id);
     });
   }
 

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -615,6 +615,12 @@ export class TerminalProcess {
         }
       }
       terminal.preservedSnapshot = snapshot;
+      // Stamp capture + initial access time so eviction (issue #10839) sorts
+      // oldest-first and a just-preserved snapshot keeps a grace window before
+      // a later exit can evict it.
+      const preservedAt = Date.now();
+      terminal.preservedAt = preservedAt;
+      terminal.preservedSnapshotLastAccessedAt = preservedAt;
       // The buffer is final from here on: bump the epoch so the next wake
       // serves the preserved snapshot, and zero the parse counter (disposed
       // headless write callbacks never fire) so that serve can serve-mark.

--- a/electron/services/pty/TerminalRegistry.ts
+++ b/electron/services/pty/TerminalRegistry.ts
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { events } from "../events.js";
 import type { TerminalSnapshot } from "./types.js";
-import { TRASH_TTL_MS } from "./types.js";
+import {
+  TRASH_TTL_MS,
+  MAX_PRESERVED_TERMINAL_SNAPSHOTS,
+  PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS,
+} from "./types.js";
 import type { TerminalProcess } from "./TerminalProcess.js";
 
 type ProjectIdCandidates = {
@@ -235,6 +239,57 @@ export class TerminalRegistry {
       roots.push({ terminalId: id, projectId: projectId ?? null, rootPid });
     }
     return roots;
+  }
+
+  /**
+   * Bound the number of in-memory preserved-snapshot terminals (issue #10839).
+   *
+   * Agent terminals that exit cleanly retain their full serialized scrollback
+   * (~1–4MB each) in memory and are otherwise removed only on explicit
+   * trash/kill or project close — within an open project they accumulate
+   * without bound. Evict oldest-first (by `preservedAt`) down to `max`, but
+   * never evict `skipId` (the terminal that just triggered eviction, whose
+   * snapshot may not be written yet) nor any snapshot served within the
+   * recent-access guard window (currently-viewed). Over-cap is tolerated rather
+   * than dropping a snapshot the user is actively inspecting.
+   *
+   * `now` is injectable for deterministic tests; callers use the default.
+   */
+  evictPreservedSnapshots(
+    max: number = MAX_PRESERVED_TERMINAL_SNAPSHOTS,
+    skipId?: string,
+    now: number = Date.now()
+  ): void {
+    const preserved: Array<{ id: string; preservedAt: number; lastAccessedAt: number }> = [];
+    for (const [id, terminal] of this.terminals.entries()) {
+      const info = terminal.getInfo();
+      if (info.preservedSnapshot === undefined) {
+        continue;
+      }
+      preserved.push({
+        id,
+        preservedAt: info.preservedAt ?? 0,
+        lastAccessedAt: info.preservedSnapshotLastAccessedAt ?? 0,
+      });
+    }
+
+    if (preserved.length <= max) {
+      return;
+    }
+
+    // Oldest first; only the entries past the cap are eviction candidates.
+    preserved.sort((a, b) => a.preservedAt - b.preservedAt);
+    const candidates = preserved.slice(0, preserved.length - max);
+
+    for (const entry of candidates) {
+      if (entry.id === skipId) {
+        continue;
+      }
+      if (now - entry.lastAccessedAt < PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS) {
+        continue;
+      }
+      this.delete(entry.id);
+    }
   }
 
   /**

--- a/electron/services/pty/TerminalRegistry.ts
+++ b/electron/services/pty/TerminalRegistry.ts
@@ -247,10 +247,11 @@ export class TerminalRegistry {
    * Agent terminals that exit cleanly retain their full serialized scrollback
    * (~1–4MB each) in memory and are otherwise removed only on explicit
    * trash/kill or project close — within an open project they accumulate
-   * without bound. Evict oldest-first (by `preservedAt`) down to `max`, but
-   * never evict `skipId` (the terminal that just triggered eviction, whose
-   * snapshot may not be written yet) nor any snapshot served within the
-   * recent-access guard window (currently-viewed). Over-cap is tolerated rather
+   * without bound. Walk preserved terminals oldest-first (by `preservedAt`) and
+   * evict until the count is back at `max`, but never evict `skipId` (the
+   * just-preserved terminal, kept as the newest entry) nor any snapshot served
+   * within the recent-access guard window (currently-viewed). When too many of
+   * the oldest entries are guarded to reach `max`, over-cap is tolerated rather
    * than dropping a snapshot the user is actively inspecting.
    *
    * `now` is injectable for deterministic tests; callers use the default.
@@ -273,15 +274,17 @@ export class TerminalRegistry {
       });
     }
 
-    if (preserved.length <= max) {
+    let excess = preserved.length - max;
+    if (excess <= 0) {
       return;
     }
 
-    // Oldest first; only the entries past the cap are eviction candidates.
+    // Oldest first — evict the oldest evictable entries until back at the cap.
     preserved.sort((a, b) => a.preservedAt - b.preservedAt);
-    const candidates = preserved.slice(0, preserved.length - max);
-
-    for (const entry of candidates) {
+    for (const entry of preserved) {
+      if (excess <= 0) {
+        break;
+      }
       if (entry.id === skipId) {
         continue;
       }
@@ -289,6 +292,7 @@ export class TerminalRegistry {
         continue;
       }
       this.delete(entry.id);
+      excess--;
     }
   }
 

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -328,7 +328,7 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     await expect(terminal.getSerializedStateAsync()).resolves.toBe(info.preservedSnapshot);
   });
 
-  it("stamps preservedAt and preservedSnapshotLastAccessedAt on preserved exit", async () => {
+  it("stamps preservedAt but not lastAccessedAt on preserved exit (fresh ≠ viewed)", async () => {
     const pty = createControllablePty();
     const terminal = createTerminal(undefined, pty);
 
@@ -343,7 +343,35 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     const info = terminal.getInfo();
     expect(info.preservedAt).toBeGreaterThanOrEqual(before);
     expect(info.preservedAt).toBeLessThanOrEqual(after);
-    expect(info.preservedSnapshotLastAccessedAt).toBe(info.preservedAt);
+    // A freshly-captured snapshot has not been viewed — leaving lastAccessedAt
+    // unset keeps it evictable so a burst of exits can't slip past the cap.
+    expect(info.preservedSnapshotLastAccessedAt).toBeUndefined();
+  });
+
+  it("fires onPreserved once the snapshot is captured, but not on non-preserved exit", async () => {
+    const preservedIds: string[] = [];
+    const onPreserved = (id: string) => preservedIds.push(id);
+
+    const ptyA = createControllablePty();
+    const a = createTerminal(undefined, ptyA);
+    // Inject the optional callback the production wiring provides.
+    (a as unknown as { callbacks: { onPreserved?: (id: string) => void } }).callbacks.onPreserved =
+      onPreserved;
+    ptyA.emitData("ok\r\n");
+    await exitAndAwaitDispose(a, ptyA);
+    expect(preservedIds).toEqual(["t1"]);
+
+    const ptyB = createControllablePty();
+    const b = createTerminal(undefined, ptyB);
+    (b as unknown as { callbacks: { onPreserved?: (id: string) => void } }).callbacks.onPreserved =
+      onPreserved;
+    ptyB.emitData("crash\r\n");
+    ptyB.emitExit(1);
+    await vi.waitFor(() => {
+      expect(b.getInfo().headlessTerminal).toBeUndefined();
+    });
+    // Non-preserved exit must not fire onPreserved.
+    expect(preservedIds).toEqual(["t1"]);
   });
 
   it("does not stamp preserved timestamps on non-preserved (non-zero) exit", async () => {
@@ -361,7 +389,7 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     expect(info.preservedSnapshotLastAccessedAt).toBeUndefined();
   });
 
-  it("refreshes preservedSnapshotLastAccessedAt each time the snapshot is served", async () => {
+  it("stamps preservedSnapshotLastAccessedAt on both sync and async serves", async () => {
     const pty = createControllablePty();
     const terminal = createTerminal(undefined, pty);
 
@@ -369,8 +397,13 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     await exitAndAwaitDispose(terminal, pty);
 
     const info = terminal.getInfo();
+
     info.preservedSnapshotLastAccessedAt = 0;
     terminal.getSerializedState();
+    expect(info.preservedSnapshotLastAccessedAt).toBeGreaterThan(0);
+
+    info.preservedSnapshotLastAccessedAt = 0;
+    await terminal.getSerializedStateAsync();
     expect(info.preservedSnapshotLastAccessedAt).toBeGreaterThan(0);
   });
 
@@ -387,6 +420,11 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     expect(terminal.getInfo().headlessTerminal).toBeUndefined();
     // Let any queued drain callback fire and hit the bail guard.
     await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(terminal.getInfo().preservedSnapshot).toBeUndefined();
+    const info = terminal.getInfo();
+    expect(info.preservedSnapshot).toBeUndefined();
+    // The bail guard runs before any stamping, so a snapshot-less terminal must
+    // never carry preserve timestamps (which would wrongly shield it / sort it).
+    expect(info.preservedAt).toBeUndefined();
+    expect(info.preservedSnapshotLastAccessedAt).toBeUndefined();
   });
 });

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -328,6 +328,52 @@ describe("TerminalProcess — snapshot and dispose preserved exited terminals", 
     await expect(terminal.getSerializedStateAsync()).resolves.toBe(info.preservedSnapshot);
   });
 
+  it("stamps preservedAt and preservedSnapshotLastAccessedAt on preserved exit", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    expect(terminal.getInfo().preservedAt).toBeUndefined();
+    expect(terminal.getInfo().preservedSnapshotLastAccessedAt).toBeUndefined();
+
+    const before = Date.now();
+    pty.emitData("stamp me\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+    const after = Date.now();
+
+    const info = terminal.getInfo();
+    expect(info.preservedAt).toBeGreaterThanOrEqual(before);
+    expect(info.preservedAt).toBeLessThanOrEqual(after);
+    expect(info.preservedSnapshotLastAccessedAt).toBe(info.preservedAt);
+  });
+
+  it("does not stamp preserved timestamps on non-preserved (non-zero) exit", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("crash output\r\n");
+    pty.emitExit(1);
+    await vi.waitFor(() => {
+      expect(terminal.getInfo().headlessTerminal).toBeUndefined();
+    });
+
+    const info = terminal.getInfo();
+    expect(info.preservedAt).toBeUndefined();
+    expect(info.preservedSnapshotLastAccessedAt).toBeUndefined();
+  });
+
+  it("refreshes preservedSnapshotLastAccessedAt each time the snapshot is served", async () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(undefined, pty);
+
+    pty.emitData("touch me\r\n");
+    await exitAndAwaitDispose(terminal, pty);
+
+    const info = terminal.getInfo();
+    info.preservedSnapshotLastAccessedAt = 0;
+    terminal.getSerializedState();
+    expect(info.preservedSnapshotLastAccessedAt).toBeGreaterThan(0);
+  });
+
   it("bails safely when dispose() lands before the drain callback fires", async () => {
     const pty = createControllablePty();
     const terminal = createTerminal(undefined, pty);

--- a/electron/services/pty/__tests__/TerminalRegistry.preservedEviction.test.ts
+++ b/electron/services/pty/__tests__/TerminalRegistry.preservedEviction.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { TerminalRegistry } from "../TerminalRegistry.js";
-import { PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS, type TerminalInfo } from "../types.js";
+import {
+  MAX_PRESERVED_TERMINAL_SNAPSHOTS,
+  PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS,
+  type TerminalInfo,
+} from "../types.js";
 import type { TerminalProcess } from "../TerminalProcess.js";
 
 const NOW = 1_000_000_000_000;
@@ -48,45 +52,63 @@ describe("TerminalRegistry.evictPreservedSnapshots", () => {
     expect(registry.has("new")).toBe(true);
   });
 
-  it("never evicts skipId even when it is the oldest, but still evicts other candidates", () => {
+  it("enforces the default cap, evicting exactly the oldest overflow", () => {
     const registry = new TerminalRegistry();
-    // skipId mimics a just-exited terminal whose preservedAt isn't written yet,
-    // so it sorts oldest (preservedAt undefined → 0).
-    registry.add("exiting", createPreservedTerminal({ id: "exiting" }));
+    // One over the production cap; the oldest must be the single eviction.
+    for (let i = 0; i <= MAX_PRESERVED_TERMINAL_SNAPSHOTS; i++) {
+      registry.add(`t${i}`, createPreservedTerminal({ id: `t${i}`, preservedAt: NOW + i }));
+    }
+
+    registry.evictPreservedSnapshots(undefined, undefined, NOW + 10_000_000);
+
+    expect(registry.size()).toBe(MAX_PRESERVED_TERMINAL_SNAPSHOTS);
+    expect(registry.has("t0")).toBe(false); // oldest
+    expect(registry.has(`t${MAX_PRESERVED_TERMINAL_SNAPSHOTS}`)).toBe(true); // newest
+  });
+
+  it("keeps skipId (the just-preserved newest entry) and evicts the oldest instead", () => {
+    const registry = new TerminalRegistry();
     registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW - 100 }));
     registry.add("b", createPreservedTerminal({ id: "b", preservedAt: NOW - 50 }));
+    // skipId mirrors the real flow: the freshly-captured (newest) terminal.
+    registry.add("fresh", createPreservedTerminal({ id: "fresh", preservedAt: NOW }));
 
-    // Cap of 1 over 3 entries → candidates are the two oldest ("exiting", "a").
-    // "exiting" is skipId so it survives; "a" is evicted.
-    registry.evictPreservedSnapshots(1, "exiting", NOW + 1_000_000);
+    registry.evictPreservedSnapshots(2, "fresh", NOW + 1_000_000);
 
-    expect(registry.has("exiting")).toBe(true);
-    expect(registry.has("a")).toBe(false);
+    expect(registry.has("fresh")).toBe(true);
+    expect(registry.has("a")).toBe(false); // oldest evicted
     expect(registry.has("b")).toBe(true);
   });
 
-  it("skips a recently-accessed snapshot and tolerates over-cap", () => {
+  it("never evicts skipId even if it is the oldest, evicting the next candidate instead", () => {
     const registry = new TerminalRegistry();
-    // Oldest by preservedAt, but accessed within the guard window.
+    registry.add("oldSkip", createPreservedTerminal({ id: "oldSkip", preservedAt: NOW - 100 }));
+    registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW - 50 }));
+    registry.add("b", createPreservedTerminal({ id: "b", preservedAt: NOW }));
+
+    registry.evictPreservedSnapshots(2, "oldSkip", NOW + 1_000_000);
+
+    expect(registry.has("oldSkip")).toBe(true);
+    expect(registry.has("a")).toBe(false); // next-oldest non-skipped
+    expect(registry.has("b")).toBe(true);
+  });
+
+  it("skips a recently-accessed snapshot and evicts the next-oldest evictable one", () => {
+    const registry = new TerminalRegistry();
+    // Oldest by preservedAt, but accessed within the guard window → kept.
     registry.add(
       "viewed",
-      createPreservedTerminal({
-        id: "viewed",
-        preservedAt: NOW - 1000,
-        lastAccessedAt: NOW,
-      })
+      createPreservedTerminal({ id: "viewed", preservedAt: NOW - 1000, lastAccessedAt: NOW })
     );
     registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW - 500 }));
     registry.add("b", createPreservedTerminal({ id: "b", preservedAt: NOW - 200 }));
 
-    // Cap of 1: candidates are the two oldest ("viewed", "a"). "viewed" is
-    // guarded, so only "a" is evicted; the registry stays over-cap at 2.
-    registry.evictPreservedSnapshots(1, undefined, NOW);
+    // Cap of 2 over 3 entries → evict 1. "viewed" is guarded, so "a" goes.
+    registry.evictPreservedSnapshots(2, undefined, NOW);
 
     expect(registry.has("viewed")).toBe(true);
     expect(registry.has("a")).toBe(false);
     expect(registry.has("b")).toBe(true);
-    expect(registry.size()).toBe(2);
   });
 
   it("treats a snapshot accessed just outside the guard window as evictable", () => {
@@ -115,7 +137,7 @@ describe("TerminalRegistry.evictPreservedSnapshots", () => {
     registry.add("p2", createPreservedTerminal({ id: "p2", preservedAt: NOW }));
 
     // Cap of 1 over 2 preserved entries → evict the oldest preserved only; live
-    // terminals are untouched.
+    // terminals are never counted or touched.
     registry.evictPreservedSnapshots(1, undefined, NOW + 1_000_000);
 
     expect(registry.has("p1")).toBe(false);
@@ -124,8 +146,10 @@ describe("TerminalRegistry.evictPreservedSnapshots", () => {
     expect(registry.has("live2")).toBe(true);
   });
 
-  it("does not evict when all over-cap candidates are guarded", () => {
+  it("tolerates over-cap when every entry is being actively viewed", () => {
     const registry = new TerminalRegistry();
+    // All entries are within the access guard, so none is a valid eviction
+    // target — the cap yields to not dropping a snapshot the user is viewing.
     registry.add(
       "g1",
       createPreservedTerminal({ id: "g1", preservedAt: NOW - 100, lastAccessedAt: NOW })
@@ -134,11 +158,39 @@ describe("TerminalRegistry.evictPreservedSnapshots", () => {
       "g2",
       createPreservedTerminal({ id: "g2", preservedAt: NOW - 50, lastAccessedAt: NOW })
     );
-    registry.add("keep", createPreservedTerminal({ id: "keep", preservedAt: NOW }));
+    registry.add(
+      "g3",
+      createPreservedTerminal({ id: "g3", preservedAt: NOW, lastAccessedAt: NOW })
+    );
 
     registry.evictPreservedSnapshots(1, undefined, NOW);
 
     expect(registry.size()).toBe(3);
+  });
+
+  it("evicts an unviewed newest entry rather than a viewed older one", () => {
+    const registry = new TerminalRegistry();
+    // Older entries are actively viewed; the newest has never been served.
+    registry.add(
+      "viewedOld",
+      createPreservedTerminal({ id: "viewedOld", preservedAt: NOW - 100, lastAccessedAt: NOW })
+    );
+    registry.add(
+      "viewedMid",
+      createPreservedTerminal({ id: "viewedMid", preservedAt: NOW - 50, lastAccessedAt: NOW })
+    );
+    registry.add(
+      "freshUnviewed",
+      createPreservedTerminal({ id: "freshUnviewed", preservedAt: NOW })
+    );
+
+    // Cap 2 over 3 → evict 1. The viewed entries are guarded, so the unviewed
+    // newest is the only valid target.
+    registry.evictPreservedSnapshots(2, undefined, NOW);
+
+    expect(registry.has("freshUnviewed")).toBe(false);
+    expect(registry.has("viewedOld")).toBe(true);
+    expect(registry.has("viewedMid")).toBe(true);
   });
 
   it("sorts a snapshot with no preservedAt as oldest", () => {
@@ -150,5 +202,21 @@ describe("TerminalRegistry.evictPreservedSnapshots", () => {
 
     expect(registry.has("noTimestamp")).toBe(false);
     expect(registry.has("a")).toBe(true);
+  });
+
+  it("evicts all unguarded entries when called with max 0", () => {
+    const registry = new TerminalRegistry();
+    registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW - 100 }));
+    registry.add(
+      "viewed",
+      createPreservedTerminal({ id: "viewed", preservedAt: NOW - 50, lastAccessedAt: NOW })
+    );
+    registry.add("b", createPreservedTerminal({ id: "b", preservedAt: NOW }));
+
+    registry.evictPreservedSnapshots(0, undefined, NOW);
+
+    expect(registry.has("a")).toBe(false);
+    expect(registry.has("b")).toBe(false);
+    expect(registry.has("viewed")).toBe(true); // guarded survives even at max 0
   });
 });

--- a/electron/services/pty/__tests__/TerminalRegistry.preservedEviction.test.ts
+++ b/electron/services/pty/__tests__/TerminalRegistry.preservedEviction.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import { TerminalRegistry } from "../TerminalRegistry.js";
+import { PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS, type TerminalInfo } from "../types.js";
+import type { TerminalProcess } from "../TerminalProcess.js";
+
+const NOW = 1_000_000_000_000;
+
+function createPreservedTerminal(options: {
+  id: string;
+  preservedAt?: number;
+  lastAccessedAt?: number;
+  preserved?: boolean;
+}): TerminalProcess {
+  const info = {
+    id: options.id,
+    preservedSnapshot: options.preserved === false ? undefined : `snapshot-${options.id}`,
+    preservedAt: options.preservedAt,
+    preservedSnapshotLastAccessedAt: options.lastAccessedAt,
+  } as unknown as TerminalInfo;
+
+  return {
+    getInfo: () => info,
+  } as unknown as TerminalProcess;
+}
+
+describe("TerminalRegistry.evictPreservedSnapshots", () => {
+  it("evicts nothing when the count is at or below the cap", () => {
+    const registry = new TerminalRegistry();
+    for (let i = 0; i < 3; i++) {
+      registry.add(`t${i}`, createPreservedTerminal({ id: `t${i}`, preservedAt: NOW + i }));
+    }
+
+    registry.evictPreservedSnapshots(3, undefined, NOW + 1000);
+
+    expect(registry.size()).toBe(3);
+  });
+
+  it("evicts the oldest snapshot when one over the cap", () => {
+    const registry = new TerminalRegistry();
+    registry.add("old", createPreservedTerminal({ id: "old", preservedAt: NOW - 100 }));
+    registry.add("mid", createPreservedTerminal({ id: "mid", preservedAt: NOW - 50 }));
+    registry.add("new", createPreservedTerminal({ id: "new", preservedAt: NOW }));
+
+    registry.evictPreservedSnapshots(2, undefined, NOW + 1_000_000);
+
+    expect(registry.has("old")).toBe(false);
+    expect(registry.has("mid")).toBe(true);
+    expect(registry.has("new")).toBe(true);
+  });
+
+  it("never evicts skipId even when it is the oldest, but still evicts other candidates", () => {
+    const registry = new TerminalRegistry();
+    // skipId mimics a just-exited terminal whose preservedAt isn't written yet,
+    // so it sorts oldest (preservedAt undefined → 0).
+    registry.add("exiting", createPreservedTerminal({ id: "exiting" }));
+    registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW - 100 }));
+    registry.add("b", createPreservedTerminal({ id: "b", preservedAt: NOW - 50 }));
+
+    // Cap of 1 over 3 entries → candidates are the two oldest ("exiting", "a").
+    // "exiting" is skipId so it survives; "a" is evicted.
+    registry.evictPreservedSnapshots(1, "exiting", NOW + 1_000_000);
+
+    expect(registry.has("exiting")).toBe(true);
+    expect(registry.has("a")).toBe(false);
+    expect(registry.has("b")).toBe(true);
+  });
+
+  it("skips a recently-accessed snapshot and tolerates over-cap", () => {
+    const registry = new TerminalRegistry();
+    // Oldest by preservedAt, but accessed within the guard window.
+    registry.add(
+      "viewed",
+      createPreservedTerminal({
+        id: "viewed",
+        preservedAt: NOW - 1000,
+        lastAccessedAt: NOW,
+      })
+    );
+    registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW - 500 }));
+    registry.add("b", createPreservedTerminal({ id: "b", preservedAt: NOW - 200 }));
+
+    // Cap of 1: candidates are the two oldest ("viewed", "a"). "viewed" is
+    // guarded, so only "a" is evicted; the registry stays over-cap at 2.
+    registry.evictPreservedSnapshots(1, undefined, NOW);
+
+    expect(registry.has("viewed")).toBe(true);
+    expect(registry.has("a")).toBe(false);
+    expect(registry.has("b")).toBe(true);
+    expect(registry.size()).toBe(2);
+  });
+
+  it("treats a snapshot accessed just outside the guard window as evictable", () => {
+    const registry = new TerminalRegistry();
+    registry.add(
+      "stale",
+      createPreservedTerminal({
+        id: "stale",
+        preservedAt: NOW - 1000,
+        lastAccessedAt: NOW - PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS - 1,
+      })
+    );
+    registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW }));
+
+    registry.evictPreservedSnapshots(1, undefined, NOW);
+
+    expect(registry.has("stale")).toBe(false);
+    expect(registry.has("a")).toBe(true);
+  });
+
+  it("ignores terminals without a preserved snapshot", () => {
+    const registry = new TerminalRegistry();
+    registry.add("live1", createPreservedTerminal({ id: "live1", preserved: false }));
+    registry.add("live2", createPreservedTerminal({ id: "live2", preserved: false }));
+    registry.add("p1", createPreservedTerminal({ id: "p1", preservedAt: NOW - 100 }));
+    registry.add("p2", createPreservedTerminal({ id: "p2", preservedAt: NOW }));
+
+    // Cap of 1 over 2 preserved entries → evict the oldest preserved only; live
+    // terminals are untouched.
+    registry.evictPreservedSnapshots(1, undefined, NOW + 1_000_000);
+
+    expect(registry.has("p1")).toBe(false);
+    expect(registry.has("p2")).toBe(true);
+    expect(registry.has("live1")).toBe(true);
+    expect(registry.has("live2")).toBe(true);
+  });
+
+  it("does not evict when all over-cap candidates are guarded", () => {
+    const registry = new TerminalRegistry();
+    registry.add(
+      "g1",
+      createPreservedTerminal({ id: "g1", preservedAt: NOW - 100, lastAccessedAt: NOW })
+    );
+    registry.add(
+      "g2",
+      createPreservedTerminal({ id: "g2", preservedAt: NOW - 50, lastAccessedAt: NOW })
+    );
+    registry.add("keep", createPreservedTerminal({ id: "keep", preservedAt: NOW }));
+
+    registry.evictPreservedSnapshots(1, undefined, NOW);
+
+    expect(registry.size()).toBe(3);
+  });
+
+  it("sorts a snapshot with no preservedAt as oldest", () => {
+    const registry = new TerminalRegistry();
+    registry.add("noTimestamp", createPreservedTerminal({ id: "noTimestamp" }));
+    registry.add("a", createPreservedTerminal({ id: "a", preservedAt: NOW - 100 }));
+
+    registry.evictPreservedSnapshots(1, undefined, NOW + 1_000_000);
+
+    expect(registry.has("noTimestamp")).toBe(false);
+    expect(registry.has("a")).toBe(true);
+  });
+});

--- a/electron/services/pty/__tests__/terminalSerialization.test.ts
+++ b/electron/services/pty/__tests__/terminalSerialization.test.ts
@@ -56,6 +56,36 @@ describe("terminalSerialization guards", () => {
     expect(errSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("serializeTerminal stamps preservedSnapshotLastAccessedAt when serving a preserved snapshot", () => {
+    const info = makeTerminalInfo({
+      preservedSnapshot: "cached",
+      preservedSnapshotLastAccessedAt: 0,
+    });
+    const before = Date.now();
+    expect(serializeTerminal("t1", info)).toBe("cached");
+    expect(info.preservedSnapshotLastAccessedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("serializeTerminalAsync stamps preservedSnapshotLastAccessedAt when serving a preserved snapshot", async () => {
+    const info = makeTerminalInfo({
+      preservedSnapshot: "cached",
+      preservedSnapshotLastAccessedAt: 0,
+    });
+    const before = Date.now();
+    await expect(serializeTerminalAsync("t1", info)).resolves.toBe("cached");
+    expect(info.preservedSnapshotLastAccessedAt).toBeGreaterThanOrEqual(before);
+  });
+
+  it("does not stamp preservedSnapshotLastAccessedAt on the non-preserved path", () => {
+    const info = makeTerminalInfo({
+      serializeAddon: makeAddon() as unknown as TerminalInfo["serializeAddon"],
+      preservedSnapshot: undefined,
+      preservedSnapshotLastAccessedAt: undefined,
+    });
+    expect(serializeTerminal("t1", info)).toBe("snapshot");
+    expect(info.preservedSnapshotLastAccessedAt).toBeUndefined();
+  });
+
   it("serializeTerminalAsync yields null without logging when disposal clears the addon mid-flight", async () => {
     const addon = makeAddon();
     // Large buffer forces the async (deferred) serialize path.

--- a/electron/services/pty/terminalSerialization.ts
+++ b/electron/services/pty/terminalSerialization.ts
@@ -4,8 +4,10 @@ import { getTerminalSerializerService } from "./TerminalSerializerService.js";
 
 export function serializeTerminal(id: string, terminalInfo: TerminalInfo): string | null {
   // Preserved exited terminal — the headless xterm is disposed and the final
-  // buffer lives as a cached string. Empty string is a valid snapshot.
+  // buffer lives as a cached string. Empty string is a valid snapshot. Stamp
+  // the access time so eviction (issue #10839) treats it as currently-viewed.
   if (terminalInfo.preservedSnapshot !== undefined) {
+    terminalInfo.preservedSnapshotLastAccessedAt = Date.now();
     return terminalInfo.preservedSnapshot;
   }
   // Non-preserved disposed terminal — disposeHeadless() clears the addon. No
@@ -24,7 +26,10 @@ export async function serializeTerminalAsync(
   id: string,
   terminalInfo: TerminalInfo
 ): Promise<string | null> {
+  // Preserved snapshot served — stamp access time so eviction (issue #10839)
+  // treats it as currently-viewed.
   if (terminalInfo.preservedSnapshot !== undefined) {
+    terminalInfo.preservedSnapshotLastAccessedAt = Date.now();
     return terminalInfo.preservedSnapshot;
   }
   // Non-preserved disposed terminal — disposeHeadless() clears both fields

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -164,8 +164,12 @@ export interface TerminalInfo extends TerminalPublicState {
   preservedAt?: number;
   /**
    * Wall-clock timestamp (`Date.now()`) of the last time `preservedSnapshot`
-   * was served by `serializeTerminal`/`serializeTerminalAsync`, seeded at
-   * capture time. Guards a currently-viewed snapshot from eviction within
+   * was served by `serializeTerminal`/`serializeTerminalAsync`. Set/updated only
+   * on an actual serve (a real view) — deliberately NOT seeded at capture, so a
+   * just-exited snapshot stays `undefined` until something serializes it. That
+   * fresh ≠ viewed distinction is what stops a burst of freshly-captured
+   * snapshots from masquerading as recently-accessed and evading eviction.
+   * Guards a currently-viewed snapshot from eviction within
    * `PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS`. Runtime-only; not persisted,
    * not crossed over IPC.
    */

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -156,6 +156,21 @@ export interface TerminalInfo extends TerminalPublicState {
    */
   preservedSnapshot?: string;
   /**
+   * Wall-clock timestamp (`Date.now()`) captured when `preservedSnapshot` is
+   * assigned. Drives oldest-first eviction in
+   * `TerminalRegistry.evictPreservedSnapshots` (issue #10839). Runtime-only;
+   * not persisted, not crossed over IPC.
+   */
+  preservedAt?: number;
+  /**
+   * Wall-clock timestamp (`Date.now()`) of the last time `preservedSnapshot`
+   * was served by `serializeTerminal`/`serializeTerminalAsync`, seeded at
+   * capture time. Guards a currently-viewed snapshot from eviction within
+   * `PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS`. Runtime-only; not persisted,
+   * not crossed over IPC.
+   */
+  preservedSnapshotLastAccessedAt?: number;
+  /**
    * Monotonic count of buffer mutations: PTY output chunks (bumped at the
    * pty-host routing site), resize reflows, and the preserved-snapshot
    * capture. Runtime-only; not persisted, not crossed over IPC. Vestigial: the
@@ -258,6 +273,18 @@ export const WRITE_INTERVAL_MS = 5;
 // output is needed for state detection; the renderer-visible scrollback is
 // larger so long agent runs don't truncate.
 export const DEFAULT_SCROLLBACK = 10000;
+
+// Preserved-snapshot eviction (issue #10839)
+// Agent terminals that exit cleanly retain their full serialized scrollback
+// (~1–4MB each) in memory so the user can reopen and inspect the session. They
+// are otherwise removed only on explicit trash/kill or project close, so within
+// an open project they accumulate without bound. Cap the in-memory count and
+// evict oldest-first; worst-case heap ceiling is ~20 × ~4MB ≈ 80MB.
+export const MAX_PRESERVED_TERMINAL_SNAPSHOTS = 20;
+// A preserved snapshot served (or freshly captured) within this window is
+// treated as currently-viewed and skipped by eviction even when over the cap,
+// so a snapshot the user is actively inspecting never vanishes mid-view.
+export const PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS = 5 * 60 * 1000; // 5 min
 
 export { TRASH_TTL_MS } from "../../../shared/config/trash.js";
 


### PR DESCRIPTION
## Summary

- Agent terminals that exit cleanly keep their serialized scrollback in `TerminalRegistry` indefinitely. Within a long-running project session they accumulate with no bound, each snapshot carrying 1-4MB of serialized state.
- This PR caps preserved snapshots at `MAX_PRESERVED_TERMINAL_SNAPSHOTS=20` (roughly 80MB worst case). A new `evictPreservedSnapshots()` method on `TerminalRegistry` walks oldest-first by `preservedAt` and removes entries until at cap. Eviction fires from a new `onPreserved` callback on `TerminalProcess` that runs after the snapshot is actually captured, so the just-preserved terminal is counted and burst exits can't slip past the cap.
- A 5-minute recent-access guard (`PRESERVED_SNAPSHOT_RECENT_ACCESS_GUARD_MS`) keeps any snapshot the user is actively viewing. `preservedSnapshotLastAccessedAt` is stamped on every serialize call (sync and async), never seeded at capture time, so a fresh snapshot doesn't inherit a "viewed" timestamp it doesn't deserve.

Resolves #10839

## Changes

- `electron/services/pty/types.ts`: `preservedAt` and `preservedSnapshotLastAccessedAt` fields on `TerminalRegistryEntry`
- `TerminalProcess.ts`: `onPreserved` callback wired to fire post-capture
- `TerminalRegistry.ts`: `evictPreservedSnapshots()` with oldest-first eviction and recent-access guard
- `terminalSerialization.ts`: stamps `preservedSnapshotLastAccessedAt` on every serialize call
- `PtyManager.ts`: connects `onPreserved` to trigger eviction after each snapshot capture
- 3 test files: new `TerminalRegistry.preservedEviction.test.ts` (12 cases), extended `TerminalProcess.snapshot.test.ts` and `terminalSerialization.test.ts`

## Testing

45 targeted tests pass. Known accepted trade-off: a preserved panel viewed passively for over 5 minutes could be evicted and show blank on a later reconnect. Cross-project-close headroom is reclaimed lazily on the next preserved exit. The `deferredOutput` byte-cap in `TerminalWriteController` (a separate renderer-side problem) is split out as a follow-on.