### PR TITLE
feat(agent): expose closed-session snapshots to the assistant via MCP (#10855)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -68,6 +68,7 @@ export const CHANNELS = {
   AGENT_SESSION_CLEAR: "agent-session:clear",
   AGENT_SESSION_GET_RETENTION: "agent-session:get-retention",
   AGENT_SESSION_SET_RETENTION: "agent-session:set-retention",
+  AGENT_SESSION_GET_SNAPSHOT: "agent-session:get-snapshot",
 
   FILES_SEARCH: "files:search",
   FILES_READ: "files:read",

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -16,6 +16,7 @@ import type { HandlerDependencies, IpcContext } from "../../types.js";
 import {
   TerminalSpawnOptionsSchema,
   AgentSessionRetentionDaysSchema,
+  AgentSessionGetSnapshotPayloadSchema,
 } from "../../../schemas/ipc.js";
 import { store } from "../../../store.js";
 import type { AgentSessionRetentionDays } from "../../../../shared/types/ipc/agentSessionHistory.js";
@@ -84,6 +85,7 @@ import {
   clearAgentSessions,
   persistAgentSession,
   pruneAgentSessions,
+  getAgentSessionSnapshot,
 } from "../../../services/pty/agentSessionHistory.js";
 import { getAgentSessionRetentionDays } from "../../../services/pty/agentSessionRetention.js";
 import type { WorkspaceClient } from "../../../services/WorkspaceClient.js";
@@ -721,6 +723,17 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     await clearAgentSessions(payload?.worktreeId, app.getPath("userData"));
   };
 
+  const handleAgentSessionGetSnapshot = async (payload: {
+    sessionId: string;
+  }): Promise<{ found: boolean; snapshot: string | null }> => {
+    const { app } = await import("electron");
+    return getAgentSessionSnapshot(
+      payload.sessionId,
+      app.getPath("userData"),
+      getAgentSessionRetentionDays()
+    );
+  };
+
   const handleAgentSessionGetRetention = async (): Promise<AgentSessionRetentionDays> =>
     getAgentSessionRetentionDays();
 
@@ -753,6 +766,11 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       restartService: op(CHANNELS.TERMINAL_RESTART_SERVICE, handleTerminalRestartService),
       agentSessionList: op(CHANNELS.AGENT_SESSION_LIST, handleAgentSessionList),
       agentSessionClear: op(CHANNELS.AGENT_SESSION_CLEAR, handleAgentSessionClear),
