### PR TITLE
feat(plugins): hot enable/disable for user plugins

### DIFF
--- a/e2e/full/panels/core-forge-stats-lifecycle.spec.ts
+++ b/e2e/full/panels/core-forge-stats-lifecycle.spec.ts
@@ -76,7 +76,7 @@ test.describe.serial("Panels: Forge stats pill lifecycle", () => {
   test("pill disappears and reappears across a live plugin disable/enable", async () => {
     // Built-ins transition LIVE (#9304) — drive the real Settings toggle, not
     // bare IPC, so the whole user path is covered: switch → plugin:set-enabled
-    // → _applyBuiltinToggle (unload/re-register + activate) → provenance
+    // → _applyEnabledToggle (unload/re-register + activate) → provenance
     // broadcast → every mounted useResolvedForgeProvider instance re-resolves.
     const window = ctx!.window;
     const pill = window.locator(SEL.github.statPillIssues);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -4755,14 +4755,14 @@ export class PluginService {
   }
 
   listPlugins(): LoadedPluginInfo[] {
-    // Desired state is the live persisted list; the running state is
-    // `this.plugins` (loaded) vs `this.disabledPlugins` (skipped). For user
-    // plugins these are fixed for the session, so a toggle diverges them and
-    // raises a "restart required" cue (#9284). Built-ins transition live
-    // (#9304): `setEnabled` moves the entry between the two maps immediately, so
-    // the running state already matches the desired state and pendingRestart is
-    // false. Reporting both keeps the switch position and the cue correct across
-    // a tab remount.
+    // Desired state is the persisted list; the running state is `this.plugins`
+    // (loaded) vs `this.disabledPlugins` (skipped). Both built-ins (#9304) and
+    // user plugins (#10887) transition live via `_applyEnabledToggle`, which
+    // moves the entry between the maps (and re-forks the worker for user
+    // plugins). `pendingRestart` can only read true transiently — during the
+    // brief in-flight window between the persist landing and the live transition
+    // settling — after which the maps match again and it clears. Reporting both
+    // keeps the switch position and the cue correct across a tab remount.
     const desiredDisabled = this.records.getDisabledIds();
     const installed = this.records.getInstalledRecords();
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -2010,18 +2010,25 @@ export class PluginService {
 
     const promise = this._doActivate(pluginId).then(
       () => {
-        // Guard against an unload that ran while activation was in flight:
-        // unload clears `activatedPlugins` and `plugins` synchronously, but a
-        // late-resolving activation would otherwise re-insert a tombstoned id.
-        if (this.plugins.has(pluginId)) {
+        // Guard against an unload — or a disable→re-enable that reloaded the id
+        // as a fresh generation — while activation was in flight. unload clears
+        // `activatedPlugins`/`plugins` synchronously, so a late-resolving stale
+        // activation must not re-insert a tombstoned id, nor mark the NEW
+        // generation activated (which would fast-path past its own worker fork,
+        // #10887). Identity-compare the loaded object, not just presence.
+        if (this.plugins.get(pluginId) === plugin) {
           this.activatedPlugins.add(pluginId);
         }
       },
       () => {
         // Error is already persisted to the provenance record inside
         // `_doActivate`. Drop the in-flight entry so a subsequent
-        // `activatePlugin(pluginId)` re-runs activation (Settings → Retry).
-        this.activationPromises.delete(pluginId);
+        // `activatePlugin(pluginId)` re-runs activation (Settings → Retry) — but
+        // only if it's still ours, so a stale generation's late rejection can't
+        // evict the new generation's in-flight promise.
+        if (this.activationPromises.get(pluginId) === promise) {
+          this.activationPromises.delete(pluginId);
+        }
       }
     );
     this.activationPromises.set(pluginId, promise);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -744,11 +744,12 @@ export class PluginService {
   private startupBlocklist: ParsedPluginBlocklist | null = null;
   private readonly blocklistService: PluginBlocklistService;
   /**
-   * Per-plugin transition chain for live built-in enable/disable (#9304). A
+   * Per-plugin transition chain for live enable/disable (#9304, #10887). A
    * rapid disable→enable→disable on the same id must not interleave the
    * unload/load mutations to `plugins`/`disabledPlugins`/`reservedNames`, so
-   * each `setEnabled` for a built-in chains onto the prior transition for that
-   * id. Keyed by `manifest.name`; the entry is dropped once its chain settles.
+   * each `setEnabled` chains onto the prior transition for that id. Applies to
+   * both built-in and user plugins. Keyed by `manifest.name`; the entry is
+   * dropped once its chain settles.
    */
   private readonly enableTransitions = new Map<string, Promise<void>>();
   private records = new PluginInstalledRecordsStore();
@@ -4843,14 +4844,15 @@ export class PluginService {
 
   /**
    * Toggle a plugin's disabled state in Preferences (#9284). Persists to
-   * `plugins.disabled` in electron-store, then — for built-in plugins only —
-   * applies the change live (#9304): disabling unloads the running plugin,
-   * enabling re-registers and re-activates it, so the toggle takes effect
-   * without an app restart. User plugins stay persist-only and surface the
-   * restart-required cue, because their on-disk code can change between toggles
-   * and Node's ESM module cache has no eviction API (the dev-worker fork path
-   * exists precisely to sidestep that for recompiling dev plugins) — re-running
-   * a built-in's bundled, immutable `activate()` carries no such risk.
+   * `plugins.disabled` in electron-store, then applies the change live (#9304,
+   * #10887): disabling unloads the running plugin, enabling re-registers and
+   * re-activates it, so the toggle takes effect without an app restart. This
+   * covers both built-in and user plugins — user (non-builtin) plugins activate
+   * inside a fresh `utilityProcess.fork` worker per lifecycle (#10526), so a
+   * toggle-driven reload reads the bundle fresh off disk in a new module realm;
+   * the old ESM-cache-staleness rationale for excluding them no longer applies
+   * (built-ins keep their bundled, immutable `activate()` on the in-process
+   * loader — the only branch, resolved inside `loadPlugin`/`_doActivate`).
    *
    * Persists first so a crash mid-transition is recoverable: next launch reads
    * the persisted intent and reaches the same state. Idempotent: toggling to
@@ -4861,17 +4863,17 @@ export class PluginService {
     // Persist intent first (throws on an empty id, validated in the store).
     this.records.setEnabled(pluginId, enabled);
 
-    const isBuiltin =
-      this.plugins.get(pluginId)?.isBuiltin ??
-      this.disabledPlugins.get(pluginId)?.isBuiltin ??
-      false;
-    if (!isBuiltin) return;
+    // Only a plugin known this session (running or skipped-at-launch) has state
+    // to transition live; an unknown id stays persist-only (its intent is
+    // recorded for the next scan). Guarding here also keeps the isBuiltin choice
+    // where it belongs — inside `_applyEnabledToggle`, derived from the map entry.
+    if (!this.plugins.has(pluginId) && !this.disabledPlugins.has(pluginId)) return;
 
     // Serialise live transitions per id so concurrent toggles can't interleave
     // their unload/load map mutations. Swallow the prior chain's rejection —
-    // `_applyBuiltinToggle` never rejects, but the guard keeps the chain alive.
+    // `_applyEnabledToggle` never rejects, but the guard keeps the chain alive.
     const prior = this.enableTransitions.get(pluginId) ?? Promise.resolve();
-    const next = prior.catch(() => {}).then(() => this._applyBuiltinToggle(pluginId, enabled));
+    const next = prior.catch(() => {}).then(() => this._applyEnabledToggle(pluginId, enabled));
     this.enableTransitions.set(pluginId, next);
     try {
       await next;
@@ -4883,25 +4885,28 @@ export class PluginService {
   }
 
   /**
-   * Apply a live enable/disable transition for a built-in plugin (#9304).
-   * Disable: tear the running plugin down through the full `unloadPlugin()`
-   * cascade, then move its manifest into `disabledPlugins` so `listPlugins()`
-   * keeps surfacing it for the toggle. Enable: clear the name reservation and
-   * skipped entry (so `loadPlugin`'s duplicate guard doesn't reject the
-   * re-load), re-register from the cached manifest dir, then activate. Always
-   * broadcasts provenance so every view re-pulls `listPlugins()` and the
-   * restart-required cue clears. Never throws — activation errors are persisted
-   * to `loadError` inside `activatePlugin`, and a failed re-register restores
-   * the skipped state.
+   * Apply a live enable/disable transition for a plugin — built-in or user
+   * (#9304, #10887). Disable: tear the running plugin down through the full
+   * `unloadPlugin()` cascade (which disposes a user plugin's activation worker
+   * via its `cleanup` closure), then move its manifest into `disabledPlugins`
+   * so `listPlugins()` keeps surfacing it for the toggle. Enable: clear the name
+   * reservation and skipped entry (so `loadPlugin`'s duplicate guard doesn't
+   * reject the re-load), re-register from the cached manifest dir, then activate
+   * — a user plugin re-forks a fresh worker (#10526). The real `isBuiltin` is
+   * carried through the disabled entry into `loadPlugin` so `_doActivate` routes
+   * built-ins in-process and user plugins to the worker. Always broadcasts
+   * provenance so every view re-pulls `listPlugins()` and the restart-required
+   * cue clears. Never throws — activation errors are persisted to `loadError`
+   * inside `activatePlugin`, and a failed re-register restores the skipped state.
    */
-  private async _applyBuiltinToggle(pluginId: string, enabled: boolean): Promise<void> {
+  private async _applyEnabledToggle(pluginId: string, enabled: boolean): Promise<void> {
     try {
       if (!enabled) {
         const running = this.plugins.get(pluginId);
         if (!running) return; // already not running — nothing to unload
-        const { manifest, dir } = running;
+        const { manifest, dir, isBuiltin } = running;
         this.unloadPlugin(pluginId);
-        this.disabledPlugins.set(pluginId, { manifest, dir, isBuiltin: true });
+        this.disabledPlugins.set(pluginId, { manifest, dir, isBuiltin });
         this.reservedNames.add(pluginId);
         return;
       }
@@ -4910,21 +4915,21 @@ export class PluginService {
       if (!entry) return; // already running — nothing to load
       // Release ONLY the name reservation up front (the duplicate guard's actual
       // gate), but keep the disabledPlugins entry in place across the async load.
-      // This keeps the id resolvable as a built-in at every await point, so a
-      // concurrent setEnabled can't slip past the isBuiltin check into the
-      // persist-only path while the load is mid-flight. loadPlugin() with an
-      // empty disabled set never touches disabledPlugins, so the entry is safe.
+      // This keeps the id resolvable at every await point, so a concurrent
+      // setEnabled reaching `_applyEnabledToggle` still sees a known plugin while
+      // the load is mid-flight. loadPlugin() with an empty disabled set never
+      // touches disabledPlugins, so the entry is safe.
       this.reservedNames.delete(pluginId);
       let loaded: LoadedPlugin | null = null;
       try {
         loaded = await this.loadPlugin(path.dirname(entry.dir), path.basename(entry.dir), {
-          isBuiltin: true,
+          isBuiltin: entry.isBuiltin,
           disabled: new Set<string>(),
         });
       } catch (err) {
         // A throw (e.g. a malformed `when` expression in the manifest) must not
         // strand the plugin in neither map — fall through to the restore path.
-        console.error(`[PluginService] Re-load of built-in "${pluginId}" threw:`, err);
+        console.error(`[PluginService] Re-load of "${pluginId}" threw:`, err);
       }
       if (!loaded) {
         // Engine gate, manifest error, or a throw: restore the reservation. The

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -2117,33 +2117,58 @@ describe("PluginService built-in plugin loading", () => {
       await expect(service.setEnabled("   ", false)).rejects.toThrow(/non-empty string/);
     });
 
-    it("user plugin disable diverges desired/running state and raises pendingRestart", async () => {
+    it("user plugin disable unloads live — disabled, not pending, no longer running (#10887)", async () => {
       storeMock._state.set("plugins", { disabled: [] });
       await writePlugin("acme.runtime", { name: "acme.runtime", version: "1.0.0" });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
       await service.initialize();
 
-      expect(service.listPlugins()[0]).toMatchObject({ disabled: false, pendingRestart: false });
+      expect(service.listPlugins()[0]).toMatchObject({
+        disabled: false,
+        pendingRestart: false,
+        isBuiltin: false,
+      });
+      broadcastToRendererMock.mockClear();
 
       await service.setEnabled("acme.runtime", false);
 
-      // User plugin stays loaded this session (no live unload); the desired
-      // state is now off, so the restart-required cue is raised.
-      expect(service.listPlugins()[0]).toMatchObject({ disabled: true, pendingRestart: true });
+      // Applied immediately: the user plugin is unloaded live (its worker torn
+      // down via the unload cascade) and surfaced from the skipped map, so
+      // loadedAt resets to 0 and no restart is required — isBuiltin stays false.
+      const row = service.listPlugins()[0];
+      expect(row).toMatchObject({ disabled: true, pendingRestart: false, isBuiltin: false });
+      expect(row.loadedAt).toBe(0);
+      expect(broadcastToRendererMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: "plugin:provenance-changed" })
+      );
     });
 
-    it("user plugin re-enable of a launch-disabled plugin stays pendingRestart", async () => {
+    it("user plugin re-enable of a launch-disabled plugin loads live — enabled, not pending (#10887)", async () => {
       storeMock._state.set("plugins", { disabled: ["acme.off"] });
       await writePlugin("acme.off", { name: "acme.off", version: "1.0.0" });
       const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
       await service.initialize();
 
-      expect(service.listPlugins()[0]).toMatchObject({ disabled: true, pendingRestart: false });
+      expect(service.listPlugins()[0]).toMatchObject({
+        disabled: true,
+        pendingRestart: false,
+        isBuiltin: false,
+      });
+      broadcastToRendererMock.mockClear();
 
       await service.setEnabled("acme.off", true);
 
-      // User plugin is not loaded live; desired state is on, so it's pending.
-      expect(service.listPlugins()[0]).toMatchObject({ disabled: false, pendingRestart: true });
+      // Applied immediately: re-registered with the real isBuiltin (false) and
+      // re-activated via a freshly forked worker, so it's running (loadedAt set)
+      // with no restart cue.
+      const row = service.listPlugins()[0];
+      expect(row).toMatchObject({ disabled: false, pendingRestart: false, isBuiltin: false });
+      expect(row.loadedAt).toBeGreaterThan(0);
+      expect(broadcastToRendererMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ name: "plugin:provenance-changed" })
+      );
     });
 
     it("built-in disable unloads live — disabled, not pending, no longer running", async () => {

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -219,10 +219,10 @@ describe("PluginManagerView", () => {
     expect(screen.queryByText("Restart required")).toBeNull();
   });
 
-  it("flashes 'Restart required' when a session-fixed user plugin is toggled (#10512)", async () => {
-    // Control for the built-in case: user plugins are fixed for the session, so
-    // a toggle genuinely diverges desired vs. running state and must surface the
-    // restart cue.
+  it("does not flash 'Restart required' when a user plugin is toggled (#10887)", async () => {
+    // User plugins now transition live too (#10887): setEnabled unloads/reloads
+    // them without a restart, so their authoritative pendingRestart stays false.
+    // The optimistic update must match — not invert — to avoid a false badge.
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
       makePlugin({ isBuiltin: false, disabled: false, pendingRestart: false }),
     ]);
@@ -230,7 +230,8 @@ describe("PluginManagerView", () => {
     const toggle = await screen.findByRole("switch", { name: "Enable Acme Demo" });
     fireEvent.click(toggle);
 
-    await waitFor(() => expect(screen.getAllByText("Restart required").length).toBeGreaterThan(0));
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
+    expect(screen.queryByText("Restart required")).toBeNull();
   });
 
   it("renders a plugin's settings form in the detail pane once selected", async () => {
@@ -457,7 +458,7 @@ describe("PluginManagerView", () => {
     expect(window.electron.plugin.uninstall).not.toHaveBeenCalled();
   });
 
-  it("calls setEnabled(false) and shows a restart badge when disabling", async () => {
+  it("calls setEnabled(false) when disabling and applies live — no restart badge (#10887)", async () => {
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
     renderDialog();
     await screen.findAllByText("Acme Demo");
@@ -467,9 +468,10 @@ describe("PluginManagerView", () => {
     await waitFor(() => {
       expect(window.electron.plugin.setEnabled).toHaveBeenCalledWith("acme.demo", false);
     });
-    await waitFor(() => {
-      expect(screen.getByText("Restart required")).toBeTruthy();
-    });
+    // User plugins now toggle live (#10887): no restart badge flashes.
+    const toggle = screen.getByRole("switch", { name: "Enable Acme Demo" });
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
+    expect(screen.queryByText("Restart required")).toBeNull();
   });
 
   it("keeps the restart badge after a remount (pendingRestart comes from listPlugins)", async () => {
@@ -502,17 +504,19 @@ describe("PluginManagerView", () => {
     expect(screen.queryByText("Restart required")).toBeNull();
   });
 
-  it("clears the restart badge when toggled back to the startup state", async () => {
+  it("toggling off then back on calls setEnabled correctly and never flashes a restart badge (#10887)", async () => {
     (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
     renderDialog();
     await screen.findAllByText("Acme Demo");
     const toggle = () => screen.getByRole("switch", { name: "Enable Acme Demo" });
 
     fireEvent.click(toggle());
-    await waitFor(() => expect(screen.getByText("Restart required")).toBeTruthy());
+    await waitFor(() => expect(toggle().getAttribute("aria-checked")).toBe("false"));
+    expect(screen.queryByText("Restart required")).toBeNull();
 
     fireEvent.click(toggle());
-    await waitFor(() => expect(screen.queryByText("Restart required")).toBeNull());
+    await waitFor(() => expect(toggle().getAttribute("aria-checked")).toBe("true"));
+    expect(screen.queryByText("Restart required")).toBeNull();
     expect(window.electron.plugin.setEnabled).toHaveBeenLastCalledWith("acme.demo", true);
   });
 
@@ -1065,16 +1069,20 @@ describe("PluginManagerView", () => {
       expect(screen.getByRole("button", { name: "Restart" })).toBeTruthy();
     });
 
-    it("appears after a toggle flips a plugin into the pending-restart state", async () => {
+    it("does not surface the restart bar after toggling a live plugin (#10887)", async () => {
+      // User plugins now apply live (#10887), so setEnabled reconciles state
+      // immediately and the optimistic update holds pendingRestart at false —
+      // toggling must not flash the global restart bar. The bar still appears
+      // when listPlugins() authoritatively reports pendingRestart (covered
+      // above); it just isn't triggered optimistically by a toggle anymore.
       (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([makePlugin()]);
       renderDialog();
-      await screen.findAllByText("Acme Demo");
+      const toggle = await screen.findByRole("switch", { name: "Enable Acme Demo" });
       expect(screen.queryByText("Restart required to apply plugin changes")).toBeNull();
 
-      fireEvent.click(screen.getByRole("switch", { name: "Enable Acme Demo" }));
-      await waitFor(() =>
-        expect(screen.getByText("Restart required to apply plugin changes")).toBeTruthy()
-      );
+      fireEvent.click(toggle);
+      await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
+      expect(screen.queryByText("Restart required to apply plugin changes")).toBeNull();
     });
 
     it("confirms before relaunching and does not restart until confirmed", async () => {

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -517,7 +517,8 @@ describe("PluginManagerView", () => {
     fireEvent.click(toggle());
     await waitFor(() => expect(toggle().getAttribute("aria-checked")).toBe("true"));
     expect(screen.queryByText("Restart required")).toBeNull();
-    expect(window.electron.plugin.setEnabled).toHaveBeenLastCalledWith("acme.demo", true);
+    expect(window.electron.plugin.setEnabled).toHaveBeenNthCalledWith(1, "acme.demo", false);
+    expect(window.electron.plugin.setEnabled).toHaveBeenNthCalledWith(2, "acme.demo", true);
   });
 
   it("renders the install buttons immediately, before the list resolves", () => {

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -287,18 +287,14 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     const wasPendingRestart = plugin.pendingRestart;
 
     setPending((prev) => new Set(prev).add(id));
-    // Optimistic flip. For session-fixed user plugins a single toggle flips both
-    // the desired state and the running/desired mismatch, so `pendingRestart`
-    // inverts. Built-ins transition live (#9304) — `setEnabled` reconciles
-    // running and desired state immediately, so their authoritative
-    // `pendingRestart` stays false; inverting it flashes a false "restart
-    // required" badge until the next refresh (#10512). Match the authoritative
-    // value by holding built-ins at false.
+    // Optimistic flip. All plugins — built-in and user — now transition live
+    // (#9304, #10887): `setEnabled` reconciles running and desired state
+    // immediately, so their authoritative `pendingRestart` stays false. Match
+    // that by holding `pendingRestart` at false; inverting it would flash a
+    // false "restart required" badge until the next refresh (#10512).
     setPlugins((prev) =>
       prev.map((p) =>
-        p.manifest.name === id
-          ? { ...p, disabled: !next, pendingRestart: p.isBuiltin ? false : !p.pendingRestart }
-          : p
+        p.manifest.name === id ? { ...p, disabled: !next, pendingRestart: false } : p
       )
     );
     try {


### PR DESCRIPTION
## Summary
- Extends the live enable/disable toggling added for built-in plugins in #9304 to user (non-builtin) plugins, so toggling a user plugin in the Plugin Manager now takes effect immediately, no app restart needed.
- The old reason for excluding user plugins was ESM module cache staleness. That no longer applies since #10526, which routes all non-builtin plugins through a fresh `utilityProcess.fork` worker per activation, reading the plugin bundle fresh off disk every time.
- Also fixes a generation-race bug in `activatePlugin` that this change widened: a stale in-flight activation from a disabled generation could otherwise fast-path past a re-enabled plugin's fresh worker fork.

Resolves #10887

## Changes
`electron/services/PluginService.ts`:
- `setEnabled()` no longer early-returns for non-builtin plugins; unknown plugin IDs still remain persist-only.
- `_applyBuiltinToggle` renamed to `_applyEnabledToggle`, and now threads the real `isBuiltin` value (sourced from the running plugin instance or the disabled entry) through `unloadPlugin` and `loadPlugin`, so `_doActivate` correctly routes user plugins to the worker process.
- `activatePlugin` success and rejection handlers are now generation-aware, using identity comparison so a stale activation from a disabled generation can't fast-path past a re-enabled plugin's fresh worker fork.

`src/components/Plugin/usePluginManager.ts`:
- The optimistic `pendingRestart` value is now unconditionally `false` for all plugins (was builtin-only), matching the authoritative value returned by `listPlugins`.

Tests:
- `electron/services/__tests__/PluginService.test.ts` rewrote two stale user-plugin `setEnabled` tests to assert live-toggle behavior instead of restart-required.
- `src/components/Plugin/__tests__/PluginManagerView.test.tsx` rewrote stale restart-badge and restart-bar assertions to assert live-toggle with no restart cue, leaving backend-reported `pendingRestart` tests intact.

## Testing
- `PluginService.test.ts`: 538 tests passing.
- `PluginManagerView.test.tsx`: 75 tests passing.
- eslint and prettier clean on changed files.