### PR TITLE
perf(panels): stop status flushes fanning out into O(worktrees) work

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -649,7 +649,6 @@ export function DndProvider({ children }: DndProviderProps) {
     [prefersReducedMotion]
   );
 
-  const panelsById = usePanelStore((state) => state.panelsById);
   const reorderTerminals = usePanelStore((s) => s.reorderTerminals);
   const reorderTabGroups = usePanelStore((s) => s.reorderTabGroups);
   const moveTerminalToPosition = usePanelStore((s) => s.moveTerminalToPosition);
@@ -661,10 +660,15 @@ export function DndProvider({ children }: DndProviderProps) {
   const activeTerminal = useMemo((): PanelInstance | null => {
     if (!activeId && !activeData) return null;
     if (activeData?.terminal) return activeData.terminal;
-    // Parse accordion IDs to get actual terminal ID
+    // Parse accordion IDs to get actual terminal ID. Read the panel map
+    // non-reactively (drag start/end already re-key this memo via activeId /
+    // activeData) rather than subscribing to the whole `panelsById` map, which
+    // re-rendered the entire DnD tree on every status-buffer flush (#10908).
     const terminalId = parseAccordionDragId(activeId!) ?? activeId;
-    return (terminalId ? getNarrowPanel(panelsById, terminalId) : null) ?? null;
-  }, [activeId, activeData, panelsById]);
+    return (
+      (terminalId ? getNarrowPanel(usePanelStore.getState().panelsById, terminalId) : null) ?? null
+    );
+  }, [activeId, activeData]);
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setIsCancelDrop(false);

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -72,6 +72,11 @@ const CONTEXT_MENU_COMPONENTS: DockLaunchMenuComponents = {
 
 export type { DockDensity } from "@/store/preferencesStore";
 
+// Stable empty refs so the narrowed dock subscriptions below can bail under
+// `useShallow` when the dock is empty instead of yielding a fresh `[]`.
+const EMPTY_DOCK_SIGNATURE: readonly string[] = [];
+const EMPTY_DOCK_TERMINALS: readonly PtyPanelData[] = [];
+
 interface ContentDockProps {
   density?: DockDensity;
 }
@@ -80,8 +85,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
 
   const trashedTerminals = usePanelStore((state) => state.trashedTerminals);
-  const panelsById = usePanelStore((state) => state.panelsById);
-  const storeTerminalIds = usePanelStore((state) => state.panelIds);
+  const storeTabGroups = usePanelStore((state) => state.tabGroups);
   const getTabGroups = usePanelStore((state) => state.getTabGroups);
   const getTabGroupPanels = usePanelStore((state) => state.getTabGroupPanels);
   const currentProject = useProjectStore((s) => s.currentProject);
@@ -93,10 +97,60 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   const { settings: projectSettings } = useProjectSettings();
   const hasDevPreview = Boolean(projectSettings?.devServerCommand?.trim());
 
+  // Narrow dock subscriptions (#10908). Subscribing to the whole `panelsById`
+  // re-rendered the dock on every panel's rAF status-buffer flush — including
+  // grid agents that never appear here. Both selectors below react only to dock
+  // panels. The dock is intentionally PTY-only: its chrome (output preview,
+  // restart, agent state) is built on terminal affordances, so `getNarrowPanel`
+  // + `isPtyPanel` is the correct gate (NOT the #10512 grid render-eligibility
+  // predicate, which deliberately does not apply to the dock).
+  //
+  // `dockPanelSignature` is a structural `${id}:${worktreeId}` list that stays
+  // referentially stable across status-buffer flushes, so the (activity-agnostic)
+  // `tabGroups` derivation recomputes only on real dock membership/scope changes.
+  const dockPanelSignature = usePanelStore(
+    useShallow((state) => {
+      const result: string[] = [];
+      for (const id of state.panelIds) {
+        const terminal = getNarrowPanel(state.panelsById, id);
+        if (
+          terminal &&
+          isPtyPanel(terminal) &&
+          terminal.location === "dock" &&
+          !state.trashedTerminals.has(terminal.id)
+        ) {
+          result.push(`${terminal.id}:${terminal.worktreeId ?? ""}`);
+        }
+      }
+      return result.length === 0 ? EMPTY_DOCK_SIGNATURE : result;
+    })
+  );
+
+  // Live dock panel objects. The dock renders live activity/agent state from
+  // these, so unlike the grid this stays object-valued — but `useShallow` only
+  // fires when a *dock* panel's reference changes, not on grid-agent churn.
+  const dockTerminalsRaw = usePanelStore(
+    useShallow((state) => {
+      const result: PtyPanelData[] = [];
+      for (const id of state.panelIds) {
+        const terminal = getNarrowPanel(state.panelsById, id);
+        if (
+          terminal &&
+          isPtyPanel(terminal) &&
+          terminal.location === "dock" &&
+          !state.trashedTerminals.has(terminal.id)
+        ) {
+          result.push(terminal);
+        }
+      }
+      return result.length === 0 ? EMPTY_DOCK_TERMINALS : result;
+    })
+  );
+
   // Get tab groups for the dock, excluding the help panel terminal
   const tabGroups = useMemo(() => {
-    void storeTerminalIds;
-    void panelsById;
+    void dockPanelSignature;
+    void storeTabGroups;
     void trashedTerminals;
     const groups = getTabGroups("dock", activeWorktreeId ?? undefined);
     if (!helpTerminalId) return groups;
@@ -104,27 +158,19 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   }, [
     getTabGroups,
     activeWorktreeId,
-    storeTerminalIds,
-    panelsById,
+    dockPanelSignature,
+    storeTabGroups,
     trashedTerminals,
     helpTerminalId,
   ]);
 
   const dockTerminals = useMemo<PtyPanelData[]>(() => {
-    // The dock is intentionally PTY-only: its chrome (output preview, restart,
-    // agent state) is built on terminal affordances. Non-PTY panels — browser,
-    // dev-preview, review, AND plugin-contributed kinds — are grid-only here,
-    // so `getNarrowPanel` + `isPtyPanel` is the correct gate (NOT the #10512
-    // grid render-eligibility predicate, which deliberately does not apply to
-    // the dock).
+    // `dockTerminalsRaw` already narrows to dock/pty/non-trashed panels; apply
+    // the help-panel and active-worktree filters here (external stores the
+    // store selector can't read).
     const result: PtyPanelData[] = [];
-    for (const id of storeTerminalIds) {
-      const terminal = getNarrowPanel(panelsById, id);
+    for (const terminal of dockTerminalsRaw) {
       if (
-        terminal &&
-        isPtyPanel(terminal) &&
-        terminal.location === "dock" &&
-        !trashedTerminals.has(terminal.id) &&
         terminal.id !== helpTerminalId &&
         (terminal.worktreeId == null || terminal.worktreeId === activeWorktreeId)
       ) {
@@ -132,7 +178,22 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
       }
     }
     return result;
-  }, [storeTerminalIds, panelsById, trashedTerminals, helpTerminalId, activeWorktreeId]);
+  }, [dockTerminalsRaw, helpTerminalId, activeWorktreeId]);
+
+  // Trashed panels resolved from the store, keyed by id. Values are the actual
+  // store panel references (not freshly constructed), so `useShallow` bails
+  // unless the trashed set — or a trashed panel's reference — actually changes,
+  // rather than on every unrelated status-buffer flush (#10908).
+  const trashedPanelsById = usePanelStore(
+    useShallow((state) => {
+      const result: Record<string, PanelInstance> = {};
+      for (const trashed of state.trashedTerminals.values()) {
+        const panel = state.panelsById[trashed.id];
+        if (panel) result[trashed.id] = panel;
+      }
+      return result;
+    })
+  );
 
   const { worktrees } = useWorktrees();
 
