### PR TITLE
fix(webview): close panel, not window, on Cmd+W

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -354,6 +354,7 @@ export const CHANNELS = {
   WEBVIEW_DIALOG_DISMISS: "webview:dialog-dismiss",
   WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
   WEBVIEW_RELOAD_SHORTCUT: "webview:reload-shortcut",
+  WEBVIEW_CLOSE_SHORTCUT: "webview:close-shortcut",
   WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
   WEBVIEW_UNRESPONSIVE: "webview:unresponsive",
   WEBVIEW_RESPONSIVE: "webview:responsive",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1960,6 +1960,8 @@ function buildElectronApi(): ElectronAPI {
       ): (() => void) => _typedOn(CHANNELS.WEBVIEW_FIND_SHORTCUT, callback),
       onReloadShortcut: (callback: (payload: { panelId: string }) => void): (() => void) =>
         _typedOn(CHANNELS.WEBVIEW_RELOAD_SHORTCUT, callback),
+      onCloseShortcut: (callback: (payload: { panelId: string }) => void): (() => void) =>
+        _typedOn(CHANNELS.WEBVIEW_CLOSE_SHORTCUT, callback),
       onNavigationBlocked: (
         callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void
       ): (() => void) => _typedOn(CHANNELS.WEBVIEW_NAVIGATION_BLOCKED, callback),

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -539,11 +539,15 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
       const mockEvent = { preventDefault: vi.fn() };
+      // The close chord is platform-specific: Cmd+W on macOS, Ctrl+W
+      // elsewhere. Match the runtime platform so this passes on both the dev
+      // machine (macOS) and CI (Linux).
+      const isMac = process.platform === "darwin";
       beforeInputHandlers[0](mockEvent, {
         type: "keyDown",
         key: "w",
-        meta: true,
-        control: false,
+        meta: isMac,
+        control: !isMac,
         alt: false,
         shift: false,
       });
@@ -572,11 +576,12 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
       const mockEvent = { preventDefault: vi.fn() };
+      const isMac = process.platform === "darwin";
       beforeInputHandlers[0](mockEvent, {
         type: "keyDown",
         key: "w",
-        meta: true,
-        control: false,
+        meta: isMac,
+        control: !isMac,
         alt: false,
         shift: false,
       });
@@ -605,11 +610,12 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
       const mockEvent = { preventDefault: vi.fn() };
+      const isMac = process.platform === "darwin";
       beforeInputHandlers[0](mockEvent, {
         type: "keyDown",
         key: "w",
-        meta: true,
-        control: false,
+        meta: isMac,
+        control: !isMac,
         alt: false,
         shift: true,
       });
@@ -618,7 +624,7 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
       expect(mockSend).not.toHaveBeenCalledWith("webview:close-shortcut", expect.anything());
     });
 
