### PR TITLE
perf(terminal): keep scrolling smooth while many agents stream

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -60,6 +60,7 @@ import {
 } from "./pty-host/handlers/index.js";
 import { PORT_BATCH_INTERACTIVE_INPUT_WINDOW_MS } from "./services/pty/types.js";
 import { isSmokeTestTerminalId } from "../shared/utils/smokeTestTerminals.js";
+import { startEventLoopMonitor } from "./pty-host/eventLoopMonitor.js";
 import { SCROLLBACK_MIN } from "../shared/config/scrollback.js";
 import { formatErrorMessage } from "../shared/utils/errorMessage.js";
 import { PERF_MARKS } from "../shared/perf/marks.js";
@@ -80,6 +81,11 @@ if (!process.parentPort) {
 const port = process.parentPort as unknown as MessagePort;
 
 appendEmergencyLog(`[${new Date().toISOString()}] [START] pid=${process.pid}\n`);
+
+// Loop-lag self-measurement for the "why am I slow?" flow-control snapshot —
+// this process is where multi-terminal parse load lands, and the main
+// process's lag monitor can't see it.
+startEventLoopMonitor();
 
 // Global error handlers to prevent silent crashes
 process.on("uncaughtException", (err) => {

--- a/electron/pty-host/__tests__/eventLoopMonitor.test.ts
+++ b/electron/pty-host/__tests__/eventLoopMonitor.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  startEventLoopMonitor,
+  getEventLoopStats,
+  stopEventLoopMonitorForTesting,
+} from "../eventLoopMonitor.js";
+
+describe("eventLoopMonitor", () => {
+  afterEach(() => {
+    stopEventLoopMonitorForTesting();
+  });
+
+  it("returns null when never started", () => {
+    expect(getEventLoopStats()).toBeNull();
+  });
+
+  it("reports finite loop stats after sampling a live loop", async () => {
+    startEventLoopMonitor();
+    // Give the histogram a few loop turns to record intervals.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const stats = getEventLoopStats();
+    expect(stats).not.toBeNull();
+    expect(Number.isFinite(stats!.p99Ms)).toBe(true);
+    expect(Number.isFinite(stats!.maxMs)).toBe(true);
+    expect(stats!.p99Ms).toBeGreaterThanOrEqual(0);
+    expect(stats!.maxMs).toBeGreaterThanOrEqual(stats!.p99Ms);
+    expect(stats!.utilization).toBeGreaterThanOrEqual(0);
+    expect(stats!.utilization).toBeLessThanOrEqual(1);
+  });
+
+  it("resets the window on each read so pulls report deltas, not high-water marks", async () => {
+    startEventLoopMonitor();
+    // Let the histogram's sampling timer establish itself before blocking.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    // Block the loop long enough to guarantee a large max in window 1.
+    const start = Date.now();
+    while (Date.now() - start < 120) {
+      // busy-wait
+    }
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const first = getEventLoopStats();
+    expect(first!.maxMs).toBeGreaterThan(50);
+
+    // A quiet second window must not inherit the first window's spike.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    const second = getEventLoopStats();
+    expect(second!.maxMs).toBeLessThan(first!.maxMs);
+  });
+
+  it("is idempotent across repeated starts", () => {
+    startEventLoopMonitor();
+    startEventLoopMonitor();
+    expect(getEventLoopStats()).not.toBeNull();
+  });
+});

--- a/electron/pty-host/eventLoopMonitor.ts
+++ b/electron/pty-host/eventLoopMonitor.ts
@@ -1,0 +1,46 @@
+import { monitorEventLoopDelay, performance, type IntervalHistogram } from "node:perf_hooks";
+import type { PtyHostEventLoopStats } from "../../shared/types/pty-host.js";
+
+/**
+ * Self-measurement of the pty-host UtilityProcess event loop. The main
+ * process's lag monitor (ResourceProfileService) watches only its OWN loop —
+ * it is blind to pty-host saturation, which is exactly where multi-terminal
+ * parse load lands. This histogram is the ground truth for "the pty-host
+ * thread was busy", surfaced through the flow-control snapshot into the
+ * "why am I slow?" panel (a stall here with zero paused terminals is the
+ * CPU-saturation signature, as opposed to queue backpressure).
+ *
+ * Snapshot reads reset the histogram so each pull reports the window since
+ * the previous pull rather than an all-time high-water mark.
+ */
+
+let histogram: IntervalHistogram | null = null;
+let lastEluSample: ReturnType<typeof performance.eventLoopUtilization> | null = null;
+
+export function startEventLoopMonitor(): void {
+  if (histogram) return;
+  histogram = monitorEventLoopDelay({ resolution: 20 });
+  histogram.enable();
+  lastEluSample = performance.eventLoopUtilization();
+}
+
+export function getEventLoopStats(): PtyHostEventLoopStats | null {
+  if (!histogram) return null;
+  const p99Ms = histogram.percentile(99) / 1e6;
+  const maxMs = histogram.max / 1e6;
+  const elu = performance.eventLoopUtilization(lastEluSample ?? undefined);
+  lastEluSample = performance.eventLoopUtilization();
+  histogram.reset();
+  return {
+    p99Ms: Number(p99Ms.toFixed(1)),
+    maxMs: Number(maxMs.toFixed(1)),
+    utilization: Number(elu.utilization.toFixed(3)),
+  };
+}
+
+/** Test seam: stop and discard the histogram. */
+export function stopEventLoopMonitorForTesting(): void {
+  histogram?.disable();
+  histogram = null;
+  lastEluSample = null;
+}

--- a/electron/pty-host/handlers/diagnostics.ts
+++ b/electron/pty-host/handlers/diagnostics.ts
@@ -3,6 +3,7 @@ import type {
   FlowControlSnapshot,
   FlowControlTerminalSnapshot,
 } from "../../../shared/types/pty-host.js";
+import { getEventLoopStats } from "../eventLoopMonitor.js";
 import type { HandlerMap, HostContext } from "./types.js";
 
 /**
@@ -92,6 +93,7 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
         // Spread-copy so later mutations don't bleed into the diagnostics object.
         stats: { ...backpressureManager.stats },
         resourceGovernor: resourceGovernor.getSnapshot(),
+        eventLoop: getEventLoopStats(),
       };
 
       sendEvent({ type: "flow-control-snapshot", requestId: msg.requestId, snapshot });

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -698,6 +698,9 @@ async function collectWhySlowPty(ptyClient?: PtyClient): Promise<WhySlowPtySumma
       pausedCount,
       suspendedCount,
       maxPausedDurationMs,
+      eventLoopP99Ms: snapshot.eventLoop?.p99Ms ?? null,
+      eventLoopMaxMs: snapshot.eventLoop?.maxMs ?? null,
+      eventLoopUtilization: snapshot.eventLoop?.utilization ?? null,
     };
   } catch {
     return null;

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -1158,6 +1158,7 @@ export class PtyClient extends EventEmitter {
         smoothedUtilizationPercent: null,
         throttleDurationMs: 0,
       },
+      eventLoop: null,
     }));
   }
 

--- a/electron/services/pty/HeadlessMirrorScheduler.ts
+++ b/electron/services/pty/HeadlessMirrorScheduler.ts
@@ -1,0 +1,298 @@
+/**
+ * Paces data feeds into the per-terminal `@xterm/headless` mirror terminals so
+ * their deferred parse work cannot saturate the pty-host event loop.
+ *
+ * Why: each mirror's WriteBuffer self-slices parsing to 12ms per macrotask,
+ * but that budget is PER INSTANCE. With M terminals streaming concurrently,
+ * every event-loop iteration runs up to M×12ms of back-to-back parse slices in
+ * the timers phase before transport flushes (setImmediate) get a turn — the
+ * "scrolling one full-screen TUI locks up every terminal" mechanism. Nothing
+ * queues past a watermark, so backpressure never engages; the thread is simply
+ * busy.
+ *
+ * How: feeds are held here (FIFO per terminal) and released by a shared drain
+ * tick under two closed-loop bounds — a per-terminal per-tick budget for
+ * fairness, and an aggregate unparsed-bytes cap across ALL mirrors. Since a
+ * mirror only parses what it has been fed, the aggregate cap bounds the total
+ * parse work any single event-loop iteration can contain (~128K chars ≈ a few
+ * ms at xterm's 5-35MB/s). Feeds are pre-sliced so no single write entry
+ * parses atomically for longer than ~16K chars' worth.
+ *
+ * What this deliberately does NOT do: drop or reorder bytes (VT frames are
+ * non-idempotent incremental deltas — every byte must eventually parse, in
+ * order, per terminal). Under sustained overload the queue grows here instead
+ * of inside xterm's WriteBuffer; growth is bounded upstream by the transport
+ * watermark pausing the PTY itself.
+ *
+ * Consumers of the mirror buffer (agent-state poll, identity watcher, wake
+ * serialize, MCP reads) tolerate bounded staleness; paths that need the tail
+ * parsed use flush(). The one strict contract preserved: enqueue callbacks
+ * fire only after the chunk has actually parsed, in per-terminal FIFO order —
+ * `pendingHeadlessWrites` gating semantics are unchanged.
+ */
+
+type MirrorWritable = {
+  write(data: string, callback?: () => void): void;
+};
+
+type FeedSlice = {
+  data: string;
+  // Fires when this slice has been parsed by the mirror. Only the final slice
+  // of an enqueued chunk carries the caller's callback.
+  onParsed?: () => void;
+};
+
+type MirrorQueue = {
+  mirror: MirrorWritable;
+  slices: FeedSlice[];
+  inFlightChars: number;
+  // Set by flush(): this queue ignores the per-tick fairness budget until it
+  // fully drains, so an exit-snapshot flush isn't stretched across many ticks.
+  expedite: boolean;
+  // Set by clear(): suppress accounting AND callbacks from any slice callbacks
+  // that still fire (mirrors today's "disposed headless write callbacks never
+  // fire" semantics — a cleared queue must not decrement counters it no longer
+  // owns).
+  cleared: boolean;
+};
+
+// Max chars in one mirror.write() entry — a single entry parses atomically
+// (the WriteBuffer's 12ms budget is only checked between entries).
+const FEED_SLICE_CHARS = 16 * 1024;
+// Max chars released to one terminal per drain tick — fairness across mirrors.
+const PER_TERMINAL_TICK_CHARS = 64 * 1024;
+// Cap on unparsed chars across all mirrors — bounds aggregate parse work per
+// event-loop iteration. Refills as parse callbacks complete (closed loop), so
+// throughput is limited by parse speed, not by this constant.
+const AGGREGATE_INFLIGHT_CHARS = 128 * 1024;
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function sliceFeed(data: string, onParsed?: () => void): FeedSlice[] {
+  if (data.length <= FEED_SLICE_CHARS) {
+    return [{ data, onParsed }];
+  }
+  const slices: FeedSlice[] = [];
+  let start = 0;
+  while (start < data.length) {
+    let end = Math.min(start + FEED_SLICE_CHARS, data.length);
+    // Defensive: keep surrogate pairs whole. xterm's decoder holds interim
+    // state across writes, so this is belt-and-braces, not load-bearing.
+    if (end < data.length && isHighSurrogate(data.charCodeAt(end - 1))) {
+      end--;
+      if (end <= start) end = Math.min(start + FEED_SLICE_CHARS, data.length);
+    }
+    slices.push({ data: data.slice(start, end) });
+    start = end;
+  }
+  slices[slices.length - 1]!.onParsed = onParsed;
+  return slices;
+}
+
+export class HeadlessMirrorScheduler {
+  private queues = new Map<string, MirrorQueue>();
+  private aggregateInFlightChars = 0;
+  private tickScheduled = false;
+  // Round-robin cursor: id of the queue served FIRST on the next tick. Set to
+  // the id AFTER the last fully-budget-consuming queue so a hot terminal can't
+  // monopolize successive ticks.
+  private nextServeId: string | null = null;
+
+  /**
+   * Queue `data` for the terminal's mirror. `onParsed` fires after the entire
+   * chunk has been parsed (FIFO per terminal). Fast path: an idle terminal
+   * under the aggregate cap feeds synchronously, so quiet/single-terminal
+   * behavior is identical to calling `mirror.write()` directly.
+   */
+  enqueue(id: string, mirror: MirrorWritable, data: string, onParsed?: () => void): void {
+    let queue = this.queues.get(id);
+    if (!queue) {
+      queue = { mirror, slices: [], inFlightChars: 0, expedite: false, cleared: false };
+      this.queues.set(id, queue);
+    }
+    // The mirror can be recreated at the same terminal id (respawn) — always
+    // track the latest instance.
+    queue.mirror = mirror;
+
+    const slices = sliceFeed(data, onParsed);
+    if (
+      queue.slices.length === 0 &&
+      this.aggregateInFlightChars + data.length <= AGGREGATE_INFLIGHT_CHARS
+    ) {
+      for (const slice of slices) {
+        this.feedSlice(id, queue, slice);
+        // A write failure clears the queue mid-loop; stop feeding into it.
+        if (queue.cleared) break;
+      }
+      return;
+    }
+
+    queue.slices.push(...slices);
+    this.scheduleTick();
+  }
+
+  /**
+   * Fire `onFlushed` once everything already queued for `id` has been fed and
+   * parsed. Marks the queue expedited (exempt from the per-tick fairness
+   * budget) so exit-path flushes complete promptly; the aggregate cap still
+   * applies, bounding the wait to other mirrors' in-flight parses.
+   *
+   * `mirror` is required because writes can reach a mirror WITHOUT the
+   * scheduler ever seeing that terminal (session restore writes directly at
+   * construction) — with no queue registered, the drain-wait must still be
+   * delegated to the mirror's own write queue via a sentinel, not skipped.
+   */
+  flush(id: string, mirror: MirrorWritable, onFlushed: () => void): void {
+    const queue = this.queues.get(id);
+    if (!queue || (queue.slices.length === 0 && queue.inFlightChars === 0)) {
+      mirror.write("", onFlushed);
+      return;
+    }
+    queue.expedite = true;
+    queue.slices.push({ data: "", onParsed: onFlushed });
+    this.scheduleTick();
+  }
+
+  /**
+   * Drop everything held for `id` and detach its accounting. Queued slices are
+   * discarded WITHOUT firing callbacks, matching the pre-scheduler behavior of
+   * disposing a headless terminal with writes still queued.
+   */
+  clear(id: string): void {
+    const queue = this.queues.get(id);
+    if (!queue) return;
+    queue.cleared = true;
+    this.aggregateInFlightChars -= queue.inFlightChars;
+    queue.inFlightChars = 0;
+    queue.slices.length = 0;
+    this.queues.delete(id);
+    if (this.nextServeId === id) this.nextServeId = null;
+    // Releasing this queue's in-flight share may unblock feeds that were
+    // waiting on the aggregate cap — and the cleared queue's parse callbacks
+    // (the usual re-arm source) are inert from here on, so re-arm explicitly
+    // or survivors could sit queued until unrelated activity ticks again.
+    if (this.hasPendingSlices()) {
+      this.scheduleTick();
+    }
+  }
+
+  /** Chars queued (not yet fed) for a terminal — test/diagnostic accessor. */
+  queuedChars(id: string): number {
+    const queue = this.queues.get(id);
+    if (!queue) return 0;
+    let total = 0;
+    for (const slice of queue.slices) total += slice.data.length;
+    return total;
+  }
+
+  /** Chars fed but not yet parsed across all mirrors — test/diagnostic accessor. */
+  inFlightChars(): number {
+    return this.aggregateInFlightChars;
+  }
+
+  private feedSlice(id: string, queue: MirrorQueue, slice: FeedSlice): void {
+    if (queue.cleared) return;
+    const chars = slice.data.length;
+    queue.inFlightChars += chars;
+    this.aggregateInFlightChars += chars;
+    try {
+      queue.mirror.write(slice.data, () => {
+        if (queue.cleared) return;
+        queue.inFlightChars -= chars;
+        this.aggregateInFlightChars -= chars;
+        slice.onParsed?.();
+        if (queue.slices.length > 0 || this.hasPendingSlices()) {
+          this.scheduleTick();
+        }
+      });
+    } catch (error) {
+      // A torn-down mirror core throws on write. Undo this slice's accounting
+      // and drop the queue — its terminal is disposing; stuck accounting would
+      // otherwise wedge the aggregate cap for every other terminal.
+      queue.inFlightChars -= chars;
+      this.aggregateInFlightChars -= chars;
+      console.error(`[HeadlessMirrorScheduler] mirror write failed for ${id}:`, error);
+      this.clear(id);
+    }
+  }
+
+  // O(queue count) scan, called from parse callbacks and clear(). Fine at the
+  // real scale (tens of terminals, each check nanoseconds next to a multi-ms
+  // parse); revisit with a pending-count field only if terminal counts grow
+  // orders of magnitude.
+  private hasPendingSlices(): boolean {
+    for (const queue of this.queues.values()) {
+      if (queue.slices.length > 0) return true;
+    }
+    return false;
+  }
+
+  private scheduleTick(): void {
+    if (this.tickScheduled) return;
+    this.tickScheduled = true;
+    setImmediate(() => {
+      this.tickScheduled = false;
+      this.tick();
+    });
+  }
+
+  private tick(): void {
+    if (this.queues.size === 0) return;
+
+    // Serve order: rotate so the queue after last tick's first-served goes
+    // first. Map preserves insertion order; build the rotation once per tick.
+    const ids = [...this.queues.keys()];
+    const startIndex = this.nextServeId ? Math.max(0, ids.indexOf(this.nextServeId)) : 0;
+    let served = 0;
+    let cursorAdvanced = false;
+
+    for (let i = 0; i < ids.length; i++) {
+      const id = ids[(startIndex + i) % ids.length]!;
+      const queue = this.queues.get(id);
+      if (!queue || queue.slices.length === 0) continue;
+
+      if (!cursorAdvanced) {
+        this.nextServeId = ids[(startIndex + i + 1) % ids.length]!;
+        cursorAdvanced = true;
+      }
+
+      let releasedThisTick = 0;
+      while (queue.slices.length > 0) {
+        // Strict cap: check the PROJECTED total so a near-full ledger can't be
+        // pushed over by one more slice (a zero-length flush sentinel always
+        // fits). Parse-completion callbacks re-arm the tick once room opens.
+        if (this.aggregateInFlightChars + queue.slices[0]!.data.length > AGGREGATE_INFLIGHT_CHARS) {
+          return;
+        }
+        // The per-terminal fairness budget is a post-check by design — it may
+        // overshoot by at most one ≤16K slice, which matters for fairness
+        // (bounded) but not for the aggregate parse bound above.
+        if (!queue.expedite && releasedThisTick >= PER_TERMINAL_TICK_CHARS) {
+          break;
+        }
+        const slice = queue.slices.shift()!;
+        releasedThisTick += slice.data.length;
+        served += slice.data.length;
+        this.feedSlice(id, queue, slice);
+        // feedSlice may have cleared the queue on a write failure.
+        if (queue.cleared) break;
+      }
+      if (queue.slices.length === 0) {
+        queue.expedite = false;
+      }
+    }
+
+    if (this.hasPendingSlices() && served > 0) {
+      this.scheduleTick();
+    }
+  }
+}
+
+/**
+ * Process-wide instance: the whole point is bounding AGGREGATE parse work
+ * across every terminal in the pty-host, so all TerminalProcess instances
+ * share one scheduler. Tests may construct their own instances.
+ */
+export const headlessMirrorScheduler = new HeadlessMirrorScheduler();

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -29,6 +29,7 @@ import { events } from "../events.js";
 import { AgentSpawnedSchema } from "../../schemas/agent.js";
 import { destroyPty, type PooledPtyDataHandoff, type PtyPool } from "../PtyPool.js";
 import { installHeadlessResponder } from "./headlessResponder.js";
+import { headlessMirrorScheduler } from "./HeadlessMirrorScheduler.js";
 import { handleOscColorQueries } from "./OscResponder.js";
 import { Osc94Parser } from "./Osc94Parser.js";
 import { SynchronizedFrameDetector } from "./SynchronizedFrameDetector.js";
@@ -571,6 +572,10 @@ export class TerminalProcess {
     if (!terminal.headlessTerminal) {
       return;
     }
+    // Drop any feeds still held for this mirror — queued-slice callbacks are
+    // discarded (matching disposed-xterm write callbacks never firing) and the
+    // scheduler's aggregate in-flight accounting is released.
+    headlessMirrorScheduler.clear(this.id);
     if (this.headlessResponderDisposable) {
       try {
         this.headlessResponderDisposable.dispose();
@@ -614,7 +619,11 @@ export class TerminalProcess {
     if (!headless || !terminal.serializeAddon) {
       return;
     }
-    headless.write("", () => {
+    // Route the drain-sentinel through the scheduler: it fires only after all
+    // feeds held for this terminal have been released AND parsed, preserving
+    // the "tail of the output must land in the buffer" contract now that
+    // chunks can be held outside xterm's own write queue.
+    headlessMirrorScheduler.flush(this.id, headless, () => {
       if (terminal.headlessTerminal !== headless || !terminal.serializeAddon) {
         return;
       }
@@ -1644,7 +1653,7 @@ export class TerminalProcess {
     return this.getVisibleActivitySnapshot(AGENT_OUTPUT_ACTIVITY_LINE_COUNT);
   }
 
-  private noteAgentOutputActivity(beforeSnapshot: VisibleContentSnapshot | undefined): void {
+  private noteAgentOutputActivity(): void {
     if (!this.isAgentLive) {
       this.agentOutputTemperature.reset();
       this.agentOutputContentSnapshot = undefined;
@@ -1657,16 +1666,19 @@ export class TerminalProcess {
     }
 
     // Throttle: viewport extraction + diff at most once per interval. Skipped
-    // chunks aren't lost — the trailing timer re-enters with no beforeSnapshot,
-    // so the diff falls back to the stored baseline and covers everything since
-    // the last accepted comparison.
+    // chunks aren't lost — the diff runs against the stored baseline from the
+    // last accepted comparison, so it covers everything since then. (A per-chunk
+    // "before" viewport walk used to seed a fresher baseline; it was dropped —
+    // a second full rows×cols extraction per note, running precisely in the
+    // settled-agent states where the user scrolls a full-screen TUI, bought
+    // only a marginally tighter diff window.)
     const now = Date.now();
     const sinceLastNote = now - this.lastAgentOutputNoteAt;
     if (sinceLastNote < AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS) {
       if (!this.agentOutputNoteTimer) {
         this.agentOutputNoteTimer = setTimeout(() => {
           this.agentOutputNoteTimer = null;
-          this.noteAgentOutputActivity(undefined);
+          this.noteAgentOutputActivity();
         }, AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS - sinceLastNote);
       }
       return;
@@ -1678,10 +1690,7 @@ export class TerminalProcess {
       return;
     }
 
-    const delta = measureVisibleContentDelta(
-      beforeSnapshot ?? this.agentOutputContentSnapshot,
-      afterSnapshot
-    );
+    const delta = measureVisibleContentDelta(this.agentOutputContentSnapshot, afterSnapshot);
     const hadFallbackBaseline = this.agentOutputContentSnapshot !== undefined;
     this.agentOutputContentSnapshot = afterSnapshot;
     if (!hadFallbackBaseline) {
@@ -1785,7 +1794,7 @@ export class TerminalProcess {
 
     if (terminal.headlessTerminal) {
       terminal.pendingHeadlessWrites = (terminal.pendingHeadlessWrites ?? 0) + 1;
-      terminal.headlessTerminal.write(prelude, () => {
+      headlessMirrorScheduler.enqueue(this.id, terminal.headlessTerminal, prelude, () => {
         terminal.pendingHeadlessWrites = (terminal.pendingHeadlessWrites ?? 1) - 1;
       });
     }
@@ -1855,21 +1864,6 @@ export class TerminalProcess {
     // added to the visible frame's latency.
     this.emitData(rendererData);
 
-    // noteAgentOutputActivity only acts on waiting/idle/completed — skip the
-    // full-viewport extraction in other states (it would be computed and
-    // discarded on every chunk during "working", the heaviest output phase)
-    // and while the note throttle window is closed (the extraction would be
-    // discarded by the throttle's early return). If the state flips before
-    // the async write callback, the `beforeSnapshot ??
-    // this.agentOutputContentSnapshot` fallback covers it.
-    const agentState = terminal.agentState;
-    const beforeContentSnapshot =
-      this.isAgentLive &&
-      (agentState === "waiting" || agentState === "idle" || agentState === "completed") &&
-      Date.now() - this.lastAgentOutputNoteAt >= AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS
-        ? this.getAgentOutputContentSnapshot()
-        : undefined;
-
     if (this.activityMonitor) {
       this.activityMonitor.onData(data);
     }
@@ -1885,14 +1879,15 @@ export class TerminalProcess {
     if (terminal.headlessTerminal) {
       // Outstanding-parse counter: the wake path only trusts a serialized
       // snapshot to cover the current contentEpoch when no headless writes
-      // are still queued in xterm's async parser.
+      // are still queued (scheduler hold + xterm's async parser both count —
+      // the callback fires only after the chunk has actually parsed).
       terminal.pendingHeadlessWrites = (terminal.pendingHeadlessWrites ?? 0) + 1;
-      terminal.headlessTerminal.write(data, () => {
+      headlessMirrorScheduler.enqueue(this.id, terminal.headlessTerminal, data, () => {
         terminal.pendingHeadlessWrites = (terminal.pendingHeadlessWrites ?? 1) - 1;
-        this.noteAgentOutputActivity(beforeContentSnapshot);
+        this.noteAgentOutputActivity();
       });
     } else {
-      this.noteAgentOutputActivity(beforeContentSnapshot);
+      this.noteAgentOutputActivity();
     }
     this.sessionSnapshotter.schedule();
 

--- a/electron/services/pty/__tests__/HeadlessMirrorScheduler.test.ts
+++ b/electron/services/pty/__tests__/HeadlessMirrorScheduler.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi } from "vitest";
+import { HeadlessMirrorScheduler } from "../HeadlessMirrorScheduler.js";
+
+const FEED_SLICE_CHARS = 16 * 1024;
+const AGGREGATE_INFLIGHT_CHARS = 128 * 1024;
+
+type WriteCall = { data: string; cb?: () => void };
+
+/** Mirror stub that records writes; parse callbacks fire only when released. */
+function createParkedMirror() {
+  const calls: WriteCall[] = [];
+  return {
+    calls,
+    write(data: string, cb?: () => void) {
+      calls.push({ data, cb });
+    },
+    /** Fire parse callbacks for all recorded writes, in order. */
+    release() {
+      const pending = calls.splice(0, calls.length);
+      for (const call of pending) call.cb?.();
+    },
+  };
+}
+
+/** Mirror stub whose parse completes synchronously (like a drained fake). */
+function createEagerMirror() {
+  const written: string[] = [];
+  return {
+    written,
+    write(data: string, cb?: () => void) {
+      written.push(data);
+      cb?.();
+    },
+  };
+}
+
+function flushTicks(): Promise<void> {
+  // Two setImmediate turns: one for the drain tick, one for any re-arm.
+  return new Promise((resolve) => setImmediate(() => setImmediate(resolve)));
+}
+
+describe("HeadlessMirrorScheduler", () => {
+  it("feeds an idle terminal synchronously (fast path)", () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createEagerMirror();
+    const onParsed = vi.fn();
+
+    scheduler.enqueue("t1", mirror, "hello", onParsed);
+
+    expect(mirror.written).toEqual(["hello"]);
+    expect(onParsed).toHaveBeenCalledTimes(1);
+    expect(scheduler.inFlightChars()).toBe(0);
+  });
+
+  it("slices large chunks into bounded write entries, callback on the last", () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createParkedMirror();
+    const onParsed = vi.fn();
+    const data = "x".repeat(FEED_SLICE_CHARS * 2 + 100);
+
+    scheduler.enqueue("t1", mirror, data, onParsed);
+
+    // Invariants: multiple bounded entries whose reassembly is the original.
+    expect(mirror.calls.length).toBeGreaterThan(1);
+    for (const call of mirror.calls) {
+      expect(call.data.length).toBeLessThanOrEqual(FEED_SLICE_CHARS);
+    }
+    expect(mirror.calls.map((c) => c.data).join("")).toBe(data);
+    // The caller's callback fires only when the FINAL slice parses.
+    for (let i = 0; i < mirror.calls.length - 1; i++) {
+      mirror.calls[i]!.cb?.();
+    }
+    expect(onParsed).not.toHaveBeenCalled();
+    mirror.calls[mirror.calls.length - 1]!.cb?.();
+    expect(onParsed).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not split a surrogate pair at a slice boundary", () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createParkedMirror();
+    // Place a surrogate pair straddling the slice boundary.
+    const data = "a".repeat(FEED_SLICE_CHARS - 1) + "\u{1F600}" + "b".repeat(10);
+
+    scheduler.enqueue("t1", mirror, data);
+
+    const first = mirror.calls[0]!.data;
+    expect(first.length).toBe(FEED_SLICE_CHARS - 1);
+    const second = mirror.calls[1]!.data;
+    expect(second.codePointAt(0)).toBe(0x1f600);
+  });
+
+  it("holds feeds past the aggregate in-flight cap and resumes on parse completion", async () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createParkedMirror();
+
+    scheduler.enqueue("t1", mirror, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+    const fedWrites = mirror.calls.length;
+    expect(scheduler.inFlightChars()).toBe(AGGREGATE_INFLIGHT_CHARS);
+
+    scheduler.enqueue("t1", mirror, "held-data");
+    await flushTicks();
+    // Cap reached: the second chunk must not have been fed.
+    expect(mirror.calls.length).toBe(fedWrites);
+    expect(scheduler.queuedChars("t1")).toBe("held-data".length);
+
+    mirror.release();
+    await flushTicks();
+    expect(scheduler.queuedChars("t1")).toBe(0);
+    expect(mirror.calls.map((c) => c.data)).toContain("held-data");
+  });
+
+  it("preserves per-terminal FIFO order across held feeds", async () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const blocker = createParkedMirror();
+    const mirror = createParkedMirror();
+
+    // Saturate the aggregate cap via another terminal.
+    scheduler.enqueue("blocker", blocker, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+    scheduler.enqueue("t1", mirror, "first");
+    scheduler.enqueue("t1", mirror, "second");
+
+    blocker.release();
+    await flushTicks();
+
+    const t1Data = mirror.calls.map((c) => c.data);
+    expect(t1Data).toEqual(["first", "second"]);
+  });
+
+  it("round-robins terminals so one hot queue cannot monopolize a tick", async () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const blocker = createParkedMirror();
+    const hot = createParkedMirror();
+    const quiet = createParkedMirror();
+
+    scheduler.enqueue("blocker", blocker, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+    // Both now queue behind the cap.
+    scheduler.enqueue("hot", hot, "h".repeat(FEED_SLICE_CHARS * 8));
+    scheduler.enqueue("quiet", quiet, "q");
+
+    blocker.release();
+    await flushTicks();
+
+    // The quiet terminal got service even though the hot one queued first
+    // and alone exceeds the per-tick budget.
+    expect(quiet.calls.length).toBe(1);
+  });
+
+  it("flush fires only after everything queued has parsed", async () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createParkedMirror();
+    const onFlushed = vi.fn();
+
+    scheduler.enqueue("t1", mirror, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+    scheduler.enqueue("t1", mirror, "tail");
+    scheduler.flush("t1", mirror, onFlushed);
+
+    await flushTicks();
+    expect(onFlushed).not.toHaveBeenCalled();
+
+    mirror.release();
+    await flushTicks();
+    // Tail + sentinel are now fed; their callbacks are parked — release them.
+    mirror.release();
+    await flushTicks();
+    expect(onFlushed).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush on an idle queue delegates to a sentinel mirror write", () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createEagerMirror();
+    const onFlushed = vi.fn();
+
+    scheduler.enqueue("t1", mirror, "data");
+    scheduler.flush("t1", mirror, onFlushed);
+
+    expect(mirror.written).toEqual(["data", ""]);
+    expect(onFlushed).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush with no registered queue still drain-waits via the provided mirror", () => {
+    // Session restore writes directly to the mirror before the scheduler ever
+    // sees the terminal — the sentinel must go to the mirror, not fire early.
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createParkedMirror();
+    const onFlushed = vi.fn();
+
+    scheduler.flush("never-enqueued", mirror, onFlushed);
+
+    expect(mirror.calls.map((c) => c.data)).toEqual([""]);
+    expect(onFlushed).not.toHaveBeenCalled();
+    mirror.release();
+    expect(onFlushed).toHaveBeenCalledTimes(1);
+  });
+
+  it("clear on the cap-holding terminal unblocks other queued terminals", async () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const hog = createParkedMirror();
+    const waiting = createParkedMirror();
+
+    scheduler.enqueue("hog", hog, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+    scheduler.enqueue("waiting", waiting, "blocked");
+    await flushTicks();
+    expect(waiting.calls.length).toBe(0);
+
+    // Dispose the hog: its parse callbacks are now inert, so clear() itself
+    // must re-arm the drain or "waiting" would strand forever.
+    scheduler.clear("hog");
+    await flushTicks();
+    expect(waiting.calls.map((c) => c.data)).toEqual(["blocked"]);
+  });
+
+  it("never exceeds the aggregate in-flight cap when releasing queued slices", async () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const near = createParkedMirror();
+    const extra = createParkedMirror();
+
+    // Fill to one slice below the cap, then queue one more slice elsewhere.
+    scheduler.enqueue("near", near, "x".repeat(AGGREGATE_INFLIGHT_CHARS - 100));
+    scheduler.enqueue("extra", extra, "y".repeat(200));
+    await flushTicks();
+
+    // 200 chars would cross the cap — the tick must hold it back entirely.
+    expect(extra.calls.length).toBe(0);
+    expect(scheduler.inFlightChars()).toBe(AGGREGATE_INFLIGHT_CHARS - 100);
+
+    near.release();
+    await flushTicks();
+    expect(extra.calls.map((c) => c.data)).toEqual(["y".repeat(200)]);
+  });
+
+  it("clear drops queued feeds without firing callbacks and releases accounting", async () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const mirror = createParkedMirror();
+    const other = createEagerMirror();
+    const onParsed = vi.fn();
+
+    scheduler.enqueue("t1", mirror, "x".repeat(AGGREGATE_INFLIGHT_CHARS));
+    scheduler.enqueue("t1", mirror, "dropped", onParsed);
+    scheduler.clear("t1");
+
+    expect(scheduler.inFlightChars()).toBe(0);
+    expect(scheduler.queuedChars("t1")).toBe(0);
+
+    // Aggregate accounting was released: another terminal feeds immediately.
+    scheduler.enqueue("t2", other, "goes-through");
+    expect(other.written).toEqual(["goes-through"]);
+
+    // Late parse callbacks from the cleared queue are inert.
+    mirror.release();
+    await flushTicks();
+    expect(onParsed).not.toHaveBeenCalled();
+    expect(scheduler.inFlightChars()).toBe(0);
+  });
+
+  it("recovers accounting when a mirror write throws", () => {
+    const scheduler = new HeadlessMirrorScheduler();
+    const broken = {
+      write() {
+        throw new Error("torn down");
+      },
+    };
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    scheduler.enqueue("t1", broken, "boom");
+    expect(scheduler.inFlightChars()).toBe(0);
+    expect(scheduler.queuedChars("t1")).toBe(0);
+
+    const healthy = createEagerMirror();
+    scheduler.enqueue("t2", healthy, "fine");
+    expect(healthy.written).toEqual(["fine"]);
+    consoleError.mockRestore();
+  });
+});

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -229,6 +229,7 @@ describe("routeHostEvent", () => {
         smoothedUtilizationPercent: null,
         throttleDurationMs: 0,
       },
+      eventLoop: null,
     };
     routeHostEvent({ type: "flow-control-snapshot", requestId: "req-fc", snapshot }, deps);
     expect(brokerCalls).toEqual([{ requestId: "req-fc", result: snapshot }]);

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -303,6 +303,20 @@ export interface FlowControlSnapshot {
   totalPendingBytes: number;
   stats: BackpressureStatsSnapshot;
   resourceGovernor: ResourceGovernorSnapshot;
+  /** Pty-host loop health since the previous pull; null if unmonitored. */
+  eventLoop: PtyHostEventLoopStats | null;
+}
+
+/**
+ * Event-loop health of the pty-host UtilityProcess over the window since the
+ * previous snapshot pull. High p99/max with zero paused terminals is the
+ * CPU-saturation signature (parse load), distinct from queue backpressure.
+ */
+export interface PtyHostEventLoopStats {
+  p99Ms: number;
+  maxMs: number;
+  /** Fraction of the window the loop was busy (perf_hooks ELU), 0-1. */
+  utilization: number;
 }
 
 /**

--- a/shared/types/whySlow.ts
+++ b/shared/types/whySlow.ts
@@ -92,6 +92,16 @@ export interface WhySlowPtySummary {
   suspendedCount: number;
   /** Longest current pause duration across terminals, in ms. */
   maxPausedDurationMs: number;
+  /**
+   * Pty-host event-loop p99 delay (ms) since the previous snapshot pull, or
+   * null when unmonitored. High values with pausedCount 0 = the host thread
+   * is CPU-saturated (parse load), not backpressured.
+   */
+  eventLoopP99Ms: number | null;
+  /** Pty-host event-loop max delay (ms) over the same window, or null. */
+  eventLoopMaxMs: number | null;
+  /** Pty-host event-loop utilization (0-1) over the same window, or null. */
+  eventLoopUtilization: number | null;
 }
 
 /** Workspace-host monitoring load: how many worktrees are watched and fetching. */

--- a/src/components/Diagnostics/WhySlowContent.tsx
+++ b/src/components/Diagnostics/WhySlowContent.tsx
@@ -285,6 +285,17 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
                 tone={snapshot.pty && snapshot.pty.pausedCount > 0 ? "warn" : "default"}
               />
               <MetricTile
+                label="PTY host lag p99"
+                value={
+                  snapshot.pty?.eventLoopP99Ms != null ? `${snapshot.pty.eventLoopP99Ms}ms` : "—"
+                }
+                tone={
+                  snapshot.pty?.eventLoopP99Ms != null && snapshot.pty.eventLoopP99Ms > 50
+                    ? "warn"
+                    : "default"
+                }
+              />
+              <MetricTile
                 label="Worktree monitors"
                 value={snapshot.worktrees ? String(snapshot.worktrees.monitorCount) : "—"}
               />

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -118,9 +118,19 @@ class TerminalInstanceService {
   private instances = new Map<string, ManagedTerminal>();
   // Throttle for the interactive resource-profile override IPC (see onActiveWheel).
   private lastInteractiveOverrideRequestAt = 0;
+  // Which terminal received the most recent alt-buffer wheel event, and when —
+  // drives the ingest service's background-drain hold during a scroll gesture.
+  // Uses the same decay window as the BURST tier so "gesture over" is one
+  // consistent notion across the renderer.
+  private lastActiveWheelId: string | null = null;
+  private lastActiveWheelAt = 0;
   private dataBuffer = new TerminalOutputIngestService(
     (id, data, chunkCount) => this.writeToTerminal(id, data, chunkCount),
-    () => usePanelStore.getState().focusedId
+    () => usePanelStore.getState().focusedId,
+    () =>
+      this.lastActiveWheelId !== null && Date.now() - this.lastActiveWheelAt < WHEEL_BURST_DECAY_MS
+        ? this.lastActiveWheelId
+        : null
   );
   private suppressedExitUntil = new Map<string, number>();
   private unseenTracker = new TerminalUnseenOutputTracker();
@@ -603,6 +613,9 @@ class TerminalInstanceService {
   private onActiveWheel(id: string): void {
     const managed = this.instances.get(id);
     if (!managed) return;
+
+    this.lastActiveWheelId = id;
+    this.lastActiveWheelAt = Date.now();
 
     this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
     if (managed.inputBurstTimer !== undefined) {

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -25,12 +25,27 @@ const INK_ERASE_LINE_PATTERN = "\x1b[2K\x1b[1A";
 const FOCUSED_DRAIN_PRIORITY_ENABLED =
   import.meta.env.DAINTREE_DISABLE_FOCUSED_DRAIN_PRIORITY !== "1";
 
+// While the user is actively wheel-scrolling a terminal, background terminals'
+// drains are HELD (re-checked on a timer) instead of merely yielded once, so
+// their xterm write-buffer parse slices don't stack up on the main thread
+// mid-gesture. Bounded fairness, not starvation: each queue drains a batch at
+// least every HOLD_MAX_MS even during a continuous scroll, and the hold decays
+// with the wheel burst itself (~1s after the last wheel event).
+const BACKGROUND_HOLD_RECHECK_MS = 24;
+const BACKGROUND_HOLD_MAX_MS = 250;
+
 type TerminalIngestQueue = {
   chunks: Array<string | Uint8Array>;
   queuedBytes: number;
   inFlightBytes: number;
   recentChars: string;
   drainScheduled: boolean;
+  holdStartedAt: number | undefined;
+  // True while the pending drainScheduled continuation is a wheel-burst HOLD
+  // recheck (as opposed to an ink-erase or yield continuation). Lets
+  // enqueueChunk drain inline for a terminal that stopped being deferrable
+  // mid-hold (e.g. focus moved to it) instead of waiting out the recheck.
+  holdScheduled: boolean;
 };
 
 // A drained batch plus how many raw queue chunks it merged. The count must
@@ -61,7 +76,13 @@ export class TerminalOutputIngestService {
     // Defaults to () => null so a bare `new TerminalOutputIngestService(write)`
     // keeps the legacy fully-synchronous drain — null focus means "drain
     // synchronously for everyone", never "defer everyone".
-    private readonly getFocusedId: () => string | null = () => null
+    private readonly getFocusedId: () => string | null = () => null,
+    // The terminal the user is actively wheel-scrolling (null when no wheel
+    // burst is live). While non-null, other non-focused terminals' drains are
+    // held on a recheck timer instead of draining after one yield. The wheeled
+    // terminal itself is exempt — scrolling an unfocused full-screen TUI is a
+    // PTY round-trip and holding its own output would stall the gesture.
+    private readonly getActiveWheelId: () => string | null = () => null
   ) {}
 
   public async initialize(): Promise<void> {
@@ -202,6 +223,8 @@ export class TerminalOutputIngestService {
         inFlightBytes: 0,
         recentChars: "",
         drainScheduled: false,
+        holdStartedAt: undefined,
+        holdScheduled: false,
       };
       this.queues.set(id, queue);
     }
@@ -245,6 +268,13 @@ export class TerminalOutputIngestService {
 
     if (!queue.drainScheduled) {
       this.scheduleOrDrain(id, queue);
+    } else if (queue.holdScheduled && !this.shouldDeferDrain(id)) {
+      // A wheel-burst hold recheck is pending, but this terminal is no longer
+      // deferrable (focus moved to it mid-gesture). Drain inline now — echo
+      // latency must not wait out the hold. The pending recheck no-ops on an
+      // empty queue. Scoped to holdScheduled: an ink-erase continuation must
+      // keep its coalescing window.
+      this.tryDrain(id, queue);
     }
   }
 
@@ -261,13 +291,47 @@ export class TerminalOutputIngestService {
    * queue.drainScheduled into one pending continuation (no per-chunk timer
    * churn, #8150); the deferred drain still routes through tryDrain, so the
    * COALESCE_BATCH_CAP_BYTES cap is respected (#4853).
+   *
+   * Exception: during an ACTIVE wheel gesture (getActiveWheelId non-null),
+   * background queues are additionally held on a bounded recheck timer — see
+   * BACKGROUND_HOLD_MAX_MS — because a scroll is a sustained interaction where
+   * even yielded-once batches stack enough parse slices to jank the gesture.
    */
   private scheduleOrDrain(id: string, queue: TerminalIngestQueue): void {
     if (!this.shouldDeferDrain(id)) {
+      queue.holdStartedAt = undefined;
       this.tryDrain(id, queue);
       return;
     }
     if (queue.drainScheduled) return;
+
+    // Active wheel gesture elsewhere: hold this background queue on a recheck
+    // timer (bounded by BACKGROUND_HOLD_MAX_MS) so its parse work stays off
+    // the thread while the user is scrolling. Not a starvation risk: the hold
+    // cap forces a drain, the wheel burst decays ~1s after the last event,
+    // and getStalledBytes treats drainScheduled=true as healthy so the
+    // watchdog never sees a held queue as stranded.
+    if (this.shouldHoldDrain(id)) {
+      const now = Date.now();
+      queue.holdStartedAt ??= now;
+      if (now - queue.holdStartedAt < BACKGROUND_HOLD_MAX_MS) {
+        queue.drainScheduled = true;
+        queue.holdScheduled = true;
+        globalThis.setTimeout(() => {
+          if (this.queues.get(id) !== queue) return;
+          queue.drainScheduled = false;
+          queue.holdScheduled = false;
+          if (queue.chunks.length === 0) {
+            queue.holdStartedAt = undefined;
+            return;
+          }
+          this.scheduleOrDrain(id, queue);
+        }, BACKGROUND_HOLD_RECHECK_MS);
+        return;
+      }
+    }
+    queue.holdStartedAt = undefined;
+
     queue.drainScheduled = true;
     void yieldToScheduler().then(() => {
       // The queue may have been cleared/replaced (resetForTerminal,
@@ -283,6 +347,11 @@ export class TerminalOutputIngestService {
     if (!FOCUSED_DRAIN_PRIORITY_ENABLED) return false;
     const focusedId = this.getFocusedId();
     return focusedId !== null && focusedId !== id;
+  }
+
+  private shouldHoldDrain(id: string): boolean {
+    const wheelId = this.getActiveWheelId();
+    return wheelId !== null && wheelId !== id;
   }
 
   private tryDrain(id: string, queue: TerminalIngestQueue): void {

--- a/src/services/terminal/TerminalWriteController.ts
+++ b/src/services/terminal/TerminalWriteController.ts
@@ -16,6 +16,59 @@ import { markRendererPerformance } from "@/utils/performance";
  * Buffer.byteLength/TextEncoder semantics exactly — lone surrogates count as
  * 3 bytes (U+FFFD), valid pairs as 4.
  */
+/**
+ * Max size of a single xterm write-buffer entry. xterm's WriteBuffer enforces
+ * its 12ms parse budget only BETWEEN entries — one entry is parsed atomically,
+ * so a 256KB coalesced batch handed to `terminal.write()` as one entry becomes
+ * a 10-50ms unyieldable main-thread task that starves wheel/keystroke dispatch
+ * (the "scrolled TUI locks itself up" mechanism). Slicing the batch into
+ * ≤32KB entries keeps each parse task under a frame while xterm's own
+ * scheduler yields between them; Chromium then dispatches pending input
+ * between the macrotask continuations.
+ */
+const WRITE_SLICE_BYTES = 32 * 1024;
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isUtf8Continuation(byte: number): boolean {
+  return (byte & 0xc0) === 0x80;
+}
+
+/**
+ * Split a chunk into ≤WRITE_SLICE_BYTES pieces without splitting a UTF-16
+ * surrogate pair (string) or mid-UTF-8-sequence (Uint8Array). xterm's stream
+ * decoders hold interim state across writes, so boundary safety is defensive
+ * rather than load-bearing; the backoff is a handful of comparisons per slice.
+ * Uint8Array slices are zero-copy subarray views.
+ */
+function sliceChunk(data: string | Uint8Array): Array<string | Uint8Array> {
+  const total = typeof data === "string" ? data.length : data.byteLength;
+  if (total <= WRITE_SLICE_BYTES) return [data];
+
+  const slices: Array<string | Uint8Array> = [];
+  let start = 0;
+  while (start < total) {
+    let end = Math.min(start + WRITE_SLICE_BYTES, total);
+    if (end < total) {
+      if (typeof data === "string") {
+        if (isHighSurrogate(data.charCodeAt(end - 1))) end--;
+      } else {
+        let backoff = 0;
+        while (end > start + 1 && backoff < 3 && isUtf8Continuation(data[end]!)) {
+          end--;
+          backoff++;
+        }
+      }
+      if (end <= start) end = Math.min(start + WRITE_SLICE_BYTES, total);
+    }
+    slices.push(typeof data === "string" ? data.slice(start, end) : data.subarray(start, end));
+    start = end;
+  }
+  return slices;
+}
+
 function utf8ByteLength(data: string): number {
   let bytes = 0;
   for (let i = 0; i < data.length; i++) {
@@ -183,7 +236,16 @@ export class TerminalWriteController {
         ? performance.now()
         : Date.now()
       : 0;
-    terminal.write(data, () => {
+    // Feed the batch as multiple ≤32KB write-buffer entries (see
+    // WRITE_SLICE_BYTES). Acks/bookkeeping ride the FINAL slice's callback:
+    // xterm parses entries FIFO, so the last callback means the whole batch
+    // has landed — the port-ack ledger and inFlightBytes stay batch-scoped
+    // and no per-slice accounting is needed.
+    const slices = sliceChunk(data);
+    for (let i = 0; i < slices.length - 1; i++) {
+      terminal.write(slices[i]!);
+    }
+    terminal.write(slices[slices.length - 1]!, () => {
       if (this.deps.getInstance(id) !== managed) return;
 
       managed.pendingWrites = Math.max(0, (managed.pendingWrites ?? 1) - 1);

--- a/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
+++ b/src/services/terminal/__tests__/TerminalOutputIngestService.test.ts
@@ -703,4 +703,123 @@ describe("TerminalOutputIngestService", () => {
       expect(writeToTerminal).toHaveBeenCalledTimes(1);
     });
   });
+
+  // During an active wheel gesture, background terminals' drains are HELD on a
+  // bounded recheck timer (not just yielded once) so their parse slices stay
+  // off the main thread mid-scroll. BACKGROUND_HOLD_RECHECK_MS=24,
+  // BACKGROUND_HOLD_MAX_MS=250.
+  describe("wheel-burst background hold", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    function makeService(
+      writeToTerminal: (id: string, data: string | Uint8Array, chunkCount: number) => void,
+      focusedId: string | null,
+      getWheelId: () => string | null
+    ) {
+      return new TerminalOutputIngestService(writeToTerminal, () => focusedId, getWheelId);
+    }
+
+    it("holds a background queue while a wheel burst is active elsewhere", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = makeService(writeToTerminal, "term-focused", () => "term-wheel");
+
+      service.bufferData("term-bg", "held");
+
+      // A plain yield tick is NOT enough — the queue is held, not yielded.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writeToTerminal).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(24);
+      expect(writeToTerminal).not.toHaveBeenCalled();
+      expect(service.getQueuedBytes("term-bg")).toBe(4);
+    });
+
+    it("releases the hold when the wheel burst ends", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      let wheelId: string | null = "term-wheel";
+      const service = makeService(writeToTerminal, "term-focused", () => wheelId);
+
+      service.bufferData("term-bg", "held");
+      await vi.advanceTimersByTimeAsync(24);
+      expect(writeToTerminal).not.toHaveBeenCalled();
+
+      wheelId = null;
+      // Next recheck falls through to the normal single-yield defer, then drains.
+      await vi.advanceTimersByTimeAsync(25);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-bg", "held", 1);
+    });
+
+    it("drains anyway once the hold cap elapses during a continuous burst", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = makeService(writeToTerminal, "term-focused", () => "term-wheel");
+
+      service.bufferData("term-bg", "capped");
+
+      // Burst never ends; the bounded-fairness cap must force a drain.
+      await vi.advanceTimersByTimeAsync(300);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-bg", "capped", 1);
+    });
+
+    it("never holds the terminal being wheeled (unfocused TUI scroll round-trip)", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = makeService(writeToTerminal, "term-focused", () => "term-wheel");
+
+      // The wheeled terminal is background (not focused) but exempt from the
+      // hold — its redraw frames ARE the scroll. Normal one-yield defer only.
+      service.bufferData("term-wheel", "frames");
+      expect(writeToTerminal).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-wheel", "frames", 1);
+    });
+
+    it("never holds the focused terminal", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      const service = makeService(writeToTerminal, "term-focused", () => "term-wheel");
+
+      service.bufferData("term-focused", "echo");
+      // Inline, same task — no timers needed.
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+    });
+
+    it("drains inline when focus moves to a held terminal mid-burst", async () => {
+      vi.stubGlobal("scheduler", undefined);
+      vi.useFakeTimers();
+      const writeToTerminal = vi.fn();
+      let focusedId = "term-focused";
+      const service = new TerminalOutputIngestService(
+        writeToTerminal,
+        () => focusedId,
+        () => "term-wheel"
+      );
+
+      service.bufferData("term-bg", "a");
+      expect(writeToTerminal).not.toHaveBeenCalled();
+
+      // Focus lands on the held terminal while its hold recheck is pending.
+      // The next chunk must not wait out the recheck — echo drains inline.
+      focusedId = "term-bg";
+      service.bufferData("term-bg", "b");
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+      expect(writeToTerminal).toHaveBeenCalledWith("term-bg", "ab", 2);
+
+      // The stale recheck continuation is a no-op on the drained queue.
+      await vi.advanceTimersByTimeAsync(30);
+      expect(writeToTerminal).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -459,4 +459,84 @@ describe("TerminalWriteController.write", () => {
       expect(onWrite).not.toHaveBeenCalled();
     });
   });
+
+  // A single xterm write entry parses atomically (the WriteBuffer's 12ms
+  // budget only applies between entries), so large coalesced batches must be
+  // fed as multiple bounded entries — while acks/bookkeeping stay batch-scoped
+  // on the final entry's callback.
+  describe("write slicing", () => {
+    const WRITE_SLICE_BYTES = 32 * 1024;
+
+    it("feeds a large string batch as bounded entries with one batch-scoped ack", () => {
+      const data = "x".repeat(WRITE_SLICE_BYTES * 2 + 500);
+      controller.write("t1", data, 7);
+
+      const term = managed.terminal as unknown as MockTerminal;
+      const calls = term.write.mock.calls;
+      // Invariants: more than one entry, every entry within the slice bound,
+      // reassembly is byte-identical, callback ONLY on the final entry.
+      expect(calls.length).toBeGreaterThan(1);
+      for (const call of calls) {
+        expect((call[0] as string).length).toBeLessThanOrEqual(WRITE_SLICE_BYTES);
+      }
+      expect(calls.map((c) => c[0]).join("")).toBe(data);
+      for (let i = 0; i < calls.length - 1; i++) {
+        expect(calls[i]![1]).toBeUndefined();
+      }
+      expect(typeof calls[calls.length - 1]![1]).toBe("function");
+      // Acks fire once, for the whole batch, with the original chunkCount.
+      expect(deps.acknowledgePortData).toHaveBeenCalledTimes(1);
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", data.length, 7);
+      expect(deps.notifyWriteComplete).toHaveBeenCalledTimes(1);
+      expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", data.length);
+    });
+
+    it("feeds a large Uint8Array batch as zero-copy subarray entries", () => {
+      const data = new Uint8Array(WRITE_SLICE_BYTES + 10).fill(0x61);
+      controller.write("t1", data);
+
+      const term = managed.terminal as unknown as MockTerminal;
+      expect(term.write).toHaveBeenCalledTimes(2);
+      const first = term.write.mock.calls[0]![0] as Uint8Array;
+      const second = term.write.mock.calls[1]![0] as Uint8Array;
+      expect(first.byteLength).toBe(WRITE_SLICE_BYTES);
+      expect(second.byteLength).toBe(10);
+      expect(first.buffer).toBe(data.buffer);
+      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", data.byteLength, 1);
+    });
+
+    it("does not split a surrogate pair at a slice boundary", () => {
+      const data = "a".repeat(WRITE_SLICE_BYTES - 1) + "\u{1F600}" + "b".repeat(8);
+      controller.write("t1", data);
+
+      const term = managed.terminal as unknown as MockTerminal;
+      const first = term.write.mock.calls[0]![0] as string;
+      expect(first.length).toBe(WRITE_SLICE_BYTES - 1);
+      const second = term.write.mock.calls[1]![0] as string;
+      expect(second.codePointAt(0)).toBe(0x1f600);
+    });
+
+    it("does not split mid-UTF-8-sequence in a binary batch", () => {
+      // 0xF0 0x9F 0x98 0x80 = 😀; place it straddling the slice boundary.
+      const data = new Uint8Array(WRITE_SLICE_BYTES + 2);
+      data.fill(0x61);
+      data.set([0xf0, 0x9f, 0x98, 0x80], WRITE_SLICE_BYTES - 2);
+
+      controller.write("t1", data);
+
+      const term = managed.terminal as unknown as MockTerminal;
+      const first = term.write.mock.calls[0]![0] as Uint8Array;
+      // Boundary backed off so the 4-byte sequence starts the next slice.
+      expect(first.byteLength).toBe(WRITE_SLICE_BYTES - 2);
+      const second = term.write.mock.calls[1]![0] as Uint8Array;
+      expect(second[0]).toBe(0xf0);
+    });
+
+    it("writes small batches as a single entry (fast path unchanged)", () => {
+      controller.write("t1", "hello");
+      const term = managed.terminal as unknown as MockTerminal;
+      expect(term.write).toHaveBeenCalledTimes(1);
+      expect(typeof term.write.mock.calls[0]![1]).toBe("function");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Fast wheel-scrolling a full-screen mouse-reporting TUI (e.g. grok build) while many agent terminals stream concurrently locks up **all** terminals — including the one being scrolled. The `paused-backpressure` pill never shows: nothing crosses a queue watermark. Both single-threaded chokepoints are simply CPU-saturated with unpreemptible parse work:

- **Renderer:** `TerminalOutputIngestService` coalesces up to 256KB into ONE `terminal.write()` entry. xterm's WriteBuffer enforces its 12ms parse budget only *between* entries, so one entry = one atomic 10–50ms main-thread task. Blink can't dispatch wheel input mid-task, so the scrolled TUI's own frames starve its own scroll. N background terminals each stack their own atomic parses on top, with no aggregate bound.
- **pty-host:** every terminal's `@xterm/headless` mirror self-slices parsing to 12ms per macrotask, but that budget is per instance. With M streaming terminals, each event-loop iteration runs up to M×12ms of back-to-back parse slices in the timers phase, starving the `setImmediate` transport flushes that deliver frames to the renderer. The recent focus-priority work (#10884/#10886) reorders *queued* work but can't preempt parse tasks — which is why the lockup survived it.

## Fix

**Renderer**
- `TerminalWriteController` feeds batches as multiple ≤32KB write entries (callback + port-ack/ledger bookkeeping stays batch-scoped on the final entry, so all accounting is unchanged). xterm's own 12ms slicer now yields between entries, and Blink's input-priority queue dispatches wheel events at every task boundary.
- `TerminalOutputIngestService` holds background terminals' drains on a bounded recheck timer during an active wheel gesture (24ms recheck, 250ms per-queue cap, 1s decay after the last wheel event). The wheeled terminal itself and the focused terminal are exempt; a terminal that gains focus mid-hold drains inline immediately.

**pty-host**
- New `HeadlessMirrorScheduler`: all mirror feeds route through a process-wide pacer — per-terminal FIFO of ≤16K-char slices, `setImmediate` round-robin drain, 64K/terminal/tick fairness budget, and a strict 128K aggregate unparsed-chars cap (closed loop via parse callbacks). Bounds the parse work any single event-loop iteration can contain to a few ms, regardless of terminal count. Nothing is dropped or reordered; a quiet terminal feeds synchronously (fast path) so idle behavior is byte-identical.
- Exit-snapshot flush and `pendingHeadlessWrites` gating semantics preserved (flush drain-waits through both the scheduler queue and xterm's internal queue, covering the restore path's direct writes).
- Dropped the per-chunk "before" viewport walk in `_runPtyPipeline` — a second full rows×cols cell extraction that ran precisely in the settled-agent states where a TUI gets scrolled; the diff now uses the stored-baseline fallback that already existed for the throttled path.

**Diagnostics**
- The pty-host now runs `monitorEventLoopDelay` + ELU self-measurement (it was the one process with no loop-lag visibility), surfaced through the flow-control snapshot into the "why am I slow?" panel as a *PTY host lag p99* tile. High lag with zero paused terminals is the CPU-saturation signature, distinct from backpressure.

## Grounding

- xterm 6.1.0-beta.288 WriteBuffer: 12ms budget checked only between entries (`node_modules/@xterm/xterm/src/common/input/WriteBuffer.ts`); wheel reports already take the user-input immediate-parse path.
- Blink scheduler design docs: the input task queue outranks the timer queue at every task boundary — smaller entries directly translate into input dispatch opportunities.
- Slice/budget constants follow prior art: Alacritty caps 64K parsed per lock hold; VS Code's flow control acks from the write callback (we already do; slicing keeps that batch-scoped).

## Tests

- New: `HeadlessMirrorScheduler.test.ts` (14 cases — FIFO, fast path, slicing invariants, aggregate cap strictness, round-robin fairness, flush/clear lifecycle incl. cap-holder-disposal unblocking, write-throw recovery), `eventLoopMonitor.test.ts` (4 cases, window-reset semantics).
- Extended: write-slicing block in `TerminalWriteController.test.ts` (5 cases incl. surrogate/UTF-8 boundary safety, batch-scoped acks), wheel-burst hold block in `TerminalOutputIngestService.test.ts` (6 cases incl. hold cap, wheeled-terminal exemption, mid-gesture focus handoff).
- Full sweeps green: `npm run check`, 1681 pty/pty-host tests, 1136 renderer terminal tests.

## Follow-ups (out of scope, noted from the investigation)

- Deterministic `e2e/local/` repro harness: synthetic alt-buffer mouse-reporting TUI fixture + real wheel-event driving + frame-gap/LoAF probes (primitives exist in `e2e/helpers/stress.ts`; nothing today dispatches real wheel events).
- If pacing proves insufficient under extreme fleets: move mirror parsing to a long-lived `worker_threads` pool inside the pty-host (node-pty stays on the parent thread; `@xterm/headless` is pure JS and worker-safe).
- Sibling DOM terminals' write-driven `forceXtermReflow` (`offsetHeight` forced layout, 250ms throttle) could be suppressed during wheel bursts.