### PR TITLE
feat(panel-palette): browsable searchable resume session list (#10851)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,6 +89,8 @@ import {
   resolveEffectiveBypass,
 } from "@shared/types/agentSettings";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+import { resolveResumeLaunchTarget } from "./utils/resumeLaunch";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
 import { AccessibilityAnnouncer } from "./components/Accessibility/AccessibilityAnnouncer";
 import { useSendToAgentPalette } from "./hooks/useSendToAgentPalette";
@@ -885,6 +887,31 @@ function AppInner() {
     [launchAgent]
   );
 
+  const launchResumeSession = useCallback(
+    (session: AgentSessionRecord) => {
+      const agentConfig = getEffectiveAgentConfig(session.agentId);
+      const resumeFlags = reconcileResumeLaunchFlags(session);
+      const command =
+        buildResumeCommand(session.agentId, session.sessionId, resumeFlags) ??
+        buildResumeLatestCommand(session.agentId, resumeFlags);
+      if (!command || !agentConfig) return;
+      const { cwd, worktreeId } = resolveResumeLaunchTarget(session, {
+        defaultTerminalCwd,
+        activeWorktreeId,
+      });
+      addPanel({
+        kind: "terminal",
+        launchAgentId: session.agentId,
+        title: agentConfig.name,
+        cwd,
+        worktreeId,
+        command,
+        location: "grid",
+      });
+    },
+    [addPanel, defaultTerminalCwd, activeWorktreeId]
+  );
+
   const closeThemePalette = useCallback(() => {
     usePaletteStore.getState().closePalette("theme");
   }, []);
