### PR TITLE
feat(terminal): journal a resume record on every agent close path

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -33,6 +33,16 @@ vi.mock("../../../../services/pty/terminalShell.js", () => ({
   getDefaultShell: vi.fn(() => "/bin/zsh"),
 }));
 
+const { persistAgentSessionMock } = vi.hoisted(() => ({
+  persistAgentSessionMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../../services/pty/agentSessionHistory.js", () => ({
+  persistAgentSession: persistAgentSessionMock,
+  listAgentSessions: vi.fn(() => []),
+  clearAgentSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
 type SafeParseable = {
   safeParse: (v: unknown) => { success: true; data: unknown } | { success: false; error: unknown };
 };
@@ -2048,5 +2058,129 @@ describe("terminal spawn handler - plugin agent ${settings:*} resolution (#10619
     expect(mockResolveSettingTemplate).not.toHaveBeenCalled();
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.command).toBe("acme-cli --interactive");
+  });
+});
+
+describe("terminal close handlers - resume journaling", () => {
+  function getKillHandler() {
+    const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+      .calls;
+    const call = calls.find((c) => c[0] === CHANNELS.TERMINAL_KILL);
+    return call?.[1] as (event: unknown, id: string) => Promise<void>;
+  }
+
+  function getGracefulKillHandler() {
+    const calls = (ipcMain.handle as unknown as { mock: { calls: Array<[string, unknown]> } }).mock
+      .calls;
+    const call = calls.find((c) => c[0] === CHANNELS.TERMINAL_GRACEFUL_KILL);
+    return call?.[1] as (event: unknown, id: string) => Promise<string | null>;
+  }
+
+  let ptyClient: {
+    getTerminalAsync: ReturnType<typeof vi.fn>;
+    gracefulKill: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  let worktreeService: { getMonitorAsync: ReturnType<typeof vi.fn> };
+
+  const agentInfo = {
+    id: "term-1",
+    launchAgentId: "claude",
+    worktreeId: "wt-1",
+    title: "Claude",
+    projectId: "proj-1",
+    cwd: "/repo/feature",
+    agentLaunchFlags: ["--resume"],
+    agentModelId: "claude-opus-4-8",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    persistAgentSessionMock.mockResolvedValue(undefined);
+    ptyClient = {
+      getTerminalAsync: vi.fn(),
+      gracefulKill: vi.fn(),
+      kill: vi.fn(),
+    };
+    worktreeService = { getMonitorAsync: vi.fn().mockResolvedValue({ branch: "feature/foo" }) };
+  });
+
+  function register() {
+    const deps = { ptyClient, worktreeService } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+  }
+
+  it("routes an agent terminal kill through gracefulKill and journals a record", async () => {
+    ptyClient.getTerminalAsync.mockResolvedValue(agentInfo);
+    ptyClient.gracefulKill.mockResolvedValue("sess-abc");
+    register();
+
+    await getKillHandler()({}, "term-1");
+
+    expect(ptyClient.gracefulKill).toHaveBeenCalledWith("term-1");
+    expect(ptyClient.kill).not.toHaveBeenCalled();
+    expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+    const [record] = persistAgentSessionMock.mock.calls[0];
+    expect(record.sessionId).toBe("sess-abc");
+    expect(record.agentId).toBe("claude");
+    expect(record.cwd).toBe("/repo/feature");
+    expect(record.branch).toBe("feature/foo");
+  });
+
+  it("hard-kills a non-agent terminal without journaling", async () => {
+    ptyClient.getTerminalAsync.mockResolvedValue({ id: "term-2", cwd: "/repo" });
+    register();
+
+    await getKillHandler()({}, "term-2");
+
+    expect(ptyClient.kill).toHaveBeenCalledWith("term-2");
+    expect(ptyClient.gracefulKill).not.toHaveBeenCalled();
+    expect(persistAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not journal when gracefulKill yields no session id", async () => {
+    ptyClient.getTerminalAsync.mockResolvedValue(agentInfo);
+    ptyClient.gracefulKill.mockResolvedValue(null);
+    register();
+
+    await getKillHandler()({}, "term-1");
+
+    expect(ptyClient.gracefulKill).toHaveBeenCalledWith("term-1");
+    expect(persistAgentSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("journals on the gracefulKill handler and returns the session id", async () => {
+    ptyClient.getTerminalAsync.mockResolvedValue(agentInfo);
+    ptyClient.gracefulKill.mockResolvedValue("sess-xyz");
+    register();
+
+    const result = await getGracefulKillHandler()({}, "term-1");
+
+    expect(result).toBe("sess-xyz");
+    expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(persistAgentSessionMock.mock.calls[0][0].sessionId).toBe("sess-xyz");
+  });
+
+  it("still journals (branch undefined) when the branch lookup fails", async () => {
+    ptyClient.getTerminalAsync.mockResolvedValue(agentInfo);
+    ptyClient.gracefulKill.mockResolvedValue("sess-abc");
+    worktreeService.getMonitorAsync.mockRejectedValue(new Error("workspace host gone"));
+    register();
+
+    await getKillHandler()({}, "term-1");
+
+    expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(persistAgentSessionMock.mock.calls[0][0].branch).toBeUndefined();
+  });
+
+  it("treats a detached HEAD as no branch", async () => {
+    ptyClient.getTerminalAsync.mockResolvedValue(agentInfo);
+    ptyClient.gracefulKill.mockResolvedValue("sess-abc");
+    worktreeService.getMonitorAsync.mockResolvedValue({ branch: "HEAD" });
+    register();
+
+    await getKillHandler()({}, "term-1");
+
+    expect(persistAgentSessionMock.mock.calls[0][0].branch).toBeUndefined();
   });
 });

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -586,15 +586,20 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     svc: WorkspaceClient | undefined
   ): Promise<string | undefined> => {
     if (!worktreeId || !svc) return undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       const snapshot = await Promise.race([
         svc.getMonitorAsync(worktreeId),
-        new Promise<null>((resolve) => setTimeout(() => resolve(null), 200)),
+        new Promise<null>((resolve) => {
+          timer = setTimeout(() => resolve(null), 200);
+        }),
       ]);
       const branch = snapshot?.branch;
       return branch && branch !== "HEAD" ? branch : undefined;
     } catch {
       return undefined;
+    } finally {
+      if (timer) clearTimeout(timer);
     }
   };
 

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -77,7 +77,9 @@ async function getPluginService(): Promise<PluginServiceSingleton> {
 import {
   listAgentSessions,
   clearAgentSessions,
+  persistAgentSession,
 } from "../../../services/pty/agentSessionHistory.js";
+import type { WorkspaceClient } from "../../../services/WorkspaceClient.js";
 import { getDefaultShell } from "../../../services/pty/terminalShell.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { quoteCommandArg } from "../../../../shared/utils/shellEscape.js";
@@ -575,12 +577,77 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     }
   };
 
+  // Resolve the worktree's branch in the main process (where the pty-host's
+  // direct-git path is unavailable). Best-effort and time-boxed: a stalled
+  // workspace-host must not hold up a terminal close, so cap the lookup at
+  // 200ms and treat any miss/timeout/detached-HEAD as "no branch".
+  const resolveBranchForMain = async (
+    worktreeId: string | undefined,
+    svc: WorkspaceClient | undefined
+  ): Promise<string | undefined> => {
+    if (!worktreeId || !svc) return undefined;
+    try {
+      const snapshot = await Promise.race([
+        svc.getMonitorAsync(worktreeId),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 200)),
+      ]);
+      const branch = snapshot?.branch;
+      return branch && branch !== "HEAD" ? branch : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  // Journal a resume record for an agent terminal close (kill / gracefulKill).
+  // Best-effort: a null sessionId (no resumable session — e.g. Cursor or a
+  // non-resume-config agent), a non-agent terminal, or a branch-lookup failure
+  // all skip silently and never fail the close. Mirrors PtyManager's trash-
+  // expiry capture, the fourth close path that already journals.
+  const persistCloseRecord = async (
+    info: Awaited<ReturnType<typeof ptyClient.getTerminalAsync>>,
+    sessionId: string | null
+  ): Promise<void> => {
+    if (!sessionId || !info?.launchAgentId) return;
+    try {
+      const branch = await resolveBranchForMain(info.worktreeId, deps.worktreeService);
+      const { app } = await import("electron");
+      await persistAgentSession(
+        {
+          sessionId,
+          agentId: info.launchAgentId,
+          worktreeId: info.worktreeId ?? null,
+          title: info.title ?? null,
+          projectId: info.projectId ?? null,
+          agentLaunchFlags: info.agentLaunchFlags,
+          agentModelId: info.agentModelId,
+          cwd: info.cwd ?? undefined,
+          branch,
+        },
+        app.getPath("userData")
+      );
+    } catch (err) {
+      console.warn("[TerminalLifecycle] Failed to persist agent session on close:", err);
+    }
+  };
+
   const handleTerminalKill = async (id: string): Promise<void> => {
     try {
       if (typeof id !== "string") {
         throw new Error("Invalid terminal ID: must be a string");
       }
-      ptyClient.kill(id);
+      // Capture a resume record before tearing down an agent terminal. The info
+      // snapshot must precede the kill (it's gone afterward), and gracefulKill —
+      // not a bare kill — is what extracts the session id, so route agent
+      // terminals through it. Plain terminals keep the original hard kill. A
+      // failed snapshot (host gone) falls back to a plain kill — never block the
+      // close on the resume-capture path.
+      const info = await ptyClient.getTerminalAsync(id).catch(() => null);
+      if (info?.launchAgentId) {
+        const sessionId = await ptyClient.gracefulKill(id);
+        await persistCloseRecord(info, sessionId);
+      } else {
+        ptyClient.kill(id);
+      }
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to kill terminal");
       throw new Error(`Failed to kill terminal: ${errorMessage}`);
@@ -591,7 +658,10 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     if (typeof id !== "string") {
       throw new Error("Invalid terminal ID: must be a string");
     }
-    return ptyClient.gracefulKill(id);
+    const info = await ptyClient.getTerminalAsync(id).catch(() => null);
+    const sessionId = await ptyClient.gracefulKill(id);
+    await persistCloseRecord(info, sessionId);
+    return sessionId;
   };
 
   const handleTerminalTrash = async (id: string): Promise<void> => {

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -3,6 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const appMock = vi.hoisted(() => ({
   on: vi.fn(),
   exit: vi.fn(),
+  getPath: vi.fn(() => "/tmp/test-shutdown"),
+}));
+
+const persistAgentSessionMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock("../../services/pty/agentSessionHistory.js", () => ({
+  persistAgentSession: persistAgentSessionMock,
 }));
 
 const dialogMock = vi.hoisted(() => ({
@@ -1027,6 +1034,106 @@ describe("registerShutdownHandler", () => {
 
       consoleSpy.mockRestore();
       vi.useRealTimers();
+    });
+  });
+
+  describe("resume journaling on shutdown", () => {
+    beforeEach(() => {
+      // The hard-timeout test above leaves mcpServerMock.stop returning a
+      // never-resolving promise; the suite's beforeEach only clearAllMocks
+      // (history, not implementations), so reset it here or the cleanup chain
+      // hangs and app.exit is never reached.
+      mcpServerMock.stop.mockResolvedValue(undefined);
+      persistAgentSessionMock.mockResolvedValue(undefined);
+    });
+
+    function makePtyClient(overrides?: Record<string, unknown>) {
+      return {
+        gracefulKillByProject: vi.fn(async () => []),
+        getAllTerminalsAsync: vi.fn(async () => []),
+        dispose: vi.fn(),
+        ...overrides,
+      } as never;
+    }
+
+    const agentTerminal = {
+      id: "t1",
+      launchAgentId: "claude",
+      worktreeId: "wt-1",
+      title: "Claude",
+      projectId: "proj-1",
+      cwd: "/repo",
+      agentLaunchFlags: ["--resume"],
+      agentModelId: "claude-opus-4-8",
+    };
+
+    it("journals a resume record for each captured agent session", async () => {
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [agentTerminal, { id: "t2", cwd: "/repo" }]),
+        gracefulKillByProject: vi.fn(async () => [
+          { id: "t1", agentSessionId: "sess-1" },
+          { id: "t2", agentSessionId: null },
+        ]),
+      });
+      const workspaceClient = {
+        dispose: vi.fn(),
+        getMonitorAsync: vi.fn(async () => ({ branch: "feature/x" })),
+      };
+      const { beforeQuitCb } = await setup({
+        getPtyClient: () => ptyClient,
+        getWorkspaceClient: () => workspaceClient as never,
+      });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+      const record = persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.sessionId).toBe("sess-1");
+      expect(record.agentId).toBe("claude");
+      expect(record.cwd).toBe("/repo");
+      expect(record.branch).toBe("feature/x");
+    });
+
+    it("does not journal non-agent terminals or null-session captures", async () => {
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [{ id: "t2", cwd: "/repo" }]),
+        gracefulKillByProject: vi.fn(async () => [{ id: "t2", agentSessionId: null }]),
+      });
+      const { beforeQuitCb } = await setup({ getPtyClient: () => ptyClient });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(persistAgentSessionMock).not.toHaveBeenCalled();
+    });
+
+    it("still journals (branch undefined) when the branch lookup rejects", async () => {
+      projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [agentTerminal]),
+        gracefulKillByProject: vi.fn(async () => [{ id: "t1", agentSessionId: "sess-1" }]),
+      });
+      const workspaceClient = {
+        dispose: vi.fn(),
+        getMonitorAsync: vi.fn(async () => {
+          throw new Error("workspace host gone");
+        }),
+      };
+      const { beforeQuitCb } = await setup({
+        getPtyClient: () => ptyClient,
+        getWorkspaceClient: () => workspaceClient as never,
+      });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(1);
+      const record = persistAgentSessionMock.mock.calls[0][0] as Record<string, unknown>;
+      expect(record.sessionId).toBe("sess-1");
+      expect(record.branch).toBeUndefined();
     });
   });
 });

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -1110,6 +1110,48 @@ describe("registerShutdownHandler", () => {
       expect(persistAgentSessionMock).not.toHaveBeenCalled();
     });
 
