### PR TITLE
perf(memory): prune unbounded add-only maps and sets

### DIFF
--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -438,11 +438,13 @@ export class ResourceGovernor {
   }
 
   private checkFdUsage(): void {
-    if (!this.fdMonitor.supported) return;
-
     const now = Date.now();
 
-    // Collect orphan candidates: PIDs killed long enough ago to have exited
+    // Collect orphan candidates: PIDs killed long enough ago to have exited.
+    // Runs unconditionally — `killedPids` is populated on every platform via
+    // `trackKilledPid`, but FD monitoring is unsupported on Windows. Gating the
+    // sweep behind `fdMonitor.supported` (as before) leaked the map there until
+    // `dispose()`; prune first, then bail out of the FD-leak check (#10842).
     const orphanCandidates: number[] = [];
     for (const [pid, killedAt] of this.killedPids) {
       if (now - killedAt > this.ORPHAN_GRACE_MS) {
@@ -450,6 +452,8 @@ export class ResourceGovernor {
         this.killedPids.delete(pid);
       }
     }
+
+    if (!this.fdMonitor.supported) return;
 
     const result = this.fdMonitor.checkForLeaks(this.deps.getTerminalCount(), orphanCandidates);
 

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -2537,5 +2537,27 @@ describe("ResourceGovernor", () => {
 
       governor.dispose();
     });
+
+    it("only sweeps PIDs past the grace window, keeping younger ones", () => {
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      // PID A killed at t=0, PID B killed at t=3000. Grace is a strict
+      // `age > ORPHAN_GRACE_MS` (4000), evaluated each 2s tick.
+      governor.trackKilledPid(1111);
+      vi.advanceTimersByTime(3000);
+      governor.trackKilledPid(2222);
+
+      // Tick at t=6000: A is 6s old (swept), B is 3s old (kept).
+      vi.advanceTimersByTime(3000);
+      expect(mockCheckForLeaks).toHaveBeenLastCalledWith(0, [1111]);
+
+      // Tick at t=8000: B is now 5s old (swept).
+      vi.advanceTimersByTime(2000);
+      expect(mockCheckForLeaks).toHaveBeenLastCalledWith(0, [2222]);
+
+      governor.dispose();
+    });
   });
 });

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -2508,5 +2508,34 @@ describe("ResourceGovernor", () => {
 
       governor.dispose();
     });