+      agentSessionGetSnapshot: opValidated(
+        CHANNELS.AGENT_SESSION_GET_SNAPSHOT,
+        AgentSessionGetSnapshotPayloadSchema,
+        handleAgentSessionGetSnapshot
+      ),
       agentSessionGetRetention: op(
         CHANNELS.AGENT_SESSION_GET_RETENTION,
         handleAgentSessionGetRetention

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2355,6 +2355,8 @@ function buildElectronApi(): ElectronAPI {
       getRetentionDays: () => _unwrappingInvoke(CHANNELS.AGENT_SESSION_GET_RETENTION),
       setRetentionDays: (days: number) =>
         _unwrappingInvoke(CHANNELS.AGENT_SESSION_SET_RETENTION, days),
+      getSnapshot: (sessionId: string) =>
+        _unwrappingInvoke(CHANNELS.AGENT_SESSION_GET_SNAPSHOT, { sessionId }),
     },
 
     // Clipboard API — bindings built from the preload-safe channel map in

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -379,6 +379,15 @@ export const AgentSessionRetentionDaysSchema = z.union([
   z.literal(0),
 ]);
 
+/**
+ * Payload for looking up a single closed session's snapshot by id (#10855).
+ * `sessionId` is required — a missing/empty value is a caller bug worth
+ * rejecting at the IPC boundary rather than silently returning `found: false`.
+ */
+export const AgentSessionGetSnapshotPayloadSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
 export const FileSearchPayloadSchema = z.object({
   cwd: z.string().min(1),
   query: z.string(),

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -341,7 +341,6 @@ const MCP_TOOL_ALLOWLIST_ENTRIES = [
   "agent.getState",
   "agent.listToolbar",
   "agentSessionHistory.list",
-  "agentSessionHistory.getSnapshot",
 
   "git.getProjectPulse",
   "git.getFileDiff",

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -341,6 +341,7 @@ const MCP_TOOL_ALLOWLIST_ENTRIES = [
   "agent.getState",
   "agent.listToolbar",
   "agentSessionHistory.list",
+  "agentSessionHistory.getSnapshot",
 
   "git.getProjectPulse",
   "git.getFileDiff",

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -8,6 +8,7 @@ import {
   listAgentSessions,
   clearAgentSessions,
   pruneAgentSessions,
+  getAgentSessionSnapshot,
   getSessionHistoryPath,
   MAX_RECORDS_PER_WORKTREE,
   SESSION_HISTORY_TTL_MS,
@@ -431,6 +432,98 @@ describe("agentSessionHistory", () => {
       expect(records.some((r) => r.sessionId === `session-${MAX_RECORDS_PER_WORKTREE + 9}`)).toBe(
         true
       );
+    });
+  });
+
+  describe("getAgentSessionSnapshot (#10855)", () => {
+    it("returns found:true with the verbatim snapshot for a matching session", async () => {
+      await persistAgentSession(
+        {
+          sessionId: "with-snap",
+          agentId: "claude",
+          worktreeId: "wt-1",
+          title: null,
+          projectId: null,
+          snapshot: "line one\nline two\n[31mred[0m",
+        },
+        userDataDir
+      );
+
+      expect(getAgentSessionSnapshot("with-snap", userDataDir)).toEqual({
+        found: true,
+        snapshot: "line one\nline two\n[31mred[0m",
+      });
+    });
+
+    it("returns found:false with null snapshot for an unknown sessionId", () => {
+      expect(getAgentSessionSnapshot("does-not-exist", userDataDir)).toEqual({
+        found: false,
+        snapshot: null,
+      });
+    });
+
+    it("returns found:true with null snapshot when the record has no snapshot", async () => {
+      await persistAgentSession(
+        {
+          sessionId: "no-snap",
+          agentId: "claude",
+          worktreeId: "wt-1",
+          title: null,
+          projectId: null,
+        },
+        userDataDir
+      );
+
+      expect(getAgentSessionSnapshot("no-snap", userDataDir)).toEqual({
+        found: true,
+        snapshot: null,
+      });
+    });
+
+    it("preserves an empty-string snapshot rather than coercing it to null", async () => {
+      await persistAgentSession(
+        {
+          sessionId: "empty-snap",
+          agentId: "claude",
+          worktreeId: "wt-1",
+          title: null,
+          projectId: null,
+          snapshot: "",
+        },
+        userDataDir
+      );
+
+      expect(getAgentSessionSnapshot("empty-snap", userDataDir)).toEqual({
+        found: true,
+        snapshot: "",
+      });
+    });
+
+    it("honors the retention window — an aged-out session is not found", async () => {
+      // Seed a 20-day-old record carrying a snapshot, keep-forever on write so
+      // the read path does the filtering, then query with a 7-day window.
+      const filePath = getSessionHistoryPath(userDataDir)!;
+      const agedRecord = {
+        sessionId: "aged-snap",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        title: null,
+        projectId: null,
+        savedAt: Date.now() - 20 * DAY_MS,
+        snapshot: "secret scrollback",
+      };
+      await fsp.writeFile(filePath, JSON.stringify([agedRecord]));
+
+      // Within a 90-day window the snapshot is reachable...
+      expect(getAgentSessionSnapshot("aged-snap", userDataDir, 90)).toEqual({
+        found: true,
+        snapshot: "secret scrollback",
+      });
+      // ...but a 7-day window evicts it, so it must not leak.
+      expect(getAgentSessionSnapshot("aged-snap", userDataDir, 7)).toEqual({
+        found: false,
+        snapshot: null,
+      });
     });
   });
 

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -163,6 +163,29 @@ export function listAgentSessions(
 }
 
 /**
+ * Look up a single closed session by `sessionId` and return its captured
+ * scrollback snapshot (#10855). Reuses `listAgentSessions` — not raw
+ * `readSessionHistory` — so retention-eviction and per-worktree-cap semantics
+ * stay identical to the `list` action: a record aged past the user's retention
+ * window (but not yet physically pruned from disk) must not leak its snapshot
+ * here. `found` distinguishes "no such session" from "session exists but has no
+ * snapshot" (opt-out, excluded project, or a pre-#10850 record). An empty-string
+ * snapshot is preserved as-is; only a truly-absent (`undefined`) snapshot maps
+ * to `null`.
+ */
+export function getAgentSessionSnapshot(
+  sessionId: string,
+  userData?: string,
+  retentionDays?: AgentSessionRetentionDays
+): { found: boolean; snapshot: string | null } {
+  const record = listAgentSessions(undefined, userData, retentionDays).find(
+    (r) => r.sessionId === sessionId
+  );
+  if (!record) return { found: false, snapshot: null };
+  return { found: true, snapshot: record.snapshot ?? null };
+}
+
+/**
  * Prune the journal to the given retention window immediately, rewriting the
  * file through the shared write queue so it can't interleave with an in-flight
  * persist. Used when the user shortens the retention setting — mirrors

--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,9 +1,9 @@
 {
-  "count": 1132,
+  "count": 1133,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 52,
     "@typescript-eslint/no-floating-promises": 88,
-    "@typescript-eslint/no-unsafe-type-assertion": 496,
+    "@typescript-eslint/no-unsafe-type-assertion": 497,
     "no-restricted-imports": 5,
     "no-restricted-syntax": 376,
     "no-useless-assignment": 19,
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 15,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-06-28T20:42:26.585Z"
+  "updatedAt": "2026-07-01T07:32:09.341Z"
 }

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -312,6 +312,7 @@ export const BUILT_IN_ACTION_IDS = [
   "agent.getState",
   "agent.listToolbar",
   "agentSessionHistory.list",
+  "agentSessionHistory.getSnapshot",
 
   // -- app settings (other) --
   "app.settings.openTab",

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -39,6 +39,7 @@ export const WORKBENCH_TIER_TOOLS = [
   "agent.getState",
   "agent.listToolbar",
   "agentSessionHistory.list",
+  "agentSessionHistory.getSnapshot",
 
   "agentSettings.get",
   "keybinding.getOverrides",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1227,6 +1227,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     clear(worktreeId?: string): Promise<void>;
     getRetentionDays(): Promise<AgentSessionRetentionDays>;
     setRetentionDays(days: AgentSessionRetentionDays): Promise<void>;
+    getSnapshot(sessionId: string): Promise<{ found: boolean; snapshot: string | null }>;
   };
   // clipboard is generated — see GeneratedElectronAPI.
   webUtils: {

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -40,6 +40,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: import("./agentSessionHistory.js").AgentSessionRetentionDays;
   };
+  "agent-session:get-snapshot": {
+    args: [payload: { sessionId: string }];
+    result: { found: boolean; snapshot: string | null };
+  };
   "agent-session:list": {
     args: [payload: { worktreeId?: string | undefined }];
     result: import("./agentSessionHistory.js").AgentSessionRecord[];

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -454,6 +454,25 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "agent",
     "danger": "safe",
     "dangerRationale": undefined,
+    "description": "Fetch the captured terminal snapshot for one closed agent session, identified by \`sessionId\` (from \`agentSessionHistory.list\`). The snapshot is a faithful, verbatim slice of the session's final scrollback captured at close time — NOT a summary or interpretation of what happened. Use it to preview a closed session before deciding whether to relaunch it. Args: \`sessionId\` (required) — the id of the closed session. Returns { sessionId, found, snapshot }: \`found\` is false when no session matches the id; \`found\` is true with \`snapshot: null\` when the session exists but has no captured snapshot (snapshot capture disabled, project excluded, or a record predating the feature); \`found\` is true with \`snapshot: "…"\` (verbatim text) on success. Never errors — returns { found: false, snapshot: null } for an unknown id.",
+    "examples": [
+      {
+        "args": {
+          "sessionId": "abc-123",
+        },
+        "description": "Preview the captured snapshot of a closed session before relaunching it",
+      },
+    ],
+    "id": "agentSessionHistory.getSnapshot",
+    "keywords": undefined,
+    "kind": "query",
+    "requiresArgs": true,
+    "title": "Get Closed Session Snapshot",
+  },
+  {
+    "category": "agent",
+    "danger": "safe",
+    "dangerRationale": undefined,
     "description": "List resumable agent sessions from the on-disk journal — the closed sessions the user can relaunch. This is a faithful record listing, NOT a summary of what happened in each session. Args: \`worktreeId\` (optional) — restrict to one worktree; omit to list every resumable session across all worktrees and projects (the default). Returns { sessions: [{ sessionId, agentId, worktreeId, title, projectId, savedAt (epoch ms; the list is newest-first), agentLaunchFlags?, agentModelId?, cwd?, branch? }] }, capped and pruned by the journal's retention policy. Never errors — returns { sessions: [] } when the journal is empty or unreadable. To relaunch a listed session, feed its \`agentId\`/\`cwd\`/\`worktreeId\`/\`agentLaunchFlags\`/\`agentModelId\` into \`agent.launch\`.",
     "examples": [
       {

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -1025,3 +1025,76 @@ describe("agentSessionHistory.list (#10854)", () => {
     expect(getDef().argsSchema?.safeParse({ worktreeId: "" }).success).toBe(false);
   });
 });
+
+describe("agentSessionHistory.getSnapshot (#10855)", () => {
+  const getSnapshotMock = vi.fn();
+
+  beforeEach(() => {
+    getSnapshotMock.mockReset();
+    getSnapshotMock.mockResolvedValue({ found: true, snapshot: "captured scrollback" });
+    // @ts-expect-error - minimal window.electron stub for the renderer IPC call
+    globalThis.window = { electron: { agentSessionHistory: { getSnapshot: getSnapshotMock } } };
+  });
+
+  afterEach(() => {
+    // @ts-expect-error - tear down the stub so it doesn't leak to other suites
+    delete globalThis.window;
+  });
+
+  function getDef(): AnyActionDefinition {
+    const def = setupActions(makeCallbacks()).get("agentSessionHistory.getSnapshot")?.() as
+      | AnyActionDefinition
+      | undefined;
+    if (!def) throw new Error("agentSessionHistory.getSnapshot not registered");
+    return def;
+  }
+
+  it("forwards the sessionId to the bridge and merges it into the result", async () => {
+    const actions = setupActions(makeCallbacks());
+    const result = await callAction(actions, "agentSessionHistory.getSnapshot", {
+      sessionId: "sess-1",
+    });
+    expect(getSnapshotMock).toHaveBeenCalledWith("sess-1");
+    expect(result).toEqual({ sessionId: "sess-1", found: true, snapshot: "captured scrollback" });
+  });
+
+  it("passes through found:false / snapshot:null for an unknown session (never throws)", async () => {
+    getSnapshotMock.mockResolvedValue({ found: false, snapshot: null });
+    const actions = setupActions(makeCallbacks());
+    const result = await callAction(actions, "agentSessionHistory.getSnapshot", {
+      sessionId: "missing",
+    });
+    expect(result).toEqual({ sessionId: "missing", found: false, snapshot: null });
+  });
+
+  it("passes through found:true / snapshot:null when the record has no snapshot", async () => {
+    getSnapshotMock.mockResolvedValue({ found: true, snapshot: null });
+    const actions = setupActions(makeCallbacks());
+    const result = await callAction(actions, "agentSessionHistory.getSnapshot", {
+      sessionId: "no-snap",
+    });
+    expect(result).toEqual({ sessionId: "no-snap", found: true, snapshot: null });
+  });
+
+  it("registers as a read-only query action advertising an MCP output schema", () => {
+    const def = getDef();
+    expect(def.kind).toBe("query");
+    expect(def.danger).toBe("safe");
+    expect(def.scope).toBe("renderer");
+    expect(def.mcpOutputSchema).toBe(true);
+  });
+
+  it("resultSchema accepts a string snapshot and a null snapshot", () => {
+    const schema = getDef().resultSchema;
+    expect(schema?.safeParse({ sessionId: "s", found: true, snapshot: "text" }).success).toBe(true);
+    expect(schema?.safeParse({ sessionId: "s", found: false, snapshot: null }).success).toBe(true);
+  });
+
+  it("argsSchema requires a non-empty sessionId", () => {
+    const schema = getDef().argsSchema;
+    expect(schema?.safeParse({ sessionId: "sess-1" }).success).toBe(true);
+    expect(schema?.safeParse({ sessionId: "" }).success).toBe(false);
+    expect(schema?.safeParse({}).success).toBe(false);
+    expect(schema?.safeParse(undefined).success).toBe(false);
+  });
+});

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -994,6 +994,24 @@ describe("agentSessionHistory.list (#10854)", () => {
     expect(result).toEqual({ sessions: [] });
   });
 
+  it("strips the raw snapshot from listed records (getSnapshot is the sole accessor, #10855)", async () => {
+    listMock.mockResolvedValue([
+      { ...SAMPLE_SESSIONS[0], snapshot: "verbatim scrollback that must not bulk-leak" },
+      { ...SAMPLE_SESSIONS[1], snapshot: "" },
+    ]);
+    const actions = setupActions(makeCallbacks());
+    const result = (await callAction(actions, "agentSessionHistory.list", {})) as {
+      sessions: Array<Record<string, unknown>>;
+    };
+    expect(result.sessions).toHaveLength(2);
+    for (const session of result.sessions) {
+      expect(session).not.toHaveProperty("snapshot");
+    }
+    // Non-snapshot fields still pass through unchanged.
+    expect(result.sessions[0]!.sessionId).toBe("sess-1");
+    expect(result.sessions[0]!.title).toBe("Auth refactor");
+  });
+
   it("registers as a read-only query action advertising an MCP output schema", () => {
     const def = getDef();
     expect(def.kind).toBe("query");

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -490,6 +490,42 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     },
   }));
 
+  actions.set("agentSessionHistory.getSnapshot", () => ({
+    id: "agentSessionHistory.getSnapshot",
+    title: "Get Closed Session Snapshot",
+    description:
+      'Fetch the captured terminal snapshot for one closed agent session, identified by `sessionId` (from `agentSessionHistory.list`). The snapshot is a faithful, verbatim slice of the session\'s final scrollback captured at close time — NOT a summary or interpretation of what happened. Use it to preview a closed session before deciding whether to relaunch it. Args: `sessionId` (required) — the id of the closed session. Returns { sessionId, found, snapshot }: `found` is false when no session matches the id; `found` is true with `snapshot: null` when the session exists but has no captured snapshot (snapshot capture disabled, project excluded, or a record predating the feature); `found` is true with `snapshot: "…"` (verbatim text) on success. Never errors — returns { found: false, snapshot: null } for an unknown id.',
+    category: "agent",
+    kind: "query",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({
+      sessionId: z
+        .string()
+        .min(1)
+        .describe(
+          "The id of the closed session to fetch the snapshot for (from agentSessionHistory.list)."
+        ),
+    }),
+    examples: [
+      {
+        args: { sessionId: "abc-123" },
+        description: "Preview the captured snapshot of a closed session before relaunching it",
+      },
+    ],
+    resultSchema: z.object({
+      sessionId: z.string(),
+      found: z.boolean(),
+      snapshot: z.string().nullable(),
+    }),
+    mcpOutputSchema: true,
+    run: async (args: unknown) => {
+      const { sessionId } = args as { sessionId: string };
+      const result = await window.electron.agentSessionHistory.getSnapshot(sessionId);
+      return { sessionId, ...result };
+    },
+  }));
+
   actions.set("agent.listToolbar", () => ({
     id: "agent.listToolbar",
     title: "List Toolbar Agents",

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -486,7 +486,15 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     run: async (args: unknown) => {
       const { worktreeId } = (args ?? {}) as { worktreeId?: string };
       const sessions = await window.electron.agentSessionHistory.list(worktreeId);
-      return { sessions };
+      // Strip the raw `snapshot` from the bulk listing so the runtime output
+      // matches the declared resultSchema (AgentSessionRecordSchema omits it)
+      // and the list stays a lean index for choosing a session to resume. The
+      // full scrollback is fetched deliberately, one record at a time, via
+      // `agentSessionHistory.getSnapshot` (#10855) — returning it here would
+      // dump every session's captured scrollback (up to 32KB each) in a single
+      // call, defeating the scoped accessor and flooding the caller.
+      const lean = sessions.map(({ snapshot: _snapshot, ...rest }) => rest);
+      return { sessions: lean };
     },
   }));
 


### PR DESCRIPTION
## Summary
- Adds a read-only MCP action `agentSessionHistory.getSnapshot` (args: `sessionId`) that returns a closed session's captured scrollback snapshot verbatim (`{ sessionId, found, snapshot }`), so the assistant can preview a closed session before deciding to resume it. Builds on #10850 (opt-in snapshot capture) and #10854 (list action).
- Full IPC chain: `AGENT_SESSION_GET_SNAPSHOT` channel → `getAgentSessionSnapshot` journal getter (retention-aware, reuses `listAgentSessions` so aged-out records can't leak their snapshot) → `opValidated` handler → preload bridge → `ElectronAPI` type. Registered in `BUILT_IN_ACTION_IDS` and the workbench (assistant) MCP tier allowlist.
- Review fix: `agentSessionHistory.list` was returning each record's snapshot verbatim over MCP (the result schema is manifest-only and never strips at runtime) — now stripped so `list` stays a lean index and `getSnapshot` is the sole deliberate snapshot accessor. `getSnapshot` is scoped to the workbench/assistant tier only (not the external API-key tier), matching the issue's assistant-only scope.

Resolves #10855

## Changes
- `electron/ipc/channels.ts`, `electron/schemas/ipc.ts`, `electron/preload.cts`, `shared/types/ipc/api.ts`, `shared/types/ipc/generated.ts` — new `AGENT_SESSION_GET_SNAPSHOT` channel plumbing
- `electron/ipc/handlers/terminal/lifecycle.ts` — validated handler for the new channel
- `electron/services/pty/agentSessionHistory.ts` — `getAgentSessionSnapshot` getter, retention-aware
- `src/services/actions/definitions/agentActions.ts` — `agentSessionHistory.getSnapshot` action definition; `list` now strips `snapshot` from its results
- `shared/config/actionIds.ts`, `shared/config/helpAssistantTierAllowlists.ts` — new action ID registered in the workbench allowlist only

## Testing
- `electron/services/pty/__tests__/agentSessionHistory.test.ts` — pure getter: found, unknown session, no-snapshot, empty-string-preserved, retention-aged-out
- `src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts` — action: arg forwarding, found/null passthrough, schema validation, list-strips-snapshot regression
- 366 targeted tests pass, typecheck + lint clean