### PR TITLE
fix(activity): don't flip agent state on mouse-report scroll

### DIFF
--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -908,10 +908,19 @@ export class ActivityMonitor {
       return;
     }
 
-    // Focus-triggered TUI redrawn during a suppression window is not new work
-    // (#8865). Skip idle→busy promotion until the window expires; lastActivity
-    // is still refreshed above so the idle timer doesn't drift.
-    if (this.state !== "busy" && result.stateHint === "busy" && !this.isFocusSuppressed(now)) {
+    // Focus-triggered TUI redraw during a suppression window is not new work
+    // (#8865), and a redraw driven by recent user input — e.g. mouse-report
+    // bytes emitted while scrolling a mouse-reporting TUI — is likewise not the
+    // agent working (#10925). Both stamp state that other promotion paths in
+    // this file already consult; skip idle→busy promotion until the windows
+    // expire. lastActivity is still refreshed above so the idle timer doesn't
+    // drift.
+    if (
+      this.state !== "busy" &&
+      result.stateHint === "busy" &&
+      !this.isFocusSuppressed(now) &&
+      !this.inputTracker.isRecentUserInput(now)
+    ) {
       this.becomeBusy({ trigger: "output" }, now);
       return;
     }
@@ -1154,6 +1163,14 @@ export class ActivityMonitor {
 
   isFocusSuppressed(now: number = Date.now()): boolean {
     return this.focusSuppressUntil > 0 && now < this.focusSuppressUntil;
+  }
+
+  // Public mirror of the private inputTracker check so the parallel
+  // agentOutputTemperature promotion paths (TerminalProcess/AnalysisSession)
+  // can gate on recent user input the same way this monitor's own paths do
+  // (#10925). Mouse-report bytes from scrolling a TUI stamp lastUserInputAt.
+  isRecentUserInput(now: number = Date.now()): boolean {
+    return this.inputTracker.isRecentUserInput(now);
   }
 
   getState(): "busy" | "idle" {

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -4095,6 +4095,104 @@ describe("ActivityMonitor", () => {
     });
   });
 
+  describe("Mouse-report input suppression (Issue #10925)", () => {
+    it("does NOT promote idle→busy from redraws that coincide with recent scroll input", () => {
+      const onStateChange = vi.fn();
+      let visible = "waiting 0";
+      const monitor = new ActivityMonitor("agent-mouse-1", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => [visible],
+        getCursorLine: () => visible,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      onStateChange.mockClear();
+
+      // Each wheel tick forwards an SGR mouse-report sequence (stamping
+      // lastUserInputAt via InputTracker) and the mouse-reporting TUI redraws
+      // its alt-screen. This is the exact sustained-tail-change rhythm that
+      // promotes idle→busy in "samples only the visible tail", but every redraw
+      // lands inside the 1s input-echo window, so the agent must stay idle. The
+      // companion recovery test below runs the same rhythm without recent input
+      // and reaches busy, proving this suppression isn't passing trivially.
+      const wheel = "\x1b[<64;10;5M";
+      for (let i = 1; i <= 4; i++) {
+        monitor.onInput(wheel);
+        visible = `redraw ${i}`;
+        monitor.onData(visible);
+        vi.advanceTimersByTime(700);
+      }
+
+      expect(monitor.getState()).toBe("idle");
+      const busyCalls = onStateChange.mock.calls.filter((call) => call[2] === "busy");
+      expect(busyCalls.length).toBe(0);
+
+      monitor.dispose();
+    });
+
+    it("still promotes idle→busy from sustained output once scrolling stops and the echo window expires", () => {
+      const onStateChange = vi.fn();
+      let visible = "waiting 0";
+      const monitor = new ActivityMonitor("agent-mouse-2", 1000, onStateChange, {
+        agentId: "claude",
+        getVisibleLines: () => [visible],
+        getCursorLine: () => visible,
+        initialState: "idle",
+        skipInitialStateEmit: true,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(100);
+      onStateChange.mockClear();
+
+      // User scrolls briefly (two wheel ticks), then stops.
+      const wheel = "\x1b[<64;10;5M";
+      for (let i = 1; i <= 2; i++) {
+        monitor.onInput(wheel);
+        visible = `scroll ${i}`;
+        monitor.onData(visible);
+        vi.advanceTimersByTime(700);
+      }
+      expect(monitor.getState()).toBe("idle");
+
+      // Scrolling stopped: let the input-echo window lapse (>1s since the last
+      // wheel tick, which also resets the temperature change-gap), then genuine
+      // sustained agent output must still recover. The fix suppresses
+      // scroll-driven redraws, not real work that follows a scroll.
+      vi.advanceTimersByTime(1100);
+      for (let i = 1; i <= 4; i++) {
+        visible = `real work ${i}`;
+        monitor.onData(visible);
+        vi.advanceTimersByTime(700);
+      }
+
+      expect(monitor.getState()).toBe("busy");
+      expect(onStateChange).toHaveBeenCalledWith("agent-mouse-2", 1000, "busy", {
+        trigger: "output",
+      });
+
+      monitor.dispose();
+    });
+
+    it("isRecentUserInput() reflects input-echo window state and clears after expiry", () => {
+      const onStateChange = vi.fn();
+      const monitor = new ActivityMonitor("agent-mouse-3", 1000, onStateChange, {
+        agentId: "claude",
+      });
+
+      expect(monitor.isRecentUserInput()).toBe(false);
+      monitor.onInput("\x1b[<64;10;5M");
+      expect(monitor.isRecentUserInput()).toBe(true);
+      vi.advanceTimersByTime(1100);
+      expect(monitor.isRecentUserInput()).toBe(false);
+
+      monitor.dispose();
+    });
+  });
+
   describe("Working silence timeout", () => {
     it("should transition polling terminal to idle after silence exceeds maxWorkingSilenceMs", () => {
       const onStateChange = vi.fn();

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1800,11 +1800,12 @@ export class TerminalProcess {
     const result = this.agentOutputTemperature.observeDelta(Date.now(), {
       changedChars: delta.changedChars,
     });
-    // ActivityMonitor.notifyFocus suppresses its own idle→busy paths, but this
-    // direct call into agentStateService is a parallel promotion path; gate it
-    // on the same window so a focus-triggered TUI repaint can't flip an idle
-    // agent to busy (#8865).
-    if (this.activityMonitor?.isFocusSuppressed()) {
+    // ActivityMonitor suppresses its own idle→busy paths on focus repaints
+    // (#8865) and on recent user input (#10925), but this direct call into
+    // agentStateService is a parallel promotion path; gate it on both windows
+    // so neither a focus-triggered TUI repaint nor a mouse-report-driven redraw
+    // from scrolling a mouse-reporting TUI can flip a settled agent to busy.
+    if (this.activityMonitor?.isFocusSuppressed() || this.activityMonitor?.isRecentUserInput()) {
       return;
     }
     if (result.stateHint === "busy" && this.terminalInfo.agentState === state) {

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -238,6 +238,56 @@ describe("TerminalProcess.submit", () => {
     expect(busyCalls.length).toBe(0);
   });
 
+  it("noteAgentOutputActivity respects ActivityMonitor recent-user-input suppression (#10925)", () => {
+    const handleActivityState = vi.fn();
+    const ctx = defaultSpawnContext();
+    const terminal = new TerminalProcess(
+      "t-input-bypass",
+      {
+        cwd: process.cwd(),
+        cols: 80,
+        rows: 24,
+        kind: "terminal",
+        launchAgentId: "claude",
+      },
+      { emitData: () => {}, onExit: () => {} },
+      {
+        agentStateService: { handleActivityState } as any,
+        ptyPool: null,
+        processTreeCache: null,
+      },
+      ctx,
+      createMockPty()
+    );
+
+    const internals = terminal as unknown as {
+      isAgentLive: boolean;
+      terminalInfo: { agentState: string };
+      activityMonitor: { onInput: (data: string) => void };
+      agentOutputContentSnapshot: unknown;
+      noteAgentOutputActivity: (before: unknown) => void;
+      getAgentOutputContentSnapshot: () => unknown;
+    };
+
+    // Force a busy-promoting condition: agent live, state idle, baseline set,
+    // visible delta after a mouse-report-driven redraw is non-trivial.
+    Object.defineProperty(terminal, "isAgentLive", { value: true, configurable: true });
+    internals.terminalInfo.agentState = "idle";
+    internals.agentOutputContentSnapshot = { lines: ["before"] };
+    internals.getAgentOutputContentSnapshot = () => ({ lines: ["after redraw with lots of new"] });
+
+    // A wheel tick sends an SGR mouse-report sequence, which stamps
+    // lastUserInputAt (mouse bytes aren't diverted to focus handling). The
+    // direct promotion path must not flip the idle agent to busy while that
+    // input-echo window is open.
+    internals.activityMonitor.onInput("\x1b[<64;10;5M");
+    handleActivityState.mockClear();
+    internals.noteAgentOutputActivity({ lines: ["before"] });
+
+    const busyCalls = handleActivityState.mock.calls.filter((call) => call[1] === "busy");
+    expect(busyCalls.length).toBe(0);
+  });
+
   it("noteAgentOutputActivity arms ActivityMonitor via notifyExternalPromotion when it promotes (#9875)", () => {
     const handleActivityState = vi.fn();
     const ctx = defaultSpawnContext();

--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -264,6 +264,7 @@ describe("TerminalProcess.submit", () => {
       isAgentLive: boolean;
       terminalInfo: { agentState: string };
       activityMonitor: { onInput: (data: string) => void };
+      agentOutputTemperature: { observeDelta: (...args: unknown[]) => unknown };
       agentOutputContentSnapshot: unknown;
       noteAgentOutputActivity: (before: unknown) => void;
       getAgentOutputContentSnapshot: () => unknown;
@@ -275,11 +276,23 @@ describe("TerminalProcess.submit", () => {
     internals.terminalInfo.agentState = "idle";
     internals.agentOutputContentSnapshot = { lines: ["before"] };
     internals.getAgentOutputContentSnapshot = () => ({ lines: ["after redraw with lots of new"] });
+    // Force the temperature to hint busy so the test actually reaches the
+    // promotion branch — otherwise a single delta never hints busy and the
+    // test would pass even with the input gate removed (mirrors #9875).
+    vi.spyOn(internals.agentOutputTemperature, "observeDelta").mockReturnValue({
+      stateHint: "busy",
+      changed: true,
+      changedChars: 64,
+      heatAdded: 50,
+      temperature: 80,
+      suppressed: false,
+      seeded: false,
+    });
 
     // A wheel tick sends an SGR mouse-report sequence, which stamps
     // lastUserInputAt (mouse bytes aren't diverted to focus handling). The
     // direct promotion path must not flip the idle agent to busy while that
-    // input-echo window is open.
+    // input-echo window is open — even though the temperature hints busy.
     internals.activityMonitor.onInput("\x1b[<64;10;5M");
     handleActivityState.mockClear();
     internals.noteAgentOutputActivity({ lines: ["before"] });

--- a/electron/services/pty/analysis/AnalysisSession.ts
+++ b/electron/services/pty/analysis/AnalysisSession.ts
@@ -484,7 +484,12 @@ export class AnalysisSession {
     const result = this.agentOutputTemperature.observeDelta(Date.now(), {
       changedChars: delta.changedChars,
     });
-    if (this.monitor?.isFocusSuppressed()) {
+    // Parallel promotion path: gate on the monitor's focus-suppression (#8865)
+    // and recent-user-input (#10925) windows, mirroring the in-thread
+    // TerminalProcess.noteAgentOutputActivity path, so a focus repaint or a
+    // mouse-report-driven redraw from scrolling a TUI can't flip a settled
+    // agent to busy.
+    if (this.monitor?.isFocusSuppressed() || this.monitor?.isRecentUserInput()) {
       return;
     }
     if (result.stateHint === "busy" && this.agentState === state) {


### PR DESCRIPTION
## Summary

- Scrolling a mouse wheel inside a terminal pane running a full-screen TUI agent with mouse reporting enabled briefly flipped the agent's detected state from idle to working for a second or two before settling back.
- Cause: the scroll sends SGR mouse-report escape sequences to the TUI, the TUI redraws its alt-screen in response, and the content-delta temperature heuristic in `ActivityMonitor` read that redraw as work and promoted the state.
- Mouse-report bytes already stamp `lastUserInputAt` via `InputTracker` (they flow through `notifyInput`; only focus CSI I/O reports are diverted elsewhere), so the signal needed to suppress this was already there. It just wasn't being consulted.

Resolves #10925

## Changes

Gates all three temperature-based idle/settled-to-busy promotion paths on recent user input, mirroring how #8865 gated the same three paths on focus suppression:

- `ActivityMonitor.applySimpleOutputTemperature` (the main simple-output path) now checks `inputTracker.isRecentUserInput(now)` in its idle-to-busy guard, matching its 8 sibling promotion sites.
- Added a public `ActivityMonitor.isRecentUserInput(now)` accessor, mirroring the existing `isFocusSuppressed`.
- `TerminalProcess.noteAgentOutputActivity` and `AnalysisSession.noteAgentOutputActivity` (the in-thread and worker direct-promotion paths) are now gated on the monitor's `isRecentUserInput` alongside the existing `isFocusSuppressed` check.

Genuine work is unaffected: a real type-then-enter promotes via `becomeBusy(trigger: "input")` and leaves the settled state before these output branches ever run, and sustained output after the ~1000ms echo window still promotes as normal.

## Testing

- Added a "Mouse-report input suppression (#10925)" block to `ActivityMonitor.test.ts` covering: scroll during idle stays idle, sustained output after the echo window still promotes, and the new `isRecentUserInput` accessor.
- Added a #10925 regression test to `TerminalProcess.submit.test.ts` that forces `observeDelta` busy so it fails if the input gate is ever reverted, which also covers the mirrored worker path.
- All 255 tests on the branch pass.
