### PR TITLE
feat(plugins): plugin blocklist / kill-switch at load (#10891)

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2219,6 +2219,7 @@ function buildElectronApi(): ElectronAPI {
           message: string;
           duration?: number;
           rateLimitKey?: string;
+          priority?: "high" | "low" | "watch";
           action?: { label: string; ipcChannel: string; data?: string };
         }) => void
       ) => _typedOn(CHANNELS.NOTIFICATION_SHOW_TOAST, callback),

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -93,6 +93,11 @@ import { PluginSettingsManager, assertSettingsKey } from "./plugin/PluginSetting
 import { PluginStorageManager, assertStorageKey } from "./plugin/PluginStorageManager.js";
 import { createListenerFailureState, invokeTrackedListener } from "./plugin/pluginCallbackUtils.js";
 import { PluginChannelRegistry, isChannelSchema } from "./plugin/PluginChannelRegistry.js";
+import {
+  PluginBlocklistService,
+  findPluginBlocklistMatch,
+  type ParsedPluginBlocklist,
+} from "./plugin/PluginBlocklistService.js";
 import { PluginInstaller } from "./plugin/PluginInstaller.js";
 import { PluginDevWorkerHost } from "./plugin/PluginDevWorkerHost.js";
 import { PluginDevWorkerMainBridge } from "./plugin/PluginDevWorkerMainBridge.js";
