### PR TITLE
perf(terminal): yield background drains for focused-terminal scroll

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -118,8 +118,9 @@ class TerminalInstanceService {
   private instances = new Map<string, ManagedTerminal>();
   // Throttle for the interactive resource-profile override IPC (see onActiveWheel).
   private lastInteractiveOverrideRequestAt = 0;
-  private dataBuffer = new TerminalOutputIngestService((id, data, chunkCount) =>
-    this.writeToTerminal(id, data, chunkCount)
+  private dataBuffer = new TerminalOutputIngestService(
+    (id, data, chunkCount) => this.writeToTerminal(id, data, chunkCount),
+    () => usePanelStore.getState().focusedId
   );
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -2,6 +2,7 @@ import type { TerminalOutputWorkerInboundMessage } from "@shared/types/terminal-
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { logDebug } from "@/utils/logger";
+import { yieldToScheduler } from "@/lib/schedulerYield";
 
 // Renderer-side backpressure layer that throttles xterm consumption. The
 // IPC-layer counterparts (the burst absorber between PTY host and renderer) live
@@ -14,6 +15,15 @@ const RENDERER_LOW_WATERMARK_BYTES = 32 * 1024;
 const COALESCE_BATCH_CAP_BYTES = 256 * 1024;
 const IPC_LOOKBACK_CHARS = 32;
 const INK_ERASE_LINE_PATTERN = "\x1b[2K\x1b[1A";
+
+// Default-on, opt-out build-time flag (mirrors DAINTREE_DISABLE_WEBGL in
+// TerminalWebGLManager). When enabled, a background (non-focused) terminal's
+// drain yields to the scheduler so a queued wheel/scroll/keystroke event on the
+// focused terminal dispatches first, instead of running every terminal's write
+// batch back-to-back in one task (#10881). Set DAINTREE_DISABLE_FOCUSED_DRAIN_PRIORITY=1
+// to fall back to the legacy fully-synchronous drain.
+const FOCUSED_DRAIN_PRIORITY_ENABLED =
+  import.meta.env.DAINTREE_DISABLE_FOCUSED_DRAIN_PRIORITY !== "1";
 
 type TerminalIngestQueue = {
   chunks: Array<string | Uint8Array>;
@@ -46,7 +56,12 @@ export class TerminalOutputIngestService {
       id: string,
       data: string | Uint8Array,
       chunkCount: number
-    ) => void
+    ) => void,
+    // Which terminal is currently focused, or null when focus is unknown.
+    // Defaults to () => null so a bare `new TerminalOutputIngestService(write)`
+    // keeps the legacy fully-synchronous drain — null focus means "drain
+    // synchronously for everyone", never "defer everyone".
+    private readonly getFocusedId: () => string | null = () => null
   ) {}
 
   public async initialize(): Promise<void> {
@@ -89,14 +104,14 @@ export class TerminalOutputIngestService {
     if (!queue) return;
     queue.inFlightBytes = Math.max(0, queue.inFlightBytes - bytes);
     if (queue.inFlightBytes <= RENDERER_LOW_WATERMARK_BYTES && queue.chunks.length > 0) {
-      this.tryDrain(id, queue);
+      this.scheduleOrDrain(id, queue);
     }
   }
 
   public notifyParsed(id: string): void {
     const queue = this.queues.get(id);
     if (!queue || queue.chunks.length === 0 || queue.drainScheduled) return;
-    this.tryDrain(id, queue);
+    this.scheduleOrDrain(id, queue);
   }
 
   /**
@@ -107,7 +122,7 @@ export class TerminalOutputIngestService {
   public resumeFlush(id: string): void {
     const queue = this.queues.get(id);
     if (!queue || queue.chunks.length === 0) return;
-    this.tryDrain(id, queue);
+    this.scheduleOrDrain(id, queue);
   }
 
   /** Held ingest bytes for a terminal — diagnostic accessor for the watchdog. */
@@ -222,15 +237,52 @@ export class TerminalOutputIngestService {
         globalThis.setTimeout(() => {
           if (this.queues.get(id) !== queue) return;
           queue.drainScheduled = false;
-          this.tryDrain(id, queue);
+          this.scheduleOrDrain(id, queue);
         }, 0);
         return;
       }
     }
 
     if (!queue.drainScheduled) {
-      this.tryDrain(id, queue);
+      this.scheduleOrDrain(id, queue);
     }
+  }
+
+  /**
+   * Drain the queue, but let a background (non-focused) terminal yield to the
+   * scheduler first so a queued wheel/scroll/keystroke event on the focused
+   * terminal dispatches ahead of this write batch (#10881). The focused
+   * terminal (and the unknown-focus / flag-disabled cases) drains inline, so
+   * keystroke-echo latency on the pane the user is watching is unchanged.
+   *
+   * A single yield is enough: it hands one task back to input dispatch, then we
+   * drain. We deliberately do NOT re-defer while still background — that would
+   * starve steady background output. Repeat triggers coalesce via
+   * queue.drainScheduled into one pending continuation (no per-chunk timer
+   * churn, #8150); the deferred drain still routes through tryDrain, so the
+   * COALESCE_BATCH_CAP_BYTES cap is respected (#4853).
+   */
+  private scheduleOrDrain(id: string, queue: TerminalIngestQueue): void {
+    if (!this.shouldDeferDrain(id)) {
+      this.tryDrain(id, queue);
+      return;
+    }
+    if (queue.drainScheduled) return;
+    queue.drainScheduled = true;
+    void yieldToScheduler().then(() => {
+      // The queue may have been cleared/replaced (resetForTerminal,
+      // forceDrain) while we were yielding — bail on a stale identity.
+      if (this.queues.get(id) !== queue) return;
+      queue.drainScheduled = false;
+      if (queue.chunks.length === 0) return;
+      this.tryDrain(id, queue);
+    });
+  }
+
+  private shouldDeferDrain(id: string): boolean {
+    if (!FOCUSED_DRAIN_PRIORITY_ENABLED) return false;
+    const focusedId = this.getFocusedId();
+    return focusedId !== null && focusedId !== id;
   }
 
   private tryDrain(id: string, queue: TerminalIngestQueue): void {

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { getSharedBuffersMock } = vi.hoisted(() => ({
   getSharedBuffersMock: vi.fn(),
@@ -578,6 +578,108 @@ describe("TerminalOutputIngestService", () => {
 
       expect(service.getQueuedBytes("term-1")).toBe(6);
       expect(service.getStalledBytes("term-1")).toBe(0);
+    });
+  });
+
+  // #10881: a background (non-focused) terminal's drain must yield to the
+  // scheduler so a queued wheel/scroll/keystroke event on the focused terminal
+  // dispatches first, while the focused terminal keeps draining synchronously.
+  // yieldToScheduler falls back to setTimeout(0) when no native `scheduler`
+  // exists, so these tests stub it away and drive fake timers to observe the
+  // deferral deterministically (mirrors schedulerYield.test.ts).
+  describe("focused-drain priority (#10881)", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it("drains the focused terminal synchronously (echo latency unchanged)", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => "term-focused");
+
+      service.bufferData("term-focused", "hello");
+
+      // No timer advance — the focused pane's write lands inline, in the same
+      // task the keystroke echo arrived in.
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-focused", "hello", 1);
+    });
+
+    it("drains synchronously when focus is unknown (null must not defer everyone)", () => {
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => null);
+
+      service.bufferData("term-bg", "data");
+
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-bg", "data", 1);
+    });
+
+    it("defers a background terminal's drain until a scheduler tick", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => "term-focused");
+
+      service.bufferData("term-bg", "background");
+
+      // Held, not written — the focused pane's input gets the current task.
+      expect(writeToTerminal).not.toHaveBeenCalled();
+      expect(service.getQueuedBytes("term-bg")).toBe(10);
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-bg", "background", 1);
+    });
+
+    it("coalesces background chunks arriving before the deferred drain fires", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => "term-focused");
+
+      service.bufferData("term-bg", "a");
+      service.bufferData("term-bg", "b");
+      service.bufferData("term-bg", "c");
+
+      // One scheduled continuation, not one per chunk (#8150).
+      expect(writeToTerminal).not.toHaveBeenCalled();
+      expect(service.getQueuedBytes("term-bg")).toBe(3);
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The deferred drain still routes through the capped coalescer (#4853),
+      // so three chunks land as one write carrying chunkCount 3.
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-bg", "abc", 3);
+    });
+
+    it("gates the notifyWriteComplete resume path, not just chunk arrival (#8371)", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => "term-focused");
+
+      // Background terminal pushed past the high watermark: the first chunk
+      // drains (deferred), the next is held behind backpressure.
+      service.bufferData("term-bg", "x".repeat(140_000));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+
+      service.bufferData("term-bg", "held");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1); // still over watermark, nothing drains
+
+      // Acknowledging the in-flight write drops below the low watermark and
+      // releases the hold — this resume must defer for a background terminal,
+      // not write inline (regression: gating only enqueueChunk would leak here).
+      service.notifyWriteComplete("term-bg", 140_000);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writeToTerminal).toHaveBeenCalledTimes(2);
+      expect(writeToTerminal).toHaveBeenLastCalledWith("term-bg", "held", 1);
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -681,5 +681,26 @@ describe("TerminalOutputIngestService", () => {
       expect(writeToTerminal).toHaveBeenCalledTimes(2);
       expect(writeToTerminal).toHaveBeenLastCalledWith("term-bg", "held", 1);
     });
