### PR TITLE
feat(terminal): extend Reopen Last Closed to the resume journal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,14 +82,7 @@ import { PanelTransitionOverlay } from "./components/Panel";
 
 import { TerminalInfoDialogHost } from "./components/Terminal/TerminalInfoDialogHost";
 import { MORE_AGENTS_PANEL_ID } from "./hooks/usePanelPalette";
-import {
-  buildResumeCommand,
-  buildResumeLatestCommand,
-  reconcileBypassFlags,
-  resolveEffectiveBypass,
-} from "@shared/types/agentSettings";
-import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
-import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+import { buildResumePanelOptions } from "./services/agentResume";
 import { resolveResumeLaunchTarget } from "./utils/resumeLaunch";
 import { VoiceRecordingAnnouncer } from "./components/Terminal/VoiceRecordingAnnouncer";
 import { AccessibilityAnnouncer } from "./components/Accessibility/AccessibilityAnnouncer";
@@ -106,31 +99,6 @@ const loadE2ENotificationBackdoor = () => import("./lib/e2eNotificationBackdoor"
 const loadJetbrainsMono500 = () => import("@fontsource/jetbrains-mono/latin-500.css");
 const loadJetbrainsMono600 = () => import("@fontsource/jetbrains-mono/latin-600.css");
 const preloadFileViewerModal = () => import("@/components/FileViewer/FileViewerModal");
-
-// Reconciles a resumed session's persisted launch flags against the current
-// global skip-permissions setting (#10432, the "resume trap"): the snapshot may
-// have been captured while the global switch was in a different state, so strip
-// the agent's canonical bypass flag and re-add it only if it currently resolves.
-function reconcileResumeLaunchFlags(session: {
-  agentId: string;
-  agentLaunchFlags?: string[];
-}): string[] | undefined {
-  const settings = useAgentSettingsStore.getState().settings;
-  const entry = settings?.agents?.[session.agentId] ?? {};
-  const effectiveBypass = resolveEffectiveBypass(
-    entry,
-    session.agentId,
-    settings?.globalSkipPermissions
-  );
-  // Pass [] when no flags were captured so global-on still injects the bypass
-  // token for a supported agent (reconcileBypassFlags no-ops for others).
-  return reconcileBypassFlags(
-    session.agentLaunchFlags ?? [],
-    session.agentId,
-    effectiveBypass,
-    entry.dangerousArgs as string | undefined
-  );
-}
 
 // Direct file import (not the Project barrel) so the lazy chunk doesn't pull
 // in barrel siblings. Renders only when no project is open, so it stays off
@@ -419,7 +387,6 @@ import { usePluginConfirmStore } from "./store/pluginConfirmStore";
 import { usePluginMcpConfirmStore } from "./store/pluginMcpConfirmStore";
 import { usePluginCapabilityConfirmStore } from "./store/pluginCapabilityConfirmStore";
 import { useDiagnosticsReviewStore } from "./store/diagnosticsReviewStore";
-import { useAgentSettingsStore } from "./store/agentSettingsStore";
 // Eager side-effect import: auto-discovers every built-in plugin renderer and
 // registers its builtin view slots at module-eval time, before first render.
 // Must stay static — a deferred/idle import races the user, so getBuiltinView
@@ -887,31 +854,6 @@ function AppInner() {
     [launchAgent]
   );
 
-  const launchResumeSession = useCallback(
-    (session: AgentSessionRecord) => {
-      const agentConfig = getEffectiveAgentConfig(session.agentId);
-      const resumeFlags = reconcileResumeLaunchFlags(session);
-      const command =
-        buildResumeCommand(session.agentId, session.sessionId, resumeFlags) ??
-        buildResumeLatestCommand(session.agentId, resumeFlags);
-      if (!command || !agentConfig) return;
-      const { cwd, worktreeId } = resolveResumeLaunchTarget(session, {
-        defaultTerminalCwd,
-        activeWorktreeId,
-      });
-      addPanel({
-        kind: "terminal",
-        launchAgentId: session.agentId,
-        title: agentConfig.name,
-        cwd,
-        worktreeId,
-        command,
-        location: "grid",
-      });
-    },
-    [addPanel, defaultTerminalCwd, activeWorktreeId]
-  );
-
   const closeThemePalette = useCallback(() => {
     usePaletteStore.getState().closePalette("theme");
   }, []);
@@ -1250,7 +1192,16 @@ function AppInner() {
                       const result = panelPalette.handleSelect(kind);
                       if (!result) return;
                       if (result.resumeSession) {
-                        launchResumeSession(result.resumeSession);
+                        const options = buildResumePanelOptions(
+                          result.resumeSession,
+                          resolveResumeLaunchTarget(result.resumeSession, {
+                            defaultTerminalCwd,
+                            activeWorktreeId,
+                          })
+                        );
+                        if (options) {
+                          addPanel(options);
+                        }
                       } else if (result.id.startsWith("agent:")) {
                         const agentId = result.id.slice("agent:".length);
                         if (agentId) {
@@ -1270,7 +1221,16 @@ function AppInner() {
                       if (!selected) return;
                       if (selected.id === MORE_AGENTS_PANEL_ID) return;
                       if (selected.resumeSession) {
-                        launchResumeSession(selected.resumeSession);
+                        const options = buildResumePanelOptions(
+                          selected.resumeSession,
+                          resolveResumeLaunchTarget(selected.resumeSession, {
+                            defaultTerminalCwd,
+                            activeWorktreeId,
+                          })
+                        );
+                        if (options) {
+                          addPanel(options);
+                        }
                       } else if (selected.id.startsWith("agent:")) {
                         const agentId = selected.id.slice("agent:".length);
                         if (agentId) {

--- a/src/services/__tests__/agentResume.test.ts
+++ b/src/services/__tests__/agentResume.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+
+const buildResumeCommandMock = vi.hoisted(() => vi.fn());
+const buildResumeLatestCommandMock = vi.hoisted(() => vi.fn());
+const reconcileBypassFlagsMock = vi.hoisted(() => vi.fn());
+const resolveEffectiveBypassMock = vi.hoisted(() => vi.fn());
+const getEffectiveAgentConfigMock = vi.hoisted(() => vi.fn());
+const agentSettingsStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+
+vi.mock("@shared/types/agentSettings", () => ({
+  buildResumeCommand: buildResumeCommandMock,
+  buildResumeLatestCommand: buildResumeLatestCommandMock,
+  reconcileBypassFlags: reconcileBypassFlagsMock,
+  resolveEffectiveBypass: resolveEffectiveBypassMock,
+}));
+vi.mock("@shared/config/agentRegistry", () => ({
+  getEffectiveAgentConfig: getEffectiveAgentConfigMock,
+}));
+vi.mock("@/store/agentSettingsStore", () => ({ useAgentSettingsStore: agentSettingsStoreMock }));
+
+import { buildResumePanelOptions, reconcileResumeLaunchFlags } from "../agentResume";
+
+const baseSession: AgentSessionRecord = {
+  sessionId: "s-1",
+  agentId: "claude",
+  worktreeId: "wt-1",
+  title: "Claude",
+  projectId: null,
+  savedAt: 1000,
+  agentLaunchFlags: ["--dangerously-skip-permissions"],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  agentSettingsStoreMock.getState.mockReturnValue({
+    settings: {
+      globalSkipPermissions: true,
+      agents: { claude: { dangerousArgs: "--dangerously-skip-permissions" } },
+    },
+  });
+  resolveEffectiveBypassMock.mockReturnValue(true);
+  reconcileBypassFlagsMock.mockReturnValue(["--dangerously-skip-permissions"]);
+  getEffectiveAgentConfigMock.mockReturnValue({ name: "Claude", command: "claude" });
+  buildResumeCommandMock.mockReturnValue("claude --resume s-1");
+  buildResumeLatestCommandMock.mockReturnValue("claude --continue");
+});
+
+describe("reconcileResumeLaunchFlags", () => {
+  it("resolves effective bypass from the live settings store and reconciles flags", () => {
+    const result = reconcileResumeLaunchFlags(baseSession);
+
+    expect(resolveEffectiveBypassMock).toHaveBeenCalledWith(
+      { dangerousArgs: "--dangerously-skip-permissions" },
+      "claude",
+      true
+    );
+    expect(reconcileBypassFlagsMock).toHaveBeenCalledWith(
+      ["--dangerously-skip-permissions"],
+      "claude",
+      true,
+      "--dangerously-skip-permissions"
+    );
+    expect(result).toEqual(["--dangerously-skip-permissions"]);
+  });
+
+  it("passes an empty flag array when the session captured none", () => {
+    reconcileResumeLaunchFlags({ agentId: "claude" });
+    expect(reconcileBypassFlagsMock).toHaveBeenCalledWith(
+      [],
+      "claude",
+      true,
+      "--dangerously-skip-permissions"
+    );
+  });
+
+  it("passes undefined dangerousArgs when the agent has no settings entry", () => {
+    reconcileResumeLaunchFlags({ agentId: "gemini" });
+    expect(resolveEffectiveBypassMock).toHaveBeenCalledWith({}, "gemini", true);
+    expect(reconcileBypassFlagsMock).toHaveBeenCalledWith([], "gemini", true, undefined);
+  });
+});
+
+describe("buildResumePanelOptions", () => {
+  it("builds terminal options with the reconciled resume command and seeds agentSessionId", () => {
+    const options = buildResumePanelOptions(baseSession, { cwd: "/active", worktreeId: "wt-1" });
+
+    expect(buildResumeCommandMock).toHaveBeenCalledWith("claude", "s-1", [
+      "--dangerously-skip-permissions",
+    ]);
+    expect(options).toEqual({
+      kind: "terminal",
+      launchAgentId: "claude",
+      title: "Claude",
+      cwd: "/active",
+      worktreeId: "wt-1",
+      command: "claude --resume s-1",
+      location: "grid",
+      agentSessionId: "s-1",
+    });
+  });
+
+  it("prefers buildResumeCommand over buildResumeLatestCommand", () => {
+    const options = buildResumePanelOptions(baseSession, { cwd: "/active", worktreeId: "wt-1" });
+    expect(options?.command).toBe("claude --resume s-1");
+    expect(buildResumeLatestCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to buildResumeLatestCommand when no exact-session command exists", () => {
+    buildResumeCommandMock.mockReturnValue(undefined);
+    const options = buildResumePanelOptions(baseSession, { cwd: "/active", worktreeId: "wt-1" });
+    expect(options?.command).toBe("claude --continue");
+  });
+
+  it("returns null when neither resume command is available", () => {
+    buildResumeCommandMock.mockReturnValue(undefined);
+    buildResumeLatestCommandMock.mockReturnValue(undefined);
+    expect(buildResumePanelOptions(baseSession, { cwd: "/active" })).toBeNull();
+  });
+
+  it("returns null when the agent has no effective config", () => {
+    getEffectiveAgentConfigMock.mockReturnValue(undefined);
+    expect(buildResumePanelOptions(baseSession, { cwd: "/active" })).toBeNull();
+  });
+
+  it("returns null for a malformed record missing sessionId", () => {
+    const malformed = { ...baseSession, sessionId: "" };
+    expect(buildResumePanelOptions(malformed, { cwd: "/active" })).toBeNull();
+    expect(getEffectiveAgentConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a malformed record missing agentId", () => {
+    const malformed = { ...baseSession, agentId: "" };
+    expect(buildResumePanelOptions(malformed, { cwd: "/active" })).toBeNull();
+  });
+});

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -4572,7 +4572,7 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "terminal",
     "danger": "safe",
     "dangerRationale": undefined,
-    "description": "Restore the most recently trashed terminal",
+    "description": "Restore the most recently trashed terminal, or resume the most recent journaled agent session once the trash window has lapsed",
     "examples": undefined,
     "id": "terminal.reopenLast",
     "keywords": undefined,

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -7,11 +7,20 @@ const layoutUndoMock = vi.hoisted(() => ({
   getState: vi.fn(() => ({ pushLayoutSnapshot: vi.fn() })),
 }));
 const buildPanelDuplicateOptionsMock = vi.hoisted(() => vi.fn());
+const flushOptimisticClosesMock = vi.hoisted(() => vi.fn());
+const buildResumePanelOptionsMock = vi.hoisted(() => vi.fn());
+const listAgentSessionsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/store/panelStore", () => ({ usePanelStore: panelStoreMock }));
 vi.mock("@/store/layoutUndoStore", () => ({ useLayoutUndoStore: layoutUndoMock }));
 vi.mock("@/services/terminal/panelDuplicationService", () => ({
   buildPanelDuplicateOptions: buildPanelDuplicateOptionsMock,
+}));
+vi.mock("@/services/terminal/optimisticPanelClose", () => ({
+  flushOptimisticCloses: flushOptimisticClosesMock,
+}));
+vi.mock("@/services/agentResume", () => ({
+  buildResumePanelOptions: buildResumePanelOptionsMock,
 }));
 
 vi.mock("@shared/config/panelKindRegistry", () => ({
@@ -44,11 +53,12 @@ vi.mock("@shared/config/panelKindRegistry", () => ({
 
 import { registerTerminalSpawnActions } from "../terminalSpawnActions";
 
-function setupActions() {
+function setupActions(overrides?: { activeWorktreeId?: string | undefined }) {
   const actions: ActionRegistry = new Map();
   const callbacks: ActionCallbacks = {
     getDefaultCwd: () => "/cwd",
-    getActiveWorktreeId: () => "wt-1",
+    getActiveWorktreeId: () =>
+      "activeWorktreeId" in (overrides ?? {}) ? overrides!.activeWorktreeId : "wt-1",
   } as unknown as ActionCallbacks;
   registerTerminalSpawnActions(actions, callbacks);
   return async (id: string, args?: unknown): Promise<unknown> => {
@@ -66,6 +76,7 @@ type MockPanel = {
   launchAgentId?: string;
   detectedAgentId?: string;
   title?: string;
+  agentSessionId?: string;
 };
 
 function setPanelState(options: {
@@ -73,6 +84,8 @@ function setPanelState(options: {
   panels?: MockPanel[];
   addPanel?: ReturnType<typeof vi.fn>;
   lastClosedConfig?: AddPanelOptions | null;
+  restoreLastTrashed?: ReturnType<typeof vi.fn>;
+  activateTerminal?: ReturnType<typeof vi.fn>;
 }) {
   const panels = options.panels ?? [];
   const panelsById: Record<string, MockPanel> = {};
@@ -83,11 +96,18 @@ function setPanelState(options: {
     panelsById,
     addPanel: options.addPanel ?? vi.fn().mockResolvedValue(undefined),
     lastClosedConfig: options.lastClosedConfig ?? null,
+    restoreLastTrashed: options.restoreLastTrashed ?? vi.fn().mockReturnValue(false),
+    activateTerminal: options.activateTerminal ?? vi.fn(),
   });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  listAgentSessionsMock.mockResolvedValue([]);
+  (globalThis as unknown as { window: { electron: unknown } }).window = {
+    ...(globalThis as unknown as { window?: object }).window,
+    electron: { agentSessionHistory: { list: listAgentSessionsMock } },
+  };
   // Mirror the real buildPanelDuplicateOptions: browser panels don't carry a title
   // into the returned options (see panelDuplicationService.ts). All other kinds
   // seed options.title from the source panel.
@@ -350,5 +370,162 @@ describe("terminal.duplicate (copy) suffix", () => {
     await run("terminal.duplicate");
 
     expect(addPanel.mock.calls[0]![0].title).toBe("My App (copy)");
+  });
+});
+
+describe("terminal.reopenLast journal fallback", () => {
+  const resumeOptions = {
+    kind: "terminal" as const,
+    launchAgentId: "claude",
+    title: "Claude",
+    cwd: "/cwd",
+    worktreeId: "wt-1",
+    command: "claude --resume s-1",
+    location: "grid" as const,
+    agentSessionId: "s-1",
+  };
+  const session = {
+    sessionId: "s-1",
+    agentId: "claude",
+    worktreeId: "wt-1",
+    title: "Claude",
+    projectId: null,
+    savedAt: 1000,
+  };
+
+  it("flushes optimistic closes then restores from trash without touching the journal", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    const restoreLastTrashed = vi.fn().mockReturnValue(true);
+    setPanelState({ panels: [], addPanel, restoreLastTrashed });
+    const run = setupActions();
+
+    await run("terminal.reopenLast");
+
+    expect(flushOptimisticClosesMock).toHaveBeenCalledTimes(1);
+    expect(restoreLastTrashed).toHaveBeenCalledTimes(1);
+    expect(listAgentSessionsMock).not.toHaveBeenCalled();
+    expect(buildResumePanelOptionsMock).not.toHaveBeenCalled();
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("resumes the most recent journaled session (scoped to active worktree) when trash is empty", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      panels: [],
+      addPanel,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    // Newest-first: only the first record should be resumed.
+    listAgentSessionsMock.mockResolvedValue([session, { ...session, sessionId: "s-old" }]);
+    buildResumePanelOptionsMock.mockReturnValue(resumeOptions);
+    const run = setupActions();
+
+    await run("terminal.reopenLast");
+
+    expect(listAgentSessionsMock).toHaveBeenCalledWith("wt-1");
+    expect(buildResumePanelOptionsMock).toHaveBeenCalledWith(session, {
+      cwd: "/cwd",
+      worktreeId: "wt-1",
+    });
+    expect(addPanel).toHaveBeenCalledWith(resumeOptions);
+  });
+
+  it("no-ops when there is no active worktree (never picks a global record)", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      panels: [],
+      addPanel,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    const run = setupActions({ activeWorktreeId: undefined });
+
+    await run("terminal.reopenLast");
+
+    expect(listAgentSessionsMock).not.toHaveBeenCalled();
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the journal is empty", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      panels: [],
+      addPanel,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    listAgentSessionsMock.mockResolvedValue([]);
+    const run = setupActions();
+
+    await run("terminal.reopenLast");
+
+    expect(buildResumePanelOptionsMock).not.toHaveBeenCalled();
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("swallows a journal list rejection without spawning", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      panels: [],
+      addPanel,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    listAgentSessionsMock.mockRejectedValue(new Error("ipc down"));
+    const run = setupActions();
+
+    await expect(run("terminal.reopenLast")).resolves.toBeUndefined();
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the record can't build resume options", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      panels: [],
+      addPanel,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    listAgentSessionsMock.mockResolvedValue([session]);
+    buildResumePanelOptionsMock.mockReturnValue(null);
+    const run = setupActions();
+
+    await run("terminal.reopenLast");
+
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("focuses an already-open panel with the same session instead of spawning a duplicate", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    const activateTerminal = vi.fn();
+    setPanelState({
+      panels: [{ id: "p-live", location: "grid", kind: "terminal", agentSessionId: "s-1" }],
+      addPanel,
+      activateTerminal,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    listAgentSessionsMock.mockResolvedValue([session]);
+    buildResumePanelOptionsMock.mockReturnValue(resumeOptions);
+    const run = setupActions();
+
+    await run("terminal.reopenLast");
+
+    expect(activateTerminal).toHaveBeenCalledWith("p-live");
+    expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("ignores a trashed panel with the same session and spawns a fresh resume", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    const activateTerminal = vi.fn();
+    setPanelState({
+      panels: [{ id: "p-trash", location: "trash", kind: "terminal", agentSessionId: "s-1" }],
+      addPanel,
+      activateTerminal,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    listAgentSessionsMock.mockResolvedValue([session]);
+    buildResumePanelOptionsMock.mockReturnValue(resumeOptions);
+    const run = setupActions();
+
+    await run("terminal.reopenLast");
+
+    expect(activateTerminal).not.toHaveBeenCalled();
+    expect(addPanel).toHaveBeenCalledWith(resumeOptions);
   });
 });

--- a/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalSpawnActions.test.ts
@@ -77,6 +77,7 @@ type MockPanel = {
   detectedAgentId?: string;
   title?: string;
   agentSessionId?: string;
+  worktreeId?: string;
 };
 
 function setPanelState(options: {
@@ -491,11 +492,19 @@ describe("terminal.reopenLast journal fallback", () => {
     expect(addPanel).not.toHaveBeenCalled();
   });
 
-  it("focuses an already-open panel with the same session instead of spawning a duplicate", async () => {
+  it("focuses an already-open panel with the same session in the active worktree instead of spawning a duplicate", async () => {
     const addPanel = vi.fn().mockResolvedValue(undefined);
     const activateTerminal = vi.fn();
     setPanelState({
-      panels: [{ id: "p-live", location: "grid", kind: "terminal", agentSessionId: "s-1" }],
+      panels: [
+        {
+          id: "p-live",
+          location: "grid",
+          kind: "terminal",
+          agentSessionId: "s-1",
+          worktreeId: "wt-1",
+        },
+      ],
       addPanel,
       activateTerminal,
       restoreLastTrashed: vi.fn().mockReturnValue(false),
@@ -508,6 +517,60 @@ describe("terminal.reopenLast journal fallback", () => {
 
     expect(activateTerminal).toHaveBeenCalledWith("p-live");
     expect(addPanel).not.toHaveBeenCalled();
+  });
+
+  it("does not steal focus across worktrees: a same-session panel in another worktree is ignored and a fresh resume spawns", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    const activateTerminal = vi.fn();
+    setPanelState({
+      panels: [
+        {
+          id: "p-elsewhere",
+          location: "grid",
+          kind: "terminal",
+          agentSessionId: "s-1",
+          worktreeId: "wt-2",
+        },
+      ],
+      addPanel,
+      activateTerminal,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    listAgentSessionsMock.mockResolvedValue([session]);
+    buildResumePanelOptionsMock.mockReturnValue(resumeOptions);
+    const run = setupActions();
+
+    await run("terminal.reopenLast");
+
+    expect(activateTerminal).not.toHaveBeenCalled();
+    expect(addPanel).toHaveBeenCalledWith(resumeOptions);
+  });
+
+  it("blocks a second overlapping dispatch so the same session is not resumed twice", async () => {
+    const addPanel = vi.fn().mockResolvedValue(undefined);
+    setPanelState({
+      panels: [],
+      addPanel,
+      restoreLastTrashed: vi.fn().mockReturnValue(false),
+    });
+    // Hold the journal lookup pending so both dispatches overlap in flight.
+    let releaseList: (records: (typeof session)[]) => void = () => {};
+    listAgentSessionsMock.mockReturnValue(
+      new Promise((resolve) => {
+        releaseList = resolve;
+      })
+    );
+    buildResumePanelOptionsMock.mockReturnValue(resumeOptions);
+    const run = setupActions();
+
+    const first = run("terminal.reopenLast");
+    const second = run("terminal.reopenLast");
+    releaseList([session]);
+    await Promise.all([first, second]);
+
+    // First dispatch set the in-flight guard before awaiting; the second bailed.
+    expect(listAgentSessionsMock).toHaveBeenCalledTimes(1);
+    expect(addPanel).toHaveBeenCalledTimes(1);
   });
 
   it("ignores a trashed panel with the same session and spawns a fresh resume", async () => {

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -9,6 +9,7 @@ import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
+import { isPtyPanel } from "@shared/types/panel";
 
 // Guards the async journal-resume fallback of `terminal.reopenLast` against a
 // second dispatch racing the first's pending `list`/`addPanel` — two rapid
@@ -196,7 +197,7 @@ export function registerTerminalSpawnActions(
           const panel = state.panelsById[id];
           return (
             panel &&
-            panel.kind === "terminal" &&
+            isPtyPanel(panel) &&
             panel.location !== "trash" &&
             panel.agentSessionId === session.sessionId &&
             panel.worktreeId === activeWorktreeId

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -9,7 +9,6 @@ import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
-import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 
 // Guards the async journal-resume fallback of `terminal.reopenLast` against a
 // second dispatch racing the first's pending `list`/`addPanel` — two rapid
@@ -180,7 +179,7 @@ export function registerTerminalSpawnActions(
       try {
         const sessions = await (window.electron?.agentSessionHistory
           ?.list(activeWorktreeId)
-          .catch(() => [] as AgentSessionRecord[]) ?? Promise.resolve([]));
+          .catch(() => []) ?? Promise.resolve([]));
         const session = sessions[0];
         if (!session) return;
 

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -10,6 +10,14 @@ import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
 import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+
+// Guards the async journal-resume fallback of `terminal.reopenLast` against a
+// second dispatch racing the first's pending `list`/`addPanel` — two rapid
+// presses could otherwise both pass the duplicate scan and spawn two terminals
+// resuming the same transcript. Module-scoped, so it's per project view (each
+// view has its own module instance), matching the worktree scope of the guard.
+let reopenJournalInFlight = false;
+
 export function registerTerminalSpawnActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -159,35 +167,50 @@ export function registerTerminalSpawnActions(
       // resumed record's cwd matches the directory we launch into — session
       // resume is directory-scoped (#4781); a globally-newest record could be
       // relaunched into the wrong worktree.
+      if (reopenJournalInFlight) return;
       const activeWorktreeId = callbacks.getActiveWorktreeId();
       if (!activeWorktreeId) return;
+      // Freeze the cwd alongside the worktree id BEFORE the await: both are live
+      // getters (useActionRegistry's ref proxy), so a worktree switch mid-IPC
+      // would otherwise pair this record's worktree with a different worktree's
+      // cwd — the exact directory mismatch #4781 warns about.
+      const cwd = callbacks.getDefaultCwd();
 
-      const sessions = await (window.electron?.agentSessionHistory
-        ?.list(activeWorktreeId)
-        .catch(() => [] as AgentSessionRecord[]) ?? Promise.resolve([]));
-      const session = sessions[0];
-      if (!session) return;
+      reopenJournalInFlight = true;
+      try {
+        const sessions = await (window.electron?.agentSessionHistory
+          ?.list(activeWorktreeId)
+          .catch(() => [] as AgentSessionRecord[]) ?? Promise.resolve([]));
+        const session = sessions[0];
+        if (!session) return;
 
-      const options = buildResumePanelOptions(session, {
-        cwd: callbacks.getDefaultCwd(),
-        worktreeId: activeWorktreeId,
-      });
-      if (!options) return;
+        const options = buildResumePanelOptions(session, { cwd, worktreeId: activeWorktreeId });
+        if (!options) return;
 
-      // Records are non-destructive/unconsumed, so a repeat press would try to
-      // resume the same session again — concurrent transcript access. If a live
-      // panel already carries this session, focus it instead of respawning.
-      const state = usePanelStore.getState();
-      const existingId = state.panelIds.find((id) => {
-        const panel = state.panelsById[id];
-        return panel && panel.location !== "trash" && panel.agentSessionId === session.sessionId;
-      });
-      if (existingId) {
-        state.activateTerminal(existingId);
-        return;
+        // Records are non-destructive/unconsumed, so a repeat press would try to
+        // resume the same session again — concurrent transcript access. If a live
+        // panel in this worktree already carries the session, focus it instead of
+        // respawning. Scope by worktree too so a panel moved to another worktree
+        // can't steal focus across worktrees.
+        const state = usePanelStore.getState();
+        const existingId = state.panelIds.find((id) => {
+          const panel = state.panelsById[id];
+          return (
+            panel &&
+            panel.location !== "trash" &&
+            panel.agentSessionId === session.sessionId &&
+            panel.worktreeId === activeWorktreeId
+          );
+        });
+        if (existingId) {
+          state.activateTerminal(existingId);
+          return;
+        }
+
+        await state.addPanel(options);
+      } finally {
+        reopenJournalInFlight = false;
       }
-
-      await state.addPanel(options);
     },
   }));
 

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -4,10 +4,12 @@ import { usePanelStore } from "@/store/panelStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { flushOptimisticCloses } from "@/services/terminal/optimisticPanelClose";
+import { buildResumePanelOptions } from "@/services/agentResume";
 import { getDefaultTitle } from "@/store/slices/panelRegistry/helpers";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import { TerminalSpawnSourceSchema, AddPanelFocusPolicySchema } from "./schemas";
 import type { PtyPanelData, TerminalSpawnSource } from "@shared/types/panel";
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 export function registerTerminalSpawnActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -139,7 +141,8 @@ export function registerTerminalSpawnActions(
   actions.set("terminal.reopenLast", () => ({
     id: "terminal.reopenLast",
     title: "Reopen Last Closed",
-    description: "Restore the most recently trashed terminal",
+    description:
+      "Restore the most recently trashed terminal, or resume the most recent journaled agent session once the trash window has lapsed",
     category: "terminal",
     kind: "command",
     danger: "safe",
@@ -148,7 +151,43 @@ export function registerTerminalSpawnActions(
       // Commit any in-flight optimistic close first — until it flushes the
       // panel isn't in `trashedTerminals` yet and restore would no-op.
       flushOptimisticCloses();
-      usePanelStore.getState().restoreLastTrashed();
+      // Fast path: restore from the in-memory trash while its window is open.
+      if (usePanelStore.getState().restoreLastTrashed()) return;
+
+      // Fallback: the trash window has lapsed. Resume the most recent journaled
+      // session for the active worktree. Scope to the active worktree so the
+      // resumed record's cwd matches the directory we launch into — session
+      // resume is directory-scoped (#4781); a globally-newest record could be
+      // relaunched into the wrong worktree.
+      const activeWorktreeId = callbacks.getActiveWorktreeId();
+      if (!activeWorktreeId) return;
+
+      const sessions = await (window.electron?.agentSessionHistory
+        ?.list(activeWorktreeId)
+        .catch(() => [] as AgentSessionRecord[]) ?? Promise.resolve([]));
+      const session = sessions[0];
+      if (!session) return;
+
+      const options = buildResumePanelOptions(session, {
+        cwd: callbacks.getDefaultCwd(),
+        worktreeId: activeWorktreeId,
+      });
+      if (!options) return;
+
+      // Records are non-destructive/unconsumed, so a repeat press would try to
+      // resume the same session again — concurrent transcript access. If a live
+      // panel already carries this session, focus it instead of respawning.
+      const state = usePanelStore.getState();
+      const existingId = state.panelIds.find((id) => {
+        const panel = state.panelsById[id];
+        return panel && panel.location !== "trash" && panel.agentSessionId === session.sessionId;
+      });
+      if (existingId) {
+        state.activateTerminal(existingId);
+        return;
+      }
+
+      await state.addPanel(options);
     },
   }));
 

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -196,6 +196,7 @@ export function registerTerminalSpawnActions(
           const panel = state.panelsById[id];
           return (
             panel &&
+            panel.kind === "terminal" &&
             panel.location !== "trash" &&
             panel.agentSessionId === session.sessionId &&
             panel.worktreeId === activeWorktreeId

--- a/src/services/agentResume.ts
+++ b/src/services/agentResume.ts
@@ -1,0 +1,81 @@
+import {
+  buildResumeCommand,
+  buildResumeLatestCommand,
+  reconcileBypassFlags,
+  resolveEffectiveBypass,
+} from "@shared/types/agentSettings";
+import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import type { AddPanelOptions } from "@shared/types/addPanelOptions";
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+
+/**
+ * Reconciles a resumed session's persisted launch flags against the current
+ * global skip-permissions setting (#10432, the "resume trap"): the snapshot may
+ * have been captured while the global switch was in a different state, so strip
+ * the agent's canonical bypass flag and re-add it only if it currently resolves.
+ *
+ * Reads `useAgentSettingsStore` synchronously (a Zustand store read, not
+ * React-bound), so it is safe to call from action definitions and effects alike.
+ */
+export function reconcileResumeLaunchFlags(session: {
+  agentId: string;
+  agentLaunchFlags?: string[];
+}): string[] | undefined {
+  const settings = useAgentSettingsStore.getState().settings;
+  const entry = settings?.agents?.[session.agentId] ?? {};
+  const effectiveBypass = resolveEffectiveBypass(
+    entry,
+    session.agentId,
+    settings?.globalSkipPermissions
+  );
+  // Pass [] when no flags were captured so global-on still injects the bypass
+  // token for a supported agent (reconcileBypassFlags no-ops for others).
+  return reconcileBypassFlags(
+    session.agentLaunchFlags ?? [],
+    session.agentId,
+    effectiveBypass,
+    entry.dangerousArgs as string | undefined
+  );
+}
+
+/**
+ * Turns a journaled/palette-selected {@link AgentSessionRecord} into the
+ * `addPanel` options that relaunch its agent with a resume command. Funnels
+ * through `buildResumeCommand ?? buildResumeLatestCommand` (never re-derives
+ * from current settings — #5343) with reconciled launch flags (#3175).
+ *
+ * Launches into the caller-provided `cwd`/`worktreeId`. Session resume is
+ * directory-scoped — the CLI locates the conversation from the launch cwd
+ * (#4781) — so callers resolve the target from the session's OWN recorded
+ * location via `resolveResumeLaunchTarget`, falling back to the active worktree
+ * only for records that predate those fields. Seeds `agentSessionId` so callers
+ * can detect an already-open resume and focus it instead of spawning a
+ * duplicate.
+ *
+ * @returns `addPanel` options, or `null` when the record is malformed or the
+ *   agent has no resume config / no buildable command.
+ */
+export function buildResumePanelOptions(
+  session: AgentSessionRecord,
+  target: { cwd: string; worktreeId?: string }
+): AddPanelOptions | null {
+  if (!session.agentId || !session.sessionId) return null;
+  const agentConfig = getEffectiveAgentConfig(session.agentId);
+  if (!agentConfig) return null;
+  const resumeFlags = reconcileResumeLaunchFlags(session);
+  const command =
+    buildResumeCommand(session.agentId, session.sessionId, resumeFlags) ??
+    buildResumeLatestCommand(session.agentId, resumeFlags);
+  if (!command) return null;
+  return {
+    kind: "terminal",
+    launchAgentId: session.agentId,
+    title: agentConfig.name,
+    cwd: target.cwd,
+    worktreeId: target.worktreeId,
+    command,
+    location: "grid",
+    agentSessionId: session.sessionId,
+  };
+}

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -839,7 +839,39 @@ export const usePanelStore = create<PanelGridState>()(
         const lastTrashed = trashedTerminals.get(lastId);
 
         if (lastTrashed?.groupRestoreId) {
-          get().restoreTrashedGroup(lastTrashed.groupRestoreId);
+          const { groupRestoreId } = lastTrashed;
+          const groupIds: string[] = [];
+          for (const [id, trashed] of trashedTerminals.entries()) {
+            if (trashed.groupRestoreId === groupRestoreId) {
+              groupIds.push(id);
+            }
+          }
+
+          // Same stale-entry race as the single-panel case below, but for a
+          // whole group: a throttled expiry timer can prune every member from
+          // panelsById while the trashedTerminals entries linger.
+          // `restoreTrashedGroup` only mutates panelsById for ids that still
+          // exist, so a fully-ghosted group is a silent no-op that would
+          // otherwise still report success — wrongly suppressing the
+          // resume-journal fallback. Treat "no surviving member" as "nothing
+          // restored": drop the stale entries and return false so the caller
+          // can fall through.
+          const hasSurvivingMember = groupIds.some((id) => {
+            const panel = get().panelsById[id];
+            return panel?.location === "trash";
+          });
+          if (!hasSurvivingMember) {
+            set((state) => {
+              const newTrashed = new Map(state.trashedTerminals);
+              for (const id of groupIds) {
+                newTrashed.delete(id);
+              }
+              return { trashedTerminals: newTrashed };
+            });
+            return false;
+          }
+
+          get().restoreTrashedGroup(groupRestoreId);
           return true;
         }
 

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -840,9 +840,27 @@ export const usePanelStore = create<PanelGridState>()(
 
         if (lastTrashed?.groupRestoreId) {
           get().restoreTrashedGroup(lastTrashed.groupRestoreId);
-        } else {
-          get().restoreTerminal(lastId);
+          return true;
         }
+
+        // A stale map entry can outlive its panel row: a background-throttled
+        // expiry timer can fire late, and `restoreTerminal` no-ops (without
+        // even cleaning the map) when `panelsById[id]` is already gone.
+        // Restoring it would be a silent no-op that still reports success —
+        // wrongly suppressing the resume-journal fallback the caller wants.
+        // Treat a missing/non-trash panel as "nothing restored": drop the stale
+        // entry and return false so the caller can fall through.
+        const panel = get().panelsById[lastId];
+        if (!panel || panel.location !== "trash") {
+          set((state) => {
+            const newTrashed = new Map(state.trashedTerminals);
+            newTrashed.delete(lastId);
+            return { trashedTerminals: newTrashed };
+          });
+          return false;
+        }
+
+        get().restoreTerminal(lastId);
         return true;
       },
 

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -232,7 +232,10 @@ export interface PanelGridState
   detachTerminalsForProjectSwitch: () => void;
   clearTerminalStoreForSwitch: () => void;
   lastClosedConfig: AddPanelOptions | null;
-  restoreLastTrashed: () => void;
+  /** Restores the most recently trashed terminal. Returns `false` when the
+   * trash is empty (nothing restored) so callers can fall back to another
+   * source (e.g. the resume journal). */
+  restoreLastTrashed: () => boolean;
 }
 
 /**
@@ -830,7 +833,7 @@ export const usePanelStore = create<PanelGridState>()(
       restoreLastTrashed: () => {
         const trashedTerminals = get().trashedTerminals;
         const trashedIds = Array.from(trashedTerminals.keys());
-        if (trashedIds.length === 0) return;
+        if (trashedIds.length === 0) return false;
 
         const lastId = trashedIds[trashedIds.length - 1]!;
         const lastTrashed = trashedTerminals.get(lastId);
@@ -840,6 +843,7 @@ export const usePanelStore = create<PanelGridState>()(
         } else {
           get().restoreTerminal(lastId);
         }
+        return true;
       },
 
       moveTerminalToPosition: (

--- a/src/store/slices/panelRegistry/__tests__/restoreLastTrashed.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restoreLastTrashed.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
+import type { TrashedTerminal } from "../types";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: { setState: vi.fn().mockResolvedValue(undefined) },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: { get: vi.fn().mockResolvedValue({}) },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+const { usePanelStore } = await import("../../../panelStore");
+
+function seedPanel(id: string, location: "grid" | "dock" | "trash") {
+  const panel = {
+    id,
+    title: id,
+    kind: "terminal" as const,
+    type: "terminal" as const,
+    location,
+    worktreeId: "wt-1",
+    isVisible: true,
+  } as unknown as PtyPanelData;
+  usePanelStore.setState((state) => ({
+    panelsById: { ...state.panelsById, [id]: panel },
+    panelIds: state.panelIds.includes(id) ? state.panelIds : [...state.panelIds, id],
+  }));
+}
+
+function seedTrashEntry(id: string) {
+  const entry: TrashedTerminal = {
+    id,
+    expiresAt: 1_000,
+    originalLocation: "grid",
+  };
+  usePanelStore.setState((state) => {
+    const trashedTerminals = new Map(state.trashedTerminals);
+    trashedTerminals.set(id, entry);
+    return { trashedTerminals };
+  });
+}
+
+describe("restoreLastTrashed boolean contract", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    await usePanelStore.getState().reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false when the trash is empty", () => {
+    expect(usePanelStore.getState().restoreLastTrashed()).toBe(false);
+  });
+
+  it("restores a live trashed panel and returns true", () => {
+    seedPanel("term-1", "trash");
+    seedTrashEntry("term-1");
+
+    const restored = usePanelStore.getState().restoreLastTrashed();
+
+    expect(restored).toBe(true);
+    // The restore consumed the trash entry (moved the panel back out of trash).
+    expect(usePanelStore.getState().trashedTerminals.has("term-1")).toBe(false);
+    expect(usePanelStore.getState().panelsById["term-1"]?.location).not.toBe("trash");
+  });
+
+  it("returns false and drops a stale entry whose panel row is gone", () => {
+    // Map entry survives but the panel was already removed from panelsById —
+    // a real drift path (throttled expiry timer + no-op restore without cleanup).
+    seedTrashEntry("ghost");
+
+    const restored = usePanelStore.getState().restoreLastTrashed();
+
+    expect(restored).toBe(false);
+    expect(usePanelStore.getState().trashedTerminals.has("ghost")).toBe(false);
+  });
+
+  it("returns false when the entry's panel is no longer in trash", () => {
+    // Panel exists but was already restored elsewhere (location back to grid);
+    // the lingering map entry must not report a phantom success.
+    seedPanel("moved", "grid");
+    seedTrashEntry("moved");
+
+    const restored = usePanelStore.getState().restoreLastTrashed();
+
+    expect(restored).toBe(false);
+    expect(usePanelStore.getState().trashedTerminals.has("moved")).toBe(false);
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/restoreLastTrashed.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restoreLastTrashed.test.ts
@@ -63,6 +63,20 @@ function seedTrashEntry(id: string) {
   });
 }
 
+function seedTrashGroupEntry(id: string, groupRestoreId: string) {
+  const entry: TrashedTerminal = {
+    id,
+    expiresAt: 1_000,
+    originalLocation: "grid",
+    groupRestoreId,
+  };
+  usePanelStore.setState((state) => {
+    const trashedTerminals = new Map(state.trashedTerminals);
+    trashedTerminals.set(id, entry);
+    return { trashedTerminals };
+  });
+}
+
 describe("restoreLastTrashed boolean contract", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -110,5 +124,35 @@ describe("restoreLastTrashed boolean contract", () => {
 
     expect(restored).toBe(false);
     expect(usePanelStore.getState().trashedTerminals.has("moved")).toBe(false);
+  });
+
+  it("returns false and drops stale entries for a fully-ghosted group", () => {
+    // Every member of the group was already pruned from panelsById (same
+    // throttled-expiry-timer race as the single-panel ghost case), but the
+    // trashedTerminals map entries linger — restoreTrashedGroup would be a
+    // silent no-op that must not report a phantom success.
+    seedTrashGroupEntry("ghost-a", "group-1");
+    seedTrashGroupEntry("ghost-b", "group-1");
+
+    const restored = usePanelStore.getState().restoreLastTrashed();
+
+    expect(restored).toBe(false);
+    expect(usePanelStore.getState().trashedTerminals.has("ghost-a")).toBe(false);
+    expect(usePanelStore.getState().trashedTerminals.has("ghost-b")).toBe(false);
+  });
+
+  it("restores a group with at least one surviving member and returns true", () => {
+    // One member of the group still exists in panelsById with location
+    // "trash"; the group restore should proceed and report success even
+    // though a sibling member was already pruned.
+    seedPanel("live-a", "trash");
+    seedTrashGroupEntry("live-a", "group-2");
+    seedTrashGroupEntry("ghost-c", "group-2");
+
+    const restored = usePanelStore.getState().restoreLastTrashed();
+
+    expect(restored).toBe(true);
+    expect(usePanelStore.getState().trashedTerminals.has("live-a")).toBe(false);
+    expect(usePanelStore.getState().trashedTerminals.has("ghost-c")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `terminal.reopenLast` (Cmd+Shift+T) used to only restore terminals from the 20 second in-memory trash window via `restoreLastTrashed()`. Once that window lapsed the shortcut went silent, even though the resume journal keeps sessions for 30 days.
- Extends `terminal.reopenLast` so that once the trash window lapses, it falls back to resuming the most recent journaled agent session, scoped strictly to the active worktree. Keeps the browser-style "reopen closed tab" muscle memory working well past the 20 second window.

Resolves #10852.

## Changes

- `terminal.reopenLast` falls back to the resume journal once `restoreLastTrashed()` returns `false` (trash empty or stale). The journal lookup is scoped to the active worktree, consistent with the directory-scoped resume work in #4781.
- The fallback funnels through `buildResumeCommand`, falling back to `buildResumeLatestCommand`, plus the same reconciled launch flags used elsewhere (#5343, #3175).
- Seeds `agentSessionId` on the resumed panel so a second press focuses the existing panel instead of double-resuming.
- Adds a per-view in-flight guard against overlapping dispatches, and freezes the current working directory before the journal IPC call awaits, so a mid-await worktree switch can't cause a resume into the wrong directory.
- `restoreLastTrashed()` now returns a boolean: `false` on an empty or stale trash, so the caller can honestly tell a no-op restore from a real one and run the journal fallback.
- Extracted `reconcileResumeLaunchFlags` and a new `buildResumePanelOptions` out of `App.tsx` into a renderer-only `src/services/agentResume.ts`, and used the shared helper to deduplicate the two near-identical palette resume blocks in `App.tsx`. Behavior-preserving.

## Testing

- New `src/services/__tests__/agentResume.test.ts` and `src/store/slices/panelRegistry/__tests__/restoreLastTrashed.test.ts`.
- Extended `terminalSpawnActions.test.ts` to cover the new fallback paths, cross-worktree dedup, and overlapping dispatch.
- All targeted test suites pass; lint ratchet net-neutral.