### PR TITLE
fix(pty-host): prioritize focused terminal in backpressure

### DIFF
--- a/electron/ipc/__tests__/channelDrift.test.ts
+++ b/electron/ipc/__tests__/channelDrift.test.ts
@@ -130,6 +130,7 @@ const DEAD_CHANNEL_ALLOWLIST = new Set<string>([
   "terminal:input",
   "terminal:resize",
   "terminal:set-activity-tier",
+  "terminal:set-focused",
   "terminal:update-observed-title",
 
   // fire-and-forget — high-frequency renderer→main streaming audio chunks

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -34,6 +34,7 @@ export const CHANNELS = {
   TERMINAL_TRASHED: "terminal:trashed",
   TERMINAL_RESTORED: "terminal:restored",
   TERMINAL_SET_ACTIVITY_TIER: "terminal:set-activity-tier",
+  TERMINAL_SET_FOCUSED: "terminal:set-focused",
   TERMINAL_GET_FOR_PROJECT: "terminal:get-for-project",
   TERMINAL_GET_AVAILABLE: "terminal:get-available",
   TERMINAL_GET_BY_STATE: "terminal:get-by-state",

--- a/electron/ipc/handlers/terminal/io.ts
+++ b/electron/ipc/handlers/terminal/io.ts
@@ -190,6 +190,30 @@ export function registerTerminalIOHandlers(deps: HandlerDependencies): () => voi
     ipcMain.removeListener(CHANNELS.TERMINAL_SET_ACTIVITY_TIER, handleTerminalSetActivityTier)
   );
 
+  const handleTerminalSetFocused = (
+    event: Electron.IpcMainEvent,
+    payload: { id: string | null }
+  ) => {
+    try {
+      if (!payload || typeof payload !== "object") return;
+      const { id } = payload;
+      if (id !== null && (typeof id !== "string" || !id)) return;
+      // Focus is inherently per-window: resolve the owning window from the
+      // sender's webContents (works for WebContentsView project views, not just
+      // the top-level BrowserWindow). Without a resolvable window the signal is
+      // dropped — it's a soft prioritization hint, so the host behaves as before.
+      const windowId = deps.windowRegistry?.getByWebContentsId(event.sender.id)?.windowId;
+      if (typeof windowId !== "number") return;
+      ptyClient.setFocusedTerminal(windowId, id);
+    } catch (error) {
+      console.error("[IPC] Failed to set focused terminal:", error);
+    }
+  };
+  ipcMain.on(CHANNELS.TERMINAL_SET_FOCUSED, handleTerminalSetFocused);
+  handlers.push(() =>
+    ipcMain.removeListener(CHANNELS.TERMINAL_SET_FOCUSED, handleTerminalSetFocused)
+  );
+
   const handleTerminalAcknowledgeData = (
     _event: Electron.IpcMainEvent,
     payload: { id: string; length: number }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1100,6 +1100,8 @@ function buildElectronApi(): ElectronAPI {
       setActivityTier: (id: string, tier: "active" | "background", pollingIntervalMs?: number) =>
         ipcRenderer.send(CHANNELS.TERMINAL_SET_ACTIVITY_TIER, { id, tier, pollingIntervalMs }),
 
+      setFocused: (id: string | null) => ipcRenderer.send(CHANNELS.TERMINAL_SET_FOCUSED, { id }),
+
       acknowledgeData: (id: string, length: number) =>
         ipcRenderer.send(CHANNELS.TERMINAL_ACKNOWLEDGE_DATA, { id, length }),
 

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -355,6 +355,9 @@ function getOrCreatePauseCoordinator(id: string): PtyPauseCoordinator | undefine
 // Per-window MessagePort connections for direct Renderer ↔ Pty Host communication
 const rendererConnections = new Map<number, RendererConnection>();
 const windowProjectMap = new Map<number, string | null>();
+// Per-window UI-focused terminal id (from the renderer's focusedId). Read by
+// each window's PortQueueManager/PortBatcher to prioritize the focused pane.
+const windowFocusedTerminalMap = new Map<number, string | null>();
 
 // Helper to send events to Main process
 function sendEvent(event: PtyHostEvent): void {
@@ -399,6 +402,7 @@ function createPortQueueManager(windowId: number): PortQueueManager {
     emitReliabilityMetric: (payload) =>
       emitReliabilityMetricWithTracking(payload, `port-${windowId}` as PauseSource),
     pauseToken: `port-queue-${windowId}`,
+    getFocusedTerminalId: () => windowFocusedTerminalMap.get(windowId) ?? null,
   });
 }
 
@@ -483,6 +487,7 @@ function disconnectWindow(windowId: number, reason: string): void {
   // that should forget the project context.
   if (reason === "explicit-disconnect") {
     windowProjectMap.delete(windowId);
+    windowFocusedTerminalMap.delete(windowId);
   }
   // A disconnect never grows scope (no project gains a viewer), so this is
   // intentionally a no-op today — kept as the single chokepoint all 3
@@ -1300,6 +1305,7 @@ const hostContext: HostContext = {
   pauseCoordinators,
   rendererConnections,
   windowProjectMap,
+  windowFocusedTerminalMap,
   ipcDataMirrorTerminals,
   get visualBuffers() {
     return visualBuffers;

--- a/electron/pty-host/__tests__/portBatcher.test.ts
+++ b/electron/pty-host/__tests__/portBatcher.test.ts
@@ -602,6 +602,92 @@ describe("PortBatcher", () => {
     });
   });
 
+  describe("focused-terminal prioritization (#10878)", () => {
+    it("flush services the focused terminal's pending entry first", () => {
+      const deps = createDeps({ getFocusedTerminalId: () => "t2" });
+      const batcher = new PortBatcher(deps);
+
+      // Written in t1, t2, t3 insertion order; the focused entry (t2) must be
+      // posted first regardless.
+      batcher.write("t1", bytes("a"), 1);
+      batcher.write("t2", bytes("b"), 1);
+      batcher.write("t3", bytes("c"), 1);
+      vi.runAllTimers();
+
+      const postMessage = deps.postMessage as ReturnType<typeof vi.fn>;
+      const order = postMessage.mock.calls.map((c) => c[0] as string);
+      expect(order).toEqual(["t2", "t1", "t3"]);
+    });
+
+    it("falls back to insertion order when no terminal is focused", () => {
+      const deps = createDeps({ getFocusedTerminalId: () => null });
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("a"), 1);
+      batcher.write("t2", bytes("b"), 1);
+      batcher.write("t3", bytes("c"), 1);
+      vi.runAllTimers();
+
+      const postMessage = deps.postMessage as ReturnType<typeof vi.fn>;
+      const order = postMessage.mock.calls.map((c) => c[0] as string);
+      expect(order).toEqual(["t1", "t2", "t3"]);
+    });
+
+    it("focused id absent from the flush leaves sibling order intact", () => {
+      const deps = createDeps({ getFocusedTerminalId: () => "t9" });
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("a"), 1);
+      batcher.write("t2", bytes("b"), 1);
+      vi.runAllTimers();
+
+      const postMessage = deps.postMessage as ReturnType<typeof vi.fn>;
+      const order = postMessage.mock.calls.map((c) => c[0] as string);
+      expect(order).toEqual(["t1", "t2"]);
+    });
+
+    it("failure on the focused-first entry reports it plus the remaining siblings in order", () => {
+      const deps = createDeps({ getFocusedTerminalId: () => "t2" });
+      (deps.postMessage as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error("port closed");
+      });
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("one"), 3);
+      batcher.write("t2", bytes("two"), 3);
+      batcher.write("t3", bytes("three"), 5);
+      vi.runAllTimers();
+
+      // t2 (focused) is attempted first and throws; failedBatches carries it
+      // ahead of the still-unprocessed siblings (t1, t3 in insertion order).
+      expect(deps.onError).toHaveBeenCalledWith(expect.any(Error), [
+        { id: "t2", data: bytes("two"), bytes: 3 },
+        { id: "t1", data: bytes("one"), bytes: 3 },
+        { id: "t3", data: bytes("three"), bytes: 5 },
+      ]);
+    });
+
+    it("failure after the focused entry succeeds excludes the already-sent focused batch", () => {
+      const deps = createDeps({ getFocusedTerminalId: () => "t2" });
+      (deps.postMessage as ReturnType<typeof vi.fn>).mockImplementation((id: string) => {
+        if (id === "t1") throw new Error("port closed");
+      });
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("one"), 3);
+      batcher.write("t2", bytes("two"), 3);
+      batcher.write("t3", bytes("three"), 5);
+      vi.runAllTimers();
+
+      // t2 (focused) posts successfully first, then t1 throws — the failed set is
+      // the failing entry plus the still-buffered remainder (t3); t2 is excluded.
+      expect(deps.onError).toHaveBeenCalledWith(expect.any(Error), [
+        { id: "t1", data: bytes("one"), bytes: 3 },
+        { id: "t3", data: bytes("three"), bytes: 5 },
+      ]);
+    });
+  });
+
   describe("per-terminal isolation", () => {
     it("quiet terminal is not stalled by a busy sibling's throughput cadence", () => {
       // Regression for #7652: previously a single class-level mode meant t1 entering

--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -575,6 +575,111 @@ describe("PortQueueManager", () => {
     });
   });
 
+  describe("focused-terminal prioritization (#10878)", () => {
+    function fillBelowPerTerminalWatermark(mgr: PortQueueManager, count: number, bytes: number) {
+      for (let i = 0; i < count; i++) {
+        mgr.addBytes(`t${i}`, bytes);
+      }
+    }
+
+    it("exempts the focused terminal from the aggregate high-watermark pause", () => {
+      const deps = createMockDeps();
+      deps.getFocusedTerminalId = () => "t0";
+      const mgr = new PortQueueManager(deps);
+
+      // 16 × 1MB = aggregate high watermark; every terminal is below its own gate.
+      fillBelowPerTerminalWatermark(mgr, 16, 1024 * 1024);
+      expect(mgr.getTotalQueuedBytes()).toBe(IPC_TOTAL_QUEUE_HIGH_WATERMARK_BYTES);
+
+      // Focused terminal is NOT paused by the aggregate trigger...
+      expect(mgr.applyBackpressure("t0", mgr.getUtilization("t0"))).toBe(false);
+      expect(mgr.isPaused("t0")).toBe(false);
+      // ...while a non-focused sibling in the same window still is.
+      expect(mgr.applyBackpressure("t1", mgr.getUtilization("t1"))).toBe(true);
+      expect(mgr.isPaused("t1")).toBe(true);
+    });
+
+    it("still pauses the focused terminal at its OWN high watermark", () => {
+      const deps = createMockDeps();
+      deps.getFocusedTerminalId = () => "t1";
+      const mgr = new PortQueueManager(deps);
+
+      // Aggregate exemption must never let the focused terminal grow unbounded:
+      // its own per-terminal watermark applies unconditionally.
+      const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+      mgr.addBytes("t1", highWatermark + 1);
+
+      expect(mgr.applyBackpressure("t1", mgr.getUtilization("t1"))).toBe(true);
+      expect(mgr.isPaused("t1")).toBe(true);
+    });
+
+    it("resumes the focused terminal first when the aggregate drains", () => {
+      const deps = createMockDeps();
+      let focused: string | null = null;
+      deps.getFocusedTerminalId = () => focused;
+      const mgr = new PortQueueManager(deps);
+
+      // Everything floods; t0 and t1 both pause on the aggregate while unfocused.
+      fillBelowPerTerminalWatermark(mgr, 16, 1024 * 1024);
+      mgr.applyBackpressure("t0", mgr.getUtilization("t0"));
+      mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+      expect(mgr.isPaused("t0")).toBe(true);
+      expect(mgr.isPaused("t1")).toBe(true);
+
+      // The user focuses t1, then everyone's queue drains. Drain t0/t1's own
+      // bytes to 0 first (aggregate still high, so no resume yet).
+      focused = "t1";
+      mgr.removeBytes("t0", 1024 * 1024);
+      mgr.removeBytes("t1", 1024 * 1024);
+      expect(mgr.isPaused("t0")).toBe(true);
+      expect(mgr.isPaused("t1")).toBe(true);
+
+      // Sibling acks drain the aggregate below the low watermark, triggering the
+      // resume sweep. Capture the order terminals are resumed in via the
+      // "running" status emissions.
+      const emit = deps.emitTerminalStatus as ReturnType<typeof vi.fn>;
+      emit.mockClear();
+      for (let i = 2; i < 10; i++) {
+        mgr.removeBytes(`t${i}`, 1024 * 1024);
+      }
+
+      expect(mgr.isPaused("t0")).toBe(false);
+      expect(mgr.isPaused("t1")).toBe(false);
+      const resumeOrder = emit.mock.calls
+        .filter((c) => c[1] === "running")
+        .map((c) => c[0] as string);
+      expect(resumeOrder).toEqual(["t1", "t0"]);
+    });
+
+    it("sweeps every paused terminal even when the focused id is not paused", () => {
+      const deps = createMockDeps();
+      // Focused terminal has no in-flight bytes of its own, so it never entered
+      // pausedTerminals — the sweep must still resume the paused siblings.
+      deps.getFocusedTerminalId = () => "focused-idle";
+      const mgr = new PortQueueManager(deps);
+
+      fillBelowPerTerminalWatermark(mgr, 16, 1024 * 1024);
+      mgr.applyBackpressure("t0", mgr.getUtilization("t0"));
+      mgr.removeBytes("t0", 1024 * 1024);
+      expect(mgr.isPaused("t0")).toBe(true);
+
+      for (let i = 1; i < 9; i++) {
+        mgr.removeBytes(`t${i}`, 1024 * 1024);
+      }
+      expect(mgr.isPaused("t0")).toBe(false);
+    });
+
+    it("with no focused id the aggregate trigger applies to every terminal", () => {
+      const deps = createMockDeps();
+      // getFocusedTerminalId omitted → behaves exactly as before.
+      const mgr = new PortQueueManager(deps);
+
+      fillBelowPerTerminalWatermark(mgr, 16, 1024 * 1024);
+      expect(mgr.applyBackpressure("t0", mgr.getUtilization("t0"))).toBe(true);
+      expect(mgr.isPaused("t0")).toBe(true);
+    });
+  });
+
   describe("constants alignment — Claude burst headroom", () => {
     it("max queue is 3MB to absorb low-single-digit-MB bursts", () => {
       expect(IPC_MAX_QUEUE_BYTES).toBe(3 * 1024 * 1024);

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -62,6 +62,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     pauseCoordinators: new Map(),
     rendererConnections: new Map(),
     windowProjectMap: new Map(),
+    windowFocusedTerminalMap: new Map(),
     ipcDataMirrorTerminals: new Set(),
     visualBuffers: [],
     visualSignalView: null,

--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -25,6 +25,7 @@ function makeCtx(stateRef: {
     pauseCoordinators: new Map(),
     rendererConnections: new Map(),
     windowProjectMap: new Map(),
+    windowFocusedTerminalMap: new Map(),
     ipcDataMirrorTerminals: new Set(),
     // Mirror the production wiring: getter/setter pairs read & write the
     // outer module-level state. Handlers must see the *current* value, not

--- a/electron/pty-host/handlers/__tests__/diagnostics.test.ts
+++ b/electron/pty-host/handlers/__tests__/diagnostics.test.ts
@@ -52,6 +52,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     pauseCoordinators: new Map(),
     rendererConnections: new Map(),
     windowProjectMap: new Map(),
+    windowFocusedTerminalMap: new Map(),
     ipcDataMirrorTerminals: new Set(),
     visualBuffers: [],
     visualSignalView: null,

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -77,6 +77,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     pauseCoordinators: new Map(),
     rendererConnections: new Map(),
     windowProjectMap: new Map(),
+    windowFocusedTerminalMap: new Map(),
     ipcDataMirrorTerminals: new Set(),
     visualBuffers: [],
     visualSignalView: null,

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -80,6 +80,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     pauseCoordinators: new Map(),
     rendererConnections: new Map(),
     windowProjectMap: new Map(),
+    windowFocusedTerminalMap: new Map(),
     ipcDataMirrorTerminals: new Set(),
     visualBuffers: [],
     visualSignalView: null,

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -21,6 +21,7 @@ function createCtx(overrides: Partial<HostContext> = {}): HostContext {
     pauseCoordinators: new Map(),
     rendererConnections: new Map(),
     windowProjectMap: new Map(),
+    windowFocusedTerminalMap: new Map(),
     ipcDataMirrorTerminals: new Set(),
     visualBuffers: [],
     visualSignalView: null,

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -13,6 +13,7 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
     ptyManager,
     rendererConnections,
     windowProjectMap,
+    windowFocusedTerminalMap,
     disconnectWindow,
     recomputeActivityTiers,
     createPortQueueManager,
@@ -56,6 +57,7 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
       const perWindowQueueManager = createPortQueueManager(windowId);
       const perWindowBatcher = new PortBatcher({
         portQueueManager: perWindowQueueManager,
+        getFocusedTerminalId: () => windowFocusedTerminalMap.get(windowId) ?? null,
         postMessage: (id, data, bytes) => {
           // Structured-clone the chunk — no transfer list. This port is
           // Electron's utility-process MessagePortMain, whose postMessage
@@ -139,6 +141,14 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
         batcher: perWindowBatcher,
       });
       console.log(`[PtyHost] MessagePort listener installed for window ${windowId}`);
+    },
+
+    "set-focused-terminal": (msg) => {
+      // Per-window focused terminal id from the renderer. Read by this window's
+      // PortQueueManager (aggregate-pause exemption + resume-first) and
+      // PortBatcher (flush-first). Keyed by windowId — never global — so each
+      // WebContentsView/project view keeps its own focus.
+      windowFocusedTerminalMap.set(msg.windowId, msg.id);
     },
 
     "disconnect-port": (msg) => {

--- a/electron/pty-host/handlers/types.ts
+++ b/electron/pty-host/handlers/types.ts
@@ -35,6 +35,13 @@ export interface HostContext {
   pauseCoordinators: Map<string, PtyPauseCoordinator>;
   rendererConnections: Map<number, RendererConnection>;
   windowProjectMap: Map<number, string | null>;
+  /**
+   * Per-window UI-focused terminal id, pushed from the renderer's
+   * `focusedId` (terminalFocusSlice). Read by each window's PortQueueManager
+   * and PortBatcher to prioritize the focused terminal under backpressure and
+   * batching. `null` (or absent) means no terminal is focused in that window.
+   */
+  windowFocusedTerminalMap: Map<number, string | null>;
   ipcDataMirrorTerminals: Set<string>;
 
   // Reassignable — backed by getter/setter pairs in the construction site

--- a/electron/pty-host/portBatcher.ts
+++ b/electron/pty-host/portBatcher.ts
@@ -21,6 +21,13 @@ export interface PortBatcherDeps {
   portQueueManager: PortQueueManager;
   postMessage: (id: string, data: Uint8Array, bytes: number) => void;
   onError: (error: unknown, failedBatches: PortBatcherFailedBatch[]) => void;
+  /**
+   * The UI-focused terminal id for this window, or null when none is focused.
+   * When set and present in a flush, its pending entry is posted first so the
+   * pane the user is watching lands ahead of noisy siblings. Optional: when
+   * absent flush() uses plain Map insertion order (prior behaviour).
+   */
+  getFocusedTerminalId?: () => string | null;
 }
 
 interface PendingTerminal {
@@ -141,33 +148,56 @@ export class PortBatcher {
       this.cancelEntryTimers(entry);
     }
 
+    // Service the focused terminal's pending entry first so the pane the user
+    // is watching lands ahead of noisy siblings. This is a pure iteration-order
+    // change: each entry is still deleted from `snapshot` before it's processed
+    // (so the catch block builds failedBatches from the failed entry plus only
+    // the still-unprocessed remainder), and mergeChunks / the owned zero-copy
+    // predicate are untouched (#8367).
+    const focusedId = this.deps.getFocusedTerminalId?.() ?? null;
+    if (focusedId !== null && snapshot.has(focusedId)) {
+      if (!this.flushEntry(focusedId, snapshot)) return;
+    }
+
     // Iterate the detached snapshot directly (no intermediate entries array on
     // the happy path); delete each entry as it's consumed so the catch block can
     // build failedBatches from the failed entry plus whatever remains.
-    for (const [id, { chunks, bytes, owned }] of snapshot) {
-      snapshot.delete(id);
-      let data: Uint8Array = new Uint8Array(0);
-      try {
-        data = mergeChunks(chunks, bytes, owned);
-        this.deps.postMessage(id, data, bytes);
-        this.deps.portQueueManager.addBytes(id, bytes);
-        this.deps.portQueueManager.applyBackpressure(
-          id,
-          this.deps.portQueueManager.getUtilization(id)
-        );
-      } catch (error) {
-        const failedBatches: PortBatcherFailedBatch[] = [{ id, data, bytes }];
-        for (const [failedId, pending] of snapshot) {
-          failedBatches.push({
-            id: failedId,
-            data: mergeChunks(pending.chunks, pending.bytes, pending.owned),
-            bytes: pending.bytes,
-          });
-        }
-        this.deps.onError(error, failedBatches);
-        return;
-      }
+    for (const id of snapshot.keys()) {
+      if (!this.flushEntry(id, snapshot)) return;
     }
+  }
+
+  // Process one pending entry out of `snapshot`: delete it, merge/post/account.
+  // Returns false when postMessage/merge threw and onError was invoked (the
+  // caller must stop draining), true otherwise. Deleting before processing keeps
+  // the failedBatches set (failed entry + whatever still remains in `snapshot`)
+  // correct regardless of the order entries are serviced in.
+  private flushEntry(id: string, snapshot: Map<string, PendingTerminal>): boolean {
+    const entry = snapshot.get(id);
+    if (!entry) return true;
+    snapshot.delete(id);
+    let data: Uint8Array = new Uint8Array(0);
+    try {
+      data = mergeChunks(entry.chunks, entry.bytes, entry.owned);
+      this.deps.postMessage(id, data, entry.bytes);
+      this.deps.portQueueManager.addBytes(id, entry.bytes);
+      this.deps.portQueueManager.applyBackpressure(
+        id,
+        this.deps.portQueueManager.getUtilization(id)
+      );
+    } catch (error) {
+      const failedBatches: PortBatcherFailedBatch[] = [{ id, data, bytes: entry.bytes }];
+      for (const [failedId, pending] of snapshot) {
+        failedBatches.push({
+          id: failedId,
+          data: mergeChunks(pending.chunks, pending.bytes, pending.owned),
+          bytes: pending.bytes,
+        });
+      }
+      this.deps.onError(error, failedBatches);
+      return false;
+    }
+    return true;
   }
 
   flushTerminal(id: string): void {

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -28,6 +28,14 @@ export interface PortQueueDeps {
   ) => void;
   emitReliabilityMetric: (payload: TerminalReliabilityMetricPayload) => void;
   pauseToken?: PauseToken;
+  /**
+   * The UI-focused terminal id for this window, or null when none is focused.
+   * The focused terminal is exempt from the aggregate (window-level) pause
+   * trigger — its own per-terminal watermark still applies unconditionally —
+   * and is resumed first when the aggregate drains. Optional: when absent the
+   * manager behaves exactly as before (no terminal is treated as focused).
+   */
+  getFocusedTerminalId?: () => string | null;
 }
 
 export class PortQueueManager {
@@ -76,7 +84,18 @@ export class PortQueueManager {
       previousTotal >= IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES &&
       this.totalQueuedBytes < IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES
     ) {
+      // Resume the focused terminal first so the pane the user is watching
+      // recovers ahead of its siblings. tryResume reads only totalQueuedBytes
+      // and per-terminal bytes (neither mutated by a resume), so visiting the
+      // focused id first is order-independent for correctness — it only changes
+      // which coordinator.resume() fires first. Every other paused terminal is
+      // still swept, so no producer is starved (#7030).
+      const focusedId = this.deps.getFocusedTerminalId?.() ?? null;
+      if (focusedId !== null && this.pausedTerminals.has(focusedId)) {
+        this.tryResume(focusedId);
+      }
       for (const pausedId of [...this.pausedTerminals.keys()]) {
+        if (pausedId === focusedId) continue;
         this.tryResume(pausedId);
       }
     }
@@ -133,8 +152,16 @@ export class PortQueueManager {
     // aggregate trigger pauses the currently producing terminal — under a
     // fleet burst every active producer reaches here within one batch flush.
     const overOwnWatermark = currentBytes >= highWatermarkBytes;
+    // The focused terminal is exempt from the aggregate trigger: it is paused
+    // LAST under a fleet burst, staying live while its siblings absorb the
+    // window-level backpressure. Its OWN watermark still applies (above), so
+    // its queue can never grow unbounded — a runaway focused terminal still
+    // pauses on its own gate and the saturated/data-loss fallback is unchanged.
+    const focusedId = this.deps.getFocusedTerminalId?.() ?? null;
     const overAggregateWatermark =
-      currentBytes > 0 && this.totalQueuedBytes >= IPC_TOTAL_QUEUE_HIGH_WATERMARK_BYTES;
+      currentBytes > 0 &&
+      id !== focusedId &&
+      this.totalQueuedBytes >= IPC_TOTAL_QUEUE_HIGH_WATERMARK_BYTES;
     if ((!overOwnWatermark && !overAggregateWatermark) || this.pausedTerminals.has(id)) {
       return false;
     }

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -199,6 +199,12 @@ export class PtyClient extends EventEmitter {
     { projectId: string | null; projectPath?: string; mode: "active" | "switch" }
   >();
   private shouldResyncProjectContext = false;
+  // Per-window UI-focused terminal id. Cached so it can be replayed to the host
+  // on port reconnect (page reload clears the host's map on port-replace) and on
+  // host restart (#5534) — the renderer only re-sends on an actual focus change,
+  // so without replay a restart would strip focus prioritization until the next
+  // click. `null` means the window has no focused terminal.
+  private windowFocusedTerminals = new Map<number, string | null>();
   private deferInitialPoolWarm = false;
   private hostStartRequested = false;
   private pendingMessagePorts = new Map<number, MessagePortMain>();
@@ -625,6 +631,12 @@ export class PtyClient extends EventEmitter {
           });
         }
       }
+      // Re-send the focused terminal too: the host clears windowFocusedTerminalMap
+      // on port-replace, and the renderer won't re-fire without a focus change.
+      const focusedId = this.windowFocusedTerminals.get(windowId);
+      if (focusedId !== undefined) {
+        this.send({ type: "set-focused-terminal", windowId, id: focusedId });
+      }
     } catch (error) {
       console.error("[PtyClient] Failed to forward MessagePort to Pty Host:", error);
       this.pendingMessagePorts.set(windowId, port);
@@ -635,6 +647,7 @@ export class PtyClient extends EventEmitter {
   disconnectMessagePort(windowId: number): void {
     this.pendingMessagePorts.delete(windowId);
     this.windowProjectContexts.delete(windowId);
+    this.windowFocusedTerminals.delete(windowId);
     this.send({ type: "disconnect-port", windowId });
   }
 
@@ -835,6 +848,17 @@ export class PtyClient extends EventEmitter {
     this.send({ type: "set-activity-tier", id, tier, pollingIntervalMs });
   }
 
+  /**
+   * Report the UI-focused terminal for a window so the host's per-window
+   * PortQueueManager/PortBatcher can prioritize it. Cached per window for replay
+   * on port reconnect and host restart. Fire-and-forget — a dropped send only
+   * loses prioritization until the next focus change or replay.
+   */
+  setFocusedTerminal(windowId: number, id: string | null): void {
+    this.windowFocusedTerminals.set(windowId, id);
+    this.send({ type: "set-focused-terminal", windowId, id });
+  }
+
   setResourceMonitoring(enabled: boolean): void {
     this.resourceMonitoringEnabled = enabled;
     this.send({ type: "set-resource-monitoring", enabled });
@@ -892,6 +916,14 @@ export class PtyClient extends EventEmitter {
           ...(ctx.projectPath ? { projectPath: ctx.projectPath } : {}),
         });
       }
+    }
+
+    // Replay per-window focused terminals on host restart. Windows with a
+    // pending port replay via connectMessagePort instead, so skip them here to
+    // avoid a duplicate send.
+    for (const [windowId, focusedId] of this.windowFocusedTerminals) {
+      if (skipWindowIds?.has(windowId)) continue;
+      this.send({ type: "set-focused-terminal", windowId, id: focusedId });
     }
   }
 
@@ -1307,6 +1339,7 @@ export class PtyClient extends EventEmitter {
     this.pendingSpawns.clear();
     this.pendingKillCount.clear();
     this.windowProjectContexts.clear();
+    this.windowFocusedTerminals.clear();
     this.ipcDataMirrorIds.clear();
     this.terminalPids.clear();
     this.removeAllListeners();

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -246,6 +246,8 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     trash(id: string): Promise<void>;
     restore(id: string): Promise<boolean>;
     setActivityTier(id: string, tier: PtyHostActivityTier, pollingIntervalMs?: number): void;
+    /** Report the UI-focused terminal (or null) so the pty-host can prioritize it under backpressure/batching. */
+    setFocused(id: string | null): void;
     acknowledgeData(id: string, length: number): void;
     getForProject(projectId: string): Promise<BackendTerminalInfo[]>;
     getAvailableTerminals(): Promise<BackendTerminalInfo[]>;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -163,6 +163,7 @@ export type PtyHostRequest =
       /** Filesystem path of the project; used to warm the PTY pool at the project root. */
       projectPath?: string;
     }
+  | { type: "set-focused-terminal"; windowId: number; id: string | null }
   | { type: "disconnect-port"; windowId: number }
   | { type: "kill-by-project"; projectId: string; requestId: string }
   | { type: "get-project-stats"; projectId: string; requestId: string }

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -440,6 +440,15 @@ export const terminalClient = {
   },
 
   /**
+   * Report the UI-focused terminal (or null) to the backend so the pty-host
+   * can prioritize it in per-window backpressure and output batching. A soft
+   * hint — fire-and-forget, deduped upstream by the focus subscription.
+   */
+  setFocusedTerminal: (id: string | null): void => {
+    window.electron.terminal.setFocused(id);
+  },
+
+  /**
    * Acknowledge processed data bytes to the backend (Flow Control — IPC path).
    */
   acknowledgeData: (id: string, length: number): void => {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -13,6 +13,7 @@ vi.mock("@/clients", () => ({
     onExit: vi.fn(),
     onAgentStateChanged: vi.fn(),
     onBroadcastResult: vi.fn().mockReturnValue(() => {}),
+    setFocusedTerminal: vi.fn(),
   },
   appClient: {
     setState: vi.fn().mockResolvedValue(undefined),

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -33,6 +33,7 @@ import { setActiveContextAccessors } from "@/lib/notify";
 import { debounce } from "@/utils/debounce";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { isPtyPanel } from "@shared/types/panel";
+import { terminalClient } from "@/clients";
 
 // Thunk form: read the live mruList at fire time, not at schedule time. A
 // snapshot captured at schedule time could be stale by the time the debounce
@@ -162,6 +163,29 @@ export function initStoreOrchestrator(): () => void {
           if (panel.hasPty === false) return;
           usePanelStore.getState().recordMru(`terminal:${focusedId}`);
           debouncedPersistMruList();
+        }
+      )
+    )
+  );
+
+  // 1d. Focused-terminal signal to pty-host: report which terminal is focused
+  //     so the backend can prioritize it in per-window backpressure and output
+  //     batching (#10878). Only a PTY panel with a live PTY qualifies; focusing
+  //     a browser/dev-preview/review panel, or clearing focus, sends null so the
+  //     host stops prioritizing. Fire-and-forget; Zustand dedupes no-op fires.
+  disposables.add(
+    toDisposable(
+      usePanelStore.subscribe(
+        (state) => state.focusedId,
+        (focusedId) => {
+          let terminalId: string | null = null;
+          if (focusedId) {
+            const panel = usePanelStore.getState().panelsById[focusedId];
+            if (panel && isPtyPanel(panel) && panel.hasPty !== false) {
+              terminalId = focusedId;
+            }
+          }
+          terminalClient.setFocusedTerminal(terminalId);
         }
       )
     )


### PR DESCRIPTION
## Summary
- `pty-host`'s `PortQueueManager` and `PortBatcher` treated every terminal identically, so the aggregate watermark could pause the focused terminal even when it had queued almost nothing, and `PortBatcher.flush()` drained pending chunks in plain map insertion order, so a busy sibling terminal could delay the focused terminal's own scroll and typing echo during multi-agent bursts.
- Adds a real per-window focused-terminal-id signal, wired from the renderer's `terminalFocusSlice` through a new `terminal:set-focused-id` IPC channel to `pty-host`, following the existing `terminal:set-activity-tier` wiring pattern.
- `PortQueueManager.applyBackpressure` now exempts the focused terminal from the aggregate watermark pause (its own per-terminal watermark still applies, so it stays bounded), resume treats the focused terminal's watermark independently of aggregate pressure, and non-focused resume is computed excluding the focused terminal's queued bytes. `PortBatcher.flush()` now services the focused terminal's pending chunk entry first when one exists, without reordering chunks within any single terminal's entry.

Resolves #10878

## Changes
- `electron/pty-host/portQueue.ts`, `electron/pty-host/portBatcher.ts`: focus-aware backpressure exemption, resume ordering, and flush prioritization
- `electron/pty-host/handlers/connection.ts`, `electron/ipc/handlers/terminal/io.ts`, `electron/ipc/channels.ts`, `electron/preload.cts`: new `terminal:set-focused-id` IPC channel and handler
- `electron/services/PtyClient.ts`, `src/clients/terminalClient.ts`, `src/store/rendererStoreOrchestrator.ts`: keep pty-host's focused id in sync with `terminalFocusSlice` on every focus change
- `shared/types/pty-host.ts`, `shared/types/ipc/api.ts`: types for the new signal
- New unit tests in `electron/pty-host/__tests__/portBatcher.test.ts` and `electron/pty-host/__tests__/portQueue.test.ts` covering the prioritization logic

## Testing
- New unit tests cover the focused-terminal exemption in `applyBackpressure`, the independent resume path, and `PortBatcher.flush()`'s prioritized draining
- Existing `pty-host` handler test suites (`backpressure`, `connection`, `diagnostics`, `dispatcher`, `lifecycle`, `terminalInfo`) updated for the new wiring and passing