+
+    it("prunes killed PIDs even when FD monitoring is unsupported (Windows)", () => {
+      // Regression for #10842: the orphan sweep used to sit behind the
+      // `if (!supported) return` guard, so on Windows (no /proc/fd) killedPids
+      // grew unbounded until dispose(). Prove the entry is swept while
+      // unsupported by flipping support on afterward and asserting the next
+      // FD check sees an empty orphan list — if the pid had leaked it would
+      // surface here.
+      mockFdMonitorSupported = false;
+
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      governor.trackKilledPid(9999);
+
+      // Past the 4s grace window — the unconditional sweep deletes the entry
+      // even though checkForLeaks never runs while unsupported.
+      vi.advanceTimersByTime(6000);
+      expect(mockCheckForLeaks).not.toHaveBeenCalled();
+
+      // FD monitoring becomes available: the next tick runs checkForLeaks with
+      // no orphan candidates, proving the pid was already pruned.
+      mockFdMonitorSupported = true;
+      vi.advanceTimersByTime(2000);
+      expect(mockCheckForLeaks).toHaveBeenLastCalledWith(0, []);
+
+      governor.dispose();
+    });
   });
 });

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -146,6 +146,15 @@ export class WorkspaceHostEventRouter {
         // WORKTREE_DELETE IPC handler's eviction does not.
         gitServiceCache.delete(event.worktreeId);
         gitServiceCache.delete(path.resolve(event.worktreeId));
+        // Prune cloud-teardown failure-toast dedup keys for the removed
+        // worktree. Keys are `${worktreeId}:${startedAt}`, so a prefix scan
+        // covers every teardown attempt; otherwise the Set only grows until
+        // `dispose()` (#10842). Deleting during `for...of` over a Set is safe.
+        for (const key of this.cloudTeardownFailureToastKeys) {
+          if (key.startsWith(`${event.worktreeId}:`)) {
+            this.cloudTeardownFailureToastKeys.delete(key);
+          }
+        }
         break;
 
       case "clear-wsl-git-opt-in": {

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -687,6 +687,61 @@ describe("WorkspaceHostEventRouter", () => {
       expect(broadcastToRenderer).not.toHaveBeenCalled();
       expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
     });
+
+    it("prunes the dedup key on worktree-removed so a re-teardown re-fires (#10842)", () => {
+      const entry = makeEntry();
+      const failure = (worktreeId: string) =>
+        makeWorktreeUpdateEvent({
+          id: worktreeId,
+          worktreeId,
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        });
+
+      // First failure for wt-1 records the dedup key and toasts once.
+      router.routeHostEvent(entry, failure("wt-1"));
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+
+      // Removing the worktree prunes its `${worktreeId}:${startedAt}` keys.
+      router.routeHostEvent(entry, {
+        type: "worktree-removed",
+        worktreeId: "wt-1",
+        epoch: "550e8400-e29b-41d4-a716-446655440000",
+        seq: 2,
+      });
+
+      // A re-created worktree reusing the id with the same startedAt must toast
+      // again — the stale key is gone.
+      router.routeHostEvent(entry, failure("wt-1"));
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+    });
+
+    it("only prunes dedup keys for the removed worktree (#10842)", () => {
+      const entry = makeEntry();
+      const failure = (worktreeId: string) =>
+        makeWorktreeUpdateEvent({
+          id: worktreeId,
+          worktreeId,
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        });
+
+      router.routeHostEvent(entry, failure("wt-1"));
+      router.routeHostEvent(entry, failure("wt-2"));
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+
+      // Remove wt-1 only — wt-2's dedup key must survive.
+      router.routeHostEvent(entry, {
+        type: "worktree-removed",
+        worktreeId: "wt-1",
+        epoch: "550e8400-e29b-41d4-a716-446655440000",
+        seq: 3,
+      });
+
+      // wt-2 is still deduped (no new toast); wt-1 re-fires (key pruned).
+      router.routeHostEvent(entry, failure("wt-2"));
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+      router.routeHostEvent(entry, failure("wt-1"));
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe("linked is the source of truth on re-emit (#8452)", () => {

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -715,6 +715,47 @@ describe("WorkspaceHostEventRouter", () => {
       expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
     });
 
+    it("prunes every dedup key for the removed worktree, not just the first (#10842)", () => {
+      const entry = makeEntry();
+      // Two distinct teardown attempts for wt-1 produce two dedup keys
+      // (`wt-1:1000`, `wt-1:2000`).
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        })
+      );
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 2000),
+        })
+      );
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+
+      router.routeHostEvent(entry, {
+        type: "worktree-removed",
+        worktreeId: "wt-1",
+        epoch: "550e8400-e29b-41d4-a716-446655440000",
+        seq: 3,
+      });
+
+      // Both keys must be gone — a first-match-only prune would leave wt-1:2000.
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 1000),
+        })
+      );
+      router.routeHostEvent(
+        entry,
+        makeWorktreeUpdateEvent({
+          lifecycleStatus: lifecycleStatus("resource-teardown", "failed", 2000),
+        })
+      );
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(4);
+    });
+
     it("only prunes dedup keys for the removed worktree (#10842)", () => {
       const entry = makeEntry();
       const failure = (worktreeId: string) =>

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1209,6 +1209,39 @@ describe("notify()", () => {
       Date.now = realDateNow;
     });
 
+    it("does not self-evict a freshly created short-window entry at the cap (#10842)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const realDateNow = Date.now;
+      Date.now = () => 1000; // freeze so nothing expires mid-test
+
+      // Saturate the cap with long-window entries.
+      for (let i = 0; i < 200; i++) {
+        notify(makeCoalescePayload(`bg:${i}`)); // windowMs 15000
+      }
+
+      // A new entry with the SMALLEST expiresAt must survive its own prune pass
+      // — otherwise the eviction-by-expiresAt would drop the entry just set.
+      const shortPayload = {
+        type: "success" as const,
+        message: "Short",
+        priority: "high" as const,
+        title: "Short",
+        duration: 5000,
+        coalesce: {
+          key: "short-window",
+          windowMs: 100,
+          buildMessage: (count: number) => `${count} short`,
+        },
+      };
+      const id1 = notify(shortPayload);
+      // The immediate follow-up must coalesce into id1, proving the entry was
+      // retained (a duplicate id would mean it was evicted then recreated).
+      const id2 = notify(shortPayload);
+      expect(id1).toBe(id2);
+
+      Date.now = realDateNow;
+    });
+
     it("drops expired coalesce entries on the next create (#10842)", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       const realDateNow = Date.now;

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -9,6 +9,7 @@ import {
   EVENT_KIND_TO_SETTING_KEY,
   type NotificationEventKind,
   _resetCoalesceMap,
+  _getActiveCoalescedSizeForTest,
   _resetEscalationTrackers,
   _resetRateLimitBuckets,
   _resetOverflowAnnouncements,
@@ -1191,6 +1192,40 @@ describe("notify()", () => {
 
       expect(secondUpdatedAt).toBeDefined();
       expect(secondUpdatedAt).toBeGreaterThanOrEqual(firstUpdatedAt!);
+    });
+
+    it("bounds the coalesce map at 200 entries under unique-key churn (#10842)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const realDateNow = Date.now;
+      Date.now = () => 1000; // freeze so no entry expires during the fill
+
+      // 250 distinct keys would otherwise leave 250 add-only entries.
+      for (let i = 0; i < 250; i++) {
+        notify(makeCoalescePayload(`overflow:${i}`));
+      }
+
+      expect(_getActiveCoalescedSizeForTest()).toBe(200);
+
+      Date.now = realDateNow;
+    });
+
+    it("drops expired coalesce entries on the next create (#10842)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const realDateNow = Date.now;
+
+      let now = 1000;
+      Date.now = () => now;
+
+      notify(makeCoalescePayload("expiring")); // expiresAt = 1000 + 15000
+      expect(_getActiveCoalescedSizeForTest()).toBe(1);
+
+      now = 20000; // past the 15s window
+      notify(makeCoalescePayload("fresh"));
+
+      // The expired "expiring" entry is swept; only "fresh" remains.
+      expect(_getActiveCoalescedSizeForTest()).toBe(1);
+
+      Date.now = realDateNow;
     });
   });
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -351,8 +351,38 @@ interface CoalesceEntry {
 
 const _activeCoalesced = new Map<string, CoalesceEntry>();
 
+// Match the 200-entry cap on the sibling `_escalationTrackers` /
+// `_rateLimitBuckets` maps. In practice only a handful of static coalesce keys
+// are live, but the map was add-only with no upper bound (#10842).
+const ACTIVE_COALESCED_MAX_ENTRIES = 200;
+
 export function _resetCoalesceMap(): void {
   _activeCoalesced.clear();
+}
+
+/** Test-only: observe the bounded coalesce map's current size. */
+export function _getActiveCoalescedSizeForTest(): number {
+  return _activeCoalesced.size;
+}
+
+// Bound `_activeCoalesced`. First drop entries whose window has already
+// elapsed (a coalesced entry is dead once `expiresAt` passes), then, if still
+// over the cap, evict the soonest-to-expire entries. Sort key is `expiresAt`,
+// not last-activity: coalesce windows are time-bounded, so the entries closest
+// to expiry are the least useful to keep.
+function pruneCoalesceMap(now: number): void {
+  for (const [key, entry] of _activeCoalesced) {
+    if (entry.expiresAt <= now) _activeCoalesced.delete(key);
+  }
+  if (_activeCoalesced.size <= ACTIVE_COALESCED_MAX_ENTRIES) return;
+
+  const entries = Array.from(_activeCoalesced.entries());
+  entries.sort((a, b) => a[1].expiresAt - b[1].expiresAt);
+
+  const toRemove = entries.slice(0, entries.length - ACTIVE_COALESCED_MAX_ENTRIES);
+  for (const [key] of toRemove) {
+    _activeCoalesced.delete(key);
+  }
 }
 
 // ── active-context suppression ──────────────────────────────────────────────
@@ -1078,6 +1108,7 @@ export function notify(payload: NotifyPayload): string {
       expiresAt: now + windowMs,
       count: 1,
     });