@@ -1223,23 +1250,7 @@ function AppInner() {
                       const result = panelPalette.handleSelect(kind);
                       if (!result) return;
                       if (result.resumeSession) {
-                        const session = result.resumeSession;
-                        const agentConfig = getEffectiveAgentConfig(session.agentId);
-                        const resumeFlags = reconcileResumeLaunchFlags(session);
-                        const command =
-                          buildResumeCommand(session.agentId, session.sessionId, resumeFlags) ??
-                          buildResumeLatestCommand(session.agentId, resumeFlags);
-                        if (command && agentConfig) {
-                          addPanel({
-                            kind: "terminal",
-                            launchAgentId: session.agentId,
-                            title: agentConfig.name,
-                            cwd: defaultTerminalCwd,
-                            worktreeId: activeWorktreeId ?? undefined,
-                            command,
-                            location: "grid",
-                          });
-                        }
+                        launchResumeSession(result.resumeSession);
                       } else if (result.id.startsWith("agent:")) {
                         const agentId = result.id.slice("agent:".length);
                         if (agentId) {
@@ -1259,23 +1270,7 @@ function AppInner() {
                       if (!selected) return;
                       if (selected.id === MORE_AGENTS_PANEL_ID) return;
                       if (selected.resumeSession) {
-                        const session = selected.resumeSession;
-                        const agentConfig = getEffectiveAgentConfig(session.agentId);
-                        const resumeFlags = reconcileResumeLaunchFlags(session);
-                        const command =
-                          buildResumeCommand(session.agentId, session.sessionId, resumeFlags) ??
-                          buildResumeLatestCommand(session.agentId, resumeFlags);
-                        if (command && agentConfig) {
-                          addPanel({
-                            kind: "terminal",
-                            launchAgentId: session.agentId,
-                            title: agentConfig.name,
-                            cwd: defaultTerminalCwd,
-                            worktreeId: activeWorktreeId ?? undefined,
-                            command,
-                            location: "grid",
-                          });
-                        }
+                        launchResumeSession(selected.resumeSession);
                       } else if (selected.id.startsWith("agent:")) {
                         const agentId = selected.id.slice("agent:".length);
                         if (agentId) {

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -110,7 +110,13 @@ export function PanelPalette({
     selectedIndex >= 0 && selectedIndex < results.length ? results[selectedIndex] : null;
 
   const renderOption = (kind: PanelKindOption, index: number) => {
-    const isUnavailable = kind.installed === false;
+    const isStale = kind.isStale === true;
+    const isUnavailable = kind.installed === false || isStale;
+    const badgeLabel = isStale
+      ? "Worktree removed"
+      : kind.installed === false
+        ? "Not installed"
+        : null;
     return (
       <button
         key={kind.id}
@@ -146,9 +152,9 @@ export function PanelPalette({
             <div className="text-xs text-daintree-text/50 truncate">{kind.description}</div>
           )}
         </div>
-        {isUnavailable && (
+        {badgeLabel && (
           <span className="shrink-0 text-[10px] font-medium text-daintree-text/40">
-            Not installed
+            {badgeLabel}
           </span>
         )}
       </button>
@@ -178,9 +184,52 @@ export function PanelPalette({
       });
     };
 
+    // Resume entries get a second grouping tier (by worktree) beneath the
+    // section header. Items already arrive newest-first, so iterating in order
+    // and keying a Map gives correct group order and intra-group recency for
+    // free. Sub-headers stay aria-hidden divs (never role="group", #9006) and
+    // are excluded from the results array that drives selection.
+    const renderResumeSection = (items: typeof results) => {
+      if (items.length === 0) return;
+      elements.push(
+        <div
+          key="header-resume"
+          className="px-3 pt-3 pb-1 text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none"
+          aria-hidden="true"
+        >
+          {SECTION_LABELS.resume}
+        </div>
+      );
+      const groups = new Map<string, typeof results>();
+      for (const kind of items) {
+        const groupKey = kind.groupKey ?? "";
+        const bucket = groups.get(groupKey);
+        if (bucket) bucket.push(kind);
+        else groups.set(groupKey, [kind]);
+      }
+      for (const [groupKey, groupItems] of groups) {
+        const label = groupItems[0]?.groupLabel;
+        if (label) {
+          elements.push(
+            <div
+              key={`resume-group-${groupKey}`}
+              className="px-4 pt-2 pb-1 text-[10px] font-medium text-daintree-text/30 select-none truncate"
+              aria-hidden="true"
+            >
+              {label}
+            </div>
+          );
+        }
+        groupItems.forEach((kind) => {
+          const index = results.indexOf(kind);
+          elements.push(renderOption(kind, index));
+        });
+      }
+    };
+
     renderSection("agent", agents);
     renderSection("tool", tools);
-    renderSection("resume", resumeSessions);
+    renderResumeSection(resumeSessions);
 
     return elements;
   };

--- a/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
+++ b/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { PanelPalette } from "../PanelPalette";
+import type { PanelKindOption } from "@/hooks/usePanelPalette";
+
+// jsdom lacks ResizeObserver (used by the palette's scroll-shadow hook) and
+// scrollIntoView (called when the selected option changes).
+beforeAll(() => {
+  class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (
+    selector: (s: { panelIds: string[]; panelsById: Record<string, unknown> }) => unknown
+  ) => selector({ panelIds: [], panelsById: {} }),
+}));
+
+vi.mock("@/store/panelLimitStore", () => ({
+  usePanelLimitStore: (selector: (s: { hardLimit: number }) => unknown) =>
+    selector({ hardLimit: 0 }),
+}));
+
+vi.mock("@/hooks/useKeybinding", () => ({
+  useEffectiveCombo: () => undefined,
+}));
+
+const baseProps = {
+  isOpen: true,
+  totalResults: undefined,
+  selectedIndex: 0,
+  matchesById: new Map(),
+  onQueryChange: vi.fn(),
+  onSelectPrevious: vi.fn(),
+  onSelectNext: vi.fn(),
+  onSelect: vi.fn(),
+  onConfirm: vi.fn(),
+  onClose: vi.fn(),
+};
+
+const resumeResults: PanelKindOption[] = [
+  { id: "agent:claude", name: "Claude", iconId: "claude", color: "#f80", category: "agent" },
+  {
+    id: "resume:a",
+    name: "Resume: Fixing auth",
+    iconId: "terminal",
+    color: "#fff",
+    category: "resume",
+    groupKey: "wt-1",
+    groupLabel: "Feature X",
+    isStale: false,
+  },
+  {
+    id: "resume:b",
+    name: "Resume: Old work",
+    iconId: "terminal",
+    color: "#fff",
+    category: "resume",
+    groupKey: "wt-removed",
+    groupLabel: "old-branch",
+    isStale: true,
+  },
+];
+
+describe("PanelPalette browsable resume list (#10851)", () => {
+  it("renders worktree group sub-headers under the resume section when browsing", () => {
+    render(<PanelPalette {...baseProps} query="" results={resumeResults} />);
+    expect(screen.getByText("Resume Sessions")).toBeTruthy();
+    expect(screen.getByText("Feature X")).toBeTruthy();
+    expect(screen.getByText("old-branch")).toBeTruthy();
+  });
+
+  it("shows a 'Worktree removed' badge on stale entries", () => {
+    render(<PanelPalette {...baseProps} query="" results={resumeResults} />);
+    expect(screen.getByText("Worktree removed")).toBeTruthy();
+  });
+
+  it("never uses role=group for headers (VoiceOver regression guard, #9006)", () => {
+    // The palette renders through a portal, so query document.body, not the
+    // render container.
+    render(<PanelPalette {...baseProps} query="" results={resumeResults} />);
+    const listbox = document.body.querySelector('[role="listbox"]')!;
+    expect(listbox).toBeTruthy();
+    expect(listbox.querySelectorAll('[role="group"]').length).toBe(0);
+    // Section + group headers stay aria-hidden so they don't enter the option index.
+    expect(listbox.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0);
+  });
+
+  it("flattens the list (no section or group headers) while searching", () => {
+    render(<PanelPalette {...baseProps} query="fix" results={resumeResults} />);
+    expect(screen.queryByText("Resume Sessions")).toBeNull();
+    expect(screen.queryByText("Feature X")).toBeNull();
+    // The options themselves still render.
+    expect(screen.getByText("Resume: Fixing auth")).toBeTruthy();
+  });
+});

--- a/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
+++ b/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
@@ -92,6 +92,33 @@ describe("PanelPalette browsable resume list (#10851)", () => {
     expect(listbox.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0);
   });
 
+  it("keys groups off groupKey, not the display label (same label, distinct keys → two headers)", () => {
+    const sameLabel: PanelKindOption[] = [
+      {
+        id: "resume:x",
+        name: "Resume: X",
+        iconId: "terminal",
+        color: "#fff",
+        category: "resume",
+        groupKey: "wt-1",
+        groupLabel: "main",
+      },
+      {
+        id: "resume:y",
+        name: "Resume: Y",
+        iconId: "terminal",
+        color: "#fff",
+        category: "resume",
+        groupKey: "wt-2",
+        groupLabel: "main",
+      },
+    ];
+    render(<PanelPalette {...baseProps} query="" results={sameLabel} />);
+    // Two worktrees that happen to share a branch name "main" must render as two
+    // separate group headers, not merge into one.
+    expect(screen.getAllByText("main")).toHaveLength(2);
+  });
+
   it("flattens the list (no section or group headers) while searching", () => {
     render(<PanelPalette {...baseProps} query="fix" results={resumeResults} />);
     expect(screen.queryByText("Resume Sessions")).toBeNull();

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -76,6 +76,20 @@ vi.mock("@/store/projectStore", () => {
   return { useProjectStore: store };
 });
 
+// The panel palette reads its open state from the palette store; mark it active
+// so the session-history fetch (now gated on `isOpen`) runs under test.
+vi.mock("@/store/paletteStore", () => {
+  const state = { activePaletteId: "panel" as const };
+  const getState = () => ({
+    ...state,
+    openPalette: vi.fn(),
+    closePalette: vi.fn(),
+  });
+  const store = (selector: (s: typeof state) => unknown) => selector(state);
+  store.getState = getState;
+  return { usePaletteStore: store };
+});
+
 import { usePanelPalette } from "../usePanelPalette";
 
 describe("usePanelPalette", () => {
@@ -406,6 +420,26 @@ describe("usePanelPalette", () => {
         expect(resume!.searchAliases).toEqual(
           expect.arrayContaining(["claude", "Claude", "Feature X", "feature/x"])
         );
+      });
+    });
+
+    it("makes a stale entry findable by its cwd basename when it has no branch", async () => {
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({
+          sessionId: "orphan",
+          worktreeId: "wt-removed",
+          branch: undefined,
+          cwd: "/repo/feature-auth",
+        }),
+      ]);
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        const resume = result.current.results.find((item) => item.id === "resume:orphan");
+        expect(resume).toBeDefined();
+        expect(resume!.groupLabel).toBe("feature-auth");
+        expect(resume!.searchAliases).toContain("feature-auth");
       });
     });
 

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -3,12 +3,6 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MORE_AGENTS_PANEL_ID } from "../usePanelPalette";
 
-interface MockWorktree {
-  id: string;
-  name: string;
-  branch?: string;
-}
-
 const {
   getPanelKindIdsMock,
   getPanelKindConfigMock,

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -3,6 +3,12 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MORE_AGENTS_PANEL_ID } from "../usePanelPalette";
 
+interface MockWorktree {
+  id: string;
+  name: string;
+  branch?: string;
+}
+
 const {
   getPanelKindIdsMock,
   getPanelKindConfigMock,
@@ -10,6 +16,8 @@ const {
   getEffectiveAgentIdsMock,
   getEffectiveAgentConfigMock,
   cliAvailabilityState,
+  worktreeState,
+  projectState,
 } = vi.hoisted(() => ({
   getPanelKindIdsMock: vi.fn(),
   getPanelKindConfigMock: vi.fn(),
@@ -26,6 +34,8 @@ const {
     initialize: vi.fn().mockResolvedValue(undefined),
     refresh: vi.fn().mockResolvedValue(undefined),
   },
+  worktreeState: { worktrees: new Map<string, { id: string; name: string; branch?: string }>() },
+  projectState: { currentProject: { id: "proj-1" } as { id: string } | null },
 }));
 
 vi.mock("@shared/config/panelKindRegistry", () => ({
@@ -56,11 +66,14 @@ vi.mock("@/store/cliAvailabilityStore", () => {
   return { useCliAvailabilityStore: store };
 });
 
-vi.mock("@/store/worktreeStore", () => {
-  const state = { activeWorktreeId: null as string | null };
-  const store = (selector: (s: typeof state) => unknown) => selector(state);
-  store.getState = () => state;
-  return { useWorktreeSelectionStore: store };
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (s: typeof worktreeState) => unknown) => selector(worktreeState),
+}));
+
+vi.mock("@/store/projectStore", () => {
+  const store = (selector: (s: typeof projectState) => unknown) => selector(projectState);
+  store.getState = () => projectState;
+  return { useProjectStore: store };
 });
 
 import { usePanelPalette } from "../usePanelPalette";
@@ -108,6 +121,9 @@ describe("usePanelPalette", () => {
     cliAvailabilityState.availability = { claude: "ready", gemini: "missing" };
     cliAvailabilityState.isInitialized = true;
     cliAvailabilityState.lastCheckedAt = Date.now();
+
+    worktreeState.worktrees = new Map();
+    projectState.currentProject = { id: "proj-1" };
 
     getEffectiveAgentIdsMock.mockReturnValue(["claude", "claude"]);
     getEffectiveAgentConfigMock.mockReturnValue({
@@ -160,7 +176,7 @@ describe("usePanelPalette", () => {
         agentId: "claude",
         worktreeId: null,
         title: null,
-        projectId: null,
+        projectId: "proj-1",
         savedAt: Date.now() - 3600000,
         agentModelId: "claude-opus-4-5",
       },
@@ -183,7 +199,7 @@ describe("usePanelPalette", () => {
         agentId: "claude",
         worktreeId: null,
         title: "Fixing bug",
-        projectId: null,
+        projectId: "proj-1",
         savedAt: Date.now() - 1000,
       },
       {
@@ -191,7 +207,7 @@ describe("usePanelPalette", () => {
         agentId: "claude",
         worktreeId: null,
         title: null,
-        projectId: null,
+        projectId: "proj-1",
         savedAt: Date.now() - 2000,
       },
     ]);
@@ -212,7 +228,7 @@ describe("usePanelPalette", () => {
         agentId: "claude",
         worktreeId: null,
         title: "Fixing auth bug",
-        projectId: null,
+        projectId: "proj-1",
         savedAt: Date.now() - 1000,
       },
     ]);
@@ -233,7 +249,7 @@ describe("usePanelPalette", () => {
         agentId: "claude",
         worktreeId: null,
         title: "claude",
-        projectId: null,
+        projectId: "proj-1",
         savedAt: Date.now() - 1000,
       },
     ]);
@@ -254,7 +270,7 @@ describe("usePanelPalette", () => {
         agentId: "claude",
         worktreeId: null,
         title: null,
-        projectId: null,
+        projectId: "proj-1",
         savedAt: Date.now() - 7200000,
         agentModelId: "claude-opus-4-5",
       },
@@ -267,6 +283,145 @@ describe("usePanelPalette", () => {
       expect(resume).toBeDefined();
       expect(resume!.description).toContain("Opus 4 5");
       expect(resume!.description).toContain("ago");
+    });
+  });
+
+  describe("browsable resume list (#10851)", () => {
+    const makeSession = (overrides: Record<string, unknown>) => ({
+      agentId: "claude",
+      worktreeId: null,
+      title: null,
+      projectId: "proj-1",
+      savedAt: Date.now() - 1000,
+      ...overrides,
+    });
+
+    it("surfaces more than 5 sessions (no hardcoded cap)", async () => {
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue(
+        Array.from({ length: 8 }, (_, i) =>
+          makeSession({ sessionId: `s-${i}`, savedAt: Date.now() - i * 1000 })
+        )
+      );
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        const resume = result.current.results.filter((item) => item.id.startsWith("resume:"));
+        expect(resume).toHaveLength(8);
+      });
+    });
+
+    it("fetches sessions across all worktrees (unscoped list call)", async () => {
+      const listSpy = window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>;
+      renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        expect(listSpy).toHaveBeenCalled();
+      });
+      // No worktree-id argument — the renderer no longer scopes to the active worktree.
+      expect(listSpy.mock.calls[0]?.[0]).toBeUndefined();
+    });
+
+    it("excludes sessions belonging to another project", async () => {
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({ sessionId: "mine", projectId: "proj-1" }),
+        makeSession({ sessionId: "theirs", projectId: "other-proj" }),
+      ]);
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        const ids = result.current.results.map((item) => item.id);
+        expect(ids).toContain("resume:mine");
+        expect(ids).not.toContain("resume:theirs");
+      });
+    });
+
+    it("keeps legacy null-project records only when their worktree resolves", async () => {
+      worktreeState.worktrees = new Map([["wt-1", { id: "wt-1", name: "Feature X" }]]);
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({ sessionId: "legacy-live", projectId: null, worktreeId: "wt-1" }),
+        makeSession({ sessionId: "legacy-gone", projectId: null, worktreeId: "wt-missing" }),
+        makeSession({ sessionId: "legacy-none", projectId: null, worktreeId: null }),
+      ]);
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        const ids = result.current.results.map((item) => item.id);
+        expect(ids).toContain("resume:legacy-live");
+        expect(ids).not.toContain("resume:legacy-gone");
+        expect(ids).not.toContain("resume:legacy-none");
+      });
+    });
+
+    it("marks a record whose worktree was removed as stale", async () => {
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({ sessionId: "orphan", worktreeId: "wt-removed", branch: "old-branch" }),
+      ]);
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        const resume = result.current.results.find((item) => item.id === "resume:orphan");
+        expect(resume).toBeDefined();
+        expect(resume!.isStale).toBe(true);
+        expect(resume!.description).toContain("Worktree removed");
+      });
+    });
+
+    it("resolves live worktree name, branch, and group label", async () => {
+      worktreeState.worktrees = new Map([
+        ["wt-1", { id: "wt-1", name: "Feature X", branch: "feature/x" }],
+      ]);
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({ sessionId: "live", worktreeId: "wt-1" }),
+      ]);
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        const resume = result.current.results.find((item) => item.id === "resume:live");
+        expect(resume).toBeDefined();
+        expect(resume!.isStale).toBe(false);
+        expect(resume!.worktreeName).toBe("Feature X");
+        expect(resume!.branchName).toBe("feature/x");
+        expect(resume!.groupKey).toBe("wt-1");
+        expect(resume!.groupLabel).toBe("Feature X");
+      });
+    });
+
+    it("broadens search aliases to agent, branch, and worktree name", async () => {
+      worktreeState.worktrees = new Map([
+        ["wt-1", { id: "wt-1", name: "Feature X", branch: "feature/x" }],
+      ]);
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({ sessionId: "aliased", worktreeId: "wt-1", title: "Some title" }),
+      ]);
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        const resume = result.current.results.find((item) => item.id === "resume:aliased");
+        expect(resume).toBeDefined();
+        expect(resume!.searchAliases).toEqual(
+          expect.arrayContaining(["claude", "Claude", "Feature X", "feature/x"])
+        );
+      });
+    });
+
+    it("does not launch a stale entry via handleSelect", async () => {
+      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeSession({ sessionId: "orphan", worktreeId: "wt-removed" }),
+      ]);
+
+      const { result, rerender } = renderHook(() => usePanelPalette());
+      await vi.waitFor(() => {
+        rerender();
+        expect(result.current.results.some((item) => item.id === "resume:orphan")).toBe(true);
+      });
+      const stale = result.current.results.find((item) => item.id === "resume:orphan");
+      expect(stale!.isStale).toBe(true);
+      expect(result.current.handleSelect(stale!)).toBeNull();
     });
   });
 

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -9,7 +9,8 @@ import {
 } from "@shared/config/pluginAgentRegistry";
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
-import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { useProjectStore } from "@/store/projectStore";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { keybindingService } from "@/services/KeybindingService";
 import { formatTimeAgo } from "@/utils/timeAgo";
