### PR TITLE
feat(plugins): background update checks and Update all (#10893)

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -946,6 +946,12 @@ export const CHANNELS = {
   PLUGIN_PICK_PATH: "plugin:pick-path",
   /** Existence probe for a stored plugin `mustExist` path setting. */
   PLUGIN_PATH_EXISTS: "plugin:path-exists",
+  /** Opt-in background plugin update check (#10893): read the enabled setting. */
+  PLUGIN_BG_UPDATE_CHECK_SETTINGS_GET: "plugin:bg-update-check-settings-get",
+  /** Opt-in background plugin update check (#10893): set the enabled setting. */
+  PLUGIN_BG_UPDATE_CHECK_SETTINGS_SET: "plugin:bg-update-check-settings-set",
+  /** Opt-in background plugin update check (#10893): hydrate the last cached result. */
+  PLUGIN_BG_UPDATE_CHECK_LATEST: "plugin:bg-update-check-latest",
   /** Bridge: main process dispatches a plugin-sourced action request to the renderer. */
   PLUGIN_DISPATCH_ACTION_REQUEST: "plugin:dispatch-action-request",
   /** Bridge: renderer returns the plugin-sourced action dispatch result to the main process. */

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -116,7 +116,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(35);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(38);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:install", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:set-enabled", expect.any(Function));
@@ -195,6 +195,18 @@ describe("registerPluginHandlers", () => {
     );
     expect(mockIpcMainHandle).toHaveBeenCalledWith(
       "plugin:settings-reveal-secret",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:bg-update-check-settings-get",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:bg-update-check-settings-set",
+      expect.any(Function)
+    );
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:bg-update-check-latest",
       expect.any(Function)
     );
     // The renderer-side menu-items IPC surface was removed (#10465) — the native

--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -70,6 +70,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "plugin:panel-badges-changed": "external",
   "plugin:panel-badges-cleared": "external",
   "plugin:provenance-changed": "external",
+  "plugin:bg-update-available": "external",
   "run-history:update": "external",
   "plugin:deep-link": "external",
   "terminal:exit": "external",

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -40,6 +40,9 @@ export const PLUGIN_METHOD_CHANNELS = {
   revealSecretSetting: "plugin:settings-reveal-secret",
   pickPath: "plugin:pick-path",
   pathExists: "plugin:path-exists",
+  getBackgroundUpdateCheckSettings: "plugin:bg-update-check-settings-get",
+  setBackgroundUpdateCheckSettings: "plugin:bg-update-check-settings-set",
+  getLatestBackgroundUpdateCheck: "plugin:bg-update-check-latest",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_METHOD_CHANNELS;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -65,6 +65,8 @@ import type {
   PluginInstallError,
   PluginInstallResult,
   PluginCheckUpdateResult,
+  PluginBackgroundUpdateCheckResult,
+  PluginBackgroundUpdateCheckSettings,
   PluginSettingsScope,
   PluginSettingsUiValues,
   PluginPickPathRequest,
@@ -412,6 +414,32 @@ async function handleCheckForUpdate(pluginId: string): Promise<PluginCheckUpdate
   // The service owns the bounded download + hash compare and returns a
   // structured result for every domain outcome (#9297).
   return (await getPluginService()).checkForUpdate(pluginId);
+}
+
+async function handleGetBackgroundUpdateCheckSettings(): Promise<PluginBackgroundUpdateCheckSettings> {
+  const { getPluginUpdateCheckService } =
+    await import("../../services/PluginUpdateCheckService.js");
+  return getPluginUpdateCheckService().getSettings();
+}
+
+async function handleSetBackgroundUpdateCheckSettings(
+  enabled: boolean
+): Promise<PluginBackgroundUpdateCheckSettings> {
+  const { getPluginUpdateCheckService } =
+    await import("../../services/PluginUpdateCheckService.js");
+  const service = getPluginUpdateCheckService();
+  // The IPC boundary is untyped at runtime — reject a malformed write without
+  // mutating state rather than trusting the declared `boolean`.
+  if (typeof enabled !== "boolean") {
+    return service.getSettings();
+  }
+  return service.updateSettings({ enabled });
+}
+
+async function handleGetLatestBackgroundUpdateCheck(): Promise<PluginBackgroundUpdateCheckResult | null> {
+  const { getPluginUpdateCheckService } =
+    await import("../../services/PluginUpdateCheckService.js");
+  return getPluginUpdateCheckService().getLatest();
 }
 
 async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
@@ -973,6 +1001,18 @@ export const pluginNamespace = defineIpcNamespace({
     revealSecretSetting: op(PLUGIN_METHOD_CHANNELS.revealSecretSetting, handleSettingsRevealSecret),
     pickPath: op(PLUGIN_METHOD_CHANNELS.pickPath, handlePickPath, { withContext: true }),
     pathExists: op(PLUGIN_METHOD_CHANNELS.pathExists, handlePathExists),
+    getBackgroundUpdateCheckSettings: op(
+      PLUGIN_METHOD_CHANNELS.getBackgroundUpdateCheckSettings,
+      handleGetBackgroundUpdateCheckSettings
+    ),
+    setBackgroundUpdateCheckSettings: op(
+      PLUGIN_METHOD_CHANNELS.setBackgroundUpdateCheckSettings,
+      handleSetBackgroundUpdateCheckSettings
+    ),
+    getLatestBackgroundUpdateCheck: op(
+      PLUGIN_METHOD_CHANNELS.getLatestBackgroundUpdateCheck,
+      handleGetLatestBackgroundUpdateCheck
+    ),
   },
 });
 

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -549,6 +549,16 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
           console.warn("[MAIN] Periodic cleanup dispose failed:", error);
         }
 
