### PR TITLE
feat(agents): make alt-screen mode configurable per-agent/global

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -260,6 +260,7 @@ export const CHANNELS = {
   AGENT_SETTINGS_GET: "agent-settings:get",
   AGENT_SETTINGS_SET: "agent-settings:set",
   AGENT_SETTINGS_SET_GLOBAL: "agent-settings:set-global",
+  AGENT_SETTINGS_SET_GLOBAL_INLINE: "agent-settings:set-global-inline",
   AGENT_SETTINGS_RESET: "agent-settings:reset",
   AGENT_SETTINGS_STAMP_VERSION: "agent-settings:stamp-version",
 

--- a/electron/ipc/handlers/__tests__/ai.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/ai.handlers.test.ts
@@ -237,6 +237,38 @@ describe("ai handler payload validation", () => {
     );
   });
 
+  it("rejects AGENT_SETTINGS_SET_GLOBAL_INLINE payload that is not a boolean (#10876)", async () => {
+    const handler = getInvokeHandler(CHANNELS.AGENT_SETTINGS_SET_GLOBAL_INLINE);
+    await expect(handler({} as never, "true" as never)).rejects.toThrow(
+      "Invalid globalUseAltScreen"
+    );
+    await expect(handler({} as never, 1 as never)).rejects.toThrow("Invalid globalUseAltScreen");
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("writes AGENT_SETTINGS_SET_GLOBAL_INLINE via a dot-path leaf without rewriting the slice (#10876)", async () => {
+    const handler = getInvokeHandler(CHANNELS.AGENT_SETTINGS_SET_GLOBAL_INLINE);
+    (storeMock.get as Mock).mockImplementation((key: string, defaultValue?: unknown) => {
+      if (key === "agentSettings") {
+        return { agents: { codex: { inlineMode: "on" } }, settingsVersion: 1 };
+      }
+      return defaultValue;
+    });
+
+    const result = await handler({} as never, true as never);
+
+    // Dot-path leaf write — never the whole `agentSettings` slice.
+    expect(storeMock.set).toHaveBeenCalledWith("agentSettings.globalUseAltScreen", true);
+    expect(storeMock.set).not.toHaveBeenCalledWith("agentSettings", expect.anything());
+    // Per-agent records are preserved untouched (no inlineMode mutation).
+    expect(result).toEqual(
+      expect.objectContaining({
+        globalUseAltScreen: true,
+        agents: { codex: { inlineMode: "on" } },
+      })
+    );
+  });
+
   it("normalizes malformed stored agent settings in AGENT_SETTINGS_RESET", async () => {
     const handler = getInvokeHandler(CHANNELS.AGENT_SETTINGS_RESET);
     (storeMock.get as Mock).mockImplementation((key: string, defaultValue?: unknown) => {

--- a/electron/ipc/handlers/ai.ts
+++ b/electron/ipc/handlers/ai.ts
@@ -136,6 +136,26 @@ export function registerAiHandlers(deps: HandlerDependencies): () => void {
           } as AgentSettings;
         }
       ),
+      // Sets the global "use alt-screen mode by default" override (#10876). Same
+      // dot-path leaf write as setGlobal so the rest of the agentSettings slice
+      // (per-agent records, version) isn't rewritten with first-launch defaults.
+      setGlobalInline: op(
+        CHANNELS.AGENT_SETTINGS_SET_GLOBAL_INLINE,
+        async (value: boolean): Promise<AgentSettings> => {
+          if (typeof value !== "boolean") {
+            throw new Error("Invalid globalUseAltScreen");
+          }
+          const currentSettings = normalizeAgentSettings(
+            store.get("agentSettings", DEFAULT_AGENT_SETTINGS)
+          );
+          store.set("agentSettings.globalUseAltScreen", value);
+          return {
+            ...currentSettings.root,
+            globalUseAltScreen: value,
+            agents: currentSettings.agents,
+          } as AgentSettings;
+        }
+      ),
     },
   });
   handlers.push(agentSettingsGlobalNamespace.register());

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1755,6 +1755,9 @@ function buildElectronApi(): ElectronAPI {
 
       setGlobal: (value: boolean) => _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_SET_GLOBAL, value),
 
+      setGlobalInline: (value: boolean) =>
+        _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_SET_GLOBAL_INLINE, value),
+
       reset: (agentType?: string) => _unwrappingInvoke(CHANNELS.AGENT_SETTINGS_RESET, agentType),
 
       stampVersion: (version: number) =>

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -171,8 +171,14 @@ export interface AgentPreset {
   dangerousMode?: "inherit" | "on" | "off";
   /** Per-preset override: extra CLI flags merged on top of agent-level customFlags */
   customFlags?: string;
-  /** Per-preset override: when set, overrides the agent-level inlineMode setting */
-  inlineMode?: boolean;
+  /**
+   * Per-preset tri-state alt-screen override (`InlineMode`), layered on top of
+   * the agent's resolved mode: `"off"` (alt-screen) vetoes an agent/global
+   * `"on"` (inline), `"inherit"`/absent defers to the agent's Default scope. A
+   * legacy boolean is read literally (`true → "on"`). Inlined union to avoid a
+   * config→types import cycle.
+   */
+  inlineMode?: boolean | "inherit" | "on" | "off";
   /** Optional brand color (CSS hex) used to tint the agent icon for this preset */
   color?: string;
   /** Optional free-form panel/button title; falls back to `name` when unset */
@@ -199,7 +205,7 @@ export interface AgentProviderTemplate {
   dangerousEnabled?: boolean;
   dangerousMode?: "inherit" | "on" | "off";
   customFlags?: string;
-  inlineMode?: boolean;
+  inlineMode?: boolean | "inherit" | "on" | "off";
 }
 
 /**

--- a/shared/types/__tests__/agentSettings.test.ts
+++ b/shared/types/__tests__/agentSettings.test.ts
@@ -10,7 +10,12 @@ import {
   resolveDangerousMode,
   combineDangerousModes,
   reconcileBypassFlags,
+  resolveInlineMode,
+  combineInlineModes,
+  resolveEffectiveInlineMode,
+  reconcileInlineModeFlag,
   isAgentBypassSupported,
+  DEFAULT_AGENT_SETTINGS,
   DEFAULT_DANGEROUS_ARGS,
 } from "../agentSettings.js";
 
@@ -922,5 +927,152 @@ describe("buildAgentLaunchFlags with globalSkipPermissions", () => {
       globalSkipPermissions: true,
     });
     expect(flags).not.toContain(DEFAULT_DANGEROUS_ARGS.gemini);
+  });
+});
+
+describe("resolveInlineMode (tri-state, #10876)", () => {
+  it("maps a genuinely-absent value to inherit", () => {
+    expect(resolveInlineMode({})).toBe("inherit");
+    expect(resolveInlineMode({ inlineMode: undefined })).toBe("inherit");
+  });
+
+  it("maps a legacy boolean literally, NOT like resolveDangerousMode", () => {
+    // The literal mapping (false → "off") is the deliberate difference from
+    // resolveDangerousMode (false → "inherit"): inlineMode was seeded with a
+    // concrete per-agent boolean, so false must stay an explicit alt-screen veto.
+    expect(resolveInlineMode({ inlineMode: true })).toBe("on");
+    expect(resolveInlineMode({ inlineMode: false })).toBe("off");
+    // Contrast: the bypass resolver collapses false to inherit.
+    expect(resolveDangerousMode({ dangerousEnabled: false })).toBe("inherit");
+  });
+
+  it("passes an explicit tri-state string through unchanged", () => {
+    expect(resolveInlineMode({ inlineMode: "inherit" })).toBe("inherit");
+    expect(resolveInlineMode({ inlineMode: "on" })).toBe("on");
+    expect(resolveInlineMode({ inlineMode: "off" })).toBe("off");
+  });
+});
+
+describe("combineInlineModes (#10876)", () => {
+  it("lets an explicit preset mode win over the agent mode", () => {
+    expect(combineInlineModes("on", "off")).toBe("off");
+    expect(combineInlineModes("off", "on")).toBe("on");
+  });
+
+  it("defers to the agent mode when the preset inherits", () => {
+    expect(combineInlineModes("on", "inherit")).toBe("on");
+    expect(combineInlineModes("off", undefined)).toBe("off");
+  });
+});
+
+describe("resolveEffectiveInlineMode (#10876)", () => {
+  it("honours an explicit on/off regardless of the global switch", () => {
+    expect(resolveEffectiveInlineMode({ inlineMode: "on" }, "codex", true)).toBe(true);
+    expect(resolveEffectiveInlineMode({ inlineMode: "off" }, "codex", false)).toBe(false);
+    // Explicit off is a veto that beats a global "use alt-screen" of false too.
+    expect(resolveEffectiveInlineMode({ inlineMode: "off" }, "codex", true)).toBe(false);
+  });
+
+  it("keeps a curated registry default winning over the global switch on inherit", () => {
+    // Grok declares defaultInlineMode: false (alt-screen) — it must stay
+    // alt-screen even when the global "use alt-screen by default" is OFF.
+    expect(resolveEffectiveInlineMode({}, "grok", false)).toBe(false);
+    expect(resolveEffectiveInlineMode({}, "grok", true)).toBe(false);
+    expect(resolveEffectiveInlineMode({ inlineMode: "inherit" }, "grok", false)).toBe(false);
+  });
+
+  it("falls back to the global switch on inherit when no registry default is declared", () => {
+    // Codex declares no defaultInlineMode → global switch decides.
+    expect(resolveEffectiveInlineMode({}, "codex", false)).toBe(true); // global off → inline
+    expect(resolveEffectiveInlineMode({}, "codex", true)).toBe(false); // global on → alt-screen
+  });
+
+  it("still lets an agent override its curated registry default explicitly", () => {
+    expect(resolveEffectiveInlineMode({ inlineMode: "on" }, "grok", false)).toBe(true);
+  });
+});
+
+describe("reconcileInlineModeFlag (resume trap, #10876)", () => {
+  it("strips a stale --no-alt-screen when the resolved decision is alt-screen", () => {
+    const flags = ["--model", "gpt", "--no-alt-screen"];
+    expect(reconcileInlineModeFlag(flags, "codex", false)).toEqual(["--model", "gpt"]);
+  });
+
+  it("re-appends the flag when inline is wanted but the snapshot lacks it", () => {
+    expect(reconcileInlineModeFlag(["--model", "gpt"], "codex", true)).toEqual([
+      "--model",
+      "gpt",
+      "--no-alt-screen",
+    ]);
+  });
+
+  it("is idempotent when the snapshot already matches the decision", () => {
+    const inline = ["--no-alt-screen", "--model", "gpt"];
+    expect(reconcileInlineModeFlag(inline, "codex", true)).toEqual(inline);
+    const alt = ["--model", "gpt"];
+    expect(reconcileInlineModeFlag(alt, "codex", false)).toEqual(alt);
+  });
+
+  it("dedupes duplicate flags, keeping the first in place, when inline is wanted", () => {
+    const flags = ["--no-alt-screen", "--model", "gpt", "--no-alt-screen"];
+    expect(reconcileInlineModeFlag(flags, "codex", true)).toEqual([
+      "--no-alt-screen",
+      "--model",
+      "gpt",
+    ]);
+  });
+
+  it("leaves flags untouched for an agent with no inlineModeFlag", () => {
+    const flags = ["--foo", "--no-alt-screen"];
+    expect(reconcileInlineModeFlag(flags, "claude", false)).toEqual(flags);
+    expect(reconcileInlineModeFlag(flags, "claude", true)).toEqual(flags);
+  });
+});
+
+describe("global alt-screen threading through command generation (#10876)", () => {
+  it("drops --no-alt-screen for an inherit agent when globalUseAltScreen is on", () => {
+    // Codex inherits (no explicit choice, no registry default) → follows global.
+    expect(buildAgentLaunchFlags({}, "codex", { globalUseAltScreen: true })).not.toContain(
+      "--no-alt-screen"
+    );
+    expect(generateAgentCommand("codex", {}, "codex", { globalUseAltScreen: true })).not.toContain(
+      "--no-alt-screen"
+    );
+  });
+
+  it("keeps --no-alt-screen for an inherit agent when globalUseAltScreen is off", () => {
+    expect(buildAgentLaunchFlags({}, "codex", { globalUseAltScreen: false })).toContain(
+      "--no-alt-screen"
+    );
+  });
+
+  it("keeps grok on alt-screen regardless of the global switch (curated default)", () => {
+    expect(buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: false })).not.toContain(
+      "--no-alt-screen"
+    );
+    expect(buildAgentLaunchFlags({}, "grok", { globalUseAltScreen: true })).not.toContain(
+      "--no-alt-screen"
+    );
+  });
+
+  it("lets an explicit per-agent choice veto the global switch", () => {
+    expect(
+      buildAgentLaunchFlags({ inlineMode: "on" }, "codex", { globalUseAltScreen: true })
+    ).toContain("--no-alt-screen");
+    expect(
+      buildAgentLaunchFlags({ inlineMode: "off" }, "codex", { globalUseAltScreen: false })
+    ).not.toContain("--no-alt-screen");
+  });
+});
+
+describe("DEFAULT_AGENT_SETTINGS inline seeding (#10876)", () => {
+  it("no longer seeds a concrete per-agent inlineMode so untouched agents inherit", () => {
+    for (const entry of Object.values(DEFAULT_AGENT_SETTINGS.agents)) {
+      expect(entry.inlineMode).toBeUndefined();
+    }
+  });
+
+  it("defaults globalUseAltScreen off", () => {
+    expect(DEFAULT_AGENT_SETTINGS.globalUseAltScreen).toBe(false);
   });
 });

--- a/shared/types/agentSettings.ts
+++ b/shared/types/agentSettings.ts
@@ -11,6 +11,19 @@ import { escapeShellArg, escapeShellArgOptional } from "../utils/shellEscape.js"
  */
 export type DangerousMode = "inherit" | "on" | "off";
 
+/**
+ * Tri-state alt-screen intent, stored on the `inlineMode` field. `"on"` =
+ * inline rendering (inject the agent's `inlineModeFlag`, e.g. `--no-alt-screen`);
+ * `"off"` = full-screen alternate buffer (no flag); `"inherit"` defers to the
+ * next level up (preset → agent registry default → the global "Use alt-screen
+ * mode by default" switch). Value polarity intentionally matches the legacy
+ * `inlineMode` boolean (`true` was inline), so a persisted boolean maps
+ * literally — `true → "on"`, `false → "off"` (see {@link resolveInlineMode}).
+ * The UI labels are decoupled from these values (the Settings control presents
+ * the choice in alt-screen terms).
+ */
+export type InlineMode = "inherit" | "on" | "off";
+
 export interface AgentSettingsEntry {
   /**
    * Tri-state pin for the toolbar: `true` (explicit pin), `false` (explicit
@@ -43,8 +56,15 @@ export interface AgentSettingsEntry {
    * top via {@link combineDangerousModes}.
    */
   dangerousMode?: DangerousMode;
-  /** Use inline rendering instead of fullscreen alt-screen TUI */
-  inlineMode?: boolean;
+  /**
+   * Alt-screen rendering intent for this agent's Default scope (#10876). Tri-state
+   * {@link InlineMode}: `"on"` = inline (inject `inlineModeFlag`), `"off"` =
+   * alt-screen, `"inherit"`/absent defers to the agent registry default and then
+   * the global `globalUseAltScreen` switch. A persisted legacy boolean is read
+   * literally by {@link resolveInlineMode} (`true → "on"`, `false → "off"`);
+   * preset overrides layer on top via {@link combineInlineModes}.
+   */
+  inlineMode?: boolean | InlineMode;
   /** When true, inject --include-directories for the clipboard temp directory (Gemini only) */
   shareClipboardDirectory?: boolean;
   /**
@@ -78,7 +98,14 @@ export interface AgentSettingsEntry {
      */
     dangerousMode?: DangerousMode;
     customFlags?: string;
-    inlineMode?: boolean;
+    /**
+     * Tri-state alt-screen override for this preset ({@link InlineMode}), layered
+     * on top of the agent's resolved mode via {@link combineInlineModes}. `"off"`
+     * (alt-screen) vetoes an agent/global `"on"`; `"inherit"`/absent defers to the
+     * agent's Default scope. Legacy boolean is read literally by
+     * {@link resolveInlineMode}.
+     */
+    inlineMode?: boolean | InlineMode;
     color?: string;
     /** Ordered preset IDs to fall over to when provider is unreachable. */
     fallbacks?: string[];
@@ -114,6 +141,18 @@ export interface AgentSettings {
    * their own independent bypass setting.
    */
   globalSkipPermissions?: boolean;
+  /**
+   * Global "use alt-screen mode by default" override (#10876). Controls what an
+   * agent's `"inherit"` inline-mode resolves to when no per-agent/preset choice
+   * and no curated registry default apply. Default off — so `inlineMode`
+   * resolves to inline (no alt-screen) globally unless something overrides it,
+   * mirroring how `globalSkipPermissions` defaults off. A curated per-agent
+   * registry `defaultInlineMode` (e.g. Grok's alt-screen) still wins over this
+   * switch; an explicit per-agent/preset `"on"`/`"off"` always vetoes it. Like
+   * the bypass override it is a *live* value OR-ed in at flag-generation time
+   * (see {@link resolveEffectiveInlineMode}), never mutating per-agent state.
+   */
+  globalUseAltScreen?: boolean;
 }
 
 export const DEFAULT_DANGEROUS_ARGS: Record<string, string> = {
@@ -142,13 +181,17 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
         customFlags: "",
         dangerousArgs: DEFAULT_DANGEROUS_ARGS[id] ?? "",
         dangerousEnabled: false,
-        inlineMode:
-          AGENT_REGISTRY[id]?.capabilities?.defaultInlineMode ??
-          !!AGENT_REGISTRY[id]?.capabilities?.inlineModeFlag,
+        // `inlineMode` is intentionally NOT seeded (#10876). Leaving it absent
+        // means an untouched agent resolves to `"inherit"`, so the agent's
+        // curated registry `defaultInlineMode` and then the global
+        // `globalUseAltScreen` switch decide — a concrete seed here would pin
+        // every agent and make the new global toggle a no-op for new users.
+        // Existing persisted booleans are still honoured via resolveInlineMode.
       },
     ])
   ),
   globalSkipPermissions: false,