+    it("journals captures from every project even if one persist call fails", async () => {
+      projectStoreMock.getAllProjects.mockReturnValue([
+        { id: "proj-1" },
+        { id: "proj-2" },
+      ] as never);
+      const ptyClient = makePtyClient({
+        getAllTerminalsAsync: vi.fn(async () => [
+          { ...agentTerminal, id: "t1", worktreeId: "wt-1" },
+          { ...agentTerminal, id: "t2", worktreeId: "wt-2" },
+        ]),
+        gracefulKillByProject: vi.fn(async (pid: string) =>
+          pid === "proj-1"
+            ? [{ id: "t1", agentSessionId: "sess-1" }]
+            : [{ id: "t2", agentSessionId: "sess-2" }]
+        ),
+      });
+      const workspaceClient = {
+        dispose: vi.fn(),
+        getMonitorAsync: vi.fn(async () => ({ branch: "feature/x" })),
+      };
+      // First persist rejects; the loop's per-record try/catch must still
+      // journal the second project's capture.
+      persistAgentSessionMock
+        .mockRejectedValueOnce(new Error("disk full"))
+        .mockResolvedValue(undefined);
+
+      const { beforeQuitCb } = await setup({
+        getPtyClient: () => ptyClient,
+        getWorkspaceClient: () => workspaceClient as never,
+      });
+
+      await beforeQuitCb(makeEvent());
+      await vi.waitFor(() => expect(appMock.exit).toHaveBeenCalled());
+
+      expect(persistAgentSessionMock).toHaveBeenCalledTimes(2);
+      const persistedIds = persistAgentSessionMock.mock.calls.map(
+        (c) => (c[0] as Record<string, unknown>).sessionId
+      );
+      expect(persistedIds).toContain("sess-1");
+      expect(persistedIds).toContain("sess-2");
+    });
+
     it("still journals (branch undefined) when the branch lookup rejects", async () => {
       projectStoreMock.getAllProjects.mockReturnValue([{ id: "proj-1" }] as never);
       const ptyClient = makePtyClient({

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -6,7 +6,9 @@ const appMock = vi.hoisted(() => ({
   getPath: vi.fn(() => "/tmp/test-shutdown"),
 }));
 
-const persistAgentSessionMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const persistAgentSessionMock = vi.hoisted(() =>
+  vi.fn((_record: unknown, _userData?: string) => Promise.resolve())
+);
 
 vi.mock("../../services/pty/agentSessionHistory.js", () => ({
   persistAgentSession: persistAgentSessionMock,

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -3,6 +3,7 @@ import { app, dialog } from "electron";
 import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
 import { projectStore } from "../services/ProjectStore.js";
+import { persistAgentSession } from "../services/pty/agentSessionHistory.js";
 import { getActiveAgentCount, showQuitWarning } from "../utils/quitWarning.js";
 import {
   disposeAgentAvailabilityStore,
@@ -161,6 +162,20 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
     const gracefulShutdownPromise = (async () => {
       if (!ptyClient) return;
       try {
+        // Snapshot terminal infos before the kills — info is gone once the PTY
+        // exits — so each captured agent session can be journaled below. Outside
+        // the 4s kill race; a failed snapshot just no-ops the journal step.
+        let terminalInfoById = new Map<
+          string,
+          Awaited<ReturnType<PtyClient["getAllTerminalsAsync"]>>[number]
+        >();
+        try {
+          const allTerminals = await ptyClient.getAllTerminalsAsync();
+          terminalInfoById = new Map(allTerminals.map((t) => [t.id, t]));
+        } catch {
+          // Snapshot is best-effort; journaling below skips when info is absent.
+        }
+
         const allProjects = projectStore.getAllProjects();
         const projectIds = allProjects.map((p) => p.id);
         const allResults = await Promise.race([
@@ -185,6 +200,66 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
             }
             return state;
           });
+        }
+
+        // Journal a resume record per captured agent session, matching the
+        // trash-expiry / kill / gracefulKill close paths. Non-agent terminals
+        // and sessions with no resumable id are skipped. Branch lookups are
+        // time-boxed (200ms each, parallel over unique worktrees) so a stalled
+        // workspace-host can't push the chain past the cleanup budget (#7151).
+        const capturedAgents = allResults
+          .flat()
+          .filter((r) => r.agentSessionId)
+          .map((r) => ({ result: r, info: terminalInfoById.get(r.id) }))
+          .filter((c): c is { result: typeof c.result; info: NonNullable<typeof c.info> } =>
+            Boolean(c.info?.launchAgentId)
+          );
+
+        if (capturedAgents.length > 0) {
+          const uniqueWorktreeIds = [
+            ...new Set(
+              capturedAgents
+                .map((c) => c.info.worktreeId)
+                .filter((w): w is string => typeof w === "string" && w.length > 0)
+            ),
+          ];
+          const branchByWorktree = new Map<string, string>();
+          await Promise.all(
+            uniqueWorktreeIds.map(async (wid) => {
+              try {
+                const snapshot = await Promise.race([
+                  workspaceClient ? workspaceClient.getMonitorAsync(wid) : Promise.resolve(null),
+                  new Promise<null>((resolve) => setTimeout(() => resolve(null), 200)),
+                ]);
+                const branch = snapshot?.branch;
+                if (branch && branch !== "HEAD") branchByWorktree.set(wid, branch);
+              } catch {
+                // best-effort
+              }
+            })
+          );
+
+          const userData = app.getPath("userData");
+          for (const { result, info } of capturedAgents) {
+            try {
+              await persistAgentSession(
+                {
+                  sessionId: result.agentSessionId as string,
+                  agentId: info.launchAgentId as string,
+                  worktreeId: info.worktreeId ?? null,
+                  title: info.title ?? null,
+                  projectId: info.projectId ?? null,
+                  agentLaunchFlags: info.agentLaunchFlags,
+                  agentModelId: info.agentModelId,
+                  cwd: info.cwd ?? undefined,
+                  branch: info.worktreeId ? branchByWorktree.get(info.worktreeId) : undefined,
+                },
+                userData
+              );
+            } catch (err) {
+              console.warn("[MAIN] Failed to journal agent session on shutdown:", err);
+            }
+          }
         }
       } catch (error) {
         console.warn("[MAIN] Graceful agent shutdown incomplete:", error);

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -178,12 +178,24 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
 
         const allProjects = projectStore.getAllProjects();
         const projectIds = allProjects.map((p) => p.id);
-        const allResults = await Promise.race([
-          Promise.all(projectIds.map((pid) => ptyClient.gracefulKillByProject(pid))),
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("graceful shutdown timeout")), 4000)
-          ),
-        ]);
+        // Cap each project's graceful kill independently (in parallel) rather
+        // than racing the whole batch against one 4s deadline: a single slow
+        // project must not discard the captured sessions of projects that did
+        // finish in time — both the projectStore write and the resume journal
+        // below depend on those partial results. Wall-clock stays ~4s (parallel).
+        const allResults = await Promise.all(
+          projectIds.map((pid) => {
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            return Promise.race([
+              ptyClient.gracefulKillByProject(pid),
+              new Promise<Array<{ id: string; agentSessionId: string | null }>>((resolve) => {
+                timer = setTimeout(() => resolve([]), 4000);
+              }),
+            ]).finally(() => {
+              if (timer) clearTimeout(timer);
+            });
+          })
+        );
 
         for (let i = 0; i < projectIds.length; i++) {
           const results = allResults[i];
@@ -226,15 +238,20 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           const branchByWorktree = new Map<string, string>();
           await Promise.all(
             uniqueWorktreeIds.map(async (wid) => {
+              let timer: ReturnType<typeof setTimeout> | undefined;
               try {
                 const snapshot = await Promise.race([
                   workspaceClient ? workspaceClient.getMonitorAsync(wid) : Promise.resolve(null),
-                  new Promise<null>((resolve) => setTimeout(() => resolve(null), 200)),
+                  new Promise<null>((resolve) => {
+                    timer = setTimeout(() => resolve(null), 200);
+                  }),
                 ]);
                 const branch = snapshot?.branch;
                 if (branch && branch !== "HEAD") branchByWorktree.set(wid, branch);
               } catch {
                 // best-effort
+              } finally {
+                if (timer) clearTimeout(timer);
               }
             })
           );

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -33,6 +33,7 @@ import { computeSpawnContext, acquirePtyProcess } from "./pty/terminalSpawn.js";
 import { disposeTerminalSerializerService } from "./pty/TerminalSerializerService.js";
 import { deleteSessionFile } from "./pty/terminalSessionPersistence.js";
 import { persistAgentSession } from "./pty/agentSessionHistory.js";
+import { getGitBranch } from "../utils/gitUtils.js";
 
 /**
  * PtyManager - Facade for terminal process management.
@@ -465,6 +466,10 @@ export class PtyManager extends EventEmitter {
         try {
           const sessionId = await this.gracefulKill(termId);
           if (sessionId && info?.launchAgentId) {
+            // Best-effort branch stamp for resume sanity checks. The pty-host
+            // has FS access but no WorkspaceClient, so resolve directly from
+            // git with a short timeout; never let it block or fail the close.
+            const branch = info.cwd ? getGitBranch(info.cwd) : null;
             await persistAgentSession({
               sessionId,
               agentId: info.launchAgentId,
@@ -473,6 +478,8 @@ export class PtyManager extends EventEmitter {
               projectId: info.projectId ?? null,
               agentLaunchFlags: info.agentLaunchFlags,
               agentModelId: info.agentModelId,
+              cwd: info.cwd ?? undefined,
+              branch: branch ?? undefined,
             });
           }
         } catch (err) {

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -201,6 +201,117 @@ describe("agentSessionHistory", () => {
     expect(records[0].worktreeId).toBe("wt-2");
   });
 
+  it("round-trips cwd and branch", async () => {
+    await persistAgentSession(
+      {
+        sessionId: "with-meta",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        title: null,
+        projectId: null,
+        cwd: "/repo/worktrees/feature",
+        branch: "feature/foo",
+      },
+      userDataDir
+    );
+
+    const records = await readSessionHistory(userDataDir);
+    expect(records).toHaveLength(1);
+    expect(records[0].cwd).toBe("/repo/worktrees/feature");
+    expect(records[0].branch).toBe("feature/foo");
+  });
+
+  it("preserves all records under concurrent writes (no lost update)", async () => {
+    const N = 25;
+    // Fire all writes without awaiting between them — the serial queue must
+    // prevent the read-modify-write from dropping records.
+    await Promise.all(
+      Array.from({ length: N }, (_, i) =>
+        persistAgentSession(
+          {
+            sessionId: `concurrent-${i}`,
+            agentId: "claude",
+            // Spread across worktrees so the per-worktree cap can't evict any.
+            worktreeId: `wt-${i}`,
+            title: null,
+            projectId: null,
+          },
+          userDataDir
+        )
+      )
+    );
+
+    const records = await readSessionHistory(userDataDir);
+    const ids = new Set(records.map((r) => r.sessionId));
+    expect(ids.size).toBe(N);
+    for (let i = 0; i < N; i++) {
+      expect(ids.has(`concurrent-${i}`)).toBe(true);
+    }
+  });
+
+  it("deduplicates on sessionId, keeping the newest record", async () => {
+    await persistAgentSession(
+      {
+        sessionId: "dup",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        title: "old title",
+        projectId: null,
+        branch: "old-branch",
+      },
+      userDataDir
+    );
+    await persistAgentSession(
+      {
+        sessionId: "dup",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        title: "new title",
+        projectId: null,
+        branch: "new-branch",
+      },
+      userDataDir
+    );
+
+    const records = await readSessionHistory(userDataDir);
+    const dups = records.filter((r) => r.sessionId === "dup");
+    expect(dups).toHaveLength(1);
+    expect(dups[0].title).toBe("new title");
+    expect(dups[0].branch).toBe("new-branch");
+  });
+
+  it("keeps old records that predate the cwd/branch fields", async () => {
+    const filePath = getSessionHistoryPath(userDataDir)!;
+    const legacyRecord = {
+      sessionId: "legacy",
+      agentId: "claude",
+      worktreeId: "wt-1",
+      title: null,
+      projectId: null,
+      savedAt: Date.now() - 1000,
+    };
+    await fsp.writeFile(filePath, JSON.stringify([legacyRecord]));
+
+    await persistAgentSession(
+      {
+        sessionId: "fresh",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        title: null,
+        projectId: null,
+        cwd: "/repo",
+        branch: "main",
+      },
+      userDataDir
+    );
+
+    const records = await readSessionHistory(userDataDir);
+    const legacy = records.find((r) => r.sessionId === "legacy");
+    expect(legacy).toBeDefined();
+    expect(legacy?.cwd).toBeUndefined();
+    expect(legacy?.branch).toBeUndefined();
+  });
+
   it("handles corrupt JSON gracefully", async () => {
     const filePath = getSessionHistoryPath(userDataDir)!;
     await fsp.writeFile(filePath, "not json at all");

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -23,13 +23,42 @@ export function getSessionHistoryPath(userData?: string): string | null {
   return path.join(dir, HISTORY_FILENAME);
 }
 
+// Serialize all read-modify-write cycles through a single promise chain. Every
+// terminal close path can call persistAgentSession (trash expiry, IPC kill /
+// gracefulKill, app quit), and during app quit several fire near-simultaneously.
+// Without serialization the read-then-write would lost-update — two callers read
+// the same array, each prepends its own record, and the last write drops the
+// other. Chaining keeps every record. `.then(fn, fn)` runs the next write whether
+// the previous resolved or rejected, so one failure can't wedge the queue.
+let writeQueue: Promise<unknown> = Promise.resolve();
+function enqueueWrite<T>(fn: () => Promise<T>): Promise<T> {
+  const run = writeQueue.then(fn, fn);
+  writeQueue = run.catch(() => {});
+  return run as Promise<T>;
+}
+
 function evictRecords(records: AgentSessionRecord[], now: number): AgentSessionRecord[] {
   // Filter expired records
   const fresh = records.filter((r) => now - r.savedAt < SESSION_HISTORY_TTL_MS);
 
+  // Deduplicate on sessionId, keeping the newest. Multiple close paths can fire
+  // for the same terminal (e.g. a user kill landing mid-shutdown), each writing
+  // a record with the same resumable sessionId — without this the journal would
+  // accumulate stale duplicates. Records arrive newest-first, so the first
+  // occurrence of each sessionId wins.
+  const seen = new Set<string>();
+  const deduped: AgentSessionRecord[] = [];
+  for (const r of fresh) {
+    if (r.sessionId) {
+      if (seen.has(r.sessionId)) continue;
+      seen.add(r.sessionId);
+    }
+    deduped.push(r);
+  }
+
   // Enforce per-worktree cap
   const buckets = new Map<string, AgentSessionRecord[]>();
-  for (const r of fresh) {
+  for (const r of deduped) {
     const key = r.worktreeId ?? "__global__";
     let bucket = buckets.get(key);
     if (!bucket) {
@@ -83,16 +112,18 @@ export async function persistAgentSession(
   const filePath = getSessionHistoryPath(userData);
   if (!filePath) return;
 
-  const dir = path.dirname(filePath);
-  await mkdir(dir, { recursive: true });
+  await enqueueWrite(async () => {
+    const dir = path.dirname(filePath);
+    await mkdir(dir, { recursive: true });
 
-  const now = Date.now();
-  const fullRecord: AgentSessionRecord = { ...record, savedAt: now };
+    const now = Date.now();
+    const fullRecord: AgentSessionRecord = { ...record, savedAt: now };
 
-  const existing = await readSessionHistory(userData);
-  const updated = evictRecords([fullRecord, ...existing], now);
+    const existing = await readSessionHistory(userData);
+    const updated = evictRecords([fullRecord, ...existing], now);
 
-  await resilientAtomicWriteFile(filePath, JSON.stringify(updated, null, 2));
+    await resilientAtomicWriteFile(filePath, JSON.stringify(updated, null, 2));
+  });
 }
 
 export function listAgentSessions(worktreeId?: string, userData?: string): AgentSessionRecord[] {
@@ -108,13 +139,17 @@ export async function clearAgentSessions(worktreeId?: string, userData?: string)
   const filePath = getSessionHistoryPath(userData);
   if (!filePath) return;
 
-  if (!worktreeId) {
-    // Clear all
-    await resilientAtomicWriteFile(filePath, "[]");
-    return;
-  }
+  // Share the write queue with persistAgentSession so a clear can't interleave
+  // with an in-flight persist's read-modify-write and resurrect a cleared record.
+  await enqueueWrite(async () => {
+    if (!worktreeId) {
+      // Clear all
+      await resilientAtomicWriteFile(filePath, "[]");
+      return;
+    }
 
-  const existing = await readSessionHistory(userData);
-  const filtered = existing.filter((r) => r.worktreeId !== worktreeId);
-  await resilientAtomicWriteFile(filePath, JSON.stringify(filtered, null, 2));
+    const existing = await readSessionHistory(userData);
+    const filtered = existing.filter((r) => r.worktreeId !== worktreeId);
+    await resilientAtomicWriteFile(filePath, JSON.stringify(filtered, null, 2));
+  });
 }

--- a/electron/utils/__tests__/gitUtils.test.ts
+++ b/electron/utils/__tests__/gitUtils.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("child_process", () => ({
+  execSync: execSyncMock,
+}));
+
+import { getGitBranch } from "../gitUtils.js";
+
+describe("getGitBranch", () => {
+  afterEach(() => {
+    execSyncMock.mockReset();
+  });
+
+  it("returns the trimmed branch name", () => {
+    execSyncMock.mockReturnValue("feature/foo\n");
+    expect(getGitBranch("/repo")).toBe("feature/foo");
+  });
+
+  it("returns null for a detached HEAD", () => {
+    execSyncMock.mockReturnValue("HEAD\n");
+    expect(getGitBranch("/repo")).toBeNull();
+  });
+
+  it("returns null when git output is empty", () => {
+    execSyncMock.mockReturnValue("\n");
+    expect(getGitBranch("/repo")).toBeNull();
+  });
+
+  it("returns null when execSync throws (not a repo / timeout)", () => {
+    execSyncMock.mockImplementation(() => {
+      throw new Error("not a git repository");
+    });
+    expect(getGitBranch("/not-a-repo")).toBeNull();
+  });
+
+  it("runs git in the given cwd with the requested timeout", () => {
+    execSyncMock.mockReturnValue("main\n");
+    getGitBranch("/repo/path", { timeout: 1234 });
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    const [cmd, opts] = execSyncMock.mock.calls[0];
+    expect(cmd).toContain("rev-parse --abbrev-ref HEAD");
+    expect(opts).toMatchObject({ cwd: "/repo/path", timeout: 1234 });
+  });
+
+  it("defaults to a short 500ms timeout", () => {
+    execSyncMock.mockReturnValue("main\n");
+    getGitBranch("/repo");
+    expect(execSyncMock.mock.calls[0][1]).toMatchObject({ timeout: 500 });
+  });
+});

--- a/electron/utils/gitUtils.ts
+++ b/electron/utils/gitUtils.ts
@@ -105,6 +105,32 @@ export function getGitCommonDir(worktreePath: string, options: GitDirOptions = {
   }
 }
 
+/**
+ * Resolve the currently checked-out branch name for a worktree. Returns `null`
+ * for a detached HEAD (git emits the literal "HEAD") or on any failure. Not
+ * cached: unlike the git dir, the branch is mutable over a worktree's life.
+ * Used best-effort at terminal-close time to stamp a resume sanity-check onto
+ * the journal record, so it runs with a short default timeout and never throws.
+ */
+export function getGitBranch(
+  worktreePath: string,
+  options: { timeout?: number } = {}
+): string | null {
+  const { timeout = 500 } = options;
+  try {
+    const result = execSync("git rev-parse --abbrev-ref HEAD", {
+      cwd: worktreePath,
+      encoding: "utf-8",
+      timeout,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (!result || result === "HEAD") return null;
+    return result;
+  } catch {
+    return null;
+  }
+}
+
 export function clearGitDirCache(worktreePath?: string): void {
   if (worktreePath) {
     gitDirCache.invalidate(worktreePath);

--- a/shared/types/ipc/agentSessionHistory.ts
+++ b/shared/types/ipc/agentSessionHistory.ts
@@ -7,4 +7,8 @@ export interface AgentSessionRecord {
   savedAt: number;
   agentLaunchFlags?: string[];
   agentModelId?: string;
+  /** Working directory the terminal was running in at capture time. */
+  cwd?: string;
+  /** Git branch checked out in `cwd` at capture time, for resume sanity checks. */
+  branch?: string;
 }


### PR DESCRIPTION
## Summary

- Previously only the 20-second trash expiry timer wrote to `agent-session-history.json`. Every other close path (`terminal.kill`, manual close, `gracefulKill`, app quit) silently discarded the resume opportunity.
- Every agent terminal close path now journals a record. `AgentSessionRecord` also gains optional `cwd` and `branch` fields for resume sanity checks.

Resolves #10849

## Changes

- `AgentSessionRecord` gets optional `cwd` and `branch` fields (`shared/types/ipc/agentSessionHistory.ts`)
- `agentSessionHistory` uses a serial write queue to prevent lost-update races when multiple close paths journal concurrently (common on app quit), plus `sessionId` dedup in eviction
- New `getGitBranch` helper in `electron/utils/gitUtils.ts`: uncached, time-boxed, detached-HEAD aware
- `PtyManager` trash-expiry path stamps `cwd` and `branch`
- `handleTerminalKill` now routes agent terminals through `gracefulKill` and journals; `handleTerminalGracefulKill` journals; branch resolved via `WorkspaceClient` with a 200ms cap
- App-quit shutdown snapshots terminals and journals a record per captured agent session. Each project's graceful kill now runs in parallel with an independent 4s cap, so a slow project no longer causes fast projects to lose their captures. Branch lookups time-boxed at 200ms.
- Guard throughout: only journals when `sessionId && launchAgentId` are both present, so plain terminals and agents with no resume config (Cursor) stay quiet

## Testing

129 tests pass across the affected files. Coverage includes:

- `agentSessionHistory`: concurrent writes with no lost-update, `sessionId` dedup, `cwd`/`branch` round-trip, legacy records without new fields survive
- `lifecycle`: kill and `gracefulKill` journaling matrix
- `shutdown`: per-project journaling plus resilience (journal failure does not abort shutdown)
- `gitUtils`: `getGitBranch` edge cases including detached HEAD and timeout