### PR TITLE
Rework resume sessions: flat recency lists, live refresh, single journal writer

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -53,6 +53,10 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "terminal:reliability-metric": "bus",
   "terminal:status": "bus",
 
+  // Agent session journaled (relayed from TypedEventBus; emitted by the main
+  // close paths and bridged from the pty-host's trash-expiry capture)
+  "agent-session:recorded": "bus",
+
   // Global broadcasts emitted externally (no TypedEventBus counterpart).
   "resource:profile-changed": "external",
   "sound:cancel": "external",

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -6,6 +6,8 @@ import { CHANNELS } from "../../channels.js";
 import { broadcastToProjectRenderers, broadcastToRenderer } from "../../utils.js";
 import { events, type DaintreeEventMap } from "../../../services/events.js";
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
+import { persistAgentSession } from "../../../services/pty/agentSessionHistory.js";
+import { getAgentSessionRetentionDays } from "../../../services/pty/agentSessionRetention.js";
 import type {
   SpawnResult,
   BroadcastWriteResultPayload,
@@ -148,6 +150,36 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
     broadcastToRenderer(CHANNELS.TERMINAL_RESTORED, payload);
   });
   handlers.push(unsubTerminalRestored);
+
+  // Resume records captured by the pty-host (trash expiry). Main is the
+  // journal's single writer — the pty-host writing the file itself would race
+  // main's own close-path writes (two processes, two write queues, one file)
+  // — so persist here with the real retention setting, then signal renderers.
+  const unsubSessionCaptured = events.on(
+    "agent-session:captured",
+    (payload: DaintreeEventMap["agent-session:captured"]) => {
+      void (async () => {
+        try {
+          const { app } = await import("electron");
+          await persistAgentSession(
+            payload.record,
+            app.getPath("userData"),
+            getAgentSessionRetentionDays()
+          );
+          // Signal AFTER the write lands so a refetch it triggers sees the record.
+          events.emit("agent-session:recorded", {
+            sessionId: payload.record.sessionId,
+            worktreeId: payload.record.worktreeId ?? null,
+            projectId: payload.record.projectId ?? null,
+            timestamp: Date.now(),
+          });
+        } catch (err) {
+          console.error("[TerminalEvents] Failed to persist captured agent session:", err);
+        }
+      })();
+    }
+  );
+  handlers.push(unsubSessionCaptured);
 
   return () => handlers.forEach((cleanup) => cleanup());
 }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -30,6 +30,7 @@ import {
   SettingTemplateError,
   substituteSettingsTemplates,
 } from "../../../services/settingsTemplateResolver.js";
+import { events } from "../../../services/events.js";
 import type * as PluginServiceModule from "../../../services/PluginService.js";
 
 type ValidatedTerminalSpawnOptions = z.output<typeof TerminalSpawnOptionsSchema>;
@@ -638,6 +639,14 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         app.getPath("userData"),
         getAgentSessionRetentionDays()
       );
+      // Signal AFTER the write lands so a refetch it triggers sees the record.
+      // Bridged to every renderer for live resume-list refresh.
+      events.emit("agent-session:recorded", {
+        sessionId,
+        worktreeId: info.worktreeId ?? null,
+        projectId: info.projectId ?? null,
+        timestamp: Date.now(),
+      });
     } catch (err) {
       console.warn("[TerminalLifecycle] Failed to persist agent session on close:", err);
     }

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1198,6 +1198,13 @@ events.on("terminal:restored", (payload) => {
   });
 });
 