+  globalUseAltScreen: false,
 };
 
 /**
@@ -191,6 +234,97 @@ export function combineDangerousModes(
   presetMode?: DangerousMode
 ): DangerousMode {
   return presetMode && presetMode !== "inherit" ? presetMode : agentMode;
+}
+
+/**
+ * Reads the tri-state {@link InlineMode} from a settings entry or preset (#10876).
+ * A persisted legacy boolean is mapped LITERALLY — `true → "on"` (inline),
+ * `false → "off"` (alt-screen) — not `false → "inherit"` the way
+ * {@link resolveDangerousMode} treats `dangerousEnabled`. The difference is
+ * deliberate: `inlineMode` was historically seeded with a concrete per-agent
+ * boolean (Grok `false`, Codex `true`), so a `false → "inherit"` mapping would
+ * retroactively hand those established choices to the new global switch. Only a
+ * genuinely-absent value resolves to `"inherit"`.
+ */
+export function resolveInlineMode(source: { inlineMode?: boolean | InlineMode }): InlineMode {
+  const value = source.inlineMode;
+  if (value === undefined) return "inherit";
+  if (typeof value === "boolean") return value ? "on" : "off";
+  return value;
+}
+
+/**
+ * Layers a preset's inline mode on top of the agent's resolved mode: the preset
+ * wins unless it defers (`"inherit"`). Mirrors {@link combineDangerousModes} —
+ * a preset `"off"` (alt-screen) is a true veto over an agent `"on"` (inline).
+ */
+export function combineInlineModes(agentMode: InlineMode, presetMode?: InlineMode): InlineMode {
+  return presetMode && presetMode !== "inherit" ? presetMode : agentMode;
+}
+
+/**
+ * Resolves the effective alt-screen decision for a launch from the (already
+ * preset-merged) entry's tri-state mode. Returns `true` when the agent should
+ * render inline — i.e. when the agent's `inlineModeFlag` should be injected.
+ *
+ * - `"on"`  → inline (inject flag).
+ * - `"off"` → alt-screen (no flag); an explicit veto that beats the global switch.
+ * - `"inherit"` → a curated per-agent registry `capabilities.defaultInlineMode`
+ *   (e.g. Grok's `false`, kept on the alternate screen because inline renders its
+ *   Rust TUI as garbled scrollback) wins if declared; otherwise defer to the
+ *   global "Use alt-screen mode by default" switch (`globalUseAltScreen` on →
+ *   alt-screen, off → inline).
+ *
+ * Callers that resolve a launch from a preset must bake the combined mode onto
+ * the entry first (see `applyPresetBehaviorOverrides`) so this single chokepoint
+ * sees the final intent.
+ */
+export function resolveEffectiveInlineMode(
+  entry: AgentSettingsEntry,
+  agentId: string | undefined,
+  globalUseAltScreen?: boolean
+): boolean {
+  const mode = resolveInlineMode(entry);
+  if (mode === "on") return true;
+  if (mode === "off") return false;
+  const registryDefault = agentId
+    ? getEffectiveAgentConfig(agentId)?.capabilities?.defaultInlineMode
+    : undefined;
+  if (typeof registryDefault === "boolean") return registryDefault;
+  return !globalUseAltScreen;
+}
+
+/**
+ * Reconciles a persisted `agentLaunchFlags` snapshot against the current
+ * effective inline-mode decision (#10876) — the alt-screen analog of
+ * {@link reconcileBypassFlags}'s "resume trap" fix.
+ *
+ * The agent's canonical single-token `inlineModeFlag` (e.g. `--no-alt-screen`)
+ * is baked into `agentLaunchFlags` by the same `buildAgentLaunchFlags` that
+ * captures the bypass flag, so a snapshot can carry a stale `--no-alt-screen`
+ * forward after the user (or the global switch) flips the decision. This strips
+ * every occurrence of that flag and re-appends a single copy only when
+ * `effectiveInline` is true, making every spawn/restart/restore/resume
+ * idempotent. Agents with no `inlineModeFlag` are left untouched.
+ */
+export function reconcileInlineModeFlag(
+  flags: readonly string[],
+  agentId: string,
+  effectiveInline: boolean
+): string[] {
+  const flag = getEffectiveAgentConfig(agentId)?.capabilities?.inlineModeFlag;
+  if (!flag) return [...flags];
+  if (!effectiveInline) return flags.filter((f) => f !== flag);
+  if (!flags.includes(flag)) return [...flags, flag];
+  // Wanted and already present: keep the first occurrence in place (preserving
+  // order so an already-correct snapshot is untouched), drop any duplicates.
+  let kept = false;
+  return flags.filter((f) => {
+    if (f !== flag) return true;
+    if (kept) return false;
+    kept = true;
+    return true;
+  });
 }
 
 /**
@@ -383,6 +517,12 @@ export interface GenerateAgentCommandOptions {
   presetArgs?: string;
   /** Global skip-permissions override (#10432); forwarded to {@link generateAgentFlags}. */
   globalSkipPermissions?: boolean;
