### PR TITLE
perf(pty-host): back off idle-agent polling and async-serialize event snapshots

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -618,6 +618,11 @@ export class ActivityMonitor {
           }
         }
       }
+      // Re-arm the idle-backoff settle timer on every idle byte so it debounces
+      // on the *last* output: a still-idle agent that emits an occasional
+      // cosmetic byte then falls silent still backs off (#10906). armFsmIdle-
+      // Backoff no-ops when the byte promoted the agent to busy (state !== idle).
+      this.armFsmIdleBackoff();
       return;
     }
 

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -55,6 +55,15 @@ const SIMPLE_COMPLETION_MIN_QUIET_MS = 1500;
 // snapshot — long enough for xterm's async parse of the last chunk (and any
 // resize/focus-triggered redraw) to land before a frame is latched.
 const SIMPLE_SNAPSHOT_SETTLE_MS = 1000;
+// Idle-agent polling backoff (#10906). Once a simple-output agent has settled
+// into idle and stayed silent this long, drop the polling cadence to
+// FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS so a prompt sitting idle for an hour
+// stops doing per-tick strip+diff temperature work at the active 50ms rate. Any
+// onData (or busy transition) cancels the backoff and restores the visibility
+// tier's interval instantly, so detection latency is preserved — state
+// transitions are always preceded by output.
+export const FSM_IDLE_BACKOFF_SETTLE_MS = 3000;
+export const FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS = 2000;
 const WORKING_INDICATOR_TTL_MS = 5000;
 const CPU_HIGH_THRESHOLD = 10;
 const CPU_LOW_THRESHOLD = 3;
