### PR TITLE
perf(terminal): cut wheel-to-frame latency for mouse-reporting TUIs

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -100,6 +100,17 @@ import {
 // turn-outcome classification still sees the tail in order.
 const AGENT_OUTPUT_FLUSH_INTERVAL_MS = 50;
 
+// Floor between agent-output content comparisons (noteAgentOutputActivity).
+// Each comparison costs two full viewport extractions from the headless mirror
+// plus a char diff, and it runs exactly while an agent is waiting/idle — i.e.
+// while the user may be wheel-scrolling a mouse-reporting TUI whose every
+// redraw chunk lands here. The temperature model needs a sustained-activity
+// signal, not per-chunk granularity, so redraw-rate extraction is pure waste.
+// A trailing timer preserves the final comparison of a burst; the persistent
+// `agentOutputContentSnapshot` baseline makes the skipped chunks' delta
+// accumulate into it rather than being lost.
+const AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS = 50;
+
 type CursorBufferLine = {
   translateToString: (trimRight?: boolean) => string;
   getCell?: (index: number, cell?: IBufferCell) => IBufferCell | undefined;
@@ -170,6 +181,10 @@ export class TerminalProcess {
   private sessionSnapshotter!: SessionSnapshotter;
   private readonly agentOutputTemperature = new AgentActivityTemperature();
   private agentOutputContentSnapshot: VisibleContentSnapshot | undefined;
+  // -Infinity so the first comparison is never throttled regardless of where
+  // the clock starts (fake test clocks sit at 0).
+  private lastAgentOutputNoteAt = Number.NEGATIVE_INFINITY;
+  private agentOutputNoteTimer: NodeJS.Timeout | null = null;
 
   private pendingAgentOutput = "";
   private pendingAgentOutputAgentId: string | null = null;
@@ -671,6 +686,10 @@ export class TerminalProcess {
     this.identityWatcher.stop();
     this.semanticBufferManager.flush();
     this.flushAgentOutput();
+    if (this.agentOutputNoteTimer) {
+      clearTimeout(this.agentOutputNoteTimer);
+      this.agentOutputNoteTimer = null;
+    }
 
     if (this.ptyDataDisposable) {
       try {
@@ -1633,6 +1652,23 @@ export class TerminalProcess {
       return;
     }
 
+    // Throttle: viewport extraction + diff at most once per interval. Skipped
+    // chunks aren't lost — the trailing timer re-enters with no beforeSnapshot,
+    // so the diff falls back to the stored baseline and covers everything since
+    // the last accepted comparison.
+    const now = Date.now();
+    const sinceLastNote = now - this.lastAgentOutputNoteAt;
+    if (sinceLastNote < AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS) {
+      if (!this.agentOutputNoteTimer) {
+        this.agentOutputNoteTimer = setTimeout(() => {
+          this.agentOutputNoteTimer = null;
+          this.noteAgentOutputActivity(undefined);
+        }, AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS - sinceLastNote);
+      }
+      return;
+    }
+    this.lastAgentOutputNoteAt = now;
+
     const afterSnapshot = this.getAgentOutputContentSnapshot();
     if (afterSnapshot === undefined) {
       return;
@@ -1795,15 +1831,38 @@ export class TerminalProcess {
   private _runPtyPipeline(data: string): void {
     const terminal = this.terminalInfo;
 
+    // OSC 10/11 color queries are answered whenever the terminal is agent-owned
+    // (spawn-time agent panel OR runtime-promoted plain terminal). The
+    // call-site gate and quick-test heuristic stay here; the responder logic
+    // lives in OscResponder. See OscResponder.ts for the strip-on-success
+    // contract that keeps the renderer's xterm.js from double-responding.
+    // This is the ONLY stage that must precede the forward — it derives the
+    // renderer-bound copy.
+    let rendererData = data;
+    if (this.shouldHandleOscColorQueries && data.includes("\x1b]1")) {
+      rendererData = handleOscColorQueries(data, (response) => {
+        terminal.ptyProcess.write(response);
+      });
+    }
+
+    // Forward to the renderer before the analysis stages below: they are
+    // bookkeeping the user never sees, and on the batcher's synchronous
+    // threshold-flush path every pre-forward millisecond is a millisecond
+    // added to the visible frame's latency.
+    this.emitData(rendererData);
+
     // noteAgentOutputActivity only acts on waiting/idle/completed — skip the
     // full-viewport extraction in other states (it would be computed and
-    // discarded on every chunk during "working", the heaviest output phase).
-    // If the state flips before the async write callback, the
-    // `beforeSnapshot ?? this.agentOutputContentSnapshot` fallback covers it.
+    // discarded on every chunk during "working", the heaviest output phase)
+    // and while the note throttle window is closed (the extraction would be
+    // discarded by the throttle's early return). If the state flips before
+    // the async write callback, the `beforeSnapshot ??
+    // this.agentOutputContentSnapshot` fallback covers it.
     const agentState = terminal.agentState;
     const beforeContentSnapshot =
       this.isAgentLive &&
-      (agentState === "waiting" || agentState === "idle" || agentState === "completed")
+      (agentState === "waiting" || agentState === "idle" || agentState === "completed") &&
+      Date.now() - this.lastAgentOutputNoteAt >= AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS
         ? this.getAgentOutputContentSnapshot()
         : undefined;
 
@@ -1817,18 +1876,6 @@ export class TerminalProcess {
     // both would double-respond and corrupt TUI parsers), so skip.
     if (!this.isAgentLive && (data.includes("\x1b[6n") || data.includes("\x1b[5n"))) {
       this.ensureHeadlessResponder();
-    }
-
-    // OSC 10/11 color queries are answered whenever the terminal is agent-owned
-    // (spawn-time agent panel OR runtime-promoted plain terminal). The
-    // call-site gate and quick-test heuristic stay here; the responder logic
-    // lives in OscResponder. See OscResponder.ts for the strip-on-success
-    // contract that keeps the renderer's xterm.js from double-responding.
-    let rendererData = data;
-    if (this.shouldHandleOscColorQueries && data.includes("\x1b]1")) {
-      rendererData = handleOscColorQueries(data, (response) => {
-        terminal.ptyProcess.write(response);
-      });
     }
 
     if (terminal.headlessTerminal) {
@@ -1845,7 +1892,6 @@ export class TerminalProcess {
     }
     this.sessionSnapshotter.schedule();
 
-    this.emitData(rendererData);
     this.forensicsBuffer.capture(data);
     this.identityWatcher.observeOutput(data);
     this.semanticBufferManager.onData(data);

--- a/electron/services/pty/__tests__/TerminalProcess.outputPipeline.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.outputPipeline.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+let ptyOnDataCallback: ((data: string) => void) | null = null;
+
+function createMockPty(): IPty {
+  const pty: Partial<IPty> = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: (cb: (data: string) => void) => {
+      ptyOnDataCallback = cb;
+      return { dispose: () => {} };
+    },
+    onExit: () => ({ dispose: () => {} }),
+  };
+  const withDestroy = pty as Partial<IPty> & { destroy: () => void };
+  withDestroy.destroy = vi.fn();
+  return pty as IPty;
+}
+
+function defaultSpawnContext(): SpawnContext {
+  return {
+    shell: "/bin/zsh",
+    args: ["-l"],
+    env: {},
+  };
+}
+
+type TerminalProcessOptions = ConstructorParameters<typeof TerminalProcess>[1];
+type TerminalProcessCallbacks = ConstructorParameters<typeof TerminalProcess>[2];
+type TerminalProcessDeps = ConstructorParameters<typeof TerminalProcess>[3];
+
+function createTerminal(
+  options?: Partial<TerminalProcessOptions>,
+  callbacks?: Partial<TerminalProcessCallbacks>,
+  agentStateService?: Partial<TerminalProcessDeps["agentStateService"]>
+): TerminalProcess {
+  return new TerminalProcess(
+    "t1",
+    {
+      cwd: process.cwd(),
+      cols: 80,
+      rows: 24,
+      kind: "terminal" as const,
+      ...options,
+    },
+    { emitData: () => {}, onExit: () => {}, ...callbacks },
+    {
+      agentStateService: {
+        handleActivityState: () => {},
+        updateAgentState: () => {},
+        emitAgentKilled: () => {},
+        ...agentStateService,
+      } as unknown as TerminalProcessDeps["agentStateService"],
+      ptyPool: null,
+      processTreeCache: null,
+    },
+    defaultSpawnContext(),
+    createMockPty()
+  );
+}
+
+// Reach the private surface the pipeline tests observe. Runtime-only access —
+// the properties exist on the instance/prototype regardless of visibility.
+type PipelineInternals = {
+  terminalInfo: {
+    agentState?: string;
+    headlessTerminal?: { write: (data: string, cb?: () => void) => void };
+  };
+  getAgentOutputContentSnapshot: () => unknown;
+};
+
+describe("TerminalProcess output pipeline ordering and throttling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    ptyOnDataCallback = null;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  it("forwards a chunk to the renderer before the analysis stages run", () => {
+    // The forward-before-analysis contract: emitData must reach the renderer
+    // callback ahead of the headless mirror parse enqueue for the same chunk —
+    // analysis cost is bookkeeping and must not sit in front of the visible
+    // frame (scroll-driven TUI redraws are latency-sensitive).
+    const order: string[] = [];
+    const terminal = createTerminal(undefined, {
+      emitData: () => {
+        order.push("emit");
+      },
+    });
+    const internals = terminal as unknown as PipelineInternals;
+    const headless = internals.terminalInfo.headlessTerminal;
+    expect(headless).toBeDefined();
+    const originalWrite = headless!.write.bind(headless);
+    headless!.write = (data: string, cb?: () => void) => {
+      order.push("headless");
+      originalWrite(data, cb);
+    };
+
+    ptyOnDataCallback!("frame bytes");
+
+    expect(order).toEqual(["emit", "headless"]);
+    terminal.dispose();
+  });
+
+  it("throttles agent-output content comparisons under a redraw-rate chunk stream", async () => {
+    // While an agent is waiting/idle (exactly when a user wheel-scrolls a
+    // settled TUI), every redraw chunk used to pay two full viewport
+    // extractions plus a diff. The throttle bounds that to one comparison per
+    // interval, with a trailing pass so the burst's final state still lands.
+    const terminal = createTerminal({ launchAgentId: "claude" });
+    const internals = terminal as unknown as PipelineInternals;
+    internals.terminalInfo.agentState = "waiting";
+    const snapshotSpy = vi.spyOn(
+      internals as unknown as Record<"getAgentOutputContentSnapshot", () => unknown>,
+      "getAgentOutputContentSnapshot"
+    );
+
+    // A scroll-driven redraw stream: chunks every 5ms for ~40ms — after the
+    // first accepted comparison, the rest land inside one throttle window.
+    for (let i = 0; i < 8; i++) {
+      ptyOnDataCallback!(`\x1b[H\x1b[2Jframe ${i}`);
+      await vi.advanceTimersByTimeAsync(5);
+    }
+    const duringBurst = snapshotSpy.mock.calls.length;
+    // Unthrottled this would be ~16 (a before + after pair per chunk). The
+    // throttle admits the first comparison and defers the rest to the trailing
+    // pass; allow a small margin for interval-boundary crossings mid-burst.
+    expect(duringBurst).toBeLessThanOrEqual(6);
+
+    // The trailing timer (still pending at t≈40ms; it fires at the 50ms window
+    // edge) must deliver the burst's final comparison — strictly more calls.
+    await vi.advanceTimersByTimeAsync(60);
+    expect(snapshotSpy.mock.calls.length).toBeGreaterThan(duringBurst);
+
+    terminal.dispose();
+  });
+
+  it("still promotes a sustained waiting-state stream to busy through the throttle", async () => {
+    // The throttle reduces comparison FREQUENCY; it must not break the
+    // temperature model's promotion semantics (needs ≥4 changed samples over a
+    // 2s dwell at ≥70 heat — trivially satisfied at the throttled ~20/s
+    // cadence, but a regression that starved samples would fail here).
+    const handleActivityState = vi.fn();
+    const terminal = createTerminal({ launchAgentId: "claude" }, undefined, {
+      handleActivityState,
+    } as never);
+    const internals = terminal as unknown as PipelineInternals;
+    internals.terminalInfo.agentState = "waiting";
+
+    // Distinct full-line updates every 100ms for 3s — a real redraw stream.
+    for (let i = 0; i < 30; i++) {
+      ptyOnDataCallback!(`\r\nstatus ${i}: ${"#".repeat(20 + (i % 7))}`);
+      await vi.advanceTimersByTimeAsync(100);
+    }
+
+    expect(handleActivityState).toHaveBeenCalledWith(expect.anything(), "busy", {
+      trigger: "output",
+    });
+    terminal.dispose();
+  });
+
+  it("clears the trailing comparison timer on teardown", async () => {
+    const terminal = createTerminal({ launchAgentId: "claude" });
+    const internals = terminal as unknown as PipelineInternals;
+    internals.terminalInfo.agentState = "waiting";
+    const snapshotSpy = vi.spyOn(
+      internals as unknown as Record<"getAgentOutputContentSnapshot", () => unknown>,
+      "getAgentOutputContentSnapshot"
+    );
+
+    // Two same-window chunks: the second arms the trailing timer.
+    ptyOnDataCallback!("\x1b[H\x1b[2Jframe a");
+    await vi.advanceTimersByTimeAsync(1);
+    ptyOnDataCallback!("\x1b[H\x1b[2Jframe b");
+    await vi.advanceTimersByTimeAsync(1);
+
+    terminal.dispose();
+    const afterDispose = snapshotSpy.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(200);
+    // A live trailing timer would fire another comparison after teardown.
+    expect(snapshotSpy.mock.calls.length).toBe(afterDispose);
+  });
+});

--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -79,6 +79,20 @@ const WHEEL_MAX_PENDING_SCREENFULS = 3;
 // slow continuous scrolling still accumulates. Don't drop below ~80ms.
 const WHEEL_STALE_GAP_MS = 120;
 
+// Chromium already rAF-aligns wheel dispatch (MainThreadEventQueue delivers at
+// most ~one coalesced wheel event per BeginMainFrame, deltas summed — Chrome 60+),
+// so a wheel event that arrives with no drain in flight IS this frame's tick.
+// Waiting for our own requestAnimationFrame on top of that alignment adds a full
+// extra frame (~8ms @120Hz / ~16.7ms @60Hz) to every dispatch. When the last
+// flush is at least this many ms old, flush synchronously on the event instead.
+// The same gap gates the rAF drain, closing both double-dispatch holes: an
+// event stream hotter than a display frame (non-coalesced synthetic floods —
+// tests, exotic input sources) falls back to the paced drain, and the rAF a
+// sync flush arms for its backlog re-arms rather than dispatching a second
+// burst in the same frame's animation phase. Keep below ~8ms so 120Hz frames
+// (~8.3ms apart, with jitter) always clear the gate.
+const WHEEL_MIN_DISPATCH_GAP_MS = 6;
+
 /**
  * Resolve the CSS px-per-line basis from the live rendered cell height, falling
  * back to the font-metric estimate and finally a fixed default. This is the
@@ -369,6 +383,15 @@ export function installTerminalBoundListeners(
   // every line at once.
   let pendingWheelLines = 0;
   let wheelFlushRaf: number | undefined;
+  // Wall-clock of the last dispatch, gating both the synchronous on-event
+  // flush and the rAF drain. -Infinity so a fresh pane's very first event
+  // qualifies regardless of where the clock starts (fake test clocks sit at 0).
+  let lastWheelFlushAt = Number.NEGATIVE_INFINITY;
+  // Non-null only while flushWheelLines is dispatching: the onData handler
+  // diverts each synthetic report here so the whole frame's reports leave as
+  // ONE PTY write (one MessagePort post, one pty-host write, one kernel read
+  // the TUI can coalesce into a single redraw) instead of up to cap-many.
+  let wheelReportBatch: string[] | null = null;
   // Coords of the most recent physical wheel — synthetic reports inherit them so
   // xterm encodes the mouse report at the cursor's actual cell.
   let lastWheelClientX = 0;
@@ -397,27 +420,56 @@ export function installTerminalBoundListeners(
     if (pendingWheelLines > maxPending) pendingWheelLines = maxPending;
     else if (pendingWheelLines < -maxPending) pendingWheelLines = -maxPending;
 
+    // A rAF armed by a synchronous on-event flush fires in the SAME frame's
+    // animation phase (input dispatch precedes rAF callbacks in the frame
+    // lifecycle) — dispatching here too would double the per-frame send rate.
+    // Re-arm for the next frame instead; the backlog is not lost.
+    if (performance.now() - lastWheelFlushAt < WHEEL_MIN_DISPATCH_GAP_MS) {
+      wheelFlushRaf = requestAnimationFrame(flushWheelLines);
+      return;
+    }
+
     const step = pendingWheelLines > 0 ? 1 : -1;
     // Fixed per-frame cap (no `elapsed`/timestamp multiply) so a late frame can
     // never "catch up" by dispatching a larger burst — that would reintroduce
     // the flood under main-thread jank. Device-aware: gentler for trackpads.
     const emit = Math.min(Math.abs(pendingWheelLines), wheelMaxLinesPerFrame);
     pendingWheelLines -= step * emit;
-    for (let i = 0; i < emit; i++) {
-      const synthetic = new WheelEvent("wheel", {
-        deltaY: step,
-        deltaMode: 1 /* DOM_DELTA_LINE — one report each, no partial-scroll carry */,
-        clientX: lastWheelClientX,
-        clientY: lastWheelClientY,
-        bubbles: true,
-        cancelable: true,
-      });
-      amplifiedWheelEvents.add(synthetic);
-      target.dispatchEvent(synthetic);
+    lastWheelFlushAt = performance.now();
+    // Collect the reports xterm's encoder emits for each synthetic event (via
+    // the onData handler below) and write them as one concatenated payload.
+    wheelReportBatch = [];
+    try {
+      for (let i = 0; i < emit; i++) {
+        const synthetic = new WheelEvent("wheel", {
+          deltaY: step,
+          deltaMode: 1 /* DOM_DELTA_LINE — one report each, no partial-scroll carry */,
+          clientX: lastWheelClientX,
+          clientY: lastWheelClientY,
+          bubbles: true,
+          cancelable: true,
+        });
+        amplifiedWheelEvents.add(synthetic);
+        target.dispatchEvent(synthetic);
+      }
+    } finally {
+      const batch = wheelReportBatch;
+      wheelReportBatch = null;
+      if (batch.length > 0) {
+        // Contain a write failure: before batching, a throwing write lost one
+        // report from inside xterm's event path; the batched equivalent must
+        // not also skip the backlog re-arm below, or the drain would stall
+        // until the next physical wheel event.
+        try {
+          writeTerminalInputOrFleet(id, batch.join(""));
+        } catch (err) {
+          logError("Wheel report batch write failed", err);
+        }
+      }
     }
     // Drain the remaining backlog on the next frame so a large gesture keeps
     // moving without dispatching it all in one burst.
-    if (pendingWheelLines !== 0) {
+    if (pendingWheelLines !== 0 && wheelFlushRaf === undefined) {
       wheelFlushRaf = requestAnimationFrame(flushWheelLines);
     }
   };
@@ -506,7 +558,16 @@ export function installTerminalBoundListeners(
     lastWheelClientY = ev.clientY;
 
     if (wheelFlushRaf === undefined) {
-      wheelFlushRaf = requestAnimationFrame(flushWheelLines);
+      // No drain in flight: Chromium's rAF-aligned wheel dispatch means this
+      // event IS the frame tick, so flush now instead of paying one extra frame
+      // of latency waiting for our own rAF. The min-gap guard keeps the
+      // per-frame send cap honest against event streams hotter than a display
+      // frame (which real coalesced input never produces).
+      if (performance.now() - lastWheelFlushAt >= WHEEL_MIN_DISPATCH_GAP_MS) {
+        flushWheelLines();
+      } else {
+        wheelFlushRaf = requestAnimationFrame(flushWheelLines);
+      }
     }
   };
   hostElement.addEventListener("wheel", onWheelNormalize, { capture: true, passive: false });
@@ -753,14 +814,24 @@ export function installTerminalBoundListeners(
 
   const inputDisposable = terminal.onData((data) => {
     if (managed.isInputLocked) return;
-    if (isNonKeyboardInput(data)) {
+    const nonKeyboard = isNonKeyboardInput(data);
+    if (nonKeyboard) {
       if (data === "\x1b") {
         deps.clearDirectingState(id, "escape-key");
       }
     } else {
       deps.onUserInput(id, data);
     }
-    writeTerminalInputOrFleet(id, data);
+    if (wheelReportBatch !== null && nonKeyboard) {
+      // Mid-flush synthetic wheel report: divert into the frame batch (written
+      // once, concatenated, when the dispatch loop ends) instead of a write per
+      // report. Only flushWheelLines' own synchronous dispatch sets the batch;
+      // the nonKeyboard guard keeps anything else xterm might ever emit
+      // synchronously during that dispatch on the ordinary per-write path.
+      wheelReportBatch.push(data);
+    } else {
+      writeTerminalInputOrFleet(id, data);
+    }
     if (managed.onInput) {
       managed.onInput(data);
     }

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -756,6 +756,7 @@ describe("installTerminalBoundListeners", () => {
         managed,
         terminal,
         deps,
+        captured,
         xtermEl,
         dispatch: (init: WheelEventInit, target: HTMLElement = managed.hostElement) => {
           const ev = new WheelEvent("wheel", { bubbles: true, cancelable: true, ...init });
@@ -806,15 +807,96 @@ describe("installTerminalBoundListeners", () => {
       }
     });
 
-    it("dispatches nothing synchronously — reports are paced onto a later frame", () => {
-      // The whole fix: a physical wheel must NOT fan out its lines inline (that
-      // round-trips every line at once and floods the PTY). Before any frame
-      // runs, zero synthetic reports have been sent.
+    it("dispatches a fresh gesture's first burst synchronously (no frame of added latency)", () => {
+      // Chromium rAF-aligns wheel delivery, so the event IS the frame tick:
+      // waiting for our own rAF would add a full frame before the first report.
+      // A single notch (≤ the per-frame cap) lands whole, inline, and the next
+      // frame has nothing left to drain.
       const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
       h.dispatch({ deltaY: 120, deltaMode: 0 });
-      expect(h.getReports()).toBe(0);
+      expect(h.getReports()).toBe(NOTCH_REPORTS); // inline, before any frame
       h.flushFrames();
+      expect(h.getReports()).toBe(NOTCH_REPORTS); // nothing queued behind it
+    });
+
+    it("caps the synchronous burst — a large fling still paces its tail across frames", () => {
+      // The flood guard survives the sync flush: only one frame-cap's worth may
+      // dispatch inline; the rest of the gesture drains on later frames.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      h.dispatch({ deltaY: 1, deltaMode: 2 }); // one screenful (24 lines)
+      const syncBurst = h.getReports();
+      expect(syncBurst).toBeGreaterThan(0);
+      expect(syncBurst).toBeLessThan(24); // capped, not the whole gesture
+      h.flushFrames();
+      expect(h.getReports()).toBe(24); // every line still delivered
+    });
+
+    it("writes a flush's reports as one concatenated PTY payload (not one write per line)", () => {
+      // Each synthetic event produces one mouse report via xterm's encoder
+      // (simulated here by feeding onData per synthetic wheel). The flush must
+      // coalesce the frame's reports into a single write — one MessagePort post,
+      // one pty write, one kernel read the TUI can redraw once for.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      h.xtermEl.addEventListener("wheel", (e) => {
+        const report = (e as WheelEvent).deltaY > 0 ? "\x1b[<65;1;1M" : "\x1b[<64;1;1M";
+        h.captured.onData!(report);
+      });
+      h.dispatch({ deltaY: 120, deltaMode: 0 });
       expect(h.getReports()).toBe(NOTCH_REPORTS);
+      expect(writeTerminalInputOrFleetMock).toHaveBeenCalledTimes(1);
+      expect(writeTerminalInputOrFleetMock).toHaveBeenCalledWith(
+        "t1",
+        "\x1b[<65;1;1M".repeat(NOTCH_REPORTS)
+      );
+    });
+
+    it("re-arms instead of double-dispatching when the rAF lands in the same frame as a sync flush", () => {
+      // The sync flush arms a rAF for its backlog; that callback fires in the
+      // SAME frame's animation phase (input dispatch precedes rAF callbacks).
+      // Dispatching there too would send 2× the per-frame cap — the min-gap
+      // guard must push the drain to the next frame instead.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      const nowSpy = vi.spyOn(performance, "now").mockReturnValue(1000);
+      h.dispatch({ deltaY: 1, deltaMode: 2 }); // screenful: sync burst + backlog
+      const syncBurst = h.getReports();
+      expect(syncBurst).toBeGreaterThan(0);
+      expect(syncBurst).toBeLessThan(24);
+      nowSpy.mockReturnValue(1004); // the armed rAF fires <6ms later — same frame
+      h.flushFrame();
+      expect(h.getReports()).toBe(syncBurst); // guard re-armed, no double burst
+      nowSpy.mockReturnValue(1020); // next real frame
+      h.flushFrame();
+      expect(h.getReports()).toBeGreaterThan(syncBurst); // drain resumed
+      nowSpy.mockRestore();
+    });
+
+    it("suppresses the batch write entirely while input is locked", () => {
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      h.xtermEl.addEventListener("wheel", () => {
+        h.captured.onData!("\x1b[<65;1;1M");
+      });
+      h.managed.isInputLocked = true;
+      h.dispatch({ deltaY: 120, deltaMode: 0 });
+      expect(h.getReports()).toBe(NOTCH_REPORTS); // reports still dispatched…
+      expect(writeTerminalInputOrFleetMock).not.toHaveBeenCalled(); // …never written
+    });
+
+    it("recovers the paced drain when a batch write throws", () => {
+      // A failed write is contained: the error must not skip the backlog
+      // re-arm, or the drain would stall until the next physical wheel event.
+      const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
+      h.xtermEl.addEventListener("wheel", () => {
+        h.captured.onData!("\x1b[<65;1;1M");
+      });
+      writeTerminalInputOrFleetMock.mockImplementationOnce(() => {
+        throw new Error("port gone");
+      });
+      h.dispatch({ deltaY: 1, deltaMode: 2 }); // screenful: burst + queued tail
+      const afterThrow = h.getReports();
+      expect(afterThrow).toBeGreaterThan(0);
+      h.flushFrames();
+      expect(h.getReports()).toBe(24); // full gesture still delivered
+      expect(writeTerminalInputOrFleetMock.mock.calls.length).toBeGreaterThan(1);
     });
 
     it("emits single-line synthetic events in the scroll direction (downward)", () => {
@@ -890,17 +972,18 @@ describe("installTerminalBoundListeners", () => {
     });
 
     it("coalesces several wheel events arriving before a frame into one paced drain", () => {
-      // Many physical events in a single frame (a momentum stream) accumulate
-      // into one backlog and drain at the per-frame cap — not one synchronous
-      // burst per event. Three notches (18 lines) queue with zero sync dispatch,
-      // the first frame stays capped below the total, and all 18 still arrive.
+      // Many physical events in a single frame (a momentum stream) must not each
+      // fan out inline: the gesture's first event may flush synchronously, but
+      // events hotter than a display frame accumulate into one backlog and drain
+      // at the per-frame cap. Three same-tick notches (18 lines) dispatch only
+      // the first burst inline, the next frame stays capped, and all 18 arrive.
       const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
       h.dispatch({ deltaY: 120, deltaMode: 0 });
       h.dispatch({ deltaY: 120, deltaMode: 0 });
       h.dispatch({ deltaY: 120, deltaMode: 0 });
-      expect(h.getReports()).toBe(0); // nothing dispatched synchronously
+      expect(h.getReports()).toBe(NOTCH_REPORTS); // only the fresh gesture's burst
       h.flushFrame();
-      expect(h.getReports()).toBeLessThan(3 * NOTCH_REPORTS); // first frame is capped
+      expect(h.getReports()).toBeLessThan(3 * NOTCH_REPORTS); // next frame is capped
       h.flushFrames();
       expect(h.getReports()).toBe(3 * NOTCH_REPORTS); // every line still delivered
     });
@@ -1033,40 +1116,42 @@ describe("installTerminalBoundListeners", () => {
     });
 
     it("cancels a pending frame on cleanup so a queued drain never dispatches late", () => {
-      // A wheel arrives (arming a frame), then the pane is torn down before the
-      // frame runs. The cancelled frame must not fire stray reports at a
-      // disposed terminal.
+      // A large gesture leaves a backlog behind its sync burst (arming a frame),
+      // then the pane is torn down before the frame runs. The cancelled frame
+      // must not fire stray reports at a disposed terminal.
       const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
-      h.dispatch({ deltaY: 120, deltaMode: 0 });
-      expect(h.getReports()).toBe(0); // still queued, not yet flushed
+      h.dispatch({ deltaY: 1, deltaMode: 2 }); // one screenful — tail stays queued
+      const afterDispatch = h.getReports();
+      expect(afterDispatch).toBeGreaterThan(0);
+      expect(afterDispatch).toBeLessThan(24); // backlog remains behind the burst
       h.runCleanups();
       h.flushFrames();
-      expect(h.getReports()).toBe(0); // queued drain was cancelled
+      expect(h.getReports()).toBe(afterDispatch); // queued drain was cancelled
     });
 
     it("paces a trackpad fling more gently per frame than an equivalent wheel fling", () => {
       // The device-aware send-rate cap: a trackpad's momentum stream (the gesture
-      // that actually floods the PTY round-trip) drains fewer lines per frame than
-      // a physical wheel's discrete detents, even for the same total distance.
+      // that actually floods the PTY round-trip) dispatches fewer lines per burst
+      // than a physical wheel's discrete detents, even for the same total
+      // distance. Measured at the synchronous first burst, where the fresh
+      // classifier verdict picks the cap.
       const wheel = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
       wheel.dispatch({ deltaX: 0, deltaY: 240, deltaMode: 0 }); // integer single-axis → wheel
-      wheel.flushFrame();
-      const wheelFirstFrame = wheel.getReports();
+      const wheelFirstBurst = wheel.getReports();
 
       const trackpad = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
       trackpad.dispatch({ deltaX: 6, deltaY: 240.5, deltaMode: 0 }); // dual-axis fractional → trackpad
-      trackpad.flushFrame();
-      const trackpadFirstFrame = trackpad.getReports();
+      const trackpadFirstBurst = trackpad.getReports();
 
-      expect(trackpadFirstFrame).toBeGreaterThan(0);
-      expect(trackpadFirstFrame).toBeLessThan(wheelFirstFrame);
-      // Pacing changes the per-frame rate, not the total: both devices deliver the
+      expect(trackpadFirstBurst).toBeGreaterThan(0);
+      expect(trackpadFirstBurst).toBeLessThan(wheelFirstBurst);
+      // Pacing changes the per-burst rate, not the total: both devices deliver the
       // same gesture in full (same distance ⇒ same line count), just spread
       // differently across frames.
       wheel.flushFrames();
       trackpad.flushFrames();
       expect(trackpad.getReports()).toBe(wheel.getReports());
-      expect(wheel.getReports()).toBeGreaterThan(wheelFirstFrame);
+      expect(wheel.getReports()).toBeGreaterThan(wheelFirstBurst);
     });
 
     it("re-detects the device after an idle gap (stale wheel history doesn't pin the cap)", () => {
@@ -1075,20 +1160,22 @@ describe("installTerminalBoundListeners", () => {
       // its very first frame — not the leftover physical-wheel verdict. Compared
       // against the same sequence with no gap, where the rolling history still
       // reads as a wheel.
-      function trackpadFirstFrameAfterWheel(gapMs: number): number {
+      function trackpadFirstBurstAfterWheel(gapMs: number): number {
         const h = setupAmplifier({ mouseTrackingMode: "any", isAltBuffer: true });
         // Fill the classifier with a physical-wheel streak and let it drain.
         for (let i = 0; i < 5; i++) h.dispatch({ deltaX: 0, deltaY: 120, deltaMode: 0 });
         h.flushFrames();
         const drained = h.getReports();
         vi.advanceTimersByTime(gapMs);
-        // Now a trackpad fling (dual-axis fractional).
+        // Now a trackpad fling (dual-axis fractional). After a real gap it
+        // flushes synchronously (fresh gesture); with no gap the min-dispatch
+        // guard defers it one frame — measure the first burst either way.
         h.dispatch({ deltaX: 6, deltaY: 240.5, deltaMode: 0 });
-        h.flushFrame();
+        if (h.getReports() === drained) h.flushFrame();
         return h.getReports() - drained;
       }
-      const afterGap = trackpadFirstFrameAfterWheel(1000); // gesture boundary → reset
-      const noGap = trackpadFirstFrameAfterWheel(0); // continuous → wheel history persists
+      const afterGap = trackpadFirstBurstAfterWheel(1000); // gesture boundary → reset
+      const noGap = trackpadFirstBurstAfterWheel(0); // continuous → wheel history persists
       expect(afterGap).toBeLessThan(noGap);
     });
 


### PR DESCRIPTION
Full-screen TUIs that enable mouse tracking (grok, lazygit, btop, and some agent CLIs) handle their own scrolling. Every wheel movement is a full round trip: we send a mouse report to the app, the app redraws, and the frame comes back. This PR makes four changes to cut latency out of that cycle.

## 1. Dispatch wheel reports synchronously

Chromium already aligns wheel events to animation frames, so waiting for our own `requestAnimationFrame` before sending reports added a whole extra frame of latency (roughly 8ms at 120Hz, 16ms at 60Hz) to every scroll step. If a wheel event arrives and no drain is pending, we now flush immediately. A minimum gap guard keeps the per-frame send cap intact, and the rAF drain re-arms instead of double-dispatching when it lands in the same frame as a synchronous flush.

## 2. Batch mouse reports into one write

All the reports generated in a single flush are now concatenated and written to the PTY once, instead of up to 8 separate writes. One MessagePort post, one PTY write, one kernel read the app can coalesce into a single redraw.

## 3. Forward output before analysis

In `pty-host`, each output chunk is now forwarded to the renderer before the analysis stages run (activity monitoring, mirror parsing, snapshot scheduling). Those were all sitting in front of the visible frame.

## 4. Throttle the viewport comparison

The agent-output comparison ran two full viewport extractions per output chunk while an agent sits idle, which is exactly when a user is scrolling a settled TUI. It's now throttled to once per 50ms with a trailing pass, so the final state of a burst is never lost. A regression test confirms a sustained output stream still promotes the agent to busy through the throttle.

## Research

I looked at how other terminals handle this and couldn't find a better approach: kitty, Alacritty and iTerm2 all send comparable report counts. Frame dropping was the other candidate, but frames are incremental updates, so dropping them isn't safe.

## Tests

All 2430 tests in the affected suites pass, with several new regression tests (synchronous first burst, per-frame cap, single-payload batching, throttle semantics). This is complementary to #10886 (focused-terminal backpressure priority) and touches none of the same files.