+  /**
+   * Global "use alt-screen mode by default" override (#10876); resolves an
+   * agent's `"inherit"` inline mode when no per-agent/preset choice or curated
+   * registry default applies (see {@link resolveEffectiveInlineMode}).
+   */
+  globalUseAltScreen?: boolean;
 }
 
 /**
@@ -429,13 +569,12 @@ export function generateAgentCommand(
       }
     }
 
-    // Add inline mode flag when enabled and agent supports it. When the user
-    // hasn't chosen (entry.inlineMode === undefined), fall back to the agent's
-    // `defaultInlineMode` (or true for flag-bearing agents that don't override),
-    // so an agent like Grok defaults to the alternate screen instead of inline.
+    // Add inline mode flag when the resolved tri-state says inline and the agent
+    // supports it (#10876). resolveEffectiveInlineMode encodes the full chain:
+    // explicit on/off → preset (already baked onto the entry) → curated registry
+    // default → the global `globalUseAltScreen` switch.
     const inlineModeFlag = agentConfig?.capabilities?.inlineModeFlag;
-    const inlineDefault = agentConfig?.capabilities?.defaultInlineMode ?? true;
-    if (inlineModeFlag && (entry.inlineMode ?? inlineDefault)) {
+    if (inlineModeFlag && resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)) {
       parts.push(inlineModeFlag);
     }
   }
@@ -646,7 +785,12 @@ export function generateAgentCommand(
 export function buildAgentLaunchFlags(
   entry: AgentSettingsEntry,
   agentId: string,
-  options?: { modelId?: string; presetArgs?: string[]; globalSkipPermissions?: boolean }
+  options?: {
+    modelId?: string;
+    presetArgs?: string[];
+    globalSkipPermissions?: boolean;
+    globalUseAltScreen?: boolean;
+  }
 ): string[] {
   const agentConfig = getEffectiveAgentConfig(agentId);
   const flags: string[] = [];
@@ -656,12 +800,10 @@ export function buildAgentLaunchFlags(
     flags.push(...agentConfig.args);
   }
 
-  // Inline mode flag when agent supports it and it's enabled. With no explicit
-  // choice, fall back to the agent's `defaultInlineMode` (or true for flag-bearing
-  // agents without an override) so e.g. Grok defaults to the alternate screen.
+  // Inline mode flag when the resolved tri-state says inline and the agent
+  // supports it (#10876) — same resolution chain as generateAgentCommand.
   const inlineModeFlag = agentConfig?.capabilities?.inlineModeFlag;
-  const inlineDefault = agentConfig?.capabilities?.defaultInlineMode ?? true;
-  if (inlineModeFlag && (entry.inlineMode ?? inlineDefault)) {
+  if (inlineModeFlag && resolveEffectiveInlineMode(entry, agentId, options?.globalUseAltScreen)) {
     flags.push(inlineModeFlag);
   }
 

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -303,6 +303,7 @@ export type {
   AgentSettingsEntry,
   AgentSettings,
   DangerousMode,
+  InlineMode,
   GenerateAgentCommandOptions,
   GenerateAgentFlagsOptions,
 } from "./agentSettings.js";
@@ -324,6 +325,10 @@ export {
   resolveDangerousMode,
   combineDangerousModes,
   reconcileBypassFlags,
+  resolveInlineMode,
+  combineInlineModes,
+  resolveEffectiveInlineMode,
+  reconcileInlineModeFlag,
 } from "./agentSettings.js";
 
 // User agent registry types - user-defined agent configuration

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -719,6 +719,12 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * dot-path leaf so per-agent records aren't rewritten with defaults.
      */
     setGlobal(value: boolean): Promise<AgentSettings>;
