### PR TITLE
perf(threading): move CPU-heavy work onto persistent worker thread pools

### DIFF
--- a/eager-import-baseline.json
+++ b/eager-import-baseline.json
@@ -74,7 +74,6 @@
     "electron/store.ts",
     "electron/utils/emergencyLog.ts",
     "electron/utils/fs.ts",
-    "electron/utils/git.ts",
     "electron/utils/gitRepoOperationState.ts",
     "electron/utils/gpuDetection.ts",
     "electron/utils/hostPerformance.ts",
@@ -1396,21 +1395,6 @@
     {
       "file": "electron/utils/fs.ts",
       "line": 156,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 156,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 417,
-      "pattern": "sync-fs"
-    },
-    {
-      "file": "electron/utils/git.ts",
-      "line": 716,
       "pattern": "sync-fs"
     },
     {

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -219,6 +219,7 @@ vi.mock("../services/PtyManager.js", () => {
     setProcessTreeCache = vi.fn();
     setImagePathProbe = vi.fn();
     setPtyPool = vi.fn();
+    setAnalysisWorkerPool = vi.fn();
     setActivityMonitorTier = vi.fn();
     spawn = vi.fn((id: string, options: { projectId?: string }) => {
       if (!hostState.terminals.has(id)) {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -311,6 +311,19 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         // Module load errors during teardown are non-fatal (PluginService may
         // never have been loaded if shutdown fired before first-interactive).
       }
+      // Stop the DB maintenance worker BEFORE the audit flushNow() calls
+      // below. The drain wait is capped (a wedged worker must not eat the
+      // shutdown budget), so it is best-effort — shutdownDbWorker() advances
+      // the write fence afterwards, making any ring write a slow worker
+      // commits later in the shutdown window a no-op. Post-shutdown, every
+      // ring write executes synchronously on main, so the final flushNow()
+      // snapshots are durable and cannot be clobbered.
+      try {
+        const { shutdownDbWorker } = await import("../services/persistence/dbWorkerClient.js");
+        await shutdownDbWorker();
+      } catch (err) {
+        console.warn("[MAIN] DB worker shutdown failed:", err);
+      }
     });
 
     const cleanupPromise = preDisposePromise

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -33,6 +33,11 @@ nodeV8.setHeapSnapshotNearHeapLimit(2);
 import { MessagePort } from "node:worker_threads";
 import os from "node:os";
 import { PtyManager } from "./services/PtyManager.js";
+import {
+  AnalysisWorkerPool,
+  analysisWorkersDisabled,
+  defaultAnalysisPoolSize,
+} from "./services/pty/analysis/AnalysisWorkerPool.js";
 import { PtyPool, getPtyPool, shouldEnablePtyPool } from "./services/PtyPool.js";
 import { ProcessTreeCache } from "./services/ProcessTreeCache.js";
 import { ImagePathProbe } from "./services/pty/ImagePathProbe.js";
@@ -119,6 +124,21 @@ process.on("unhandledRejection", (reason) => {
 });
 
 const ptyManager = new PtyManager();
+
+// Analysis worker pool: moves the per-chunk analysis stack (headless xterm
+// mirror + ActivityMonitor) off this thread so the pty-host event loop only
+// does I/O (node-pty reads, batching/backpressure, forwarding). Kill switch:
+// DAINTREE_DISABLE_ANALYSIS_WORKERS=1 restores the legacy in-thread path.
+let analysisWorkerPool: AnalysisWorkerPool | null = null;
+if (!analysisWorkersDisabled()) {
+  const analysisPoolSize = defaultAnalysisPoolSize();
+  analysisWorkerPool = new AnalysisWorkerPool(analysisPoolSize);
+  ptyManager.setAnalysisWorkerPool(analysisWorkerPool);
+  console.log(`[PtyHost] Analysis worker pool enabled (max ${analysisPoolSize} workers)`);
+} else {
+  console.log("[PtyHost] Analysis workers disabled; running analysis in-thread");
+}
+
 // 1.5s base poll interval. With 2-poll hysteresis in ProcessDetector, that's
 // ~3s to commit an agent/process change. Short enough for "I just ran claude
 // and want to see the chrome flip" to feel responsive, long enough to filter
@@ -1320,6 +1340,7 @@ const hostContext: HostContext = {
   windowProjectMap,
   windowFocusedTerminalMap,
   ipcDataMirrorTerminals,
+  analysisWorkerPool,
   get visualBuffers() {
     return visualBuffers;
   },
@@ -1408,6 +1429,11 @@ function cleanup(): void {
   }
 
   ptyManager.dispose();
+
+  // Workers are persistent by design (never terminated — Electron 37+
+  // flush_tasks_ assertion); dispose only drops bookkeeping. The unref'd
+  // threads die with the process.
+  analysisWorkerPool?.dispose();
 
   // Release SharedArrayBuffer references so V8 can GC shared memory regions
   visualBuffers = [];

--- a/electron/pty-host/analysisWorker.ts
+++ b/electron/pty-host/analysisWorker.ts
@@ -1,0 +1,16 @@
+import { parentPort } from "node:worker_threads";
+import { AnalysisWorkerRuntime } from "../services/pty/analysis/AnalysisWorkerRuntime.js";
+import type { HostToWorkerMessage } from "../services/pty/analysisWorkerProtocol.js";
+
+if (!parentPort) {
+  throw new Error("[AnalysisWorker] Must run as a worker thread");
+}
+
+const port = parentPort;
+const runtime = new AnalysisWorkerRuntime((msg) => port.postMessage(msg));
+
+port.on("message", (msg: HostToWorkerMessage) => {
+  runtime.handleMessage(msg);
+});
+
+port.postMessage({ type: "ready" });

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -27,6 +27,7 @@ function makeRendererConnection(): RendererConnection {
 
 function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   return {
+    analysisWorkerPool: null,
     ptyManager: {
       getTerminal: vi.fn(() => undefined),
       getAll: vi.fn(() => []),

--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -15,6 +15,7 @@ function makeCtx(stateRef: {
   } as unknown as HostContext["ptyManager"];
 
   return {
+    analysisWorkerPool: null,
     ptyManager,
     processTreeCache: {} as HostContext["processTreeCache"],
     terminalResourceMonitor: {} as HostContext["terminalResourceMonitor"],

--- a/electron/pty-host/handlers/__tests__/diagnostics.test.ts
+++ b/electron/pty-host/handlers/__tests__/diagnostics.test.ts
@@ -24,6 +24,7 @@ function makePortConnection(
 
 function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   return {
+    analysisWorkerPool: null,
     ptyManager: {} as HostContext["ptyManager"],
     processTreeCache: {} as HostContext["processTreeCache"],
     terminalResourceMonitor: {} as HostContext["terminalResourceMonitor"],

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -49,6 +49,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   } as unknown as HostContext["ptyManager"];
 
   return {
+    analysisWorkerPool: null,
     ptyManager,
     processTreeCache: { setPollInterval: vi.fn() } as unknown as HostContext["processTreeCache"],
     terminalResourceMonitor: {

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -52,6 +52,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
   } as unknown as HostContext["resourceGovernor"];
 
   return {
+    analysisWorkerPool: null,
     ptyManager,
     processTreeCache: { setPollInterval: vi.fn() } as unknown as HostContext["processTreeCache"],
     terminalResourceMonitor: {

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -9,6 +9,7 @@ function createCtx(overrides: Partial<HostContext> = {}): HostContext {
   } as unknown as HostContext["ptyManager"];
 
   return {
+    analysisWorkerPool: null,
     ptyManager,
     // The mapper only touches `ptyManager`; the rest of the surface is irrelevant
     // for these tests but must satisfy the structural type.

--- a/electron/pty-host/handlers/resourceConfig.ts
+++ b/electron/pty-host/handlers/resourceConfig.ts
@@ -56,6 +56,9 @@ export function createResourceConfigHandlers(ctx: HostContext): HandlerMap {
           ? msg.registry
           : {};
       setPluginAgentRegistry(registry);
+      // Analysis workers resolve detection patterns on their own thread —
+      // mirror the registry there too (new workers receive it at spawn).
+      ctx.analysisWorkerPool?.setPluginAgentRegistry(registry);
     },
   };
 }

--- a/electron/pty-host/handlers/types.ts
+++ b/electron/pty-host/handlers/types.ts
@@ -1,6 +1,7 @@
 import type { MessagePort } from "node:worker_threads";
 import type { PtyManager } from "../../services/PtyManager.js";
 import type { PtyPool } from "../../services/PtyPool.js";
+import type { AnalysisWorkerPool } from "../../services/pty/analysis/AnalysisWorkerPool.js";
 import type { ProcessTreeCache } from "../../services/ProcessTreeCache.js";
 import type { TerminalResourceMonitor } from "../../services/pty/TerminalResourceMonitor.js";
 import type { PtyHostEvent } from "../../../shared/types/pty-host.js";
@@ -43,6 +44,8 @@ export interface HostContext {
    */
   windowFocusedTerminalMap: Map<number, string | null>;
   ipcDataMirrorTerminals: Set<string>;
+  /** Analysis worker pool (null when DAINTREE_DISABLE_ANALYSIS_WORKERS=1). */
+  analysisWorkerPool: AnalysisWorkerPool | null;
 
   // Reassignable — backed by getter/setter pairs in the construction site
   // so handlers always see the current value after init-buffers reassigns.

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -8,6 +8,7 @@ import {
   probeDb,
   attemptRecovery,
 } from "./persistence/db.js";
+import { runDbWork } from "./persistence/dbWorkerClient.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 
 const TICK_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
@@ -19,6 +20,7 @@ class DatabaseMaintenanceService {
   private backupPromise: Promise<void> | null = null;
   private disposed = false;
   private initialized = false;
+  private deferredQuickCheckPending = false;
 
   initialize(wasCleanExit = false): void {
     if (this.initialized) return;
@@ -38,6 +40,10 @@ class DatabaseMaintenanceService {
       } else {
         console.warn("[DatabaseMaintenance] No backup to restore — fresh database will be created");
       }
+    } else if (wasCleanExit) {
+      // Clean-exit boots skip the O(size) quick_check; run it once from the
+      // first idle tick on the DB worker thread instead.
+      this.deferredQuickCheckPending = true;
     }
 
     console.log("[DatabaseMaintenance] Initialized (probe complete)");
@@ -54,7 +60,7 @@ class DatabaseMaintenanceService {
 
     try {
       this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
-        this.checkpoint("PASSIVE");
+        void runDbWork({ op: "checkpoint", mode: "PASSIVE" }, () => this.checkpoint("PASSIVE"));
       });
     } catch {
       // SystemSleepService may not be initialized yet at early startup.
@@ -107,8 +113,30 @@ class DatabaseMaintenanceService {
     const sqlite = getSharedSqlite();
     if (!sqlite) return;
 
-    this.checkpoint("TRUNCATE");
+    // PASSIVE at runtime: a TRUNCATE/RESTART checkpoint from the worker
+    // connection blocks concurrent writers while it waits out readers, which
+    // would spin a main-thread write on its busy_timeout. The full TRUNCATE
+    // runs once, on main, from dispose() at shutdown.
+    void runDbWork({ op: "checkpoint", mode: "PASSIVE" }, () => this.checkpoint("PASSIVE"));
+    this.runDeferredQuickCheck();
     this.backupPromise = this.runBackup();
+  }
+
+  private runDeferredQuickCheck(): void {
+    if (!this.deferredQuickCheckPending) return;
+    this.deferredQuickCheckPending = false;
+    // Advisory only, and never on main — when the worker is unavailable the
+    // fallback skips the scan rather than stalling the event loop for it.
+    void runDbWork<string | null>({ op: "quickCheck" }, () => null).then((result) => {
+      if (result === null) {
+        console.warn("[DatabaseMaintenance] Deferred quick_check skipped — DB worker unavailable");
+      } else if (result !== "ok") {
+        console.error(
+          `[DatabaseMaintenance] Deferred quick_check reported corruption in ${getDbPath()}:`,
+          result
+        );
+      }
+    });
   }
 
   private checkpoint(mode: "PASSIVE" | "TRUNCATE"): void {

--- a/electron/services/PluginActionAuditService.ts
+++ b/electron/services/PluginActionAuditService.ts
@@ -44,7 +44,7 @@ function summarizePlaintext(args: unknown): string | undefined {
 
 export interface PluginAuditLogStore {
   read(): unknown;
-  write(records: PluginActionAuditRecord[]): void;
+  write(records: PluginActionAuditRecord[], options?: { sync?: boolean }): void;
 }
 
 // Persists the ring in the dedicated audit-logs store (migration023) so
@@ -53,8 +53,8 @@ export interface PluginAuditLogStore {
 // the injected config closures.
 const defaultLogStore: PluginAuditLogStore = {
   read: () => auditRingStore.readAll("pluginAuditLog"),
-  write: (records) =>
-    auditRingStore.writeAll("pluginAuditLog", records, PLUGIN_AUDIT_DEFAULT_MAX_RECORDS),
+  write: (records, options) =>
+    auditRingStore.writeAll("pluginAuditLog", records, PLUGIN_AUDIT_DEFAULT_MAX_RECORDS, options),
 };
 
 /**
@@ -215,21 +215,24 @@ export class PluginActionAuditService {
     this.flushTimer.unref?.();
   }
 
-  private flush(): void {
+  private flush(sync = false): void {
     if (!this.hydrated) return;
     try {
-      this.logStore.write([...this.records]);
+      this.logStore.write([...this.records], { sync });
     } catch (err) {
       console.error("[PluginAudit] Failed to flush audit log:", err);
     }
   }
 
+  // Critical-moment flush (clear, dispose, shutdown): persists synchronously
+  // on the main connection instead of the fire-and-forget worker path, so the
+  // snapshot is durable when this returns.
   flushNow(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.flush();
+    this.flush(true);
   }
 
   /** Newest-first view of all persisted records. */

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -7,6 +7,7 @@ import type { PtyPool } from "./PtyPool.js";
 import type { ProcessTreeCache } from "./ProcessTreeCache.js";
 import type { DetectionResult } from "./ProcessDetector.js";
 import type { ImagePathProbe } from "./pty/ImagePathProbe.js";
+import type { AnalysisWorkerPool } from "./pty/analysis/AnalysisWorkerPool.js";
 import { createLogger } from "../utils/logger.js";
 
 const logger = createLogger("pty-host:PtyManager");
@@ -64,6 +65,7 @@ export class PtyManager extends EventEmitter {
   private ptyPool: PtyPool | null = null;
   private processTreeCache: ProcessTreeCache | null = null;
   private imagePathProbe: ImagePathProbe | null = null;
+  private analysisWorkerPool: AnalysisWorkerPool | null = null;
   private activeProjectId: string | null = null;
   private sabModeEnabled = false;
   // Resize requests that arrived before the terminal was registered.
@@ -84,6 +86,16 @@ export class PtyManager extends EventEmitter {
 
   setImagePathProbe(probe: ImagePathProbe): void {
     this.imagePathProbe = probe;
+  }
+
+  /**
+   * Route per-terminal analysis (headless mirror + ActivityMonitor) into the
+   * worker pool. Terminals spawned before this is set — and all terminals when
+   * it never is (tests, DAINTREE_DISABLE_ANALYSIS_WORKERS=1) — use the legacy
+   * in-thread path.
+   */
+  setAnalysisWorkerPool(pool: AnalysisWorkerPool | null): void {
+    this.analysisWorkerPool = pool;
   }
 
   /**
@@ -311,6 +323,7 @@ export class PtyManager extends EventEmitter {
           sabModeEnabled: this.sabModeEnabled,
           processTreeCache: this.processTreeCache,
           imagePathProbe: this.imagePathProbe,
+          analysisWorkerPool: this.analysisWorkerPool,
         },
         spawnContext,
         ptyProcess,
@@ -439,7 +452,9 @@ export class PtyManager extends EventEmitter {
     const terminal = this.registry.get(id);
     if (terminal) {
       const wasExited = terminal.getInfo().isExited;
-      terminal.kill(reason, options?.escalationDelayMs);
+      terminal.kill(reason, options?.escalationDelayMs, {
+        skipFinalSessionPersist: !options?.preserveSession,
+      });
       // Note: deletion handled in onExit callback
       if (wasExited) {
         this.registry.delete(id);
@@ -470,7 +485,7 @@ export class PtyManager extends EventEmitter {
             // Best-effort branch stamp for resume sanity checks. The pty-host
             // has FS access but no WorkspaceClient, so resolve directly from
             // git with a short timeout; never let it block or fail the close.
-            const branch = info.cwd ? getGitBranch(info.cwd) : null;
+            const branch = info.cwd ? await getGitBranch(info.cwd) : null;
             // Ship the captured record to Main rather than writing the journal
             // here — Main is the journal's single writer (two processes with
             // separate write queues doing read-modify-write on one file can

--- a/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
@@ -34,6 +34,13 @@ vi.mock("../SystemSleepService.js", () => ({
 
 vi.mock("../persistence/db.js", () => mockDbModule);
 
+// Worker unavailable in unit tests — runDbWork executes the fallback
+// synchronously, matching the client's disabled/degraded behavior, so the
+// exact-sequence pragma assertions below hold unchanged.
+vi.mock("../persistence/dbWorkerClient.js", () => ({
+  runDbWork: vi.fn((_op: unknown, fallback: () => unknown) => Promise.resolve(fallback())),
+}));
+
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   return {
@@ -124,8 +131,8 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     expect(mockSqlite.backup).toHaveBeenCalledTimes(2);
     expect(mockSqlite.pragma.mock.calls).toEqual([
-      ["wal_checkpoint(TRUNCATE)"],
-      ["wal_checkpoint(TRUNCATE)"],
+      ["wal_checkpoint(PASSIVE)"],
+      ["wal_checkpoint(PASSIVE)"],
       ["optimize"],
       ["wal_checkpoint(TRUNCATE)"],
     ]);
@@ -195,7 +202,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
     expect(mockSqlite.pragma.mock.calls).toEqual([
-      ["wal_checkpoint(TRUNCATE)"],
+      ["wal_checkpoint(PASSIVE)"],
       ["wal_checkpoint(PASSIVE)"],
     ]);
 

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -24,6 +24,12 @@ const mockDbModule = vi.hoisted(() => ({
   closeSharedDb: vi.fn(),
 }));
 
+// Worker unavailable in unit tests — runDbWork executes the fallback
+// synchronously, matching the client's disabled/degraded behavior.
+const mockRunDbWork = vi.hoisted(() =>
+  vi.fn((_op: unknown, fallback: () => unknown) => Promise.resolve(fallback()))
+);
+
 vi.mock("electron", () => ({
   powerMonitor: mockPowerMonitor,
 }));
@@ -33,6 +39,10 @@ vi.mock("../SystemSleepService.js", () => ({
 }));
 
 vi.mock("../persistence/db.js", () => mockDbModule);
+
+vi.mock("../persistence/dbWorkerClient.js", () => ({
+  runDbWork: mockRunDbWork,
+}));
 
 // Must mock fs.existsSync / renameSync for backup cleanup
 vi.mock("node:fs", async () => {
@@ -144,7 +154,7 @@ describe("DatabaseMaintenanceService", () => {
     // Advance past tick interval (5 minutes)
     vi.advanceTimersByTime(5 * 60 * 1000 + 100);
 
-    expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+    expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(PASSIVE)");
     expect(mockSqlite.backup).toHaveBeenCalled();
     void service.dispose();
   });
@@ -246,6 +256,52 @@ describe("DatabaseMaintenanceService", () => {
 
     // onSuspend should only register once even if called twice
     expect(mockSystemSleepService.onSuspend).toHaveBeenCalledTimes(1);
+    void service.dispose();
+  });
+
+  it("routes the idle-tick checkpoint through the worker client", () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+
+    expect(mockRunDbWork).toHaveBeenCalledWith(
+      { op: "checkpoint", mode: "PASSIVE" },
+      expect.any(Function)
+    );
+    void service.dispose();
+  });
+
+  it("defers the full quick_check to a single idle tick after a clean-exit boot", () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize(true);
+    service.startMaintenance();
+
+    const quickCheckOps = () =>
+      mockRunDbWork.mock.calls.filter(([op]) => (op as { op: string }).op === "quickCheck");
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+    expect(quickCheckOps()).toHaveLength(1);
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+    expect(quickCheckOps()).toHaveLength(1);
+
+    // The deferred scan must never run on the main connection.
+    expect(mockSqlite.pragma).not.toHaveBeenCalledWith("quick_check", { simple: true });
+    void service.dispose();
+  });
+
+  it("does not schedule a deferred quick_check when the boot probe already ran the full scan", () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize(false);
+    service.startMaintenance();
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+
+    expect(
+      mockRunDbWork.mock.calls.filter(([op]) => (op as { op: string }).op === "quickCheck")
+    ).toHaveLength(0);
     void service.dispose();
   });
 });

--- a/electron/services/forge/auditLog.ts
+++ b/electron/services/forge/auditLog.ts
@@ -144,7 +144,7 @@ export function summarizeForgeArgs(
  */
 export interface ForgeAuditLogStore {
   read(): unknown;
-  write(records: ForgeAuditRecord[]): void;
+  write(records: ForgeAuditRecord[], options?: { sync?: boolean }): void;
 }
 
 export class ForgeAuditService {
@@ -418,21 +418,24 @@ export class ForgeAuditService {
     this.flushTimer.unref?.();
   }
 
-  private flush(): void {
+  private flush(sync = false): void {
     if (!this.hydrated) return;
     try {
-      this.logStore.write([...this.records]);
+      this.logStore.write([...this.records], { sync });
     } catch (err) {
       console.error("[Forge] Failed to flush audit log:", err);
     }
   }
 
+  // Critical-moment flush (clear, shutdown): persists synchronously on the
+  // main connection instead of the fire-and-forget worker path, so the
+  // snapshot is durable when this returns.
   flushNow(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.flush();
+    this.flush(true);
   }
 
   /** Newest-first view of the ring buffer. */

--- a/electron/services/forge/forgeAuditService.ts
+++ b/electron/services/forge/forgeAuditService.ts
@@ -40,8 +40,8 @@ function persistConfig(patch: Record<string, unknown>): void {
 // `auditMaxRecords` stay in config.json (`forgeAudit`).
 const forgeAuditLogStore: ForgeAuditLogStore = {
   read: () => auditRingStore.readAll("forgeAuditLog"),
-  write: (records) =>
-    auditRingStore.writeAll("forgeAuditLog", records, FORGE_AUDIT_DEFAULT_MAX_RECORDS),
+  write: (records, options) =>
+    auditRingStore.writeAll("forgeAuditLog", records, FORGE_AUDIT_DEFAULT_MAX_RECORDS, options),
 };
 
 export const forgeAuditService = new ForgeAuditService(

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -47,7 +47,7 @@ const P95_Z_SCORE_MIN_TOOLS = 5;
 
 export interface McpAuditLogStore {
   read(): unknown;
-  write(records: McpLogRecord[]): void;
+  write(records: McpLogRecord[], options?: { sync?: boolean }): void;
 }
 
 // Persists the ring in the dedicated audit-logs store so settings writes to
@@ -56,8 +56,8 @@ export interface McpAuditLogStore {
 // config.json (`mcpServer`), read via the injected config closures.
 const defaultLogStore: McpAuditLogStore = {
   read: () => auditRingStore.readAll("mcpAuditLog"),
-  write: (records) =>
-    auditRingStore.writeAll("mcpAuditLog", records, MCP_AUDIT_DEFAULT_MAX_RECORDS),
+  write: (records, options) =>
+    auditRingStore.writeAll("mcpAuditLog", records, MCP_AUDIT_DEFAULT_MAX_RECORDS, options),
 };
 
 function percentile(values: number[], p: number): number {
@@ -567,21 +567,24 @@ export class AuditService {
     this.flushTimer.unref?.();
   }
 
-  private flush(): void {
+  private flush(sync = false): void {
     if (!this.hydrated) return;
     try {
-      this.logStore.write([...this.records]);
+      this.logStore.write([...this.records], { sync });
     } catch (err) {
       console.error("[MCP] Failed to flush audit log:", err);
     }
   }
 
+  // Critical-moment flush (clear, session teardown, shutdown): persists
+  // synchronously on the main connection instead of the fire-and-forget
+  // worker path, so the snapshot is durable when this returns.
   flushNow(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.flush();
+    this.flush(true);
   }
 
   /**

--- a/electron/services/mcp-server/turnOutcomeLog.ts
+++ b/electron/services/mcp-server/turnOutcomeLog.ts
@@ -15,15 +15,15 @@ import { AUDIT_FLUSH_DEBOUNCE_MS, TIER_NOT_PERMITTED_CODE } from "./shared.js";
 
 export interface TurnOutcomeLogStore {
   read(): unknown;
-  write(records: AssistantTurnRecord[]): void;
+  write(records: AssistantTurnRecord[], options?: { sync?: boolean }): void;
 }
 
 // Persists the ring in the dedicated audit-logs store; see the matching note
 // in auditLog.ts. Config flags stay in config.json.
 const defaultLogStore: TurnOutcomeLogStore = {
   read: () => auditRingStore.readAll("mcpTurnOutcomeLog"),
-  write: (records) =>
-    auditRingStore.writeAll("mcpTurnOutcomeLog", records, MCP_AUDIT_DEFAULT_MAX_RECORDS),
+  write: (records, options) =>
+    auditRingStore.writeAll("mcpTurnOutcomeLog", records, MCP_AUDIT_DEFAULT_MAX_RECORDS, options),
 };
 
 /**
@@ -506,21 +506,24 @@ export class TurnOutcomeService {
     this.flushTimer.unref?.();
   }
 
-  private flush(): void {
+  private flush(sync = false): void {
     if (!this.hydrated) return;
     try {
-      this.logStore.write([...this.records]);
+      this.logStore.write([...this.records], { sync });
     } catch (err) {
       console.error("[MCP] Failed to flush turn outcome log:", err);
     }
   }
 
+  // Critical-moment flush (clear, session teardown, shutdown): persists
+  // synchronously on the main connection instead of the fire-and-forget
+  // worker path, so the snapshot is durable when this returns.
   flushNow(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.flush();
+    this.flush(true);
   }
 
   getRecords(): AssistantTurnRecord[] {

--- a/electron/services/persistence/__tests__/auditRingStore.test.ts
+++ b/electron/services/persistence/__tests__/auditRingStore.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: () => "/fake/userData",
+    getAppPath: () => "/fake/appPath",
+  },
+}));
+
+const mockRunDbWork = vi.hoisted(() => vi.fn());
+const mockFence = vi.hoisted(() => vi.fn());
+
+vi.mock("../dbWorkerClient.js", () => ({
+  runDbWork: mockRunDbWork,
+  fenceDbWorkerWrites: mockFence,
+}));
+
+const mockSqlite = vi.hoisted(() => {
+  const insert = { run: vi.fn() };
+  const trim = { run: vi.fn() };
+  const clear = { run: vi.fn() };
+  const read = { all: vi.fn(() => [] as { record: string }[]) };
+  return {
+    insert,
+    trim,
+    clear,
+    read,
+    handle: {
+      prepare: vi.fn((sql: string) => {
+        if (sql.startsWith("INSERT")) return insert;
+        if (sql.startsWith("SELECT")) return read;
+        if (sql.includes("NOT IN")) return trim;
+        return clear;
+      }),
+      transaction: vi.fn((fn: () => void) => ({ immediate: () => fn() })),
+    },
+  };
+});
+
+vi.mock("../db.js", () => ({
+  getSharedSqlite: () => mockSqlite.handle,
+}));
+
+import { auditRingStore } from "../auditRingStore.js";
+
+describe("auditRingStore.writeAll routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunDbWork.mockResolvedValue(undefined);
+  });
+
+  it("routes background writes through the worker without touching the main connection", () => {
+    auditRingStore.writeAll("mcpAuditLog", [{ a: 1 }], 5);
+
+    expect(mockRunDbWork).toHaveBeenCalledWith(
+      { op: "ringWriteAll", ring: "mcpAuditLog", records: ['{"a":1}'], maxRecords: 5 },
+      expect.any(Function)
+    );
+    expect(mockFence).not.toHaveBeenCalled();
+    expect(mockSqlite.insert.run).not.toHaveBeenCalled();
+  });
+
+  it("sync writes fence queued worker snapshots first, then persist on the main connection", () => {
+    auditRingStore.writeAll("mcpAuditLog", [{ a: 1 }, { b: 2 }], 5, { sync: true });
+
+    expect(mockRunDbWork).not.toHaveBeenCalled();
+    expect(mockFence).toHaveBeenCalledTimes(1);
+    expect(mockSqlite.clear.run).toHaveBeenCalledWith("mcpAuditLog");
+    expect(mockSqlite.insert.run).toHaveBeenCalledTimes(2);
+    expect(mockSqlite.insert.run).toHaveBeenCalledWith(
+      "mcpAuditLog",
+      '{"a":1}',
+      expect.any(Number)
+    );
+    expect(mockSqlite.trim.run).toHaveBeenCalledWith("mcpAuditLog", "mcpAuditLog", 5);
+    // Fence moves BEFORE the write, so a stale queued snapshot can never land
+    // on top of this one.
+    expect(mockFence.mock.invocationCallOrder[0]!).toBeLessThan(
+      mockSqlite.insert.run.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("runs the main-connection write when the worker path falls back", async () => {
+    mockRunDbWork.mockImplementation((_op: unknown, fallback: () => unknown) =>
+      Promise.resolve(fallback())
+    );
+
+    auditRingStore.writeAll("forgeAuditLog", [{ c: 3 }], 4);
+    await Promise.resolve();
+
+    expect(mockFence).not.toHaveBeenCalled();
+    expect(mockSqlite.insert.run).toHaveBeenCalledWith(
+      "forgeAuditLog",
+      '{"c":3}',
+      expect.any(Number)
+    );
+  });
+});

--- a/electron/services/persistence/__tests__/dbMaintenanceWorker.test.ts
+++ b/electron/services/persistence/__tests__/dbMaintenanceWorker.test.ts
@@ -1,0 +1,286 @@
+import Database from "better-sqlite3";
+import { build } from "esbuild";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { DbWorkerOp, DbWorkerResponse } from "../dbWorkerProtocol.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const AUDIT_RINGS_DDL = `
+  CREATE TABLE audit_rings (
+    id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+    ring text NOT NULL,
+    record text NOT NULL,
+    created_at integer NOT NULL
+  );
+`;
+
+let bundleDir: string;
+let workerFile: string;
+
+// Bundle the TS worker entry once for the suite — the production bundle is
+// emitted by scripts/build-main.mjs; this mirrors it just enough to spawn the
+// real thread. better-sqlite3 stays external, pinned to its absolute path so
+// the bundle resolves it from os.tmpdir().
+beforeAll(async () => {
+  bundleDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-db-worker-"));
+  workerFile = path.join(bundleDir, "dbMaintenanceWorker.mjs");
+  await build({
+    entryPoints: [path.resolve(__dirname, "../dbMaintenanceWorker.ts")],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile: workerFile,
+    logLevel: "silent",
+    plugins: [
+      {
+        name: "external-better-sqlite3",
+        setup(builder) {
+          builder.onResolve({ filter: /^better-sqlite3$/ }, () => ({
+            path: require.resolve("better-sqlite3"),
+            external: true,
+          }));
+        },
+      },
+    ],
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(bundleDir, { recursive: true, force: true });
+});
+
+let nextRequestId = 1;
+
+function request(worker: Worker, op: DbWorkerOp, fence = 0): Promise<DbWorkerResponse> {
+  const id = nextRequestId++;
+  return new Promise((resolve, reject) => {
+    const onMessage = (response: DbWorkerResponse) => {
+      if (response.id !== id) return;
+      cleanup();
+      resolve(response);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      worker.off("message", onMessage);
+      worker.off("error", onError);
+    };
+    worker.on("message", onMessage);
+    worker.on("error", onError);
+    worker.postMessage({ ...op, id, fence });
+  });
+}
+
+describe("dbMaintenanceWorker (real worker thread)", () => {
+  let tmpDir: string;
+  let dbPath: string;
+  let mainDb: Database.Database;
+  let worker: Worker | null;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-db-worker-db-"));
+    dbPath = path.join(tmpDir, "test.db");
+    mainDb = new Database(dbPath);
+    mainDb.pragma("journal_mode = WAL");
+    mainDb.pragma("busy_timeout = 3000");
+    mainDb.exec(AUDIT_RINGS_DDL);
+    worker = null;
+  });
+
+  afterEach(async () => {
+    if (worker) {
+      const w = worker;
+      worker = null;
+      await new Promise<void>((resolve) => {
+        w.once("exit", () => resolve());
+        request(w, { op: "close" }).catch(() => {});
+        setTimeout(() => void w.terminate().then(() => resolve()), 2000).unref();
+      });
+    }
+    mainDb.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function spawn(targetDbPath = dbPath): Worker {
+    const w = new Worker(workerFile, { workerData: { dbPath: targetDbPath } });
+    worker = w;
+    return w;
+  }
+
+  it("truncates the WAL on checkpoint while the main connection stays open", async () => {
+    const insert = mainDb.prepare(
+      "INSERT INTO audit_rings (ring, record, created_at) VALUES (?, ?, ?)"
+    );
+    for (let i = 0; i < 500; i++) {
+      insert.run("wal-growth", JSON.stringify({ i }), Date.now());
+    }
+    const walPath = dbPath + "-wal";
+    expect(fs.statSync(walPath).size).toBeGreaterThan(0);
+
+    const w = spawn();
+    const response = await request(w, { op: "checkpoint", mode: "TRUNCATE" });
+    expect(response.ok).toBe(true);
+    expect(fs.statSync(walPath).size).toBe(0);
+
+    // Main connection still fully usable after the worker checkpointed.
+    const count = mainDb.prepare("SELECT COUNT(*) AS n FROM audit_rings").get() as { n: number };
+    expect(count.n).toBe(500);
+  });
+
+  it("writes ring snapshots that the main connection reads back, honoring the trim cap", async () => {
+    const w = spawn();
+    const records = ["a", "b", "c", "d", "e"].map((v) => JSON.stringify({ v }));
+    const first = await request(w, {
+      op: "ringWriteAll",
+      ring: "testRing",
+      records,
+      maxRecords: 3,
+    });
+    expect(first.ok).toBe(true);
+
+    const rows = mainDb
+      .prepare("SELECT record FROM audit_rings WHERE ring = ? ORDER BY id ASC")
+      .all("testRing") as { record: string }[];
+    expect(rows.map((r) => (JSON.parse(r.record) as { v: string }).v)).toEqual(["c", "d", "e"]);
+
+    // Snapshot semantics: a second write replaces the ring entirely.
+    const second = await request(w, {
+      op: "ringWriteAll",
+      ring: "testRing",
+      records: [JSON.stringify({ v: "z" })],
+      maxRecords: 3,
+    });
+    expect(second.ok).toBe(true);
+    const after = mainDb
+      .prepare("SELECT record FROM audit_rings WHERE ring = ? ORDER BY id ASC")
+      .all("testRing") as { record: string }[];
+    expect(after.map((r) => (JSON.parse(r.record) as { v: string }).v)).toEqual(["z"]);
+  });
+
+  it("no-ops a stale queued ring write once the fence has advanced — newer main data survives", async () => {
+    const w = spawn();
+    // Baseline snapshot applied through the worker at epoch 0.
+    const baseline = await request(w, {
+      op: "ringWriteAll",
+      ring: "fenced",
+      records: [JSON.stringify({ v: "worker-old" })],
+      maxRecords: 10,
+    });
+    expect(baseline).toMatchObject({ ok: true, result: true });
+
+    // Main degrades: it advances the fence, then runs its fallback write
+    // (the newer snapshot) directly on the main connection.
+    mainDb.pragma("user_version = 1");
+    mainDb.transaction(() => {
+      mainDb.prepare("DELETE FROM audit_rings WHERE ring = ?").run("fenced");
+      mainDb
+        .prepare("INSERT INTO audit_rings (ring, record, created_at) VALUES (?, ?, ?)")
+        .run("fenced", JSON.stringify({ v: "main-newer" }), Date.now());
+    })();
+
+    // The stale write — queued before the degrade, stamped with the old epoch —
+    // reaches the worker afterwards. It must no-op.
+    const stale = await request(
+      w,
+      {
+        op: "ringWriteAll",
+        ring: "fenced",
+        records: [JSON.stringify({ v: "worker-stale" })],
+        maxRecords: 10,
+      },
+      0
+    );
+    expect(stale).toMatchObject({ ok: true, result: false });
+
+    const rows = mainDb
+      .prepare("SELECT record FROM audit_rings WHERE ring = ? ORDER BY id ASC")
+      .all("fenced") as { record: string }[];
+    expect(rows.map((r) => (JSON.parse(r.record) as { v: string }).v)).toEqual(["main-newer"]);
+
+    // A fresh write stamped with the advanced epoch applies again.
+    const fresh = await request(
+      w,
+      {
+        op: "ringWriteAll",
+        ring: "fenced",
+        records: [JSON.stringify({ v: "post-fence" })],
+        maxRecords: 10,
+      },
+      1
+    );
+    expect(fresh).toMatchObject({ ok: true, result: true });
+    const after = mainDb
+      .prepare("SELECT record FROM audit_rings WHERE ring = ? ORDER BY id ASC")
+      .all("fenced") as { record: string }[];
+    expect(after.map((r) => (JSON.parse(r.record) as { v: string }).v)).toEqual(["post-fence"]);
+  });
+
+  it("no-ops a ring write that lands after a shutdown-drain fence while main holds the write lock", async () => {
+    const w = spawn();
+
+    // Emulate the shutdown-drain-timeout sequence with real lock contention:
+    // main opens an immediate transaction (holding the write lock), advances
+    // the fence, and writes its final synchronous snapshot; the worker's
+    // queued write arrives mid-transaction and blocks on its busy_timeout
+    // until main commits — then must see the moved fence and no-op.
+    mainDb.exec("BEGIN IMMEDIATE");
+    mainDb.pragma("user_version = 1");
+    mainDb
+      .prepare("INSERT INTO audit_rings (ring, record, created_at) VALUES (?, ?, ?)")
+      .run("drain", JSON.stringify({ v: "final-flush" }), Date.now());
+
+    const late = request(
+      w,
+      {
+        op: "ringWriteAll",
+        ring: "drain",
+        records: [JSON.stringify({ v: "late-worker" })],
+        maxRecords: 10,
+      },
+      0
+    );
+    // Give the worker a moment to start and block on the held write lock.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    mainDb.exec("COMMIT");
+
+    expect(await late).toMatchObject({ ok: true, result: false });
+    const rows = mainDb
+      .prepare("SELECT record FROM audit_rings WHERE ring = ? ORDER BY id ASC")
+      .all("drain") as { record: string }[];
+    expect(rows.map((r) => (JSON.parse(r.record) as { v: string }).v)).toEqual(["final-flush"]);
+  });
+
+  it("reports quick_check ok on a healthy database", async () => {
+    const w = spawn();
+    const response = await request(w, { op: "quickCheck" });
+    expect(response).toMatchObject({ ok: true, result: "ok" });
+  });
+
+  it("responds to close and exits without terminate()", async () => {
+    const w = spawn();
+    const exited = new Promise<number>((resolve) => w.once("exit", resolve));
+    const response = await request(w, { op: "close" });
+    expect(response.ok).toBe(true);
+    await expect(exited).resolves.toBe(0);
+    worker = null;
+  });
+
+  it("refuses to create a missing database file", async () => {
+    const w = new Worker(workerFile, {
+      workerData: { dbPath: path.join(tmpDir, "missing.db") },
+    });
+    const error = await new Promise<{ code?: string }>((resolve) => w.once("error", resolve));
+    expect(error.code).toBe("SQLITE_CANTOPEN");
+    expect(fs.existsSync(path.join(tmpDir, "missing.db"))).toBe(false);
+    await new Promise<void>((resolve) => w.once("exit", () => resolve()));
+  });
+});

--- a/electron/services/persistence/__tests__/dbWorkerClient.test.ts
+++ b/electron/services/persistence/__tests__/dbWorkerClient.test.ts
@@ -1,0 +1,312 @@
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DbWorkerRequest, DbWorkerResponse } from "../dbWorkerProtocol.js";
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: () => "/fake/userData",
+    getAppPath: () => "/fake/appPath",
+  },
+}));
+
+import { DbWorkerClient } from "../dbWorkerClient.js";
+
+class FakeWorker extends EventEmitter {
+  posted: DbWorkerRequest[] = [];
+  unrefCalls = 0;
+
+  constructor(private readonly onPost?: (worker: FakeWorker, msg: DbWorkerRequest) => void) {
+    super();
+  }
+
+  postMessage(msg: DbWorkerRequest): void {
+    this.posted.push(msg);
+    this.onPost?.(this, msg);
+  }
+
+  unref(): void {
+    this.unrefCalls++;
+  }
+
+  respond(response: DbWorkerResponse): void {
+    this.emit("message", response);
+  }
+
+  asWorker(): Worker {
+    return this as unknown as Worker;
+  }
+}
+
+function echoWorker(result: unknown = null): FakeWorker {
+  return new FakeWorker((worker, msg) => {
+    setImmediate(() => worker.respond({ id: msg.id, ok: true, result }));
+  });
+}
+
+// In-memory stand-in for the main connection's PRAGMA user_version fence.
+function fakeFenceDb(initialEpoch = 0, onAdvance?: () => void) {
+  const state = { epoch: initialEpoch };
+  const handle = {
+    pragma: (source: string) => {
+      if (source === "user_version") return state.epoch;
+      if (source.startsWith("user_version = ")) {
+        state.epoch = Number(source.slice("user_version = ".length));
+        onAdvance?.();
+      }
+      return undefined;
+    },
+  };
+  return { state, handle };
+}
+
+const checkpointOp = { op: "checkpoint", mode: "TRUNCATE" } as const;
+
+describe("DbWorkerClient", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runs the fallback on main when the kill switch is set, without spawning", async () => {
+    const spawnWorker = vi.fn();
+    const fallback = vi.fn(() => "main-result");
+    const client = new DbWorkerClient({
+      spawnWorker,
+      isDbReady: () => true,
+      isDisabled: () => true,
+    });
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(spawnWorker).not.toHaveBeenCalled();
+  });
+
+  it("runs the fallback when the main DB has not been opened yet", async () => {
+    const spawnWorker = vi.fn();
+    const fallback = vi.fn(() => "main-result");
+    const client = new DbWorkerClient({
+      spawnWorker,
+      isDbReady: () => false,
+      isDisabled: () => false,
+    });
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    expect(spawnWorker).not.toHaveBeenCalled();
+  });
+
+  it("resolves with the worker result and skips the fallback on success", async () => {
+    const worker = echoWorker("worker-result");
+    const fallback = vi.fn();
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+    });
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("worker-result");
+    expect(fallback).not.toHaveBeenCalled();
+    expect(worker.unrefCalls).toBe(1);
+    expect(worker.posted).toHaveLength(1);
+    expect(worker.posted[0]).toMatchObject({ op: "checkpoint", mode: "TRUNCATE" });
+  });
+
+  it("preserves request order across sequential calls", async () => {
+    const worker = echoWorker();
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+    });
+
+    await Promise.all([
+      client.run({ op: "ringWriteAll", ring: "a", records: ["1"], maxRecords: 5 }, () => null),
+      client.run({ op: "ringWriteAll", ring: "a", records: ["2"], maxRecords: 5 }, () => null),
+      client.run({ op: "ringWriteAll", ring: "a", records: ["3"], maxRecords: 5 }, () => null),
+    ]);
+
+    const ids = worker.posted.map((msg) => msg.id);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    expect(worker.posted.map((msg) => (msg.op === "ringWriteAll" ? msg.records[0] : ""))).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+  });
+
+  it("falls back to main when the worker reports an op failure", async () => {
+    const worker = new FakeWorker((w, msg) => {
+      setImmediate(() => w.respond({ id: msg.id, ok: false, error: "disk I/O error" }));
+    });
+    const fallback = vi.fn(() => "main-result");
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+    });
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to main and advances the fence when the worker dies mid-request", async () => {
+    const worker = new FakeWorker((w) => {
+      setImmediate(() => w.emit("exit", 1));
+    });
+    const fence = fakeFenceDb(0);
+    const fallback = vi.fn(() => "main-result");
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+      getMainSqlite: () => fence.handle,
+    });
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(fence.state.epoch).toBe(1);
+  });
+
+  it("caps spawn attempts and degrades to main-only after repeated spawn failures", async () => {
+    const spawnWorker = vi.fn(() => {
+      throw new Error("spawn failed");
+    });
+    const fallback = vi.fn(() => "main-result");
+    const client = new DbWorkerClient({
+      spawnWorker,
+      isDbReady: () => true,
+      isDisabled: () => false,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    }
+    expect(fallback).toHaveBeenCalledTimes(5);
+    expect(spawnWorker).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back on timeout and stops using the wedged worker afterwards", async () => {
+    const worker = new FakeWorker(); // never responds
+    const fallback = vi.fn(() => "main-result");
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+      requestTimeoutMs: 10,
+    });
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    expect(worker.posted).toHaveLength(1);
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    expect(worker.posted).toHaveLength(1);
+    expect(fallback).toHaveBeenCalledTimes(2);
+  });
+
+  it("shutdown sends close after queued work and routes later runs to the fallback", async () => {
+    const worker = echoWorker();
+    const fallback = vi.fn(() => "main-result");
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+    });
+
+    await client.run({ op: "ringWriteAll", ring: "a", records: ["1"], maxRecords: 5 }, fallback);
+    await client.shutdown();
+
+    expect(worker.posted.map((msg) => msg.op)).toEqual(["ringWriteAll", "close"]);
+
+    await expect(client.run(checkpointOp, fallback)).resolves.toBe("main-result");
+    expect(worker.posted).toHaveLength(2);
+  });
+
+  it("shutdown is a no-op when the worker never spawned", async () => {
+    const spawnWorker = vi.fn();
+    const client = new DbWorkerClient({
+      spawnWorker,
+      isDbReady: () => true,
+      isDisabled: () => false,
+    });
+
+    await expect(client.shutdown()).resolves.toBeUndefined();
+    expect(spawnWorker).not.toHaveBeenCalled();
+  });
+
+  it("stamps worker requests with the fence epoch read from the main connection", async () => {
+    const fence = fakeFenceDb(7);
+    const worker = echoWorker();
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+      getMainSqlite: () => fence.handle,
+    });
+
+    await client.run({ op: "ringWriteAll", ring: "a", records: ["1"], maxRecords: 5 }, () => null);
+    expect(worker.posted[0]!.fence).toBe(7);
+  });
+
+  it("advances the fence BEFORE replaying fallbacks, in submission order, on timeout-degrade", async () => {
+    const events: string[] = [];
+    const fence = fakeFenceDb(0, () => events.push("fence-advanced"));
+    const worker = new FakeWorker(); // wedged — never responds
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+      getMainSqlite: () => fence.handle,
+      requestTimeoutMs: 10,
+    });
+
+    const first = client.run(
+      { op: "ringWriteAll", ring: "a", records: ["1"], maxRecords: 5 },
+      () => {
+        events.push("fallback-1");
+        return null;
+      }
+    );
+    const second = client.run(
+      { op: "ringWriteAll", ring: "a", records: ["2"], maxRecords: 5 },
+      () => {
+        events.push("fallback-2");
+        return null;
+      }
+    );
+    await Promise.all([first, second]);
+
+    // The fence moves before any fallback write, so the wedged worker's queued
+    // snapshots can never clobber them; fallbacks replay in submission order.
+    expect(events).toEqual(["fence-advanced", "fallback-1", "fallback-2"]);
+    expect(fence.state.epoch).toBe(1);
+    expect(worker.posted.map((msg) => msg.fence)).toEqual([0, 0]);
+  });
+
+  it("advances the fence when the shutdown drain times out", async () => {
+    const fence = fakeFenceDb(0);
+    const worker = new FakeWorker((w, msg) => {
+      if (msg.op !== "close") {
+        setImmediate(() => w.respond({ id: msg.id, ok: true, result: null }));
+      }
+      // close is swallowed — the worker outlives the drain cap.
+    });
+    const client = new DbWorkerClient({
+      spawnWorker: () => worker.asWorker(),
+      isDbReady: () => true,
+      isDisabled: () => false,
+      getMainSqlite: () => fence.handle,
+      shutdownDrainTimeoutMs: 20,
+    });
+
+    await client.run(checkpointOp, () => null);
+    expect(fence.state.epoch).toBe(0);
+
+    await client.shutdown();
+    // A late worker commit after the timed-out drain would carry the old
+    // epoch and no-op against this advanced fence.
+    expect(fence.state.epoch).toBe(1);
+  });
+});

--- a/electron/services/persistence/auditRingStore.ts
+++ b/electron/services/persistence/auditRingStore.ts
@@ -1,6 +1,7 @@
 // eager-import-allow: reads/writes audit ring records via the shared SQLite DB
 import type Database from "better-sqlite3";
 import { getSharedSqlite } from "./db.js";
+import { fenceDbWorkerWrites, runDbWork } from "./dbWorkerClient.js";
 
 export type AuditRingName =
   | "mcpAuditLog"
@@ -69,8 +70,42 @@ class AuditRingStore {
   /**
    * Overwrite the ring with a new array, trimming to `maxRecords`. Runs inside
    * an immediate transaction so readers always see a consistent snapshot.
+   *
+   * The write is a full-snapshot rewrite (last write wins) whose result no
+   * caller consumes, so it runs on the DB worker thread; when the worker is
+   * unavailable it falls back to the synchronous main-thread path. Safe because
+   * every ring's owner hydrates via readAll BEFORE its first write and treats
+   * its in-memory array as the source of truth afterwards.
+   *
+   * `options.sync` is for flushNow()-style critical moments (clear, dispose,
+   * session teardown) that need the snapshot durable on return: the write runs
+   * synchronously on the main connection, after advancing the write fence so a
+   * snapshot still queued on the worker can never land on top of it.
    */
-  writeAll<T>(ring: AuditRingName, records: T[], maxRecords: number): void {
+  writeAll<T>(
+    ring: AuditRingName,
+    records: T[],
+    maxRecords: number,
+    options?: { sync?: boolean }
+  ): void {
+    let serialized: string[];
+    try {
+      serialized = records.map((record) => JSON.stringify(record));
+    } catch (error) {
+      console.warn(`[AuditRingStore] writeAll failed for "${ring}":`, error);
+      return;
+    }
+    if (options?.sync) {
+      fenceDbWorkerWrites();
+      this.writeAllSerialized(ring, serialized, maxRecords);
+      return;
+    }
+    void runDbWork({ op: "ringWriteAll", ring, records: serialized, maxRecords }, () =>
+      this.writeAllSerialized(ring, serialized, maxRecords)
+    );
+  }
+
+  private writeAllSerialized(ring: AuditRingName, records: string[], maxRecords: number): void {
     const sqlite = this.db();
     if (!sqlite) return;
     try {
@@ -84,7 +119,7 @@ class AuditRingStore {
         .transaction(() => {
           clear.run(ring);
           for (const record of records) {
-            insert.run(ring, JSON.stringify(record), now);
+            insert.run(ring, record, now);
           }
           if (maxRecords > 0) {
             trim.run(ring, ring, maxRecords);

--- a/electron/services/persistence/dbMaintenanceWorker.ts
+++ b/electron/services/persistence/dbMaintenanceWorker.ts
@@ -21,8 +21,18 @@ const { dbPath } = workerData as DbWorkerData;
 // spawns once the shared handle exists) — never create or migrate from here.
 const sqlite = new Database(dbPath, { fileMustExist: true });
 sqlite.pragma("journal_mode = WAL");
+// Intentionally above main's 3000ms: under write contention the worker must
+// out-wait main rather than throw SQLITE_BUSY at it.
 sqlite.pragma("busy_timeout = 5000");
 sqlite.pragma("synchronous = NORMAL");
+// Mirror openDb's per-connection perf pragmas (db.ts) — without them
+// quick_check and the ring-write transactions run on SQLite defaults
+// (mmap_size especially matters for quick_check on a large DB).
+sqlite.pragma("temp_store = MEMORY");
+sqlite.pragma("mmap_size = 10737418240");
+sqlite.pragma("cache_size = -65536");
+sqlite.pragma("journal_size_limit = 5242880");
+sqlite.pragma("foreign_keys = ON");
 
 interface RingStatements {
   insert: Database.Statement;

--- a/electron/services/persistence/dbMaintenanceWorker.ts
+++ b/electron/services/persistence/dbMaintenanceWorker.ts
@@ -1,0 +1,104 @@
+// Persistent worker thread that services deferrable SQLite work (WAL
+// checkpoints, quick_check scans, audit-ring snapshot writes) so better-sqlite3
+// never stalls the main-process event loop for them. Opens its OWN connection
+// to the same WAL database — safe alongside main's connection because WAL
+// permits concurrent readers plus a single writer, and both connections set a
+// busy_timeout so write contention blocks briefly instead of throwing
+// SQLITE_BUSY.
+import Database from "better-sqlite3";
+import { parentPort, workerData } from "node:worker_threads";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
+import type { DbWorkerData, DbWorkerRequest, DbWorkerResponse } from "./dbWorkerProtocol.js";
+
+const port = parentPort;
+if (!port) {
+  throw new Error("dbMaintenanceWorker must be spawned as a worker thread");
+}
+
+const { dbPath } = workerData as DbWorkerData;
+
+// Main's openDb/migrate always runs before this worker spawns (the client only
+// spawns once the shared handle exists) — never create or migrate from here.
+const sqlite = new Database(dbPath, { fileMustExist: true });
+sqlite.pragma("journal_mode = WAL");
+sqlite.pragma("busy_timeout = 5000");
+sqlite.pragma("synchronous = NORMAL");
+
+interface RingStatements {
+  insert: Database.Statement;
+  trim: Database.Statement;
+  clear: Database.Statement;
+}
+
+let ringStatements: RingStatements | null = null;
+
+// Mirrors AuditRingStore's SQL exactly — the worker is an alternate executor
+// for the same audit_rings table, not a second schema owner.
+function getRingStatements(): RingStatements {
+  if (!ringStatements) {
+    ringStatements = {
+      insert: sqlite.prepare("INSERT INTO audit_rings (ring, record, created_at) VALUES (?, ?, ?)"),
+      trim: sqlite.prepare(
+        "DELETE FROM audit_rings WHERE ring = ? AND id NOT IN (SELECT id FROM audit_rings WHERE ring = ? ORDER BY id DESC LIMIT ?)"
+      ),
+      clear: sqlite.prepare("DELETE FROM audit_rings WHERE ring = ?"),
+    };
+  }
+  return ringStatements;
+}
+
+function execute(request: DbWorkerRequest): unknown {
+  switch (request.op) {
+    case "checkpoint":
+      sqlite.pragma(`wal_checkpoint(${request.mode})`);
+      return null;
+    case "quickCheck":
+      return sqlite.pragma("quick_check", { simple: true });
+    case "ringWriteAll": {
+      const { ring, records, maxRecords, fence } = request;
+      const { insert, trim, clear } = getRingStatements();
+      const now = Date.now();
+      let applied = false;
+      sqlite
+        .transaction(() => {
+          // Write-fence check INSIDE the immediate transaction: BEGIN IMMEDIATE
+          // holds the write lock and sees the latest committed snapshot, so a
+          // fence bump main committed before its fallback write is always
+          // visible here — a stale queued snapshot can never clobber newer
+          // main-thread data. SQLite's writer serialization makes this atomic.
+          const epoch = Number(sqlite.pragma("user_version", { simple: true }));
+          if (epoch !== fence) return;
+          clear.run(ring);
+          for (const record of records) {
+            insert.run(ring, record, now);
+          }
+          if (maxRecords > 0) {
+            trim.run(ring, ring, maxRecords);
+          }
+          applied = true;
+        })
+        .immediate();
+      return applied;
+    }
+    case "close":
+      sqlite.close();
+      return null;
+  }
+}
+
+port.on("message", (request: DbWorkerRequest) => {
+  let response: DbWorkerResponse;
+  try {
+    response = { id: request.id, ok: true, result: execute(request) };
+  } catch (error) {
+    response = {
+      id: request.id,
+      ok: false,
+      error: formatErrorMessage(error, "db worker op failed"),
+    };
+  }
+  port.postMessage(response);
+  if (request.op === "close") {
+    port.close();
+  }
+});

--- a/electron/services/persistence/dbWorkerClient.ts
+++ b/electron/services/persistence/dbWorkerClient.ts
@@ -1,0 +1,277 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { getDbPath, getSharedSqlite } from "./db.js";
+import type {
+  DbWorkerData,
+  DbWorkerOp,
+  DbWorkerRequest,
+  DbWorkerResponse,
+} from "./dbWorkerProtocol.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const SHUTDOWN_DRAIN_TIMEOUT_MS = 5_000;
+// The Electron `!flush_tasks_` crash is triggered by repeated worker
+// spawn/terminate cycles, so the worker is persistent (spawned once, never
+// terminate()'d) and respawn-after-crash is capped hard.
+const MAX_SPAWN_ATTEMPTS = 3;
+
+/**
+ * Resolves the compiled maintenance worker on disk. esbuild may emit this
+ * module into a shared chunk under `dist-electron/electron/chunks/`, so
+ * `__dirname` can point at that chunks dir — step up to the electron root, then
+ * down to the worker's own bundle. Mirrors `resolveVadWorkerPath()` in
+ * `OpenAITranscriptionProvider.ts`.
+ */
+function resolveDbWorkerPath(): string {
+  const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
+  return path.join(electronDir, "services", "persistence", "dbMaintenanceWorker.js");
+}
+
+/** Narrow view of the main better-sqlite3 handle used for fence reads/bumps. */
+export interface DbFenceHandle {
+  pragma(source: string, options?: { simple?: boolean }): unknown;
+}
+
+export interface DbWorkerClientDeps {
+  spawnWorker: () => Worker;
+  isDbReady: () => boolean;
+  isDisabled: () => boolean;
+  getMainSqlite: () => DbFenceHandle | null;
+  requestTimeoutMs: number;
+  shutdownDrainTimeoutMs: number;
+}
+
+const defaultDeps: DbWorkerClientDeps = {
+  spawnWorker: () =>
+    new Worker(resolveDbWorkerPath(), {
+      workerData: { dbPath: getDbPath() } satisfies DbWorkerData,
+    }),
+  // The worker opens a second connection to the same file — main's
+  // openDb/migrate must have completed first. Spawn-on-first-use is post-boot
+  // in practice; this makes it a hard invariant.
+  isDbReady: () => getSharedSqlite() !== null,
+  isDisabled: () => process.env.DAINTREE_DISABLE_DB_WORKER === "1",
+  getMainSqlite: () => getSharedSqlite(),
+  requestTimeoutMs: REQUEST_TIMEOUT_MS,
+  shutdownDrainTimeoutMs: SHUTDOWN_DRAIN_TIMEOUT_MS,
+};
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export class DbWorkerClient {
+  private readonly deps: DbWorkerClientDeps;
+  private worker: Worker | null = null;
+  private readonly pending = new Map<number, PendingRequest>();
+  private nextRequestId = 1;
+  private spawnAttempts = 0;
+  private degraded = false;
+  private shuttingDown = false;
+  private fenceEpoch: number | null = null;
+
+  constructor(deps: Partial<DbWorkerClientDeps> = {}) {
+    this.deps = { ...defaultDeps, ...deps };
+  }
+
+  /**
+   * Run `op` on the worker thread; on any failure (kill switch, DB not open
+   * yet, spawn failure, worker crash, timeout) run `fallback` synchronously on
+   * the main thread instead — the pre-worker behavior.
+   */
+  async run<T>(op: DbWorkerOp, fallback: () => T): Promise<T> {
+    if (!this.canUseWorker()) {
+      return fallback();
+    }
+    try {
+      return (await this.request(op)) as T;
+    } catch (error) {
+      console.warn(`[DbWorker] "${op.op}" failed — running on main thread:`, error);
+      return fallback();
+    }
+  }
+
+  /**
+   * Advance the DB-level write fence when a synchronous main-thread ring write
+   * is about to run while a worker exists. Any ring write already queued on the
+   * worker was stamped with the previous epoch and will no-op, so an older
+   * snapshot can never land after the newer synchronous one. Collateral: queued
+   * snapshots for OTHER rings are dropped too — harmless, since every write is
+   * a full snapshot and the owner's next flush rewrites it.
+   */
+  fence(): void {
+    if (this.worker === null && this.pending.size === 0) return;
+    this.advanceFence();
+  }
+
+  /**
+   * Drain queued work and stop the worker via a `close` message (never
+   * `terminate()` — Electron's repeated spawn/terminate worker crash). The
+   * worker services messages FIFO, so the close response confirms every
+   * previously queued write was applied — but the wait is capped, and a worker
+   * that outlives the cap could still commit queued writes later in the
+   * shutdown window. The fence advance below makes any such late ring write a
+   * no-op. After this resolves, every subsequent `run()` executes its fallback
+   * synchronously on main — exactly what the shutdown-time `flushNow()` drains
+   * need.
+   */
+  async shutdown(): Promise<void> {
+    if (this.shuttingDown) return;
+    this.shuttingDown = true;
+    if (this.worker) {
+      try {
+        await Promise.race([
+          this.request({ op: "close" }),
+          new Promise<void>((resolve) => {
+            const timer = setTimeout(resolve, this.deps.shutdownDrainTimeoutMs);
+            timer.unref?.();
+          }),
+        ]);
+      } catch {
+        // Worker already gone — nothing left to drain.
+      }
+      this.fence();
+    }
+  }
+
+  private canUseWorker(): boolean {
+    if (this.degraded || this.shuttingDown) return false;
+    if (this.deps.isDisabled()) return false;
+    if (this.worker === null && !this.deps.isDbReady()) return false;
+    return true;
+  }
+
+  private ensureWorker(): Worker {
+    if (this.worker) return this.worker;
+    if (this.spawnAttempts >= MAX_SPAWN_ATTEMPTS) {
+      this.degraded = true;
+      throw new Error("db worker spawn attempts exhausted");
+    }
+    this.spawnAttempts++;
+    const worker = this.deps.spawnWorker();
+    // The maintenance worker must never keep the app alive.
+    worker.unref();
+    worker.on("message", (response: DbWorkerResponse) => this.settle(response));
+    worker.on("error", (error) => this.handleWorkerDown(worker, `error: ${error.message}`));
+    worker.on("exit", (code) => this.handleWorkerDown(worker, `exited with code ${code}`));
+    this.worker = worker;
+    return worker;
+  }
+
+  private request(op: DbWorkerOp): Promise<unknown> {
+    const worker = this.ensureWorker();
+    const id = this.nextRequestId++;
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        // A wedged worker could apply a stale queued write AFTER a main-thread
+        // fallback ran. Degrade permanently, then fail every pending request in
+        // FIFO order — failAllPending advances the fence first, so anything
+        // still queued on the worker no-ops, and the fallbacks replay in
+        // submission order ahead of any later synchronous write.
+        this.degraded = true;
+        this.failAllPending(new Error(`db worker request timed out: ${op.op}`));
+      }, this.deps.requestTimeoutMs);
+      timer.unref?.();
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        worker.postMessage({ ...op, id, fence: this.currentFence() } satisfies DbWorkerRequest);
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  private settle(response: DbWorkerResponse): void {
+    const entry = this.pending.get(response.id);
+    if (!entry) return;
+    this.pending.delete(response.id);
+    clearTimeout(entry.timer);
+    if (response.ok) {
+      entry.resolve(response.result);
+    } else {
+      entry.reject(new Error(response.error));
+    }
+  }
+
+  private handleWorkerDown(worker: Worker, reason: string): void {
+    if (this.worker !== worker) return;
+    this.worker = null;
+    if (this.spawnAttempts >= MAX_SPAWN_ATTEMPTS) {
+      this.degraded = true;
+    }
+    this.failAllPending(new Error(`db worker unavailable: ${reason}`));
+  }
+
+  private failAllPending(error: Error): void {
+    if (this.pending.size === 0) return;
+    this.advanceFence();
+    const entries = [...this.pending.values()];
+    this.pending.clear();
+    for (const entry of entries) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+    }
+  }
+
+  /**
+   * Bump `PRAGMA user_version` on the MAIN connection. Worker requests are
+   * stamped with the epoch current at post time and the worker re-reads
+   * user_version inside its immediate write transaction, so SQLite's writer
+   * serialization guarantees that once the bump commits, every still-queued
+   * ring write no-ops.
+   */
+  private advanceFence(): void {
+    const db = this.deps.getMainSqlite();
+    if (!db) return;
+    try {
+      const next = this.currentFence() + 1;
+      db.pragma(`user_version = ${next}`);
+      this.fenceEpoch = next;
+    } catch (error) {
+      console.warn("[DbWorker] Failed to advance write fence:", error);
+    }
+  }
+
+  private currentFence(): number {
+    if (this.fenceEpoch === null) {
+      const db = this.deps.getMainSqlite();
+      const value = db ? Number(db.pragma("user_version", { simple: true })) : 0;
+      this.fenceEpoch = Number.isFinite(value) ? value : 0;
+    }
+    return this.fenceEpoch;
+  }
+}
+
+let instance: DbWorkerClient | null = null;
+
+export function getDbWorkerClient(): DbWorkerClient {
+  if (!instance) {
+    instance = new DbWorkerClient();
+  }
+  return instance;
+}
+
+export function runDbWork<T>(op: DbWorkerOp, fallback: () => T): Promise<T> {
+  return getDbWorkerClient().run(op, fallback);
+}
+
+/**
+ * Fence any queued worker ring writes before a synchronous main-thread write.
+ * No-ops when the client (and thus the worker) was never created.
+ */
+export function fenceDbWorkerWrites(): void {
+  instance?.fence();
+}
+
+export async function shutdownDbWorker(): Promise<void> {
+  if (instance) {
+    await instance.shutdown();
+  }
+}

--- a/electron/services/persistence/dbWorkerProtocol.ts
+++ b/electron/services/persistence/dbWorkerProtocol.ts
@@ -1,0 +1,21 @@
+export interface DbWorkerData {
+  dbPath: string;
+}
+
+export type DbWorkerOp =
+  | { op: "checkpoint"; mode: "PASSIVE" | "TRUNCATE" }
+  | { op: "quickCheck" }
+  | { op: "ringWriteAll"; ring: string; records: string[]; maxRecords: number }
+  | { op: "close" };
+
+// `fence` is the write-fence epoch (PRAGMA user_version — unused elsewhere in
+// the schema) current when the request was posted. The worker re-reads
+// user_version inside its immediate write transaction and no-ops any ring
+// write whose epoch no longer matches — this is how main invalidates stale
+// queued snapshots after a degrade or a shutdown-drain timeout. Idempotent ops
+// (checkpoint, quickCheck) ignore it.
+export type DbWorkerRequest = DbWorkerOp & { id: number; fence: number };
+
+export type DbWorkerResponse =
+  | { id: number; ok: true; result: unknown }
+  | { id: number; ok: false; error: string };

--- a/electron/services/plugin-mcp/PluginMcpAuditService.ts
+++ b/electron/services/plugin-mcp/PluginMcpAuditService.ts
@@ -70,7 +70,7 @@ export interface PluginMcpAuditInput {
  */
 export interface PluginMcpAuditLogStore {
   read(): unknown;
-  write(records: PluginMcpAuditRecord[]): void;
+  write(records: PluginMcpAuditRecord[], options?: { sync?: boolean }): void;
 }
 
 export class PluginMcpAuditService {
@@ -159,21 +159,24 @@ export class PluginMcpAuditService {
     this.flushTimer.unref?.();
   }
 
-  private flush(): void {
+  private flush(sync = false): void {
     if (!this.hydrated) return;
     try {
-      this.logStore.write([...this.records]);
+      this.logStore.write([...this.records], { sync });
     } catch (err) {
       console.error("[PluginMcpAudit] Failed to flush audit log:", err);
     }
   }
 
+  // Critical-moment flush (clear, shutdown): persists synchronously on the
+  // main connection instead of the fire-and-forget worker path, so the
+  // snapshot is durable when this returns.
   flushNow(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.flush();
+    this.flush(true);
   }
 
   /** Newest-first view of all persisted records. */

--- a/electron/services/plugin-mcp/instances.ts
+++ b/electron/services/plugin-mcp/instances.ts
@@ -29,11 +29,12 @@ export function getPluginMcpAuditService(): PluginMcpAuditService {
       () => (store.get("pluginMcpAudit") ?? {}) as Record<string, unknown>,
       {
         read: () => auditRingStore.readAll("pluginMcpAuditLog"),
-        write: (records) =>
+        write: (records, options) =>
           auditRingStore.writeAll(
             "pluginMcpAuditLog",
             records,
-            PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS
+            PLUGIN_MCP_AUDIT_DEFAULT_MAX_RECORDS,
+            options
           ),
       }
     );

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -18,7 +18,10 @@ export interface SessionSnapshotterHost {
   hasBannerMarkers(): boolean;
   getSerializedState(): string | null;
   getSerializedStateAsync(): Promise<string | null>;
-  serializeForPersistence(): string | null;
+  // Sync string in-thread; a Promise when the buffer lives in an analysis
+  // worker. The sync flush paths degrade to best-effort async persistence for
+  // Promise-returning hosts.
+  serializeForPersistence(): string | null | Promise<string | null>;
 }
 
 export class SessionSnapshotter {
@@ -60,9 +63,9 @@ export class SessionSnapshotter {
     this.inFlight = true;
     try {
       this.dirty = false;
-      const state = this.host.hasBannerMarkers()
+      const state = await (this.host.hasBannerMarkers()
         ? this.host.serializeForPersistence()
-        : await this.host.getSerializedStateAsync();
+        : this.host.getSerializedStateAsync());
       // Re-check lifecycle after the await — a kill or dispose during async
       // serialize would otherwise stomp the sync snapshot written from kill().
       if (this.disposed || this.host.wasKilled) return;
@@ -108,9 +111,9 @@ export class SessionSnapshotter {
     this.eventDrivenInFlight = true;
     this.lastEventDrivenFlushAt = now;
     try {
-      const state = this.host.hasBannerMarkers()
+      const state = await (this.host.hasBannerMarkers()
         ? this.host.serializeForPersistence()
-        : await this.host.getSerializedStateAsync();
+        : this.host.getSerializedStateAsync());
       // Re-check lifecycle after the await — a kill or dispose during async
       // serialize would otherwise stomp the sync snapshot written from kill().
       if (this.disposed || this.host.wasKilled) return;
@@ -137,12 +140,31 @@ export class SessionSnapshotter {
 
     try {
       const state = this.host.serializeForPersistence();
-      if (state) {
+      if (typeof state === "string") {
         persistSessionSnapshotSync(this.host.id, state);
+      } else if (state) {
+        // Worker-backed host: the buffer serializes off-thread, so a sync
+        // flush is impossible. The serialize request is already in the
+        // worker's queue ahead of the free message, so this best-effort async
+        // persist still captures the pre-kill buffer.
+        this.persistDeferred(state);
       }
     } catch {
       // best-effort only
     }
+  }
+
+  private persistDeferred(state: Promise<string | null>): void {
+    void state
+      .then((s) => {
+        if (!s) return;
+        if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
+        if (isSessionPersistSuppressed()) return;
+        return persistSessionSnapshotAsync(this.host.id, s);
+      })
+      .catch(() => {
+        // best-effort only
+      });
   }
 
   // Sync flush invoked from dispose() when the debounced timer never fired.
@@ -155,7 +177,13 @@ export class SessionSnapshotter {
     if (this.host.wasKilled) return;
 
     try {
-      const state = this.host.serializeForPersistence() ?? this.host.getSerializedState();
+      const raw = this.host.serializeForPersistence();
+      if (raw !== null && typeof raw === "object") {
+        this.persistDeferred(raw);
+        this.dirty = false;
+        return;
+      }
+      const state = raw ?? this.host.getSerializedState();
       if (state) {
         persistSessionSnapshotSync(this.host.id, state);
         this.dirty = false;

--- a/electron/services/pty/TerminalAgentDetection.ts
+++ b/electron/services/pty/TerminalAgentDetection.ts
@@ -2,7 +2,7 @@ import { isBuiltInAgentId, type BuiltInAgentId } from "../../../shared/config/ag
 import { getEffectiveAgentConfig } from "../../../shared/config/agentRegistry.js";
 import type { DetectionResult, DetectionState } from "../ProcessDetector.js";
 import { events } from "../events.js";
-import type { ActivityMonitor } from "../ActivityMonitor.js";
+import type { PatternDetectionConfig } from "./AgentPatternDetector.js";
 import type { ActivityHeadlineGenerator } from "../ActivityHeadlineGenerator.js";
 import type { AgentStateService } from "./AgentStateService.js";
 import type { SemanticBufferManager } from "./SemanticBufferManager.js";
@@ -17,8 +17,9 @@ export interface TerminalAgentDetectionHost {
   readonly agentStateService: AgentStateService;
   readonly headlineGenerator: ActivityHeadlineGenerator;
   readonly semanticBufferManager: SemanticBufferManager;
-  readonly activityMonitor: ActivityMonitor | null;
+  readonly hasActivityMonitor: boolean;
   lastDetectedProcessIconId: string | undefined;
+  reconfigureActivityMonitor(agentId: string, patternConfig?: PatternDetectionConfig): void;
   startActivityMonitor(): void;
   stopActivityMonitor(): void;
 }
@@ -89,8 +90,8 @@ export function handleAgentDetection(
 
       const detection = getEffectiveAgentConfig(detectedAgentId)?.detection;
       const patternConfig = buildPatternConfig(detection, detectedAgentId);
-      if (host.activityMonitor) {
-        host.activityMonitor.reconfigure(detectedAgentId, patternConfig);
+      if (host.hasActivityMonitor) {
+        host.reconfigureActivityMonitor(detectedAgentId, patternConfig);
       } else {
         // Runtime promotion: plain terminal now hosts an agent. Start the
         // activity monitor immediately so the renderer sees state

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -639,7 +639,17 @@ export class TerminalProcess {
         this.flushAgentOutput();
         this.deps.agentStateService.handleActivityState(this.terminalInfo, state, metadata);
       },
-      onWaitingTimeout: (_spawnedAt) => {
+      onWaitingTimeout: (spawnedAt) => {
+        // Same session guard as onActivityState: after a worker respawn or
+        // slot re-registration a late timeout from an old monitor generation
+        // must not fire a watchdog transition against the current terminal.
+        if (this.terminalInfo.spawnedAt !== spawnedAt) {
+          console.warn(
+            `[TerminalProcess] Rejected stale waiting-timeout from old monitor ${this.id} ` +
+              `(session ${spawnedAt} vs current ${this.terminalInfo.spawnedAt})`
+          );
+          return;
+        }
         this.flushAgentOutput();
         this.deps.agentStateService.updateAgentState(
           this.terminalInfo,
@@ -704,7 +714,18 @@ export class TerminalProcess {
         processStateValidator,
         initialState: opts.initialState,
         skipInitialStateEmit: opts.skipInitialStateEmit,
-        onWaitingTimeout: (_id, _spawnedAt) => {
+        onWaitingTimeout: (_id, cbSpawnedAt) => {
+          // Structurally the in-thread monitor can't outlive its session
+          // (stopMonitorInThread disposes it synchronously and spawnedAt is
+          // immutable per TerminalProcess), but keep the same guard the
+          // worker delegate and both activity-state paths use.
+          if (this.terminalInfo.spawnedAt !== cbSpawnedAt) {
+            console.warn(
+              `[TerminalProcess] Rejected stale waiting-timeout from old monitor ${this.id} ` +
+                `(session ${cbSpawnedAt} vs current ${this.terminalInfo.spawnedAt})`
+            );
+            return;
+          }
           this.flushAgentOutput();
           this.deps.agentStateService.updateAgentState(
             this.terminalInfo,

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -51,7 +51,7 @@ import {
   OUTPUT_SETTLE_MAX_WAIT_MS,
   OUTPUT_SETTLE_POLL_INTERVAL_MS,
 } from "./terminalInput.js";
-import type { IBufferCell, IMarker } from "@xterm/headless";
+import type { IMarker } from "@xterm/headless";
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
   isSessionPersistSuppressed,
@@ -80,15 +80,26 @@ import {
   serializeForPersistence,
 } from "./terminalSerialization.js";
 import { ForegroundProcessGroupProbe } from "./ForegroundProcessGroupProbe.js";
+import type { AnalysisBackend, MonitorStartOptions } from "./analysis/AnalysisBackend.js";
+import {
+  InThreadAnalysisBackend,
+  type InThreadAnalysisHost,
+} from "./analysis/InThreadAnalysisBackend.js";
+import type { WorkerAnalysisDelegate } from "./analysis/WorkerAnalysisBackend.js";
+import type { AnalysisWorkerPool } from "./analysis/AnalysisWorkerPool.js";
+import {
+  readCursorLine,
+  readLastNLines,
+  readVisibleActivityLines,
+  readVisibleActivitySnapshot,
+} from "./analysis/headlessViewport.js";
+import type { AnalysisFinalSnapshot } from "./analysisWorkerProtocol.js";
 import { TerminalExitObservers, type TerminalExitArgs } from "./TerminalExitObservers.js";
 import { gracefulShutdown as runGracefulShutdown } from "./TerminalGracefulShutdown.js";
 import { handleAgentDetection as runHandleAgentDetection } from "./TerminalAgentDetection.js";
 import { TerminalProcessLifecycle } from "./TerminalProcessLifecycle.js";
 import {
-  createVisibleCellContentSnapshot,
-  createVisibleContentSnapshot,
   measureVisibleContentDelta,
-  type VisibleContentCell,
   type VisibleContentSnapshot,
 } from "./SustainedChangeTracker.js";
 import {
@@ -112,18 +123,6 @@ const AGENT_OUTPUT_FLUSH_INTERVAL_MS = 50;
 // accumulate into it rather than being lost.
 const AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS = 50;
 
-type CursorBufferLine = {
-  translateToString: (trimRight?: boolean) => string;
-  getCell?: (index: number, cell?: IBufferCell) => IBufferCell | undefined;
-};
-
-type CursorBuffer = {
-  cursorY?: number;
-  baseY: number;
-  getNullCell?: () => IBufferCell;
-  getLine: (index: number) => CursorBufferLine | undefined;
-};
-
 export interface TerminalProcessCallbacks {
   emitData: (id: string, data: string | Uint8Array) => void;
   onExit: (id: string, exitCode: number, signal?: number) => void;
@@ -143,9 +142,19 @@ export interface TerminalProcessDependencies {
   sabModeEnabled?: boolean;
   processTreeCache: ProcessTreeCache | null;
   imagePathProbe?: ImagePathProbe | null;
+  /**
+   * When set, the analysis stack (headless mirror + ActivityMonitor) runs in
+   * a persistent worker_threads pool instead of on this thread. Absent/null →
+   * legacy in-thread path (the DAINTREE_DISABLE_ANALYSIS_WORKERS fallback).
+   */
+  analysisWorkerPool?: AnalysisWorkerPool | null;
 }
 
 export class TerminalProcess {
+  // Analysis seam: in-thread (legacy, kill-switch) or worker-pool backed.
+  // In worker mode `activityMonitor`, `headlessTerminal`, and `serializeAddon`
+  // stay null/undefined on this thread — the stack lives in the worker slot.
+  private analysis!: AnalysisBackend;
   private activityMonitor: ActivityMonitor | null = null;
   // Streaming OSC 9;4 parser (#8701). Created once per TerminalProcess and
   // fed every PTY chunk upstream of `activityMonitor.onData()`. Callbacks
@@ -238,6 +247,33 @@ export class TerminalProcess {
   }
 
   private createSessionSnapshotter(): SessionSnapshotter {
+    if (this.analysis.kind === "worker") {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const parent = this;
+      const host: SessionSnapshotterHost = {
+        get id() {
+          return parent.id;
+        },
+        get wasKilled() {
+          return parent.terminalInfo.wasKilled === true;
+        },
+        get launchAgentId() {
+          return parent.terminalInfo.launchAgentId;
+        },
+        get contentEpoch() {
+          return parent.terminalInfo.contentEpoch;
+        },
+        // Route every persistence serialize through the worker's banner-aware
+        // op (it falls back to a plain serialize when no banner markers exist),
+        // so the host never needs to know whether a restore banner is present.
+        hasBannerMarkers: () => true,
+        getSerializedState: () => null,
+        getSerializedStateAsync: () => parent.getSerializedStateAsync(),
+        serializeForPersistence: () => parent.analysis.serializeForPersistence(),
+      };
+      return new SessionSnapshotter(host);
+    }
+
     class Host implements SessionSnapshotterHost {
       constructor(private parent: TerminalProcess) {}
 
@@ -357,28 +393,6 @@ export class TerminalProcess {
     // plain tier" split was retired along with the tiered capability model.
     this._scrollback = DEFAULT_SCROLLBACK;
 
-    const headlessTerminal: HeadlessTerminalType = new HeadlessTerminal({
-      cols: options.cols,
-      rows: options.rows,
-      scrollback: this._scrollback,
-      allowProposedApi: true,
-    });
-    // SynchronizedFrameAnalyzer reads cell.width from this buffer; without
-    // Unicode 11 widths, emoji and CJK rows would mis-report column counts.
-    headlessTerminal.loadAddon(new Unicode11Addon());
-    headlessTerminal.unicode.activeVersion = "11";
-    const serializeAddon: SerializeAddonType = new SerializeAddon();
-    headlessTerminal.loadAddon(serializeAddon);
-
-    // Structural-signal tier (#6668): hook the headless parser for DEC mode
-    // 2026 brackets so frame snapshots can drive the analyzer. Lifetime ties
-    // to the headless terminal — disposed alongside it in disposeHeadless().
-    // The callback resolves activityMonitor lazily so frame events fire even
-    // for plain terminals that are promoted to agents post-spawn.
-    this.synchronizedFrameDetector = new SynchronizedFrameDetector(headlessTerminal, (snapshot) => {
-      this.activityMonitor?.onSynchronizedFrame(snapshot);
-    });
-
     this.terminalInfo = {
       id,
       projectId: options.projectId,
@@ -402,8 +416,6 @@ export class TerminalProcess {
       lastCheckTime: spawnedAt,
       contentEpoch: 0,
       semanticBuffer: [],
-      headlessTerminal,
-      serializeAddon,
       restartCount: 0,
       // Analysis is enabled whenever an agent is expected or live. Plain
       // terminals enable it on the fly when the process detector promotes.
@@ -417,7 +429,25 @@ export class TerminalProcess {
       spawnArgs,
     };
 
-    this.restoreSessionIfPresent(headlessTerminal);
+    // Analysis backend selection: worker pool when available, else the legacy
+    // in-thread stack. The worker slot performs its own session restore (the
+    // banner markers live with the buffer, wherever it is).
+    const workerPool = deps.analysisWorkerPool ?? null;
+    const workerBackend = workerPool
+      ? workerPool.createBackend(
+          {
+            terminalId: id,
+            cols: options.cols,
+            rows: options.rows,
+            scrollback: this._scrollback,
+            restore:
+              TERMINAL_SESSION_PERSISTENCE_ENABLED && !hasLaunchHint && options.restore !== false,
+            spawnedAt,
+          },
+          this.createWorkerAnalysisDelegate()
+        )
+      : null;
+    this.analysis = workerBackend ?? this.setupInThreadAnalysis(options);
 
     // NOTE: The headless responder is intentionally NOT installed for agent
     // terminals. It would forward query responses (CSI 6n cursor position,
@@ -495,41 +525,11 @@ export class TerminalProcess {
     // terminals start the monitor only when detection promotes them; see
     // `handleAgentDetection`.
     if (hasLaunchHint) {
-      const processStateValidator = createProcessStateValidator(ptyPid, deps.processTreeCache);
-      this.activityMonitor = new ActivityMonitor(
-        id,
-        spawnedAt,
-        (_termId, cbSpawnedAt, state, metadata) => {
-          if (this.terminalInfo.spawnedAt !== cbSpawnedAt) {
-            console.warn(
-              `[TerminalProcess] Rejected stale activity state from old monitor ${_termId} ` +
-                `(session ${cbSpawnedAt} vs current ${this.terminalInfo.spawnedAt})`
-            );
-            return;
-          }
-          this.flushAgentOutput();
-          deps.agentStateService.handleActivityState(this.terminalInfo, state, metadata);
-        },
-        {
-          ...buildActivityMonitorOptions(launchAgentId, {
-            getVisibleLines: (n) => this.getVisibleActivityLines(n),
-            getVisibleContentSnapshot: (n) => this.getVisibleActivitySnapshot(n),
-            getCursorLine: () => this.getCursorLine(),
-          }),
-          processStateValidator,
-          onWaitingTimeout: (_id, _spawnedAt) => {
-            this.flushAgentOutput();
-            deps.agentStateService.updateAgentState(
-              this.terminalInfo,
-              { type: "watchdog-timeout" },
-              "timeout",
-              0.6
-            );
-          },
-          onBootComplete: (timestamp) => this.recordBootComplete(timestamp),
-        }
-      );
-      this.activityMonitor.startPolling();
+      this.analysis.startMonitor({
+        agentId: launchAgentId,
+        initialState: "idle",
+        skipInitialStateEmit: false,
+      });
     }
 
     if (hasLaunchHint && launchAgentId) {
@@ -565,7 +565,196 @@ export class TerminalProcess {
     throw new Error("Headless terminal unavailable (unexpected)");
   }
 
+  /**
+   * Builds the legacy in-thread analysis stack: headless xterm + addons +
+   * synchronized-frame detector, then wraps it behind the AnalysisBackend
+   * seam. Also the fallback when the worker pool can't provide a slot.
+   */
+  private setupInThreadAnalysis(options: PtySpawnOptions): InThreadAnalysisBackend {
+    const headlessTerminal: HeadlessTerminalType = new HeadlessTerminal({
+      cols: options.cols,
+      rows: options.rows,
+      scrollback: this._scrollback,
+      allowProposedApi: true,
+    });
+    // SynchronizedFrameAnalyzer reads cell.width from this buffer; without
+    // Unicode 11 widths, emoji and CJK rows would mis-report column counts.
+    headlessTerminal.loadAddon(new Unicode11Addon());
+    headlessTerminal.unicode.activeVersion = "11";
+    const serializeAddon: SerializeAddonType = new SerializeAddon();
+    headlessTerminal.loadAddon(serializeAddon);
+
+    // Structural-signal tier (#6668): hook the headless parser for DEC mode
+    // 2026 brackets so frame snapshots can drive the analyzer. Lifetime ties
+    // to the headless terminal — disposed alongside it in disposeHeadless().
+    // The callback resolves activityMonitor lazily so frame events fire even
+    // for plain terminals that are promoted to agents post-spawn.
+    this.synchronizedFrameDetector = new SynchronizedFrameDetector(headlessTerminal, (snapshot) => {
+      this.activityMonitor?.onSynchronizedFrame(snapshot);
+    });
+
+    this.terminalInfo.headlessTerminal = headlessTerminal;
+    this.terminalInfo.serializeAddon = serializeAddon;
+    this.restoreSessionIfPresent(headlessTerminal);
+
+    return new InThreadAnalysisBackend(this.createInThreadAnalysisHost());
+  }
+
+  private createInThreadAnalysisHost(): InThreadAnalysisHost {
+    return {
+      feedChunk: (data) => this.feedChunkInThread(data),
+      feedPrelude: (data) => this.feedPreludeInThread(data),
+      resize: (cols, rows) => this.resizeAnalysisInThread(cols, rows),
+      handleFocus: () => this.handleFocusInThread(),
+      getMonitor: () => this.activityMonitor,
+      startMonitor: (opts) => this.startMonitorInThread(opts),
+      stopMonitor: () => this.stopMonitorInThread(),
+      setScrollback: (lines) => {
+        if (!this.terminalInfo.headlessTerminal) return false;
+        this.terminalInfo.headlessTerminal.options.scrollback = lines;
+        return true;
+      },
+      readViewportLines: (n) => readLastNLines(this.terminalInfo.headlessTerminal, n),
+      readCursorLine: () => readCursorLine(this.terminalInfo.headlessTerminal),
+      serialize: () => serializeTerminalAsync(this.id, this.terminalInfo),
+      serializeForPersistence: () => this.serializeForPersistence(),
+      captureFinalSnapshot: async (): Promise<AnalysisFinalSnapshot> => {
+        const snapshot = await serializeTerminalAsync(this.id, this.terminalInfo);
+        return { snapshot, persistence: this.serializeForPersistence() };
+      },
+      releaseHeadless: () => this.disposeHeadlessInThread(),
+    };
+  }
+
+  private createWorkerAnalysisDelegate(): WorkerAnalysisDelegate {
+    return {
+      onActivityState: (spawnedAt, state, metadata) => {
+        if (this.terminalInfo.spawnedAt !== spawnedAt) {
+          console.warn(
+            `[TerminalProcess] Rejected stale activity state from old monitor ${this.id} ` +
+              `(session ${spawnedAt} vs current ${this.terminalInfo.spawnedAt})`
+          );
+          return;
+        }
+        this.flushAgentOutput();
+        this.deps.agentStateService.handleActivityState(this.terminalInfo, state, metadata);
+      },
+      onWaitingTimeout: (_spawnedAt) => {
+        this.flushAgentOutput();
+        this.deps.agentStateService.updateAgentState(
+          this.terminalInfo,
+          { type: "watchdog-timeout" },
+          "timeout",
+          0.6
+        );
+      },
+      onBootComplete: (timestamp) => this.recordBootComplete(timestamp),
+      onPtyResponse: (data) => {
+        if (this.terminalInfo.wasKilled || !this.lifecycle.isAlive) return;
+        try {
+          this.terminalInfo.ptyProcess.write(data);
+        } catch (error) {
+          this.logWriteError(error, { operation: "write(analysis-responder)" });
+        }
+      },
+      getProcessState: () => {
+        const validator = createProcessStateValidator(
+          this.terminalInfo.ptyProcess.pid,
+          this.deps.processTreeCache
+        );
+        if (!validator) return null;
+        return {
+          hasActiveChildren: validator.hasActiveChildren(),
+          cpuUsage: validator.getDescendantsCpuUsage?.() ?? 0,
+        };
+      },
+      getAgentContext: () => ({
+        agentLive: this.isAgentLive,
+        agentState: this.terminalInfo.agentState,
+      }),
+    };
+  }
+
+  private startMonitorInThread(opts: MonitorStartOptions): void {
+    if (this.activityMonitor) return;
+    const processStateValidator = createProcessStateValidator(
+      this.terminalInfo.ptyProcess.pid,
+      this.deps.processTreeCache
+    );
+    this.activityMonitor = new ActivityMonitor(
+      this.id,
+      this.terminalInfo.spawnedAt,
+      (_termId, cbSpawnedAt, state, metadata) => {
+        if (this.terminalInfo.spawnedAt !== cbSpawnedAt) {
+          console.warn(
+            `[TerminalProcess] Rejected stale activity state from old monitor ${_termId} ` +
+              `(session ${cbSpawnedAt} vs current ${this.terminalInfo.spawnedAt})`
+          );
+          return;
+        }
+        this.flushAgentOutput();
+        this.deps.agentStateService.handleActivityState(this.terminalInfo, state, metadata);
+      },
+      {
+        ...buildActivityMonitorOptions(opts.agentId, {
+          getVisibleLines: (n) => this.getVisibleActivityLines(n),
+          getVisibleContentSnapshot: (n) => this.getVisibleActivitySnapshot(n),
+          getCursorLine: () => this.getCursorLine(),
+        }),
+        processStateValidator,
+        initialState: opts.initialState,
+        skipInitialStateEmit: opts.skipInitialStateEmit,
+        onWaitingTimeout: (_id, _spawnedAt) => {
+          this.flushAgentOutput();
+          this.deps.agentStateService.updateAgentState(
+            this.terminalInfo,
+            { type: "watchdog-timeout" },
+            "timeout",
+            0.6
+          );
+        },
+        onBootComplete: (timestamp) => this.recordBootComplete(timestamp),
+      }
+    );
+    this.activityMonitor.startPolling();
+  }
+
+  private stopMonitorInThread(): void {
+    if (this.activityMonitor) {
+      this.activityMonitor.dispose();
+      this.activityMonitor = null;
+    }
+    // Clear any in-flight OSC 9;4 fragment so a sequence split across the
+    // teardown boundary can't trigger a callback against a stale monitor.
+    this.osc94Parser.reset();
+  }
+
+  private handleFocusInThread(): void {
+    this.activityMonitor?.notifyFocus();
+    this.agentOutputTemperature.reset();
+    this.agentOutputContentSnapshot = undefined;
+  }
+
+  private resizeAnalysisInThread(cols: number, rows: number): void {
+    const terminal = this.terminalInfo;
+    if (terminal.headlessTerminal) {
+      terminal.headlessTerminal.resize(cols, rows);
+      // Reflow rewraps the buffer — invalidate any wake no-change skip.
+      terminal.contentEpoch++;
+    }
+    // Notify activity monitor so reflow bytes are suppressed. Issue #2364.
+    if (this.activityMonitor) {
+      this.activityMonitor.notifyResize();
+    }
+    this.agentOutputTemperature.noteResize(Date.now());
+    this.agentOutputContentSnapshot = undefined;
+  }
+
   private disposeHeadless(): void {
+    this.analysis.release();
+  }
+
+  private disposeHeadlessInThread(): void {
     const terminal = this.terminalInfo;
     this.agentOutputTemperature.reset();
     this.agentOutputContentSnapshot = undefined;
@@ -614,6 +803,10 @@ export class TerminalProcess {
    * existing buffer beats serving nothing, at the cost of the memory.
    */
   private snapshotAndDisposePreserved(): void {
+    if (this.analysis.kind === "worker") {
+      this.snapshotAndDisposePreservedViaWorker();
+      return;
+    }
     const terminal = this.terminalInfo;
     const headless = terminal.headlessTerminal;
     if (!headless || !terminal.serializeAddon) {
@@ -666,6 +859,44 @@ export class TerminalProcess {
       // Bound the in-memory preserved-snapshot count now that this terminal's
       // snapshot is actually present — counting it (unlike an onExit-time sweep)
       // keeps the cap accurate under bursts of simultaneous exits.
+      this.callbacks.onPreserved?.(this.id);
+    });
+  }
+
+  // Worker-mode counterpart of the in-thread capture above: the drain +
+  // serialize happens in the worker slot; on failure the slot is kept alive
+  // (serving the live buffer beats serving nothing), matching the in-thread
+  // keep-on-serialize-failure semantics.
+  private snapshotAndDisposePreservedViaWorker(): void {
+    const terminal = this.terminalInfo;
+    void this.analysis.captureFinalSnapshot().then(({ snapshot, persistence }) => {
+      // dispose() may have run while the capture was in flight (LRU eviction,
+      // app shutdown) — the slot is already released and the registry entry
+      // may be gone; a late snapshot must not resurrect preserved state or
+      // fire onPreserved. Mirrors the in-thread capture's same-headless-
+      // instance guard.
+      if (this.lifecycle.isDisposed) {
+        return;
+      }
+      if (snapshot === null) {
+        return;
+      }
+      if (
+        TERMINAL_SESSION_PERSISTENCE_ENABLED &&
+        !isSessionPersistSuppressed() &&
+        !terminal.launchAgentId
+      ) {
+        try {
+          persistSessionSnapshotSync(this.id, persistence ?? snapshot);
+        } catch {
+          // best-effort only
+        }
+      }
+      terminal.preservedSnapshot = snapshot;
+      terminal.preservedAt = Date.now();
+      terminal.contentEpoch++;
+      terminal.pendingHeadlessWrites = 0;
+      this.analysis.release();
       this.callbacks.onPreserved?.(this.id);
     });
   }
@@ -889,11 +1120,11 @@ export class TerminalProcess {
     if (traceId !== undefined) {
       terminal.traceId = traceId || undefined;
     }
-    if (this.activityMonitor) {
+    if (this.analysis.hasMonitor()) {
       if (isFocusReport(data)) {
         this.handleFocusInput();
       } else {
-        this.activityMonitor.onInput(data);
+        this.analysis.notifyInput(data);
       }
     }
 
@@ -922,11 +1153,11 @@ export class TerminalProcess {
       terminal.traceId = traceId || undefined;
     }
 
-    if (this.activityMonitor) {
+    if (this.analysis.hasMonitor()) {
       if (isFocusReport(data)) {
         this.handleFocusInput();
       } else {
-        this.activityMonitor.onInput(data);
+        this.analysis.notifyInput(data);
       }
     }
 
@@ -1004,8 +1235,8 @@ export class TerminalProcess {
     // state transitions before the async write sequence in performSubmit().
     // Without this, the split between body write and Enter write causes the
     // character-by-character detection in onInput() to miss the submission.
-    if (this.activityMonitor && text.trim().length > 0) {
-      this.activityMonitor.notifySubmission();
+    if (this.analysis.hasMonitor() && text.trim().length > 0) {
+      this.analysis.notifySubmission();
     }
 
     this.writeQueue.submit(text);
@@ -1058,8 +1289,8 @@ export class TerminalProcess {
     // Notify activity monitor at execution time (not just enqueue time) to ensure
     // the working state transition happens even for queued submissions that execute
     // after a potential idle transition. Issue #2185.
-    if (this.activityMonitor && text.trim().length > 0) {
-      this.activityMonitor.notifySubmission();
+    if (this.analysis.hasMonitor() && text.trim().length > 0) {
+      this.analysis.notifySubmission();
     }
 
     const normalized = normalizeSubmitText(text);
@@ -1125,9 +1356,10 @@ export class TerminalProcess {
     const terminal = this.terminalInfo;
     if (terminal.isExited) {
       try {
-        if (terminal.headlessTerminal) {
-          terminal.headlessTerminal.resize(cols, rows);
+        this.analysis.resize(cols, rows);
+        if (this.analysis.kind === "worker") {
           // Reflow rewraps the buffer — invalidate any wake no-change skip.
+          // (The in-thread path bumps the epoch itself, gated on a live buffer.)
           terminal.contentEpoch++;
         }
       } catch (error) {
@@ -1145,18 +1377,10 @@ export class TerminalProcess {
 
       terminal.ptyProcess.resize(cols, rows);
 
-      if (terminal.headlessTerminal) {
-        terminal.headlessTerminal.resize(cols, rows);
-        // Reflow rewraps the buffer — invalidate any wake no-change skip.
+      this.analysis.resize(cols, rows);
+      if (this.analysis.kind === "worker") {
         terminal.contentEpoch++;
       }
-
-      // Notify activity monitor so reflow bytes are suppressed. Issue #2364.
-      if (this.activityMonitor) {
-        this.activityMonitor.notifyResize();
-      }
-      this.agentOutputTemperature.noteResize(Date.now());
-      this.agentOutputContentSnapshot = undefined;
     } catch (error) {
       console.error(`Failed to resize terminal ${this.id}:`, error);
     }
@@ -1174,7 +1398,11 @@ export class TerminalProcess {
     });
   }
 
-  kill(reason?: string, escalationDelayMs?: number): void {
+  kill(
+    reason?: string,
+    escalationDelayMs?: number,
+    options?: { skipFinalSessionPersist?: boolean }
+  ): void {
     const terminal = this.terminalInfo;
     const exitReason: ExitReason = reason === "graceful-shutdown" ? "graceful-shutdown" : "kill";
 
@@ -1182,7 +1410,16 @@ export class TerminalProcess {
     // Once teardown disposes the writeQueue and processTreeKiller.abort() fires,
     // debounced writes are lost — so this is the last chance.
     // See lesson #3177.
-    this.sessionSnapshotter.flushSyncOnKill();
+    //
+    // Worker-mode caveat: the flush degrades to an async worker round-trip,
+    // which would race — and lose to — PtyManager.kill's deleteSessionFile,
+    // resurrecting a file the caller intends to delete. When the caller is
+    // about to delete the session anyway (skipFinalSessionPersist), skip the
+    // deferred flush; the in-thread path keeps its sync persist-then-delete
+    // ordering unchanged.
+    if (!(options?.skipFinalSessionPersist && this.analysis.kind === "worker")) {
+      this.sessionSnapshotter.flushSyncOnKill();
+    }
 
     if (!this.teardown(exitReason)) {
       return;
@@ -1228,144 +1465,23 @@ export class TerminalProcess {
     };
   }
 
+  // Serves IdentityWatcher's sync reads: in-thread it reads the live headless
+  // buffer; in worker mode it reads the throttled viewport mirror pushed by
+  // the analysis worker.
   getLastNLines(n: number): string[] {
-    const terminal = this.terminalInfo.headlessTerminal;
-    if (!terminal) return [];
-
-    const buffer = terminal.buffer.active;
-    if (!buffer) return [];
-
-    const viewportTop = buffer.baseY;
-    const viewportBottom = buffer.baseY + terminal.rows;
-
-    const lines: string[] = [];
-    for (let i = viewportTop; i < viewportBottom; i++) {
-      const line = buffer.getLine(i);
-      if (!line) continue;
-      const text = line.translateToString(true);
-      if (text.trim().length > 0) {
-        lines.push(text);
-      }
-    }
-    return lines.slice(-n);
+    return this.analysis.getViewportLines(n);
   }
 
   getVisibleActivityLines(n: number): string[] {
-    const terminal = this.terminalInfo.headlessTerminal;
-    if (!terminal) return [];
-
-    const buffer = terminal.buffer.active as CursorBuffer;
-    if (!buffer || typeof buffer.getLine !== "function") return [];
-
-    const viewportTop = buffer.baseY;
-    const viewportBottom = buffer.baseY + terminal.rows;
-    const end = viewportBottom;
-    const start = Math.max(viewportTop, end - n);
-
-    const lines: string[] = [];
-    for (let i = start; i < end; i += 1) {
-      const line = buffer.getLine(i);
-      if (line) lines.push(line.translateToString(true));
-    }
-    return lines;
+    return readVisibleActivityLines(this.terminalInfo.headlessTerminal, n);
   }
 
   getVisibleActivitySnapshot(n: number): VisibleContentSnapshot | undefined {
-    const cells = this.getVisibleActivityCells();
-    return cells
-      ? createVisibleCellContentSnapshot(cells)
-      : createVisibleContentSnapshot(this.getVisibleActivityLines(n));
-  }
-
-  private getVisibleActivityCells(): VisibleContentCell[][] | undefined {
-    const terminal = this.terminalInfo.headlessTerminal;
-    if (!terminal) return undefined;
-
-    const buffer = terminal.buffer.active as CursorBuffer;
-    if (
-      !buffer ||
-      typeof buffer.getLine !== "function" ||
-      typeof buffer.getNullCell !== "function"
-    ) {
-      return undefined;
-    }
-
-    const viewportTop = buffer.baseY;
-    const viewportBottom = buffer.baseY + terminal.rows;
-    const end = viewportBottom;
-    // Scan the FULL visible viewport. A cursor-anchored bottom-n window (the
-    // v0.19.0 regression) misses spinner/status activity that TUI agents
-    // (Claude/Gemini/Codex) stream ABOVE a pinned bottom input box: with the
-    // cursor parked low, the window collapsed to the bottom rows and the
-    // changing rows above produced changedChars=0, so the temperature decayed
-    // and a busy agent flipped to "waiting" during low-output thinking (and
-    // waiting→working recovery was starved). Blank cells are skipped below, so
-    // scanning the whole viewport costs reads but not allocations. The line
-    // budget only constrains the line-based fallback in getVisibleActivitySnapshot.
-    const start = viewportTop;
-    const reusableCell = buffer.getNullCell();
-
-    const rows: VisibleContentCell[][] = [];
-    for (let y = start; y < end; y += 1) {
-      const line = buffer.getLine(y);
-      if (!line || typeof line.getCell !== "function") {
-        continue;
-      }
-
-      const row: VisibleContentCell[] = [];
-      for (let x = 0; x < terminal.cols; x += 1) {
-        const cell = line.getCell(x, reusableCell);
-        if (!cell) continue;
-        // Same predicate as visibleCellUnit (SustainedChangeTracker): blank
-        // cells never contribute a unit, so skip before allocating — most of
-        // an idle viewport is whitespace.
-        const width = cell.getWidth();
-        if (width === 0) continue;
-        const chars = cell.getChars();
-        if (chars.length === 0 || /^\s*$/u.test(chars)) continue;
-        row.push(this.createVisibleContentCell(cell, chars, width));
-      }
-      rows.push(row);
-    }
-
-    return rows;
-  }
-
-  private createVisibleContentCell(
-    cell: IBufferCell,
-    chars: string,
-    width: number
-  ): VisibleContentCell {
-    const attributes =
-      (cell.isBold() ? 1 : 0) |
-      (cell.isItalic() ? 1 << 1 : 0) |
-      (cell.isDim() ? 1 << 2 : 0) |
-      (cell.isUnderline() ? 1 << 3 : 0) |
-      (cell.isBlink() ? 1 << 4 : 0) |
-      (cell.isInverse() ? 1 << 5 : 0) |
-      (cell.isInvisible() ? 1 << 6 : 0) |
-      (cell.isStrikethrough() ? 1 << 7 : 0) |
-      (cell.isOverline() ? 1 << 8 : 0);
-
-    return {
-      chars,
-      code: cell.getCode(),
-      width,
-      fgColorMode: cell.getFgColorMode(),
-      fgColor: cell.getFgColor(),
-      attributes,
-    };
+    return readVisibleActivitySnapshot(this.terminalInfo.headlessTerminal, n);
   }
 
   getCursorLine(): string | null {
-    const terminal = this.terminalInfo.headlessTerminal;
-    if (!terminal) return null;
-
-    const buffer = terminal.buffer.active as CursorBuffer;
-    if (!buffer || typeof buffer.getLine !== "function") return null;
-    const cursorY = buffer.cursorY ?? 0;
-    const line = buffer.getLine(buffer.baseY + cursorY);
-    return line ? line.translateToString(true) : null;
+    return this.analysis.getCursorLine();
   }
 
   private createIdentityWatcherDelegate(): IdentityWatcherDelegate {
@@ -1430,7 +1546,15 @@ export class TerminalProcess {
   }
 
   getSerializedStateAsync(): Promise<string | null> {
-    return serializeTerminalAsync(this.id, this.terminalInfo);
+    const terminal = this.terminalInfo;
+    // Preserved snapshot served — stamp access time so eviction (issue #10839)
+    // treats it as currently-viewed. Checked host-side in both modes; the
+    // in-thread serialize path repeats the check harmlessly.
+    if (terminal.preservedSnapshot !== undefined) {
+      terminal.preservedSnapshotLastAccessedAt = Date.now();
+      return Promise.resolve(terminal.preservedSnapshot);
+    }
+    return this.analysis.serialize();
   }
 
   serializeForPersistence(): string | null {
@@ -1512,61 +1636,19 @@ export class TerminalProcess {
   }
 
   startActivityMonitor(options?: { preserveState?: boolean }): void {
-    if (!this.activityMonitor) {
-      const ptyPid = this.terminalInfo.ptyProcess.pid;
-      const processStateValidator = createProcessStateValidator(ptyPid, this.deps.processTreeCache);
-
-      const preserveState = options?.preserveState ?? false;
-      const currentAgentState = this.terminalInfo.agentState;
-      const initialState = preserveState && currentAgentState === "working" ? "busy" : "idle";
-
-      this.activityMonitor = new ActivityMonitor(
-        this.id,
-        this.terminalInfo.spawnedAt,
-        (_termId, cbSpawnedAt, state, metadata) => {
-          if (this.terminalInfo.spawnedAt !== cbSpawnedAt) {
-            console.warn(
-              `[TerminalProcess] Rejected stale activity state from old monitor ${_termId} ` +
-                `(session ${cbSpawnedAt} vs current ${this.terminalInfo.spawnedAt})`
-            );
-            return;
-          }
-          this.flushAgentOutput();
-          this.deps.agentStateService.handleActivityState(this.terminalInfo, state, metadata);
-        },
-        {
-          ...buildActivityMonitorOptions(getLiveAgentId(this.terminalInfo), {
-            getVisibleLines: (n) => this.getVisibleActivityLines(n),
-            getVisibleContentSnapshot: (n) => this.getVisibleActivitySnapshot(n),
-            getCursorLine: () => this.getCursorLine(),
-          }),
-          processStateValidator,
-          initialState,
-          skipInitialStateEmit: preserveState,
-          onWaitingTimeout: (_id, _spawnedAt) => {
-            this.flushAgentOutput();
-            this.deps.agentStateService.updateAgentState(
-              this.terminalInfo,
-              { type: "watchdog-timeout" },
-              "timeout",
-              0.6
-            );
-          },
-          onBootComplete: (timestamp) => this.recordBootComplete(timestamp),
-        }
-      );
-      this.activityMonitor.startPolling();
-    }
+    if (this.analysis.hasMonitor()) return;
+    const preserveState = options?.preserveState ?? false;
+    const currentAgentState = this.terminalInfo.agentState;
+    const initialState = preserveState && currentAgentState === "working" ? "busy" : "idle";
+    this.analysis.startMonitor({
+      agentId: getLiveAgentId(this.terminalInfo),
+      initialState,
+      skipInitialStateEmit: preserveState,
+    });
   }
 
   stopActivityMonitor(): void {
-    if (this.activityMonitor) {
-      this.activityMonitor.dispose();
-      this.activityMonitor = null;
-    }
-    // Clear any in-flight OSC 9;4 fragment so a sequence split across the
-    // teardown boundary can't trigger a callback against a stale monitor.
-    this.osc94Parser.reset();
+    this.analysis.stopMonitor();
   }
 
   setActivityMonitorTier(tier: "active" | "background", pollingIntervalMs: number): void {
@@ -1576,9 +1658,7 @@ export class TerminalProcess {
     // only adjusts the headless agent-state poll cadence.
     this._activityTier = tier;
 
-    if (this.activityMonitor) {
-      this.activityMonitor.setPollingInterval(pollingIntervalMs);
-    }
+    this.analysis.setPollingInterval(pollingIntervalMs);
   }
 
   getActivityTier(): "active" | "background" {
@@ -1592,16 +1672,14 @@ export class TerminalProcess {
   // xterm 6.0 actively resizes the buffer when scrollback shrinks (verified in headless-scrollback-trim.test.ts).
   trimScrollback(targetLines: number): void {
     if (this._scrollback <= targetLines) return;
-    if (!this.terminalInfo.headlessTerminal) return;
+    if (!this.analysis.setScrollback(targetLines)) return;
     this._scrollback = targetLines;
-    this.terminalInfo.headlessTerminal.options.scrollback = targetLines;
   }
 
   growScrollback(targetLines: number): void {
     if (this._scrollback >= targetLines) return;
-    if (!this.terminalInfo.headlessTerminal) return;
+    if (!this.analysis.setScrollback(targetLines)) return;
     this._scrollback = targetLines;
-    this.terminalInfo.headlessTerminal.options.scrollback = targetLines;
   }
 
   /**
@@ -1726,9 +1804,7 @@ export class TerminalProcess {
   // window AND invalidate the agentOutputTemperature baseline so the redraw
   // that follows the focus event is treated as a fresh comparison point.
   private handleFocusInput(): void {
-    this.activityMonitor?.notifyFocus();
-    this.agentOutputTemperature.reset();
-    this.agentOutputContentSnapshot = undefined;
+    this.analysis.notifyFocus();
   }
 
   /**
@@ -1792,16 +1868,21 @@ export class TerminalProcess {
     }
     terminal.lastOutputTime = now;
 
+    this.analysis.feedPrelude(prelude);
+    this.sessionSnapshotter.schedule();
+    this.emitData(prelude);
+    this.forensicsBuffer.capture(prelude);
+    this.semanticBufferManager.onData(prelude);
+  }
+
+  private feedPreludeInThread(prelude: string): void {
+    const terminal = this.terminalInfo;
     if (terminal.headlessTerminal) {
       terminal.pendingHeadlessWrites = (terminal.pendingHeadlessWrites ?? 0) + 1;
       headlessMirrorScheduler.enqueue(this.id, terminal.headlessTerminal, prelude, () => {
         terminal.pendingHeadlessWrites = (terminal.pendingHeadlessWrites ?? 1) - 1;
       });
     }
-    this.sessionSnapshotter.schedule();
-    this.emitData(prelude);
-    this.forensicsBuffer.capture(prelude);
-    this.semanticBufferManager.onData(prelude);
   }
 
   private handlePtyData(ptyProcess: pty.IPty, data: string): void {
@@ -1817,15 +1898,6 @@ export class TerminalProcess {
       terminal.firstByteAt = now;
     }
     terminal.lastOutputTime = now;
-
-    // Tap OSC 9;4 progress sequences upstream of the rest of the pipeline so
-    // the agent-state signal is viewport-independent (#8701). The parser is
-    // a read-only side channel; `IdleSequenceFilter.stripIdleTerminalSequences`
-    // still removes the sequence from the ActivityMonitor byte-volume /
-    // activity-gate path, so those detectors stay clean (the renderer keeps
-    // the raw bytes — see TerminalProcess.osc.test.ts). This runs per-chunk for
-    // backgrounded terminals too so the heartbeat never lags (#8753, #10744).
-    this.osc94Parser.feed(data, now);
 
     // Hibernation removed: PTY output ALWAYS flows through the live parse
     // pipeline regardless of activity tier, so a backgrounded pane's renderer
@@ -1864,6 +1936,46 @@ export class TerminalProcess {
     // added to the visible frame's latency.
     this.emitData(rendererData);
 
+    // Analysis stack: OSC 9;4 tap, ActivityMonitor onData, headless mirror
+    // write, agent-output temperature. In worker mode this is one postMessage.
+    this.analysis.feedChunk(data, {
+      agentLive: this.isAgentLive,
+      agentState: terminal.agentState,
+    });
+    this.sessionSnapshotter.schedule();
+
+    this.forensicsBuffer.capture(data);
+    this.identityWatcher.observeOutput(data);
+    this.semanticBufferManager.onData(data);
+
+    // Output mirror for agent consumers: keep a rolling recent-output
+    // buffer and emit agent:output whenever an agent is live (launched
+    // hint or detection). Plain terminals skip both to save work.
+    if (this.isAgentLive) {
+      terminal.outputBuffer += data;
+      if (terminal.outputBuffer.length > OUTPUT_BUFFER_SIZE) {
+        terminal.outputBuffer = terminal.outputBuffer.slice(-OUTPUT_BUFFER_SIZE);
+      }
+
+      const liveId = getLiveAgentId(terminal);
+      if (liveId) {
+        this.queueAgentOutput(liveId, data);
+      }
+    }
+  }
+
+  private feedChunkInThread(data: string): void {
+    const terminal = this.terminalInfo;
+
+    // Tap OSC 9;4 progress sequences upstream of the rest of the analysis so
+    // the agent-state signal is viewport-independent (#8701). The parser is
+    // a read-only side channel; `IdleSequenceFilter.stripIdleTerminalSequences`
+    // still removes the sequence from the ActivityMonitor byte-volume /
+    // activity-gate path, so those detectors stay clean (the renderer keeps
+    // the raw bytes — see TerminalProcess.osc.test.ts). This runs per-chunk for
+    // backgrounded terminals too so the heartbeat never lags (#8753, #10744).
+    this.osc94Parser.feed(data, Date.now());
+
     if (this.activityMonitor) {
       this.activityMonitor.onData(data);
     }
@@ -1888,26 +2000,6 @@ export class TerminalProcess {
       });
     } else {
       this.noteAgentOutputActivity();
-    }
-    this.sessionSnapshotter.schedule();
-
-    this.forensicsBuffer.capture(data);
-    this.identityWatcher.observeOutput(data);
-    this.semanticBufferManager.onData(data);
-
-    // Output mirror for agent consumers: keep a rolling recent-output
-    // buffer and emit agent:output whenever an agent is live (launched
-    // hint or detection). Plain terminals skip both to save work.
-    if (this.isAgentLive) {
-      terminal.outputBuffer += data;
-      if (terminal.outputBuffer.length > OUTPUT_BUFFER_SIZE) {
-        terminal.outputBuffer = terminal.outputBuffer.slice(-OUTPUT_BUFFER_SIZE);
-      }
-
-      const liveId = getLiveAgentId(terminal);
-      if (liveId) {
-        this.queueAgentOutput(liveId, data);
-      }
     }
   }
 
@@ -2067,9 +2159,11 @@ export class TerminalProcess {
         agentStateService: this.deps.agentStateService,
         headlineGenerator: this.headlineGenerator,
         semanticBufferManager: this.semanticBufferManager,
-        get activityMonitor() {
-          return self.activityMonitor;
+        get hasActivityMonitor() {
+          return self.analysis.hasMonitor();
         },
+        reconfigureActivityMonitor: (agentId, patternConfig) =>
+          this.analysis.reconfigureMonitor(agentId, patternConfig),
         get lastDetectedProcessIconId() {
           return self.lastDetectedProcessIconId;
         },

--- a/electron/services/pty/__tests__/TerminalProcess.workerAnalysis.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.workerAnalysis.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import type { IPty } from "node-pty";
+import { TerminalProcess } from "../TerminalProcess.js";
+import { AnalysisWorkerPool, type WorkerLike } from "../analysis/AnalysisWorkerPool.js";
+import type { SpawnContext } from "../terminalSpawn.js";
+import type { HostToWorkerMessage, WorkerToHostMessage } from "../analysisWorkerProtocol.js";
+
+vi.mock("node-pty", () => {
+  return { spawn: vi.fn() };
+});
+
+class FakeWorker implements WorkerLike {
+  posted: HostToWorkerMessage[] = [];
+  private listeners = new Map<string, Array<(arg: never) => void>>();
+
+  postMessage(msg: unknown): void {
+    this.posted.push(msg as HostToWorkerMessage);
+  }
+
+  on(event: string, cb: (arg: never) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    list.push(cb);
+    this.listeners.set(event, list);
+  }
+
+  unref(): void {}
+
+  emit(event: "message", msg: WorkerToHostMessage): void {
+    for (const cb of this.listeners.get(event) ?? []) {
+      (cb as (a: unknown) => void)(msg);
+    }
+  }
+}
+
+function createMockPty(): IPty {
+  const pty: Partial<IPty> = {
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: () => {},
+    pause: () => {},
+    resume: () => {},
+    onData: () => ({ dispose: () => {} }),
+    onExit: () => ({ dispose: () => {} }),
+  };
+  return pty as IPty;
+}
+
+function createWorkerModeTerminal() {
+  const workers: FakeWorker[] = [];
+  const pool = new AnalysisWorkerPool(1, () => {
+    const worker = new FakeWorker();
+    workers.push(worker);
+    return worker;
+  });
+  const agentStateService = {
+    handleActivityState: vi.fn(),
+    updateAgentState: vi.fn(),
+  };
+  const ctx: SpawnContext = { shell: "/bin/zsh", args: ["-l"], env: {} };
+  const terminal = new TerminalProcess(
+    "t1",
+    { cwd: process.cwd(), cols: 80, rows: 24, kind: "terminal" as const },
+    { emitData: () => {}, onExit: () => {} },
+    {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      agentStateService: agentStateService as any,
+      ptyPool: null,
+      processTreeCache: null,
+      analysisWorkerPool: pool,
+    },
+    ctx,
+    createMockPty()
+  );
+  return { terminal, worker: workers[0], agentStateService, pool };
+}
+
+describe("TerminalProcess worker-mode analysis events", () => {
+  it("rejects a stale waiting-timeout from an old monitor generation", () => {
+    const { terminal, worker, agentStateService } = createWorkerModeTerminal();
+    const spawnedAt = terminal.getInfo().spawnedAt;
+
+    worker.emit("message", {
+      type: "waiting-timeout",
+      terminalId: "t1",
+      spawnedAt: spawnedAt - 1,
+    });
+    expect(agentStateService.updateAgentState).not.toHaveBeenCalled();
+
+    worker.emit("message", { type: "waiting-timeout", terminalId: "t1", spawnedAt });
+    expect(agentStateService.updateAgentState).toHaveBeenCalledTimes(1);
+    expect(agentStateService.updateAgentState).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "t1" }),
+      { type: "watchdog-timeout" },
+      "timeout",
+      0.6
+    );
+  });
+
+  it("rejects stale activity-state with the same session guard", () => {
+    const { terminal, worker, agentStateService } = createWorkerModeTerminal();
+    const spawnedAt = terminal.getInfo().spawnedAt;
+
+    worker.emit("message", {
+      type: "activity-state",
+      terminalId: "t1",
+      spawnedAt: spawnedAt - 1,
+      state: "busy",
+      metadata: { trigger: "output" },
+    });
+    expect(agentStateService.handleActivityState).not.toHaveBeenCalled();
+
+    worker.emit("message", {
+      type: "activity-state",
+      terminalId: "t1",
+      spawnedAt,
+      state: "busy",
+      metadata: { trigger: "output" },
+    });
+    expect(agentStateService.handleActivityState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/services/pty/__tests__/analysisWorkerPool.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerPool.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AnalysisWorkerPool, type WorkerLike } from "../analysis/AnalysisWorkerPool.js";
+import type { WorkerAnalysisDelegate } from "../analysis/WorkerAnalysisBackend.js";
+import type { HostToWorkerMessage, WorkerToHostMessage } from "../analysisWorkerProtocol.js";
+
+class FakeWorker implements WorkerLike {
+  posted: HostToWorkerMessage[] = [];
+  private listeners = new Map<string, Array<(arg: never) => void>>();
+
+  postMessage(msg: unknown): void {
+    this.posted.push(msg as HostToWorkerMessage);
+  }
+
+  on(event: string, cb: (arg: never) => void): void {
+    const list = this.listeners.get(event) ?? [];
+    list.push(cb);
+    this.listeners.set(event, list);
+  }
+
+  unref(): void {}
+
+  emit(event: "message", msg: WorkerToHostMessage): void;
+  emit(event: "exit", code: number): void;
+  emit(event: string, arg: unknown): void {
+    for (const cb of this.listeners.get(event) ?? []) {
+      (cb as (a: unknown) => void)(arg);
+    }
+  }
+
+  messagesOfType<T extends HostToWorkerMessage["type"]>(
+    type: T
+  ): Extract<HostToWorkerMessage, { type: T }>[] {
+    return this.posted.filter((m) => m.type === type) as Extract<
+      HostToWorkerMessage,
+      { type: T }
+    >[];
+  }
+}
+
+function makeDelegate(): WorkerAnalysisDelegate {
+  return {
+    onActivityState: vi.fn(),
+    onWaitingTimeout: vi.fn(),
+    onBootComplete: vi.fn(),
+    onPtyResponse: vi.fn(),
+    getProcessState: () => null,
+    getAgentContext: () => ({ agentLive: false, agentState: undefined }),
+  };
+}
+
+function makeSpec(terminalId: string) {
+  return {
+    terminalId,
+    cols: 80,
+    rows: 24,
+    scrollback: 1000,
+    restore: false,
+    spawnedAt: 1000,
+  };
+}
+
+describe("AnalysisWorkerPool", () => {
+  let workers: FakeWorker[];
+  let pool: AnalysisWorkerPool;
+
+  beforeEach(() => {
+    workers = [];
+    pool = new AnalysisWorkerPool(2, () => {
+      const worker = new FakeWorker();
+      workers.push(worker);
+      return worker;
+    });
+  });
+
+  afterEach(() => {
+    pool.dispose();
+    vi.useRealTimers();
+  });
+
+  it("assigns terminals sticky and spreads across workers up to the pool size", () => {
+    const b1 = pool.createBackend(makeSpec("t1"), makeDelegate());
+    const b2 = pool.createBackend(makeSpec("t2"), makeDelegate());
+    const b3 = pool.createBackend(makeSpec("t3"), makeDelegate());
+    expect(b1 && b2 && b3).toBeTruthy();
+    expect(workers).toHaveLength(2);
+
+    // Each backend posted exactly one create to its assigned worker; the
+    // third terminal reuses an existing worker (least-loaded), never a third.
+    const creates = workers.flatMap((w) => w.messagesOfType("create"));
+    expect(creates.map((c) => c.terminalId).sort()).toEqual(["t1", "t2", "t3"]);
+
+    // Sticky routing: data for t1 lands only on t1's worker.
+    b1!.feedChunk("hello", { agentLive: false });
+    const dataCarriers = workers.filter((w) => w.messagesOfType("data").length > 0);
+    expect(dataCarriers).toHaveLength(1);
+    expect(dataCarriers[0].messagesOfType("create").some((c) => c.terminalId === "t1")).toBe(true);
+  });
+
+  it("resolves requests via correlated responses", async () => {
+    const backend = pool.createBackend(makeSpec("t1"), makeDelegate())!;
+    const worker = workers[0];
+
+    const promise = backend.serialize();
+    const request = worker.messagesOfType("request")[0];
+    expect(request.op).toBe("serialize");
+
+    worker.emit("message", {
+      type: "response",
+      requestId: request.requestId,
+      terminalId: "t1",
+      result: "SNAPSHOT",
+    });
+    await expect(promise).resolves.toBe("SNAPSHOT");
+  });
+
+  it("routes worker events to the owning backend", () => {
+    const delegate = makeDelegate();
+    pool.createBackend(makeSpec("t1"), delegate);
+    const worker = workers[0];
+
+    worker.emit("message", {
+      type: "activity-state",
+      terminalId: "t1",
+      spawnedAt: 1000,
+      state: "busy",
+      metadata: { trigger: "output" },
+    });
+    expect(delegate.onActivityState).toHaveBeenCalledWith(1000, "busy", { trigger: "output" });
+
+    worker.emit("message", { type: "pty-response", terminalId: "t1", data: "\x1b[1;1R" });
+    expect(delegate.onPtyResponse).toHaveBeenCalledWith("\x1b[1;1R");
+  });
+
+  it("respawns a dead worker once and rebuilds its slots with fresh, persist-suppressed state", async () => {
+    vi.useFakeTimers();
+    const backend = pool.createBackend(makeSpec("t1"), makeDelegate())!;
+    backend.startMonitor({ agentId: "claude", initialState: "idle", skipInitialStateEmit: false });
+    const dead = workers[0];
+
+    // In-flight request at crash time resolves empty instead of hanging.
+    const inflight = backend.serialize();
+    dead.emit("exit", 1);
+    await expect(inflight).resolves.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(workers).toHaveLength(2);
+    const replacement = workers[1];
+
+    // Fresh slot: create with restore:false, then monitor-start preserving the
+    // agent id but with preserve-state semantics (no boot re-emit).
+    const create = replacement.messagesOfType("create")[0];
+    expect(create).toMatchObject({ terminalId: "t1", restore: false });
+    const monitorStart = replacement.messagesOfType("monitor-start")[0];
+    expect(monitorStart).toMatchObject({
+      agentId: "claude",
+      initialState: "idle",
+      skipInitialStateEmit: true,
+    });
+
+    // Persistence stays suppressed (fresh empty buffer must not clobber the
+    // on-disk snapshot) until real output dirties the new buffer.
+    await expect(backend.serializeForPersistence()).resolves.toBeNull();
+    expect(replacement.messagesOfType("request")).toHaveLength(0);
+
+    backend.feedChunk("new output", { agentLive: true, agentState: "working" });
+    const persistReq = backend.serializeForPersistence();
+    const request = replacement.messagesOfType("request")[0];
+    expect(request.op).toBe("serialize-persistence");
+    replacement.emit("message", {
+      type: "response",
+      requestId: request.requestId,
+      terminalId: "t1",
+      result: "PERSISTED",
+    });
+    await expect(persistReq).resolves.toBe("PERSISTED");
+    vi.useRealTimers();
+  });
+
+  it("seeds the respawned monitor busy when the host FSM is mid-work", async () => {
+    vi.useFakeTimers();
+    const delegate = makeDelegate();
+    delegate.getAgentContext = () => ({ agentLive: true, agentState: "working" });
+    const backend = pool.createBackend(makeSpec("t1"), delegate)!;
+    backend.startMonitor({ agentId: "claude", initialState: "idle", skipInitialStateEmit: false });
+
+    workers[0].emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(600);
+    const replacement = workers[1];
+
+    // A monitor seeded idle would strand the host in "working": the monitor's
+    // idle/completion transitions only run from its internal busy state.
+    const monitorStart = replacement.messagesOfType("monitor-start")[0];
+    expect(monitorStart).toMatchObject({
+      agentId: "claude",
+      initialState: "busy",
+      skipInitialStateEmit: true,
+    });
+    vi.useRealTimers();
+  });
+
+  it("redistributes terminals to surviving workers once a slot's respawn budget is spent", async () => {
+    vi.useFakeTimers();
+    const b1 = pool.createBackend(makeSpec("t1"), makeDelegate())!;
+    pool.createBackend(makeSpec("t2"), makeDelegate());
+    expect(workers).toHaveLength(2);
+    const first = workers[0];
+
+    first.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(600);
+    expect(workers).toHaveLength(3);
+
+    // Second crash of the same slot exhausts the budget → t1 moves to the
+    // surviving worker.
+    workers[2].emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(workers).toHaveLength(3);
+
+    b1.feedChunk("after move", { agentLive: false });
+    const survivor = workers[1];
+    expect(survivor.messagesOfType("create").some((c) => c.terminalId === "t1")).toBe(true);
+    expect(survivor.messagesOfType("data").some((d) => d.terminalId === "t1")).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("frees the slot and stops routing after release", () => {
+    const backend = pool.createBackend(makeSpec("t1"), makeDelegate())!;
+    const worker = workers[0];
+    backend.release();
+    expect(worker.messagesOfType("free")).toHaveLength(1);
+
+    backend.feedChunk("late", { agentLive: false });
+    expect(worker.messagesOfType("data")).toHaveLength(0);
+    expect(pool.getStats().terminals).toBe(0);
+  });
+
+  it("broadcasts the plugin agent registry to live and future workers", () => {
+    pool.createBackend(makeSpec("t1"), makeDelegate());
+    const registry = {} as Record<string, never>;
+    pool.setPluginAgentRegistry(registry);
+    expect(workers[0].messagesOfType("plugin-agent-registry")).toHaveLength(1);
+
+    pool.createBackend(makeSpec("t2"), makeDelegate());
+    expect(workers[1].messagesOfType("plugin-agent-registry")).toHaveLength(1);
+  });
+});

--- a/electron/services/pty/__tests__/analysisWorkerPool.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerPool.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AnalysisWorkerPool, type WorkerLike } from "../analysis/AnalysisWorkerPool.js";
-import type { WorkerAnalysisDelegate } from "../analysis/WorkerAnalysisBackend.js";
+import {
+  WorkerAnalysisBackend,
+  type AnalysisPoolHost,
+  type WorkerAnalysisDelegate,
+} from "../analysis/WorkerAnalysisBackend.js";
+import { AnalysisWorkerRuntime } from "../analysis/AnalysisWorkerRuntime.js";
 import type { HostToWorkerMessage, WorkerToHostMessage } from "../analysisWorkerProtocol.js";
 
 class FakeWorker implements WorkerLike {
@@ -35,6 +40,32 @@ class FakeWorker implements WorkerLike {
       { type: T }
     >[];
   }
+}
+
+// A WorkerLike backed by a real in-process AnalysisWorkerRuntime — lets a test
+// drive the full host→worker→host path (real headless serialize) without a
+// worker_threads thread.
+class RuntimeBackedWorker implements WorkerLike {
+  private readonly runtime: AnalysisWorkerRuntime;
+  private readonly msgListeners: Array<(msg: WorkerToHostMessage) => void> = [];
+
+  constructor() {
+    this.runtime = new AnalysisWorkerRuntime((msg) => {
+      for (const cb of this.msgListeners) cb(msg);
+    });
+  }
+
+  postMessage(msg: unknown): void {
+    this.runtime.handleMessage(msg as HostToWorkerMessage);
+  }
+
+  on(event: string, cb: (arg: never) => void): void {
+    if (event === "message") {
+      this.msgListeners.push(cb as (msg: WorkerToHostMessage) => void);
+    }
+  }
+
+  unref(): void {}
 }
 
 function makeDelegate(): WorkerAnalysisDelegate {
@@ -241,5 +272,170 @@ describe("AnalysisWorkerPool", () => {
 
     pool.createBackend(makeSpec("t2"), makeDelegate());
     expect(workers[1].messagesOfType("plugin-agent-registry")).toHaveLength(1);
+  });
+
+  it("holds feeds above the high watermark and flushes them coalesced once acks drop below low", () => {
+    const backend = pool.createBackend(
+      {
+        ...makeSpec("t1"),
+        flowControl: { highWatermark: 100, lowWatermark: 40, holdHardCap: 500 },
+      },
+      makeDelegate()
+    )!;
+    const worker = workers[0];
+
+    backend.feedChunk("a".repeat(60), { agentLive: false });
+    backend.feedChunk("b".repeat(60), { agentLive: false });
+    expect(worker.messagesOfType("data")).toHaveLength(2);
+
+    // Outstanding (120) is above the high watermark — further chunks coalesce
+    // host-side instead of being posted.
+    backend.feedChunk("c".repeat(30), { agentLive: false });
+    backend.feedChunk("d".repeat(30), { agentLive: true, agentState: "working" });
+    expect(worker.messagesOfType("data")).toHaveLength(2);
+
+    // First ack leaves outstanding (70) above the low watermark — still held.
+    worker.emit("message", { type: "data-ack", terminalId: "t1", bytes: 50, epoch: 0 });
+    expect(worker.messagesOfType("data")).toHaveLength(2);
+
+    // Second ack drops outstanding (20) below low — the hold flushes as ONE
+    // data message carrying the concatenated payload and the latest flags.
+    worker.emit("message", { type: "data-ack", terminalId: "t1", bytes: 50, epoch: 0 });
+    const dataMessages = worker.messagesOfType("data");
+    expect(dataMessages).toHaveLength(3);
+    expect(dataMessages[2].data).toBe("c".repeat(30) + "d".repeat(30));
+    expect(dataMessages[2].flags).toEqual({ agentLive: true, agentState: "working" });
+  });
+
+  it("drops the hold and rebuilds the slot fresh once the hard cap is exceeded", async () => {
+    const backend = pool.createBackend(
+      {
+        ...makeSpec("t1"),
+        flowControl: { highWatermark: 10, lowWatermark: 5, holdHardCap: 50 },
+      },
+      makeDelegate()
+    )!;
+    const worker = workers[0];
+
+    backend.feedChunk("x".repeat(20), { agentLive: false }); // posted
+    backend.feedChunk("y".repeat(30), { agentLive: false }); // held (30)
+    expect(worker.messagesOfType("create")).toHaveLength(1);
+
+    backend.feedChunk("z".repeat(30), { agentLive: false }); // held 60 > cap 50
+    const creates = worker.messagesOfType("create");
+    expect(creates).toHaveLength(2);
+    expect(creates[1]).toMatchObject({ terminalId: "t1", restore: false });
+    // The held data was dropped, never posted.
+    expect(worker.messagesOfType("data")).toHaveLength(1);
+
+    // Persistence suppressed until real output dirties the fresh buffer.
+    await expect(backend.serializeForPersistence()).resolves.toBeNull();
+    expect(worker.messagesOfType("request")).toHaveLength(0);
+
+    // Ledger reset: the next chunk posts normally and clears suppression.
+    backend.feedChunk("w", { agentLive: false });
+    expect(worker.messagesOfType("data")).toHaveLength(2);
+  });
+
+  it("flushes the coalesced host-side hold before a serialize request reaches the worker", async () => {
+    // End-to-end via a real runtime: data held above the high watermark must be
+    // posted BEFORE the request, or the serialize would miss it (the runtime
+    // barrier only orders already-posted messages — an unflushed hold is
+    // invisible to it). This is the SessionSnapshotter pre-kill guarantee.
+    const e2ePool = new AnalysisWorkerPool(1, () => new RuntimeBackedWorker());
+    const backend = e2ePool.createBackend(
+      {
+        ...makeSpec("t1"),
+        flowControl: { highWatermark: 10, lowWatermark: 5, holdHardCap: 100_000 },
+      },
+      makeDelegate()
+    )!;
+
+    backend.feedChunk("X".repeat(20), { agentLive: false }); // crosses high watermark
+    backend.feedChunk("MARKER-held-bytes\r\n", { agentLive: false }); // held host-side
+
+    const result = await backend.serializeForPersistence();
+    expect(result).toContain("MARKER-held-bytes");
+
+    e2ePool.dispose();
+  });
+
+  it("ignores a data-ack from a superseded generation after a fresh-slot rebuild", async () => {
+    vi.useFakeTimers();
+    const backend = pool.createBackend(
+      {
+        ...makeSpec("t1"),
+        flowControl: { highWatermark: 100, lowWatermark: 40, holdHardCap: 100_000 },
+      },
+      makeDelegate()
+    )!;
+
+    // Worker loss → respawn bumps the feed epoch to 1 and rebuilds the slot.
+    workers[0].emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(600);
+    const worker = workers[1];
+
+    backend.feedChunk("a".repeat(60), { agentLive: false }); // posted, outstanding 60
+    backend.feedChunk("b".repeat(60), { agentLive: false }); // posted, outstanding 120
+    backend.feedChunk("HELD", { agentLive: false }); // held (120 >= 100)
+    const dataBefore = worker.messagesOfType("data").length;
+
+    // A late ack from the OLD generation (epoch 0) must be discarded — it must
+    // not debit the fresh ledger or release the hold.
+    worker.emit("message", { type: "data-ack", terminalId: "t1", bytes: 100, epoch: 0 });
+    expect(worker.messagesOfType("data")).toHaveLength(dataBefore);
+
+    // The current-generation ack (epoch 1) drops outstanding below low and
+    // flushes the hold.
+    worker.emit("message", { type: "data-ack", terminalId: "t1", bytes: 100, epoch: 1 });
+    const dataMsgs = worker.messagesOfType("data");
+    expect(dataMsgs).toHaveLength(dataBefore + 1);
+    expect(dataMsgs[dataMsgs.length - 1].data).toBe("HELD");
+    vi.useRealTimers();
+  });
+});
+
+describe("WorkerAnalysisBackend feed accounting", () => {
+  function stubBackend() {
+    const posted: HostToWorkerMessage[] = [];
+    const control = { sendSucceeds: true };
+    const pool: AnalysisPoolHost = {
+      post: (_id, msg) => {
+        posted.push(msg);
+        return control.sendSucceeds;
+      },
+      request: () => Promise.resolve(null),
+      unregister: () => {},
+    };
+    const backend = new WorkerAnalysisBackend(
+      {
+        terminalId: "t1",
+        cols: 80,
+        rows: 24,
+        scrollback: 1000,
+        restore: false,
+        spawnedAt: 1,
+        flowControl: { highWatermark: 100, lowWatermark: 40, holdHardCap: 100_000 },
+      },
+      makeDelegate(),
+      pool
+    );
+    backend.init();
+    const dataMessages = () => posted.filter((m) => m.type === "data") as Array<{ data: string }>;
+    return { backend, control, dataMessages };
+  }
+
+  it("credits outstanding bytes only when the post was actually sent", () => {
+    const { backend, control, dataMessages } = stubBackend();
+
+    // A failed post must not credit outstanding — phantom bytes would push the
+    // ledger over the high watermark and wrongly start holding real output.
+    control.sendSucceeds = false;
+    backend.feedChunk("X".repeat(200), { agentLive: false });
+    control.sendSucceeds = true;
+
+    // Outstanding is still 0, so this posts rather than coalescing into a hold.
+    backend.feedChunk("Y".repeat(10), { agentLive: false });
+    expect(dataMessages().some((m) => m.data.startsWith("Y"))).toBe(true);
   });
 });

--- a/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { AnalysisWorkerRuntime } from "../analysis/AnalysisWorkerRuntime.js";
+import { ANALYSIS_ACK_FLUSH_BYTES } from "../analysis/AnalysisSession.js";
 import type { WorkerToHostMessage } from "../analysisWorkerProtocol.js";
 
 // Exercises the worker-side protocol end-to-end without spawning a real
@@ -29,6 +30,16 @@ describe("AnalysisWorkerRuntime", () => {
   let emitted: WorkerToHostMessage[];
   let runtime: AnalysisWorkerRuntime;
 
+  function sendData(data: string, agentLive = false, epoch = 0): void {
+    runtime.handleMessage({
+      type: "data",
+      terminalId: "t1",
+      data,
+      flags: { agentLive },
+      epoch,
+    });
+  }
+
   beforeEach(() => {
     emitted = [];
     runtime = new AnalysisWorkerRuntime((msg) => emitted.push(msg));
@@ -40,6 +51,7 @@ describe("AnalysisWorkerRuntime", () => {
       scrollback: 1000,
       restore: false,
       spawnedAt: 4242,
+      epoch: 0,
     });
   });
 
@@ -48,12 +60,7 @@ describe("AnalysisWorkerRuntime", () => {
   });
 
   it("serializes buffer content written via data messages", async () => {
-    runtime.handleMessage({
-      type: "data",
-      terminalId: "t1",
-      data: "hello from the worker\r\n",
-      flags: { agentLive: false },
-    });
+    sendData("hello from the worker\r\n");
     runtime.handleMessage({ type: "request", requestId: 1, terminalId: "t1", op: "serialize" });
 
     const response = await waitFor(() =>
@@ -88,12 +95,7 @@ describe("AnalysisWorkerRuntime", () => {
   });
 
   it("pushes a throttled viewport digest after output lands", async () => {
-    runtime.handleMessage({
-      type: "data",
-      terminalId: "t1",
-      data: "prompt-line-content\r\n",
-      flags: { agentLive: false },
-    });
+    sendData("prompt-line-content\r\n");
 
     const digest = await waitFor(() => emitted.find((m) => m.type === "viewport"));
     if (digest.type === "viewport") {
@@ -101,13 +103,51 @@ describe("AnalysisWorkerRuntime", () => {
     }
   });
 
-  it("serves a pending serialize before a free that arrives behind it", async () => {
+  it("acks parsed data bytes on the trailing batch timer, echoing the create epoch", async () => {
+    const payload = "hello flow control\r\n";
+    sendData(payload, false, 0);
+
+    const ack = await waitFor(() => emitted.find((m) => m.type === "data-ack"));
+    if (ack.type === "data-ack") {
+      expect(ack.terminalId).toBe("t1");
+      expect(ack.bytes).toBe(payload.length);
+      expect(ack.epoch).toBe(0);
+    }
+  });
+
+  it("stamps acks with the latest data epoch after a slot recreate", async () => {
+    // A fresh-slot rebuild recreates the session with a bumped epoch; acks for
+    // its data must carry the new epoch so the host doesn't discard them.
     runtime.handleMessage({
-      type: "data",
+      type: "create",
       terminalId: "t1",
-      data: "pre-kill content\r\n",
-      flags: { agentLive: false },
+      cols: 80,
+      rows: 24,
+      scrollback: 1000,
+      restore: false,
+      spawnedAt: 4242,
+      epoch: 7,
     });
+    sendData("post-rebuild output\r\n", false, 7);
+
+    const ack = await waitFor(() => emitted.find((m) => m.type === "data-ack"));
+    if (ack.type === "data-ack") {
+      expect(ack.epoch).toBe(7);
+    }
+  });
+
+  it("flushes the ack batch once the byte threshold is crossed", async () => {
+    const payload = "x".repeat(ANALYSIS_ACK_FLUSH_BYTES + 1024);
+    sendData(payload);
+
+    const ack = await waitFor(() => emitted.find((m) => m.type === "data-ack"));
+    if (ack.type === "data-ack") {
+      expect(ack.bytes).toBe(payload.length);
+    }
+  });
+
+  it("serves a pending serialize before a free that arrives behind it", async () => {
+    sendData("pre-kill content\r\n");
     // The kill path posts serialize-persistence then free back-to-back; the
     // request's async drain must act as an ordering barrier — the session may
     // only be disposed after the response has been produced.
@@ -133,12 +173,7 @@ describe("AnalysisWorkerRuntime", () => {
   });
 
   it("keeps a chained request behind an earlier one on the same terminal", async () => {
-    runtime.handleMessage({
-      type: "data",
-      terminalId: "t1",
-      data: "ordered content\r\n",
-      flags: { agentLive: false },
-    });
+    sendData("ordered content\r\n");
     runtime.handleMessage({ type: "request", requestId: 11, terminalId: "t1", op: "serialize" });
     runtime.handleMessage({ type: "request", requestId: 12, terminalId: "t1", op: "serialize" });
     runtime.handleMessage({ type: "free", terminalId: "t1" });
@@ -162,12 +197,7 @@ describe("AnalysisWorkerRuntime", () => {
   });
 
   it("captures a final snapshot and frees the slot", async () => {
-    runtime.handleMessage({
-      type: "data",
-      terminalId: "t1",
-      data: "final content\r\n",
-      flags: { agentLive: false },
-    });
+    sendData("final content\r\n");
     runtime.handleMessage({
       type: "request",
       requestId: 2,

--- a/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
+++ b/electron/services/pty/__tests__/analysisWorkerRuntime.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { AnalysisWorkerRuntime } from "../analysis/AnalysisWorkerRuntime.js";
+import type { WorkerToHostMessage } from "../analysisWorkerProtocol.js";
+
+// Exercises the worker-side protocol end-to-end without spawning a real
+// worker thread: the runtime + AnalysisSession (headless xterm, monitor) run
+// in-process, exactly as they do inside the worker.
+
+function waitFor<T>(check: () => T | undefined, timeoutMs = 3000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = () => {
+      const value = check();
+      if (value !== undefined) {
+        resolve(value);
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error("waitFor timed out"));
+        return;
+      }
+      setTimeout(tick, 10);
+    };
+    tick();
+  });
+}
+
+describe("AnalysisWorkerRuntime", () => {
+  let emitted: WorkerToHostMessage[];
+  let runtime: AnalysisWorkerRuntime;
+
+  beforeEach(() => {
+    emitted = [];
+    runtime = new AnalysisWorkerRuntime((msg) => emitted.push(msg));
+    runtime.handleMessage({
+      type: "create",
+      terminalId: "t1",
+      cols: 80,
+      rows: 24,
+      scrollback: 1000,
+      restore: false,
+      spawnedAt: 4242,
+    });
+  });
+
+  afterEach(() => {
+    runtime.handleMessage({ type: "free", terminalId: "t1" });
+  });
+
+  it("serializes buffer content written via data messages", async () => {
+    runtime.handleMessage({
+      type: "data",
+      terminalId: "t1",
+      data: "hello from the worker\r\n",
+      flags: { agentLive: false },
+    });
+    runtime.handleMessage({ type: "request", requestId: 1, terminalId: "t1", op: "serialize" });
+
+    const response = await waitFor(() =>
+      emitted.find((m) => m.type === "response" && m.requestId === 1)
+    );
+    expect(response.type).toBe("response");
+    if (response.type === "response") {
+      expect(typeof response.result).toBe("string");
+      expect(response.result).toContain("hello from the worker");
+    }
+  });
+
+  it("emits activity-state transitions from the monitor with the session spawnedAt", async () => {
+    runtime.handleMessage({
+      type: "monitor-start",
+      terminalId: "t1",
+      agentId: "claude",
+      initialState: "idle",
+      skipInitialStateEmit: true,
+      hasProcessValidator: false,
+    });
+    runtime.handleMessage({ type: "submission", terminalId: "t1" });
+
+    const busy = await waitFor(() =>
+      emitted.find((m) => m.type === "activity-state" && m.state === "busy")
+    );
+    if (busy.type === "activity-state") {
+      expect(busy.terminalId).toBe("t1");
+      expect(busy.spawnedAt).toBe(4242);
+      expect(busy.metadata?.trigger).toBe("input");
+    }
+  });
+
+  it("pushes a throttled viewport digest after output lands", async () => {
+    runtime.handleMessage({
+      type: "data",
+      terminalId: "t1",
+      data: "prompt-line-content\r\n",
+      flags: { agentLive: false },
+    });
+
+    const digest = await waitFor(() => emitted.find((m) => m.type === "viewport"));
+    if (digest.type === "viewport") {
+      expect(digest.lines.some((line) => line.includes("prompt-line-content"))).toBe(true);
+    }
+  });
+
+  it("serves a pending serialize before a free that arrives behind it", async () => {
+    runtime.handleMessage({
+      type: "data",
+      terminalId: "t1",
+      data: "pre-kill content\r\n",
+      flags: { agentLive: false },
+    });
+    // The kill path posts serialize-persistence then free back-to-back; the
+    // request's async drain must act as an ordering barrier — the session may
+    // only be disposed after the response has been produced.
+    runtime.handleMessage({
+      type: "request",
+      requestId: 5,
+      terminalId: "t1",
+      op: "serialize-persistence",
+    });
+    runtime.handleMessage({ type: "free", terminalId: "t1" });
+
+    const response = await waitFor(() =>
+      emitted.find((m) => m.type === "response" && m.requestId === 5)
+    );
+    if (response.type === "response") {
+      expect(response.error).toBeUndefined();
+      expect(typeof response.result).toBe("string");
+      expect(response.result).toContain("pre-kill content");
+    }
+
+    // The deferred free still runs once the barrier clears.
+    await waitFor(() => (runtime.sessionCount() === 0 ? true : undefined));
+  });
+
+  it("keeps a chained request behind an earlier one on the same terminal", async () => {
+    runtime.handleMessage({
+      type: "data",
+      terminalId: "t1",
+      data: "ordered content\r\n",
+      flags: { agentLive: false },
+    });
+    runtime.handleMessage({ type: "request", requestId: 11, terminalId: "t1", op: "serialize" });
+    runtime.handleMessage({ type: "request", requestId: 12, terminalId: "t1", op: "serialize" });
+    runtime.handleMessage({ type: "free", terminalId: "t1" });
+
+    await waitFor(() => emitted.find((m) => m.type === "response" && m.requestId === 12));
+    const responseIds = emitted
+      .filter((m) => m.type === "response")
+      .map((m) => (m.type === "response" ? m.requestId : -1));
+    expect(responseIds).toEqual([11, 12]);
+    await waitFor(() => (runtime.sessionCount() === 0 ? true : undefined));
+  });
+
+  it("responds with an error result for requests against unknown terminals", async () => {
+    runtime.handleMessage({ type: "request", requestId: 9, terminalId: "nope", op: "serialize" });
+    const response = emitted.find((m) => m.type === "response" && m.requestId === 9);
+    expect(response).toBeDefined();
+    if (response?.type === "response") {
+      expect(response.result).toBeNull();
+      expect(response.error).toBe("no-session");
+    }
+  });
+
+  it("captures a final snapshot and frees the slot", async () => {
+    runtime.handleMessage({
+      type: "data",
+      terminalId: "t1",
+      data: "final content\r\n",
+      flags: { agentLive: false },
+    });
+    runtime.handleMessage({
+      type: "request",
+      requestId: 2,
+      terminalId: "t1",
+      op: "final-snapshot",
+    });
+
+    const response = await waitFor(() =>
+      emitted.find((m) => m.type === "response" && m.requestId === 2)
+    );
+    if (response.type === "response") {
+      expect(response.result).not.toBeNull();
+      expect(typeof response.result).toBe("object");
+      const result = response.result as { snapshot: string | null; persistence: string | null };
+      expect(result.snapshot).toContain("final content");
+      // No restore banner → persistence equals the plain serialize.
+      expect(result.persistence).toContain("final content");
+    }
+
+    expect(runtime.sessionCount()).toBe(1);
+    runtime.handleMessage({ type: "free", terminalId: "t1" });
+    expect(runtime.sessionCount()).toBe(0);
+  });
+});

--- a/electron/services/pty/analysis/AnalysisBackend.ts
+++ b/electron/services/pty/analysis/AnalysisBackend.ts
@@ -1,0 +1,53 @@
+import type { PatternDetectionConfig } from "../AgentPatternDetector.js";
+import type { AnalysisChunkFlags, AnalysisFinalSnapshot } from "../analysisWorkerProtocol.js";
+
+export interface MonitorStartOptions {
+  agentId?: string;
+  initialState: "busy" | "idle";
+  skipInitialStateEmit: boolean;
+}
+
+/**
+ * The per-terminal analysis stack (headless xterm mirror + SerializeAddon +
+ * ActivityMonitor + agent-output temperature) behind a mode-agnostic seam.
+ *
+ * - `InThreadAnalysisBackend`: the legacy path — everything runs on the
+ *   pty-host main thread (kill-switch fallback, keeps all existing tests
+ *   meaningful).
+ * - `WorkerAnalysisBackend`: proxies to a persistent worker_threads pool so
+ *   the pty-host main thread only does I/O.
+ */
+export interface AnalysisBackend {
+  readonly kind: "in-thread" | "worker";
+
+  /** Per-chunk pipeline: monitor onData, headless write, output temperature. */
+  feedChunk(data: string, flags: AnalysisChunkFlags): void;
+  /** Pooled-shell prelude replay: headless write only, no monitor feed. */
+  feedPrelude(data: string): void;
+  /** Headless resize + monitor resize suppression + temperature reset. */
+  resize(cols: number, rows: number): void;
+
+  notifyInput(data: string): void;
+  notifyFocus(): void;
+  notifySubmission(): void;
+
+  startMonitor(opts: MonitorStartOptions): void;
+  stopMonitor(): void;
+  reconfigureMonitor(agentId: string, patternConfig?: PatternDetectionConfig): void;
+  setPollingInterval(intervalMs: number): void;
+  hasMonitor(): boolean;
+
+  /** Returns false when there is no live buffer to apply the cap to. */
+  setScrollback(lines: number): boolean;
+
+  getViewportLines(n: number): string[];
+  getCursorLine(): string | null;
+
+  serialize(): Promise<string | null>;
+  serializeForPersistence(): Promise<string | null>;
+  /** Drain pending parses, then capture both preserved + persistence forms. */
+  captureFinalSnapshot(): Promise<AnalysisFinalSnapshot>;
+
+  /** Free the analysis resources (worker slot / headless instance). Idempotent. */
+  release(): void;
+}

--- a/electron/services/pty/analysis/AnalysisSession.ts
+++ b/electron/services/pty/analysis/AnalysisSession.ts
@@ -1,0 +1,468 @@
+import type { Terminal as HeadlessTerminalType, IMarker } from "@xterm/headless";
+import headless from "@xterm/headless";
+const { Terminal: HeadlessTerminal } = headless;
+import serialize, { type SerializeAddon as SerializeAddonType } from "@xterm/addon-serialize";
+const { SerializeAddon } = serialize;
+import unicode11 from "@xterm/addon-unicode11";
+const { Unicode11Addon } = unicode11;
+
+import { getEffectiveAgentConfig } from "../../../../shared/config/agentRegistry.js";
+import type { AgentState } from "../../../../shared/types/agent.js";
+import { ActivityMonitor, type ProcessStateValidator } from "../../ActivityMonitor.js";
+import { buildActivityMonitorOptions, buildPatternConfig } from "../terminalActivityPatterns.js";
+import { installHeadlessResponder } from "../headlessResponder.js";
+import { Osc94Parser } from "../Osc94Parser.js";
+import { SynchronizedFrameDetector } from "../SynchronizedFrameDetector.js";
+import { restoreSessionFromFile } from "../terminalSessionPersistence.js";
+import {
+  measureVisibleContentDelta,
+  type VisibleContentSnapshot,
+} from "../SustainedChangeTracker.js";
+import {
+  AGENT_OUTPUT_ACTIVITY_LINE_COUNT,
+  AgentActivityTemperature,
+} from "../AgentActivityTemperature.js";
+import {
+  readCursorLine,
+  readVisibleActivityLines,
+  readVisibleActivitySnapshot,
+  readViewportNonEmptyLines,
+} from "./headlessViewport.js";
+import type {
+  AnalysisCreateSpec,
+  AnalysisFinalSnapshot,
+  AnalysisMonitorStartSpec,
+  WorkerToHostMessage,
+} from "../analysisWorkerProtocol.js";
+
+// Mirrors AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS in TerminalProcess: floor between
+// agent-output content comparisons.
+const AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS = 50;
+// Trailing-edge throttle on the viewport digest pushed to the host (serves
+// IdentityWatcher's sync reads; its own poll cadence is 200ms).
+const VIEWPORT_DIGEST_THROTTLE_MS = 200;
+
+type Emit = (msg: WorkerToHostMessage) => void;
+
+/**
+ * Worker-side per-terminal analysis stack: headless xterm mirror, serialize
+ * addon, ActivityMonitor, OSC 9;4 tap, synchronized-frame detector, and the
+ * agent-output temperature tracker. One instance per terminal slot; assembled
+ * from the same modules the in-thread path uses so behavior stays aligned.
+ */
+export class AnalysisSession {
+  private readonly terminalId: string;
+  private readonly spawnedAt: number;
+  private readonly emit: Emit;
+
+  private headlessTerminal: HeadlessTerminalType | null;
+  private serializeAddon: SerializeAddonType | null;
+  private frameDetector: SynchronizedFrameDetector | null;
+  private responderDisposable: { dispose: () => void } | null = null;
+  private restoreBannerStart: IMarker | null = null;
+  private restoreBannerEnd: IMarker | null = null;
+
+  private monitor: ActivityMonitor | null = null;
+  private readonly osc94Parser: Osc94Parser;
+
+  // Host-pushed mirrors (refreshed per data chunk + on out-of-band pushes).
+  private agentLive = false;
+  private agentState: AgentState | undefined;
+  private processState = { hasActiveChildren: true, cpuUsage: 0 };
+
+  // Agent-output temperature tracker (mirrors TerminalProcess's
+  // noteAgentOutputActivity machinery).
+  private readonly agentOutputTemperature = new AgentActivityTemperature();
+  private agentOutputContentSnapshot: VisibleContentSnapshot | undefined;
+  private lastAgentOutputNoteAt = Number.NEGATIVE_INFINITY;
+  private agentOutputNoteTimer: NodeJS.Timeout | null = null;
+
+  private digestTimer: NodeJS.Timeout | null = null;
+  private disposed = false;
+
+  constructor(spec: AnalysisCreateSpec, emit: Emit) {
+    this.terminalId = spec.terminalId;
+    this.spawnedAt = spec.spawnedAt;
+    this.emit = emit;
+
+    const terminal = new HeadlessTerminal({
+      cols: spec.cols,
+      rows: spec.rows,
+      scrollback: spec.scrollback,
+      allowProposedApi: true,
+    });
+    terminal.loadAddon(new Unicode11Addon());
+    terminal.unicode.activeVersion = "11";
+    const serializeAddon = new SerializeAddon();
+    terminal.loadAddon(serializeAddon);
+    this.headlessTerminal = terminal;
+    this.serializeAddon = serializeAddon;
+
+    this.frameDetector = new SynchronizedFrameDetector(terminal, (snapshot) => {
+      this.monitor?.onSynchronizedFrame(snapshot);
+    });
+    this.osc94Parser = new Osc94Parser({
+      onWorking: (now) => this.monitor?.onOscProgressWorking(now),
+      onIdle: (now) => this.monitor?.onOscProgressIdle(now),
+    });
+
+    if (spec.restore) {
+      const result = restoreSessionFromFile(terminal, this.terminalId);
+      if (result.restored) {
+        this.restoreBannerStart = result.bannerStartMarker;
+        this.restoreBannerEnd = result.bannerEndMarker;
+        this.scheduleDigest();
+      }
+    }
+  }
+
+  feedChunk(data: string, flags: { agentLive: boolean; agentState?: AgentState }): void {
+    if (this.disposed || !this.headlessTerminal) return;
+    const now = Date.now();
+    this.agentLive = flags.agentLive;
+    this.agentState = flags.agentState;
+
+    this.osc94Parser.feed(data, now);
+
+    this.monitor?.onData(data);
+
+    if (!this.agentLive && (data.includes("\x1b[6n") || data.includes("\x1b[5n"))) {
+      this.ensureResponder();
+    }
+
+    this.headlessTerminal.write(data, () => {
+      this.noteAgentOutputActivity();
+      this.scheduleDigest();
+    });
+  }
+
+  feedPrelude(data: string): void {
+    if (this.disposed || !this.headlessTerminal) return;
+    this.headlessTerminal.write(data, () => {
+      this.scheduleDigest();
+    });
+  }
+
+  resize(cols: number, rows: number): void {
+    if (this.disposed || !this.headlessTerminal) return;
+    try {
+      this.headlessTerminal.resize(cols, rows);
+    } catch (error) {
+      console.error(`[AnalysisSession] Failed to resize ${this.terminalId}:`, error);
+      return;
+    }
+    this.monitor?.notifyResize();
+    this.agentOutputTemperature.noteResize(Date.now());
+    this.agentOutputContentSnapshot = undefined;
+    this.scheduleDigest();
+  }
+
+  notifyInput(data: string): void {
+    this.monitor?.onInput(data);
+  }
+
+  notifyFocus(): void {
+    this.monitor?.notifyFocus();
+    this.agentOutputTemperature.reset();
+    this.agentOutputContentSnapshot = undefined;
+  }
+
+  notifySubmission(): void {
+    this.monitor?.notifySubmission();
+  }
+
+  updateAgentContext(agentLive: boolean, agentState: AgentState | undefined): void {
+    this.agentLive = agentLive;
+    this.agentState = agentState;
+  }
+
+  updateProcessState(hasActiveChildren: boolean, cpuUsage: number): void {
+    this.processState.hasActiveChildren = hasActiveChildren;
+    this.processState.cpuUsage = cpuUsage;
+  }
+
+  startMonitor(spec: AnalysisMonitorStartSpec): void {
+    if (this.disposed || this.monitor) return;
+
+    const validator: ProcessStateValidator | undefined = spec.hasProcessValidator
+      ? {
+          hasActiveChildren: () => this.processState.hasActiveChildren,
+          getDescendantsCpuUsage: () => this.processState.cpuUsage,
+        }
+      : undefined;
+
+    this.monitor = new ActivityMonitor(
+      this.terminalId,
+      this.spawnedAt,
+      (_termId, cbSpawnedAt, state, metadata) => {
+        this.emit({
+          type: "activity-state",
+          terminalId: this.terminalId,
+          spawnedAt: cbSpawnedAt,
+          state,
+          metadata,
+        });
+      },
+      {
+        ...buildActivityMonitorOptions(spec.agentId, {
+          getVisibleLines: (n) => readVisibleActivityLines(this.headlessTerminal ?? undefined, n),
+          getVisibleContentSnapshot: (n) =>
+            readVisibleActivitySnapshot(this.headlessTerminal ?? undefined, n),
+          getCursorLine: () => readCursorLine(this.headlessTerminal ?? undefined),
+        }),
+        processStateValidator: validator,
+        initialState: spec.initialState,
+        skipInitialStateEmit: spec.skipInitialStateEmit,
+        onWaitingTimeout: (_id, cbSpawnedAt) => {
+          this.emit({
+            type: "waiting-timeout",
+            terminalId: this.terminalId,
+            spawnedAt: cbSpawnedAt,
+          });
+        },
+        onBootComplete: (timestamp) => {
+          this.emit({
+            type: "boot-complete",
+            terminalId: this.terminalId,
+            spawnedAt: this.spawnedAt,
+            timestamp,
+          });
+        },
+      }
+    );
+    if (spec.pollingIntervalMs !== undefined) {
+      this.monitor.setPollingInterval(spec.pollingIntervalMs);
+    }
+    this.monitor.startPolling();
+  }
+
+  stopMonitor(): void {
+    if (this.monitor) {
+      this.monitor.dispose();
+      this.monitor = null;
+    }
+    this.osc94Parser.reset();
+  }
+
+  reconfigureMonitor(agentId: string): void {
+    if (!this.monitor) return;
+    const detection = getEffectiveAgentConfig(agentId)?.detection;
+    const patternConfig = buildPatternConfig(detection, agentId);
+    this.monitor.reconfigure(agentId, patternConfig);
+  }
+
+  setPollingInterval(intervalMs: number): void {
+    this.monitor?.setPollingInterval(intervalMs);
+  }
+
+  hasMonitor(): boolean {
+    return this.monitor !== null;
+  }
+
+  setScrollback(lines: number): void {
+    if (this.disposed || !this.headlessTerminal) return;
+    this.headlessTerminal.options.scrollback = lines;
+  }
+
+  serialize(): Promise<string | null> {
+    return this.drainThen(() => this.serializeFull());
+  }
+
+  serializeForPersistence(): Promise<string | null> {
+    return this.drainThen(() => this.serializeBannerAware());
+  }
+
+  captureFinalSnapshot(): Promise<AnalysisFinalSnapshot> {
+    return this.drainThen(() => ({
+      snapshot: this.serializeFull(),
+      persistence: this.serializeBannerAware(),
+    }));
+  }
+
+  free(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.stopMonitor();
+    if (this.agentOutputNoteTimer) {
+      clearTimeout(this.agentOutputNoteTimer);
+      this.agentOutputNoteTimer = null;
+    }
+    if (this.digestTimer) {
+      clearTimeout(this.digestTimer);
+      this.digestTimer = null;
+    }
+    if (this.responderDisposable) {
+      try {
+        this.responderDisposable.dispose();
+      } catch {
+        // Ignore disposal errors
+      }
+      this.responderDisposable = null;
+    }
+    if (this.frameDetector) {
+      try {
+        this.frameDetector.dispose();
+      } catch {
+        // Ignore disposal errors
+      }
+      this.frameDetector = null;
+    }
+    if (this.headlessTerminal) {
+      try {
+        this.headlessTerminal.dispose();
+      } catch {
+        // Ignore disposal errors
+      }
+      this.headlessTerminal = null;
+      this.serializeAddon = null;
+    }
+  }
+
+  // Runs `fn` after xterm's async parse queue has drained, so the tail of the
+  // output is in the buffer before serialization. Falls back to immediate
+  // execution when the buffer is already gone.
+  private drainThen<T>(fn: () => T): Promise<T> {
+    const terminal = this.headlessTerminal;
+    if (this.disposed || !terminal) {
+      return Promise.resolve(fn());
+    }
+    return new Promise<T>((resolve) => {
+      terminal.write("", () => {
+        resolve(fn());
+      });
+    });
+  }
+
+  private serializeFull(): string | null {
+    if (!this.serializeAddon) return null;
+    try {
+      return this.serializeAddon.serialize();
+    } catch (error) {
+      console.error(`[AnalysisSession] Failed to serialize ${this.terminalId}:`, error);
+      return null;
+    }
+  }
+
+  // Banner-stripped serialize for persistence; mirrors
+  // terminalSerialization.serializeForPersistence.
+  private serializeBannerAware(): string | null {
+    const addon = this.serializeAddon;
+    const terminal = this.headlessTerminal;
+    if (!addon || !terminal) return null;
+
+    const startMarker = this.restoreBannerStart;
+    const endMarker = this.restoreBannerEnd;
+    if (!startMarker || !endMarker || startMarker.line < 0 || endMarker.line < 0) {
+      return this.serializeFull();
+    }
+
+    try {
+      const bufLen = terminal.buffer.active.length;
+      const bannerStart = startMarker.line;
+      const bannerEnd = endMarker.line;
+
+      const beforePart =
+        bannerStart > 0 ? addon.serialize({ range: { start: 0, end: bannerStart - 1 } }) : "";
+      const afterPart =
+        bannerEnd < bufLen - 1
+          ? addon.serialize({ range: { start: bannerEnd, end: bufLen - 1 } })
+          : "";
+
+      if (beforePart && afterPart) return beforePart + "\r\n" + afterPart;
+      return beforePart || afterPart || null;
+    } catch {
+      return this.serializeFull();
+    }
+  }
+
+  private ensureResponder(): void {
+    if (this.disposed || this.responderDisposable || !this.headlessTerminal) return;
+    this.responderDisposable = installHeadlessResponder(this.headlessTerminal, (data) => {
+      this.emit({ type: "pty-response", terminalId: this.terminalId, data });
+    });
+  }
+
+  private getAgentOutputContentSnapshot(): VisibleContentSnapshot | undefined {
+    if (!this.headlessTerminal) return undefined;
+    return readVisibleActivitySnapshot(this.headlessTerminal, AGENT_OUTPUT_ACTIVITY_LINE_COUNT);
+  }
+
+  // Mirrors TerminalProcess.noteAgentOutputActivity: temperature-based
+  // waiting→working promotion for agents whose FSM sits in a settled state.
+  // Diffs against the stored baseline from the last accepted comparison
+  // (per-chunk "before" viewport walks were dropped with #10919 — the second
+  // full extraction per note bought only a marginally tighter diff window).
+  private noteAgentOutputActivity(): void {
+    if (this.disposed) return;
+    if (!this.agentLive) {
+      this.agentOutputTemperature.reset();
+      this.agentOutputContentSnapshot = undefined;
+      return;
+    }
+
+    const state = this.agentState;
+    if (state !== "waiting" && state !== "idle" && state !== "completed") {
+      return;
+    }
+
+    const now = Date.now();
+    const sinceLastNote = now - this.lastAgentOutputNoteAt;
+    if (sinceLastNote < AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS) {
+      if (!this.agentOutputNoteTimer) {
+        this.agentOutputNoteTimer = setTimeout(() => {
+          this.agentOutputNoteTimer = null;
+          this.noteAgentOutputActivity();
+        }, AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS - sinceLastNote);
+      }
+      return;
+    }
+    this.lastAgentOutputNoteAt = now;
+
+    const afterSnapshot = this.getAgentOutputContentSnapshot();
+    if (afterSnapshot === undefined) {
+      return;
+    }
+
+    const delta = measureVisibleContentDelta(this.agentOutputContentSnapshot, afterSnapshot);
+    const hadFallbackBaseline = this.agentOutputContentSnapshot !== undefined;
+    this.agentOutputContentSnapshot = afterSnapshot;
+    if (!hadFallbackBaseline) {
+      this.agentOutputTemperature.observeDelta(Date.now(), { changedChars: 0 });
+      return;
+    }
+
+    const result = this.agentOutputTemperature.observeDelta(Date.now(), {
+      changedChars: delta.changedChars,
+    });
+    if (this.monitor?.isFocusSuppressed()) {
+      return;
+    }
+    if (result.stateHint === "busy" && this.agentState === state) {
+      this.emit({
+        type: "activity-state",
+        terminalId: this.terminalId,
+        spawnedAt: this.spawnedAt,
+        state: "busy",
+        metadata: { trigger: "output" },
+      });
+      // Arm the monitor's private busy state so its idle paths can transition
+      // the FSM back to waiting (#9875 — same rationale as the in-thread path).
+      this.monitor?.notifyExternalPromotion();
+    }
+  }
+
+  private scheduleDigest(): void {
+    if (this.disposed || this.digestTimer) return;
+    this.digestTimer = setTimeout(() => {
+      this.digestTimer = null;
+      if (this.disposed || !this.headlessTerminal) return;
+      this.emit({
+        type: "viewport",
+        terminalId: this.terminalId,
+        lines: readViewportNonEmptyLines(this.headlessTerminal),
+        cursorLine: readCursorLine(this.headlessTerminal),
+      });
+    }, VIEWPORT_DIGEST_THROTTLE_MS);
+    this.digestTimer.unref?.();
+  }
+}

--- a/electron/services/pty/analysis/AnalysisSession.ts
+++ b/electron/services/pty/analysis/AnalysisSession.ts
@@ -41,6 +41,11 @@ const AGENT_OUTPUT_NOTE_MIN_INTERVAL_MS = 50;
 // Trailing-edge throttle on the viewport digest pushed to the host (serves
 // IdentityWatcher's sync reads; its own poll cadence is 200ms).
 const VIEWPORT_DIGEST_THROTTLE_MS = 200;
+// Flow-control ack batching: a `data-ack` is emitted once this much data-
+// message payload has parsed, or on a trailing timer so a quiet tail still
+// drains the host's outstanding counter. Exported for tests.
+export const ANALYSIS_ACK_FLUSH_BYTES = 256 * 1024;
+export const ANALYSIS_ACK_FLUSH_INTERVAL_MS = 100;
 
 type Emit = (msg: WorkerToHostMessage) => void;
 
@@ -53,6 +58,9 @@ type Emit = (msg: WorkerToHostMessage) => void;
 export class AnalysisSession {
   private readonly terminalId: string;
   private readonly spawnedAt: number;
+  // Slot generation this session belongs to; stamped onto every data-ack so
+  // the host can discard acks from a superseded generation.
+  private epoch: number;
   private readonly emit: Emit;
 
   private headlessTerminal: HeadlessTerminalType | null;
@@ -78,11 +86,14 @@ export class AnalysisSession {
   private agentOutputNoteTimer: NodeJS.Timeout | null = null;
 
   private digestTimer: NodeJS.Timeout | null = null;
+  private pendingAckBytes = 0;
+  private ackTimer: NodeJS.Timeout | null = null;
   private disposed = false;
 
   constructor(spec: AnalysisCreateSpec, emit: Emit) {
     this.terminalId = spec.terminalId;
     this.spawnedAt = spec.spawnedAt;
+    this.epoch = spec.epoch;
     this.emit = emit;
 
     const terminal = new HeadlessTerminal({
@@ -116,8 +127,15 @@ export class AnalysisSession {
     }
   }
 
-  feedChunk(data: string, flags: { agentLive: boolean; agentState?: AgentState }): void {
+  feedChunk(
+    data: string,
+    flags: { agentLive: boolean; agentState?: AgentState },
+    epoch?: number
+  ): void {
     if (this.disposed || !this.headlessTerminal) return;
+    // Data always belongs to this session's create-generation, but track the
+    // per-message epoch defensively so acks always echo the live generation.
+    if (epoch !== undefined) this.epoch = epoch;
     const now = Date.now();
     this.agentLive = flags.agentLive;
     this.agentState = flags.agentState;
@@ -131,6 +149,7 @@ export class AnalysisSession {
     }
 
     this.headlessTerminal.write(data, () => {
+      this.noteProcessed(data.length);
       this.noteAgentOutputActivity();
       this.scheduleDigest();
     });
@@ -281,6 +300,10 @@ export class AnalysisSession {
 
   free(): void {
     if (this.disposed) return;
+    // Final ack flush BEFORE marking disposed: parsed-but-unflushed bytes must
+    // still drain the host's outstanding counter (an overflow-reset `create`
+    // frees this session while its backend stays registered).
+    this.flushAck();
     this.disposed = true;
     this.stopMonitor();
     if (this.agentOutputNoteTimer) {
@@ -316,6 +339,33 @@ export class AnalysisSession {
       this.headlessTerminal = null;
       this.serializeAddon = null;
     }
+  }
+
+  private noteProcessed(bytes: number): void {
+    if (this.disposed || bytes <= 0) return;
+    this.pendingAckBytes += bytes;
+    if (this.pendingAckBytes >= ANALYSIS_ACK_FLUSH_BYTES) {
+      this.flushAck();
+      return;
+    }
+    if (!this.ackTimer) {
+      this.ackTimer = setTimeout(() => {
+        this.ackTimer = null;
+        this.flushAck();
+      }, ANALYSIS_ACK_FLUSH_INTERVAL_MS);
+      this.ackTimer.unref?.();
+    }
+  }
+
+  private flushAck(): void {
+    if (this.ackTimer) {
+      clearTimeout(this.ackTimer);
+      this.ackTimer = null;
+    }
+    if (this.pendingAckBytes === 0) return;
+    const bytes = this.pendingAckBytes;
+    this.pendingAckBytes = 0;
+    this.emit({ type: "data-ack", terminalId: this.terminalId, bytes, epoch: this.epoch });
   }
 
   // Runs `fn` after xterm's async parse queue has drained, so the tail of the

--- a/electron/services/pty/analysis/AnalysisWorkerPool.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerPool.ts
@@ -41,7 +41,15 @@ export function defaultAnalysisPoolSize(): number {
   }
   const parallelism =
     typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length;
-  return Math.max(2, Math.min(6, Math.floor(parallelism / 4)));
+  const cpuDerived = Math.max(2, Math.min(6, Math.floor(parallelism / 4)));
+  // Boot-time memory cap: worker isolates aren't free, so a full CPU-derived
+  // pool is unjustified on low-RAM machines. Runtime resizing (e.g. via
+  // ResourceProfileService) is a documented follow-up — downsizing can't
+  // terminate workers under the Electron flush_tasks_ crash constraint.
+  const GIB = 1024 * 1024 * 1024;
+  const totalMem = os.totalmem();
+  const memCap = totalMem < 8 * GIB ? 2 : totalMem < 16 * GIB ? 4 : Number.POSITIVE_INFINITY;
+  return Math.min(cpuDerived, memCap);
 }
 
 export function analysisWorkersDisabled(): boolean {
@@ -106,14 +114,16 @@ export class AnalysisWorkerPool implements AnalysisPoolHost {
     return backend;
   }
 
-  post(terminalId: string, msg: HostToWorkerMessage): void {
-    if (this.disposed) return;
+  post(terminalId: string, msg: HostToWorkerMessage): boolean {
+    if (this.disposed) return false;
     const slot = this.assignments.get(terminalId);
-    if (!slot?.alive || !slot.worker) return;
+    if (!slot?.alive || !slot.worker) return false;
     try {
       slot.worker.postMessage(msg);
+      return true;
     } catch (error) {
       console.error(`[AnalysisWorkerPool] postMessage failed for ${terminalId}:`, error);
+      return false;
     }
   }
 

--- a/electron/services/pty/analysis/AnalysisWorkerPool.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerPool.ts
@@ -1,0 +1,327 @@
+import { Worker } from "node:worker_threads";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { AgentConfig } from "../../../../shared/config/agentRegistry.js";
+import {
+  WorkerAnalysisBackend,
+  type AnalysisPoolHost,
+  type WorkerAnalysisDelegate,
+  type WorkerBackendSpec,
+} from "./WorkerAnalysisBackend.js";
+import type {
+  AnalysisRequestOp,
+  AnalysisRequestResult,
+  HostToWorkerMessage,
+  WorkerToHostMessage,
+} from "../analysisWorkerProtocol.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// esbuild may emit this module into a shared chunk under
+// `dist-electron/electron/chunks/` — step up to the electron root, then down
+// to the worker's own bundled entry (registered in scripts/build-main.mjs).
+// Mirrors resolveVadWorkerPath in OpenAITranscriptionProvider.
+function resolveAnalysisWorkerPath(): string {
+  const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
+  return path.join(electronDir, "pty-host", "analysisWorker.js");
+}
+
+const REQUEST_TIMEOUT_MS = 15_000;
+const RESPAWN_BACKOFF_MS = 500;
+// KNOWN ELECTRON BUG (37+): repeated worker spawn/terminate crashes with
+// `Assertion failed: !flush_tasks_`. Workers are therefore persistent — never
+// terminated in normal operation — and each pool slot respawns at most once.
+const MAX_RESPAWNS_PER_SLOT = 1;
+
+export function defaultAnalysisPoolSize(): number {
+  const override = Number.parseInt(process.env.DAINTREE_ANALYSIS_WORKERS ?? "", 10);
+  if (Number.isFinite(override) && override > 0) {
+    return Math.min(16, override);
+  }
+  const parallelism =
+    typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length;
+  return Math.max(2, Math.min(6, Math.floor(parallelism / 4)));
+}
+
+export function analysisWorkersDisabled(): boolean {
+  return process.env.DAINTREE_DISABLE_ANALYSIS_WORKERS === "1";
+}
+
+export interface WorkerLike {
+  postMessage(msg: unknown): void;
+  on(event: "message", cb: (msg: WorkerToHostMessage) => void): void;
+  on(event: "exit", cb: (code: number) => void): void;
+  on(event: "error", cb: (err: Error) => void): void;
+  unref(): void;
+}
+
+interface PoolSlot {
+  index: number;
+  worker: WorkerLike | null;
+  terminals: Set<string>;
+  respawnCount: number;
+  alive: boolean;
+}
+
+interface PendingRequest {
+  resolve: (result: AnalysisRequestResult) => void;
+  timer: NodeJS.Timeout;
+  slotIndex: number;
+  op: AnalysisRequestOp;
+}
+
+function emptyResult(op: AnalysisRequestOp): AnalysisRequestResult {
+  return op === "final-snapshot" ? { snapshot: null, persistence: null } : null;
+}
+
+export class AnalysisWorkerPool implements AnalysisPoolHost {
+  private readonly slots: PoolSlot[] = [];
+  private readonly assignments = new Map<string, PoolSlot>();
+  private readonly backends = new Map<string, WorkerAnalysisBackend>();
+  private readonly pending = new Map<number, PendingRequest>();
+  private nextRequestId = 1;
+  private pluginAgentRegistry: Record<string, AgentConfig> | null = null;
+  private disposed = false;
+
+  constructor(
+    private readonly size: number = defaultAnalysisPoolSize(),
+    private readonly spawnWorker: () => WorkerLike = () => {
+      const worker = new Worker(resolveAnalysisWorkerPath());
+      worker.unref();
+      return worker;
+    }
+  ) {}
+
+  createBackend(
+    spec: WorkerBackendSpec,
+    delegate: WorkerAnalysisDelegate
+  ): WorkerAnalysisBackend | null {
+    if (this.disposed) return null;
+    const slot = this.assignSlot(spec.terminalId);
+    if (!slot) return null;
+    const backend = new WorkerAnalysisBackend(spec, delegate, this);
+    this.backends.set(spec.terminalId, backend);
+    backend.init();
+    return backend;
+  }
+
+  post(terminalId: string, msg: HostToWorkerMessage): void {
+    if (this.disposed) return;
+    const slot = this.assignments.get(terminalId);
+    if (!slot?.alive || !slot.worker) return;
+    try {
+      slot.worker.postMessage(msg);
+    } catch (error) {
+      console.error(`[AnalysisWorkerPool] postMessage failed for ${terminalId}:`, error);
+    }
+  }
+
+  request(terminalId: string, op: AnalysisRequestOp): Promise<AnalysisRequestResult> {
+    const slot = this.assignments.get(terminalId);
+    if (this.disposed || !slot?.alive || !slot.worker) {
+      return Promise.resolve(emptyResult(op));
+    }
+    return new Promise<AnalysisRequestResult>((resolve) => {
+      const requestId = this.nextRequestId++;
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        console.warn(`[AnalysisWorkerPool] ${op} request timed out for ${terminalId}`);
+        resolve(emptyResult(op));
+      }, REQUEST_TIMEOUT_MS);
+      timer.unref();
+      this.pending.set(requestId, { resolve, timer, slotIndex: slot.index, op });
+      try {
+        slot.worker!.postMessage({ type: "request", requestId, terminalId, op });
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(requestId);
+        console.error(`[AnalysisWorkerPool] request post failed for ${terminalId}:`, error);
+        resolve(emptyResult(op));
+      }
+    });
+  }
+
+  unregister(terminalId: string): void {
+    this.backends.delete(terminalId);
+    const slot = this.assignments.get(terminalId);
+    if (slot) {
+      slot.terminals.delete(terminalId);
+      this.assignments.delete(terminalId);
+    }
+  }
+
+  setPluginAgentRegistry(registry: Record<string, AgentConfig>): void {
+    this.pluginAgentRegistry = registry;
+    for (const slot of this.slots) {
+      if (slot.alive && slot.worker) {
+        try {
+          slot.worker.postMessage({ type: "plugin-agent-registry", registry });
+        } catch {
+          // Slot exit handling covers a dying worker.
+        }
+      }
+    }
+  }
+
+  getStats(): { workers: number; aliveWorkers: number; terminals: number } {
+    return {
+      workers: this.slots.length,
+      aliveWorkers: this.slots.filter((s) => s.alive).length,
+      terminals: this.assignments.size,
+    };
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    for (const [, req] of this.pending) {
+      clearTimeout(req.timer);
+      req.resolve(emptyResult(req.op));
+    }
+    this.pending.clear();
+    // Workers are intentionally NOT terminated (Electron flush_tasks_ crash);
+    // they are unref'd and torn down when the pty-host process exits.
+  }
+
+  private assignSlot(terminalId: string): PoolSlot | null {
+    const existing = this.assignments.get(terminalId);
+    if (existing?.alive) return existing;
+
+    const alive = this.slots.filter((s) => s.alive);
+    let slot: PoolSlot | null = null;
+    if (this.slots.length < this.size) {
+      slot = this.spawnSlot();
+    }
+    if (!slot) {
+      slot = alive.reduce<PoolSlot | null>(
+        (best, s) => (best === null || s.terminals.size < best.terminals.size ? s : best),
+        null
+      );
+    }
+    if (!slot) return null;
+    slot.terminals.add(terminalId);
+    this.assignments.set(terminalId, slot);
+    return slot;
+  }
+
+  private spawnSlot(): PoolSlot | null {
+    const slot: PoolSlot = {
+      index: this.slots.length,
+      worker: null,
+      terminals: new Set(),
+      respawnCount: 0,
+      alive: false,
+    };
+    if (!this.spawnIntoSlot(slot)) return null;
+    this.slots.push(slot);
+    return slot;
+  }
+
+  private spawnIntoSlot(slot: PoolSlot): boolean {
+    let worker: WorkerLike;
+    try {
+      worker = this.spawnWorker();
+    } catch (error) {
+      console.error("[AnalysisWorkerPool] Failed to spawn analysis worker:", error);
+      return false;
+    }
+    slot.worker = worker;
+    slot.alive = true;
+    worker.on("message", (msg) => this.onWorkerMessage(msg));
+    worker.on("error", (err) => {
+      console.error(`[AnalysisWorkerPool] Worker ${slot.index} error:`, err);
+    });
+    worker.on("exit", (code) => this.onWorkerExit(slot, code));
+    if (this.pluginAgentRegistry) {
+      try {
+        worker.postMessage({
+          type: "plugin-agent-registry",
+          registry: this.pluginAgentRegistry,
+        });
+      } catch {
+        // exit handler covers it
+      }
+    }
+    return true;
+  }
+
+  private onWorkerMessage(msg: WorkerToHostMessage): void {
+    if (msg.type === "response") {
+      const req = this.pending.get(msg.requestId);
+      if (req) {
+        this.pending.delete(msg.requestId);
+        clearTimeout(req.timer);
+        req.resolve(msg.result);
+      }
+      return;
+    }
+    if (msg.type === "ready") {
+      return;
+    }
+    this.backends.get(msg.terminalId)?.handleWorkerEvent(msg);
+  }
+
+  private onWorkerExit(slot: PoolSlot, code: number): void {
+    if (this.disposed || !slot.alive) return;
+    slot.alive = false;
+    slot.worker = null;
+    console.error(
+      `[AnalysisWorkerPool] Analysis worker ${slot.index} exited unexpectedly (code ${code}); ` +
+        `${slot.terminals.size} terminal(s) affected`
+    );
+
+    // Fail requests routed at the dead worker.
+    for (const [requestId, req] of [...this.pending]) {
+      if (req.slotIndex === slot.index) {
+        this.pending.delete(requestId);
+        clearTimeout(req.timer);
+        req.resolve(emptyResult(req.op));
+      }
+    }
+
+    if (slot.respawnCount < MAX_RESPAWNS_PER_SLOT) {
+      slot.respawnCount++;
+      const backoff = RESPAWN_BACKOFF_MS * slot.respawnCount;
+      const timer = setTimeout(() => {
+        if (this.disposed) return;
+        if (this.spawnIntoSlot(slot)) {
+          console.warn(`[AnalysisWorkerPool] Analysis worker ${slot.index} respawned`);
+          for (const terminalId of slot.terminals) {
+            this.backends.get(terminalId)?.handleWorkerLost();
+          }
+        } else {
+          this.redistribute(slot);
+        }
+      }, backoff);
+      timer.unref();
+      return;
+    }
+
+    this.redistribute(slot);
+  }
+
+  private redistribute(deadSlot: PoolSlot): void {
+    const terminals = [...deadSlot.terminals];
+    deadSlot.terminals.clear();
+    const alive = this.slots.filter((s) => s.alive);
+    for (const terminalId of terminals) {
+      const backend = this.backends.get(terminalId);
+      if (!backend) {
+        this.assignments.delete(terminalId);
+        continue;
+      }
+      const target = alive.reduce<PoolSlot | null>(
+        (best, s) => (best === null || s.terminals.size < best.terminals.size ? s : best),
+        null
+      );
+      if (!target) {
+        this.assignments.delete(terminalId);
+        backend.handleDetached();
+        continue;
+      }
+      target.terminals.add(terminalId);
+      this.assignments.set(terminalId, target);
+      backend.handleWorkerLost();
+    }
+  }
+}

--- a/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
@@ -1,0 +1,177 @@
+import { setPluginAgentRegistry } from "../../../../shared/config/pluginAgentRegistry.js";
+import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { AnalysisSession } from "./AnalysisSession.js";
+import type { HostToWorkerMessage, WorkerToHostMessage } from "../analysisWorkerProtocol.js";
+
+/**
+ * Worker-side message dispatcher. Holds the terminal-slot map and routes
+ * host messages to per-terminal AnalysisSessions. Plain class (no
+ * worker_threads dependency) so protocol behavior is unit-testable
+ * in-process; `electron/pty-host/analysisWorker.ts` is the thin entry that
+ * binds it to `parentPort`.
+ */
+export class AnalysisWorkerRuntime {
+  private readonly sessions = new Map<string, AnalysisSession>();
+  // Per-terminal ordering barrier. A `request` op is asynchronous — it drains
+  // xterm's parse queue (an async write callback) before serializing — while
+  // every other op applies synchronously. Without a barrier, a `free`/`resize`/
+  // `set-scrollback`/`create` arriving behind a pending request would dispose
+  // or reflow the buffer BEFORE the drain callback runs, breaking the
+  // SessionSnapshotter kill-path guarantee that a serialize request queued
+  // ahead of `free` captures the pre-kill buffer. While a request is pending,
+  // ALL subsequent messages for that terminal chain behind it, preserving
+  // total per-terminal message order.
+  private readonly barriers = new Map<string, Promise<void>>();
+
+  constructor(private readonly emit: (msg: WorkerToHostMessage) => void) {}
+
+  handleMessage(msg: HostToWorkerMessage): void {
+    const terminalId = "terminalId" in msg ? msg.terminalId : undefined;
+    if (terminalId === undefined) {
+      void this.runSafe(msg);
+      return;
+    }
+    const pending = this.barriers.get(terminalId);
+    if (pending) {
+      this.extendBarrier(
+        terminalId,
+        pending.then(() => this.runSafe(msg))
+      );
+      return;
+    }
+    const result = this.runSafe(msg);
+    if (result) {
+      this.extendBarrier(terminalId, result);
+    }
+  }
+
+  sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  private runSafe(msg: HostToWorkerMessage): Promise<void> | void {
+    try {
+      const result = this.dispatch(msg);
+      if (result) {
+        return result.catch((error: unknown) => {
+          console.error("[AnalysisWorker] Failed to handle message:", msg?.type, error);
+        });
+      }
+    } catch (error) {
+      console.error("[AnalysisWorker] Failed to handle message:", msg?.type, error);
+    }
+  }
+
+  private extendBarrier(terminalId: string, work: Promise<void>): void {
+    const barrier = work.then(
+      () => undefined,
+      () => undefined
+    );
+    this.barriers.set(terminalId, barrier);
+    void barrier.then(() => {
+      if (this.barriers.get(terminalId) === barrier) {
+        this.barriers.delete(terminalId);
+      }
+    });
+  }
+
+  private dispatch(msg: HostToWorkerMessage): Promise<void> | void {
+    switch (msg.type) {
+      case "create": {
+        this.sessions.get(msg.terminalId)?.free();
+        this.sessions.set(msg.terminalId, new AnalysisSession(msg, this.emit));
+        return;
+      }
+      case "data":
+        this.sessions.get(msg.terminalId)?.feedChunk(msg.data, msg.flags);
+        return;
+      case "prelude":
+        this.sessions.get(msg.terminalId)?.feedPrelude(msg.data);
+        return;
+      case "resize":
+        this.sessions.get(msg.terminalId)?.resize(msg.cols, msg.rows);
+        return;
+      case "input":
+        this.sessions.get(msg.terminalId)?.notifyInput(msg.data);
+        return;
+      case "focus":
+        this.sessions.get(msg.terminalId)?.notifyFocus();
+        return;
+      case "submission":
+        this.sessions.get(msg.terminalId)?.notifySubmission();
+        return;
+      case "monitor-start":
+        this.sessions.get(msg.terminalId)?.startMonitor(msg);
+        return;
+      case "monitor-stop":
+        this.sessions.get(msg.terminalId)?.stopMonitor();
+        return;
+      case "monitor-reconfigure":
+        this.sessions.get(msg.terminalId)?.reconfigureMonitor(msg.agentId);
+        return;
+      case "set-polling-interval":
+        this.sessions.get(msg.terminalId)?.setPollingInterval(msg.intervalMs);
+        return;
+      case "agent-context":
+        this.sessions.get(msg.terminalId)?.updateAgentContext(msg.agentLive, msg.agentState);
+        return;
+      case "process-state":
+        this.sessions.get(msg.terminalId)?.updateProcessState(msg.hasActiveChildren, msg.cpuUsage);
+        return;
+      case "set-scrollback":
+        this.sessions.get(msg.terminalId)?.setScrollback(msg.lines);
+        return;
+      case "free": {
+        const session = this.sessions.get(msg.terminalId);
+        if (session) {
+          session.free();
+          this.sessions.delete(msg.terminalId);
+        }
+        return;
+      }
+      case "plugin-agent-registry":
+        setPluginAgentRegistry(msg.registry);
+        return;
+      case "request": {
+        const session = this.sessions.get(msg.terminalId);
+        if (!session) {
+          this.emit({
+            type: "response",
+            requestId: msg.requestId,
+            terminalId: msg.terminalId,
+            result: msg.op === "final-snapshot" ? { snapshot: null, persistence: null } : null,
+            error: "no-session",
+          });
+          return;
+        }
+        const promise =
+          msg.op === "serialize"
+            ? session.serialize()
+            : msg.op === "serialize-persistence"
+              ? session.serializeForPersistence()
+              : session.captureFinalSnapshot();
+        // Returned so handleMessage arms the per-terminal barrier: later
+        // messages must not mutate the session until this settles.
+        return promise.then(
+          (result) => {
+            this.emit({
+              type: "response",
+              requestId: msg.requestId,
+              terminalId: msg.terminalId,
+              result,
+            });
+          },
+          (error: unknown) => {
+            this.emit({
+              type: "response",
+              requestId: msg.requestId,
+              terminalId: msg.terminalId,
+              result: msg.op === "final-snapshot" ? { snapshot: null, persistence: null } : null,
+              error: formatErrorMessage(error, "analysis request failed"),
+            });
+          }
+        );
+      }
+    }
+  }
+}

--- a/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerRuntime.ts
@@ -83,7 +83,7 @@ export class AnalysisWorkerRuntime {
         return;
       }
       case "data":
-        this.sessions.get(msg.terminalId)?.feedChunk(msg.data, msg.flags);
+        this.sessions.get(msg.terminalId)?.feedChunk(msg.data, msg.flags, msg.epoch);
         return;
       case "prelude":
         this.sessions.get(msg.terminalId)?.feedPrelude(msg.data);

--- a/electron/services/pty/analysis/InThreadAnalysisBackend.ts
+++ b/electron/services/pty/analysis/InThreadAnalysisBackend.ts
@@ -1,0 +1,107 @@
+import type { ActivityMonitor } from "../../ActivityMonitor.js";
+import type { PatternDetectionConfig } from "../AgentPatternDetector.js";
+import type { AnalysisBackend, MonitorStartOptions } from "./AnalysisBackend.js";
+import type { AnalysisChunkFlags, AnalysisFinalSnapshot } from "../analysisWorkerProtocol.js";
+
+/**
+ * The legacy single-threaded analysis path, adapted to the AnalysisBackend
+ * seam. All state (headless terminal, ActivityMonitor, output temperature)
+ * stays on TerminalProcess/TerminalInfo where the existing code — and the
+ * existing test suite — expects it; this class is a thin dispatch table.
+ * Selected when analysis workers are disabled (DAINTREE_DISABLE_ANALYSIS_WORKERS=1)
+ * or the worker pool is unavailable.
+ */
+export interface InThreadAnalysisHost {
+  feedChunk(data: string): void;
+  feedPrelude(data: string): void;
+  resize(cols: number, rows: number): void;
+  handleFocus(): void;
+  getMonitor(): ActivityMonitor | null;
+  startMonitor(opts: MonitorStartOptions): void;
+  stopMonitor(): void;
+  setScrollback(lines: number): boolean;
+  readViewportLines(n: number): string[];
+  readCursorLine(): string | null;
+  serialize(): Promise<string | null>;
+  serializeForPersistence(): string | null;
+  captureFinalSnapshot(): Promise<AnalysisFinalSnapshot>;
+  releaseHeadless(): void;
+}
+
+export class InThreadAnalysisBackend implements AnalysisBackend {
+  readonly kind = "in-thread" as const;
+
+  constructor(private readonly host: InThreadAnalysisHost) {}
+
+  feedChunk(data: string, _flags: AnalysisChunkFlags): void {
+    this.host.feedChunk(data);
+  }
+
+  feedPrelude(data: string): void {
+    this.host.feedPrelude(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.host.resize(cols, rows);
+  }
+
+  notifyInput(data: string): void {
+    this.host.getMonitor()?.onInput(data);
+  }
+
+  notifyFocus(): void {
+    this.host.handleFocus();
+  }
+
+  notifySubmission(): void {
+    this.host.getMonitor()?.notifySubmission();
+  }
+
+  startMonitor(opts: MonitorStartOptions): void {
+    this.host.startMonitor(opts);
+  }
+
+  stopMonitor(): void {
+    this.host.stopMonitor();
+  }
+
+  reconfigureMonitor(agentId: string, patternConfig?: PatternDetectionConfig): void {
+    this.host.getMonitor()?.reconfigure(agentId, patternConfig);
+  }
+
+  setPollingInterval(intervalMs: number): void {
+    this.host.getMonitor()?.setPollingInterval(intervalMs);
+  }
+
+  hasMonitor(): boolean {
+    return this.host.getMonitor() !== null;
+  }
+
+  setScrollback(lines: number): boolean {
+    return this.host.setScrollback(lines);
+  }
+
+  getViewportLines(n: number): string[] {
+    return this.host.readViewportLines(n);
+  }
+
+  getCursorLine(): string | null {
+    return this.host.readCursorLine();
+  }
+
+  serialize(): Promise<string | null> {
+    return this.host.serialize();
+  }
+
+  serializeForPersistence(): Promise<string | null> {
+    return Promise.resolve(this.host.serializeForPersistence());
+  }
+
+  captureFinalSnapshot(): Promise<AnalysisFinalSnapshot> {
+    return this.host.captureFinalSnapshot();
+  }
+
+  release(): void {
+    this.host.releaseHeadless();
+  }
+}

--- a/electron/services/pty/analysis/WorkerAnalysisBackend.ts
+++ b/electron/services/pty/analysis/WorkerAnalysisBackend.ts
@@ -16,6 +16,24 @@ import type {
 // is ~1.5s, so 2s keeps the mirror as fresh as the source without hot-path cost.
 const PROCESS_STATE_PUSH_INTERVAL_MS = 2000;
 
+// Flow control on the analysis feed (worker_threads postMessage queues
+// unbounded in the receiver, so a saturated worker would otherwise accumulate
+// data messages without limit). Units are string length — the same measure the
+// worker acks. Above HIGH, chunks coalesce into one host-side pending string;
+// acks dropping outstanding to LOW flush it as a single data message
+// (hysteresis, one alloc). HOLD_HARD_CAP bounds the host-side hold: past it
+// the held data is dropped and the slot is rebuilt fresh (analysis-only
+// degradation; the renderer path is untouched). Exported for tests.
+export const ANALYSIS_FEED_HIGH_WATERMARK = 4 * 1024 * 1024;
+export const ANALYSIS_FEED_LOW_WATERMARK = 1024 * 1024;
+export const ANALYSIS_FEED_HOLD_HARD_CAP = 32 * 1024 * 1024;
+
+export interface AnalysisFeedFlowControl {
+  highWatermark: number;
+  lowWatermark: number;
+  holdHardCap: number;
+}
+
 export interface WorkerAnalysisDelegate {
   onActivityState(
     spawnedAt: number,
@@ -36,11 +54,14 @@ export interface WorkerBackendSpec {
   scrollback: number;
   restore: boolean;
   spawnedAt: number;
+  /** Test hook: override the feed flow-control watermarks. */
+  flowControl?: AnalysisFeedFlowControl;
 }
 
 /** The pool surface a backend needs; implemented by AnalysisWorkerPool. */
 export interface AnalysisPoolHost {
-  post(terminalId: string, msg: HostToWorkerMessage): void;
+  /** Returns true when the message was actually handed to a live worker. */
+  post(terminalId: string, msg: HostToWorkerMessage): boolean;
   request(terminalId: string, op: AnalysisRequestOp): Promise<AnalysisRequestResult>;
   unregister(terminalId: string): void;
 }
@@ -62,6 +83,15 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
   private lastRows: number;
   private currentScrollback: number;
   private processPushTimer: NodeJS.Timeout | null = null;
+  // Flow control: string-length units posted-but-unacked, and the coalesced
+  // hold accumulated while above the high watermark.
+  private outstandingFeedBytes = 0;
+  private heldFeed: { data: string; flags: AnalysisChunkFlags } | null = null;
+  private readonly flowControl: AnalysisFeedFlowControl;
+  // Monotonic slot generation. Bumped on every fresh-slot rebuild (worker
+  // loss, feed overflow); stamped on create/data and echoed in data-ack so a
+  // late ack from a superseded generation can't debit the fresh ledger.
+  private feedEpoch = 0;
 
   constructor(
     private readonly spec: WorkerBackendSpec,
@@ -71,6 +101,11 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     this.lastCols = spec.cols;
     this.lastRows = spec.rows;
     this.currentScrollback = spec.scrollback;
+    this.flowControl = spec.flowControl ?? {
+      highWatermark: ANALYSIS_FEED_HIGH_WATERMARK,
+      lowWatermark: ANALYSIS_FEED_LOW_WATERMARK,
+      holdHardCap: ANALYSIS_FEED_HOLD_HARD_CAP,
+    };
   }
 
   get terminalId(): string {
@@ -86,18 +121,59 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
       scrollback: this.spec.scrollback,
       restore: this.spec.restore,
       spawnedAt: this.spec.spawnedAt,
+      epoch: this.feedEpoch,
     });
   }
 
   feedChunk(data: string, flags: AnalysisChunkFlags): void {
     if (this.inactive()) return;
     this.persistSuppressed = false;
-    this.pool.post(this.spec.terminalId, {
+
+    // Above the high watermark (or while a hold already exists — FIFO), stop
+    // posting and coalesce host-side. Acks release the hold below the low
+    // watermark; the hard cap rebuilds the slot fresh instead of growing
+    // without bound.
+    if (this.heldFeed !== null || this.outstandingFeedBytes >= this.flowControl.highWatermark) {
+      if (this.heldFeed === null) {
+        this.heldFeed = { data, flags };
+      } else {
+        this.heldFeed.data += data;
+        this.heldFeed.flags = flags;
+      }
+      if (this.heldFeed.data.length > this.flowControl.holdHardCap) {
+        this.overflowResetSlot();
+      }
+      return;
+    }
+
+    this.postData(data, flags);
+  }
+
+  // Posts a data message stamped with the current epoch, crediting outstanding
+  // bytes ONLY when the worker actually received it (a no-op/failed post must
+  // not leave phantom outstanding bytes that never ack).
+  private postData(data: string, flags: AnalysisChunkFlags): void {
+    const sent = this.pool.post(this.spec.terminalId, {
       type: "data",
       terminalId: this.spec.terminalId,
       data,
       flags,
+      epoch: this.feedEpoch,
     });
+    if (sent) {
+      this.outstandingFeedBytes += data.length;
+    }
+  }
+
+  // Force-posts any host-side hold, regardless of the low watermark. Called
+  // before every serialize request so the per-terminal barrier in the worker
+  // runtime orders request-after-data — otherwise a request would overtake the
+  // coalesced hold and serialize a buffer missing up to the whole hold.
+  private flushHeldFeed(): void {
+    if (this.heldFeed === null || this.inactive()) return;
+    const held = this.heldFeed;
+    this.heldFeed = null;
+    this.postData(held.data, held.flags);
   }
 
   feedPrelude(data: string): void {
@@ -219,18 +295,21 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
 
   async serialize(): Promise<string | null> {
     if (this.inactive()) return null;
+    this.flushHeldFeed();
     const result = await this.pool.request(this.spec.terminalId, "serialize");
     return typeof result === "string" ? result : null;
   }
 
   async serializeForPersistence(): Promise<string | null> {
     if (this.inactive() || this.persistSuppressed) return null;
+    this.flushHeldFeed();
     const result = await this.pool.request(this.spec.terminalId, "serialize-persistence");
     return typeof result === "string" ? result : null;
   }
 
   async captureFinalSnapshot(): Promise<AnalysisFinalSnapshot> {
     if (this.inactive()) return { snapshot: null, persistence: null };
+    this.flushHeldFeed();
     const result = await this.pool.request(this.spec.terminalId, "final-snapshot");
     if (result !== null && typeof result === "object") {
       return this.persistSuppressed ? { ...result, persistence: null } : result;
@@ -243,6 +322,10 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     this.released = true;
     this.stopProcessStatePush();
     this.monitorSpec = null;
+    // Drop any host-side hold (up to the hard cap) — no future ack will arrive
+    // to flush it once the slot is freed.
+    this.heldFeed = null;
+    this.outstandingFeedBytes = 0;
     if (!this.detached) {
       this.pool.post(this.spec.terminalId, {
         type: "free",
@@ -255,6 +338,9 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
   handleWorkerEvent(msg: WorkerToHostMessage): void {
     if (this.released) return;
     switch (msg.type) {
+      case "data-ack":
+        this.handleDataAck(msg.epoch, msg.bytes);
+        return;
       case "activity-state":
         this.delegate.onActivityState(msg.spawnedAt, msg.state, msg.metadata);
         return;
@@ -285,6 +371,55 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
    */
   handleWorkerLost(): void {
     if (this.released) return;
+    // The dead worker's queued messages (and their acks) are gone — the ledger
+    // reset and epoch bump happen in rebuildFreshSlot.
+    this.rebuildFreshSlot();
+  }
+
+  private handleDataAck(epoch: number, bytes: number): void {
+    // Stale ack from a superseded generation (worker loss / feed overflow
+    // recreated the slot). Ignoring it keeps the fresh ledger honest —
+    // otherwise a late pre-reset ack debits bytes the new generation never
+    // posted, and under sustained output that skew defeats hold decisions.
+    if (epoch !== this.feedEpoch) return;
+    this.outstandingFeedBytes = Math.max(0, this.outstandingFeedBytes - bytes);
+    if (
+      this.heldFeed !== null &&
+      this.outstandingFeedBytes <= this.flowControl.lowWatermark &&
+      !this.inactive()
+    ) {
+      const held = this.heldFeed;
+      this.heldFeed = null;
+      this.postData(held.data, held.flags);
+    }
+  }
+
+  // Hard-cap escape hatch: the worker is so far behind that the host-side
+  // hold has grown past the cap. Drop the hold and rebuild the slot fresh —
+  // detection continues from live output with a fresh buffer instead of the
+  // host accumulating unbounded memory. Analysis-only degradation (renderer
+  // path unaffected); persistence stays suppressed until real output dirties
+  // the fresh buffer (same machinery as worker respawn).
+  private overflowResetSlot(): void {
+    const heldLength = this.heldFeed?.data.length ?? 0;
+    console.error(
+      `[WorkerAnalysisBackend] Analysis feed overflow for ${this.spec.terminalId} ` +
+        `(held ${heldLength} chars past cap ${this.flowControl.holdHardCap}); ` +
+        `dropping held output and rebuilding the analysis slot fresh`
+    );
+    this.rebuildFreshSlot();
+  }
+
+  // Shared slot rebuild for worker-loss and feed-overflow: fresh buffer, no
+  // session restore (a phantom restore banner must not surface in wake
+  // snapshots), persistence suppressed until real output dirties the new
+  // buffer, monitor restarted with preserve-state semantics. Bumps the feed
+  // epoch and resets the flow-control ledger so acks from the old generation
+  // (and the dropped hold) can't debit the new one.
+  private rebuildFreshSlot(): void {
+    this.feedEpoch++;
+    this.outstandingFeedBytes = 0;
+    this.heldFeed = null;
     this.viewportLines = [];
     this.cursorLine = null;
     this.persistSuppressed = true;
@@ -296,6 +431,7 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
       scrollback: this.currentScrollback,
       restore: false,
       spawnedAt: this.spec.spawnedAt,
+      epoch: this.feedEpoch,
     });
     if (this.monitorSpec) {
       this.postAgentContext();
@@ -323,6 +459,9 @@ export class WorkerAnalysisBackend implements AnalysisBackend {
     if (this.released) return;
     this.detached = true;
     this.stopProcessStatePush();
+    // No worker to flush a hold into — drop it and zero the ledger.
+    this.heldFeed = null;
+    this.outstandingFeedBytes = 0;
     console.error(
       `[WorkerAnalysisBackend] No analysis worker available for ${this.spec.terminalId}; agent-state analysis disabled for this terminal`
     );

--- a/electron/services/pty/analysis/WorkerAnalysisBackend.ts
+++ b/electron/services/pty/analysis/WorkerAnalysisBackend.ts
@@ -1,0 +1,372 @@
+import type { AgentState } from "../../../../shared/types/agent.js";
+import type { ActivityStateMetadata } from "../../ActivityMonitor.js";
+import type { PatternDetectionConfig } from "../AgentPatternDetector.js";
+import type { AnalysisBackend, MonitorStartOptions } from "./AnalysisBackend.js";
+import type {
+  AnalysisChunkFlags,
+  AnalysisFinalSnapshot,
+  AnalysisRequestOp,
+  AnalysisRequestResult,
+  HostToWorkerMessage,
+  WorkerToHostMessage,
+} from "../analysisWorkerProtocol.js";
+
+// Cadence for mirroring host process-tree state (CPU / child liveness) into
+// the worker's ProcessStateValidator. The underlying ProcessTreeCache refresh
+// is ~1.5s, so 2s keeps the mirror as fresh as the source without hot-path cost.
+const PROCESS_STATE_PUSH_INTERVAL_MS = 2000;
+
+export interface WorkerAnalysisDelegate {
+  onActivityState(
+    spawnedAt: number,
+    state: "busy" | "idle" | "completed",
+    metadata?: ActivityStateMetadata
+  ): void;
+  onWaitingTimeout(spawnedAt: number): void;
+  onBootComplete(timestamp: number): void;
+  onPtyResponse(data: string): void;
+  getProcessState(): { hasActiveChildren: boolean; cpuUsage: number } | null;
+  getAgentContext(): { agentLive: boolean; agentState?: AgentState };
+}
+
+export interface WorkerBackendSpec {
+  terminalId: string;
+  cols: number;
+  rows: number;
+  scrollback: number;
+  restore: boolean;
+  spawnedAt: number;
+}
+
+/** The pool surface a backend needs; implemented by AnalysisWorkerPool. */
+export interface AnalysisPoolHost {
+  post(terminalId: string, msg: HostToWorkerMessage): void;
+  request(terminalId: string, op: AnalysisRequestOp): Promise<AnalysisRequestResult>;
+  unregister(terminalId: string): void;
+}
+
+export class WorkerAnalysisBackend implements AnalysisBackend {
+  readonly kind = "worker" as const;
+
+  private released = false;
+  private detached = false;
+  // After a worker respawn the fresh empty buffer must not clobber previously
+  // persisted scrollback: persistence-oriented serialization returns null
+  // until real PTY output has landed in the new buffer.
+  private persistSuppressed = false;
+  private viewportLines: string[] = [];
+  private cursorLine: string | null = null;
+  private monitorSpec: MonitorStartOptions | null = null;
+  private pollingIntervalMs: number | undefined;
+  private lastCols: number;
+  private lastRows: number;
+  private currentScrollback: number;
+  private processPushTimer: NodeJS.Timeout | null = null;
+
+  constructor(
+    private readonly spec: WorkerBackendSpec,
+    private readonly delegate: WorkerAnalysisDelegate,
+    private readonly pool: AnalysisPoolHost
+  ) {
+    this.lastCols = spec.cols;
+    this.lastRows = spec.rows;
+    this.currentScrollback = spec.scrollback;
+  }
+
+  get terminalId(): string {
+    return this.spec.terminalId;
+  }
+
+  init(): void {
+    this.pool.post(this.spec.terminalId, {
+      type: "create",
+      terminalId: this.spec.terminalId,
+      cols: this.spec.cols,
+      rows: this.spec.rows,
+      scrollback: this.spec.scrollback,
+      restore: this.spec.restore,
+      spawnedAt: this.spec.spawnedAt,
+    });
+  }
+
+  feedChunk(data: string, flags: AnalysisChunkFlags): void {
+    if (this.inactive()) return;
+    this.persistSuppressed = false;
+    this.pool.post(this.spec.terminalId, {
+      type: "data",
+      terminalId: this.spec.terminalId,
+      data,
+      flags,
+    });
+  }
+
+  feedPrelude(data: string): void {
+    if (this.inactive()) return;
+    this.pool.post(this.spec.terminalId, {
+      type: "prelude",
+      terminalId: this.spec.terminalId,
+      data,
+    });
+  }
+
+  resize(cols: number, rows: number): void {
+    if (this.inactive()) return;
+    this.lastCols = cols;
+    this.lastRows = rows;
+    this.pool.post(this.spec.terminalId, {
+      type: "resize",
+      terminalId: this.spec.terminalId,
+      cols,
+      rows,
+    });
+  }
+
+  notifyInput(data: string): void {
+    if (this.inactive() || !this.monitorSpec) return;
+    this.pool.post(this.spec.terminalId, {
+      type: "input",
+      terminalId: this.spec.terminalId,
+      data,
+    });
+  }
+
+  notifyFocus(): void {
+    if (this.inactive() || !this.monitorSpec) return;
+    this.pool.post(this.spec.terminalId, { type: "focus", terminalId: this.spec.terminalId });
+  }
+
+  notifySubmission(): void {
+    if (this.inactive() || !this.monitorSpec) return;
+    this.pool.post(this.spec.terminalId, {
+      type: "submission",
+      terminalId: this.spec.terminalId,
+    });
+  }
+
+  startMonitor(opts: MonitorStartOptions): void {
+    if (this.inactive() || this.monitorSpec) return;
+    this.monitorSpec = opts;
+    this.postAgentContext();
+    this.pool.post(this.spec.terminalId, {
+      type: "monitor-start",
+      terminalId: this.spec.terminalId,
+      agentId: opts.agentId,
+      initialState: opts.initialState,
+      skipInitialStateEmit: opts.skipInitialStateEmit,
+      hasProcessValidator: this.delegate.getProcessState() !== null,
+      pollingIntervalMs: this.pollingIntervalMs,
+    });
+    this.startProcessStatePush();
+  }
+
+  stopMonitor(): void {
+    if (this.released) return;
+    this.stopProcessStatePush();
+    if (!this.monitorSpec) return;
+    this.monitorSpec = null;
+    if (this.detached) return;
+    this.pool.post(this.spec.terminalId, {
+      type: "monitor-stop",
+      terminalId: this.spec.terminalId,
+    });
+  }
+
+  reconfigureMonitor(agentId: string, _patternConfig?: PatternDetectionConfig): void {
+    if (this.inactive() || !this.monitorSpec) return;
+    // The worker recompiles the pattern config from the (mirrored) agent
+    // registry — RegExp banks never cross the thread boundary.
+    this.monitorSpec = { ...this.monitorSpec, agentId };
+    this.postAgentContext();
+    this.pool.post(this.spec.terminalId, {
+      type: "monitor-reconfigure",
+      terminalId: this.spec.terminalId,
+      agentId,
+    });
+  }
+
+  setPollingInterval(intervalMs: number): void {
+    this.pollingIntervalMs = intervalMs;
+    if (this.inactive() || !this.monitorSpec) return;
+    this.pool.post(this.spec.terminalId, {
+      type: "set-polling-interval",
+      terminalId: this.spec.terminalId,
+      intervalMs,
+    });
+  }
+
+  hasMonitor(): boolean {
+    return this.monitorSpec !== null;
+  }
+
+  setScrollback(lines: number): boolean {
+    if (this.inactive()) return false;
+    this.currentScrollback = lines;
+    this.pool.post(this.spec.terminalId, {
+      type: "set-scrollback",
+      terminalId: this.spec.terminalId,
+      lines,
+    });
+    return true;
+  }
+
+  getViewportLines(n: number): string[] {
+    return this.viewportLines.slice(-n);
+  }
+
+  getCursorLine(): string | null {
+    return this.cursorLine;
+  }
+
+  async serialize(): Promise<string | null> {
+    if (this.inactive()) return null;
+    const result = await this.pool.request(this.spec.terminalId, "serialize");
+    return typeof result === "string" ? result : null;
+  }
+
+  async serializeForPersistence(): Promise<string | null> {
+    if (this.inactive() || this.persistSuppressed) return null;
+    const result = await this.pool.request(this.spec.terminalId, "serialize-persistence");
+    return typeof result === "string" ? result : null;
+  }
+
+  async captureFinalSnapshot(): Promise<AnalysisFinalSnapshot> {
+    if (this.inactive()) return { snapshot: null, persistence: null };
+    const result = await this.pool.request(this.spec.terminalId, "final-snapshot");
+    if (result !== null && typeof result === "object") {
+      return this.persistSuppressed ? { ...result, persistence: null } : result;
+    }
+    return { snapshot: null, persistence: null };
+  }
+
+  release(): void {
+    if (this.released) return;
+    this.released = true;
+    this.stopProcessStatePush();
+    this.monitorSpec = null;
+    if (!this.detached) {
+      this.pool.post(this.spec.terminalId, {
+        type: "free",
+        terminalId: this.spec.terminalId,
+      });
+    }
+    this.pool.unregister(this.spec.terminalId);
+  }
+
+  handleWorkerEvent(msg: WorkerToHostMessage): void {
+    if (this.released) return;
+    switch (msg.type) {
+      case "activity-state":
+        this.delegate.onActivityState(msg.spawnedAt, msg.state, msg.metadata);
+        return;
+      case "waiting-timeout":
+        this.delegate.onWaitingTimeout(msg.spawnedAt);
+        return;
+      case "boot-complete":
+        this.delegate.onBootComplete(msg.timestamp);
+        return;
+      case "pty-response":
+        this.delegate.onPtyResponse(msg.data);
+        return;
+      case "viewport":
+        this.viewportLines = msg.lines;
+        this.cursorLine = msg.cursorLine;
+        return;
+      default:
+        return;
+    }
+  }
+
+  /**
+   * Called by the pool after the assigned worker died and a replacement is
+   * available (respawn or reassignment). Rebuilds the slot with FRESH state:
+   * no session restore (a phantom restore banner must not surface in wake
+   * snapshots) and persistence suppressed until real output dirties the new
+   * buffer, so the fresh empty buffer can't clobber a good on-disk snapshot.
+   */
+  handleWorkerLost(): void {
+    if (this.released) return;
+    this.viewportLines = [];
+    this.cursorLine = null;
+    this.persistSuppressed = true;
+    this.pool.post(this.spec.terminalId, {
+      type: "create",
+      terminalId: this.spec.terminalId,
+      cols: this.lastCols,
+      rows: this.lastRows,
+      scrollback: this.currentScrollback,
+      restore: false,
+      spawnedAt: this.spec.spawnedAt,
+    });
+    if (this.monitorSpec) {
+      this.postAgentContext();
+      // Preserve-state semantics (mirrors the in-thread preserveState path):
+      // no boot "busy" re-emit, and a host FSM mid-work seeds the fresh
+      // monitor busy — the monitor's idle/completion transitions only run
+      // from its internal busy state, so seeding idle would strand a quietly
+      // working agent in the host's "working" state forever.
+      const agentState = this.delegate.getAgentContext().agentState;
+      this.pool.post(this.spec.terminalId, {
+        type: "monitor-start",
+        terminalId: this.spec.terminalId,
+        agentId: this.monitorSpec.agentId,
+        initialState: agentState === "working" ? "busy" : "idle",
+        skipInitialStateEmit: true,
+        hasProcessValidator: this.delegate.getProcessState() !== null,
+        pollingIntervalMs: this.pollingIntervalMs,
+      });
+      this.pushProcessState();
+    }
+  }
+
+  /** No workers left to host this terminal — degrade to inert analysis. */
+  handleDetached(): void {
+    if (this.released) return;
+    this.detached = true;
+    this.stopProcessStatePush();
+    console.error(
+      `[WorkerAnalysisBackend] No analysis worker available for ${this.spec.terminalId}; agent-state analysis disabled for this terminal`
+    );
+  }
+
+  private inactive(): boolean {
+    return this.released || this.detached;
+  }
+
+  private postAgentContext(): void {
+    const ctx = this.delegate.getAgentContext();
+    this.pool.post(this.spec.terminalId, {
+      type: "agent-context",
+      terminalId: this.spec.terminalId,
+      agentLive: ctx.agentLive,
+      agentState: ctx.agentState,
+    });
+  }
+
+  private pushProcessState(): void {
+    const state = this.delegate.getProcessState();
+    if (!state) return;
+    this.pool.post(this.spec.terminalId, {
+      type: "process-state",
+      terminalId: this.spec.terminalId,
+      hasActiveChildren: state.hasActiveChildren,
+      cpuUsage: state.cpuUsage,
+    });
+  }
+
+  private startProcessStatePush(): void {
+    if (this.processPushTimer) return;
+    this.pushProcessState();
+    this.processPushTimer = setInterval(() => {
+      if (this.inactive() || !this.monitorSpec) return;
+      this.pushProcessState();
+    }, PROCESS_STATE_PUSH_INTERVAL_MS);
+    this.processPushTimer.unref();
+  }
+
+  private stopProcessStatePush(): void {
+    if (this.processPushTimer) {
+      clearInterval(this.processPushTimer);
+      this.processPushTimer = null;
+    }
+  }
+}

--- a/electron/services/pty/analysis/headlessViewport.ts
+++ b/electron/services/pty/analysis/headlessViewport.ts
@@ -1,0 +1,173 @@
+import type { IBufferCell, Terminal as HeadlessTerminal } from "@xterm/headless";
+import {
+  createVisibleCellContentSnapshot,
+  createVisibleContentSnapshot,
+  type VisibleContentCell,
+  type VisibleContentSnapshot,
+} from "../SustainedChangeTracker.js";
+
+type CursorBufferLine = {
+  translateToString: (trimRight?: boolean) => string;
+  getCell?: (index: number, cell?: IBufferCell) => IBufferCell | undefined;
+};
+
+type CursorBuffer = {
+  cursorY?: number;
+  baseY: number;
+  getNullCell?: () => IBufferCell;
+  getLine: (index: number) => CursorBufferLine | undefined;
+};
+
+export function readLastNLines(terminal: HeadlessTerminal | undefined, n: number): string[] {
+  if (!terminal) return [];
+
+  const buffer = terminal.buffer.active;
+  if (!buffer) return [];
+
+  const viewportTop = buffer.baseY;
+  const viewportBottom = buffer.baseY + terminal.rows;
+
+  const lines: string[] = [];
+  for (let i = viewportTop; i < viewportBottom; i++) {
+    const line = buffer.getLine(i);
+    if (!line) continue;
+    const text = line.translateToString(true);
+    if (text.trim().length > 0) {
+      lines.push(text);
+    }
+  }
+  return lines.slice(-n);
+}
+
+export function readVisibleActivityLines(
+  terminal: HeadlessTerminal | undefined,
+  n: number
+): string[] {
+  if (!terminal) return [];
+
+  const buffer = terminal.buffer.active as CursorBuffer;
+  if (!buffer || typeof buffer.getLine !== "function") return [];
+
+  const viewportTop = buffer.baseY;
+  const viewportBottom = buffer.baseY + terminal.rows;
+  const end = viewportBottom;
+  const start = Math.max(viewportTop, end - n);
+
+  const lines: string[] = [];
+  for (let i = start; i < end; i += 1) {
+    const line = buffer.getLine(i);
+    if (line) lines.push(line.translateToString(true));
+  }
+  return lines;
+}
+
+export function readVisibleActivitySnapshot(
+  terminal: HeadlessTerminal | undefined,
+  n: number
+): VisibleContentSnapshot | undefined {
+  const cells = readVisibleActivityCells(terminal);
+  return cells
+    ? createVisibleCellContentSnapshot(cells)
+    : createVisibleContentSnapshot(readVisibleActivityLines(terminal, n));
+}
+
+// Scans the FULL visible viewport (not a cursor-anchored bottom-n window):
+// TUI agents stream spinner/status activity above a pinned bottom input box,
+// and a collapsed window starves the temperature model (v0.19.0 regression).
+// Blank cells are skipped before allocation, so an idle viewport costs reads
+// but not allocations.
+function readVisibleActivityCells(
+  terminal: HeadlessTerminal | undefined
+): VisibleContentCell[][] | undefined {
+  if (!terminal) return undefined;
+
+  const buffer = terminal.buffer.active as CursorBuffer;
+  if (!buffer || typeof buffer.getLine !== "function" || typeof buffer.getNullCell !== "function") {
+    return undefined;
+  }
+
+  const viewportTop = buffer.baseY;
+  const viewportBottom = buffer.baseY + terminal.rows;
+  const end = viewportBottom;
+  const start = viewportTop;
+  const reusableCell = buffer.getNullCell();
+
+  const rows: VisibleContentCell[][] = [];
+  for (let y = start; y < end; y += 1) {
+    const line = buffer.getLine(y);
+    if (!line || typeof line.getCell !== "function") {
+      continue;
+    }
+
+    const row: VisibleContentCell[] = [];
+    for (let x = 0; x < terminal.cols; x += 1) {
+      const cell = line.getCell(x, reusableCell);
+      if (!cell) continue;
+      const width = cell.getWidth();
+      if (width === 0) continue;
+      const chars = cell.getChars();
+      if (chars.length === 0 || /^\s*$/u.test(chars)) continue;
+      row.push(createVisibleContentCellFrom(cell, chars, width));
+    }
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function createVisibleContentCellFrom(
+  cell: IBufferCell,
+  chars: string,
+  width: number
+): VisibleContentCell {
+  const attributes =
+    (cell.isBold() ? 1 : 0) |
+    (cell.isItalic() ? 1 << 1 : 0) |
+    (cell.isDim() ? 1 << 2 : 0) |
+    (cell.isUnderline() ? 1 << 3 : 0) |
+    (cell.isBlink() ? 1 << 4 : 0) |
+    (cell.isInverse() ? 1 << 5 : 0) |
+    (cell.isInvisible() ? 1 << 6 : 0) |
+    (cell.isStrikethrough() ? 1 << 7 : 0) |
+    (cell.isOverline() ? 1 << 8 : 0);
+
+  return {
+    chars,
+    code: cell.getCode(),
+    width,
+    fgColorMode: cell.getFgColorMode(),
+    fgColor: cell.getFgColor(),
+    attributes,
+  };
+}
+
+export function readCursorLine(terminal: HeadlessTerminal | undefined): string | null {
+  if (!terminal) return null;
+
+  const buffer = terminal.buffer.active as CursorBuffer;
+  if (!buffer || typeof buffer.getLine !== "function") return null;
+  const cursorY = buffer.cursorY ?? 0;
+  const line = buffer.getLine(buffer.baseY + cursorY);
+  return line ? line.translateToString(true) : null;
+}
+
+// All non-empty viewport lines in order (the pre-slice list `readLastNLines`
+// draws from). Used to build the host-side viewport mirror in worker mode.
+export function readViewportNonEmptyLines(terminal: HeadlessTerminal | undefined): string[] {
+  if (!terminal) return [];
+  const buffer = terminal.buffer.active;
+  if (!buffer) return [];
+
+  const viewportTop = buffer.baseY;
+  const viewportBottom = buffer.baseY + terminal.rows;
+  const lines: string[] = [];
+  for (let i = viewportTop; i < viewportBottom; i++) {
+    const line = buffer.getLine(i);
+    if (!line) continue;
+    const text = line.translateToString(true);
+    if (text.trim().length > 0) {
+      lines.push(text);
+    }
+  }
+  return lines;
+}

--- a/electron/services/pty/analysisWorkerProtocol.ts
+++ b/electron/services/pty/analysisWorkerProtocol.ts
@@ -1,0 +1,86 @@
+import type { AgentState } from "../../../shared/types/agent.js";
+import type { ActivityStateMetadata } from "../ActivityMonitor.js";
+import type { AgentConfig } from "../../../shared/config/agentRegistry.js";
+
+// Typed message protocol between the pty-host main thread and the analysis
+// worker_threads pool. All payloads must be structured-clone-safe.
+
+export interface AnalysisCreateSpec {
+  terminalId: string;
+  cols: number;
+  rows: number;
+  scrollback: number;
+  /** Replay the persisted session snapshot into the fresh headless buffer. */
+  restore: boolean;
+  spawnedAt: number;
+}
+
+export interface AnalysisMonitorStartSpec {
+  agentId?: string;
+  initialState: "busy" | "idle";
+  skipInitialStateEmit: boolean;
+  /** Whether the host has a live process-state validator to mirror. */
+  hasProcessValidator: boolean;
+  pollingIntervalMs?: number;
+}
+
+export interface AnalysisChunkFlags {
+  agentLive: boolean;
+  agentState?: AgentState;
+}
+
+export type AnalysisRequestOp = "serialize" | "serialize-persistence" | "final-snapshot";
+
+export type HostToWorkerMessage =
+  | ({ type: "create" } & AnalysisCreateSpec)
+  | { type: "data"; terminalId: string; data: string; flags: AnalysisChunkFlags }
+  | { type: "prelude"; terminalId: string; data: string }
+  | { type: "resize"; terminalId: string; cols: number; rows: number }
+  | { type: "input"; terminalId: string; data: string }
+  | { type: "focus"; terminalId: string }
+  | { type: "submission"; terminalId: string }
+  | ({ type: "monitor-start"; terminalId: string } & AnalysisMonitorStartSpec)
+  | { type: "monitor-stop"; terminalId: string }
+  | { type: "monitor-reconfigure"; terminalId: string; agentId: string }
+  | { type: "set-polling-interval"; terminalId: string; intervalMs: number }
+  | { type: "agent-context"; terminalId: string; agentLive: boolean; agentState?: AgentState }
+  | {
+      type: "process-state";
+      terminalId: string;
+      hasActiveChildren: boolean;
+      cpuUsage: number;
+    }
+  | { type: "set-scrollback"; terminalId: string; lines: number }
+  | { type: "free"; terminalId: string }
+  | { type: "plugin-agent-registry"; registry: Record<string, AgentConfig> }
+  | { type: "request"; requestId: number; terminalId: string; op: AnalysisRequestOp };
+
+export interface AnalysisFinalSnapshot {
+  /** Full-buffer serialize (banner included) for the preserved snapshot. */
+  snapshot: string | null;
+  /** Banner-stripped serialize for on-disk session persistence. */
+  persistence: string | null;
+}
+
+export type AnalysisRequestResult = string | null | AnalysisFinalSnapshot;
+
+export type WorkerToHostMessage =
+  | { type: "ready" }
+  | {
+      type: "activity-state";
+      terminalId: string;
+      spawnedAt: number;
+      state: "busy" | "idle" | "completed";
+      metadata?: ActivityStateMetadata;
+    }
+  | { type: "waiting-timeout"; terminalId: string; spawnedAt: number }
+  | { type: "boot-complete"; terminalId: string; spawnedAt: number; timestamp: number }
+  | { type: "pty-response"; terminalId: string; data: string }
+  | { type: "viewport"; terminalId: string; lines: string[]; cursorLine: string | null }
+  | {
+      type: "response";
+      requestId: number;
+      terminalId: string;
+      result: AnalysisRequestResult;
+      error?: string;
+    };

--- a/electron/services/pty/analysisWorkerProtocol.ts
+++ b/electron/services/pty/analysisWorkerProtocol.ts
@@ -13,6 +13,12 @@ export interface AnalysisCreateSpec {
   /** Replay the persisted session snapshot into the fresh headless buffer. */
   restore: boolean;
   spawnedAt: number;
+  /**
+   * Monotonic slot generation. Bumped by the host on every fresh-slot rebuild
+   * (worker loss, feed overflow). The worker stamps it onto `data-ack` so the
+   * host can discard acks from a superseded generation.
+   */
+  epoch: number;
 }
 
 export interface AnalysisMonitorStartSpec {
@@ -33,7 +39,7 @@ export type AnalysisRequestOp = "serialize" | "serialize-persistence" | "final-s
 
 export type HostToWorkerMessage =
   | ({ type: "create" } & AnalysisCreateSpec)
-  | { type: "data"; terminalId: string; data: string; flags: AnalysisChunkFlags }
+  | { type: "data"; terminalId: string; data: string; flags: AnalysisChunkFlags; epoch: number }
   | { type: "prelude"; terminalId: string; data: string }
   | { type: "resize"; terminalId: string; cols: number; rows: number }
   | { type: "input"; terminalId: string; data: string }
@@ -66,6 +72,21 @@ export type AnalysisRequestResult = string | null | AnalysisFinalSnapshot;
 
 export type WorkerToHostMessage =
   | { type: "ready" }
+  | {
+      /**
+       * Batched flow-control ack: `bytes` of data-message payload (string
+       * length, the same unit the host counts) have been fully parsed by this
+       * terminal's mirror. The host decrements its outstanding-unacked counter
+       * and releases held feeds once below the low watermark. `epoch` echoes
+       * the slot generation the acked data belonged to — the host ignores acks
+       * from a superseded generation so a late pre-reset ack can't debit the
+       * fresh slot's ledger.
+       */
+      type: "data-ack";
+      terminalId: string;
+      bytes: number;
+      epoch: number;
+    }
   | {
       type: "activity-state";
       terminalId: string;

--- a/electron/services/runHistory/runHistoryLog.ts
+++ b/electron/services/runHistory/runHistoryLog.ts
@@ -75,7 +75,10 @@ export class RunHistoryLog {
   private hydrated = false;
 
   constructor(
-    private readonly saveRecords: (records: RunHistoryRecord[]) => void,
+    private readonly saveRecords: (
+      records: RunHistoryRecord[],
+      options?: { sync?: boolean }
+    ) => void,
     private readonly readRecords: () => unknown,
     private readonly maxRecords: number = RUN_HISTORY_DEFAULT_MAX_RECORDS
   ) {}
@@ -191,20 +194,23 @@ export class RunHistoryLog {
     this.flushTimer.unref?.();
   }
 
-  private flush(): void {
+  private flush(sync = false): void {
     if (!this.hydrated) return;
     try {
-      this.saveRecords([...this.records]);
+      this.saveRecords([...this.records], { sync });
     } catch (err) {
       console.error("[RunHistory] Failed to flush run history:", err);
     }
   }
 
+  // Critical-moment flush (clear, shutdown): persists synchronously on the
+  // main connection instead of the fire-and-forget worker path, so the
+  // snapshot is durable when this returns.
   flushNow(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
       this.flushTimer = null;
     }
-    this.flush();
+    this.flush(true);
   }
 }

--- a/electron/services/runHistory/runHistoryService.ts
+++ b/electron/services/runHistory/runHistoryService.ts
@@ -18,8 +18,8 @@ function readRecords(): unknown {
   return auditRingStore.readAll("runHistoryRecords");
 }
 
-function saveRecords(records: RunHistoryRecord[]): void {
-  auditRingStore.writeAll("runHistoryRecords", records, RUN_HISTORY_DEFAULT_MAX_RECORDS);
+function saveRecords(records: RunHistoryRecord[], options?: { sync?: boolean }): void {
+  auditRingStore.writeAll("runHistoryRecords", records, RUN_HISTORY_DEFAULT_MAX_RECORDS, options);
 }
 
 export const runHistoryLog = new RunHistoryLog(saveRecords, readRecords);

--- a/electron/services/worktree/NoteFileReader.ts
+++ b/electron/services/worktree/NoteFileReader.ts
@@ -63,7 +63,7 @@ export class NoteFileReader {
       return undefined;
     }
 
-    const gitDir = getGitDir(this.worktreePath, { logErrors: true });
+    const gitDir = await getGitDir(this.worktreePath, { logErrors: true });
     if (!gitDir) {
       return undefined;
     }

--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -18,12 +18,12 @@ vi.mock("fs", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
   return {
     ...actual,
-    realpathSync: vi.fn((p: string) => p),
     promises: {
       ...(actual as { promises: Record<string, unknown> }).promises,
       access: vi.fn().mockResolvedValue(undefined),
       stat: vi.fn().mockResolvedValue({ mtimeMs: 1000, size: 512 }),
       readFile: readFileMock,
+      realpath: vi.fn(async (p: string) => p),
     },
   };
 });

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { readFileSync, watch, type FSWatcher } from "fs";
+import { watch, type FSWatcher } from "fs";
+import { readFile } from "fs/promises";
 import { join as pathJoin } from "path";
 import parcelWatcher from "@parcel/watcher";
 import { getGitDir } from "../gitUtils.js";
@@ -13,7 +14,10 @@ vi.mock("@parcel/watcher", () => ({
 
 vi.mock("fs", () => ({
   watch: vi.fn(),
-  readFileSync: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn(),
 }));
 
 vi.mock("../gitUtils.js", () => ({
@@ -101,10 +105,8 @@ describe("GitFileWatcher", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
 
-    vi.mocked(getGitDir).mockReturnValue(pathJoin("/repo", ".git"));
-    vi.mocked(readFileSync).mockImplementation(() => {
-      throw new Error("commondir missing");
-    });
+    vi.mocked(getGitDir).mockResolvedValue(pathJoin("/repo", ".git"));
+    vi.mocked(readFile).mockRejectedValue(new Error("commondir missing"));
     vi.mocked(watch).mockImplementation(() => createMockWatcher());
     // Default subscribe: resolve immediately so non-worktree tests don't hang
     subscribeMock.mockResolvedValue(createMockSubscription());
@@ -116,7 +118,7 @@ describe("GitFileWatcher", () => {
 
   // ---- Per-file .git/ arm tests (unchanged semantics) ----
 
-  it("watches correct directories and de-duplicates shared paths", () => {
+  it("watches correct directories and de-duplicates shared paths", async () => {
     const gitDir = pathJoin("/repo", ".git");
     const gitWatcher = new GitFileWatcher({
       worktreePath: "/repo",
@@ -125,7 +127,7 @@ describe("GitFileWatcher", () => {
       onChange: vi.fn(),
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const watchedPaths = vi.mocked(watch).mock.calls.map(([path]) => path);
     expect(watchedPaths).toContain(gitDir);
@@ -149,7 +151,7 @@ describe("GitFileWatcher", () => {
       onChange,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const dotGitCall = vi.mocked(watch).mock.calls.find(([path]) => path === gitDir) as
       | [unknown, unknown, unknown]
@@ -182,7 +184,7 @@ describe("GitFileWatcher", () => {
       onChange,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const dotGitCall = vi.mocked(watch).mock.calls.find(([path]) => path === gitDir) as
       | [unknown, unknown, unknown]
@@ -219,7 +221,7 @@ describe("GitFileWatcher", () => {
       onChange,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const dotGitCall = vi.mocked(watch).mock.calls.find(([path]) => path === gitDir) as
       | [unknown, unknown, unknown]
@@ -244,7 +246,7 @@ describe("GitFileWatcher", () => {
       onChange,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const logsCall = vi
       .mocked(watch)
@@ -279,7 +281,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 2000,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     mock.resolve();
     const cb = mock.getCallback();
@@ -306,7 +308,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 2000,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
     expect(cb).toBeDefined();
@@ -338,7 +340,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 2000,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -364,7 +366,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 2000,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const dotGitCall = vi.mocked(watch).mock.calls.find(([path]) => path === gitDir) as
       | [unknown, unknown, unknown]
@@ -394,7 +396,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 1500,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -422,7 +424,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 1500,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -456,7 +458,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxDebounceMs: 800,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -485,7 +487,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 1500,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -521,7 +523,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 1500,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -546,7 +548,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 1500,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -575,7 +577,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxWaitMs: 1500,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -608,7 +610,7 @@ describe("GitFileWatcher", () => {
           onWatcherFailed,
         });
 
-        gitWatcher.start();
+        await gitWatcher.start();
 
         const enospcError = new Error("ENOSPC") as NodeJS.ErrnoException;
         enospcError.code = "ENOSPC";
@@ -643,7 +645,7 @@ describe("GitFileWatcher", () => {
           onInotifyLimitReached,
         });
 
-        gitWatcher.start();
+        await gitWatcher.start();
 
         const enospcError = new Error("ENOSPC") as NodeJS.ErrnoException;
         enospcError.code = "ENOSPC";
@@ -679,7 +681,7 @@ describe("GitFileWatcher", () => {
           onInotifyLimitReached,
         });
 
-        gitWatcher.start();
+        await gitWatcher.start();
 
         const otherError = new Error("permission denied") as NodeJS.ErrnoException;
         otherError.code = "EACCES";
@@ -715,7 +717,7 @@ describe("GitFileWatcher", () => {
           onInotifyLimitReached,
         });
 
-        expect(gitWatcher.start()).toBe(true);
+        await expect(gitWatcher.start()).resolves.toBe(true);
 
         const enospcError = new Error("ENOSPC") as NodeJS.ErrnoException;
         enospcError.code = "ENOSPC";
@@ -754,7 +756,7 @@ describe("GitFileWatcher", () => {
           onEmfileLimitReached,
         });
 
-        gitWatcher.start();
+        await gitWatcher.start();
 
         const emfileError = new Error("EMFILE") as NodeJS.ErrnoException;
         emfileError.code = "EMFILE";
@@ -790,7 +792,7 @@ describe("GitFileWatcher", () => {
           onEmfileLimitReached,
         });
 
-        gitWatcher.start();
+        await gitWatcher.start();
 
         const fseventError = new Error("file descriptor limit reached") as NodeJS.ErrnoException;
         mock.reject(fseventError);
@@ -825,7 +827,7 @@ describe("GitFileWatcher", () => {
           onEmfileLimitReached,
         });
 
-        gitWatcher.start();
+        await gitWatcher.start();
 
         const otherError = new Error("permission denied") as NodeJS.ErrnoException;
         otherError.code = "EACCES";
@@ -861,7 +863,7 @@ describe("GitFileWatcher", () => {
           onEmfileLimitReached,
         });
 
-        expect(gitWatcher.start()).toBe(true);
+        await expect(gitWatcher.start()).resolves.toBe(true);
 
         const emfileError = new Error("EMFILE") as NodeJS.ErrnoException;
         emfileError.code = "EMFILE";
@@ -902,7 +904,7 @@ describe("GitFileWatcher", () => {
           onInotifyLimitReached,
         });
 
-        expect(gitWatcher.start()).toBe(true);
+        await expect(gitWatcher.start()).resolves.toBe(true);
         mock.resolve();
         const cb = mock.getCallback();
 
@@ -937,7 +939,7 @@ describe("GitFileWatcher", () => {
           onEmfileLimitReached,
         });
 
-        expect(gitWatcher.start()).toBe(true);
+        await expect(gitWatcher.start()).resolves.toBe(true);
         mock.resolve();
         const cb = mock.getCallback();
 
@@ -952,7 +954,7 @@ describe("GitFileWatcher", () => {
       }
     });
 
-    it("does not signal emfile-limit on non-Darwin platforms for EMFILE runtime error", () => {
+    it("does not signal emfile-limit on non-Darwin platforms for EMFILE runtime error", async () => {
       const onChange = vi.fn();
       const onWatcherFailed = vi.fn();
       const onEmfileLimitReached = vi.fn();
@@ -972,7 +974,7 @@ describe("GitFileWatcher", () => {
           onEmfileLimitReached,
         });
 
-        expect(gitWatcher.start()).toBe(true);
+        await expect(gitWatcher.start()).resolves.toBe(true);
         mock.resolve();
         const cb = mock.getCallback();
 
@@ -986,7 +988,7 @@ describe("GitFileWatcher", () => {
       }
     });
 
-    it("does not signal inotify-limit on non-Linux platforms for ENOSPC runtime error", () => {
+    it("does not signal inotify-limit on non-Linux platforms for ENOSPC runtime error", async () => {
       const onChange = vi.fn();
       const onWatcherFailed = vi.fn();
       const onInotifyLimitReached = vi.fn();
@@ -1006,7 +1008,7 @@ describe("GitFileWatcher", () => {
           onInotifyLimitReached,
         });
 
-        expect(gitWatcher.start()).toBe(true);
+        await expect(gitWatcher.start()).resolves.toBe(true);
         mock.resolve();
         const cb = mock.getCallback();
 
@@ -1020,7 +1022,7 @@ describe("GitFileWatcher", () => {
       }
     });
 
-    it("unknown runtime errors do not fire platform-specific callbacks", () => {
+    it("unknown runtime errors do not fire platform-specific callbacks", async () => {
       const onChange = vi.fn();
       const onWatcherFailed = vi.fn();
       const onInotifyLimitReached = vi.fn();
@@ -1038,7 +1040,7 @@ describe("GitFileWatcher", () => {
         onEmfileLimitReached,
       });
 
-      expect(gitWatcher.start()).toBe(true);
+      await expect(gitWatcher.start()).resolves.toBe(true);
       mock.resolve();
       const cb = mock.getCallback();
 
@@ -1064,7 +1066,7 @@ describe("GitFileWatcher", () => {
       onChange,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const dotGitCalls = vi
       .mocked(watch)
@@ -1101,7 +1103,7 @@ describe("GitFileWatcher", () => {
       onChange,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
 
     const refsCall = vi
       .mocked(watch)
@@ -1126,7 +1128,7 @@ describe("GitFileWatcher", () => {
   // ---- Ignore filter tests ----
 
   describe("worktree ignore filter", () => {
-    it("passes WORKTREE_IGNORE_GLOBS to subscribe as native ignore option", () => {
+    it("passes WORKTREE_IGNORE_GLOBS to subscribe as native ignore option", async () => {
       const mock = setupSubscribeMock();
 
       const gitWatcher = new GitFileWatcher({
@@ -1139,7 +1141,7 @@ describe("GitFileWatcher", () => {
         worktreeMaxDebounceMs: 100,
       });
 
-      gitWatcher.start();
+      await gitWatcher.start();
 
       const options = mock.getOptions();
       expect(options).toBeDefined();
@@ -1187,7 +1189,7 @@ describe("GitFileWatcher", () => {
         worktreeMaxDebounceMs: 100,
       });
 
-      expect(gitWatcher.start()).toBe(true);
+      await expect(gitWatcher.start()).resolves.toBe(true);
       mock.resolve();
       const cb = mock.getCallback();
 
@@ -1210,7 +1212,7 @@ describe("GitFileWatcher", () => {
         worktreeMaxDebounceMs: 800,
       });
 
-      expect(gitWatcher.start()).toBe(true);
+      await expect(gitWatcher.start()).resolves.toBe(true);
       mock.resolve();
       const cb = mock.getCallback();
 
@@ -1239,7 +1241,7 @@ describe("GitFileWatcher", () => {
         worktreeMaxDebounceMs: 100,
       });
 
-      expect(gitWatcher.start()).toBe(true);
+      await expect(gitWatcher.start()).resolves.toBe(true);
       mock.resolve();
       const cb = mock.getCallback();
 
@@ -1263,7 +1265,7 @@ describe("GitFileWatcher", () => {
       watchWorktree: true,
     });
 
-    gitWatcher.start();
+    await gitWatcher.start();
 
     const sub = mock.resolveSub();
     // Flush microtasks so the .then() callback stores worktreeSubscription
@@ -1285,7 +1287,7 @@ describe("GitFileWatcher", () => {
       watchWorktree: true,
     });
 
-    gitWatcher.start();
+    await gitWatcher.start();
     gitWatcher.dispose();
 
     const sub = createMockSubscription();
@@ -1311,7 +1313,7 @@ describe("GitFileWatcher", () => {
       worktreeMaxDebounceMs: 100,
     });
 
-    expect(gitWatcher.start()).toBe(true);
+    await expect(gitWatcher.start()).resolves.toBe(true);
     mock.resolve();
     const cb = mock.getCallback();
 
@@ -1341,7 +1343,7 @@ describe("GitFileWatcher", () => {
         onInotifyLimitReached,
       });
 
-      gitWatcher.start();
+      await gitWatcher.start();
       gitWatcher.dispose();
 
       const enospcError = new Error("ENOSPC") as NodeJS.ErrnoException;
@@ -1380,7 +1382,7 @@ describe("GitFileWatcher", () => {
         onInotifyLimitReached,
       });
 
-      expect(gitWatcher.start()).toBe(true);
+      await expect(gitWatcher.start()).resolves.toBe(true);
       mock.resolve();
       const cb = mock.getCallback();
 
@@ -1419,7 +1421,7 @@ describe("GitFileWatcher", () => {
         onEmfileLimitReached,
       });
 
-      gitWatcher.start();
+      await gitWatcher.start();
 
       const enoentError = new Error("file not found") as NodeJS.ErrnoException;
       enoentError.code = "ENOENT";
@@ -1449,7 +1451,7 @@ describe("GitFileWatcher", () => {
       watchWorktree: true,
     });
 
-    gitWatcher.start();
+    await gitWatcher.start();
 
     const sub = {
       unsubscribe: vi.fn().mockRejectedValue(new Error("native teardown failed")),

--- a/electron/utils/__tests__/gitUtils.test.ts
+++ b/electron/utils/__tests__/gitUtils.test.ts
@@ -1,52 +1,142 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { join as pathJoin } from "path";
 
-const execSyncMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock("child_process", () => ({
-  execSync: execSyncMock,
+  execFile: execFileMock,
 }));
 
-import { getGitBranch } from "../gitUtils.js";
+import {
+  getGitBranch,
+  getGitDir,
+  getGitCommonDir,
+  clearGitDirCache,
+  clearGitCommonDirCache,
+} from "../gitUtils.js";
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+function mockGitOutput(stdout: string): void {
+  execFileMock.mockImplementation((_file, _args, _opts, cb: ExecCallback) => cb(null, stdout, ""));
+}
+
+function mockGitFailure(message: string): void {
+  execFileMock.mockImplementation((_file, _args, _opts, cb: ExecCallback) =>
+    cb(new Error(message), "", "")
+  );
+}
+
+beforeEach(() => {
+  clearGitDirCache();
+  clearGitCommonDirCache();
+});
+
+afterEach(() => {
+  execFileMock.mockReset();
+});
 
 describe("getGitBranch", () => {
-  afterEach(() => {
-    execSyncMock.mockReset();
+  it("returns the trimmed branch name", async () => {
+    mockGitOutput("feature/foo\n");
+    await expect(getGitBranch("/repo")).resolves.toBe("feature/foo");
   });
 
-  it("returns the trimmed branch name", () => {
-    execSyncMock.mockReturnValue("feature/foo\n");
-    expect(getGitBranch("/repo")).toBe("feature/foo");
+  it("returns null for a detached HEAD", async () => {
+    mockGitOutput("HEAD\n");
+    await expect(getGitBranch("/repo")).resolves.toBeNull();
   });
 
-  it("returns null for a detached HEAD", () => {
-    execSyncMock.mockReturnValue("HEAD\n");
-    expect(getGitBranch("/repo")).toBeNull();
+  it("returns null when git output is empty", async () => {
+    mockGitOutput("\n");
+    await expect(getGitBranch("/repo")).resolves.toBeNull();
   });
 
-  it("returns null when git output is empty", () => {
-    execSyncMock.mockReturnValue("\n");
-    expect(getGitBranch("/repo")).toBeNull();
+  it("returns null when git fails (not a repo / timeout)", async () => {
+    mockGitFailure("not a git repository");
+    await expect(getGitBranch("/not-a-repo")).resolves.toBeNull();
   });
 
-  it("returns null when execSync throws (not a repo / timeout)", () => {
-    execSyncMock.mockImplementation(() => {
-      throw new Error("not a git repository");
-    });
-    expect(getGitBranch("/not-a-repo")).toBeNull();
-  });
-
-  it("runs git in the given cwd with the requested timeout", () => {
-    execSyncMock.mockReturnValue("main\n");
-    getGitBranch("/repo/path", { timeout: 1234 });
-    expect(execSyncMock).toHaveBeenCalledTimes(1);
-    const [cmd, opts] = execSyncMock.mock.calls[0];
-    expect(cmd).toContain("rev-parse --abbrev-ref HEAD");
+  it("runs git in the given cwd with the requested timeout", async () => {
+    mockGitOutput("main\n");
+    await getGitBranch("/repo/path", { timeout: 1234 });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [file, args, opts] = execFileMock.mock.calls[0];
+    expect(file).toBe("git");
+    expect(args).toEqual(["rev-parse", "--abbrev-ref", "HEAD"]);
     expect(opts).toMatchObject({ cwd: "/repo/path", timeout: 1234 });
   });
 
-  it("defaults to a short 500ms timeout", () => {
-    execSyncMock.mockReturnValue("main\n");
-    getGitBranch("/repo");
-    expect(execSyncMock.mock.calls[0][1]).toMatchObject({ timeout: 500 });
+  it("defaults to a short 500ms timeout", async () => {
+    mockGitOutput("main\n");
+    await getGitBranch("/repo");
+    expect(execFileMock.mock.calls[0][2]).toMatchObject({ timeout: 500 });
+  });
+});
+
+describe("getGitDir caching", () => {
+  it("resolves a relative git dir against the worktree path", async () => {
+    mockGitOutput(".git\n");
+    await expect(getGitDir("/repo")).resolves.toBe(pathJoin("/repo", ".git"));
+  });
+
+  it("dedupes concurrent callers into a single git spawn", async () => {
+    const callbacks: ExecCallback[] = [];
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecCallback) => {
+      callbacks.push(cb);
+    });
+
+    const first = getGitDir("/repo");
+    const second = getGitDir("/repo");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    callbacks[0](null, ".git\n", "");
+    await expect(first).resolves.toBe(pathJoin("/repo", ".git"));
+    await expect(second).resolves.toBe(pathJoin("/repo", ".git"));
+  });
+
+  it("serves later callers from the cache after resolution", async () => {
+    mockGitOutput(".git\n");
+    await getGitDir("/repo");
+    await getGitDir("/repo");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches failures by default so a broken path doesn't re-spawn per call", async () => {
+    mockGitFailure("not a git repository");
+    await expect(getGitDir("/broken")).resolves.toBeNull();
+    await expect(getGitDir("/broken")).resolves.toBeNull();
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache failures when cacheErrors is false", async () => {
+    mockGitFailure("not a git repository");
+    await expect(getGitDir("/broken", { cacheErrors: false })).resolves.toBeNull();
+    await expect(getGitDir("/broken", { cacheErrors: false })).resolves.toBeNull();
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("bypasses the cache entirely when cache is false", async () => {
+    mockGitOutput(".git\n");
+    await getGitDir("/repo", { cache: false });
+    await getGitDir("/repo", { cache: false });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-resolves after clearGitDirCache", async () => {
+    mockGitOutput(".git\n");
+    await getGitDir("/repo");
+    clearGitDirCache("/repo");
+    await getGitDir("/repo");
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps git-dir and common-dir caches independent", async () => {
+    mockGitOutput("/repo/.git\n");
+    await expect(getGitDir("/repo")).resolves.toBe("/repo/.git");
+    await expect(getGitCommonDir("/repo")).resolves.toBe("/repo/.git");
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    expect(execFileMock.mock.calls[0][1]).toEqual(["rev-parse", "--git-dir"]);
+    expect(execFileMock.mock.calls[1][1]).toEqual(["rev-parse", "--git-common-dir"]);
   });
 });

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -1,6 +1,5 @@
-// eager-import-allow: performs sync fs checks while resolving git metadata
 import { dirname, resolve } from "path";
-import { realpathSync, promises as fs } from "fs";
+import { promises as fs } from "fs";
 import type { SimpleGit, StatusResult } from "simple-git";
 import type { FileChangeDetail, GitStatus, WorktreeChanges } from "../types/index.js";
 import { WorktreeRemovedError, toGitOperationError } from "./errorTypes.js";
@@ -151,9 +150,9 @@ export async function getPerFileDiffStats(
     const toplevel = (await git.revparse(["--show-toplevel"])).trim();
     if (!toplevel) return new Map();
     // Normalize to forward slashes on both sides so the absolute-to-relative
-    // re-keying works on Windows, where `realpathSync` returns backslashes
+    // re-keying works on Windows, where `realpath` returns backslashes
     // but `status.files[].path` uses forward slashes.
-    const gitRoot = realpathSync(toplevel).replace(/\\/g, "/");
+    const gitRoot = (await fs.realpath(toplevel)).replace(/\\/g, "/");
     const diffOutput = await git.diff(args);
     const byAbsolutePath = parseNumstat(diffOutput, gitRoot);
 
@@ -448,7 +447,7 @@ export async function getWorktreeChangesWithStats(
         LAST_COMMIT_LOG_CACHE.set(headOid, logOutput);
       }
 
-      const gitRoot = realpathSync(toplevelRaw.trim());
+      const gitRoot = await fs.realpath(toplevelRaw.trim());
 
       let lastCommitMessage: string | undefined;
       let lastCommitTimestampMs: number | undefined;
@@ -747,7 +746,7 @@ export async function getWorktreeChangesWithStats(
 
       const tracking = status.tracking && status.tracking.length > 0 ? status.tracking : null;
       const result: WorktreeChanges = {
-        worktreeId: realpathSync(cwd),
+        worktreeId: await fs.realpath(cwd),
         rootPath: gitRoot,
         changes,
         changedFileCount: changes.length,

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -1,4 +1,5 @@
-import { watch as fsWatch, FSWatcher, readFileSync } from "fs";
+import { watch as fsWatch, FSWatcher } from "fs";
+import { readFile } from "fs/promises";
 import { join as pathJoin, dirname, isAbsolute, basename, normalize as pathNormalize } from "path";
 import parcelWatcher from "@parcel/watcher";
 import { getGitDir } from "./gitUtils.js";
@@ -109,18 +110,23 @@ export class GitFileWatcher {
     this.watchWorktree = options.watchWorktree ?? false;
   }
 
-  start(): boolean {
+  async start(): Promise<boolean> {
     if (this.disposed) {
       return false;
     }
 
-    const gitDir = getGitDir(this.worktreePath, { cache: true, logErrors: false });
-    if (!gitDir) {
+    const gitDir = await getGitDir(this.worktreePath, { cache: true, logErrors: false });
+    if (this.disposed || !gitDir) {
       return false;
     }
 
     try {
-      const commonDir = this.resolveCommonDir(gitDir);
+      const commonDir = await this.resolveCommonDir(gitDir);
+      // Re-check after the async resolution: a dispose() during the await
+      // must not arm watchers that nothing will ever close.
+      if (this.disposed) {
+        return false;
+      }
       const headPath = pathJoin(gitDir, "HEAD");
 
       this.watchFile(headPath);
@@ -217,10 +223,10 @@ export class GitFileWatcher {
     }
   }
 
-  private resolveCommonDir(gitDir: string): string {
+  private async resolveCommonDir(gitDir: string): Promise<string> {
     try {
       const commondirPath = pathJoin(gitDir, "commondir");
-      const commondir = readFileSync(commondirPath, "utf-8").trim();
+      const commondir = (await readFile(commondirPath, "utf-8")).trim();
       return isAbsolute(commondir) ? commondir : pathJoin(gitDir, commondir);
     } catch {
       return gitDir;

--- a/electron/utils/gitUtils.ts
+++ b/electron/utils/gitUtils.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFile } from "child_process";
 import { isAbsolute, join as pathJoin } from "path";
 import { logWarn } from "./logger.js";
 import { Cache } from "./cache.js";
@@ -6,12 +6,19 @@ import { Cache } from "./cache.js";
 // worktreePath → gitDir/commonDir is immutable for a live worktree and all
 // removal/switch paths invalidate explicitly via clearGitDirCache /
 // clearGitCommonDirCache, so successful resolutions never expire — a TTL
-// would only force periodic blocking execSync re-resolution on hot poll
-// paths. Cached error (null) entries keep the default TTL so transient
-// failures self-heal.
+// would only force periodic git re-resolution on hot poll paths. Cached
+// error (null) entries keep the default TTL so transient failures self-heal.
+// The cache stores the resolution promise itself so concurrent callers for
+// the same worktree share a single git spawn.
 const SUCCESS_TTL_MS = Number.POSITIVE_INFINITY;
-const gitDirCache = new Cache<string, string | null>({ maxSize: 200, defaultTTL: 600_000 });
-const gitCommonDirCache = new Cache<string, string | null>({ maxSize: 200, defaultTTL: 600_000 });
+const gitDirCache = new Cache<string, Promise<string | null>>({
+  maxSize: 200,
+  defaultTTL: 600_000,
+});
+const gitCommonDirCache = new Cache<string, Promise<string | null>>({
+  maxSize: 200,
+  defaultTTL: 600_000,
+});
 
 export interface GitDirOptions {
   cache?: boolean;
@@ -20,42 +27,87 @@ export interface GitDirOptions {
   cacheErrors?: boolean;
 }
 
-export function getGitDir(worktreePath: string, options: GitDirOptions = {}): string | null {
-  const { cache = true, timeout = 5000, logErrors = false, cacheErrors = true } = options;
+function execGit(args: string[], cwd: string, timeout: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile("git", args, { cwd, timeout, encoding: "utf-8" }, (error, stdout) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(typeof stdout === "string" ? stdout : String(stdout));
+      }
+    });
+  });
+}
 
-  if (cache && gitDirCache.has(worktreePath)) {
-    return gitDirCache.get(worktreePath)!;
-  }
-
+async function resolveGitPath(
+  revParseFlag: string,
+  worktreePath: string,
+  timeout: number,
+  logErrors: boolean,
+  warnMessage: string
+): Promise<string | null> {
   try {
-    const result = execSync("git rev-parse --git-dir", {
-      cwd: worktreePath,
-      encoding: "utf-8",
-      timeout,
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-
-    const resolved = isAbsolute(result) ? result : pathJoin(worktreePath, result);
-
-    if (cache) {
-      gitDirCache.set(worktreePath, resolved, SUCCESS_TTL_MS);
-    }
-
-    return resolved;
+    const result = (await execGit(["rev-parse", revParseFlag], worktreePath, timeout)).trim();
+    return isAbsolute(result) ? result : pathJoin(worktreePath, result);
   } catch (error) {
     if (logErrors) {
-      logWarn("Failed to resolve git directory", {
+      logWarn(warnMessage, {
         path: worktreePath,
         error: (error as Error).message,
       });
     }
-
-    if (cache && cacheErrors) {
-      gitDirCache.set(worktreePath, null);
-    }
-
     return null;
   }
+}
+
+function cachedResolveGitPath(
+  cacheStore: Cache<string, Promise<string | null>>,
+  revParseFlag: string,
+  warnMessage: string,
+  worktreePath: string,
+  options: GitDirOptions
+): Promise<string | null> {
+  const { cache = true, timeout = 5000, logErrors = false, cacheErrors = true } = options;
+
+  if (cache) {
+    const cached = cacheStore.get(worktreePath);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
+
+  const promise = resolveGitPath(revParseFlag, worktreePath, timeout, logErrors, warnMessage);
+
+  if (cache) {
+    // Insert at the error TTL while in flight; upgrade to the permanent TTL
+    // on success, or drop the entry when errors shouldn't be cached.
+    cacheStore.set(worktreePath, promise);
+    void promise.then((resolved) => {
+      if (cacheStore.get(worktreePath) !== promise) {
+        return;
+      }
+      if (resolved !== null) {
+        cacheStore.set(worktreePath, promise, SUCCESS_TTL_MS);
+      } else if (!cacheErrors) {
+        cacheStore.invalidate(worktreePath);
+      }
+    });
+  }
+
+  return promise;
+}
+
+export function getGitDir(
+  worktreePath: string,
+  options: GitDirOptions = {}
+): Promise<string | null> {
+  return cachedResolveGitPath(
+    gitDirCache,
+    "--git-dir",
+    "Failed to resolve git directory",
+    worktreePath,
+    options
+  );
 }
 
 /**
@@ -67,42 +119,17 @@ export function getGitDir(worktreePath: string, options: GitDirOptions = {}): st
  * touches `.git/objects` or `packed-refs` — most importantly background
  * fetches across sibling worktrees.
  */
-export function getGitCommonDir(worktreePath: string, options: GitDirOptions = {}): string | null {
-  const { cache = true, timeout = 5000, logErrors = false, cacheErrors = true } = options;
-
-  if (cache && gitCommonDirCache.has(worktreePath)) {
-    return gitCommonDirCache.get(worktreePath)!;
-  }
-
-  try {
-    const result = execSync("git rev-parse --git-common-dir", {
-      cwd: worktreePath,
-      encoding: "utf-8",
-      timeout,
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-
-    const resolved = isAbsolute(result) ? result : pathJoin(worktreePath, result);
-
-    if (cache) {
-      gitCommonDirCache.set(worktreePath, resolved, SUCCESS_TTL_MS);
-    }
-
-    return resolved;
-  } catch (error) {
-    if (logErrors) {
-      logWarn("Failed to resolve git common directory", {
-        path: worktreePath,
-        error: (error as Error).message,
-      });
-    }
-
-    if (cache && cacheErrors) {
-      gitCommonDirCache.set(worktreePath, null);
-    }
-
-    return null;
-  }
+export function getGitCommonDir(
+  worktreePath: string,
+  options: GitDirOptions = {}
+): Promise<string | null> {
+  return cachedResolveGitPath(
+    gitCommonDirCache,
+    "--git-common-dir",
+    "Failed to resolve git common directory",
+    worktreePath,
+    options
+  );
 }
 
 /**
@@ -112,18 +139,15 @@ export function getGitCommonDir(worktreePath: string, options: GitDirOptions = {
  * Used best-effort at terminal-close time to stamp a resume sanity-check onto
  * the journal record, so it runs with a short default timeout and never throws.
  */
-export function getGitBranch(
+export async function getGitBranch(
   worktreePath: string,
   options: { timeout?: number } = {}
-): string | null {
+): Promise<string | null> {
   const { timeout = 500 } = options;
   try {
-    const result = execSync("git rev-parse --abbrev-ref HEAD", {
-      cwd: worktreePath,
-      encoding: "utf-8",
-      timeout,
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
+    const result = (
+      await execGit(["rev-parse", "--abbrev-ref", "HEAD"], worktreePath, timeout)
+    ).trim();
     if (!result || result === "HEAD") return null;
     return result;
   } catch {
@@ -147,10 +171,10 @@ export function clearGitCommonDirCache(worktreePath?: string): void {
   }
 }
 
-export function getGitNotePath(
+export async function getGitNotePath(
   worktreePath: string,
   filename: string = "daintree/note"
-): string | null {
-  const gitDir = getGitDir(worktreePath);
+): Promise<string | null> {
+  const gitDir = await getGitDir(worktreePath);
   return gitDir ? pathJoin(gitDir, filename) : null;
 }

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -23,7 +23,7 @@ nodeV8.setHeapSnapshotNearHeapLimit(2);
 
 import { MessagePort } from "node:worker_threads";
 import { initializeLogger, setLogLevelOverrides } from "./utils/logger.js";
-import { copyTreeService } from "./services/CopyTreeService.js";
+import { copytreeWorkerClient } from "./workspace-host/CopytreeWorkerClient.js";
 import { fileTreeService } from "./services/FileTreeService.js";
 import { projectPulseService } from "./services/ProjectPulseService.js";
 import type { CopyTreeProgress } from "../shared/types/ipc.js";
@@ -592,7 +592,7 @@ port.on("message", async (rawMsg: any) => {
         };
 
         try {
-          const result = await copyTreeService.generate(
+          const result = await copytreeWorkerClient.generate(
             rootPath,
             options || {},
             onProgress,
@@ -616,7 +616,7 @@ port.on("message", async (rawMsg: any) => {
       }
 
       case "copytree:cancel":
-        copyTreeService.cancel(request.operationId);
+        copytreeWorkerClient.cancel(request.operationId);
         break;
 
       case "copytree:test-config": {
@@ -624,7 +624,11 @@ port.on("message", async (rawMsg: any) => {
         console.log(`[WorkspaceHost] CopyTree test-config started`);
 
         try {
-          const result = await copyTreeService.testConfig(rootPath, options || {}, operationId);
+          const result = await copytreeWorkerClient.testConfig(
+            rootPath,
+            options || {},
+            operationId
+          );
           sendEvent({
             type: "copytree:test-config-result",
             requestId,

--- a/electron/workspace-host/CopytreeWorkerClient.ts
+++ b/electron/workspace-host/CopytreeWorkerClient.ts
@@ -1,0 +1,260 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+import { copyTreeService, type ProgressCallback } from "../services/CopyTreeService.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { logWarn } from "../utils/logger.js";
+import type { CopyTreeOptions, CopyTreeResult } from "../types/index.js";
+import type { CopyTreeTestConfigResult } from "../../shared/types/index.js";
+import type { CopytreeWorkerRequest, CopytreeWorkerResponse } from "./copytreeWorkerProtocol.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolves the compiled copytree worker on disk. esbuild may emit this module
+ * into a shared chunk under `dist-electron/electron/chunks/`, so `__dirname`
+ * can point at that chunks dir — step up to the electron root, then down to
+ * the worker's own output path. Mirrors `resolveVadWorkerPath()` in
+ * `OpenAITranscriptionProvider.ts`.
+ */
+function resolveCopytreeWorkerPath(): string {
+  const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
+  return path.join(electronDir, "workspace-host", "copytreeWorker.js");
+}
+
+/**
+ * Client-side backstop for a wedged worker. The main process's
+ * `sendWithResponse` gives up at 120s, so past this point the request is
+ * already lost main-side — reject, drop the pending entry (it would
+ * otherwise leak forever), and ask the worker to abort the op so its CPU is
+ * reclaimed. Deliberately above the main-side timeout so the in-band result
+ * always wins while the worker is healthy.
+ */
+const WORKER_OP_TIMEOUT_MS = 180_000;
+
+interface PendingGenerate {
+  resolve: (result: CopyTreeResult) => void;
+  reject: (error: Error) => void;
+  onProgress?: ProgressCallback;
+  timer: NodeJS.Timeout;
+}
+
+interface PendingTestConfig {
+  resolve: (result: CopyTreeTestConfigResult) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/**
+ * Runs copytree operations on a persistent worker thread so the CPU-heavy
+ * walk/format work stays off the workspace-host event loop.
+ *
+ * - The worker is spawned lazily on the first request and never terminated in
+ *   normal operation (Electron 37+ crashes on repeated worker
+ *   spawn/terminate cycles inside a utilityProcess — `!flush_tasks_`).
+ * - `DAINTREE_DISABLE_COPYTREE_WORKER=1` or a spawn failure falls back to the
+ *   in-thread CopyTreeService path; an unexpected worker exit fails in-flight
+ *   operations and pins the fallback for the rest of the host's life.
+ * - Result/error shapes match the in-thread path: copytree-level failures
+ *   arrive as error-shaped results, only transport/infra failures reject.
+ */
+export class CopytreeWorkerClient {
+  private worker: Worker | null = null;
+  private workerFailed = false;
+  private readonly pendingGenerate = new Map<string, PendingGenerate>();
+  private readonly pendingTestConfig = new Map<string, PendingTestConfig>();
+
+  constructor(
+    private readonly createWorker: () => Worker = () => new Worker(resolveCopytreeWorkerPath())
+  ) {}
+
+  async generate(
+    rootPath: string,
+    options: CopyTreeOptions = {},
+    onProgress?: ProgressCallback,
+    operationId?: string
+  ): Promise<CopyTreeResult> {
+    const id = operationId || crypto.randomUUID();
+    const worker = this.getWorker();
+    if (!worker) {
+      return copyTreeService.generate(rootPath, options, onProgress, id);
+    }
+    const pending = new Promise<CopyTreeResult>((resolve, reject) => {
+      this.pendingGenerate.set(id, {
+        resolve,
+        reject,
+        onProgress,
+        timer: this.armOperationTimeout(id),
+      });
+    });
+    try {
+      worker.postMessage({
+        type: "generate",
+        id,
+        rootPath,
+        options,
+      } satisfies CopytreeWorkerRequest);
+    } catch (error) {
+      this.takePendingGenerate(id);
+      logWarn("copytree worker postMessage failed; running in-process", {
+        error: formatErrorMessage(error, "postMessage failed"),
+      });
+      return copyTreeService.generate(rootPath, options, onProgress, id);
+    }
+    return pending;
+  }
+
+  async testConfig(
+    rootPath: string,
+    options: CopyTreeOptions = {},
+    operationId?: string
+  ): Promise<CopyTreeTestConfigResult> {
+    const id = operationId || crypto.randomUUID();
+    const worker = this.getWorker();
+    if (!worker) {
+      return copyTreeService.testConfig(rootPath, options, id);
+    }
+    const pending = new Promise<CopyTreeTestConfigResult>((resolve, reject) => {
+      this.pendingTestConfig.set(id, { resolve, reject, timer: this.armOperationTimeout(id) });
+    });
+    try {
+      worker.postMessage({
+        type: "test-config",
+        id,
+        rootPath,
+        options,
+      } satisfies CopytreeWorkerRequest);
+    } catch (error) {
+      this.takePendingTestConfig(id);
+      logWarn("copytree worker postMessage failed; running in-process", {
+        error: formatErrorMessage(error, "postMessage failed"),
+      });
+      return copyTreeService.testConfig(rootPath, options, id);
+    }
+    return pending;
+  }
+
+  /**
+   * Cancel an operation wherever it runs. Both sides treat an unknown id as a
+   * no-op, so forwarding to both is safe and covers the fallback path.
+   */
+  cancel(operationId: string): void {
+    copyTreeService.cancel(operationId);
+    if (this.pendingGenerate.has(operationId) || this.pendingTestConfig.has(operationId)) {
+      this.postCancel(operationId);
+    }
+  }
+
+  private workerDisabled(): boolean {
+    return process.env.DAINTREE_DISABLE_COPYTREE_WORKER === "1";
+  }
+
+  private getWorker(): Worker | null {
+    if (this.workerDisabled() || this.workerFailed) return null;
+    if (this.worker) return this.worker;
+    try {
+      const worker = this.createWorker();
+      worker.on("message", (message: CopytreeWorkerResponse) => this.handleMessage(message));
+      worker.on("error", (error) => this.handleWorkerDown(error));
+      worker.on("exit", (code) => {
+        this.handleWorkerDown(new Error(`copytree worker exited with code ${code}`));
+      });
+      // The worker must never keep the host alive on its own; the host's
+      // lifetime is owned by the parent port.
+      worker.unref();
+      this.worker = worker;
+      return worker;
+    } catch (error) {
+      this.workerFailed = true;
+      logWarn("copytree worker spawn failed; falling back to in-process generation", {
+        error: formatErrorMessage(error, "spawn failed"),
+      });
+      return null;
+    }
+  }
+
+  private armOperationTimeout(id: string): NodeJS.Timeout {
+    const timer = setTimeout(() => this.timeOutOperation(id), WORKER_OP_TIMEOUT_MS);
+    timer.unref?.();
+    return timer;
+  }
+
+  private timeOutOperation(id: string): void {
+    const pending = this.takePendingGenerate(id) ?? this.takePendingTestConfig(id);
+    if (!pending) return;
+    // Best-effort abort so the worker reclaims the CPU; an already-finished
+    // (or unknown) id is a no-op on the worker side.
+    this.postCancel(id);
+    pending.reject(new Error(`copytree worker did not respond within ${WORKER_OP_TIMEOUT_MS}ms`));
+  }
+
+  private postCancel(id: string): void {
+    try {
+      this.worker?.postMessage({ type: "cancel", id } satisfies CopytreeWorkerRequest);
+    } catch {
+      // Worker already torn down — nothing left to cancel.
+    }
+  }
+
+  private takePendingGenerate(id: string): PendingGenerate | undefined {
+    const pending = this.pendingGenerate.get(id);
+    if (pending) {
+      this.pendingGenerate.delete(id);
+      clearTimeout(pending.timer);
+    }
+    return pending;
+  }
+
+  private takePendingTestConfig(id: string): PendingTestConfig | undefined {
+    const pending = this.pendingTestConfig.get(id);
+    if (pending) {
+      this.pendingTestConfig.delete(id);
+      clearTimeout(pending.timer);
+    }
+    return pending;
+  }
+
+  private handleWorkerDown(error: unknown): void {
+    // Persistent-worker policy: no respawn. A crashing worker would otherwise
+    // enter the Electron spawn/terminate crash path, so all future requests
+    // take the in-thread fallback instead.
+    this.workerFailed = true;
+    this.worker = null;
+    const failure = new Error(formatErrorMessage(error, "copytree worker failed"));
+    for (const pending of this.pendingGenerate.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(failure);
+    }
+    this.pendingGenerate.clear();
+    for (const pending of this.pendingTestConfig.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(failure);
+    }
+    this.pendingTestConfig.clear();
+    logWarn("copytree worker down; falling back to in-process generation", {
+      error: failure.message,
+    });
+  }
+
+  private handleMessage(message: CopytreeWorkerResponse): void {
+    switch (message.type) {
+      case "progress":
+        this.pendingGenerate.get(message.id)?.onProgress?.(message.progress);
+        break;
+      case "generate-result":
+        this.takePendingGenerate(message.id)?.resolve(message.result);
+        break;
+      case "generate-error":
+        this.takePendingGenerate(message.id)?.reject(new Error(message.error));
+        break;
+      case "test-config-result":
+        this.takePendingTestConfig(message.id)?.resolve(message.result);
+        break;
+      case "test-config-error":
+        this.takePendingTestConfig(message.id)?.reject(new Error(message.error));
+        break;
+    }
+  }
+}
+
+export const copytreeWorkerClient = new CopytreeWorkerClient();

--- a/electron/workspace-host/CopytreeWorkerClient.ts
+++ b/electron/workspace-host/CopytreeWorkerClient.ts
@@ -27,10 +27,12 @@ function resolveCopytreeWorkerPath(): string {
  * `sendWithResponse` gives up at 120s, so past this point the request is
  * already lost main-side — reject, drop the pending entry (it would
  * otherwise leak forever), and ask the worker to abort the op so its CPU is
- * reclaimed. Deliberately above the main-side timeout so the in-band result
- * always wins while the worker is healthy.
+ * reclaimed. The 5s margin over the main-side timeout exists only so the
+ * main-side timeout surfaces first (the in-band result always wins while the
+ * worker is healthy); keeping it tight stops the worker grinding on an op the
+ * caller has already abandoned — and possibly already retried.
  */
-const WORKER_OP_TIMEOUT_MS = 180_000;
+const WORKER_OP_TIMEOUT_MS = 125_000;
 
 interface PendingGenerate {
   resolve: (result: CopyTreeResult) => void;

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -171,9 +171,16 @@ export class RepoFetchCoordinator {
    * serialized on a single per-repo promise chain.
    */
   async fetchForWorktree(opts: FetchOptions): Promise<FetchResult> {
-    const commonDir = getGitCommonDir(opts.worktreePath, { logErrors: false });
+    const baseGenerationAtStart = this.baseGeneration;
+    const commonDir = await getGitCommonDir(opts.worktreePath, { logErrors: false });
     if (!commonDir) {
       return { status: "skipped", skipReason: "no-common-dir" };
+    }
+    if (this.baseGeneration !== baseGenerationAtStart) {
+      // destroy() ran while the commondir resolved. Creating state now would
+      // repopulate the cleared map at the fresh generation, letting this
+      // stale continuation dodge runFetch's stale-generation guard.
+      return { status: "skipped", skipReason: "stale-generation" };
     }
 
     const state = this.getOrCreateState(commonDir);

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -53,6 +53,16 @@ export interface WatcherControllerHost {
 export class WatcherController {
   private gitWatcher = new MutableDisposable<IDisposable>();
   private gitWatcherMode: WatcherMode = "none";
+  /**
+   * In-flight `GitFileWatcher.start()` (the git-dir resolution is async).
+   * While set, the controller reports the arm's target mode optimistically —
+   * poll-cadence and focus-rotation decisions made during the short arming
+   * window then match what a synchronous arm would have produced. Any
+   * teardown/rotation cancels the arm via `cancelPendingArm()`; the arm's
+   * completion handler recognizes the cancellation by identity and discards
+   * itself.
+   */
+  private pendingArm: { watcher: GitFileWatcher; mode: WatcherMode } | null = null;
   private gitWatchDebounceTimer: NodeJS.Timeout | null = null;
   private gitWatchRefreshPending = false;
   private watcherRetryTimer: NodeJS.Timeout | null = null;
@@ -71,7 +81,7 @@ export class WatcherController {
   constructor(private readonly host: WatcherControllerHost) {}
 
   get hasWatcher(): boolean {
-    return this.gitWatcher.value !== undefined;
+    return this.gitWatcher.value !== undefined || this.pendingArm !== null;
   }
 
   get currentMode(): WatcherMode {
@@ -114,7 +124,7 @@ export class WatcherController {
    */
   start(mode: "git-only" | "recursive" = this.desiredMode()): void {
     if (this.disposed) return;
-    if (!this.host.isRunning || !this.host.gitWatchEnabled || this.gitWatcher.value) {
+    if (!this.host.isRunning || !this.host.gitWatchEnabled || this.hasWatcher) {
       return;
     }
 
@@ -132,44 +142,71 @@ export class WatcherController {
       onEmfileLimitReached: () => this.host.onEmfileLimitReached(this.host.worktreeId),
     });
 
-    const started = watcher.start();
-    if (started) {
-      this.gitWatcher.value = toDisposable(() => watcher.dispose());
-      this.gitWatcherMode = mode;
-      if (mode === "recursive" && this.wasDegraded) {
-        // Recursive coverage restored after a degradation. Signal recovery
-        // exactly once per degradation episode so the host can reset its
-        // one-shot guards and clear the persistent degraded indicator.
-        this.wasDegraded = false;
-        this.host.onWatcherRecovered?.();
+    const arm = { watcher, mode };
+    this.pendingArm = arm;
+    // Optimistic: the mode reflects the arm's target while it's in flight so
+    // pollIntervalMs()/desiredMode() comparisons behave as if the arm were
+    // synchronous. The completion handler corrects it on failure.
+    this.gitWatcherMode = mode;
+
+    void watcher.start().then((started) => {
+      if (this.pendingArm !== arm) {
+        // Superseded by stop()/update()/handleWatcherFailed() during the arm.
+        watcher.dispose();
+        return;
       }
-      // Retry budget is managed by stop(true) (reset) and scheduleRetry()
-      // (increment). Resetting it here would defeat exhaustion — a failing
-      // git-only fallback path would keep getting fresh budget every cycle.
-    } else {
-      watcher.dispose();
-      if (mode === "recursive") {
-        // Recursive arm failed — mark degraded so the eventual successful
-        // re-arm signals recovery, even if the watcher returned false without
-        // routing through `onWatcherFailed`.
-        this.wasDegraded = true;
-        // The recursive watcher fires `onWatcherFailed` synchronously on
-        // startup ENOSPC/EMFILE before returning false, so handleWatcherFailed
-        // may have already installed a git-only fallback by this point. Only
-        // attempt the downgrade ourselves when no degraded watcher exists.
-        if (!this.gitWatcher.value) {
-          this.start("git-only");
+      this.pendingArm = null;
+      if (this.disposed) {
+        watcher.dispose();
+        return;
+      }
+      if (started) {
+        this.gitWatcher.value = toDisposable(() => watcher.dispose());
+        if (mode === "recursive" && this.wasDegraded) {
+          // Recursive coverage restored after a degradation. Signal recovery
+          // exactly once per degradation episode so the host can reset its
+          // one-shot guards and clear the persistent degraded indicator.
+          this.wasDegraded = false;
+          this.host.onWatcherRecovered?.();
         }
-        // Background worktrees don't want recursive at all, so don't keep
-        // poking at it; the next focus flip re-arms via the focus change.
-        if (this.host.isCurrent) {
-          this.scheduleRetry();
-        }
+        // Retry budget is managed by stop(true) (reset) and scheduleRetry()
+        // (increment). Resetting it here would defeat exhaustion — a failing
+        // git-only fallback path would keep getting fresh budget every cycle.
       } else {
-        // git-only itself failed (e.g. getGitDir returned null). Stay dark
-        // and let the polling fallback cover it; no retry loop.
+        watcher.dispose();
         this.gitWatcherMode = "none";
+        if (mode === "recursive") {
+          // Recursive arm failed — mark degraded so the eventual successful
+          // re-arm signals recovery, even if the watcher returned false without
+          // routing through `onWatcherFailed`.
+          this.wasDegraded = true;
+          // `onWatcherFailed` may already have fired during the arm and
+          // installed a git-only fallback via handleWatcherFailed. Only
+          // attempt the downgrade ourselves when no degraded watcher exists.
+          if (!this.hasWatcher) {
+            this.start("git-only");
+          }
+          // Background worktrees don't want recursive at all, so don't keep
+          // poking at it; the next focus flip re-arms via the focus change.
+          if (this.host.isCurrent) {
+            this.scheduleRetry();
+          }
+        }
+        // git-only itself failed (e.g. getGitDir returned null): stay dark
+        // and let the polling fallback cover it; no retry loop.
       }
+    });
+  }
+
+  /**
+   * Abandon an in-flight arm. The arm's completion handler detects the
+   * identity mismatch and self-discards; disposing here additionally stops
+   * `GitFileWatcher.start()` from arming any watchers after its await points.
+   */
+  private cancelPendingArm(): void {
+    if (this.pendingArm) {
+      this.pendingArm.watcher.dispose();
+      this.pendingArm = null;
     }
   }
 
@@ -180,6 +217,7 @@ export class WatcherController {
    * (`stop(true)`) or a feature disable should reset it.
    */
   stop(resetRetryBudget: boolean = true): void {
+    this.cancelPendingArm();
     this.gitWatcher.clear();
     this.gitWatcherMode = "none";
     if (this.gitWatchDebounceTimer) {
@@ -227,14 +265,14 @@ export class WatcherController {
    * defeat the hysteresis the moment a focused worktree turns background.
    */
   ensureState(): void {
-    if (!this.host.gitWatchEnabled && this.gitWatcher.value) {
+    if (!this.host.gitWatchEnabled && this.hasWatcher) {
       this.stop();
-    } else if (this.host.gitWatchEnabled && this.host.isRunning && !this.gitWatcher.value) {
+    } else if (this.host.gitWatchEnabled && this.host.isRunning && !this.hasWatcher) {
       this.start();
     } else if (
       this.host.gitWatchEnabled &&
       this.host.isRunning &&
-      this.gitWatcher.value &&
+      this.hasWatcher &&
       this.gitWatcherMode !== this.desiredMode() &&
       this.downgradeTimer === null
     ) {
@@ -246,7 +284,7 @@ export class WatcherController {
   }
 
   restartIfRunning(): void {
-    if (this.gitWatcher.value) {
+    if (this.hasWatcher) {
       this.update();
     }
   }
@@ -273,7 +311,7 @@ export class WatcherController {
         clearTimeout(this.downgradeTimer);
         this.downgradeTimer = null;
       }
-      if (!this.gitWatcher.value) {
+      if (!this.hasWatcher) {
         // Recovery path: a previous start failed and left us with no
         // watcher. Focusing should attempt to arm the recursive variant.
         this.start();
@@ -286,7 +324,7 @@ export class WatcherController {
       return false;
     }
 
-    if (!this.gitWatcher.value || this.gitWatcherMode !== "recursive") {
+    if (!this.hasWatcher || this.gitWatcherMode !== "recursive") {
       return false;
     }
     if (this.downgradeTimer) {
@@ -417,6 +455,7 @@ export class WatcherController {
     // other runtime failure. Arm the recovery signal for the next successful
     // recursive re-arm.
     this.wasDegraded = true;
+    this.cancelPendingArm();
     this.gitWatcher.clear();
     this.gitWatcherMode = "none";
     this.start("git-only");
@@ -452,6 +491,7 @@ export class WatcherController {
       ) {
         // Drop any current git-only instance so start()'s idempotent
         // guard doesn't bail; reconstruction installs the recursive variant.
+        this.cancelPendingArm();
         this.gitWatcher.clear();
         this.gitWatcherMode = "none";
         this.start("recursive");

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -609,11 +609,11 @@ export class WorkspaceService {
       }
 
       const rawWorktrees = await this.listService.list();
-      const worktrees = this.listService.mapToWorktrees(rawWorktrees);
+      const worktrees = await this.listService.mapToWorktrees(rawWorktrees);
 
       await this.syncMonitors(worktrees, this.activeWorktreeId, this.mainBranch, undefined, true);
 
-      this.startTopologyWatcher();
+      await this.startTopologyWatcher();
       // Started independently of startTopologyWatcher() — that method no-ops
       // when `.git/worktrees/` is absent (the exact "all worktrees removed"
       // case), so gating the safety net on it would defeat its purpose (#8510).
@@ -1200,7 +1200,7 @@ export class WorkspaceService {
           ) {
             return;
           }
-          this.applyFetchResultToSiblings(target, {
+          await this.applyFetchResultToSiblings(target, {
             lastFetchedAt: result.lastFetchedAt ?? null,
             authFailed: result.authFailed ?? false,
             networkFailed: result.networkFailed ?? false,
@@ -1419,7 +1419,7 @@ export class WorkspaceService {
    * the fetch would surface "Last fetched X ago"; sibling cards would still
    * show stale (or absent) timestamps.
    *
-   * `getGitCommonDir` is synchronous and cached, so the O(n) scan is cheap
+   * `getGitCommonDir` resolutions are cached, so the O(n) scan is cheap
    * after the first call per worktree.
    *
    * Note: `isFetchInFlight` is intentionally excluded from this fan-out —
@@ -1428,11 +1428,11 @@ export class WorkspaceService {
    * fatigue pattern that drove removal of the `panel-state-working` breathe
    * loop. Only the row that triggered the fetch shows the in-flight pulse.
    */
-  private applyFetchResultToSiblings(
+  private async applyFetchResultToSiblings(
     triggering: WorktreeMonitor,
     result: { lastFetchedAt: number | null; authFailed: boolean; networkFailed: boolean }
-  ): void {
-    const triggeringCommonDir = getGitCommonDir(triggering.path, { logErrors: false });
+  ): Promise<void> {
+    const triggeringCommonDir = await getGitCommonDir(triggering.path, { logErrors: false });
     if (!triggeringCommonDir) {
       // Without a commondir we can't identify siblings. Apply to the
       // triggering monitor only — its own card still benefits.
@@ -1441,7 +1441,7 @@ export class WorkspaceService {
     }
     for (const monitor of this.monitors.values()) {
       if (!monitor.isRunning) continue;
-      const monitorCommonDir = getGitCommonDir(monitor.path, { logErrors: false });
+      const monitorCommonDir = await getGitCommonDir(monitor.path, { logErrors: false });
       if (monitorCommonDir === triggeringCommonDir) {
         monitor.setFetchState(result.lastFetchedAt, result.authFailed, result.networkFailed);
       }
@@ -1590,9 +1590,9 @@ export class WorkspaceService {
     }
   }
 
-  private worktreeMetadataDirPath(): string | null {
+  private async worktreeMetadataDirPath(): Promise<string | null> {
     if (!this.projectRootPath) return null;
-    const commonDir = getGitCommonDir(this.projectRootPath);
+    const commonDir = await getGitCommonDir(this.projectRootPath);
     if (!commonDir) return null;
     return `${commonDir}/worktrees`;
   }
@@ -1610,13 +1610,25 @@ export class WorkspaceService {
     this.periodicSafetyTimer = timer;
   }
 
-  private startTopologyWatcher(): void {
+  private async startTopologyWatcher(): Promise<void> {
     if (!this.topologyWatcherEnabled) return;
     if (this.topologyWatcherSubscription.value) return;
 
-    const metadataDir = this.worktreeMetadataDirPath();
+    const generationAtStart = this.topologyWatcherGeneration;
+    const metadataDir = await this.worktreeMetadataDirPath();
     if (!metadataDir) return;
     if (!existsSync(metadataDir)) return;
+    // Re-validate after the async commondir resolution: a stop (pause,
+    // project switch, dispose) bumps the generation, and a concurrent start
+    // that won the race either holds the subscription already or bumped the
+    // generation itself below.
+    if (
+      generationAtStart !== this.topologyWatcherGeneration ||
+      !this.topologyWatcherEnabled ||
+      this.topologyWatcherSubscription.value
+    ) {
+      return;
+    }
 
     const generation = ++this.topologyWatcherGeneration;
     const drain = () => this.drainTopologyEventBuffer();
@@ -2157,7 +2169,7 @@ export class WorkspaceService {
       }
     }
 
-    const worktrees = this.listService.mapToWorktrees(rawWorktrees);
+    const worktrees = await this.listService.mapToWorktrees(rawWorktrees);
 
     await this.syncMonitors(worktrees, this.activeWorktreeId, this.mainBranch, undefined, true);
   }
@@ -2411,7 +2423,7 @@ export class WorkspaceService {
         isDetached: false,
         isCurrent: false,
         isMainWorktree: false,
-        gitDir: getGitDir(absolutePath) || undefined,
+        gitDir: (await getGitDir(absolutePath)) || undefined,
       };
       const canonicalWorktreeId = createdWorktree.id;
       const isActive = canonicalWorktreeId === this.activeWorktreeId;
@@ -3186,7 +3198,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       for (const monitor of this.monitors.values()) {
         monitor.resumePolling();
       }
-      this.startTopologyWatcher();
+      void this.startTopologyWatcher();
       // stopTopologyWatcher() (run on the !enabled branch) cleared the safety
       // timer, so resume must restart it symmetrically (#8510).
       this.startPeriodicSafetyTimer();

--- a/electron/workspace-host/WorktreeListService.ts
+++ b/electron/workspace-host/WorktreeListService.ts
@@ -180,35 +180,37 @@ export class WorktreeListService {
     }
   }
 
-  mapToWorktrees(rawWorktrees: RawWorktreeRecord[]): Worktree[] {
-    return rawWorktrees.map((wt) => {
-      const normalizedPath = pathResolve(wt.path);
-      let name: string;
-      if (wt.isMainWorktree) {
-        name = normalizedPath.split(/[/\\]/).pop() || "Main";
-      } else if (wt.isDetached) {
-        name = normalizedPath.split(/[/\\]/).pop() || wt.head?.substring(0, 7) || "Detached";
-      } else if (wt.branch) {
-        name = wt.branch;
-      } else {
-        name = normalizedPath.split(/[/\\]/).pop() || "Worktree";
-      }
+  mapToWorktrees(rawWorktrees: RawWorktreeRecord[]): Promise<Worktree[]> {
+    return Promise.all(
+      rawWorktrees.map(async (wt) => {
+        const normalizedPath = pathResolve(wt.path);
+        let name: string;
+        if (wt.isMainWorktree) {
+          name = normalizedPath.split(/[/\\]/).pop() || "Main";
+        } else if (wt.isDetached) {
+          name = normalizedPath.split(/[/\\]/).pop() || wt.head?.substring(0, 7) || "Detached";
+        } else if (wt.branch) {
+          name = wt.branch;
+        } else {
+          name = normalizedPath.split(/[/\\]/).pop() || "Worktree";
+        }
 
-      return {
-        id: normalizedPath,
-        path: normalizedPath,
-        name: name,
-        branch: wt.branch || undefined,
-        head: wt.head,
-        isDetached: wt.isDetached,
-        isCurrent: false,
-        isMainWorktree: wt.isMainWorktree,
-        gitDir: getGitDir(normalizedPath) || undefined,
-        isLocked: wt.isLocked,
-        lockReason: wt.lockReason,
-        isPrunable: wt.isPrunable,
-        prunableReason: wt.prunableReason,
-      };
-    });
+        return {
+          id: normalizedPath,
+          path: normalizedPath,
+          name: name,
+          branch: wt.branch || undefined,
+          head: wt.head,
+          isDetached: wt.isDetached,
+          isCurrent: false,
+          isMainWorktree: wt.isMainWorktree,
+          gitDir: (await getGitDir(normalizedPath)) || undefined,
+          isLocked: wt.isLocked,
+          lockReason: wt.lockReason,
+          isPrunable: wt.isPrunable,
+          prunableReason: wt.prunableReason,
+        };
+      })
+    );
   }
 }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1513,92 +1513,116 @@ export class WorktreeMonitor {
     if (this._isUpdating) {
       return;
     }
+    // Claim the single-flight slot before the first await. Everything below
+    // suspends (git-dir resolution, the stat pre-check), and forced refreshes
+    // bypass both the worktree-changes in-flight cache and the pre-check — so
+    // without the early claim two rapid forced refreshes could pass the guard
+    // together and run duplicate status passes with out-of-order commits.
+    this._isUpdating = true;
 
-    // Skip the git status invocation while a rebase/merge/cherry-pick/revert
-    // is in progress — running it would compete with the user's git client
-    // for .git/index.lock. The watcher tracks the same sentinel files, so
-    // it fires when the operation finishes and triggers a fresh refresh.
-    // Polling continues uninterrupted, so the next scheduled poll after
-    // sentinels clear also picks up the change.
-    const gitDir = getGitDir(this.path, { cache: true, logErrors: false });
+    // Definite-assignment: assigned as the first statement of the try below;
+    // the status pass (the only later reader) is unreachable unless that try
+    // completed normally, so every read is dominated by the assignment.
+    let gitDir!: string | null;
+    let reachedStatusPass = false;
+    try {
+      // Skip the git status invocation while a rebase/merge/cherry-pick/revert
+      // is in progress — running it would compete with the user's git client
+      // for .git/index.lock. The watcher tracks the same sentinel files, so
+      // it fires when the operation finishes and triggers a fresh refresh.
+      // Polling continues uninterrupted, so the next scheduled poll after
+      // sentinels clear also picks up the change.
+      gitDir = await getGitDir(this.path, { cache: true, logErrors: false });
 
-    // Detect blocking git operation state from sentinel files so the renderer
-    // can surface it even when git status is skipped.
-    let opState: import("../../shared/types/git.js").RepoState | undefined;
-    if (gitDir) {
-      opState = getRepoOperationStateSync(gitDir);
-      if (opState !== this._repoState) {
-        this._repoState = opState;
-        if (this._hasInitialStatus) {
+      // Detect blocking git operation state from sentinel files so the renderer
+      // can surface it even when git status is skipped.
+      let opState: import("../../shared/types/git.js").RepoState | undefined;
+      if (gitDir) {
+        opState = getRepoOperationStateSync(gitDir);
+        if (opState !== this._repoState) {
+          this._repoState = opState;
+          if (this._hasInitialStatus) {
+            this.emitUpdate();
+          }
+        }
+      } else {
+        this._repoState = undefined;
+      }
+
+      if (gitDir && opState !== undefined) {
+        // Stamp the completion timestamp before any emit so every snapshot below
+        // carries the advanced value. Git status was skipped, but the sentinel
+        // state was freshly observed above, so the freshness signal is accurate
+        // and the heartbeat-gap detector (which reads this field) won't
+        // false-positive on a long blocking operation. Without this, a
+        // user-triggered refresh during a stuck blocking operation never advances
+        // lastGitStatusCompletedAt, leaving the freshness pill permanently stale
+        // and its Refresh button a no-op (#10715).
+        this.lastGitStatusCompletedAt = Date.now();
+        if (!this._hasInitialStatus) {
+          // First poll started mid-operation (e.g. app started mid-rebase) — emit
+          // a default snapshot so the renderer can still display the worktree.
+          // Mirrors startWithoutGitStatus()'s contract.
+          this._hasInitialStatus = true;
+          this.emitUpdate();
+        } else if (forceRefresh) {
+          // The user clicked Refresh on a stale card. Emit so the renderer
+          // receives the advanced timestamp and the freshness pill resets —
+          // otherwise the click is silently dropped. Background polls stamp
+          // silently; the watcher emits a real status once sentinels clear.
           this.emitUpdate();
         }
+        return;
       }
-    } else {
-      this._repoState = undefined;
-    }
 
-    if (gitDir && opState !== undefined) {
-      // Stamp the completion timestamp before any emit so every snapshot below
-      // carries the advanced value. Git status was skipped, but the sentinel
-      // state was freshly observed above, so the freshness signal is accurate
-      // and the heartbeat-gap detector (which reads this field) won't
-      // false-positive on a long blocking operation. Without this, a
-      // user-triggered refresh during a stuck blocking operation never advances
-      // lastGitStatusCompletedAt, leaving the freshness pill permanently stale
-      // and its Refresh button a no-op (#10715).
-      this.lastGitStatusCompletedAt = Date.now();
-      if (!this._hasInitialStatus) {
-        // First poll started mid-operation (e.g. app started mid-rebase) — emit
-        // a default snapshot so the renderer can still display the worktree.
-        // Mirrors startWithoutGitStatus()'s contract.
-        this._hasInitialStatus = true;
-        this.emitUpdate();
-      } else if (forceRefresh) {
-        // The user clicked Refresh on a stale card. Emit so the renderer
-        // receives the advanced timestamp and the freshness pill resets —
-        // otherwise the click is silently dropped. Background polls stamp
-        // silently; the watcher emits a real status once sentinels clear.
-        this.emitUpdate();
-      }
-      return;
-    }
-
-    // Cheap stat pre-check: when the four git files we care about haven't
-    // changed since the last baseline and no watcher event has fired since,
-    // the simple-git fork-exec would be redundant. Skip it. This is the
-    // common case on a quiet repo — the per-poll cost drops from ~15-50ms
-    // (fork + git status) to ~1ms (four stat() calls).
-    //
-    // The baseline only exists after the first real check, so this branch
-    // is a no-op on the very first poll. Forced refreshes (watcher events,
-    // user actions) always run the full check.
-    if (!forceRefresh && gitDir && this._hasInitialStatus && this.lastStatBaseline !== null) {
-      const baselineAt = this.lastStatBaselineAt;
-      const checkStartedAt = Date.now();
-      try {
-        const commonDir = await this.resolveCommonDirAsync(gitDir);
-        const fresh = await this.buildStatBaseline(gitDir, commonDir);
-        if (
-          fresh !== null &&
-          this.lastWatcherEventAt <= baselineAt &&
-          this.statBaselineMatches(this.lastStatBaseline, fresh)
-        ) {
-          // Treat the skip as a no-change observation so the idle backoff
-          // ramps up the next interval. lastGitStatusCompletedAt bumps too,
-          // otherwise the heartbeat-gap check would false-positive on a
-          // long quiet streak that only ran stat-skips.
-          this.pollingStrategy.recordNoChange();
-          this.lastStatBaselineAt = checkStartedAt;
-          this.lastGitStatusCompletedAt = Date.now();
-          return;
+      // Cheap stat pre-check: when the four git files we care about haven't
+      // changed since the last baseline and no watcher event has fired since,
+      // the simple-git fork-exec would be redundant. Skip it. This is the
+      // common case on a quiet repo — the per-poll cost drops from ~15-50ms
+      // (fork + git status) to ~1ms (four stat() calls).
+      //
+      // The baseline only exists after the first real check, so this branch
+      // is a no-op on the very first poll. Forced refreshes (watcher events,
+      // user actions) always run the full check.
+      if (!forceRefresh && gitDir && this._hasInitialStatus && this.lastStatBaseline !== null) {
+        const baselineAt = this.lastStatBaselineAt;
+        const checkStartedAt = Date.now();
+        try {
+          const commonDir = await this.resolveCommonDirAsync(gitDir);
+          const fresh = await this.buildStatBaseline(gitDir, commonDir);
+          if (
+            fresh !== null &&
+            this.lastWatcherEventAt <= baselineAt &&
+            this.statBaselineMatches(this.lastStatBaseline, fresh)
+          ) {
+            // Treat the skip as a no-change observation so the idle backoff
+            // ramps up the next interval. lastGitStatusCompletedAt bumps too,
+            // otherwise the heartbeat-gap check would false-positive on a
+            // long quiet streak that only ran stat-skips.
+            this.pollingStrategy.recordNoChange();
+            this.lastStatBaselineAt = checkStartedAt;
+            this.lastGitStatusCompletedAt = Date.now();
+            return;
+          }
+        } catch {
+          // Unexpected stat error — fall through to the full git check.
+          // Don't poison the baseline; the post-check rebuild will refresh it.
         }
-      } catch {
-        // Unexpected stat error — fall through to the full git check.
-        // Don't poison the baseline; the post-check rebuild will refresh it.
+      }
+
+      reachedStatusPass = true;
+    } finally {
+      // Early exits (sentinel skip, stat skip, a throw above) release the
+      // claim here and drain any pending watcher flush that queued while it
+      // was held. The status pass below keeps the claim; its own finally is
+      // the release point — and stays the LAST code to touch the flag, so a
+      // flush-triggered synchronous re-entry can't have its claim clobbered.
+      if (!reachedStatusPass) {
+        this._isUpdating = false;
+        this.watcherController.flushPendingIfReady(true);
       }
     }
 
-    this._isUpdating = true;
     // Tracks whether the try block reached a clean exit point — either the
     // no-change early return or the post-emit fall-through. The catch block
     // doesn't flip it (so the finally clears the stale baseline) which means
@@ -1842,7 +1866,7 @@ export class WorktreeMonitor {
    * inside `<repo>/.git/worktrees/<name>/` points at `commondir`, which
    * holds packed-refs and the shared refs/heads tree). Returns `gitDir`
    * itself for the main worktree, or when the commondir file is missing.
-   * Mirrors `GitFileWatcher.resolveCommonDir` but uses async `readFile`.
+   * Mirrors `GitFileWatcher.resolveCommonDir`.
    */
   private async resolveCommonDirAsync(gitDir: string): Promise<string> {
     // The commondir pointer is immutable for the lifetime of a worktree, so
@@ -1935,7 +1959,7 @@ export class WorktreeMonitor {
   }
 
   private async readCurrentBranch(): Promise<string | undefined> {
-    const gitDir = getGitDir(this.path, { cache: true, logErrors: false });
+    const gitDir = await getGitDir(this.path, { cache: true, logErrors: false });
     if (!gitDir) {
       this._isDetached = false;
       this._head = undefined;
@@ -2079,7 +2103,7 @@ export class WorktreeMonitor {
   ): Promise<string | null> {
     const branch = this._branch;
     if (!branch) return null;
-    const gitDir = getGitDir(this.path, { cache: true, logErrors: false });
+    const gitDir = await getGitDir(this.path, { cache: true, logErrors: false });
     if (!gitDir) return null;
     try {
       const commonDir = await this.resolveCommonDirAsync(gitDir);

--- a/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
+++ b/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
@@ -1,0 +1,215 @@
+import { EventEmitter } from "node:events";
+import type { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../services/CopyTreeService.js", () => ({
+  copyTreeService: {
+    generate: vi.fn(),
+    testConfig: vi.fn(),
+    cancel: vi.fn(),
+  },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+import { copyTreeService } from "../../services/CopyTreeService.js";
+import { CopytreeWorkerClient } from "../CopytreeWorkerClient.js";
+import type { CopytreeWorkerRequest } from "../copytreeWorkerProtocol.js";
+
+class FakeWorker extends EventEmitter {
+  postMessage = vi.fn();
+  unref = vi.fn();
+}
+
+function makeClient(worker: FakeWorker = new FakeWorker()) {
+  const factory = vi.fn(() => worker as unknown as Worker);
+  return { client: new CopytreeWorkerClient(factory), factory, worker };
+}
+
+const inlineResult = { content: "inline", fileCount: 1 };
+const inlineTestResult = {
+  includedFiles: 2,
+  includedSize: 10,
+  excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
+};
+
+beforeEach(() => {
+  vi.mocked(copyTreeService.generate).mockResolvedValue(inlineResult);
+  vi.mocked(copyTreeService.testConfig).mockResolvedValue(inlineTestResult);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe("CopytreeWorkerClient", () => {
+  it("runs on the worker and resolves with the worker's result", async () => {
+    const { client, factory, worker } = makeClient();
+
+    const promise = client.generate("/root", {}, undefined, "op-1");
+    expect(factory).toHaveBeenCalledTimes(1);
+    const sent = worker.postMessage.mock.calls[0][0] as CopytreeWorkerRequest;
+    expect(sent).toMatchObject({ type: "generate", id: "op-1", rootPath: "/root" });
+
+    const workerResult = { content: "from-worker", fileCount: 3 };
+    worker.emit("message", { type: "generate-result", id: "op-1", result: workerResult });
+
+    await expect(promise).resolves.toEqual(workerResult);
+    expect(copyTreeService.generate).not.toHaveBeenCalled();
+  });
+
+  it("relays worker progress to the caller's onProgress", async () => {
+    const { client, worker } = makeClient();
+    const onProgress = vi.fn();
+
+    const promise = client.generate("/root", {}, onProgress, "op-1");
+    const progress = { stage: "Scanning", progress: 0.5, message: "half" };
+    worker.emit("message", { type: "progress", id: "op-1", progress });
+    worker.emit("message", {
+      type: "generate-result",
+      id: "op-1",
+      result: { content: "", fileCount: 0 },
+    });
+
+    await promise;
+    expect(onProgress).toHaveBeenCalledWith(progress);
+  });
+
+  it("reuses one persistent worker across requests", async () => {
+    const { client, factory, worker } = makeClient();
+
+    const first = client.generate("/root", {}, undefined, "op-1");
+    const second = client.testConfig("/root", {}, "op-2");
+    worker.emit("message", {
+      type: "generate-result",
+      id: "op-1",
+      result: { content: "", fileCount: 0 },
+    });
+    worker.emit("message", { type: "test-config-result", id: "op-2", result: inlineTestResult });
+
+    await Promise.all([first, second]);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back in-thread when DAINTREE_DISABLE_COPYTREE_WORKER=1", async () => {
+    vi.stubEnv("DAINTREE_DISABLE_COPYTREE_WORKER", "1");
+    const { client, factory } = makeClient();
+
+    await expect(client.generate("/root", {}, undefined, "op-1")).resolves.toEqual(inlineResult);
+    expect(factory).not.toHaveBeenCalled();
+    expect(copyTreeService.generate).toHaveBeenCalledWith("/root", {}, undefined, "op-1");
+  });
+
+  it("falls back in-thread when the worker fails to spawn, and stays there", async () => {
+    const factory = vi.fn(() => {
+      throw new Error("no worker for you");
+    });
+    const client = new CopytreeWorkerClient(factory);
+
+    await expect(client.generate("/root", {}, undefined, "op-1")).resolves.toEqual(inlineResult);
+    await expect(client.testConfig("/root", {}, "op-2")).resolves.toEqual(inlineTestResult);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(copyTreeService.generate).toHaveBeenCalledTimes(1);
+    expect(copyTreeService.testConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects in-flight operations and pins the fallback when the worker dies", async () => {
+    const { client, factory, worker } = makeClient();
+
+    const promise = client.generate("/root", {}, undefined, "op-1");
+    worker.emit("error", new Error("worker crashed"));
+    await expect(promise).rejects.toThrow("worker crashed");
+
+    await expect(client.generate("/root", {}, undefined, "op-2")).resolves.toEqual(inlineResult);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects the pending test-config when the worker reports an error result", async () => {
+    const { client, worker } = makeClient();
+
+    const promise = client.testConfig("/root", {}, "op-1");
+    worker.emit("message", { type: "test-config-error", id: "op-1", error: "boom" });
+    await expect(promise).rejects.toThrow("boom");
+  });
+
+  it("routes cancel to both the worker op and the in-thread service", async () => {
+    const { client, worker } = makeClient();
+
+    const promise = client.generate("/root", {}, undefined, "op-1");
+    client.cancel("op-1");
+
+    expect(copyTreeService.cancel).toHaveBeenCalledWith("op-1");
+    const cancelMessage = worker.postMessage.mock.calls
+      .map((c) => c[0] as CopytreeWorkerRequest)
+      .find((m) => m.type === "cancel");
+    expect(cancelMessage).toEqual({ type: "cancel", id: "op-1" });
+
+    worker.emit("message", {
+      type: "generate-result",
+      id: "op-1",
+      result: { content: "", fileCount: 0, error: "Context generation cancelled" },
+    });
+    await expect(promise).resolves.toMatchObject({ error: "Context generation cancelled" });
+  });
+
+  it("does not post a cancel message for unknown operations", () => {
+    const { client, worker } = makeClient();
+    client.cancel("nope");
+    expect(copyTreeService.cancel).toHaveBeenCalledWith("nope");
+    expect(worker.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back in-thread for an op whose postMessage throws, leaving no pending entry", async () => {
+    const worker = new FakeWorker();
+    worker.postMessage.mockImplementation(() => {
+      throw new Error("worker port closed");
+    });
+    const { client } = makeClient(worker);
+
+    await expect(client.generate("/root", {}, undefined, "op-1")).resolves.toEqual(inlineResult);
+    expect(copyTreeService.generate).toHaveBeenCalledWith("/root", {}, undefined, "op-1");
+
+    await expect(client.testConfig("/root", {}, "op-2")).resolves.toEqual(inlineTestResult);
+    expect(copyTreeService.testConfig).toHaveBeenCalledWith("/root", {}, "op-2");
+
+    // No leaked pending entries: late worker messages for those ids are no-ops.
+    expect(() =>
+      worker.emit("message", {
+        type: "generate-result",
+        id: "op-1",
+        result: { content: "", fileCount: 0 },
+      })
+    ).not.toThrow();
+  });
+
+  it("times out a wedged worker op: rejects, drops the pending entry, posts a cancel", async () => {
+    vi.useFakeTimers();
+    try {
+      const { client, worker } = makeClient();
+
+      const promise = client.generate("/root", {}, undefined, "op-1");
+      const rejection = expect(promise).rejects.toThrow("did not respond");
+      await vi.advanceTimersByTimeAsync(180_000);
+      await rejection;
+
+      const cancelMessage = worker.postMessage.mock.calls
+        .map((c) => c[0] as CopytreeWorkerRequest)
+        .find((m) => m.type === "cancel");
+      expect(cancelMessage).toEqual({ type: "cancel", id: "op-1" });
+
+      // A late result after the timeout finds no pending entry.
+      expect(() =>
+        worker.emit("message", {
+          type: "generate-result",
+          id: "op-1",
+          result: { content: "", fileCount: 0 },
+        })
+      ).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
+++ b/electron/workspace-host/__tests__/CopytreeWorkerClient.test.ts
@@ -192,7 +192,7 @@ describe("CopytreeWorkerClient", () => {
 
       const promise = client.generate("/root", {}, undefined, "op-1");
       const rejection = expect(promise).rejects.toThrow("did not respond");
-      await vi.advanceTimersByTimeAsync(180_000);
+      await vi.advanceTimersByTimeAsync(125_000);
       await rejection;
 
       const cancelMessage = worker.postMessage.mock.calls

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -747,6 +747,40 @@ describe("RepoFetchCoordinator", () => {
     expect(onFetchSuccess).not.toHaveBeenCalled();
   });
 
+  it("destroy() during the async commondir resolution discards the fetch and creates no state", async () => {
+    let resolveCommonDir: ((value: string | null) => void) | undefined;
+    mockGetGitCommonDir.mockImplementation(
+      () =>
+        new Promise<string | null>((res) => {
+          resolveCommonDir = res;
+        })
+    );
+    mockCreateBackgroundFetchGit.mockReturnValue(makeMockGit(() => Promise.resolve()));
+
+    const onFetchSuccess = vi.fn();
+    const coord = new RepoFetchCoordinator({ onFetchSuccess });
+
+    const inFlight = coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+    expect(resolveCommonDir).toBeDefined();
+
+    // Tear down while the commondir promise is still pending, then resolve it.
+    // The stale continuation must not repopulate the cleared state map at the
+    // fresh generation — that would let the fetch dodge the stale-generation
+    // guard and run against a destroyed coordinator.
+    coord.destroy();
+    resolveCommonDir?.("/repo/.git");
+
+    const result = await inFlight;
+    expect(result.status).toBe("skipped");
+    expect(result.skipReason).toBe("stale-generation");
+    expect(onFetchSuccess).not.toHaveBeenCalled();
+    expect(mockCreateBackgroundFetchGit).not.toHaveBeenCalled();
+    expect((coord as unknown as { states: Map<string, unknown> }).states.size).toBe(0);
+  });
+
   it("classifies native AbortError (name === 'AbortError') as transient", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
     const abortError = new Error("The operation was aborted");

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -41,7 +41,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
         if (this.watchWorktree && mockWatcherStartFiresFailure && !result) {
           this.onWatcherFailed?.();
         }
-        return result;
+        return Promise.resolve(result);
       }
       dispose() {}
     },
@@ -49,6 +49,14 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
 });
 
 import { WatcherController, type WatcherControllerHost } from "../WatcherController.js";
+
+// Flush the microtask chain behind an async watcher arm (arm completion may
+// itself initiate a fallback arm whose completion lands one tick later).
+async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
+}
 
 interface MutableHost {
   isRunning: boolean;
@@ -102,46 +110,54 @@ describe("WatcherController", () => {
     vi.useRealTimers();
   });
 
-  it("does not start when host.isRunning is false", () => {
+  it("does not start when host.isRunning is false", async () => {
     const host = makeHost({ isRunning: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(watcherStartCallCount).toBe(0);
     expect(ctrl.hasWatcher).toBe(false);
   });
 
-  it("does not start when host.gitWatchEnabled is false", () => {
+  it("does not start when host.gitWatchEnabled is false", async () => {
     const host = makeHost({ gitWatchEnabled: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(watcherStartCallCount).toBe(0);
   });
 
-  it("starts in recursive mode for focused worktrees", () => {
+  it("starts in recursive mode for focused worktrees", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(watcherStartCallCount).toBe(1);
     expect(ctrl.currentMode).toBe("recursive");
     expect(ctrl.hasWatcher).toBe(true);
     expect(capturedWatcherOptions?.watchWorktree).toBe(true);
   });
 
-  it("starts in git-only mode for background worktrees", () => {
+  it("starts in git-only mode for background worktrees", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
     expect(capturedWatcherOptions?.watchWorktree).toBe(false);
   });
 
-  it("falls back to git-only when recursive fails synchronously via onWatcherFailed", () => {
+  it("falls back to git-only when recursive fails synchronously via onWatcherFailed", async () => {
     // Recursive fails AND fires onWatcherFailed synchronously; git-only succeeds.
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
@@ -150,53 +166,61 @@ describe("WatcherController", () => {
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
     expect(ctrl.hasWatcher).toBe(true);
   });
 
-  it("schedules a recursive retry after a failed recursive start (focused only)", () => {
+  it("schedules a recursive retry after a failed recursive start (focused only)", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
 
     // After the retry interval, recursive succeeds.
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
     expect(ctrl.currentMode).toBe("recursive");
   });
 
-  it("does not fire onWatcherRecovered on a clean cold start", () => {
+  it("does not fire onWatcherRecovered on a clean cold start", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("recursive");
     expect(host.onWatcherRecovered).not.toHaveBeenCalled();
   });
 
-  it("fires onWatcherRecovered once when the recursive arm recovers via retry", () => {
+  it("fires onWatcherRecovered once when the recursive arm recovers via retry", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
     expect(host.onWatcherRecovered).not.toHaveBeenCalled();
 
     // Retry succeeds — recovery should signal exactly once.
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
     expect(ctrl.currentMode).toBe("recursive");
     expect(host.onWatcherRecovered).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fire a false onWatcherRecovered after disable then re-enable", () => {
+  it("does not fire a false onWatcherRecovered after disable then re-enable", async () => {
     // Degrade, then simulate a feature-disable (stop with budget reset) and a
     // later re-enable that arms recursive cleanly. No real recovery occurred,
     // so onWatcherRecovered must not fire.
@@ -206,17 +230,20 @@ describe("WatcherController", () => {
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
 
     ctrl.stop(); // feature disable — ends the degradation episode
     mockRecursiveStartResult = true;
     ctrl.start("recursive");
+    await settle();
 
     expect(ctrl.currentMode).toBe("recursive");
     expect(host.onWatcherRecovered).not.toHaveBeenCalled();
   });
 
-  it("preserves the recovery signal across a benign rotation (stop(false))", () => {
+  it("preserves the recovery signal across a benign rotation (stop(false))", async () => {
     // update() calls stop(false) then start(); a degraded watcher rotating
     // this way must still signal recovery when recursive finally arms.
     mockRecursiveStartResult = false;
@@ -225,16 +252,19 @@ describe("WatcherController", () => {
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
 
     mockRecursiveStartResult = true;
     ctrl.update(); // stop(false) + start() — preserves wasDegraded
+    await settle();
 
     expect(ctrl.currentMode).toBe("recursive");
     expect(host.onWatcherRecovered).toHaveBeenCalledTimes(1);
   });
 
-  it("fires onWatcherRecovered after a synchronous onWatcherFailed fallback recovers", () => {
+  it("fires onWatcherRecovered after a synchronous onWatcherFailed fallback recovers", async () => {
     // Recursive fails + fires onWatcherFailed synchronously; git-only succeeds.
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
@@ -243,17 +273,19 @@ describe("WatcherController", () => {
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
     expect(host.onWatcherRecovered).not.toHaveBeenCalled();
 
     mockRecursiveStartResult = true;
     mockWatcherStartFiresFailure = false;
-    vi.advanceTimersByTime(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
     expect(ctrl.currentMode).toBe("recursive");
     expect(host.onWatcherRecovered).toHaveBeenCalledTimes(1);
   });
 
-  it("does not schedule a retry for background worktrees", () => {
+  it("does not schedule a retry for background worktrees", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: false });
@@ -261,52 +293,58 @@ describe("WatcherController", () => {
 
     // Background goes straight to git-only with no retry budget.
     ctrl.start();
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
 
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     // Still git-only — no retry was scheduled.
     expect(ctrl.currentMode).toBe("git-only");
   });
 
-  it("respects the WATCHER_MAX_RETRIES (5) budget", () => {
+  it("respects the WATCHER_MAX_RETRIES (5) budget", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     // 5 retries × 30s — should attempt to upgrade but always fail.
     for (let i = 0; i < 6; i++) {
-      vi.advanceTimersByTime(31_000);
+      await vi.advanceTimersByTimeAsync(31_000);
     }
     // After exhaustion, no further retry scheduled.
     const startsAtCap = watcherStartCallCount;
-    vi.advanceTimersByTime(120_000);
+    await vi.advanceTimersByTimeAsync(120_000);
     expect(watcherStartCallCount).toBe(startsAtCap);
   });
 
-  it("update() rotates without resetting the retry budget", () => {
+  it("update() rotates without resetting the retry budget", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     // Burn 2 retries.
-    vi.advanceTimersByTime(31_000);
-    vi.advanceTimersByTime(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
 
     // Rotate (e.g. branch checkout) — budget should NOT reset.
     ctrl.update();
+    await settle();
 
     // Now allow recursive to succeed; remaining budget = 3 retries.
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
     expect(ctrl.currentMode).toBe("recursive");
   });
 
-  it("stop(true) resets the retry budget — restart allows a full 5-retry budget", () => {
+  it("stop(true) resets the retry budget — restart allows a full 5-retry budget", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
@@ -314,23 +352,25 @@ describe("WatcherController", () => {
 
     // Burn 3 retries on the first run.
     ctrl.start();
-    vi.advanceTimersByTime(31_000);
-    vi.advanceTimersByTime(31_000);
-    vi.advanceTimersByTime(31_000);
+    await settle();
+    await vi.advanceTimersByTimeAsync(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
 
     ctrl.stop(true);
 
     // Restart — fresh budget should mean recursive can succeed within budget.
     ctrl.start();
+    await settle();
     // Now allow recursive to succeed at the next retry — budget was reset
     // so retryCount=1 at this point. If reset failed and budget was still
     // close to MAX_RETRIES, recursive might never get an upgrade.
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(31_000);
+    await vi.advanceTimersByTimeAsync(31_000);
     expect(ctrl.currentMode).toBe("recursive");
   });
 
-  it("stop(false) preserves the retry budget — exhausted budget stays exhausted across rotation", () => {
+  it("stop(false) preserves the retry budget — exhausted budget stays exhausted across rotation", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
@@ -338,72 +378,84 @@ describe("WatcherController", () => {
 
     // Exhaust the entire 5-retry budget on the first run.
     ctrl.start();
+    await settle();
     for (let i = 0; i < 6; i++) {
-      vi.advanceTimersByTime(31_000);
+      await vi.advanceTimersByTimeAsync(31_000);
     }
 
     // Capture starts after exhaustion — confirm we hit the cap.
     const startsAtExhaustion = watcherStartCallCount;
-    vi.advanceTimersByTime(120_000);
+    await vi.advanceTimersByTimeAsync(120_000);
     expect(watcherStartCallCount).toBe(startsAtExhaustion);
 
     // Rotation should NOT grant a fresh budget — stop(false) preserves count.
     ctrl.stop(false);
     ctrl.start();
+    await settle();
     const startsAfterRotation = watcherStartCallCount;
 
     // Even if recursive could succeed now, no retry should fire because
     // the budget was already exhausted before rotation.
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(120_000);
+    await vi.advanceTimersByTimeAsync(120_000);
     expect(watcherStartCallCount).toBe(startsAfterRotation);
     expect(ctrl.currentMode).toBe("git-only");
   });
 
-  it("ensureState() stops the watcher when gitWatchEnabled flips off", () => {
+  it("ensureState() stops the watcher when gitWatchEnabled flips off", async () => {
     mockWatcherStartResult = true;
     const host = makeHost();
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.hasWatcher).toBe(true);
 
     host.gitWatchEnabled = false;
     ctrl.ensureState();
+    await settle();
     expect(ctrl.hasWatcher).toBe(false);
   });
 
-  it("ensureState() starts the watcher when re-enabled mid-run", () => {
+  it("ensureState() starts the watcher when re-enabled mid-run", async () => {
     const host = makeHost({ gitWatchEnabled: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.ensureState();
+
+    await settle();
     expect(ctrl.hasWatcher).toBe(false);
 
     mockWatcherStartResult = true;
     host.gitWatchEnabled = true;
     ctrl.ensureState();
+    await settle();
     expect(ctrl.hasWatcher).toBe(true);
   });
 
-  it("ensureState() rotates when granularity disagrees with focus", () => {
+  it("ensureState() rotates when granularity disagrees with focus", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("recursive");
 
     host.isCurrent = false;
     ctrl.ensureState();
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
   });
 
-  it("triggers onTriggerUpdate when a file change arrives outside the cooldown", () => {
+  it("triggers onTriggerUpdate when a file change arrives outside the cooldown", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ lastGitStatusCompletedAt: 0 });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     // Advance Date.now beyond the 1s cooldown.
     vi.setSystemTime(2_000);
@@ -418,6 +470,7 @@ describe("WatcherController", () => {
     const host = makeHost({ isUpdating: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     (capturedWatcherOptions?.onChange as () => void)();
     expect(host.onTriggerUpdate).not.toHaveBeenCalled();
@@ -432,11 +485,12 @@ describe("WatcherController", () => {
     expect(host.onTriggerUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("queues the pending flag when a change arrives within the cooldown window", () => {
+  it("queues the pending flag when a change arrives within the cooldown window", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ lastGitStatusCompletedAt: Date.now() });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     (capturedWatcherOptions?.onChange as () => void)();
     expect(host.onTriggerUpdate).not.toHaveBeenCalled();
@@ -446,11 +500,12 @@ describe("WatcherController", () => {
     expect(host.onTriggerUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("flushPendingIfReady(respectDebounce=true) is a no-op while a debounce timer is armed", () => {
+  it("flushPendingIfReady(respectDebounce=true) is a no-op while a debounce timer is armed", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isUpdating: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     (capturedWatcherOptions?.onChange as () => void)();
     // Debounce timer is armed. Now finalize the update.
@@ -459,72 +514,80 @@ describe("WatcherController", () => {
     // Still no trigger — debounce will handle it.
     expect(host.onTriggerUpdate).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(301);
+    await vi.advanceTimersByTimeAsync(301);
     expect(host.onTriggerUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("scheduleDelayedFlush() arms a debounce timer that flushes when ready", () => {
+  it("scheduleDelayedFlush() arms a debounce timer that flushes when ready", async () => {
     mockWatcherStartResult = true;
     const host = makeHost();
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     ctrl.markPending();
     ctrl.scheduleDelayedFlush();
     expect(host.onTriggerUpdate).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(301);
+    await vi.advanceTimersByTimeAsync(301);
     expect(host.onTriggerUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("clearRetryTimer() cancels the retry without disposing the watcher", () => {
+  it("clearRetryTimer() cancels the retry without disposing the watcher", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
 
     ctrl.clearRetryTimer();
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(120_000);
+    await vi.advanceTimersByTimeAsync(120_000);
     // No retry — still git-only.
     expect(ctrl.currentMode).toBe("git-only");
     // But the watcher is still active.
     expect(ctrl.hasWatcher).toBe(true);
   });
 
-  it("stop(true) clears watcher and retry state", () => {
+  it("stop(true) clears watcher and retry state", async () => {
     mockWatcherStartResult = true;
     const host = makeHost();
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     ctrl.stop(true);
     expect(ctrl.hasWatcher).toBe(false);
     expect(ctrl.currentMode).toBe("none");
   });
 
-  it("stop(true) cancels pending retry timers", () => {
+  it("stop(true) cancels pending retry timers", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
+
+    await settle();
     ctrl.stop(true);
     mockRecursiveStartResult = true;
-    vi.advanceTimersByTime(120_000);
+    await vi.advanceTimersByTimeAsync(120_000);
     // No retry should have run.
     expect(ctrl.currentMode).toBe("none");
   });
 
-  it("forwards onInotifyLimitReached and onEmfileLimitReached", () => {
+  it("forwards onInotifyLimitReached and onEmfileLimitReached", async () => {
     mockWatcherStartResult = true;
     const host = makeHost();
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     capturedOnInotifyLimitReached?.();
     capturedOnEmfileLimitReached?.();
@@ -532,25 +595,28 @@ describe("WatcherController", () => {
     expect(host.onEmfileLimitReached).toHaveBeenCalledWith("/test/worktree");
   });
 
-  it("uses the 250ms worktree min-debounce floor", () => {
+  it("uses the 250ms worktree min-debounce floor", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     expect(capturedWatcherOptions).toMatchObject({ worktreeMinDebounceMs: 250 });
   });
 
-  it("handleFocusChange(false) defers the downgrade by the settle delay", () => {
+  it("handleFocusChange(false) defers the downgrade by the settle delay", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
     expect(ctrl.currentMode).toBe("recursive");
     const startsBeforeFlip = watcherStartCallCount;
 
     host.isCurrent = false;
     const rotated = ctrl.handleFocusChange(false);
+    await settle();
 
     expect(rotated).toBe(false);
     // No synchronous rebuild — the recursive watcher stays armed.
@@ -558,69 +624,76 @@ describe("WatcherController", () => {
     expect(ctrl.currentMode).toBe("recursive");
 
     // After the 3s settle delay, the controller rebuilds in git-only mode.
-    vi.advanceTimersByTime(3_000);
+    await vi.advanceTimersByTimeAsync(3_000);
     expect(watcherStartCallCount).toBe(startsBeforeFlip + 1);
     expect(ctrl.currentMode).toBe("git-only");
   });
 
-  it("handleFocusChange(true) cancels a pending downgrade and keeps recursive", () => {
+  it("handleFocusChange(true) cancels a pending downgrade and keeps recursive", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
     const startsBeforeFlip = watcherStartCallCount;
 
     host.isCurrent = false;
     ctrl.handleFocusChange(false);
+    await settle();
 
     // Re-focus before the settle window elapses.
-    vi.advanceTimersByTime(1_500);
+    await vi.advanceTimersByTimeAsync(1_500);
     host.isCurrent = true;
     const rotated = ctrl.handleFocusChange(true);
+    await settle();
 
     // Already recursive — no rotation needed.
     expect(rotated).toBe(false);
 
     // Let the original settle window pass — the timer should not fire.
-    vi.advanceTimersByTime(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
     expect(watcherStartCallCount).toBe(startsBeforeFlip);
     expect(ctrl.currentMode).toBe("recursive");
   });
 
-  it("handleFocusChange(true) immediately upgrades a git-only watcher and reports rotation", () => {
+  it("handleFocusChange(true) immediately upgrades a git-only watcher and reports rotation", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
     expect(ctrl.currentMode).toBe("git-only");
     const startsBeforeFlip = watcherStartCallCount;
 
     host.isCurrent = true;
     const rotated = ctrl.handleFocusChange(true);
+    await settle();
 
     expect(rotated).toBe(true);
     expect(watcherStartCallCount).toBe(startsBeforeFlip + 1);
     expect(ctrl.currentMode).toBe("recursive");
   });
 
-  it("stop() cancels a pending downgrade timer", () => {
+  it("stop() cancels a pending downgrade timer", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
     const startsBeforeFlip = watcherStartCallCount;
 
     host.isCurrent = false;
     ctrl.handleFocusChange(false);
+    await settle();
     ctrl.stop(true);
 
-    vi.advanceTimersByTime(5_000);
+    await vi.advanceTimersByTimeAsync(5_000);
     // Timer was cleared — no rebuild fired after stop.
     expect(watcherStartCallCount).toBe(startsBeforeFlip);
     expect(ctrl.currentMode).toBe("none");
   });
 
-  it("arms a drain timer when a change arrives inside the cooldown window", () => {
+  it("arms a drain timer when a change arrives inside the cooldown window", async () => {
     mockWatcherStartResult = true;
     // Pin "now" at t=2s and place `lastGitStatusCompletedAt` 500ms back —
     // we're 500ms into the 1s self-trigger cooldown, so the drain should
@@ -629,37 +702,40 @@ describe("WatcherController", () => {
     const host = makeHost({ lastGitStatusCompletedAt: 1_500 });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     (capturedWatcherOptions?.onChange as () => void)();
     expect(host.onTriggerUpdate).not.toHaveBeenCalled();
 
     // Advance past the remaining cooldown + the 10ms epsilon.
-    vi.advanceTimersByTime(600);
+    await vi.advanceTimersByTimeAsync(600);
     expect(host.onTriggerUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("does not double-arm the drain timer when multiple changes land in the cooldown", () => {
+  it("does not double-arm the drain timer when multiple changes land in the cooldown", async () => {
     mockWatcherStartResult = true;
     vi.setSystemTime(2_000);
     const host = makeHost({ lastGitStatusCompletedAt: 1_500 });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     const onChange = capturedWatcherOptions?.onChange as () => void;
     onChange();
     onChange();
     onChange();
 
-    vi.advanceTimersByTime(600);
+    await vi.advanceTimersByTimeAsync(600);
     // Drain still fires exactly once — pending flag collapses bursts.
     expect(host.onTriggerUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it("ensureState() does not bypass a pending downgrade timer", () => {
+  it("ensureState() does not bypass a pending downgrade timer", async () => {
     mockWatcherStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
     expect(ctrl.currentMode).toBe("recursive");
     const startsBeforeFlip = watcherStartCallCount;
 
@@ -668,18 +744,20 @@ describe("WatcherController", () => {
     // alive through the periodic reconciliation pass.
     host.isCurrent = false;
     ctrl.handleFocusChange(false);
+    await settle();
     ctrl.ensureState();
+    await settle();
 
     expect(watcherStartCallCount).toBe(startsBeforeFlip);
     expect(ctrl.currentMode).toBe("recursive");
 
     // After the settle delay, the controller rebuilds in git-only mode.
-    vi.advanceTimersByTime(3_000);
+    await vi.advanceTimersByTimeAsync(3_000);
     expect(ctrl.currentMode).toBe("git-only");
     expect(watcherStartCallCount).toBe(startsBeforeFlip + 1);
   });
 
-  it("handleFocusChange(true) starts a watcher when none exists", () => {
+  it("handleFocusChange(true) starts a watcher when none exists", async () => {
     // Simulate: a previous start failed (mode 'none', no watcher), then
     // the user focuses this worktree via setActiveWorktree. The watcher
     // must be re-attempted, not silently skipped.
@@ -687,6 +765,7 @@ describe("WatcherController", () => {
     const host = makeHost({ isCurrent: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
     expect(ctrl.hasWatcher).toBe(false);
     expect(ctrl.currentMode).toBe("none");
     const startsBeforeFlip = watcherStartCallCount;
@@ -694,6 +773,7 @@ describe("WatcherController", () => {
     mockWatcherStartResult = true;
     host.isCurrent = true;
     const rotated = ctrl.handleFocusChange(true);
+    await settle();
 
     expect(rotated).toBe(true);
     expect(watcherStartCallCount).toBe(startsBeforeFlip + 1);
@@ -701,34 +781,37 @@ describe("WatcherController", () => {
     expect(ctrl.currentMode).toBe("recursive");
   });
 
-  it("stop() cancels a pending cooldown drain timer", () => {
+  it("stop() cancels a pending cooldown drain timer", async () => {
     mockWatcherStartResult = true;
     vi.setSystemTime(2_000);
     const host = makeHost({ lastGitStatusCompletedAt: 1_500 });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
+    await settle();
 
     (capturedWatcherOptions?.onChange as () => void)();
     ctrl.stop(true);
 
-    vi.advanceTimersByTime(1_000);
+    await vi.advanceTimersByTimeAsync(1_000);
     // Drain timer cleared on stop — no flush fires after teardown.
     expect(host.onTriggerUpdate).not.toHaveBeenCalled();
   });
 
   describe("resetRetryBudget", () => {
-    it("resets exhausted budget so subsequent failure schedules a retry", () => {
+    it("resets exhausted budget so subsequent failure schedules a retry", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
       const host = makeHost({ isCurrent: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
+
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
       const startsAtExhaustion = watcherStartCallCount;
-      vi.advanceTimersByTime(120_000);
+      await vi.advanceTimersByTimeAsync(120_000);
       expect(watcherStartCallCount).toBe(startsAtExhaustion);
 
       const result = ctrl.resetRetryBudget();
@@ -737,11 +820,12 @@ describe("WatcherController", () => {
       // update() tears down git-only and re-attempts recursive. Recursive
       // fails → git-only installed + scheduleRetry() with fresh counter.
       ctrl.update();
-      vi.advanceTimersByTime(31_000);
+      await settle();
+      await vi.advanceTimersByTimeAsync(31_000);
       expect(watcherStartCallCount).toBeGreaterThan(startsAtExhaustion);
     });
 
-    it("no-ops when watcherRetryCount is zero (does not consume cap)", () => {
+    it("no-ops when watcherRetryCount is zero (does not consume cap)", async () => {
       const host = makeHost({ isCurrent: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
       const result = ctrl.resetRetryBudget();
@@ -751,21 +835,24 @@ describe("WatcherController", () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
       ctrl.start();
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
       expect(ctrl.resetRetryBudget()).toBe(true);
     });
 
-    it("capped at MAX_RESETS_PER_SESSION (3)", () => {
+    it("capped at MAX_RESETS_PER_SESSION (3)", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
       const host = makeHost({ isCurrent: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
+
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
 
       // 3 resets allowed; update() re-arms after each reset so retries
@@ -773,23 +860,26 @@ describe("WatcherController", () => {
       for (let r = 0; r < 3; r++) {
         expect(ctrl.resetRetryBudget()).toBe(true);
         ctrl.update();
+        await settle();
         for (let i = 0; i < 6; i++) {
-          vi.advanceTimersByTime(31_000);
+          await vi.advanceTimersByTimeAsync(31_000);
         }
       }
       // 4th reset denied.
       expect(ctrl.resetRetryBudget()).toBe(false);
     });
 
-    it("clears a pending retry timer", () => {
+    it("clears a pending retry timer", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
       const host = makeHost({ isCurrent: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
+
+      await settle();
       // Let one retry fire so a new timer for retry 2 is pending.
-      vi.advanceTimersByTime(31_000);
+      await vi.advanceTimersByTimeAsync(31_000);
       const startsAfterOneRetry = watcherStartCallCount;
 
       const result = ctrl.resetRetryBudget();
@@ -797,26 +887,29 @@ describe("WatcherController", () => {
 
       // The pending timer was cleared — advancing 30s should NOT fire a retry
       // since the budget just reset (count=0) and nothing scheduled a new one.
-      vi.advanceTimersByTime(31_000);
+      await vi.advanceTimersByTimeAsync(31_000);
       expect(watcherStartCallCount).toBe(startsAfterOneRetry);
     });
 
-    it("stop(true) resets both the retry budget and the session cap", () => {
+    it("stop(true) resets both the retry budget and the session cap", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
       const host = makeHost({ isCurrent: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
+
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
       // Consume all 3 resets.
       for (let r = 0; r < 3; r++) {
         expect(ctrl.resetRetryBudget()).toBe(true);
         ctrl.update();
+        await settle();
         for (let i = 0; i < 6; i++) {
-          vi.advanceTimersByTime(31_000);
+          await vi.advanceTimersByTimeAsync(31_000);
         }
       }
       expect(ctrl.resetRetryBudget()).toBe(false);
@@ -825,26 +918,30 @@ describe("WatcherController", () => {
       ctrl.stop(true);
       // After stop(true), budget starts fresh. Re-arm and exhaust.
       ctrl.start();
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
       expect(ctrl.resetRetryBudget()).toBe(true);
     });
 
-    it("stop(false) preserves both the retry count and the session cap", () => {
+    it("stop(false) preserves both the retry count and the session cap", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
       const host = makeHost({ isCurrent: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
+
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
       expect(ctrl.resetRetryBudget()).toBe(true);
       ctrl.update();
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
       // 2nd reset — should succeed (2 of 3 consumed).
       expect(ctrl.resetRetryBudget()).toBe(true);
@@ -852,8 +949,9 @@ describe("WatcherController", () => {
       // stop(false) should NOT restore the 2 already-consumed resets.
       ctrl.stop(false);
       ctrl.start();
+      await settle();
       for (let i = 0; i < 6; i++) {
-        vi.advanceTimersByTime(31_000);
+        await vi.advanceTimersByTimeAsync(31_000);
       }
       const result = ctrl.resetRetryBudget();
       // After 2 resets consumed, the 3rd (last) should succeed.

--- a/electron/workspace-host/__tests__/WorkspaceService.activeWorktreeEvents.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.activeWorktreeEvents.test.ts
@@ -94,7 +94,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -102,7 +102,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },
@@ -1381,8 +1381,8 @@ describe("WorkspaceService.loadProject performance behavior", () => {
     expect(mockSimpleGit.raw).toHaveBeenCalledTimes(2);
   });
 
-  it("uses the worktree folder name for detached worktrees", () => {
-    const mapped = service["listService"].mapToWorktrees([
+  it("uses the worktree folder name for detached worktrees", async () => {
+    const mapped = await service["listService"].mapToWorktrees([
       {
         path: "/repo/daintree-bisect/cross-worktree-diff-2026-03-06",
         branch: "",

--- a/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
@@ -101,7 +101,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -124,7 +124,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -100,7 +100,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
@@ -100,7 +100,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.gitWatcherBudget.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => ({
       this.armed = true;
       watcherLive.current++;
       watcherLive.peak = Math.max(watcherLive.peak, watcherLive.current);
-      return true;
+      return Promise.resolve(true);
     }
     dispose() {
       if (this.armed) {

--- a/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
@@ -102,7 +102,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.rateLimit.test.ts
@@ -102,7 +102,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.refreshResilience.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.refreshResilience.test.ts
@@ -99,7 +99,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -103,7 +103,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.retryAuthFetch.test.ts
@@ -102,7 +102,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
   return {
     GitFileWatcher: class {
       start() {
-        return false;
+        return Promise.resolve(false);
       }
       dispose() {}
     },

--- a/electron/workspace-host/__tests__/WorkspaceService.wslGitPrune.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.wslGitPrune.test.ts
@@ -119,7 +119,7 @@ vi.mock("../../services/events.js", () => ({ events: mockEvents }));
 vi.mock("../../utils/gitFileWatcher.js", () => ({
   GitFileWatcher: class {
     start() {
-      return false;
+      return Promise.resolve(false);
     }
     dispose() {}
   },

--- a/electron/workspace-host/__tests__/WorktreeListService.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeListService.test.ts
@@ -231,7 +231,7 @@ describe("WorktreeListService", () => {
   });
 
   describe("mapToWorktrees", () => {
-    it("uses directory name for main worktree display name", () => {
+    it("uses directory name for main worktree display name", async () => {
       const raw = [
         {
           path: "/projects/my-repo",
@@ -247,13 +247,13 @@ describe("WorktreeListService", () => {
         },
       ];
 
-      const worktrees = service.mapToWorktrees(raw);
+      const worktrees = await service.mapToWorktrees(raw);
 
       expect(worktrees[0].name).toBe("my-repo");
       expect(worktrees[1].name).toBe("feature/cool");
     });
 
-    it("normalizes listed paths before using them as worktree IDs", () => {
+    it("normalizes listed paths before using them as worktree IDs", async () => {
       const basePath = path.resolve("/projects/my-repo");
       const rawPath = `${basePath}${path.sep}..${path.sep}my-repo-feature`;
       const expectedPath = path.resolve(basePath, "..", "my-repo-feature");
@@ -266,14 +266,14 @@ describe("WorktreeListService", () => {
         },
       ];
 
-      const worktrees = service.mapToWorktrees(raw);
+      const worktrees = await service.mapToWorktrees(raw);
 
       expect(worktrees[0].id).toBe(expectedPath);
       expect(worktrees[0].path).toBe(expectedPath);
       expect(worktrees[0].gitDir).toBe(`${expectedPath}/.git`);
     });
 
-    it("propagates locked/prunable fields to the mapped Worktree", () => {
+    it("propagates locked/prunable fields to the mapped Worktree", async () => {
       const raw = [
         {
           path: "/projects/my-repo",
@@ -293,7 +293,7 @@ describe("WorktreeListService", () => {
         },
       ];
 
-      const worktrees = service.mapToWorktrees(raw);
+      const worktrees = await service.mapToWorktrees(raw);
 
       expect(worktrees[0].isLocked).toBeUndefined();
       expect(worktrees[1].isLocked).toBe(true);

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -122,7 +122,7 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
         if (this.watchWorktree && mockWatcherStartFiresFailure && !result) {
           this.onWatcherFailed?.();
         }
-        return result;
+        return Promise.resolve(result);
       }
       dispose() {}
     },
@@ -212,7 +212,7 @@ describe("WorktreeMonitor", () => {
     capturedWatcherOptions = undefined;
     capturedWatcherOptionsHistory.length = 0;
     mockGetRepoOperationStateSync.mockReturnValue(undefined);
-    vi.mocked(getGitDir).mockReturnValue(null);
+    vi.mocked(getGitDir).mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -912,7 +912,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("reuses cached divergence on forced passes until a tracked ref's stat changes", async () => {
-      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(getGitDir).mockResolvedValue("/test/worktree/.git");
       vi.mocked(readFile).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
       vi.mocked(stat).mockResolvedValue({ mtimeMs: 1_000 } as unknown as Awaited<
         ReturnType<typeof stat>
@@ -1591,7 +1591,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("deduplicates rapid poll calls — only one executePoll per cycle", async () => {
-      let resolveGit!: () => void;
+      let resolveGit: (() => void) | undefined;
       mockGetWorktreeChangesWithStats.mockImplementation(
         () =>
           new Promise<{
@@ -1621,10 +1621,51 @@ describe("WorktreeMonitor", () => {
       const p1 = (monitor as unknown as { poll: () => Promise<void> }).poll();
       const p2 = (monitor as unknown as { poll: () => Promise<void> }).poll();
 
+      // The poll path resolves the git dir asynchronously before reaching
+      // getWorktreeChangesWithStats — flush microtasks until the mock arms.
+      for (let i = 0; i < 50 && resolveGit === undefined; i++) {
+        await Promise.resolve();
+      }
       // Resolve the single git call
-      resolveGit();
+      resolveGit!();
       await p1;
       await p2;
+
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+      monitor.stop();
+    });
+
+    it("single-flights forced refreshes across the async git-dir resolution", async () => {
+      // Both forced refreshes arrive while the FIRST getGitDir is still
+      // pending (later calls inside the status pass resolve immediately). The
+      // second refresh must be rejected by the single-flight claim —
+      // forceRefresh bypasses getWorktreeChangesWithStats' in-flight cache,
+      // so without the early claim both would run duplicate status passes.
+      let resolveFirstGitDir: ((value: string | null) => void) | undefined;
+      vi.mocked(getGitDir).mockImplementationOnce(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveFirstGitDir = resolve;
+          })
+      );
+      vi.mocked(getGitDir).mockResolvedValue(null);
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+      monitor.startWithoutGitStatus();
+
+      const first = monitor.updateGitStatus(true);
+      const second = monitor.updateGitStatus(true);
+      expect(resolveFirstGitDir).toBeDefined();
+      resolveFirstGitDir?.(null);
+      await Promise.all([first, second]);
 
       expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
       monitor.stop();
@@ -2637,7 +2678,7 @@ describe("WorktreeMonitor", () => {
 
   describe("git operation skip (rebase / merge / cherry-pick)", () => {
     it("skips getWorktreeChangesWithStats while a git operation is in progress", async () => {
-      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(getGitDir).mockResolvedValue("/test/worktree/.git");
       mockGetRepoOperationStateSync.mockReturnValue("REBASING");
 
       const callbacks = makeCallbacks();
@@ -2653,7 +2694,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("runs git status normally once the operation finishes", async () => {
-      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(getGitDir).mockResolvedValue("/test/worktree/.git");
       mockGetRepoOperationStateSync.mockReturnValue("MERGING");
       mockGetWorktreeChangesWithStats.mockResolvedValue({
         worktreeId: "/test/worktree",
@@ -2687,7 +2728,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("emits an initial snapshot when start() is skipped mid-operation", async () => {
-      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(getGitDir).mockResolvedValue("/test/worktree/.git");
       mockGetRepoOperationStateSync.mockReturnValue("REBASING");
 
       const callbacks = makeCallbacks();
@@ -2706,7 +2747,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("forced refresh during a blocking operation stamps freshness and re-emits (#10715)", async () => {
-      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(getGitDir).mockResolvedValue("/test/worktree/.git");
       mockGetRepoOperationStateSync.mockReturnValue("REVERTING");
 
       const callbacks = makeCallbacks();
@@ -2734,7 +2775,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("background poll during a blocking operation stamps silently without re-emitting", async () => {
-      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(getGitDir).mockResolvedValue("/test/worktree/.git");
       mockGetRepoOperationStateSync.mockReturnValue("REBASING");
 
       const callbacks = makeCallbacks();
@@ -2754,7 +2795,7 @@ describe("WorktreeMonitor", () => {
     });
 
     it("does not check operation sentinels when getGitDir returns null", async () => {
-      vi.mocked(getGitDir).mockReturnValue(null);
+      vi.mocked(getGitDir).mockResolvedValue(null);
       mockGetWorktreeChangesWithStats.mockResolvedValue({
         worktreeId: "/test/worktree",
         rootPath: "/test",
@@ -3086,7 +3127,7 @@ describe("WorktreeMonitor", () => {
     };
 
     beforeEach(() => {
-      vi.mocked(getGitDir).mockReturnValue("/test/worktree/.git");
+      vi.mocked(getGitDir).mockResolvedValue("/test/worktree/.git");
       // No commondir file → commondir defaults to gitDir for the test worktree
       vi.mocked(readFile).mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
       mockGetWorktreeChangesWithStats.mockResolvedValue(CLEAN_CHANGES);

--- a/electron/workspace-host/copytreeWorker.ts
+++ b/electron/workspace-host/copytreeWorker.ts
@@ -1,0 +1,61 @@
+/**
+ * Copytree worker for the workspace-host.
+ *
+ * Context generation (file-tree walk, fast-glob, reading many files, XML
+ * formatting) is CPU-bound and used to run on the workspace-host event loop,
+ * competing with git polling and file watching. This worker moves that CPU
+ * off-thread; the host relays requests/results over the worker port.
+ *
+ * The worker is persistent: Electron 37+ crashes on repeated worker
+ * spawn/terminate cycles inside a utilityProcess (`!flush_tasks_`), so the
+ * host spawns this once and never terminates it in normal operation.
+ */
+import { parentPort } from "node:worker_threads";
+import { copyTreeService } from "../services/CopyTreeService.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import type { CopytreeWorkerRequest, CopytreeWorkerResponse } from "./copytreeWorkerProtocol.js";
+
+const port = parentPort;
+if (!port) {
+  throw new Error("copytreeWorker must run as a worker thread");
+}
+
+function post(message: CopytreeWorkerResponse): void {
+  port!.postMessage(message);
+}
+
+port.on("message", (message: CopytreeWorkerRequest) => {
+  switch (message.type) {
+    case "generate": {
+      const { id, rootPath, options } = message;
+      void copyTreeService
+        .generate(rootPath, options, (progress) => post({ type: "progress", id, progress }), id)
+        .then(
+          (result) => post({ type: "generate-result", id, result }),
+          (error: unknown) =>
+            post({
+              type: "generate-error",
+              id,
+              error: formatErrorMessage(error, "Failed to generate context"),
+            })
+        );
+      break;
+    }
+    case "test-config": {
+      const { id, rootPath, options } = message;
+      void copyTreeService.testConfig(rootPath, options, id).then(
+        (result) => post({ type: "test-config-result", id, result }),
+        (error: unknown) =>
+          post({
+            type: "test-config-error",
+            id,
+            error: formatErrorMessage(error, "Failed to test CopyTree config"),
+          })
+      );
+      break;
+    }
+    case "cancel":
+      copyTreeService.cancel(message.id);
+      break;
+  }
+});

--- a/electron/workspace-host/copytreeWorkerProtocol.ts
+++ b/electron/workspace-host/copytreeWorkerProtocol.ts
@@ -1,0 +1,19 @@
+import type { CopyTreeOptions, CopyTreeResult, CopyTreeProgress } from "../types/index.js";
+import type { CopyTreeTestConfigResult } from "../../shared/types/index.js";
+
+/**
+ * Message protocol between the workspace-host and the copytree worker thread.
+ * Cancellation is a message (AbortSignal can't cross threads); the worker maps
+ * it onto its own per-operation AbortController inside CopyTreeService.
+ */
+export type CopytreeWorkerRequest =
+  | { type: "generate"; id: string; rootPath: string; options: CopyTreeOptions }
+  | { type: "test-config"; id: string; rootPath: string; options: CopyTreeOptions }
+  | { type: "cancel"; id: string };
+
+export type CopytreeWorkerResponse =
+  | { type: "progress"; id: string; progress: CopyTreeProgress }
+  | { type: "generate-result"; id: string; result: CopyTreeResult }
+  | { type: "generate-error"; id: string; error: string }
+  | { type: "test-config-result"; id: string; result: CopyTreeTestConfigResult }
+  | { type: "test-config-error"; id: string; error: string };

--- a/electron/workspace-host/worktreeUtils.ts
+++ b/electron/workspace-host/worktreeUtils.ts
@@ -108,7 +108,7 @@ export function nextAvailableBranchName(baseName: string, existing: Set<string>)
 }
 
 export async function ensureNoteFile(worktreePath: string): Promise<void> {
-  const gitDir = getGitDir(worktreePath);
+  const gitDir = await getGitDir(worktreePath);
   if (!gitDir) {
     return;
   }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -746,7 +746,8 @@ export default tseslint.config(
   },
 
   // Allowlist — react-diff-view file viewer and worktree diff (DiffViewer's
-  // helper modules live in the same lazy chunk).
+  // helper modules live in the same lazy chunk; diffTokenizer is also the
+  // diff-tokenize worker's entrypoint into react-diff-view, bundled separately).
   {
     files: [
       "src/components/FileViewer/FileViewerModal.tsx",
@@ -754,6 +755,7 @@ export default tseslint.config(
       "src/components/Worktree/diffEditSuppression.ts",
       "src/components/Worktree/diffMovedUtils.ts",
       "src/components/Worktree/diffTokenRanges.ts",
+      "src/components/Worktree/diffTokenizer.ts",
     ],
     rules: { "no-restricted-imports": "off" },
   },

--- a/scripts/build-main.mjs
+++ b/scripts/build-main.mjs
@@ -523,6 +523,14 @@ async function run() {
       // `new Worker()` from OpenAITranscriptionProvider; needs its own entry so
       // esbuild emits a standalone bundle at the resolved worker path.
       "electron/services/voice/openaiVadWorker.ts",
+      // Multi-threading workers: per-terminal analysis (headless xterm +
+      // activity detection) inside pty-host, SQLite maintenance off the main
+      // event loop, and copytree generation inside workspace-host. Each is
+      // loaded via `new Worker()` and needs a standalone bundle at its
+      // resolved worker path (same pattern as openaiVadWorker).
+      "electron/pty-host/analysisWorker.ts",
+      "electron/services/persistence/dbMaintenanceWorker.ts",
+      "electron/workspace-host/copytreeWorker.ts",
       ...discoverBuiltInPluginMainEntries(),
       // Sample plugins compiled for the host-contract e2e harness (#9286, #9592).
       // Sideloaded via `DAINTREE_E2E_SIDELOAD_PLUGIN_DIR`; absent in prod because

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -14,9 +15,6 @@ import {
   Diff,
   Hunk,
   Decoration,
-  tokenize,
-  markEdits,
-  pickRanges,
   getChangeKey,
   expandFromRawCode,
   getCollapsedLinesCountBetween,
@@ -29,19 +27,8 @@ import type {
   RenderGutter,
   RenderToken,
   TokenNode,
-  TokenizeOptions,
   ViewType,
 } from "react-diff-view";
-import { refractor } from "refractor/core";
-import type { Syntax } from "refractor/core";
-import bash from "refractor/bash";
-import css from "refractor/css";
-import javascript from "refractor/javascript";
-import jsx from "refractor/jsx";
-import json from "refractor/json";
-import markdown from "refractor/markdown";
-import tsx from "refractor/tsx";
-import typescript from "refractor/typescript";
 import "react-diff-view/style/index.css";
 // Our overrides — must come after the library stylesheet it overrides.
 import "./DiffViewer.css";
@@ -70,78 +57,13 @@ import {
   estimateFileDiffBytes,
 } from "./diffCollapseUtils";
 import { detectMovedLines } from "./diffMovedUtils";
-import { suppressFullLineEdits } from "./diffEditSuppression";
 import { computeSearchRanges, computeTrailingWsRanges } from "./diffTokenRanges";
 import type { SideRanges } from "./diffTokenRanges";
+import { isLanguageFailed } from "./diffRefractor";
+import { diffTokenizeClient } from "@/services/DiffTokenizeService";
 import { formatBytes } from "@/lib/formatBytes";
 
-for (const lang of [bash, css, javascript, jsx, json, markdown, tsx, typescript]) {
-  refractor.register(lang);
-}
-
-/**
- * react-diff-view's tokenize expects refractor v3's highlight() contract — a
- * plain array of nodes. refractor v4+ returns a hast Root object, whose
- * non-iterable shape makes the token tree walk throw, which the catch in
- * useTokens silently turns into tokens = null: no syntax highlighting, no
- * word-level edit pills, no search marks. Unwrapping .children restores the
- * v3 shape the library walks correctly.
- */
-// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- structurally satisfies the lib's { highlight } contract; the v5 Root type can't
-const refractorAdapter = {
-  highlight: (code: string, language: string) => refractor.highlight(code, language).children,
-} as unknown as typeof refractor;
-
-const LANG_LOADERS: Record<string, () => Promise<{ default: Syntax }>> = {
-  c: () => import("refractor/c"),
-  cpp: () => import("refractor/cpp"),
-  csharp: () => import("refractor/csharp"),
-  docker: () => import("refractor/docker"),
-  go: () => import("refractor/go"),
-  graphql: () => import("refractor/graphql"),
-  java: () => import("refractor/java"),
-  kotlin: () => import("refractor/kotlin"),
-  less: () => import("refractor/less"),
-  makefile: () => import("refractor/makefile"),
-  markup: () => import("refractor/markup"),
-  php: () => import("refractor/php"),
-  python: () => import("refractor/python"),
-  ruby: () => import("refractor/ruby"),
-  rust: () => import("refractor/rust"),
-  sass: () => import("refractor/sass"),
-  scss: () => import("refractor/scss"),
-  sql: () => import("refractor/sql"),
-  swift: () => import("refractor/swift"),
-  toml: () => import("refractor/toml"),
-  yaml: () => import("refractor/yaml"),
-};
-
-const langLoadPromises = new Map<string, Promise<void>>();
-const FAILED_LANGS = new Set<string>();
-
-export function _resetLangStateForTests(): void {
-  FAILED_LANGS.clear();
-  langLoadPromises.clear();
-}
-
-function ensureLanguage(language: string): Promise<void> {
-  if (refractor.registered(language)) return Promise.resolve();
-  const loader = LANG_LOADERS[language];
-  if (!loader) return Promise.resolve();
-  let pending = langLoadPromises.get(language);
-  if (!pending) {
-    pending = loader()
-      .then((mod) => {
-        refractor.register(mod.default);
-      })
-      .catch((err: unknown) => {
-        console.warn(`Failed to load refractor grammar for "${language}"`, err);
-        FAILED_LANGS.add(language);
-      });
-    langLoadPromises.set(language, pending);
-  }
-  return pending;
-}
+export { _resetLangStateForTests } from "./diffRefractor";
 
 export interface DiffViewerProps {
   diff: string;
@@ -252,8 +174,13 @@ export const renderTokenWithInvisibles: RenderToken = (token, renderDefault, ind
   );
 };
 
-/** Changed-line budget above which word-level edit marking is skipped. */
-const MAX_INTRALINE_CHANGES = 3000;
+interface TokenizePass {
+  hunks: HunkData[];
+  language: string;
+  highlight: boolean;
+  tokens: HunkTokens | null;
+  langLoadFailed: boolean;
+}
 
 function useTokens(
   hunks: HunkData[],
@@ -265,79 +192,49 @@ function useTokens(
   tokens: HunkTokens | null;
   langLoadFailed: boolean;
 } {
-  const needsGrammar = enabled && highlight;
-  const [langReady, setLangReady] = useState(() => refractor.registered(language));
-  const [langLoadFailed, setLangLoadFailed] = useState(() => FAILED_LANGS.has(language));
-
-  useEffect(() => {
-    if (!needsGrammar) return;
-    if (refractor.registered(language)) {
-      setLangReady(true);
-      setLangLoadFailed(false);
-      return;
-    }
-    setLangReady(false);
-    let cancelled = false;
-    void ensureLanguage(language).then(() => {
-      if (!cancelled) {
-        setLangReady(refractor.registered(language));
-        setLangLoadFailed(FAILED_LANGS.has(language));
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [language, needsGrammar]);
-
-  const [tokens, setTokens] = useState<HunkTokens | null>(null);
+  const requestKey = useId();
+  const [pass, setPass] = useState<TokenizePass | null>(null);
 
   // Two-pass paint: the unhighlighted table commits first, then tokenization
-  // runs post-paint and lands as a low-priority update. Collapsed files skip
-  // the work entirely until expanded; size-gated files keep markEdits
-  // word-level marks but skip the grammar walk (highlight: false).
+  // runs in the diff-tokenize worker and lands as a low-priority update.
+  // Collapsed files skip the work entirely until expanded; size-gated files
+  // keep markEdits word-level marks but skip the grammar walk (highlight:
+  // false). While a request is in flight the previous pass keeps rendering —
+  // tokens are dropped at derivation when the hunks, language, or highlight
+  // mode they were built from change, so a stale tree never mismatches the
+  // rendered rows or the active grammar. extraRanges is deliberately not
+  // gated: keeping the previous search marks visible until the new pass lands
+  // mirrors the old useDeferredValue semantics.
   useEffect(() => {
-    if (!enabled || !hunks.length || (highlight && !langReady)) {
-      setTokens(null);
+    if (!enabled || !hunks.length) {
+      setPass(null);
       return;
     }
     let cancelled = false;
-    // Past the budget, intra-line diffing (diff-match-patch per change block)
-    // is churn-on-churn: the marks stop being review signal and the per-block
-    // diffs get slow. Whole-line fills only — the same large-hunk fallback
-    // git diff-highlight and VS Code apply.
-    let changedLines = 0;
-    for (const hunk of hunks) {
-      for (const change of hunk.changes) {
-        if (change.type !== "normal") changedLines++;
-      }
-    }
-    const intraLineEdits = changedLines <= MAX_INTRALINE_CHANGES;
-    const options: TokenizeOptions = {
-      highlight,
-      refractor: refractorAdapter,
-      language,
-      enhancers: [
-        ...(intraLineEdits ? [markEdits(hunks, { type: "block" }), suppressFullLineEdits()] : []),
-        ...(extraRanges ? [pickRanges(extraRanges.old, extraRanges.new)] : []),
-      ],
-    };
-    startTransition(() => {
-      if (cancelled) return;
-      try {
-        setTokens(tokenize(hunks, options) ?? null);
-      } catch (err) {
-        // A null token pass silently degrades highlighting, edit pills, and
-        // search marks to plain text — keep the failure observable.
-        console.warn("Diff tokenization failed", err);
-        setTokens(null);
-      }
-    });
+    void diffTokenizeClient
+      .tokenize(requestKey, { hunks, language, highlight, extraRanges })
+      .then((result) => {
+        if (cancelled || !result) return;
+        startTransition(() => {
+          setPass({
+            hunks,
+            language,
+            highlight,
+            tokens: result.tokens,
+            langLoadFailed: result.langLoadFailed,
+          });
+        });
+      });
     return () => {
       cancelled = true;
     };
-  }, [hunks, language, langReady, enabled, highlight, extraRanges]);
+  }, [hunks, language, enabled, highlight, extraRanges, requestKey]);
 
-  return { tokens, langLoadFailed };
+  const passCurrent = pass !== null && pass.hunks === hunks && pass.language === language;
+  return {
+    tokens: passCurrent && pass.highlight === highlight ? pass.tokens : null,
+    langLoadFailed: passCurrent ? pass.langLoadFailed : isLanguageFailed(language),
+  };
 }
 
 /**
@@ -685,7 +582,7 @@ function FileDiff({
   const relPath = getFilePath(file);
   const language = useMemo(() => {
     const derived = getLanguageForFile(relPath);
-    return FAILED_LANGS.has(derived) ? "plaintext" : derived;
+    return isLanguageFailed(derived) ? "plaintext" : derived;
   }, [relPath]);
   const diffType: DiffType = file.type as DiffType;
 

--- a/src/components/Worktree/diffRefractor.ts
+++ b/src/components/Worktree/diffRefractor.ts
@@ -1,0 +1,94 @@
+import { refractor } from "refractor/core";
+import type { Syntax } from "refractor/core";
+import bash from "refractor/bash";
+import css from "refractor/css";
+import javascript from "refractor/javascript";
+import jsx from "refractor/jsx";
+import json from "refractor/json";
+import markdown from "refractor/markdown";
+import tsx from "refractor/tsx";
+import typescript from "refractor/typescript";
+
+for (const lang of [bash, css, javascript, jsx, json, markdown, tsx, typescript]) {
+  refractor.register(lang);
+}
+
+/**
+ * react-diff-view's tokenize expects refractor v3's highlight() contract — a
+ * plain array of nodes. refractor v4+ returns a hast Root object, whose
+ * non-iterable shape makes the token tree walk throw, which the catch in
+ * runDiffTokenize silently turns into tokens = null: no syntax highlighting,
+ * no word-level edit pills, no search marks. Unwrapping .children restores the
+ * v3 shape the library walks correctly.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- structurally satisfies the lib's { highlight } contract; the v5 Root type can't
+export const refractorAdapter = {
+  highlight: (code: string, language: string) => refractor.highlight(code, language).children,
+} as unknown as typeof refractor;
+
+const LANG_LOADERS: Record<string, () => Promise<{ default: Syntax }>> = {
+  c: () => import("refractor/c"),
+  cpp: () => import("refractor/cpp"),
+  csharp: () => import("refractor/csharp"),
+  docker: () => import("refractor/docker"),
+  go: () => import("refractor/go"),
+  graphql: () => import("refractor/graphql"),
+  java: () => import("refractor/java"),
+  kotlin: () => import("refractor/kotlin"),
+  less: () => import("refractor/less"),
+  makefile: () => import("refractor/makefile"),
+  markup: () => import("refractor/markup"),
+  php: () => import("refractor/php"),
+  python: () => import("refractor/python"),
+  ruby: () => import("refractor/ruby"),
+  rust: () => import("refractor/rust"),
+  sass: () => import("refractor/sass"),
+  scss: () => import("refractor/scss"),
+  sql: () => import("refractor/sql"),
+  swift: () => import("refractor/swift"),
+  toml: () => import("refractor/toml"),
+  yaml: () => import("refractor/yaml"),
+};
+
+const langLoadPromises = new Map<string, Promise<void>>();
+const FAILED_LANGS = new Set<string>();
+
+export function _resetLangStateForTests(): void {
+  FAILED_LANGS.clear();
+  langLoadPromises.clear();
+}
+
+export function isLanguageRegistered(language: string): boolean {
+  return refractor.registered(language);
+}
+
+export function isLanguageFailed(language: string): boolean {
+  return FAILED_LANGS.has(language);
+}
+
+/**
+ * Grammar failures in the worker happen in its own module instance; the client
+ * mirrors them here so the renderer-side plaintext downgrade stays coherent.
+ */
+export function markLanguageFailed(language: string): void {
+  FAILED_LANGS.add(language);
+}
+
+export function ensureLanguage(language: string): Promise<void> {
+  if (refractor.registered(language)) return Promise.resolve();
+  const loader = LANG_LOADERS[language];
+  if (!loader) return Promise.resolve();
+  let pending = langLoadPromises.get(language);
+  if (!pending) {
+    pending = loader()
+      .then((mod) => {
+        refractor.register(mod.default);
+      })
+      .catch((err: unknown) => {
+        console.warn(`Failed to load refractor grammar for "${language}"`, err);
+        FAILED_LANGS.add(language);
+      });
+    langLoadPromises.set(language, pending);
+  }
+  return pending;
+}

--- a/src/components/Worktree/diffTokenizer.ts
+++ b/src/components/Worktree/diffTokenizer.ts
@@ -1,0 +1,79 @@
+import { tokenize, markEdits, pickRanges } from "react-diff-view";
+import type { HunkData, HunkTokens, TokenizeOptions } from "react-diff-view";
+import {
+  ensureLanguage,
+  isLanguageFailed,
+  isLanguageRegistered,
+  refractorAdapter,
+} from "./diffRefractor";
+import { suppressFullLineEdits } from "./diffEditSuppression";
+import type { SideRanges } from "./diffTokenRanges";
+
+export interface DiffTokenizeRequest {
+  hunks: HunkData[];
+  language: string;
+  highlight: boolean;
+  extraRanges: SideRanges | null;
+}
+
+export interface DiffTokenizeResult {
+  tokens: HunkTokens | null;
+  langLoadFailed: boolean;
+}
+
+export type DiffTokenizeWorkerRequest = DiffTokenizeRequest & { id: number };
+
+export type DiffTokenizeWorkerResponse =
+  | ({ id: number; ok: true } & DiffTokenizeResult)
+  | { id: number; ok: false; error: string };
+
+/** Changed-line budget above which word-level edit marking is skipped. */
+const MAX_INTRALINE_CHANGES = 3000;
+
+// Past the budget, intra-line diffing (diff-match-patch per change block) is
+// churn-on-churn: the marks stop being review signal and the per-block diffs
+// get slow. Whole-line fills only — the same large-hunk fallback git
+// diff-highlight and VS Code apply.
+function shouldMarkIntraLineEdits(hunks: HunkData[]): boolean {
+  let changedLines = 0;
+  for (const hunk of hunks) {
+    for (const change of hunk.changes) {
+      if (change.type !== "normal") changedLines++;
+    }
+  }
+  return changedLines <= MAX_INTRALINE_CHANGES;
+}
+
+/**
+ * The one tokenize implementation — the Web Worker and the in-thread fallback
+ * both call this, so their behavior can't drift. Grammar loading is lazy per
+ * language; failures downgrade to an unhighlighted pass and are reported via
+ * langLoadFailed.
+ */
+export async function runDiffTokenize(request: DiffTokenizeRequest): Promise<DiffTokenizeResult> {
+  const { hunks, language, highlight, extraRanges } = request;
+  if (highlight) await ensureLanguage(language);
+  const langLoadFailed = isLanguageFailed(language);
+  if (highlight && !isLanguageRegistered(language)) {
+    return { tokens: null, langLoadFailed };
+  }
+  try {
+    const options: TokenizeOptions = {
+      highlight,
+      refractor: refractorAdapter,
+      language,
+      enhancers: [
+        ...(shouldMarkIntraLineEdits(hunks)
+          ? [markEdits(hunks, { type: "block" }), suppressFullLineEdits()]
+          : []),
+        ...(extraRanges ? [pickRanges(extraRanges.old, extraRanges.new)] : []),
+      ],
+    };
+    return { tokens: tokenize(hunks, options) ?? null, langLoadFailed };
+  } catch (err) {
+    // A null token pass silently degrades highlighting, edit pills, and
+    // search marks to plain text — keep the failure observable.
+    console.warn("Diff tokenization failed", err);
+    return { tokens: null, langLoadFailed };
+  }
+}

--- a/src/services/DiffTokenizeService.ts
+++ b/src/services/DiffTokenizeService.ts
@@ -3,9 +3,26 @@
  *
  * Owns one persistent worker shared by every diff viewer. Requests carry ids;
  * a newer request under the same key supersedes the older one (its promise
- * resolves null and any late worker response is dropped). If the worker can't
- * be constructed or a request errors, the client permanently falls back to
- * in-thread tokenization for the session.
+ * resolves null and any late worker response is dropped).
+ *
+ * Failure handling:
+ * - A request unanswered for REQUEST_TIMEOUT_MS means the worker thread is
+ *   wedged (pathological grammar regex or markEdits input). The request
+ *   resolves null — the diff renders un-highlighted — and is never re-run:
+ *   in-thread it would freeze the UI with the same pathology. The wedged
+ *   worker is terminated (safe for renderer Web Workers, unlike Node
+ *   worker_threads) and replaced, surviving requests move to the replacement,
+ *   and after MAX_WORKER_REPLACEMENTS the client stops replacing and falls
+ *   back permanently instead.
+ * - Construction, postMessage, crash, and response errors skip the
+ *   replacement budget and permanently fall back in-thread right away: they
+ *   signal an environment problem, not a poisoned input.
+ * - All in-thread tokenization — failover survivors AND every request issued
+ *   while in permanent-fallback mode — flows through one shared serialized
+ *   queue, run a single item at a time with a macrotask yield before each and
+ *   newest-per-key winning. A dying worker can't dump a synchronous tokenize
+ *   burst, and new fallback work is appended behind queued survivors instead
+ *   of racing ahead of (or double-running with) them.
  */
 
 import { runDiffTokenize } from "@/components/Worktree/diffTokenizer";
@@ -21,7 +38,18 @@ interface PendingRequest {
   key: string;
   request: DiffTokenizeRequest;
   resolve: (result: DiffTokenizeResult | null) => void;
+  timer: ReturnType<typeof setTimeout>;
 }
+
+interface InThreadJob {
+  key: string;
+  id: number;
+  request: DiffTokenizeRequest;
+  resolve: (result: DiffTokenizeResult | null) => void;
+}
+
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_WORKER_REPLACEMENTS = 2;
 
 function createDefaultWorker(): Worker {
   return new Worker(new URL("../workers/diffTokenize.worker.ts", import.meta.url), {
@@ -29,13 +57,20 @@ function createDefaultWorker(): Worker {
   });
 }
 
+function yieldToMacrotask(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 export class DiffTokenizeClient {
   private readonly createWorker: () => Worker;
   private worker: Worker | null = null;
   private workerFailed = false;
+  private replacements = 0;
   private nextId = 1;
   private readonly pending = new Map<number, PendingRequest>();
   private readonly latestByKey = new Map<string, number>();
+  private readonly inThreadQueue: InThreadJob[] = [];
+  private draining = false;
 
   constructor(createWorker: () => Worker = createDefaultWorker) {
     this.createWorker = createWorker;
@@ -51,6 +86,7 @@ export class DiffTokenizeClient {
     if (previousId !== undefined) {
       const previous = this.pending.get(previousId);
       if (previous) {
+        clearTimeout(previous.timer);
         this.pending.delete(previousId);
         previous.resolve(null);
       }
@@ -58,10 +94,11 @@ export class DiffTokenizeClient {
     this.latestByKey.set(key, id);
 
     const worker = this.workerFailed ? null : this.ensureWorker();
-    if (!worker) return this.runInThread(key, id, request);
+    if (!worker) return this.enqueueInThread(key, id, request);
 
     return new Promise<DiffTokenizeResult | null>((resolve) => {
-      this.pending.set(id, { key, request, resolve });
+      const timer = setTimeout(() => this.handleTimeout(id), REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { key, request, resolve, timer });
       const message: DiffTokenizeWorkerRequest = { id, ...request };
       try {
         worker.postMessage(message);
@@ -98,10 +135,63 @@ export class DiffTokenizeClient {
       this.failOver(new Error(response.error));
       return;
     }
+    clearTimeout(entry.timer);
     this.pending.delete(response.id);
     this.clearLatest(entry.key, response.id);
     if (response.langLoadFailed) markLanguageFailed(entry.request.language);
     entry.resolve({ tokens: response.tokens, langLoadFailed: response.langLoadFailed });
+  }
+
+  private handleTimeout(id: number): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    this.clearLatest(entry.key, id);
+    // "Oldest unanswered" is a heuristic for which request wedged the worker.
+    // It resolves null (un-highlighted) and is never re-run in-thread — that
+    // would freeze the UI with the same pathology. The tradeoff — a slow but
+    // healthy request may be sacrificed and cost a replacement — is accepted:
+    // the replacement worker re-serves all subsequent work, and a genuinely
+    // poisoned input just times out again and triggers the next replacement.
+    entry.resolve(null);
+    if (this.replacements >= MAX_WORKER_REPLACEMENTS) {
+      this.failOver(new Error("Diff tokenize worker kept timing out"));
+      return;
+    }
+    this.replacements++;
+    console.warn(
+      `Diff tokenize request timed out after ${REQUEST_TIMEOUT_MS}ms; replacing the worker (${this.replacements}/${MAX_WORKER_REPLACEMENTS})`
+    );
+    this.replaceWorker();
+  }
+
+  /** Terminate the wedged worker and move surviving requests to a fresh one. */
+  private replaceWorker(): void {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    const worker = this.ensureWorker();
+    if (!worker) {
+      this.failOver(new Error("Diff tokenize worker replacement failed"));
+      return;
+    }
+    for (const [id, entry] of [...this.pending.entries()]) {
+      clearTimeout(entry.timer);
+      if (this.latestByKey.get(entry.key) !== id) {
+        this.pending.delete(id);
+        entry.resolve(null);
+        continue;
+      }
+      entry.timer = setTimeout(() => this.handleTimeout(id), REQUEST_TIMEOUT_MS);
+      const message: DiffTokenizeWorkerRequest = { id, ...entry.request };
+      try {
+        worker.postMessage(message);
+      } catch (err) {
+        this.failOver(err);
+        return;
+      }
+    }
   }
 
   private async runInThread(
@@ -133,17 +223,59 @@ export class DiffTokenizeClient {
     }
   }
 
-  /** Fail over to in-thread tokenization, re-running still-relevant pending requests. */
+  /** Fail over to in-thread tokenization, queueing still-relevant pending requests. */
   private failOver(err: unknown): void {
     this.enterFallback(err);
     const entries = [...this.pending.entries()];
     this.pending.clear();
     for (const [id, entry] of entries) {
+      clearTimeout(entry.timer);
       if (this.latestByKey.get(entry.key) !== id) {
         entry.resolve(null);
         continue;
       }
-      void this.runInThread(entry.key, id, entry.request).then(entry.resolve);
+      this.inThreadQueue.push({
+        key: entry.key,
+        id,
+        request: entry.request,
+        resolve: entry.resolve,
+      });
+    }
+    void this.pumpInThread();
+  }
+
+  private enqueueInThread(
+    key: string,
+    id: number,
+    request: DiffTokenizeRequest
+  ): Promise<DiffTokenizeResult | null> {
+    return new Promise<DiffTokenizeResult | null>((resolve) => {
+      this.inThreadQueue.push({ key, id, request, resolve });
+      void this.pumpInThread();
+    });
+  }
+
+  // Single runner for every in-thread tokenize (failover survivors and
+  // permanent-fallback requests share this queue). One item at a time with a
+  // yield before each keeps the main thread responsive; the per-item
+  // supersession recheck drops any job no longer newest for its key so a
+  // later same-key request wins without a double-run.
+  private async pumpInThread(): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      while (this.inThreadQueue.length > 0) {
+        await yieldToMacrotask();
+        const job = this.inThreadQueue.shift();
+        if (!job) break;
+        if (this.latestByKey.get(job.key) !== job.id) {
+          job.resolve(null);
+          continue;
+        }
+        job.resolve(await this.runInThread(job.key, job.id, job.request));
+      }
+    } finally {
+      this.draining = false;
     }
   }
 }

--- a/src/services/DiffTokenizeService.ts
+++ b/src/services/DiffTokenizeService.ts
@@ -1,0 +1,151 @@
+/**
+ * DiffTokenizeService - Client for the diff tokenization Web Worker.
+ *
+ * Owns one persistent worker shared by every diff viewer. Requests carry ids;
+ * a newer request under the same key supersedes the older one (its promise
+ * resolves null and any late worker response is dropped). If the worker can't
+ * be constructed or a request errors, the client permanently falls back to
+ * in-thread tokenization for the session.
+ */
+
+import { runDiffTokenize } from "@/components/Worktree/diffTokenizer";
+import type {
+  DiffTokenizeRequest,
+  DiffTokenizeResult,
+  DiffTokenizeWorkerRequest,
+  DiffTokenizeWorkerResponse,
+} from "@/components/Worktree/diffTokenizer";
+import { markLanguageFailed } from "@/components/Worktree/diffRefractor";
+
+interface PendingRequest {
+  key: string;
+  request: DiffTokenizeRequest;
+  resolve: (result: DiffTokenizeResult | null) => void;
+}
+
+function createDefaultWorker(): Worker {
+  return new Worker(new URL("../workers/diffTokenize.worker.ts", import.meta.url), {
+    type: "module",
+  });
+}
+
+export class DiffTokenizeClient {
+  private readonly createWorker: () => Worker;
+  private worker: Worker | null = null;
+  private workerFailed = false;
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly latestByKey = new Map<string, number>();
+
+  constructor(createWorker: () => Worker = createDefaultWorker) {
+    this.createWorker = createWorker;
+  }
+
+  /**
+   * Tokenize hunks off the main thread. Resolves null when a newer request
+   * under the same key superseded this one — callers must ignore that result.
+   */
+  tokenize(key: string, request: DiffTokenizeRequest): Promise<DiffTokenizeResult | null> {
+    const id = this.nextId++;
+    const previousId = this.latestByKey.get(key);
+    if (previousId !== undefined) {
+      const previous = this.pending.get(previousId);
+      if (previous) {
+        this.pending.delete(previousId);
+        previous.resolve(null);
+      }
+    }
+    this.latestByKey.set(key, id);
+
+    const worker = this.workerFailed ? null : this.ensureWorker();
+    if (!worker) return this.runInThread(key, id, request);
+
+    return new Promise<DiffTokenizeResult | null>((resolve) => {
+      this.pending.set(id, { key, request, resolve });
+      const message: DiffTokenizeWorkerRequest = { id, ...request };
+      try {
+        worker.postMessage(message);
+      } catch (err) {
+        this.failOver(err);
+      }
+    });
+  }
+
+  private ensureWorker(): Worker | null {
+    if (this.worker) return this.worker;
+    try {
+      this.worker = this.createWorker();
+    } catch (err) {
+      this.enterFallback(err);
+      return null;
+    }
+    this.worker.onmessage = (event: MessageEvent<DiffTokenizeWorkerResponse>) => {
+      this.handleResponse(event.data);
+    };
+    this.worker.onerror = (event: ErrorEvent) => {
+      this.failOver(event.error ?? new Error(event.message || "Diff tokenize worker error"));
+    };
+    this.worker.onmessageerror = () => {
+      this.failOver(new Error("Diff tokenize worker message could not be deserialized"));
+    };
+    return this.worker;
+  }
+
+  private handleResponse(response: DiffTokenizeWorkerResponse): void {
+    const entry = this.pending.get(response.id);
+    if (!entry) return;
+    if (!response.ok) {
+      this.failOver(new Error(response.error));
+      return;
+    }
+    this.pending.delete(response.id);
+    this.clearLatest(entry.key, response.id);
+    if (response.langLoadFailed) markLanguageFailed(entry.request.language);
+    entry.resolve({ tokens: response.tokens, langLoadFailed: response.langLoadFailed });
+  }
+
+  private async runInThread(
+    key: string,
+    id: number,
+    request: DiffTokenizeRequest
+  ): Promise<DiffTokenizeResult | null> {
+    const result = await runDiffTokenize(request);
+    if (this.latestByKey.get(key) !== id) return null;
+    this.latestByKey.delete(key);
+    return result;
+  }
+
+  private clearLatest(key: string, id: number): void {
+    if (this.latestByKey.get(key) === id) this.latestByKey.delete(key);
+  }
+
+  private enterFallback(err: unknown): void {
+    if (!this.workerFailed) {
+      this.workerFailed = true;
+      console.warn(
+        "Diff tokenize worker unavailable; tokenizing on the main thread for this session",
+        err
+      );
+    }
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+  }
+
+  /** Fail over to in-thread tokenization, re-running still-relevant pending requests. */
+  private failOver(err: unknown): void {
+    this.enterFallback(err);
+    const entries = [...this.pending.entries()];
+    this.pending.clear();
+    for (const [id, entry] of entries) {
+      if (this.latestByKey.get(entry.key) !== id) {
+        entry.resolve(null);
+        continue;
+      }
+      void this.runInThread(entry.key, id, entry.request).then(entry.resolve);
+    }
+  }
+}
+
+export const diffTokenizeClient = new DiffTokenizeClient();

--- a/src/services/__tests__/DiffTokenizeService.test.ts
+++ b/src/services/__tests__/DiffTokenizeService.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type {
+  DiffTokenizeRequest,
+  DiffTokenizeResult,
+  DiffTokenizeWorkerRequest,
+  DiffTokenizeWorkerResponse,
+} from "@/components/Worktree/diffTokenizer";
+import { DiffTokenizeClient } from "../DiffTokenizeService";
+
+const { mockRunDiffTokenize, mockMarkLanguageFailed } = vi.hoisted(() => ({
+  mockRunDiffTokenize: vi.fn(),
+  mockMarkLanguageFailed: vi.fn(),
+}));
+
+vi.mock("@/components/Worktree/diffTokenizer", () => ({
+  runDiffTokenize: mockRunDiffTokenize,
+}));
+
+vi.mock("@/components/Worktree/diffRefractor", () => ({
+  markLanguageFailed: mockMarkLanguageFailed,
+}));
+
+class MockWorker {
+  posted: DiffTokenizeWorkerRequest[] = [];
+  terminated = false;
+  onmessage: ((event: MessageEvent<DiffTokenizeWorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+
+  postMessage(message: DiffTokenizeWorkerRequest): void {
+    this.posted.push(message);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  respond(response: DiffTokenizeWorkerResponse): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- minimal MessageEvent shape for the handler under test
+    this.onmessage?.({ data: response } as MessageEvent<DiffTokenizeWorkerResponse>);
+  }
+
+  fail(message: string): void {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- minimal ErrorEvent shape for the handler under test
+    this.onerror?.({ message } as ErrorEvent);
+  }
+}
+
+function makeRequest(language = "typescript"): DiffTokenizeRequest {
+  return {
+    hunks: [
+      {
+        content: "@@ -1,1 +1,1 @@",
+        oldStart: 1,
+        newStart: 1,
+        oldLines: 1,
+        newLines: 1,
+        changes: [{ type: "insert", content: "added", lineNumber: 1 }],
+      },
+    ],
+    language,
+    highlight: true,
+    extraRanges: null,
+  };
+}
+
+const tokensA: DiffTokenizeResult = { tokens: { old: [], new: [] }, langLoadFailed: false };
+
+function createClient(): { client: DiffTokenizeClient; worker: MockWorker; factory: () => Worker } {
+  const worker = new MockWorker();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- MockWorker implements the Worker surface the client uses
+  const factory = vi.fn(() => worker as unknown as Worker);
+  return { client: new DiffTokenizeClient(factory), worker, factory };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+describe("DiffTokenizeClient worker path", () => {
+  it("resolves tokens from the worker response", async () => {
+    const { client, worker } = createClient();
+    const promise = client.tokenize("viewer-1", makeRequest());
+
+    expect(worker.posted).toHaveLength(1);
+    worker.respond({ id: worker.posted[0]!.id, ok: true, ...tokensA });
+
+    await expect(promise).resolves.toEqual(tokensA);
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
+  });
+
+  it("discards a superseded request and keeps the latest for the same key", async () => {
+    const { client, worker } = createClient();
+    const first = client.tokenize("viewer-1", makeRequest());
+    const second = client.tokenize("viewer-1", makeRequest());
+
+    await expect(first).resolves.toBeNull();
+
+    const [firstMessage, secondMessage] = worker.posted;
+    worker.respond({ id: secondMessage!.id, ok: true, ...tokensA });
+    await expect(second).resolves.toEqual(tokensA);
+
+    // A late response for the superseded id is ignored without side effects.
+    worker.respond({ id: firstMessage!.id, ok: true, tokens: null, langLoadFailed: true });
+    expect(mockMarkLanguageFailed).not.toHaveBeenCalled();
+  });
+
+  it("keeps requests under different keys independent", async () => {
+    const { client, worker } = createClient();
+    const first = client.tokenize("viewer-1", makeRequest());
+    const second = client.tokenize("viewer-2", makeRequest());
+
+    worker.respond({ id: worker.posted[0]!.id, ok: true, ...tokensA });
+    worker.respond({ id: worker.posted[1]!.id, ok: true, ...tokensA });
+
+    await expect(first).resolves.toEqual(tokensA);
+    await expect(second).resolves.toEqual(tokensA);
+  });
+
+  it("mirrors worker-side grammar failures into the renderer registry", async () => {
+    const { client, worker } = createClient();
+    const promise = client.tokenize("viewer-1", makeRequest("rust"));
+
+    worker.respond({ id: worker.posted[0]!.id, ok: true, tokens: null, langLoadFailed: true });
+
+    await expect(promise).resolves.toEqual({ tokens: null, langLoadFailed: true });
+    expect(mockMarkLanguageFailed).toHaveBeenCalledWith("rust");
+  });
+});
+
+describe("DiffTokenizeClient fallback", () => {
+  it("falls back in-thread when worker construction throws", async () => {
+    const factory = vi.fn(() => {
+      throw new Error("Worker is not defined");
+    });
+    const client = new DiffTokenizeClient(factory);
+    mockRunDiffTokenize.mockResolvedValue(tokensA);
+
+    await expect(client.tokenize("viewer-1", makeRequest())).resolves.toEqual(tokensA);
+    await expect(client.tokenize("viewer-1", makeRequest())).resolves.toEqual(tokensA);
+
+    // Fallback is permanent for the session: one construction attempt, one warning.
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(mockRunDiffTokenize).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails over pending requests in-thread when a request errors", async () => {
+    const { client, worker, factory } = createClient();
+    mockRunDiffTokenize.mockResolvedValue(tokensA);
+    const pending = client.tokenize("viewer-1", makeRequest());
+
+    worker.respond({ id: worker.posted[0]!.id, ok: false, error: "tokenize blew up" });
+
+    await expect(pending).resolves.toEqual(tokensA);
+    expect(mockRunDiffTokenize).toHaveBeenCalledTimes(1);
+    expect(worker.terminated).toBe(true);
+
+    // Subsequent requests skip the worker entirely.
+    await expect(client.tokenize("viewer-1", makeRequest())).resolves.toEqual(tokensA);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(worker.posted).toHaveLength(1);
+  });
+
+  it("fails over pending requests when the worker itself errors", async () => {
+    const { client, worker } = createClient();
+    mockRunDiffTokenize.mockResolvedValue(tokensA);
+    const pending = client.tokenize("viewer-1", makeRequest());
+
+    worker.fail("worker crashed");
+
+    await expect(pending).resolves.toEqual(tokensA);
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("discards superseded in-thread requests", async () => {
+    const factory = vi.fn(() => {
+      throw new Error("Worker is not defined");
+    });
+    const client = new DiffTokenizeClient(factory);
+    let resolveFirst: (result: DiffTokenizeResult) => void = () => undefined;
+    mockRunDiffTokenize
+      .mockImplementationOnce(
+        () =>
+          new Promise<DiffTokenizeResult>((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockResolvedValueOnce(tokensA);
+
+    const first = client.tokenize("viewer-1", makeRequest());
+    const second = client.tokenize("viewer-1", makeRequest());
+
+    resolveFirst({ tokens: null, langLoadFailed: false });
+
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toEqual(tokensA);
+  });
+});

--- a/src/services/__tests__/DiffTokenizeService.test.ts
+++ b/src/services/__tests__/DiffTokenizeService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import type {
   DiffTokenizeRequest,
   DiffTokenizeResult,
@@ -73,9 +73,28 @@ function createClient(): { client: DiffTokenizeClient; worker: MockWorker; facto
   return { client: new DiffTokenizeClient(factory), worker, factory };
 }
 
+function createReplacingClient(): {
+  client: DiffTokenizeClient;
+  workers: MockWorker[];
+  factory: () => Worker;
+} {
+  const workers: MockWorker[] = [];
+  const factory = vi.fn(() => {
+    const worker = new MockWorker();
+    workers.push(worker);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- MockWorker implements the Worker surface the client uses
+    return worker as unknown as Worker;
+  });
+  return { client: new DiffTokenizeClient(factory), workers, factory };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.spyOn(console, "warn").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("DiffTokenizeClient worker path", () => {
@@ -174,11 +193,77 @@ describe("DiffTokenizeClient fallback", () => {
     expect(worker.terminated).toBe(true);
   });
 
-  it("discards superseded in-thread requests", async () => {
+  it("discards superseded in-thread requests without running them", async () => {
     const factory = vi.fn(() => {
       throw new Error("Worker is not defined");
     });
     const client = new DiffTokenizeClient(factory);
+    mockRunDiffTokenize.mockResolvedValue(tokensA);
+
+    const first = client.tokenize("viewer-1", makeRequest());
+    const second = client.tokenize("viewer-1", makeRequest());
+
+    await expect(first).resolves.toBeNull();
+    await expect(second).resolves.toEqual(tokensA);
+    // The superseded request is skipped at the queue's supersession recheck —
+    // only the surviving (latest) request actually tokenizes.
+    expect(mockRunDiffTokenize).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes a mid-drain tokenize through the shared queue, behind survivors", async () => {
+    vi.useFakeTimers();
+    const { client, worker } = createClient();
+    const order: string[] = [];
+    mockRunDiffTokenize.mockImplementation(async (req: DiffTokenizeRequest) => {
+      order.push(req.language);
+      return tokensA;
+    });
+
+    const survivorA = client.tokenize("viewer-a", makeRequest("lang-a"));
+    const survivorB = client.tokenize("viewer-b", makeRequest("lang-b"));
+
+    worker.fail("worker crashed"); // both enqueued as survivors
+
+    // A NEW request arrives after failover, now in fallback mode. It must be
+    // appended behind the queued survivors, not run ahead of them.
+    const late = client.tokenize("viewer-c", makeRequest("lang-c"));
+
+    await vi.runAllTimersAsync();
+
+    await expect(survivorA).resolves.toEqual(tokensA);
+    await expect(survivorB).resolves.toEqual(tokensA);
+    await expect(late).resolves.toEqual(tokensA);
+    expect(order).toEqual(["lang-a", "lang-b", "lang-c"]);
+  });
+
+  it("supersedes a queued survivor with a same-key mid-drain request, no double run", async () => {
+    vi.useFakeTimers();
+    const { client, worker } = createClient();
+    const order: string[] = [];
+    mockRunDiffTokenize.mockImplementation(async (req: DiffTokenizeRequest) => {
+      order.push(req.language);
+      return tokensA;
+    });
+
+    const survivor = client.tokenize("viewer-a", makeRequest("survivor"));
+
+    worker.fail("worker crashed"); // survivor enqueued
+
+    // Same-key request after failover supersedes the queued survivor.
+    const replacement = client.tokenize("viewer-a", makeRequest("replacement"));
+
+    await vi.runAllTimersAsync();
+
+    // The superseded survivor resolves null and never runs; only the
+    // replacement tokenizes — no same-key double run.
+    await expect(survivor).resolves.toBeNull();
+    await expect(replacement).resolves.toEqual(tokensA);
+    expect(order).toEqual(["replacement"]);
+  });
+
+  it("re-runs only newest-per-key requests sequentially on failover", async () => {
+    vi.useFakeTimers();
+    const { client, worker } = createClient();
     let resolveFirst: (result: DiffTokenizeResult) => void = () => undefined;
     mockRunDiffTokenize
       .mockImplementationOnce(
@@ -189,12 +274,93 @@ describe("DiffTokenizeClient fallback", () => {
       )
       .mockResolvedValueOnce(tokensA);
 
-    const first = client.tokenize("viewer-1", makeRequest());
-    const second = client.tokenize("viewer-1", makeRequest());
+    const staleA = client.tokenize("viewer-a", makeRequest());
+    const latestA = client.tokenize("viewer-a", makeRequest());
+    const latestB = client.tokenize("viewer-b", makeRequest());
 
-    resolveFirst({ tokens: null, langLoadFailed: false });
+    worker.fail("worker crashed");
+
+    // Superseded request resolves null without an in-thread re-run; survivors
+    // have not started yet — the drain yields to a macrotask first.
+    await expect(staleA).resolves.toBeNull();
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockRunDiffTokenize).toHaveBeenCalledTimes(1);
+
+    // The second survivor waits for the first to finish plus another yield.
+    resolveFirst(tokensA);
+    await vi.runAllTimersAsync();
+    expect(mockRunDiffTokenize).toHaveBeenCalledTimes(2);
+
+    await expect(latestA).resolves.toEqual(tokensA);
+    await expect(latestB).resolves.toEqual(tokensA);
+  });
+});
+
+describe("DiffTokenizeClient timeout", () => {
+  it("resolves a wedged request null, replaces the worker, and never re-runs the input", async () => {
+    vi.useFakeTimers();
+    const { client, workers } = createReplacingClient();
+    const wedged = client.tokenize("viewer-1", makeRequest());
+    expect(workers).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(wedged).resolves.toBeNull();
+    expect(workers).toHaveLength(2);
+    expect(workers[0]!.terminated).toBe(true);
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
+
+    // The replacement serves subsequent requests normally.
+    const next = client.tokenize("viewer-1", makeRequest());
+    expect(workers[1]!.posted).toHaveLength(1);
+    workers[1]!.respond({ id: workers[1]!.posted[0]!.id, ok: true, ...tokensA });
+    await expect(next).resolves.toEqual(tokensA);
+  });
+
+  it("re-posts other pending requests to the replacement worker", async () => {
+    vi.useFakeTimers();
+    const { client, workers } = createReplacingClient();
+    const wedged = client.tokenize("viewer-a", makeRequest());
+    const queued = client.tokenize("viewer-b", makeRequest());
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await expect(wedged).resolves.toBeNull();
+    expect(workers).toHaveLength(2);
+    expect(workers[1]!.posted).toHaveLength(1);
+
+    workers[1]!.respond({ id: workers[1]!.posted[0]!.id, ok: true, ...tokensA });
+    await expect(queued).resolves.toEqual(tokensA);
+    expect(mockRunDiffTokenize).not.toHaveBeenCalled();
+  });
+
+  it("falls back permanently once the replacement budget is exhausted", async () => {
+    vi.useFakeTimers();
+    const { client, workers, factory } = createReplacingClient();
+
+    const first = client.tokenize("viewer-1", makeRequest());
+    await vi.advanceTimersByTimeAsync(30_000);
+    const second = client.tokenize("viewer-1", makeRequest());
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(workers).toHaveLength(3);
+
+    const third = client.tokenize("viewer-1", makeRequest());
+    await vi.advanceTimersByTimeAsync(30_000);
 
     await expect(first).resolves.toBeNull();
-    await expect(second).resolves.toEqual(tokensA);
+    await expect(second).resolves.toBeNull();
+    await expect(third).resolves.toBeNull();
+    expect(workers[2]!.terminated).toBe(true);
+
+    // No further replacements: requests run in-thread (through the shared
+    // queue, which yields before running) from here on.
+    mockRunDiffTokenize.mockResolvedValue(tokensA);
+    const fourth = client.tokenize("viewer-1", makeRequest());
+    await vi.runAllTimersAsync();
+    await expect(fourth).resolves.toEqual(tokensA);
+    expect(factory).toHaveBeenCalledTimes(3);
+    expect(mockRunDiffTokenize).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/workers/diffTokenize.worker.ts
+++ b/src/workers/diffTokenize.worker.ts
@@ -1,0 +1,31 @@
+/**
+ * Diff Tokenization Web Worker
+ *
+ * Runs react-diff-view's tokenize (refractor syntax highlighting, markEdits
+ * word-level diffing, pickRanges search/whitespace marks) off the renderer
+ * main thread so large diffs can't freeze the UI. Grammars lazy-load per
+ * language inside the worker via the same shared loader map the in-thread
+ * fallback uses.
+ */
+
+import { runDiffTokenize } from "../components/Worktree/diffTokenizer";
+import type {
+  DiffTokenizeWorkerRequest,
+  DiffTokenizeWorkerResponse,
+} from "../components/Worktree/diffTokenizer";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+function postTypedMessage(message: DiffTokenizeWorkerResponse): void {
+  self.postMessage(message);
+}
+
+self.onmessage = (event: MessageEvent<DiffTokenizeWorkerRequest>) => {
+  const { id, ...request } = event.data;
+  void runDiffTokenize(request)
+    .then((result) => {
+      postTypedMessage({ id, ok: true, ...result });
+    })
+    .catch((err: unknown) => {
+      postTypedMessage({ id, ok: false, error: formatErrorMessage(err, "Tokenization failed") });
+    });
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1005,6 +1005,14 @@ export default defineConfig(({ command, mode }) => {
       alias: {
         "@": path.resolve(__dirname, "./src"),
         "@shared": path.resolve(__dirname, "./shared"),
+        // refractor/core eagerly imports parse-entities, whose browser-condition
+        // decode-named-character-reference touches `document` at module scope —
+        // that crashes the diff-tokenize Web Worker at startup. Pin the package's
+        // worker-safe default build (character-entities map, no DOM) everywhere.
+        "decode-named-character-reference": path.resolve(
+          __dirname,
+          "node_modules/decode-named-character-reference/index.js"
+        ),
       },
     },
     server: {


### PR DESCRIPTION
This is a big experimental PR that adds real multi-threading to Daintree. We've been saturating single event loops (the pty host worst of all) while the machine's cores sit mostly idle. This change moves the CPU-heavy work onto persistent worker thread pools in four areas:

- **pty host:** per-terminal output analysis (the headless xterm mirror, `ActivityMonitor` pattern detection, buffer serialization) now runs in a pool of worker threads behind an `AnalysisBackend` seam. The pty host event loop only does I/O: node-pty reads, batching, backpressure, and forwarding to the renderer.
- **Main process:** SQLite maintenance (`wal_checkpoint`, `quick_check`) and all six audit-ring snapshot writes run on a worker thread with a second WAL connection. A `PRAGMA user_version` fence guarantees a stale worker write can never clobber a newer main-thread write, including at shutdown.
- **Workspace host:** copytree context generation runs in a worker thread, and the blocking `execSync`/`realpathSync`/`readFileSync` calls on the git poll and watcher-arm hot paths are now fully async.
- **Renderer:** diff syntax highlighting (refractor tokenization) runs in a module Web Worker with an in-thread fallback.

Every area keeps the old single-threaded path and falls back to it automatically if a worker dies. Kill switches: `DAINTREE_DISABLE_ANALYSIS_WORKERS=1`, `DAINTREE_DISABLE_DB_WORKER=1`, `DAINTREE_DISABLE_COPYTREE_WORKER=1`. The analysis pool size can be forced with `DAINTREE_ANALYSIS_WORKERS=N` (the default scales with core count, capped at 6). Workers are never terminated at runtime because of the Electron 37+ worker-churn crash (`!flush_tasks_`), so the pools are persistent and die with their process.

The full suite passes (36,764 tests) and the production build is green. An external review pass found about a dozen concurrency bugs (ordering barriers, respawn state seeding, stale-write fencing, single-flight races) which were all fixed and regression-tested before this PR went up.

I still want to treat this as experimental until it's been run on real workloads. Worth watching: agent state detection accuracy after a worker crash, WAL size growth now that runtime checkpoints are passive, and whether the pty host actually feels lighter with a big terminal fleet.

One heads-up: this will conflict with #10919 if that lands first. Both touch the `TerminalProcess` pipeline, and whichever merges second needs a careful rebase.