### PR TITLE
fix(agent-settings): attribute alt-screen inherit hint to the registry default (#10894)

### DIFF
--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -19,7 +19,7 @@ interface BehavioralControlsProps {
   inlineMode: InlineMode;
   /** Whether the inline "Default" (inherit) option resolves to inline (vs alt screen). */
   inlineInheritResolvesToInline: boolean;
-  /** Where the inline "Default" inherits from — "global setting" or "agent default". */
+  /** Where the inline "Default" inherits from — "global setting", "agent default", or "the agent's built-in default" (a curated registry default that shadows the global switch, #10894). */
   inlineInheritOriginLabel: string;
   customArgsValue: string;
   customArgsPlaceholder: string;

--- a/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
+++ b/src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { DEFAULT_AGENT_SETTINGS, type AgentSettingsEntry } from "@shared/types";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useAgentScope } from "../useAgentScope";
+
+// The alt-screen "Default (inherit)" hint attributes the resolved value to a
+// source. Its correctness depends on the three-tier precedence in
+// `resolveEffectiveInlineMode` (explicit → curated registry `defaultInlineMode`
+// → global switch). These tests exercise the real agent registry so the
+// registry-default tier (Grok) is genuinely present. #10894.
+
+function makeProps(
+  agentId: string,
+  activeEntry: AgentSettingsEntry = {}
+): Parameters<typeof useAgentScope>[0] {
+  return {
+    agentId,
+    activeEntry,
+    ccrPresets: undefined,
+    projectPresets: undefined,
+    editingPresetId: null,
+    setEditingPresetId: () => {},
+    editName: "",
+    setEditName: () => {},
+    lastEditTimeRef: { current: 0 },
+    setIsAddDialogOpen: () => {},
+    setAddDialogAgentId: () => {},
+    updateAgent: async () => {},
+    onSettingsChange: () => {},
+  };
+}
+
+function setGlobalAltScreen(globalUseAltScreen: boolean) {
+  useAgentSettingsStore.setState({
+    settings: { ...DEFAULT_AGENT_SETTINGS, globalUseAltScreen },
+  });
+}
+
+describe("useAgentScope — inline-mode inherit origin label (#10894)", () => {
+  beforeEach(() => {
+    useAgentSettingsStore.setState({ settings: DEFAULT_AGENT_SETTINGS });
+  });
+
+  it("attributes an agent with a curated registry default (Grok) to its built-in default, not the global setting", () => {
+    setGlobalAltScreen(false);
+    const { result } = renderHook(() => useAgentScope(makeProps("grok")));
+
+    expect(result.current.scopeKind).toBe("default");
+    expect(result.current.inlineInheritOriginLabel).toBe("the agent's built-in default");
+    // Grok's registry default is alt-screen (`defaultInlineMode: false`).
+    expect(result.current.inlineInheritResolvesToInline).toBe(false);
+  });
+
+  it("keeps attributing to the built-in default even when the global alt-screen switch is on (the registry default shadows it)", () => {
+    setGlobalAltScreen(true);
+    const { result } = renderHook(() => useAgentScope(makeProps("grok")));
+
+    // Global toggle flipped, but Grok's built-in default still decides —
+    // proving the label is not merely echoing the global switch.
+    expect(result.current.inlineInheritOriginLabel).toBe("the agent's built-in default");
+    expect(result.current.inlineInheritResolvesToInline).toBe(false);
+  });
+
+  it("attributes an agent without a registry default (Codex) to the global setting, and tracks the global switch", () => {
+    setGlobalAltScreen(false);
+    const { result, rerender } = renderHook(() => useAgentScope(makeProps("codex")));
+
+    expect(result.current.scopeKind).toBe("default");
+    expect(result.current.inlineInheritOriginLabel).toBe("global setting");
+    // No registry default → resolves to `!globalUseAltScreen`.
+    expect(result.current.inlineInheritResolvesToInline).toBe(true);
+
+    setGlobalAltScreen(true);
+    rerender();
+    expect(result.current.inlineInheritOriginLabel).toBe("global setting");
+    expect(result.current.inlineInheritResolvesToInline).toBe(false);
+  });
+
+  it("labels a custom preset scope as the agent default regardless of the registry tier", () => {
+    setGlobalAltScreen(false);
+    const entry: AgentSettingsEntry = {
+      customPresets: [{ id: "user-1", name: "My preset" }],
+      presetId: "user-1",
+    };
+    const { result } = renderHook(() => useAgentScope(makeProps("grok", entry)));
+
+    expect(result.current.scopeKind).toBe("custom");
+    expect(result.current.inlineInheritOriginLabel).toBe("agent default");
+  });
+});

--- a/src/components/Settings/AgentScopeEditor/useAgentScope.ts
+++ b/src/components/Settings/AgentScopeEditor/useAgentScope.ts
@@ -125,7 +125,19 @@ export function useAgentScope({
   // What the inline "Default" (inherit) segment resolves to and where from.
   const inlineInheritResolvesToInline =
     scopeKind === "custom" ? agentResolvedInline : resolveInline("inherit");
-  const inlineInheritOriginLabel = scopeKind === "custom" ? "agent default" : "global setting";
+  // Mirror the three-tier precedence in `resolveEffectiveInlineMode`: a preset
+  // inherits from the agent Default scope; the agent Default scope inherits from
+  // the curated registry default (`capabilities.defaultInlineMode`, currently
+  // only Grok) when one exists, and only otherwise from the global switch.
+  // Attributing a registry-shadowed value to the global setting (#10894) is wrong
+  // — the global toggle has no effect while the built-in default decides.
+  const hasRegistryInlineDefault = typeof agentCfg?.capabilities?.defaultInlineMode === "boolean";
+  const inlineInheritOriginLabel =
+    scopeKind === "custom"
+      ? "agent default"
+      : hasRegistryInlineDefault
+        ? "the agent's built-in default"
+        : "global setting";
 
   const effectiveInlineMode =
     scopeKind === "custom"


### PR DESCRIPTION
## Summary
- In agent settings, the alt-screen-mode `Default (inherit)` hint always said "Inherited from global setting", even when a curated per-agent registry default (`capabilities.defaultInlineMode`, currently only set for Grok) actually decided the resolved value and overrode the global toggle entirely. Toggling the global "Use alt-screen mode by default" switch never changed Grok's Default, so blaming the global setting was wrong.
- Fixed by deriving `inlineInheritOriginLabel` in `useAgentScope.ts` from the same three-tier precedence order already used by `resolveEffectiveInlineMode` (explicit override, then registry default, then global setting). When a registry default exists, the hint now attributes the value to "the agent's built-in default" instead of always blaming the global setting.
- Cosmetic UI accuracy fix only. No change to the resolved alt-screen value itself.

Resolves #10894

## Changes
- `src/components/Settings/AgentScopeEditor/useAgentScope.ts`: derive the origin label from the three-tier precedence instead of a binary custom/global check.
- `src/components/Settings/AgentScopeEditor/BehavioralControls.tsx`: updated prop comment to match.
- `src/components/Settings/AgentScopeEditor/__tests__/useAgentScope.test.tsx` (new): covers the hook's origin-label logic across all three tiers.

## Testing
- Added unit tests for `useAgentScope`'s origin-label derivation (explicit override, registry default, global setting cases).