+        // Stop the opt-in plugin update checker and drain any in-flight pass
+        // (#10893) — its timers/wake listeners must not survive teardown.
+        try {
+          const { getPluginUpdateCheckService } =
+            await import("../services/PluginUpdateCheckService.js");
+          await getPluginUpdateCheckService().dispose();
+        } catch (error) {
+          console.warn("[MAIN] Plugin update check dispose failed:", error);
+        }
+
         try {
           await getDatabaseMaintenanceService().dispose();
         } catch (error) {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2840,6 +2840,11 @@ function buildElectronApi(): ElectronAPI {
         _eventBusOn("plugin:actions-changed", callback),
       onProvenanceChanged: (callback: (payload: Record<string, never>) => void) =>
         _eventBusOn("plugin:provenance-changed", callback),
+      onBackgroundUpdateAvailable: (
+        callback: (
+          payload: import("../shared/types/plugin.js").PluginBackgroundUpdateCheckResult
+        ) => void
+      ) => _eventBusOn("plugin:bg-update-available", callback),
       onPanelKindsChanged: (callback: (payload: { kinds: PanelKindConfig[] }) => void) =>
         _eventBusOn("plugin:panel-kinds-changed", callback),
       onAgentsChanged: (

--- a/electron/services/PluginUpdateCheckService.ts
+++ b/electron/services/PluginUpdateCheckService.ts
@@ -1,0 +1,328 @@
+// eager-import-allow: reads opt-in config via store.get synchronously; the heavy
+// PluginService is lazy-imported inside the pass, never at module load.
+import { powerMonitor } from "electron";
+import type {
+  PluginBackgroundUpdateCheckResult,
+  PluginBackgroundUpdateCheckSettings,
+  PluginBackgroundUpdateEntry,
+} from "../../shared/types/plugin.js";
+import { store } from "../store.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
+import { broadcastToRenderer } from "../ipc/utils.js";
+import { CHANNELS } from "../ipc/channels.js";
+import { logInfo, logError } from "../utils/logger.js";
+
+// Daily cadence. A URL re-fetch of every installed plugin is cheap but not free,
+// so once a day is the coarsest useful granularity for "an update landed."
+const DAILY_MS = 24 * 60 * 60 * 1000;
+// Wall-clock revalidation tick. A bare 24h setInterval doesn't "catch up" across
+// sleep, so we tick hourly and compare `lastCheckedAt` against the wall clock —
+// the interval is a heartbeat, the timestamp is the source of truth.
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+const IDLE_THRESHOLD_S = 60; // 60s of system idle before a background pass
+const INITIAL_CHECK_DELAY_MS = 10_000; // let startup settle before the first pass
+const RESUME_CHECK_DELAY_MS = 7_000; // let the OS stabilize after wake
+// Chromium caps ~6 connections/host and each check streams an archive to a temp
+// dir, so an unbounded Promise.all would exhaust the socket pool and spike memory.
+const CONCURRENCY = 2;
+
+/**
+ * PluginUpdateCheckService — opt-in periodic background update check for all
+ * URL-installed plugins (#10893).
+ *
+ * Reuses the existing lock-free `PluginService.checkForUpdate` (the #9297 manual
+ * mechanism) per plugin with a small concurrency cap, collects the `available`
+ * results, and — when any are found — broadcasts one batched event that the
+ * renderer turns into a single low-priority inbox notification. It never
+ * installs; the user still confirms each reinstall through the manager's
+ * capability-diff flow.
+ *
+ * @pattern Factory/Accessor Methods
+ *
+ * Structurally mirrors {@link IdleBackgroundAutoCloseService} (opt-in config in
+ * electron-store, off by default, start/stop on toggle) and
+ * {@link WindowsStoreNotifierService} (main-side `lastDetected` cache for
+ * late-subscriber hydration, resume-triggered revalidation). Defaults OFF.
+ */
+export class PluginUpdateCheckService {
+  private checkInterval: NodeJS.Timeout | null = null;
+  private initialCheckTimer: NodeJS.Timeout | null = null;
+  private resumeTimeout: NodeJS.Timeout | null = null;
+  private removeSuspendListener: (() => void) | null = null;
+  private removeWakeListener: (() => void) | null = null;
+  private inFlight = false;
+  private inFlightPromise: Promise<void> | null = null;
+  private disposed = false;
+  private lastDetected: PluginBackgroundUpdateCheckResult | null = null;
+
+  getSettings(): PluginBackgroundUpdateCheckSettings {
+    const raw = store.get("pluginBackgroundUpdateCheck");
+    return {
+      enabled: typeof raw?.enabled === "boolean" ? raw.enabled : false,
+    };
+  }
+
+  private getLastCheckedAt(): number | null {
+    const raw = store.get("pluginBackgroundUpdateCheck");
+    return typeof raw?.lastCheckedAt === "number" ? raw.lastCheckedAt : null;
+  }
+
+  private setLastCheckedAt(value: number | null): void {
+    const raw = store.get("pluginBackgroundUpdateCheck");
+    store.set("pluginBackgroundUpdateCheck", {
+      enabled: typeof raw?.enabled === "boolean" ? raw.enabled : false,
+      lastCheckedAt: value,
+    });
+  }
+
+  updateSettings(
+    patch: Partial<PluginBackgroundUpdateCheckSettings>
+  ): PluginBackgroundUpdateCheckSettings {
+    const current = this.getSettings();
+    const next: PluginBackgroundUpdateCheckSettings = {
+      enabled: typeof patch.enabled === "boolean" ? patch.enabled : current.enabled,
+    };
+    store.set("pluginBackgroundUpdateCheck", {
+      enabled: next.enabled,
+      lastCheckedAt: this.getLastCheckedAt(),
+    });
+
+    if (next.enabled) {
+      this.start();
+    } else {
+      // Drop the cached detection so a re-enable doesn't immediately re-surface
+      // a stale set the user already dismissed.
+      this.lastDetected = null;
+      this.stop();
+    }
+    logInfo("plugin-update-check-settings-updated", { enabled: next.enabled });
+    return next;
+  }
+
+  getLatest(): PluginBackgroundUpdateCheckResult | null {
+    return this.lastDetected;
+  }
+
+  /** Idempotent. Installs the revalidation tick + wake listener when enabled. */
+  start(): void {
+    if (this.disposed) return;
+    if (!this.getSettings().enabled) return;
+
+    if (!this.initialCheckTimer && !this.checkInterval) {
+      this.initialCheckTimer = setTimeout(() => {
+        this.initialCheckTimer = null;
+        void this.maybeRunDue("Initial");
+      }, INITIAL_CHECK_DELAY_MS);
+    }
+
+    if (!this.checkInterval) {
+      this.checkInterval = setInterval(() => {
+        void this.maybeRunDue("Periodic");
+      }, CHECK_INTERVAL_MS);
+    }
+
+    try {
+      this.removeSuspendListener ??= getSystemSleepService().onSuspend(() => {
+        if (this.checkInterval) {
+          clearInterval(this.checkInterval);
+          this.checkInterval = null;
+        }
+        if (this.resumeTimeout) {
+          clearTimeout(this.resumeTimeout);
+          this.resumeTimeout = null;
+        }
+      });
+      this.removeWakeListener ??= getSystemSleepService().onWake(() => {
+        if (this.resumeTimeout) return;
+        this.resumeTimeout = setTimeout(() => {
+          this.resumeTimeout = null;
+          void this.maybeRunDue("Resume");
+          if (!this.checkInterval && !this.disposed && this.getSettings().enabled) {
+            this.checkInterval = setInterval(() => {
+              void this.maybeRunDue("Periodic");
+            }, CHECK_INTERVAL_MS);
+          }
+        }, RESUME_CHECK_DELAY_MS);
+      });
+    } catch {
+      // SystemSleepService may not be initialized yet — the periodic tick covers it.
+    }
+    logInfo("plugin-update-check-started");
+  }
+
+  stop(): void {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = null;
+    }
+    if (this.initialCheckTimer) {
+      clearTimeout(this.initialCheckTimer);
+      this.initialCheckTimer = null;
+    }
+    if (this.resumeTimeout) {
+      clearTimeout(this.resumeTimeout);
+      this.resumeTimeout = null;
+    }
+    if (this.removeSuspendListener) {
+      this.removeSuspendListener();
+      this.removeSuspendListener = null;
+    }
+    if (this.removeWakeListener) {
+      this.removeWakeListener();
+      this.removeWakeListener = null;
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.stop();
+    if (this.inFlightPromise) {
+      try {
+        await this.inFlightPromise;
+      } catch {
+        // Each plugin's check is isolated in runPass(); nothing to add here.
+      }
+    }
+    this.lastDetected = null;
+    logInfo("plugin-update-check-disposed");
+  }
+
+  /**
+   * Gate a pass on enabled + not-disposed + not-in-flight + system-idle + due
+   * (wall-clock elapsed since `lastCheckedAt` ≥ 24h). Public so tests can drive
+   * it without flushing timers.
+   */
+  async maybeRunDue(context: "Initial" | "Periodic" | "Resume"): Promise<void> {
+    if (this.disposed || this.inFlight) return;
+    if (!this.getSettings().enabled) return;
+
+    try {
+      if (powerMonitor.getSystemIdleTime() < IDLE_THRESHOLD_S) return;
+    } catch {
+      // powerMonitor may not be ready (early startup / Wayland) — skip this tick.
+      return;
+    }
+
+    const last = this.getLastCheckedAt();
+    if (last !== null && Date.now() - last < DAILY_MS) return;
+
+    await this.runPassGuarded(context);
+  }
+
+  /** Test seam: run a pass now, bypassing the idle + due gates (respects enabled). */
+  async _checkNowForTest(): Promise<void> {
+    if (this.disposed || !this.getSettings().enabled) return;
+    await this.runPassGuarded("Periodic");
+  }
+
+  private async runPassGuarded(context: "Initial" | "Periodic" | "Resume"): Promise<void> {
+    if (this.inFlight) return;
+    this.inFlight = true;
+    this.inFlightPromise = this.runPass(context);
+    try {
+      await this.inFlightPromise;
+    } finally {
+      this.inFlight = false;
+      this.inFlightPromise = null;
+    }
+  }
+
+  private async runPass(context: "Initial" | "Periodic" | "Resume"): Promise<void> {
+    let updates: PluginBackgroundUpdateEntry[] = [];
+    try {
+      const { pluginService } = await import("./PluginService.js");
+      try {
+        await pluginService.waitForInit();
+      } catch {
+        // If init never settled the list read below simply returns what's loaded.
+      }
+      // Re-check enabled after the async init — a toggle-off mid-wait aborts.
+      if (this.disposed || !this.getSettings().enabled) return;
+
+      const targets = pluginService
+        .listPlugins()
+        .filter((p) => !p.isBuiltin && !!p.originalUrl && !!p.archiveHash)
+        .map((p) => p.manifest.name);
+
+      updates = await this.checkAll(pluginService, targets);
+    } catch (err) {
+      logError("plugin-update-check-pass-failed", err);
+      // Fall through: still persist lastCheckedAt so a hard failure doesn't
+      // retry-storm on every tick.
+    }
+
+    // Persist the pass timestamp even on partial fetch failures — the next pass
+    // is a day out regardless, matching the daily cadence.
+    this.setLastCheckedAt(Date.now());
+
+    if (this.disposed || updates.length === 0) return;
+
+    const result: PluginBackgroundUpdateCheckResult = {
+      checkedAt: Date.now(),
+      updates,
+      signature: computeSignature(updates),
+    };
+    this.lastDetected = result;
+    logInfo("plugin-update-check-available", { count: updates.length, context });
+    try {
+      broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+        name: "plugin:bg-update-available",
+        payload: result,
+      });
+    } catch {
+      // All windows may be closing.
+    }
+  }
+
+  /** Bounded worker-pool over the plugin ids; collects only `available` results. */
+  private async checkAll(
+    pluginService: typeof import("./PluginService.js").pluginService,
+    ids: string[]
+  ): Promise<PluginBackgroundUpdateEntry[]> {
+    const found: PluginBackgroundUpdateEntry[] = [];
+    let cursor = 0;
+
+    const worker = async (): Promise<void> => {
+      while (cursor < ids.length) {
+        if (this.disposed || !this.getSettings().enabled) return;
+        const id = ids[cursor++];
+        try {
+          const result = await pluginService.checkForUpdate(id);
+          if (result.status === "available") {
+            found.push({
+              pluginId: id,
+              displayName: result.displayName ?? result.name,
+              version: result.version,
+              capabilities: result.capabilities,
+            });
+          }
+        } catch (err) {
+          // Isolate per plugin — one failed fetch never aborts the batch.
+          logError("plugin-update-check-single-failed", err, { pluginId: id });
+        }
+      }
+    };
+
+    const pool = Math.min(CONCURRENCY, Math.max(ids.length, 1));
+    await Promise.all(Array.from({ length: pool }, () => worker()));
+    return found;
+  }
+}
+
+/** Deterministic digest of the update set so repeated passes dedupe to one row. */
+function computeSignature(updates: PluginBackgroundUpdateEntry[]): string {
+  return updates
+    .map((u) => `${u.pluginId}@${u.version}`)
+    .sort()
+    .join(",");
+}
+
+let instance: PluginUpdateCheckService | null = null;
+
+export function getPluginUpdateCheckService(): PluginUpdateCheckService {
+  if (!instance) {
+    instance = new PluginUpdateCheckService();
+  }
+  return instance;
+}

--- a/electron/services/PluginUpdateCheckService.ts
+++ b/electron/services/PluginUpdateCheckService.ts
@@ -229,34 +229,39 @@ export class PluginUpdateCheckService {
   }
 
   private async runPass(context: "Initial" | "Periodic" | "Resume"): Promise<void> {
-    let updates: PluginBackgroundUpdateEntry[] = [];
+    // `null` means the pass aborted before checking (disabled/disposed mid-init)
+    // — don't touch lastCheckedAt or the cache. `inconclusive` is true when the
+    // pass couldn't fully determine status (import/list threw, or a per-plugin
+    // fetch failed), so a partial-failure pass doesn't clear a valid cache.
+    let outcome: { updates: PluginBackgroundUpdateEntry[]; inconclusive: boolean } | null;
     try {
-      const { pluginService } = await import("./PluginService.js");
-      try {
-        await pluginService.waitForInit();
-      } catch {
-        // If init never settled the list read below simply returns what's loaded.
-      }
-      // Re-check enabled after the async init — a toggle-off mid-wait aborts.
-      if (this.disposed || !this.getSettings().enabled) return;
-
-      const targets = pluginService
-        .listPlugins()
-        .filter((p) => !p.isBuiltin && !!p.originalUrl && !!p.archiveHash)
-        .map((p) => p.manifest.name);
-
-      updates = await this.checkAll(pluginService, targets);
+      outcome = await this.collectUpdates();
     } catch (err) {
       logError("plugin-update-check-pass-failed", err);
-      // Fall through: still persist lastCheckedAt so a hard failure doesn't
-      // retry-storm on every tick.
+      // A hard failure still persists lastCheckedAt (below) so it doesn't
+      // retry-storm on every tick, but is inconclusive so the cache survives.
+      outcome = { updates: [], inconclusive: true };
     }
+
+    if (outcome === null) return;
 
     // Persist the pass timestamp even on partial fetch failures — the next pass
     // is a day out regardless, matching the daily cadence.
     this.setLastCheckedAt(Date.now());
 
-    if (this.disposed || updates.length === 0) return;
+    // Re-check after the awaited checks: a toggle-off (updateSettings) or dispose
+    // during the network round-trip must not resurrect a broadcast or a cache
+    // entry it already cleared.
+    if (this.disposed || !this.getSettings().enabled) return;
+
+    const { updates, inconclusive } = outcome;
+    if (updates.length === 0) {
+      // A conclusive empty pass supersedes any cached detection so a
+      // late-mounting renderer doesn't hydrate an already-resolved update. Keep
+      // the cache when the pass was inconclusive — we genuinely don't know.
+      if (!inconclusive) this.lastDetected = null;
+      return;
+    }
 
     const result: PluginBackgroundUpdateCheckResult = {
       checkedAt: Date.now(),
@@ -275,12 +280,48 @@ export class PluginUpdateCheckService {
     }
   }
 
-  /** Bounded worker-pool over the plugin ids; collects only `available` results. */
+  /**
+   * Resolve the plugin service, gather URL-installed targets, and check them.
+   * Returns `null` when the pass should abort without touching state (disabled
+   * or disposed mid-init); otherwise the available updates + whether the pass
+   * was inconclusive (any per-plugin fetch failure).
+   */
+  private async collectUpdates(): Promise<{
+    updates: PluginBackgroundUpdateEntry[];
+    inconclusive: boolean;
+  } | null> {
+    const { pluginService } = await import("./PluginService.js");
+    try {
+      await pluginService.waitForInit();
+    } catch {
+      // If init never settled the list read below simply returns what's loaded.
+    }
+    // Re-check enabled after the async init — a toggle-off mid-wait aborts.
+    if (this.disposed || !this.getSettings().enabled) return null;
+
+    const targets = pluginService
+      .listPlugins()
+      .filter((p) => !p.isBuiltin && !!p.originalUrl && !!p.archiveHash)
+      .map((p) => p.manifest.name);
+
+    const { found, hadError } = await this.checkAll(pluginService, targets);
+    return { updates: found, inconclusive: hadError };
+  }
+
+  /**
+   * Bounded worker-pool over the plugin ids; collects only `available` results.
+   * `hadError` is true if any per-plugin check threw, so the caller can tell a
+   * clean "nothing available" pass from one that couldn't determine status.
+   */
   private async checkAll(
     pluginService: typeof import("./PluginService.js").pluginService,
     ids: string[]
-  ): Promise<PluginBackgroundUpdateEntry[]> {
+  ): Promise<{ found: PluginBackgroundUpdateEntry[]; hadError: boolean }> {
     const found: PluginBackgroundUpdateEntry[] = [];
+    // Ids we couldn't determine this pass (fetch-failed or threw). Collected as
+    // a pushed-to array (like `found`) so the caller can tell a clean "nothing
+    // available" pass from an inconclusive one.
+    const failedIds: string[] = [];
     let cursor = 0;
 
     const worker = async (): Promise<void> => {
@@ -296,9 +337,12 @@ export class PluginUpdateCheckService {
               version: result.version,
               capabilities: result.capabilities,
             });
+          } else if (result.status === "fetch-failed") {
+            failedIds.push(id);
           }
         } catch (err) {
           // Isolate per plugin — one failed fetch never aborts the batch.
+          failedIds.push(id);
           logError("plugin-update-check-single-failed", err, { pluginId: id });
         }
       }