+    /**
+     * Set the global "use alt-screen mode by default" override (#10876).
+     * Persisted as a dot-path leaf so per-agent records aren't rewritten with
+     * defaults.
+     */
+    setGlobalInline(value: boolean): Promise<AgentSettings>;
     reset(agentId?: AgentId): Promise<AgentSettings>;
     /**
      * Mark the persisted store with the given schema version. Only called by
@@ -1217,7 +1223,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
           color?: string;
           dangerousEnabled?: boolean;
           customFlags?: string;
-          inlineMode?: boolean;
+          inlineMode?: boolean | "inherit" | "on" | "off";
         }>;
       }) => void
     ): () => void;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -52,6 +52,10 @@ export interface GeneratedIpcInvokeMap {
     args: [value: boolean];
     result: import("../agentSettings.js").AgentSettings;
   };
+  "agent-settings:set-global-inline": {
+    args: [value: boolean];
+    result: import("../agentSettings.js").AgentSettings;
+  };
   "app:clear-quarantined-panel": {
     args: [panelId: string];
     result: { cleared: boolean };

--- a/src/clients/__tests__/agentSettingsClient.test.ts
+++ b/src/clients/__tests__/agentSettingsClient.test.ts
@@ -7,6 +7,7 @@ let agentSettingsClient: typeof import("../agentSettingsClient").agentSettingsCl
 let getMock: ReturnType<typeof vi.fn>;
 let setMock: ReturnType<typeof vi.fn>;
 let setGlobalMock: ReturnType<typeof vi.fn>;
+let setGlobalInlineMock: ReturnType<typeof vi.fn>;
 let resetMock: ReturnType<typeof vi.fn>;
 let stampVersionMock: ReturnType<typeof vi.fn>;
 
@@ -17,6 +18,7 @@ describe("agentSettingsClient", () => {
     getMock = vi.fn();
     setMock = vi.fn().mockResolvedValue({});
     setGlobalMock = vi.fn().mockResolvedValue({});
+    setGlobalInlineMock = vi.fn().mockResolvedValue({});
     resetMock = vi.fn().mockResolvedValue({});
     stampVersionMock = vi.fn().mockResolvedValue({});
 
@@ -26,6 +28,7 @@ describe("agentSettingsClient", () => {
           get: getMock,
           set: setMock,
           setGlobal: setGlobalMock,
+          setGlobalInline: setGlobalInlineMock,
           reset: resetMock,
           stampVersion: stampVersionMock,
         },
@@ -148,6 +151,26 @@ describe("agentSettingsClient", () => {
 
     resolve({});
     await expect(fresh).resolves.toEqual({ globalSkipPermissions: true });
+  });
+
+  it("setGlobalInline() forwards the value and clears the inflight get() (#10876)", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getMock.mockReturnValueOnce(deferred);
+
+    const stale = agentSettingsClient.get();
+    void agentSettingsClient.setGlobalInline(true);
+    expect(setGlobalInlineMock).toHaveBeenCalledWith(true);
+
+    getMock.mockResolvedValue({ globalUseAltScreen: true });
+    const fresh = agentSettingsClient.get();
+    expect(fresh).not.toBe(stale);
+    expect(getMock).toHaveBeenCalledTimes(2);
+
+    resolve({});
+    await expect(fresh).resolves.toEqual({ globalUseAltScreen: true });
   });
 
   it("reset() and stampVersion() also clear the inflight get()", async () => {

--- a/src/clients/agentSettingsClient.ts
+++ b/src/clients/agentSettingsClient.ts
@@ -55,6 +55,11 @@ export const agentSettingsClient = {
     return window.electron.agentSettings.setGlobal(value).finally(invalidate);
   },
 
+  setGlobalInline: (value: boolean): Promise<AgentSettings> => {
+    invalidate();
+    return window.electron.agentSettings.setGlobalInline(value).finally(invalidate);
+  },
+
   reset: (agentType?: string): Promise<AgentSettings> => {
     invalidate();
     return window.electron.agentSettings.reset(agentType).finally(invalidate);

--- a/src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx
+++ b/src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx
@@ -136,19 +136,18 @@ export function AgentScopeEditor(props: AgentScopeEditorProps) {
             effectiveSkipPerms={scope.effectiveSkipPerms}
             inheritResolvesToOn={scope.inheritResolvesToOn}
             inheritOriginLabel={scope.inheritOriginLabel}
-            effectiveInlineMode={scope.effectiveInlineMode}
-            agentDefaultInline={scope.agentDefaultInline}
+            inlineMode={scope.inlineMode}
+            inlineInheritResolvesToInline={scope.inlineInheritResolvesToInline}
+            inlineInheritOriginLabel={scope.inlineInheritOriginLabel}
             customArgsValue={scope.customArgsValue}
             customArgsPlaceholder={scope.customArgsPlaceholder}
             customArgsDescription={scope.customArgsDescription}
-            inlineOverride={scope.inlineOverride}
             customFlagsOverride={scope.customFlagsOverride}
             supportsInlineMode={scope.supportsInlineMode}
             defaultDangerousArg={defaultDangerousArg}
             onDangerousModeChange={scope.handleDangerousModeChange}
             onInlineModeChange={scope.handleInlineModeChange}
             onCustomFlagsChange={scope.handleCustomFlagsChange}
-            onInlineOverrideReset={scope.handleInlineOverrideReset}
             onCustomFlagsOverrideReset={scope.handleCustomFlagsOverrideReset}
           />
         )}

--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -1,9 +1,8 @@
 import { useMemo } from "react";
 import { RotateCcw } from "lucide-react";
-import { SettingsSwitchCard } from "../SettingsSwitchCard";
 import { SettingsChoicebox, type ChoiceboxOption } from "../SettingsChoicebox";
 import type { ScopeKind } from "./scopeUtils";
-import type { DangerousMode } from "@shared/types";
+import type { DangerousMode, InlineMode } from "@shared/types";
 
 interface BehavioralControlsProps {
   scopeKind: ScopeKind;
@@ -16,19 +15,21 @@ interface BehavioralControlsProps {
   inheritResolvesToOn: boolean;
   /** Where "Default" inherits from — "global setting" or "agent default". */
   inheritOriginLabel: string;
-  effectiveInlineMode: boolean;
-  agentDefaultInline: boolean;
+  /** Current alt-screen mode for the active scope (agent Default or preset). */
+  inlineMode: InlineMode;
+  /** Whether the inline "Default" (inherit) option resolves to inline (vs alt screen). */
+  inlineInheritResolvesToInline: boolean;
+  /** Where the inline "Default" inherits from — "global setting" or "agent default". */
+  inlineInheritOriginLabel: string;
   customArgsValue: string;
   customArgsPlaceholder: string;
   customArgsDescription: string;
-  inlineOverride: boolean | undefined;
   customFlagsOverride: string | undefined;
   supportsInlineMode: boolean;
   defaultDangerousArg: string;
   onDangerousModeChange: (mode: DangerousMode) => void;
-  onInlineModeChange: () => void;
+  onInlineModeChange: (mode: InlineMode) => void;
   onCustomFlagsChange: (value: string) => void;
-  onInlineOverrideReset: () => void;
   onCustomFlagsOverrideReset: () => void;
 }
 
