### PR TITLE
fix(terminal): extend interactive scroll override to ordinary scrollback (#10858)

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -341,6 +341,7 @@ class TerminalInstanceService {
         this.agentStateController.clearDirectingState(id, trigger),
       onUserInput: (id, data) => this.onUserInput(id, data),
       onActiveWheel: (id) => this.onActiveWheel(id),
+      onUserScrollIntent: (id) => this.onUserScrollIntent(id),
       onEnterPressed: (id) => this.onEnterPressed(id),
       updateLastObservedTitle: (id, title) =>
         usePanelStore.getState().updateLastObservedTitle(id, title),
@@ -587,6 +588,22 @@ class TerminalInstanceService {
       current.inputBurstTimer = undefined;
       this.rendererPolicy.applyRendererPolicy(id, current.getRefreshTier());
     }, WHEEL_BURST_DECAY_MS);
+
+    this.requestInteractiveProfileOverride();
+  }
+
+  /**
+   * Ordinary scrollback wheel/key scrolling (not mouse-reporting forwarding).
+   * Holds the resource profile off efficiency for the same reason as
+   * `onActiveWheel` — a profile downgrade mid-scroll drops the WebGL upper
+   * threshold and can force the visible terminal onto the DOM renderer right
+   * as the user is scrolling it (#10858). Unlike `onActiveWheel`, plain
+   * scrollback is client-side xterm rendering with no PTY round-trip per
+   * line, so there's no renderer-tier boost to apply here.
+   */
+  private onUserScrollIntent(id: string): void {
+    const managed = this.instances.get(id);
+    if (!managed) return;
 
     this.requestInteractiveProfileOverride();
   }

