### PR TITLE
perf(persistence): speed up main-process hot paths as history grows (#10907)

### DIFF
--- a/electron/__tests__/windowState.test.ts
+++ b/electron/__tests__/windowState.test.ts
@@ -62,7 +62,7 @@ vi.mock("../services/ProjectStore.js", () => ({
   },
 }));
 
-import { createWindowWithState } from "../windowState.js";
+import { createWindowWithState, pruneWindowStateForPath } from "../windowState.js";
 
 describe("createWindowWithState", () => {
   // Helper: fire the deferred 'show' handler (fullscreen is applied after show)
@@ -797,6 +797,97 @@ describe("createWindowWithState", () => {
       expect(constructorCalls[0]).toEqual(
         expect.objectContaining({ x: 530, y: 312, width: 1024, height: 768 })
       );
+    });
+  });
+
+  describe("MRU cap and prune", () => {
+    // Wire the mocked store to a real backing object so successive saves
+    // accumulate the way electron-store would.
+    function makeStateful(initial: Record<string, unknown> = {}) {
+      let state: Record<string, unknown> = { ...initial };
+      windowStatesStoreMock.get.mockImplementation(() => state);
+      windowStatesStoreMock.set.mockImplementation(
+        (_key: string, value: Record<string, unknown>) => {
+          state = value;
+        }
+      );
+      return () => state;
+    }
+
+    function saveForPath(projectPath: string) {
+      createWindowWithState({ show: false }, projectPath);
+      eventHandlers.get("close")!();
+    }
+
+    it("caps project entries at the MRU limit, evicting the oldest, keeping __legacy__", () => {
+      const getState = makeStateful();
+      for (let i = 0; i < 55; i++) saveForPath(`/proj/${i}`);
+
+      const state = getState();
+      const projectKeys = Object.keys(state).filter((k) => k !== "__legacy__");
+      expect(projectKeys).toHaveLength(50);
+      // The five oldest are evicted; the newest survive.
+      expect(state["/proj/0"]).toBeUndefined();
+      expect(state["/proj/4"]).toBeUndefined();
+      expect(state["/proj/5"]).toBeDefined();
+      expect(state["/proj/54"]).toBeDefined();
+      // The cold-start fallback is exempt from the cap.
+      expect(state["__legacy__"]).toBeDefined();
+    });
+
+    it("re-touching a path moves it to most-recent and shields it from eviction", () => {
+      const getState = makeStateful();
+      for (let i = 0; i < 50; i++) saveForPath(`/keep/${i}`);
+      // Touch the oldest so it becomes most-recent...
+      saveForPath("/keep/0");
+      // ...then add one new path, forcing exactly one eviction.
+      saveForPath("/new");
+
+      const state = getState();
+      expect(state["/keep/0"]).toBeDefined();
+      // /keep/1 is now the oldest and is evicted instead of the refreshed /keep/0.
+      expect(state["/keep/1"]).toBeUndefined();
+      expect(state["/new"]).toBeDefined();
+      expect(Object.keys(state).filter((k) => k !== "__legacy__")).toHaveLength(50);
+    });
+
+    it("pruneWindowStateForPath removes only the target, preserving others and __legacy__", () => {
+      const entry = {
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 600,
+        isMaximized: false,
+        isFullScreen: false,
+      };
+      const getState = makeStateful({ "/a": entry, "/b": entry, __legacy__: entry });
+
+      pruneWindowStateForPath("/a");
+
+      const state = getState();
+      expect(state["/a"]).toBeUndefined();
+      expect(state["/b"]).toBeDefined();
+      expect(state["__legacy__"]).toBeDefined();
+      // Never persists an `undefined` value (electron-store v11 rejects it).
+      const lastSet = windowStatesStoreMock.set.mock.calls.at(-1)?.[1] as Record<string, unknown>;
+      expect(Object.values(lastSet)).not.toContain(undefined);
+    });
+
+    it("pruneWindowStateForPath is a no-op when the path is absent", () => {
+      const entry = {
+        x: 0,
+        y: 0,
+        width: 800,
+        height: 600,
+        isMaximized: false,
+        isFullScreen: false,
+      };
+      makeStateful({ "/b": entry, __legacy__: entry });
+      windowStatesStoreMock.set.mockClear();
+
+      pruneWindowStateForPath("/missing");
+
+      expect(windowStatesStoreMock.set).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/ipc/handlers/__tests__/project.remove.test.ts
+++ b/electron/ipc/handlers/__tests__/project.remove.test.ts
@@ -38,6 +38,12 @@ vi.mock("../../../services/ProjectSwitchService.js", () => ({
   },
 }));
 
+const windowStateMock = vi.hoisted(() => ({
+  pruneWindowStateForPath: vi.fn(),
+}));
+
+vi.mock("../../../windowState.js", () => windowStateMock);
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerProjectCrudHandlers } from "../projectCrud/index.js";
@@ -124,6 +130,54 @@ describe("project:remove handler", () => {
     await handler(fakeEvent, "proj-4");
 
     expect(projectStoreMock.removeProject).toHaveBeenCalledWith("proj-4");
+  });
+
+  it("resolves the path before removeProject and prunes window state after removal", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "proj-5", path: "/home/user/proj-5" });
+    projectStoreMock.removeProject.mockResolvedValue(undefined);
+
+    const deps = { mainWindow: {} as unknown } as unknown as HandlerDependencies;
+    registerProjectCrudHandlers(deps);
+    const handler = getHandler(CHANNELS.PROJECT_REMOVE);
+
+    await handler(fakeEvent, "proj-5");
+
+    expect(projectStoreMock.getProjectById).toHaveBeenCalledWith("proj-5");
+    expect(windowStateMock.pruneWindowStateForPath).toHaveBeenCalledWith("/home/user/proj-5");
+
+    // The path must be resolved before removeProject deletes the row...
+    const lookupOrder = projectStoreMock.getProjectById.mock.invocationCallOrder[0];
+    const removeOrder = projectStoreMock.removeProject.mock.invocationCallOrder[0];
+    expect(lookupOrder).toBeLessThan(removeOrder);
+    // ...and the prune must run after removal succeeds.
+    const pruneOrder = windowStateMock.pruneWindowStateForPath.mock.invocationCallOrder[0];
+    expect(removeOrder).toBeLessThan(pruneOrder);
+  });
+
+  it("skips the window-state prune when the project path can't be resolved", async () => {
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    projectStoreMock.removeProject.mockResolvedValue(undefined);
+
+    const deps = { mainWindow: {} as unknown } as unknown as HandlerDependencies;
+    registerProjectCrudHandlers(deps);
+    const handler = getHandler(CHANNELS.PROJECT_REMOVE);
+
+    await handler(fakeEvent, "proj-6");
+
+    expect(projectStoreMock.removeProject).toHaveBeenCalledWith("proj-6");
+    expect(windowStateMock.pruneWindowStateForPath).not.toHaveBeenCalled();
+  });
+
+  it("does not prune window state when removeProject rejects", async () => {
+    projectStoreMock.getProjectById.mockReturnValue({ id: "proj-7", path: "/home/user/proj-7" });
+    projectStoreMock.removeProject.mockRejectedValue(new Error("db locked"));
+
+    const deps = { mainWindow: {} as unknown } as unknown as HandlerDependencies;
+    registerProjectCrudHandlers(deps);
+    const handler = getHandler(CHANNELS.PROJECT_REMOVE);
+
+    await expect(handler(fakeEvent, "proj-7")).rejects.toThrow("db locked");
+    expect(windowStateMock.pruneWindowStateForPath).not.toHaveBeenCalled();
   });
 
   it("throws on invalid projectId without calling cleanup or removal", async () => {

--- a/electron/ipc/handlers/projectCrud/crud.ts
+++ b/electron/ipc/handlers/projectCrud/crud.ts
@@ -9,6 +9,7 @@ import type { HandlerDependencies } from "../../types.js";
 import type { Project } from "../../../types/index.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
 import { AppError } from "../../../utils/errorTypes.js";
+import { pruneWindowStateForPath } from "../../../windowState.js";
 
 /**
  * Validate, register, and broadcast a project for the given absolute path.
@@ -72,6 +73,10 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
       throw new Error("Invalid project ID");
     }
 
+    // Resolve the path before removeProject() deletes the row — the prune below
+    // keys window-states.json by path, which is unrecoverable once the row is gone.
+    const removedPath = projectStore.getProjectById(projectId)?.path ?? null;
+
     if (deps.ptyClient) {
       await deps.ptyClient.killByProject(projectId).catch((err: unknown) => {
         console.error(`[IPC] project:remove: Failed to kill terminals for ${projectId}:`, err);
@@ -79,6 +84,9 @@ export function registerProjectCrudCoreHandlers(deps: HandlerDependencies): () =
     }
 
     await projectStore.removeProject(projectId);
+    if (removedPath) {
+      pruneWindowStateForPath(removedPath);
+    }
     broadcastToRenderer(CHANNELS.PROJECT_REMOVED, projectId);
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_REMOVE, handleProjectRemove));

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -461,44 +461,48 @@ export class ProjectStore {
     const validStatuses: ProjectStatus[] = ["active", "background", "closed", "missing"];
     const currentProjectId = this.getCurrentProjectId();
 
-    db.transaction(
-      (tx) => {
-        for (const row of rows) {
-          if (row.id === currentProjectId) {
-            if (row.status !== "active") {
-              tx.update(projectsTable)
-                .set({ status: "active" })
-                .where(eq(projectsTable.id, row.id))
-                .run();
-              row.status = "active";
-            }
-          } else {
-            if (row.status === "active") {
-              if (process.env.DAINTREE_VERBOSE) {
-                console.warn(
-                  `[ProjectStore] Demoting incorrectly active project ${row.id} to background`
-                );
-              }
-              tx.update(projectsTable)
-                .set({ status: "background" })
-                .where(eq(projectsTable.id, row.id))
-                .run();
-              row.status = "background";
-            } else if (
-              row.status !== null &&
-              !validStatuses.includes(row.status as ProjectStatus)
-            ) {
-              tx.update(projectsTable)
-                .set({ status: "closed" })
-                .where(eq(projectsTable.id, row.id))
-                .run();
-              row.status = "closed";
-            }
-          }
+    // Compute the status repairs first without touching the DB, mutating each
+    // row's in-memory status so the returned projects are always reconciled.
+    // Only open a write-locking IMMEDIATE transaction when at least one row
+    // actually needs repair — the common case (statuses already correct on a
+    // repeat read) skips the transaction entirely, which is the hot-path win as
+    // the projects list grows.
+    const statusUpdates: Array<{ id: string; status: ProjectStatus }> = [];
+    for (const row of rows) {
+      if (row.id === currentProjectId) {
+        if (row.status !== "active") {
+          statusUpdates.push({ id: row.id, status: "active" });
+          row.status = "active";
         }
-      },
-      { behavior: "immediate" }
-    );
+      } else {
+        if (row.status === "active") {
+          if (process.env.DAINTREE_VERBOSE) {
+            console.warn(
+              `[ProjectStore] Demoting incorrectly active project ${row.id} to background`
+            );
+          }
+          statusUpdates.push({ id: row.id, status: "background" });
+          row.status = "background";
+        } else if (row.status !== null && !validStatuses.includes(row.status as ProjectStatus)) {
+          statusUpdates.push({ id: row.id, status: "closed" });
+          row.status = "closed";
+        }
+      }
+    }
+
+    if (statusUpdates.length > 0) {
+      db.transaction(
+        (tx) => {
+          for (const update of statusUpdates) {
+            tx.update(projectsTable)
+              .set({ status: update.status })
+              .where(eq(projectsTable.id, update.id))
+              .run();
+          }
+        },
+        { behavior: "immediate" }
+      );
+    }
 
     if (process.env.DAINTREE_VERBOSE) {
       console.log(

--- a/electron/services/__tests__/ProjectStore.test.ts
+++ b/electron/services/__tests__/ProjectStore.test.ts
@@ -795,14 +795,18 @@ describe("ProjectStore.getAllProjects reconciliation", () => {
     warnSpy.mockRestore();
   });
 
-  it("no-ops when all statuses are already correct (empty transaction)", () => {
+  it("no-ops when all statuses are already correct (no transaction opened)", () => {
     // First call reconciles everything
     store.getAllProjects();
 
-    // Second call should be a no-op — no writes needed
+    // Second call should be a no-op — no write-locking transaction is opened
+    // when every row's status is already correct (the hot-path win).
     const updateSpy = vi.spyOn(db, "update");
+    const txSpy = vi.spyOn(db, "transaction");
     store.getAllProjects();
+    expect(txSpy).not.toHaveBeenCalled();
     expect(updateSpy).not.toHaveBeenCalled();
+    txSpy.mockRestore();
     updateSpy.mockRestore();
   });
 });

--- a/electron/services/persistence/__tests__/db.openDb.test.ts
+++ b/electron/services/persistence/__tests__/db.openDb.test.ts
@@ -316,7 +316,6 @@ describe("openDb (integration)", () => {
     ).entries as Array<{ when: number; tag: string }>;
     // Everything except the most recent migration is "already applied".
     const applied = journal.slice(0, -1);
-    const latest = journal[journal.length - 1];
 
     const Database = (await import("better-sqlite3")).default;
     const seed = new Database(dbPath);
@@ -342,18 +341,23 @@ describe("openDb (integration)", () => {
     for (const entry of applied) ins.run(entry.tag, entry.when);
     seed.close();
 
-    // The last migration's effect must be absent before the upgrade for the test
-    // to mean anything — the seed `projects` table above omits `auto_parked_at`,
-    // which the final migration (0005) adds.
-    expect(latest.tag).toContain("auto_parked_at");
+    // The final migration's effect must be absent before the upgrade for the test
+    // to mean anything — the seed `projects` table was created without indexes, and
+    // the final migration (0006) adds projects_path_idx + projects_frecency_last_opened_idx.
+    const preCheck = new Database(dbPath, { readonly: true });
+    const seededIndexes = (
+      preCheck.prepare("PRAGMA index_list(projects)").all() as Array<{ name: string }>
+    ).map((i) => i.name);
+    preCheck.close();
+    expect(seededIndexes).not.toContain("projects_frecency_last_opened_idx");
 
     const { sqlite } = openDb(dbPath, migrationsFolder);
     try {
-      const projectColumns = sqlite.prepare("PRAGMA table_info(projects)").all() as Array<{
-        name: string;
-      }>;
-      const hasAutoParkedAt = projectColumns.some((c) => c.name === "auto_parked_at");
-      expect(hasAutoParkedAt).toBe(true);
+      const projectIndexes = (
+        sqlite.prepare("PRAGMA index_list(projects)").all() as Array<{ name: string }>
+      ).map((i) => i.name);
+      expect(projectIndexes).toContain("projects_path_idx");
+      expect(projectIndexes).toContain("projects_frecency_last_opened_idx");
 
       // The skipped migration is now recorded — total equals the full journal.
       const migrations = sqlite.prepare("SELECT id FROM __drizzle_migrations").all();

--- a/electron/services/persistence/migrations/0006_daffy_kid_colt.sql
+++ b/electron/services/persistence/migrations/0006_daffy_kid_colt.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS `projects_path_idx` ON `projects` (`path`);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `projects_frecency_last_opened_idx` ON `projects` (`frecency_score`,`last_opened`);

--- a/electron/services/persistence/migrations/meta/_journal.json
+++ b/electron/services/persistence/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1782000000000,
       "tag": "0005_add_auto_parked_at",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1782980261485,
+      "tag": "0006_daffy_kid_colt",
+      "breakpoints": true
     }
   ]
 }

--- a/electron/services/persistence/schema.ts
+++ b/electron/services/persistence/schema.ts
@@ -1,24 +1,36 @@
-import { sqliteTable, text, integer, real } from "drizzle-orm/sqlite-core";
+import { sqliteTable, text, integer, real, index } from "drizzle-orm/sqlite-core";
 
-export const projects = sqliteTable("projects", {
-  id: text("id").primaryKey(),
-  path: text("path").notNull(),
-  name: text("name").notNull(),
-  emoji: text("emoji").notNull(),
-  lastOpened: integer("last_opened").notNull(),
-  color: text("color"),
-  status: text("status"),
-  daintreeConfigPresent: integer("daintree_config_present", { mode: "boolean" }),
-  inRepoSettings: integer("in_repo_settings", { mode: "boolean" }),
-  pinned: integer("pinned").notNull().default(0),
-  frecencyScore: real("frecency_score").notNull().default(3.0),
-  lastAccessedAt: integer("last_accessed_at").notNull().default(0),
-  // Timestamp (ms) the background-idle auto-close swept this project to `closed`.
-  // Null for projects closed manually or still open; drives the distinct
-  // "Suspended to free memory" label in the project switcher. Cleared when the
-  // project is reopened (`setCurrentProject`).
-  autoParkedAt: integer("auto_parked_at"),
-});
+export const projects = sqliteTable(
+  "projects",
+  {
+    id: text("id").primaryKey(),
+    path: text("path").notNull(),
+    name: text("name").notNull(),
+    emoji: text("emoji").notNull(),
+    lastOpened: integer("last_opened").notNull(),
+    color: text("color"),
+    status: text("status"),
+    daintreeConfigPresent: integer("daintree_config_present", { mode: "boolean" }),
+    inRepoSettings: integer("in_repo_settings", { mode: "boolean" }),
+    pinned: integer("pinned").notNull().default(0),
+    frecencyScore: real("frecency_score").notNull().default(3.0),
+    lastAccessedAt: integer("last_accessed_at").notNull().default(0),
+    // Timestamp (ms) the background-idle auto-close swept this project to `closed`.
+    // Null for projects closed manually or still open; drives the distinct
+    // "Suspended to free memory" label in the project switcher. Cleared when the
+    // project is reopened (`setCurrentProject`).
+    autoParkedAt: integer("auto_parked_at"),
+  },
+  (table) => [
+    // Equality lookup for getProjectByPath().
+    index("projects_path_idx").on(table.path),
+    // Ordering index for getAllProjects()'s `ORDER BY frecency_score DESC,
+    // last_opened DESC`. Declared ASC/ASC: SQLite reverse-scans it to satisfy a
+    // DESC/DESC order-by (both terms same direction), skipping the sort as the
+    // projects list grows.
+    index("projects_frecency_last_opened_idx").on(table.frecencyScore, table.lastOpened),
+  ]
+);
 
 export const appState = sqliteTable("app_state", {
   key: text("key").primaryKey(),

--- a/electron/services/pty/__tests__/agentSessionHistory.test.ts
+++ b/electron/services/pty/__tests__/agentSessionHistory.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   persistAgentSession,
   readSessionHistory,
+  readSessionHistorySync,
   listAgentSessions,
   clearAgentSessions,
   pruneAgentSessions,
@@ -464,6 +465,71 @@ describe("agentSessionHistory", () => {
       expect(records.some((r) => r.sessionId === `session-${MAX_RECORDS_PER_WORKTREE + 9}`)).toBe(
         true
       );
+    });
+  });
+
+  describe("in-memory cache", () => {
+    it("reflects a direct on-disk change after a prior read cached it", async () => {
+      const filePath = getSessionHistoryPath(userDataDir)!;
+      await persistAgentSession(
+        {
+          sessionId: "cached",
+          agentId: "claude",
+          worktreeId: "wt-1",
+          title: null,
+          projectId: null,
+        },
+        userDataDir
+      );
+      // Prime the cache.
+      expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["cached"]);
+
+      // Overwrite the journal directly, bypassing the writers — the stat gate
+      // must notice the size/mtime change and re-read rather than serve stale.
+      await fsp.writeFile(
+        filePath,
+        JSON.stringify([
+          {
+            sessionId: "external",
+            agentId: "claude",
+            worktreeId: "wt-1",
+            title: null,
+            projectId: null,
+            savedAt: Date.now(),
+          },
+        ])
+      );
+
+      expect((await readSessionHistory(userDataDir)).map((r) => r.sessionId)).toEqual(["external"]);
+      expect(listAgentSessions(undefined, userDataDir).map((r) => r.sessionId)).toEqual([
+        "external",
+      ]);
+    });
+
+    it("serves the same parsed array reference on a cache hit (no re-parse)", async () => {
+      await persistAgentSession(
+        { sessionId: "hot", agentId: "claude", worktreeId: "wt-1", title: null, projectId: null },
+        userDataDir
+      );
+      // Two reads with no write between them and an unchanged file: a cache hit
+      // returns the exact same array reference, proving the journal wasn't
+      // re-read and re-parsed (a fresh parse would allocate a new array).
+      const first = readSessionHistorySync(userDataDir);
+      const second = readSessionHistorySync(userDataDir);
+      expect(second).toBe(first);
+      expect(second.map((r) => r.sessionId)).toEqual(["hot"]);
+    });
+
+    it("a writer refreshes the cache so the next sync read sees new data", async () => {
+      // Prime the cache with an empty-journal read.
+      expect(listAgentSessions(undefined, userDataDir)).toEqual([]);
+      await persistAgentSession(
+        { sessionId: "fresh", agentId: "claude", worktreeId: "wt-1", title: null, projectId: null },
+        userDataDir
+      );
+      // No direct read between persist and this list — only the writer's cache
+      // refresh makes the new record visible to the sync path.
+      expect(listAgentSessions(undefined, userDataDir).map((r) => r.sessionId)).toEqual(["fresh"]);
     });
   });
 

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -1,6 +1,6 @@
 // eager-import-allow: reads/writes agent session history via sync fs
-import { readFileSync } from "fs";
-import { mkdir, readFile } from "node:fs/promises";
+import { readFileSync, statSync } from "fs";
+import { mkdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { resilientAtomicWriteFile } from "../../utils/fs.js";
 import type {
@@ -121,13 +121,67 @@ function normalizeRecords(parsed: unknown): AgentSessionRecord[] {
   });
 }
 
+// In-memory cache of the parsed journal, keyed by resolved file path. The resume
+// palette calls listAgentSessions() -> readSessionHistorySync() on every open,
+// which otherwise re-reads and re-parses the whole journal (up to 50 records per
+// worktree) each time. The cache is gated on the file's stat (size + mtimeMs) so
+// a direct on-disk change (or a write from any other path) is still picked up on
+// the next read; every writer refreshes it with the array it just persisted.
+// Memory-only — rebuilt from disk on first read after boot, no cross-process
+// coordination needed (all journal I/O runs on the single main-process loop).
+interface HistoryCacheEntry {
+  records: AgentSessionRecord[];
+  size: number;
+  mtimeMs: number;
+}
+const historyCache = new Map<string, HistoryCacheEntry>();
+
+function readCache(
+  filePath: string,
+  size: number,
+  mtimeMs: number
+): AgentSessionRecord[] | undefined {
+  const entry = historyCache.get(filePath);
+  if (entry && entry.size === size && entry.mtimeMs === mtimeMs) {
+    return entry.records;
+  }
+  return undefined;
+}
+
+function writeCache(
+  filePath: string,
+  records: AgentSessionRecord[],
+  size: number,
+  mtimeMs: number
+): void {
+  historyCache.set(filePath, { records, size, mtimeMs });
+}
+
+// Refresh the cache after a write with the exact array just persisted, keyed to
+// the freshly-written file's stat so the next read is a cache hit. If the stat
+// fails, drop the entry so the next read falls back to a disk re-read.
+function refreshCacheAfterWrite(filePath: string, records: AgentSessionRecord[]): void {
+  try {
+    const s = statSync(filePath);
+    writeCache(filePath, records, s.size, s.mtimeMs);
+  } catch {
+    historyCache.delete(filePath);
+  }
+}
+
 export function readSessionHistorySync(userData?: string): AgentSessionRecord[] {
   const filePath = getSessionHistoryPath(userData);
   if (!filePath) return [];
   try {
+    const s = statSync(filePath);
+    const cached = readCache(filePath, s.size, s.mtimeMs);
+    if (cached) return cached;
     const content = readFileSync(filePath, "utf8");
-    return normalizeRecords(JSON.parse(content));
+    const records = normalizeRecords(JSON.parse(content));
+    writeCache(filePath, records, s.size, s.mtimeMs);
+    return records;
   } catch {
+    historyCache.delete(filePath);
     return [];
   }
 }
@@ -136,9 +190,15 @@ export async function readSessionHistory(userData?: string): Promise<AgentSessio
   const filePath = getSessionHistoryPath(userData);
   if (!filePath) return [];
   try {
+    const s = await stat(filePath);
+    const cached = readCache(filePath, s.size, s.mtimeMs);
+    if (cached) return cached;
     const content = await readFile(filePath, "utf8");
-    return normalizeRecords(JSON.parse(content));
+    const records = normalizeRecords(JSON.parse(content));
+    writeCache(filePath, records, s.size, s.mtimeMs);
+    return records;
   } catch {
+    historyCache.delete(filePath);
     return [];
   }
 }
@@ -162,6 +222,7 @@ export async function persistAgentSession(
     const updated = evictRecords([fullRecord, ...existing], now, retentionDaysToMs(retentionDays));
 
     await resilientAtomicWriteFile(filePath, JSON.stringify(updated, null, 2));
+    refreshCacheAfterWrite(filePath, updated);
   });
 }
 
@@ -196,6 +257,7 @@ export async function pruneAgentSessions(
     const existing = await readSessionHistory(userData);
     const pruned = evictRecords(existing, Date.now(), retentionDaysToMs(retentionDays));
     await resilientAtomicWriteFile(filePath, JSON.stringify(pruned, null, 2));
+    refreshCacheAfterWrite(filePath, pruned);
   });
 }
 
@@ -209,11 +271,13 @@ export async function clearAgentSessions(worktreeId?: string, userData?: string)
     if (!worktreeId) {
       // Clear all
       await resilientAtomicWriteFile(filePath, "[]");
+      refreshCacheAfterWrite(filePath, []);
       return;
     }
 
     const existing = await readSessionHistory(userData);
     const filtered = existing.filter((r) => r.worktreeId !== worktreeId);
     await resilientAtomicWriteFile(filePath, JSON.stringify(filtered, null, 2));
+    refreshCacheAfterWrite(filePath, filtered);
   });
 }

--- a/electron/services/pty/agentSessionHistory.ts
+++ b/electron/services/pty/agentSessionHistory.ts
@@ -169,6 +169,11 @@ function refreshCacheAfterWrite(filePath: string, records: AgentSessionRecord[])
   }
 }
 
+// NOTE: on a cache hit these readers return the cached array BY REFERENCE (that
+// shared-instance reuse is the whole point — a copy on every read would defeat
+// the cache). Callers MUST treat the result as read-only; never sort/push/splice
+// it in place. The production caller, listAgentSessions(), is safe: evictRecords()
+// only reads the input and returns freshly-built arrays.
 export function readSessionHistorySync(userData?: string): AgentSessionRecord[] {
   const filePath = getSessionHistoryPath(userData);
   if (!filePath) return [];

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, screen } from "electron";
-import { windowStatesStore } from "./store.js";
+import { windowStatesStore, type WindowStateEntry } from "./store.js";
 
 const LEGACY_KEY = "__legacy__";
 const MRU_OFFSET_PX = 30;
@@ -169,7 +169,10 @@ function resolveWindowBounds(projectPath: string | null | undefined): WindowStat
   return { width: 1200, height: 800, isMaximized: false, isFullScreen: false };
 }
 
-type WindowStatesMap = Record<string, WindowStateBounds>;
+// Mirror the store's own entry type (isFullScreen optional) so the map read back
+// from windowStatesStore is assignable here; WindowStateBounds (stricter, with a
+// required isFullScreen) is still assignable INTO these slots on write.
+type WindowStatesMap = Record<string, WindowStateEntry>;
 
 // Single capped writer all mutation paths route through (per lesson #7586), so
 // the MRU cap lives in exactly one place rather than being duplicated across the

--- a/electron/windowState.ts
+++ b/electron/windowState.ts
@@ -4,6 +4,13 @@ import { windowStatesStore } from "./store.js";
 const LEGACY_KEY = "__legacy__";
 const MRU_OFFSET_PX = 30;
 
+// Cap on how many per-project window-state entries `window-states.json` retains.
+// Without it the map grows one entry per project ever opened, is never pruned,
+// and electron-store re-serializes the whole file on every window move/resize
+// (500ms debounce) plus a 60s crash-recovery snapshot. The `__legacy__`
+// cold-start fallback is exempt — it never counts toward or is evicted by the cap.
+const WINDOW_STATE_MRU_CAP = 50;
+
 interface DebouncedFunction<T extends (...args: unknown[]) => void> {
   (...args: Parameters<T>): void;
   cancel: () => void;
@@ -162,14 +169,50 @@ function resolveWindowBounds(projectPath: string | null | undefined): WindowStat
   return { width: 1200, height: 800, isMaximized: false, isFullScreen: false };
 }
 
+type WindowStatesMap = Record<string, WindowStateBounds>;
+
+// Single capped writer all mutation paths route through (per lesson #7586), so
+// the MRU cap lives in exactly one place rather than being duplicated across the
+// save and prune paths. Object key order is insertion order for these string
+// keys, so the earliest project keys are the least-recently-touched — evict them
+// first when over the cap. `__legacy__` is never counted or evicted.
+function commitWindowStates(windowStates: WindowStatesMap): void {
+  const projectKeys = Object.keys(windowStates).filter((k) => k !== LEGACY_KEY);
+  const overflow = projectKeys.length - WINDOW_STATE_MRU_CAP;
+  for (let i = 0; i < overflow; i++) {
+    delete windowStates[projectKeys[i]];
+  }
+  windowStatesStore.set("windowStates", windowStates);
+}
+
 function saveWindowStates(projectPath: string | null | undefined, bounds: WindowStateBounds): void {
-  const windowStates = windowStatesStore.get("windowStates") ?? {};
+  const windowStates: WindowStatesMap = windowStatesStore.get("windowStates") ?? {};
   if (projectPath) {
+    // Delete then re-add so a touched path moves to the most-recent slot in
+    // insertion order and can't be picked as the eviction victim below.
+    delete windowStates[projectPath];
     windowStates[projectPath] = bounds;
   }
   windowStates[LEGACY_KEY] = bounds;
-  windowStatesStore.set("windowStates", windowStates);
+  commitWindowStates(windowStates);
   lastSavedProjectPath = projectPath ?? LEGACY_KEY;
+}
+
+/**
+ * Drop a project's saved window state — called when the project is removed so
+ * `window-states.json` doesn't retain bounds for projects that no longer exist.
+ * Routes through the same capped writer as the save path and never writes
+ * `undefined` (electron-store v11 rejects it). No-op if the path isn't present.
+ */
+export function pruneWindowStateForPath(projectPath: string): void {
+  if (!projectPath) return;
+  const windowStates: WindowStatesMap | undefined = windowStatesStore.get("windowStates");
+  if (!windowStates || !(projectPath in windowStates)) return;
+  delete windowStates[projectPath];
+  commitWindowStates(windowStates);
+  if (lastSavedProjectPath === projectPath) {
+    lastSavedProjectPath = null;
+  }
 }
 
 export function createWindowWithState(


### PR DESCRIPTION
## Summary
- Three main-process persistence hot paths get slower as usage history accumulates across restarts. This fixes all three.
- `ProjectStore.getAllProjects()` was doing a full table scan on every read, plus taking an unconditional write lock to normalize status.
- `agentSessionHistory` and `windowState` had unbounded re-parsing and unbounded growth respectively.

Resolves #10907

## Changes

**ProjectStore.getAllProjects()**
- Adds `projects_path_idx` (on `path`) and `projects_frecency_last_opened_idx` (on `frecency_score`, `last_opened`) via migration `0006`, so the ordered project list and `getProjectByPath` both hit an index instead of scanning the table.
- Makes the status-normalization `IMMEDIATE` transaction conditional: it only opens when a row actually needs repair, so the common already-normalized read path skips the write lock.

**agentSessionHistory**
- Adds a stat-gated in-memory cache of the parsed journal, so the resume palette's `listAgentSessions()` stops re-reading and re-parsing the whole file on every open.
- Each writer refreshes the cache with the array it just persisted, so the cache never goes stale between writes.

**windowState**
- Caps `window-states.json` at 50 most-recently-used project entries, with pruning on project removal, routed through a single capped writer.
- The `__legacy__` cold-start fallback entry is exempt from the cap.

## Testing
- 146 targeted unit tests pass: `ProjectStore` and its variants, `agentSessionHistory`, `windowState`, `project.remove`.
- SQLite `EXPLAIN QUERY PLAN` confirms both new indexes are used by the query planner.
- prettier and eslint are clean on the changed files.