-    it("ignores Ctrl+Cmd+W on macOS — the opposite-platform modifier disqualifies it (#10859)", () => {
+    it("ignores Cmd+Ctrl+W — the opposite-platform modifier disqualifies the close chord (#10859)", () => {
       const mockSend = vi.fn();
       mockFromWebContents.mockReturnValue({
         isDestroyed: () => false,
@@ -636,8 +642,9 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
       const mockEvent = { preventDefault: vi.fn() };
-      // On macOS (the test platform) the close chord is Cmd+W; adding Ctrl
-      // must disqualify it so it isn't treated as a plain panel close.
+      // Both modifiers held is always disqualified: on macOS the extra Ctrl
+      // voids the Cmd+W chord, and on Linux/Windows the extra Cmd voids the
+      // Ctrl+W chord — so this is rejected on every platform.
       beforeInputHandlers[0](mockEvent, {
         type: "keyDown",
         key: "w",

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -543,7 +543,7 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
         type: "keyDown",
         key: "w",
         meta: true,
-        control: true,
+        control: false,
         alt: false,
         shift: false,
       });
@@ -576,7 +576,7 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
         type: "keyDown",
         key: "w",
         meta: true,
-        control: true,
+        control: false,
         alt: false,
         shift: false,
       });
@@ -609,9 +609,42 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
         type: "keyDown",
         key: "w",
         meta: true,
-        control: true,
+        control: false,
         alt: false,
         shift: true,
+      });
+
+      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalledWith("webview:close-shortcut", expect.anything());
+    });
+
+    it("ignores Ctrl+Cmd+W on macOS — the opposite-platform modifier disqualifies it (#10859)", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-1"),
+        getPanelKind: vi.fn(() => "dev-preview"),
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
+      const mockEvent = { preventDefault: vi.fn() };
+      // On macOS (the test platform) the close chord is Cmd+W; adding Ctrl
+      // must disqualify it so it isn't treated as a plain panel close.
+      beforeInputHandlers[0](mockEvent, {
+        type: "keyDown",
+        key: "w",
+        meta: true,
+        control: true,
+        alt: false,
+        shift: false,
       });
 
       expect(mockEvent.preventDefault).not.toHaveBeenCalled();

--- a/electron/setup/__tests__/protocols.test.ts
+++ b/electron/setup/__tests__/protocols.test.ts
@@ -128,6 +128,7 @@ vi.mock("../../ipc/channels.js", () => ({
   CHANNELS: {
     WEBVIEW_FIND_SHORTCUT: "webview:find-shortcut",
     WEBVIEW_RELOAD_SHORTCUT: "webview:reload-shortcut",
+    WEBVIEW_CLOSE_SHORTCUT: "webview:close-shortcut",
     WEBVIEW_NAVIGATION_BLOCKED: "webview:navigation-blocked",
     WEBVIEW_DIALOG_DISMISS: "webview:dialog-dismiss",
   },
@@ -518,6 +519,103 @@ describe("setupWebviewCSP — webview guest navigation restriction", () => {
 
       expect(mockEvent.preventDefault).not.toHaveBeenCalled();
       expect(mockSend).not.toHaveBeenCalledWith("webview:reload-shortcut", expect.anything());
+    });
+
+    it("sends close shortcut (Cmd/Ctrl+W) to the parent window and prevents default for dev-preview webviews (#10859)", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-1"),
+        getPanelKind: vi.fn(() => "dev-preview"),
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
+      const mockEvent = { preventDefault: vi.fn() };
+      beforeInputHandlers[0](mockEvent, {
+        type: "keyDown",
+        key: "w",
+        meta: true,
+        control: true,
+        alt: false,
+        shift: false,
+      });
+
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockSend).toHaveBeenCalledWith("webview:close-shortcut", {
+        panelId: "panel-1",
+      });
+    });
+
+    it("also sends close shortcut (Cmd/Ctrl+W) for non-dev-preview webviews like browser panels — unlike reload, no panel-kind gate applies (#10859)", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-browser-1"),
+        getPanelKind: vi.fn(() => "browser"),
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
+      const mockEvent = { preventDefault: vi.fn() };
+      beforeInputHandlers[0](mockEvent, {
+        type: "keyDown",
+        key: "w",
+        meta: true,
+        control: true,
+        alt: false,
+        shift: false,
+      });
+
+      expect(mockEvent.preventDefault).toHaveBeenCalledTimes(1);
+      expect(mockSend).toHaveBeenCalledWith("webview:close-shortcut", {
+        panelId: "panel-browser-1",
+      });
+    });
+
+    it("ignores Cmd/Ctrl+Shift+W so it does not shadow other shortcuts (#10859)", () => {
+      const mockSend = vi.fn();
+      mockFromWebContents.mockReturnValue({
+        isDestroyed: () => false,
+        webContents: { send: mockSend },
+      });
+      mockedGetWebviewDialogService.mockReturnValue({
+        registerDialog: vi.fn(),
+        getPanelId: vi.fn(() => "panel-1"),
+        getPanelKind: vi.fn(() => "dev-preview"),
+      } as unknown as ReturnType<typeof getWebviewDialogService>);
+
+      const contents = createMockWebContents("webview");
+      (contents as unknown as { hostWebContents: unknown }).hostWebContents = { id: 99 };
+      simulateWebContentsCreated(contents);
+
+      const beforeInputHandlers = getEventHandlers(contents, "before-input-event");
+      const mockEvent = { preventDefault: vi.fn() };
+      beforeInputHandlers[0](mockEvent, {
+        type: "keyDown",
+        key: "w",
+        meta: true,
+        control: true,
+        alt: false,
+        shift: true,
+      });
+
+      expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+      expect(mockSend).not.toHaveBeenCalledWith("webview:close-shortcut", expect.anything());
     });
   });
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -965,8 +965,14 @@ export function setupWebviewCSP(): void {
         }
 
         const isReload = mod && input.key.toLowerCase() === "r" && !input.alt && !input.shift;