+    pruneCoalesceMap(now);
     return id;
   }
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -369,18 +369,21 @@ export function _getActiveCoalescedSizeForTest(): number {
 // elapsed (a coalesced entry is dead once `expiresAt` passes), then, if still
 // over the cap, evict the soonest-to-expire entries. Sort key is `expiresAt`,
 // not last-activity: coalesce windows are time-bounded, so the entries closest
-// to expiry are the least useful to keep.
-function pruneCoalesceMap(now: number): void {
+// to expiry are the least useful to keep. `protectKey` is the entry the caller
+// just set — it must never be evicted by its own prune pass, even when it has
+// the smallest `expiresAt` (a short coalesce window), or the very next call for
+// that key would spawn a duplicate toast instead of coalescing.
+function pruneCoalesceMap(now: number, protectKey?: string): void {
   for (const [key, entry] of _activeCoalesced) {
-    if (entry.expiresAt <= now) _activeCoalesced.delete(key);
+    if (key !== protectKey && entry.expiresAt <= now) _activeCoalesced.delete(key);
   }
   if (_activeCoalesced.size <= ACTIVE_COALESCED_MAX_ENTRIES) return;
 
-  const entries = Array.from(_activeCoalesced.entries());
-  entries.sort((a, b) => a[1].expiresAt - b[1].expiresAt);
+  const candidates = Array.from(_activeCoalesced.entries()).filter(([key]) => key !== protectKey);
+  candidates.sort((a, b) => a[1].expiresAt - b[1].expiresAt);
 
-  const toRemove = entries.slice(0, entries.length - ACTIVE_COALESCED_MAX_ENTRIES);
-  for (const [key] of toRemove) {
+  const removeCount = _activeCoalesced.size - ACTIVE_COALESCED_MAX_ENTRIES;
+  for (const [key] of candidates.slice(0, removeCount)) {
     _activeCoalesced.delete(key);
   }
 }
@@ -1108,7 +1111,7 @@ export function notify(payload: NotifyPayload): string {
       expiresAt: now + windowMs,
       count: 1,
     });
-    pruneCoalesceMap(now);
+    pruneCoalesceMap(now, coalesce.key);
     return id;
   }
 

--- a/src/store/__tests__/forgeProviderHealthStore.test.ts
+++ b/src/store/__tests__/forgeProviderHealthStore.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   useForgeProviderHealthStore,
   selectForgeProviderHealth,
   DEFAULT_PROVIDER_HEALTH,
 } from "@/store/forgeProviderHealthStore";
