### PR TITLE
perf(terminal): lazy-load xterm ImageAddon and Unicode11Addon

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -497,7 +497,9 @@ export function XtermAdapter({
       }
 
       onReadyRef.current?.();
-    })();
+    })().catch((err) => {
+      if (!disposed) logError("[XtermAdapter] Terminal attach failed", err);
+    });
 
     return () => {
       disposed = true;

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -249,244 +249,255 @@ export function XtermAdapter({
     if (!container) return;
 
     let disposed = false;
+    // Captured inside the async setup below and read by the synchronous cleanup
+    // closure. Stays undefined if the component unmounts before attach runs —
+    // detach()/setVisible() both tolerate the never-attached state.
+    let attachGen: number | undefined;
 
-    const managed = terminalInstanceService.getOrCreate(
-      terminalId,
-      launchAgentId,
-      terminalOptionsRef.current,
-      stableRefreshTierProvider,
-      stableOnInput,
-      stableCwdProvider
-    );
-    // getOrCreate applies the current options itself (creation or its internal
-    // updateOptions call for existing instances) — record them so the options
-    // effect doesn't re-apply the same values on this commit.
-    appliedOptionsRef.current = terminalOptionsRef.current;
+    // getOrCreate is async because the lazy Unicode11 addon (#10840) is awaited
+    // during terminal construction. Run the attach sequence in an IIFE and guard
+    // every post-await step with `disposed` so a fast unmount during the addon
+    // load can't attach a terminal whose cleanup has already run.
+    void (async () => {
+      const managed = await terminalInstanceService.getOrCreate(
+        terminalId,
+        launchAgentId,
+        terminalOptionsRef.current,
+        stableRefreshTierProvider,
+        stableOnInput,
+        stableCwdProvider
+      );
+      if (disposed) return;
+      // getOrCreate applies the current options itself (creation or its internal
+      // updateOptions call for existing instances) — record them so the options
+      // effect doesn't re-apply the same values on this commit.
+      appliedOptionsRef.current = terminalOptionsRef.current;
 
-    const wasDetachedForSwitch = managed.isDetached === true;
-    const hasSavedTargetDims = !!(managed.targetCols && managed.targetRows);
-    managed.isAttaching = true;
+      const wasDetachedForSwitch = managed.isDetached === true;
+      const hasSavedTargetDims = !!(managed.targetCols && managed.targetRows);
+      managed.isAttaching = true;
 
-    terminalInstanceService.attach(terminalId, container);
-    const attachGen = terminalInstanceService.getAttachGeneration(terminalId);
-    // Force visibility immediately on mount - don't wait for IntersectionObserver.
-    // This prevents data from being dropped during the brief window before the observer fires.
-    terminalInstanceService.setVisible(terminalId, true);
+      terminalInstanceService.attach(terminalId, container);
+      attachGen = terminalInstanceService.getAttachGeneration(terminalId);
+      // Force visibility immediately on mount - don't wait for IntersectionObserver.
+      // This prevents data from being dropped during the brief window before the observer fires.
+      terminalInstanceService.setVisible(terminalId, true);
 
-    if (!managed.keyHandlerInstalled) {
-      managed.terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
-        // Only process keydown events to avoid double-firing
-        if (event.type !== "keydown") {
-          return true;
-        }
+      if (!managed.keyHandlerInstalled) {
+        managed.terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+          // Only process keydown events to avoid double-firing
+          if (event.type !== "keydown") {
+            return true;
+          }
 
-        // Get normalized key for modifier-only detection
-        const normalizedKey = keybindingService.normalizeKeyForBinding(event);
-        const isModifierOnly = MODIFIER_KEYS.has(normalizedKey);
+          // Get normalized key for modifier-only detection
+          const normalizedKey = keybindingService.normalizeKeyForBinding(event);
+          const isModifierOnly = MODIFIER_KEYS.has(normalizedKey);
 
-        // Don't process modifier-only keypresses
-        if (isModifierOnly) {
-          return true;
-        }
+          // Don't process modifier-only keypresses
+          if (isModifierOnly) {
+            return true;
+          }
 
-        // During IME/voice composition, let xterm's CompositionHelper handle the
-        // full lifecycle (composed text + \r). keyCode 229 is Chromium's "Process"
-        // key signal during active composition where isComposing may not yet be set.
-        if (event.isComposing || event.keyCode === 229) {
-          return true;
-        }
+          // During IME/voice composition, let xterm's CompositionHelper handle the
+          // full lifecycle (composed text + \r). keyCode 229 is Chromium's "Process"
+          // key signal during active composition where isComposing may not yet be set.
+          if (event.isComposing || event.keyCode === 229) {
+            return true;
+          }
 
-        // Plain Tab and Shift+Tab are terminal input. xterm v6 intentionally
-        // leaves key events uncanceled in screen-reader mode, which lets
-        // Chromium's native focus traversal run after xterm accepts Tab.
-        // Cancel only the DOM/default path; return true so xterm still emits
-        // HT for Tab and CSI Z for Shift+Tab.
-        if (
-          (event.key === "Tab" || event.code === "Tab" || event.keyCode === 9) &&
-          !event.ctrlKey &&
-          !event.altKey &&
-          !event.metaKey
-        ) {
-          event.preventDefault();
-          event.stopPropagation();
-          return true;
-        }
-
-        // Bare F11 is Electron's fullscreen accelerator on Linux/Windows. xterm
-        // v6 leaves handled keys uncanceled in screen-reader mode, so the event
-        // bubbles to the menu accelerator. Cancel the DOM/default path; return
-        // true so xterm still emits the F11 sequence to the PTY.
-        if (
-          (event.key === "F11" || event.code === "F11" || event.keyCode === 122) &&
-          !event.ctrlKey &&
-          !event.altKey &&
-          !event.metaKey &&
-          !event.shiftKey
-        ) {
-          event.preventDefault();
-          event.stopPropagation();
-          return true;
-        }
-
-        // Skip repeat events
-        if (event.repeat) {
-          return true;
-        }
-
-        // Let Shift+F10 and ContextMenu key bubble to DOM for panel context menu
-        if (
-          event.key === "ContextMenu" ||
-          (event.key === "F10" &&
-            event.shiftKey &&
+          // Plain Tab and Shift+Tab are terminal input. xterm v6 intentionally
+          // leaves key events uncanceled in screen-reader mode, which lets
+          // Chromium's native focus traversal run after xterm accepts Tab.
+          // Cancel only the DOM/default path; return true so xterm still emits
+          // HT for Tab and CSI Z for Shift+Tab.
+          if (
+            (event.key === "Tab" || event.code === "Tab" || event.keyCode === 9) &&
             !event.ctrlKey &&
-            !event.metaKey &&
-            !event.altKey)
-        ) {
-          return false;
-        }
-
-        // Intercept F6 for macro-region focus cycling before terminal processing
-        if (event.key === "F6") {
-          return false;
-        }
-
-        // Allow critical Ctrl+<key> bindings to reach the TUI before checking global shortcuts
-        if (event.ctrlKey && !event.shiftKey && TUI_KEYBINDS.has(event.key)) {
-          return true;
-        }
-
-        // Intercept global keybindings before terminal processing
-        // Check when: (1) modifier is pressed, OR (2) chord is pending
-        const hasModifier = event.metaKey || event.ctrlKey;
-        const pendingChord = keybindingService.getPendingChord();
-        if (hasModifier || pendingChord) {
-          const result = keybindingService.resolveKeybinding(event);
-          if (result.shouldConsume) {
+            !event.altKey &&
+            !event.metaKey
+          ) {
             event.preventDefault();
             event.stopPropagation();
+            return true;
+          }
 
-            if (result.match) {
-              // Dispatch the matched action
-              void actionService
-                .dispatch(
-                  result.match.actionId as Parameters<typeof actionService.dispatch>[0],
-                  undefined,
-                  {
-                    source: "keybinding",
-                  }
-                )
-                .then((dispatchResult) => {
-                  if (!dispatchResult.ok) {
-                    logError(
-                      `[XtermKeybinding] Action "${result.match!.actionId}" failed`,
-                      undefined,
-                      { error: dispatchResult.error }
-                    );
-                  }
-                })
-                .catch((error) => {
-                  logError("[XtermKeybinding] Unexpected error", error);
-                });
-            }
-            // Chord prefix consumed to prevent terminal leakage
+          // Bare F11 is Electron's fullscreen accelerator on Linux/Windows. xterm
+          // v6 leaves handled keys uncanceled in screen-reader mode, so the event
+          // bubbles to the menu accelerator. Cancel the DOM/default path; return
+          // true so xterm still emits the F11 sequence to the PTY.
+          if (
+            (event.key === "F11" || event.code === "F11" || event.keyCode === 122) &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey &&
+            !event.shiftKey
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+            return true;
+          }
+
+          // Skip repeat events
+          if (event.repeat) {
+            return true;
+          }
+
+          // Let Shift+F10 and ContextMenu key bubble to DOM for panel context menu
+          if (
+            event.key === "ContextMenu" ||
+            (event.key === "F10" &&
+              event.shiftKey &&
+              !event.ctrlKey &&
+              !event.metaKey &&
+              !event.altKey)
+          ) {
             return false;
           }
-        }
 
-        // Let the OS handle meta combinations (e.g., Cmd+C/V).
-        // Paste (Cmd+V) is handled by Electron's native Edit > Paste menu role,
-        // which dispatches a paste event that xterm.js processes natively
-        // (including bracketed paste mode wrapping).
-        // Keep Alt/Option available for word navigation/editing inside the TUI.
-        if (event.metaKey) {
-          return false;
-        }
+          // Intercept F6 for macro-region focus cycling before terminal processing
+          if (event.key === "F6") {
+            return false;
+          }
 
-        // Allow critical Ctrl+<key> bindings to reach the TUI
-        if (event.ctrlKey && !event.shiftKey && TUI_KEYBINDS.has(event.key)) {
+          // Allow critical Ctrl+<key> bindings to reach the TUI before checking global shortcuts
+          if (event.ctrlKey && !event.shiftKey && TUI_KEYBINDS.has(event.key)) {
+            return true;
+          }
+
+          // Intercept global keybindings before terminal processing
+          // Check when: (1) modifier is pressed, OR (2) chord is pending
+          const hasModifier = event.metaKey || event.ctrlKey;
+          const pendingChord = keybindingService.getPendingChord();
+          if (hasModifier || pendingChord) {
+            const result = keybindingService.resolveKeybinding(event);
+            if (result.shouldConsume) {
+              event.preventDefault();
+              event.stopPropagation();
+
+              if (result.match) {
+                // Dispatch the matched action
+                void actionService
+                  .dispatch(
+                    result.match.actionId as Parameters<typeof actionService.dispatch>[0],
+                    undefined,
+                    {
+                      source: "keybinding",
+                    }
+                  )
+                  .then((dispatchResult) => {
+                    if (!dispatchResult.ok) {
+                      logError(
+                        `[XtermKeybinding] Action "${result.match!.actionId}" failed`,
+                        undefined,
+                        { error: dispatchResult.error }
+                      );
+                    }
+                  })
+                  .catch((error) => {
+                    logError("[XtermKeybinding] Unexpected error", error);
+                  });
+              }
+              // Chord prefix consumed to prevent terminal leakage
+              return false;
+            }
+          }
+
+          // Let the OS handle meta combinations (e.g., Cmd+C/V).
+          // Paste (Cmd+V) is handled by Electron's native Edit > Paste menu role,
+          // which dispatches a paste event that xterm.js processes natively
+          // (including bracketed paste mode wrapping).
+          // Keep Alt/Option available for word navigation/editing inside the TUI.
+          if (event.metaKey) {
+            return false;
+          }
+
+          // Allow critical Ctrl+<key> bindings to reach the TUI
+          if (event.ctrlKey && !event.shiftKey && TUI_KEYBINDS.has(event.key)) {
+            return true;
+          }
+
+          if (
+            event.key === "Enter" &&
+            event.shiftKey &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+            if (event.type === "keydown" && !managed.isInputLocked) {
+              // "Soft" newline for agent CLIs.
+              // Codex CLI commonly expects LF (\n / Ctrl+J) for a newline without submit.
+              // Other agent CLIs use the legacy ESC+CR sequence.
+              // Soft-newline sequence follows the live process. If a Codex
+              // session is currently running, use its sequence even if this
+              // terminal was launched as Claude or as a plain shell.
+              const softNewline = getSoftNewlineSequence(
+                detectedAgentIdRef.current ?? launchAgentIdRef.current
+              );
+              writeTerminalInputOrFleet(terminalId, softNewline);
+              terminalInstanceService.notifyUserInput(terminalId);
+              stableOnInput(softNewline);
+            }
+            return false;
+          }
+
+          if (
+            (event.key === "Enter" || event.key === "Return" || event.code === "NumpadEnter") &&
+            !event.shiftKey &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey
+          ) {
+            event.preventDefault();
+            event.stopPropagation();
+            if (event.type === "keydown" && !managed.isInputLocked) {
+              const submit = "\r";
+              writeTerminalInputOrFleet(terminalId, submit);
+              terminalInstanceService.notifyUserInput(terminalId);
+              stableOnInput(submit);
+              // Plain Enter is a submit. The custom key handler returns `false`
+              // before xterm's onKey/onData fire, so the listener-installed
+              // onEnterPressed path is bypassed — call it explicitly to close
+              // the `directing` synthetic state. No-op when not in directing.
+              terminalInstanceService.notifyEnterPressed(terminalId);
+            }
+            return false;
+          }
           return true;
-        }
-
-        if (
-          event.key === "Enter" &&
-          event.shiftKey &&
-          !event.ctrlKey &&
-          !event.altKey &&
-          !event.metaKey
-        ) {
-          event.preventDefault();
-          event.stopPropagation();
-          if (event.type === "keydown" && !managed.isInputLocked) {
-            // "Soft" newline for agent CLIs.
-            // Codex CLI commonly expects LF (\n / Ctrl+J) for a newline without submit.
-            // Other agent CLIs use the legacy ESC+CR sequence.
-            // Soft-newline sequence follows the live process. If a Codex
-            // session is currently running, use its sequence even if this
-            // terminal was launched as Claude or as a plain shell.
-            const softNewline = getSoftNewlineSequence(
-              detectedAgentIdRef.current ?? launchAgentIdRef.current
-            );
-            writeTerminalInputOrFleet(terminalId, softNewline);
-            terminalInstanceService.notifyUserInput(terminalId);
-            stableOnInput(softNewline);
-          }
-          return false;
-        }
-
-        if (
-          (event.key === "Enter" || event.key === "Return" || event.code === "NumpadEnter") &&
-          !event.shiftKey &&
-          !event.ctrlKey &&
-          !event.altKey &&
-          !event.metaKey
-        ) {
-          event.preventDefault();
-          event.stopPropagation();
-          if (event.type === "keydown" && !managed.isInputLocked) {
-            const submit = "\r";
-            writeTerminalInputOrFleet(terminalId, submit);
-            terminalInstanceService.notifyUserInput(terminalId);
-            stableOnInput(submit);
-            // Plain Enter is a submit. The custom key handler returns `false`
-            // before xterm's onKey/onData fire, so the listener-installed
-            // onEnterPressed path is bypassed — call it explicitly to close
-            // the `directing` synthetic state. No-op when not in directing.
-            terminalInstanceService.notifyEnterPressed(terminalId);
-          }
-          return false;
-        }
-        return true;
-      });
-      managed.keyHandlerInstalled = true;
-    }
-
-    exitUnsubRef.current = terminalInstanceService.addExitListener(terminalId, (code) => {
-      onExitRef.current?.(code);
-    });
-
-    if (!wasDetachedForSwitch || !hasSavedTargetDims) {
-      performFit();
-    }
-
-    if (
-      restoreOnAttach &&
-      !(wasDetachedForSwitch && hasSavedTargetDims) &&
-      !hasVisibleBufferContent()
-    ) {
-      void terminalInstanceService
-        .fetchAndRestore(terminalId)
-        .then((restored) => {
-          if (disposed) return;
-          if (restored) {
-            requestAnimationFrame(() => performFit());
-          }
-        })
-        .catch((err) => {
-          if (!disposed) logError("Failed to restore terminal buffer", err);
         });
-    }
+        managed.keyHandlerInstalled = true;
+      }
 
-    onReadyRef.current?.();
+      exitUnsubRef.current = terminalInstanceService.addExitListener(terminalId, (code) => {
+        onExitRef.current?.(code);
+      });
+
+      if (!wasDetachedForSwitch || !hasSavedTargetDims) {
+        performFit();
+      }
+
+      if (
+        restoreOnAttach &&
+        !(wasDetachedForSwitch && hasSavedTargetDims) &&
+        !hasVisibleBufferContent()
+      ) {
+        void terminalInstanceService
+          .fetchAndRestore(terminalId)
+          .then((restored) => {
+            if (disposed) return;
+            if (restored) {
+              requestAnimationFrame(() => performFit());
+            }
+          })
+          .catch((err) => {
+            if (!disposed) logError("Failed to restore terminal buffer", err);
+          });
+      }
+
+      onReadyRef.current?.();
+    })();
 
     return () => {
       disposed = true;

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -123,7 +123,7 @@ class TerminalRegistryController {
    * Prewarm a terminal's renderer-side xterm instance.
    * Call this after spawning to ensure no output is lost.
    */
-  prewarm(id: string, location: PanelLocation, launchAgentId?: string): void {
+  async prewarm(id: string, location: PanelLocation, launchAgentId?: string): Promise<void> {
     const isAgent = Boolean(launchAgentId);
     try {
       const appearance = getTerminalAppearanceSnapshot();
@@ -148,7 +148,10 @@ class TerminalRegistryController {
       const widthPx = location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH;
       const heightPx = location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT;
 
-      terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
+      // Awaited so the instance exists before any sendPtyResize below targets
+      // it — prewarmTerminal is async now that the lazy Unicode11 addon is
+      // loaded during terminal construction (#10840).
+      await terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
         offscreen,
         widthPx,
         heightPx,

--- a/src/services/terminal/TerminalAddonManager.ts
+++ b/src/services/terminal/TerminalAddonManager.ts
@@ -3,7 +3,6 @@ import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import type { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
-import type { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { FileLinksAddon, HoverCallback } from "./FileLinksAddon";
 import { ImageLinksAddon, OnActivateFigure } from "./ImageLinksAddon";
@@ -17,8 +16,11 @@ const IMAGE_ADDON_OPTIONS = { pixelLimit: 2_000_000, storageLimit: 8 };
 // TerminalWebGLManager.ts: a module-level class cache plus a single in-flight
 // promise guard so concurrent callers share one import, and the promise is nulled
 // on failure so a later call can retry.
-type ImageAddonConstructor = new (options?: typeof IMAGE_ADDON_OPTIONS) => ImageAddon;
-type Unicode11AddonConstructor = new () => Unicode11Addon;
+// Constructor types are derived from the modules themselves (`typeof import(...)`
+// is a type-only construct — erased at compile time, no eager runtime import), so
+// the resolved class assigns to the cache without a type assertion.
+type ImageAddonConstructor = (typeof import("@xterm/addon-image"))["ImageAddon"];
+type Unicode11AddonConstructor = (typeof import("@xterm/addon-unicode11"))["Unicode11Addon"];
 
 let ImageAddonClass: ImageAddonConstructor | null = null;
 let imageAddonLoadPromise: Promise<ImageAddonConstructor> | null = null;
@@ -28,7 +30,7 @@ function loadImageAddon(): Promise<ImageAddonConstructor> {
   if (imageAddonLoadPromise) return imageAddonLoadPromise;
   imageAddonLoadPromise = import("@xterm/addon-image").then(
     (mod) => {
-      ImageAddonClass = mod.ImageAddon as unknown as ImageAddonConstructor;
+      ImageAddonClass = mod.ImageAddon;
       return ImageAddonClass;
     },
     (err) => {
@@ -47,7 +49,7 @@ function loadUnicode11Addon(): Promise<Unicode11AddonConstructor> {
   if (unicode11AddonLoadPromise) return unicode11AddonLoadPromise;
   unicode11AddonLoadPromise = import("@xterm/addon-unicode11").then(
     (mod) => {
-      Unicode11AddonClass = mod.Unicode11Addon as unknown as Unicode11AddonConstructor;
+      Unicode11AddonClass = mod.Unicode11Addon;
       return Unicode11AddonClass;
     },
     (err) => {

--- a/src/services/terminal/TerminalAddonManager.ts
+++ b/src/services/terminal/TerminalAddonManager.ts
@@ -1,14 +1,62 @@
 import { Terminal, IDisposable } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
-import { ImageAddon } from "@xterm/addon-image";
+import type { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
-import { Unicode11Addon } from "@xterm/addon-unicode11";
+import type { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { FileLinksAddon, HoverCallback } from "./FileLinksAddon";
 import { ImageLinksAddon, OnActivateFigure } from "./ImageLinksAddon";
 
 const IMAGE_ADDON_OPTIONS = { pixelLimit: 2_000_000, storageLimit: 8 };
+
+// @xterm/addon-image (~79KB) and @xterm/addon-unicode11 (~14KB) load via dynamic
+// import so their module code stays out of the renderer's eager critical path —
+// they are parsed/compiled only when a terminal actually needs them, not on every
+// project-view load (#10840). This mirrors the lazy WebGL loader in
+// TerminalWebGLManager.ts: a module-level class cache plus a single in-flight
+// promise guard so concurrent callers share one import, and the promise is nulled
+// on failure so a later call can retry.
+type ImageAddonConstructor = new (options?: typeof IMAGE_ADDON_OPTIONS) => ImageAddon;
+type Unicode11AddonConstructor = new () => Unicode11Addon;
+
+let ImageAddonClass: ImageAddonConstructor | null = null;
+let imageAddonLoadPromise: Promise<ImageAddonConstructor> | null = null;
+
+function loadImageAddon(): Promise<ImageAddonConstructor> {
+  if (ImageAddonClass) return Promise.resolve(ImageAddonClass);
+  if (imageAddonLoadPromise) return imageAddonLoadPromise;
+  imageAddonLoadPromise = import("@xterm/addon-image").then(
+    (mod) => {
+      ImageAddonClass = mod.ImageAddon as unknown as ImageAddonConstructor;
+      return ImageAddonClass;
+    },
+    (err) => {
+      imageAddonLoadPromise = null;
+      throw err;
+    }
+  );
+  return imageAddonLoadPromise;
+}
+
+let Unicode11AddonClass: Unicode11AddonConstructor | null = null;
+let unicode11AddonLoadPromise: Promise<Unicode11AddonConstructor> | null = null;
+
+function loadUnicode11Addon(): Promise<Unicode11AddonConstructor> {
+  if (Unicode11AddonClass) return Promise.resolve(Unicode11AddonClass);
+  if (unicode11AddonLoadPromise) return unicode11AddonLoadPromise;
+  unicode11AddonLoadPromise = import("@xterm/addon-unicode11").then(
+    (mod) => {
+      Unicode11AddonClass = mod.Unicode11Addon as unknown as Unicode11AddonConstructor;
+      return Unicode11AddonClass;
+    },
+    (err) => {
+      unicode11AddonLoadPromise = null;
+      throw err;
+    }
+  );
+  return unicode11AddonLoadPromise;
+}
 
 export const SEARCH_HIGHLIGHT_LIMIT = 1000;
 
@@ -27,7 +75,7 @@ export interface WebLinksHoverHandlers {
   leave: () => void;
 }
 
-export function setupTerminalAddons(terminal: Terminal): TerminalAddons {
+export async function setupTerminalAddons(terminal: Terminal): Promise<TerminalAddons> {
   // Eager core set — only the addons whose absence would corrupt the very first
   // frame or break restore. FitAddon (sizing) and SerializeAddon (snapshot
   // save/restore) are always needed; Unicode11 must be active before any data
@@ -45,9 +93,22 @@ export function setupTerminalAddons(terminal: Terminal): TerminalAddons {
   // xterm 6.0 ships with Unicode 6 width tables, so modern emoji and many CJK
   // glyphs render at 1 cell instead of 2. Activate Unicode 11 widths before any
   // data is written so the buffer records correct cell widths from the start.
-  const unicode11Addon = new Unicode11Addon();
-  terminal.loadAddon(unicode11Addon);
-  terminal.unicode.activeVersion = "11";
+  // The addon module is lazy-loaded (#10840), so this is awaited here — and the
+  // single caller, getOrCreate(), awaits setupTerminalAddons before wiring the
+  // PTY data listener, keeping the activation strictly before any write. A load
+  // failure degrades gracefully to Unicode 6 widths rather than failing terminal
+  // creation: a terminal with mis-measured emoji is far better than no terminal.
+  try {
+    const Unicode11AddonCtor = await loadUnicode11Addon();
+    const unicode11Addon = new Unicode11AddonCtor();
+    terminal.loadAddon(unicode11Addon);
+    terminal.unicode.activeVersion = "11";
+  } catch (err) {
+    console.warn(
+      "[TerminalAddonManager] Failed to load Unicode11 addon — falling back to Unicode 6 widths",
+      err
+    );
+  }
 
   // SearchAddon registers no parser hooks and does nothing until a search is
   // invoked, so it stays in the eager set — keeping it non-null avoids a
@@ -66,8 +127,9 @@ export function setupTerminalAddons(terminal: Terminal): TerminalAddons {
   };
 }
 
-export function createImageAddon(terminal: Terminal): ImageAddon {
-  const addon = new ImageAddon(IMAGE_ADDON_OPTIONS);
+export async function createImageAddon(terminal: Terminal): Promise<ImageAddon> {
+  const ImageAddonCtor = await loadImageAddon();
+  const addon = new ImageAddonCtor(IMAGE_ADDON_OPTIONS);
   terminal.loadAddon(addon);
   return addon;
 }
@@ -102,3 +164,16 @@ export function createWebLinksAddon(
   terminal.loadAddon(addon);
   return addon;
 }
+
+// Internal hooks — exposed only for tests in this repo. The lazy loaders cache
+// the resolved class at module scope, so a test that exercises a load failure
+// must reset that cache to avoid leaking state into the next test. Mirrors the
+// `__testing` surface on TerminalWebGLManager.
+export const __testing = {
+  resetLoaderState(): void {
+    ImageAddonClass = null;
+    imageAddonLoadPromise = null;
+    Unicode11AddonClass = null;
+    unicode11AddonLoadPromise = null;
+  },
+};

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1945,7 +1945,11 @@ class TerminalInstanceService {
     if (!managed.imageAddon) {
       try {
         const imageAddon = await createImageAddon(managed.terminal);
-        if (managed.imageAddon) {
+        // Dispose the loser rather than leak it if, during the async import, a
+        // concurrent caller already populated the slot OR the terminal was
+        // destroyed/replaced (its instance is no longer the one in the map, so
+        // its own teardown will never dispose this addon).
+        if (managed.imageAddon || this.instances.get(id) !== managed) {
           imageAddon.dispose();
         } else {
           managed.imageAddon = imageAddon;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -188,7 +188,7 @@ class TerminalInstanceService {
           managed.lastScrollbackReduceAt = undefined;
           restoreScrollback(managed);
 
-          this.ensureDeferredAddons(id, managed);
+          void this.ensureDeferredAddons(id, managed);
         }
 
         if (this.wantsWebGLAtTier(managed, tier)) {
@@ -603,13 +603,13 @@ class TerminalInstanceService {
     this.agentStateController.clearDirectingState(id);
   }
 
-  prewarmTerminal(
+  async prewarmTerminal(
     id: string,
     launchAgentId: string | undefined,
     options: ConstructorParameters<typeof Terminal>[0],
     params: { offscreen?: boolean; widthPx?: number; heightPx?: number } = {}
-  ): ManagedTerminal {
-    const managed = this.getOrCreate(
+  ): Promise<ManagedTerminal> {
+    const managed = await this.getOrCreate(
       id,
       launchAgentId,
       options,
@@ -1354,14 +1354,14 @@ class TerminalInstanceService {
     });
   }
 
-  getOrCreate(
+  async getOrCreate(
     id: string,
     launchAgentId: string | undefined,
     options: ConstructorParameters<typeof Terminal>[0],
     getRefreshTier: RefreshTierProvider = () => TerminalRefreshTier.FOCUSED,
     onInput?: (data: string) => void,
     getCwd?: () => string
-  ): ManagedTerminal {
+  ): Promise<ManagedTerminal> {
     const existing = this.instances.get(id);
     if (existing) {
       existing.getRefreshTier = getRefreshTier;
@@ -1410,7 +1410,10 @@ class TerminalInstanceService {
     // Only the eager core addons are built here. Image/file-link/web-link addons
     // are deferred to ensureDeferredAddons(), called once the terminal is opened
     // in attach() — keeping their construction off the bulk-create cold path.
-    const addons = setupTerminalAddons(terminal);
+    // Awaited so Unicode11 (lazy-loaded, #10840) is active before the PTY data
+    // listener is wired below — terminalClient.onData flushes any buffered early
+    // output synchronously on registration, so the activation must land first.
+    const addons = await setupTerminalAddons(terminal);
 
     const hostElement = document.createElement("div");
     hostElement.style.width = "100%";
@@ -1873,14 +1876,10 @@ class TerminalInstanceService {
    * and the BACKGROUND→active tier-upgrade path. Never call it for a BACKGROUND
    * terminal; the tier machinery disposes these addons there on purpose (#9809).
    */
-  private ensureDeferredAddons(id: string, managed: ManagedTerminal): void {
-    if (!managed.imageAddon) {
-      try {
-        managed.imageAddon = createImageAddon(managed.terminal);
-      } catch (err) {
-        logWarn("Failed to create ImageAddon", { id, error: err });
-      }
-    }
+  private async ensureDeferredAddons(id: string, managed: ManagedTerminal): Promise<void> {
+    // The file/image/web link providers are synchronous, so build them first and
+    // unconditionally — the lazy, async ImageAddon load below must not defer them
+    // behind a microtask (they are observable synchronously on tier upgrade).
     if (!managed.fileLinksDisposable) {
       try {
         managed.fileLinksDisposable = createFileLinksAddon(
@@ -1938,6 +1937,23 @@ class TerminalInstanceService {
         logWarn("Failed to create WebLinksAddon", { id, error: err });
       }
     }
+    // ImageAddon is lazy-loaded (#10840), so creation is async and runs last —
+    // after the synchronous link providers above. Two callers can reach this
+    // concurrently (the cold-open path in ensureOpened() and the BACKGROUND→
+    // active tier-upgrade path), so re-check the slot after the await and dispose
+    // the loser to avoid loading two addons onto one terminal.
+    if (!managed.imageAddon) {
+      try {
+        const imageAddon = await createImageAddon(managed.terminal);
+        if (managed.imageAddon) {
+          imageAddon.dispose();
+        } else {
+          managed.imageAddon = imageAddon;
+        }
+      } catch (err) {
+        logWarn("Failed to create ImageAddon", { id, error: err });
+      }
+    }
   }
 
   /**
@@ -1979,7 +1995,7 @@ class TerminalInstanceService {
     // panes stay fully content-live; only the WebGL context differs by
     // visibility (gated separately below). Previously this skipped the addons on
     // background, degrading content for hidden panes.
-    this.ensureDeferredAddons(id, managed);
+    void this.ensureDeferredAddons(id, managed);
     if (this.wantsWebGLAtTier(managed, managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);
     }

--- a/src/services/terminal/__tests__/TerminalAddonManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalAddonManager.test.ts
@@ -22,6 +22,7 @@ import {
   createWebLinksAddon,
   createFileLinksAddon,
   SEARCH_HIGHLIGHT_LIMIT,
+  __testing,
 } from "../TerminalAddonManager";
 import type { Terminal } from "@xterm/xterm";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -38,12 +39,15 @@ function createMockTerminal() {
 describe("TerminalAddonManager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // ImageAddon and Unicode11Addon are lazy-loaded and cached at module scope
+    // (#10840); reset that cache so each test re-imports against a clean mock.
+    __testing.resetLoaderState();
   });
 
   describe("setupTerminalAddons", () => {
-    it("defers ImageAddon off the eager core set (#9809)", () => {
+    it("defers ImageAddon off the eager core set (#9809)", async () => {
       const terminal = createMockTerminal();
-      const addons = setupTerminalAddons(terminal);
+      const addons = await setupTerminalAddons(terminal);
 
       // ImageAddon is built lazily via createImageAddon once a terminal is
       // actually opened, not on the bulk-create cold path.
@@ -51,9 +55,9 @@ describe("TerminalAddonManager", () => {
       expect(addons.imageAddon).toBeNull();
     });
 
-    it("defers file-link and web-link providers off the eager core set (#9809)", () => {
+    it("defers file-link and web-link providers off the eager core set (#9809)", async () => {
       const terminal = createMockTerminal();
-      const addons = setupTerminalAddons(terminal);
+      const addons = await setupTerminalAddons(terminal);
 
       expect(FileLinksAddon).not.toHaveBeenCalled();
       expect(WebLinksAddon).not.toHaveBeenCalled();
@@ -61,29 +65,44 @@ describe("TerminalAddonManager", () => {
       expect(addons.webLinksAddon).toBeNull();
     });
 
-    it("creates SearchAddon eagerly with highlightLimit for bounded match counts", () => {
+    it("creates SearchAddon eagerly with highlightLimit for bounded match counts", async () => {
       const terminal = createMockTerminal();
-      setupTerminalAddons(terminal);
+      await setupTerminalAddons(terminal);
 
       expect(mockSearchAddon).toHaveBeenCalledWith({
         highlightLimit: SEARCH_HIGHLIGHT_LIMIT,
       });
     });
 
-    it("activates Unicode 11 widths so modern emoji and CJK glyphs render at 2 cells (issue #7205)", () => {
+    it("activates Unicode 11 widths so modern emoji and CJK glyphs render at 2 cells (issue #7205)", async () => {
       const terminal = createMockTerminal();
-      setupTerminalAddons(terminal);
+      await setupTerminalAddons(terminal);
 
       expect(mockUnicode11Addon).toHaveBeenCalledTimes(1);
       expect(terminal.loadAddon).toHaveBeenCalledWith(expect.any(mockUnicode11Addon));
       expect(terminal.unicode.activeVersion).toBe("11");
     });
+
+    it("degrades to Unicode 6 widths when the Unicode11 addon fails rather than failing setup", async () => {
+      mockUnicode11Addon.mockImplementationOnce(() => {
+        throw new Error("addon load failed");
+      });
+      const terminal = createMockTerminal();
+
+      // Setup still resolves with the rest of the eager core intact — a terminal
+      // with mis-measured emoji beats no terminal at all.
+      const addons = await setupTerminalAddons(terminal);
+
+      expect(terminal.unicode.activeVersion).toBe("6");
+      expect(mockSearchAddon).toHaveBeenCalledTimes(1);
+      expect(addons.searchAddon).toBeDefined();
+    });
   });
 
   describe("createImageAddon", () => {
-    it("creates ImageAddon with memory-safe options", () => {
+    it("creates ImageAddon with memory-safe options", async () => {
       const terminal = createMockTerminal();
-      createImageAddon(terminal);
+      await createImageAddon(terminal);
 
       expect(mockImageAddon).toHaveBeenCalledWith({
         pixelLimit: 2_000_000,
@@ -91,9 +110,9 @@ describe("TerminalAddonManager", () => {
       });
     });
 
-    it("loads the addon onto the terminal", () => {
+    it("loads the addon onto the terminal", async () => {
       const terminal = createMockTerminal();
-      createImageAddon(terminal);
+      await createImageAddon(terminal);
 
       expect(terminal.loadAddon).toHaveBeenCalledWith(expect.any(mockImageAddon));
     });

--- a/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.captureBufferText.test.ts
@@ -62,8 +62,8 @@ vi.mock("@/store/projectSettingsStore", () => ({
 
 const { terminalInstanceService } = await import("../TerminalInstanceService");
 
-function createManagedTerminal(id: string) {
-  return terminalInstanceService.getOrCreate(id, undefined, {
+async function createManagedTerminal(id: string) {
+  return await terminalInstanceService.getOrCreate(id, undefined, {
     rows: 24,
     cols: 80,
     allowProposedApi: true,
@@ -80,16 +80,16 @@ describe("captureBufferText", () => {
     expect(terminalInstanceService.captureBufferText("nonexistent")).toBe("");
   });
 
-  it("returns empty string for empty buffer", () => {
-    createManagedTerminal("test-1");
+  it("returns empty string for empty buffer", async () => {
+    await createManagedTerminal("test-1");
     // Fresh terminal has no content written
     const result = terminalInstanceService.captureBufferText("test-1");
     // Buffer may have empty lines from initialization, but should be blank
     expect(result.trim()).toBe("");
   });
 
-  it("captures written text from the buffer", () => {
-    const managed = createManagedTerminal("test-2");
+  it("captures written text from the buffer", async () => {
+    const managed = await createManagedTerminal("test-2");
     // Write some plain text to the terminal
     managed.terminal.write("Hello World\r\n");
     managed.terminal.write("Second line\r\n");
@@ -105,8 +105,8 @@ describe("captureBufferText", () => {
     });
   });
 
-  it("strips ANSI escape codes from captured text", () => {
-    const managed = createManagedTerminal("test-3");
+  it("strips ANSI escape codes from captured text", async () => {
+    const managed = await createManagedTerminal("test-3");
     // Write text with ANSI color codes
     managed.terminal.write("\x1b[31mRed text\x1b[0m\r\n");
     managed.terminal.write("\x1b[1;32mBold green\x1b[0m\r\n");
@@ -124,8 +124,8 @@ describe("captureBufferText", () => {
     });
   });
 
-  it("truncates to maxChars keeping the tail", () => {
-    const managed = createManagedTerminal("test-4");
+  it("truncates to maxChars keeping the tail", async () => {
+    const managed = await createManagedTerminal("test-4");
     // Write enough text to exceed a small maxChars limit
     for (let i = 0; i < 20; i++) {
       managed.terminal.write(`Line number ${i.toString().padStart(3, "0")}\r\n`);
@@ -142,8 +142,8 @@ describe("captureBufferText", () => {
     });
   });
 
-  it("preserves head lines when the whole buffer fits within maxChars", () => {
-    const managed = createManagedTerminal("test-head");
+  it("preserves head lines when the whole buffer fits within maxChars", async () => {
+    const managed = await createManagedTerminal("test-head");
     managed.terminal.write("FIRST line marker\r\n");
     managed.terminal.write("middle line\r\n");
     managed.terminal.write("LAST line marker\r\n");
@@ -163,8 +163,8 @@ describe("captureBufferText", () => {
     });
   });
 
-  it("fills maxChars from the tail when visible content exceeds it", () => {
-    const managed = createManagedTerminal("test-fill");
+  it("fills maxChars from the tail when visible content exceeds it", async () => {
+    const managed = await createManagedTerminal("test-fill");
     // ~50 lines of plain text — well over a small maxChars budget.
     for (let i = 0; i < 50; i++) {
       managed.terminal.write(`row ${i.toString().padStart(3, "0")} payload\r\n`);

--- a/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.dataLoss.test.ts
@@ -62,8 +62,8 @@ vi.mock("@/store/projectSettingsStore", () => ({
 
 const { terminalInstanceService } = await import("../TerminalInstanceService");
 
-function createManagedTerminal(id: string) {
-  return terminalInstanceService.getOrCreate(id, undefined, {
+async function createManagedTerminal(id: string) {
+  return await terminalInstanceService.getOrCreate(id, undefined, {
     rows: 24,
     cols: 80,
     allowProposedApi: true,
@@ -75,8 +75,8 @@ describe("injectDataLossMarker", () => {
     terminalInstanceService.dispose();
   });
 
-  it("writes a structured OSC 57301 sequence, not a raw ANSI line", () => {
-    const managed = createManagedTerminal("dl-1");
+  it("writes a structured OSC 57301 sequence, not a raw ANSI line", async () => {
+    const managed = await createManagedTerminal("dl-1");
     const writeSpy = vi.spyOn(managed.terminal, "write");
 
     terminalInstanceService.injectDataLossMarker("dl-1", 1234);
@@ -101,7 +101,7 @@ describe("injectDataLossMarker", () => {
   });
 
   it("renders the yellow marker via the OSC handler round-trip", async () => {
-    createManagedTerminal("dl-3");
+    await createManagedTerminal("dl-3");
     terminalInstanceService.injectDataLossMarker("dl-3", 2048);
 
     await new Promise<void>((resolve) => setTimeout(resolve, 50));
@@ -114,7 +114,7 @@ describe("injectDataLossMarker", () => {
   });
 
   it("uses a generic label when the dropped byte count is zero", async () => {
-    createManagedTerminal("dl-4");
+    await createManagedTerminal("dl-4");
     terminalInstanceService.injectDataLossMarker("dl-4", 0);
 
     await new Promise<void>((resolve) => setTimeout(resolve, 50));

--- a/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.fontGrid.test.ts
@@ -105,14 +105,14 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();
 
-    const m1 = terminalInstanceService.getOrCreate(
+    const m1 = await terminalInstanceService.getOrCreate(
       "repair-fit-1",
       undefined,
       {},
       () => TerminalRefreshTier.FOCUSED,
       undefined
     );
-    const m2 = terminalInstanceService.getOrCreate(
+    const m2 = await terminalInstanceService.getOrCreate(
       "repair-fit-2",
       undefined,
       {},
@@ -136,14 +136,14 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();
 
-    const active = terminalInstanceService.getOrCreate(
+    const active = await terminalInstanceService.getOrCreate(
       "repair-active",
       undefined,
       {},
       () => TerminalRefreshTier.FOCUSED,
       undefined
     );
-    const hibernated = terminalInstanceService.getOrCreate(
+    const hibernated = await terminalInstanceService.getOrCreate(
       "repair-hibernated",
       undefined,
       {},
@@ -168,7 +168,7 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "repair-poke",
       undefined,
       {},
@@ -206,7 +206,7 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "repair-default",
       undefined,
       {},
@@ -237,7 +237,7 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
     const { terminalInstanceService } = await import("../TerminalInstanceService");
     stubMatchMedia();
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "repair-dims",
       undefined,
       {},
@@ -261,7 +261,7 @@ describe("TerminalInstanceService - repairFontGrid (#9776)", () => {
 
     expect(registeredLateArrivalCallback).toBeTypeOf("function");
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "repair-callback",
       undefined,
       {},

--- a/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
@@ -194,8 +194,8 @@ describe("TerminalInstanceService — installTerminalBoundListeners call-site pa
     vi.useRealTimers();
   });
 
-  it("create path: getOrCreate installs terminal-bound listeners exactly once", () => {
-    service.getOrCreate("t1", undefined, {});
+  it("create path: getOrCreate installs terminal-bound listeners exactly once", async () => {
+    await service.getOrCreate("t1", undefined, {});
 
     expect(installMock).toHaveBeenCalledTimes(1);
     expect(installMock).toHaveBeenCalledWith(

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -80,7 +80,7 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options",
       undefined,
       {},
@@ -109,7 +109,7 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options",
       "claude",
       {},
@@ -139,7 +139,7 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options",
       "claude",
       {},
@@ -168,7 +168,7 @@ describe("TerminalInstanceService - options", () => {
     });
 
     // First creation — agent terminal
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options",
       "claude",
       {},
@@ -180,7 +180,7 @@ describe("TerminalInstanceService - options", () => {
 
     // Simulate XtermAdapter re-rendering with fresh options from getXtermOptions()
     // which includes cursorBlink: true from BASE_TERMINAL_OPTIONS
-    terminalInstanceService.getOrCreate(
+    await terminalInstanceService.getOrCreate(
       "test-options",
       "claude",
       { cursorBlink: true, fontSize: 14 },
@@ -207,7 +207,7 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options-theme",
       undefined,
       {},
@@ -239,7 +239,7 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options-font",
       undefined,
       {},
@@ -269,7 +269,7 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options-both",
       undefined,
       {},
@@ -302,7 +302,7 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const managed = terminalInstanceService.getOrCreate(
+    const managed = await terminalInstanceService.getOrCreate(
       "test-options-hibernated",
       undefined,
       {},
@@ -338,14 +338,14 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const m1 = terminalInstanceService.getOrCreate(
+    const m1 = await terminalInstanceService.getOrCreate(
       "test-global-1",
       undefined,
       {},
       () => TerminalRefreshTier.FOCUSED,
       undefined
     );
-    const m2 = terminalInstanceService.getOrCreate(
+    const m2 = await terminalInstanceService.getOrCreate(
       "test-global-2",
       undefined,
       {},
@@ -378,14 +378,14 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const m1 = terminalInstanceService.getOrCreate(
+    const m1 = await terminalInstanceService.getOrCreate(
       "test-global-font-1",
       undefined,
       {},
       () => TerminalRefreshTier.FOCUSED,
       undefined
     );
-    const m2 = terminalInstanceService.getOrCreate(
+    const m2 = await terminalInstanceService.getOrCreate(
       "test-global-font-2",
       undefined,
       {},
@@ -416,14 +416,14 @@ describe("TerminalInstanceService - options", () => {
       removeListener: vi.fn(),
     });
 
-    const active = terminalInstanceService.getOrCreate(
+    const active = await terminalInstanceService.getOrCreate(
       "test-global-active",
       undefined,
       {},
       () => TerminalRefreshTier.FOCUSED,
       undefined
     );
-    const hibernated = terminalInstanceService.getOrCreate(
+    const hibernated = await terminalInstanceService.getOrCreate(
       "test-global-hibernated",
       undefined,
       {},

--- a/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.restore.test.ts
@@ -161,7 +161,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-1";
     const smallState = "x".repeat(1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -185,7 +185,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-2";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes + 1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -226,7 +226,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-3";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 3);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -257,7 +257,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-4";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 5);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -291,7 +291,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const state1 = "a".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 2);
     const state2 = "b".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 2);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -322,7 +322,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-6";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 2);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -361,7 +361,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-7";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 2);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -396,7 +396,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-no-scroll-sync";
     const smallState = "x".repeat(1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -420,7 +420,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-terminal-no-scroll-incr";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes + 1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -453,7 +453,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-scroll-sync-preserve";
     const smallState = "x".repeat(1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -496,7 +496,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-scroll-sync-at-bottom";
     const smallState = "x".repeat(1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -521,7 +521,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-scroll-incr-preserve";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes + 1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -574,7 +574,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-scroll-sync-clamp";
     const smallState = "x".repeat(1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -608,7 +608,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
     const id = "test-scroll-incr-clamp";
     const largeState = "x".repeat(INCREMENTAL_RESTORE_CONFIG.indicatorThresholdBytes + 1000);
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},
@@ -655,7 +655,7 @@ describe("TerminalInstanceService - Incremental Restore", () => {
 
     (global as any).scheduler = undefined;
 
-    const terminal = terminalInstanceService.getOrCreate(
+    const terminal = await terminalInstanceService.getOrCreate(
       id,
       "terminal",
       {},

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -209,6 +209,10 @@ describe("TerminalInstanceService - Activity Tier", () => {
       expect(createImageAddon).toHaveBeenCalled();
       expect(createFileLinksAddon).toHaveBeenCalled();
       expect(createWebLinksAddon).toHaveBeenCalled();
+      // The link providers attach synchronously; the lazy ImageAddon (#10840)
+      // resolves a microtask later, so flush before asserting its slot is set.
+      await Promise.resolve();
+      await Promise.resolve();
       expect(managed.imageAddon).not.toBeNull();
       expect(managed.fileLinksDisposable).not.toBeNull();
       expect(managed.webLinksAddon).not.toBeNull();
@@ -274,8 +278,8 @@ describe("TerminalInstanceService - Activity Tier", () => {
       expect(createWebLinksAddon).not.toHaveBeenCalled();
     });
 
-    it("keeps content addons live and sets lastAppliedTier for terminals created at BACKGROUND tier", () => {
-      const managed = service.prewarmTerminal("t-bg", "terminal", {});
+    it("keeps content addons live and sets lastAppliedTier for terminals created at BACKGROUND tier", async () => {
+      const managed = await service.prewarmTerminal("t-bg", "terminal", {});
       const m = managed as unknown as {
         imageAddon: unknown;
         fileLinksDisposable: unknown;
@@ -314,17 +318,17 @@ describe("TerminalInstanceService - Activity Tier", () => {
   });
 
   describe("host-pushed tier reconciliation (issue #9778)", () => {
-    it("subscribes to terminalClient.onTierChanged on first terminal creation", () => {
+    it("subscribes to terminalClient.onTierChanged on first terminal creation", async () => {
       // The subscription is installed lazily (alongside onData/onExit) so that
       // merely constructing the singleton never reaches into terminalClient —
       // keeping it out of unrelated component tests' import graph.
-      service.prewarmTerminal("warm", "terminal", {});
+      await service.prewarmTerminal("warm", "terminal", {});
       expect(capturedTierChangedCb).toBeTypeOf("function");
     });
 
-    it("re-arms the outbound dedupe baseline when the host pushes a background demotion (#9778)", () => {
+    it("re-arms the outbound dedupe baseline when the host pushes a background demotion (#9778)", async () => {
       // Create a terminal so the lazy onTierChanged subscription is installed.
-      service.prewarmTerminal("warm", "terminal", {});
+      await service.prewarmTerminal("warm", "terminal", {});
 
       const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.VISIBLE });
       service.instances.set("t1", managed as unknown as Record<string, unknown>);
@@ -348,8 +352,8 @@ describe("TerminalInstanceService - Activity Tier", () => {
       expect(mockTerminalClient.setActivityTier).toHaveBeenCalledWith("t1", "active", 50);
     });
 
-    it("does not arm needsWake on a host-pushed tier (the field is permanently false)", () => {
-      service.prewarmTerminal("warm", "terminal", {});
+    it("does not arm needsWake on a host-pushed tier (the field is permanently false)", async () => {
+      await service.prewarmTerminal("warm", "terminal", {});
 
       const managed = makeMockManaged({
         lastAppliedTier: TerminalRefreshTier.FOCUSED,

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -1,7 +1,7 @@
 import { Terminal, IDisposable, IMarker, ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { SerializeAddon } from "@xterm/addon-serialize";
-import { ImageAddon } from "@xterm/addon-image";
+import type { ImageAddon } from "@xterm/addon-image";
 import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -547,7 +547,10 @@ export const createAddPanelActions = (
           (options.worktreeId ?? null) !== (currentActiveWorktreeId ?? null));
 
       if (!isAgent) {
-        terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
+        // Awaited so the managed instance and its PTY data listener exist before
+        // the queued spawn runs — prewarmTerminal is async now that the lazy
+        // Unicode11 addon is loaded during terminal construction (#10840).
+        await terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
           offscreen: false,
           widthPx: location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH,
           heightPx: location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT,
@@ -558,7 +561,10 @@ export const createAddPanelActions = (
         const widthPx = location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH;
         const heightPx = location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT;
 
-        terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
+        // Awaited so the instance exists before the sendPtyResize below targets
+        // it — prewarmTerminal is async now that the lazy Unicode11 addon is
+        // loaded during terminal construction (#10840).
+        await terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
           offscreen: false,
           widthPx,
           heightPx,


### PR DESCRIPTION
## Summary

- Converts static imports of `ImageAddon` (~79KB) and `Unicode11Addon` (~14KB) in `TerminalAddonManager` to lazy dynamic imports, keeping ~93KB of addon parse/compile off the renderer critical path on every project-view load.
- Preserves the #7403 invariant (Unicode11 active before first PTY write) by awaiting the load and activating the addon before `getOrCreate` wires the PTY data listener, with graceful degradation to Unicode 6 widths on failure.
- Adds dispose guards for concurrent-load races; the async cascade flows through `getOrCreate`, `prewarmTerminal`, `addPanel`, `TerminalRegistryController`, and `XtermAdapter`.

Resolves #10840

## Changes

- `TerminalAddonManager`: module-level class caches + single-promise load guards for both addons, mirroring the existing lazy WebGL loader in `TerminalWebGLManager`; `createImageAddon` and `ensureDeferredAddons` become async
- `XtermAdapter`: attach sequence wrapped in a disposed-guarded async IIFE with `attachGen` hoisted into the cleanup closure
- `TerminalInstanceService`, `TerminalRegistryController`, `addPanel`: propagate the async cascade
- `types.ts`: `ImageAddon` import converted to `import type`

## Testing

Typecheck clean on changed files; eslint 0 errors. Full terminal-services and Terminal-component test suites: 1854 passed / 0 failed, including async-cascade await updates, tier BACKGROUND to VISIBLE/FOCUSED transitions, `XtermAdapter` lifecycle, and a new Unicode11-load-failure degrade test. `panelRegistry` tests: 327 passed.