@@ -718,6 +723,27 @@ export class PluginService {
     { manifest: PluginManifest; dir: string; isBuiltin: boolean }
   >();
   /**
+   * Manifest metadata for plugins refused at load time by the remote blocklist
+   * / kill-switch (#10891), keyed by `manifest.name`. Populated at `loadPlugin()`
+   * skip time so `listPlugins()` can surface the block (with `blocklisted: true`
+   * and the reason) without re-scanning. Parallel to `disabledPlugins` but a
+   * distinct, host-decided state the user cannot toggle off. `reason` is the
+   * human-facing explanation for the UI/notification.
+   */
+  private blockedPlugins = new Map<
+    string,
+    { manifest: PluginManifest; dir: string; isBuiltin: boolean; reason: string }
+  >();
+  /**
+   * The blocklist resolved once at `initialize()` and enforced for the whole
+   * session (including later install-time loads). `null` when no validated list
+   * is available (offline first run, fetch failure) — the fail-open state.
+   * Resolved once up front rather than per-plugin so the `Promise.allSettled`
+   * load fan-out never awaits a network call (#9428).
+   */
+  private startupBlocklist: ParsedPluginBlocklist | null = null;
+  private readonly blocklistService: PluginBlocklistService;
+  /**
    * Per-plugin transition chain for live built-in enable/disable (#9304). A
    * rapid disable→enable→disable on the same id must not interleave the
    * unload/load mutations to `plugins`/`disabledPlugins`/`reservedNames`, so
@@ -840,12 +866,17 @@ export class PluginService {
   constructor(
     pluginsRoot?: string,
     appVersion?: string,
-    options?: { builtinPluginsRoot?: string; sideloadPluginsRoot?: string }
+    options?: {
+      builtinPluginsRoot?: string;
+      sideloadPluginsRoot?: string;
+      blocklistService?: PluginBlocklistService;
+    }
   ) {
     this.pluginsRoot = pluginsRoot ?? path.join(os.homedir(), ".daintree", "plugins");
     this.appVersion = appVersion ?? app.getVersion();
     this.builtinPluginsRoot = options?.builtinPluginsRoot;
     this.sideloadPluginsRoot = options?.sideloadPluginsRoot;
+    this.blocklistService = options?.blocklistService ?? new PluginBlocklistService();
 
     this.initPromise = new Promise<void>((resolve) => {
       this.resolveInit = resolve;
@@ -905,6 +936,7 @@ export class PluginService {
       getPlugin: (pluginId) => this.plugins.get(pluginId) ?? this.disabledPlugins.get(pluginId),
       reservedNames: this.reservedNames,
       disabledPlugins: this.disabledPlugins,
+      blockedPlugins: this.blockedPlugins,
     });
 
     const offRegister = onPanelKindRegistered(() => this.broadcaster.schedulePanelKindsBroadcast());
@@ -1013,6 +1045,13 @@ export class PluginService {
     // session, so this can't race a live temp dir; it only touches the user
     // root, never the built-in or sideload roots.
     await this.installer.sweepStalePluginTempDirs();
+
+    // Resolve the kill-switch blocklist once, before any scan, so the
+    // per-plugin load gate below reads a single immutable snapshot and the
+    // Promise.allSettled fan-out never awaits a network call (#9428). Fails
+    // open: getBlocklist() returns null on any fetch/parse failure with no
+    // cached list, and plugins then load normally.
+    this.startupBlocklist = await this.blocklistService.getBlocklist();
 
     // Built-ins load first so user plugins with a colliding manifest.name are
     // rejected by the duplicate guard in loadPlugin() — built-in wins.
@@ -1186,6 +1225,39 @@ export class PluginService {
           );
         }
       }
+    }
+
+    // Kill-switch: refuse to load any plugin whose name + version matches the
+    // remote blocklist (#10891). Checked before the disabled gate so a plugin
+    // that is both disabled and blocklisted still surfaces as blocked (the
+    // security signal wins). The name is reserved so a later dir scan can't
+    // hijack the namespace, and the manifest is tracked so listPlugins() can
+    // surface the block. No `activate` runs — it never enters `this.plugins`.
+    const blockMatch = findPluginBlocklistMatch(this.startupBlocklist, {
+      name: manifest.name,
+      version: manifest.version,
+    });
+    if (blockMatch) {
+      console.warn(
+        `[PluginService] Plugin "${manifest.name}" v${manifest.version} is blocklisted (${blockMatch.reason}) — refusing to load`
+      );
+      this.reservedNames.add(manifest.name);
+      if (!this.blockedPlugins.has(manifest.name)) {
+        this.blockedPlugins.set(manifest.name, {
+          manifest,
+          dir: pluginDir,
+          isBuiltin: opts.isBuiltin,
+          reason: blockMatch.message,
+        });
+        broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
+          type: "warning",
+          priority: "low",
+          title: "Plugin blocked",
+          message: `"${manifest.displayName ?? manifest.name}" was blocked from loading: ${blockMatch.message}`,
+          rateLimitKey: `plugin-blocklist:${manifest.name}`,
+        });
+      }
+      return null;
     }
 
     // Plugins disabled in Preferences are skipped entirely — neither
@@ -4689,12 +4761,15 @@ export class PluginService {
     const toInfo = (
       p: { manifest: PluginManifest; dir: string; isBuiltin: boolean },
       loadedAt: number,
-      isRunning: boolean
+      isRunning: boolean,
+      blocklistReason?: string
     ): LoadedPluginInfo => {
       const disabled = desiredDisabled.has(p.manifest.name);
       // pendingRestart: desired state diverges from running state.
       // Running + now-disabled → unload pending; skipped + now-enabled → load pending.
-      const pendingRestart = isRunning ? disabled : !disabled;
+      // Blocklisted plugins are host-refused, not user-toggled — no pending cue.
+      const blocklisted = blocklistReason !== undefined;
+      const pendingRestart = blocklisted ? false : isRunning ? disabled : !disabled;
       const pluginDanger = computePluginDanger(p.manifest);
       if (p.isBuiltin) {
         return {
@@ -4712,6 +4787,8 @@ export class PluginService {
           devMode: false,
           pendingRestart,
           pluginDanger,
+          blocklisted,
+          blocklistReason,
         };
       }
       const record = installed[p.manifest.name];
@@ -4731,6 +4808,8 @@ export class PluginService {
         devMode: record?.devMode ?? false,
         pendingRestart,
         pluginDanger,
+        blocklisted,
+        blocklistReason,
       };
     };
 
@@ -4741,7 +4820,13 @@ export class PluginService {
     // `loadedAt` — the main module never ran — so it's reported as 0.
     const skipped = Array.from(this.disabledPlugins.values()).map((p) => toInfo(p, 0, false));
 
-    return [...running, ...skipped];
+    // Plugins refused at launch by the blocklist / kill-switch (#10891). Also
+    // never ran (`loadedAt: 0`); the reason drives the "Blocked" badge/banner.
+    const blocked = Array.from(this.blockedPlugins.values()).map((p) =>
+      toInfo(p, 0, false, p.reason)
+    );
+
+    return [...running, ...skipped, ...blocked];
   }
 
   /**

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -4802,7 +4802,9 @@ export class PluginService {
         updatedAt: record?.updatedAt,
         archiveHash: record?.archiveHash ?? null,
         originalUrl: record?.originalUrl ?? null,
-        loadError: record?.loadError ?? null,
+        // A blocklisted plugin is a policy refusal, not a technical failure —
+        // suppress any stale activation error so the UI shows only "Blocked".
+        loadError: blocklisted ? null : (record?.loadError ?? null),
         disabled,
         updateAvailable: record?.updateAvailable ?? null,
         devMode: record?.devMode ?? false,

--- a/electron/services/__tests__/PluginService.install.test.ts
+++ b/electron/services/__tests__/PluginService.install.test.ts
@@ -112,6 +112,15 @@ vi.mock("../plugin-capability/instances.js", () => ({
 import { PluginService } from "../PluginService.js";
 import { packPluginArchive } from "../PluginArchive.js";
 import { resilientRename } from "../../utils/fs.js";
+import { PluginBlocklistService } from "../plugin/PluginBlocklistService.js";
+
+/** A PluginBlocklistService backed by an in-memory list (no network/disk). */
+function fakeBlocklist(entries: Array<Record<string, unknown>>): PluginBlocklistService {
+  return new PluginBlocklistService({
+    cachePath: path.join(tmpDir, "no-such-blocklist-cache.json"),
+    fetchImpl: async () => ({ ok: true, status: 200, json: async () => ({ entries }) }),
+  });
+}
 
 const storeState = storeMock._state;
 
@@ -782,6 +791,63 @@ describe("loadDevPlugin — trust gates (#10518)", () => {
     ).records.setEnabled("acme.dev-honor", false);
 
     await expect(service.loadDevPlugin("acme.dev-honor")).rejects.toThrow(/disabled|Couldn't load/);
+
+    service.dispose();
+  });
+});
+
+describe("installPlugin — blocklist interaction (#10891)", () => {
+  it("installs a fixed version over a plugin that was blocklisted at startup", async () => {
+    // A blocked v1 is on disk at launch: reserves its name + records a blocked row.
+    await fs.mkdir(path.join(pluginsRoot, "acme.bad"), { recursive: true });
+    await fs.writeFile(
+      path.join(pluginsRoot, "acme.bad", "plugin.json"),
+      JSON.stringify({ name: "acme.bad", version: "1.0.0" })
+    );
+    const service = new PluginService(pluginsRoot, "0.0.0", {
+      blocklistService: fakeBlocklist([{ name: "acme.bad", ranges: ["<2.0.0"], reason: "cve" }]),
+    });
+    await service.initialize();
+    expect(service.listPlugins().find((p) => p.manifest.name === "acme.bad")?.blocklisted).toBe(
+      true
+    );
+
+    // Installing a no-longer-blocklisted v2 must clear the stale reservation and load.
+    const archive = await makeArchive({ name: "acme.bad", version: "2.0.0" });
+    const result = await service.installPlugin(archive);
+
+    expect(result).toEqual({ status: "installed", pluginId: "acme.bad" });
+    const info = service.listPlugins().find((p) => p.manifest.name === "acme.bad");
+    expect(info?.blocklisted).toBe(false);
+    expect(info?.loadedAt).toBeGreaterThan(0);
+
+    service.dispose();
+  });
+
+  it("restores the previous good version when an upgrade to a blocklisted version fails", async () => {
+    // Good v1 installed and running.
+    const v1 = await makeArchive({ name: "acme.up", version: "1.0.0" });
+    const service = new PluginService(pluginsRoot, "0.0.0", {
+      blocklistService: fakeBlocklist([
+        { name: "acme.up", ranges: [">=2.0.0"], reason: "revoked" },
+      ]),
+    });
+    await service.initialize();
+    await service.installPlugin(v1);
+    expect(
+      service.listPlugins().find((p) => p.manifest.name === "acme.up")?.loadedAt
+    ).toBeGreaterThan(0);
+
+    // Upgrading to a blocklisted v2 fails to load; rollback must restore v1 live,
+    // not strand it behind the stale reservation the blocked v2 left behind.
+    const v2 = await makeArchive({ name: "acme.up", version: "2.0.0" });
+    const result = await service.installPlugin(v2);
+
+    expect(result.status).toBe("failed");
+    const info = service.listPlugins().find((p) => p.manifest.name === "acme.up");
+    expect(info?.blocklisted).toBe(false);
+    expect(info?.manifest.version).toBe("1.0.0");
+    expect(info?.loadedAt).toBeGreaterThan(0);
 
     service.dispose();
   });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -251,6 +251,10 @@ import {
   unregisterFileDecorationProviderImpls,
 } from "../fileDecorationRegistry.js";
 import { CHANNELS } from "../../ipc/channels.js";
+import {
+  PluginBlocklistService,
+  type ParsedPluginBlocklist,
+} from "../plugin/PluginBlocklistService.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
   return {
@@ -9589,5 +9593,130 @@ describe("dev-mode hot reload (#9304)", () => {
     clearPriorRegistrations();
 
     expect(service.listPluginActions().some((a) => a.id === "acme.dev.do-thing")).toBe(true);
+  });
+});
+
+describe("PluginService blocklist / kill-switch (#10891)", () => {
+  function blocklistService(
+    entries: ParsedPluginBlocklist["entries"],
+    fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ entries }),
+    }))
+  ) {
+    // Route disk cache into the test tmpDir so a real userData path is never touched.
+    const svc = new PluginBlocklistService({
+      fetchImpl,
+      cachePath: path.join(tmpDir, "blocklist-cache.json"),
+    });
+    return { svc, fetchImpl };
+  }
+
+  it("refuses to load a blocklisted plugin and surfaces it in listPlugins", async () => {
+    await writePlugin("bad", { name: "acme.bad", version: "1.2.3" });
+    const { svc } = blocklistService([
+      { name: "acme.bad", ranges: ["<2.0.0"], reason: "malware", message: "Steals tokens" },
+    ]);
+
+    const service = new PluginService(tmpDir, undefined, { blocklistService: svc });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    const info = plugins[0];
+    expect(info.manifest.name).toBe("acme.bad");
+    expect(info.blocklisted).toBe(true);
+    expect(info.blocklistReason).toBe("Steals tokens");
+    // Never ran — no activation, no pending-restart cue, no load error.
+    expect(info.loadedAt).toBe(0);
+    expect(info.pendingRestart).toBe(false);
+    expect(info.loadError).toBeNull();
+    // Not registered as a running panel-contributing plugin.
+    expect(registerPanelKind).not.toHaveBeenCalled();
+  });
+
+  it("emits a low-priority inbox notification for a blocked plugin", async () => {
+    await writePlugin("bad", {
+      name: "acme.bad",
+      version: "1.0.0",
+      displayName: "Bad Plugin",
+    });
+    const { svc } = blocklistService([
+      { name: "acme.bad", ranges: ["*"], reason: "malware", message: "Known-bad build" },
+    ]);
+
+    const service = new PluginService(tmpDir, undefined, { blocklistService: svc });
+    await service.initialize();
+
+    expect(broadcastToRendererMock).toHaveBeenCalledWith(
+      CHANNELS.NOTIFICATION_SHOW_TOAST,
+      expect.objectContaining({
+        type: "warning",
+        priority: "low",
+        title: "Plugin blocked",
+        message: expect.stringContaining("Bad Plugin"),
+      })
+    );
+  });
+
+  it("loads a plugin whose version is outside every blocklisted range", async () => {
+    await writePlugin("ok", { name: "acme.ok", version: "3.0.0" });
+    const { svc } = blocklistService([{ name: "acme.ok", ranges: ["<2.0.0"], reason: "old-cve" }]);
+
+    const service = new PluginService(tmpDir, undefined, { blocklistService: svc });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].blocklisted).toBe(false);
+    expect(plugins[0].loadedAt).toBeGreaterThan(0);
+  });
+
+  it("reports a disabled-and-blocklisted plugin as blocklisted (block gate wins)", async () => {
+    storeMock._state.set("plugins", { disabled: ["acme.bad"] });
+    await writePlugin("bad", { name: "acme.bad", version: "1.0.0" });
+    const { svc } = blocklistService([
+      { name: "acme.bad", ranges: ["*"], reason: "revoked", message: "Publisher revoked" },
+    ]);
+
+    const service = new PluginService(tmpDir, undefined, { blocklistService: svc });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].blocklisted).toBe(true);
+    expect(plugins[0].blocklistReason).toBe("Publisher revoked");
+  });
+
+  it("fails open — a fetch failure loads plugins normally", async () => {
+    await writePlugin("ok", { name: "acme.ok", version: "1.0.0" });
+    const failing = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const { svc } = blocklistService([], failing);
+
+    const service = new PluginService(tmpDir, undefined, { blocklistService: svc });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].blocklisted).toBe(false);
+    expect(plugins[0].loadedAt).toBeGreaterThan(0);
+  });
+
+  it("resolves the blocklist once at initialize, not once per plugin", async () => {
+    await writePlugin("a", { name: "acme.a", version: "1.0.0" });
+    await writePlugin("b", { name: "acme.b", version: "1.0.0" });
+    await writePlugin("c", { name: "acme.c", version: "1.0.0" });
+    const { svc, fetchImpl } = blocklistService([
+      { name: "acme.a", ranges: ["<0.0.1"], reason: "n/a" },
+    ]);
+
+    const service = new PluginService(tmpDir, undefined, { blocklistService: svc });
+    await service.initialize();
+
+    // A single fetch backs the whole multi-plugin scan.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -9614,7 +9614,17 @@ describe("PluginService blocklist / kill-switch (#10891)", () => {
   }
 
   it("refuses to load a blocklisted plugin and surfaces it in listPlugins", async () => {
-    await writePlugin("bad", { name: "acme.bad", version: "1.2.3" });
+    // Declare a panel so the "no registration" assertion is meaningful: a
+    // manifest that *has* a contribution yet registers nothing proves the gate
+    // runs before contribution registration, not merely that there was nothing
+    // to register.
+    await writePlugin("bad", {
+      name: "acme.bad",
+      version: "1.2.3",
+      contributes: {
+        panels: [{ id: "viewer", name: "Viewer", iconId: "eye", color: "#ff0000" }],
+      },
+    });
     const { svc } = blocklistService([
       { name: "acme.bad", ranges: ["<2.0.0"], reason: "malware", message: "Steals tokens" },
     ]);
@@ -9632,7 +9642,7 @@ describe("PluginService blocklist / kill-switch (#10891)", () => {
     expect(info.loadedAt).toBe(0);
     expect(info.pendingRestart).toBe(false);
     expect(info.loadError).toBeNull();
-    // Not registered as a running panel-contributing plugin.
+    // The declared panel must NOT register — the gate precedes contribution wiring.
     expect(registerPanelKind).not.toHaveBeenCalled();
   });
 

--- a/electron/services/plugin/PluginBlocklistService.ts
+++ b/electron/services/plugin/PluginBlocklistService.ts
@@ -118,7 +118,11 @@ export class PluginBlocklistService {
       return disk.data;
     }
 
-    return null;
+    // Disk is also gone/corrupt. If we ever validated a list this session,
+    // keep enforcing it (stale) rather than dropping to no-blocklist — a
+    // kill-switch should not forget a known-bad plugin just because the TTL
+    // lapsed and the network is down.
+    return this.memCache?.data ?? null;
   }
 
   private async refresh(): Promise<ParsedPluginBlocklist | null> {

--- a/electron/services/plugin/PluginBlocklistService.ts
+++ b/electron/services/plugin/PluginBlocklistService.ts
@@ -1,0 +1,287 @@
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import * as semver from "semver";
+import { z } from "zod";
+
+import {
+  PLUGIN_BLOCKLIST_URL,
+  PLUGIN_BLOCKLIST_CACHE_FILENAME,
+  PLUGIN_BLOCKLIST_TTL_MS,
+  PLUGIN_BLOCKLIST_FETCH_TIMEOUT_MS,
+} from "../../../shared/config/pluginBlocklist.js";
+
+/**
+ * One blocklist entry. OSV-inspired minimal shape: a plugin `name`, one or
+ * more semver `ranges` covering the bad versions, a machine `reason` code, an
+ * optional human `message`, and an optional `jti` allow-scoping reserved for a
+ * future signed-identity model (unused today — see the matcher).
+ */
+const PluginBlocklistEntrySchema = z.object({
+  name: z.string().min(1),
+  ranges: z.array(z.string().min(1)).min(1),
+  jti: z.array(z.string().min(1)).min(1).optional(),
+  reason: z.string().min(1),
+  message: z.string().min(1).optional(),
+});
+
+const PluginBlocklistSchema = z.object({
+  entries: z.array(PluginBlocklistEntrySchema),
+});
+
+export type PluginBlocklistEntry = z.infer<typeof PluginBlocklistEntrySchema>;
+export type ParsedPluginBlocklist = z.infer<typeof PluginBlocklistSchema>;
+
+/** Result of a positive blocklist match, surfaced to the UI/notification. */
+export interface PluginBlocklistMatch {
+  /** The blocklist entry's machine reason code. */
+  reason: string;
+  /** Human-facing explanation — `message` if present, else `reason`. */
+  message: string;
+}
+
+interface DiskPayload {
+  fetchedAt: number;
+  raw: unknown;
+}
+
+interface CachedBlocklist {
+  data: ParsedPluginBlocklist;
+  fetchedAt: number;
+}
+
+interface BlocklistDeps {
+  /** Override for disk-cache path. Defaults to `app.getPath('userData')/plugin-blocklist.json`. */
+  cachePath?: string;
+  /** Override for `fetch` (used by tests). Defaults to Electron's `net.fetch`. */
+  fetchImpl?: (
+    url: string,
+    init?: { signal?: AbortSignal; headers?: Record<string, string> }
+  ) => Promise<{
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+  }>;
+  /** Override for the clock (used by tests). Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/**
+ * Resolves the remote plugin blocklist / kill-switch (#10891) with a
+ * disk-backed stale-while-revalidate cache and singleflight dedup, mirroring
+ * `AgentModelCatalogService`. The contract is **fail open**: every failure
+ * path (network, HTTP error, malformed body, missing/corrupt cache) resolves
+ * to `null` and never throws, so a user's plugins are never bricked just
+ * because the blocklist couldn't be fetched. A previously-cached list is still
+ * enforced while offline — security-favorable, and the intended behavior for a
+ * kill-switch — which is why "fail open" here means "fail open when no
+ * validated blocklist is available", not "ignore a stale one".
+ */
+export class PluginBlocklistService {
+  private inFlight: Promise<ParsedPluginBlocklist | null> | null = null;
+  private memCache: CachedBlocklist | null = null;
+
+  constructor(private readonly deps: BlocklistDeps = {}) {}
+
+  private now(): number {
+    return this.deps.now ? this.deps.now() : Date.now();
+  }
+
+  /** Force a re-resolve on the next `getBlocklist()` call. Used by tests. */
+  clearCache(): void {
+    this.memCache = null;
+  }
+
+  /** Returns the parsed blocklist, or `null` when no validated list is available. */
+  async getBlocklist(): Promise<ParsedPluginBlocklist | null> {
+    if (this.memCache && this.now() - this.memCache.fetchedAt < PLUGIN_BLOCKLIST_TTL_MS) {
+      return this.memCache.data;
+    }
+
+    if (this.inFlight) return this.inFlight;
+
+    this.inFlight = this.refresh()
+      .catch((err) => {
+        console.warn("[PluginBlocklistService] refresh failed", err);
+        return null;
+      })
+      .finally(() => {
+        this.inFlight = null;
+      });
+
+    const fresh = await this.inFlight;
+    if (fresh) return fresh;
+
+    // Network failed — fall back to disk if memCache was never warmed.
+    const disk = await this.readDisk();
+    if (disk) {
+      this.memCache = { data: disk.data, fetchedAt: disk.fetchedAt };
+      return disk.data;
+    }
+
+    return null;
+  }
+
+  private async refresh(): Promise<ParsedPluginBlocklist | null> {
+    const disk = await this.readDisk();
+    if (disk && this.now() - disk.fetchedAt < PLUGIN_BLOCKLIST_TTL_MS) {
+      this.memCache = { data: disk.data, fetchedAt: disk.fetchedAt };
+      return disk.data;
+    }
+
+    const fetched = await this.fetchRemote();
+    if (fetched) {
+      this.memCache = { data: fetched.parsed, fetchedAt: fetched.fetchedAt };
+      // Best-effort persist; a write failure must never block enforcement.
+      void this.writeDisk(fetched.fetchedAt, fetched.raw).catch((err) => {
+        console.warn("[PluginBlocklistService] disk write failed", err);
+      });
+      return fetched.parsed;
+    }
+
+    // Network failed but a stale cache exists — enforce the last-known list.
+    if (disk) {
+      this.memCache = { data: disk.data, fetchedAt: disk.fetchedAt };
+      return disk.data;
+    }
+
+    return null;
+  }
+
+  private async fetchRemote(): Promise<{
+    parsed: ParsedPluginBlocklist;
+    raw: unknown;
+    fetchedAt: number;
+  } | null> {
+    const fetchImpl = this.deps.fetchImpl ?? (await getElectronNetFetch());
+    if (!fetchImpl) return null;
+
+    try {
+      const res = await fetchImpl(PLUGIN_BLOCKLIST_URL, {
+        signal: AbortSignal.timeout(PLUGIN_BLOCKLIST_FETCH_TIMEOUT_MS),
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Daintree-Electron",
+        },
+      });
+      if (!res.ok) {
+        console.warn(`[PluginBlocklistService] HTTP ${res.status} from ${PLUGIN_BLOCKLIST_URL}`);
+        return null;
+      }
+      const raw = await res.json();
+      const parsed = PluginBlocklistSchema.safeParse(raw);
+      if (!parsed.success) {
+        console.warn("[PluginBlocklistService] blocklist schema rejected", parsed.error.message);
+        return null;
+      }
+      return { parsed: parsed.data, raw, fetchedAt: this.now() };
+    } catch (err) {
+      // `AbortSignal.timeout()` surfaces inconsistently across Chromium
+      // versions — sometimes `TimeoutError`, sometimes `AbortError`. Both, and
+      // any other network error, are fail-open cases.
+      console.warn("[PluginBlocklistService] blocklist fetch failed", err);
+      return null;
+    }
+  }
+
+  private async readDisk(): Promise<{ data: ParsedPluginBlocklist; fetchedAt: number } | null> {
+    const cachePath = await this.resolveCachePath();
+    if (!cachePath) return null;
+    try {
+      const text = await fs.readFile(cachePath, "utf-8");
+      const payload = JSON.parse(text) as Partial<DiskPayload>;
+      if (typeof payload.fetchedAt !== "number") return null;
+      const parsed = PluginBlocklistSchema.safeParse(payload.raw);
+      if (!parsed.success) return null;
+      return { data: parsed.data, fetchedAt: payload.fetchedAt };
+    } catch (err: unknown) {
+      if (isNodeError(err) && err.code === "ENOENT") return null;
+      console.warn("[PluginBlocklistService] disk read failed", err);
+      return null;
+    }
+  }
+
+  private async writeDisk(fetchedAt: number, raw: unknown): Promise<void> {
+    const cachePath = await this.resolveCachePath();
+    if (!cachePath) return;
+    const dir = path.dirname(cachePath);
+    await fs.mkdir(dir, { recursive: true });
+    const payload: DiskPayload = { fetchedAt, raw };
+    await fs.writeFile(cachePath, JSON.stringify(payload), "utf-8");
+  }
+
+  private async resolveCachePath(): Promise<string | null> {
+    if (this.deps.cachePath) return this.deps.cachePath;
+    try {
+      const { app } = await import("electron");
+      return path.join(app.getPath("userData"), PLUGIN_BLOCKLIST_CACHE_FILENAME);
+    } catch {
+      // Outside Electron (tests without override) — skip disk cache.
+      return null;
+    }
+  }
+}
+
+/**
+ * Pure matcher — kept exported and side-effect-free so the semver / malformed
+ * -range / prerelease / jti-scoping behavior can be unit-tested directly.
+ *
+ * A candidate matches an entry when the `name` is exactly equal AND at least
+ * one of the entry's `ranges` covers `candidate.version` via
+ * `semver.satisfies(..., { includePrerelease: true })` — the `includePrerelease`
+ * flag is mandatory (matching the existing `engines.daintree` check) or a
+ * prerelease-tagged version silently slips a `<x.y.z`-style range. Malformed
+ * ranges are ignored entry-locally rather than treated as a match or a whole
+ * -blocklist failure.
+ *
+ * `jti` scoping is reserved for a future signed-identity model: an entry that
+ * declares `jti` only matches when the candidate carries one of those ids.
+ * Today plugins expose no `jti`, so `jti`-scoped entries never over-block.
+ */
+export function findPluginBlocklistMatch(
+  blocklist: ParsedPluginBlocklist | null,
+  candidate: { name: string; version: string; jti?: string }
+): PluginBlocklistMatch | null {
+  if (!blocklist) return null;
+
+  for (const entry of blocklist.entries) {
+    if (entry.name !== candidate.name) continue;
+
+    if (entry.jti && entry.jti.length > 0) {
+      if (!candidate.jti || !entry.jti.includes(candidate.jti)) continue;
+    }
+
+    const versionMatches = entry.ranges.some((range) => {
+      if (!semver.validRange(range, { includePrerelease: true })) return false;
+      return semver.satisfies(candidate.version, range, { includePrerelease: true });
+    });
+    if (!versionMatches) continue;
+
+    return { reason: entry.reason, message: entry.message ?? entry.reason };
+  }
+
+  return null;
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
+/**
+ * Resolve Electron's `net.fetch` lazily so this module can be imported in
+ * Node-only test runners. Returns a `fetch`-compatible function, or null when
+ * `net.fetch` is unavailable.
+ */
+async function getElectronNetFetch(): Promise<BlocklistDeps["fetchImpl"] | null> {
+  try {
+    const { net } = await import("electron");
+    if (typeof net?.fetch !== "function") return null;
+    return (url: string, init?: { signal?: AbortSignal; headers?: Record<string, string> }) =>
+      net.fetch(url, init).then((res) => ({
+        ok: res.ok,
+        status: res.status,
+        json: () => res.json() as Promise<unknown>,
+      }));
+  } catch {
+    return null;
+  }
+}

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -490,6 +490,18 @@ export class PluginInstaller {
         return { status: "installed", pluginId };
       }
 
+      // Installing this id authoritatively replaces whatever startup state it
+      // had. If it was refused by the blocklist at launch (#10891) its name is
+      // still reserved and a blocked row is tracked — clear both so a fixed,
+      // no-longer-blocklisted version can load instead of tripping the
+      // duplicate-name guard. Scoped to the block state (only touch the
+      // reservation when we actually held a block) so disabled-plugin reinstall
+      // behavior is unchanged. loadPlugin re-adds the block if the new version
+      // still matches.
+      if (this.deps.blockedPlugins.delete(pluginId)) {
+        this.deps.reservedNames.delete(pluginId);
+      }
+
       let loaded: unknown;
       try {
         loaded = await this.deps.loadPlugin(this.pluginsRoot, pluginId, {
@@ -621,6 +633,16 @@ export class PluginInstaller {
       const records = this.records.getInstalledRecords();
       records[pluginId] = previousRecord;
       this.records.writeInstalledRecords(records);
+    }
+
+    // The failed new version may have been refused by the blocklist, which
+    // reserved its name and recorded a blocked row (#10891). Clear that
+    // transient state before reloading the old version — otherwise the restored
+    // (good) version is rejected by the duplicate-name guard and a stale
+    // "Blocked" row lingers for the rolled-back plugin. If the old version is
+    // itself blocklisted, loadPlugin re-establishes the block below.
+    if (this.deps.blockedPlugins.delete(pluginId)) {
+      this.deps.reservedNames.delete(pluginId);
     }
 
     try {

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -472,6 +472,20 @@ export class PluginInstaller {
           : { installedAt: Date.now() }),
       });
 
+      // Installing this id authoritatively replaces whatever startup state it
+      // had. If it was refused by the blocklist at launch (#10891) its name is
+      // still reserved and a blocked row is tracked — clear both so a fixed,
+      // no-longer-blocklisted version can load instead of tripping the
+      // duplicate-name guard, and so no stale "Blocked" row lingers. Cleared
+      // BEFORE the disabled early-return below so it also applies to a plugin
+      // that was both disabled and blocklisted. Scoped to the block state (only
+      // touch the reservation when we actually held a block) so disabled-plugin
+      // reinstall behavior is otherwise unchanged. loadPlugin re-adds the block
+      // if the new version still matches.
+      if (this.deps.blockedPlugins.delete(pluginId)) {
+        this.deps.reservedNames.delete(pluginId);
+      }
+
       // A plugin disabled in Preferences installs to disk but is intentionally
       // not loaded this session (`loadPlugin` would return null for it). The
       // files and provenance are committed, so this is a successful install.
@@ -488,18 +502,6 @@ export class PluginInstaller {
         }
         this.deps.broadcastProvenanceChanged();
         return { status: "installed", pluginId };
-      }
-
-      // Installing this id authoritatively replaces whatever startup state it
-      // had. If it was refused by the blocklist at launch (#10891) its name is
-      // still reserved and a blocked row is tracked — clear both so a fixed,
-      // no-longer-blocklisted version can load instead of tripping the
-      // duplicate-name guard. Scoped to the block state (only touch the
-      // reservation when we actually held a block) so disabled-plugin reinstall
-      // behavior is unchanged. loadPlugin re-adds the block if the new version
-      // still matches.
-      if (this.deps.blockedPlugins.delete(pluginId)) {
-        this.deps.reservedNames.delete(pluginId);
       }
 
       let loaded: unknown;

--- a/electron/services/plugin/PluginInstaller.ts
+++ b/electron/services/plugin/PluginInstaller.ts
@@ -92,6 +92,8 @@ interface PluginInstallerDeps {
   reservedNames: Set<string>;
   /** Shared skipped-at-launch manifest map — stays PluginService-owned. */
   disabledPlugins: Map<string, unknown>;
+  /** Shared blocklisted-at-launch manifest map (#10891) — stays PluginService-owned. */
+  blockedPlugins: Map<string, unknown>;
 }
 
 /**
@@ -1041,6 +1043,10 @@ export class PluginInstaller {
       // throws, the record stays so the row remains and the user can retry,
       // rather than seeing a "gone" plugin whose files are still on disk.
       this.deps.disabledPlugins.delete(pluginId);
+      // Clear any blocklist-skipped row (#10891) so uninstalling a blocked
+      // plugin removes its "Blocked" entry from the manager rather than
+      // stranding a row whose files are already gone.
+      this.deps.blockedPlugins.delete(pluginId);
       // Release the launch-time name reservation (set when a disabled plugin is
       // skipped at startup) so a same-session reinstall isn't rejected as a
       // duplicate name.

--- a/electron/services/plugin/__tests__/PluginBlocklistService.test.ts
+++ b/electron/services/plugin/__tests__/PluginBlocklistService.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+
+import {
+  PluginBlocklistService,
+  findPluginBlocklistMatch,
+  type ParsedPluginBlocklist,
+} from "../PluginBlocklistService.js";
+import { PLUGIN_BLOCKLIST_TTL_MS } from "../../../../shared/config/pluginBlocklist.js";
+
+const BLOCKLIST: ParsedPluginBlocklist = {
+  entries: [
+    { name: "acme.bad", ranges: ["<2.0.0"], reason: "malware", message: "Steals tokens" },
+    { name: "acme.multi", ranges: ["1.0.0", ">=3.0.0 <4.0.0"], reason: "cve" },
+  ],
+};
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+/**
+ * Wait for a file to appear and be readable. `writeDisk` is intentionally
+ * fire-and-forget (`void this.writeDisk(...)`) so a slow disk never blocks
+ * `getBlocklist()` resolution — which means the persisted cache lands a few
+ * ticks after the promise resolves. Poll rather than assume it's synchronous.
+ */
+async function waitForFile(filePath: string, timeoutMs = 1000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      return await fs.readFile(filePath, "utf-8");
+    } catch (err) {
+      if (Date.now() > deadline) throw err;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+}
+
+/** A fetchImpl that records call count and returns the given body. */
+function stubFetch(body: unknown, opts: { ok?: boolean; status?: number } = {}) {
+  const fn = vi.fn(async () => jsonResponse(body, opts.ok ?? true, opts.status ?? 200));
+  return fn;
+}
+
+describe("findPluginBlocklistMatch", () => {
+  it("returns null for an empty or null blocklist", () => {
+    expect(findPluginBlocklistMatch(null, { name: "acme.bad", version: "1.0.0" })).toBeNull();
+    expect(
+      findPluginBlocklistMatch({ entries: [] }, { name: "acme.bad", version: "1.0.0" })
+    ).toBeNull();
+  });
+
+  it("does not match when the name differs", () => {
+    expect(findPluginBlocklistMatch(BLOCKLIST, { name: "acme.good", version: "1.0.0" })).toBeNull();
+  });
+
+  it("does not match when the version is outside every range", () => {
+    expect(findPluginBlocklistMatch(BLOCKLIST, { name: "acme.bad", version: "2.5.0" })).toBeNull();
+  });
+
+  it("matches when the version satisfies the range and returns message over reason", () => {
+    const match = findPluginBlocklistMatch(BLOCKLIST, { name: "acme.bad", version: "1.9.9" });
+    expect(match).toEqual({ reason: "malware", message: "Steals tokens" });
+  });
+
+  it("falls back to reason as the message when no message is provided", () => {
+    const match = findPluginBlocklistMatch(BLOCKLIST, { name: "acme.multi", version: "1.0.0" });
+    expect(match).toEqual({ reason: "cve", message: "cve" });
+  });
+
+  it("matches when any one of multiple ranges is satisfied", () => {
+    expect(
+      findPluginBlocklistMatch(BLOCKLIST, { name: "acme.multi", version: "3.4.0" })
+    ).not.toBeNull();
+    // Between the two ranges — no match.
+    expect(
+      findPluginBlocklistMatch(BLOCKLIST, { name: "acme.multi", version: "2.0.0" })
+    ).toBeNull();
+  });
+
+  it("matches a prerelease-tagged version against a stable range (includePrerelease)", () => {
+    // Without { includePrerelease: true } semver excludes prereleases from a
+    // plain `<2.0.0` range, letting a malicious `1.9.9-rc.1` bypass the block.
+    const match = findPluginBlocklistMatch(BLOCKLIST, { name: "acme.bad", version: "1.9.9-rc.1" });
+    expect(match).not.toBeNull();
+  });
+
+  it("ignores a malformed range without matching or throwing", () => {
+    const bl: ParsedPluginBlocklist = {
+      entries: [{ name: "acme.x", ranges: ["not-a-range"], reason: "r" }],
+    };
+    expect(findPluginBlocklistMatch(bl, { name: "acme.x", version: "1.0.0" })).toBeNull();
+  });
+
+  it("still matches a valid range when a sibling range is malformed", () => {
+    const bl: ParsedPluginBlocklist = {
+      entries: [{ name: "acme.x", ranges: ["not-a-range", "1.0.0"], reason: "r" }],
+    };
+    expect(findPluginBlocklistMatch(bl, { name: "acme.x", version: "1.0.0" })).not.toBeNull();
+  });
+
+  it("does not match a jti-scoped entry when the candidate has no jti", () => {
+    const bl: ParsedPluginBlocklist = {
+      entries: [{ name: "acme.x", ranges: ["*"], jti: ["abc"], reason: "revoked" }],
+    };
+    expect(findPluginBlocklistMatch(bl, { name: "acme.x", version: "1.0.0" })).toBeNull();
+  });
+
+  it("matches a jti-scoped entry only when the candidate carries a listed jti", () => {
+    const bl: ParsedPluginBlocklist = {
+      entries: [{ name: "acme.x", ranges: ["*"], jti: ["abc"], reason: "revoked" }],
+    };
+    expect(
+      findPluginBlocklistMatch(bl, { name: "acme.x", version: "1.0.0", jti: "other" })
+    ).toBeNull();
+    expect(
+      findPluginBlocklistMatch(bl, { name: "acme.x", version: "1.0.0", jti: "abc" })
+    ).not.toBeNull();
+  });
+});
+
+describe("PluginBlocklistService", () => {
+  let cachePath: string;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-blocklist-test-"));
+    cachePath = path.join(tmpDir, "plugin-blocklist.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("fetches, parses, and persists the blocklist to disk", async () => {
+    const fetchImpl = stubFetch(BLOCKLIST);
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl });
+
+    const result = await svc.getBlocklist();
+    expect(result?.entries).toHaveLength(2);
+
+    // Disk cache written with the fetched body (persist is fire-and-forget).
+    const onDisk = JSON.parse(await waitForFile(cachePath));
+    expect(onDisk.raw.entries[0].name).toBe("acme.bad");
+    expect(typeof onDisk.fetchedAt).toBe("number");
+  });
+
+  it("fails open (returns null) when the fetch throws and there is no cache", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl });
+    expect(await svc.getBlocklist()).toBeNull();
+  });
+
+  it("fails open on a timeout/abort error", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    });
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl });
+    expect(await svc.getBlocklist()).toBeNull();
+  });
+
+  it("fails open on a non-OK HTTP status", async () => {
+    const fetchImpl = stubFetch(BLOCKLIST, { ok: false, status: 503 });
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl });
+    expect(await svc.getBlocklist()).toBeNull();
+  });
+
+  it("fails open on a malformed remote body", async () => {
+    const fetchImpl = stubFetch({ entries: "not-an-array" });
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl });
+    expect(await svc.getBlocklist()).toBeNull();
+  });
+
+  it("enforces the stale disk cache when the network fails (stale-while-revalidate)", async () => {
+    // Warm the disk with an old timestamp so the TTL is expired.
+    await fs.writeFile(cachePath, JSON.stringify({ fetchedAt: 0, raw: BLOCKLIST }), "utf-8");
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    // `now` well past the TTL so the disk copy is stale and a fetch is attempted.
+    const svc = new PluginBlocklistService({
+      cachePath,
+      fetchImpl,
+      now: () => PLUGIN_BLOCKLIST_TTL_MS + 1,
+    });
+
+    const result = await svc.getBlocklist();
+    expect(result?.entries).toHaveLength(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // it tried the network, then fell back
+  });
+
+  it("serves a fresh disk cache without hitting the network", async () => {
+    await fs.writeFile(cachePath, JSON.stringify({ fetchedAt: 1000, raw: BLOCKLIST }), "utf-8");
+    const fetchImpl = stubFetch(BLOCKLIST);
+    // now within TTL of the disk timestamp.
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl, now: () => 2000 });
+
+    const result = await svc.getBlocklist();
+    expect(result?.entries).toHaveLength(2);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails open on a malformed disk cache", async () => {
+    await fs.writeFile(cachePath, "{ not json", "utf-8");
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl });
+    expect(await svc.getBlocklist()).toBeNull();
+  });
+
+  it("dedupes concurrent getBlocklist() calls into a single fetch", async () => {
+    const fetchImpl = stubFetch(BLOCKLIST);
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl });
+
+    const [a, b] = await Promise.all([svc.getBlocklist(), svc.getBlocklist()]);
+    expect(a).toBe(b);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves the in-memory cache on a second call within the TTL", async () => {
+    const fetchImpl = stubFetch(BLOCKLIST);
+    let clock = 5000;
+    const svc = new PluginBlocklistService({ cachePath, fetchImpl, now: () => clock });
+
+    await svc.getBlocklist();
+    clock += 1000; // still within TTL
+    await svc.getBlocklist();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/shared/config/pluginBlocklist.ts
+++ b/shared/config/pluginBlocklist.ts
@@ -1,0 +1,35 @@
+/**
+ * Configuration for the plugin blocklist / kill-switch (#10891).
+ *
+ * A small remote list of plugins Daintree refuses to load — the cheaper,
+ * faster precursor to full publisher-identity signing. Fetched once at
+ * startup from a Daintree-controlled endpoint, cached on disk for offline
+ * enforcement, and matched by `{ name, versionRange }` (with `jti` reserved
+ * for a future signed-identity model). The fetch fails open: a network or
+ * parse failure never blocks a user's plugins.
+ */
+
+/**
+ * Remote blocklist endpoint. Served from the same CDN as the update feeds
+ * (`updates.daintree.org`). The server-side resource is owned by product;
+ * tests inject a `fetchImpl` and never hit the network.
+ */
+export const PLUGIN_BLOCKLIST_URL = "https://updates.daintree.org/plugins/blocklist.json";
+
+/** On-disk cache filename under `app.getPath("userData")`. */
+export const PLUGIN_BLOCKLIST_CACHE_FILENAME = "plugin-blocklist.json";
+
+/**
+ * Cache freshness window. Shorter than the 24h model-catalog TTL because a
+ * kill-switch entry should propagate to already-running installs within a few
+ * hours, not a day. On a cache older than this the next startup re-fetches;
+ * a stale cache is still enforced while offline (stale-while-revalidate).
+ */
+export const PLUGIN_BLOCKLIST_TTL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Fetch timeout ceiling. Bounds how long a hung CDN can delay plugin loading
+ * at startup before the fetch aborts and enforcement falls back to the disk
+ * cache (or fails open if there is none).
+ */
+export const PLUGIN_BLOCKLIST_FETCH_TIMEOUT_MS = 8000;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -207,6 +207,14 @@ export interface MainProcessToastPayload {
    * critical notification into a generic overflow row.
    */
   rateLimitKey?: string;
+  /**
+   * Routing priority threaded through to `notify({ priority })`. Omit for the
+   * default `"high"` (toast when focused). `"low"` routes to the history inbox
+   * only — never a toast or OS notification — for signals the user can act on
+   * later (e.g. a plugin refused by the blocklist / kill-switch, #10891).
+   * `"watch"` always shows both an in-app toast and an OS native notification.
+   */
+  priority?: "high" | "low" | "watch";
   action?: {
     label: string;
     /** IPC channel to invoke when the action button is clicked */

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -919,6 +919,23 @@ export interface LoadedPluginInfo {
    * `PluginMcpTierAuth`; do not re-declare it anywhere else.
    */
   pluginDanger: "safe" | "confirm";
+  /**
+   * True when the plugin was refused at load time by the remote blocklist /
+   * kill-switch (#10891) — its `manifest.name` matched a blocklist entry whose
+   * version range covers `manifest.version`. Distinct from `disabled` (a
+   * user-togglable Preferences state) and `loadError` (a technical activation
+   * failure): this is a host-decided policy refusal the user cannot toggle off.
+   * A blocklisted plugin is never registered in the running set — no `activate`
+   * runs and it contributes no panels/actions — but it is still surfaced in the
+   * Plugin Manager so the block is visible.
+   */
+  blocklisted: boolean;
+  /**
+   * Human-readable explanation for the block (from the matched entry's
+   * `message`, falling back to its machine `reason`). `undefined` unless
+   * `blocklisted` is true.
+   */
+  blocklistReason?: string;
 }
 
 export interface PluginIpcContext {

--- a/src/components/Plugin/PluginDetailPane.tsx
+++ b/src/components/Plugin/PluginDetailPane.tsx
@@ -354,7 +354,15 @@ export function PluginDetailPane({
               </span>
               <span className={BADGE_CLASS}>{categoryLabel}</span>
               <span className={BADGE_CLASS}>{sourceLabel}</span>
-              {plugin.disabled === true && <span className={BADGE_CLASS}>Disabled</span>}
+              {plugin.blocklisted === true && (
+                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-status-danger uppercase tracking-wide">
+                  <AlertCircle className="w-3 h-3" aria-hidden="true" />
+                  Blocked
+                </span>
+              )}
+              {plugin.blocklisted !== true && plugin.disabled === true && (
+                <span className={BADGE_CLASS}>Disabled</span>
+              )}
               {plugin.devMode && <span className={BADGE_CLASS}>Dev</span>}
               {restartRequired && (
                 <span className={`${BADGE_CLASS} text-daintree-text/50`}>Restart required</span>
@@ -463,6 +471,16 @@ export function PluginDetailPane({
 
           {plugin.manifest.authors && plugin.manifest.authors.length > 0 && (
             <PluginContributors authors={plugin.manifest.authors} />
+          )}
+
+          {plugin.blocklisted === true && (
+            <div className="flex items-start gap-2 p-2 rounded-[var(--radius-md)] bg-status-danger/10 border border-status-danger/20">
+              <AlertCircle className="w-3.5 h-3.5 text-status-danger shrink-0 mt-0.5" />
+              <p className="text-[11px] text-status-danger break-words">
+                Blocked from loading:{" "}
+                {plugin.blocklistReason ?? "flagged by the Daintree blocklist"}
+              </p>
+            </div>
           )}
 
           {plugin.loadError && (

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -100,7 +100,10 @@ function PluginRow({
   highlighted,
 }: PluginRowProps) {
   const label = pluginLabel(plugin);
-  const enabled = plugin.disabled !== true;
+  const blocklisted = plugin.blocklisted === true;
+  // Blocklisted plugins render as not-enabled (dimmed, switch off) even though
+  // their user `disabled` state is false — the block is host-decided.
+  const enabled = plugin.disabled !== true && !blocklisted;
   const restartRequired = plugin.pendingRestart === true;
   const sourceLabel = SOURCE_BADGE_LABELS[plugin.source] ?? plugin.source;
   const tagline = plugin.manifest.tagline;
@@ -151,9 +154,18 @@ function PluginRow({
             !plugin.isBuiltin ||
             plugin.devMode ||
             restartRequired ||
-            plugin.loadError) && (
+            plugin.loadError ||
+            blocklisted) && (
             <span className="mt-1 flex items-center gap-1 flex-wrap">
-              {!enabled && <span className={ROW_BADGE_CLASS}>Disabled</span>}
+              {blocklisted && (
+                <span className="inline-flex items-center gap-0.5 text-[10px] font-medium text-status-danger uppercase tracking-wide">
+                  <AlertCircle className="w-3 h-3" aria-hidden="true" />
+                  Blocked
+                </span>
+              )}
+              {!blocklisted && plugin.disabled === true && (
+                <span className={ROW_BADGE_CLASS}>Disabled</span>
+              )}
               {!plugin.isBuiltin && <span className={ROW_BADGE_CLASS}>{sourceLabel}</span>}
               {plugin.devMode && <span className={ROW_BADGE_CLASS}>Dev</span>}
               {restartRequired && (
@@ -174,7 +186,7 @@ function PluginRow({
         <SettingsSwitch
           checked={enabled}
           onCheckedChange={onToggle}
-          disabled={toggling}
+          disabled={toggling || blocklisted}
           aria-label={`Enable ${label}`}
         />
       </span>

--- a/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
+++ b/src/components/Plugin/__tests__/PluginDetailPane.test.tsx
@@ -77,6 +77,7 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
     updateAvailable: null,
     devMode: false,
     pluginDanger: "safe",
+    blocklisted: false,
     ...overrides,
   };
 }
@@ -280,5 +281,22 @@ describe("PluginDetailPane MCP servers tab (issue #10584)", () => {
     fireEvent.click(screen.getByRole("tab", { name: "MCP servers" }));
     expect(await screen.findByText("Demo Server")).toBeTruthy();
     expect(pluginMcpListMock).toHaveBeenCalled();
+  });
+});
+
+describe("PluginDetailPane blocklist (#10891)", () => {
+  it("shows the blocked banner with the reason in the overview", () => {
+    renderOverview(makePlugin({ blocklisted: true, blocklistReason: "Steals tokens" }));
+    expect(screen.getByText(/Blocked from loading: Steals tokens/)).toBeTruthy();
+  });
+
+  it("falls back to a generic reason when none is provided", () => {
+    renderOverview(makePlugin({ blocklisted: true }));
+    expect(screen.getByText(/flagged by the Daintree blocklist/)).toBeTruthy();
+  });
+
+  it("does not show the blocked banner for a normal plugin", () => {
+    renderOverview(makePlugin());
+    expect(screen.queryByText(/Blocked from loading/)).toBeNull();
   });
 });

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -78,6 +78,7 @@ function makePlugin(overrides: Partial<LoadedPluginInfo> = {}): LoadedPluginInfo
     updateAvailable: null,
     devMode: false,
     pluginDanger: "safe",
+    blocklisted: false,
     ...overrides,
   };
 }
@@ -184,6 +185,21 @@ describe("PluginManagerView", () => {
     await screen.findAllByText("Acme Demo");
     const toggle = screen.getByRole("switch", { name: "Enable Acme Demo" });
     expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("shows a 'Blocked' badge and disables the toggle for a blocklisted plugin (#10891)", async () => {
+    (window.electron.plugin.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makePlugin({ disabled: false, blocklisted: true, blocklistReason: "Steals tokens" }),
+    ]);
+    renderDialog();
+    await screen.findAllByText("Acme Demo");
+
+    expect(screen.getAllByText("Blocked").length).toBeGreaterThan(0);
+    // A blocklisted plugin's user-disabled state is false, but it must not read
+    // as enabled and the toggle must be inert — the block is host-decided.
+    const toggle = screen.getByRole("switch", { name: "Enable Acme Demo" });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect((toggle as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("does not flash 'Restart required' when a built-in plugin is toggled (#10512)", async () => {

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -53,6 +53,7 @@ function makePlugin(name: string): LoadedPluginInfo {
     updateAvailable: null,
     devMode: false,
     pluginDanger: "safe",
+    blocklisted: false,
   };
 }
 

--- a/src/hooks/__tests__/useMainProcessToastListener.test.tsx
+++ b/src/hooks/__tests__/useMainProcessToastListener.test.tsx
@@ -17,6 +17,7 @@ type ToastCallback = (payload: {
   message: string;
   duration?: number;
   rateLimitKey?: string;
+  priority?: "high" | "low" | "watch";
   action?: { label: string; ipcChannel: string };
 }) => void;
 
@@ -96,6 +97,21 @@ describe("useMainProcessToastListener", () => {
     expect(notifyMock).toHaveBeenCalledWith(
       expect.objectContaining({ rateLimitKey: "cloud-teardown-failure" })
     );
+  });
+
+  it("threads priority through to notify (low → inbox-only)", () => {
+    renderHook(() => useMainProcessToastListener());
+
+    act(() => {
+      capturedCallback!({
+        type: "warning",
+        title: "Plugin blocked",
+        message: "acme.bad was blocked from loading",
+        priority: "low",
+      });
+    });
+
+    expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ priority: "low" }));
   });
 
   it("threads duration through to notify when provided", () => {

--- a/src/hooks/useMainProcessToastListener.ts
+++ b/src/hooks/useMainProcessToastListener.ts
@@ -42,6 +42,7 @@ export function useMainProcessToastListener(): void {
         message: payload.message,
         duration: payload.duration,
         rateLimitKey: payload.rateLimitKey,
+        priority: payload.priority,
         action,
       });
     });

--- a/src/lib/__tests__/pluginSearch.test.ts
+++ b/src/lib/__tests__/pluginSearch.test.ts
@@ -48,6 +48,7 @@ function makePlugin(overrides: {
     updateAvailable: null,
     devMode: false,
     pluginDanger: "safe",
+    blocklisted: false,
   };
 }
 


### PR DESCRIPTION
## Summary

- Implements the design-only kill-switch spec from `docs/plugins/architecture.md`: a startup-time plugin blocklist.
- On launch, `PluginService` fetches a small CDN-hosted blocklist and refuses to load any installed plugin whose manifest `name`/`version` matches an entry. Blocked plugins get a badge and reason banner in the Plugin Manager, plus a low-priority inbox notification explaining why.
- Fails open: any fetch or parse failure never bricks a user's plugins. Publisher signing is explicitly out of scope, planned as later work.

Resolves #10891

## Changes

- New `PluginBlocklistService` (`net.fetch` + `AbortSignal.timeout`, Zod-validated, stale-while-revalidate disk cache under `userData`) mirroring `AgentModelCatalogService`; a pure `findPluginBlocklistMatch` function with semver `includePrerelease` matching, malformed-range skipping, and `jti` future-proofing.
- Blocklist resolved once in `PluginService.initialize()` and enforced in `loadPlugin()` before the disabled/duplicate gates. Blocked plugins are tracked in a `blockedPlugins` map and surfaced via `listPlugins()` (`blocklisted`/`blocklistReason` on `LoadedPluginInfo`).
- Notification priority threaded through `MainProcessToastPayload` → preload → `useMainProcessToastListener` so Main can emit a `priority: "low"` inbox notification.
- Plugin Manager UI: a "Blocked" badge and disabled toggle in `PluginManagerView`, and a reason banner in `PluginDetailPane`.
- Installer clears stale block bookkeeping (before the install load, before the disabled early-return, and on rollback), so a fixed version can install over a startup-blocked plugin and an upgrade-to-blocked rollback restores the previous good version. Uninstall clears `blockedPlugins`.

## Testing

737 targeted tests pass: a new `PluginBlocklistService` suite covering fail-open, stale-while-revalidate, `includePrerelease`, and the matcher; `PluginService` integration tests for gate precedence, fetch-once behavior, and notification; install-flow regression tests for install-over-blocked and upgrade-rollback; notify-bridge priority tests; Plugin Manager badge/toggle and detail banner tests. Own-file lint (0 errors), prettier, and IPC codegen guards pass locally. Full suite and build run on CI.

**Known limitation:** a brand-new install of an already-blocklisted plugin currently returns a generic "failed to load" install status. The block is enforced and the low-priority notification does fire; a subsequent fixed-version install works correctly.

**Note:** the blocklist endpoint URL (`updates.daintree.org/plugins/blocklist.json`) is a config constant. The server-side resource itself is product-owned, outside the scope of this PR.