@@ -39,19 +40,18 @@ export function BehavioralControls({
   effectiveSkipPerms,
   inheritResolvesToOn,
   inheritOriginLabel,
-  effectiveInlineMode,
-  agentDefaultInline,
+  inlineMode,
+  inlineInheritResolvesToInline,
+  inlineInheritOriginLabel,
   customArgsValue,
   customArgsPlaceholder,
   customArgsDescription,
-  inlineOverride,
   customFlagsOverride,
   supportsInlineMode,
   defaultDangerousArg,
   onDangerousModeChange,
   onInlineModeChange,
   onCustomFlagsChange,
-  onInlineOverrideReset,
   onCustomFlagsOverrideReset,
 }: BehavioralControlsProps) {
   const dangerousModeOptions = useMemo<ReadonlyArray<ChoiceboxOption<DangerousMode>>>(
@@ -66,6 +66,23 @@ export function BehavioralControls({
       { value: "off", label: "Off" },
     ],
     [inheritResolvesToOn]
+  );
+
+  // Alt-screen tri-state. Labels describe the effect ("Inline" / "Alt screen")
+  // and are decoupled from the stored `inlineMode` value polarity ("on" = inline,
+  // "off" = alt screen) so the field name and its values stay self-consistent.
+  const inlineModeOptions = useMemo<ReadonlyArray<ChoiceboxOption<InlineMode>>>(
+    () => [
+      {
+        value: "inherit",
+        label: "Default",
+        resolvedLabel: `(${inlineInheritResolvesToInline ? "Inline" : "Alt screen"})`,
+        muted: true,
+      },
+      { value: "on", label: "Inline" },
+      { value: "off", label: "Alt screen" },
+    ],
+    [inlineInheritResolvesToInline]
   );
 
   return (
@@ -98,28 +115,6 @@ export function BehavioralControls({
         <p className="text-xs text-daintree-text/40 select-text">{customArgsDescription}</p>
       </div>
 
-      {supportsInlineMode && (
-        <div id="agents-inline-mode">
-          <SettingsSwitchCard
-            variant="compact"
-            title="Inline mode"
-            subtitle={
-              scopeKind === "custom" && inlineOverride === undefined
-                ? `Using default (${agentDefaultInline ? "On" : "Off"})`
-                : "Disable fullscreen TUI for better resize handling and scrollback"
-            }
-            isEnabled={effectiveInlineMode}
-            onChange={onInlineModeChange}
-            ariaLabel={`Inline mode for ${scopeLabel}`}
-            isModified={scopeKind === "custom" && inlineOverride !== undefined}
-            onReset={scopeKind === "custom" ? onInlineOverrideReset : undefined}
-            resetAriaLabel={
-              scopeKind === "custom" ? `Reset inline mode override for ${scopeLabel}` : undefined
-            }
-          />
-        </div>
-      )}
-
       <div id="agents-skip-permissions" className="space-y-1.5">
         <SettingsChoicebox<DangerousMode>
           label="Skip permissions"
@@ -141,6 +136,24 @@ export function BehavioralControls({
           </div>
         )}
       </div>
+
+      {supportsInlineMode && (
+        <div id="agents-inline-mode" className="space-y-1.5">
+          <SettingsChoicebox<InlineMode>
+            label="Alt-screen mode"
+            description="Alt screen matches the CLI's native full-screen TUI; inline is smoother (WebGL scrollback, clean resize). Off vetoes the global setting for this scope."
+            columns={3}
+            value={inlineMode}
+            onChange={onInlineModeChange}
+            options={inlineModeOptions}
+          />
+          {inlineMode === "inherit" && (
+            <p className="text-xs text-daintree-text/40 select-text">
+              Inherited from {inlineInheritOriginLabel}
+            </p>
+          )}
+        </div>
+      )}
     </>
   );
 }

--- a/src/components/Settings/AgentScopeEditor/__tests__/BehavioralControls.test.tsx
+++ b/src/components/Settings/AgentScopeEditor/__tests__/BehavioralControls.test.tsx
@@ -14,19 +14,18 @@ function makeProps(overrides: Partial<Props> = {}): Props {
     effectiveSkipPerms: false,
     inheritResolvesToOn: true,
     inheritOriginLabel: "global setting",
-    effectiveInlineMode: false,
-    agentDefaultInline: false,
+    inlineMode: "inherit",
+    inlineInheritResolvesToInline: true,
+    inlineInheritOriginLabel: "global setting",
     customArgsValue: "",
     customArgsPlaceholder: "--flag",
     customArgsDescription: "Extra CLI flags",
-    inlineOverride: undefined,
     customFlagsOverride: undefined,
     supportsInlineMode: true,
     defaultDangerousArg: "--dangerously-skip-permissions",
     onDangerousModeChange: vi.fn(),
     onInlineModeChange: vi.fn(),
     onCustomFlagsChange: vi.fn(),
-    onInlineOverrideReset: vi.fn(),
     onCustomFlagsOverrideReset: vi.fn(),
     ...overrides,
   };
@@ -53,12 +52,51 @@ describe("BehavioralControls — skip permissions control", () => {
   });
 
   it("shows the inherit provenance hint only while Default is selected", () => {
-    const { rerender } = render(
+    // Scope to the skip-permissions region — the alt-screen control renders its
+    // own identical "Inherited from …" hint when it is also on Default.
+    const region = (container: HTMLElement) => {
+      const el = container.querySelector("#agents-skip-permissions");
+      if (!(el instanceof HTMLElement)) throw new Error("skip-permissions region not found");
+      return within(el);
+    };
+    const { container, rerender } = render(
       <BehavioralControls {...makeProps({ dangerousMode: "inherit" })} />
     );
-    expect(screen.getByText("Inherited from global setting")).toBeTruthy();
+    expect(region(container).getByText("Inherited from global setting")).toBeTruthy();
 
     rerender(<BehavioralControls {...makeProps({ dangerousMode: "on" })} />);
-    expect(screen.queryByText("Inherited from global setting")).toBeNull();
+    expect(region(container).queryByText("Inherited from global setting")).toBeNull();
+  });
+});
+
+describe("BehavioralControls — alt-screen mode control (#10876)", () => {
+  it("renders the alt-screen control as three radios only when the agent supports inline mode", () => {
+    const { container, rerender } = render(<BehavioralControls {...makeProps()} />);
+    const region = container.querySelector("#agents-inline-mode");
+    if (!(region instanceof HTMLElement)) throw new Error("inline-mode region not found");
+    expect(within(region).getAllByRole("radio")).toHaveLength(3);
+
+    rerender(<BehavioralControls {...makeProps({ supportsInlineMode: false })} />);
+    expect(container.querySelector("#agents-inline-mode")).toBeNull();
+  });
+
+  it("labels the options by effect (Inline / Alt screen), decoupled from stored value polarity", () => {
+    const { container } = render(<BehavioralControls {...makeProps()} />);
+    const region = container.querySelector("#agents-inline-mode") as HTMLElement;
+    const scoped = within(region);
+    // Exact names so "Inline" doesn't also match the "Default (Inline)" option.
+    expect(scoped.getByRole("radio", { name: "Inline" })).toBeTruthy();
+    expect(scoped.getByRole("radio", { name: "Alt screen" })).toBeTruthy();
+  });
+
+  it("surfaces what the inline Default resolves to and flips with the parent state", () => {
+    const { container, rerender } = render(
+      <BehavioralControls {...makeProps({ inlineInheritResolvesToInline: true })} />
+    );
+    const region = () => container.querySelector("#agents-inline-mode") as HTMLElement;
+    expect(within(region()).getByRole("radio", { name: /Default \(Inline\)/ })).toBeTruthy();
+
+    rerender(<BehavioralControls {...makeProps({ inlineInheritResolvesToInline: false })} />);
+    expect(within(region()).getByRole("radio", { name: /Default \(Alt screen\)/ })).toBeTruthy();
   });
 });

--- a/src/components/Settings/AgentScopeEditor/useAgentScope.ts
+++ b/src/components/Settings/AgentScopeEditor/useAgentScope.ts
@@ -7,8 +7,12 @@ import {
   isAgentBypassSupported,
   resolveDangerousMode,
   combineDangerousModes,
+  resolveInlineMode,
+  combineInlineModes,
+  resolveEffectiveInlineMode,
   type AgentSettingsEntry,
   type DangerousMode,
+  type InlineMode,
 } from "@shared/types";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 
@@ -67,11 +71,8 @@ export function useAgentScope({
   const agentCfg = getAgentConfig(agentId);
   const supportsInlineMode = !!agentCfg?.capabilities?.inlineModeFlag;
 
-  const agentDefaultInline =
-    activeEntry.inlineMode ?? agentCfg?.capabilities?.defaultInlineMode ?? true;
   const agentDefaultCustomFlags = activeEntry.customFlags ?? "";
 
-  const inlineOverride = selectedPreset?.inlineMode;
   const customFlagsOverride = selectedPreset?.customFlags;
 
   // Tri-state bypass (#10432 follow-up). The control edits the *active scope's
@@ -105,8 +106,31 @@ export function useAgentScope({
       ? resolveMode(combineDangerousModes(agentMode, presetMode))
       : agentResolvedDangerous;
 
+  // Tri-state alt-screen mode (#10876), mirroring the bypass control above. The
+  // stored value polarity is "on" = inline, "off" = alt screen; "Default"
+  // (inherit) defers to the agent registry default and then the global
+  // "Use alt-screen mode by default" switch.
+  const globalUseAltScreen = useAgentSettingsStore((s) => s.settings?.globalUseAltScreen ?? false);
+  const agentInlineMode = resolveInlineMode(activeEntry);
+  const presetInlineMode = selectedPreset ? resolveInlineMode(selectedPreset) : undefined;
+  const inlineMode: InlineMode =
+    scopeKind === "custom" ? (presetInlineMode ?? "inherit") : agentInlineMode;
+
+  // Resolve a tri-state to the effective "is inline" decision via the SAME
+  // shared chokepoint the launch path uses, so the UI can't drift from behavior.
+  const resolveInline = (mode: InlineMode): boolean =>
+    resolveEffectiveInlineMode({ inlineMode: mode }, agentId, globalUseAltScreen);
+
+  const agentResolvedInline = resolveInline(agentInlineMode);
+  // What the inline "Default" (inherit) segment resolves to and where from.
+  const inlineInheritResolvesToInline =
+    scopeKind === "custom" ? agentResolvedInline : resolveInline("inherit");
+  const inlineInheritOriginLabel = scopeKind === "custom" ? "agent default" : "global setting";
+
   const effectiveInlineMode =
-    scopeKind === "custom" ? (inlineOverride ?? agentDefaultInline) : agentDefaultInline;
+    scopeKind === "custom"
+      ? resolveInline(combineInlineModes(agentInlineMode, presetInlineMode))
+      : agentResolvedInline;
 
   const isEditableScope = scopeKind === "default" || scopeKind === "custom";
   const customArgsValue =
@@ -234,16 +258,16 @@ export function useAgentScope({
     }
   };
 
-  const handleInlineModeChange = () => {
+  const handleInlineModeChange = (mode: InlineMode) => {
     if (scopeKind === "default") {
       void (async () => {
-        await updateAgent(agentId, {
-          inlineMode: !agentDefaultInline,
-        } as Partial<AgentSettingsEntry>);
+        await updateAgent(agentId, { inlineMode: mode } as Partial<AgentSettingsEntry>);
         onSettingsChange?.();
       })();
     } else if (scopeKind === "custom" && selectedPreset) {
-      handleUpdatePreset(selectedPreset.id, { inlineMode: !effectiveInlineMode });
+      // "Default" clears the override (undefined, dropped on serialize) so the
+      // preset inherits the agent's resolved mode.
+      handleUpdatePreset(selectedPreset.id, { inlineMode: mode === "inherit" ? undefined : mode });
     }
   };
 
@@ -259,12 +283,6 @@ export function useAgentScope({
     if (scopeKind === "custom" && selectedPreset) {
       // Store empty/whitespace as undefined so the title falls back to `name`.
       handleUpdatePreset(selectedPreset.id, { displayTitle: value.trim() ? value : undefined });
-    }
-  };
-
-  const handleInlineOverrideReset = () => {
-    if (scopeKind === "custom" && selectedPreset) {
-      handleUpdatePreset(selectedPreset.id, { inlineMode: undefined });
     }
   };
 
@@ -290,14 +308,15 @@ export function useAgentScope({
     globalBypassActive,
     inheritResolvesToOn,
     inheritOriginLabel,
+    inlineMode,
     effectiveInlineMode,
+    inlineInheritResolvesToInline,
+    inlineInheritOriginLabel,
     customArgsValue,
     customArgsPlaceholder,
     customArgsDescription,
     agentEnvSuggestions,
-    agentDefaultInline,
     agentDefaultCustomFlags,
-    inlineOverride,
     customFlagsOverride,
     customPresets,
     ccrPresets,
@@ -315,7 +334,6 @@ export function useAgentScope({
     handleInlineModeChange,
     handleCustomFlagsChange,
     handleDisplayTitleChange,
-    handleInlineOverrideReset,
     handleCustomFlagsOverrideReset,
   };
 }

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -170,6 +170,7 @@ export function AgentSettings({
     updateAgent,
     setAgentPinned,
     setGlobalSkipPermissions,
+    setGlobalUseAltScreen,
     reset,
   } = useAgentSettingsStore();
 
@@ -427,6 +428,21 @@ export function AgentSettings({
                 onChange={() => {
                   void (async () => {
                     await setGlobalSkipPermissions(!(settings?.globalSkipPermissions ?? false));
+                    onSettingsChange?.();
+                  })();
+                }}
+              />
+            </div>
+            <div id="agents-alt-screen">
+              <SettingsSwitchCard
+                variant="compact"
+                title="Use alt-screen mode by default"
+                subtitle="Render supported agents on the full-screen alternate buffer instead of inline. Inline is smoother (WebGL scrollback, clean resize); alt-screen matches the CLI's native full-screen TUI. Sets the default for every agent; override per agent below"
+                ariaLabel="Use alt-screen mode by default"
+                isEnabled={settings?.globalUseAltScreen ?? false}
+                onChange={() => {
+                  void (async () => {
+                    await setGlobalUseAltScreen(!(settings?.globalUseAltScreen ?? false));
                     onSettingsChange?.();
                   })();
                 }}

--- a/src/components/Worktree/__tests__/panelSpawning.test.ts
+++ b/src/components/Worktree/__tests__/panelSpawning.test.ts
@@ -138,6 +138,7 @@ describe("spawnPanelsFromRecipe", () => {
         clipboardDirectory: "/tmp/daintree/daintree-clipboard",
         modelId: "sonnet",
         globalSkipPermissions: false,
+        globalUseAltScreen: false,
       }
     );
     expect(mockAddPanel).toHaveBeenCalledWith(

--- a/src/components/Worktree/panelSpawning.ts
+++ b/src/components/Worktree/panelSpawning.ts
@@ -107,11 +107,13 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
             const baseCommand = agentConfig?.command ?? "";
             const entry = agentSettings?.agents?.[agentId] ?? {};
             const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
+            const globalUseAltScreen = agentSettings?.globalUseAltScreen ?? false;
             const command = generateAgentCommand(baseCommand, entry, agentId, {
               clipboardDirectory,
               modelId: t.agentModelId,
               recipeArgs: t.args?.trim() || undefined,
               globalSkipPermissions,
+              globalUseAltScreen,
             });
             // Preserve flags the caller already captured (the clone-layout path
             // projects a live panel's `agentLaunchFlags` onto the recipe). For
@@ -124,6 +126,7 @@ export async function spawnPanelsFromRecipe(options: SpawnPanelsOptions): Promis
               ...buildAgentLaunchFlags(entry, agentId, {
                 modelId: t.agentModelId,
                 globalSkipPermissions,
+                globalUseAltScreen,
               }),
               ...(t.args?.trim().split(/\s+/).filter(Boolean) ?? []),
             ];

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -182,7 +182,13 @@ export function getMergedPresets(
         typeof preset.customFlags === "string" && !hasShellMetachar(preset.customFlags)
           ? preset.customFlags.slice(0, 10000)
           : undefined,
-      inlineMode: typeof preset.inlineMode === "boolean" ? preset.inlineMode : undefined,
+      inlineMode:
+        preset.inlineMode === "inherit" ||
+        preset.inlineMode === "on" ||
+        preset.inlineMode === "off" ||
+        typeof preset.inlineMode === "boolean"
+          ? preset.inlineMode
+          : undefined,
       color:
         typeof preset.color === "string" &&
         /^#[0-9a-fA-F]{3,4}$|^#[0-9a-fA-F]{6}$|^#[0-9a-fA-F]{8}$/.test(preset.color)

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -478,6 +478,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             cachedLaunchCliDetail
           );
           const globalSkipPermissions = launchSettings?.globalSkipPermissions ?? false;
+          const globalUseAltScreen = launchSettings?.globalUseAltScreen ?? false;
           command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
             initialPrompt: launchOptions?.prompt,
             interactive: launchOptions?.interactive ?? true,
@@ -485,6 +486,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             modelId: launchOptions?.modelId,
             presetArgs: preset?.args?.join(" "),
             globalSkipPermissions,
+            globalUseAltScreen,
           });
 
           // Capture process-level flags for session resume persistence
@@ -493,6 +495,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               modelId: launchOptions?.modelId,
               presetArgs: preset?.args,
               globalSkipPermissions,
+              globalUseAltScreen,
             });
           }
 

--- a/src/services/__tests__/agentResume.test.ts
+++ b/src/services/__tests__/agentResume.test.ts
@@ -5,6 +5,8 @@ const buildResumeCommandMock = vi.hoisted(() => vi.fn());
 const buildResumeLatestCommandMock = vi.hoisted(() => vi.fn());
 const reconcileBypassFlagsMock = vi.hoisted(() => vi.fn());
 const resolveEffectiveBypassMock = vi.hoisted(() => vi.fn());
+const reconcileInlineModeFlagMock = vi.hoisted(() => vi.fn());
+const resolveEffectiveInlineModeMock = vi.hoisted(() => vi.fn());
 const getEffectiveAgentConfigMock = vi.hoisted(() => vi.fn());
 const agentSettingsStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
 
@@ -13,6 +15,8 @@ vi.mock("@shared/types/agentSettings", () => ({
   buildResumeLatestCommand: buildResumeLatestCommandMock,
   reconcileBypassFlags: reconcileBypassFlagsMock,
   resolveEffectiveBypass: resolveEffectiveBypassMock,
+  reconcileInlineModeFlag: reconcileInlineModeFlagMock,
+  resolveEffectiveInlineMode: resolveEffectiveInlineModeMock,
 }));
 vi.mock("@shared/config/agentRegistry", () => ({
   getEffectiveAgentConfig: getEffectiveAgentConfigMock,
@@ -41,6 +45,10 @@ beforeEach(() => {
   });
   resolveEffectiveBypassMock.mockReturnValue(true);
   reconcileBypassFlagsMock.mockReturnValue(["--dangerously-skip-permissions"]);
+  // Inline reconciliation is layered after bypass; pass the flags through so the
+  // existing resume-command assertions (bypass token) still hold (#10876).
+  resolveEffectiveInlineModeMock.mockReturnValue(false);
+  reconcileInlineModeFlagMock.mockImplementation((flags: string[]) => flags);
   getEffectiveAgentConfigMock.mockReturnValue({ name: "Claude", command: "claude" });
   buildResumeCommandMock.mockReturnValue("claude --resume s-1");
   buildResumeLatestCommandMock.mockReturnValue("claude --continue");

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -108,7 +108,7 @@ export const AgentPresetSchema = z.object({
   dangerousEnabled: z.boolean().optional(),
   dangerousMode: z.enum(["inherit", "on", "off"]).optional(),
   customFlags: z.string().optional(),
-  inlineMode: z.boolean().optional(),
+  inlineMode: z.union([z.boolean(), z.enum(["inherit", "on", "off"])]).optional(),
   color: z.string().optional(),
   displayTitle: z.string().optional(),
   fallbacks: z.array(z.string()).optional(),

--- a/src/services/agentResume.ts
+++ b/src/services/agentResume.ts
@@ -2,7 +2,9 @@ import {
   buildResumeCommand,
   buildResumeLatestCommand,
   reconcileBypassFlags,
+  reconcileInlineModeFlag,
   resolveEffectiveBypass,
+  resolveEffectiveInlineMode,
 } from "@shared/types/agentSettings";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import type { AddPanelOptions } from "@shared/types/addPanelOptions";
@@ -11,9 +13,10 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 
 /**
  * Reconciles a resumed session's persisted launch flags against the current
- * global skip-permissions setting (#10432, the "resume trap"): the snapshot may
- * have been captured while the global switch was in a different state, so strip
- * the agent's canonical bypass flag and re-add it only if it currently resolves.
+ * global settings (#10432 skip-permissions, #10876 alt-screen — both "resume
+ * traps"): the snapshot may have been captured while a global switch was in a
+ * different state, so strip the agent's canonical bypass / inline flags and
+ * re-add them only if they currently resolve.
  *
  * Reads `useAgentSettingsStore` synchronously (a Zustand store read, not
  * React-bound), so it is safe to call from action definitions and effects alike.
@@ -29,13 +32,22 @@ export function reconcileResumeLaunchFlags(session: {
     session.agentId,
     settings?.globalSkipPermissions
   );
-  // Pass [] when no flags were captured so global-on still injects the bypass
-  // token for a supported agent (reconcileBypassFlags no-ops for others).
-  return reconcileBypassFlags(
-    session.agentLaunchFlags ?? [],
+  const effectiveInline = resolveEffectiveInlineMode(
+    entry,
     session.agentId,
-    effectiveBypass,
-    entry.dangerousArgs as string | undefined
+    settings?.globalUseAltScreen
+  );
+  // Pass [] when no flags were captured so a global-on still injects the token
+  // for a supported agent (each reconcile no-ops for agents without one).
+  return reconcileInlineModeFlag(
+    reconcileBypassFlags(
+      session.agentLaunchFlags ?? [],
+      session.agentId,
+      effectiveBypass,
+      entry.dangerousArgs as string | undefined
+    ),
+    session.agentId,
+    effectiveInline
   );
 }
 

--- a/src/services/terminal/__tests__/panelDuplicationService.test.ts
+++ b/src/services/terminal/__tests__/panelDuplicationService.test.ts
@@ -581,7 +581,9 @@ describe("adversarial: behavioral overrides flow to generateAgentCommand in dupl
     await buildPanelDuplicateOptions(panel, "grid");
 
     const entry = spy.mock.calls[0]![1] as Record<string, unknown>;
-    expect(entry.inlineMode).toBe(false);
+    // Baked as the tri-state "off" (alt-screen) now (#10876): the preset's
+    // alt-screen choice still vetoes the base's inline (true → "on").
+    expect(entry.inlineMode).toBe("off");
   });
 
   it("preset.dangerousEnabled=undefined does NOT clobber base true (undefined guard)", async () => {

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -54,6 +54,7 @@ async function resolveCommandForPanel(panel: PanelInstance): Promise<ResolvedCom
         });
         const { preset, presetWasStale, effectiveEntry } = runtimeSettings;
         const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
+        const globalUseAltScreen = agentSettings?.globalUseAltScreen ?? false;
         const clipboardDirectory = tmpDir ? `${tmpDir}/daintree-clipboard` : undefined;
         const command = generateAgentCommand(
           agentConfig.command,
@@ -65,13 +66,14 @@ async function resolveCommandForPanel(panel: PanelInstance): Promise<ResolvedCom
             modelId: panel.agentModelId,
             presetArgs: preset?.args?.join(" "),
             globalSkipPermissions,
+            globalUseAltScreen,
           }
         );
         const agentLaunchFlags = buildAgentLaunchFlagsForRuntimeSettings(
           effectiveEntry,
           panel.launchAgentId,
           preset,
-          { modelId: panel.agentModelId, globalSkipPermissions }
+          { modelId: panel.agentModelId, globalSkipPermissions, globalUseAltScreen }
         );
         return { command, env: runtimeSettings.env, agentLaunchFlags, preset, presetWasStale };
       } catch (error) {

--- a/src/store/__tests__/agentSettingsStore.adversarial.test.ts
+++ b/src/store/__tests__/agentSettingsStore.adversarial.test.ts
@@ -6,6 +6,7 @@ const clientMock = vi.hoisted(() => ({
   invalidate: vi.fn(),
   set: vi.fn(),
   setGlobal: vi.fn(),
+  setGlobalInline: vi.fn(),
   reset: vi.fn(),
   stampVersion: vi.fn(),
 }));
@@ -792,6 +793,39 @@ describe("agentSettingsStore adversarial", () => {
 
     const state = useAgentSettingsStore.getState();
     expect(state.settings?.globalSkipPermissions).toBe(false);
+    expect(state.error).toBeTruthy();
+  });
+
+  it("setGlobalUseAltScreen optimistically updates the root field without touching per-agent inlineMode (#10876)", async () => {
+    useAgentSettingsStore.setState({
+      settings: {
+        agents: { codex: { inlineMode: "on" } },
+        globalUseAltScreen: false,
+      },
+    });
+    clientMock.setGlobalInline.mockResolvedValueOnce({});
+
+    await useAgentSettingsStore.getState().setGlobalUseAltScreen(true);
+
+    expect(clientMock.setGlobalInline).toHaveBeenCalledWith(true);
+    const settings = useAgentSettingsStore.getState().settings;
+    expect(settings?.globalUseAltScreen).toBe(true);
+    // The per-agent choice must be left untouched — the global is a live override.
+    expect(settings?.agents.codex?.inlineMode).toBe("on");
+  });
+
+  it("setGlobalUseAltScreen rolls back to the prior value when the IPC write rejects (#10876)", async () => {
+    useAgentSettingsStore.setState({
+      settings: { agents: { codex: {} }, globalUseAltScreen: false },
+    });
+    clientMock.setGlobalInline.mockRejectedValueOnce(new Error("ipc down"));
+
+    await expect(useAgentSettingsStore.getState().setGlobalUseAltScreen(true)).rejects.toThrow(
+      "ipc down"
+    );
+
+    const state = useAgentSettingsStore.getState();
+    expect(state.settings?.globalUseAltScreen).toBe(false);
     expect(state.error).toBeTruthy();
   });
 });

--- a/src/store/agentSettingsStore.ts
+++ b/src/store/agentSettingsStore.ts
@@ -229,6 +229,12 @@ interface AgentSettingsActions {
    */
   setGlobalSkipPermissions: (value: boolean) => Promise<void>;
   /**
+   * Set the global "use alt-screen mode by default" override (#10876). Writes
+   * the root-level `globalUseAltScreen` field only — does not mutate any
+   * per-agent `inlineMode`. Optimistic with rollback on IPC failure.
+   */
+  setGlobalUseAltScreen: (value: boolean) => Promise<void>;
+  /**
    * Set or clear the worktree-scoped preset override for an agent. Reads the
    * current `worktreePresets` map, spreads sibling keys, then writes the merged
    * map — bypasses the IPC handler's shallow-merge clobber on the submap.
@@ -441,6 +447,30 @@ export const useAgentSettingsStore = create<AgentSettingsStore>()((set, get) => 
       if (myEpoch !== normalizeEpoch) return;
       if (previous) set({ settings: previous });
       set({ error: formatErrorMessage(e, "Failed to update global skip-permissions setting") });
+      throw e;
+    }
+  },
+
+  setGlobalUseAltScreen: async (value: boolean) => {
+    const myEpoch = ++normalizeEpoch;
+    set({ error: null });
+    const previous = get().settings;
+    // Optimistic top-level spread — never route through updateAgent (which
+    // merges into the agents record and would not touch this root field, #5514).
+    // This must not mutate any per-agent `inlineMode`; it is a live override
+    // resolved at flag-generation time (#10876).
+    if (previous) {
+      set({ settings: { ...previous, globalUseAltScreen: value } });
+    }
+    try {
+      await agentSettingsClient.setGlobalInline(value);
+      if (myEpoch !== normalizeEpoch) return;
+      // The IPC response echoes the persisted value; the optimistic state
+      // already reflects it, so keep the renderer-normalized snapshot.
+    } catch (e) {
+      if (myEpoch !== normalizeEpoch) return;
+      if (previous) set({ settings: previous });
+      set({ error: formatErrorMessage(e, "Failed to update global alt-screen setting") });
       throw e;
     }
   },

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -821,6 +821,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               : undefined;
             const entry = agentSettings?.agents?.[agentId] ?? {};
             const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
+            const globalUseAltScreen = agentSettings?.globalUseAltScreen ?? false;
 
             // Resolve the selected preset to parity with manual launches
             // (useAgentLauncher): the worktree-scoped pick wins over the
@@ -879,6 +880,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
               recipeArgs: terminal.args?.trim() || undefined,
               presetArgs: preset?.args?.join(" "),
               globalSkipPermissions,
+              globalUseAltScreen,
             });
             // Persist the process-level launch flags so restart/resume/continue
             // reproduce the same configuration. Without this the panel arrives
@@ -895,6 +897,7 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
                 modelId: terminal.agentModelId,
                 presetArgs: preset?.args,
                 globalSkipPermissions,
+                globalUseAltScreen,
               }),
               ...(terminal.args?.trim().split(/\s+/).filter(Boolean) ?? []),
             ];

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -14,7 +14,9 @@ import {
   buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
   reconcileBypassFlags,
+  reconcileInlineModeFlag,
   resolveEffectiveBypass,
+  resolveEffectiveInlineMode,
 } from "@shared/types";
 import type { AgentSettingsEntry } from "@shared/types/agentSettings";
 import type { AgentState } from "@/types";
@@ -62,6 +64,8 @@ interface LoadedAgentRuntimeSettings {
   tmpDir: string;
   /** Global skip-permissions override at restart time (#10432). */
   globalSkipPermissions: boolean;
+  /** Global "use alt-screen mode by default" override at restart time (#10876). */
+  globalUseAltScreen: boolean;
 }
 
 function mergeSpawnEnv(
@@ -369,6 +373,7 @@ export const createRestartActions = (
           settings,
           tmpDir,
           globalSkipPermissions: agentSettings?.globalSkipPermissions ?? false,
+          globalUseAltScreen: agentSettings?.globalUseAltScreen ?? false,
         };
         if (settings.presetWasStale) {
           nextAgentPresetId = undefined;
@@ -393,6 +398,7 @@ export const createRestartActions = (
         {
           modelId: currentTerminal.agentModelId,
           globalSkipPermissions: runtimeForEnv.globalSkipPermissions,
+          globalUseAltScreen: runtimeForEnv.globalUseAltScreen,
         }
       );
     }
@@ -405,13 +411,14 @@ export const createRestartActions = (
           presetForLaunchFlags
         );
       }
-      // Reconcile the persisted bypass flag against the current effective
-      // setting before any resume/from-flags command is built (#10432, the
-      // "resume trap"): a snapshot captured while the global skip-permissions
-      // switch was on must not survive once it's toggled off, and vice-versa.
-      // `nextAgentLaunchFlags` (stored + from-flags rebuild) reconciles only
-      // captured flags; `resumeFlags` additionally injects the bypass token into
-      // an empty snapshot so a session launched before bypass honours global-on.
+      // Reconcile the persisted bypass (#10432) and inline (#10876) flags against
+      // the current effective settings before any resume/from-flags command is
+      // built (the "resume trap"): a snapshot captured while the global
+      // skip-permissions or alt-screen switch was in a different state must not
+      // survive once it's flipped. `nextAgentLaunchFlags` (stored + from-flags
+      // rebuild) reconciles only captured flags; `resumeFlags` additionally
+      // injects the tokens into an empty snapshot so a session launched before
+      // either feature honours the current resolution.
       let resumeFlags = nextAgentLaunchFlags;
       if (runtimeForEnv) {
         const effectiveBypass = resolveEffectiveBypass(
@@ -419,17 +426,24 @@ export const createRestartActions = (
           effectiveAgentId,
           runtimeForEnv.globalSkipPermissions
         );
+        const effectiveInline = resolveEffectiveInlineMode(
+          runtimeForEnv.settings.effectiveEntry,
+          effectiveAgentId,
+          runtimeForEnv.globalUseAltScreen
+        );
         const dangerousArgs = runtimeForEnv.settings.effectiveEntry.dangerousArgs;
-        if (nextAgentLaunchFlags && nextAgentLaunchFlags.length > 0) {
-          nextAgentLaunchFlags = reconcileBypassFlags(
-            nextAgentLaunchFlags,
+        const reconcileFlags = (base: string[]): string[] =>
+          reconcileInlineModeFlag(
+            reconcileBypassFlags(base, effectiveAgentId, effectiveBypass, dangerousArgs),
             effectiveAgentId,
-            effectiveBypass,
-            dangerousArgs
+            effectiveInline
           );
+        if (nextAgentLaunchFlags && nextAgentLaunchFlags.length > 0) {
+          nextAgentLaunchFlags = reconcileFlags(nextAgentLaunchFlags);
           resumeFlags = nextAgentLaunchFlags;
-        } else if (effectiveBypass) {
-          resumeFlags = reconcileBypassFlags([], effectiveAgentId, effectiveBypass, dangerousArgs);
+        } else {
+          const injectedFromEmpty = reconcileFlags([]);
+          if (injectedFromEmpty.length > 0) resumeFlags = injectedFromEmpty;
         }
       }
       const sessionId = currentTerminal.agentSessionId;
@@ -466,6 +480,7 @@ export const createRestartActions = (
             {
               modelId: currentTerminal.agentModelId,
               globalSkipPermissions: runtimeSettings.globalSkipPermissions,
+              globalUseAltScreen: runtimeSettings.globalUseAltScreen,
             }
           );
           hasPersistedFlags = nextAgentLaunchFlags.length > 0;
@@ -505,6 +520,7 @@ export const createRestartActions = (
                   modelId: currentTerminal.agentModelId,
                   presetArgs: runtimeSettings.settings.preset?.args?.join(" "),
                   globalSkipPermissions: runtimeSettings.globalSkipPermissions,
+                  globalUseAltScreen: runtimeSettings.globalUseAltScreen,
                 }
               );
             }
@@ -1031,16 +1047,19 @@ export const createRestartActions = (
       const agentConfig = getAgentConfig(effectiveAgentId);
       const baseCommand = agentConfig?.command || effectiveAgentId;
       const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
+      const globalUseAltScreen = agentSettings?.globalUseAltScreen ?? false;
       const commandToRun = generateAgentCommand(baseCommand, effectiveEntry, effectiveAgentId, {
         clipboardDirectory,
         modelId: terminal.agentModelId,
         presetArgs: nextPreset.args?.join(" "),
         globalSkipPermissions,
+        globalUseAltScreen,
       });
       const nextLaunchFlags = buildAgentLaunchFlags(effectiveEntry, effectiveAgentId, {
         modelId: terminal.agentModelId,
         presetArgs: nextPreset.args,
         globalSkipPermissions,
+        globalUseAltScreen,
       });
 
       // Capture live terminal dimensions before teardown

--- a/src/utils/agentRuntimeSettings.ts
+++ b/src/utils/agentRuntimeSettings.ts
@@ -1,6 +1,12 @@
 import type { AgentPreset } from "@/config/agents";
 import { getMergedPreset, sanitizeAgentEnv } from "@/config/agents";
-import { buildAgentLaunchFlags, combineDangerousModes, resolveDangerousMode } from "@shared/types";
+import {
+  buildAgentLaunchFlags,
+  combineDangerousModes,
+  combineInlineModes,
+  resolveDangerousMode,
+  resolveInlineMode,
+} from "@shared/types";
 import type { AgentSettingsEntry } from "@shared/types/agentSettings";
 
 export interface AgentRuntimeSettingsResolution {
@@ -32,12 +38,18 @@ export function applyPresetBehaviorOverrides(
     resolveDangerousMode(entry),
     resolveDangerousMode(preset)
   );
+  // Layer the preset's tri-state inline mode on top of the agent's resolved mode
+  // and bake the combined result onto the effective entry, so the single
+  // resolveEffectiveInlineMode chokepoint sees the final intent (#10876) — a
+  // preset "off" (alt-screen) vetoes an agent/global "on" (inline), just like
+  // the bypass tri-state above.
+  const combinedInline = combineInlineModes(resolveInlineMode(entry), resolveInlineMode(preset));
   return {
     ...entry,
     dangerousMode: combinedMode,
     dangerousEnabled: combinedMode === "on",
+    inlineMode: combinedInline,
     ...(preset.customFlags !== undefined && { customFlags: preset.customFlags }),
-    ...(preset.inlineMode !== undefined && { inlineMode: preset.inlineMode }),
   };
 }
 
@@ -90,11 +102,12 @@ export function buildAgentLaunchFlagsForRuntimeSettings(
   entry: AgentSettingsEntry,
   agentId: string,
   preset: AgentPreset | undefined,
-  options?: { modelId?: string; globalSkipPermissions?: boolean }
+  options?: { modelId?: string; globalSkipPermissions?: boolean; globalUseAltScreen?: boolean }
 ): string[] {
   return buildAgentLaunchFlags(entry, agentId, {
     modelId: options?.modelId,
     presetArgs: preset?.args,
     globalSkipPermissions: options?.globalSkipPermissions,
+    globalUseAltScreen: options?.globalUseAltScreen,
   });
 }

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1979,7 +1979,9 @@ describe("adversarial: behavioral overrides flow through to generateAgentCommand
       undefined
     );
     const entry = generateAgentCommandMock.mock.calls[0]![1] as Record<string, unknown>;
-    expect(entry.inlineMode).toBe(false);
+    // Baked as the tri-state "off" (alt-screen) now (#10876): the preset's
+    // alt-screen choice still vetoes the base's inline (true → "on").
+    expect(entry.inlineMode).toBe("off");
   });
 
   it("preset.dangerousEnabled=undefined does NOT clobber base true (undefined guard)", () => {

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -12,7 +12,9 @@ import {
   buildResumeLatestCommand,
   buildLaunchCommandFromFlags,
   reconcileBypassFlags,
+  reconcileInlineModeFlag,
   resolveEffectiveBypass,
+  resolveEffectiveInlineMode,
 } from "@shared/types";
 import { inferKind as inferKindShared } from "@shared/utils/inferPanelKind";
 import { isAbsolute } from "@shared/utils/path";
@@ -163,6 +165,7 @@ interface ReconnectedTerminalData {
 interface AgentSettingsData {
   agents?: Record<string, Record<string, unknown>>;
   globalSkipPermissions?: boolean;
+  globalUseAltScreen?: boolean;
 }
 
 export function inferAgentIdFromTitle(
@@ -428,25 +431,36 @@ export function buildArgsForRespawn(
     // once it's toggled off, and vice-versa. Strip-and-re-add against the
     // current resolution so every restart/restore replays clean flags.
     const globalSkipPermissions = agentSettings?.globalSkipPermissions ?? false;
+    const globalUseAltScreen = agentSettings?.globalUseAltScreen ?? false;
     const effectiveBypass = resolveEffectiveBypass(effectiveEntry, agentId, globalSkipPermissions);
+    const effectiveInline = resolveEffectiveInlineMode(effectiveEntry, agentId, globalUseAltScreen);
     const dangerousArgs = effectiveEntry.dangerousArgs as string | undefined;
     const rawPersistedFlags = presetWasStale ? undefined : saved.agentLaunchFlags;
     const hasPersistedFlags = Boolean(rawPersistedFlags && rawPersistedFlags.length > 0);
+    // Reconcile the persisted snapshot against both live resolutions (#10432 the
+    // bypass token, #10876 the `--no-alt-screen` inline flag): a snapshot must
+    // not carry a stale flag forward once the global switch or per-agent choice
+    // is flipped. Applied together so restart/restore/resume replay clean flags.
+    const reconcileFlags = (base: string[]): string[] =>
+      reconcileInlineModeFlag(
+        reconcileBypassFlags(base, agentId, effectiveBypass, dangerousArgs),
+        agentId,
+        effectiveInline
+      );
     // Reconcile only the flags actually captured: this drives the stored
     // snapshot and the from-flags rebuild, so it must NOT synthesize a flag set
     // out of nothing (that would mask the fresh-launch fallback).
     const persistedFlags = hasPersistedFlags
-      ? reconcileBypassFlags(rawPersistedFlags as string[], agentId, effectiveBypass, dangerousArgs)
+      ? reconcileFlags(rawPersistedFlags as string[])
       : rawPersistedFlags;
     reconciledLaunchFlags = persistedFlags;
-    // Resume commands prepend launch flags, so the bypass token must be injected
-    // even when no flags were captured — a session launched before bypass
-    // existed should honour global-on (#10432). Only diverges from persistedFlags
-    // in that inject-from-empty case.
+    // Resume commands prepend launch flags, so the bypass / inline tokens must be
+    // injected even when no flags were captured — a session launched before
+    // either feature existed should honour the current resolution (#10432, #10876).
+    // Only diverges from persistedFlags in that inject-from-empty case.
+    const injectedFromEmpty = reconcileFlags([]);
     const resumeFlags =
-      effectiveBypass && !hasPersistedFlags
-        ? reconcileBypassFlags([], agentId, effectiveBypass, dangerousArgs)
-        : persistedFlags;
+      !hasPersistedFlags && injectedFromEmpty.length > 0 ? injectedFromEmpty : persistedFlags;
 
     const buildFromPersistedFlags = () =>
       buildLaunchCommandFromFlags(baseCommand, agentId, persistedFlags as string[], {
@@ -467,6 +481,7 @@ export function buildArgsForRespawn(
           modelId: saved.agentModelId,
           presetArgs: preset?.args?.join(" "),
           globalSkipPermissions,
+          globalUseAltScreen,
         });
         sessionLostOnRestore = true;
       }
@@ -486,6 +501,7 @@ export function buildArgsForRespawn(
           modelId: saved.agentModelId,
           presetArgs: preset?.args?.join(" "),
           globalSkipPermissions,
+          globalUseAltScreen,
         });
         sessionLostOnRestore = true;
       }


### PR DESCRIPTION
## Summary

- Extends the per-agent `inlineMode` boolean into a tri-state (on/off/inherit), mirroring the existing DangerousMode/globalSkipPermissions architecture: `on` means inline, `off` means alt-screen, `inherit` follows a new global default.
- Adds a `globalUseAltScreen` toggle (default off) plus resolver functions (`resolveInlineMode`, `combineInlineModes`, `resolveEffectiveInlineMode`, `reconcileInlineModeFlag`) and threads the global setting and reconciled `--no-alt-screen` flag through every launch, restart, and resume path, including resume-trap parity with #10432.
- Replaces the boolean inline-mode switch in Settings with a tri-state `SettingsChoicebox` under Skip permissions, plus the new global toggle.

Resolves #10876

## Changes

- `shared/types/agentSettings.ts`: tri-state `InlineMode` type and resolver functions (`resolveInlineMode`, `combineInlineModes`, `resolveEffectiveInlineMode`, `reconcileInlineModeFlag`)
- New `setGlobalInline` IPC operation (`electron/ipc/channels.ts`, `electron/ipc/handlers/ai.ts`, `electron/preload.cts`) and `setGlobalUseAltScreen` store action (`src/store/agentSettingsStore.ts`)
- Global + reconciled flag threaded through launch, restart, and resume paths (`src/services/agentResume.ts`, `src/store/slices/panelRegistry/restart.ts`, `src/utils/agentRuntimeSettings.ts`, `src/hooks/useAgentLauncher.ts`, `src/components/Worktree/panelSpawning.ts`, `src/utils/stateHydration/statePatcher.ts`)
- Settings UI: tri-state `SettingsChoicebox` under Skip permissions plus a new global toggle (`src/components/Settings/AgentScopeEditor/BehavioralControls.tsx`, `src/components/Settings/AgentSettings.tsx`)

## Testing

- `npm run typecheck` (exit 0)
- 461 branch tests pass
- `eslint` (0 errors on changed files)