### PR TITLE
fix(terminal): circuit-break watchdog geometry re-wrap

### DIFF
--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -19,6 +19,16 @@ export const WATCHDOG_REPAIR_COOLDOWN_MS = 6000;
 // context attach) allowed per tick. Light repairs (flush, reflow) are uncapped.
 export const WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK = 2;
 
+// Consecutive geometry-convergence repairs allowed for one terminal before the
+// circuit breaker trips (#10909). The cooldown spaces repairs ~2 ticks apart but
+// never caps them, so a pane whose proposeDimensions() never converges (a stable
+// off-by-one, e.g. a scrollbar-gutter width step it can't reach) would re-wrap its
+// full scrollback — renderer xterm plus the 10000-line headless copy — every
+// cooldown window indefinitely. After this many issued repairs still fail to
+// converge, stop repairing and log once, matching TerminalWebGLManager's
+// LOSS_THRESHOLD one-way-trip pattern. Reset on genuine convergence or re-attach.
+export const WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS = 3;
+
 /** Narrow structural type for the private xterm.js render-pause flag. */
 interface XtermCoreRenderPause {
   _renderService?: { _isPaused?: boolean };
@@ -393,29 +403,74 @@ export class TerminalReconciliationWatchdog {
     // grid that all diverges at once never lands as a single long task.
     if (!inSynchronizedBlock) {
       const proposal = managed.fitAddon.proposeDimensions?.();
-      if (
-        proposal &&
-        proposal.cols > 1 &&
-        proposal.rows > 1 &&
-        (proposal.cols !== managed.terminal.cols || proposal.rows !== managed.terminal.rows)
-      ) {
-        if (heavyBudget <= 0) return 0;
-        managed.lastWatchdogRepairAt = now;
-        logWarn(
-          "[TerminalReconciliationWatchdog] geometry divergence for on-screen terminal — reconciling",
-          {
-            id,
-            xtermCols: managed.terminal.cols,
-            xtermRows: managed.terminal.rows,
-            proposedCols: proposal.cols,
-            proposedRows: proposal.rows,
-            isAltBuffer: managed.isAltBuffer === true,
+      if (proposal && proposal.cols > 1 && proposal.rows > 1) {
+        const diverged =
+          proposal.cols !== managed.terminal.cols || proposal.rows !== managed.terminal.rows;
+        if (!diverged) {
+          // Converged: the grid now matches what the container can hold. Re-arm the
+          // circuit breaker (#10909) so a pane that self-corrected — e.g. a resize
+          // moved the container to a reachable width — isn't permanently barred from
+          // future repairs. reconcileRevealGeometry's boolean is measurability, not
+          // convergence, so this proposeDimensions comparison is the only real signal.
+          if (managed.geometryRepairAttempts || managed.geometryRepairGaveUp) {
+            managed.geometryRepairAttempts = 0;
+            managed.geometryRepairGaveUp = false;
           }
-        );
-        if (this.deps.reconcileRevealGeometry(id)) {
-          this.unpauseIfNeeded(managed, element);
+        } else {
+          // A fresh incarnation reusing this id must start with a clean counter —
+          // the old instance's give-up state can't apply to new geometry (mirrors
+          // the revealPendingGeneration guard above).
+          if (managed.geometryRepairGeneration !== managed.attachGeneration) {
+            managed.geometryRepairGeneration = managed.attachGeneration;
+            managed.geometryRepairAttempts = 0;
+            managed.geometryRepairGaveUp = false;
+          }
+          // Breaker tripped: stop re-wrapping this pane's scrollback. Fall through so
+          // the cheaper render-pause / WebGL layers below still reconcile — the
+          // breaker disables only the expensive geometry repair, not the whole chain.
+          if (!managed.geometryRepairGaveUp) {
+            const attempts = managed.geometryRepairAttempts ?? 0;
+            if (attempts >= WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS) {
+              managed.geometryRepairGaveUp = true;
+              logWarn(
+                "[TerminalReconciliationWatchdog] geometry never converged after repeated repairs — giving up (circuit breaker)",
+                {
+                  id,
+                  attempts,
+                  limit: WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS,
+                  xtermCols: managed.terminal.cols,
+                  xtermRows: managed.terminal.rows,
+                  proposedCols: proposal.cols,
+                  proposedRows: proposal.rows,
+                  isAltBuffer: managed.isAltBuffer === true,
+                }
+              );
+            } else {
+              // Count only issued repairs — a budget-deferred tick wasn't a failed
+              // convergence, just an untried one, so the check gates before the bump.
+              if (heavyBudget <= 0) return 0;
+              managed.geometryRepairAttempts = attempts + 1;
+              managed.lastWatchdogRepairAt = now;
+              logWarn(
+                "[TerminalReconciliationWatchdog] geometry divergence for on-screen terminal — reconciling",
+                {
+                  id,
+                  attempt: managed.geometryRepairAttempts,
+                  limit: WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS,
+                  xtermCols: managed.terminal.cols,
+                  xtermRows: managed.terminal.rows,
+                  proposedCols: proposal.cols,
+                  proposedRows: proposal.rows,
+                  isAltBuffer: managed.isAltBuffer === true,
+                }
+              );
+              if (this.deps.reconcileRevealGeometry(id)) {
+                this.unpauseIfNeeded(managed, element);
+              }
+              return 1;
+            }
+          }
         }
-        return 1;
       }
     }
 

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -689,7 +689,7 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(managed.geometryRepairGaveUp).toBe(true);
 
       // A fresh incarnation reusing the id must not inherit the give-up state.
-      (managed as unknown as { attachGeneration: number }).attachGeneration += 1;
+      managed.attachGeneration += 1;
       vi.mocked(deps.reconcileRevealGeometry).mockClear();
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(managed.geometryRepairGaveUp).toBe(false);
@@ -697,17 +697,19 @@ describe("TerminalReconciliationWatchdog", () => {
     });
 
     it("does not count a budget-deferred tick as a repair attempt", () => {
+      const panes: ManagedTerminal[] = [];
       for (let i = 0; i < WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1; i++) {
         const managed = makeManaged({ isAltBuffer: true });
         setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
         instances.set(`t${i}`, managed);
+        panes.push(managed);
       }
       const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
 
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
-      const repaired = instances.get("t0") as ManagedTerminal;
-      const deferred = instances.get(`t${WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK}`) as ManagedTerminal;
+      const repaired = panes[0];
+      const deferred = panes[WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK];
       expect(repaired.geometryRepairAttempts).toBe(1);
       // The pane skipped purely for heavy budget was never tried — no attempt spent.
       expect(deferred.geometryRepairAttempts).toBe(0);

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -640,6 +640,14 @@ describe("TerminalReconciliationWatchdog", () => {
       );
       expect(managed.geometryRepairGaveUp).toBe(true);
       expect(giveUpLogCount()).toBe(1);
+      // The logged attempt count must equal the repairs actually issued — proving
+      // the counter tracks issued repairs, not divergence detections or budget skips.
+      const giveUpLog = vi
+        .mocked(logWarn)
+        .mock.calls.find((c) => String(c[0]).includes("giving up"));
+      expect(giveUpLog?.[1]).toMatchObject({
+        attempts: vi.mocked(deps.reconcileRevealGeometry).mock.calls.length,
+      });
 
       // Further ticks neither repair again nor re-log the give-up.
       for (let i = 0; i < 6; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
@@ -705,12 +713,17 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deferred.geometryRepairAttempts).toBe(0);
     });
 
-    it("never trips the breaker while a synchronized-output block stays open", () => {
+    it("neither advances nor resets the breaker while a synchronized-output block stays open", () => {
       const managed = makeManaged({ isAltBuffer: true });
       (
         managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
       ).modes.synchronizedOutputMode = true;
       setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      // Seed a partial count so the assertion is breaker-specific: a synchronized
+      // block skips the whole geometry branch, so it must neither increment the
+      // count (repair path) nor clear it (convergence-reset path).
+      managed.geometryRepairAttempts = 1;
+      managed.geometryRepairGeneration = managed.attachGeneration;
       instances.set("t1", managed);
       const deps = makeDeps(instances);
       watchdog = new TerminalReconciliationWatchdog(deps);
@@ -718,7 +731,7 @@ describe("TerminalReconciliationWatchdog", () => {
       for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
       expect(managed.geometryRepairGaveUp).toBeFalsy();
-      expect(managed.geometryRepairAttempts ?? 0).toBe(0);
+      expect(managed.geometryRepairAttempts).toBe(1);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -710,9 +710,9 @@ describe("TerminalReconciliationWatchdog", () => {
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       const repaired = panes[0];
       const deferred = panes[WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK];
-      expect(repaired.geometryRepairAttempts).toBe(1);
+      expect(repaired?.geometryRepairAttempts).toBe(1);
       // The pane skipped purely for heavy budget was never tried — no attempt spent.
-      expect(deferred.geometryRepairAttempts).toBe(0);
+      expect(deferred?.geometryRepairAttempts).toBe(0);
     });
 
     it("neither advances nor resets the breaker while a synchronized-output block stays open", () => {

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   TerminalReconciliationWatchdog,
   WATCHDOG_INTERVAL_MS,
+  WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS,
   WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK,
   WATCHDOG_REPAIR_COOLDOWN_MS,
   isXtermRenderPaused,
@@ -607,6 +608,117 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(
         WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1
       );
+    });
+  });
+
+  describe("geometry circuit breaker (#10909)", () => {
+    // A permanently-mismatched proposal where reconcileRevealGeometry keeps
+    // returning true (box measurable) but the grid never actually converges —
+    // the exact stable off-by-one that made the watchdog re-wrap forever.
+    function makeDivergedTerminal(): ManagedTerminal {
+      const managed = makeManaged({ isAltBuffer: true });
+      setRenderPaused(managed, false);
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      return managed;
+    }
+
+    function giveUpLogCount(): number {
+      return vi.mocked(logWarn).mock.calls.filter((c) => String(c[0]).includes("giving up")).length;
+    }
+
+    it("stops repairing and logs once after the pane fails to converge repeatedly", () => {
+      const managed = makeDivergedTerminal();
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      // Well past the point where the cooldown-spaced repairs would fire.
+      for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(
+        WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS
+      );
+      expect(managed.geometryRepairGaveUp).toBe(true);
+      expect(giveUpLogCount()).toBe(1);
+
+      // Further ticks neither repair again nor re-log the give-up.
+      for (let i = 0; i < 6; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(
+        WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS
+      );
+      expect(giveUpLogCount()).toBe(1);
+    });
+
+    it("re-arms when the grid converges again, so a self-corrected pane can repair later", () => {
+      const managed = makeDivergedTerminal();
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.geometryRepairGaveUp).toBe(true);
+
+      // Container reaches a width the grid matches — one success clears the breaker.
+      setGrid(managed, { cols: 100, rows: 40 }, { cols: 100, rows: 40 });
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.geometryRepairGaveUp).toBe(false);
+      expect(managed.geometryRepairAttempts).toBe(0);
+
+      // Divergence returns — repairs resume instead of staying permanently barred.
+      vi.mocked(deps.reconcileRevealGeometry).mockClear();
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-arms when the terminal re-attaches under a new attachGeneration", () => {
+      const managed = makeDivergedTerminal();
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.geometryRepairGaveUp).toBe(true);
+
+      // A fresh incarnation reusing the id must not inherit the give-up state.
+      (managed as unknown as { attachGeneration: number }).attachGeneration += 1;
+      vi.mocked(deps.reconcileRevealGeometry).mockClear();
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(managed.geometryRepairGaveUp).toBe(false);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not count a budget-deferred tick as a repair attempt", () => {
+      for (let i = 0; i < WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK + 1; i++) {
+        const managed = makeManaged({ isAltBuffer: true });
+        setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+        instances.set(`t${i}`, managed);
+      }
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      const repaired = instances.get("t0") as ManagedTerminal;
+      const deferred = instances.get(`t${WATCHDOG_MAX_HEAVY_REPAIRS_PER_TICK}`) as ManagedTerminal;
+      expect(repaired.geometryRepairAttempts).toBe(1);
+      // The pane skipped purely for heavy budget was never tried — no attempt spent.
+      expect(deferred.geometryRepairAttempts).toBe(0);
+    });
+
+    it("never trips the breaker while a synchronized-output block stays open", () => {
+      const managed = makeManaged({ isAltBuffer: true });
+      (
+        managed.terminal as unknown as { modes: { synchronizedOutputMode: boolean } }
+      ).modes.synchronizedOutputMode = true;
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      for (let i = 0; i < 12; i++) vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(managed.geometryRepairGaveUp).toBeFalsy();
+      expect(managed.geometryRepairAttempts ?? 0).toBe(0);
     });
   });
 

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -65,6 +65,20 @@ export interface ManagedTerminal {
   // Last time the reconciliation watchdog issued a repair for this terminal —
   // per-terminal cooldown so a persistently-diverging layer never repair-loops.
   lastWatchdogRepairAt?: number;
+  // Circuit breaker for the watchdog's geometry-convergence repair (#10909).
+  // The cooldown only SPACES repairs; it doesn't CAP them, so a pane whose
+  // proposeDimensions() never converges (e.g. a stable off-by-one column) would
+  // re-wrap its full scrollback every cooldown window forever. These fields bound
+  // that: count consecutive issued geometry repairs, trip after
+  // WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS, and log the give-up exactly once.
+  geometryRepairAttempts?: number;
+  // Once tripped, the geometry branch stops issuing repairs (other repair layers
+  // still run). Cleared when the grid converges again or the terminal re-attaches.
+  geometryRepairGaveUp?: boolean;
+  // The attachGeneration the counter accrued under — a fresh incarnation reusing
+  // the same id must not inherit a prior instance's give-up state (mirrors the
+  // revealPendingGeneration guard).
+  geometryRepairGeneration?: number;
   // Visibility tracking
   isVisible: boolean;
   lastActiveTime: number;


### PR DESCRIPTION
## Summary

- The reconciliation watchdog compares `fitAddon.proposeDimensions()` against a terminal's actual `cols`/`rows` every few seconds and repairs any mismatch with a full scrollback re-wrap on every on-screen pane, limited only by a per-terminal cooldown.
- If a pane's dimensions never converge (for example, a scrollbar gutter toggling the available width by one column), that pane pays the cost of an expensive re-wrap indefinitely.
- This adds a per-terminal circuit breaker so a pane that never converges stops paying for the re-wrap after a few attempts.

Resolves #10909

## Changes

- New fields on `ManagedTerminal`: `geometryRepairAttempts`, `geometryRepairGaveUp`, `geometryRepairGeneration`.
- New constant `WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS` (3).
- The breaker trips after 3 issued non-converging repairs and logs once, matching the one-way-trip pattern already used by `TerminalWebGLManager`.
- It re-arms on genuine convergence, determined by comparing `proposeDimensions()` directly against `cols`/`rows` rather than the measurability boolean returned by `reconcileRevealGeometry`, or when a fresh `attachGeneration` appears.
- Only repairs that were actually issued count toward the limit.
- When tripped, the watchdog still falls through to the render and WebGL layers, so only the expensive re-wrap step is disabled, not the other repair layers.
- 5 new tests in `TerminalReconciliationWatchdog.test.ts`.

Files: `src/services/terminal/TerminalReconciliationWatchdog.ts`, `src/services/terminal/types.ts`, `src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts`.

## Verification note (#10898)

Separately verified the related finding referenced from #10898: the conditional scrollbar gutter constant `GRID_SCROLLBAR_GUTTER_PX` (22px) can shift the usable terminal width by about one column, but the `isScrollMode` flag that toggles it can't flap back and forth because it has hysteresis built in. So any divergence it causes is a steady, one-time state, not an oscillation. That means the circuit breaker is the correct general fix regardless of this finding. The mismatch between the hardcoded gutter constant and the browser's real scrollbar width is a separate, valid follow-up and isn't fixed in this PR.

## Testing

- 47 tests passing locally.
- `prettier` clean.
- `eslint` reports 0 errors on the touched files.