--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -262,6 +262,15 @@ export interface TerminalListenerInstallDeps {
    * efficiency so an active scroll stays responsive (symptom B).
    */
   onActiveWheel: (id: string) => void;
+  /**
+   * Fired on ordinary scrollback wheel/key scrolling (not mouse-reporting
+   * forwarding). Holds the resource profile off efficiency for the scroll's
+   * duration so an in-progress profile downgrade doesn't drop the terminal's
+   * WebGL threshold mid-scroll (#10858). Unlike `onActiveWheel`, this does
+   * not boost the renderer tier — plain scrollback is client-side xterm
+   * rendering, not a PTY round-trip per redraw.
+   */
+  onUserScrollIntent: (id: string) => void;
   onEnterPressed: (id: string) => void;
 
   // Panel store side effects (routed through deps to keep this module
@@ -560,9 +569,13 @@ export function installTerminalBoundListeners(
   const onWheel = () => {
     managed._userScrollIntent = true;
     managed.lastWheelAt = Date.now();
+    deps.onUserScrollIntent(id);
   };
   const onKeydownScroll = (e: KeyboardEvent) => {
-    if (SCROLL_KEYS.has(e.key)) managed._userScrollIntent = true;
+    if (SCROLL_KEYS.has(e.key)) {
+      managed._userScrollIntent = true;
+      deps.onUserScrollIntent(id);
+    }
   };
   hostElement.addEventListener("wheel", onWheel, { passive: true });
   hostElement.addEventListener("keydown", onKeydownScroll);

--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -566,9 +566,16 @@ export function installTerminalBoundListeners(
   managed.listeners.push(() => scrollDisposable.dispose());
 
   const SCROLL_KEYS = new Set(["PageUp", "PageDown", "Home", "End", "ArrowUp", "ArrowDown"]);
-  const onWheel = () => {
+  const onWheel = (ev: WheelEvent) => {
     managed._userScrollIntent = true;
     managed.lastWheelAt = Date.now();
+    // Skip the synthetic per-line events the alt-buffer mouse-reporting
+    // amplifier dispatches (already drives the profile hold via onActiveWheel)
+    // and modifier-held wheels (pinch-zoom/etc, not scrollback navigation) —
+    // mirrors the gating onWheelNormalize already applies for the same reasons.
+    if (amplifiedWheelEvents.has(ev) || ev.ctrlKey || ev.altKey || ev.metaKey || ev.shiftKey) {
+      return;
+    }
     deps.onUserScrollIntent(id);
   };
   const onKeydownScroll = (e: KeyboardEvent) => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
@@ -212,7 +212,7 @@ describe("TerminalInstanceService — installTerminalBoundListeners call-site pa
   it("onUserScrollIntent dep requests an interactive profile-hold over IPC (#10858)", async () => {
     await service.getOrCreate("t1", undefined, {});
 
-    const deps = installMock.mock.calls[0][3] as { onUserScrollIntent: (id: string) => void };
+    const deps = installMock.mock.calls[0]?.[3] as { onUserScrollIntent: (id: string) => void };
     deps.onUserScrollIntent("t1");
 
     expect(

--- a/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts
@@ -181,6 +181,9 @@ describe("TerminalInstanceService — installTerminalBoundListeners call-site pa
         writeSelection: vi.fn().mockResolvedValue(undefined),
         readSelection: vi.fn().mockResolvedValue({ text: "" }),
       },
+      system: {
+        requestInteractiveOverride: vi.fn().mockResolvedValue(undefined),
+      },
     };
 
     ({ terminalInstanceService: service } =
@@ -204,6 +207,21 @@ describe("TerminalInstanceService — installTerminalBoundListeners call-site pa
       "t1",
       expect.any(Object)
     );
+  });
+
+  it("onUserScrollIntent dep requests an interactive profile-hold over IPC (#10858)", async () => {
+    await service.getOrCreate("t1", undefined, {});
+
+    const deps = installMock.mock.calls[0][3] as { onUserScrollIntent: (id: string) => void };
+    deps.onUserScrollIntent("t1");
+
+    expect(
+      (
+        window as unknown as {
+          electron: { system: { requestInteractiveOverride: ReturnType<typeof vi.fn> } };
+        }
+      ).electron.system.requestInteractiveOverride
+    ).toHaveBeenCalledWith(1500);
   });
 
   it("detach path: detachForProjectSwitch does not install listeners", () => {

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -182,6 +182,7 @@ function makeDeps(
     clearDirectingState: vi.fn(),
     onUserInput: vi.fn(),
     onActiveWheel: vi.fn(),
+    onUserScrollIntent: vi.fn(),
     onEnterPressed: vi.fn(),
     updateLastObservedTitle: vi.fn(),
     notifyXtermFocused: vi.fn(),
@@ -620,6 +621,73 @@ describe("installTerminalBoundListeners", () => {
     (terminal.modes as { mouseTrackingMode: string }).mouseTrackingMode = "any";
 
     expect(captured.wheelHandler!({} as WheelEvent)).toBe(true);
+  });
+
+  describe("onUserScrollIntent (#10858)", () => {
+    function install() {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const managed = makeMockManaged();
+      const deps = makeDeps();
+
+      managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+      installTerminalBoundListeners(
+        terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+        managed,
+        "t1",
+        deps
+      );
+      return { managed, deps };
+    }
+
+    it("fires on an ordinary scrollback wheel event", () => {
+      const { managed, deps } = install();
+
+      managed.hostElement.dispatchEvent(new WheelEvent("wheel", { deltaY: 10 }));
+
+      expect(deps.onUserScrollIntent).toHaveBeenCalledWith("t1");
+    });
+
+    it.each(["PageUp", "PageDown", "Home", "End", "ArrowUp", "ArrowDown"])(
+      "fires on a %s keydown",
+      (key) => {
+        const { managed, deps } = install();
+
+        managed.hostElement.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+
+        expect(deps.onUserScrollIntent).toHaveBeenCalledWith("t1");
+      }
+    );
+
+    it("does not fire for a non-scroll keydown", () => {
+      const { managed, deps } = install();
+
+      managed.hostElement.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+
+      expect(deps.onUserScrollIntent).not.toHaveBeenCalled();
+    });
+
+    it("does not fire from terminal.onScroll (programmatic auto-scroll guard)", () => {
+      const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+      const terminal = makeMockTerminal(captured);
+      const managed = makeMockManaged();
+      const deps = makeDeps();
+
+      managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+      installTerminalBoundListeners(
+        terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+        managed,
+        "t1",
+        deps
+      );
+
+      // Simulate a PTY-output-driven programmatic scroll via xterm's onScroll —
+      // must NOT be wired to onUserScrollIntent, or every streaming terminal
+      // would stay pinned off efficiency indefinitely (defeats the downgrade).
+      captured.onScroll?.();
+
+      expect(deps.onUserScrollIntent).not.toHaveBeenCalled();
+    });
   });
 
   describe("wheel amplification for mouse-tracking TUIs", () => {


### PR DESCRIPTION
## Summary

The WebGL versus DOM rendering mode for terminal panes uses a hysteresis threshold pair sourced from the active resource profile (performance, balanced, efficiency). When the profile downgrades under CPU or event-loop-lag pressure, the WebGL upper threshold drops too (balanced `12` to efficiency `8`, for example), pushing visible terminals onto the slower DOM renderer at exactly the moment a user might be actively scrolling one of them.

This extends the interactive-scroll resource-profile override introduced in #10848 (`requestInteractiveOverride`). That override previously fired only on alt-buffer mouse-reporting TUI wheel forwarding (`onActiveWheel`). It now also fires on ordinary scrollback wheel and key scrolling via a new `onUserScrollIntent` dependency, wired through the existing `onWheel` and `onKeydownScroll` listeners in `TerminalListenerInstaller.ts` that already isolate genuine user-scroll intent from programmatic auto-scroll.

Unlike `onActiveWheel`, the new path doesn't boost the renderer tier to BURST. Plain scrollback is client-side xterm rendering, not a PTY round trip per redraw, so there's no need for it.

The change gates on real user wheel events: it skips modifier-held wheels (ctrl/alt/meta/shift, e.g. pinch zoom) and synthetic amplified-wheel-line events coming from the alt-buffer forwarding path, mirroring the existing `onWheelNormalize` gating.

I also looked at decoupling the WebGL threshold from the resource profile entirely, basing it on an independent GPU or memory pressure signal instead. Rejected that after confirming Electron 42 / Chromium 148 doesn't expose a real GPU or VRAM pressure API to build on.

Resolves #10858

## Changes

- `src/services/terminal/TerminalListenerInstaller.ts`: wire `onUserScrollIntent` through the existing `onWheel`/`onKeydownScroll` listeners, gated on real user wheel events.
- `src/services/terminal/TerminalInstanceService.ts`: extend `requestInteractiveOverride` to accept the new scrollback scroll-intent trigger alongside the existing alt-buffer wheel trigger.
- `src/services/terminal/__tests__/TerminalListenerInstaller.test.ts`, `src/services/terminal/__tests__/TerminalInstanceService.installerCallSite.test.ts`: coverage for the new dependency and gating behavior.

## Testing

- Targeted vitest run across both test files: 86 tests passing.
- prettier and eslint clean on changed files.
- Reviewed via two adversarial Codex passes (code and tests). No critical findings; minor findings on modifier and synthetic event gating, and a missing IPC-level test, were fixed inline and re-verified.