### PR TITLE
fix(worktree): drop Continue/Abort rebase buttons from card

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -22,8 +22,6 @@ import {
 } from "../../store/projectSettingsStore";
 import { useWorktreeFilterStore } from "../../store/worktreeFilterStore";
 import { errorsClient, worktreeClient } from "@/clients";
-import { notify } from "@/lib/notify";
-import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { actionService } from "@/services/ActionService";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -669,63 +667,6 @@ export function WorktreeCard({
       .catch(() => {});
   }, [isActive, worktree.lastGitStatusCheckedAt]);
 
-  // Abort/continue a stuck blocking git operation (revert/rebase/merge/
-  // cherry-pick) directly from the card. The IPC handlers live in
-  // git-write.ts; this mirrors ReviewHubContent's wiring. After the call we
-  // refresh the worktree directly (not via handleRevalidate, which has a 10s
-  // freshness gate that would suppress this user-driven refresh) so the card
-  // recovers immediately instead of waiting for the filesystem watcher.
-  // Named function expressions so the Retry action can re-invoke the operation
-  // via the function's own internal name. Referencing the outer useCallback
-  // binding from inside itself is a React Compiler TDZ error ("accessed before
-  // it is declared"); the internal name is in scope throughout the body.
-  const handleAbortRepositoryOperation = useCallback(
-    async function runAbort() {
-      try {
-        await window.electron.git.abortRepositoryOperation(worktree.path);
-      } catch (err) {
-        // The git abort itself failed — the operation is still in progress.
-        notify({
-          type: "error",
-          title: "Abort failed",
-          message: formatErrorMessage(
-            err,
-            "Couldn't abort the operation. The working tree is unchanged."
-          ),
-          action: { label: "Retry", onClick: () => void runAbort() },
-          context: { eventKind: "git" },
-        });
-        throw err;
-      }
-      // Abort succeeded; a refresh failure is non-fatal (the watcher will pick up
-      // the cleared sentinel), so swallow it rather than report a false "failed".
-      await worktreeClient.refresh(worktree.id).catch(() => {});
-    },
-    [worktree.path, worktree.id]
-  );
-
-  const handleContinueRepositoryOperation = useCallback(
-    async function runContinue() {
-      try {
-        await window.electron.git.continueRepositoryOperation(worktree.path);
-      } catch (err) {
-        notify({
-          type: "error",
-          title: "Continue failed",
-          message: formatErrorMessage(
-            err,
-            "Couldn't continue the operation. Resolve any remaining conflicts and try again."
-          ),
-          action: { label: "Retry", onClick: () => void runContinue() },
-          context: { eventKind: "git" },
-        });
-        throw err;
-      }
-      await worktreeClient.refresh(worktree.id).catch(() => {});
-    },
-    [worktree.path, worktree.id]
-  );
-
   const handlePointerEnter = useCallback(() => {
     if (isActive || !worktree.lastGitStatusCheckedAt) return;
     if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
@@ -1011,8 +952,6 @@ export function WorktreeCard({
                   onOpenPlan: worktree.hasPlanFile ? () => setShowPlanViewer(true) : undefined,
                 }}
                 gitStateIndicator={gitStateIndicator}
-                onAbortRepositoryOperation={handleAbortRepositoryOperation}
-                onContinueRepositoryOperation={handleContinueRepositoryOperation}
                 menu={{
                   launchAgents,
                   recipes,

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -1,14 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AgentState, TerminalRecipe, WorktreeState } from "@/types";
-import type { RepoState } from "@shared/types";
 import type { GitStateIndicator } from "./hooks/useWorktreeStatus";
 import { cn } from "@/lib/utils";
 import { STATE_LABELS, STATE_PRIORITY } from "../terminalStateConfig";
 import { BranchLabel } from "../BranchLabel";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
-import { Sprout, Pin, BellOff, RefreshCw, Play, Ban } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { Sprout, Pin, BellOff, RefreshCw } from "lucide-react";
 import type { AggregateCounts } from "./MainWorktreeSummaryRows";
 import { IssueBadge } from "./IssueBadge";
 import { PRBadge } from "./PRBadge";
@@ -61,8 +58,6 @@ export interface WorktreeHeaderProps {
   };
 
   gitStateIndicator: GitStateIndicator | null;
-  onAbortRepositoryOperation?: () => Promise<void>;
-  onContinueRepositoryOperation?: () => Promise<void>;
 
   menu: {
     launchAgents: import("../WorktreeMenuItems").WorktreeLaunchAgentItem[];
@@ -220,135 +215,6 @@ function GitStatusFreshnessPill({
   );
 }
 
-// Blocking git operations the card can recover from inline.
-type BlockingOpKind = "reverting" | "rebasing" | "merging" | "cherry-picking";
-
-// Derived from worktree.repoState (the raw in-progress operation), NOT from
-// gitStateIndicator: the indicator gives "conflicted" priority over the
-// operation, so a revert/rebase/merge/cherry-pick that hit conflicts — the
-// canonical stuck case — would otherwise never surface the recovery row
-// (#10715). The Continue button stays disabled while conflicts remain.
-const REPO_STATE_TO_BLOCKING_KIND: Partial<Record<RepoState, BlockingOpKind>> = {
-  REVERTING: "reverting",
-  REBASING: "rebasing",
-  MERGING: "merging",
-  CHERRY_PICKING: "cherry-picking",
-};
-
-// User-facing operation noun (lowercase, for inline button/dialog copy).
-const BLOCKING_OP_LABEL: Record<BlockingOpKind, string> = {
-  reverting: "revert",
-  rebasing: "rebase",
-  merging: "merge",
-  "cherry-picking": "cherry-pick",
-};
-
-// Abort consequence copy, mirrored from ConflictPanel's ABORT_RESTORE_SUFFIX so
-// the dialog states the specific outcome rather than generic irreversibility.
-const BLOCKING_OP_ABORT_DESCRIPTION: Record<BlockingOpKind, string> = {
-  reverting:
-    "Discards the in-progress revert and restores the working tree to the state before it started.",
-  rebasing: "Discards the in-progress rebase and returns HEAD to the original branch tip.",
-  merging: "Discards the in-progress merge and restores the working tree to its pre-merge state.",
-  "cherry-picking":
-    "Discards the in-progress cherry-pick and restores the working tree to the state before it started.",
-};
-
-/**
- * Inline recovery row for a stuck blocking git operation (revert/rebase/merge/
- * cherry-pick) — surfaced on the card so the user isn't left with a permanent
- * state badge and no way out (#10715). Continue is disabled while conflicts
- * remain unresolved; Abort is a D1 destructive action gated by a ConfirmDialog.
- */
-function BlockingOpRow({
-  kind,
-  hasUnresolvedConflicts,
-  onAbort,
-  onContinue,
-}: {
-  kind: BlockingOpKind;
-  hasUnresolvedConflicts: boolean;
-  onAbort: () => Promise<void>;
-  onContinue: () => Promise<void>;
-}) {
-  const [isAbortOpen, setIsAbortOpen] = useState(false);
-  const [isAborting, setIsAborting] = useState(false);
-  const [isContinuing, setIsContinuing] = useState(false);
-  const label = BLOCKING_OP_LABEL[kind];
-
-  const handleAbort = useCallback(async () => {
-    setIsAborting(true);
-    try {
-      await onAbort();
-      setIsAbortOpen(false);
-    } catch {
-      // Error surfaced via notify() in the parent; keep the dialog open to retry.
-    } finally {
-      setIsAborting(false);
-    }
-  }, [onAbort]);
-
-  const handleContinue = useCallback(async () => {
-    setIsContinuing(true);
-    try {
-      await onContinue();
-    } catch {
-      // Error surfaced via notify() in the parent.
-    } finally {
-      setIsContinuing(false);
-    }
-  }, [onContinue]);
-
-  return (
-    <div className="mt-1.5 flex items-center gap-1.5">
-      <Button
-        type="button"
-        size="xs"
-        variant="outline"
-        loading={isContinuing}
-        disabled={hasUnresolvedConflicts || isAborting || isAbortOpen}
-        title={
-          hasUnresolvedConflicts ? "Resolve the remaining conflicts before continuing" : undefined
-        }
-        onClick={(e) => {
-          e.stopPropagation();
-          void handleContinue();
-        }}
-      >
-        <Play aria-hidden="true" />
-        Continue {label}
-      </Button>
-      <Button
-        type="button"
-        size="xs"
-        variant="ghost-danger"
-        disabled={isContinuing}
-        onClick={(e) => {
-          e.stopPropagation();
-          setIsAbortOpen(true);
-        }}
-      >
-        <Ban aria-hidden="true" />
-        Abort {label}
-      </Button>
-
-      <ConfirmDialog
-        isOpen={isAbortOpen}
-        onClose={() => {
-          if (!isAborting) setIsAbortOpen(false);
-        }}
-        title={`Abort ${label}?`}
-        description={BLOCKING_OP_ABORT_DESCRIPTION[kind]}
-        confirmLabel={`Abort ${label}`}
-        cancelLabel="Keep working"
-        onConfirm={() => void handleAbort()}
-        isConfirmLoading={isAborting}
-        variant="destructive"
-      />
-    </div>
-  );
-}
-
 export function WorktreeHeader({
   worktree,
   isActive,
@@ -380,8 +246,6 @@ export function WorktreeHeader({
   onCleanupWorktree,
   badges,
   gitStateIndicator,
-  onAbortRepositoryOperation,
-  onContinueRepositoryOperation,
   menu,
 }: WorktreeHeaderProps) {
   const recipeOptions = useMemo(
@@ -428,19 +292,6 @@ export function WorktreeHeader({
     (worktree.matchedForgeProviderId != null || worktree.linked?.providerId != null)
   );
   const isMainStandardLayout = !!(isMainOnStandardBranch && !hasDisplayTitle);
-
-  // Inline recovery for a stuck blocking git operation (revert/rebase/merge/
-  // cherry-pick). Mounts whenever an operation is in progress, even when it has
-  // conflicts (the badge then reads "conflicted" but the op is still abortable).
-  // Continue is gated on there being no unresolved conflicts so a half-resolved
-  // operation can't be advanced prematurely.
-  const blockingOpKind = worktree.repoState
-    ? (REPO_STATE_TO_BLOCKING_KIND[worktree.repoState] ?? null)
-    : null;
-  const hasUnresolvedConflicts = !!worktree.worktreeChanges?.changes?.some(
-    (c) => c.status === "conflicted"
-  );
-  const showBlockingOpRow = !isCollapsed && blockingOpKind !== null;
 
   const prState = worktree.linked?.pr?.state;
   const isPrLive = prState !== undefined && prState !== "closed" && prState !== "declined";
@@ -608,18 +459,6 @@ export function WorktreeHeader({
           handleLaunchAgent={handleLaunchAgent}
         />
       </div>
-
-      {showBlockingOpRow &&
-        blockingOpKind &&
-        onAbortRepositoryOperation &&
-        onContinueRepositoryOperation && (
-          <BlockingOpRow
-            kind={blockingOpKind}
-            hasUnresolvedConflicts={hasUnresolvedConflicts}
-            onAbort={onAbortRepositoryOperation}
-            onContinue={onContinueRepositoryOperation}
-          />
-        )}
 
       {!isCollapsed && isMainStandardLayout && (
         <MainWorktreeSecondaryRow

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1494,42 +1494,12 @@ describe("WorktreeHeader upstream sync indicator", () => {
   });
 });
 
-describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
-  // The row mounts off worktree.repoState (the raw in-progress operation), NOT
-  // gitStateIndicator — so it surfaces even when conflicts make the badge read
-  // "conflicted". gitStateIndicator only drives the inert badge label.
-  function conflictedChanges(): WorktreeState["worktreeChanges"] {
-    return {
-      worktreeId: "test-wt",
-      rootPath: "/tmp/test-wt",
-      changedFileCount: 1,
-      changes: [{ path: "a.ts", status: "conflicted", insertions: null, deletions: null }],
-    };
-  }
-
-  function blockingHeader(
-    repoState: WorktreeState["repoState"],
-    overrides: Partial<Omit<WorktreeHeaderProps, "worktree">> & {
-      worktree?: Partial<WorktreeState>;
-    } = {}
-  ) {
-    const { worktree: worktreeOverride, ...rest } = overrides;
-    return renderHeader({
-      worktree: { ...baseWorktree, repoState, ...(worktreeOverride ?? {}) },
-      onAbortRepositoryOperation: vi.fn().mockResolvedValue(undefined),
-      onContinueRepositoryOperation: vi.fn().mockResolvedValue(undefined),
-      ...rest,
-    });
-  }
-
-  // getAllByRole(...)[i] is `HTMLElement | undefined` under noUncheckedIndexedAccess.
-  function nthButton(name: string, index: number): HTMLElement {
-    const els = screen.getAllByRole("button", { name });
-    const el = index < 0 ? els[els.length + index] : els[index];
-    if (!el) throw new Error(`button "${name}" at index ${index} not found`);
-    return el;
-  }
-
+describe("WorktreeHeader blocking-op passive indicator (#10921)", () => {
+  // The interactive Continue/Abort recovery row (#10715) was removed: agents run
+  // rebases/merges in their own PTY, so a second git process from the card either
+  // collides with the live operation or gates on stale (frozen-during-op) status.
+  // The card now only surfaces the passive gitStateIndicator badge; the deliberate
+  // takeover surface lives in the Review Hub's ConflictPanel.
   const BLOCKING = [
     { repoState: "REVERTING", label: "revert" },
     { repoState: "REBASING", label: "rebase" },
@@ -1537,86 +1507,39 @@ describe("WorktreeHeader blocking-op recovery row (#10715)", () => {
     { repoState: "CHERRY_PICKING", label: "cherry-pick" },
   ] as const;
 
-  it.each(BLOCKING)("renders Continue + Abort for $repoState", ({ repoState, label }) => {
-    blockingHeader(repoState);
-    expect(screen.getByRole("button", { name: `Continue ${label}` })).toBeTruthy();
-    expect(screen.getByRole("button", { name: `Abort ${label}` })).toBeTruthy();
-  });
-
-  it("renders the row for an in-progress operation that has conflicts (the canonical stuck case)", () => {
-    blockingHeader("REVERTING", { worktree: { worktreeChanges: conflictedChanges() } });
-    // Row still mounts even though the badge would read "conflicted"...
-    expect(screen.getByRole("button", { name: "Abort revert" })).toBeTruthy();
-    // ...and Continue is disabled until the conflicts are resolved.
-    const cont = screen.getByRole("button", { name: "Continue revert" });
-    expect(cont.hasAttribute("disabled")).toBe(true);
-  });
-
-  it("does not render the row when no operation is in progress", () => {
-    renderHeader({
-      worktree: { ...baseWorktree, repoState: undefined, isDetached: true },
-      onAbortRepositoryOperation: vi.fn(),
-      onContinueRepositoryOperation: vi.fn(),
-    });
+  it.each(BLOCKING)("renders no Continue/Abort buttons for $repoState", ({ repoState }) => {
+    renderHeader({ worktree: { ...baseWorktree, repoState } });
     expect(screen.queryByRole("button", { name: /^Continue / })).toBeNull();
     expect(screen.queryByRole("button", { name: /^Abort / })).toBeNull();
   });
 
-  it("does not render the row when collapsed", () => {
-    blockingHeader("REVERTING", { isCollapsed: true });
-    expect(screen.queryByRole("button", { name: "Continue revert" })).toBeNull();
-  });
-
-  it("does not render the row when callbacks are absent", () => {
-    renderHeader({ worktree: { ...baseWorktree, repoState: "REVERTING" } });
-    expect(screen.queryByRole("button", { name: "Continue revert" })).toBeNull();
-  });
-
-  it("Abort opens a destructive ConfirmDialog and confirming invokes onAbort", async () => {
-    const onAbort = vi.fn().mockResolvedValue(undefined);
-    blockingHeader("REVERTING", { onAbortRepositoryOperation: onAbort });
-    // The inline Abort button only opens the dialog — it must not call IPC directly.
-    fireEvent.click(nthButton("Abort revert", 0));
-    expect(onAbort).not.toHaveBeenCalled();
-
-    // The dialog's confirm button carries the same verb-noun label; it's the
-    // last "Abort revert" button now that the dialog has opened.
-    fireEvent.click(nthButton("Abort revert", -1));
-    await Promise.resolve();
-    expect(onAbort).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps the abort dialog open when the abort fails so the user can retry", async () => {
-    const onAbort = vi.fn().mockRejectedValue(new Error("nope"));
-    blockingHeader("REVERTING", { onAbortRepositoryOperation: onAbort });
-    fireEvent.click(nthButton("Abort revert", 0));
-    fireEvent.click(nthButton("Abort revert", -1));
-    await Promise.resolve();
-    await Promise.resolve();
-    // Dialog still mounted (both trigger + confirm present) and not stuck loading.
-    expect(screen.getAllByRole("button", { name: "Abort revert" }).length).toBeGreaterThan(1);
-    expect(onAbort).toHaveBeenCalledTimes(1);
-  });
-
-  it("Continue invokes onContinue when there are no unresolved conflicts", async () => {
-    const onContinue = vi.fn().mockResolvedValue(undefined);
-    blockingHeader("REBASING", { onContinueRepositoryOperation: onContinue });
-    const btn = screen.getByRole("button", { name: "Continue rebase" });
-    expect(btn.hasAttribute("disabled")).toBe(false);
-    fireEvent.click(btn);
-    await Promise.resolve();
-    expect(onContinue).toHaveBeenCalledTimes(1);
-  });
-
-  it("Continue is disabled while unresolved conflicts remain", () => {
-    const onContinue = vi.fn();
-    blockingHeader("REBASING", {
-      worktree: { worktreeChanges: conflictedChanges() },
-      onContinueRepositoryOperation: onContinue,
+  it("still renders the passive gitStateIndicator badge for an in-progress operation", () => {
+    renderHeader({
+      worktree: { ...baseWorktree, repoState: "REBASING" },
+      gitStateIndicator: { kind: "rebasing", label: "rebasing", tone: "warning" },
     });
-    const btn = screen.getByRole("button", { name: "Continue rebase" });
-    expect(btn.hasAttribute("disabled")).toBe(true);
-    fireEvent.click(btn);
-    expect(onContinue).not.toHaveBeenCalled();
+    expect(screen.getByText("rebasing")).toBeDefined();
+    // ...and no interactive recovery buttons alongside it.
+    expect(screen.queryByRole("button", { name: /^Continue / })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Abort / })).toBeNull();
+  });
+
+  it("renders no recovery buttons even when the operation has conflicts", () => {
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        repoState: "REVERTING",
+        worktreeChanges: {
+          worktreeId: "test-wt",
+          rootPath: "/tmp/test-wt",
+          changedFileCount: 1,
+          changes: [{ path: "a.ts", status: "conflicted", insertions: null, deletions: null }],
+        },
+      },
+      gitStateIndicator: { kind: "conflicted", label: "conflicted", tone: "error" },
+    });
+    expect(screen.getByText("conflicted")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /^Continue / })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Abort / })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Removes the interactive `Continue rebase` / `Abort rebase` buttons (the `BlockingOpRow` component) from the worktree card, with related cleanup in `WorktreeCard.tsx`.
- In this app, rebases and merges are almost always run by a coding agent inside its own terminal (PTY). A second git process fired from the card either collides with that live operation, or acts on stale git status, since status polling is intentionally frozen during a live operation to avoid contending for `.git/index.lock`. Either way, the buttons mostly can't do what they say they can.
- The row was originally added for a rare case (#10715) where Daintree itself started and left a rebase/merge stuck. That case is too rare to justify buttons that look clickable but usually fail or do nothing useful.

Resolves #10921

## Changes

- Dropped the interactive recovery row from `src/components/Worktree/WorktreeCard/WorktreeHeader.tsx` and `src/components/Worktree/WorktreeCard.tsx`.
- Kept the passive `gitStateIndicator` badge, so an in-progress rebase/merge is still visible on the card, just not interactive.
- Scope is card-only. The Review Hub's `ConflictPanel` is a separate, coherent manual conflict resolver and isn't touched, the issue's "both surfaces" note rested on a false premise that it shares `BlockingOpRow`. The underlying IPC methods `abortRepositoryOperation` and `continueRepositoryOperation` are left intact for `ConflictPanel`'s use.

## Testing

- Rewrote the recovery-row tests in `WorktreeHeader.test.tsx` as passive-indicator assertions.
- `WorktreeHeader.test.tsx` and `WorktreeCardInteraction.test.tsx` pass (122 tests).
- Prettier clean, no new lint issues.