+import { usePluginRuntimeStore, _resetPluginRuntimeStoreForTest } from "@/store/pluginRuntimeStore";
 import { BUILTIN_GITHUB_PROVIDER_ID } from "@shared/utils/forgeProviderIds";
 
 const FAKE = "acme.gitlab.gitlab";
@@ -11,6 +12,10 @@ const FAKE = "acme.gitlab.gitlab";
 describe("forgeProviderHealthStore", () => {
   beforeEach(() => {
     useForgeProviderHealthStore.setState({ providers: {} });
+  });
+
+  afterEach(() => {
+    _resetPluginRuntimeStoreForTest();
   });
 
   it("returns the default health for an unseen provider", () => {
@@ -257,5 +262,64 @@ describe("forgeProviderHealthStore", () => {
       selectForgeProviderHealth(BUILTIN_GITHUB_PROVIDER_ID)(useForgeProviderHealthStore.getState())
         .tokenBannerDismissed
     ).toBe(false);
+  });
+
+  describe("removeProvider (#10842)", () => {
+    it("drops one provider's slice and preserves the others", () => {
+      const store = useForgeProviderHealthStore.getState();
+      store.applyRateLimit(BUILTIN_GITHUB_PROVIDER_ID, { blocked: true, kind: "primary" });
+      store.applyRateLimit(FAKE, { blocked: true, kind: "primary" });
+
+      store.removeProvider(FAKE);
+
+      // Removed provider falls back to the frozen default.
+      expect(selectForgeProviderHealth(FAKE)(useForgeProviderHealthStore.getState())).toEqual(
+        DEFAULT_PROVIDER_HEALTH
+      );
+      // The other provider is untouched.
+      expect(
+        selectForgeProviderHealth(BUILTIN_GITHUB_PROVIDER_ID)(
+          useForgeProviderHealthStore.getState()
+        ).rateLimitBlocked
+      ).toBe(true);
+      expect(FAKE in useForgeProviderHealthStore.getState().providers).toBe(false);
+    });
+
+    it("is a no-op for an absent provider (no new object reference)", () => {
+      const before = useForgeProviderHealthStore.getState().providers;
+      useForgeProviderHealthStore.getState().removeProvider("never.seen.provider");
+      expect(useForgeProviderHealthStore.getState().providers).toBe(before);
+    });
+  });
+
+  describe("plugin-disable pruning (#10842)", () => {
+    it("removes providers whose owning plugin is disabled, keeping the rest", () => {
+      const store = useForgeProviderHealthStore.getState();
+      store.applyRateLimit(FAKE, { blocked: true, kind: "primary" });
+      store.setProviderMeta(FAKE, { providerName: "GitLab", pluginId: "acme.gitlab" });
+      store.applyRateLimit(BUILTIN_GITHUB_PROVIDER_ID, { blocked: true, kind: "primary" });
+      store.setProviderMeta(BUILTIN_GITHUB_PROVIDER_ID, {
+        providerName: "GitHub",
+        pluginId: "daintree.github",
+      });
+
+      // Disabling the GitLab plugin must evict only its provider slice.
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set(["acme.gitlab"]) });
+
+      expect(FAKE in useForgeProviderHealthStore.getState().providers).toBe(false);
+      expect(BUILTIN_GITHUB_PROVIDER_ID in useForgeProviderHealthStore.getState().providers).toBe(
+        true
+      );
+    });
+
+    it("leaves providers without a pluginId untouched when a plugin is disabled", () => {
+      const store = useForgeProviderHealthStore.getState();
+      // No setProviderMeta → pluginId stays null.
+      store.applyRateLimit(FAKE, { blocked: true, kind: "primary" });
+
+      usePluginRuntimeStore.setState({ disabledPluginIds: new Set(["some.other.plugin"]) });
+
+      expect(FAKE in useForgeProviderHealthStore.getState().providers).toBe(true);
+    });
   });
 });