@@ -322,7 +383,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
 
   const trashedItems = Array.from(trashedTerminals.values())
     .map((trashed) => ({
-      terminal: panelsById[trashed.id] as PanelInstance | undefined,
+      terminal: trashedPanelsById[trashed.id] as PanelInstance | undefined,
       trashedInfo: trashed,
     }))
     .filter(

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -108,10 +108,14 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   // `dockPanelSignature` is a structural `${id}:${worktreeId}` list that stays
   // referentially stable across status-buffer flushes, so the (activity-agnostic)
   // `tabGroups` derivation recomputes only on real dock membership/scope changes.
+  // It iterates `panelsById` (not `panelIds`) so a batched dock panel — committed
+  // to `panelsById` before `panelIds` is revealed at flush — still invalidates
+  // `tabGroups`, matching the old whole-map subscription's recompute and letting
+  // `getTabGroups` surface the index-only panel (#9649).
   const dockPanelSignature = usePanelStore(
     useShallow((state) => {
       const result: string[] = [];
-      for (const id of state.panelIds) {
+      for (const id of Object.keys(state.panelsById)) {
         const terminal = getNarrowPanel(state.panelsById, id);
         if (
           terminal &&

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -52,7 +52,13 @@ import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import type { PendingCreation } from "@/store/worktreeStore";
-import { useFleetArmingStore, collectFilterArmEligibleIds } from "@/store/fleetArmingStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import {
+  selectSidebarVisiblePanelIds,
+  selectSidebarAgentStateByPanelId,
+  selectSidebarFleetEligibleWorktreeById,
+  computePanelStateByWorktree,
+} from "./sidebarPanelDerivation";
 import { useShallow } from "zustand/react/shallow";
 import { systemClient } from "@/clients";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
@@ -83,9 +89,6 @@ import { useScrollIndicator } from "./useScrollIndicator";
 import { useRecipeDialogState } from "./useRecipeDialogState";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
 import { RecipeManager } from "@/components/TerminalRecipe/RecipeManager";
-import { isAgentTerminal } from "@/utils/terminalType";
-import { isPtyPanel } from "@shared/types/panel";
-import { isTerminalVisible } from "@/lib/terminalVisibility";
 import { useWorktreeIds } from "@/hooks/useTerminalSelectors";
 import { logError } from "@/utils/logger";
 import { useWorktreeSidebarKeyboard, type SidebarKeyboardItem } from "./useWorktreeSidebarKeyboard";
@@ -112,6 +115,10 @@ const QUICK_STATE_LABELS: Record<"working" | "waiting" | "finished", string> = {
 };
 
 const KEYBOARD_REORDER_ANNOUNCEMENT_DEBOUNCE_MS = 150;
+
+// Stable empty ref so `filterArmEligibleIds` can bail to a constant when no
+// worktrees are in scope instead of yielding a fresh `[]`.
+const EMPTY_ELIGIBLE_IDS: readonly string[] = [];
 
 // Virtuoso overscan in pixels — covers ~2–5 rows at the 120–260px height range,
 // keeping useSortable hooks alive in a small window beyond the viewport so a
@@ -631,64 +638,29 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const worktreeIdList = useMemo(() => deferredWorktrees.map((w) => w.id), [deferredWorktrees]);
   const panelIds = usePanelStore((state) => state.panelIds);
   const panelIdsByWorktreeId = usePanelStore((state) => state.panelIdsByWorktreeId);
-  const panelsById = usePanelStore((state) => state.panelsById);
-  const isInTrash = usePanelStore((state) => state.isInTrash);
-  const panelStateByWorktree = useMemo(() => {
-    const result: Record<
-      string,
-      {
-        terminalCount: number;
-        waitingTerminalCount: number;
-        hasWorkingAgent: boolean;
-        hasWaitingAgent: boolean;
-        hasCompletedAgent: boolean;
-        hasExitedAgent: boolean;
-      }
-    > = {};
-    for (const worktreeId of worktreeIdList) {
-      const ids = panelIdsByWorktreeId[worktreeId];
-      if (!ids || ids.length === 0) {
-        result[worktreeId] = {
-          terminalCount: 0,
-          waitingTerminalCount: 0,
-          hasWorkingAgent: false,
-          hasWaitingAgent: false,
-          hasCompletedAgent: false,
-          hasExitedAgent: false,
-        };
-        continue;
-      }
-      let terminalCount = 0;
-      let waitingTerminalCount = 0;
-      let hasWorkingAgent = false;
-      let hasWaitingAgent = false;
-      let hasCompletedAgent = false;
-      let hasExitedAgent = false;
-      for (const id of ids) {
-        const t = panelsById[id];
-        if (!t) continue;
-        if (!isTerminalVisible(t, isInTrash, worktreeIds)) continue;
-        terminalCount++;
-        if (!isAgentTerminal(t) || !isPtyPanel(t)) continue;
-        if (t.agentState === "working") hasWorkingAgent = true;
-        if (t.agentState === "waiting") {
-          hasWaitingAgent = true;
-          waitingTerminalCount++;
-        }
-        if (t.agentState === "completed") hasCompletedAgent = true;
-        if (t.agentState === "exited") hasExitedAgent = true;
-      }
-      result[worktreeId] = {
-        terminalCount,
-        waitingTerminalCount,
-        hasWorkingAgent,
-        hasWaitingAgent,
-        hasCompletedAgent,
-        hasExitedAgent,
-      };
-    }
-    return result;
-  }, [worktreeIdList, panelIdsByWorktreeId, panelsById, isInTrash, worktreeIds]);
+  // Subscribing to the whole `panelsById` map re-ran every rollup below on each
+  // rAF status-buffer flush (up to 60×/sec while an agent streams), because the
+  // buffer replaces the map reference every flush (#10908). Instead subscribe to
+  // flat primitive maps of ONLY the fields these rollups read (see
+  // `sidebarPanelDerivation.ts`) — none of which the buffer writes — so
+  // `useShallow` bails on buffer flushes and re-renders fire only on real
+  // structural, agent-state, or fleet-eligibility changes.
+  const visiblePanelIds = usePanelStore(useShallow(selectSidebarVisiblePanelIds));
+  const agentStateByPanelId = usePanelStore(useShallow(selectSidebarAgentStateByPanelId));
+  const fleetEligibleWorktreeById = usePanelStore(
+    useShallow(selectSidebarFleetEligibleWorktreeById)
+  );
+  const panelStateByWorktree = useMemo(
+    () =>
+      computePanelStateByWorktree(
+        worktreeIdList,
+        panelIdsByWorktreeId,
+        visiblePanelIds,
+        agentStateByPanelId,
+        worktreeIds
+      ),
+    [worktreeIdList, panelIdsByWorktreeId, visiblePanelIds, agentStateByPanelId, worktreeIds]
+  );
 
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -1045,15 +1017,18 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // Fleet-eligible terminals inside the currently visible worktrees, split so an
   // arm/disarm elsewhere only re-walks the unarmed tally rather than re-scanning
   // every panel. Drives the QuickStateFilterBar arm affordance.
-  const filterArmEligibleIds = useMemo(
-    () =>
-      collectFilterArmEligibleIds(
-        filteredWorktrees.map((w) => w.id),
-        panelIds,
-        panelsById
-      ),
-    [filteredWorktrees, panelIds, panelsById]
-  );
+  const filterArmEligibleIds = useMemo(() => {
+    const worktreeIdSet = new Set(filteredWorktrees.map((w) => w.id));
+    if (worktreeIdSet.size === 0) return EMPTY_ELIGIBLE_IDS;
+    const ids: string[] = [];
+    for (const id of panelIds) {
+      const worktreeId = fleetEligibleWorktreeById[id];
+      if (worktreeId === undefined) continue; // not eligible
+      if (!worktreeId || !worktreeIdSet.has(worktreeId)) continue;
+      ids.push(id);
+    }
+    return ids;
+  }, [filteredWorktrees, panelIds, fleetEligibleWorktreeById]);
   const filterArmUnarmedCount = useMemo(() => {
     let unarmed = 0;
     for (const id of filterArmEligibleIds) {

--- a/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
@@ -72,6 +72,29 @@ describe("sidebarPanelDerivation selectors", () => {
     expect(selectSidebarVisiblePanelIds(state)).toEqual({ a: 1 });
   });
 
+  it("counts panels committed to panelsById before panelIds is revealed (spawn batch)", () => {
+    // During a spawn/hydration batch the panel lands in panelsById immediately
+    // but panelIds is deferred until flush (#9649). The selectors iterate
+    // panelsById so the sidebar still counts it before the batch flush.
+    const state: SidebarPanelDerivationState = {
+      panelIds: [], // not yet revealed
+      panelsById: { batched: agentPanel({ id: "batched", agentState: "working" }) },
+      isInTrash: () => false,
+    };
+
+    expect(selectSidebarVisiblePanelIds(state)).toEqual({ batched: 1 });
+
+    const rollup = computePanelStateByWorktree(
+      ["wt-1"],
+      { "wt-1": ["batched"] },
+      selectSidebarVisiblePanelIds(state),
+      selectSidebarAgentStateByPanelId(state),
+      new Set(["wt-1"])
+    );
+    expect(rollup["wt-1"]?.terminalCount).toBe(1);
+    expect(rollup["wt-1"]?.hasWorkingAgent).toBe(true);
+  });
+
   it("fleet eligibility maps live PTY panels to their worktree id", () => {
     const state = makeState({
       a: agentPanel({ id: "a", worktreeId: "wt-1", runtimeStatus: "running" }),
@@ -106,6 +129,21 @@ describe("computePanelStateByWorktree", () => {
       hasCompletedAgent: false,
       hasExitedAgent: false,
     });
+  });
+
+  it("sets completed and exited flags from agent state", () => {
+    const result = computePanelStateByWorktree(
+      ["wt-1"],
+      { "wt-1": ["a", "b"] },
+      { a: 1, b: 1 },
+      { a: "completed", b: "exited" },
+      new Set(["wt-1"])
+    );
+
+    expect(result["wt-1"]?.hasCompletedAgent).toBe(true);
+    expect(result["wt-1"]?.hasExitedAgent).toBe(true);
+    expect(result["wt-1"]?.hasWorkingAgent).toBe(false);
+    expect(result["wt-1"]?.waitingTerminalCount).toBe(0);
   });
 
   it("does not count panels absent from the visible map", () => {

--- a/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
+++ b/src/components/Sidebar/__tests__/sidebarPanelDerivation.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import type { PanelInstance } from "@shared/types/panel";
+import {
+  selectSidebarVisiblePanelIds,
+  selectSidebarAgentStateByPanelId,
+  selectSidebarFleetEligibleWorktreeById,
+  computePanelStateByWorktree,
+  type SidebarPanelDerivationState,
+} from "../sidebarPanelDerivation";
+
+function agentPanel(overrides: Partial<PanelInstance> = {}): PanelInstance {
+  return {
+    id: "p",
+    kind: "terminal",
+    title: "T",
+    cwd: "/w",
+    cols: 80,
+    rows: 24,
+    location: "grid",
+    worktreeId: "wt-1",
+    hasPty: true,
+    launchAgentId: "claude",
+    agentState: "working",
+    ...overrides,
+  } as PanelInstance;
+}
+
+function makeState(
+  panelsById: Record<string, PanelInstance>,
+  trashed: Set<string> = new Set()
+): SidebarPanelDerivationState {
+  return {
+    panelIds: Object.keys(panelsById),
+    panelsById,
+    isInTrash: (id) => trashed.has(id),
+  };
+}
+
+describe("sidebarPanelDerivation selectors", () => {
+  it("agent-state map is unchanged when only a buffer-written field (activityHeadline) changes", () => {
+    const before = makeState({ a: agentPanel({ id: "a", agentState: "working" }) });
+    // Simulate a status-buffer flush: same references replaced, only the
+    // high-frequency activity fields differ. Agent state and visibility must not.
+    const after = makeState({
+      a: agentPanel({ id: "a", agentState: "working", activityHeadline: "streaming…" }),
+    });
+
+    expect(selectSidebarAgentStateByPanelId(after)).toEqual(
+      selectSidebarAgentStateByPanelId(before)
+    );
+    expect(selectSidebarVisiblePanelIds(after)).toEqual(selectSidebarVisiblePanelIds(before));
+  });
+
+  it("agent-state map DOES change on a real agentState transition (no stale rollup)", () => {
+    const working = makeState({ a: agentPanel({ id: "a", agentState: "working" }) });
+    const waiting = makeState({ a: agentPanel({ id: "a", agentState: "waiting" }) });
+
+    expect(selectSidebarAgentStateByPanelId(working)).toEqual({ a: "working" });
+    expect(selectSidebarAgentStateByPanelId(waiting)).toEqual({ a: "waiting" });
+  });
+
+  it("visibility excludes trashed and non-visible locations", () => {
+    const state = makeState(
+      {
+        a: agentPanel({ id: "a", location: "grid" }),
+        b: agentPanel({ id: "b", location: "background" }),
+        c: agentPanel({ id: "c", location: "grid" }),
+      },
+      new Set(["c"])
+    );
+
+    expect(selectSidebarVisiblePanelIds(state)).toEqual({ a: 1 });
+  });
+
+  it("fleet eligibility maps live PTY panels to their worktree id", () => {
+    const state = makeState({
+      a: agentPanel({ id: "a", worktreeId: "wt-1", runtimeStatus: "running" }),
+      exited: agentPanel({ id: "exited", worktreeId: "wt-1", runtimeStatus: "exited" }),
+    });
+
+    const eligible = selectSidebarFleetEligibleWorktreeById(state);
+    expect(eligible.a).toBe("wt-1");
+    // A panel whose runtimeStatus has crossed into "exited" is not arm-eligible.
+    expect(eligible.exited).toBeUndefined();
+  });
+});
+
+describe("computePanelStateByWorktree", () => {
+  it("counts visible terminals and rolls up agent-state flags per worktree", () => {
+    const visible = { a: 1, b: 1, c: 1 } as Record<string, 1>;
+    const agentState = { a: "working", b: "waiting", c: "waiting" } as const;
+
+    const result = computePanelStateByWorktree(
+      ["wt-1"],
+      { "wt-1": ["a", "b", "c"] },
+      visible,
+      agentState,
+      new Set(["wt-1"])
+    );
+
+    expect(result["wt-1"]).toEqual({
+      terminalCount: 3,
+      waitingTerminalCount: 2,
+      hasWorkingAgent: true,
+      hasWaitingAgent: true,
+      hasCompletedAgent: false,
+      hasExitedAgent: false,
+    });
+  });
+
+  it("does not count panels absent from the visible map", () => {
+    const result = computePanelStateByWorktree(
+      ["wt-1"],
+      { "wt-1": ["a", "hidden"] },
+      { a: 1 },
+      { a: "working" },
+      new Set(["wt-1"])
+    );
+
+    expect(result["wt-1"]?.terminalCount).toBe(1);
+    expect(result["wt-1"]?.hasWorkingAgent).toBe(true);
+  });
+
+  it("emits an empty summary for orphaned worktrees (not in the valid set)", () => {
+    const result = computePanelStateByWorktree(
+      ["wt-orphan"],
+      { "wt-orphan": ["a"] },
+      { a: 1 },
+      { a: "working" },
+      new Set(["wt-1"])
+    );
+
+    expect(result["wt-orphan"]).toEqual({
+      terminalCount: 0,
+      waitingTerminalCount: 0,
+      hasWorkingAgent: false,
+      hasWaitingAgent: false,
+      hasCompletedAgent: false,
+      hasExitedAgent: false,
+    });
+  });
+});

--- a/src/components/Sidebar/sidebarPanelDerivation.ts
+++ b/src/components/Sidebar/sidebarPanelDerivation.ts
@@ -1,0 +1,133 @@
+import { isPtyPanel, type PanelInstance } from "@shared/types/panel";
+import type { AgentState } from "@shared/types/agent";
+import { isAgentTerminal } from "@/utils/terminalType";
+import { isTerminalVisible } from "@/lib/terminalVisibility";
+import { isFleetArmEligible } from "@/store/fleetArmingStore";
+import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+
+// Per-worktree rollups consumed by the sidebar (terminal counts + agent-state
+// flags). These live outside the component so their churn-safety and reactivity
+// invariants are unit-testable (#10908): subscribing to the whole `panelsById`
+// map re-ran every rollup on each rAF status-buffer flush, because the buffer
+// replaces the map reference every flush. The three selectors below read ONLY
+// fields the rollups depend on — none of which the buffer writes (it touches
+// activity/flow/held/runtimeStatus) — and return flat primitive maps so
+// `useShallow` bails on buffer flushes yet still fires on real structural,
+// agent-state, or fleet-eligibility changes.
+
+// Orphaning is worktree-scoped, so the intrinsic visibility pass disables
+// `isTerminalVisible`'s orphan check with an empty set; `computePanelStateByWorktree`
+// re-applies it once per worktree using the live worktree id set.
+const EMPTY_WORKTREE_IDS: ReadonlySet<string> = new Set();
+
+/** Minimal panel-store shape the sidebar derivations read. */
+export interface SidebarPanelDerivationState {
+  panelIds: readonly string[];
+  panelsById: Record<string, PanelInstance>;
+  isInTrash: (id: string) => boolean;
+}
+
+export interface WorktreePanelSummary {
+  terminalCount: number;
+  waitingTerminalCount: number;
+  hasWorkingAgent: boolean;
+  hasWaitingAgent: boolean;
+  hasCompletedAgent: boolean;
+  hasExitedAgent: boolean;
+}
+
+/** Panels passing intrinsic visibility (trash/location/persistence), sans orphan. */
+export function selectSidebarVisiblePanelIds(
+  state: SidebarPanelDerivationState
+): Record<string, 1> {
+  const result: Record<string, 1> = {};
+  for (const id of state.panelIds) {
+    const panel = state.panelsById[id];
+    if (panel && isTerminalVisible(panel, state.isInTrash, EMPTY_WORKTREE_IDS)) {
+      result[id] = 1;
+    }
+  }
+  return result;
+}
+
+/** Agent-state per PTY agent panel (absent when there is no live agent state). */
+export function selectSidebarAgentStateByPanelId(
+  state: SidebarPanelDerivationState
+): Record<string, AgentState> {
+  const result: Record<string, AgentState> = {};
+  for (const id of state.panelIds) {
+    const panel = state.panelsById[id];
+    if (!panel || !isPtyPanel(panel)) continue;
+    const agentState = panel.agentState;
+    if (!agentState) continue;
+    if (!isAgentTerminal(panel)) continue;
+    result[id] = agentState;
+  }
+  return result;
+}
+
+/**
+ * Fleet-arm-eligible panels → their worktree id. `isFleetArmEligible` reads
+ * `runtimeStatus`, which the buffer writes, but only its exited/error transition
+ * flips eligibility and the buffer never sets those on the flow path
+ * (`panelStatusBuffer.ts`) — so the eligible set is stable across flushes.
+ */
+export function selectSidebarFleetEligibleWorktreeById(
+  state: SidebarPanelDerivationState
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const id of state.panelIds) {
+    const panel = getNarrowPanel(state.panelsById, id);
+    if (!isFleetArmEligible(panel)) continue;
+    result[id] = panel.worktreeId ?? "";
+  }
+  return result;
+}
+
+function emptySummary(): WorktreePanelSummary {
+  return {
+    terminalCount: 0,
+    waitingTerminalCount: 0,
+    hasWorkingAgent: false,
+    hasWaitingAgent: false,
+    hasCompletedAgent: false,
+    hasExitedAgent: false,
+  };
+}
+
+/** Roll the flat maps up into per-worktree terminal counts + agent-state flags. */
+export function computePanelStateByWorktree(
+  worktreeIdList: readonly string[],
+  panelIdsByWorktreeId: Record<string, string[]>,
+  visiblePanelIds: Record<string, 1>,
+  agentStateByPanelId: Record<string, AgentState>,
+  worktreeIds: ReadonlySet<string>
+): Record<string, WorktreePanelSummary> {
+  const result: Record<string, WorktreePanelSummary> = {};
+  for (const worktreeId of worktreeIdList) {
+    const ids = panelIdsByWorktreeId[worktreeId];
+    // Every panel indexed under `worktreeId` carries that worktreeId, so the
+    // orphan check is constant across the group and evaluated once here.
+    const worktreeOrphaned = worktreeIds.size > 0 && !worktreeIds.has(worktreeId);
+    if (!ids || ids.length === 0 || worktreeOrphaned) {
+      result[worktreeId] = emptySummary();
+      continue;
+    }
+    const summary = emptySummary();
+    for (const id of ids) {
+      if (!visiblePanelIds[id]) continue;
+      summary.terminalCount++;
+      const agentState = agentStateByPanelId[id];
+      if (!agentState) continue;
+      if (agentState === "working") summary.hasWorkingAgent = true;
+      if (agentState === "waiting") {
+        summary.hasWaitingAgent = true;
+        summary.waitingTerminalCount++;
+      }
+      if (agentState === "completed") summary.hasCompletedAgent = true;
+      if (agentState === "exited") summary.hasExitedAgent = true;
+    }
+    result[worktreeId] = summary;
+  }
+  return result;
+}

--- a/src/components/Sidebar/sidebarPanelDerivation.ts
+++ b/src/components/Sidebar/sidebarPanelDerivation.ts
@@ -18,7 +18,7 @@ import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 // Orphaning is worktree-scoped, so the intrinsic visibility pass disables
 // `isTerminalVisible`'s orphan check with an empty set; `computePanelStateByWorktree`
 // re-applies it once per worktree using the live worktree id set.
-const EMPTY_WORKTREE_IDS: ReadonlySet<string> = new Set();
+const EMPTY_WORKTREE_IDS: Set<string> = new Set();
 
 /** Minimal panel-store shape the sidebar derivations read. */
 export interface SidebarPanelDerivationState {
@@ -26,6 +26,14 @@ export interface SidebarPanelDerivationState {
   panelsById: Record<string, PanelInstance>;
   isInTrash: (id: string) => boolean;
 }
+
+// The per-worktree rollups iterate `panelsById` rather than `panelIds`: during
+// a spawn/hydration batch a panel is committed to `panelsById` and the worktree
+// index immediately, but `panelIds` is deferred until the batch flush
+// (panelRegistry/core.ts). The old inline rollup walked the worktree index and
+// read `panelsById`, so it counted batched panels before flush; keying the flat
+// maps off `panelsById` preserves that (#9649). `computePanelStateByWorktree`
+// still gates on the worktree index, so extra entries here are simply ignored.
 
 export interface WorktreePanelSummary {
   terminalCount: number;
@@ -41,7 +49,7 @@ export function selectSidebarVisiblePanelIds(
   state: SidebarPanelDerivationState
 ): Record<string, 1> {
   const result: Record<string, 1> = {};
-  for (const id of state.panelIds) {
+  for (const id of Object.keys(state.panelsById)) {
     const panel = state.panelsById[id];
     if (panel && isTerminalVisible(panel, state.isInTrash, EMPTY_WORKTREE_IDS)) {
       result[id] = 1;
@@ -55,7 +63,7 @@ export function selectSidebarAgentStateByPanelId(
   state: SidebarPanelDerivationState
 ): Record<string, AgentState> {
   const result: Record<string, AgentState> = {};
-  for (const id of state.panelIds) {
+  for (const id of Object.keys(state.panelsById)) {
     const panel = state.panelsById[id];
     if (!panel || !isPtyPanel(panel)) continue;
     const agentState = panel.agentState;

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -265,8 +265,24 @@ describe("rendererStoreOrchestrator", () => {
   it("prunes plugin panel badges for every terminal removed in one batch", () => {
     usePanelStore.setState({
       panelsById: {
-        a: { id: "a", title: "A", kind: "terminal" as const, cwd: "/", cols: 80, rows: 24 },
-        b: { id: "b", title: "B", kind: "terminal" as const, cwd: "/", cols: 80, rows: 24 },
+        a: {
+          id: "a",
+          title: "A",
+          kind: "terminal" as const,
+          cwd: "/",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+        b: {
+          id: "b",
+          title: "B",
+          kind: "terminal" as const,
+          cwd: "/",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
       },
       panelIds: ["a", "b"],
     });

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -84,6 +84,7 @@ const { useTerminalInputStore } = await import("../terminalInputStore");
 const { useConsoleCaptureStore } = await import("../consoleCaptureStore");
 const { useResourceMonitoringStore } = await import("../resourceMonitoringStore");
 const { useVoiceRecordingStore } = await import("../voiceRecordingStore");
+const { usePluginPanelBadgeStore } = await import("../pluginPanelBadgeStore");
 const { unregisterInputController } = await import("../terminalInputStore");
 const { semanticAnalysisService } = await import("@/services/SemanticAnalysisService");
 const { useCliAvailabilityStore, cleanupCliAvailabilityStore } =
@@ -114,6 +115,7 @@ describe("rendererStoreOrchestrator", () => {
     useConsoleCaptureStore.setState({ messages: new Map() });
     useResourceMonitoringStore.setState({ metrics: new Map() });
     useVoiceRecordingStore.setState({ panelBuffers: {} });
+    usePluginPanelBadgeStore.setState({ badgesByPanelId: {} });
   });
 
   afterEach(() => {
@@ -226,6 +228,58 @@ describe("rendererStoreOrchestrator", () => {
     usePanelStore.getState().removePanel(panelId);
 
     expect(useConsoleCaptureStore.getState().messages.has(panelId)).toBe(false);
+  });
+
+  it("prunes plugin panel badges when a terminal is removed", () => {
+    const panelId = "term-badge";
+
+    usePanelStore.setState({
+      panelsById: {
+        [panelId]: {
+          id: panelId,
+          title: "T",
+          kind: "terminal" as const,
+          cwd: "/test",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: [panelId],
+    });
+    usePluginPanelBadgeStore.setState({
+      badgesByPanelId: {
+        [panelId]: { "plugin-1": { kind: "dot" } },
+        keep: { "plugin-1": { kind: "dot" } },
+      },
+    });
+
+    usePanelStore.getState().removePanel(panelId);
+
+    const badges = usePluginPanelBadgeStore.getState().badgesByPanelId;
+    expect(badges[panelId]).toBeUndefined();
+    // Unrelated panels' badges survive the prune.
+    expect(badges.keep).toEqual({ "plugin-1": { kind: "dot" } });
+  });
+
+  it("prunes plugin panel badges for every terminal removed in one batch", () => {
+    usePanelStore.setState({
+      panelsById: {
+        a: { id: "a", title: "A", kind: "terminal" as const, cwd: "/", cols: 80, rows: 24 },
+        b: { id: "b", title: "B", kind: "terminal" as const, cwd: "/", cols: 80, rows: 24 },
+      },
+      panelIds: ["a", "b"],
+    });
+    usePluginPanelBadgeStore.setState({
+      badgesByPanelId: {
+        a: { "plugin-1": { kind: "dot" } },
+        b: { "plugin-1": { kind: "dot" } },
+      },
+    });
+
+    usePanelStore.setState({ panelsById: {}, panelIds: [] });
+
+    expect(usePluginPanelBadgeStore.getState().badgesByPanelId).toEqual({});
   });
 
   it("cleans up input store when terminal is removed", () => {

--- a/src/store/pluginPanelBadgeStore.test.ts
+++ b/src/store/pluginPanelBadgeStore.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { PluginPanelBadge } from "@shared/types/plugin";
+import {
+  usePluginPanelBadgeStore,
+  _resetPluginPanelBadgeStoreForTest,
+} from "./pluginPanelBadgeStore";
+
+const DOT: PluginPanelBadge = { kind: "dot", color: "success" };
+const LABEL: PluginPanelBadge = { kind: "label", text: "PR", color: "warning" };
+
+function seed(badgesByPanelId: Record<string, Record<string, PluginPanelBadge>>): void {
+  usePluginPanelBadgeStore.setState({ badgesByPanelId });
+}
+
+describe("pluginPanelBadgeStore.removePanel", () => {
+  beforeEach(() => {
+    _resetPluginPanelBadgeStoreForTest();
+  });
+
+  it("drops all badges for the removed panel and leaves other panels untouched", () => {
+    seed({
+      "panel-a": { "plugin-1": DOT, "plugin-2": LABEL },
+      "panel-b": { "plugin-1": DOT },
+    });
+
+    const untouchedBefore = usePluginPanelBadgeStore.getState().badgesByPanelId["panel-b"];
+
+    usePluginPanelBadgeStore.getState().removePanel("panel-a");
+
+    const after = usePluginPanelBadgeStore.getState().badgesByPanelId;
+    expect(after["panel-a"]).toBeUndefined();
+    expect(after["panel-b"]).toEqual({ "plugin-1": DOT });
+    // Unaffected panel keeps its object identity so its subscribers don't re-render.
+    expect(after["panel-b"]).toBe(untouchedBefore);
+  });
+
+  it("is a reference-preserving no-op when the panel has no badges", () => {
+    seed({ "panel-a": { "plugin-1": DOT } });
+    const before = usePluginPanelBadgeStore.getState().badgesByPanelId;
+
+    usePluginPanelBadgeStore.getState().removePanel("panel-missing");
+
+    // Same root reference — no spurious store notification.
+    expect(usePluginPanelBadgeStore.getState().badgesByPanelId).toBe(before);
+  });
+
+  it("removes a new map reference when a panel is pruned", () => {
+    seed({ "panel-a": { "plugin-1": DOT }, "panel-b": { "plugin-1": DOT } });
+    const before = usePluginPanelBadgeStore.getState().badgesByPanelId;
+
+    usePluginPanelBadgeStore.getState().removePanel("panel-a");
+
+    expect(usePluginPanelBadgeStore.getState().badgesByPanelId).not.toBe(before);
+    expect(Object.keys(usePluginPanelBadgeStore.getState().badgesByPanelId)).toEqual(["panel-b"]);
+  });
+});

--- a/src/store/pluginPanelBadgeStore.ts
+++ b/src/store/pluginPanelBadgeStore.ts
@@ -20,6 +20,14 @@ interface PluginPanelBadgeState {
   badgesByPanelId: BadgesByPanelId;
   /** Idempotent: subscribes to live badge updates. */
   init: () => void;
+  /**
+   * Drop all badges for a closed panel. Called from the renderer store
+   * orchestrator's terminal-removal cleanup when `panelIds` shrinks — without
+   * it a closed panel's badge entry leaks for the renderer's lifetime (#10908).
+   * Idempotent: a no-op (preserving the root reference so subscribers don't
+   * re-render) when the panel has no badges.
+   */
+  removePanel: (panelId: string) => void;
 }
 
 let initialized = false;
@@ -83,6 +91,12 @@ export const usePluginPanelBadgeStore = create<PluginPanelBadgeState>((set, get)
       set({ badgesByPanelId: applyPluginBadges(get().badgesByPanelId, pluginId, {}) });
     });
   },
+  removePanel: (panelId) =>
+    set((state) => {
+      if (!(panelId in state.badgesByPanelId)) return state;
+      const { [panelId]: _removed, ...badgesByPanelId } = state.badgesByPanelId;
+      return { badgesByPanelId };
+    }),
 }));
 
 /** Stable empty reference so panels with no badges never re-render on identity. */

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -14,6 +14,7 @@ import { semanticAnalysisService } from "@/services/SemanticAnalysisService";
 import { useConsoleCaptureStore } from "./consoleCaptureStore";
 import { useResourceMonitoringStore } from "./resourceMonitoringStore";
 import { useVoiceRecordingStore } from "./voiceRecordingStore";
+import { usePluginPanelBadgeStore } from "./pluginPanelBadgeStore";
 import { useLayoutUndoStore } from "./layoutUndoStore";
 import { useCliAvailabilityStore } from "./cliAvailabilityStore";
 import { useAgentSettingsStore } from "./agentSettingsStore";
@@ -244,6 +245,10 @@ export function initStoreOrchestrator(): () => void {
             // would otherwise leak the `metrics` Map entry. `removePanel` is a
             // no-op when the id is absent, so the double-call is safe (#9536).
             useResourceMonitoringStore.getState().removePanel(removedId);
+            // Prune the panel's plugin badge entries (#10908). Like the
+            // resource-metrics store above this leaks otherwise: badges are
+            // keyed by panelId and nothing else drops them when a panel closes.
+            usePluginPanelBadgeStore.getState().removePanel(removedId);
             useVoiceRecordingStore.getState().clearPanelBuffer(removedId);
             // Drop the dictation lock if it was pinned to this panel — panelIds
             // are ephemeral and a stale lock would silently break routing.


### PR DESCRIPTION
## Summary

- The rAF-batched panel status buffer replaces the whole `panelsById` object reference on every flush, up to 60 times a second while an agent is streaming output.
- `SidebarContent`, `ContentDock`, and `DndProvider` are always mounted and were each subscribed to the whole map, recomputing derived structures every flush.
- This narrows each subscriber to the fields it actually needs so a status change in one panel no longer fans out into O(worktrees) or O(panels) recomputes across the app.

Resolves #10908

## Changes

- `SidebarContent` derives per-worktree rollups from flat primitive `useShallow` selectors (visibility, agent state, fleet-eligibility) that only read fields the status buffer never writes. Pure derivation logic extracted into `sidebarPanelDerivation.ts` with its own unit tests for churn-safety and staleness. Selectors still iterate `panelsById` eagerly so pre-flush spawn-batched panels are still counted, preserving the behavior from #9649.
- `ContentDock` narrowed to dock-only selectors: a stable id signature drives the activity-agnostic `tabGroups` computation, a live dock-object selector fires only on dock churn (not grid-agent churn), and a trashed-panel selector replaces the old whole-map read.
- `DndProvider` reads the active drag panel via `getState()` as a drag-start snapshot instead of maintaining a live `panelsById` subscription.
- `pluginPanelBadgeStore` gains an idempotent `removePanel`, wired into the renderer store orchestrator's terminal-removal cleanup, so closed panels stop leaking plugin badge entries.

## Testing

- Full typecheck passes clean.
- Targeted vitest suites all pass: badge store, sidebar derivation, orchestrator, ContentDock, and the full Sidebar and DragDrop suites (500 tests).
- Changed files are prettier-clean; eslint reports zero errors.
- Reviewed by Codex across two passes, which found and led to fixes for two typecheck errors and two pre-flush batch-visibility regressions.