@@ -306,7 +350,7 @@ export class PluginUpdateCheckService {
 
     const pool = Math.min(CONCURRENCY, Math.max(ids.length, 1));
     await Promise.all(Array.from({ length: pool }, () => worker()));
-    return found;
+    return { found, hadError: failedIds.length > 0 };
   }
 }
 

--- a/electron/services/__tests__/PluginUpdateCheckService.test.ts
+++ b/electron/services/__tests__/PluginUpdateCheckService.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const powerMonitorMock = vi.hoisted(() => ({
+  getSystemIdleTime: vi.fn().mockReturnValue(120),
+}));
+
+const broadcastMock = vi.hoisted(() => vi.fn());
+
+const storeState = vi.hoisted(() => ({
+  value: { enabled: false, lastCheckedAt: null } as {
+    enabled: boolean;
+    lastCheckedAt: number | null;
+  },
+}));
+
+const storeMock = vi.hoisted(() => ({
+  get: vi.fn((key: string): unknown =>
+    key === "pluginBackgroundUpdateCheck" ? storeState.value : undefined
+  ),
+  set: vi.fn((key: string, val: unknown) => {
+    if (key === "pluginBackgroundUpdateCheck") {
+      storeState.value = val as { enabled: boolean; lastCheckedAt: number | null };
+    }
+  }),
+}));
+
+const systemSleepMock = vi.hoisted(() => ({
+  onSuspend: vi.fn(() => () => {}),
+  onWake: vi.fn(() => () => {}),
+}));
+
+const pluginServiceMock = vi.hoisted(() => ({
+  waitForInit: vi.fn(async () => {}),
+  listPlugins: vi.fn(() => [] as unknown[]),
+  checkForUpdate: vi.fn(async (_id: string) => ({ status: "up-to-date" }) as unknown),
+}));
+
+vi.mock("electron", () => ({ powerMonitor: powerMonitorMock }));
+vi.mock("../../ipc/utils.js", () => ({ broadcastToRenderer: broadcastMock }));
+vi.mock("../../store.js", () => ({ store: storeMock }));
+vi.mock("../../ipc/channels.js", () => ({ CHANNELS: { EVENTS_PUSH: "events:push" } }));
+vi.mock("../SystemSleepService.js", () => ({ getSystemSleepService: () => systemSleepMock }));
+vi.mock("../PluginService.js", () => ({ pluginService: pluginServiceMock }));
+vi.mock("../../utils/logger.js", () => ({
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
+import { PluginUpdateCheckService } from "../PluginUpdateCheckService.js";
+
+function urlPlugin(name: string, over: Record<string, unknown> = {}) {
+  return {
+    manifest: { name, version: "1.0.0", displayName: name },
+    isBuiltin: false,
+    originalUrl: `https://example.com/${name}.dntr`,
+    archiveHash: "abc",
+    ...over,
+  };
+}
+
+function available(name: string, version: string) {
+  return {
+    status: "available",
+    name,
+    version,
+    displayName: name,
+    capabilities: ["commands"],
+  };
+}
+
+describe("PluginUpdateCheckService", () => {
+  beforeEach(() => {
+    storeState.value = { enabled: false, lastCheckedAt: null };
+    powerMonitorMock.getSystemIdleTime.mockReturnValue(120);
+    pluginServiceMock.waitForInit.mockResolvedValue(undefined);
+    pluginServiceMock.listPlugins.mockReturnValue([]);
+    pluginServiceMock.checkForUpdate.mockResolvedValue({ status: "up-to-date" });
+    broadcastMock.mockClear();
+    storeMock.set.mockClear();
+    pluginServiceMock.checkForUpdate.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does nothing while disabled (the default)", async () => {
+    const svc = new PluginUpdateCheckService();
+    await svc.maybeRunDue("Periodic");
+    expect(pluginServiceMock.checkForUpdate).not.toHaveBeenCalled();
+    expect(broadcastMock).not.toHaveBeenCalled();
+  });
+
+  it("checks only URL-installed plugins and broadcasts available updates", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue([
+      urlPlugin("pub.a"),
+      urlPlugin("pub.b"),
+      // builtin — skipped
+      {
+        manifest: { name: "pub.builtin", version: "1.0.0" },
+        isBuiltin: true,
+        originalUrl: null,
+        archiveHash: null,
+      },
+      // sideload (no url) — skipped
+      {
+        manifest: { name: "pub.side", version: "1.0.0" },
+        isBuiltin: false,
+        originalUrl: null,
+        archiveHash: null,
+      },
+    ]);
+    pluginServiceMock.checkForUpdate.mockImplementation(async (id: string) =>
+      id === "pub.a" ? available("pub.a", "2.0.0") : { status: "up-to-date" }
+    );
+
+    const svc = new PluginUpdateCheckService();
+    await svc._checkNowForTest();
+
+    const checkedIds = pluginServiceMock.checkForUpdate.mock.calls.map((c) => c[0]);
+    expect(checkedIds.sort()).toEqual(["pub.a", "pub.b"]);
+    expect(broadcastMock).toHaveBeenCalledTimes(1);
+    const [, payload] = broadcastMock.mock.calls[0];
+    expect(payload.name).toBe("plugin:bg-update-available");
+    expect(payload.payload.updates).toHaveLength(1);
+    expect(payload.payload.updates[0].pluginId).toBe("pub.a");
+    expect(payload.payload.signature).toBe("pub.a@2.0.0");
+  });
+
+  it("does not broadcast when nothing is available but still records lastCheckedAt", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+    pluginServiceMock.checkForUpdate.mockResolvedValue({ status: "up-to-date" });
+
+    const svc = new PluginUpdateCheckService();
+    await svc._checkNowForTest();
+
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(storeState.value.lastCheckedAt).not.toBeNull();
+  });
+
+  it("records lastCheckedAt even when every check fails (no retry storm)", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+    pluginServiceMock.checkForUpdate.mockRejectedValue(new Error("network"));
+
+    const svc = new PluginUpdateCheckService();
+    await svc._checkNowForTest();
+
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(storeState.value.lastCheckedAt).not.toBeNull();
+  });
+
+  it("skips a due pass while the user is active (below the idle threshold)", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    powerMonitorMock.getSystemIdleTime.mockReturnValue(5);
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+
+    const svc = new PluginUpdateCheckService();
+    await svc.maybeRunDue("Periodic");
+
+    expect(pluginServiceMock.checkForUpdate).not.toHaveBeenCalled();
+    // Not run → timestamp untouched so it retries on the next idle tick.
+    expect(storeState.value.lastCheckedAt).toBeNull();
+  });
+
+  it("skips when the last check was under a day ago", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: Date.now() - 60 * 60 * 1000 };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+
+    const svc = new PluginUpdateCheckService();
+    await svc.maybeRunDue("Periodic");
+
+    expect(pluginServiceMock.checkForUpdate).not.toHaveBeenCalled();
+  });
+
+  it("runs a due pass when more than a day has elapsed", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: Date.now() - 25 * 60 * 60 * 1000 };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+
+    const svc = new PluginUpdateCheckService();
+    await svc.maybeRunDue("Periodic");
+
+    expect(pluginServiceMock.checkForUpdate).toHaveBeenCalledWith("pub.a");
+  });
+
+  it("caps concurrency at 2", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue(
+      Array.from({ length: 6 }, (_, i) => urlPlugin(`pub.${i}`))
+    );
+    let active = 0;
+    let peak = 0;
+    pluginServiceMock.checkForUpdate.mockImplementation(async () => {
+      active++;
+      peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 5));
+      active--;
+      return { status: "up-to-date" };
+    });
+
+    const svc = new PluginUpdateCheckService();
+    await svc._checkNowForTest();
+
+    expect(peak).toBeLessThanOrEqual(2);
+    expect(pluginServiceMock.checkForUpdate).toHaveBeenCalledTimes(6);
+  });
+
+  it("updateSettings persists enabled and starts/stops the wake listener", () => {
+    const svc = new PluginUpdateCheckService();
+    const on = svc.updateSettings({ enabled: true });
+    expect(on.enabled).toBe(true);
+    expect(storeState.value.enabled).toBe(true);
+    expect(systemSleepMock.onWake).toHaveBeenCalled();
+
+    const off = svc.updateSettings({ enabled: false });
+    expect(off.enabled).toBe(false);
+    expect(storeState.value.enabled).toBe(false);
+    expect(svc.getLatest()).toBeNull();
+  });
+
+  it("dispose stops the service and prevents further passes", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+    const svc = new PluginUpdateCheckService();
+    await svc.dispose();
+    await svc._checkNowForTest();
+    expect(pluginServiceMock.checkForUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/PluginUpdateCheckService.test.ts
+++ b/electron/services/__tests__/PluginUpdateCheckService.test.ts
@@ -228,4 +228,67 @@ describe("PluginUpdateCheckService", () => {
     await svc._checkNowForTest();
     expect(pluginServiceMock.checkForUpdate).not.toHaveBeenCalled();
   });
+
+  it("clears a stale cache on a clean no-update pass", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+    pluginServiceMock.checkForUpdate.mockResolvedValue(available("pub.a", "2.0.0"));
+    const svc = new PluginUpdateCheckService();
+    await svc._checkNowForTest();
+    expect(svc.getLatest()).not.toBeNull();
+
+    // A later pass finds nothing available (e.g. the user updated manually) —
+    // the obsolete cache must not hydrate a fresh renderer.
+    pluginServiceMock.checkForUpdate.mockResolvedValue({ status: "up-to-date" });
+    await svc._checkNowForTest();
+    expect(svc.getLatest()).toBeNull();
+  });
+
+  it("keeps the cache when a no-update pass is inconclusive (fetch failure)", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a"), urlPlugin("pub.b")]);
+    pluginServiceMock.checkForUpdate.mockImplementation(async (id: string) =>
+      id === "pub.a" ? available("pub.a", "2.0.0") : { status: "up-to-date" }
+    );
+    const svc = new PluginUpdateCheckService();
+    await svc._checkNowForTest();
+    expect(svc.getLatest()).not.toBeNull();
+
+    // Now 0 available but one plugin couldn't be checked → don't clear the cache.
+    pluginServiceMock.checkForUpdate.mockImplementation(async (id: string) =>
+      id === "pub.a" ? { status: "fetch-failed", message: "net" } : { status: "up-to-date" }
+    );
+    await svc._checkNowForTest();
+    expect(svc.getLatest()).not.toBeNull();
+  });
+
+  it("does not broadcast or cache when disabled mid-pass", async () => {
+    storeState.value = { enabled: true, lastCheckedAt: null };
+    pluginServiceMock.listPlugins.mockReturnValue([urlPlugin("pub.a")]);
+    let resolveCheck: ((v: unknown) => void) | undefined;
+    pluginServiceMock.checkForUpdate.mockImplementation(
+      () =>
+        new Promise((res) => {
+          resolveCheck = res;
+        })
+    );
+    const svc = new PluginUpdateCheckService();
+    const pass = svc._checkNowForTest();
+    await Promise.resolve();
+    // User flips the toggle off while the network check is in flight.
+    storeState.value = { enabled: false, lastCheckedAt: storeState.value.lastCheckedAt };
+    resolveCheck?.(available("pub.a", "2.0.0"));
+    await pass;
+
+    expect(broadcastMock).not.toHaveBeenCalled();
+    expect(svc.getLatest()).toBeNull();
+  });
+
+  it("start() is idempotent and registers the wake listener only once", () => {
+    storeState.value = { enabled: true, lastCheckedAt: Date.now() };
+    const svc = new PluginUpdateCheckService();
+    svc.start();
+    svc.start();
+    expect(systemSleepMock.onWake).toHaveBeenCalledTimes(1);
+  });
 });

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -98,6 +98,11 @@ export interface StoreSchema {
     enabled: boolean;
     thresholdMinutes: number;
   };
