### PR TITLE
fix(terminal): keep invalid slash-command drafts editable

### DIFF
--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -1743,18 +1743,93 @@ describe("two-press Backspace on /slash chips", () => {
     view.destroy();
   });
 
-  it("two-press also works for invalid /slash commands (still atomic)", () => {
+  it("does not solidify an invalid /slash command into an atomic chip", () => {
     const map = new Map<string, SlashCommand>();
     const view = makeView("/unknowncmd ", map);
     const chipEnd = "/unknowncmd".length;
     view.dispatch({ selection: { anchor: chipEnd } });
 
-    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
-    expect(view.state.doc.toString()).toBe("/unknowncmd ");
-    expect(view.state.field(chipPendingDeleteField)).toEqual({ from: 0, to: chipEnd });
+    // A still-draft / mistyped command stays plain editable text: Backspace must
+    // NOT stage-and-select the whole token. The chip binding declines (returns
+    // false) so the event falls through to the default keymap, which deletes one
+    // character in the real editor; the jsdom harness has no default keymap, so
+    // we assert the binding declined and nothing was staged.
+    const handled = runScopeHandlers(
+      view,
+      new KeyboardEvent("keydown", { key: "Backspace" }),
+      "editor"
+    );
+    expect(handled).toBe(false);
+    expect(view.state.field(chipPendingDeleteField)).toBeNull();
+    expect(view.state.selection.main.empty).toBe(true);
 
-    runScopeHandlers(view, new KeyboardEvent("keydown", { key: "Backspace" }), "editor");
-    expect(view.state.doc.toString()).toBe(" ");
+    // The invalid token is not registered as an atomic range.
+    let covered = false;
+    for (const getRanges of view.state.facet(EditorView.atomicRanges)) {
+      getRanges(view).between(0, chipEnd, () => {
+        covered = true;
+        return false;
+      });
+    }
+    expect(covered).toBe(false);
+
+    // It renders as an editable mark (the "no match" hint), not a replace widget.
+    expect(view.dom.querySelector('[role="img"]')).toBeNull();
+    expect(view.dom.querySelector(".cm-slash-command-chip-invalid")).not.toBeNull();
+    view.destroy();
+  });
+
+  it("still solidifies a valid /slash command into an atomic chip", () => {
+    const map = new Map<string, SlashCommand>([["/build", makeSlashCommand("/build")]]);
+    const view = makeView("/build ", map);
+    const chipEnd = "/build".length;
+    view.dispatch({ selection: { anchor: chipEnd } });
+
+    let covered = false;
+    for (const getRanges of view.state.facet(EditorView.atomicRanges)) {
+      getRanges(view).between(0, chipEnd, () => {
+        covered = true;
+        return false;
+      });
+    }
+    expect(covered).toBe(true);
+    view.destroy();
+  });
+
+  it("renders a mixed valid + invalid doc: widget for valid, editable mark for invalid", () => {
+    // Exercises the combined decoration set (a replace widget and a plain mark
+    // in the same Decoration.set) plus the atomicRanges split.
+    const map = new Map<string, SlashCommand>([["/build", makeSlashCommand("/build")]]);
+    const view = makeView("/build /unknowncmd", map);
+
+    // Exactly one solidified chip widget, for the valid command.
+    const widgets = view.dom.querySelectorAll('[role="img"]');
+    expect(widgets).toHaveLength(1);
+    expect(widgets[0]?.textContent).toBe("/build");
+
+    // The invalid token renders as an editable "no match" mark, not a widget.
+    expect(view.dom.querySelector(".cm-slash-command-chip-invalid")?.textContent).toBe(
+      "/unknowncmd"
+    );
+
+    const coversRange = (from: number, to: number) => {
+      let covered = false;
+      for (const getRanges of view.state.facet(EditorView.atomicRanges)) {
+        getRanges(view).between(from, to, (rFrom, rTo) => {
+          if (rFrom === from && rTo === to) {
+            covered = true;
+            return false;
+          }
+          return undefined;
+        });
+      }
+      return covered;
+    };
+
+    // Only the valid command is atomic.
+    expect(coversRange(0, "/build".length)).toBe(true);
+    const invalidStart = "/build ".length;
+    expect(coversRange(invalidStart, invalidStart + "/unknowncmd".length)).toBe(false);
     view.destroy();
   });
 });

--- a/src/components/Terminal/inputEditorExtensions/slashChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/slashChip.ts
@@ -73,6 +73,16 @@ export function createSlashChipField(config: SlashChipFieldConfig) {
         if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
         const pending = view.state.field(chipPendingDeleteField, false) ?? null;
         const ranges = fieldValue.tokens.map((token) => {
+          // Only a recognized command solidifies into an atomic chip. A token
+          // that's still being typed or mistyped stays plain editable text
+          // (single-char Backspace) with just a "no match" hint, so a finger
+          // slip is fixable instead of nuking the whole draft.
+          if (!token.isValid) {
+            return Decoration.mark({ class: "cm-slash-command-chip-invalid" }).range(
+              token.start,
+              token.end
+            );
+          }
           const selected = isChipSelected(pending, token.start, token.end);
           return Decoration.replace({
             widget: new SlashChipWidget(token.command, token.isValid, selected),
@@ -83,7 +93,10 @@ export function createSlashChipField(config: SlashChipFieldConfig) {
       EditorView.atomicRanges.of((view) => {
         const fieldValue = view.state.field(f, false);
         if (!fieldValue || fieldValue.tokens.length === 0) return Decoration.none;
-        const ranges = fieldValue.tokens.map((t) => Decoration.mark({}).range(t.start, t.end));
+        const ranges = fieldValue.tokens
+          .filter((t) => t.isValid)
+          .map((t) => Decoration.mark({}).range(t.start, t.end));
+        if (ranges.length === 0) return Decoration.none;
         return Decoration.set(ranges, true);
       }),
     ],


### PR DESCRIPTION
When a slash command is entered in the prompt input, it renders as a single atomic block: the first Backspace selects the whole token, and the second deletes it.

The problem is that this also applied to commands that were still being typed or were mistyped. So a user would type `/issbe` instead of `/issue`, then press Backspace to fix the slip. Instead of deleting one character, the first Backspace selected the entire token and the second wiped the whole draft. Justin reported it, and it caught him a few times before he worked out what was happening.

The fix is to only solidify a fully recognized command into the atomic block. A partial or unrecognized command stays normal editable text with single-character Backspace. It keeps the red no-match underline, but that is styling only now, not an atomic chip.

This matches how Slack, Discord, Notion, VS Code, and Claude Code all handle it: a draft or unrecognized token stays plain editable text, and only a committed command becomes an atomic unit.

## Changes

- `slashChip.ts`: the decorations provider renders invalid tokens as a non-atomic `Decoration.mark` (keeps the `cm-slash-command-chip-invalid` underline) instead of a replace widget, and the `atomicRanges` provider filters to valid commands only.
- `chipBackspace.ts` is unchanged. It reads the `atomicRanges` facet generically, so dropping invalid tokens from that facet stops the two-press staging on its own.

## Tests

- Flipped the old `two-press also works for invalid /slash commands (still atomic)` test, which baked in the wrong behaviour.
- Added coverage that an invalid token is not staged, not registered as an atomic range, and renders as an editable mark rather than a widget.
- Added a mixed `/build /unknowncmd` doc test to exercise the combined decoration set (one replace widget, one editable mark, atomic coverage on the valid command only).

All 120 tests in the suite pass, plus typecheck, lint, and format.
