### PR TITLE
Smooth out scrolling in full-screen mouse-reporting TUIs

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -118,6 +118,7 @@ export const CHANNELS = {
   SYSTEM_GET_HARDWARE_INFO: "system:get-hardware-info",
   SYSTEM_GET_RESOURCE_PROFILE: "system:get-resource-profile",
   SYSTEM_GET_RESOURCE_PROFILE_SNAPSHOT: "system:get-resource-profile-snapshot",
+  SYSTEM_REQUEST_INTERACTIVE_OVERRIDE: "system:request-interactive-override",
   DIAGNOSTICS_GET_PROCESS_METRICS: "diagnostics:get-process-metrics",
   DIAGNOSTICS_GET_HEAP_STATS: "diagnostics:get-heap-stats",
   DIAGNOSTICS_GET_INFO: "diagnostics:get-info",

--- a/electron/ipc/handlers/resourceProfile.preload.ts
+++ b/electron/ipc/handlers/resourceProfile.preload.ts
@@ -3,6 +3,7 @@ import type { IpcInvokeMap } from "../../types/index.js";
 export const RESOURCE_PROFILE_METHOD_CHANNELS = {
   getResourceProfile: "system:get-resource-profile",
   getResourceProfileSnapshot: "system:get-resource-profile-snapshot",
+  requestInteractiveOverride: "system:request-interactive-override",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof RESOURCE_PROFILE_METHOD_CHANNELS;

--- a/electron/ipc/handlers/resourceProfile.ts
+++ b/electron/ipc/handlers/resourceProfile.ts
@@ -41,6 +41,15 @@ export function registerResourceProfileHandlers(_deps: HandlerDependencies): () 
           );
         }
       ),
+      // Renderer-driven, fire-and-forget: hold the profile at ≥ balanced for a
+      // short window because the user is actively interacting (scrolling a
+      // full-screen mouse-reporting TUI). No-ops if the service hasn't started.
+      requestInteractiveOverride: op(
+        RESOURCE_PROFILE_METHOD_CHANNELS.requestInteractiveOverride,
+        async (durationMs: number): Promise<void> => {
+          getResourceProfileService()?.requestInteractiveOverride(durationMs);
+        }
+      ),
     },
   });
 

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -79,6 +79,13 @@ const LAG_EXIT_WINDOW_SAMPLES = 9; // 45s sliding window
 const LAG_EXIT_CLEAN_REQUIRED = 7; // 7-of-9 clean tolerates 2 noisy samples
 const LAG_PRESSURE_MAX_MS = 120_000; // 2-minute hard cap on stuck latch
 
+// Upper bound on a SINGLE interactive-override request, so one bad/oversized
+// call can't hold the profile off efficiency for long. The trusted renderer
+// requests ~1.5s windows and re-requests while interaction continues, so a
+// genuine continuous scroll renews the hold — and the hold self-expires within
+// this bound once interaction stops, letting efficiency relief resume.
+const MAX_INTERACTIVE_OVERRIDE_MS = 5_000;
+
 // Memory-pressure thresholds scale with device RAM so machines with very
 // different physical memory behave sensibly. On an 8 GB machine these
 // fractions evaluate to ~1229 MB / ~655 MB, preserving the originally-tuned
