### PR TITLE
feat(terminal): reveal file-path links in the OS file manager (#10873)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -94,6 +94,7 @@ export const CHANNELS = {
 
   SYSTEM_OPEN_EXTERNAL: "system:open-external",
   SYSTEM_OPEN_PATH: "system:open-path",
+  SYSTEM_SHOW_ITEM_IN_FOLDER: "system:show-item-in-folder",
   SYSTEM_OPEN_IN_EDITOR: "system:open-in-editor",
   SYSTEM_CHECK_COMMAND: "system:check-command",
   SYSTEM_CHECK_DIRECTORY: "system:check-directory",

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -9,6 +9,7 @@ const ipcMainMock = vi.hoisted(() => ({
 const shellMock = vi.hoisted(() => ({
   openPath: vi.fn(() => Promise.resolve("")),
   openExternal: vi.fn(() => Promise.resolve()),
+  showItemInFolder: vi.fn<(p: string) => void>(() => undefined),
 }));
 
 const appMock = vi.hoisted(() => ({
@@ -24,6 +25,7 @@ vi.mock("electron", () => ({
 const fsMock = vi.hoisted(() => ({
   promises: {
     realpath: vi.fn<(p: string) => Promise<string>>((p: string) => Promise.resolve(p)),
+    stat: vi.fn<(p: string) => Promise<unknown>>(() => Promise.resolve({})),
   },
 }));
 
@@ -245,6 +247,80 @@ describe("system:open-in-editor containment", () => {
         : path.join(PROJECT_ROOT, "scripts", "setup.desktop");
     await handler(fakeEvent, { path: scriptPath });
     expect(openFileMock).toHaveBeenCalledWith(scriptPath, undefined, undefined, null);
+  });
+});
+
+describe("system:show-item-in-folder containment", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsMock.promises.realpath.mockImplementation(realpathEcho);
+    fsMock.promises.stat.mockImplementation(() => Promise.resolve({}));
+    projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
+    appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
+    storeMock.get.mockReturnValue(undefined);
+    cleanup = registerSystemShellHandlers({} as HandlerDependencies);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reveals a path contained in a project root", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
+    const sourcePath = path.join(PROJECT_ROOT, "src", "index.ts");
+    await handler(fakeEvent, { path: sourcePath });
+    expect(shellMock.showItemInFolder).toHaveBeenCalledWith(sourcePath);
+  });
+
+  it("rejects a path outside all roots with OUTSIDE_ROOT", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
+    await expect(handler(fakeEvent, { path: "/etc/passwd" })).rejects.toMatchObject({
+      code: "OUTSIDE_ROOT",
+    });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-absolute path with INVALID_PATH", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
+    await expect(handler(fakeEvent, { path: "relative/file.txt" })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  // The key behavior difference from system:open-path: revealing an item only
+  // selects it in the file manager, it never launches it — so the executable
+  // deny-list (which blocks .app / .exe / .desktop for the launcher) must NOT
+  // apply. Revealing an executable the user can already see is safe.
+  it("allows revealing an executable extension inside a root (deny-list relaxed)", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
+    const executablePath = path.join(PROJECT_ROOT, deniedLauncherName);
+    await handler(fakeEvent, { path: executablePath });
+    expect(shellMock.showItemInFolder).toHaveBeenCalledWith(executablePath);
+  });
+
+  it("throws NOT_FOUND without revealing when the path no longer exists", async () => {
+    fsMock.promises.stat.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
+    await expect(
+      handler(fakeEvent, { path: path.join(PROJECT_ROOT, "gone.txt") })
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("reveals the realpath-resolved target, not the original path", async () => {
+    const link = path.join(PROJECT_ROOT, "link.txt");
+    const resolved = path.join(PROJECT_ROOT, "real.txt");
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      Promise.resolve(path.normalize(p) === path.normalize(link) ? resolved : path.normalize(p))
+    );
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
+    await handler(fakeEvent, { path: link });
+    expect(shellMock.showItemInFolder).toHaveBeenCalledWith(resolved);
   });
 });
 

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -25,7 +25,6 @@ vi.mock("electron", () => ({
 const fsMock = vi.hoisted(() => ({
   promises: {
     realpath: vi.fn<(p: string) => Promise<string>>((p: string) => Promise.resolve(p)),
-    stat: vi.fn<(p: string) => Promise<unknown>>(() => Promise.resolve({})),
   },
 }));
 
@@ -256,7 +255,6 @@ describe("system:show-item-in-folder containment", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fsMock.promises.realpath.mockImplementation(realpathEcho);
-    fsMock.promises.stat.mockImplementation(() => Promise.resolve({}));
     projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
     appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
     storeMock.get.mockReturnValue(undefined);
@@ -301,14 +299,21 @@ describe("system:show-item-in-folder containment", () => {
     expect(shellMock.showItemInFolder).toHaveBeenCalledWith(executablePath);
   });
 
-  it("throws NOT_FOUND without revealing when the path no longer exists", async () => {
-    fsMock.promises.stat.mockRejectedValueOnce(
-      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+  // A file detected in terminal output can be deleted before the user reveals
+  // it. resolveContainedPath realpaths the target, so a missing path is
+  // rejected (INVALID_PATH) before shell.showItemInFolder — which has no
+  // failure signal — is ever called. Mock realpath to reject like real Node.
+  it("rejects a since-deleted path (realpath ENOENT) without revealing", async () => {
+    const missing = path.join(PROJECT_ROOT, "gone.txt");
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      path.normalize(p) === path.normalize(missing)
+        ? Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+        : realpathEcho(p)
     );
     const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER);
-    await expect(
-      handler(fakeEvent, { path: path.join(PROJECT_ROOT, "gone.txt") })
-    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+    await expect(handler(fakeEvent, { path: missing })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
     expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
   });
 

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -21,6 +21,7 @@ import {
 } from "../../schemas/index.js";
 import type { HandlerDependencies } from "../types.js";
 import { typedHandle, typedHandleValidated } from "../utils.js";
+import { defineIpcNamespace, opValidated } from "../define.js";
 import type {
   SystemOpenExternalPayload,
   SystemOpenPathPayload,
@@ -194,28 +195,35 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
     )
   );
 
-  const handleSystemShowItemInFolder = async ({ path: targetPath }: SystemOpenPathPayload) => {
-    try {
-      // Reveal-in-file-manager only selects the item — it never launches it —
-      // so the "editor" flavor (containment check, relaxed executable
-      // deny-list) is correct: revealing an .app/.exe the user can already see
-      // must not be blocked. assertPathAllowed → resolveContainedPath realpaths
-      // the target, so a since-deleted path is already rejected (INVALID_PATH)
-      // before we reach shell.showItemInFolder (which gives no failure signal).
-      const realTarget = await assertPathAllowed(targetPath, "editor");
-      shell.showItemInFolder(realTarget);
-    } catch (error) {
-      console.error("Failed to reveal item in folder:", error);
-      throw error;
-    }
-  };
-  handlers.push(
-    typedHandleValidated(
-      CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER,
-      SystemOpenPathPayloadSchema,
-      handleSystemShowItemInFolder
-    )
-  );
+  // Registered via defineIpcNamespace (not a hand-written IpcInvokeMap entry)
+  // so the channel is codegen'd into GeneratedIpcInvokeMap — new IPC handlers
+  // must not grow the hand-written map (ipc-handwritten ratchet).
+  const systemShellNamespace = defineIpcNamespace({
+    name: "systemShell",
+    ops: {
+      showItemInFolder: opValidated(
+        CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER,
+        SystemOpenPathPayloadSchema,
+        async (payload: SystemOpenPathPayload): Promise<void> => {
+          try {
+            // Reveal-in-file-manager only selects the item — it never launches
+            // it — so the "editor" flavor (containment check, relaxed
+            // executable deny-list) is correct: revealing an .app/.exe the user
+            // can already see must not be blocked. assertPathAllowed →
+            // resolveContainedPath realpaths the target, so a since-deleted
+            // path is already rejected (INVALID_PATH) before we reach
+            // shell.showItemInFolder (which gives no failure signal).
+            const realTarget = await assertPathAllowed(payload.path, "editor");
+            shell.showItemInFolder(realTarget);
+          } catch (error) {
+            console.error("Failed to reveal item in folder:", error);
+            throw error;
+          }
+        }
+      ),
+    },
+  });
+  handlers.push(systemShellNamespace.register());
 
   const handleSystemOpenInEditor = async ({
     path: targetPath,

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -199,21 +199,10 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
       // Reveal-in-file-manager only selects the item — it never launches it —
       // so the "editor" flavor (containment check, relaxed executable
       // deny-list) is correct: revealing an .app/.exe the user can already see
-      // must not be blocked.
+      // must not be blocked. assertPathAllowed → resolveContainedPath realpaths
+      // the target, so a since-deleted path is already rejected (INVALID_PATH)
+      // before we reach shell.showItemInFolder (which gives no failure signal).
       const realTarget = await assertPathAllowed(targetPath, "editor");
-      // shell.showItemInFolder is void and gives no success/failure signal, so
-      // a since-deleted path would silently no-op. Stat first to surface a
-      // real NOT_FOUND error the renderer can toast.
-      const fs = await import("fs");
-      try {
-        await fs.promises.stat(realTarget);
-      } catch {
-        throw new AppError({
-          code: "NOT_FOUND",
-          message: `Cannot reveal path that no longer exists: ${realTarget}`,
-          context: { targetPath: realTarget },
-        });
-      }
       shell.showItemInFolder(realTarget);
     } catch (error) {
       console.error("Failed to reveal item in folder:", error);

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -194,6 +194,40 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
     )
   );
 
+  const handleSystemShowItemInFolder = async ({ path: targetPath }: SystemOpenPathPayload) => {
+    try {
+      // Reveal-in-file-manager only selects the item — it never launches it —
+      // so the "editor" flavor (containment check, relaxed executable
+      // deny-list) is correct: revealing an .app/.exe the user can already see
+      // must not be blocked.
+      const realTarget = await assertPathAllowed(targetPath, "editor");
+      // shell.showItemInFolder is void and gives no success/failure signal, so
+      // a since-deleted path would silently no-op. Stat first to surface a
+      // real NOT_FOUND error the renderer can toast.
+      const fs = await import("fs");
+      try {
+        await fs.promises.stat(realTarget);
+      } catch {
+        throw new AppError({
+          code: "NOT_FOUND",
+          message: `Cannot reveal path that no longer exists: ${realTarget}`,
+          context: { targetPath: realTarget },
+        });
+      }
+      shell.showItemInFolder(realTarget);
+    } catch (error) {
+      console.error("Failed to reveal item in folder:", error);
+      throw error;
+    }
+  };
+  handlers.push(
+    typedHandleValidated(
+      CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER,
+      SystemOpenPathPayloadSchema,
+      handleSystemShowItemInFolder
+    )
+  );
+
   const handleSystemOpenInEditor = async ({
     path: targetPath,
     line,

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1300,6 +1300,9 @@ function buildElectronApi(): ElectronAPI {
 
       openPath: (path: string) => _unwrappingInvoke(CHANNELS.SYSTEM_OPEN_PATH, { path }),
 
+      showItemInFolder: (path: string) =>
+        _unwrappingInvoke(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER, { path }),
+
       openInEditor: (payload: { path: string; line?: number; col?: number; projectId?: string }) =>
         _unwrappingInvoke(CHANNELS.SYSTEM_OPEN_IN_EDITOR, payload),
 

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -146,6 +146,7 @@ export const BUILT_IN_ACTION_IDS = [
   "file.openDiff",
   "file.openInEditor",
   "file.openImageViewer",
+  "file.showItemInFolder",
 
   // -- slashCommandsActions --
   "slashCommands.list",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -360,6 +360,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
   system: GeneratedElectronAPI["system"] & {
     openExternal(url: string): Promise<void>;
     openPath(path: string): Promise<void>;
+    showItemInFolder(path: string): Promise<void>;
     openInEditor(payload: SystemOpenInEditorPayload & { projectId?: string }): Promise<void>;
     checkCommand(command: string): Promise<boolean>;
     checkDirectory(path: string): Promise<boolean>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1265,6 +1265,10 @@ export interface GeneratedIpcInvokeMap {
     args: [durationMs: number];
     result: void;
   };
+  "system:show-item-in-folder": {
+    args: [payload: { path: string }];
+    result: void;
+  };
   "telemetry:get": {
     args: [];
     result: { enabled: boolean; hasSeenPrompt: boolean };

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -277,10 +277,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [payload: SystemOpenPathPayload];
     result: void;
   };
-  "system:show-item-in-folder": {
-    args: [payload: SystemOpenPathPayload];
-    result: void;
-  };
   "system:open-in-editor": {
     args: [payload: SystemOpenInEditorPayload];
     result: void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -277,6 +277,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [payload: SystemOpenPathPayload];
     result: void;
   };
+  "system:show-item-in-folder": {
+    args: [payload: SystemOpenPathPayload];
+    result: void;
+  };
   "system:open-in-editor": {
     args: [payload: SystemOpenInEditorPayload];
     result: void;

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -22,6 +22,10 @@ export const systemClient = {
     return window.electron.system.openPath(path);
   },
 
+  showItemInFolder: (path: string): Promise<void> => {
+    return window.electron.system.showItemInFolder(path);
+  },
+
   openInEditor: (payload: {
     path: string;
     line?: number;

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { isMac } from "@/lib/platform";
+import { isMac, isWindows } from "@/lib/platform";
 import type React from "react";
 import { type PanelLocation } from "@/types";
 import { usePanelStore } from "@/store";
@@ -12,6 +12,7 @@ import { actionService } from "@/services/ActionService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isBrowserPanel, isDevPreviewPanel, isPtyPanel, isReviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { reportFileLinkFailure } from "@/services/terminal/FileLinksAddon";
 import { useIsHibernated } from "@/hooks/useIsHibernated";
 import { usePluginContextMenuItems } from "@/hooks/usePluginContextMenuItems";
 import { PluginContextMenuSection } from "@/components/Plugin/PluginContextMenuSection";
@@ -49,7 +50,7 @@ import {
   Trash2,
   Unlock,
 } from "lucide-react";
-import { FolderGit2 } from "@/components/icons";
+import { FolderGit2, FolderOpen } from "@/components/icons";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -119,6 +120,7 @@ export function TerminalContextMenu({
 
   const [hasSelection, setHasSelection] = useState(false);
   const [hoveredUrl, setHoveredUrl] = useState<string | null>(null);
+  const [hoveredFilePath, setHoveredFilePath] = useState<string | null>(null);
   const suppressNextCloseAutoFocusRef = useRef(false);
   // Local confirm dialog for single-terminal kill/restart when an agent
   // session is mid-work. Bare PTY terminals skip this gate and run
@@ -177,11 +179,13 @@ export function TerminalContextMenu({
       if (!managed?.terminal) {
         setHasSelection(false);
         setHoveredUrl(null);
+        setHoveredFilePath(null);
         return;
       }
       const selection = managed.terminal.getSelection();
       setHasSelection(!!selection);
       setHoveredUrl(terminalInstanceService.getHoveredLinkText(terminalId));
+      setHoveredFilePath(terminalInstanceService.getHoveredFilePath(terminalId));
     },
     [terminalId, recentVoiceTargets]
   );
@@ -209,6 +213,22 @@ export function TerminalContextMenu({
       if (actionId.startsWith("copy-link:")) {
         const url = actionId.slice("copy-link:".length);
         void actionService.dispatch("terminal.copyLink", { url }, { source: sourceRef.current });
+        return;
+      }
+
+      if (actionId.startsWith("reveal-in-finder:")) {
+        const path = actionId.slice("reveal-in-finder:".length);
+        // Unlike copy-link, guard rejections (OUTSIDE_ROOT) and a since-deleted
+        // file (NOT_FOUND) are real, expected failure modes here — surface them
+        // rather than fire-and-forget. dispatch wraps the thrown error as
+        // EXECUTION_ERROR, so the original coded error lives on `.details`.
+        void actionService
+          .dispatch("file.showItemInFolder", { path }, { source: sourceRef.current })
+          .then((result) => {
+            if (!result.ok) {
+              reportFileLinkFailure("Failed to reveal in file manager", result.error.details, path);
+            }
+          });
         return;
       }
 
@@ -752,6 +772,17 @@ export function TerminalContextMenu({
                   <ContextMenuItem onSelect={() => handleAction(`copy-link:${hoveredUrl}`)}>
                     <Link className={ICON_CLASS} aria-hidden="true" />
                     Copy link address
+                  </ContextMenuItem>
+                </>
+              )}
+              {hoveredFilePath && (
+                <>
+                  <ContextMenuSeparator />
+                  <ContextMenuItem
+                    onSelect={() => handleAction(`reveal-in-finder:${hoveredFilePath}`)}
+                  >
+                    <FolderOpen className={ICON_CLASS} aria-hidden="true" />
+                    {mac ? "Reveal in Finder" : isWindows() ? "Show in Explorer" : "Show in folder"}
                   </ContextMenuItem>
                 </>
               )}

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -11,6 +11,7 @@ export {
   Activity, // project pulse / live activity heartbeat
   BellDot, // watch alert / notify on completion
   FolderGit2, // git worktree (single)
+  FolderOpen, // reveal in file manager (Finder / Explorer / file manager)
   Folders, // copy tree / file hierarchy capture (two overlapping folders)
   GitPullRequest, // forge provider / code-host plugin category
   History, // resume closed session / session history

--- a/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
+++ b/src/services/actions/__tests__/__snapshots__/actionDefinitions.quality.test.ts.snap
@@ -1303,6 +1303,18 @@ exports[`ActionService.list() snapshot > produces a stable, sorted manifest snap
     "category": "files",
     "danger": "safe",
     "dangerRationale": undefined,
+    "description": "Reveal a file or directory in the OS file manager (Finder on macOS, Explorer on Windows, the default file manager on Linux) with the item selected. Args: \`path\` (required) — absolute file or directory path. Reveals only; it never opens or launches the item. Errors when the path is missing, outside your project roots, or no longer exists.",
+    "examples": undefined,
+    "id": "file.showItemInFolder",
+    "keywords": undefined,
+    "kind": "command",
+    "requiresArgs": true,
+    "title": "Reveal in File Manager",
+  },
+  {
+    "category": "files",
+    "danger": "safe",
+    "dangerRationale": undefined,
     "description": "Open a file in the in-app file viewer modal (read-only, with optional line/column scroll). Args: \`path\` (required) — absolute or repo-relative file path; \`rootPath\` (optional) — repo root used to resolve a relative \`path\`; \`line\`/\`col\` (optional, positive ints) to scroll to a location. Returns nothing (fires the viewer event). Errors when \`path\` is missing. Use \`file.openInEditor\` instead to open in the external editor.",
     "examples": [
       {

--- a/src/services/actions/definitions/__tests__/fileActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/fileActions.adversarial.test.ts
@@ -5,6 +5,7 @@ import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../..
 const systemClientMock = vi.hoisted(() => ({
   openInEditor: vi.fn(),
   openPath: vi.fn(),
+  showItemInFolder: vi.fn(),
 }));
 
 const projectStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
@@ -33,6 +34,7 @@ beforeEach(() => {
   dispatchSpy.mockReset().mockReturnValue(true);
   systemClientMock.openInEditor.mockResolvedValue(undefined);
   systemClientMock.openPath.mockResolvedValue(undefined);
+  systemClientMock.showItemInFolder.mockResolvedValue(undefined);
   projectStoreMock.getState.mockReturnValue({
     currentProject: { id: "proj-1", path: "/repo" },
   });
@@ -99,6 +101,22 @@ describe("fileActions adversarial", () => {
     await run("file.openImageViewer", { path: "/img/x.png" });
 
     expect(systemClientMock.openPath).toHaveBeenCalledWith("/img/x.png");
+  });
+
+  it("file.showItemInFolder forwards path to systemClient.showItemInFolder", async () => {
+    const run = setupActions();
+    await run("file.showItemInFolder", { path: "/repo/src/x.ts" });
+
+    expect(systemClientMock.showItemInFolder).toHaveBeenCalledWith("/repo/src/x.ts");
+  });
+
+  it("file.showItemInFolder propagates systemClient errors to caller", async () => {
+    systemClientMock.showItemInFolder.mockRejectedValueOnce(new Error("outside root"));
+    const run = setupActions();
+
+    await expect(run("file.showItemInFolder", { path: "/repo/x.ts" })).rejects.toThrow(
+      "outside root"
+    );
   });
 
   it("file.view dispatches correct shape even with only path supplied", async () => {

--- a/src/services/actions/definitions/fileActions.ts
+++ b/src/services/actions/definitions/fileActions.ts
@@ -152,7 +152,7 @@ export function registerFileActions(actions: ActionRegistry, _callbacks: ActionC
     scope: "renderer",
     argsSchema: showItemInFolderArgsSchema,
     run: async (args: unknown) => {
-      const { path } = args as z.infer<typeof showItemInFolderArgsSchema>;
+      const { path } = showItemInFolderArgsSchema.parse(args);
       await systemClient.showItemInFolder(path);
     },
   }));

--- a/src/services/actions/definitions/fileActions.ts
+++ b/src/services/actions/definitions/fileActions.ts
@@ -48,6 +48,10 @@ const openImageViewerArgsSchema = z.object({
   path: z.string(),
 });
 
+const showItemInFolderArgsSchema = z.object({
+  path: z.string().min(1),
+});
+
 export function registerFileActions(actions: ActionRegistry, _callbacks: ActionCallbacks): void {
   actions.set("file.view", () => ({
     id: "file.view",
@@ -134,6 +138,22 @@ export function registerFileActions(actions: ActionRegistry, _callbacks: ActionC
     run: async (args: unknown) => {
       const { path } = args as z.infer<typeof openImageViewerArgsSchema>;
       await systemClient.openPath(path);
+    },
+  }));
+
+  actions.set("file.showItemInFolder", () => ({
+    id: "file.showItemInFolder",
+    title: "Reveal in File Manager",
+    description:
+      "Reveal a file or directory in the OS file manager (Finder on macOS, Explorer on Windows, the default file manager on Linux) with the item selected. Args: `path` (required) — absolute file or directory path. Reveals only; it never opens or launches the item. Errors when the path is missing, outside your project roots, or no longer exists.",
+    category: "files",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: showItemInFolderArgsSchema,
+    run: async (args: unknown) => {
+      const { path } = args as z.infer<typeof showItemInFolderArgsSchema>;
+      await systemClient.showItemInFolder(path);
     },
   }));
 }

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -58,9 +58,6 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
     case "INVALID_PATH":
       body = "Path is not a valid file";
       break;
-    case "NOT_FOUND":
-      body = "File no longer exists";
-      break;
     default:
       body = userMessage ?? formatErrorMessage(error, "Couldn't open this file");
   }

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -6,6 +6,7 @@ import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
 import { isClientAppError } from "@/utils/clientAppError";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import type { TerminalLink } from "./types";
 
 interface ResolvedFilePath {
   absolutePath: string;
@@ -57,6 +58,9 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
     case "INVALID_PATH":
       body = "Path is not a valid file";
       break;
+    case "NOT_FOUND":
+      body = "File no longer exists";
+      break;
     default:
       body = userMessage ?? formatErrorMessage(error, "Couldn't open this file");
   }
@@ -95,7 +99,7 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
   logError(`[FileLinksAddon] ${reason}`, error, { absolutePath });
 }
 
-export type HoverCallback = (link: ILink | null) => void;
+export type HoverCallback = (link: TerminalLink | null) => void;
 
 export class FileLinksAddon implements ILinkProvider {
   private _terminal: Terminal;
@@ -217,6 +221,11 @@ export class FileLinksAddon implements ILinkProvider {
 }
 
 class FileLink implements ILink {
+  // Structural discriminant read by the context menu (via `TerminalLink`) to
+  // distinguish a resolved file link from a plain URL link without an
+  // `instanceof` check across the addon/service boundary.
+  readonly kind = "file" as const;
+
   constructor(
     public range: IBufferRange,
     public text: string,
@@ -226,6 +235,11 @@ class FileLink implements ILink {
     private _rootPath?: string,
     private _onHover?: HoverCallback
   ) {}
+
+  /** Resolved absolute path for this file link (relative paths already joined to cwd). */
+  get absolutePath(): string {
+    return this._absolutePath;
+  }
 
   activate(event: MouseEvent, _text: string): void {
     const isModified = event.metaKey || event.ctrlKey;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1,4 +1,4 @@
-import { Terminal, ILink, IBufferRange } from "@xterm/xterm";
+import { Terminal, IBufferRange } from "@xterm/xterm";
 import { isMac } from "@/lib/platform";
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier } from "@/types";
@@ -8,6 +8,7 @@ import {
   RefreshTierProvider,
   AgentStateCallback,
   PostCompleteHook,
+  TerminalLink,
   isWebGLEligibleTier,
   WRITE_BURST_DECAY_MS,
 } from "./types";
@@ -364,6 +365,18 @@ class TerminalInstanceService {
   }
 
   /**
+   * Returns the resolved absolute path of the currently-hovered link when it's
+   * a file link (not a URL / OSC 8 link), else null. Used by the right-click
+   * context menu to show a "Reveal in Finder" item only for genuine file
+   * paths. Distinct from {@link getHoveredLinkText}, which returns the raw
+   * matched text for any link kind.
+   */
+  getHoveredFilePath(id: string): string | null {
+    const link = this.instances.get(id)?.hoveredLink;
+    return link?.kind === "file" ? (link.absolutePath ?? null) : null;
+  }
+
+  /**
    * Opens the currently-hovered link by delegating to its own activate()
    * method. File links route through the actionService (file.view); URL and
    * OSC 8 links route through TerminalLinkHandler (localhost → browser panel
@@ -392,8 +405,13 @@ class TerminalInstanceService {
    * don't expose an ILink natively). activate() routes through the link
    * handler so localhost URLs hit the browser-panel path when needed.
    */
-  private makeSyntheticLink(text: string, range: IBufferRange | null, terminalId: string): ILink {
+  private makeSyntheticLink(
+    text: string,
+    range: IBufferRange | null,
+    terminalId: string
+  ): TerminalLink {
     return {
+      kind: "url",
       range: range ?? { start: { x: 0, y: 0 }, end: { x: 0, y: 0 } },
       text,
       activate: (event: MouseEvent, uri: string) => {
@@ -1468,7 +1486,7 @@ class TerminalInstanceService {
       this.linkHandler.openLink(url, id, event);
     };
 
-    const setHoveredLink = (link: ILink | null) => {
+    const setHoveredLink = (link: TerminalLink | null) => {
       const current = this.instances.get(id);
       if (!current) return;
       current.hoveredLink = link;

--- a/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hoveredLink.test.ts
@@ -58,6 +58,7 @@ describe("TerminalInstanceService hovered link API", () => {
   const service = terminalInstanceService as unknown as {
     instances: Map<string, unknown>;
     getHoveredLinkText: (id: string) => string | null;
+    getHoveredFilePath: (id: string) => string | null;
     openHoveredLink: (id: string, event?: MouseEvent) => Promise<void>;
   };
 
@@ -83,6 +84,28 @@ describe("TerminalInstanceService hovered link API", () => {
     const link = { text: "https://example.com", range: {}, activate: vi.fn() };
     service.instances.set("t1", { hoveredLink: link });
     expect(service.getHoveredLinkText("t1")).toBe("https://example.com");
+  });
+
+  it("getHoveredFilePath returns null when terminal is missing", () => {
+    expect(service.getHoveredFilePath("missing")).toBeNull();
+  });
+
+  it("getHoveredFilePath returns the absolute path for a file link", () => {
+    const link = {
+      kind: "file",
+      text: "./src/x.ts",
+      absolutePath: "/repo/src/x.ts",
+      range: {},
+      activate: vi.fn(),
+    };
+    service.instances.set("t1", { hoveredLink: link });
+    expect(service.getHoveredFilePath("t1")).toBe("/repo/src/x.ts");
+  });
+
+  it("getHoveredFilePath returns null for a URL link (not a file)", () => {
+    const link = { kind: "url", text: "https://example.com", range: {}, activate: vi.fn() };
+    service.instances.set("t1", { hoveredLink: link });
+    expect(service.getHoveredFilePath("t1")).toBeNull();
   });
 
   it("openHoveredLink delegates to the link's activate() with link.text", async () => {

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -10,6 +10,20 @@ import type { TerminalScrollbackRestoreError } from "@shared/types/panel";
 
 export type RefreshTierProvider = () => TerminalRefreshTier;
 
+/**
+ * A hovered terminal link, tagged with a structural discriminant so the
+ * right-click context menu can tell a resolved file-path link (`kind: "file"`,
+ * carrying the resolved `absolutePath`) from a plain URL / OSC 8 link
+ * (`kind: "url"`). Avoids an `instanceof FileLink` check across the addon/service
+ * module boundary. `hoveredLink` is polymorphic — real `FileLink` instances from
+ * FileLinksAddon and synthetic link objects for URLs both land here.
+ */
+export interface TerminalLink extends ILink {
+  kind: "file" | "url";
+  /** Resolved absolute path — present only when `kind === "file"`. */
+  absolutePath?: string;
+}
+
 export type AgentStateCallback = (state: AgentState) => void;
 
 export type PostCompleteHook = (output: string) => void | Promise<void>;
@@ -35,7 +49,7 @@ export interface ManagedTerminal {
   // Currently-hovered link (tracked via xterm addon hover/leave callbacks).
   // Read synchronously by the right-click context menu so it reflects the
   // same detection xterm uses for plain URLs, file paths, and OSC 8 links.
-  hoveredLink: ILink | null;
+  hoveredLink: TerminalLink | null;
   hostElement: HTMLDivElement;
   isOpened: boolean;
   listeners: Array<() => void>;


### PR DESCRIPTION
## Summary

- Adds a platform-adaptive `Reveal in Finder` / `Show in Explorer` / `Show in folder` item to the terminal right-click context menu for detected file-path links (not web URLs).
- Wires `shell.showItemInFolder` through a new `system:show-item-in-folder` IPC channel and handler, reusing the existing `assertPathAllowed` guard in its editor flavor: revealing only selects a file in the OS file manager, it never launches it, so executable extensions are allowed here unlike the `open-path` handler.
- Adds a `file.showItemInFolder` action (`danger:safe`) and a structural `kind`/`absolutePath` discriminant on the hovered link type, so the context menu can tell a file link apart from a URL without an `instanceof` check.

Resolves #10873

## Changes

- `electron/ipc/channels.ts`, `electron/preload.cts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts`: new `system:show-item-in-folder` channel wired end to end.
- `electron/ipc/handlers/systemShell.ts`: handler reusing `assertPathAllowed` in editor flavor.
- `src/clients/systemClient.ts`: renderer-side client method.
- `shared/config/actionIds.ts`, `src/services/actions/definitions/fileActions.ts`: `file.showItemInFolder` action (`danger:safe`).
- `src/services/terminal/types.ts`, `src/services/terminal/FileLinksAddon.ts`, `src/services/terminal/TerminalInstanceService.ts`: structural `kind`/`absolutePath` discriminant on the hovered link type.
- `src/components/Terminal/TerminalContextMenu.tsx`: new context menu item with the platform-specific label.
- `src/components/icons/index.ts`: icon alias for the new item.

This is a read-only D0 action, so no confirm dialog is needed.

## Testing

- `npm run typecheck` clean
- Channel-drift guard clean
- 91 targeted tests passing: `systemShell` handlers (containment, `OUTSIDE_ROOT`, `INVALID_PATH`, executable-allowed, deleted-path cases), `fileActions` adversarial tests, the `hoveredLink` `getHoveredFilePath` test, `FileLinksAddon` tests, and the action-manifest quality snapshot
- Scoped prettier and eslint clean