### PR TITLE
fix(grid): make the scrollbar gutter conditional on scroll mode

### DIFF
--- a/src/components/Terminal/ContentGridDefault.tsx
+++ b/src/components/Terminal/ContentGridDefault.tsx
@@ -116,17 +116,27 @@ export function ContentGridDefault({
                   // Stop xterm scrollback / overflow strip-of-history from
                   // chaining into the outer chrome via overscroll bounces.
                   overscrollBehavior: "contain",
-                  // Reserve a real gutter on the right for the custom
-                  // GridScrollbar so panels never sit under the handle. The
-                  // native scrollbar is hidden in CSS; this is the only gutter.
-                  // Reserved unconditionally (not gated on `isScrollMode`):
-                  // toggling this padding mutated the content-box of the exact
-                  // `#panel-grid` div the ResizeObserver measures, so entering
-                  // scroll mode shrank the measured width, which could flip the
-                  // mode back — the self-referential oscillation in #10871.
-                  // GridScrollbar renders nothing when content doesn't overflow,
-                  // so in non-scroll mode this is just an inert blank strip.
-                  paddingRight: GRID_SCROLLBAR_GUTTER_PX,
+                  // Reserve a real gutter on the right, only in scroll mode, so
+                  // the custom overlay GridScrollbar never sits over panel
+                  // content. Non-scroll mode keeps the symmetric `p-1` (4px) and
+                  // reclaims the 22px — an always-on gutter wastes a strip the
+                  // width of a mini-column when no bar is shown.
+                  //
+                  // This does NOT re-open the #10871 oscillation. That loop ran
+                  // through the ResizeObserver reading `entry.contentRect`
+                  // (content-box, padding-EXCLUSIVE), so toggling this padding
+                  // shrank the measured width and fed back into the col/row math.
+                  // Two shipped guards make the toggle inert now: (1) all three
+                  // measurement paths read `clientWidth`/`clientHeight` — the
+                  // padding-box (content + padding), and `#panel-grid` hides its
+                  // native scrollbar in CSS (zero width) — so toggling this
+                  // padding only reallocates content↔padding inside a fixed box
+                  // and leaves the measured dimensions untouched — no feedback;
+                  // (2) the scroll-mode boundary itself is a Schmitt trigger
+                  // (`gridRowsOverflowWithHysteresis`), so a resize through the
+                  // threshold flips at most once per direction. Keep both before
+                  // re-narrowing this gutter.
+                  paddingRight: ctx.isScrollMode ? GRID_SCROLLBAR_GUTTER_PX : undefined,
                 }}
                 id="panel-grid"
                 data-grid-container="true"

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -582,11 +582,15 @@ export function useContentGridContext({
         if (entry) {
           // Read the same `clientWidth`/`clientHeight` (content-box + padding)
           // the initial-mount and post-unlock paths use, rather than
-          // `entry.contentRect` (content-box, excludes padding). The gutter
-          // padding is now constant, but the three paths must still agree on
-          // box model so a re-subscription never jumps the measured size — the
-          // downstream `maxFeasibleCols`/`gridRowsOverflow` math subtracts
-          // `GRID_PADDING_PX` and expects the padding-inclusive dimension.
+          // `entry.contentRect` (content-box, excludes padding). The scroll
+          // gutter toggles with scroll mode, but because this measurement is
+          // padding-inclusive (and `#panel-grid` hides its native scrollbar in
+          // CSS), that toggle doesn't move the measured size — it's what lets
+          // the gutter be conditional without re-opening #10871's feedback. The
+          // three paths must still agree on box model so a re-subscription never
+          // jumps the measured size — the downstream
+          // `maxFeasibleCols`/`gridRowsOverflow` math subtracts `GRID_PADDING_PX`
+          // and expects the padding-inclusive dimension.
           const width = container.clientWidth;
           const height = container.clientHeight;
           setGridWidth((prev) => (prev === width ? prev : width));


### PR DESCRIPTION
## Summary
After #10872 fixed the scroll-mode flicker (#10871), the terminal grid reserved the 22px scrollbar gutter at all times. That's a waste of space when nothing is scrolling. With only 3 panels on a big screen, there's a permanent blank strip down the right side. This PR makes the gutter conditional on scroll mode again.

## Why this doesn't reintroduce the flicker
The feedback loop in #10871 went through the ResizeObserver reading `entry.contentRect`, which excludes padding, so toggling the gutter changed the measured width and fed back into the layout math. All measurement paths now read `clientWidth`/`clientHeight`, which include padding, and the native scrollbar on `#panel-grid` is hidden in CSS. Toggling the padding just reallocates space inside a fixed box, so the measured size never moves. The scroll-mode boundary also has hysteresis (`gridRowsOverflowWithHysteresis`) as a second guard, so even if something did nudge the measurement, it can't oscillate.

The unconditional gutter was belt-and-suspenders on top of those two fixes. With both in place it only costs 22px for nothing.

## Changes
- `ContentGridDefault.tsx`: `paddingRight` on `#panel-grid` is now `ctx.isScrollMode ? GRID_SCROLLBAR_GUTTER_PX : undefined`, with a comment documenting which guards make the toggle safe.
- `useContentGridContext.tsx`: fixed the now-stale "gutter padding is now constant" comment on the ResizeObserver callback.

## Testing
Typecheck, lint, format, and the existing grid unit tests (72 passing, including the `gridRowsOverflowWithHysteresis` suite from #10872) all pass. A second-opinion review verified the padding-invariance reasoning end to end and found no remaining feedback edge, no column/scroll-mode coupling, and confirmed the Tailwind `p-1` still supplies the 4px right padding in non-scroll mode.

## Notes
One known minor: during a dock drag, the overlay scrollbar can briefly overlap content, because the drag placeholder counts toward the item count but not toward the scroll-mode row math. That matches the pre-#10872 behaviour and is a transient visual overlap during the drag, not an oscillation. Not worth new scroll-metric state to fix here.