@@ -27,6 +28,20 @@ export interface PanelKindOption {
   category: "agent" | "tool" | "resume";
   installed?: boolean;
   resumeSession?: AgentSessionRecord;
+  /**
+   * Resume entry whose recorded worktree no longer resolves in the live
+   * worktree map (deleted/removed). Rendered greyed-out with a "Worktree
+   * removed" badge and excluded from keyboard navigation / launch (#10851).
+   */
+  isStale?: boolean;
+  /** Live worktree display name for a resume entry, when it still resolves. */
+  worktreeName?: string;
+  /** Branch a resume entry was captured on (live value preferred over recorded). */
+  branchName?: string;
+  /** Grouping key for the browse view: worktree id, or a no-worktree sentinel. */
+  groupKey?: string;
+  /** Human label for the resume entry's worktree group header. */
+  groupLabel?: string;
 }
 
 export type UsePanelPaletteReturn = UseSearchablePaletteReturn<PanelKindOption> & {
@@ -42,6 +57,16 @@ import {
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+// Group key for resume records that were never tied to a worktree (e.g. a
+// terminal launched at the project root before worktree scoping existed).
+const NO_WORKTREE_GROUP_KEY = "__no-worktree__";
+
+function pathBasename(p: string | null | undefined): string {
+  if (!p) return "";
+  const parts = p.split(/[/\\]/).filter(Boolean);
+  return parts[parts.length - 1] ?? "";
+}
 
 const AGENT_LAUNCH_ACTIONS: Record<string, KeyAction> = Object.fromEntries(
   LAUNCHABLE_AGENT_IDS.map((id) => [id, `agent.${id}` as KeyAction])
@@ -76,7 +101,10 @@ export function usePanelPalette(): UsePanelPaletteReturn {
   const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
   const [keybindingVersion, setKeybindingVersion] = useState(0);
   const [resumeSessions, setResumeSessions] = useState<AgentSessionRecord[]>([]);
-  const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
+  // Live per-view worktree map: drives stale-entry detection and group labels.
+  const worktrees = useWorktreeStore((state) => state.worktrees);
+  // Scope the browsable resume list to the current project's own history.
+  const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
   // Re-render when a plugin loads/unloads mid-session so agent icon/name/color
   // refresh from the updated registry (#9879).
   const pluginAgentRegistry = useSyncExternalStore(
@@ -163,9 +191,17 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       }
     }
 
+    // The journal is fetched unscoped (all worktrees/projects, newest-first).
+    // Keep this project's records, then map each to a rich, groupable option.
+    // Legacy records with a null projectId (pre-scoping) are kept only when
+    // their worktree still resolves in the live map — otherwise there's no
+    // reliable way to know they belong here.
     const resumeOptions: PanelKindOption[] = resumeSessions
       .filter((session) => !!session.sessionId)
-      .slice(0, 5)
+      .filter((session) => {
+        if (session.projectId) return session.projectId === currentProjectId;
+        return !!session.worktreeId && worktrees.has(session.worktreeId);
+      })
       .map((session) => {
         const agentConfig = getEffectiveAgentConfig(session.agentId);
         const timeAgo = formatTimeAgo(session.savedAt);
@@ -173,18 +209,53 @@ export function usePanelPalette(): UsePanelPaletteReturn {
         const agentName = agentConfig?.name ?? session.agentId;
         const hasMeaningfulTitle = !!session.title && !isUselessTitle(session.title);
         const name = hasMeaningfulTitle ? `Resume: ${session.title}` : `Resume ${agentName}`;
-        const descriptionParts = [modelPart, hasMeaningfulTitle ? agentName : null, timeAgo].filter(
-          (part): part is string => !!part
-        );
+
+        const liveWorktree = session.worktreeId ? worktrees.get(session.worktreeId) : undefined;
+        const isStale = !!session.worktreeId && !liveWorktree;
+        const worktreeName = liveWorktree?.name;
+        const branchName = liveWorktree?.branch ?? session.branch;
+
+        const groupKey = session.worktreeId ?? NO_WORKTREE_GROUP_KEY;
+        const groupLabel = liveWorktree
+          ? liveWorktree.name
+          : isStale
+            ? session.branch || pathBasename(session.cwd) || "Removed worktree"
+            : "No worktree";
+
+        // Second metadata line: agent/model, where it ran, and how long ago.
+        const locationPart = isStale ? "Worktree removed" : (worktreeName ?? branchName ?? null);
+        const descriptionParts = [
+          modelPart,
+          hasMeaningfulTitle ? agentName : null,
+          locationPart,
+          timeAgo,
+        ].filter((part): part is string => !!part);
         const description = descriptionParts.join(" · ");
+
+        // Broaden search beyond the title so an agent, branch, model, or
+        // worktree name matches even when it never appears in the title.
+        const searchAliases = [
+          session.agentId,
+          agentName,
+          modelPart,
+          worktreeName,
+          branchName,
+        ].filter((alias): alias is string => !!alias);
+
         return {
           id: `resume:${session.sessionId}`,
           name,
           iconId: agentConfig?.iconId ?? "terminal",
           color: agentConfig?.color ?? "var(--color-daintree-text)",
           description,
+          searchAliases,
           category: "resume" as const,
           resumeSession: session,
+          isStale,
+          worktreeName,
+          branchName,
+          groupKey,
+          groupLabel,
         };
       });
 
@@ -205,6 +276,8 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     userRegistry,
     keybindingVersion,
     resumeSessions,
+    worktrees,
+    currentProjectId,
     availability,
     isAvailabilityInitialized,
     pluginAgentRegistry,
@@ -215,7 +288,11 @@ export function usePanelPalette(): UsePanelPaletteReturn {
       items: availableKinds,
       fuseOptions: PANEL_FUSE_OPTIONS,
       includeMatches: true,
-      maxResults: 20,
+      // Higher ceiling than the default 20 so the browsable resume list can
+      // surface many closed sessions across worktrees without one crowding out
+      // agents/tools; rendered DOM stays capped via the palette overflow notice.
+      maxResults: 60,
+      canNavigate: (item) => !item.isStale,
       paletteId: "panel",
     });
 
@@ -233,8 +310,10 @@ export function usePanelPalette(): UsePanelPaletteReturn {
 
   useEffect(() => {
     let cancelled = false;
+    // Fetch unscoped (all worktrees) so the list is browsable; the memo above
+    // filters to the current project and flags stale entries (#10851).
     window.electron?.agentSessionHistory
-      ?.list(activeWorktreeId ?? undefined)
+      ?.list()
       .then((sessions) => {
         if (!cancelled) setResumeSessions(sessions);
       })
@@ -242,10 +321,13 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     return () => {
       cancelled = true;
     };
-  }, [isOpen, activeWorktreeId]);
+  }, [isOpen]);
 
   const handleSelect = useCallback(
     (option: PanelKindOption): PanelKindOption | null => {
+      // Stale resume entries (removed worktree) can't be launched — swallow the
+      // click rather than routing to the setup wizard or attempting a resume.
+      if (option.isStale) return null;
       if (option.id === MORE_AGENTS_PANEL_ID || option.installed === false) {
         close();
         window.dispatchEvent(
@@ -265,6 +347,7 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     if (results.length === 0 || selectedIndex < 0) return null;
     const selected = results[selectedIndex];
     if (!selected) return null;
+    if (selected.isStale) return null;
 
     if (selected.id === MORE_AGENTS_PANEL_ID || selected.installed === false) {
       close();

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -233,13 +233,16 @@ export function usePanelPalette(): UsePanelPaletteReturn {
         const description = descriptionParts.join(" · ");
 
         // Broaden search beyond the title so an agent, branch, model, or
-        // worktree name matches even when it never appears in the title.
+        // worktree name matches even when it never appears in the title. The
+        // cwd basename is included so a stale entry whose group label falls
+        // back to it (no branch, no live worktree) stays findable.
         const searchAliases = [
           session.agentId,
           agentName,
           modelPart,
           worktreeName,
           branchName,
+          pathBasename(session.cwd),
         ].filter((alias): alias is string => !!alias);
 
         return {
@@ -309,9 +312,11 @@ export function usePanelPalette(): UsePanelPaletteReturn {
   }, [isOpen]);
 
   useEffect(() => {
+    if (!isOpen) return;
     let cancelled = false;
     // Fetch unscoped (all worktrees) so the list is browsable; the memo above
-    // filters to the current project and flags stale entries (#10851).
+    // filters to the current project and flags stale entries (#10851). Gated on
+    // open so closing the palette doesn't re-read the whole journal.
     window.electron?.agentSessionHistory
       ?.list()
       .then((sessions) => {

--- a/src/utils/__tests__/resumeLaunch.test.ts
+++ b/src/utils/__tests__/resumeLaunch.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { resolveResumeLaunchTarget } from "../resumeLaunch";
+
+describe("resolveResumeLaunchTarget", () => {
+  const fallback = { defaultTerminalCwd: "/active/cwd", activeWorktreeId: "wt-active" };
+
+  it("uses the session's own cwd and worktree when recorded", () => {
+    const target = resolveResumeLaunchTarget(
+      { cwd: "/repo/worktree-a", worktreeId: "wt-a" },
+      fallback
+    );
+    expect(target).toEqual({ cwd: "/repo/worktree-a", worktreeId: "wt-a" });
+  });
+
+  it("does not launch into the active worktree when the session belongs elsewhere", () => {
+    // The whole point of #4781: a session captured in worktree A must resume in
+    // A even while worktree B is the one currently active in the UI.
+    const target = resolveResumeLaunchTarget(
+      { cwd: "/repo/worktree-a", worktreeId: "wt-a" },
+      { defaultTerminalCwd: "/repo/worktree-b", activeWorktreeId: "wt-b" }
+    );
+    expect(target.cwd).toBe("/repo/worktree-a");
+    expect(target.worktreeId).toBe("wt-a");
+  });
+
+  it("falls back to the active worktree defaults when the record predates cwd/worktree", () => {
+    const target = resolveResumeLaunchTarget({ cwd: undefined, worktreeId: null }, fallback);
+    expect(target).toEqual({ cwd: "/active/cwd", worktreeId: "wt-active" });
+  });
+
+  it("falls back cwd independently of worktree", () => {
+    const target = resolveResumeLaunchTarget({ cwd: "/repo/wt-a", worktreeId: null }, fallback);
+    expect(target.cwd).toBe("/repo/wt-a");
+    expect(target.worktreeId).toBe("wt-active");
+  });
+
+  it("yields an undefined worktreeId when neither record nor active worktree is set", () => {
+    const target = resolveResumeLaunchTarget(
+      { cwd: undefined, worktreeId: null },
+      { defaultTerminalCwd: "/active/cwd", activeWorktreeId: null }
+    );
+    expect(target.worktreeId).toBeUndefined();
+    expect(target.cwd).toBe("/active/cwd");
+  });
+});

--- a/src/utils/resumeLaunch.ts
+++ b/src/utils/resumeLaunch.ts
@@ -1,0 +1,21 @@
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+
+/**
+ * Resolve the directory + worktree a resume should launch in.
+ *
+ * Session resume is directory-coupled — `claude --resume`/Gemini fail if the
+ * cwd doesn't match the original session's project path (#4781) — so once the
+ * resume list is browsable across worktrees (#10851), the launch MUST use the
+ * session's own recorded cwd/worktree, not whatever worktree happens to be
+ * active in the UI. Records that predate these fields fall back to the
+ * active-worktree defaults so older history still resumes as before.
+ */
+export function resolveResumeLaunchTarget(
+  session: Pick<AgentSessionRecord, "cwd" | "worktreeId">,
+  fallback: { defaultTerminalCwd: string; activeWorktreeId: string | null | undefined }
+): { cwd: string; worktreeId: string | undefined } {
+  return {
+    cwd: session.cwd ?? fallback.defaultTerminalCwd,
+    worktreeId: session.worktreeId ?? fallback.activeWorktreeId ?? undefined,
+  };
+}


### PR DESCRIPTION
## Summary

- Turns the panel palette's Resume Sessions section into a real browsable, searchable list instead of a fixed top-5 slice scoped to the active worktree.
- Fetches agent session history unscoped and shows every closed session for the current project (the journal retains up to 50 per worktree for 30 days), grouped by worktree with nested `aria-hidden` group headers, never `role=group`, per #9006. Flattens to relevance order while searching.
- Fixes a directory-coupled resume bug (#4781): each session now launches in its own recorded cwd/worktree via a new `resolveResumeLaunchTarget` helper, instead of always using the active worktree, which would silently mis-resume Claude and Gemini sessions once the list spans multiple worktrees.

Resolves #10851.

## Changes

- Broadens fuzzy search to match agent, model, branch, worktree name, and cwd basename, not just the title.
- Greys out entries whose worktree was removed, shows a "Worktree removed" badge, skips them in keyboard navigation, and blocks launching them.
- Gates the now-unscoped history read on palette-open so the full journal isn't re-read on every close.

## Testing

- 48 unit tests added across `usePanelPalette` (browsable list, stale entries, project scoping, search aliases), `resolveResumeLaunchTarget` (cwd/worktree resolution and fallbacks), and `PanelPalette` render tests (grouping headers, stale badge, aria-hidden guard per #9006, group-key vs label).
- eslint and prettier clean on all changed files.