+        // Match the host-level guard in createWindow.ts: require the
+        // platform-correct close modifier and reject the opposite one, so
+        // Ctrl+Cmd+W isn't treated as a plain close.
         const isCloseShortcut =
-          mod && input.key.toLowerCase() === "w" && !input.alt && !input.shift;
+          input.key.toLowerCase() === "w" &&
+          ((isMac && input.meta && !input.control) || (!isMac && input.control && !input.meta)) &&
+          !input.alt &&
+          !input.shift;
 
         if (!shortcut && !isReload && !isCloseShortcut) return;
 

--- a/electron/setup/protocols.ts
+++ b/electron/setup/protocols.ts
@@ -945,10 +945,11 @@ export function setupWebviewCSP(): void {
       contents.on("render-process-gone", dismissPendingDialogs);
       contents.once("destroyed", dismissPendingDialogs);
 
-      // Intercept find-in-page (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape) and reload
-      // (Cmd/Ctrl+R) shortcuts from webview guests. When the guest has focus
-      // Chromium routes keystrokes directly to it, so the outer renderer's
-      // keydown listener never sees these — they must be caught here.
+      // Intercept find-in-page (Cmd/Ctrl+F, Cmd/Ctrl+G, Escape), reload
+      // (Cmd/Ctrl+R), and close (Cmd/Ctrl+W) shortcuts from webview guests.
+      // When the guest has focus Chromium routes keystrokes directly to it
+      // — bypassing the host webContents' setIgnoreMenuShortcuts guards —
+      // so they must be caught and forwarded here.
       contents.on("before-input-event", (event, input) => {
         if (input.type !== "keyDown") return;
         const isMac = process.platform === "darwin";
@@ -964,8 +965,10 @@ export function setupWebviewCSP(): void {
         }
 
         const isReload = mod && input.key.toLowerCase() === "r" && !input.alt && !input.shift;
+        const isCloseShortcut =
+          mod && input.key.toLowerCase() === "w" && !input.alt && !input.shift;
 
-        if (!shortcut && !isReload) return;
+        if (!shortcut && !isReload && !isCloseShortcut) return;
 
         const dialogService = getWebviewDialogService();
         const panelId = dialogService.getPanelId(contents.id);
@@ -983,6 +986,20 @@ export function setupWebviewCSP(): void {
           if (findParentWindow && !findParentWindow.isDestroyed()) {
             event.preventDefault();
             getAppWebContents(findParentWindow).send(CHANNELS.WEBVIEW_RELOAD_SHORTCUT, {
+              panelId,
+            });
+          }
+          return;
+        }
+
+        if (isCloseShortcut) {
+          // Applies to every webview-hosting panel kind (dev-preview, browser)
+          // — unlike reload, all of them need Cmd/Ctrl+W to close the panel
+          // instead of falling through to the native role:"close" accelerator,
+          // which would otherwise close the whole window (#10859).
+          if (findParentWindow && !findParentWindow.isDestroyed()) {
+            event.preventDefault();
+            getAppWebContents(findParentWindow).send(CHANNELS.WEBVIEW_CLOSE_SHORTCUT, {
               panelId,
             });
           }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -886,6 +886,8 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     ): () => void;
     /** Subscribe to reload shortcut (Cmd/Ctrl+R) forwarded from focused webview guests */
     onReloadShortcut(callback: (payload: { panelId: string }) => void): () => void;
+    /** Subscribe to close shortcut (Cmd/Ctrl+W) forwarded from focused webview guests */
+    onCloseShortcut(callback: (payload: { panelId: string }) => void): () => void;
     /** Subscribe to blocked cross-origin navigation events from webview guests */
     onNavigationBlocked(
       callback: (payload: { panelId: string; url: string; canOpenExternal: boolean }) => void

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1733,6 +1733,11 @@ export interface IpcEventMap {
     panelId: string;
   };
 
+  // Webview close shortcut (Cmd/Ctrl+W) forwarded from focused guest
+  "webview:close-shortcut": {
+    panelId: string;
+  };
+
   // Webview navigation blocked — cross-origin navigation was prevented
   "webview:navigation-blocked": {
     panelId: string;

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -537,6 +537,18 @@ export function BrowserPane({
     };
   }, [id]);
 
+  // Listen for the close shortcut (Cmd/Ctrl+W) forwarded from the focused
+  // webview guest (#10859). Without this, focus inside the guest bypasses the
+  // host window's setIgnoreMenuShortcuts guard and the native role:"close"
+  // menu accelerator closes the whole window instead of just this panel.
+  useEffect(() => {
+    const cleanup = window.electron.webview.onCloseShortcut((payload) => {
+      if (payload.panelId !== id) return;
+      void actionService.dispatch("terminal.close", { terminalId: id }, { source: "keybinding" });
+    });
+    return cleanup;
+  }, [id]);
+
   // Clear crash state when the user navigates to a fresh URL. Depending on
   // crashState here would create an instant-reset loop: the effect would fire
   // the moment crashState transitions from "none" and clear it back. Track the

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -249,6 +249,7 @@ describe("BrowserPane webview lifecycle regression", () => {
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onUnresponsive: vi.fn(() => vi.fn()),
         onResponsive: vi.fn(() => vi.fn()),
+        onCloseShortcut: vi.fn(() => vi.fn()),
         getNavigationHistory: vi.fn(() =>
           Promise.resolve({ entries: [], activeIndex: 0, canGoBack: false, canGoForward: false })
         ),
@@ -922,6 +923,35 @@ describe("BrowserPane webview lifecycle regression", () => {
         "browser.openExternal",
         { terminalId: "browser-panel-1", url: "https://oauth.provider.com/auth" },
         { source: "user" }
+      );
+    });
+
+    it("closes this panel when onCloseShortcut fires for it, and ignores other panels (#10859)", () => {
+      render(<BrowserPane {...baseProps} />);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = (window as any).electron.webview.onCloseShortcut;
+      const closeCb = mock.mock.calls[mock.mock.calls.length - 1][0] as (payload: {
+        panelId: string;
+      }) => void;
+
+      // A shortcut targeting a different panel must not close this one
+      act(() => {
+        closeCb({ panelId: "some-other-panel" });
+      });
+      expect(actionDispatchMock).not.toHaveBeenCalledWith(
+        "terminal.close",
+        expect.anything(),
+        expect.anything()
+      );
+
+      // A shortcut targeting this panel closes exactly this panel by id
+      act(() => {
+        closeCb({ panelId: "browser-panel-1" });
+      });
+      expect(actionDispatchMock).toHaveBeenCalledWith(
+        "terminal.close",
+        { terminalId: "browser-panel-1" },
+        { source: "keybinding" }
       );
     });
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1488,6 +1488,18 @@ export function DevPreviewPane({
     return cleanup;
   }, [id, handleHardReload]);
 
+  // Listen for the close shortcut (Cmd/Ctrl+W) forwarded from the focused
+  // webview guest (#10859). Without this, focus inside the guest bypasses the
+  // host window's setIgnoreMenuShortcuts guard and the native role:"close"
+  // menu accelerator closes the whole window instead of just this panel.
+  useEffect(() => {
+    const cleanup = window.electron.webview.onCloseShortcut((payload) => {
+      if (payload.panelId !== id) return;
+      void actionService.dispatch("terminal.close", { terminalId: id }, { source: "keybinding" });
+    });
+    return cleanup;
+  }, [id]);
+
   // Listen for action-driven hard-reload events
   useEffect(() => {
     const handleHardReloadEvent = (e: Event) => {

--- a/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.webview.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DevPreviewPaneProps } from "../DevPreviewPane";
 import { DevPreviewPane } from "../DevPreviewPane";
 import { projectClient } from "@/clients";
+import { actionService } from "@/services/ActionService";
 
 const notifyMock = vi.hoisted(() => vi.fn());
 
@@ -415,6 +416,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
         onReloadShortcut: vi.fn(() => vi.fn()),
+        onCloseShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         setLifecycleState: vi.fn().mockResolvedValue(undefined),
@@ -492,6 +494,54 @@ describe("DevPreviewPane webview lifecycle regression", () => {
 
     const { unmount } = render(<DevPreviewPane {...baseProps} />);
     expect(electron.webview.onReloadShortcut).toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it("closes this panel when onCloseShortcut fires for it, and ignores other panels (#10859)", async () => {
+    let closeCb: ((payload: { panelId: string }) => void) | undefined;
+    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+      .electron;
+    electron.webview.onCloseShortcut = vi.fn((cb: (payload: { panelId: string }) => void) => {
+      closeCb = cb;
+      return vi.fn();
+    });
+    const dispatchSpy = vi
+      .spyOn(actionService, "dispatch")
+      .mockResolvedValue({ ok: true } as Awaited<ReturnType<typeof actionService.dispatch>>);
+
+    render(<DevPreviewPane {...baseProps} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(closeCb).toBeDefined();
+
+    // A shortcut targeting a different panel must not close this one
+    act(() => {
+      closeCb?.({ panelId: "some-other-panel" });
+    });
+    expect(dispatchSpy).not.toHaveBeenCalled();
+
+    // A shortcut targeting this panel closes exactly this panel by id
+    act(() => {
+      closeCb?.({ panelId: "dev-preview-panel-1" });
+    });
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      "terminal.close",
+      { terminalId: "dev-preview-panel-1" },
+      { source: "keybinding" }
+    );
+  });
+
+  it("unsubscribes from onCloseShortcut on unmount (#10859)", () => {
+    const unsubscribe = vi.fn();
+    const electron = (window as unknown as { electron: { webview: Record<string, unknown> } })
+      .electron;
+    electron.webview.onCloseShortcut = vi.fn(() => unsubscribe);
+
+    const { unmount } = render(<DevPreviewPane {...baseProps} />);
+    expect(electron.webview.onCloseShortcut).toHaveBeenCalled();
     unmount();
     expect(unsubscribe).toHaveBeenCalled();
   });
@@ -886,6 +936,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
         onReloadShortcut: vi.fn(() => vi.fn()),
+        onCloseShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         onUnresponsive: vi.fn(() => vi.fn()),
@@ -945,6 +996,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
         onReloadShortcut: vi.fn(() => vi.fn()),
+        onCloseShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         onUnresponsive: vi.fn(() => vi.fn()),
@@ -994,6 +1046,7 @@ describe("DevPreviewPane webview lifecycle regression", () => {
         onDialogRequest: vi.fn(() => vi.fn()),
         onFindShortcut: vi.fn(() => vi.fn()),
         onReloadShortcut: vi.fn(() => vi.fn()),
+        onCloseShortcut: vi.fn(() => vi.fn()),
         onNavigationBlocked: vi.fn(() => vi.fn()),
         onOAuthLoopbackStatus: vi.fn(() => vi.fn()),
         onUnresponsive: vi.fn(() => vi.fn()),


### PR DESCRIPTION
## Summary

- Pressing Cmd+W (or Ctrl+W elsewhere) while a webview has keyboard focus, dev preview or browser panel, closed the entire app window instead of just the panel
- Electron's native `role:close` accelerator dispatches to whichever webContents holds OS keyboard focus. We already guard the main window and each project's `WebContentsView`, but a `<webview>` tag is a separate guest webContents that those guards never see, so the native close fired unblocked
- Extended the existing webview-guest `before-input-event` handler (already handling Cmd+F, Cmd+G, Escape, Cmd+R) to also intercept Cmd/Ctrl+W and forward a close request to the host instead of letting it through

Resolves #10859

## Changes

- `electron/setup/protocols.ts`: intercept Cmd/Ctrl+W in the webview-guest handler (platform-correct modifier, Ctrl+Cmd+W explicitly rejected), `preventDefault()`, and forward a new `WEBVIEW_CLOSE_SHORTCUT` IPC message with the `panelId`
- `electron/ipc/channels.ts`, `shared/types/ipc/maps.ts`, `shared/types/ipc/api.ts`, `electron/preload.cts`: wire up the new IPC channel
- `src/components/DevPreview/DevPreviewPane.tsx`, `src/components/Browser/BrowserPane.tsx`: listen for `WEBVIEW_CLOSE_SHORTCUT` and dispatch `terminal.close` for the panel
- No panel-kind gating, both webview-backed panels had the identical bug

## Testing

- 305 targeted tests pass across the `protocols`, `DevPreview webview`, and `Browser webview` suites
- Typecheck clean
- eslint and prettier clean
- All 4 IPC/channel codegen drift guards pass