@@ -258,8 +267,15 @@ export class ActivityMonitor {
   private simpleSnapshotCacheKey = 0;
   private simpleSnapshotSettleFrom = 0;
 
-  // Polling interval configuration
+  // Polling interval configuration.
+  // POLLING_INTERVAL_MS is the *currently applied* interval driving setInterval.
+  // requestedPollingIntervalMs is the visibility tier's desired cadence (50/500);
+  // while idle-backoff owns the live interval they diverge, and the wake path
+  // restores POLLING_INTERVAL_MS to requestedPollingIntervalMs (#10906).
   private POLLING_INTERVAL_MS: number;
+  private requestedPollingIntervalMs: number;
+  private fsmIdleBackoffTimer?: ReturnType<typeof setTimeout>;
+  private fsmIdleBackoffActive = false;
 
   // Tier-aware recovery thresholds (#6641). The output volume detector is now
   // sample-cadence invariant (#6666), so only the working-signal debouncer
@@ -369,6 +385,7 @@ export class ActivityMonitor {
 
     // Polling interval
     this.POLLING_INTERVAL_MS = options?.pollingIntervalMs ?? 50;
+    this.requestedPollingIntervalMs = this.POLLING_INTERVAL_MS;
 
     this.cpuTracker = new CpuHighStateTracker(this.processStateValidator, {
       cpuHighThreshold: CPU_HIGH_THRESHOLD,
@@ -544,6 +561,9 @@ export class ActivityMonitor {
         return;
       }
       this.lastDataTimestamp = now;
+      // Wake-on-data: any output means the agent is live again — restore the
+      // full polling cadence before the settle timer fires or while backed off.
+      this.cancelFsmIdleBackoff(true);
       // Boot detection runs in the simple-output path too so onBootComplete
       // (#7616) fires for real agent terminals — `simpleOutputState` is true
       // for every agent monitor built via `buildActivityMonitorOptions`.
@@ -1057,6 +1077,8 @@ export class ActivityMonitor {
     // Defense-in-depth: the call site already gates on focus suppression, but
     // keep the guard so any future caller inherits it (#8865).
     if (this.isFocusSuppressed(now)) return;
+    // Direct busy promotion bypasses becomeBusy(), so cancel idle-backoff here.
+    this.cancelFsmIdleBackoff(true);
     this.lastActivityTimestamp = now;
     this.lastDataTimestamp = now;
     this.recordWorkingSignal(now);
@@ -1170,6 +1192,12 @@ export class ActivityMonitor {
 
     this.pollingInterval = setInterval(() => this.runPollingCycle(), this.POLLING_INTERVAL_MS);
     this.pollingInterval.unref();
+
+    // A restored/relaunched agent may start already idle (skipInitialStateEmit
+    // with a settled screen) — arm the backoff so it doesn't poll at full rate.
+    if (this.simpleOutputState && this.state === "idle") {
+      this.armFsmIdleBackoff();
+    }
   }
 
   private runPollingCycle(): void {
@@ -1518,6 +1546,9 @@ export class ActivityMonitor {
   }
 
   stopPolling(): void {
+    // Reset idle-backoff first so POLLING_INTERVAL_MS returns to the requested
+    // cadence — a later startPolling() reads it to seed the new interval.
+    this.cancelFsmIdleBackoff(false);
     if (this.pollingInterval) {
       clearInterval(this.pollingInterval);
       this.pollingInterval = undefined;
@@ -1527,24 +1558,87 @@ export class ActivityMonitor {
 
   setPollingInterval(intervalMs: number): void {
     if (this.isDisposed) return;
-    if (this.POLLING_INTERVAL_MS === intervalMs) {
+    // Guard on the *requested* cadence, not the applied one: while idle-backoff
+    // owns the live interval they differ, and a same-request no-op must not be
+    // read from the backoff value (#10906, #8998).
+    if (this.requestedPollingIntervalMs === intervalMs) {
       return;
     }
-
-    const wasPolling = this.pollingInterval !== undefined;
-    this.POLLING_INTERVAL_MS = intervalMs;
-
-    if (wasPolling && this.pollingInterval) {
-      clearInterval(this.pollingInterval);
-      this.pollingInterval = setInterval(() => this.runPollingCycle(), this.POLLING_INTERVAL_MS);
-      this.pollingInterval.unref();
-    }
+    this.requestedPollingIntervalMs = intervalMs;
 
     // The working-signal debouncer needs to track polling cadence, otherwise
     // the 1500ms delay becomes impossible to satisfy at 500ms polling (#6641).
     // The output volume detector is sample-cadence invariant (#6666) and
-    // needs no tier handling here.
+    // needs no tier handling here. Tier always tracks the visibility cadence,
+    // never the transient backoff interval (a 2000ms backoff must not classify
+    // as "background").
     this.applyTier(this.tierForInterval(intervalMs));
+
+    // While backed off, only record the request; the wake path
+    // (onData/becomeBusy) restores this cadence when activity resumes.
+    if (!this.fsmIdleBackoffActive) {
+      this.applyPollingInterval(intervalMs);
+    }
+  }
+
+  // Swaps the live polling interval. Keeps POLLING_INTERVAL_MS (the applied
+  // cadence) in sync even when no interval is currently running so a later
+  // startPolling() picks up the right value.
+  private applyPollingInterval(intervalMs: number): void {
+    this.POLLING_INTERVAL_MS = intervalMs;
+    if (this.pollingInterval !== undefined) {
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = setInterval(() => this.runPollingCycle(), intervalMs);
+      this.pollingInterval.unref();
+    }
+  }
+
+  // Arms the idle-backoff settle timer for a settled simple-output agent. After
+  // FSM_IDLE_BACKOFF_SETTLE_MS of continued silence the polling cadence drops to
+  // FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS. Any onData/busy transition cancels it.
+  private armFsmIdleBackoff(): void {
+    if (this.isDisposed) return;
+    // Only agents (simpleOutputState) do the per-tick temperature work this
+    // backoff exists to throttle; non-agent monitors are left untouched.
+    if (!this.simpleOutputState) return;
+    if (this.state !== "idle") return;
+    if (this.pollingInterval === undefined) return;
+    if (this.fsmIdleBackoffActive) return;
+    if (this.fsmIdleBackoffTimer !== undefined) return;
+
+    const armedAtData = this.lastDataTimestamp;
+    this.fsmIdleBackoffTimer = setTimeout(() => {
+      this.fsmIdleBackoffTimer = undefined;
+      if (this.isDisposed) return;
+      if (this.state !== "idle") return;
+      if (this.pollingInterval === undefined) return;
+      // Belt-and-suspenders: data during the settle window cancels the timer
+      // outright via cancelFsmIdleBackoff, but re-check in case a wake path
+      // moved the clock without clearing the timer.
+      if (this.lastDataTimestamp !== armedAtData) return;
+      this.fsmIdleBackoffActive = true;
+      this.applyPollingInterval(FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS);
+    }, FSM_IDLE_BACKOFF_SETTLE_MS);
+    this.fsmIdleBackoffTimer.unref();
+  }
+
+  // Cancels the settle timer and, if backoff was live, leaves it. When
+  // restorePolling is true the live interval is swapped back to the visibility
+  // cadence; when false (stop/dispose) the applied-interval field is still reset
+  // to the requested cadence so a later startPolling() never restarts at the
+  // stale backoff value.
+  private cancelFsmIdleBackoff(restorePolling: boolean): void {
+    if (this.fsmIdleBackoffTimer !== undefined) {
+      clearTimeout(this.fsmIdleBackoffTimer);
+      this.fsmIdleBackoffTimer = undefined;
+    }
+    if (!this.fsmIdleBackoffActive) return;
+    this.fsmIdleBackoffActive = false;
+    if (restorePolling && !this.isDisposed) {
+      this.applyPollingInterval(this.requestedPollingIntervalMs);
+    } else {
+      this.POLLING_INTERVAL_MS = this.requestedPollingIntervalMs;
+    }
   }
 
   private recordWorkingSignal(now: number): void {
@@ -1570,6 +1664,7 @@ export class ActivityMonitor {
         trigger: "pattern",
         patternConfidence: 0.85,
       });
+      this.armFsmIdleBackoff();
     }, COMPLETION_HOLD_MS);
 
     this.onStateChange(this.terminalId, this.spawnedAt, "completed", {
@@ -1643,6 +1738,7 @@ export class ActivityMonitor {
       trigger: "timeout",
       waitingReason,
     });
+    this.armFsmIdleBackoff();
   }
 
   private becomeBusyFromPattern(confidence: number, now: number): void {
@@ -1651,6 +1747,7 @@ export class ActivityMonitor {
 
   private becomeBusy(metadata: ActivityStateMetadata, now: number = Date.now()): void {
     if (this.isDisposed) return;
+    this.cancelFsmIdleBackoff(true);
     this.inputTracker.clearPendingInput();
     if (metadata.trigger === "input") {
       this.lastActivityTimestamp = now;

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -144,19 +144,28 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
 
-    it("does not back off while data keeps arriving within the settle window", () => {
+    it("debounces on the last idle byte: keeps resetting while data trickles in, backs off after silence", () => {
       const setIntervalSpy = vi.spyOn(global, "setInterval");
       const { monitor } = createIdleAgent(50);
 
       monitor.startPolling();
       setIntervalSpy.mockClear();
 
-      // Data before the settle timer fires cancels it — no backoff.
-      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS - 500);
-      monitor.onData("x");
-      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS * 2);
-
+      // A byte every 1500ms (< the 3000ms settle) keeps re-arming the timer, so
+      // it never fires while the agent stays idle-but-trickling.
+      for (let i = 0; i < 4; i++) {
+        vi.advanceTimersByTime(1500);
+        monitor.onData("x");
+      }
+      expect(monitor.getState()).toBe("idle");
       expect(setIntervalSpy).not.toHaveBeenCalledWith(
+        expect.any(Function),
+        FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS
+      );
+
+      // Silence past the settle window after the last byte → backoff engages.
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS);
+      expect(setIntervalSpy).toHaveBeenCalledWith(
         expect.any(Function),
         FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS
       );

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ActivityMonitor } from "../ActivityMonitor.js";
+import {
+  ActivityMonitor,
+  FSM_IDLE_BACKOFF_SETTLE_MS,
+  FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS,
+} from "../ActivityMonitor.js";
 import { AGENT_OUTPUT_ACTIVITY_LINE_COUNT } from "../pty/AgentActivityTemperature.js";
 import { buildActivityMonitorOptions } from "../pty/terminalActivityPatterns.js";
 import {
@@ -103,6 +107,163 @@ describe("ActivityMonitor", () => {
       // Verify new interval takes effect
       vi.advanceTimersByTime(500);
       expect(getVisibleLines).toHaveBeenCalled();
+    });
+  });
+
+  describe("idle-agent polling backoff (#10906)", () => {
+    // Builds a simple-output agent monitor that starts already idle (the
+    // restored-session shape), so startPolling() arms the settle timer.
+    function createIdleAgent(pollingIntervalMs = 50) {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("agent-1", 1000, onStateChange, {
+        simpleOutputState: true,
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        initialState: "idle",
+        skipInitialStateEmit: true,
+        pollingIntervalMs,
+      });
+      return { monitor, onStateChange };
+    }
+
+    it("drops to the backoff cadence after a settled idle agent stays silent", () => {
+      const setIntervalSpy = vi.spyOn(global, "setInterval");
+      const { monitor } = createIdleAgent(50);
+
+      monitor.startPolling();
+      setIntervalSpy.mockClear();
+
+      // Still silent through the settle window → swap to the backoff cadence.
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS);
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS
+      );
+
+      monitor.dispose();
+    });
+
+    it("does not back off while data keeps arriving within the settle window", () => {
+      const setIntervalSpy = vi.spyOn(global, "setInterval");
+      const { monitor } = createIdleAgent(50);
+
+      monitor.startPolling();
+      setIntervalSpy.mockClear();
+
+      // Data before the settle timer fires cancels it — no backoff.
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS - 500);
+      monitor.onData("x");
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS * 2);
+
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(
+        expect.any(Function),
+        FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS
+      );
+
+      monitor.dispose();
+    });
+
+    it("restores the requested cadence on wake, not a hardcoded 50ms", () => {
+      const setIntervalSpy = vi.spyOn(global, "setInterval");
+      const { monitor } = createIdleAgent(50);
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS); // backoff engages
+
+      // A visibility change arrives while backed off — recorded, not applied live.
+      monitor.setPollingInterval(500);
+      setIntervalSpy.mockClear();
+
+      // Wake on data → restore the latest requested interval (500), never 50.
+      monitor.onData("x");
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 500);
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 50);
+
+      monitor.dispose();
+    });
+
+    it("does not apply a visibility change live while backed off", () => {
+      const setIntervalSpy = vi.spyOn(global, "setInterval");
+      const { monitor } = createIdleAgent(50);
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS); // backoff engages (2000ms live)
+      setIntervalSpy.mockClear();
+
+      // While backed off, a background-tier request must not swap the live timer.
+      monitor.setPollingInterval(500);
+
+      expect(setIntervalSpy).not.toHaveBeenCalled();
+
+      monitor.dispose();
+    });
+
+    it("restarts at the requested cadence after stop, not the stale backoff value", () => {
+      const setIntervalSpy = vi.spyOn(global, "setInterval");
+      const { monitor } = createIdleAgent(50);
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS); // backoff engages
+
+      monitor.stopPolling();
+      setIntervalSpy.mockClear();
+      monitor.startPolling();
+
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 50);
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(
+        expect.any(Function),
+        FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS
+      );
+
+      monitor.dispose();
+    });
+
+    it("clears the pending settle timer on dispose", () => {
+      const setIntervalSpy = vi.spyOn(global, "setInterval");
+      const { monitor } = createIdleAgent(50);
+
+      monitor.startPolling();
+      // Dispose before the settle timer fires.
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS - 500);
+      monitor.dispose();
+      setIntervalSpy.mockClear();
+
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS * 2);
+
+      expect(setIntervalSpy).not.toHaveBeenCalledWith(
+        expect.any(Function),
+        FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS
+      );
+    });
+
+    it("backs off again after a busy→idle round trip", () => {
+      const setIntervalSpy = vi.spyOn(global, "setInterval");
+      const { monitor } = createIdleAgent(50);
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS); // backoff engages
+
+      // Wake, go busy, then settle back to idle — a fresh backoff must arm.
+      monitor.onData("x");
+      monitor.notifyExternalPromotion();
+      expect(monitor.getState()).toBe("busy");
+      setIntervalSpy.mockClear();
+
+      // Return to idle via the simple-output idle gate: quiet past IDLE_DEBOUNCE_MS.
+      vi.advanceTimersByTime(9000);
+      expect(monitor.getState()).toBe("idle");
+
+      // Then silent through another settle window → backoff re-engages.
+      setIntervalSpy.mockClear();
+      vi.advanceTimersByTime(FSM_IDLE_BACKOFF_SETTLE_MS);
+      expect(setIntervalSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        FSM_IDLE_BACKOFF_POLLING_INTERVAL_MS
+      );
+
+      monitor.dispose();
     });
   });
 

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -12,6 +12,9 @@ export interface SessionSnapshotterHost {
   readonly id: string;
   readonly wasKilled: boolean;
   readonly launchAgentId: string | undefined;
+  // Monotonic buffer-mutation counter (bumped per PTY chunk / resize / snapshot
+  // capture). Read as a dirty check so an unchanged buffer is not re-serialized.
+  readonly contentEpoch: number;
   hasBannerMarkers(): boolean;
   getSerializedState(): string | null;
   getSerializedStateAsync(): Promise<string | null>;
@@ -23,6 +26,8 @@ export class SessionSnapshotter {
   private dirty = false;
   private inFlight = false;
   private lastEventDrivenFlushAt = -Infinity;
+  private eventDrivenInFlight = false;
+  private lastFlushedEpoch = -1;
   private disposed = false;
 
   constructor(private readonly host: SessionSnapshotterHost) {}
@@ -74,21 +79,52 @@ export class SessionSnapshotter {
   }
 
   flushEventDriven(): void {
+    void this.flushEventDrivenAsync();
+  }
+
+  // Async event-driven flush fired on agent state settles (waiting/completed/
+  // exited). Mirrors persistAsync()'s banner-branch + post-await lifecycle
+  // re-check so serializing up to 10k lines no longer blocks the pty-host event
+  // loop on every transition. Two short-circuits keep it cheap: an unchanged
+  // contentEpoch skips serialization entirely, and a 2s throttle caps churn from
+  // rapid changed-content transitions.
+  private async flushEventDrivenAsync(): Promise<void> {
     if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
     if (isSessionPersistSuppressed()) return;
     if (this.host.wasKilled) return;
     if (this.disposed) return;
 
+    // Buffer unchanged since the last persisted snapshot — nothing to write.
+    // Checked before the throttle so an unchanged flush never consumes the
+    // throttle window a later changed-content flush needs.
+    const epoch = this.host.contentEpoch;
+    if (epoch === this.lastFlushedEpoch) return;
+
     const now = performance.now();
     if (now - this.lastEventDrivenFlushAt < EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS) return;
+
+    // Drop overlapping flushes: the in-flight one already covers this settle.
+    if (this.eventDrivenInFlight) return;
+    this.eventDrivenInFlight = true;
     this.lastEventDrivenFlushAt = now;
-
-    const state = this.host.serializeForPersistence();
-    if (!state) return;
-
-    persistSessionSnapshotAsync(this.host.id, state).catch((error) => {
+    try {
+      const state = this.host.hasBannerMarkers()
+        ? this.host.serializeForPersistence()
+        : await this.host.getSerializedStateAsync();
+      // Re-check lifecycle after the await — a kill or dispose during async
+      // serialize would otherwise stomp the sync snapshot written from kill().
+      if (this.disposed || this.host.wasKilled) return;
+      if (!state) return;
+      await persistSessionSnapshotAsync(this.host.id, state);
+      // Mark coverage only after a successful persist. Uses the entry epoch, so
+      // content that changed mid-serialize (epoch > entry) still triggers a
+      // later flush.
+      this.lastFlushedEpoch = epoch;
+    } catch (error) {
       console.warn(`[TerminalProcess] Event-driven snapshot failed for ${this.host.id}:`, error);
-    });
+    } finally {
+      this.eventDrivenInFlight = false;
+    }
   }
 
   // Last-chance unconditional flush invoked by kill() before wasKilled is set.

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -252,6 +252,10 @@ export class TerminalProcess {
         return this.parent.terminalInfo.launchAgentId;
       }
 
+      get contentEpoch(): number {
+        return this.parent.terminalInfo.contentEpoch;
+      }
+
       hasBannerMarkers(): boolean {
         return !!(this.parent._restoreBannerStart || this.parent._restoreBannerEnd);
       }

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -19,12 +19,22 @@ vi.mock("../terminalSessionPersistence.js", async (importOriginal) => {
 interface MutableHost extends SessionSnapshotterHost {
   wasKilled: boolean;
   launchAgentId: string | undefined;
+  contentEpoch: number;
   bannerMarkers: boolean;
   serializedState: string | null;
   serializedStateAsync: string | null;
   serializedForPersistence: string | null;
   asyncResolve: () => void;
   asyncResolved: boolean;
+}
+
+// Event-driven flush is fire-and-forget; drain its microtask chain
+// (getSerializedStateAsync → persistSessionSnapshotAsync) so assertions see the
+// completed persist.
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 function createHost(overrides: Partial<MutableHost> = {}): MutableHost {
@@ -37,6 +47,7 @@ function createHost(overrides: Partial<MutableHost> = {}): MutableHost {
     id: "t-test",
     wasKilled: false,
     launchAgentId: undefined,
+    contentEpoch: 1,
     bannerMarkers: false,
     serializedState: "sync-state",
     serializedStateAsync: "async-state",
@@ -235,83 +246,181 @@ describe("SessionSnapshotter", () => {
   });
 
   describe("flushEventDriven", () => {
-    it("persists using banner-aware serialization", () => {
+    it("uses async serialization for the non-banner path", async () => {
       const host = createHost();
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
-      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "async-state");
     });
 
-    it("strips restore banner via serializeForPersistence when banner markers are present", () => {
+    it("strips restore banner via sync serializeForPersistence when banner markers are present", async () => {
       const host = createHost({ bannerMarkers: true });
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
       expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
     });
 
-    it("throttles repeated calls within 2s", () => {
+    it("throttles repeated calls within 2s", async () => {
       const host = createHost();
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
+      await flushMicrotasks();
+      // Content changed but the throttle window has not elapsed → suppressed.
+      host.contentEpoch = 2;
       snap.flushEventDriven();
+      host.contentEpoch = 3;
       snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
     });
 
-    it("allows another flush after throttle window elapses", () => {
+    it("allows another flush after throttle window elapses when content changed", async () => {
       const host = createHost();
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
+      await flushMicrotasks();
+
       vi.advanceTimersByTime(2001);
+      host.contentEpoch = 2;
       snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(2);
     });
 
-    it("does NOT skip for agent terminals (snapshots agents on event)", () => {
-      const host = createHost({ launchAgentId: "claude" });
+    it("skips serialization when contentEpoch is unchanged since the last persist", async () => {
+      const host = createHost();
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // Same epoch, and past the throttle window — still skipped (buffer unchanged).
+      vi.advanceTimersByTime(2001);
+      snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
     });
 
-    it("skips when wasKilled is true", () => {
+    it("checks the epoch before the throttle so an unchanged call never starves a later changed flush", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+      await flushMicrotasks(); // persists epoch 1, stamps throttle
+
+      // An unchanged call inside the throttle window must not re-stamp the
+      // throttle clock; a changed flush after the window still goes through.
+      snap.flushEventDriven();
+      await flushMicrotasks();
+
+      vi.advanceTimersByTime(2001);
+      host.contentEpoch = 2;
+      snap.flushEventDriven();
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does NOT skip for agent terminals (snapshots agents on event)", async () => {
+      const host = createHost({ launchAgentId: "claude" });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips when wasKilled is true", async () => {
       const host = createHost({ wasKilled: true });
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).not.toHaveBeenCalled();
     });
 
-    it("skips when disposed", () => {
+    it("skips when disposed", async () => {
       const host = createHost();
       const snap = new SessionSnapshotter(host);
 
       snap.dispose();
       snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).not.toHaveBeenCalled();
     });
 
-    it("skips when serialized state is null", () => {
-      const host = createHost({ serializedForPersistence: null });
+    it("skips when serialized state is null", async () => {
+      const host = createHost({ serializedStateAsync: null });
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
+      await flushMicrotasks();
 
       expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("re-checks lifecycle after the await and skips persist when killed mid-serialize", async () => {
+      const host = createHost();
+      host.asyncResolved = false;
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+      // Kill lands while the async serialize is still pending.
+      host.wasKilled = true;
+      host.asyncResolve();
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).not.toHaveBeenCalled();
+    });
+
+    it("drops a re-entrant flush while one is already in flight", async () => {
+      const host = createHost();
+      host.asyncResolved = false;
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+      // Second call before the first resolves — must not start a second serialize.
+      host.contentEpoch = 2;
+      snap.flushEventDriven();
+
+      host.asyncResolve();
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not mark the epoch flushed when persist fails (retries after throttle)", async () => {
+      const host = createHost();
+      const snap = new SessionSnapshotter(host);
+      persistAsyncMock.mockRejectedValueOnce(new Error("disk full"));
+
+      snap.flushEventDriven();
+      await flushMicrotasks();
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+
+      // Same epoch, but the failed persist left it uncovered → a later flush retries.
+      vi.advanceTimersByTime(2001);
+      snap.flushEventDriven();
+      await flushMicrotasks();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -393,12 +393,21 @@ describe("SessionSnapshotter", () => {
     it("drops a re-entrant flush while one is already in flight", async () => {
       const host = createHost();
       host.asyncResolved = false;
+      const serializeSpy = vi.spyOn(host, "getSerializedStateAsync");
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
-      // Second call before the first resolves — must not start a second serialize.
+      await Promise.resolve(); // let the first flush reach its stalled serialize
+
+      // Advance past the throttle window and change content so the second call
+      // clears the epoch + throttle gates and actually reaches the in-flight
+      // guard — which must drop it (no second serialize starts).
+      vi.advanceTimersByTime(2001);
       host.contentEpoch = 2;
       snap.flushEventDriven();
+      await Promise.resolve();
+
+      expect(serializeSpy).toHaveBeenCalledTimes(1);
 
       host.asyncResolve();
       await flushMicrotasks();

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -122,44 +122,57 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
     persistSyncMock.mockReset();
   });
 
-  it("calls persistSessionSnapshotAsync for agent terminals", () => {
+  // Event-driven flush is fire-and-forget and now serializes off the event loop
+  // via getSerializedStateAsync — drain its microtask chain before asserting.
+  async function flushMicrotasks(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  it("persists for agent terminals via async serialization (non-banner path)", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("agent-scrollback");
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue("agent-scrollback");
 
     terminal.flushEventDrivenSnapshot();
+    await flushMicrotasks();
 
     expect(persistAsyncMock).toHaveBeenCalledWith("t1", "agent-scrollback");
   });
 
-  it("throttles rapid calls within 2 seconds", () => {
+  it("suppresses an immediate repeat with unchanged content", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("data");
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue("data");
 
     terminal.flushEventDrivenSnapshot();
+    await flushMicrotasks();
     expect(persistAsyncMock).toHaveBeenCalledTimes(1);
 
-    // Second call within 2s should be suppressed
+    // Second call within 2s / unchanged buffer should be suppressed
     terminal.flushEventDrivenSnapshot();
+    await flushMicrotasks();
     expect(persistAsyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not flush when serialized state is null", () => {
+  it("does not flush when serialized state is null", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue(null);
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue(null);
 
     terminal.flushEventDrivenSnapshot();
+    await flushMicrotasks();
 
     expect(persistAsyncMock).not.toHaveBeenCalled();
   });
 
-  it("does not flush when terminal is killed", () => {
+  it("does not flush when terminal is killed", async () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("data");
+    vi.spyOn(terminal, "getSerializedStateAsync").mockResolvedValue("data");
 
     terminal.kill("test");
 
     persistAsyncMock.mockReset();
     terminal.flushEventDrivenSnapshot();
+    await flushMicrotasks();
 
     expect(persistAsyncMock).not.toHaveBeenCalled();
   });

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -177,9 +177,9 @@ export interface TerminalInfo extends TerminalPublicState {
   /**
    * Monotonic count of buffer mutations: PTY output chunks (bumped at the
    * pty-host routing site), resize reflows, and the preserved-snapshot
-   * capture. Runtime-only; not persisted, not crossed over IPC. Vestigial: the
-   * only reader was the wake no-change short-circuit, removed with the rest of
-   * the hibernation/wake teardown — kept as a write-only counter for now.
+   * capture. Runtime-only; not persisted, not crossed over IPC. Read by
+   * SessionSnapshotter (via SessionSnapshotterHost.contentEpoch) as the dirty
+   * check that skips re-serializing an unchanged buffer on event-driven flush.
    */
   contentEpoch: number;
   /**


### PR DESCRIPTION
## Summary

- `ActivityMonitor` polled every agent terminal every 50ms regardless of what the agent was doing. It now backs off to a 2000ms cadence once the agent FSM settles into idle and stays silent for 3 seconds (debounced off the last PTY byte). Any output or a transition to busy cancels the backoff immediately and restores the prior visibility-tier cadence, so detection latency doesn't regress since state transitions are always preceded by output.
- `SessionSnapshotter.flushEventDriven()`, called on every agent transition to `waiting`, `completed`, or `exited`, used to serialize up to 10000 lines of scrollback synchronously on the shared pty-host event loop. It now serializes off the event loop through the existing `getSerializedStateAsync()` path, skips entirely when the buffer's `contentEpoch` hasn't changed since the last persist, and guards against overlapping in-flight flushes.

Resolves #10906

## Changes

- `electron/services/ActivityMonitor.ts`: idle backoff wired through dedicated arm/cancel methods, kept separate from the existing focus/visibility tier so the same-tier no-op guard can't swallow it. `stop`/`dispose` reset the applied interval so a restart never inherits a stale backoff value.
- `electron/services/pty/SessionSnapshotter.ts`: `flushEventDriven()` moved to the async serialize path, mirroring how the debounced `persistAsync()` branch already works, including the same post-await `disposed`/`wasKilled` lifecycle re-check. The synchronous last-resort flush paths used on kill and dispose are untouched.
- `electron/services/pty/TerminalProcess.ts`, `electron/services/pty/types.ts`: supporting wiring for the async flush and backoff inputs.

## Testing

Added/updated unit tests:

- `electron/services/__tests__/ActivityMonitor.test.ts`: 8 backoff lifecycle tests (arm-on-settle, debounce-on-last-byte, wake restores the requested cadence rather than a hardcoded 50ms, no live swap during backoff, restart uses the requested cadence rather than a stale backoff value, dispose clears the settle timer, re-arm after busy to idle).
- `electron/services/pty/__tests__/SessionSnapshotter.test.ts`: async path, epoch skip, epoch-before-throttle ordering, in-flight drop, killed-mid-serialize re-check, failed-persist-no-epoch-update retry.
- `electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts`: async wiring.

All targeted suites green (34 / 18 / 238).