+events.on("agent-session:captured", (payload) => {
+  sendEvent({
+    type: "agent-session-captured",
+    record: payload.record,
+  });
+});
+
 // Ack-driven backpressure helpers for SAB path
 function tryReplayAndResume(id: string): void {
   const segments = backpressureManager.getPendingSegments(id);

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -32,7 +32,7 @@ import {
 import { computeSpawnContext, acquirePtyProcess } from "./pty/terminalSpawn.js";
 import { disposeTerminalSerializerService } from "./pty/TerminalSerializerService.js";
 import { deleteSessionFile } from "./pty/terminalSessionPersistence.js";
-import { persistAgentSession } from "./pty/agentSessionHistory.js";
+import { events } from "./events.js";
 import { getGitBranch } from "../utils/gitUtils.js";
 import type { GracefulKillResult } from "../../shared/types/pty-host.js";
 
@@ -471,8 +471,14 @@ export class PtyManager extends EventEmitter {
             // has FS access but no WorkspaceClient, so resolve directly from
             // git with a short timeout; never let it block or fail the close.
             const branch = info.cwd ? getGitBranch(info.cwd) : null;
-            await persistAgentSession(
-              {
+            // Ship the captured record to Main rather than writing the journal
+            // here — Main is the journal's single writer (two processes with
+            // separate write queues doing read-modify-write on one file can
+            // silently drop each other's records), and only Main can read the
+            // real retention setting. Forwarded by the pty-host entry, bridged
+            // onto the main bus, persisted in the terminal event handlers.
+            events.emit("agent-session:captured", {
+              record: {
                 sessionId,
                 agentId: info.launchAgentId,
                 worktreeId: info.worktreeId ?? null,
@@ -483,16 +489,10 @@ export class PtyManager extends EventEmitter {
                 cwd: info.cwd ?? undefined,
                 branch: branch ?? undefined,
               },
-              undefined,
-              // Defer age-eviction (0 = keep forever) — the pty-host has no store
-              // access to read the retention setting, so evicting here with the
-              // 30-day default would drop records a longer retention window wants
-              // to keep. The main-process list/prune paths enforce the real window.
-              0
-            );
+            });
           }
         } catch (err) {
-          logError("[PtyManager] Failed to persist agent session on trash expiry", err);
+          logError("[PtyManager] Failed to capture agent session on trash expiry", err);
           // Ensure the terminal is killed even if gracefulKill failed
           try {
             this.kill(termId, "trash-expired");

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -270,6 +270,18 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: false,
     description: "Terminal restored from trash",
   },
+  "agent-session:captured": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: false,
+    description: "Pty-host captured a resumable session; Main must persist it",
+  },
+  "agent-session:recorded": {
+    category: "agent",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "A close path journaled a resumable agent session",
+  },
   "terminal:activity": {
     category: "agent",
     requiresContext: false,
@@ -738,6 +750,33 @@ export type DaintreeEventMap = {
   };
 
   /**
+   * Emitted in the pty-host when trash expiry captures a resumable session,
+   * and re-emitted on the Main bus by PtyEventsBridge. Main persists the
+   * record (single journal writer — the pty-host writing the file itself
+   * would race Main's own close-path writes) and then emits
+   * `agent-session:recorded`.
+   */
+  "agent-session:captured": {
+    record: Omit<
+      import("../../shared/types/ipc/agentSessionHistory.js").AgentSessionRecord,
+      "savedAt"
+    >;
+  };
+
+  /**
+   * Emitted after a close path journals a resumable agent session (trash
+   * expiry via `agent-session:captured`, or the main-process kill /
+   * gracefulKill handlers). Resume surfaces refetch on it so a session that
+   * leaves the trash appears in the list right away.
+   */
+  "agent-session:recorded": {
+    sessionId: string;
+    worktreeId: string | null;
+    projectId: string | null;
+    timestamp: number;
+  };
+
+  /**
    * Emitted when a terminal's activity state changes (busy/idle).
    * For shell terminals, this uses process tree inspection for accuracy.
    * For agent terminals, this includes human-readable status headlines.
@@ -870,6 +909,8 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "action:dispatched",
   "terminal:trashed",
   "terminal:restored",
+  "agent-session:captured",
+  "agent-session:recorded",
   "terminal:activity",
   "terminal:status",
   "terminal:backgrounded",

--- a/electron/services/pty/PtyEventsBridge.ts
+++ b/electron/services/pty/PtyEventsBridge.ts
@@ -160,6 +160,10 @@ export function bridgePtyEvent(event: PtyHostEvent, config?: PtyEventsBridgeConf
       events.emit("terminal:restored", { id: event.id });
       return true;
 
+    case "agent-session-captured":
+      events.emit("agent-session:captured", { record: event.record });
+      return true;
+
     case "terminal-status": {
       const statusPayload = {
         id: event.id,

--- a/electron/services/pty/__tests__/PtyEventsBridge.test.ts
+++ b/electron/services/pty/__tests__/PtyEventsBridge.test.ts
@@ -188,6 +188,31 @@ describe("bridgePtyEvent", () => {
     expect(callbackPayloads).toEqual([{ id: "term-3", status: "data-loss", droppedBytes: 1024 }]);
   });
 
+  it("re-emits a pty-host captured session onto the main bus for persistence", () => {
+    const payloads: Array<{ sessionId: string; worktreeId: string | null }> = [];
+    events.on("agent-session:captured", (payload) => {
+      payloads.push({
+        sessionId: payload.record.sessionId,
+        worktreeId: payload.record.worktreeId,
+      });
+    });
+
+    const handled = bridgePtyEvent({
+      type: "agent-session-captured",
+      record: {
+        sessionId: "sess-1",
+        agentId: "claude",
+        worktreeId: null,
+        title: null,
+        projectId: "proj-1",
+        cwd: "/repo/wt-a",
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(payloads).toEqual([{ sessionId: "sess-1", worktreeId: null }]);
+  });
+
   it("returns false for unhandled event types", () => {
     const handled = bridgePtyEvent({ type: "unknown-event" } as never);
     expect(handled).toBe(false);

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1377,6 +1377,14 @@ export interface IpcEventMap {
   "terminal:error": [id: string, error: string];
   "terminal:trashed": { id: string; expiresAt: number };
   "terminal:restored": { id: string };
+  // A close path journaled a resumable agent session (trash expiry, kill,
+  // gracefulKill). Signal-only for resume surfaces to refetch the journal.
+  "agent-session:recorded": {
+    sessionId: string;
+    worktreeId: string | null;
+    projectId: string | null;
+    timestamp: number;
+  };
   "terminal:status": TerminalStatusPayload;
   "terminal:reliability-metric": TerminalReliabilityMetricPayload;
   "terminal:fd-leak-warning": FdLeakWarningPayload;
@@ -2032,6 +2040,8 @@ export type IpcEventBusMap = Pick<
   // Terminal observability
   | "terminal:reliability-metric"
   | "terminal:status"
+  // Agent session journaled — resume surfaces refetch (global broadcast)
+  | "agent-session:recorded"
   // Watchdog deadlock detector — emitted once on cap-hit; global broadcast.
   | "watchdog:disabled"
   | "watchdog:active"

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -12,6 +12,7 @@ import type { PanelKind, TerminalFlowStatus, PanelTitleMode } from "./panel.js";
 import type { ResourceProfile } from "./resourceProfile.js";
 import type { BuiltInAgentId } from "../config/agentIds.js";
 import type { AgentConfig } from "../config/agentRegistry.js";
+import type { AgentSessionRecord } from "./ipc/agentSessionHistory.js";
 import type { SemanticSearchMatch, TerminalInfoPayload } from "./ipc/terminal.js";
 
 export type { TerminalFlowStatus };
@@ -424,6 +425,16 @@ export type PtyHostEvent =
   | { type: "agent-killed"; payload: AgentKilledPayload }
   | { type: "terminal-trashed"; id: string; expiresAt: number }
   | { type: "terminal-restored"; id: string }
+  | {
+      /**
+       * Trash expiry captured a resumable session in the pty-host. The record
+       * is shipped to Main for persistence — Main is the journal's single
+       * writer, so cross-process read-modify-write races on the file can't
+       * drop records, and the real retention setting applies.
+       */
+      type: "agent-session-captured";
+      record: Omit<AgentSessionRecord, "savedAt">;
+    }
   | { type: "terminal-pid"; id: string; pid: number }
   | { type: "snapshot"; id: string; requestId: string; snapshot: PtyHostTerminalSnapshot | null }
   | { type: "all-snapshots"; requestId: string; snapshots: PtyHostTerminalSnapshot[] }

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -184,52 +184,9 @@ export function PanelPalette({
       });
     };
 
-    // Resume entries get a second grouping tier (by worktree) beneath the
-    // section header. Items already arrive newest-first, so iterating in order
-    // and keying a Map gives correct group order and intra-group recency for
-    // free. Sub-headers stay aria-hidden divs (never role="group", #9006) and
-    // are excluded from the results array that drives selection.
-    const renderResumeSection = (items: typeof results) => {
-      if (items.length === 0) return;
-      elements.push(
-        <div
-          key="header-resume"
-          className="px-3 pt-3 pb-1 text-[10px] font-medium tracking-wider uppercase text-daintree-text/40 select-none"
-          aria-hidden="true"
-        >
-          {SECTION_LABELS.resume}
-        </div>
-      );
-      const groups = new Map<string, typeof results>();
-      for (const kind of items) {
-        const groupKey = kind.groupKey ?? "";
-        const bucket = groups.get(groupKey);
-        if (bucket) bucket.push(kind);
-        else groups.set(groupKey, [kind]);
-      }
-      for (const [groupKey, groupItems] of groups) {
-        const label = groupItems[0]?.groupLabel;
-        if (label) {
-          elements.push(
-            <div
-              key={`resume-group-${groupKey}`}
-              className="px-4 pt-2 pb-1 text-[10px] font-medium text-daintree-text/30 select-none truncate"
-              aria-hidden="true"
-            >
-              {label}
-            </div>
-          );
-        }
-        groupItems.forEach((kind) => {
-          const index = results.indexOf(kind);
-          elements.push(renderOption(kind, index));
-        });
-      }
-    };
-
     renderSection("agent", agents);
     renderSection("tool", tools);
-    renderResumeSection(resumeSessions);
+    renderSection("resume", resumeSessions);
 
     return elements;
   };

--- a/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
+++ b/src/components/PanelPalette/__tests__/PanelPalette.test.tsx
@@ -52,8 +52,7 @@ const resumeResults: PanelKindOption[] = [
     iconId: "terminal",
     color: "#fff",
     category: "resume",
-    groupKey: "wt-1",
-    groupLabel: "Feature X",
+    worktreeName: "Feature X",
     isStale: false,
   },
   {
@@ -62,18 +61,18 @@ const resumeResults: PanelKindOption[] = [
     iconId: "terminal",
     color: "#fff",
     category: "resume",
-    groupKey: "wt-removed",
-    groupLabel: "old-branch",
     isStale: true,
   },
 ];
 
-describe("PanelPalette browsable resume list (#10851)", () => {
-  it("renders worktree group sub-headers under the resume section when browsing", () => {
+describe("PanelPalette resume section", () => {
+  it("renders a flat resume section (no per-worktree sub-headers) when browsing", () => {
     render(<PanelPalette {...baseProps} query="" results={resumeResults} />);
     expect(screen.getByText("Resume Sessions")).toBeTruthy();
-    expect(screen.getByText("Feature X")).toBeTruthy();
-    expect(screen.getByText("old-branch")).toBeTruthy();
+    // Rows render in journal order with no location headers between them.
+    expect(screen.getByText("Resume: Fixing auth")).toBeTruthy();
+    expect(screen.getByText("Resume: Old work")).toBeTruthy();
+    expect(screen.queryByText("Feature X")).toBeNull();
   });
 
   it("shows a 'Worktree removed' badge on stale entries", () => {
@@ -88,41 +87,13 @@ describe("PanelPalette browsable resume list (#10851)", () => {
     const listbox = document.body.querySelector('[role="listbox"]')!;
     expect(listbox).toBeTruthy();
     expect(listbox.querySelectorAll('[role="group"]').length).toBe(0);
-    // Section + group headers stay aria-hidden so they don't enter the option index.
+    // Section headers stay aria-hidden so they don't enter the option index.
     expect(listbox.querySelectorAll('[aria-hidden="true"]').length).toBeGreaterThan(0);
   });
 
-  it("keys groups off groupKey, not the display label (same label, distinct keys → two headers)", () => {
-    const sameLabel: PanelKindOption[] = [
-      {
-        id: "resume:x",
-        name: "Resume: X",
-        iconId: "terminal",
-        color: "#fff",
-        category: "resume",
-        groupKey: "wt-1",
-        groupLabel: "main",
-      },
-      {
-        id: "resume:y",
-        name: "Resume: Y",
-        iconId: "terminal",
-        color: "#fff",
-        category: "resume",
-        groupKey: "wt-2",
-        groupLabel: "main",
-      },
-    ];
-    render(<PanelPalette {...baseProps} query="" results={sameLabel} />);
-    // Two worktrees that happen to share a branch name "main" must render as two
-    // separate group headers, not merge into one.
-    expect(screen.getAllByText("main")).toHaveLength(2);
-  });
-
-  it("flattens the list (no section or group headers) while searching", () => {
+  it("flattens the list (no section headers) while searching", () => {
     render(<PanelPalette {...baseProps} query="fix" results={resumeResults} />);
     expect(screen.queryByText("Resume Sessions")).toBeNull();
-    expect(screen.queryByText("Feature X")).toBeNull();
     // The options themselves still render.
     expect(screen.getByText("Resume: Fixing auth")).toBeTruthy();
   });

--- a/src/components/Terminal/ContentGridEmptyState.tsx
+++ b/src/components/Terminal/ContentGridEmptyState.tsx
@@ -194,7 +194,7 @@ export function ContentGridEmptyState({
           </div>
         )}
 
-        {hasActiveWorktree && <ResumeSessionsCard activeWorktreeId={activeWorktreeId} />}
+        {hasActiveWorktree && <ResumeSessionsCard />}
 
         {hasActiveWorktree && hasEverLaunchedAgent && (
           <div className="flex flex-col items-center gap-4 mt-4">

--- a/src/components/Terminal/ResumeSessionsCard.tsx
+++ b/src/components/Terminal/ResumeSessionsCard.tsx
@@ -1,49 +1,30 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { ArrowRight } from "lucide-react";
 import { History } from "@/components/icons";
 import { PanelKindIcon } from "@/components/PanelPalette/PanelKindIcon";
 import { actionService } from "@/services/ActionService";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useProjectStore } from "@/store/projectStore";
+import { useAgentSessionRecords } from "@/hooks/useAgentSessionRecords";
 import { buildResumeSessionItems, type ResumeSessionItem } from "@/services/resumeSessionItems";
 import { useResumeAgentSession } from "@/hooks/useResumeAgentSession";
-import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 
 const SHOWN_COUNT = 3;
 
 /**
  * First-run-quiet discovery card for the empty grid. Fetches the project's
- * closed-session journal and, when there is something to resume, offers the
- * most recent few as one-click launches plus a "browse all" entry into the
- * searchable resume launcher. Renders nothing when the project has no
+ * closed-session journal (kept live — a session that leaves the trash appears
+ * here the moment it's journaled) and, when there is something to resume,
+ * offers the most recent few as one-click launches plus a "browse all" entry
+ * into the searchable resume launcher. Renders nothing when the project has no
  * resumable sessions, so genuine first-run stays quiet and doesn't compete
  * with the RecipeRunner / welcome CTA (empty-state rules).
  */
-export function ResumeSessionsCard({ activeWorktreeId }: { activeWorktreeId?: string | null }) {
-  const [sessions, setSessions] = useState<AgentSessionRecord[]>([]);
-  const [loaded, setLoaded] = useState(false);
+export function ResumeSessionsCard() {
   const worktrees = useWorktreeStore((state) => state.worktrees);
   const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
   const resume = useResumeAgentSession();
-
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const list = (await window.electron?.agentSessionHistory?.list()) ?? [];
-        if (!cancelled) setSessions(list);
-      } catch {
-        if (!cancelled) setSessions([]);
-      } finally {
-        if (!cancelled) setLoaded(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-    // Refetch when the project/worktree context changes so a switch surfaces
-    // the right project's history.
-  }, [activeWorktreeId, currentProjectId]);
+  const { sessions, hasLoaded } = useAgentSessionRecords(true);
 
   const items = useMemo(
     () => buildResumeSessionItems(sessions, { currentProjectId, worktrees }),
@@ -54,7 +35,7 @@ export function ResumeSessionsCard({ activeWorktreeId }: { activeWorktreeId?: st
 
   // Render nothing until loaded (avoids a flash of empty card) or when the
   // project has nothing to resume.
-  if (!loaded || resumable.length === 0) return null;
+  if (!hasLoaded || resumable.length === 0) return null;
 
   const openLauncher = () => {
     void actionService.dispatch("terminal.resumeSessions", undefined, { source: "user" });

--- a/src/components/Terminal/ResumeSessionsPalette.tsx
+++ b/src/components/Terminal/ResumeSessionsPalette.tsx
@@ -70,6 +70,10 @@ export function ResumeSessionsPalette() {
     selectNext,
     close,
     isLoading,
+    isSearching,
+    visibleResults,
+    hiddenCount,
+    showMore,
   } = useResumeSessionsPalette();
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -83,12 +87,14 @@ export function ResumeSessionsPalette() {
     }
   }, [isOpen]);
 
+  // Depends on visibleResults (not results) so arrowing past the visible end —
+  // which lazily reveals the next page — re-runs once the row actually exists.
   useEffect(() => {
     if (selectedIndex >= 0 && results[selectedIndex]) {
       const node = itemsRef.current.get(results[selectedIndex]!.id);
       node?.scrollIntoView({ block: "nearest" });
     }
-  }, [selectedIndex, results]);
+  }, [selectedIndex, results, visibleResults]);
 
   const launch = useCallback(
     (item: ResumeSessionItem) => {
@@ -142,8 +148,6 @@ export function ResumeSessionsPalette() {
     []
   );
 
-  const isSearching = query.trim().length > 0;
-
   const renderRow = (item: ResumeSessionItem) => {
     const index = results.indexOf(item);
     return (
@@ -156,36 +160,6 @@ export function ResumeSessionsPalette() {
         itemRef={setItemRef(item.id)}
       />
     );
-  };
-
-  // Grouped by worktree when browsing; flat, relevance-ordered while searching.
-  // Items arrive newest-first, so a keyed Map yields correct group order and
-  // intra-group recency for free. Sub-headers stay aria-hidden (never
-  // role="group", #9006) and are excluded from the selection-driving results.
-  const renderGrouped = () => {
-    const groups = new Map<string, ResumeSessionItem[]>();
-    for (const item of results) {
-      const bucket = groups.get(item.groupKey);
-      if (bucket) bucket.push(item);
-      else groups.set(item.groupKey, [item]);
-    }
-    const elements: React.ReactNode[] = [];
-    for (const [groupKey, groupItems] of groups) {
-      const label = groupItems[0]?.groupLabel;
-      if (label) {
-        elements.push(
-          <div
-            key={`resume-group-${groupKey}`}
-            className="px-3 pt-3 pb-1 text-[10px] font-medium text-daintree-text/40 select-none truncate"
-            aria-hidden="true"
-          >
-            {label}
-          </div>
-        );
-      }
-      for (const item of groupItems) elements.push(renderRow(item));
-    }
-    return elements;
   };
 
   const selected = selectedIndex >= 0 ? results[selectedIndex] : undefined;
@@ -224,9 +198,23 @@ export function ResumeSessionsPalette() {
         ) : (
           <>
             <div id="resume-session-list" role="listbox" aria-label="Closed sessions">
-              {isSearching ? results.map(renderRow) : renderGrouped()}
+              {visibleResults.map(renderRow)}
             </div>
-            {totalResults != null && (
+            {!isSearching && hiddenCount > 0 && (
+              <button
+                type="button"
+                tabIndex={-1}
+                onPointerDown={(e) => e.preventDefault()}
+                onClick={showMore}
+                className="w-full px-3 py-2 rounded-[var(--radius-md)] text-xs text-daintree-text/50 transition-colors hover:bg-overlay-subtle hover:text-daintree-text/80"
+              >
+                Load more ({hiddenCount})
+              </button>
+            )}
+            {/* Fully-paged browse and search both surface records beyond the
+                result cap — search is the only way to reach them. The notice
+                self-hides when nothing overflows. */}
+            {hiddenCount === 0 && totalResults != null && (
               <PaletteOverflowNotice shown={results.length} total={totalResults} />
             )}
           </>

--- a/src/hooks/__tests__/useAgentSessionRecords.test.tsx
+++ b/src/hooks/__tests__/useAgentSessionRecords.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAgentSessionRecords } from "../useAgentSessionRecords";
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+
+function rec(sessionId: string): AgentSessionRecord {
+  return {
+    sessionId,
+    agentId: "claude",
+    worktreeId: null,
+    title: null,
+    projectId: "p1",
+    savedAt: Date.now(),
+  };
+}
+
+describe("useAgentSessionRecords", () => {
+  let listMock: ReturnType<typeof vi.fn>;
+  let onMock: ReturnType<typeof vi.fn>;
+  let unsubscribeMock: ReturnType<typeof vi.fn>;
+  let recordedCallback: (() => void) | undefined;
+
+  beforeEach(() => {
+    listMock = vi.fn().mockResolvedValue([rec("a")]);
+    unsubscribeMock = vi.fn();
+    recordedCallback = undefined;
+    onMock = vi.fn((name: string, cb: () => void) => {
+      if (name === "agent-session:recorded") recordedCallback = cb;
+      return unsubscribeMock;
+    });
+    (window as unknown as { electron: unknown }).electron = {
+      agentSessionHistory: { list: listMock },
+      events: { on: onMock },
+    };
+  });
+
+  it("fetches on enable and exposes the records", async () => {
+    const { result } = renderHook(() => useAgentSessionRecords(true));
+    await waitFor(() => {
+      expect(result.current.hasLoaded).toBe(true);
+    });
+    expect(result.current.sessions.map((s) => s.sessionId)).toEqual(["a"]);
+    expect(listMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing while disabled", () => {
+    renderHook(() => useAgentSessionRecords(false));
+    expect(listMock).not.toHaveBeenCalled();
+    expect(onMock).not.toHaveBeenCalled();
+  });
+
+  it("refetches when a session is journaled (agent-session:recorded push)", async () => {
+    const { result } = renderHook(() => useAgentSessionRecords(true));
+    await waitFor(() => {
+      expect(result.current.hasLoaded).toBe(true);
+    });
+
+    listMock.mockResolvedValue([rec("b"), rec("a")]);
+    act(() => {
+      recordedCallback?.();
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessions.map((s) => s.sessionId)).toEqual(["b", "a"]);
+    });
+    // The quiet refresh never flips the loading flag once loaded.
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("unsubscribes on unmount", async () => {
+    const { unmount } = renderHook(() => useAgentSessionRecords(true));
+    await waitFor(() => {
+      expect(onMock).toHaveBeenCalled();
+    });
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalled();
+  });
+
+  it("unsubscribes and resets loading when disabled mid-fetch", async () => {
+    // A list() that never resolves — disable must not strand isLoading.
+    listMock.mockReturnValue(new Promise(() => {}));
+    const { result, rerender } = renderHook(({ enabled }) => useAgentSessionRecords(enabled), {
+      initialProps: { enabled: true },
+    });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    rerender({ enabled: false });
+    expect(unsubscribeMock).toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("ignores a stale response resolving after a newer fetch (latest wins)", async () => {
+    let resolveFirst: (v: AgentSessionRecord[]) => void = () => {};
+    listMock.mockReturnValueOnce(
+      new Promise<AgentSessionRecord[]>((resolve) => {
+        resolveFirst = resolve;
+      })
+    );
+    const { result } = renderHook(() => useAgentSessionRecords(true));
+    await waitFor(() => {
+      expect(recordedCallback).toBeDefined();
+    });
+
+    // Event-driven refetch resolves first with the fresh list…
+    listMock.mockResolvedValue([rec("fresh")]);
+    act(() => {
+      recordedCallback?.();
+    });
+    await waitFor(() => {
+      expect(result.current.sessions.map((s) => s.sessionId)).toEqual(["fresh"]);
+    });
+
+    // …then the original slow fetch resolves late and must be discarded.
+    act(() => {
+      resolveFirst([rec("stale")]);
+    });
+    await waitFor(() => {
+      expect(result.current.hasLoaded).toBe(true);
+    });
+    expect(result.current.sessions.map((s) => s.sessionId)).toEqual(["fresh"]);
+  });
+});

--- a/src/hooks/__tests__/usePanelPalette.test.tsx
+++ b/src/hooks/__tests__/usePanelPalette.test.tsx
@@ -304,7 +304,7 @@ describe("usePanelPalette", () => {
       ...overrides,
     });
 
-    it("surfaces more than 5 sessions (no hardcoded cap)", async () => {
+    it("caps the resume shelf at the 5 most recent sessions", async () => {
       (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue(
         Array.from({ length: 8 }, (_, i) =>
           makeSession({ sessionId: `s-${i}`, savedAt: Date.now() - i * 1000 })
@@ -315,7 +315,15 @@ describe("usePanelPalette", () => {
       await vi.waitFor(() => {
         rerender();
         const resume = result.current.results.filter((item) => item.id.startsWith("resume:"));
-        expect(resume).toHaveLength(8);
+        expect(resume).toHaveLength(5);
+        // Records arrive newest-first; the shelf keeps the head of the list.
+        expect(resume.map((item) => item.id)).toEqual([
+          "resume:s-0",
+          "resume:s-1",
+          "resume:s-2",
+          "resume:s-3",
+          "resume:s-4",
+        ]);
       });
     });
 
@@ -362,22 +370,24 @@ describe("usePanelPalette", () => {
       });
     });
 
-    it("marks a record whose worktree was removed as stale", async () => {
+    it("excludes a record whose worktree was removed from the shelf", async () => {
       (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
         makeSession({ sessionId: "orphan", worktreeId: "wt-removed", branch: "old-branch" }),
+        makeSession({ sessionId: "fresh", projectId: "proj-1" }),
       ]);
 
       const { result, rerender } = renderHook(() => usePanelPalette());
       await vi.waitFor(() => {
         rerender();
-        const resume = result.current.results.find((item) => item.id === "resume:orphan");
-        expect(resume).toBeDefined();
-        expect(resume!.isStale).toBe(true);
-        expect(resume!.description).toContain("Worktree removed");
+        const ids = result.current.results.map((item) => item.id);
+        // Stale entries can't launch, so the short shelf drops them; the
+        // dedicated resume palette is where they remain visible (greyed).
+        expect(ids).toContain("resume:fresh");
+        expect(ids).not.toContain("resume:orphan");
       });
     });
 
-    it("resolves live worktree name, branch, and group label", async () => {
+    it("resolves live worktree name and branch", async () => {
       worktreeState.worktrees = new Map([
         ["wt-1", { id: "wt-1", name: "Feature X", branch: "feature/x" }],
       ]);
@@ -393,8 +403,6 @@ describe("usePanelPalette", () => {
         expect(resume!.isStale).toBe(false);
         expect(resume!.worktreeName).toBe("Feature X");
         expect(resume!.branchName).toBe("feature/x");
-        expect(resume!.groupKey).toBe("wt-1");
-        expect(resume!.groupLabel).toBe("Feature X");
       });
     });
 
@@ -415,41 +423,6 @@ describe("usePanelPalette", () => {
           expect.arrayContaining(["claude", "Claude", "Feature X", "feature/x"])
         );
       });
-    });
-
-    it("makes a stale entry findable by its cwd basename when it has no branch", async () => {
-      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
-        makeSession({
-          sessionId: "orphan",
-          worktreeId: "wt-removed",
-          branch: undefined,
-          cwd: "/repo/feature-auth",
-        }),
-      ]);
-
-      const { result, rerender } = renderHook(() => usePanelPalette());
-      await vi.waitFor(() => {
-        rerender();
-        const resume = result.current.results.find((item) => item.id === "resume:orphan");
-        expect(resume).toBeDefined();
-        expect(resume!.groupLabel).toBe("feature-auth");
-        expect(resume!.searchAliases).toContain("feature-auth");
-      });
-    });
-
-    it("does not launch a stale entry via handleSelect", async () => {
-      (window.electron!.agentSessionHistory!.list as ReturnType<typeof vi.fn>).mockResolvedValue([
-        makeSession({ sessionId: "orphan", worktreeId: "wt-removed" }),
-      ]);
-
-      const { result, rerender } = renderHook(() => usePanelPalette());
-      await vi.waitFor(() => {
-        rerender();
-        expect(result.current.results.some((item) => item.id === "resume:orphan")).toBe(true);
-      });
-      const stale = result.current.results.find((item) => item.id === "resume:orphan");
-      expect(stale!.isStale).toBe(true);
-      expect(result.current.handleSelect(stale!)).toBeNull();
     });
   });
 

--- a/src/hooks/useAgentSessionRecords.ts
+++ b/src/hooks/useAgentSessionRecords.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+
+/**
+ * Fetches the (unscoped, newest-first) closed-session journal and keeps it
+ * live: refetches whenever a close path journals a new record (trash expiry,
+ * kill, gracefulKill) via the `agent-session:recorded` push. Shared by every
+ * resume surface — the resume launcher palette, the empty-grid card, and the
+ * panel palette — so a session that leaves the trash appears in all of them
+ * right away instead of waiting for the next open/remount.
+ *
+ * `enabled` gates both the fetch and the subscription so transient surfaces
+ * (palettes) don't re-read the journal or hold listeners while closed.
+ */
+export function useAgentSessionRecords(enabled: boolean) {
+  const [sessions, setSessions] = useState<AgentSessionRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    // Latest-wins guard: the initial fetch and event-driven refetches can
+    // overlap, and an older response resolving late must not overwrite a newer
+    // one (it could hide the just-recorded session the event announced).
+    let latestFetch = 0;
+
+    const fetchSessions = async (initial: boolean) => {
+      const fetchId = ++latestFetch;
+      if (initial) setIsLoading(true);
+      try {
+        const list = (await window.electron?.agentSessionHistory?.list()) ?? [];
+        if (!cancelled && fetchId === latestFetch) setSessions(list);
+      } catch {
+        if (!cancelled && fetchId === latestFetch) setSessions([]);
+      } finally {
+        if (!cancelled && initial) {
+          setIsLoading(false);
+          setHasLoaded(true);
+        }
+      }
+    };
+
+    void fetchSessions(true);
+    // Event-driven refresh is quiet (no isLoading flip) so an already-rendered
+    // list gains the new row without a skeleton/empty flash.
+    const unsubscribe = window.electron?.events?.on("agent-session:recorded", () => {
+      void fetchSessions(false);
+    });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+      // Disable mid-fetch must not strand isLoading — the cancelled flag stops
+      // the finally block from ever resetting it.
+      setIsLoading(false);
+    };
+  }, [enabled]);
+
+  return { sessions, isLoading, hasLoaded };
+}

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -11,15 +11,11 @@ import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useProjectStore } from "@/store/projectStore";
+import { usePaletteStore } from "@/store/paletteStore";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
 import { keybindingService } from "@/services/KeybindingService";
-import { formatTimeAgo } from "@/utils/timeAgo";
-import {
-  NO_WORKTREE_GROUP_KEY,
-  pathBasename,
-  prettifyModelId,
-} from "@/services/resumeSessionItems";
-import { isUselessTitle } from "@shared/utils/isUselessTitle";
+import { buildResumeSessionItems } from "@/services/resumeSessionItems";
+import { useAgentSessionRecords } from "@/hooks/useAgentSessionRecords";
 import type { KeyAction } from "@shared/types/keymap";
 import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 
@@ -43,10 +39,6 @@ export interface PanelKindOption {
   worktreeName?: string;
   /** Branch a resume entry was captured on (live value preferred over recorded). */
   branchName?: string;
-  /** Grouping key for the browse view: worktree id, or a no-worktree sentinel. */
-  groupKey?: string;
-  /** Human label for the resume entry's worktree group header. */
-  groupLabel?: string;
 }
 
 export type UsePanelPaletteReturn = UseSearchablePaletteReturn<PanelKindOption> & {
@@ -62,6 +54,13 @@ import {
 import { isAgentInstalled } from "../../shared/utils/agentAvailability";
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * Resume entries shown in the panel palette — a short "most recent" shelf.
+ * The dedicated resume launcher (`terminal.resumeSessions`) is the browse and
+ * search surface for the full journal.
+ */
+const RECENT_RESUME_COUNT = 5;
 
 const AGENT_LAUNCH_ACTIONS: Record<string, KeyAction> = Object.fromEntries(
   LAUNCHABLE_AGENT_IDS.map((id) => [id, `agent.${id}` as KeyAction])
@@ -84,8 +83,14 @@ export function usePanelPalette(): UsePanelPaletteReturn {
   const availability = useCliAvailabilityStore((state) => state.availability);
   const isAvailabilityInitialized = useCliAvailabilityStore((state) => state.isInitialized);
   const [keybindingVersion, setKeybindingVersion] = useState(0);
-  const [resumeSessions, setResumeSessions] = useState<AgentSessionRecord[]>([]);
-  // Live per-view worktree map: drives stale-entry detection and group labels.
+  // Open state read straight from the palette store (the same source
+  // useSearchablePalette derives isOpen from) so the journal fetch can be
+  // gated on it before the palette hook runs.
+  const paletteIsOpen = usePaletteStore((state) => state.activePaletteId === "panel");
+  // Journal fetch gated on open; refreshed live when a close path journals a
+  // new record, so a just-expired session appears without reopening.
+  const { sessions: resumeSessions } = useAgentSessionRecords(paletteIsOpen);
+  // Live per-view worktree map: drives stale-entry detection and location labels.
   const worktrees = useWorktreeStore((state) => state.worktrees);
   // Scope the browsable resume list to the current project's own history.
   const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
@@ -176,75 +181,27 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     }
 
     // The journal is fetched unscoped (all worktrees/projects, newest-first).
-    // Keep this project's records, then map each to a rich, groupable option.
-    // Legacy records with a null projectId (pre-scoping) are kept only when
-    // their worktree still resolves in the live map — otherwise there's no
-    // reliable way to know they belong here.
-    const resumeOptions: PanelKindOption[] = resumeSessions
-      .filter((session) => !!session.sessionId)
-      .filter((session) => {
-        if (session.projectId) return session.projectId === currentProjectId;
-        return !!session.worktreeId && worktrees.has(session.worktreeId);
-      })
-      .map((session) => {
-        const agentConfig = getEffectiveAgentConfig(session.agentId);
-        const timeAgo = formatTimeAgo(session.savedAt);
-        const modelPart = session.agentModelId ? prettifyModelId(session.agentModelId) : null;
-        const agentName = agentConfig?.name ?? session.agentId;
-        const hasMeaningfulTitle = !!session.title && !isUselessTitle(session.title);
-        const name = hasMeaningfulTitle ? `Resume: ${session.title}` : `Resume ${agentName}`;
-
-        const liveWorktree = session.worktreeId ? worktrees.get(session.worktreeId) : undefined;
-        const isStale = !!session.worktreeId && !liveWorktree;
-        const worktreeName = liveWorktree?.name;
-        const branchName = liveWorktree?.branch ?? session.branch;
-
-        const groupKey = session.worktreeId ?? NO_WORKTREE_GROUP_KEY;
-        const groupLabel = liveWorktree
-          ? liveWorktree.name
-          : isStale
-            ? session.branch || pathBasename(session.cwd) || "Removed worktree"
-            : "No worktree";
-
-        // Second metadata line: agent/model, where it ran, and how long ago.
-        const locationPart = isStale ? "Worktree removed" : (worktreeName ?? branchName ?? null);
-        const descriptionParts = [
-          modelPart,
-          hasMeaningfulTitle ? agentName : null,
-          locationPart,
-          timeAgo,
-        ].filter((part): part is string => !!part);
-        const description = descriptionParts.join(" · ");
-
-        // Broaden search beyond the title so an agent, branch, model, or
-        // worktree name matches even when it never appears in the title. The
-        // cwd basename is included so a stale entry whose group label falls
-        // back to it (no branch, no live worktree) stays findable.
-        const searchAliases = [
-          session.agentId,
-          agentName,
-          modelPart,
-          worktreeName,
-          branchName,
-          pathBasename(session.cwd),
-        ].filter((alias): alias is string => !!alias);
-
-        return {
-          id: `resume:${session.sessionId}`,
-          name,
-          iconId: agentConfig?.iconId ?? "terminal",
-          color: agentConfig?.color ?? "var(--color-daintree-text)",
-          description,
-          searchAliases,
-          category: "resume" as const,
-          resumeSession: session,
-          isStale,
-          worktreeName,
-          branchName,
-          groupKey,
-          groupLabel,
-        };
-      });
+    // The shared builder scopes it to this project and maps each record to
+    // rich metadata; the palette keeps only a launchable most-recent shelf.
+    const resumeOptions: PanelKindOption[] = buildResumeSessionItems(resumeSessions, {
+      currentProjectId,
+      worktrees,
+    })
+      .filter((item) => !item.isStale)
+      .slice(0, RECENT_RESUME_COUNT)
+      .map((item) => ({
+        id: item.id,
+        name: item.name,
+        iconId: item.iconId,
+        color: item.color,
+        description: item.description,
+        searchAliases: item.searchAliases,
+        category: "resume" as const,
+        resumeSession: item.session,
+        isStale: item.isStale,
+        worktreeName: item.worktreeName,
+        branchName: item.branchName,
+      }));
 
     return [
       ...agentDedup.values(),
@@ -293,23 +250,6 @@ export function usePanelPalette(): UsePanelPaletteReturn {
     }
     const isStale = !lastCheckedAt || Date.now() - lastCheckedAt > STALE_THRESHOLD_MS;
     if (isStale) void refresh().catch(() => {});
-  }, [isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    let cancelled = false;
-    // Fetch unscoped (all worktrees) so the list is browsable; the memo above
-    // filters to the current project and flags stale entries (#10851). Gated on
-    // open so closing the palette doesn't re-read the whole journal.
-    window.electron?.agentSessionHistory
-      ?.list()
-      .then((sessions) => {
-        if (!cancelled) setResumeSessions(sessions);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
   }, [isOpen]);
 
   const handleSelect = useCallback(

--- a/src/hooks/useResumeAgentSession.ts
+++ b/src/hooks/useResumeAgentSession.ts
@@ -51,7 +51,13 @@ export function useResumeAgentSession() {
       const activeWorktree = activeWorktreeId ? worktrees.get(activeWorktreeId) : undefined;
       const defaultTerminalCwd = activeWorktree?.path ?? currentProject?.path ?? "";
 
-      const target = resolveResumeLaunchTarget(session, { defaultTerminalCwd, activeWorktreeId });
+      // Live worktree paths let a null-worktree record re-home by cwd, keeping
+      // the launch target consistent with the group the row was shown under.
+      const target = resolveResumeLaunchTarget(
+        session,
+        { defaultTerminalCwd, activeWorktreeId },
+        [...worktrees.values()].map((wt) => ({ id: wt.id, path: wt.path }))
+      );
 
       // A record whose recorded worktree no longer resolves can't be resumed —
       // it would spawn into a dead worktree. Callers already filter stale rows,

--- a/src/hooks/useResumeSessionsPalette.ts
+++ b/src/hooks/useResumeSessionsPalette.ts
@@ -1,10 +1,21 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { IFuseOptions } from "fuse.js";
 import { useSearchablePalette } from "@/hooks/useSearchablePalette";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useProjectStore } from "@/store/projectStore";
+import { usePaletteStore, type PaletteId } from "@/store/paletteStore";
+import { useAgentSessionRecords } from "@/hooks/useAgentSessionRecords";
 import { buildResumeSessionItems, type ResumeSessionItem } from "@/services/resumeSessionItems";
-import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
+
+const RESUME_PALETTE_ID: PaletteId = "resume-sessions";
+
+/**
+ * Browse-mode page size. Nobody scrolls fifty sessions deep to resume one —
+ * the recent few plus search cover real usage — so browsing shows the newest
+ * page and lazily reveals more (button click or arrowing past the end) instead
+ * of dumping the whole 30-day journal into the DOM.
+ */
+export const RESUME_PAGE_SIZE = 20;
 
 const RESUME_FUSE_OPTIONS: IFuseOptions<ResumeSessionItem> = {
   keys: [
@@ -18,16 +29,23 @@ const RESUME_FUSE_OPTIONS: IFuseOptions<ResumeSessionItem> = {
 
 /**
  * Data + search state for the resume-sessions launcher (`Cmd+K Cmd+R` / toolbar).
- * Fetches the journal unscoped on open (gated so closing doesn't re-read the
- * whole file), scopes it to the current project across all worktrees, and feeds
- * the rich items through the shared searchable-palette machinery.
+ * Fetches the journal unscoped while open (gated so closing doesn't re-read the
+ * whole file; refreshed live when a close path journals a new record), scopes
+ * it to the current project across all worktrees, and feeds the rich items
+ * through the shared searchable-palette machinery.
+ *
+ * Browsing is a flat, newest-first list paged by {@link RESUME_PAGE_SIZE};
+ * searching is flat and relevance-ordered over the full journal.
  */
 export function useResumeSessionsPalette() {
-  const [sessions, setSessions] = useState<AgentSessionRecord[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-
   const worktrees = useWorktreeStore((state) => state.worktrees);
   const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
+
+  // Open state read straight from the shared palette store — the same source
+  // useSearchablePalette derives its isOpen from — so the journal fetch can be
+  // gated on it without a circular items → palette → isOpen dependency.
+  const isOpen = usePaletteStore((state) => state.activePaletteId === RESUME_PALETTE_ID);
+  const { sessions, isLoading } = useAgentSessionRecords(isOpen);
 
   const items = useMemo(
     () => buildResumeSessionItems(sessions, { currentProjectId, worktrees }),
@@ -40,45 +58,58 @@ export function useResumeSessionsPalette() {
     includeMatches: true,
     maxResults: 100,
     canNavigate: (item) => !item.isStale,
-    paletteId: "resume-sessions",
+    paletteId: RESUME_PALETTE_ID,
     getItemId: (item) => item.id,
   });
 
-  const { isOpen, setQuery } = palette;
+  const { query, results, selectedIndex, setQuery } = palette;
+  const isSearching = query.trim().length > 0;
 
-  // Fetch on open (gated). The palette is opened via `paletteStore.openPalette`
-  // from the action, which bypasses `useSearchablePalette.open()` — so reset the
-  // query here too, mirroring ThemePalette.
+  const [visibleCount, setVisibleCount] = useState(RESUME_PAGE_SIZE);
+
+  // Reset the query and paging on open. The palette is opened via
+  // `paletteStore.openPalette` from the action, which bypasses
+  // `useSearchablePalette.open()` — so reset here too, mirroring ThemePalette.
   const wasOpenRef = useRef(false);
   useEffect(() => {
     if (isOpen && !wasOpenRef.current) {
       wasOpenRef.current = true;
       setQuery("");
-      let cancelled = false;
-      setIsLoading(true);
-      void (async () => {
-        try {
-          const list = (await window.electron?.agentSessionHistory?.list()) ?? [];
-          if (!cancelled) setSessions(list);
-        } catch {
-          if (!cancelled) setSessions([]);
-        } finally {
-          if (!cancelled) setIsLoading(false);
-        }
-      })();
-      return () => {
-        cancelled = true;
-      };
+      setVisibleCount(RESUME_PAGE_SIZE);
     }
     if (!isOpen) {
       wasOpenRef.current = false;
     }
-    return undefined;
   }, [isOpen, setQuery]);
+
+  // Keyboard lazy-load: arrowing past the visible end reveals the next page.
+  // The grown count is derived synchronously (not via an effect) so the row
+  // `aria-activedescendant` points at exists in the same commit the selection
+  // moves — selection walks the full results and must never target an
+  // unrendered row, even transiently. The effect below only commits the growth
+  // to state so the list never shrinks when selection moves back up.
+  const grownCount =
+    !isSearching && selectedIndex >= visibleCount
+      ? Math.ceil((selectedIndex + 1) / RESUME_PAGE_SIZE) * RESUME_PAGE_SIZE
+      : visibleCount;
+  useEffect(() => {
+    if (grownCount > visibleCount) setVisibleCount(grownCount);
+  }, [grownCount, visibleCount]);
+
+  const visibleResults = isSearching ? results : results.slice(0, grownCount);
+  const hiddenCount = results.length - visibleResults.length;
+
+  const showMore = useCallback(() => {
+    setVisibleCount((count) => count + RESUME_PAGE_SIZE);
+  }, []);
 
   return {
     ...palette,
     isLoading,
+    isSearching,
+    visibleResults,
+    hiddenCount,
+    showMore,
     hasSessions: items.length > 0,
   };
 }

--- a/src/services/__tests__/resumeSessionItems.test.ts
+++ b/src/services/__tests__/resumeSessionItems.test.ts
@@ -3,7 +3,6 @@ import {
   buildResumeSessionItems,
   pathBasename,
   prettifyModelId,
-  NO_WORKTREE_GROUP_KEY,
   type ResumeWorktreeLike,
 } from "../resumeSessionItems";
 import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
@@ -21,8 +20,8 @@ function rec(over: Partial<AgentSessionRecord> = {}): AgentSessionRecord {
 }
 
 const worktrees = new Map<string, ResumeWorktreeLike>([
-  ["wt1", { name: "feature-a", branch: "feat/a" }],
-  ["wt2", { name: "feature-b", branch: "feat/b" }],
+  ["wt1", { name: "feature-a", branch: "feat/a", path: "/repo/wt-a" }],
+  ["wt2", { name: "feature-b", branch: "feat/b", path: "/repo/wt-b" }],
 ]);
 
 describe("buildResumeSessionItems", () => {
@@ -45,27 +44,64 @@ describe("buildResumeSessionItems", () => {
     expect(items.map((i) => i.session.sessionId)).toEqual(["keep"]);
   });
 
+  it("keeps a legacy null-project, null-worktree record when its cwd resolves to a live worktree", () => {
+    const items = buildResumeSessionItems(
+      [
+        rec({ sessionId: "keep", projectId: null, worktreeId: null, cwd: "/repo/wt-a/src" }),
+        rec({ sessionId: "drop", projectId: null, worktreeId: null, cwd: "/somewhere/else" }),
+        rec({ sessionId: "drop2", projectId: null, worktreeId: null }),
+      ],
+      { currentProjectId: "p1", worktrees }
+    );
+    expect(items.map((i) => i.session.sessionId)).toEqual(["keep"]);
+  });
+
   it("flags a same-project record whose worktree no longer resolves as stale", () => {
     const [item] = buildResumeSessionItems([rec({ worktreeId: "gone", branch: "old/branch" })], {
       currentProjectId: "p1",
       worktrees,
     });
     expect(item?.isStale).toBe(true);
-    // Stale rows fall back to a recorded-branch label so they stay identifiable.
-    expect(item?.groupLabel).toBe("old/branch");
+    expect(item?.description).toContain("Worktree removed");
   });
 
-  it("groups by live worktree with its display name, and non-worktree records under a sentinel", () => {
-    const items = buildResumeSessionItems(
-      [rec({ sessionId: "a", worktreeId: "wt1" }), rec({ sessionId: "b", worktreeId: null })],
+  it("keeps a stale entry findable by its cwd basename when it has no branch", () => {
+    const [item] = buildResumeSessionItems(
+      [rec({ worktreeId: "gone", branch: undefined, cwd: "/repo/feature-auth" })],
       { currentProjectId: "p1", worktrees }
     );
-    const byId = new Map(items.map((i) => [i.session.sessionId, i]));
-    expect(byId.get("a")?.groupKey).toBe("wt1");
-    expect(byId.get("a")?.groupLabel).toBe("feature-a");
-    expect(byId.get("a")?.isStale).toBe(false);
-    expect(byId.get("b")?.groupKey).toBe(NO_WORKTREE_GROUP_KEY);
-    expect(byId.get("b")?.groupLabel).toBe("No worktree");
+    expect(item?.isStale).toBe(true);
+    expect(item?.searchAliases).toContain("feature-auth");
+  });
+
+  it("re-homes a null-worktree record onto the live worktree containing its cwd", () => {
+    const [item] = buildResumeSessionItems(
+      [rec({ worktreeId: null, cwd: "/repo/wt-a/packages/core" })],
+      { currentProjectId: "p1", worktrees }
+    );
+    expect(item?.isStale).toBe(false);
+    expect(item?.worktreeName).toBe("feature-a");
+    expect(item?.branchName).toBe("feat/a");
+    expect(item?.description).toContain("feature-a");
+  });
+
+  it("never marks a null-worktree record stale, even when its cwd resolves nowhere", () => {
+    const [item] = buildResumeSessionItems([rec({ worktreeId: null, cwd: "/tmp/elsewhere" })], {
+      currentProjectId: "p1",
+      worktrees,
+    });
+    expect(item?.isStale).toBe(false);
+    expect(item?.worktreeName).toBeUndefined();
+  });
+
+  it("resolves the live worktree's display name and branch for recorded worktrees", () => {
+    const [item] = buildResumeSessionItems([rec({ worktreeId: "wt1" })], {
+      currentProjectId: "p1",
+      worktrees,
+    });
+    expect(item?.isStale).toBe(false);
+    expect(item?.worktreeName).toBe("feature-a");
+    expect(item?.branchName).toBe("feat/a");
   });
 
   it("titles the row from a meaningful title, else falls back to the agent name", () => {

--- a/src/services/resumeSessionItems.ts
+++ b/src/services/resumeSessionItems.ts
@@ -1,14 +1,15 @@
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { isUselessTitle } from "@shared/utils/isUselessTitle";
 import { formatTimeAgo } from "@/utils/timeAgo";
+import { inferWorktreeIdFromCwd } from "@/utils/worktreePaths";
 import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 
 /**
  * Shared model for a browsable "resume closed session" entry. Built from a
  * journaled {@link AgentSessionRecord} plus the live worktree map so the resume
  * launcher (`ResumeSessionsPalette`), the empty-grid card (`ResumeSessionsCard`)
- * and the panel palette all render the same metadata, grouping and stale flags
- * without duplicating the mapping. Kept renderer-pure (no store reads) so it is
+ * and the panel palette all render the same metadata and stale flags without
+ * duplicating the mapping. Kept renderer-pure (no store reads) so it is
  * trivially unit-testable.
  */
 export interface ResumeSessionItem {
@@ -36,19 +37,14 @@ export interface ResumeSessionItem {
   worktreeName?: string;
   /** Branch the session was captured on (live value preferred over recorded). */
   branchName?: string;
-  /** Grouping key for the browse view: worktree id, or a no-worktree sentinel. */
-  groupKey: string;
-  /** Human label for the worktree group header. */
-  groupLabel: string;
 }
-
-/** Group key for resume records that were never tied to a worktree. */
-export const NO_WORKTREE_GROUP_KEY = "__no-worktree__";
 
 /** Minimal shape of a live worktree needed for labelling/stale detection. */
 export interface ResumeWorktreeLike {
   name: string;
   branch?: string | null;
+  /** Absolute worktree root path — enables cwd-based worktree inference. */
+  path?: string;
 }
 
 /** Last path segment of a POSIX or Windows path (for cwd-derived labels). */
@@ -72,10 +68,15 @@ export function prettifyModelId(modelId: string): string {
 
 /**
  * Filter the (unscoped, newest-first) journal to the current project and map
- * each record to a rich, groupable {@link ResumeSessionItem}. Legacy records
- * with a null projectId (pre-scoping) are kept only when their worktree still
- * resolves in the live map — otherwise there's no reliable way to know they
- * belong to this project.
+ * each record to a rich {@link ResumeSessionItem}. Legacy records with a null
+ * projectId (pre-scoping) are kept only when their worktree still resolves in
+ * the live map — otherwise there's no reliable way to know they belong to this
+ * project.
+ *
+ * Records journaled without a worktreeId (terminals spawned before worktree
+ * selection settled, "global" terminals) are re-homed by cwd: longest-prefix
+ * matching against live worktree paths. That keeps the row's location line and
+ * the launch target accurate instead of pretending the session ran nowhere.
  */
 export function buildResumeSessionItems(
   sessions: AgentSessionRecord[],
@@ -85,13 +86,21 @@ export function buildResumeSessionItems(
   }
 ): ResumeSessionItem[] {
   const { currentProjectId, worktrees } = opts;
+  const worktreePaths = [...worktrees].flatMap(([id, wt]) =>
+    wt.path ? [{ id, path: wt.path }] : []
+  );
   return sessions
     .filter((session) => !!session.sessionId)
-    .filter((session) => {
+    .map((session) => ({
+      session,
+      resolvedWorktreeId:
+        session.worktreeId ?? inferWorktreeIdFromCwd(session.cwd, worktreePaths) ?? null,
+    }))
+    .filter(({ session, resolvedWorktreeId }) => {
       if (session.projectId) return session.projectId === currentProjectId;
-      return !!session.worktreeId && worktrees.has(session.worktreeId);
+      return !!resolvedWorktreeId && worktrees.has(resolvedWorktreeId);
     })
-    .map((session) => {
+    .map(({ session, resolvedWorktreeId }) => {
       const agentConfig = getEffectiveAgentConfig(session.agentId);
       const timeAgo = formatTimeAgo(session.savedAt);
       const modelPart = session.agentModelId ? prettifyModelId(session.agentModelId) : null;
@@ -99,17 +108,13 @@ export function buildResumeSessionItems(
       const hasMeaningfulTitle = !!session.title && !isUselessTitle(session.title);
       const name = hasMeaningfulTitle ? `Resume: ${session.title}` : `Resume ${agentName}`;
 
-      const liveWorktree = session.worktreeId ? worktrees.get(session.worktreeId) : undefined;
+      const liveWorktree = resolvedWorktreeId ? worktrees.get(resolvedWorktreeId) : undefined;
+      // Stale means the RECORDED worktree no longer resolves — an inferred id
+      // always resolves (it came from the live map), so inference never
+      // produces a stale row.
       const isStale = !!session.worktreeId && !liveWorktree;
       const worktreeName = liveWorktree?.name;
       const branchName = liveWorktree?.branch ?? session.branch;
-
-      const groupKey = session.worktreeId ?? NO_WORKTREE_GROUP_KEY;
-      const groupLabel = liveWorktree
-        ? liveWorktree.name
-        : isStale
-          ? session.branch || pathBasename(session.cwd) || "Removed worktree"
-          : "No worktree";
 
       const locationPart = isStale ? "Worktree removed" : (worktreeName ?? branchName ?? null);
       const description = [modelPart, hasMeaningfulTitle ? agentName : null, locationPart, timeAgo]
@@ -136,8 +141,6 @@ export function buildResumeSessionItems(
         isStale,
         worktreeName,
         branchName,
-        groupKey,
-        groupLabel,
       };
     });
 }

--- a/src/utils/__tests__/resumeLaunch.test.ts
+++ b/src/utils/__tests__/resumeLaunch.test.ts
@@ -42,4 +42,37 @@ describe("resolveResumeLaunchTarget", () => {
     expect(target.worktreeId).toBeUndefined();
     expect(target.cwd).toBe("/active/cwd");
   });
+
+  it("re-homes a null-worktree record onto the live worktree containing its cwd", () => {
+    // The record was journaled before worktree selection settled, but its cwd
+    // pins it to worktree A — launch there, not into the active worktree.
+    const target = resolveResumeLaunchTarget(
+      { cwd: "/repo/wt-a/src", worktreeId: null },
+      fallback,
+      [
+        { id: "wt-a", path: "/repo/wt-a" },
+        { id: "wt-b", path: "/repo/wt-b" },
+      ]
+    );
+    expect(target.cwd).toBe("/repo/wt-a/src");
+    expect(target.worktreeId).toBe("wt-a");
+  });
+
+  it("prefers the recorded worktree over cwd inference", () => {
+    const target = resolveResumeLaunchTarget(
+      { cwd: "/repo/wt-a", worktreeId: "wt-recorded" },
+      fallback,
+      [{ id: "wt-a", path: "/repo/wt-a" }]
+    );
+    expect(target.worktreeId).toBe("wt-recorded");
+  });
+
+  it("falls back to the active worktree when cwd resolves to no live worktree", () => {
+    const target = resolveResumeLaunchTarget(
+      { cwd: "/tmp/elsewhere", worktreeId: null },
+      fallback,
+      [{ id: "wt-a", path: "/repo/wt-a" }]
+    );
+    expect(target.worktreeId).toBe("wt-active");
+  });
 });

--- a/src/utils/resumeLaunch.ts
+++ b/src/utils/resumeLaunch.ts
@@ -1,3 +1,4 @@
+import { inferWorktreeIdFromCwd } from "@/utils/worktreePaths";
 import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
 
 /**
@@ -7,15 +8,25 @@ import type { AgentSessionRecord } from "@shared/types/ipc/agentSessionHistory";
  * cwd doesn't match the original session's project path (#4781) — so once the
  * resume list is browsable across worktrees (#10851), the launch MUST use the
  * session's own recorded cwd/worktree, not whatever worktree happens to be
- * active in the UI. Records that predate these fields fall back to the
+ * active in the UI.
+ *
+ * Records journaled without a worktreeId are re-homed by cwd against the live
+ * worktree list — matching the resume list's grouping, so a session displayed
+ * under a worktree actually launches into it instead of silently attaching to
+ * the active one. Records that predate cwd/worktree fields fall back to the
  * active-worktree defaults so older history still resumes as before.
  */
 export function resolveResumeLaunchTarget(
   session: Pick<AgentSessionRecord, "cwd" | "worktreeId">,
-  fallback: { defaultTerminalCwd: string; activeWorktreeId: string | null | undefined }
+  fallback: { defaultTerminalCwd: string; activeWorktreeId: string | null | undefined },
+  worktrees?: ReadonlyArray<{ id: string; path: string }>
 ): { cwd: string; worktreeId: string | undefined } {
   return {
     cwd: session.cwd ?? fallback.defaultTerminalCwd,
-    worktreeId: session.worktreeId ?? fallback.activeWorktreeId ?? undefined,
+    worktreeId:
+      session.worktreeId ??
+      inferWorktreeIdFromCwd(session.cwd, worktrees) ??
+      fallback.activeWorktreeId ??
+      undefined,
   };
 }

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -595,37 +595,10 @@ export function buildArgsForNonPtyRecreation(
   return base;
 }
 
-// Normalizes separators (backslash → forward slash) and trims trailing slashes
-// so cwd and worktree paths compare apples-to-apples on Windows, where node-pty
-// returns backslashes but simple-git returns forward slashes.
-function normalizeForComparison(p: string): string {
-  return p.replace(/\\/g, "/").replace(/\/+$/, "");
-}
-
-/**
- * Infer a worktreeId from a terminal's cwd by longest-prefix matching against the
- * worktrees list. Returns undefined when no worktree's path is a prefix of cwd.
- * Uses segment-aware matching after normalizing separators on both sides, so
- * mixed POSIX/Windows separators between cwd and worktree paths still match.
- */
-export function inferWorktreeIdFromCwd(
-  cwd: string | undefined,
-  worktrees: ReadonlyArray<{ id: string; path: string }> | undefined
-): string | undefined {
-  if (!cwd || !worktrees || worktrees.length === 0) return undefined;
-  const normalizedCwd = normalizeForComparison(cwd);
-  let best: { id: string; normalizedLength: number } | undefined;
-  for (const wt of worktrees) {
-    if (!wt.path) continue;
-    const normalizedWtPath = normalizeForComparison(wt.path);
-    if (normalizedCwd === normalizedWtPath || normalizedCwd.startsWith(normalizedWtPath + "/")) {
-      if (!best || normalizedWtPath.length > best.normalizedLength) {
-        best = { id: wt.id, normalizedLength: normalizedWtPath.length };
-      }
-    }
-  }
-  return best?.id;
-}
+// Moved to a standalone module so renderer-pure consumers (resume grouping,
+// resume launch) can use it without pulling in the hydration import graph.
+// Re-exported here for the existing hydration-side callers.
+export { inferWorktreeIdFromCwd } from "../worktreePaths";
 
 export function buildArgsForOrphanedTerminal(
   terminal: BackendTerminalData,

--- a/src/utils/worktreePaths.ts
+++ b/src/utils/worktreePaths.ts
@@ -1,0 +1,31 @@
+// Normalizes separators (backslash → forward slash) and trims trailing slashes
+// so cwd and worktree paths compare apples-to-apples on Windows, where node-pty
+// returns backslashes but simple-git returns forward slashes.
+function normalizeForComparison(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+/**
+ * Infer a worktreeId from a terminal's cwd by longest-prefix matching against the
+ * worktrees list. Returns undefined when no worktree's path is a prefix of cwd.
+ * Uses segment-aware matching after normalizing separators on both sides, so
+ * mixed POSIX/Windows separators between cwd and worktree paths still match.
+ */
+export function inferWorktreeIdFromCwd(
+  cwd: string | undefined,
+  worktrees: ReadonlyArray<{ id: string; path: string }> | undefined
+): string | undefined {
+  if (!cwd || !worktrees || worktrees.length === 0) return undefined;
+  const normalizedCwd = normalizeForComparison(cwd);
+  let best: { id: string; normalizedLength: number } | undefined;
+  for (const wt of worktrees) {
+    if (!wt.path) continue;
+    const normalizedWtPath = normalizeForComparison(wt.path);
+    if (normalizedCwd === normalizedWtPath || normalizedCwd.startsWith(normalizedWtPath + "/")) {
+      if (!best || normalizedWtPath.length > best.normalizedLength) {
+        best = { id: wt.id, normalizedLength: normalizedWtPath.length };
+      }
+    }
+  }
+  return best?.id;
+}


### PR DESCRIPTION
This PR is a fairly significant rework of the resume-closed-sessions feature. It changes five things:

## 1. Removes worktree grouping

The grouping by worktree was buggy. Sessions from the default worktree would split into a spurious "No worktree" group sitting right next to the real worktree group, because agents launched before worktree selection settled were journaled with a null `worktreeId`. It also made sessions harder to scan.

Instead of grouping, we now just list sessions flat, newest first.

## 2. Re-homes sessions without a worktree

Sessions recorded without a worktree reference now get re-homed by matching their working directory against live worktree paths (`inferWorktreeIdFromCwd`, moved out of the hydration code into `src/utils/worktreePaths.ts`). This means the location label in the row is accurate, and resuming actually launches into the right worktree instead of silently attaching to whatever happens to be active.

## 3. Refreshes open resume views the moment a session is journaled

We now push a new event, `agent-session:recorded`, whenever a close path journals a resumable session. Any open resume surface (the palette, the empty-grid card, the panel palette) refreshes immediately, instead of only when you reopen it. So when a terminal leaves the trash, it shows up in the resume list right away.

This required restructuring how we write the journal. Previously the pty-host wrote `agent-session-history.json` from a second process while the main process also wrote it from its own close paths. Each side would read the file, modify it, and write it back, so one process could silently overwrite the other's records. It also meant the pty-host couldn't apply the user's retention setting.

The fix is to make the main process the single writer. The pty-host now ships the captured record over a new `agent-session-captured` wire event, and main persists it with the real retention window before signalling renderers.

## 4. Pages the dedicated resume palette

The resume palette no longer dumps the entire 30-day journal. Browsing shows the 20 most recent sessions with a "Load more" button, and arrowing past the end grows the list automatically. Search still spans everything fetched, and an overflow notice appears when there's more beyond the result cap.

## 5. Flattens the panel palette resume section

The resume section in the panel palette is now a short shelf of the 5 most recent launchable sessions. The dedicated palette is the browse-and-search surface for the full journal.

---

All three surfaces now read the journal through one shared hook (`useAgentSessionRecords`) and one shared mapping (`buildResumeSessionItems`), which replaced a fully duplicated copy of the mapping logic in `usePanelPalette`. The net diff came out at roughly -26 lines before review fixes.

A review pass confirmed the cross-process write race and it's fixed here via the single-writer change. One deliberate skip: case-insensitive path matching on Windows is left as a follow-up.