--- a/src/store/forgeProviderHealthStore.ts
+++ b/src/store/forgeProviderHealthStore.ts
@@ -161,6 +161,12 @@ export const useForgeProviderHealthStore = create<ForgeProviderHealthStore>((set
 // cascade). Plain `subscribe` (pluginRuntimeStore has no `subscribeWithSelector`
 // middleware) fires on any state change, so guard on the `disabledPluginIds`
 // reference and bail when no providers are tracked.
+//
+// Known gap (out of scope for #10842, which targets unbounded growth): a push
+// already in flight when the plugin is disabled could re-add a single slice
+// after this pass, and it won't re-fire (the set reference is unchanged). That
+// is one stale slice for a finite, reused provider id — bounded, not a leak —
+// and the main process gates plugin-backed IPC, so the race is narrow.
 usePluginRuntimeStore.subscribe((state, prev) => {
   if (state.disabledPluginIds === prev.disabledPluginIds) return;
   const { providers, removeProvider } = useForgeProviderHealthStore.getState();

--- a/src/store/forgeProviderHealthStore.ts
+++ b/src/store/forgeProviderHealthStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { ForgeRateLimitKind } from "@shared/types";
 import type { ForgeTokenHealthState } from "@shared/types/forge";
+import { usePluginRuntimeStore } from "./pluginRuntimeStore";
 
 /**
  * Renderer source of truth for forge provider health (rate-limit + token
@@ -70,6 +71,7 @@ interface ForgeProviderHealthStore {
   setTokenUnhealthy: (providerId: string, value: boolean, state?: ForgeTokenHealthState) => void;
   setProviderMeta: (providerId: string, meta: ForgeProviderMeta) => void;
   dismissTokenBanner: (providerId: string) => void;
+  removeProvider: (providerId: string) => void;
 }
 
 function mergeProvider(
@@ -141,7 +143,33 @@ export const useForgeProviderHealthStore = create<ForgeProviderHealthStore>((set
     set((s) => ({
       providers: mergeProvider(s, providerId, { tokenBannerDismissed: true }),
     })),
+  // Drop a provider's slice entirely. Without this the `providers` Record only
+  // ever grew (every `mergeProvider` adds, nothing removes), so a plugin that
+  // registered a forge provider leaked its health slice for the renderer's
+  // lifetime after the plugin was disabled (#10842).
+  removeProvider: (providerId) =>
+    set((s) => {
+      if (!(providerId in s.providers)) return s;
+      const { [providerId]: _removed, ...rest } = s.providers;
+      return { providers: rest };
+    }),
 }));
+
+// Evict health slices for providers whose owning plugin has been disabled.
+// `pluginRuntimeStore` is the renderer's ground truth for plugin enable state
+// (#9322 — renderer cleanup is a separate path from the main-process unload
+// cascade). Plain `subscribe` (pluginRuntimeStore has no `subscribeWithSelector`
+// middleware) fires on any state change, so guard on the `disabledPluginIds`
+// reference and bail when no providers are tracked.
+usePluginRuntimeStore.subscribe((state, prev) => {
+  if (state.disabledPluginIds === prev.disabledPluginIds) return;
+  const { providers, removeProvider } = useForgeProviderHealthStore.getState();
+  for (const [providerId, health] of Object.entries(providers)) {
+    if (health.pluginId && state.disabledPluginIds.has(health.pluginId)) {
+      removeProvider(providerId);
+    }
+  }
+});
 
 /**
  * Selector factory for one provider's health, with the default-fallback for a

--- a/src/store/listeners/panel/__tests__/identity.test.ts
+++ b/src/store/listeners/panel/__tests__/identity.test.ts
@@ -480,7 +480,7 @@ describe("identity listener — map eviction on panel removal (#10842)", () => {
 
     // Remove only term-1; term-2 keeps wt-1 alive, so the coalesce timestamp
     // must be retained (no over-pruning).
-    const survivor = usePanelStore.getState().panelsById["term-2"];
+    const survivor = usePanelStore.getState().panelsById["term-2"]!;
     usePanelStore.setState({ panelsById: { "term-2": survivor }, panelIds: ["term-2"] });
 
     // term-2 completes within the window → coalesced, no second notify.

--- a/src/store/listeners/panel/__tests__/identity.test.ts
+++ b/src/store/listeners/panel/__tests__/identity.test.ts
@@ -396,3 +396,98 @@ describe("identity listener — completed-with-changes notification", () => {
     d.dispose();
   });
 });
+
+describe("identity listener — map eviction on panel removal (#10842)", () => {
+  function setupTwoPanels() {
+    const makePanel = (id: string) =>
+      ({
+        id,
+        kind: "terminal",
+        title: id,
+        cwd: "/tmp/wt-1",
+        cols: 80,
+        rows: 24,
+        location: "grid" as const,
+        worktreeId: "wt-1",
+      }) as unknown as ReturnType<typeof usePanelStore.getState>["panelsById"][string];
+    usePanelStore.setState({
+      panelsById: { "term-1": makePanel("term-1"), "term-2": makePanel("term-2") },
+      panelIds: ["term-1", "term-2"],
+    });
+  }
+
+  it("prunes _changedFileBaseline when a panel disappears without an exit event", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    // Capture a baseline of 0 for term-1.
+    mockChangedFileCount = 0;
+    transition("working", "idle");
+
+    // Force-kill: the panel vanishes from the store with no completed/exited
+    // event (the gap this fix closes). The panelIds subscriber must evict the
+    // stale baseline.
+    usePanelStore.setState({ panelsById: {}, panelIds: [] });
+
+    // A reused-id panel completes without a fresh working event. A surviving
+    // baseline (0) would make the grown count (5) fire; a correct prune leaves
+    // no baseline, so nothing fires.
+    setupPanel();
+    mockChangedFileCount = 5;
+    transition("completed", "idle");
+
+    expect(notify).not.toHaveBeenCalled();
+
+    d.dispose();
+  });
+
+  it("prunes _lastReviewInboxAt when the last PTY panel for a worktree is removed", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 0;
+    transition("working", "idle");
+    mockChangedFileCount = 3;
+    transition("completed", "working");
+    expect(notify).toHaveBeenCalledTimes(1); // records _lastReviewInboxAt[wt-1]
+
+    // The worktree's last panel goes away → its coalesce timestamp must evict.
+    usePanelStore.setState({ panelsById: {}, panelIds: [] });
+
+    // A brand-new agent on wt-1 completing within the 5s coalesce window must
+    // still notify; a surviving stale timestamp would suppress it.
+    setupPanel();
+    mockChangedFileCount = 3;
+    transition("working", "idle");
+    mockChangedFileCount = 6;
+    transition("completed", "working");
+    expect(notify).toHaveBeenCalledTimes(2);
+
+    d.dispose();
+  });
+
+  it("retains _lastReviewInboxAt while another PTY panel for the worktree survives", () => {
+    setupTwoPanels();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 0;
+    transition("working", "idle", "term-1");
+    transition("working", "idle", "term-2");
+
+    mockChangedFileCount = 3;
+    transition("completed", "working", "term-1");
+    expect(notify).toHaveBeenCalledTimes(1); // records _lastReviewInboxAt[wt-1]
+
+    // Remove only term-1; term-2 keeps wt-1 alive, so the coalesce timestamp
+    // must be retained (no over-pruning).
+    const survivor = usePanelStore.getState().panelsById["term-2"];
+    usePanelStore.setState({ panelsById: { "term-2": survivor }, panelIds: ["term-2"] });
+
+    // term-2 completes within the window → coalesced, no second notify.
+    mockChangedFileCount = 6;
+    transition("completed", "working", "term-2");
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    d.dispose();
+  });
+});

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -190,6 +190,12 @@ export function setupIdentityListeners(): DisposableStore {
   // its `_changedFileBaseline` entry; `_lastReviewInboxAt` had no eviction at
   // all. `panelIds` is the canonical liveness signal — drop any tracked id no
   // longer present, and any worktree with no remaining PTY panel (#10842).
+  //
+  // Keyed on `panelIds` only: a `moveTerminalToWorktree` that rewrites a
+  // panel's `worktreeId` without changing `panelIds` won't fire this, so a
+  // stale `_lastReviewInboxAt[oldWorktreeId]` lingers until the next `panelIds`
+  // change. Bounded (worktree ids are finite/reused, not add-only) and benign
+  // — at worst one 5s-window inbox dedupe is missed after a rare move.
   d.add(
     toDisposable(
       usePanelStore.subscribe(

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -184,6 +184,38 @@ export function setupIdentityListeners(): DisposableStore {
     )
   );
 
+  // Prune the per-terminal/per-worktree maps when panels disappear. The
+  // `agent:exited`/`completed` deletes above cover graceful teardown, but a
+  // force-kill mid-"working" removes the panel without an exit event, leaking
+  // its `_changedFileBaseline` entry; `_lastReviewInboxAt` had no eviction at
+  // all. `panelIds` is the canonical liveness signal — drop any tracked id no
+  // longer present, and any worktree with no remaining PTY panel (#10842).
+  d.add(
+    toDisposable(
+      usePanelStore.subscribe(
+        (s) => s.panelIds,
+        (panelIds) => {
+          if (_changedFileBaseline.size === 0 && _lastReviewInboxAt.size === 0) return;
+          const liveIds = new Set(panelIds);
+          for (const terminalId of _changedFileBaseline.keys()) {
+            if (!liveIds.has(terminalId)) _changedFileBaseline.delete(terminalId);
+          }
+          if (_lastReviewInboxAt.size === 0) return;
+          const { panelsById } = usePanelStore.getState();
+          const liveWorktreeIds = new Set(
+            panelIds.flatMap((id) => {
+              const panel = panelsById[id];
+              return isPtyPanel(panel) && panel.worktreeId ? [panel.worktreeId] : [];
+            })
+          );
+          for (const worktreeId of _lastReviewInboxAt.keys()) {
+            if (!liveWorktreeIds.has(worktreeId)) _lastReviewInboxAt.delete(worktreeId);
+          }
+        }
+      )
+    )
+  );
+
   d.add(
     toDisposable(
       terminalRegistryController.onAgentDetected((data) => {

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -211,7 +211,7 @@ export function setupIdentityListeners(): DisposableStore {
           const liveWorktreeIds = new Set(
             panelIds.flatMap((id) => {
               const panel = panelsById[id];
-              return isPtyPanel(panel) && panel.worktreeId ? [panel.worktreeId] : [];
+              return panel && isPtyPanel(panel) && panel.worktreeId ? [panel.worktreeId] : [];
             })
           );
           for (const worktreeId of _lastReviewInboxAt.keys()) {


### PR DESCRIPTION
## Summary

- Adds pruning at natural teardown points for five module-scope add-only `Map`/`Set` structures that only ever grew.
- Fixes a Windows-only bug where `killedPids` orphan detection was silently skipped because the sweep was gated on `FdMonitor.supported` (unsupported on Windows).
- Caps `notify._activeCoalesced` at 200 entries (expired-first, then oldest-by-`expiresAt`), matching the sibling `_escalationTrackers` and `_rateLimitBuckets` maps.

Closes #10842

## Changes

- `ResourceGovernor.killedPids` (`electron/pty-host/ResourceGovernor.ts`) -- orphan-PID sweep now runs unconditionally; the `FdMonitor.supported` gate only belongs on the FD-count check, not the orphan cleanup.
- `WorkspaceHostEventRouter.cloudTeardownFailureToastKeys` (`electron/services/workspace-client/WorkspaceHostEventRouter.ts`) -- prefix-pruned on `worktree-removed` so stale keys don't outlive their worktree.
- `forgeProviderHealthStore.providers` (`src/store/forgeProviderHealthStore.ts`) -- new `removeProvider` action wired to a `pluginRuntimeStore` subscriber that evicts slices when the owning plugin is disabled.
- `identity.ts` listener maps (`src/store/listeners/panel/identity.ts`) -- `_changedFileBaseline` and `_lastReviewInboxAt` are now pruned by the `panelIds` subscriber on force-kill and last-PTY-panel-removed.
- `notify._activeCoalesced` (`src/lib/notify.ts`) -- capped at 200; just-set key is protected from self-eviction within the same call.

Deliberately excluded (per the issue, not re-filed): `PtyManager.pendingResizes` (intentional deferred-delete pattern, trivial bytes), `NewWorktreeDialog.branchListCache` (the real problem is staleness after `git fetch`, not memory), `issueExtractor.issueCache` (negligible and the cached regex is cheap).

## Testing

Renderer: 271 targeted tests pass. Electron: 140 targeted tests pass. Own-file prettier and eslint clean.