+
+    it("flushForTerminal drains a pending deferred background drain synchronously, once", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = new TerminalOutputIngestService(writeToTerminal, () => "term-focused");
+
+      service.bufferData("term-bg", "pending");
+      expect(writeToTerminal).not.toHaveBeenCalled(); // deferred behind the yield
+
+      // A teardown/resize flush is a forceDrain path — it must not wait on the
+      // scheduler; it drains the held bytes now and deletes the queue.
+      service.flushForTerminal("term-bg");
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-bg", "pending", 1);
+
+      // The already-scheduled continuation must be a no-op: its stale-queue
+      // identity guard bails because the queue was deleted — no double write.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS?: string;
   readonly DAINTREE_PERF_CAPTURE?: string;
   readonly DAINTREE_VERBOSE?: string;
+  readonly DAINTREE_DISABLE_FOCUSED_DRAIN_PRIORITY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- `TerminalOutputIngestService` was draining a terminal's output queue synchronously the moment a chunk arrived, up to the 128KB high watermark, on the renderer's single main thread.
- For background terminals this could block a queued scroll-wheel or keystroke event on the currently focused terminal until the background write finished.
- Background (non-focused) drains now yield to the scheduler via `yieldToScheduler` so a pending scroll or keystroke on the focused terminal dispatches first, while the focused terminal, terminals with no defined focus, and drains with the feature flag disabled still drain synchronously so echo latency is unchanged.

Resolves #10881

## Changes
- Added a `scheduleOrDrain` helper and routed all four `tryDrain` entry points plus the existing ink-erase-triggered continuation through it.
- Shipped behind a default-on opt-out flag, `DAINTREE_DISABLE_FOCUSED_DRAIN_PRIORITY`.
- Added 6 regression tests covering the yield behavior and an explicit echo-latency bound.

## Testing
- `vitest` (37 tests in `TerminalOutputIngestService.test.ts`) pass.
- `eslint` and `prettier` clean.