### PR TITLE
spike(plugin): map scopes.fs.allowedPaths to Node permission flags

### DIFF
--- a/electron/plugin-dev-worker.ts
+++ b/electron/plugin-dev-worker.ts
@@ -123,4 +123,13 @@ port.on("message", (rawMsg: unknown) => {
 
 // Announce readiness only after the message listener is attached, so the
 // parent's `start` (sent on `ready`) can never race ahead of the listener.
-post({ type: "ready" });
+//
+// `permission.present` is the spike self-check (#10890): report whether Node's
+// experimental permission model is actually active in this worker. `process`
+// only exposes `.permission` when `--permission` engaged, so its mere presence
+// is the honest signal for whether Electron honored the `execArgv` flags. On
+// Electron 42 this is expected to be `false` even when the flags were passed.
+const permissionPresent =
+  (process as { permission?: unknown }).permission !== undefined &&
+  (process as { permission?: unknown }).permission !== null;
+post({ type: "ready", permission: { present: permissionPresent } });

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -98,6 +98,7 @@ import { PluginDevWorkerHost } from "./plugin/PluginDevWorkerHost.js";
 import { PluginDevWorkerMainBridge } from "./plugin/PluginDevWorkerMainBridge.js";
 import {
   buildPluginPermissionExecArgv,
+  classifyPluginPermissionPaths,
   derivePluginPermissionCapabilities,
   isPluginPermissionModelSpikeEnabled,
 } from "./plugin/pluginPermissionFlags.js";
@@ -1730,8 +1731,27 @@ export class PluginService {
     // this, but guard defensively against the unload-race re-entry path.
     if (this.pluginWorkers.has(pluginId)) return;
 
+    // Spike #10890 (opt-in): compute the permission-model execArgv flags BEFORE
+    // creating the host, so the default (env-off) path never awaits and stays
+    // byte-for-byte the current fork behavior. Only the opt-in path yields — and
+    // it fails open (fork without flags) and re-checks liveness after the await,
+    // since a prototype/measurement must never break activation or fork a worker
+    // for a plugin that unloaded mid-computation (#9533).
+    let permissionExecArgv: string[] | undefined;
+    if (isPluginPermissionModelSpikeEnabled()) {
+      try {
+        permissionExecArgv = await this.buildWorkerPermissionExecArgv(pluginId, plugin);
+      } catch (err) {
+        console.warn(
+          `[PluginService] permission-model flag computation failed for ${pluginId}; forking without flags:`,
+          err
+        );
+        permissionExecArgv = undefined;
+      }
+      if (!this.plugins.has(pluginId)) return;
+    }
+
     const { host, revoke } = this.createHost(pluginId);
-    const permissionExecArgv = await this.buildWorkerPermissionExecArgv(pluginId, plugin);
     const workerHost = new PluginDevWorkerHost({
       pluginId,
       pluginDir: plugin.dir,
@@ -3374,17 +3394,11 @@ export class PluginService {
 
   /**
    * Spike #10890: compute the Node permission-model `execArgv` flags for a
-   * plugin worker, or `undefined` when the spike env flag is off (preserving the
-   * exact current fork behavior). Maps the plugin's resolved `allowedPaths` +
-   * capabilities onto `--permission --allow-fs-read/-write` (plus
-   * `--allow-child-process` for `shell:exec` and `--allow-addons`).
-   *
-   * Read/write split: every resolved root is readable; a root is writable only
-   * when its class has the matching write capability (`fs:project-write` /
-   * `fs:user-data-write`), and the implicit per-plugin data dir is always
-   * writable (it is the plugin's private scratch space). The plugin's own bundle
-   * dir is added as a read root so the worker can import its code if a future
-   * Electron ever honors the flags.
+   * plugin worker from its resolved `allowedPaths` + capabilities —
+   * `--permission --allow-fs-read/-write` (per-root-class capability gated,
+   * mirroring the sanctioned host.fs surface) plus `--allow-child-process` for
+   * `shell:exec` and `--allow-addons`. The env gate lives in the caller
+   * (`activateViaWorker`), so this always computes when called.
    *
    * Fork-time `${worktree}` limitation: the flags are fixed at fork and the
    * `${worktree}` token resolves against whichever worktree is current now — so a
@@ -3395,27 +3409,17 @@ export class PluginService {
   private async buildWorkerPermissionExecArgv(
     pluginId: string,
     plugin: LoadedPlugin
-  ): Promise<string[] | undefined> {
-    if (!isPluginPermissionModelSpikeEnabled()) return undefined;
-
+  ): Promise<string[]> {
     const capabilities = plugin.manifest.capabilities ?? [];
     const { allowChildProcess, allowNativeAddons } =
       derivePluginPermissionCapabilities(capabilities);
-    const hasProjectWrite = capabilities.includes("fs:project-write");
-    const hasUserDataWrite = capabilities.includes("fs:user-data-write");
-    const dataDir = this.pluginDataDir(pluginId);
 
     const entries = await this.expandAllowedPathEntries(pluginId, { includeDataDir: true });
-    const readPaths: string[] = [plugin.dir];
-    const writePaths: string[] = [];
-    for (const entry of entries) {
-      readPaths.push(entry.path);
-      const writable =
-        entry.path === dataDir ||
-        (entry.rootClass === "project" && hasProjectWrite) ||
-        (entry.rootClass === "user-data" && hasUserDataWrite);
-      if (writable) writePaths.push(entry.path);
-    }
+    const { readPaths, writePaths } = classifyPluginPermissionPaths(
+      entries,
+      capabilities,
+      plugin.dir
+    );
 
     return buildPluginPermissionExecArgv({
       readPaths,

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -96,6 +96,11 @@ import { PluginChannelRegistry, isChannelSchema } from "./plugin/PluginChannelRe
 import { PluginInstaller } from "./plugin/PluginInstaller.js";
 import { PluginDevWorkerHost } from "./plugin/PluginDevWorkerHost.js";
 import { PluginDevWorkerMainBridge } from "./plugin/PluginDevWorkerMainBridge.js";
+import {
+  buildPluginPermissionExecArgv,
+  derivePluginPermissionCapabilities,
+  isPluginPermissionModelSpikeEnabled,
+} from "./plugin/pluginPermissionFlags.js";
 import { PluginInvokeOwnershipError } from "./plugin/PluginInvokeErrors.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
 import {
@@ -1726,11 +1731,13 @@ export class PluginService {
     if (this.pluginWorkers.has(pluginId)) return;
 
     const { host, revoke } = this.createHost(pluginId);
+    const permissionExecArgv = await this.buildWorkerPermissionExecArgv(pluginId, plugin);
     const workerHost = new PluginDevWorkerHost({
       pluginId,
       pluginDir: plugin.dir,
       bundlePath: plugin.resolvedMain,
       mode: plugin.devMode ? "dev" : "prod",
+      permissionExecArgv,
     });
     const bridge = new PluginDevWorkerMainBridge({
       pluginId,
@@ -3363,6 +3370,59 @@ export class PluginService {
     return (
       rel === "" || (rel !== ".." && !rel.startsWith(".." + path.sep) && !path.isAbsolute(rel))
     );
+  }
+
+  /**
+   * Spike #10890: compute the Node permission-model `execArgv` flags for a
+   * plugin worker, or `undefined` when the spike env flag is off (preserving the
+   * exact current fork behavior). Maps the plugin's resolved `allowedPaths` +
+   * capabilities onto `--permission --allow-fs-read/-write` (plus
+   * `--allow-child-process` for `shell:exec` and `--allow-addons`).
+   *
+   * Read/write split: every resolved root is readable; a root is writable only
+   * when its class has the matching write capability (`fs:project-write` /
+   * `fs:user-data-write`), and the implicit per-plugin data dir is always
+   * writable (it is the plugin's private scratch space). The plugin's own bundle
+   * dir is added as a read root so the worker can import its code if a future
+   * Electron ever honors the flags.
+   *
+   * Fork-time `${worktree}` limitation: the flags are fixed at fork and the
+   * `${worktree}` token resolves against whichever worktree is current now — so a
+   * static flag set reflects only the fork-time worktree and would go stale on a
+   * worktree switch (no worker restart). `${project}` (main worktree) is stable.
+   * Documented as a known limitation of the prototype, not solved here.
+   */
+  private async buildWorkerPermissionExecArgv(
+    pluginId: string,
+    plugin: LoadedPlugin
+  ): Promise<string[] | undefined> {
+    if (!isPluginPermissionModelSpikeEnabled()) return undefined;
+
+    const capabilities = plugin.manifest.capabilities ?? [];
+    const { allowChildProcess, allowNativeAddons } =
+      derivePluginPermissionCapabilities(capabilities);
+    const hasProjectWrite = capabilities.includes("fs:project-write");
+    const hasUserDataWrite = capabilities.includes("fs:user-data-write");
+    const dataDir = this.pluginDataDir(pluginId);
+
+    const entries = await this.expandAllowedPathEntries(pluginId, { includeDataDir: true });
+    const readPaths: string[] = [plugin.dir];
+    const writePaths: string[] = [];
+    for (const entry of entries) {
+      readPaths.push(entry.path);
+      const writable =
+        entry.path === dataDir ||
+        (entry.rootClass === "project" && hasProjectWrite) ||
+        (entry.rootClass === "user-data" && hasUserDataWrite);
+      if (writable) writePaths.push(entry.path);
+    }
+
+    return buildPluginPermissionExecArgv({
+      readPaths,
+      writePaths,
+      allowChildProcess,
+      allowNativeAddons,
+    });
   }
 
   /**

--- a/electron/services/plugin/PluginDevWorkerHost.ts
+++ b/electron/services/plugin/PluginDevWorkerHost.ts
@@ -55,6 +55,14 @@ export interface PluginDevWorkerHostOptions {
    * fork lifecycle, and graceful dispose are identical in both modes.
    */
   mode?: "dev" | "prod";
+  /**
+   * Permission-model spike (#10890): extra `execArgv` flags (`--permission`,
+   * `--allow-fs-*`, …) appended after the V8 heap cap. Empty/absent (the
+   * default) preserves the exact current fork behavior. When present, the worker
+   * reports back whether Electron actually honored them (`ready.permission`),
+   * which this host logs — the flags are a prototype/measurement, not a boundary.
+   */
+  permissionExecArgv?: readonly string[];
 }
 
 /**
@@ -81,6 +89,8 @@ export class PluginDevWorkerHost extends EventEmitter {
   private readonly serviceName: string;
   private readonly mode: "dev" | "prod";
   private readonly workerKind: string;
+  /** Spike #10890: permission-model execArgv flags appended at fork time. */
+  private readonly permissionExecArgv: readonly string[];
 
   private watcher: fs.FSWatcher | null = null;
   private reloadTimer: NodeJS.Timeout | null = null;
@@ -111,6 +121,7 @@ export class PluginDevWorkerHost extends EventEmitter {
     this.bundlePath = options.bundlePath;
     this.mode = options.mode ?? "dev";
     this.workerKind = this.mode === "prod" ? PLUGIN_PROD_WORKER_KIND : PLUGIN_DEV_WORKER_KIND;
+    this.permissionExecArgv = options.permissionExecArgv ?? [];
 
     const safeName = options.pluginId.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 40);
     // Hash the plugin dir so two plugins sharing a sanitized name still get
@@ -390,7 +401,7 @@ export class PluginDevWorkerHost extends EventEmitter {
         serviceName: this.serviceName,
         stdio: "pipe",
         cwd: this.pluginDir || os.homedir(),
-        execArgv: ["--max-old-space-size=256"],
+        execArgv: ["--max-old-space-size=256", ...this.permissionExecArgv],
         env: {
           // env REPLACES process.env in a utility process (#6081) — spread first.
           ...(process.env as Record<string, string>),
@@ -431,6 +442,19 @@ export class PluginDevWorkerHost extends EventEmitter {
   private handleWorkerMessage(msg: PluginWorkerToHostMessage): void {
     if (this.isDisposed) return;
     if (msg.type === "ready") {
+      // Spike #10890: record whether Electron honored the permission-model
+      // execArgv flags. Only logged when we actually requested them, so a
+      // normal fork stays quiet. `honored=false` on Electron 42 is the expected
+      // finding — the utility-process bootstrap never runs Node's `--permission`
+      // parsing, so the flags are inert (the real boundary stays host.fs realpath
+      // containment). This log is the measurement surface the spike asks for.
+      if (this.permissionExecArgv.length > 0) {
+        logger.info(`[${this.serviceName}] plugin permission model spike`, {
+          requested: true,
+          honored: msg.permission?.present ?? false,
+          flags: this.permissionExecArgv,
+        });
+      }
       // Re-import the bundle and re-run activate on every (re)start.
       this.send({
         type: "start",

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "events";
 import { Readable } from "node:stream";
 
-const { forkMock, mockChildren, appMock, watchMock, watchCalls } = vi.hoisted(() => {
+const { forkMock, mockChildren, appMock, watchMock, watchCalls, loggerMock } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { EventEmitter } = require("events") as typeof import("events");
   const forkMock = vi.fn();
@@ -16,7 +16,8 @@ const { forkMock, mockChildren, appMock, watchMock, watchCalls } = vi.hoisted(()
     watchCalls.push({ dir, cb });
     return watcher;
   });
-  return { forkMock, mockChildren, appMock, watchMock, watchCalls };
+  const loggerMock = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  return { forkMock, mockChildren, appMock, watchMock, watchCalls, loggerMock };
 });
 
 class MockUtilityChild extends EventEmitter {
@@ -54,7 +55,7 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 vi.mock("../../../utils/logger.js", () => ({
-  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  createLogger: () => loggerMock,
 }));
 
 async function loadModule(): Promise<typeof import("../PluginDevWorkerHost.js")> {
@@ -81,6 +82,10 @@ describe("PluginDevWorkerHost", () => {
     watchCalls.length = 0;
     watchMock.mockClear();
     appMock.removeAllListeners();
+    loggerMock.debug.mockClear();
+    loggerMock.info.mockClear();
+    loggerMock.warn.mockClear();
+    loggerMock.error.mockClear();
     forkMock.mockImplementation(() => new MockUtilityChild());
   });
 
@@ -127,19 +132,52 @@ describe("PluginDevWorkerHost", () => {
     host.dispose();
   });
 
-  it("appends permissionExecArgv after the heap cap when provided (spike #10890)", async () => {
+  it("appends permissionExecArgv directly after the heap cap, in order (spike #10890)", async () => {
     const { PluginDevWorkerHost } = await loadModule();
-    const host = new PluginDevWorkerHost({
-      ...OPTS,
-      permissionExecArgv: ["--permission", "--allow-fs-read=/plugins/acme.demo"],
-    });
+    const permissionExecArgv = ["--permission", "--allow-fs-read=/plugins/acme.demo"];
+    const host = new PluginDevWorkerHost({ ...OPTS, permissionExecArgv });
     host.waitForReady().catch(() => {});
     void host.start();
 
     const execArgv: string[] = forkMock.mock.calls[0][2].execArgv;
     expect(execArgv[0]).toMatch(/^--max-old-space-size=\d+$/);
-    expect(execArgv).toContain("--permission");
-    expect(execArgv).toContain("--allow-fs-read=/plugins/acme.demo");
+    expect(execArgv.slice(1)).toEqual(permissionExecArgv);
+    host.dispose();
+  });
+
+  it("logs the permission-model honored verdict from ready when flags were requested (spike #10890)", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const permissionExecArgv = ["--permission", "--allow-fs-read=/plugins/acme.demo"];
+    const host = new PluginDevWorkerHost({ ...OPTS, permissionExecArgv });
+    const ready = host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready", permission: { present: false } });
+    await ready;
+
+    const spikeLog = loggerMock.info.mock.calls.find(
+      ([, fields]) => fields && typeof fields === "object" && "honored" in fields
+    );
+    expect(spikeLog).toBeDefined();
+    expect(spikeLog?.[1]).toMatchObject({
+      requested: true,
+      honored: false,
+      flags: permissionExecArgv,
+    });
+    host.dispose();
+  });
+
+  it("stays quiet on ready when no permission flags were requested (spike #10890)", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    const ready = host.start();
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+    await ready;
+
+    const spikeLog = loggerMock.info.mock.calls.find(
+      ([, fields]) => fields && typeof fields === "object" && "honored" in fields
+    );
+    expect(spikeLog).toBeUndefined();
     host.dispose();
   });
 

--- a/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
+++ b/electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts
@@ -116,6 +116,33 @@ describe("PluginDevWorkerHost", () => {
     host.dispose();
   });
 
+  it("omits permission-model flags by default (spike #10890)", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost(OPTS);
+    host.waitForReady().catch(() => {});
+    void host.start();
+
+    const execArgv: string[] = forkMock.mock.calls[0][2].execArgv;
+    expect(execArgv.some((arg) => arg.startsWith("--permission"))).toBe(false);
+    host.dispose();
+  });
+
+  it("appends permissionExecArgv after the heap cap when provided (spike #10890)", async () => {
+    const { PluginDevWorkerHost } = await loadModule();
+    const host = new PluginDevWorkerHost({
+      ...OPTS,
+      permissionExecArgv: ["--permission", "--allow-fs-read=/plugins/acme.demo"],
+    });
+    host.waitForReady().catch(() => {});
+    void host.start();
+
+    const execArgv: string[] = forkMock.mock.calls[0][2].execArgv;
+    expect(execArgv[0]).toMatch(/^--max-old-space-size=\d+$/);
+    expect(execArgv).toContain("--permission");
+    expect(execArgv).toContain("--allow-fs-read=/plugins/acme.demo");
+    host.dispose();
+  });
+
   it("exports CRASH_WINDOW_MS aligned with the other guards (30 minutes)", async () => {
     const mod = await loadModule();
     expect(mod.CRASH_WINDOW_MS).toBe(30 * 60 * 1000);

--- a/electron/services/plugin/__tests__/pluginPermissionFlags.test.ts
+++ b/electron/services/plugin/__tests__/pluginPermissionFlags.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import type { PluginCapability } from "../../../../shared/types/plugin.js";
+import {
+  buildPluginPermissionExecArgv,
+  derivePluginPermissionCapabilities,
+  isPluginPermissionModelSpikeEnabled,
+  PLUGIN_PERMISSION_MODEL_SPIKE_ENV,
+} from "../pluginPermissionFlags.js";
+
+/** Extract the comma-separated payload of a single `--allow-fs-*=…` flag. */
+function pathsOf(flags: string[], kind: "read" | "write"): string[] {
+  const prefix = `--allow-fs-${kind}=`;
+  const flag = flags.find((f) => f.startsWith(prefix));
+  return flag ? flag.slice(prefix.length).split(",") : [];
+}
+
+describe("derivePluginPermissionCapabilities", () => {
+  it("maps shell:exec onto --allow-child-process", () => {
+    expect(derivePluginPermissionCapabilities(["shell:exec"]).allowChildProcess).toBe(true);
+  });
+
+  it("withholds child-process when shell:exec is absent", () => {
+    const caps: PluginCapability[] = ["fs:project-read", "network:fetch"];
+    expect(derivePluginPermissionCapabilities(caps).allowChildProcess).toBe(false);
+  });
+
+  it("always allows native addons (no capability distinguishes them)", () => {
+    expect(derivePluginPermissionCapabilities([]).allowNativeAddons).toBe(true);
+    expect(derivePluginPermissionCapabilities(["shell:exec"]).allowNativeAddons).toBe(true);
+  });
+});
+
+describe("buildPluginPermissionExecArgv", () => {
+  const base = { allowChildProcess: false, allowNativeAddons: false } as const;
+
+  it("always engages the permission model as the first flag", () => {
+    const flags = buildPluginPermissionExecArgv({ ...base, readPaths: [], writePaths: [] });
+    expect(flags[0]).toBe("--permission");
+  });
+
+  it("emits no fs flags when there are no paths", () => {
+    const flags = buildPluginPermissionExecArgv({ ...base, readPaths: [], writePaths: [] });
+    expect(flags.some((f) => f.startsWith("--allow-fs-"))).toBe(false);
+  });
+
+  it("emits read paths under --allow-fs-read", () => {
+    const flags = buildPluginPermissionExecArgv({
+      ...base,
+      readPaths: ["/a", "/b"],
+      writePaths: [],
+    });
+    expect(pathsOf(flags, "read")).toEqual(["/a", "/b"]);
+    expect(flags.some((f) => f.startsWith("--allow-fs-write"))).toBe(false);
+  });
+
+  it("also grants read for every write path (Node write does not imply read)", () => {
+    const flags = buildPluginPermissionExecArgv({
+      ...base,
+      readPaths: ["/read-only"],
+      writePaths: ["/writable"],
+    });
+    expect(pathsOf(flags, "read")).toEqual(["/read-only", "/writable"]);
+    expect(pathsOf(flags, "write")).toEqual(["/writable"]);
+  });
+
+  it("dedupes and sorts paths for deterministic output regardless of input order", () => {
+    const a = buildPluginPermissionExecArgv({
+      ...base,
+      readPaths: ["/z", "/a", "/z"],
+      writePaths: ["/a"],
+    });
+    const b = buildPluginPermissionExecArgv({
+      ...base,
+      readPaths: ["/a", "/z"],
+      writePaths: ["/a", "/a"],
+    });
+    expect(a).toEqual(b);
+    expect(pathsOf(a, "read")).toEqual(["/a", "/z"]);
+  });
+
+  it("drops empty-string paths", () => {
+    const flags = buildPluginPermissionExecArgv({
+      ...base,
+      readPaths: ["", "/real"],
+      writePaths: [""],
+    });
+    expect(pathsOf(flags, "read")).toEqual(["/real"]);
+    expect(flags.some((f) => f.startsWith("--allow-fs-write"))).toBe(false);
+  });
+
+  it("appends --allow-child-process and --allow-addons only when requested", () => {
+    const none = buildPluginPermissionExecArgv({
+      readPaths: [],
+      writePaths: [],
+      allowChildProcess: false,
+      allowNativeAddons: false,
+    });
+    expect(none).not.toContain("--allow-child-process");
+    expect(none).not.toContain("--allow-addons");
+
+    const both = buildPluginPermissionExecArgv({
+      readPaths: [],
+      writePaths: [],
+      allowChildProcess: true,
+      allowNativeAddons: true,
+    });
+    expect(both).toContain("--allow-child-process");
+    expect(both).toContain("--allow-addons");
+  });
+});
+
+describe("isPluginPermissionModelSpikeEnabled", () => {
+  it("is off for absent / empty / disabled values", () => {
+    expect(isPluginPermissionModelSpikeEnabled({})).toBe(false);
+    for (const value of ["", "0", "false"]) {
+      expect(
+        isPluginPermissionModelSpikeEnabled({ [PLUGIN_PERMISSION_MODEL_SPIKE_ENV]: value })
+      ).toBe(false);
+    }
+  });
+
+  it("is on for any other truthy value", () => {
+    for (const value of ["1", "true", "yes", "on"]) {
+      expect(
+        isPluginPermissionModelSpikeEnabled({ [PLUGIN_PERMISSION_MODEL_SPIKE_ENV]: value })
+      ).toBe(true);
+    }
+  });
+});

--- a/electron/services/plugin/__tests__/pluginPermissionFlags.test.ts
+++ b/electron/services/plugin/__tests__/pluginPermissionFlags.test.ts
@@ -2,16 +2,17 @@ import { describe, it, expect } from "vitest";
 import type { PluginCapability } from "../../../../shared/types/plugin.js";
 import {
   buildPluginPermissionExecArgv,
+  classifyPluginPermissionPaths,
   derivePluginPermissionCapabilities,
   isPluginPermissionModelSpikeEnabled,
   PLUGIN_PERMISSION_MODEL_SPIKE_ENV,
+  type PluginPermissionRoot,
 } from "../pluginPermissionFlags.js";
 
-/** Extract the comma-separated payload of a single `--allow-fs-*=…` flag. */
+/** Collect the path payload of every `--allow-fs-<kind>=…` flag, in order. */
 function pathsOf(flags: string[], kind: "read" | "write"): string[] {
   const prefix = `--allow-fs-${kind}=`;
-  const flag = flags.find((f) => f.startsWith(prefix));
-  return flag ? flag.slice(prefix.length).split(",") : [];
+  return flags.filter((f) => f.startsWith(prefix)).map((f) => f.slice(prefix.length));
 }
 
 describe("derivePluginPermissionCapabilities", () => {
@@ -30,6 +31,51 @@ describe("derivePluginPermissionCapabilities", () => {
   });
 });
 
+describe("classifyPluginPermissionPaths", () => {
+  const projectRoot: PluginPermissionRoot = { path: "/proj", rootClass: "project" };
+  const dataRoot: PluginPermissionRoot = { path: "/data", rootClass: "user-data" };
+
+  it("always grants read on the bundle dir regardless of capabilities", () => {
+    const { readPaths } = classifyPluginPermissionPaths([], [], "/bundle");
+    expect(readPaths).toContain("/bundle");
+  });
+
+  it("gates project roots on fs:project-* capabilities", () => {
+    const readOnly = classifyPluginPermissionPaths([projectRoot], ["fs:project-read"], "/bundle");
+    expect(readOnly.readPaths).toContain("/proj");
+    expect(readOnly.writePaths).not.toContain("/proj");
+
+    const writeOnly = classifyPluginPermissionPaths([projectRoot], ["fs:project-write"], "/bundle");
+    // Write-only must NOT imply read — mirrors the sanctioned host.fs boundary.
+    expect(writeOnly.readPaths).not.toContain("/proj");
+    expect(writeOnly.writePaths).toContain("/proj");
+  });
+
+  it("gates user-data roots (incl. the data dir) on fs:user-data-* capabilities", () => {
+    const none = classifyPluginPermissionPaths([dataRoot], [], "/bundle");
+    expect(none.readPaths).not.toContain("/data");
+    expect(none.writePaths).not.toContain("/data");
+
+    const both = classifyPluginPermissionPaths(
+      [dataRoot],
+      ["fs:user-data-read", "fs:user-data-write"],
+      "/bundle"
+    );
+    expect(both.readPaths).toContain("/data");
+    expect(both.writePaths).toContain("/data");
+  });
+
+  it("does not cross classes — a project cap never unlocks a user-data root", () => {
+    const { readPaths, writePaths } = classifyPluginPermissionPaths(
+      [dataRoot],
+      ["fs:project-read", "fs:project-write"],
+      "/bundle"
+    );
+    expect(readPaths).not.toContain("/data");
+    expect(writePaths).not.toContain("/data");
+  });
+});
+
 describe("buildPluginPermissionExecArgv", () => {
   const base = { allowChildProcess: false, allowNativeAddons: false } as const;
 
@@ -43,36 +89,47 @@ describe("buildPluginPermissionExecArgv", () => {
     expect(flags.some((f) => f.startsWith("--allow-fs-"))).toBe(false);
   });
 
-  it("emits read paths under --allow-fs-read", () => {
+  it("emits one repeated flag per read path (never comma-joined)", () => {
     const flags = buildPluginPermissionExecArgv({
       ...base,
       readPaths: ["/a", "/b"],
       writePaths: [],
     });
-    expect(pathsOf(flags, "read")).toEqual(["/a", "/b"]);
-    expect(flags.some((f) => f.startsWith("--allow-fs-write"))).toBe(false);
+    expect(flags).toContain("--allow-fs-read=/a");
+    expect(flags).toContain("--allow-fs-read=/b");
+    // Comma-joining would grant neither path in Node's permission model.
+    expect(flags.some((f) => f.includes(","))).toBe(false);
   });
 
-  it("also grants read for every write path (Node write does not imply read)", () => {
+  it("keeps read and write independent — a write path is not auto-readable", () => {
     const flags = buildPluginPermissionExecArgv({
       ...base,
       readPaths: ["/read-only"],
       writePaths: ["/writable"],
     });
-    expect(pathsOf(flags, "read")).toEqual(["/read-only", "/writable"]);
+    expect(pathsOf(flags, "read")).toEqual(["/read-only"]);
     expect(pathsOf(flags, "write")).toEqual(["/writable"]);
+  });
+
+  it("preserves a path that contains a comma as a single flag value", () => {
+    const flags = buildPluginPermissionExecArgv({
+      ...base,
+      readPaths: ["/weird,dir"],
+      writePaths: [],
+    });
+    expect(pathsOf(flags, "read")).toEqual(["/weird,dir"]);
   });
 
   it("dedupes and sorts paths for deterministic output regardless of input order", () => {
     const a = buildPluginPermissionExecArgv({
       ...base,
       readPaths: ["/z", "/a", "/z"],
-      writePaths: ["/a"],
+      writePaths: [],
     });
     const b = buildPluginPermissionExecArgv({
       ...base,
       readPaths: ["/a", "/z"],
-      writePaths: ["/a", "/a"],
+      writePaths: [],
     });
     expect(a).toEqual(b);
     expect(pathsOf(a, "read")).toEqual(["/a", "/z"]);

--- a/electron/services/plugin/pluginPermissionFlags.ts
+++ b/electron/services/plugin/pluginPermissionFlags.ts
@@ -1,0 +1,99 @@
+// Spike (#10890): map a plugin's declared `scopes.fs.allowedPaths` + capabilities
+// onto Node's experimental permission-model `execArgv` flags (`--permission`,
+// `--allow-fs-read`, `--allow-fs-write`, `--allow-child-process`, `--allow-addons`)
+// for the `utilityProcess.fork` plugin worker.
+//
+// IMPORTANT — this is a PROTOTYPE, not enforcement. Empirically (verified against
+// the repo's own Electron 42.4.0 binary), `utilityProcess.fork()` does NOT honor
+// these flags: the worker's `process.permission` is `undefined` and out-of-scope
+// `child_process`/`fs` calls are not blocked, because Electron's utility-process
+// bootstrap never runs Node's `--permission` CLI parsing. The real, audited
+// boundary remains `pluginFsContainment.ts` realpath containment on the sanctioned
+// `host.fs` / `host.git` surface. This module + the worker's boot self-check exist
+// to (a) have the mapping ready if a future Electron honors the flags, and (b)
+// measure whether it does. See `PluginDevWorkerHost` for the runtime verdict log.
+//
+// This module is intentionally pure (no Electron / fs / process deps) so it is
+// deterministic and unit-testable.
+
+import type { PluginCapability } from "../../../shared/types/plugin.js";
+
+/** Node permission-model inputs derived from a plugin's declared capabilities. */
+export interface PluginPermissionCapabilities {
+  /** Whether the worker may spawn child processes (`--allow-child-process`). */
+  allowChildProcess: boolean;
+  /** Whether the worker may load native addons (`--allow-addons`). */
+  allowNativeAddons: boolean;
+}
+
+/** Fully-resolved path inputs + capability gates for the flag builder. */
+export interface PluginPermissionExecArgvInput {
+  /** Absolute paths the worker may read (`--allow-fs-read`). */
+  readPaths: readonly string[];
+  /** Absolute paths the worker may write (`--allow-fs-write`). */
+  writePaths: readonly string[];
+  allowChildProcess: boolean;
+  allowNativeAddons: boolean;
+}
+
+/**
+ * Classify a plugin's declared capabilities into permission-model gates.
+ *
+ * `shell:exec` is the only capability that implies the worker legitimately
+ * spawns child processes, so it maps to `--allow-child-process`. No capability
+ * distinguishes native-addon needs, so — to honor the issue's "must not break
+ * plugins that load native addons" constraint — the spike allows addons
+ * unconditionally when the permission model is enabled. This is a deliberate,
+ * documented limitation of the prototype (addon use cannot be attenuated from
+ * the manifest today), NOT an oversight.
+ */
+export function derivePluginPermissionCapabilities(
+  capabilities: readonly PluginCapability[]
+): PluginPermissionCapabilities {
+  return {
+    allowChildProcess: capabilities.includes("shell:exec"),
+    allowNativeAddons: true,
+  };
+}
+
+/** Dedupe + sort for deterministic, order-independent flag output. */
+function normalizePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths.filter((p) => p.length > 0))].sort();
+}
+
+/**
+ * Build the ordered `execArgv` permission flags for a plugin worker. Returns
+ * `[]` (no flags — current behavior preserved) is NOT this function's job; the
+ * caller decides whether to invoke it at all (env-gated spike opt-in). When
+ * called it always emits `--permission` so the model is actually engaged.
+ *
+ * Node's permission model treats read and write independently — a writable path
+ * is not implicitly readable — so every write path is also emitted as a read
+ * path. Paths are comma-joined into a single `--allow-fs-*` argument (Node
+ * accepts comma-separated lists), deduped and sorted so tests are stable and the
+ * same inputs never produce differently-ordered flag strings.
+ */
+export function buildPluginPermissionExecArgv(input: PluginPermissionExecArgvInput): string[] {
+  const readPaths = normalizePaths([...input.readPaths, ...input.writePaths]);
+  const writePaths = normalizePaths(input.writePaths);
+
+  const flags: string[] = ["--permission"];
+  if (readPaths.length > 0) flags.push(`--allow-fs-read=${readPaths.join(",")}`);
+  if (writePaths.length > 0) flags.push(`--allow-fs-write=${writePaths.join(",")}`);
+  if (input.allowChildProcess) flags.push("--allow-child-process");
+  if (input.allowNativeAddons) flags.push("--allow-addons");
+  return flags;
+}
+
+/**
+ * Env-var name that opts a build into the permission-model spike. Absent/falsy
+ * (the default) preserves the exact current worker `execArgv`; set to a truthy
+ * value to append the mapped permission flags at fork time.
+ */
+export const PLUGIN_PERMISSION_MODEL_SPIKE_ENV = "DAINTREE_PLUGIN_PERMISSION_MODEL_SPIKE";
+
+/** Whether the permission-model spike is enabled for this process. */
+export function isPluginPermissionModelSpikeEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const value = env[PLUGIN_PERMISSION_MODEL_SPIKE_ENV];
+  return value !== undefined && value !== "" && value !== "0" && value !== "false";
+}

--- a/electron/services/plugin/pluginPermissionFlags.ts
+++ b/electron/services/plugin/pluginPermissionFlags.ts
@@ -36,6 +36,47 @@ export interface PluginPermissionExecArgvInput {
   allowNativeAddons: boolean;
 }
 
+/** Root class of a resolved allowed-path, mirroring the sanctioned host.fs surface. */
+export type PluginPermissionRootClass = "project" | "user-data";
+
+/** A resolved allowed-path root and the capability class that gates it. */
+export interface PluginPermissionRoot {
+  path: string;
+  rootClass: PluginPermissionRootClass;
+}
+
+/**
+ * Split resolved allowed-path roots into read/write path sets, gated per root
+ * class exactly like the sanctioned `host.fs` surface: a `project` root needs
+ * `fs:project-read` / `fs:project-write`, a `user-data` root (including the
+ * implicit per-plugin data dir) needs `fs:user-data-read` / `fs:user-data-write`.
+ * Read and write are independent — a write-only plugin gets no read grant — so
+ * the flag mapping never over-grants relative to the host-mediated boundary.
+ *
+ * `bundleDir` (the plugin's own code dir) is always added as a read root,
+ * independent of declared capabilities: a permission-honoring runtime must be
+ * able to read the plugin's bundle to import it at all, so withholding it would
+ * make every plugin unloadable rather than merely scope-limited.
+ */
+export function classifyPluginPermissionPaths(
+  roots: readonly PluginPermissionRoot[],
+  capabilities: readonly PluginCapability[],
+  bundleDir: string
+): { readPaths: string[]; writePaths: string[] } {
+  const caps = new Set<PluginCapability>(capabilities);
+  const readPaths: string[] = [bundleDir];
+  const writePaths: string[] = [];
+  for (const root of roots) {
+    const readCap: PluginCapability =
+      root.rootClass === "project" ? "fs:project-read" : "fs:user-data-read";
+    const writeCap: PluginCapability =
+      root.rootClass === "project" ? "fs:project-write" : "fs:user-data-write";
+    if (caps.has(readCap)) readPaths.push(root.path);
+    if (caps.has(writeCap)) writePaths.push(root.path);
+  }
+  return { readPaths, writePaths };
+}
+
 /**
  * Classify a plugin's declared capabilities into permission-model gates.
  *
@@ -62,24 +103,25 @@ function normalizePaths(paths: readonly string[]): string[] {
 }
 
 /**
- * Build the ordered `execArgv` permission flags for a plugin worker. Returns
- * `[]` (no flags — current behavior preserved) is NOT this function's job; the
- * caller decides whether to invoke it at all (env-gated spike opt-in). When
+ * Build the ordered `execArgv` permission flags for a plugin worker. Whether to
+ * call this at all is the caller's decision (env-gated spike opt-in); when
  * called it always emits `--permission` so the model is actually engaged.
  *
- * Node's permission model treats read and write independently — a writable path
- * is not implicitly readable — so every write path is also emitted as a read
- * path. Paths are comma-joined into a single `--allow-fs-*` argument (Node
- * accepts comma-separated lists), deduped and sorted so tests are stable and the
- * same inputs never produce differently-ordered flag strings.
+ * Read and write path sets are emitted independently — the caller has already
+ * gated them per capability, so no read is implied from a write here. Each path
+ * becomes its OWN `--allow-fs-read` / `--allow-fs-write` flag rather than a
+ * comma-joined list: Node treats a comma-joined value as a single literal path
+ * (so `/a,/b` would grant neither `/a` nor `/b`), and repeated flags also sidestep
+ * any comma-in-path ambiguity. Paths are deduped and sorted so the same inputs
+ * never produce differently-ordered flags, keeping tests deterministic.
  */
 export function buildPluginPermissionExecArgv(input: PluginPermissionExecArgvInput): string[] {
-  const readPaths = normalizePaths([...input.readPaths, ...input.writePaths]);
+  const readPaths = normalizePaths(input.readPaths);
   const writePaths = normalizePaths(input.writePaths);
 
   const flags: string[] = ["--permission"];
-  if (readPaths.length > 0) flags.push(`--allow-fs-read=${readPaths.join(",")}`);
-  if (writePaths.length > 0) flags.push(`--allow-fs-write=${writePaths.join(",")}`);
+  for (const p of readPaths) flags.push(`--allow-fs-read=${p}`);
+  for (const p of writePaths) flags.push(`--allow-fs-write=${p}`);
   if (input.allowChildProcess) flags.push("--allow-child-process");
   if (input.allowNativeAddons) flags.push("--allow-addons");
   return flags;

--- a/shared/types/pluginDevWorker.ts
+++ b/shared/types/pluginDevWorker.ts
@@ -147,10 +147,22 @@ export type PluginHostToWorkerMessage =
    */
   | { type: "register-error"; registrationKey: string; error: string };
 
+/**
+ * Empirical permission-model self-check the worker reports at boot (spike
+ * #10890). `present` is `true` when Node's permission model is actually active
+ * in the worker (`process.permission` exists). It lets the host record whether
+ * Electron honored the `--permission` `execArgv` flags — expected `false` on
+ * Electron 42, whose utility-process bootstrap does not run Node's permission
+ * CLI parsing. Optional so older workers (no self-check) stay protocol-compatible.
+ */
+export interface PluginWorkerPermissionStatus {
+  present: boolean;
+}
+
 /** Messages sent worker → main. */
 export type PluginWorkerToHostMessage =
   /** Worker booted, parent-port listener attached, ready for `start`. */
-  | { type: "ready" }
+  | { type: "ready"; permission?: PluginWorkerPermissionStatus }
   /** `activate(proxy)` resolved. `hasCleanup` records whether it returned a disposer. */
   | { type: "activated"; hasCleanup: boolean }
   /** `activate(proxy)` threw or rejected. */


### PR DESCRIPTION
## Summary

Spike for #10890: prototype enforcing a plugin's declared `scopes.fs.allowedPaths` inside the plugin worker using Node's experimental permission model.

- Maps `allowedPaths` and capabilities onto `--permission`, `--allow-fs-read`, `--allow-fs-write`, `--allow-child-process`, and `--allow-addons` execArgv flags for the `utilityProcess.fork` worker.
- Gated behind `DAINTREE_PLUGIN_PERMISSION_MODEL_SPIKE`, defaulting off, so there's no behavior change on the default path.
- The worker reports whether `process.permission` is present at boot; the host logs the honored verdict as the spike's measurement surface.

Resolves #10890

## Key empirical finding

Verified against the repo's own Electron 42.4.0 binary: `utilityProcess.fork()` does **not** honor Node's `--permission` and `--allow-*` execArgv flags. `process.permission` is undefined in the worker, and out-of-scope `fs`/`child_process` calls are not blocked, because Electron's utility-process bootstrap never runs Node's `--permission` CLI parsing.

So the flags are inert in Electron today. The real enforcement boundary stays `pluginFsContainment.ts` realpath containment on the sanctioned `host.fs`/`host.git` surface.

This PR delivers the flag-mapping code, ready if a future Electron version honors the flags, plus the boot-time measurement instrumentation that produces the data the spike asked for. It also documents a limitation: `execArgv` is fixed at fork time, but the `${worktree}` token in `allowedPaths` resolves per-call, so a static flag set only reflects the fork-time worktree.

## Changes

- `electron/services/plugin/pluginPermissionFlags.ts` (new) - pure mapper, classifier, capability deriver
- `electron/services/plugin/__tests__/pluginPermissionFlags.test.ts` (new)
- `electron/services/plugin/PluginDevWorkerHost.ts` - `permissionExecArgv` option, verdict log
- `electron/services/plugin/__tests__/PluginDevWorkerHost.test.ts`
- `electron/services/PluginService.ts` - env-gated wiring in `activateViaWorker`
- `electron/plugin-dev-worker.ts` - boot-time self-check
- `shared/types/pluginDevWorker.ts` - ready message extension

## Testing

- Prettier and eslint clean on all changed files
- 33 targeted vitest tests passing: pure mapper capability matrix, comma-separated paths, repeated-flag output, host wiring, verdict log
- Two rounds of Codex review, fixes applied: repeated flags instead of comma-joining, per-class read gating, synchronous env-gate check with fail-open behavior and a liveness re-check