### PR TITLE
fix(pty): stop Codex agent-detection flapping and terminal scrollback loss (#10911)

### DIFF
--- a/electron/services/ProcessDetector/ProcessDetector.ts
+++ b/electron/services/ProcessDetector/ProcessDetector.ts
@@ -406,6 +406,27 @@ export class ProcessDetector {
             this.onStreak = 0;
             this.pendingDetected = null;
             gatedCommitted = true;
+
+            // Anchor runtime-promoted agents once the process tree corroborates
+            // them. A plain terminal the user typed `codex`/`claude` into starts
+            // with isLaunchAnchored=false, so process-tree-absence ticks would
+            // otherwise demote it every hysteresis window. Once tree evidence
+            // (process_tree / both) confirms a real agent process, latch the
+            // anchor so only an explicit lifecycle signal (prompt-return via
+            // clearShellCommandEvidence, or PTY exit) can demote — matching the
+            // launch-anchored contract. Shell-command-only evidence is not
+            // corroboration and must not anchor. #10911
+            if (
+              !this.isLaunchAnchored &&
+              rawAgent !== null &&
+              (this.lastEvidenceSource === "process_tree" || this.lastEvidenceSource === "both")
+            ) {
+              this.setLaunchAnchored(true);
+              logIdentityDebug(
+                `[IdentityDebug] runtime-agent-anchored term=${this.terminalId.slice(-8)} ` +
+                  `agent=${rawAgent} evidence=${this.lastEvidenceSource}`
+              );
+            }
           }
         } else if (shellStickyActive) {
           // OFF direction suppressed by fresh shell evidence — hold committed

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -1037,6 +1037,59 @@ describe("ProcessDetector", () => {
       vi.useRealTimers();
     });
 
+    it("anchors a runtime-promoted agent once the process tree corroborates it (#10911)", () => {
+      // User typed `codex` into a plain shell (no launchAgentId ⇒ isLaunchAnchored
+      // starts false). Once the process tree confirms a real codex process, the
+      // agent must become sticky so process-tree-absence ticks (idle TUI, argv
+      // rewrite) can't flap it back to a plain terminal.
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "codex", command: "codex" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-runtime-anchor",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        false
+      );
+      detector.start();
+      cache.emitRefresh(); // second poll commits via process-tree hysteresis
+      expect(detector.getLastDetected()).toBe("codex");
+      callback.mockClear();
+
+      // Empty tree would demote an un-anchored runtime promotion after the
+      // hysteresis window; anchoring must hold it instead.
+      cache.setChildren(100, []);
+      cache.emitRefresh();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBe("codex");
+      expect(callback.mock.calls.filter(([r]) => r.detectionState === "no_agent")).toHaveLength(0);
+    });
+
+    it("prompt-return still demotes a runtime-promoted agent anchored by the process tree (#10911)", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "codex", command: "codex" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-runtime-anchor-demote",
+        Date.now(),
+        100,
+        callback,
+        cache as never,
+        false
+      );
+      detector.start();
+      cache.emitRefresh();
+      expect(detector.getLastDetected()).toBe("codex");
+
+      // Explicit lifecycle signal must override the anchor.
+      detector.clearShellCommandEvidence("prompt-return");
+      expect(detector.getLastDetected()).toBeNull();
+    });
+
     it("retains expired shell-agent evidence while the PTY still has a live child", () => {
       // Real agent CLIs can rewrite argv/comm so process-tree matching never
       // corroborates the shell command, but a live child still proves the

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -1069,6 +1069,45 @@ describe("ProcessDetector", () => {
       expect(callback.mock.calls.filter(([r]) => r.detectionState === "no_agent")).toHaveLength(0);
     });
 
+    it("does not anchor a runtime-promoted agent on shell-command-only evidence (#10911)", () => {
+      // Anchoring must require process-tree corroboration. A shell-command-only
+      // commit (no matching process in the tree) must stay un-anchored so it
+      // can still demote via the off-streak path once its sticky evidence is
+      // gone — otherwise a mistyped/aliased command would stick forever.
+      const base = Date.now();
+      vi.setSystemTime(base);
+      const cache = createCacheMock();
+      cache.setChildren(100, []); // no corroborating process
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-shell-only-noanchor",
+        base,
+        100,
+        callback,
+        cache as never,
+        false
+      );
+      detector.start();
+
+      detector.injectShellCommandEvidence(
+        { agentType: "codex", processIconId: "codex", processName: "codex" },
+        "codex",
+        base
+      );
+      expect(detector.getLastDetected()).toBe("codex");
+
+      // Drop the shell evidence (manual clear keeps the committed agent but
+      // removes the sticky TTL), then let empty-tree polls run past hysteresis.
+      // An un-anchored agent must demote; an incorrectly anchored one would hold.
+      detector.clearShellCommandEvidence();
+      cache.emitRefresh();
+      cache.emitRefresh();
+      cache.emitRefresh();
+
+      expect(detector.getLastDetected()).toBeNull();
+      vi.useRealTimers();
+    });
+
     it("prompt-return still demotes a runtime-promoted agent anchored by the process tree (#10911)", () => {
       const cache = createCacheMock();
       cache.setChildren(100, [{ pid: 200, comm: "codex", command: "codex" }]);

--- a/electron/services/pty/ForegroundProcessGroupProbe.ts
+++ b/electron/services/pty/ForegroundProcessGroupProbe.ts
@@ -15,7 +15,7 @@ const FOREGROUND_SNAPSHOT_PROBE_TIMEOUT_MS = 750;
 // "Windows / unsupported" fallback branch and falsely mark the shell idle for
 // demotion. Any value where shellPgid !== foregroundPgid (and both > 0) keeps
 // the demotion gate closed; the real probe overwrites this within a few ms.
-const INITIAL_FOREGROUND_SENTINEL = Object.freeze({
+export const INITIAL_FOREGROUND_SENTINEL = Object.freeze({
   shellPgid: 1,
   foregroundPgid: 2,
 });

--- a/electron/services/pty/IdentityWatcher.ts
+++ b/electron/services/pty/IdentityWatcher.ts
@@ -20,6 +20,14 @@ const SHELL_ONLY_SINGLE_CHAR_PROMPT_PATTERN = /^\s*[$#%]\s*$/;
 const AGENT_ONLY_SINGLE_CHAR_PROMPT_PATTERN = /^\s*[>❯›]\s*$/;
 const POSIX_USER_HOST_PROMPT_PATTERN = /^\s*[A-Za-z0-9_.-]+@\S+(?:\s+[^\r\n]*)?\s*[#$%>]\s*$/;
 const DECORATED_SHELL_PROMPT_PATTERN = /^\s*[➜➤➟➔❯›]\s+.*$/;
+// Same as above but without the `❯`/`›` glyphs. While an agent owns the
+// terminal those glyphs are the agent's own composer/input prompt (Codex uses
+// `›`, Claude uses `❯`), not a returned shell prompt — matching them there let
+// agent echo lines masquerade as a prompt return and demote a live agent
+// (#10911). Real oh-my-zsh prompts (`➜` etc.) still count. The process-group
+// probe and process-tree evidence are the authoritative demotion signals while
+// an agent is committed.
+const DECORATED_SHELL_PROMPT_PATTERN_NO_AGENT_GLYPHS = /^\s*[➜➤➟➔]\s+.*$/;
 const MAC_BASH_PROMPT_PATTERN = /^\s*\S+:\S+\s+\S+\s*[#$%>]\s*$/;
 const POWERSHELL_PROMPT_PATTERN = /^\s*PS\s+\S.*>\s*$/i;
 
@@ -37,6 +45,16 @@ const SHELL_PROMPT_PATTERNS = [
   POWERSHELL_PROMPT_PATTERN,
 ] as const;
 
+// Same as SHELL_PROMPT_PATTERNS but with the decorated pattern swapped for the
+// variant that ignores the `❯`/`›` agent-composer glyphs. Used by the poll's
+// prompt scan while an agent is committed so a Codex/Claude composer line can't
+// register as a returned shell prompt. #10911
+const SHELL_PROMPT_PATTERNS_NO_AGENT_GLYPHS = SHELL_PROMPT_PATTERNS.map((pattern) =>
+  pattern === DECORATED_SHELL_PROMPT_PATTERN
+    ? DECORATED_SHELL_PROMPT_PATTERN_NO_AGENT_GLYPHS
+    : pattern
+);
+
 const UNAMBIGUOUS_SHELL_PROMPT_PATTERNS = [
   SHELL_ONLY_SINGLE_CHAR_PROMPT_PATTERN,
   POSIX_USER_HOST_PROMPT_PATTERN,
@@ -47,12 +65,18 @@ const UNAMBIGUOUS_SHELL_PROMPT_PATTERNS = [
 const ACTIVE_AGENT_PROMPT_PATTERN =
   /(?:welcome to claude code|claude code v\d|tips for getting started|\?\s+for\s+shortcuts|welcome\s+back!)/i;
 
-function isUnambiguousShellPromptLine(line: string | undefined): boolean {
+function isUnambiguousShellPromptLine(line: string | undefined, agentCommitted = false): boolean {
   if (line === undefined) return false;
   if (UNAMBIGUOUS_SHELL_PROMPT_PATTERNS.some((pattern) => pattern.test(line))) {
     return true;
   }
-  return DECORATED_SHELL_PROMPT_PATTERN.test(line) && !/^\s*[>❯›]\s+\d+\./.test(line);
+  // While an agent is committed, `❯`/`›` are agent chrome rather than a shell
+  // prompt — exclude them so an agent composer line can't trigger a false
+  // prompt-return demotion. #10911
+  const decorated = agentCommitted
+    ? DECORATED_SHELL_PROMPT_PATTERN_NO_AGENT_GLYPHS
+    : DECORATED_SHELL_PROMPT_PATTERN;
+  return decorated.test(line) && !/^\s*[>❯›]\s+\d+\./.test(line);
 }
 
 // Locale-independent fallback signals for "command not found" detection. POSIX
@@ -129,6 +153,12 @@ export class IdentityWatcher {
   private committed = false;
   private promptStreak = 0;
   private sawPtyDescendant = false;
+  // Latched once the foreground-PGID probe returns a usable reading on this
+  // terminal, so a later null read is treated as a transient failure (fail
+  // closed while an agent is committed) rather than an unsupported platform.
+  // Persists across stop()/re-arm — the probe's availability is a property of
+  // the terminal, not of a single command. #10911
+  private sawForegroundSnapshot = false;
   private suppressNext = false;
   private inputBuffer = "";
   // ESC parser state, persisted across captureInput calls so a VT sequence
@@ -376,9 +406,11 @@ export class IdentityWatcher {
       return;
     }
 
+    // We only reach here past the guard above, so an agent identity is
+    // committed — exclude the agent's own `❯`/`›` glyphs from prompt matching.
     if (
       !this.hasRecentCommandFailureOutput() &&
-      this.hasUnambiguousShellPromptInText(data) &&
+      this.hasUnambiguousShellPromptInText(data, true) &&
       !this.hasAgentUiPromptFalsePositive(false)
     ) {
       this.clearShellCommandEvidenceAfterPromptReturn();
@@ -430,7 +462,7 @@ export class IdentityWatcher {
     return COMMAND_NOT_FOUND_REGEX.test(recent);
   }
 
-  private hasUnambiguousShellPromptVisible(): boolean {
+  private hasUnambiguousShellPromptVisible(agentCommitted = false): boolean {
     const lines = this.delegate.getLastNLines(SHELL_IDENTITY_FALLBACK_SCAN_LINES);
     const lastVisibleLine = [...lines]
       .reverse()
@@ -440,9 +472,9 @@ export class IdentityWatcher {
       .reverse()
       .find((line) => line.trim().length > 0);
     return (
-      isUnambiguousShellPromptLine(cursorLine ?? undefined) ||
-      isUnambiguousShellPromptLine(lastVisibleLine) ||
-      isUnambiguousShellPromptLine(recentOutputLine)
+      isUnambiguousShellPromptLine(cursorLine ?? undefined, agentCommitted) ||
+      isUnambiguousShellPromptLine(lastVisibleLine, agentCommitted) ||
+      isUnambiguousShellPromptLine(recentOutputLine, agentCommitted)
     );
   }
 
@@ -452,8 +484,10 @@ export class IdentityWatcher {
     return this.getOutputTailLines(recentOutput);
   }
 
-  private hasUnambiguousShellPromptInText(text: string): boolean {
-    return this.getOutputTailLines(text).some((line) => isUnambiguousShellPromptLine(line));
+  private hasUnambiguousShellPromptInText(text: string, agentCommitted = false): boolean {
+    return this.getOutputTailLines(text).some((line) =>
+      isUnambiguousShellPromptLine(line, agentCommitted)
+    );
   }
 
   private getOutputTailLines(text: string): string[] {
@@ -493,20 +527,33 @@ export class IdentityWatcher {
     readonly supported: boolean;
   } {
     const snapshot = this.delegate.readForegroundProcessGroupSnapshot();
-    if (!snapshot) {
-      // Non-POSIX and unsupported environments fall back to the legacy prompt
-      // path. On macOS/Linux this snapshot is the authoritative demotion gate.
-      return { shellIdle: true, supported: false };
+    if (snapshot && snapshot.shellPgid > 0 && snapshot.foregroundPgid > 0) {
+      // A usable reading exists. Record that the probe works on this terminal so
+      // a later null read is recognized as a transient failure rather than an
+      // unsupported platform (see fail-closed branch below).
+      this.sawForegroundSnapshot = true;
+      return {
+        shellIdle: snapshot.shellPgid === snapshot.foregroundPgid,
+        supported: true,
+      };
     }
 
-    if (snapshot.shellPgid <= 0 || snapshot.foregroundPgid <= 0) {
-      return { shellIdle: true, supported: false };
+    // No usable snapshot. Two distinct cases:
+    //  - The probe never produced a reading (Windows, or non-positive pgids):
+    //    it is unsupported here, so fall back to the legacy prompt / child-exit
+    //    path (supported:false) — matches prior behavior.
+    //  - The probe has worked before and just returned null (ps timeout, exit
+    //    race): a transient stale window. While an agent is committed, FAIL
+    //    CLOSED — treat the unknown foreground state as "child still active" so
+    //    a stale-probe window can't let a false prompt match demote a live
+    //    agent (#10911). PTY exit and a fresh idle snapshot remain the
+    //    authoritative demotion signals.
+    const agentCommitted =
+      Boolean(this.identity?.agentType) || Boolean(this.delegate.detectedAgentId);
+    if (this.sawForegroundSnapshot && agentCommitted) {
+      return { shellIdle: false, supported: true };
     }
-
-    return {
-      shellIdle: snapshot.shellPgid === snapshot.foregroundPgid,
-      supported: true,
-    };
+    return { shellIdle: true, supported: false };
   }
 
   private poll(): void {
@@ -539,13 +586,17 @@ export class IdentityWatcher {
       this.sawPtyDescendant = true;
     }
 
-    const unambiguousShellPromptVisible = this.hasUnambiguousShellPromptVisible();
+    const agentCommitted =
+      Boolean(this.identity?.agentType) || Boolean(this.delegate.detectedAgentId);
+    const unambiguousShellPromptVisible = this.hasUnambiguousShellPromptVisible(agentCommitted);
     const promptVisible =
       unambiguousShellPromptVisible ||
       detectPrompt(
         this.delegate.getLastNLines(SHELL_IDENTITY_FALLBACK_SCAN_LINES),
         {
-          promptPatterns: [...SHELL_PROMPT_PATTERNS],
+          promptPatterns: agentCommitted
+            ? [...SHELL_PROMPT_PATTERNS_NO_AGENT_GLYPHS]
+            : [...SHELL_PROMPT_PATTERNS],
           promptHintPatterns: [],
           promptScanLineCount: SHELL_IDENTITY_FALLBACK_SCAN_LINES,
           promptConfidence: 0.85,

--- a/electron/services/pty/IdentityWatcher.ts
+++ b/electron/services/pty/IdentityWatcher.ts
@@ -7,6 +7,7 @@ import {
 } from "../ProcessDetector.js";
 import { stripAnsi } from "./AgentPatternDetector.js";
 import { detectPrompt } from "./PromptDetector.js";
+import { INITIAL_FOREGROUND_SENTINEL } from "./ForegroundProcessGroupProbe.js";
 import { MutableDisposable, toDisposable, type IDisposable } from "../../utils/lifecycle.js";
 
 export const SHELL_IDENTITY_FALLBACK_COMMIT_MS = 1200;
@@ -528,10 +529,16 @@ export class IdentityWatcher {
   } {
     const snapshot = this.delegate.readForegroundProcessGroupSnapshot();
     if (snapshot && snapshot.shellPgid > 0 && snapshot.foregroundPgid > 0) {
-      // A usable reading exists. Record that the probe works on this terminal so
-      // a later null read is recognized as a transient failure rather than an
-      // unsupported platform (see fail-closed branch below).
-      this.sawForegroundSnapshot = true;
+      // Record that the probe genuinely works on this terminal so a later null
+      // read is recognized as a transient failure rather than an unsupported
+      // platform (see fail-closed branch below). The warm-up sentinel is a
+      // synthetic placeholder, not proof the probe succeeded — latching on it
+      // would fail closed forever on a box where `ps` never resolves, so it is
+      // excluded here (identity compare: the probe returns the frozen singleton
+      // by reference). #10911
+      if (snapshot !== INITIAL_FOREGROUND_SENTINEL) {
+        this.sawForegroundSnapshot = true;
+      }
       return {
         shellIdle: snapshot.shellPgid === snapshot.foregroundPgid,
         supported: true,

--- a/electron/services/pty/__tests__/IdentityWatcher.test.ts
+++ b/electron/services/pty/__tests__/IdentityWatcher.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IdentityWatcher, type IdentityWatcherDelegate } from "../IdentityWatcher.js";
 import type { ProcessDetector } from "../../ProcessDetector.js";
+import { INITIAL_FOREGROUND_SENTINEL } from "../ForegroundProcessGroupProbe.js";
 
 interface FakeDelegateState {
   isExited: boolean;
@@ -1506,6 +1507,58 @@ describe("IdentityWatcher", () => {
       state.cursorLine = "user@host daintree % ";
       watcher.observeOutput("user@host daintree % \n");
       await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(clear).not.toHaveBeenCalledWith("prompt-return");
+      expect(watcher.isFallbackCommitted).toBe(true);
+      watcher.dispose();
+    });
+
+    it("falls open (legacy path) when the probe only ever returned the warm-up sentinel", async () => {
+      // Regression guard for the sentinel latch: during warm-up the probe hands
+      // back INITIAL_FOREGROUND_SENTINEL (synthetic, not a real reading). If the
+      // real `ps` probe then never resolves and returns null, the terminal must
+      // fall back to the legacy prompt path — NOT fail closed forever — because
+      // the probe was never actually confirmed to work here. #10911
+      const { delegate, state, clear } = makeCommittedCodexWatcher({
+        foreground: INITIAL_FOREGROUND_SENTINEL,
+      });
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("codex");
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(watcher.isFallbackCommitted).toBe(true);
+
+      state.foreground = null; // real probe died before ever succeeding
+      state.visibleLines = ["Codex exited", "user@host daintree % "];
+      state.cursorLine = "user@host daintree % ";
+      state.ptyDescendantCount = 0;
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(clear).toHaveBeenCalledWith("prompt-return");
+      watcher.dispose();
+    });
+
+    it("does not treat bare or numbered `›`/`❯` agent lines as a prompt while committed", async () => {
+      const { delegate, state, clear } = makeCommittedCodexWatcher();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("codex");
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(watcher.isFallbackCommitted).toBe(true);
+
+      state.foreground = { shellPgid: 123, foregroundPgid: 123 };
+      for (const line of [
+        "›",
+        "❯",
+        "❯ write the tests",
+        "› 1. first option",
+        "> 1. first option",
+      ]) {
+        state.visibleLines = ["Codex ready", line];
+        state.cursorLine = line;
+        watcher.observeOutput(`${line}\n`);
+      }
+      await vi.advanceTimersByTimeAsync(400);
 
       expect(clear).not.toHaveBeenCalledWith("prompt-return");
       expect(watcher.isFallbackCommitted).toBe(true);

--- a/electron/services/pty/__tests__/IdentityWatcher.test.ts
+++ b/electron/services/pty/__tests__/IdentityWatcher.test.ts
@@ -1426,4 +1426,110 @@ describe("IdentityWatcher", () => {
       expect(watcher.hasAgentUiPromptFalsePositive()).toBe(true);
     });
   });
+
+  describe("Codex agent-detection flap hardening (#10911)", () => {
+    function makeCommittedCodexWatcher(
+      overrides: Partial<Parameters<typeof createFakeDelegate>[0]> = {}
+    ) {
+      const inject = vi.fn();
+      const clear = vi.fn();
+      const fakeDetector = {
+        injectShellCommandEvidence: inject,
+        clearShellCommandEvidence: clear,
+      } as unknown as ProcessDetector;
+      const { delegate, state } = createFakeDelegate({
+        processDetector: fakeDetector,
+        visibleLines: ["codex", "Codex ready"],
+        cursorLine: "Codex ready",
+        ptyDescendantCount: 1,
+        // A valid foreground snapshot (child active) during commit both keeps
+        // the agent from demoting and latches sawForegroundSnapshot so a later
+        // null read is treated as a transient failure.
+        foreground: { shellPgid: 123, foregroundPgid: 456 },
+        ...overrides,
+      });
+      return { delegate, state, clear, inject };
+    }
+
+    it("does not demote on a Codex `›` composer line while the shell is idle", async () => {
+      const { delegate, state, clear } = makeCommittedCodexWatcher();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("codex");
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(watcher.isFallbackCommitted).toBe(true);
+
+      // Foreground genuinely reports idle, but the visible tail is Codex's own
+      // composer echo — the `›` glyph must NOT count as a returned prompt.
+      state.foreground = { shellPgid: 123, foregroundPgid: 123 };
+      state.visibleLines = ["Codex ready", "› draft a commit message"];
+      state.cursorLine = "› draft a commit message";
+      watcher.observeOutput("› draft a commit message\n");
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(clear).not.toHaveBeenCalledWith("prompt-return");
+      expect(watcher.isFallbackCommitted).toBe(true);
+      watcher.dispose();
+    });
+
+    it("still demotes on a real oh-my-zsh `➜` prompt while committed (exclusion is surgical)", async () => {
+      const { delegate, state, clear } = makeCommittedCodexWatcher();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("codex");
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(watcher.isFallbackCommitted).toBe(true);
+
+      state.foreground = { shellPgid: 123, foregroundPgid: 123 };
+      state.visibleLines = ["Codex ready", "➜  my-repo git:(main)"];
+      state.cursorLine = "➜  my-repo git:(main)";
+      state.ptyDescendantCount = 0;
+      watcher.observeOutput("➜  my-repo git:(main)\n");
+
+      expect(clear).toHaveBeenCalledWith("prompt-return");
+      watcher.dispose();
+    });
+
+    it("fails closed on a transient null foreground snapshot instead of demoting", async () => {
+      const { delegate, state, clear } = makeCommittedCodexWatcher();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("codex");
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(watcher.isFallbackCommitted).toBe(true);
+
+      // Probe goes stale/null (ps timeout) right as a real-looking shell prompt
+      // scrolls by. Because the probe worked before, this is a transient window
+      // and must hold the agent rather than demote on ambiguous state.
+      state.foreground = null;
+      state.visibleLines = ["Codex ready", "user@host daintree % "];
+      state.cursorLine = "user@host daintree % ";
+      watcher.observeOutput("user@host daintree % \n");
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(clear).not.toHaveBeenCalledWith("prompt-return");
+      expect(watcher.isFallbackCommitted).toBe(true);
+      watcher.dispose();
+    });
+
+    it("still demotes on a genuine idle shell after the agent exits", async () => {
+      const { delegate, state, clear } = makeCommittedCodexWatcher();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("codex");
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(watcher.isFallbackCommitted).toBe(true);
+
+      // Real exit: foreground ownership returns to the shell and the child is
+      // gone. A fresh idle snapshot is authoritative — demotion must proceed.
+      state.foreground = { shellPgid: 123, foregroundPgid: 123 };
+      state.visibleLines = ["Codex exited", "user@host daintree % "];
+      state.cursorLine = "user@host daintree % ";
+      state.ptyDescendantCount = 0;
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(clear).toHaveBeenCalledWith("prompt-return");
+      watcher.dispose();
+    });
+  });
 });

--- a/src/services/terminal/TerminalScrollbackController.ts
+++ b/src/services/terminal/TerminalScrollbackController.ts
@@ -70,6 +70,8 @@ export function restoreScrollback(managed: ManagedTerminal): void {
   const { performanceMode } = usePerformanceModeStore.getState();
 
   if (performanceMode) {
+    // Deliberate memory downshift — apply it unconditionally, matching the
+    // `force` path of reduceScrollback used by bulk memory-pressure actions.
     writeScrollback(managed, PERFORMANCE_MODE_SCROLLBACK);
     return;
   }
@@ -81,6 +83,38 @@ export function restoreScrollback(managed: ManagedTerminal): void {
       )
     : undefined;
   const globalScrollback = getValidScrollbackBase(scrollbackLines) ?? 0;
+  const targetLines = getScrollbackForType(isAgent, projectScrollback ?? globalScrollback);
 
-  writeScrollback(managed, getScrollbackForType(isAgent, projectScrollback ?? globalScrollback));
+  // Growth (agent promotion, resource-tier upgrade) is non-destructive — always
+  // apply it. A shrink, though, synchronously and irreversibly evicts the
+  // oldest buffer lines in xterm (same primitive as reduceScrollback). When
+  // this "restore" would actually drop history — e.g. an agent→plain demotion
+  // during a detection flap where the plain target is smaller than the agent
+  // ceiling — apply the same protections as reduceScrollback so a focused,
+  // selecting, or scrolled-back user doesn't lose scrollback to transient
+  // flapping. #10911
+  const currentScrollback = readScrollback(managed);
+  if (targetLines < currentScrollback) {
+    const scrollbackUsed = managed.terminal.buffer.active.length - managed.terminal.rows;
+    const wouldEvict = scrollbackUsed > targetLines;
+    if (wouldEvict) {
+      if (managed.isFocused) return;
+      if (managed.isUserScrolledBack) return;
+      if (managed.isAltBuffer) return;
+      if (managed.terminal.hasSelection()) return;
+
+      const lastReduceAt = managed.lastScrollbackReduceAt;
+      if (lastReduceAt !== undefined && Date.now() - lastReduceAt < SCROLLBACK_REDUCE_COOLDOWN_MS) {
+        return;
+      }
+    }
+
+    writeScrollback(managed, targetLines);
+    if (wouldEvict) {
+      managed.lastScrollbackReduceAt = Date.now();
+    }
+    return;
+  }
+
+  writeScrollback(managed, targetLines);
 }

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -269,5 +269,100 @@ describe("TerminalScrollbackController", () => {
       restoreScrollback(managed);
       expect(managed.terminal.options.scrollback).toBe(5000);
     });
+
+    // #10911 — a demotion flap (agent→plain) calls restoreScrollback with a
+    // smaller plain target. That write irreversibly evicts scrollback in
+    // xterm, so it must respect the same protections as reduceScrollback when
+    // history would actually be dropped. Growth must stay unguarded.
+    describe("destructive shrink guard (#10911)", () => {
+      function setBufferLength(managed: ManagedTerminal, length: number): void {
+        (managed.terminal.buffer.active as unknown as { length: number }).length = length;
+      }
+
+      it("skips a demotion shrink for a focused terminal (preserves history)", () => {
+        const managed = makeMockManaged({ isFocused: true });
+        managed.terminal.options.scrollback = 5000; // was an agent
+        setBufferLength(managed, 5000);
+
+        restoreScrollback(managed); // plain target is 1500
+        expect(managed.terminal.options.scrollback).toBe(5000);
+        expect(managed.lastScrollbackReduceAt).toBeUndefined();
+      });
+
+      it("skips a demotion shrink when the user has scrolled back", () => {
+        const managed = makeMockManaged({ isUserScrolledBack: true });
+        managed.terminal.options.scrollback = 5000;
+        setBufferLength(managed, 5000);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(5000);
+      });
+
+      it("skips a demotion shrink in alt-buffer mode", () => {
+        const managed = makeMockManaged({ isAltBuffer: true });
+        managed.terminal.options.scrollback = 5000;
+        setBufferLength(managed, 5000);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(5000);
+      });
+
+      it("skips a demotion shrink with an active text selection", () => {
+        const managed = makeMockManaged();
+        managed.terminal.hasSelection = vi.fn(() => true);
+        managed.terminal.options.scrollback = 5000;
+        setBufferLength(managed, 5000);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(5000);
+      });
+
+      it("applies the shrink and stamps the cooldown for an idle background terminal", () => {
+        const managed = makeMockManaged();
+        managed.terminal.options.scrollback = 5000;
+        setBufferLength(managed, 5000);
+        const before = Date.now();
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(1500);
+        expect(managed.lastScrollbackReduceAt).toBeGreaterThanOrEqual(before);
+      });
+
+      it("shrinks even a focused terminal when no lines would be evicted", () => {
+        const managed = makeMockManaged({ isFocused: true });
+        managed.terminal.options.scrollback = 5000;
+        setBufferLength(managed, 100); // scrollbackUsed (76) < 1500 target
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(1500);
+        // Non-destructive shrink is not a "reduce" — leave the cooldown alone.
+        expect(managed.lastScrollbackReduceAt).toBeUndefined();
+      });
+
+      it("respects the reduce cooldown for destructive shrinks", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          const managed = makeMockManaged();
+          managed.lastScrollbackReduceAt = 10_000;
+          managed.terminal.options.scrollback = 5000;
+          setBufferLength(managed, 5000);
+
+          nowSpy.mockReturnValue(11_000); // 1000ms later, inside 2000ms cooldown
+          restoreScrollback(managed);
+          expect(managed.terminal.options.scrollback).toBe(5000);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
+
+      it("never guards a growth restore even when focused", () => {
+        const managed = makeMockManaged({ isFocused: true });
+        managed.terminal.options.scrollback = 500; // below plain target 1500
+        setBufferLength(managed, 5000);
+
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(1500);
+      });
+    });
   });
 });

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { reduceScrollback, restoreScrollback } from "../TerminalScrollbackController";
-import type { ManagedTerminal } from "../types";
+import { type ManagedTerminal, SCROLLBACK_REDUCE_COOLDOWN_MS } from "../types";
+import { getScrollbackForType } from "@/utils/scrollbackConfig";
 import { logInfo } from "@/utils/logger";
 
 const mockScrollbackStore = { scrollbackLines: 5000 };
@@ -275,66 +276,73 @@ describe("TerminalScrollbackController", () => {
     // xterm, so it must respect the same protections as reduceScrollback when
     // history would actually be dropped. Growth must stay unguarded.
     describe("destructive shrink guard (#10911)", () => {
+      // Derived, not copied: the plain-terminal target is whatever the policy
+      // computes for the current global setting. A "large current" above that
+      // target stands in for the pre-demotion agent-era scrollback.
+      const plainTarget = getScrollbackForType(false, 5000);
+      const largeCurrent = plainTarget * 3;
+
       function setBufferLength(managed: ManagedTerminal, length: number): void {
         (managed.terminal.buffer.active as unknown as { length: number }).length = length;
       }
 
       it("skips a demotion shrink for a focused terminal (preserves history)", () => {
         const managed = makeMockManaged({ isFocused: true });
-        managed.terminal.options.scrollback = 5000; // was an agent
-        setBufferLength(managed, 5000);
+        managed.terminal.options.scrollback = largeCurrent; // was an agent
+        setBufferLength(managed, largeCurrent);
 
-        restoreScrollback(managed); // plain target is 1500
-        expect(managed.terminal.options.scrollback).toBe(5000);
+        restoreScrollback(managed);
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
         expect(managed.lastScrollbackReduceAt).toBeUndefined();
       });
 
       it("skips a demotion shrink when the user has scrolled back", () => {
         const managed = makeMockManaged({ isUserScrolledBack: true });
-        managed.terminal.options.scrollback = 5000;
-        setBufferLength(managed, 5000);
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(5000);
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
       });
 
       it("skips a demotion shrink in alt-buffer mode", () => {
         const managed = makeMockManaged({ isAltBuffer: true });
-        managed.terminal.options.scrollback = 5000;
-        setBufferLength(managed, 5000);
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(5000);
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
       });
 
       it("skips a demotion shrink with an active text selection", () => {
         const managed = makeMockManaged();
         managed.terminal.hasSelection = vi.fn(() => true);
-        managed.terminal.options.scrollback = 5000;
-        setBufferLength(managed, 5000);
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(5000);
+        expect(managed.terminal.options.scrollback).toBe(largeCurrent);
       });
 
       it("applies the shrink and stamps the cooldown for an idle background terminal", () => {
         const managed = makeMockManaged();
-        managed.terminal.options.scrollback = 5000;
-        setBufferLength(managed, 5000);
+        managed.terminal.options.scrollback = largeCurrent;
+        setBufferLength(managed, largeCurrent);
         const before = Date.now();
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(1500);
+        expect(managed.terminal.options.scrollback).toBe(plainTarget);
         expect(managed.lastScrollbackReduceAt).toBeGreaterThanOrEqual(before);
       });
 
       it("shrinks even a focused terminal when no lines would be evicted", () => {
         const managed = makeMockManaged({ isFocused: true });
-        managed.terminal.options.scrollback = 5000;
-        setBufferLength(managed, 100); // scrollbackUsed (76) < 1500 target
+        managed.terminal.options.scrollback = largeCurrent;
+        // Used scrollback well below the target ⇒ shrink drops nothing.
+        setBufferLength(managed, managed.terminal.rows + 10);
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(1500);
+        expect(managed.terminal.options.scrollback).toBe(plainTarget);
         // Non-destructive shrink is not a "reduce" — leave the cooldown alone.
         expect(managed.lastScrollbackReduceAt).toBeUndefined();
       });
@@ -344,12 +352,12 @@ describe("TerminalScrollbackController", () => {
         try {
           const managed = makeMockManaged();
           managed.lastScrollbackReduceAt = 10_000;
-          managed.terminal.options.scrollback = 5000;
-          setBufferLength(managed, 5000);
+          managed.terminal.options.scrollback = largeCurrent;
+          setBufferLength(managed, largeCurrent);
 
-          nowSpy.mockReturnValue(11_000); // 1000ms later, inside 2000ms cooldown
+          nowSpy.mockReturnValue(10_000 + SCROLLBACK_REDUCE_COOLDOWN_MS - 1); // still inside cooldown
           restoreScrollback(managed);
-          expect(managed.terminal.options.scrollback).toBe(5000);
+          expect(managed.terminal.options.scrollback).toBe(largeCurrent);
         } finally {
           nowSpy.mockRestore();
         }
@@ -357,11 +365,11 @@ describe("TerminalScrollbackController", () => {
 
       it("never guards a growth restore even when focused", () => {
         const managed = makeMockManaged({ isFocused: true });
-        managed.terminal.options.scrollback = 500; // below plain target 1500
-        setBufferLength(managed, 5000);
+        managed.terminal.options.scrollback = Math.floor(plainTarget / 3); // below target ⇒ grow
+        setBufferLength(managed, largeCurrent);
 
         restoreScrollback(managed);
-        expect(managed.terminal.options.scrollback).toBe(1500);
+        expect(managed.terminal.options.scrollback).toBe(plainTarget);
       });
     });
   });

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -283,7 +283,10 @@ describe("TerminalScrollbackController", () => {
       const largeCurrent = plainTarget * 3;
 
       function setBufferLength(managed: ManagedTerminal, length: number): void {
-        (managed.terminal.buffer.active as unknown as { length: number }).length = length;
+        Object.defineProperty(managed.terminal.buffer.active, "length", {
+          value: length,
+          writable: true,
+        });
       }
 
       it("skips a demotion shrink for a focused terminal (preserves history)", () => {


### PR DESCRIPTION
## Summary

Codex CLI terminals were intermittently flapping between "detected as agent" and "plain terminal", and every flip destroyed the terminal's xterm scrollback. Root cause was a transient null foreground-PGID probe opening the demotion gate, combined with Codex's composer glyphs matching the shell-prompt heuristic and `restoreScrollback` having none of the guards its sibling `reduceScrollback` has.

Resolves #10911

## Changes

1. **`IdentityWatcher` fails closed on a transient null foreground-PGID probe while an agent identity is committed.** A latched `sawForegroundSnapshot` flag (excluding the warm-up sentinel) distinguishes a probe that never worked (Windows/unsupported, still fails open) from one that worked and then went stale (now fails closed).
2. **Shell-prompt matching excludes the agent composer glyphs `›`/`❯` while an agent identity is committed**, so a Codex composer line can't masquerade as a returned shell prompt. Real oh-my-zsh `➜` prompts still count.
3. **Runtime-promoted agents are anchored via `ProcessDetector.setLaunchAnchored(true)`** once process-tree evidence corroborates them, so process-tree-absence ticks can't flap them. Prompt-return still demotes normally.
4. **`restoreScrollback` is guarded against destructive (evicting) shrinks** with the same focus/scroll/alt-buffer/selection/cooldown checks `reduceScrollback` already had. Growth and non-evicting shrinks stay unguarded.

The issue's proposed fifth change (a dedicated keep-warm timer for the probe) was left out intentionally, it's over-engineering here. Change 1 already neutralizes the stale-probe demotion gate, and the existing 200ms poll plus per-output `observeOutput` already refresh the probe during active agent output.

## Testing

Added 8 `IdentityWatcher` test cases, 3 `ProcessDetector` test cases, and 8 `TerminalScrollbackController` test cases. Full targeted suites pass (267 tests).