@@ -160,6 +167,11 @@ export class ResourceProfileService {
   private lagEnterTicks = 0;
   private lagExitWindow: boolean[] = [];
   private lagPressureStartedAt: number | null = null;
+  // Wall-clock until which an interactive override is in effect. While active,
+  // the profile is clamped to ≥ balanced (efficiency is never entered/held) so
+  // an actively-scrolled full-screen TUI keeps full PTY throughput. Renderer-
+  // driven and time-boxed (see requestInteractiveOverride); 0 = inactive.
+  private interactiveOverrideUntil = 0;
 
   constructor(private deps: ResourceProfileDeps) {
     const totalRamMb = os.totalmem() / 1024 / 1024;
@@ -230,6 +242,39 @@ export class ResourceProfileService {
 
   getProfile(): ResourceProfile {
     return this.currentProfile;
+  }
+
+  private isInteractiveOverrideActive(): boolean {
+    return Date.now() < this.interactiveOverrideUntil;
+  }
+
+  /**
+   * Hold the profile at ≥ balanced for `durationMs` because the user is actively
+   * interacting (e.g. scrolling a full-screen mouse-reporting TUI). Efficiency
+   * stretches the pty-host's port-batch delay 16ms→40ms, which throttles the
+   * returned-redraw stream and makes scroll feel slow ("gets slow and stays
+   * slow"). This is the deliberate, lighter "no efficiency while scrolling" clamp
+   * (NOT a full Performance pin): it (1) lifts out of efficiency immediately if
+   * we're there, releasing the lag latch, and (2) blocks re-entry to efficiency
+   * for the window via the guards in sampleLag/applyProfile. The window is
+   * time-boxed and extended on each call (the renderer throttles calls), so it
+   * self-expires shortly after interaction stops; the next lag/eval sample then
+   * resumes normal scoring with no explicit revert needed.
+   */
+  requestInteractiveOverride(durationMs: number): void {
+    if (this.disposed) return;
+    // Reject non-finite input: a NaN would poison `interactiveOverrideUntil`
+    // (Date.now() < NaN is always false, and Math.max(NaN, x) === NaN), bricking
+    // every future request until restart. Negatives/Infinity are clamped below.
+    if (!Number.isFinite(durationMs)) return;
+    const clamped = Math.max(0, Math.min(durationMs, MAX_INTERACTIVE_OVERRIDE_MS));
+    this.interactiveOverrideUntil = Math.max(this.interactiveOverrideUntil, Date.now() + clamped);
+    // Lift out of efficiency right now if we're sitting in it — releasing the lag
+    // latch so normal scoring (now clamped to ≥ balanced by the guards) governs.
+    if (this.currentProfile === "efficiency") {
+      this.clearLagPressure();
+      this.applyProfile("balanced");
+    }
   }
 
   /**
@@ -485,6 +530,16 @@ export class ResourceProfileService {
       return;
     }
 
+    // While an interactive override holds the floor at ≥ balanced, do not enter
+    // the efficiency latch. applyProfile would redirect efficiency→balanced
+    // anyway, so latching here would only strand a held-but-not-applied latch.
+    // Lag is still sampled (the histogram was reset above), so detection resumes
+    // cleanly the instant the override expires.
+    if (this.isInteractiveOverrideActive()) {
+      this.lagEnterTicks = 0;
+      return;
+    }
+
     // Severe-spike fast path: a single sample above the escalation threshold
     // with sustained high ELU enters the latch immediately, halving the
     // worst-case reaction time for genuine saturation bursts. ELU is still
@@ -637,6 +692,7 @@ export class ResourceProfileService {
     }
     this.lagPreviousElu = null;
     this.clearLagPressure();
+    this.interactiveOverrideUntil = 0;
     this.thermalState = "unknown";
     this.isOnBattery = false;
     this.speedLimit = 100;
@@ -771,7 +827,27 @@ export class ResourceProfileService {
   private applyProfile(profile: ResourceProfile): void {
     if (this.disposed) return;
 
+    // While an interactive override is active, never drop to efficiency — clamp
+    // to balanced. This is the single choke point for ALL transitions, so it
+    // catches both the lag-latch entry (sampleLag) and a memory/fleet-driven
+    // downgrade (computeTargetProfile) without each needing its own guard.
+    if (profile === "efficiency" && this.isInteractiveOverrideActive()) {
+      profile = "balanced";
+    }
+
     const previous = this.currentProfile;
+
+    // No-op transition: skip the fan-out + broadcast. This matters for the
+    // override redirect above — a scoring-driven efficiency target redirected to
+    // balanced while ALREADY balanced would otherwise re-push profile settings
+    // and fire resource:profile-changed, churning renderer WebGL/scrollback work
+    // during the very interaction the override is protecting. Candidate state is
+    // still cleared so the hold machinery doesn't re-fire the same target.
+    if (profile === previous) {
+      this.candidateProfile = null;
+      this.candidateFirstSeenAt = null;
+      return;
+    }
     this.currentProfile = profile;
     this.candidateProfile = null;
     this.candidateFirstSeenAt = null;

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -21,7 +21,9 @@ const appMock = vi.hoisted(() => ({
   exit: vi.fn(),
   // GPU feature status is empty until Chromium classifies the GPU; default to
   // undefined so the startup-status logger is a no-op unless a test opts in.
-  getGPUFeatureStatus: vi.fn(() => undefined),
+  // Annotate the return type so `mockReturnValue({...})` opt-ins type-check —
+  // a bare `() => undefined` pins the mock's return to `undefined`.
+  getGPUFeatureStatus: vi.fn((): Record<string, string> | undefined => undefined),
   getGPUInfo: vi.fn(() => Promise.resolve(null)),
 }));
 

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -1178,6 +1178,139 @@ describe("ResourceProfileService adversarial", () => {
     });
   });
 
+  describe("interactive override (symptom B — keep active TUI scroll off efficiency)", () => {
+    it("lifts lag-driven efficiency back to balanced immediately on request", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85); // sustained event-loop lag
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.requestInteractiveOverride(2_000);
+      // The hold lifts out of efficiency synchronously (the win: restores the
+      // pty-host's 16ms port-batch delay instead of efficiency's 40ms).
+      expect(service.getProfile()).toBe("balanced");
+
+      service.stop();
+    });
+
+    it("blocks lag from (re-)entering efficiency while interaction is ongoing", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85); // sustained lag that would normally latch efficiency in ~10s
+      // Continuous interaction re-requests the override well within its window
+      // (mirrors the renderer's throttled re-requests while scrolling). Drive 20s
+      // of lag — well past the sustained-entry threshold — and assert efficiency
+      // is never entered.
+      for (let elapsed = 0; elapsed < 20_000; elapsed += 1_000) {
+        service.requestInteractiveOverride(2_000);
+        vi.advanceTimersByTime(1_000);
+        expect(service.getProfile()).not.toBe("efficiency");
+      }
+
+      service.stop();
+    });
+
+    it("resumes normal lag-driven efficiency once interaction stops and the hold expires", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.requestInteractiveOverride(2_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      // Interaction stopped — no further re-requests. Sustained lag continues, so
+      // after the hold expires the latch re-engages on the normal cadence.
+      vi.advanceTimersByTime(20_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("caps the hold so a runaway caller can't pin the profile off efficiency", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      // Request an absurdly long hold ONCE; it is clamped, so sustained lag
+      // re-latches efficiency well before the requested duration elapses.
+      service.requestInteractiveOverride(10 * 60_000);
+      expect(service.getProfile()).toBe("balanced");
+      vi.advanceTimersByTime(20_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("ignores a non-finite duration without poisoning later valid requests", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85);
+      vi.advanceTimersByTime(5_000);
+      vi.advanceTimersByTime(5_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      // A malformed call (NaN) must no-op, not brick the deadline — NaN would
+      // make `Date.now() < until` and `Math.max(until, ...)` permanently false.
+      service.requestInteractiveOverride(Number.NaN);
+      expect(service.getProfile()).toBe("efficiency"); // not lifted by garbage
+
+      // A subsequent VALID request still works (the deadline wasn't poisoned).
+      service.requestInteractiveOverride(2_000);
+      expect(service.getProfile()).toBe("balanced");
+
+      service.stop();
+    });
+
+    it("does not strand the lag latch while blocking entry from balanced", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+      mockGetAppMetrics.mockReturnValue([]);
+      mockIsOnBatteryPower.mockReturnValue(false);
+
+      setLag(300, 0.85); // sustained lag throughout
+      for (let elapsed = 0; elapsed < 15_000; elapsed += 1_000) {
+        service.requestInteractiveOverride(2_000);
+        vi.advanceTimersByTime(1_000);
+      }
+      // Entry was blocked, AND the latch flag itself was never set — so when the
+      // override lapses, detection resumes from a clean state rather than a
+      // held-but-not-applied latch.
+      expect(service.getProfile()).not.toBe("efficiency");
+      expect(service.getSnapshot().lagPressureActive).toBe(false);
+
+      service.stop();
+    });
+  });
+
   describe("active-agent count filtering", () => {
     it("counts terminals across all ACTIVE_AGENT_STATES (working, waiting, directing)", async () => {
       const { deps, pty } = createDeps();

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -612,6 +612,9 @@ export interface GeneratedElectronAPI {
     getResourceProfileSnapshot(
       ...args: IpcInvokeMap["system:get-resource-profile-snapshot"]["args"]
     ): Promise<IpcInvokeMap["system:get-resource-profile-snapshot"]["result"]>;
+    requestInteractiveOverride(
+      ...args: IpcInvokeMap["system:request-interactive-override"]["args"]
+    ): Promise<IpcInvokeMap["system:request-interactive-override"]["result"]>;
   };
   systemSleep: {
     getAwakeTime(

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1249,6 +1249,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("../resourceProfile.js").ResourceProfileSnapshot;
   };
+  "system:request-interactive-override": {
+    args: [durationMs: number];
+    result: void;
+  };
   "telemetry:get": {
     args: [];
     result: { enabled: boolean; hasSeenPrompt: boolean };

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -96,6 +96,9 @@ const RESIZE_PASS_CHUNK_SIZE = 1;
 // mid-scroll; both are short so the hold self-expires soon after scrolling stops.
 const INTERACTIVE_OVERRIDE_DURATION_MS = 1500;
 const INTERACTIVE_OVERRIDE_THROTTLE_MS = 500;
+// BURST-tier hold after a wheel scroll before reverting to the computed tier —
+// matches the keystroke input-burst decay so a scroll feels just as responsive.
+const WHEEL_BURST_DECAY_MS = 1000;
 
 interface Waiter {
   resolve: () => void;
@@ -583,7 +586,7 @@ class TerminalInstanceService {
       if (!current) return;
       current.inputBurstTimer = undefined;
       this.rendererPolicy.applyRendererPolicy(id, current.getRefreshTier());
-    }, 1000);
+    }, WHEEL_BURST_DECAY_MS);
 
     this.requestInteractiveProfileOverride();
   }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -47,6 +47,7 @@ import { logDebug, logWarn, logError } from "@/utils/logger";
 import { yieldToScheduler } from "@/lib/schedulerYield";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { stripAnsiAndOscCodes } from "@shared/utils/urlUtils";
 
 export { isNonKeyboardInput } from "./inputUtils";
@@ -89,6 +90,13 @@ const TERMINAL_BATCH_SETTLE_TIMEOUT_MS = 30000;
 // terminals instead of freezing the renderer for the whole batch.
 const RESIZE_PASS_CHUNK_SIZE = 1;
 
+// Interactive resource-profile override (symptom B): while actively scrolling a
+// full-screen TUI, ask the main process to hold the profile off efficiency.
+// DURATION must exceed THROTTLE so re-requests overlap and the hold never lapses
+// mid-scroll; both are short so the hold self-expires soon after scrolling stops.
+const INTERACTIVE_OVERRIDE_DURATION_MS = 1500;
+const INTERACTIVE_OVERRIDE_THROTTLE_MS = 500;
+
 interface Waiter {
   resolve: () => void;
   reject: (error: Error) => void;
@@ -104,6 +112,8 @@ function canAutoInitializeTerminalIngest(): boolean {
 
 class TerminalInstanceService {
   private instances = new Map<string, ManagedTerminal>();
+  // Throttle for the interactive resource-profile override IPC (see onActiveWheel).
+  private lastInteractiveOverrideRequestAt = 0;
   private dataBuffer = new TerminalOutputIngestService((id, data, chunkCount) =>
     this.writeToTerminal(id, data, chunkCount)
   );
@@ -327,6 +337,7 @@ class TerminalInstanceService {
       clearDirectingState: (id, trigger) =>
         this.agentStateController.clearDirectingState(id, trigger),
       onUserInput: (id, data) => this.onUserInput(id, data),
+      onActiveWheel: (id) => this.onActiveWheel(id),
       onEnterPressed: (id) => this.onEnterPressed(id),
       updateLastObservedTitle: (id, title) =>
         usePanelStore.getState().updateLastObservedTitle(id, title),
@@ -546,6 +557,61 @@ class TerminalInstanceService {
     }, 1000);
 
     this.agentStateController.onUserInput(id, data);
+  }
+
+  /**
+   * Active wheel scroll in a focused full-screen mouse-reporting TUI. Scrolling
+   * such a TUI is an app-owned PTY round-trip per line, and a focused-but-idle
+   * pane sits at FOCUSED (10fps): without this the first flick repaints slowly
+   * until the TUI's own redraw output happens to bump the tier. We (1) lift the
+   * renderer to BURST (60fps) for the scroll — reusing the input-burst decay
+   * timer, since a scroll wants the same ~1s revert as a keystroke — and (2) ask
+   * the main process to hold the resource profile at ≥ balanced, so efficiency
+   * mode's stretched port-batch delay (40ms vs 16ms) can't throttle the
+   * returned-redraw stream mid-scroll ("gets slow and stays slow", symptom B).
+   */
+  private onActiveWheel(id: string): void {
+    const managed = this.instances.get(id);
+    if (!managed) return;
+
+    this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
+    if (managed.inputBurstTimer !== undefined) {
+      clearTimeout(managed.inputBurstTimer);
+    }
+    managed.inputBurstTimer = window.setTimeout(() => {
+      const current = this.instances.get(id);
+      if (!current) return;
+      current.inputBurstTimer = undefined;
+      this.rendererPolicy.applyRendererPolicy(id, current.getRefreshTier());
+    }, 1000);
+
+    this.requestInteractiveProfileOverride();
+  }
+
+  /**
+   * Fire-and-forget request that the main process keep the resource profile off
+   * efficiency while the user is actively scrolling. Throttled hard because a
+   * trackpad momentum stream calls this dozens of times/sec; the override window
+   * (INTERACTIVE_OVERRIDE_DURATION_MS) is longer than the throttle so the hold
+   * never lapses between requests, and self-expires shortly after scrolling stops.
+   */
+  private requestInteractiveProfileOverride(): void {
+    const now = Date.now();
+    if (now - this.lastInteractiveOverrideRequestAt < INTERACTIVE_OVERRIDE_THROTTLE_MS) return;
+    this.lastInteractiveOverrideRequestAt = now;
+    try {
+      // safeFireAndForget swallows the ASYNC rejection (channel skew during a
+      // reload, future validation), which a bare synchronous try/catch around a
+      // Promise-returning IPC call would miss; the try/catch still guards a
+      // synchronous throw if `window.electron.system` is absent. Either way the
+      // renderer-side BURST boost above already applied — this is non-critical.
+      safeFireAndForget(
+        window.electron.system.requestInteractiveOverride(INTERACTIVE_OVERRIDE_DURATION_MS),
+        { context: "terminal.requestInteractiveProfileOverride" }
+      );
+    } catch {
+      // window.electron.system unavailable — non-critical.
+    }
   }
 
   /**

--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -256,6 +256,12 @@ export interface TerminalListenerInstallDeps {
   // Input
   clearDirectingState: (id: string, trigger?: string) => void;
   onUserInput: (id: string, data: string) => void;
+  /**
+   * Fired when a wheel scroll is actively forwarded to a mouse-reporting TUI.
+   * Lets the host boost the renderer tier and hold the resource profile off
+   * efficiency so an active scroll stays responsive (symptom B).
+   */
+  onActiveWheel: (id: string) => void;
   onEnterPressed: (id: string) => void;
 
   // Panel store side effects (routed through deps to keep this module
@@ -476,6 +482,10 @@ export function installTerminalBoundListeners(
       resolveWheelPixelsPerLine(terminal)
     );
     if (lines === 0) return;
+
+    // A real scroll is being forwarded to the TUI — keep the pane fast: boost the
+    // renderer tier and hold the resource profile off efficiency for the gesture.
+    deps.onActiveWheel(id);
 
     pendingWheelLines += lines;
     // Clamp the backlog so a long momentum tail can't queue an unbounded coast.

--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -9,6 +9,9 @@ import type { ManagedTerminal } from "./types";
 import { isNonKeyboardInput } from "./inputUtils";
 import { installLinuxPrimarySelectionListeners } from "./primarySelection";
 import { writeTerminalInputOrFleet } from "./fleetInputRouter";
+import { getXtermCellDimensions } from "./TerminalResizeController";
+import { MouseWheelClassifier } from "./mouseWheelClassifier";
+import { getTerminalMetrics } from "@/config/xtermConfig";
 
 // Debounce: coalesce a burst of OSC 0/2 title changes from agent shells
 // (which can emit many per second) into a single panel-store / main-process
@@ -20,45 +23,78 @@ const OBSERVED_TITLE_DEBOUNCE_MS = 150;
 // when an agent briefly idles mid-task.
 const WAITING_TITLE_HYSTERESIS_MS = 250;
 
-// Pixel-mode gesture distance (CSS px) that scrolls one line / emits one wheel
-// report in a mouse-reporting TUI. macOS reports a physical mouse detent as a
-// single ~120px pixel event, so 20px/line makes one detent scroll ~6 lines —
-// the brisk feel we want in dense agent TUIs — while keeping the mapping
-// PROPORTIONAL to distance. Proportionality is the point: the previous bimodal
-// rule (any pixel event >=40px -> a FLAT 6 lines, magnitude ignored) dropped
-// motion in two opposite ways. (1) When Chromium coalesces several physical
-// detents into one large-delta event under render load, the flat rule collapsed
-// them to a single 6-line scroll — genuinely "eaten" scrolling. (2) A trackpad /
-// Magic Mouse momentum stream (many medium continuous deltas, each >=40px) was
-// amplified to 6 lines *per event*, running away into a disconnected overscroll.
-// Dividing by a fixed pixel budget fixes both: coalesced detents scroll
-// proportionally more, momentum scrolls its true distance, and sub-line motion
-// still accumulates via `carry` so slow scrolling never damps to nothing.
-// Line-mode events (Windows / Linux mice) carry the OS step in deltaY and are
-// left untouched.
-const WHEEL_PIXELS_PER_LINE = 20;
+// ─────────────────────────────────────────────────────────────────────────────
+// Wheel forwarding for full-screen mouse-reporting TUIs (grok, lazygit, btop).
+//
+// xterm-audit (beta.288): xterm's own scroll fixes #5391 (partial wheel
+// tracking), #5037 (smooth scroll ≤ once/frame) and #5437 (alt-buffer page-
+// scroll guard) are ALL present. We still override xterm's wheel handling for
+// the alt-screen mouse-reporting case on purpose: `MouseService._consumeWheelEvent`
+// multiplies likely-trackpad deltas by 0.3 then floors, so a small gesture
+// computes `lines === 0` and sends NO report (scrolling feels dead). We
+// intercept the physical wheel, normalize it ourselves (lossless accumulator,
+// below), and re-dispatch synthetic `deltaMode:1` events — deltaMode 1 routes
+// through xterm's encoder with NO 0.3×/partial-scroll math, so each synthetic
+// event maps to exactly one SGR mouse report. `attachCustomWheelEventHandler`
+// (already wired below) is the supported suppression hook. smoothScrollDuration
+// is globally 0 (xtermConfig.ts) and never runs on this synthetic-report path
+// regardless. Do NOT "delete this as redundant with #5391" — the override is
+// deliberate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Fallback CSS px-per-line when the rendered cell height is unavailable (pre
+// first-render). The live basis is the actual rendered cell height
+// (getXtermCellDimensions → getTerminalMetrics(fontSize) → this), matching the
+// quantity xterm itself normalizes against (cell height / dpr). One rendered
+// text-row of pixel travel ⇒ one line report: a ~120px macOS mouse detent ⇒
+// ~6 lines at a 14px font. Pixel-mode only — line/page events carry the OS step.
+const WHEEL_FALLBACK_PIXELS_PER_LINE = 20;
+const DEFAULT_FONT_SIZE_PX = 14;
 
 // Max synthetic line-reports flushed per animation frame for a mouse-reporting
-// TUI. Each report is an independent PTY round-trip — the app redraws its whole
-// scroll region and ships a full frame back through IPC — so dispatching a whole
-// gesture's worth at once (a trackpad/Magic-Mouse momentum flick coalesces into
-// dozens of lines, a page-mode fling into a screenful) floods the pipe with
-// redraws the user never sees: the renderer paints once per frame, so every
-// returned frame but the last is parsed and immediately overwritten. We instead
-// accumulate the gesture and drain it at most this many lines per frame, pacing
-// reports to roughly the rate the TUI can repaint. A single physical notch
-// (~120px → 6 lines) still clears in one frame, so discrete scrolling stays
-// crisp; only floods are spread. Tunable: lower = gentler on the pipe but slower
-// momentum, higher = brisker momentum but larger per-frame bursts.
-const WHEEL_MAX_LINES_PER_FRAME = 8;
+// TUI — the SEND-RATE lever (NOT a render-FPS lever). Each report is an
+// independent PTY round-trip: the app redraws its whole scroll region and ships
+// a full frame back through IPC, so dispatching a whole gesture at once floods
+// the pipe with redraws the user never sees (the renderer paints once per
+// frame). We drain at most this many lines per frame. Split by input device:
+// a physical wheel's discrete detents stay crisp at a higher cap, while a
+// trackpad/Magic-Mouse momentum stream (dozens of events/sec — the actual
+// symptom-A flood) is paced gentler. Keep ≤ ~10: above that the IPC redraw
+// return saturates the renderer, which IS the flood we are avoiding.
+const WHEEL_MAX_LINES_PER_FRAME_WHEEL = 8;
+const WHEEL_MAX_LINES_PER_FRAME_TRACKPAD = 4;
 
 // Ceiling on the un-drained backlog, in screenfuls. The proportional normalizer
 // already bounds pending to the distance physically scrolled, so this only
 // catches a pathological long momentum tail — it caps how far the view can keep
-// coasting after the gesture ends (≈ this many screenfuls ÷ per-frame rate), so
-// pacing never resurrects the disconnected-overscroll feel the proportional
-// rewrite removed.
+// coasting after the gesture ends, so pacing never resurrects the disconnected-
+// overscroll feel the proportional rewrite removed.
 const WHEEL_MAX_PENDING_SCREENFULS = 3;
+
+// A physical-wheel gap longer than this ends the gesture: a paused-then-resumed
+// scroll re-detects the device (classifier reset) and drops any un-drained coast,
+// instead of letting the previous gesture bias the cap or keep scrolling. Trackpad
+// momentum events arrive ~every 8-16ms, so 120ms cannot chop a continuous gesture;
+// it only fires after a real pause. Sub-line carry is preserved across the gap so
+// slow continuous scrolling still accumulates. Don't drop below ~80ms.
+const WHEEL_STALE_GAP_MS = 120;
+
+/**
+ * Resolve the CSS px-per-line basis from the live rendered cell height, falling
+ * back to the font-metric estimate and finally a fixed default. This is the
+ * "intent unit" for a mouse-reporting TUI: the app scrolls its own region, so
+ * px-per-line is one visible text-row of travel ⇒ one report, not a viewport
+ * distance. Cheap (one private-field read); fine to call per gesture.
+ */
+function resolveWheelPixelsPerLine(terminal: Terminal): number {
+  const measured = getXtermCellDimensions(terminal)?.height;
+  if (typeof measured === "number" && measured > 0) return measured;
+  const fontSize =
+    typeof terminal.options.fontSize === "number"
+      ? terminal.options.fontSize
+      : DEFAULT_FONT_SIZE_PX;
+  return getTerminalMetrics(fontSize).cellHeight;
+}
 
 // The synthetic wheel events the normalizer re-dispatches are tracked here so
 // its own capture-phase listener skips them instead of recursing. A WeakSet
@@ -81,11 +117,16 @@ const amplifiedWheelEvents = new WeakSet<WheelEvent>();
  * proportionally more (never collapsed to one notch), and sub-line motion adds
  * up across events instead of being damped to nothing. Line-mode and page-mode
  * events already carry an OS step and pass through unchanged.
+ *
+ * `pixelsPerLine` is the CSS px-per-line basis for pixel-mode events (the live
+ * rendered cell height; see `resolveWheelPixelsPerLine`). Defaults to the fixed
+ * fallback so callers/tests that don't need the live basis stay simple.
  */
 export function wheelEventToLineCount(
   ev: WheelEvent,
   rows: number,
-  carry: { partial: number }
+  carry: { partial: number },
+  pixelsPerLine: number = WHEEL_FALLBACK_PIXELS_PER_LINE
 ): number {
   if (ev.deltaY === 0) return 0;
   const clamp = (n: number): number => Math.max(-rows, Math.min(rows, n));
@@ -98,12 +139,13 @@ export function wheelEventToLineCount(
     return (ev.deltaY > 0 ? 1 : -1) * rows;
   }
   // Pixel mode (macOS mouse + trackpad; also precision touchpads on any OS).
-  // `carry.partial` accumulates raw pixels and we divide ONCE to whole lines, so
-  // the count is proportional to the gesture (coalesced detents and momentum
-  // both scroll their true distance) and sub-line motion is never discarded.
-  // Accumulating pixels rather than pre-divided line fractions keeps exact
-  // multiples exact: ten 2px events sum to 20px = one line, whereas summing
-  // ten `2/20` fractions lands at 0.9999999999999999 and silently drops the line.
+  // `carry.partial` accumulates raw pixels and we divide ONCE by the live
+  // px-per-line basis (rendered cell height), so the count is proportional to
+  // the gesture (coalesced detents and momentum both scroll their true distance)
+  // and sub-line motion is never discarded. Accumulating pixels rather than
+  // pre-divided line fractions keeps exact multiples exact: ten 2px events sum to
+  // 20px = one line at a 20px basis, whereas summing ten `2/20` fractions lands
+  // at 0.9999999999999999 and silently drops the line.
   //
   // Drop a stale opposite-direction remainder so a reversal registers right away
   // instead of first having to cancel unreported forward motion — that would be
@@ -111,9 +153,10 @@ export function wheelEventToLineCount(
   if (carry.partial !== 0 && Math.sign(ev.deltaY) !== Math.sign(carry.partial)) {
     carry.partial = 0;
   }
+  const basis = pixelsPerLine > 0 ? pixelsPerLine : WHEEL_FALLBACK_PIXELS_PER_LINE;
   carry.partial += ev.deltaY;
-  const whole = Math.trunc(carry.partial / WHEEL_PIXELS_PER_LINE);
-  carry.partial -= whole * WHEEL_PIXELS_PER_LINE;
+  const whole = Math.trunc(carry.partial / basis);
+  carry.partial -= whole * basis;
   return clamp(whole);
 }
 
@@ -291,22 +334,24 @@ export function installTerminalBoundListeners(
   });
 
   // Reliable wheel forwarding for TUIs that capture the mouse and draw their own
-  // scroll region (e.g. the grok CLI, lazygit, btop). xterm dampens likely
-  // trackpad deltas (×0.3) before its one-line threshold, so small movements
-  // compute zero lines and send NO mouse-wheel report — whole scroll gestures
-  // get dropped and scrolling feels dead (see MouseService._consumeWheelEvent /
-  // _sendEvent in @xterm/xterm 6.1). We intercept the physical wheel in the
-  // capture phase, suppress xterm's handling, and re-dispatch one synthetic
-  // wheel event per line we computed — reusing xterm's own SGR/x10 encoding — so
-  // a notch scrolls a line or two and fine motion accumulates instead of being
-  // discarded. Gated on the alt buffer + active mouse tracking so plain shells
-  // and the wheel→arrow case above are untouched; modified wheels (ctrl-zoom
-  // etc.) pass through unchanged.
+  // scroll region (e.g. the grok CLI, lazygit, btop). See the wheel-audit block
+  // at the top of this file for why we override xterm here and re-dispatch
+  // synthetic deltaMode:1 events. Gated on the alt buffer + active mouse tracking
+  // so plain shells and the wheel→arrow case above are untouched; modified wheels
+  // (ctrl-zoom etc.) pass through unchanged.
   const wheelCarry = { partial: 0 };
+  // Per-terminal device classifier (trackpad vs physical wheel). Drives only the
+  // per-frame send-rate cap — trackpad momentum is the gesture that floods.
+  const wheelClassifier = new MouseWheelClassifier();
+  // Latest device verdict, updated on each physical event and read by the flush
+  // (which runs a frame later, so it must read the closure, not recompute).
+  let wheelMaxLinesPerFrame = WHEEL_MAX_LINES_PER_FRAME_TRACKPAD;
+  // Wall-clock of the last accepted physical wheel, for the stale-gesture gap.
+  let lastPhysicalWheelAt = 0;
   // Whole-line backlog awaiting dispatch, signed (down positive). Filled
-  // synchronously from each physical wheel event, drained at WHEEL_MAX_LINES_PER_FRAME
-  // per animation frame so a momentum flood paces to the TUI's redraw rate
-  // instead of round-tripping every line at once.
+  // synchronously from each physical wheel event, drained per animation frame so
+  // a momentum flood paces to the TUI's redraw rate instead of round-tripping
+  // every line at once.
   let pendingWheelLines = 0;
   let wheelFlushRaf: number | undefined;
   // Coords of the most recent physical wheel — synthetic reports inherit them so
@@ -338,7 +383,10 @@ export function installTerminalBoundListeners(
     else if (pendingWheelLines < -maxPending) pendingWheelLines = -maxPending;
 
     const step = pendingWheelLines > 0 ? 1 : -1;
-    const emit = Math.min(Math.abs(pendingWheelLines), WHEEL_MAX_LINES_PER_FRAME);
+    // Fixed per-frame cap (no `elapsed`/timestamp multiply) so a late frame can
+    // never "catch up" by dispatching a larger burst — that would reintroduce
+    // the flood under main-thread jank. Device-aware: gentler for trackpads.
+    const emit = Math.min(Math.abs(pendingWheelLines), wheelMaxLinesPerFrame);
     pendingWheelLines -= step * emit;
     for (let i = 0; i < emit; i++) {
       const synthetic = new WheelEvent("wheel", {
@@ -385,6 +433,27 @@ export function installTerminalBoundListeners(
     ev.preventDefault();
     ev.stopImmediatePropagation();
 
+    // Stale-gesture gap: a long pause since the last physical event ends the
+    // gesture. Treat the resumed scroll as fresh — forget the previous device so
+    // its rolling history can't bias the new cap, and drop any coast the rAF
+    // hasn't drained yet (e.g. while the main thread was janked). MUST run before
+    // classify/accumulate below. Sub-line carry is deliberately PRESERVED: a
+    // genuinely slow continuous scroll (hi-res wheel emitting sub-line pixel
+    // deltas >120ms apart) must still accumulate, not be reset to nothing.
+    const now = Date.now();
+    if (now - lastPhysicalWheelAt > WHEEL_STALE_GAP_MS) {
+      wheelClassifier.reset();
+      pendingWheelLines = 0;
+    }
+    lastPhysicalWheelAt = now;
+
+    // Classify the device from the raw deltas and pick the per-frame send-rate
+    // cap accordingly (physical wheel = crisper, trackpad = gentler flood pacing).
+    wheelClassifier.accept(ev.timeStamp, ev.deltaX, ev.deltaY);
+    wheelMaxLinesPerFrame = wheelClassifier.isPhysicalMouseWheel()
+      ? WHEEL_MAX_LINES_PER_FRAME_WHEEL
+      : WHEEL_MAX_LINES_PER_FRAME_TRACKPAD;
+
     // A direction change drops the stale opposite-direction backlog so the
     // reversal scrolls the new way immediately rather than first coasting out
     // un-dispatched travel. Keyed on the raw deltaY sign, NOT the whole-line
@@ -400,7 +469,12 @@ export function installTerminalBoundListeners(
       pendingWheelLines = 0;
     }
 
-    const lines = wheelEventToLineCount(ev, terminal.rows, wheelCarry);
+    const lines = wheelEventToLineCount(
+      ev,
+      terminal.rows,
+      wheelCarry,
+      resolveWheelPixelsPerLine(terminal)
+    );
     if (lines === 0) return;
 
     pendingWheelLines += lines;

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -181,6 +181,7 @@ function makeDeps(
     notifyUserInput: vi.fn(),
     clearDirectingState: vi.fn(),
     onUserInput: vi.fn(),
+    onActiveWheel: vi.fn(),
     onEnterPressed: vi.fn(),
     updateLastObservedTitle: vi.fn(),
     notifyXtermFocused: vi.fn(),
@@ -686,6 +687,7 @@ describe("installTerminalBoundListeners", () => {
       return {
         managed,
         terminal,
+        deps,
         xtermEl,
         dispatch: (init: WheelEventInit, target: HTMLElement = managed.hostElement) => {
           const ev = new WheelEvent("wheel", { bubbles: true, cancelable: true, ...init });
@@ -1036,6 +1038,25 @@ describe("installTerminalBoundListeners", () => {
       h.dispatch({ deltaY: 10, deltaMode: 0 }); // resume same direction
       h.flushFrames();
       expect(h.getReports()).toBe(1); // the two halves still crossed a line boundary
+    });
+
+    it("signals onActiveWheel only when a real scroll is forwarded, not for sub-line motion", () => {
+      // onActiveWheel drives the renderer BURST boost + resource-profile hold,
+      // so it must fire on a forwarded scroll (lines !== 0) and stay silent for a
+      // sub-line nudge that forwards nothing.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      h.dispatch({ deltaY: 10, deltaMode: 0 }); // half a line (20px basis) → no forward
+      expect(h.deps.onActiveWheel).not.toHaveBeenCalled();
+      h.dispatch({ deltaY: 120, deltaMode: 0 }); // a real notch → forwarded
+      expect(h.deps.onActiveWheel).toHaveBeenCalledWith("t1");
+    });
+
+    it("does not signal onActiveWheel when it does not take over the wheel", () => {
+      // Normal buffer (no mouse-reporting TUI): the wheel passes through to
+      // xterm's own scrollback, so no boost is requested.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: false });
+      h.dispatch({ deltaY: 120, deltaMode: 0 });
+      expect(h.deps.onActiveWheel).not.toHaveBeenCalled();
     });
 
     it("clears a single notch within one frame and adds nothing on the next", () => {

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -70,6 +70,10 @@ function makeMockTerminal(captured: CapturedCallbacks) {
     rows: 24,
     cols: 80,
     modes: { bracketedPasteMode: false, mouseTrackingMode: "none" as const },
+    // Rendered cell dimensions read by getXtermCellDimensions(): a 20px cell
+    // height makes the wheel normalizer's px-per-line basis exactly 20, the
+    // value the amplifier/normalizer tests are written against.
+    _core: { _renderService: { dimensions: { css: { cell: { width: 9, height: 20 } } } } },
     buffer: {
       active: { length: 0, type: "normal", baseY: 0, viewportY: 0 },
       onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -636,9 +640,15 @@ describe("installTerminalBoundListeners", () => {
       mouseTrackingMode: string;
       isAltBuffer: boolean;
       runtimeAgentId?: string;
+      cellHeight?: number;
     }) {
       const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
       const terminal = makeMockTerminal(captured);
+      if (opts.cellHeight !== undefined) {
+        // Override the rendered cell height the px-per-line basis resolves from,
+        // so a test can exercise the live-cell-height resolution end to end.
+        terminal._core._renderService.dimensions.css.cell.height = opts.cellHeight;
+      }
       // The normalizer gate does NOT depend on runtimeAgentId (a plain
       // lazygit/btop terminal must amplify too); default to an agent but let
       // callers clear it to cover the no-agent case.
@@ -963,6 +973,98 @@ describe("installTerminalBoundListeners", () => {
       h.flushFrames();
       expect(h.getReports()).toBe(0); // queued drain was cancelled
     });
+
+    it("paces a trackpad fling more gently per frame than an equivalent wheel fling", () => {
+      // The device-aware send-rate cap: a trackpad's momentum stream (the gesture
+      // that actually floods the PTY round-trip) drains fewer lines per frame than
+      // a physical wheel's discrete detents, even for the same total distance.
+      const wheel = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      wheel.dispatch({ deltaX: 0, deltaY: 240, deltaMode: 0 }); // integer single-axis → wheel
+      wheel.flushFrame();
+      const wheelFirstFrame = wheel.getReports();
+
+      const trackpad = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      trackpad.dispatch({ deltaX: 6, deltaY: 240.5, deltaMode: 0 }); // dual-axis fractional → trackpad
+      trackpad.flushFrame();
+      const trackpadFirstFrame = trackpad.getReports();
+
+      expect(trackpadFirstFrame).toBeGreaterThan(0);
+      expect(trackpadFirstFrame).toBeLessThan(wheelFirstFrame);
+      // Pacing changes the per-frame rate, not the total: both devices deliver the
+      // same gesture in full (same distance ⇒ same line count), just spread
+      // differently across frames.
+      wheel.flushFrames();
+      trackpad.flushFrames();
+      expect(trackpad.getReports()).toBe(wheel.getReports());
+      expect(wheel.getReports()).toBeGreaterThan(wheelFirstFrame);
+    });
+
+    it("re-detects the device after an idle gap (stale wheel history doesn't pin the cap)", () => {
+      // The classifier is reset at a gesture boundary, so a trackpad gesture that
+      // follows a long pause after wheel scrolling is paced by the TRACKPAD cap on
+      // its very first frame — not the leftover physical-wheel verdict. Compared
+      // against the same sequence with no gap, where the rolling history still
+      // reads as a wheel.
+      function trackpadFirstFrameAfterWheel(gapMs: number): number {
+        const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+        // Fill the classifier with a physical-wheel streak and let it drain.
+        for (let i = 0; i < 5; i++) h.dispatch({ deltaX: 0, deltaY: 120, deltaMode: 0 });
+        h.flushFrames();
+        const drained = h.getReports();
+        vi.advanceTimersByTime(gapMs);
+        // Now a trackpad fling (dual-axis fractional).
+        h.dispatch({ deltaX: 6, deltaY: 240.5, deltaMode: 0 });
+        h.flushFrame();
+        return h.getReports() - drained;
+      }
+      const afterGap = trackpadFirstFrameAfterWheel(1000); // gesture boundary → reset
+      const noGap = trackpadFirstFrameAfterWheel(0); // continuous → wheel history persists
+      expect(afterGap).toBeLessThan(noGap);
+    });
+
+    it("preserves sub-line carry across an idle gap (slow scrolling still accumulates)", () => {
+      // The gap resets the device/backlog but NOT the lossless pixel carry: two
+      // sub-line nudges separated by a long pause must still combine into a line,
+      // otherwise a slow hi-res wheel would scroll nothing.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      h.dispatch({ deltaY: 10, deltaMode: 0 }); // half a line (20px basis), carried
+      h.flushFrames();
+      expect(h.getReports()).toBe(0);
+
+      vi.advanceTimersByTime(1000); // a clearly human-idle pause
+
+      h.dispatch({ deltaY: 10, deltaMode: 0 }); // resume same direction
+      h.flushFrames();
+      expect(h.getReports()).toBe(1); // the two halves still crossed a line boundary
+    });
+
+    it("clears a single notch within one frame and adds nothing on the next", () => {
+      // A discrete notch (below the per-frame cap) must not be split across frames
+      // — it should land whole on the first frame, then the next frame is a no-op.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      h.dispatch({ deltaY: 120, deltaMode: 0 });
+      h.flushFrame();
+      const afterOneFrame = h.getReports();
+      expect(afterOneFrame).toBe(NOTCH_REPORTS); // all of the notch, in one frame
+      h.flushFrame();
+      expect(h.getReports()).toBe(afterOneFrame); // nothing left to drain
+    });
+
+    it("resolves lines from the live rendered cell height (bigger cell ⇒ fewer lines)", () => {
+      // End-to-end through the real handler: the px-per-line basis is the rendered
+      // cell height, so the SAME 120px gesture yields fewer line reports on a
+      // taller cell. Guards the getXtermCellDimensions resolution path.
+      const tall = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true, cellHeight: 40 });
+      tall.dispatch({ deltaY: 120, deltaMode: 0 });
+      tall.flushFrames();
+
+      const short = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true, cellHeight: 10 });
+      short.dispatch({ deltaY: 120, deltaMode: 0 });
+      short.flushFrames();
+
+      expect(tall.getReports()).toBeGreaterThan(0);
+      expect(tall.getReports()).toBeLessThan(short.getReports()); // 120/40 < 120/10
+    });
   });
 
   it("registers the same listener count on every call (idempotent shape)", () => {
@@ -1190,6 +1292,34 @@ describe("wheelEventToLineCount", () => {
     // value; the tests below pin the surrounding invariants relationally so they
     // survive retuning the budget.
     expect(wheelEventToLineCount(ev(120, 0), 24, { partial: 0 })).toBe(6);
+  });
+
+  it("converts pixels at the supplied cell-height basis, inversely to cell size", () => {
+    // The px-per-line basis is the live rendered cell height, not a constant. The
+    // same 120px gesture must scroll proportionally fewer lines as the basis grows
+    // (line count × basis ≈ the pixel distance), and halving the basis doubles the
+    // lines — a relationship, not a pinned literal.
+    const at10 = wheelEventToLineCount(ev(120, 0), 99, { partial: 0 }, 10);
+    const at20 = wheelEventToLineCount(ev(120, 0), 99, { partial: 0 }, 20);
+    const at40 = wheelEventToLineCount(ev(120, 0), 99, { partial: 0 }, 40);
+    expect(at10).toBe(at20 * 2);
+    expect(at20).toBe(at40 * 2);
+    expect(at20 * 20).toBe(120); // basis × lines recovers the gesture distance
+  });
+
+  it("falls back to the default basis for a non-positive pixelsPerLine", () => {
+    // A zero/negative basis (e.g. a degenerate cell measurement) must not divide
+    // by zero or invert the sign — it behaves exactly as if the arg were omitted.
+    const omitted = wheelEventToLineCount(ev(120, 0), 99, { partial: 0 });
+    expect(wheelEventToLineCount(ev(120, 0), 99, { partial: 0 }, 0)).toBe(omitted);
+    expect(wheelEventToLineCount(ev(120, 0), 99, { partial: 0 }, -5)).toBe(omitted);
+  });
+
+  it("ignores pixelsPerLine for line-mode and page-mode events", () => {
+    // Only pixel-mode (deltaMode 0) events divide by the basis; line/page events
+    // carry the OS step already, so a wildly different basis must not change them.
+    expect(wheelEventToLineCount(ev(3, 1), 24, { partial: 0 }, 7)).toBe(3); // line mode
+    expect(wheelEventToLineCount(ev(1, 2), 24, { partial: 0 }, 7)).toBe(24); // page mode → rows
   });
 
   it("scrolls clearly more than a single line per notch (the dead-scroll fix)", () => {

--- a/src/services/terminal/__tests__/mouseWheelClassifier.test.ts
+++ b/src/services/terminal/__tests__/mouseWheelClassifier.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { MouseWheelClassifier } from "../mouseWheelClassifier";
+
+// Behavioral tests: feed a realistic device's wheel-event stream and assert the
+// trackpad-vs-physical-wheel verdict. Inputs are device signatures (integer
+// single-axis repeating = wheel; fractional / dual-axis = trackpad), not the
+// algorithm's internal scores, so these are regression guards, not change
+// detectors.
+describe("MouseWheelClassifier", () => {
+  function feed(c: MouseWheelClassifier, events: Array<[number, number]>): void {
+    let t = 0;
+    for (const [dx, dy] of events) c.accept((t += 16), dx, dy);
+  }
+
+  it("reports trackpad (false) before any event is seen", () => {
+    // No evidence yet → assume the gentler-pacing device until a discrete wheel
+    // detent proves otherwise.
+    expect(new MouseWheelClassifier().isPhysicalMouseWheel()).toBe(false);
+  });
+
+  it("classifies a single clean integer single-axis detent as a physical wheel", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [[0, 120]]);
+    expect(c.isPhysicalMouseWheel()).toBe(true);
+  });
+
+  it("classifies a stream of repeating integer single-axis detents as a physical wheel", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [
+      [0, 120],
+      [0, 120],
+      [0, 120],
+      [0, 120],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(true);
+  });
+
+  it("classifies line-mode integer steps (Windows/Linux mice) as a physical wheel", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [
+      [0, 3],
+      [0, 3],
+      [0, 3],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(true);
+  });
+
+  it("classifies dual-axis motion as a trackpad", () => {
+    const c = new MouseWheelClassifier();
+    // Both axes moving at once is the trackpad/Magic-Mouse signature.
+    feed(c, [
+      [2.5, 8.2],
+      [1.1, 11.7],
+      [0.4, 6.3],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(false);
+  });
+
+  it("classifies fractional single-axis deltas as a trackpad", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [
+      [0, 4.5],
+      [0, 7.25],
+      [0, 2.75],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(false);
+  });
+
+  it("flips from wheel to trackpad as the device changes mid-stream", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [
+      [0, 120],
+      [0, 120],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(true);
+    // Switch to trackpad motion; the weighted average tips within a few events.
+    feed(c, [
+      [3.3, 9.1],
+      [1.7, 12.4],
+      [0.9, 5.6],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(false);
+  });
+
+  it("recovers from trackpad to wheel when the device changes back", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [
+      [3.3, 9.1],
+      [1.7, 12.4],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(false);
+    // Switch to clean wheel detents; the weighted average tips back within a few.
+    feed(c, [
+      [0, 120],
+      [0, 120],
+      [0, 120],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(true);
+  });
+
+  it("stays trackpad through an occasional integer single-axis delta in a trackpad stream", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [
+      [2.4, 8.1],
+      [0, 9], // one clean-looking integer delta mid-gesture
+      [1.6, 11.3],
+      [0.7, 6.9],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(false);
+  });
+
+  it("weighs recent events more than older ones (a wheel streak survives one trackpad blip)", () => {
+    const c = new MouseWheelClassifier();
+    // A single trackpad-looking event at the END of a wheel streak shouldn't flip
+    // the verdict on its own — recency is weighted, but one event isn't a majority.
+    feed(c, [
+      [0, 120],
+      [0, 120],
+      [0, 120],
+      [0, 120],
+      [0, 5.5], // lone fractional blip (newest)
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(true);
+  });
+
+  it("resets to an empty verdict, forgetting prior device history", () => {
+    const c = new MouseWheelClassifier();
+    feed(c, [
+      [0, 120],
+      [0, 120],
+    ]);
+    expect(c.isPhysicalMouseWheel()).toBe(true);
+    c.reset();
+    expect(c.isPhysicalMouseWheel()).toBe(false); // empty again
+    // After reset a single trackpad event classifies as trackpad immediately,
+    // unbiased by the prior wheel streak.
+    feed(c, [[3.1, 8.8]]);
+    expect(c.isPhysicalMouseWheel()).toBe(false);
+  });
+
+  it("keeps per-instance state independent (two panes, two devices)", () => {
+    const wheel = new MouseWheelClassifier();
+    const trackpad = new MouseWheelClassifier();
+    feed(wheel, [
+      [0, 120],
+      [0, 120],
+    ]);
+    feed(trackpad, [
+      [2.1, 7.7],
+      [1.4, 9.2],
+    ]);
+    expect(wheel.isPhysicalMouseWheel()).toBe(true);
+    expect(trackpad.isPhysicalMouseWheel()).toBe(false);
+  });
+});

--- a/src/services/terminal/mouseWheelClassifier.ts
+++ b/src/services/terminal/mouseWheelClassifier.ts
@@ -1,0 +1,149 @@
+/**
+ * Classifies a stream of wheel events as coming from a physical mouse wheel
+ * (discrete detents) versus a trackpad / Magic Mouse (continuous, high-rate
+ * motion). Ported from VS Code's `MouseWheelClassifier`
+ * (`src/vs/base/browser/ui/scrollbar/scrollableElement.ts`) — the same algorithm
+ * xterm bundles privately for its own viewport smooth-scroll gating.
+ *
+ * Daintree uses it for ONE thing: choosing the per-frame send-rate cap for
+ * synthetic mouse-wheel reports in a mouse-reporting TUI. Trackpad momentum is
+ * the gesture that floods the PTY round-trip (dozens of events/sec), so it gets
+ * a gentler cap than a physical wheel's discrete detents. None of VS Code's
+ * other uses (smooth scroll, inertial scroll, ctrl-zoom) apply to our synthetic
+ * report path — the verdict is only an input to pacing.
+ *
+ * Per-terminal instance (NOT a singleton like VS Code's): two panes can be
+ * scrolled by different devices at the same time.
+ *
+ * Algorithm: a 5-event circular buffer; each event is scored 0 (mouse) → 1
+ * (trackpad) by `_computeScore`, and `isPhysicalMouseWheel()` returns whether an
+ * exponentially-weighted average of the buffered scores sits at or below 0.5.
+ */
+class MouseWheelClassifierItem {
+  public score = 0;
+  constructor(
+    public readonly timestamp: number,
+    public readonly deltaX: number,
+    public readonly deltaY: number
+  ) {}
+}
+
+export class MouseWheelClassifier {
+  private readonly _capacity = 5;
+  private _memory: MouseWheelClassifierItem[] = [];
+  private _front = -1;
+  private _rear = -1;
+
+  /**
+   * Forget all buffered events — call at a gesture boundary (e.g. after an idle
+   * gap) so the previous gesture's device history doesn't bias the next verdict.
+   */
+  public reset(): void {
+    this._memory = [];
+    this._front = -1;
+    this._rear = -1;
+  }
+
+  /** Feed one physical wheel event. `timestamp` is stored for parity but unused by the verdict. */
+  public accept(timestamp: number, deltaX: number, deltaY: number): void {
+    let previousItem: MouseWheelClassifierItem | null = null;
+    const item = new MouseWheelClassifierItem(timestamp, deltaX, deltaY);
+
+    if (this._front === -1 && this._rear === -1) {
+      this._memory[0] = item;
+      this._front = 0;
+      this._rear = 0;
+    } else {
+      previousItem = this._memory[this._rear] ?? null;
+      this._rear = (this._rear + 1) % this._capacity;
+      if (this._rear === this._front) {
+        this._front = (this._front + 1) % this._capacity;
+      }
+      this._memory[this._rear] = item;
+    }
+
+    item.score = this._computeScore(item, previousItem);
+  }
+
+  /**
+   * Score one event: physical wheels move on a single axis with integer deltas
+   * that repeat by a consistent factor (the OS acceleration step); trackpads
+   * emit fractional, often dual-axis deltas. 0 = mouse, 1 = trackpad.
+   */
+  private _computeScore(
+    item: MouseWheelClassifierItem,
+    previousItem: MouseWheelClassifierItem | null
+  ): number {
+    // Both axes moving at once is a trackpad/Magic-Mouse signature — a physical
+    // wheel reports a single axis.
+    if (Math.abs(item.deltaX) > 0 && Math.abs(item.deltaY) > 0) {
+      return 1;
+    }
+
+    let score = 0.5;
+
+    // Fractional deltas come from continuous (trackpad) motion.
+    if (!this._isAlmostInt(item.deltaX) || !this._isAlmostInt(item.deltaY)) {
+      score += 0.25;
+    }
+
+    if (previousItem) {
+      const absDeltaX = Math.abs(item.deltaX);
+      const absDeltaY = Math.abs(item.deltaY);
+      const absPreviousDeltaX = Math.abs(previousItem.deltaX);
+      const absPreviousDeltaY = Math.abs(previousItem.deltaY);
+
+      const minDeltaX = Math.max(Math.min(absDeltaX, absPreviousDeltaX), 1);
+      const minDeltaY = Math.max(Math.min(absDeltaY, absPreviousDeltaY), 1);
+      const maxDeltaX = Math.max(absDeltaX, absPreviousDeltaX);
+      const maxDeltaY = Math.max(absDeltaY, absPreviousDeltaY);
+
+      // A consistent multiplicative relationship between consecutive deltas is
+      // the OS wheel-acceleration fingerprint of a physical wheel.
+      const isSameModulo = maxDeltaX % minDeltaX === 0 && maxDeltaY % minDeltaY === 0;
+      if (isSameModulo) {
+        score -= 0.5;
+      }
+    }
+
+    return Math.min(Math.max(score, 0), 1);
+  }
+
+  private _isAlmostInt(value: number): boolean {
+    const delta = Math.abs(Math.round(value) - value);
+    return delta < 0.01;
+  }
+
+  /**
+   * Verdict: an exponentially-weighted average of the buffered scores (most
+   * recent event weighted 0.5, then 0.25, 0.125, …). At or below 0.5 → physical
+   * wheel. An empty buffer reports `false` (treated as trackpad) so the gentler
+   * cap applies until we have evidence of a discrete wheel.
+   */
+  public isPhysicalMouseWheel(): boolean {
+    if (this._front === -1 && this._rear === -1) {
+      return false;
+    }
+
+    let remainingInfluence = 1;
+    let score = 0;
+    let iteration = 1;
+    let index = this._rear;
+    let done = false;
+
+    while (!done) {
+      const influence = index === this._front ? remainingInfluence : Math.pow(2, -iteration);
+      remainingInfluence -= influence;
+      score += (this._memory[index]?.score ?? 0) * influence;
+
+      if (index === this._front) {
+        done = true;
+      } else {
+        index = (this._capacity + index - 1) % this._capacity;
+        iteration++;
+      }
+    }
+
+    return score <= 0.5;
+  }
+}


### PR DESCRIPTION
This fixes the laggy, stuttering scroll in full-screen TUIs that capture the mouse (the grok build was the worst offender). In that mode the app owns scrolling, so every wheel line is a full round-trip through the PTY, and a couple of things were making that worse than it needed to be.

Three parts.

## 1. Reworked wheel-input path

The normalizer that turns physical wheel events into synthetic mouse reports got an overhaul:

- **Device classification.** Ported VS Code's `MouseWheelClassifier` (`src/services/terminal/mouseWheelClassifier.ts`) so we can tell a trackpad from a physical mouse wheel. It's a per-terminal instance rather than a singleton, since two panes can be scrolled by different devices at once.
- **Cell-height line conversion.** Pixels convert to lines off the live rendered cell height (`resolveWheelPixelsPerLine`) instead of a hardcoded `20`, so the feel holds up at any font size.
- **Device-aware pacing.** Reports drain per animation frame with a cap that depends on the device: 8 lines/frame for a wheel's discrete detents, 4 for a trackpad's momentum stream (the trackpad flood is what actually saturates the round-trip).
- **Idle-gap reset.** A pause longer than `WHEEL_STALE_GAP_MS` ends the gesture: it re-detects the device and drops any leftover coast, but keeps the sub-line carry so slow scrolling still accumulates.

Worth noting: xterm beta.288 already has the relevant upstream fixes (`#5391`, `#5037`, `#5437`) and smooth scroll is globally off, so our normalizer is a deliberate override of xterm's lossy `_consumeWheelEvent` path, not a workaround for something missing. There's a comment in the code spelling that out so nobody deletes it later.

## 2. Keep an actively-scrolled pane out of efficiency

This is the one that fixes the "smooth at first, then slow and stays slow" symptom. Under event-loop lag the resource profile latches to `efficiency`, which stretches the pty-host's port-batch delay from 16ms to 40ms and throttles the returned-redraw stream right while you're scrolling.

`ResourceProfileService.requestInteractiveOverride()` holds the profile at balanced or better while you scroll. It lifts straight out of efficiency, blocks re-entry through a single `applyProfile` redirect plus a `sampleLag` guard, and self-expires shortly after you stop. The renderer drives it on the wheel (throttled, fire-and-forget) through a new `system:request-interactive-override` IPC channel, and also boosts the pane to the `BURST` refresh tier so the first flick doesn't render at 10fps.

## 3. GPU test typecheck fix

Small one. `GpuCrashMonitorService.test.ts` had a mock typed `vi.fn(() => undefined)` that three `mockReturnValue({...})` calls contradicted, which only surfaces under `tsc -b electron`. It predates this branch (it came in with the GPU-trace commit) but it was blocking the full `npm run check`, so I cleaned it up here.

## One thing I left out

VS Code's matching fix (`#204769`) removed their PTY input throttle and ESC-splitting write queue. We carry a near-identical copy, but it is not the scroll problem: scroll reports are ~13 bytes and take the 512-byte fast-path in `TerminalProcess.write()`, bypassing the queue entirely. It only slows large escape-laden writes (big pastes, context injection). Removing it would need real Windows ConPTY testing, and I'm on macOS, so I've left it as a follow-up rather than ship something I can't verify.

## Testing

Full `npm run check` passes (typecheck, lint ratchet, format, IPC guards). New unit coverage for the classifier, the device-aware pacing and idle-gap behaviour, and the resource-profile override (immediate lift, no re-entry while active, resume after stop, the duration cap, and malformed input). The approach follows the fixes from VS Code and xterm.