+  pluginBackgroundUpdateCheck: {
+    enabled: boolean;
+    /** Wall-clock ms of the last completed pass; null until the first runs. */
+    lastCheckedAt: number | null;
+  };
   appState: {
     activeWorktreeId?: string;
     sidebarWidth: number;
@@ -523,6 +528,12 @@ const storeOptions = {
     idleBackgroundAutoClose: {
       enabled: false,
       thresholdMinutes: 15,
+    },
+    // Background plugin update checks default OFF (#10893): a periodic network
+    // re-fetch of every URL-installed plugin is an opt-in behavior, not a default.
+    pluginBackgroundUpdateCheck: {
+      enabled: false,
+      lastCheckedAt: null,
     },
     appState: {
       sidebarWidth: 350,

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -770,6 +770,18 @@ export async function initGlobalServices(
     },
   });
 
+  // Opt-in background plugin update checks (#10893). Registered after
+  // `plugin-service` so the checker reads a populated list; `start()` no-ops
+  // while the feature is disabled (the default), so this is free when off.
+  registerDeferredTask({
+    name: "plugin-update-check-service",
+    run: async () => {
+      const { getPluginUpdateCheckService } =
+        await import("../services/PluginUpdateCheckService.js");
+      getPluginUpdateCheckService().start();
+    },
+  });
+
   if (windowRegistry) {
     const registryRef = windowRegistry;
     // Wire `helpSessionService.mcpRegistry` synchronously by construction (no

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1807,6 +1807,14 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      */
     onProvenanceChanged(callback: (payload: Record<string, never>) => void): () => void;
     /**
+     * Subscribe to background update-check results (#10893). Fires with the
+     * batched set of URL-installed plugins that have updates available. Returns
+     * a cleanup.
+     */
+    onBackgroundUpdateAvailable(
+      callback: (payload: import("../plugin.js").PluginBackgroundUpdateCheckResult) => void
+    ): () => void;
+    /**
      * Subscribe to file-decoration invalidations. The callback fires with the
      * changed scope (and optionally the narrowed paths) — it carries no
      * decoration data; re-pull via {@link getDecorations}. Returns a cleanup.

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -403,6 +403,9 @@ export interface GeneratedElectronAPI {
     getAuditRecords(
       ...args: IpcInvokeMap["plugin:get-audit-records"]["args"]
     ): Promise<IpcInvokeMap["plugin:get-audit-records"]["result"]>;
+    getBackgroundUpdateCheckSettings(
+      ...args: IpcInvokeMap["plugin:bg-update-check-settings-get"]["args"]
+    ): Promise<IpcInvokeMap["plugin:bg-update-check-settings-get"]["result"]>;
     getDecorations(
       ...args: IpcInvokeMap["plugin:file-decorations-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:file-decorations-get"]["result"]>;
@@ -412,6 +415,9 @@ export interface GeneratedElectronAPI {
     getForgeProviders(
       ...args: IpcInvokeMap["plugin:forge-providers-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:forge-providers-get"]["result"]>;
+    getLatestBackgroundUpdateCheck(
+      ...args: IpcInvokeMap["plugin:bg-update-check-latest"]["args"]
+    ): Promise<IpcInvokeMap["plugin:bg-update-check-latest"]["result"]>;
     getPanelKinds(
       ...args: IpcInvokeMap["plugin:panel-kinds-get"]["args"]
     ): Promise<IpcInvokeMap["plugin:panel-kinds-get"]["result"]>;
@@ -457,6 +463,9 @@ export interface GeneratedElectronAPI {
     setAuditMaxRecords(
       ...args: IpcInvokeMap["plugin:set-audit-max-records"]["args"]
     ): Promise<IpcInvokeMap["plugin:set-audit-max-records"]["result"]>;
+    setBackgroundUpdateCheckSettings(
+      ...args: IpcInvokeMap["plugin:bg-update-check-settings-set"]["args"]
+    ): Promise<IpcInvokeMap["plugin:bg-update-check-settings-set"]["result"]>;
     setEnabled(
       ...args: IpcInvokeMap["plugin:set-enabled"]["args"]
     ): Promise<IpcInvokeMap["plugin:set-enabled"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -903,6 +903,18 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: Record<string, import("../../config/agentRegistry.js").AgentConfig>;
   };
+  "plugin:bg-update-check-latest": {
+    args: [];
+    result: import("../plugin.js").PluginBackgroundUpdateCheckResult | null;
+  };
+  "plugin:bg-update-check-settings-get": {
+    args: [];
+    result: import("../plugin.js").PluginBackgroundUpdateCheckSettings;
+  };
+  "plugin:bg-update-check-settings-set": {
+    args: [enabled: boolean];
+    result: import("../plugin.js").PluginBackgroundUpdateCheckSettings;
+  };
   "plugin:check-for-update": {
     args: [pluginId: string];
     result: import("../plugin.js").PluginCheckUpdateResult;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1914,6 +1914,11 @@ export interface IpcEventMap {
   // renderer re-pulls via `plugin:list` for the full data.
   "plugin:provenance-changed": Record<string, never>;
 
+  // Background plugin update check found available updates (main → renderer,
+  // #10893). Carries the batched set so the renderer can raise one low-priority
+  // inbox notification. Broadcast only when at least one update is available.
+  "plugin:bg-update-available": import("../plugin.js").PluginBackgroundUpdateCheckResult;
+
   // Run history changed (main → renderer, #9949). Carries the full newest-first
   // snapshot so every live window updates without a reload after a recipe/fleet
   // run is recorded or the log is cleared.
@@ -2035,6 +2040,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:panel-badges-cleared"
   // Plugin provenance record changed (global broadcast)
   | "plugin:provenance-changed"
+  // Background plugin update check found updates (global broadcast)
+  | "plugin:bg-update-available"
   // Run history changed (global broadcast)
   | "run-history:update"
   // Plugin deep-link intent (targeted at the primary window)

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -716,6 +716,37 @@ export type PluginCheckUpdateResult =
   | { status: "invalid-id" }
   | { status: "fetch-failed"; message: string };
 
+/**
+ * One URL-installed plugin found to have an update available by the opt-in
+ * background check (#10893). A trimmed projection of the `available` variant of
+ * {@link PluginCheckUpdateResult} — enough for the inbox notification copy and
+ * the manager's "Update all" queue without re-querying.
+ */
+export interface PluginBackgroundUpdateEntry {
+  pluginId: string;
+  displayName: string;
+  version: string;
+  capabilities: PluginCapability[];
+}
+
+/**
+ * Result of a background update-check pass across all URL-installed plugins
+ * (#10893). Broadcast to renderers (and cached in main for late-subscriber
+ * hydration) only when `updates` is non-empty. `signature` is a deterministic
+ * digest of the update set so the renderer can dedupe repeated passes that
+ * surface the same set into a single inbox row.
+ */
+export interface PluginBackgroundUpdateCheckResult {
+  checkedAt: number;
+  updates: PluginBackgroundUpdateEntry[];
+  signature: string;
+}
+
+/** Opt-in state for the background update check (#10893). OFF by default. */
+export interface PluginBackgroundUpdateCheckSettings {
+  enabled: boolean;
+}
+
 export interface PluginLoadError {
   message: string;
   stack?: string;

--- a/src/__tests__/PostHydrationListeners.test.tsx
+++ b/src/__tests__/PostHydrationListeners.test.tsx
@@ -15,6 +15,7 @@ const recipeFocus = vi.fn();
 const devServerSync = vi.fn();
 const soundPlayback = vi.fn();
 const storeUpdate = vi.fn();
+const pluginUpdateCheck = vi.fn();
 const mark = vi.fn();
 
 vi.mock("@/hooks/useHibernationNotifications", () => ({
@@ -38,6 +39,9 @@ vi.mock("@/hooks/useSoundPlaybackListener", () => ({
 vi.mock("@/hooks/useStoreUpdateListener", () => ({
   useStoreUpdateListener: () => storeUpdate(),
 }));
+vi.mock("@/hooks/usePluginUpdateCheckListener", () => ({
+  usePluginUpdateCheckListener: () => pluginUpdateCheck(),
+}));
 vi.mock("@/hooks/app", () => ({
   useRecipeFocusReload: () => recipeFocus(),
   useWorktreeDevServerStateSync: () => devServerSync(),
@@ -56,6 +60,7 @@ const allHooks = [
   devServerSync,
   soundPlayback,
   storeUpdate,
+  pluginUpdateCheck,
 ];
 
 describe("PostHydrationListeners", () => {

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -7,6 +7,7 @@ import {
   AlertCircle,
   AlertTriangle,
   ChevronLeft,
+  RefreshCw,
   X,
 } from "lucide-react";
 import { useState, useEffect, useRef, useMemo, useDeferredValue } from "react";
@@ -560,6 +561,17 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
                 <Link2 />
                 Install from URL
               </Button>
+              {pm.hasUpdatablePlugins && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void pm.checkAllForUpdates()}
+                  loading={pm.isCheckingAllUpdates}
+                >
+                  <RefreshCw />
+                  Update all
+                </Button>
+              )}
             </div>
             <div className="space-y-2">
               <input
@@ -803,7 +815,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
 
       <ConfirmDialog
         isOpen={pm.pendingUpdate !== null}
-        onClose={pm.isReinstalling ? undefined : () => pm.setPendingUpdate(null)}
+        onClose={pm.isReinstalling ? undefined : () => pm.dismissPendingUpdate()}
         title={pm.pendingUpdate ? `Update '${pluginLabel(pm.pendingUpdate.plugin)}'?` : ""}
         description="Downloads the latest archive and reinstalls over the current version. Your settings are kept."
         confirmLabel="Reinstall plugin"

--- a/src/components/Plugin/__tests__/PluginManagerView.test.tsx
+++ b/src/components/Plugin/__tests__/PluginManagerView.test.tsx
@@ -1477,4 +1477,91 @@ describe("PluginManagerView", () => {
       await waitFor(() => expect(screen.getByText("Explore plugins")).toBeTruthy());
     });
   });
+
+  describe("Update all (#10893)", () => {
+    const makeUrl = (name: string, displayName: string, url?: string) =>
+      makePlugin({
+        manifest: { ...makePlugin().manifest, name, displayName },
+        source: "url",
+        originalUrl: url ?? `https://example.com/${name}.dntr`,
+        archiveHash: "h",
+      });
+
+    const listMock = () => window.electron.plugin.list as ReturnType<typeof vi.fn>;
+    const checkMock = () => window.electron.plugin.checkForUpdate as ReturnType<typeof vi.fn>;
+    const installMock = () => window.electron.plugin.installFromUrl as ReturnType<typeof vi.fn>;
+
+    it("hides the Update all button when no plugins are URL-installed", async () => {
+      listMock().mockResolvedValue([makePlugin()]); // sideload — originalUrl null
+      renderDialog();
+      await screen.findAllByText("Acme Demo");
+      expect(screen.queryByRole("button", { name: "Update all" })).toBeNull();
+    });
+
+    it("checks only URL-installed plugins and opens the confirm for the first available", async () => {
+      listMock().mockResolvedValue([
+        makeUrl("acme.a", "Plugin A"),
+        makeUrl("acme.b", "Plugin B"),
+        makePlugin(), // sideload — must be skipped
+      ]);
+      checkMock().mockImplementation(async (id: string) =>
+        id === "acme.a"
+          ? { status: "available", name: "acme.a", version: "2.0.0", capabilities: [] }
+          : { status: "up-to-date" }
+      );
+      renderDialog();
+      fireEvent.click(await screen.findByRole("button", { name: "Update all" }));
+
+      await waitFor(() => expect(screen.getByText("Update 'Plugin A'?")).toBeTruthy());
+      const checkedIds = checkMock().mock.calls.map((c) => c[0]);
+      expect(checkedIds).toContain("acme.a");
+      expect(checkedIds).toContain("acme.b");
+      expect(checkedIds).not.toContain("acme.demo");
+
+      fireEvent.click(screen.getByRole("button", { name: "Reinstall plugin" }));
+      await waitFor(() =>
+        expect(installMock()).toHaveBeenCalledWith("https://example.com/acme.a.dntr")
+      );
+    });
+
+    it("drains multiple available updates one confirm at a time", async () => {
+      listMock().mockResolvedValue([makeUrl("acme.a", "Plugin A"), makeUrl("acme.b", "Plugin B")]);
+      checkMock().mockImplementation(async (id: string) => ({
+        status: "available",
+        name: id,
+        version: "2.0.0",
+        capabilities: [],
+      }));
+      renderDialog();
+      fireEvent.click(await screen.findByRole("button", { name: "Update all" }));
+
+      await waitFor(() => expect(screen.getByText("Update 'Plugin A'?")).toBeTruthy());
+      fireEvent.click(screen.getByRole("button", { name: "Reinstall plugin" }));
+
+      await waitFor(() => expect(screen.getByText("Update 'Plugin B'?")).toBeTruthy());
+      fireEvent.click(screen.getByRole("button", { name: "Reinstall plugin" }));
+
+      await waitFor(() => expect(installMock()).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(screen.queryByText(/^Update '/)).toBeNull());
+    });
+
+    it("routes an http update through the HTTP confirm before installing", async () => {
+      listMock().mockResolvedValue([makeUrl("acme.a", "Plugin A", "http://example.com/a.dntr")]);
+      checkMock().mockResolvedValue({
+        status: "available",
+        name: "acme.a",
+        version: "2.0.0",
+        capabilities: [],
+      });
+      renderDialog();
+      fireEvent.click(await screen.findByRole("button", { name: "Update all" }));
+
+      await waitFor(() => expect(screen.getByText("Update 'Plugin A'?")).toBeTruthy());
+      fireEvent.click(screen.getByRole("button", { name: "Reinstall plugin" }));
+
+      await waitFor(() => expect(screen.getByText("Install over HTTP?")).toBeTruthy());
+      // The HTTP gate must fire before any download leaves the app.
+      expect(installMock()).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -129,7 +129,15 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   const upToDateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [pendingUpdate, setPendingUpdate] = useState<PendingUpdate | null>(null);
   const [isReinstalling, setIsReinstalling] = useState(false);
+  // Synchronous reentrancy guard for the reinstall — `isReinstalling` state lags
+  // a render, leaving a double-click window that would fire two installs and
+  // double-advance the batch queue (same class as the #4703 check guard).
+  const reinstallingRef = useRef(false);
   const [pendingHttpUrl, setPendingHttpUrl] = useState<string | null>(null);
+  // Synchronous mirror of `pendingHttpUrl` so confirm/cancel are one-shot even
+  // if the dialog fires a re-entrant close before the state flush — otherwise a
+  // second cancel could re-read stale state and reopen the manual URL dialog.
+  const pendingHttpUrlRef = useRef<string | null>(null);
   // "Update all" (#10893) drains available updates through the SAME per-plugin
   // capability-diff confirm as a single check: the queue holds the not-yet-shown
   // updates, `pendingUpdate` shows the head, and each confirm/skip/HTTP-gate
@@ -204,6 +212,7 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     setDeleteSettings(false);
     setPendingUpdate(null);
     setPendingHttpUrl(null);
+    pendingHttpUrlRef.current = null;
     // Abandon any in-flight "Update all" batch — the fresh list supersedes it.
     isBatchActiveRef.current = false;
     pendingQueueRef.current = [];
@@ -401,6 +410,7 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
       // own. Cancelling reopens the input with the URL intact so the user can
       // switch to https; confirming proceeds with the install.
       setShowUrlDialog(false);
+      pendingHttpUrlRef.current = url;
       setPendingHttpUrl(url);
       return;
     }
@@ -408,8 +418,10 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   };
 
   const confirmHttpInstall = async () => {
-    if (!pendingHttpUrl) return;
-    const url = pendingHttpUrl;
+    // Read+clear the ref synchronously so a re-entrant confirm is a one-shot.
+    const url = pendingHttpUrlRef.current;
+    if (!url) return;
+    pendingHttpUrlRef.current = null;
     const fromReinstall = httpFromReinstallRef.current;
     httpFromReinstallRef.current = false;
     setPendingHttpUrl(null);
@@ -420,12 +432,17 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   };
 
   const cancelHttpInstall = () => {
+    // Read+clear the ref synchronously so a re-entrant close can't reclassify a
+    // reinstall cancel as a manual one (or double-advance the batch).
+    if (!pendingHttpUrlRef.current) return;
+    pendingHttpUrlRef.current = null;
+    const fromReinstall = httpFromReinstallRef.current;
+    httpFromReinstallRef.current = false;
     setPendingHttpUrl(null);
     // A reinstall-over-http cancel must NOT reopen the manual install dialog
     // (that URL was never user-entered); during a batch it just skips to the
     // next queued update (#10893). Manual installs keep the reopen-to-edit UX.
-    if (httpFromReinstallRef.current) {
-      httpFromReinstallRef.current = false;
+    if (fromReinstall) {
       if (isBatchActiveRef.current) advanceUpdateQueue();
       return;
     }
@@ -653,6 +670,18 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
 
   const confirmReinstall = async () => {
     if (!pendingUpdate) return;
+    if (reinstallingRef.current) return;
+    // Guard against a plugin uninstalled in another window mid-batch: never
+    // reinstall a record that's no longer in the authoritative list. Since a
+    // batch suppresses the provenance auto-clear of `pendingUpdate`, this is the
+    // batch's equivalent staleness check (#10893).
+    const stillInstalled = plugins.some(
+      (p) => p.manifest.name === pendingUpdate.plugin.manifest.name
+    );
+    if (!stillInstalled) {
+      advanceUpdateQueue();
+      return;
+    }
     const url = pendingUpdate.plugin.originalUrl;
     if (!url) {
       advanceUpdateQueue();
@@ -673,9 +702,11 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
       // Mark the origin so the HTTP confirm's cancel doesn't reopen the manual
       // install dialog and its resolution advances the batch (#10893).
       httpFromReinstallRef.current = true;
+      pendingHttpUrlRef.current = url;
       setPendingHttpUrl(url);
       return;
     }
+    reinstallingRef.current = true;
     setIsReinstalling(true);
     try {
       setError(null);
@@ -689,6 +720,7 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
       // leaves its confirm untouched (advanceUpdateQueue clears it either way).
       if (isBatchActiveRef.current) advanceUpdateQueue();
     } finally {
+      reinstallingRef.current = false;
       setIsReinstalling(false);
     }
   };

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -655,13 +655,14 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
         }
       }
       if (refreshKeyRef.current !== startKey) return;
-      if (available.length === 0) {
+      const [first, ...rest] = available;
+      if (!first) {
         setNotice("All plugins are up to date.");
         return;
       }
-      pendingQueueRef.current = available.slice(1);
+      pendingQueueRef.current = rest;
       isBatchActiveRef.current = true;
-      setPendingUpdate(available[0]);
+      setPendingUpdate(first);
     } finally {
       isCheckingAllUpdatesRef.current = false;
       setIsCheckingAllUpdates(false);

--- a/src/components/Plugin/usePluginManager.ts
+++ b/src/components/Plugin/usePluginManager.ts
@@ -130,6 +130,19 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   const [pendingUpdate, setPendingUpdate] = useState<PendingUpdate | null>(null);
   const [isReinstalling, setIsReinstalling] = useState(false);
   const [pendingHttpUrl, setPendingHttpUrl] = useState<string | null>(null);
+  // "Update all" (#10893) drains available updates through the SAME per-plugin
+  // capability-diff confirm as a single check: the queue holds the not-yet-shown
+  // updates, `pendingUpdate` shows the head, and each confirm/skip/HTTP-gate
+  // resolution advances to the next. Refs (not state) so the async confirm flow
+  // reads the live queue without a render lag.
+  const [isCheckingAllUpdates, setIsCheckingAllUpdates] = useState(false);
+  const isCheckingAllUpdatesRef = useRef(false);
+  const pendingQueueRef = useRef<PendingUpdate[]>([]);
+  const isBatchActiveRef = useRef(false);
+  // True while an HTTP-downgrade confirm originated from a reinstall (single or
+  // batch) rather than a manual URL install — so cancelling it doesn't wrongly
+  // reopen the manual install dialog, and resolving it advances the batch queue.
+  const httpFromReinstallRef = useRef(false);
   // Integer depth counter so the overlay survives child enter/leave churn
   // without flicker (same pattern as the terminal drop zone). The boolean is
   // derived from it for the overlay render.
@@ -191,6 +204,10 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     setDeleteSettings(false);
     setPendingUpdate(null);
     setPendingHttpUrl(null);
+    // Abandon any in-flight "Update all" batch — the fresh list supersedes it.
+    isBatchActiveRef.current = false;
+    pendingQueueRef.current = [];
+    httpFromReinstallRef.current = false;
     setShowUrlDialog(false);
     setUrlInput("");
     // Reset the drop overlay so a drag-enter that was interrupted by a
@@ -244,8 +261,11 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
       setRefreshKey((k) => k + 1);
       // A plugin may have been uninstalled (or uninstalled-then-reinstalled with
       // the same name) in another window — close any open confirm so it can't
-      // fire `installFromUrl` / `uninstall` against a stale record.
-      setPendingUpdate(null);
+      // fire `installFromUrl` / `uninstall` against a stale record. Exception:
+      // during an "Update all" batch, each reinstall we perform fires this same
+      // provenance broadcast; clearing here would nuke the next queued update, so
+      // the batch owns `pendingUpdate` and advances it itself (#10893).
+      if (!isBatchActiveRef.current) setPendingUpdate(null);
       setPendingUninstall(null);
     });
   }, []);
@@ -390,12 +410,25 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
   const confirmHttpInstall = async () => {
     if (!pendingHttpUrl) return;
     const url = pendingHttpUrl;
+    const fromReinstall = httpFromReinstallRef.current;
+    httpFromReinstallRef.current = false;
     setPendingHttpUrl(null);
     await performInstallFromUrl(url);
+    // A reinstall-over-http came from the update flow, not the manual install
+    // dialog — advance the "Update all" queue if one is draining (#10893).
+    if (fromReinstall && isBatchActiveRef.current) advanceUpdateQueue();
   };
 
   const cancelHttpInstall = () => {
     setPendingHttpUrl(null);
+    // A reinstall-over-http cancel must NOT reopen the manual install dialog
+    // (that URL was never user-entered); during a batch it just skips to the
+    // next queued update (#10893). Manual installs keep the reopen-to-edit UX.
+    if (httpFromReinstallRef.current) {
+      httpFromReinstallRef.current = false;
+      if (isBatchActiveRef.current) advanceUpdateQueue();
+      return;
+    }
     setShowUrlDialog(true);
   };
 
@@ -549,11 +582,80 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     }
   };
 
+  // Advance an in-flight "Update all" batch to the next queued update, or end it
+  // when the queue drains. Single-plugin checks (batch inactive) just close the
+  // confirm as before (#10893).
+  const advanceUpdateQueue = () => {
+    if (!isBatchActiveRef.current) {
+      setPendingUpdate(null);
+      return;
+    }
+    const next = pendingQueueRef.current.shift() ?? null;
+    if (next) {
+      setPendingUpdate(next);
+    } else {
+      isBatchActiveRef.current = false;
+      setPendingUpdate(null);
+    }
+  };
+
+  // The confirm dialog's cancel/skip. During a batch it moves to the next
+  // queued update instead of ending the whole run.
+  const dismissPendingUpdate = () => {
+    advanceUpdateQueue();
+  };
+
+  // "Update all" (#10893): check every URL-installed plugin, then drain the ones
+  // with an update through the same per-plugin capability-diff confirm flow as a
+  // single check. Reuses `checkForUpdate` + `confirmReinstall`; never installs
+  // silently and never collapses the per-plugin capability preview into one
+  // blanket accept.
+  const checkAllForUpdates = async () => {
+    if (isCheckingAllUpdatesRef.current) return;
+    const targets = plugins.filter((p) => !p.isBuiltin && !!p.originalUrl);
+    if (targets.length === 0) return;
+    isCheckingAllUpdatesRef.current = true;
+    setIsCheckingAllUpdates(true);
+    setError(null);
+    setNotice(null);
+    setUpToDateId(null);
+    // Same staleness guard as the single check: if the list refreshes mid-run
+    // (reopen, mutation, cross-window change), discard rather than surface a
+    // confirm for a plugin that may no longer exist.
+    const startKey = refreshKeyRef.current;
+    const available: PendingUpdate[] = [];
+    try {
+      for (const plugin of targets) {
+        try {
+          const result = await window.electron.plugin.checkForUpdate(plugin.manifest.name);
+          if (refreshKeyRef.current !== startKey) return;
+          if (result.status === "available") {
+            available.push({ plugin, result });
+          }
+        } catch (err) {
+          // Isolate per plugin — one failed check never aborts the batch.
+          logError("Failed to check plugin for update (Update all)", err);
+        }
+      }
+      if (refreshKeyRef.current !== startKey) return;
+      if (available.length === 0) {
+        setNotice("All plugins are up to date.");
+        return;
+      }
+      pendingQueueRef.current = available.slice(1);
+      isBatchActiveRef.current = true;
+      setPendingUpdate(available[0]);
+    } finally {
+      isCheckingAllUpdatesRef.current = false;
+      setIsCheckingAllUpdates(false);
+    }
+  };
+
   const confirmReinstall = async () => {
     if (!pendingUpdate) return;
     const url = pendingUpdate.plugin.originalUrl;
     if (!url) {
-      setPendingUpdate(null);
+      advanceUpdateQueue();
       return;
     }
     // Tier D2: a plugin first installed over http:// keeps an http upstream, so
@@ -568,6 +670,9 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     }
     if (protocol === "http:") {
       setPendingUpdate(null);
+      // Mark the origin so the HTTP confirm's cancel doesn't reopen the manual
+      // install dialog and its resolution advances the batch (#10893).
+      httpFromReinstallRef.current = true;
       setPendingHttpUrl(url);
       return;
     }
@@ -575,11 +680,14 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     try {
       setError(null);
       const result = await window.electron.plugin.installFromUrl(url);
-      setPendingUpdate(null);
       handleInstallResult(result);
+      advanceUpdateQueue();
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to reinstall plugin"));
       logError("Failed to reinstall plugin from URL", err);
+      // In a batch, skip the failed plugin and keep draining; a single check
+      // leaves its confirm untouched (advanceUpdateQueue clears it either way).
+      if (isBatchActiveRef.current) advanceUpdateQueue();
     } finally {
       setIsReinstalling(false);
     }
@@ -622,6 +730,10 @@ export function usePluginManager(isOpen: boolean, deepLink?: PluginManagerDeepLi
     setPendingUpdate,
     isReinstalling,
     confirmReinstall,
+    dismissPendingUpdate,
+    checkAllForUpdates,
+    isCheckingAllUpdates,
+    hasUpdatablePlugins: plugins.some((p) => !p.isBuiltin && !!p.originalUrl),
     handleToggle,
     isDragOverFiles,
     handleDragEnter,

--- a/src/components/PostHydrationListeners.tsx
+++ b/src/components/PostHydrationListeners.tsx
@@ -8,6 +8,7 @@ import { useDiskSpaceWarnings } from "../hooks/useDiskSpaceWarnings";
 import { useForgeTokenHealth } from "../hooks/useForgeTokenHealth";
 import { useForgeRateLimit } from "../hooks/useForgeRateLimit";
 import { useStoreUpdateListener } from "../hooks/useStoreUpdateListener";
+import { usePluginUpdateCheckListener } from "../hooks/usePluginUpdateCheckListener";
 import { useSoundPlaybackListener } from "../hooks/useSoundPlaybackListener";
 import { useRecipeFocusReload, useWorktreeDevServerStateSync } from "../hooks/app";
 
@@ -35,6 +36,7 @@ export function PostHydrationListeners() {
   useWorktreeDevServerStateSync();
   useSoundPlaybackListener();
   useStoreUpdateListener();
+  usePluginUpdateCheckListener();
 
   useEffect(() => {
     markRendererPerformance(PERF_MARKS.POST_HYDRATION_LISTENERS_MOUNT);

--- a/src/components/Settings/PluginsTab.tsx
+++ b/src/components/Settings/PluginsTab.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from "react";
-import { Package } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Package, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { useDeferredLoading } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { actionService } from "@/services/ActionService";
+import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 
 /**
@@ -16,6 +18,12 @@ import { logError } from "@/utils/logger";
 export function PluginsTab() {
   const [count, setCount] = useState<number | null>(null);
   const showInlineLoading = useDeferredLoading(count === null, UI_DOHERTY_THRESHOLD);
+  // Opt-in background update check (#10893). `null` until the main-process
+  // electron-store value loads; renders OFF while loading so it never implies
+  // the feature is on before we know.
+  const [backgroundChecksEnabled, setBackgroundChecksEnabled] = useState<boolean | null>(null);
+  const [backgroundChecksSaving, setBackgroundChecksSaving] = useState(false);
+  const isMountedRef = useRef(true);
 
   // Re-pull the count when a plugin is installed or uninstalled anywhere so the
   // summary stays accurate while the settings dialog is open (#9285).
@@ -42,6 +50,66 @@ export function PluginsTab() {
       unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!window.electron?.plugin?.getBackgroundUpdateCheckSettings) {
+      // Older preload (e.g. tests) — default to OFF, the persisted default.
+      setBackgroundChecksEnabled(false);
+      return;
+    }
+    let cancelled = false;
+    window.electron.plugin
+      .getBackgroundUpdateCheckSettings()
+      .then((result) => {
+        if (!cancelled) setBackgroundChecksEnabled(result.enabled);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        logError("Failed to load plugin background update check setting", err);
+        setBackgroundChecksEnabled(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleBackgroundChecksToggle = async () => {
+    if (backgroundChecksSaving || backgroundChecksEnabled === null) return;
+    if (!window.electron?.plugin?.setBackgroundUpdateCheckSettings) return;
+    const prev = backgroundChecksEnabled;
+    const next = !prev;
+    setBackgroundChecksEnabled(next);
+    setBackgroundChecksSaving(true);
+    try {
+      const result = await window.electron.plugin.setBackgroundUpdateCheckSettings(next);
+      if (isMountedRef.current) setBackgroundChecksEnabled(result.enabled);
+    } catch (err) {
+      logError("Failed to save plugin background update check setting", err);
+      if (isMountedRef.current) setBackgroundChecksEnabled(prev);
+      notify({
+        type: "error",
+        title: "Couldn't save setting",
+        message: "Background update check preference couldn't be saved.",
+        actions: [
+          {
+            label: "Try again",
+            variant: "primary",
+            onClick: () => void handleBackgroundChecksToggle(),
+          },
+        ],
+        context: { eventKind: "uiFeedback" },
+      });
+    } finally {
+      if (isMountedRef.current) setBackgroundChecksSaving(false);
+    }
+  };
 
   const openManager = () => {
     void actionService.dispatch("app.pluginManager", undefined, { source: "user" });
@@ -78,6 +146,16 @@ export function PluginsTab() {
           Open plugin manager
         </Button>
       </div>
+
+      <SettingsSwitchCard
+        icon={RefreshCw}
+        title="Check for plugin updates in the background"
+        subtitle="Checks URL-installed plugins about once a day and adds an inbox notification when updates are available"
+        isEnabled={backgroundChecksEnabled ?? false}
+        onChange={() => void handleBackgroundChecksToggle()}
+        ariaLabel="Background plugin update checks"
+        disabled={backgroundChecksEnabled === null || backgroundChecksSaving}
+      />
     </div>
   );
 }

--- a/src/components/Settings/__tests__/PluginsTab.test.tsx
+++ b/src/components/Settings/__tests__/PluginsTab.test.tsx
@@ -19,6 +19,8 @@ vi.mock("@/services/ActionService", () => ({
   },
 }));
 
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
 function makePlugin(name: string): LoadedPluginInfo {
   return {
     manifest: {
@@ -63,6 +65,8 @@ beforeEach(() => {
     plugin: {
       list: vi.fn().mockResolvedValue([]),
       onProvenanceChanged: vi.fn().mockReturnValue(() => {}),
+      getBackgroundUpdateCheckSettings: vi.fn().mockResolvedValue({ enabled: false }),
+      setBackgroundUpdateCheckSettings: vi.fn().mockResolvedValue({ enabled: true }),
     },
   } as unknown as typeof window.electron;
 });
@@ -118,5 +122,45 @@ describe("PluginsTab (settings entry point)", () => {
 
     fireProvenance?.();
     await waitFor(() => expect(listMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("loads the background update check toggle as off by default", async () => {
+    render(<PluginsTab />);
+    const toggle = await screen.findByRole("switch", {
+      name: "Background plugin update checks",
+    });
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
+  });
+
+  it("optimistically enables background checks and persists via IPC", async () => {
+    render(<PluginsTab />);
+    const toggle = await screen.findByRole("switch", {
+      name: "Background plugin update checks",
+    });
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
+
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(window.electron.plugin.setBackgroundUpdateCheckSettings).toHaveBeenCalledWith(true)
+    );
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("true"));
+  });
+
+  it("reverts the toggle when the save fails", async () => {
+    (
+      window.electron.plugin.setBackgroundUpdateCheckSettings as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error("boom"));
+    render(<PluginsTab />);
+    const toggle = await screen.findByRole("switch", {
+      name: "Background plugin update checks",
+    });
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
+
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(window.electron.plugin.setBackgroundUpdateCheckSettings).toHaveBeenCalledWith(true)
+    );
+    // Optimistic flip, then revert on the rejected save.
+    await waitFor(() => expect(toggle.getAttribute("aria-checked")).toBe("false"));
   });
 });

--- a/src/hooks/__tests__/usePluginUpdateCheckListener.test.tsx
+++ b/src/hooks/__tests__/usePluginUpdateCheckListener.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+import type { PluginBackgroundUpdateCheckResult } from "@shared/types/plugin";
+
+const notifyMock = vi.hoisted(() => vi.fn());
+const dispatchMock = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+
+import { usePluginUpdateCheckListener } from "../usePluginUpdateCheckListener";
+
+function Harness() {
+  usePluginUpdateCheckListener();
+  return null;
+}
+
+function result(
+  updates: Array<{ pluginId: string; version: string }>,
+  signature: string
+): PluginBackgroundUpdateCheckResult {
+  return {
+    checkedAt: 1,
+    signature,
+    updates: updates.map((u) => ({
+      pluginId: u.pluginId,
+      displayName: u.pluginId,
+      version: u.version,
+      capabilities: [],
+    })),
+  };
+}
+
+type Listener = (payload: PluginBackgroundUpdateCheckResult) => void;
+
+function installElectron(opts: {
+  latest?: PluginBackgroundUpdateCheckResult | null;
+  captureListener?: (fn: Listener) => void;
+}) {
+  const onBackgroundUpdateAvailable = vi.fn((cb: Listener) => {
+    opts.captureListener?.(cb);
+    return () => {};
+  });
+  (window as unknown as { electron: unknown }).electron = {
+    plugin: {
+      getLatestBackgroundUpdateCheck: vi.fn(async () => opts.latest ?? null),
+      onBackgroundUpdateAvailable,
+    },
+  };
+  return { onBackgroundUpdateAvailable };
+}
+
+describe("usePluginUpdateCheckListener", () => {
+  beforeEach(() => {
+    notifyMock.mockClear();
+    dispatchMock.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    delete (window as unknown as { electron?: unknown }).electron;
+  });
+
+  it("hydrates from the main-process cache into one low-priority inbox notification", async () => {
+    installElectron({ latest: result([{ pluginId: "pub.a", version: "2.0.0" }], "pub.a@2.0.0") });
+    render(<Harness />);
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+    const payload = notifyMock.mock.calls[0][0];
+    expect(payload.priority).toBe("low");
+    expect(payload.supersedeKey).toBe("plugin-updates-available");
+    expect(payload.action.actionId).toBe("app.pluginManager");
+    expect(payload.message).toContain("1 plugin update");
+  });
+
+  it("pluralizes the message for multiple updates", async () => {
+    installElectron({
+      latest: result(
+        [
+          { pluginId: "pub.a", version: "2.0.0" },
+          { pluginId: "pub.b", version: "3.0.0" },
+        ],
+        "pub.a@2.0.0,pub.b@3.0.0"
+      ),
+    });
+    render(<Harness />);
+
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+    expect(notifyMock.mock.calls[0][0].message).toContain("2 plugin updates");
+  });
+
+  it("surfaces live events and dedupes a repeated signature in-session", async () => {
+    let listener: Listener | undefined;
+    installElectron({ latest: null, captureListener: (fn) => (listener = fn) });
+    render(<Harness />);
+
+    await waitFor(() => expect(listener).toBeDefined());
+    const r = result([{ pluginId: "pub.a", version: "2.0.0" }], "pub.a@2.0.0");
+    listener!(r);
+    listener!(r); // same signature — ignored
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+
+    // A new signature re-notifies.
+    listener!(result([{ pluginId: "pub.a", version: "3.0.0" }], "pub.a@3.0.0"));
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not notify when there are no updates", async () => {
+    let listener: Listener | undefined;
+    installElectron({ latest: null, captureListener: (fn) => (listener = fn) });
+    render(<Harness />);
+    await waitFor(() => expect(listener).toBeDefined());
+    listener!(result([], ""));
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+
+  it("the notification action falls back to dispatching the plugin manager", async () => {
+    installElectron({ latest: result([{ pluginId: "pub.a", version: "2.0.0" }], "pub.a@2.0.0") });
+    render(<Harness />);
+    await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
+    notifyMock.mock.calls[0][0].action.onClick();
+    expect(dispatchMock).toHaveBeenCalledWith("app.pluginManager", undefined, { source: "user" });
+  });
+});

--- a/src/hooks/__tests__/usePluginUpdateCheckListener.test.tsx
+++ b/src/hooks/__tests__/usePluginUpdateCheckListener.test.tsx
@@ -72,7 +72,7 @@ describe("usePluginUpdateCheckListener", () => {
     render(<Harness />);
 
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
-    const payload = notifyMock.mock.calls[0][0];
+    const payload = notifyMock.mock.calls[0]![0];
     expect(payload.priority).toBe("low");
     expect(payload.supersedeKey).toBe("plugin-updates-available");
     expect(payload.action.actionId).toBe("app.pluginManager");
@@ -92,7 +92,7 @@ describe("usePluginUpdateCheckListener", () => {
     render(<Harness />);
 
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
-    expect(notifyMock.mock.calls[0][0].message).toContain("2 plugin updates");
+    expect(notifyMock.mock.calls[0]![0].message).toContain("2 plugin updates");
   });
 
   it("surfaces live events and dedupes a repeated signature in-session", async () => {
@@ -124,7 +124,7 @@ describe("usePluginUpdateCheckListener", () => {
     installElectron({ latest: result([{ pluginId: "pub.a", version: "2.0.0" }], "pub.a@2.0.0") });
     render(<Harness />);
     await waitFor(() => expect(notifyMock).toHaveBeenCalledTimes(1));
-    notifyMock.mock.calls[0][0].action.onClick();
+    notifyMock.mock.calls[0]![0].action.onClick();
     expect(dispatchMock).toHaveBeenCalledWith("app.pluginManager", undefined, { source: "user" });
   });
 });

--- a/src/hooks/usePluginUpdateCheckListener.ts
+++ b/src/hooks/usePluginUpdateCheckListener.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from "react";
+import { logError } from "@/utils/logger";
+import { notify } from "@/lib/notify";
+import { actionService } from "@/services/ActionService";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import type { PluginBackgroundUpdateCheckResult } from "@shared/types/plugin";
+
+const SUPERSEDE_KEY = "plugin-updates-available";
+
+function showPluginUpdatesNotification(result: PluginBackgroundUpdateCheckResult): void {
+  const count = result.updates.length;
+  if (count === 0) return;
+  // eslint-disable-next-line no-restricted-syntax -- notify-event-kind: ok — a background "updates available" nudge has no fitting EVENT_POLICY kind; mirrors useStoreUpdateListener.
+  notify({
+    type: "info",
+    // priority:"low" routes inbox-only — no toast, no OS notification. A
+    // background heads-up about optional plugin updates belongs in history, not
+    // competing with active work (#10893).
+    priority: "low",
+    // supersedeKey collapses repeated daily passes that surface the same set
+    // into a single inbox row rather than stacking duplicates.
+    supersedeKey: SUPERSEDE_KEY,
+    title: "Plugin updates available",
+    message:
+      count === 1
+        ? "1 plugin update is available. Open the plugin manager to review it."
+        : `${count} plugin updates are available. Open the plugin manager to review them.`,
+    duration: 0,
+    // actionId drives the button on the inbox-history path (a bare onClick is
+    // dropped there — see useStoreUpdateListener); onClick is the toast-path
+    // fallback in case priority routing changes.
+    action: {
+      label: "Open plugin manager",
+      actionId: "app.pluginManager",
+      onClick: () => {
+        safeFireAndForget(
+          actionService.dispatch("app.pluginManager", undefined, { source: "user" }),
+          { context: "Open plugin manager from update notification" }
+        );
+      },
+    },
+  });
+}
+
+/**
+ * Surfaces the opt-in background plugin update check (#10893) as a single
+ * low-priority inbox notification. Hydrates from the main-process cache on mount
+ * (so an update found during the launch window still surfaces) and subscribes to
+ * live results. Deduped in-session by the result `signature` so re-checks that
+ * find the same set don't re-notify.
+ */
+export function usePluginUpdateCheckListener(): void {
+  const lastSignatureRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const plugin = window.electron?.plugin;
+    if (!plugin?.onBackgroundUpdateAvailable) return;
+
+    const surface = (result: PluginBackgroundUpdateCheckResult) => {
+      if (result.updates.length === 0) return;
+      if (lastSignatureRef.current === result.signature) return;
+      lastSignatureRef.current = result.signature;
+      showPluginUpdatesNotification(result);
+    };
+
+    plugin
+      .getLatestBackgroundUpdateCheck?.()
+      ?.then((result) => {
+        if (result) surface(result);
+      })
+      .catch((err) => logError("[usePluginUpdateCheckListener] getLatest failed", err));
+
+    const cleanup = plugin.onBackgroundUpdateAvailable(surface);
+    return () => {
+      cleanup();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in background plugin update check service and a Plugin Manager "Update all" affordance, built entirely on the existing lock-free `PluginInstaller.checkForUpdate` mechanism.
- No new install path, no online catalog. This is purely about surfacing and applying updates to what's already installed.
- Off by default, so nothing changes for anyone until they flip the toggle in Settings.

Resolves #10893

## Changes

- New `PluginUpdateCheckService` (main process): opt-in, off by default. Runs on a daily cadence using a wall-clock `lastCheckedAt` timestamp plus `powerMonitor` resume revalidation rather than a bare `setInterval`. Idle-gated, caps concurrency at 2, and reuses `checkForUpdate` across all URL-installed plugins. Broadcasts one batched result when updates are found. Wired into `globalServicesInit` start and shutdown dispose.
- Config persisted in electron-store as `pluginBackgroundUpdateCheck`, off by default. New plugin IPC (`getBackgroundUpdateCheckSettings`, `set`, `getLatest`) added via the `defineIpcNamespace` codegen, plus a `plugin:bg-update-available` push event.
- New `usePluginUpdateCheckListener` hook: shows a single low-priority inbox notification deduped by signature, hydrates from the main process cache, and its action opens the Plugin Manager.
- Plugin Manager "Update all": queue-drains available updates through the existing per-plugin capability-diff confirm dialog. Preserves the HTTP-downgrade gate and `refreshKeyRef` staleness discard. Hardened against double-confirm, mid-batch external uninstall, and HTTP confirm/cancel re-entrancy.
- Opt-in toggle added in Settings > Plugins.

## Testing

- 140 targeted tests pass across the new service, notify-hook, Update-all queue, settings-toggle, and listener-wiring suites.
- prettier and eslint clean on changed files.
- IPC codegen guards pass.