### PR TITLE
test(plugins): contract test that every manifest field has a runtime consumer

### DIFF
--- a/electron/schemas/__tests__/manifestContributionConsumers.test.ts
+++ b/electron/schemas/__tests__/manifestContributionConsumers.test.ts
@@ -39,6 +39,11 @@ import {
  * for shape without runtime authority (documented in the schema). The runtime
  * sweep below is the regression guard; the `satisfies`/assignment check adds a
  * compile-time break when a field is added to a schema without a map entry.
+ *
+ * Scope note: this is a curated map, not a static usage analysis — it proves a
+ * consumer file EXISTS and is documented for every accepted field, and that the
+ * schema's field set can't drift from the map. It does not statically prove the
+ * cited symbol still reads the field; that stays a human-reviewed claim.
  */
 
 type ConsumerMode = "verbatim" | "derived-input" | "cross-reference" | "intentional-metadata";
@@ -470,9 +475,9 @@ const MANIFEST_CONTRIBUTION_FIELD_CONSUMERS = {
       note: "Switches local vs network provider presentation.",
     },
     capabilities: {
-      mode: "intentional-metadata",
-      consumers: [{ file: FORGE_REGISTRY, symbol: "freezeContribution" }],
-      note: "Frozen into the descriptor as informational metadata; behavior gates on the runtime ForgeProviderImpl, never on these strings (schema doc, frozen at 1.0).",
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "ProviderSettingsBody (capabilities list)" }],
+      note: "Rendered as the provider's capability list in settings; informational only — behavior gates on the runtime ForgeProviderImpl, never on these strings (schema doc).",
     },
     credentialFields: {
       mode: "verbatim",
@@ -799,11 +804,14 @@ describe("manifest contribution field → consumer contract (#10888)", () => {
       expect(SWEPT_SCHEMAS).toHaveProperty(key);
       expect(MANIFEST_CONTRIBUTION_FIELD_CONSUMERS).toHaveProperty(key);
     }
-    // ...and every declared top-level group must be a real contributes key, so
-    // a removed contribution kind can't leave a stale consumer group behind.
-    for (const group of TOP_LEVEL_GROUPS) {
-      expect(parsed.data.contributes).toHaveProperty(group);
-    }
+    // Exact set match against the parsed empty manifest: a new contribution kind
+    // shows up here (every contributes.* array is `.default([])`, so an empty
+    // manifest materializes them all) and forces a swept-schema + consumer entry;
+    // a removed kind can't leave a stale group behind. Caveat: a future kind
+    // declared `.optional()` WITHOUT a default would not appear on the empty
+    // parse and would slip this guard — the `.default([])` convention on every
+    // array kind (see MANIFEST_CONTRIBUTION_CAPS) is what keeps that watertight.
+    expect(Object.keys(parsed.data.contributes).sort()).toEqual([...TOP_LEVEL_GROUPS].sort());
   });
 
   it.each(Object.keys(SWEPT_SCHEMAS) as SweptGroup[])(

--- a/electron/schemas/__tests__/manifestContributionConsumers.test.ts
+++ b/electron/schemas/__tests__/manifestContributionConsumers.test.ts
@@ -1,0 +1,846 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  AgentContributionSchema,
+  AgentDetectionConfigSchema,
+  CommandContributionSchema,
+  ContextMenuContributionSchema,
+  CredentialFieldSchema,
+  FileDecorationContributionSchema,
+  ForgeProviderContributionSchema,
+  getPluginManifestSchema,
+  KeybindingContributionSchema,
+  McpServerContributionSchema,
+  MenuItemContributionSchema,
+  PanelContributionSchema,
+  SettingDefinitionObjectSchema,
+  ToolbarButtonContributionSchema,
+  ViewContributionSchema,
+} from "../plugin.js";
+
+/**
+ * Contract test for #10888: every field the plugin-manifest schema accepts must
+ * have a real runtime (or first-party tooling) consumer. The manifest schema is
+ * strict and will be frozen at 1.0 — a field an author can set that nothing
+ * reads is a silent lie in the public contract. This test walks each
+ * `contributes.*` contribution schema (and the high-fanout nested schemas) and
+ * asserts every accepted field is present in a hand-authored field→consumer
+ * map. A new schema field fails this test until it is wired to a consumer (or
+ * cut), which keeps the schema and the runtime from silently drifting apart.
+ *
+ * The map is the assertion, not the source of truth: it records WHERE and HOW
+ * each field is consumed. `mode` distinguishes a value read and applied
+ * verbatim from one that only feeds a host-derived value (`danger` → the
+ * host-authoritative `effectiveDanger`, #8331), one validated only as a
+ * cross-reference against another contribution, and one deliberately validated
+ * for shape without runtime authority (documented in the schema). The runtime
+ * sweep below is the regression guard; the `satisfies`/assignment check adds a
+ * compile-time break when a field is added to a schema without a map entry.
+ */
+
+type ConsumerMode = "verbatim" | "derived-input" | "cross-reference" | "intentional-metadata";
+
+const ALL_MODES: readonly ConsumerMode[] = [
+  "verbatim",
+  "derived-input",
+  "cross-reference",
+  "intentional-metadata",
+];
+
+interface ConsumerRef {
+  /** Repo-relative path (POSIX) to a file that consumes the field. */
+  file: string;
+  /** The symbol / function / component that reads the field, for the reader. */
+  symbol: string;
+}
+
+interface ConsumerDescriptor {
+  mode: ConsumerMode;
+  consumers: readonly ConsumerRef[];
+  /** Why/how the field is consumed — kept short but always present. */
+  note: string;
+}
+
+const PLUGIN_SERVICE = "electron/services/PluginService.ts";
+const TERMINAL_ACTIVITY_PATTERNS = "electron/services/pty/terminalActivityPatterns.ts";
+const PLUGIN_SETTINGS_FORM = "src/components/Settings/PluginSettingsForm.tsx";
+const CODE_FORGE_TAB = "src/components/Settings/CodeForgeSettingsTab.tsx";
+const FORGE_REGISTRY = "electron/services/forgeProviderRegistry.ts";
+const AGENT_REGISTRY = "shared/config/pluginAgentRegistry.ts";
+const MCP_SUPERVISOR = "electron/services/PluginMcpSupervisor.ts";
+const PLUGIN_SCHEMA = "electron/schemas/plugin.ts";
+
+/**
+ * The schemas swept for field coverage. The first block matches the twelve
+ * `contributes.*` array kinds one-to-one; the second block covers the
+ * high-fanout nested object schemas (a new detection tuning field or credential
+ * field would otherwise be able to drift silently under a top-level kind).
+ */
+const SWEPT_SCHEMAS = {
+  panels: PanelContributionSchema,
+  toolbarButtons: ToolbarButtonContributionSchema,
+  menuItems: MenuItemContributionSchema,
+  keybindings: KeybindingContributionSchema,
+  contextMenus: ContextMenuContributionSchema,
+  commands: CommandContributionSchema,
+  views: ViewContributionSchema,
+  mcpServers: McpServerContributionSchema,
+  forgeProviders: ForgeProviderContributionSchema,
+  fileDecorationProviders: FileDecorationContributionSchema,
+  agents: AgentContributionSchema,
+  settings: SettingDefinitionObjectSchema,
+  "agents.detection": AgentDetectionConfigSchema,
+  "forgeProviders.credentialFields": CredentialFieldSchema,
+  "forgeProviders.slots": ForgeProviderContributionSchema.shape.slots,
+} as const;
+
+type SweptGroup = keyof typeof SWEPT_SCHEMAS;
+
+/**
+ * The twelve keys that must line up one-to-one with `contributes.*`. Kept
+ * separate from the nested-group keys so the "no unknown contribution kind"
+ * guard can compare against exactly the parsed `contributes` shape.
+ */
+const TOP_LEVEL_GROUPS = [
+  "panels",
+  "toolbarButtons",
+  "menuItems",
+  "keybindings",
+  "contextMenus",
+  "commands",
+  "views",
+  "mcpServers",
+  "forgeProviders",
+  "fileDecorationProviders",
+  "agents",
+  "settings",
+] as const;
+
+/** Reduce a swept schema entry to its ZodObject and read the field keys. */
+function shapeKeys(schema: z.ZodType): string[] {
+  const object =
+    schema instanceof z.ZodObject
+      ? schema
+      : (schema as z.ZodOptional<z.ZodObject<z.ZodRawShape>>).unwrap();
+  if (!(object instanceof z.ZodObject)) {
+    throw new Error("Expected a ZodObject (directly or under an optional wrapper)");
+  }
+  return Object.keys(object.shape).sort();
+}
+
+/**
+ * Compile-time coverage: `satisfies` this type checks the map literal in BOTH
+ * directions per group — a NEW schema field breaks the build here (map missing
+ * the key) and a STALE map entry for a removed field is flagged as excess. This
+ * is the fast signal; the runtime sweep below is the backstop that also guards
+ * against `z.infer` edge cases and anyone weakening these types.
+ */
+type ForgeSlots = NonNullable<z.infer<typeof ForgeProviderContributionSchema>["slots"]>;
+type FieldConsumerCoverage = {
+  panels: Record<keyof z.infer<typeof PanelContributionSchema>, ConsumerDescriptor>;
+  toolbarButtons: Record<keyof z.infer<typeof ToolbarButtonContributionSchema>, ConsumerDescriptor>;
+  menuItems: Record<keyof z.infer<typeof MenuItemContributionSchema>, ConsumerDescriptor>;
+  keybindings: Record<keyof z.infer<typeof KeybindingContributionSchema>, ConsumerDescriptor>;
+  contextMenus: Record<keyof z.infer<typeof ContextMenuContributionSchema>, ConsumerDescriptor>;
+  commands: Record<keyof z.infer<typeof CommandContributionSchema>, ConsumerDescriptor>;
+  views: Record<keyof z.infer<typeof ViewContributionSchema>, ConsumerDescriptor>;
+  mcpServers: Record<keyof z.infer<typeof McpServerContributionSchema>, ConsumerDescriptor>;
+  forgeProviders: Record<keyof z.infer<typeof ForgeProviderContributionSchema>, ConsumerDescriptor>;
+  fileDecorationProviders: Record<
+    keyof z.infer<typeof FileDecorationContributionSchema>,
+    ConsumerDescriptor
+  >;
+  agents: Record<keyof z.infer<typeof AgentContributionSchema>, ConsumerDescriptor>;
+  settings: Record<keyof z.infer<typeof SettingDefinitionObjectSchema>, ConsumerDescriptor>;
+  "agents.detection": Record<keyof z.infer<typeof AgentDetectionConfigSchema>, ConsumerDescriptor>;
+  "forgeProviders.credentialFields": Record<
+    keyof z.infer<typeof CredentialFieldSchema>,
+    ConsumerDescriptor
+  >;
+  "forgeProviders.slots": Record<keyof ForgeSlots, ConsumerDescriptor>;
+};
+
+const MANIFEST_CONTRIBUTION_FIELD_CONSUMERS = {
+  panels: {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin (panelId `${name}.${id}`)" }],
+      note: "Namespaced into the registered panel-kind id.",
+    },
+    name: {
+      mode: "verbatim",
+      consumers: [{ file: "shared/config/panelKindRegistry.ts", symbol: "registerPanelKind" }],
+      note: "Registered as the panel kind's display name.",
+    },
+    iconId: {
+      mode: "verbatim",
+      consumers: [{ file: "shared/config/panelKindRegistry.ts", symbol: "registerPanelKind" }],
+      note: "Registered as the panel kind icon.",
+    },
+    color: {
+      mode: "verbatim",
+      consumers: [{ file: "shared/config/panelKindRegistry.ts", symbol: "registerPanelKind" }],
+      note: "Registered as the panel kind accent color.",
+    },
+    hasPty: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin (panels loop)" }],
+      note: "Selects PTY vs view rendering and gates the view componentPath attach.",
+    },
+    canRestart: {
+      mode: "verbatim",
+      consumers: [{ file: "shared/config/panelKindRegistry.ts", symbol: "registerPanelKind" }],
+      note: "Registered as the panel kind restart policy.",
+    },
+    canConvert: {
+      mode: "verbatim",
+      consumers: [{ file: "shared/config/panelKindRegistry.ts", symbol: "registerPanelKind" }],
+      note: "Registered as the panel kind convert policy.",
+    },
+    showInPalette: {
+      mode: "verbatim",
+      consumers: [{ file: "shared/config/panelKindRegistry.ts", symbol: "registerPanelKind" }],
+      note: "Registered as the panel kind palette visibility.",
+    },
+  },
+  toolbarButtons: {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin → registerToolbarButton" }],
+      note: "Namespaced into the registered toolbar button id.",
+    },
+    label: {
+      mode: "verbatim",
+      consumers: [
+        { file: "shared/config/toolbarButtonRegistry.ts", symbol: "registerToolbarButton" },
+      ],
+      note: "Registered as the toolbar button label.",
+    },
+    iconId: {
+      mode: "verbatim",
+      consumers: [
+        { file: "shared/config/toolbarButtonRegistry.ts", symbol: "registerToolbarButton" },
+      ],
+      note: "Registered as the toolbar button icon.",
+    },
+    actionId: {
+      mode: "verbatim",
+      consumers: [
+        { file: "shared/config/toolbarButtonRegistry.ts", symbol: "registerToolbarButton" },
+      ],
+      note: "Registered as the action the button dispatches.",
+    },
+    priority: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin (priority ?? 3)" }],
+      note: "Registered as the toolbar button ordering priority (defaulted to 3).",
+    },
+  },
+  menuItems: {
+    label: {
+      mode: "verbatim",
+      consumers: [
+        { file: "electron/services/pluginMenuRegistry.ts", symbol: "registerPluginMenuItem" },
+      ],
+      note: "Registered into the plugin menu registry read by the renderer menus.",
+    },
+    actionId: {
+      mode: "verbatim",
+      consumers: [
+        { file: "electron/services/pluginMenuRegistry.ts", symbol: "registerPluginMenuItem" },
+      ],
+      note: "Registered as the action the menu item dispatches.",
+    },
+    location: {
+      mode: "verbatim",
+      consumers: [
+        { file: "electron/services/pluginMenuRegistry.ts", symbol: "registerPluginMenuItem" },
+      ],
+      note: "Registered as the menu surface the item is placed into.",
+    },
+    accelerator: {
+      mode: "verbatim",
+      consumers: [
+        { file: "electron/services/pluginMenuRegistry.ts", symbol: "registerPluginMenuItem" },
+      ],
+      note: "Registered as the menu item accelerator.",
+    },
+    when: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin → trackPluginExpression" }],
+      note: "Tracked and evaluated as the item's visibility expression.",
+    },
+  },
+  keybindings: {
+    actionId: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "electron/services/pluginKeybindingRegistry.ts",
+          symbol: "registerPluginKeybinding",
+        },
+      ],
+      note: "Registered as the action the keybinding dispatches.",
+    },
+    combo: {
+      mode: "verbatim",
+      consumers: [{ file: "src/services/keybindingUtils.ts", symbol: "parseCombo" }],
+      note: "Parsed and matched against pressed key combos.",
+    },
+    scope: {
+      mode: "verbatim",
+      consumers: [{ file: "src/services/KeybindingService.ts", symbol: "KeybindingService" }],
+      note: "Gates the binding to the active key scope (defaulted to global in the hook).",
+    },
+    description: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "electron/services/pluginKeybindingRegistry.ts",
+          symbol: "registerPluginKeybinding",
+        },
+      ],
+      note: "Registered as the keybinding description shown in the renderer.",
+    },
+    when: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin → trackPluginExpression" }],
+      note: "Tracked and evaluated as the binding's enablement expression.",
+    },
+  },
+  contextMenus: {
+    actionId: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "electron/services/pluginContextMenuRegistry.ts",
+          symbol: "registerPluginContextMenuItem",
+        },
+      ],
+      note: "Registered as the action the context-menu item dispatches.",
+    },
+    location: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "electron/services/pluginContextMenuRegistry.ts",
+          symbol: "registerPluginContextMenuItem",
+        },
+      ],
+      note: "Registered as the context-menu surface the item is placed into.",
+    },
+    label: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "electron/services/pluginContextMenuRegistry.ts",
+          symbol: "registerPluginContextMenuItem",
+        },
+      ],
+      note: "Registered as the context-menu item label.",
+    },
+    when: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin → trackPluginExpression" }],
+      note: "Tracked and evaluated as the item's visibility expression.",
+    },
+  },
+  commands: {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor" }],
+      note: "Namespaced into the registered action descriptor id.",
+    },
+    title: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor" }],
+      note: "Copied into the action descriptor title.",
+    },
+    description: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor" }],
+      note: "Copied into the action descriptor description.",
+    },
+    category: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor" }],
+      note: "Copied into the action descriptor category.",
+    },
+    kind: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor" }],
+      note: "Copied into the action descriptor kind (command vs query).",
+    },
+    danger: {
+      mode: "derived-input",
+      consumers: [
+        { file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor (effectiveDanger)" },
+      ],
+      note: "Advisory input to the host-authoritative effectiveDanger; raised, never trusted verbatim (#8331).",
+    },
+    keywords: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor" }],
+      note: "Copied into the action descriptor keywords for palette search.",
+    },
+    inputSchema: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "validateAndBuildActionDescriptor" }],
+      note: "Copied into the action descriptor inputSchema for arg validation.",
+    },
+  },
+  views: {
+    id: {
+      mode: "cross-reference",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin (view → panel id match)" }],
+      note: "Matched against a contributes.panels entry id to attach the view.",
+    },
+    componentPath: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "loadPlugin → buildPluginViewUrl" }],
+      note: "Resolved to a plugin:// URL and attached to the panel kind.",
+    },
+    location: {
+      mode: "cross-reference",
+      consumers: [{ file: PLUGIN_SCHEMA, symbol: "ViewContributionSchema (literal 'panel')" }],
+      note: "Literal gate tying the view to the panel host; a sidebar host is rejected at parse.",
+    },
+    iconId: {
+      mode: "verbatim",
+      consumers: [
+        { file: "packages/daintree-plugin/src/commands/validate.ts", symbol: "validateManifest" },
+      ],
+      note: "Advisory: the SDK validate command flags an unrenderable view icon id.",
+    },
+  },
+  mcpServers: {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "findMcpServerContribution" }],
+      note: "Keys the supervised server state and IPC lookups.",
+    },
+    name: {
+      mode: "verbatim",
+      consumers: [{ file: MCP_SUPERVISOR, symbol: "PluginMcpSupervisor (handshake/display)" }],
+      note: "Used in the server's display name and handshake diagnostics.",
+    },
+    command: {
+      mode: "verbatim",
+      consumers: [{ file: MCP_SUPERVISOR, symbol: "resolveContribution → spawn" }],
+      note: "Substituted for ${settings:*} and spawned as the MCP subprocess command.",
+    },
+    args: {
+      mode: "verbatim",
+      consumers: [{ file: MCP_SUPERVISOR, symbol: "resolveContribution → spawn" }],
+      note: "Substituted for ${settings:*} and passed as the subprocess argv.",
+    },
+    env: {
+      mode: "verbatim",
+      consumers: [{ file: MCP_SUPERVISOR, symbol: "resolveContribution → spawn" }],
+      note: "Substituted for ${settings:*} and folded into the subprocess env.",
+    },
+  },
+  forgeProviders: {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: FORGE_REGISTRY, symbol: "registerForgeProviders" }],
+      note: "Keys the frozen forge-provider descriptor and impl binding.",
+    },
+    name: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "src/components/Settings/ForgeIntegrationsTab.tsx",
+          symbol: "ForgeIntegrationsTab",
+        },
+      ],
+      note: "Displayed as the provider name in settings.",
+    },
+    matches: {
+      mode: "verbatim",
+      consumers: [{ file: FORGE_REGISTRY, symbol: "hostnameMatchesAny" }],
+      note: "Matched against a repo host to route to the provider.",
+    },
+    kind: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CodeForgeSettingsTab (kind === 'local')" }],
+      note: "Switches local vs network provider presentation.",
+    },
+    capabilities: {
+      mode: "intentional-metadata",
+      consumers: [{ file: FORGE_REGISTRY, symbol: "freezeContribution" }],
+      note: "Frozen into the descriptor as informational metadata; behavior gates on the runtime ForgeProviderImpl, never on these strings (schema doc, frozen at 1.0).",
+    },
+    credentialFields: {
+      mode: "verbatim",
+      consumers: [
+        { file: "electron/services/forge/forgeCredentialUtils.ts", symbol: "credentialFieldsFor" },
+      ],
+      note: "Read to render the credential form and pick the primary token value.",
+    },
+    settingsScopeRef: {
+      mode: "cross-reference",
+      consumers: [{ file: PLUGIN_SCHEMA, symbol: "getPluginManifestSchema superRefine (#10620)" }],
+      note: "Validated against a declared contributes.settings id; a dangling ref is a parse error.",
+    },
+    viewRefs: {
+      mode: "cross-reference",
+      consumers: [{ file: PLUGIN_SCHEMA, symbol: "getPluginManifestSchema superRefine (#10620)" }],
+      note: "Validated against declared contributes.views ids and frozen into the descriptor.",
+    },
+    slots: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CodeForgeSettingsTab (slot resolution)" }],
+      note: "Resolved to renderer view ids for the provider's UI slots.",
+    },
+  },
+  fileDecorationProviders: {
+    id: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "electron/services/fileDecorationRegistry.ts",
+          symbol: "registerFileDecorationProviders",
+        },
+      ],
+      note: "Keys the file-decoration provider descriptor.",
+    },
+    scopes: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SERVICE, symbol: "scopeMatchesPattern routing" }],
+      note: "Matched to route renderer decoration pulls to the provider.",
+    },
+  },
+  agents: {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "registerPluginAgents" }],
+      note: "Keys the registered plugin agent config.",
+    },
+    name: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "toPluginAgentConfig" }],
+      note: "Copied into the runtime agent config display name.",
+    },
+    command: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "resolvePluginAgentCommand" }],
+      note: "Resolved against the plugin dir and spawned as the agent CLI.",
+    },
+    args: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "toPluginAgentConfig" }],
+      note: "Copied into the runtime agent config argv.",
+    },
+    color: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "toPluginAgentConfig" }],
+      note: "Copied into the runtime agent config color.",
+    },
+    iconId: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "toPluginAgentConfig" }],
+      note: "Copied into the runtime agent config icon.",
+    },
+    supportsContextInjection: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "toPluginAgentConfig" }],
+      note: "Copied into the runtime agent config context-injection flag.",
+    },
+    detection: {
+      mode: "verbatim",
+      consumers: [{ file: AGENT_REGISTRY, symbol: "toPluginAgentConfig" }],
+      note: "Copied into the runtime agent config detection block (see agents.detection).",
+    },
+  },
+  settings: {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.id)" }],
+      note: "Keys the stored setting value and form field.",
+    },
+    type: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "settingType (def.type)" }],
+      note: "Selects the rendered control and value coercion.",
+    },
+    label: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.label)" }],
+      note: "Rendered as the setting label.",
+    },
+    description: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.description)" }],
+      note: "Rendered as the setting help text.",
+    },
+    default: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.default)" }],
+      note: "Seeds the control's initial/reset value.",
+    },
+    scope: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "electron/services/plugin/PluginSettingsManager.ts",
+          symbol: "PluginSettingsManager",
+        },
+      ],
+      note: "Selects the user vs project storage scope.",
+    },
+    options: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.options)" }],
+      note: "Rendered as the enum select options.",
+    },
+    min: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.min)" }],
+      note: "Enforced as the numeric minimum on input.",
+    },
+    max: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.max)" }],
+      note: "Enforced as the numeric maximum on input.",
+    },
+    mustExist: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.mustExist)" }],
+      note: "Drives the advisory path-existence check for path/file settings.",
+    },
+    extensions: {
+      mode: "verbatim",
+      consumers: [{ file: PLUGIN_SETTINGS_FORM, symbol: "PluginSettingField (def.extensions)" }],
+      note: "Passed as the native file-chooser extension filter.",
+    },
+    secret: {
+      mode: "derived-input",
+      consumers: [
+        { file: PLUGIN_SCHEMA, symbol: "SettingDefinitionSchema transform (→ type 'secret')" },
+      ],
+      note: "Normalized into type: 'secret' by the schema; also read directly by the form.",
+    },
+  },
+  "agents.detection": {
+    primaryPatterns: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildPatternConfig" }],
+      note: "Compiled into the working-state detector's primary patterns.",
+    },
+    fallbackPatterns: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildPatternConfig" }],
+      note: "Compiled into the detector's fallback patterns.",
+    },
+    bootCompletePatterns: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildBootCompletePatterns" }],
+      note: "Compiled into the boot-complete detector patterns.",
+    },
+    promptPatterns: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildPromptPatterns" }],
+      note: "Compiled into the prompt detector patterns.",
+    },
+    promptHintPatterns: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildPromptHintPatterns" }],
+      note: "Compiled into the prompt-hint detector patterns.",
+    },
+    completionPatterns: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildCompletionPatterns" }],
+      note: "Compiled into the completion detector patterns.",
+    },
+    scanLineCount: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildPatternConfig" }],
+      note: "Passed as the pattern detector's scan-line window.",
+    },
+    promptScanLineCount: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildActivityMonitorOptions" }],
+      note: "Passed as the prompt detector's scan-line window.",
+    },
+    debounceMs: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: TERMINAL_ACTIVITY_PATTERNS,
+          symbol: "buildActivityMonitorOptions (idleDebounceMs)",
+        },
+      ],
+      note: "Floors the idle debounce for the waiting-state transition.",
+    },
+    promptFastPathMinQuietMs: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildActivityMonitorOptions" }],
+      note: "Floors the prompt fast-path quiet window.",
+    },
+    primaryConfidence: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildPatternConfig" }],
+      note: "Passed as the primary-tier confidence weight.",
+    },
+    fallbackConfidence: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildPatternConfig" }],
+      note: "Passed as the fallback-tier confidence weight.",
+    },
+    promptConfidence: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildActivityMonitorOptions" }],
+      note: "Passed as the prompt-tier confidence weight.",
+    },
+    completionConfidence: {
+      mode: "verbatim",
+      consumers: [{ file: TERMINAL_ACTIVITY_PATTERNS, symbol: "buildActivityMonitorOptions" }],
+      note: "Passed as the completion-tier confidence weight.",
+    },
+    titleStatePatterns: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "src/services/terminal/TerminalListenerInstaller.ts",
+          symbol: "TerminalListenerInstaller",
+        },
+      ],
+      note: "Read to drive title-based working/waiting state detection.",
+    },
+  },
+  "forgeProviders.credentialFields": {
+    id: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CredentialFieldsForm (field.id)" }],
+      note: "Keys the entered value and the primary-value pick.",
+    },
+    label: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CredentialFieldsForm (field.label)" }],
+      note: "Rendered as the credential field label.",
+    },
+    type: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CredentialFieldsForm (field.type)" }],
+      note: "Selects password masking and the primary-value field.",
+    },
+    placeholder: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CredentialFieldsForm (field.placeholder)" }],
+      note: "Rendered as the credential input placeholder.",
+    },
+    helpText: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CredentialFieldsForm (field.helpText)" }],
+      note: "Rendered as the credential field help text.",
+    },
+  },
+  "forgeProviders.slots": {
+    settingsTab: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CodeForgeSettingsTab (settingsTab slot)" }],
+      note: "Resolved to the provider's settings-tab renderer view.",
+    },
+    icon: {
+      mode: "verbatim",
+      consumers: [{ file: CODE_FORGE_TAB, symbol: "CodeForgeSettingsTab (icon slot)" }],
+      note: "Resolved to the provider's icon renderer view.",
+    },
+    statsDropdown: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "src/components/Layout/ForgeStatsToolbarButton.tsx",
+          symbol: "ForgeStatsToolbarButton",
+        },
+      ],
+      note: "Resolved to the provider's stats-dropdown renderer view.",
+    },
+    bulkCreateWorktreeDialog: {
+      mode: "verbatim",
+      consumers: [{ file: "src/components/Sidebar/SidebarContent.tsx", symbol: "SidebarContent" }],
+      note: "Resolved to the provider's bulk-create-worktree dialog view.",
+    },
+    issueSelector: {
+      mode: "verbatim",
+      consumers: [
+        {
+          file: "src/components/Worktree/views/IssueSelectorView.tsx",
+          symbol: "IssueSelectorView",
+        },
+      ],
+      note: "Resolved to the provider's issue-selector renderer view.",
+    },
+  },
+} satisfies FieldConsumerCoverage;
+
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+
+function parseEmptyContributes() {
+  return getPluginManifestSchema(false).safeParse({
+    name: "acme.consumer-contract",
+    version: "1.0.0",
+    contributes: {},
+  });
+}
+
+describe("manifest contribution field → consumer contract (#10888)", () => {
+  it("maps a consumer for every contributes.* contribution kind", () => {
+    // Guard against a new contribution kind being added to the schema without a
+    // matching swept schema + consumer group (mirrors contributionCaps.test.ts).
+    const parsed = parseEmptyContributes();
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    for (const key of Object.keys(parsed.data.contributes)) {
+      expect(SWEPT_SCHEMAS).toHaveProperty(key);
+      expect(MANIFEST_CONTRIBUTION_FIELD_CONSUMERS).toHaveProperty(key);
+    }
+    // ...and every declared top-level group must be a real contributes key, so
+    // a removed contribution kind can't leave a stale consumer group behind.
+    for (const group of TOP_LEVEL_GROUPS) {
+      expect(parsed.data.contributes).toHaveProperty(group);
+    }
+  });
+
+  it.each(Object.keys(SWEPT_SCHEMAS) as SweptGroup[])(
+    "declares a consumer for every field the %s schema accepts",
+    (group) => {
+      const schemaFields = shapeKeys(SWEPT_SCHEMAS[group]);
+      const mappedFields = Object.keys(MANIFEST_CONTRIBUTION_FIELD_CONSUMERS[group]).sort();
+      // Exact match in BOTH directions: a new schema field with no consumer
+      // (missing here) and a stale map entry for a removed field (extra here)
+      // both fail — the field set and its documented consumers can't drift.
+      expect(mappedFields).toEqual(schemaFields);
+    }
+  );
+
+  const allDescriptors: { group: SweptGroup; field: string; descriptor: ConsumerDescriptor }[] = (
+    Object.keys(SWEPT_SCHEMAS) as SweptGroup[]
+  ).flatMap((group) =>
+    Object.entries(MANIFEST_CONTRIBUTION_FIELD_CONSUMERS[group]).map(([field, descriptor]) => ({
+      group,
+      field,
+      descriptor,
+    }))
+  );
+
+  it.each(allDescriptors)(
+    "records a concrete, existing consumer for $group.$field",
+    ({ descriptor }) => {
+      expect(ALL_MODES).toContain(descriptor.mode);
+      expect(descriptor.note.trim().length).toBeGreaterThan(0);
+      expect(descriptor.consumers.length).toBeGreaterThan(0);
+      for (const consumer of descriptor.consumers) {
+        expect(consumer.symbol.trim().length).toBeGreaterThan(0);
+        // A consumer must live in first-party source (main, renderer, shared) or
+        // the first-party plugin SDK/tooling — not point at a plugin or nowhere.
+        expect(consumer.file).toMatch(/^(electron|src|shared|packages)\//);
+        expect(existsSync(join(REPO_ROOT, consumer.file))).toBe(true);
+      }
+    }
+  );
+});

--- a/electron/schemas/__tests__/pluginManifestIntegrity.test.ts
+++ b/electron/schemas/__tests__/pluginManifestIntegrity.test.ts
@@ -27,7 +27,7 @@ function command(id: string): Record<string, unknown> {
   };
 }
 function view(id: string): Record<string, unknown> {
-  return { id, name: "View", componentPath: "./view/index.js", location: "panel" };
+  return { id, componentPath: "./view/index.js", location: "panel" };
 }
 function setting(id: string): Record<string, unknown> {
   return { id, type: "string" };

--- a/electron/schemas/__tests__/viewContribution.test.ts
+++ b/electron/schemas/__tests__/viewContribution.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { ViewContributionSchema } from "../plugin.js";
 
-const base = { id: "main", name: "Main", componentPath: "./dist/view.js", location: "panel" };
+const base = { id: "main", componentPath: "./dist/view.js", location: "panel" };
 
 describe("ViewContributionSchema (issue #10464)", () => {
   it("accepts a minimal panel view contribution", () => {
@@ -14,13 +14,16 @@ describe("ViewContributionSchema (issue #10464)", () => {
     );
   });
 
-  it("accepts optional iconId and description", () => {
-    const result = ViewContributionSchema.safeParse({
-      ...base,
-      iconId: "Plug",
-      description: "A view",
-    });
+  it("accepts an optional iconId", () => {
+    const result = ViewContributionSchema.safeParse({ ...base, iconId: "Plug" });
     expect(result.success).toBe(true);
+  });
+
+  // `name` and `description` were removed (#10888): the matching panel owns a
+  // view's display metadata, so nothing at runtime read them. Strict validation
+  // now rejects them, keeping the frozen contract honest.
+  it.each(["name", "description"])("rejects the removed view field %s (strict)", (field) => {
+    expect(ViewContributionSchema.safeParse({ ...base, [field]: "x" }).success).toBe(false);
   });
 
   it("rejects location 'sidebar' at the schema boundary (no sidebar host yet)", () => {

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -184,14 +184,19 @@ function isSafePluginViewComponentPath(componentPath: string): boolean {
 export const ViewContributionSchema = z
   .object({
     id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
-    name: z.string().min(1),
     componentPath: z.string().min(1).refine(isSafePluginViewComponentPath, {
       message:
         "componentPath must be a relative plugin asset path (no leading /, backslash, URL scheme, NUL, or .. segments)",
     }),
     location: z.literal("panel"),
+    // `iconId` is advisory only — the SDK `validate` command flags an
+    // unrenderable id, but at runtime the matching `contributes.panels` entry
+    // owns the rendered icon (the panels loop reads `panel.iconId`, never the
+    // view's). No `name`/`description` here: the matching panel is the single
+    // source of truth for a view's display metadata, so those fields had no
+    // runtime consumer and were removed (#10888) rather than validate a value
+    // the runtime silently ignores.
     iconId: z.string().min(1).optional(),
-    description: z.string().optional(),
   })
   .strict();
 
@@ -223,7 +228,7 @@ export const McpServerContributionSchema = z
  */
 const RESERVED_CREDENTIAL_FIELD_IDS = new Set(["__proto__", "constructor", "prototype"]);
 
-const CredentialFieldSchema = z
+export const CredentialFieldSchema = z
   .object({
     // A field id keys the entered value into a plain record at save time; a
     // reserved key (`__proto__` etc.) would resolve to the object prototype
@@ -739,7 +744,7 @@ export const PluginPanelBadgeSchema = z.discriminatedUnion("kind", [
  * `type` is optional on the string/number/boolean branch. Strict so a misspelled
  * field key surfaces as a manifest error rather than silently dropping.
  */
-export const SettingDefinitionSchema = z
+export const SettingDefinitionObjectSchema = z
   .object({
     // Constrained to the shared safe-id grammar so a declared setting id can
     // always be referenced by a `${settings:id}` token — the MCP supervisor's
@@ -764,40 +769,47 @@ export const SettingDefinitionSchema = z
     extensions: z.array(z.string().min(1)).min(1).optional(),
     secret: z.boolean().optional(),
   })
-  .strict()
-  .superRefine((val, ctx) => {
-    const effectiveType = val.secret === true ? "secret" : (val.type ?? "string");
-    if (effectiveType === "enum" && (!val.options || val.options.length === 0)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Settings of type "enum" require a non-empty options array',
-        path: ["options"],
-      });
-    }
-    if (val.min !== undefined && val.max !== undefined && val.min > val.max) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Setting min cannot be greater than max",
-        path: ["min"],
-      });
-    }
-    // `extensions` narrows the native file chooser — it is only meaningful for
-    // `type: "file"`. Reject it on every other type at the manifest gate so a
-    // misplaced filter surfaces loudly instead of silently doing nothing.
-    if (val.extensions !== undefined && effectiveType !== "file") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Setting "extensions" is only valid for type "file"',
-        path: ["extensions"],
-      });
-    }
-  })
-  .transform((val) => {
-    if (val.secret === true && val.type !== "secret") {
-      return { ...val, type: "secret" as const };
-    }
-    return val;
-  });
+  .strict();
+
+/**
+ * The validated `contributes.settings` entry: the object base plus the
+ * cross-field refinement and the `secret → type: "secret"` normalization.
+ * The unrefined {@link SettingDefinitionObjectSchema} is exported separately so
+ * the field-consumer contract test can enumerate `.shape` without reaching
+ * through the transform wrapper.
+ */
+export const SettingDefinitionSchema = SettingDefinitionObjectSchema.superRefine((val, ctx) => {
+  const effectiveType = val.secret === true ? "secret" : (val.type ?? "string");
+  if (effectiveType === "enum" && (!val.options || val.options.length === 0)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Settings of type "enum" require a non-empty options array',
+      path: ["options"],
+    });
+  }
+  if (val.min !== undefined && val.max !== undefined && val.min > val.max) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Setting min cannot be greater than max",
+      path: ["min"],
+    });
+  }
+  // `extensions` narrows the native file chooser — it is only meaningful for
+  // `type: "file"`. Reject it on every other type at the manifest gate so a
+  // misplaced filter surfaces loudly instead of silently doing nothing.
+  if (val.extensions !== undefined && effectiveType !== "file") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Setting "extensions" is only valid for type "file"',
+      path: ["extensions"],
+    });
+  }
+}).transform((val) => {
+  if (val.secret === true && val.type !== "secret") {
+    return { ...val, type: "secret" as const };
+  }
+  return val;
+});
 
 /**
  * Per-array upper bounds for `contributes.*`. A crafted manifest with tens of

--- a/electron/services/__tests__/PluginArchive.integration.test.ts
+++ b/electron/services/__tests__/PluginArchive.integration.test.ts
@@ -364,7 +364,6 @@ describe("verifyPluginArchive", () => {
             views: [
               {
                 id: "panel-view",
-                name: "Panel View",
                 componentPath: "dist/PanelView.js",
                 location: "panel",
               },
@@ -398,7 +397,6 @@ describe("verifyPluginArchive", () => {
             views: [
               {
                 id: "panel-view",
-                name: "Panel View",
                 componentPath: "./dist/PanelView.js",
                 location: "panel",
               },

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -7858,7 +7858,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.no-path",
       version: "1.0.0",
       contributes: {
-        views: [{ id: "main", name: "Main", location: "panel" }],
+        views: [{ id: "main", location: "panel" }],
       },
     });
     expect(result.success).toBe(false);

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -756,8 +756,8 @@ describe("PluginManifestSchema forgeProviders contribution", () => {
         ],
         settings: [{ id: "github", type: "string", label: "GitHub" }],
         views: [
-          { id: "github-issues", name: "Issues", componentPath: "./issues.js", location: "panel" },
-          { id: "github-prs", name: "PRs", componentPath: "./prs.js", location: "panel" },
+          { id: "github-issues", componentPath: "./issues.js", location: "panel" },
+          { id: "github-prs", componentPath: "./prs.js", location: "panel" },
         ],
         forgeProviders: [
           {
@@ -917,7 +917,7 @@ describe("PluginManifestSchema contributes strict validation", () => {
       contributes: {
         // A view needs a matching panel id (view_panel_ref_unknown, #10620).
         panels: [{ id: "v", name: "V", iconId: "eye", color: "#abc" }],
-        views: [{ id: "v", name: "V", componentPath: "./v.js", location: "panel" }],
+        views: [{ id: "v", componentPath: "./v.js", location: "panel" }],
       },
     });
     expect(result.success).toBe(true);
@@ -943,7 +943,7 @@ describe("PluginManifestSchema contributes strict validation", () => {
       contributes: {
         // A view needs a matching panel id (view_panel_ref_unknown, #10620).
         panels: [{ id: "v", name: "V", iconId: "eye", color: "#abc" }],
-        experimental_views: [{ id: "v", name: "V", componentPath: "./v.js", location: "panel" }],
+        experimental_views: [{ id: "v", componentPath: "./v.js", location: "panel" }],
       },
     });
     expect(result.success).toBe(true);
@@ -975,10 +975,8 @@ describe("PluginManifestSchema contributes strict validation", () => {
       contributes: {
         // The surviving canonical view needs a matching panel id (#10620).
         panels: [{ id: "canonical", name: "Canonical", iconId: "eye", color: "#abc" }],
-        views: [{ id: "canonical", name: "Canonical", componentPath: "./c.js", location: "panel" }],
-        experimental_views: [
-          { id: "legacy", name: "Legacy", componentPath: "./l.js", location: "panel" },
-        ],
+        views: [{ id: "canonical", componentPath: "./c.js", location: "panel" }],
+        experimental_views: [{ id: "legacy", componentPath: "./l.js", location: "panel" }],
       },
     });
     expect(result.success).toBe(true);
@@ -994,9 +992,7 @@ describe("PluginManifestSchema contributes strict validation", () => {
       ...validBase,
       contributes: {
         views: [],
-        experimental_views: [
-          { id: "legacy", name: "Legacy", componentPath: "./l.js", location: "panel" },
-        ],
+        experimental_views: [{ id: "legacy", componentPath: "./l.js", location: "panel" }],
       },
     });
     expect(result.success).toBe(true);
@@ -7395,7 +7391,6 @@ describe("reserved contribution point warnings", () => {
         views: [
           {
             id: "main",
-            name: "Main",
             componentPath: "./dist/view.js",
             location: "panel",
           },
@@ -7430,7 +7425,6 @@ describe("reserved contribution point warnings", () => {
         views: [
           {
             id: "ghost",
-            name: "Ghost",
             componentPath: "./dist/view.js",
             location: "panel",
           },
@@ -7462,7 +7456,6 @@ describe("reserved contribution point warnings", () => {
         views: [
           {
             id: "main",
-            name: "Main",
             componentPath: "./dist/view.js",
             location: "sidebar",
           },
@@ -7494,7 +7487,6 @@ describe("reserved contribution point warnings", () => {
         views: [
           {
             id: "main",
-            name: "Main",
             componentPath: "./dist/view.js",
             location: "panel",
           },
@@ -7526,7 +7518,6 @@ describe("reserved contribution point warnings", () => {
         views: [
           {
             id: "main",
-            name: "Main",
             componentPath: "../escape.js",
             location: "panel",
           },
@@ -7557,7 +7548,6 @@ describe("reserved contribution point warnings", () => {
         views: [
           {
             id: "main",
-            name: "Main",
             componentPath: "https://evil.example/view.js",
             location: "panel",
           },
@@ -7584,8 +7574,8 @@ describe("reserved contribution point warnings", () => {
       contributes: {
         panels: [{ id: "main", name: "Main", iconId: "eye", color: "#abc" }],
         views: [
-          { id: "main", name: "First", componentPath: "./first.js", location: "panel" },
-          { id: "main", name: "Second", componentPath: "./second.js", location: "panel" },
+          { id: "main", componentPath: "./first.js", location: "panel" },
+          { id: "main", componentPath: "./second.js", location: "panel" },
         ],
       },
     });
@@ -7656,7 +7646,6 @@ describe("reserved contribution point warnings", () => {
         views: [
           {
             id: "github-issues",
-            name: "Issues",
             componentPath: "./issues.js",
             location: "panel",
           },
@@ -7758,9 +7747,7 @@ describe("reserved contribution point warnings", () => {
       engines: { daintree: "^0.7.0" },
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
-        experimental_views: [
-          { id: "viewer", name: "Viewer", componentPath: "./v.js", location: "panel" },
-        ],
+        experimental_views: [{ id: "viewer", componentPath: "./v.js", location: "panel" }],
         experimental_mcpServers: [{ id: "svc", name: "Svc", command: "node" }],
       },
     });
@@ -7807,7 +7794,7 @@ describe("reserved contribution point warnings", () => {
       engines: { daintree: "^0.7.0" },
       contributes: {
         panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#000" }],
-        views: [{ id: "viewer", name: "Viewer", componentPath: "./v.js", location: "panel" }],
+        views: [{ id: "viewer", componentPath: "./v.js", location: "panel" }],
         mcpServers: [{ id: "svc", name: "Svc", command: "node" }],
       },
     });
@@ -7834,8 +7821,8 @@ describe("reserved contribution point warnings", () => {
         // (view_panel_ref_unknown superRefine) rather than logging a warning.
         panels: [{ id: "a", name: "A", iconId: "eye", color: "#000" }],
         views: [
-          { id: "a", name: "A", componentPath: "./a.js", location: "panel" },
-          { id: "c", name: "C", componentPath: "./c.js", location: "panel" },
+          { id: "a", componentPath: "./a.js", location: "panel" },
+          { id: "c", componentPath: "./c.js", location: "panel" },
         ],
       },
     });
@@ -7860,7 +7847,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.bad-location",
       version: "1.0.0",
       contributes: {
-        views: [{ id: "main", name: "Main", componentPath: "./v.js", location: "floating" }],
+        views: [{ id: "main", componentPath: "./v.js", location: "floating" }],
       },
     });
     expect(result.success).toBe(false);
@@ -8832,7 +8819,7 @@ describe("Deferred activation — activatePlugin", () => {
               showInPalette: true,
             },
           ],
-          views: [{ id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" }],
+          views: [{ id: "viewer", componentPath: "view.mjs", location: "panel" }],
         },
       })
     );
@@ -8881,7 +8868,7 @@ describe("Deferred activation — activatePlugin", () => {
               showInPalette: true,
             },
           ],
-          views: [{ id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" }],
+          views: [{ id: "viewer", componentPath: "view.mjs", location: "panel" }],
         },
       })
     );
@@ -8929,7 +8916,7 @@ describe("Deferred activation — activatePlugin", () => {
               showInPalette: true,
             },
           ],
-          views: [{ id: "viewer", name: "Viewer", componentPath: "view.mjs", location: "panel" }],
+          views: [{ id: "viewer", componentPath: "view.mjs", location: "panel" }],
         },
       })
     );

--- a/packages/daintree-plugin/src/__tests__/validate.test.ts
+++ b/packages/daintree-plugin/src/__tests__/validate.test.ts
@@ -267,9 +267,7 @@ describe("runValidate", () => {
       engines: { daintree: ">=0.11.0" },
       contributes: {
         panels: [{ id: "main", name: "Main", iconId: "puzzle", color: "var(--x)" }],
-        views: [
-          { id: "main", name: "Main", componentPath: "src/missing-panel.js", location: "panel" },
-        ],
+        views: [{ id: "main", componentPath: "src/missing-panel.js", location: "panel" }],
       },
     });
     await fs.mkdir(path.join(tmpDir, "src"));

--- a/packages/daintree-plugin/src/scaffold/templates.ts
+++ b/packages/daintree-plugin/src/scaffold/templates.ts
@@ -321,7 +321,6 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
           views: [
             {
               id: "main",
-              name: ctx.displayName,
               componentPath: "dist/panel.js",
               location: "panel",
             },
@@ -374,7 +373,6 @@ export function buildTemplateFiles(ctx: ScaffoldContext): Record<string, string>
           views: [
             {
               id: "main",
-              name: ctx.displayName,
               componentPath: "dist/panel.js",
               location: "panel",
             },

--- a/plugins/sample/rich-daintree/plugin.json
+++ b/plugins/sample/rich-daintree/plugin.json
@@ -29,7 +29,6 @@
     "views": [
       {
         "id": "rich-panel",
-        "name": "Rich Panel",
         "componentPath": "./view/rich-panel-view.js",
         "location": "panel"
       }

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -132,11 +132,12 @@ export type ViewLocation = "panel";
 
 export interface ViewContribution {
   id: string;
-  name: string;
   componentPath: string;
   location: ViewLocation;
+  // Advisory only — the matching `contributes.panels` entry owns the rendered
+  // icon/name at runtime. `name`/`description` were removed (#10888) because no
+  // runtime path consumed them.
   iconId?: string;
-  description?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `electron/schemas/__tests__/manifestContributionConsumers.test.ts`, a contract test that walks every plugin manifest `contributes.*` schema (view, `agents.detection`, `credentialFields`, slots included) and checks every field the schema accepts maps to a real runtime or tooling consumer
- Uses a `satisfies`-typed field-to-consumer map plus a runtime `.shape` sweep over the zod schemas, so a new schema field fails the test until it's wired to a consumer
- Running the sweep surfaced two orphan fields on the view contribution, `name` and `description`, which were removed since the matching panel already owns that display metadata; `iconId` was kept because the SDK `validate` command reads it

Resolves #10888

## Changes
- New contract test: `electron/schemas/__tests__/manifestContributionConsumers.test.ts`
- `electron/schemas/plugin.ts`: exported `SettingDefinitionObjectSchema` and `CredentialFieldSchema` for introspection, split `SettingDefinitionSchema` to derive from the base object schema instead of duplicating it
- Removed the orphaned view `name`/`description` fields from the schema, sample plugin, SDK, and related tests
- Updated `PluginService.test.ts`, `pluginManifestIntegrity.test.ts`, `viewContribution.test.ts`, `PluginArchive.integration.test.ts`, and the daintree-plugin SDK's `validate.test.ts` for the schema change

## Testing
- Targeted suite passes: 724 tests plus 49 more across the touched files