### PR TITLE
fix(terminal): persist launch env so restored sessions keep their provider (#10922)

### DIFF
--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -151,6 +151,10 @@ export const TerminalSnapshotSchema = z
     agentPresetId: z.string().optional(),
     agentPresetColor: z.string().optional(),
     originalPresetId: z.string().optional(),
+    // Captured launch env replayed on restore so a session keeps its provider
+    // environment (#10922). Re-sanitized on the renderer serialize/respawn
+    // boundary; validated here only as a string map.
+    env: z.record(z.string(), z.string()).optional(),
     isUsingFallback: z.boolean().optional(),
     fallbackChainIndex: z.number().int().nonnegative().optional(),
     pluginId: z.string().optional(),

--- a/shared/types/ipc/terminal.ts
+++ b/shared/types/ipc/terminal.ts
@@ -121,6 +121,8 @@ export interface TerminalState {
   agentPresetColor?: string;
   /** Original user-selected preset ID; unchanged across fallback hops */
   originalPresetId?: string;
+  /** Captured launch env replayed on restore so a session keeps its provider environment (#10922) */
+  env?: Record<string, string>;
   /** Whether this panel is currently running on a fallback preset */
   isUsingFallback?: boolean;
   /** How many fallback hops have been consumed */

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -334,6 +334,14 @@ export interface PtyPanelData extends BasePanelData {
   lastCommand?: string;
   /** Command to execute after shell starts (e.g., 'claude --model sonnet-4' for AI agents) */
   command?: string;
+  /**
+   * Caller-resolved launch environment (preset/recipe/caller layers) captured at
+   * spawn time. Persisted so a restored session replays the same provider env it
+   * launched with instead of re-deriving from a preset that may no longer resolve
+   * (#10922). Sanitized via `sanitizeAgentEnv` on the serialize/restore boundary.
+   * The live global/project env layer is re-merged fresh at spawn, not stored here.
+   */
+  env?: Record<string, string>;
   /** Counter incremented on restart to trigger React re-render without unmounting parent */
   restartKey?: number;
   /** Guard flag to prevent auto-trash during restart flow (exit event race condition) */

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -116,6 +116,13 @@ export interface PanelSnapshot {
   agentSessionId?: string;
   /** Process-level flags captured at launch time, persisted for session resume */
   agentLaunchFlags?: string[];
+  /**
+   * Caller-resolved launch env (preset/recipe/caller layers) captured at launch,
+   * persisted so a restored session replays the same provider environment it
+   * launched with rather than re-deriving it from a preset that may no longer
+   * resolve (#10922). Sanitized via `sanitizeAgentEnv` on write and read.
+   */
+  env?: Record<string, string>;
   /** Model ID selected at launch time for per-panel model selection */
   agentModelId?: string;
   /** Preset ID active at launch time, used to restore colored icon on reload */

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -419,6 +419,12 @@ function TerminalPaneComponent({
       agentModelId: panel.agentModelId,
       agentPresetId: panel.agentPresetId,
       env: presetEnv,
+      // Carry the gate panel's persistence policy through the re-launch. Since
+      // env is now persisted onto the panel (#10922), dropping these would let a
+      // session-scoped secret (e.g. DAINTREE_MCP_TOKEN on a help session, which
+      // launches excluded) leak into the on-disk snapshot on "Run anyway".
+      excludeFromPersistence: panel.excludeFromPersistence,
+      removeOnExit: panel.removeOnExit,
     });
   };
 

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -52,6 +52,9 @@ const PTY_FIELD_CLASSIFICATION = {
   agentPresetId: true,
   agentPresetColor: true,
   originalPresetId: true,
+  // Captured launch env replayed on restore so a session keeps its provider
+  // environment (#10922); sanitized on the serialize/restore boundary.
+  env: true,
   isUsingFallback: true,
   fallbackChainIndex: true,
   agentState: true,
@@ -269,6 +272,7 @@ const terminalFixture: PtySerializeInput = {
   agentPresetId: "blue-provider",
   agentPresetColor: "#3366ff",
   originalPresetId: "primary-provider",
+  env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" },
   isUsingFallback: true,
   fallbackChainIndex: 1,
   agentState: "idle",

--- a/src/panels/terminal/__tests__/serializer.test.ts
+++ b/src/panels/terminal/__tests__/serializer.test.ts
@@ -112,6 +112,49 @@ describe("serializePtyPanel — agentPresetColor (Bug: not serialized)", () => {
   });
 });
 
+// Launch env persistence (#10922): a terminal launched via a preset/recipe
+// pointing Claude Code at an alternate provider (Z.AI/GLM) must replay the same
+// provider env on restore. The serializer captures the sanitized launch env so
+// the restored session doesn't silently fall back to the default provider.
+describe("serializePtyPanel — launch env (#10922)", () => {
+  it("serializes safe provider env keys into the snapshot", () => {
+    const panel = makePanel({
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "glm-5.2",
+      },
+    });
+    const snapshot = serializePtyPanel(panel);
+    expect(snapshot.env).toEqual({
+      ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "glm-5.2",
+    });
+  });
+
+  it("omits env entirely when the panel carries none", () => {
+    const snapshot = serializePtyPanel(makePanel());
+    expect("env" in snapshot).toBe(false);
+  });
+
+  it("strips dangerous keys and injection values, keeping safe ones", () => {
+    const panel = makePanel({
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+        PATH: "/evil/bin",
+        EVIL: "$(rm -rf /)",
+      } as Record<string, string>,
+    });
+    const snapshot = serializePtyPanel(panel);
+    expect(snapshot.env).toEqual({ ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" });
+  });
+
+  it("omits env when sanitization leaves nothing safe", () => {
+    const panel = makePanel({ env: { PATH: "/evil/bin" } as Record<string, string> });
+    const snapshot = serializePtyPanel(panel);
+    expect("env" in snapshot).toBe(false);
+  });
+});
+
 // "directing" is a renderer-only ephemeral state owned by
 // TerminalAgentStateController (#5832). Persisting it could resurrect a stuck
 // indicator on the next reload because setAgentState explicitly ignores

--- a/src/panels/terminal/serializer.ts
+++ b/src/panels/terminal/serializer.ts
@@ -1,9 +1,14 @@
+import { sanitizeAgentEnv } from "@/config/agents";
 import type { PtyPanelData } from "@shared/types/panel";
 import type { PanelSnapshot } from "@shared/types/project";
 
 export type PtySerializeInput = PtyPanelData;
 
 export function serializePtyPanel(t: PtySerializeInput): Partial<PanelSnapshot> {
+  // Sanitize the captured launch env on write so a compromised/edited on-disk
+  // snapshot can't smuggle PATH/LD_PRELOAD or shell-injection values back in on
+  // the next restore (#10922). Omitted entirely when nothing safe remains.
+  const env = sanitizeAgentEnv(t.env);
   return {
     launchAgentId: t.launchAgentId,
     cwd: t.cwd,
@@ -11,6 +16,7 @@ export function serializePtyPanel(t: PtySerializeInput): Partial<PanelSnapshot> 
     ...(t.exitBehavior !== undefined && { exitBehavior: t.exitBehavior }),
     ...(t.agentSessionId && { agentSessionId: t.agentSessionId }),
     ...(t.agentLaunchFlags?.length && { agentLaunchFlags: t.agentLaunchFlags }),
+    ...(env && { env }),
     ...(t.agentModelId && { agentModelId: t.agentModelId }),
     ...(t.agentPresetId && { agentPresetId: t.agentPresetId }),
     ...(t.agentPresetColor && { agentPresetColor: t.agentPresetColor }),

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -360,10 +360,11 @@ export const createAddPanelActions = (
       agentPresetId: options.agentPresetId,
       agentPresetColor: options.agentPresetColor,
       originalPresetId: options.originalPresetId ?? options.agentPresetId,
-      // Caller-resolved launch env (preset/recipe/caller layers) captured so a
-      // restored session replays the SAME provider environment it launched with
-      // (#10922). The live global/project env re-merge happens fresh at spawn
-      // time below, so only this non-live layer is preserved on the panel.
+      // Caller-resolved launch env captured so a restored session replays the
+      // SAME provider environment it launched with (#10922). This is the
+      // launcher's merged env (agent global + preset/recipe + caller layers); the
+      // ambient global/project env is still re-fetched fresh at spawn time below
+      // and layered UNDER this, so only the launch-resolved layer is frozen here.
       ...(options.env && { env: options.env }),
       isUsingFallback: options.isUsingFallback,
       fallbackChainIndex: options.fallbackChainIndex,

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -360,6 +360,11 @@ export const createAddPanelActions = (
       agentPresetId: options.agentPresetId,
       agentPresetColor: options.agentPresetColor,
       originalPresetId: options.originalPresetId ?? options.agentPresetId,
+      // Caller-resolved launch env (preset/recipe/caller layers) captured so a
+      // restored session replays the SAME provider environment it launched with
+      // (#10922). The live global/project env re-merge happens fresh at spawn
+      // time below, so only this non-live layer is preserved on the panel.
+      ...(options.env && { env: options.env }),
       isUsingFallback: options.isUsingFallback,
       fallbackChainIndex: options.fallbackChainIndex,
       sessionLostOnRestore: options.sessionLostOnRestore,

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1638,6 +1638,126 @@ describe("buildArgsForReconnectedFallback — agent launch flags", () => {
   });
 });
 
+// ── persisted launch env replay (#10922) ─────────────────────────────────────
+// A session launched via a preset/recipe pointing Claude Code at an alternate
+// provider (Z.AI/GLM) must replay the SAME provider env on restore, even when
+// that preset/recipe no longer resolves in the current store. The snapshot env
+// is preferred over live preset re-resolution.
+describe("buildArgsForRespawn — persisted launch env (#10922)", () => {
+  beforeEach(() => {
+    getMergedPresetMock.mockReset();
+  });
+
+  it("prefers the saved snapshot env over live preset re-resolution", () => {
+    // Live resolution would yield {A: "live", B: "liveB"}; the persisted launch
+    // env must win wholesale (it already captured every launch layer).
+    getMergedPresetMock.mockReturnValue({
+      id: "user-aaa",
+      name: "Preset",
+      env: { A: "live", B: "liveB" },
+    });
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentPresetId: "user-aaa",
+        agentSessionId: "sess-1",
+        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic", A: "saved" },
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.env).toEqual({
+      ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic",
+      A: "saved",
+    });
+    // The live-only key must NOT leak in — saved env replaces, not merges.
+    expect(result.env).not.toHaveProperty("B");
+  });
+
+  it("replays the saved env even when the originating preset is now stale", () => {
+    // The exact recipe/deleted-preset failure mode from the issue: no preset
+    // resolves, so live re-resolution is empty, but the launch env survives.
+    getMergedPresetMock.mockReturnValue(undefined);
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentPresetId: "user-deleted",
+        agentSessionId: "sess-1",
+        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" },
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.env).toEqual({ ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" });
+    // Stale-preset split-brain guard still clears the visual preset identity.
+    expect(result.agentPresetId).toBeUndefined();
+  });
+
+  it("falls back to live preset env for legacy snapshots without saved env", () => {
+    getMergedPresetMock.mockReturnValue({
+      id: "user-aaa",
+      name: "Preset",
+      env: { A: "live" },
+    });
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentPresetId: "user-aaa",
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.env).toEqual({ A: "live" });
+  });
+
+  it("falls back to live preset env when saved env sanitizes to nothing safe", () => {
+    getMergedPresetMock.mockReturnValue({
+      id: "user-aaa",
+      name: "Preset",
+      env: { A: "live" },
+    });
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentPresetId: "user-aaa",
+        // Non-string values are dropped by sanitizeAgentEnv → no safe entries.
+        env: { ANTHROPIC_BASE_URL: 123 as unknown as string },
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.env).toEqual({ A: "live" });
+  });
+});
+
 // ── preset override path ──────────────────────────────────────────────────────
 
 describe("buildArgsForRespawn — preset overrides", () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1756,6 +1756,135 @@ describe("buildArgsForRespawn — persisted launch env (#10922)", () => {
     );
     expect(result.env).toEqual({ A: "live" });
   });
+
+  it("falls back to live preset env when saved env is an empty object", () => {
+    getMergedPresetMock.mockReturnValue({ id: "user-aaa", name: "Preset", env: { A: "live" } });
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentPresetId: "user-aaa",
+        env: {},
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.env).toEqual({ A: "live" });
+  });
+
+  it("replays saved env for a recipe-launched agent with no preset id", () => {
+    // Recipe inline env has no preset identity to re-resolve — the persisted
+    // snapshot env is the only way to recover it.
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-1",
+        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" },
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      undefined
+    );
+    expect(result.env).toEqual({ ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" });
+    // No preset was consulted (no agentPresetId on the saved snapshot).
+    expect(getMergedPresetMock).not.toHaveBeenCalled();
+  });
+
+  it("replays saved env for a non-agent terminal", () => {
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        cwd: "/p",
+        location: "grid",
+        env: { MY_VAR: "value" },
+      },
+      "terminal",
+      "/p",
+      { agents: {} },
+      false,
+      undefined
+    );
+    expect(result.env).toEqual({ MY_VAR: "value" });
+  });
+
+  it("keeps the saved env alongside the sessionLostOnRestore signal", () => {
+    // Session can't be resumed → fresh launch + signal, but the provider env
+    // must still replay so the fresh session lands on the right provider.
+    buildResumeCommandMock.mockReturnValue(undefined);
+    const result = buildArgsForRespawn(
+      {
+        id: "t1",
+        kind: "terminal",
+        agentId: "claude",
+        cwd: "/p",
+        location: "grid",
+        agentSessionId: "sess-expired",
+        agentLaunchFlags: ["--flag"],
+        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" },
+      },
+      "agent",
+      "/p",
+      { agents: { claude: {} } },
+      false,
+      "/tmp"
+    );
+    expect(result.sessionLostOnRestore).toBe(true);
+    expect(result.env).toEqual({ ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" });
+  });
+});
+
+// Reconnect paths attach UI state to a still-live PTY (whose process env is
+// already fixed), but they must still carry the captured env forward so the
+// re-serialized snapshot keeps it — otherwise a project switch / renderer reload
+// silently drops env and reintroduces the provider swap on the next full restart.
+describe("reconnect builders forward the captured launch env (#10922)", () => {
+  it("buildArgsForBackendTerminal forwards sanitized saved.env", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", launchAgentId: "claude" },
+      {
+        id: "t1",
+        location: "grid",
+        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic", BAD: 1 as unknown as string },
+      },
+      "/p"
+    );
+    expect(result.env).toEqual({ ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" });
+  });
+
+  it("buildArgsForReconnectedFallback forwards sanitized saved.env", () => {
+    const result = buildArgsForReconnectedFallback(
+      { id: "t1", cwd: "/p" },
+      {
+        id: "t1",
+        location: "grid",
+        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" },
+      },
+      "/p"
+    );
+    expect(result.env).toEqual({ ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic" });
+  });
+
+  it("buildArgsForBackendTerminal omits env when the snapshot has none", () => {
+    const result = buildArgsForBackendTerminal(
+      { id: "t1", cwd: "/p", kind: "terminal", launchAgentId: "claude" },
+      { id: "t1", location: "grid" },
+      "/p"
+    );
+    expect(result.env).toBeUndefined();
+  });
 });
 
 // ── preset override path ──────────────────────────────────────────────────────

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1746,7 +1746,7 @@ describe("buildArgsForRespawn — persisted launch env (#10922)", () => {
         location: "grid",
         agentPresetId: "user-aaa",
         // Non-string values are dropped by sanitizeAgentEnv → no safe entries.
-        env: { ANTHROPIC_BASE_URL: 123 as unknown as string },
+        env: { ANTHROPIC_BASE_URL: 123 },
       },
       "agent",
       "/p",
@@ -1857,7 +1857,7 @@ describe("reconnect builders forward the captured launch env (#10922)", () => {
       {
         id: "t1",
         location: "grid",
-        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic", BAD: 1 as unknown as string },
+        env: { ANTHROPIC_BASE_URL: "https://api.z.ai/api/anthropic", BAD: 1 },
       },
       "/p"
     );

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -4,7 +4,7 @@ import type { BrowserHistory } from "@shared/types/browser";
 import type { PanelExitBehavior } from "@shared/types/panel";
 import type { AddPanelOptionsBase } from "@shared/types/addPanelOptions";
 import type { BuiltInAgentId } from "@shared/config/agentIds";
-import { getAgentConfig } from "@/config/agents";
+import { getAgentConfig, sanitizeAgentEnv } from "@/config/agents";
 import type { AgentPreset } from "@/config/agents";
 import {
   generateAgentCommand,
@@ -94,6 +94,14 @@ export interface SavedTerminalData {
   agentPresetId?: string;
   agentPresetColor?: string;
   originalPresetId?: string;
+  /**
+   * Caller-resolved launch env captured at launch time (#10922). Preferred over
+   * live preset re-resolution on respawn so a restored session replays the same
+   * provider environment it launched with. Typed as `unknown`-valued because it
+   * is untrusted on-disk JSON — sanitized via `sanitizeAgentEnv` at the read
+   * boundary before use.
+   */
+  env?: Record<string, unknown>;
   isUsingFallback?: boolean;
   fallbackChainIndex?: number;
   /** @deprecated pre-#5459 legacy key; read-only fallback, never written. */
@@ -555,7 +563,12 @@ export function buildArgsForRespawn(
     isUsingFallback: presetWasStale ? undefined : saved.isUsingFallback,
     fallbackChainIndex: presetWasStale ? undefined : saved.fallbackChainIndex,
     sessionLostOnRestore: sessionLostOnRestore || undefined,
-    env: presetEnv,
+    // Prefer the launch env captured in the snapshot (#10922) so the restored
+    // session replays the same provider environment (e.g. a Z.AI/GLM preset or a
+    // recipe's inline env) even when that preset/recipe no longer resolves in the
+    // current store. Falls back to live re-resolution for legacy snapshots saved
+    // before env was persisted, or when the saved env sanitizes to nothing safe.
+    env: sanitizeAgentEnv(saved.env) ?? presetEnv,
     extensionState: saved.extensionState,
     pluginId: saved.pluginId,
     restore: true,

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -303,6 +303,11 @@ export function buildArgsForBackendTerminal(
       backendTerminal.originalAgentPresetId ??
       readPresetId(saved) ??
       backendTerminal.agentPresetId,
+    // Carry the captured launch env forward so a reconnect (project switch /
+    // renderer reload to a still-live PTY) re-serializes the snapshot WITH env,
+    // instead of dropping it and reintroducing the provider swap on the next
+    // full restart (#10922). Not used to spawn here — the PTY already has it.
+    env: sanitizeAgentEnv(saved.env),
     isUsingFallback: saved.isUsingFallback,
     fallbackChainIndex: saved.fallbackChainIndex,
     extensionState: saved.extensionState,
@@ -370,6 +375,10 @@ export function buildArgsForReconnectedFallback(
       reconnectedTerminal.originalAgentPresetId ??
       readPresetId(saved) ??
       reconnectedTerminal.agentPresetId,
+    // Carry the captured launch env forward so a reconnect re-serializes the
+    // snapshot WITH env rather than dropping it and reintroducing the provider
+    // swap on the next full restart (#10922). Not used to spawn — PTY has it.
+    env: sanitizeAgentEnv(saved.env),
     isUsingFallback: saved.isUsingFallback,
     fallbackChainIndex: saved.fallbackChainIndex,
     extensionState: saved.extensionState,
@@ -523,8 +532,10 @@ export function buildArgsForRespawn(
   // Stale-preset split-brain: when saved.agentPresetId was set but the preset
   // no longer resolves (deleted custom preset, CCR route removed from config),
   // clear agentPresetId/agentPresetColor and strip the preset suffix from the
-  // title so the respawned panel doesn't lie about its identity — it's now
-  // running default env/command, so it should look like default.
+  // title so the respawned panel doesn't lie about its preset identity. Note the
+  // captured launch env (`env` below) is still replayed independently (#10922) —
+  // a deleted preset shouldn't silently swap a live session's provider — so the
+  // command/env are not necessarily "default" here, only the preset badge is.
   presetWasStale = isAgentPanel && presetWasStale;
   const respawnAgentPresetId = presetWasStale ? undefined : savedPresetIdForRespawn;
   const respawnAgentPresetColor = presetWasStale


### PR DESCRIPTION
## Summary

- Restored terminal sessions launched via a preset or recipe pointed at the Z.AI provider (GLM models like `glm-5.2`) were losing their provider environment after an app restart, silently resuming on default Anthropic and falling back to `opus`.
- Root cause: the launch environment was transient. It was built at spawn time but never stored on the panel or serialized, so on restore the code tried to rebuild it purely from the preset id, which can't reproduce a recipe's inline env and comes up empty when the preset is stale or unloaded.
- Fix: capture the caller-resolved launch env on the panel, persist it, and replay it on respawn, preferred over live preset re-resolution, even when the originating preset or recipe no longer resolves. The env is sanitized with `sanitizeAgentEnv` on both write and read.

Resolves #10922

## Changes

- `shared/types/panel.ts`, `shared/types/project.ts`, `shared/types/ipc/terminal.ts`, `electron/schemas/ipc.ts`: add an `env` field to `PtyPanelData`, `PanelSnapshot`, `TerminalState`, and `TerminalSnapshotSchema`.
- `src/store/slices/panelRegistry/addPanel.ts`: store `options.env` on the panel.
- `src/panels/terminal/serializer.ts`: serialize `env` at the write boundary, sanitized.
- `src/utils/stateHydration/statePatcher.ts`: add `env` to `SavedTerminalData`; `buildArgsForRespawn` now prefers `saved.env`, forwarded through the reconnect builders.
- `src/components/Terminal/TerminalPane.tsx`: preserve `excludeFromPersistence` and `removeOnExit` on the "Run anyway" path, to avoid a session secret leak now that env persists.
- Added 15 tests across `serializer.test.ts`, `statePatcher.test.ts`, and `registry.fieldcoverage.test.ts`.

## Testing

- 212 targeted tests pass locally.
- Own-file prettier and eslint clean (0 errors).
- Reviewed twice by Codex (adversarial pass and verification pass), no remaining issues.