### PR TITLE
feat(actions): expose resumable agent sessions via MCP

### DIFF
--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -340,6 +340,7 @@ const MCP_TOOL_ALLOWLIST_ENTRIES = [
   "agent.terminal",
   "agent.getState",
   "agent.listToolbar",
+  "agentSessionHistory.list",
 
   "git.getProjectPulse",
   "git.getFileDiff",

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -309,6 +309,7 @@ export const BUILT_IN_ACTION_IDS = [
   "agent.focusPreviousAgent",
   "agent.getState",
   "agent.listToolbar",
+  "agentSessionHistory.list",
 
   // -- app settings (other) --
   "app.settings.openTab",

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -38,6 +38,7 @@ export const WORKBENCH_TIER_TOOLS = [
 
   "agent.getState",
   "agent.listToolbar",
+  "agentSessionHistory.list",
 
   "agentSettings.get",
   "keybinding.getOverrides",

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -451,6 +451,23 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "title": "Launch Terminal",
   },
   {
+    "category": "agent",
+    "danger": "safe",
+    "dangerRationale": undefined,
+    "description": "List resumable agent sessions from the on-disk journal — the closed sessions the user can relaunch. This is a faithful record listing, NOT a summary of what happened in each session. Args: \`worktreeId\` (optional) — restrict to one worktree; omit to list every resumable session across all worktrees and projects (the default). Returns { sessions: [{ sessionId, agentId, worktreeId, title, projectId, savedAt (epoch ms; the list is newest-first), agentLaunchFlags?, agentModelId?, cwd?, branch? }] }, capped and pruned by the journal's retention policy. Never errors — returns { sessions: [] } when the journal is empty or unreadable. To relaunch a listed session, feed its \`agentId\`/\`cwd\`/\`worktreeId\`/\`agentLaunchFlags\`/\`agentModelId\` into \`agent.launch\`.",
+    "examples": [
+      {
+        "args": {},
+        "description": "List every resumable agent session across the whole workspace",
+      },
+    ],
+    "id": "agentSessionHistory.list",
+    "keywords": undefined,
+    "kind": "query",
+    "requiresArgs": false,
+    "title": "List Resumable Sessions",
+  },
+  {
     "category": "settings",
     "danger": "safe",
     "dangerRationale": undefined,

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
 
 const panelStoreMock = vi.hoisted(() => ({
@@ -918,5 +918,99 @@ describe("agent.listToolbar (#10838)", () => {
     expect(def.scope).toBe("renderer");
     expect(def.mcpVisibility).toBe("discoverable");
     expect(def.argsSchema).toBeUndefined();
+  });
+});
+
+describe("agentSessionHistory.list (#10854)", () => {
+  const SAMPLE_SESSIONS = [
+    {
+      sessionId: "sess-1",
+      agentId: "claude",
+      worktreeId: "wt-1",
+      title: "Auth refactor",
+      projectId: "proj-1",
+      savedAt: 1_700_000_000_000,
+      agentLaunchFlags: ["--model", "opus"],
+      agentModelId: "claude-opus",
+      cwd: "/repo",
+      branch: "feature/auth",
+    },
+    {
+      // Minimal record: nullable fields null, all optionals absent.
+      sessionId: "sess-2",
+      agentId: "codex",
+      worktreeId: null,
+      title: null,
+      projectId: null,
+      savedAt: 1_699_000_000_000,
+    },
+  ];
+
+  const listMock = vi.fn();
+
+  beforeEach(() => {
+    listMock.mockReset();
+    listMock.mockResolvedValue(SAMPLE_SESSIONS);
+    // @ts-expect-error - minimal window.electron stub for the renderer IPC call
+    globalThis.window = { electron: { agentSessionHistory: { list: listMock } } };
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - tear down the stub so it doesn't leak to other suites
+    delete globalThis.window;
+  });
+
+  function getDef(): AnyActionDefinition {
+    const def = setupActions(makeCallbacks()).get("agentSessionHistory.list")?.() as
+      | AnyActionDefinition
+      | undefined;
+    if (!def) throw new Error("agentSessionHistory.list not registered");
+    return def;
+  }
+
+  it("forwards the worktreeId arg to the bridge and wraps the result in { sessions }", async () => {
+    const actions = setupActions(makeCallbacks());
+    const result = await callAction(actions, "agentSessionHistory.list", { worktreeId: "wt-1" });
+    expect(listMock).toHaveBeenCalledWith("wt-1");
+    expect(result).toEqual({ sessions: SAMPLE_SESSIONS });
+  });
+
+  it("passes undefined (cross-project) when no worktreeId is given", async () => {
+    const actions = setupActions(makeCallbacks());
+    await callAction(actions, "agentSessionHistory.list");
+    expect(listMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("passes undefined when called with an empty args object", async () => {
+    const actions = setupActions(makeCallbacks());
+    await callAction(actions, "agentSessionHistory.list", {});
+    expect(listMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it("returns the bridge's empty array verbatim (never throws on empty journal)", async () => {
+    listMock.mockResolvedValue([]);
+    const actions = setupActions(makeCallbacks());
+    const result = await callAction(actions, "agentSessionHistory.list", {});
+    expect(result).toEqual({ sessions: [] });
+  });
+
+  it("registers as a read-only query action advertising an MCP output schema", () => {
+    const def = getDef();
+    expect(def.kind).toBe("query");
+    expect(def.danger).toBe("safe");
+    expect(def.scope).toBe("renderer");
+    expect(def.mcpOutputSchema).toBe(true);
+  });
+
+  it("resultSchema accepts both a full record and a null/absent-optional record", () => {
+    const parsed = getDef().resultSchema?.safeParse({ sessions: SAMPLE_SESSIONS });
+    expect(parsed?.success).toBe(true);
+  });
+
+  it("resultSchema rejects a session missing the required sessionId", () => {
+    const parsed = getDef().resultSchema?.safeParse({
+      sessions: [{ agentId: "claude", worktreeId: null, title: null, projectId: null, savedAt: 1 }],
+    });
+    expect(parsed?.success).toBe(false);
   });
 });

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -1013,4 +1013,15 @@ describe("agentSessionHistory.list (#10854)", () => {
     });
     expect(parsed?.success).toBe(false);
   });
+
+  it("argsSchema accepts an omitted worktreeId and a non-empty one", () => {
+    const schema = getDef().argsSchema;
+    expect(schema?.safeParse(undefined).success).toBe(true);
+    expect(schema?.safeParse({}).success).toBe(true);
+    expect(schema?.safeParse({ worktreeId: "wt-1" }).success).toBe(true);
+  });
+
+  it("argsSchema rejects an empty worktreeId (would silently unfilter to cross-project)", () => {
+    expect(getDef().argsSchema?.safeParse({ worktreeId: "" }).success).toBe(false);
+  });
 });

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -4,6 +4,7 @@ import {
   LaunchLocationSchema,
   TerminalSpawnSourceSchema,
   AddPanelFocusPolicySchema,
+  AgentSessionRecordSchema,
 } from "./schemas";
 import { z } from "zod";
 import { usePanelStore } from "@/store/panelStore";
@@ -445,6 +446,42 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         terminalId: null,
         found: false,
       };
+    },
+  }));
+
+  actions.set("agentSessionHistory.list", () => ({
+    id: "agentSessionHistory.list",
+    title: "List Resumable Sessions",
+    description:
+      "List resumable agent sessions from the on-disk journal — the closed sessions the user can relaunch. This is a faithful record listing, NOT a summary of what happened in each session. Args: `worktreeId` (optional) — restrict to one worktree; omit to list every resumable session across all worktrees and projects (the default). Returns { sessions: [{ sessionId, agentId, worktreeId, title, projectId, savedAt (epoch ms; the list is newest-first), agentLaunchFlags?, agentModelId?, cwd?, branch? }] }, capped and pruned by the journal's retention policy. Never errors — returns { sessions: [] } when the journal is empty or unreadable. To relaunch a listed session, feed its `agentId`/`cwd`/`worktreeId`/`agentLaunchFlags`/`agentModelId` into `agent.launch`.",
+    category: "agent",
+    kind: "query",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z
+      .object({
+        worktreeId: z
+          .string()
+          .optional()
+          .describe(
+            "Restrict the listing to one worktree id. Omit to list resumable sessions across all worktrees and projects."
+          ),
+      })
+      .optional(),
+    examples: [
+      {
+        args: {},
+        description: "List every resumable agent session across the whole workspace",
+      },
+    ],
+    resultSchema: z.object({
+      sessions: z.array(AgentSessionRecordSchema),
+    }),
+    mcpOutputSchema: true,
+    run: async (args: unknown) => {
+      const { worktreeId } = (args ?? {}) as { worktreeId?: string };
+      const sessions = await window.electron.agentSessionHistory.list(worktreeId);
+      return { sessions };
     },
   }));
 

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -460,8 +460,13 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     scope: "renderer",
     argsSchema: z
       .object({
+        // `.min(1)`: an empty string would fall through the bridge's `if
+        // (!worktreeId)` guard to an unfiltered cross-project listing — a
+        // surprising result for a caller that passed a (blank) id expecting a
+        // scoped one. Reject it; omit the arg to list across all worktrees.
         worktreeId: z
           .string()
+          .min(1)
           .optional()
           .describe(
             "Restrict the listing to one worktree id. Omit to list resumable sessions across all worktrees and projects."

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -221,3 +221,23 @@ export const RecipeSummarySchema = z.object({
   terminalCount: z.number(),
   showInEmptyState: z.boolean(),
 });
+
+// Mirror of `AgentSessionRecord` (shared/types/ipc/agentSessionHistory.ts) — the
+// journaled record for a closed, resumable agent session. Nullable vs optional
+// tracks the TS type exactly: `worktreeId`/`title`/`projectId` are always present
+// but may be null; `agentLaunchFlags`/`agentModelId`/`cwd`/`branch` are `?:` and
+// may be absent, so the advertised MCP outputSchema must not mark them required.
+export const AgentSessionRecordSchema = z.object({
+  sessionId: z.string(),
+  agentId: z.string(),
+  worktreeId: z.string().nullable(),
+  title: z.string().nullable(),
+  projectId: z.string().nullable(),
+  // Epoch ms the resume record was captured (session close), for newest-first ordering.
+  savedAt: z.number(),
+  // Original launch flags/model, preserved so a relaunch reproduces the session (#3175).
+  agentLaunchFlags: z.array(z.string()).optional(),
+  agentModelId: z.string().optional(),
+  cwd: z.string().optional(),
+  branch: z.string().optional(),
+});


### PR DESCRIPTION
## Summary
- Adds a new MCP-registered action, `agentSessionHistory.list`, that lists resumable agent sessions from the on-disk journal. It's read-only and simply wraps the existing `window.electron.agentSessionHistory.list` bridge.
- Registered in `BUILT_IN_ACTION_IDS` and allowlisted at the assistant's baseline tier (`WORKBENCH_TIER_TOOLS`) and in the MCP default-deny allowlist (`MCP_TOOL_ALLOWLIST_ENTRIES`), so the assistant can answer "what sessions are available to resume?" and feed a listed record's fields into `agent.launch` to relaunch one.
- Strictly read-only and observation-only: returns the faithful record list rather than a summary. Resuming or relaunching a session is already covered by the existing `agent.launch` action, so that's out of scope here.

Resolves #10854.

## Changes
- `src/services/actions/definitions/agentActions.ts`: new `agentSessionHistory.list` action.
- `src/services/actions/definitions/schemas.ts`: new `AgentSessionRecordSchema` mirroring the on-disk journal record type.
- `shared/config/actionIds.ts`: registers the action ID.
- `shared/config/helpAssistantTierAllowlists.ts`: allowlists the action at the assistant's baseline tier.
- `electron/services/mcp-server/shared.ts`: allowlists the action for MCP.
- `worktreeId` uses `.min(1)` validation so a blank id can't silently unfilter and leak cross-project results.

## Testing
- 10 new tests in `src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts` covering the new action, including the empty-`worktreeId` rejection.