### PR TITLE
Fix PTY flow-control accounting and restore quality under heavy output

### DIFF
--- a/docs/architecture/terminal-lifecycle.md
+++ b/docs/architecture/terminal-lifecycle.md
@@ -35,6 +35,7 @@ Because it is a pulse, it is excluded from persistence at the type level: `Persi
 - The pty-host carries the signal in-band as a structured private-use **OSC 57301** sequence (wire format `ESC ] 57301 ; <droppedBytes> ; <reasonCode> BEL`), written via `injectDataLossMarker` in `TerminalInstanceService`. Presentation is kept off the wire.
 - The OSC handler registered in `TerminalParserHandler` parses the payload, consumes the sequence (it never reaches the buffer as text), and fires an `onDataLoss` callback. The callback draws the user-visible yellow `⚠ Output dropped` line into xterm scrollback, deferred via `queueMicrotask` to avoid write-during-parse reentrancy.
 - The marker is a gap indicator only. Recovery is the xterm scrollback above and below it; the user sees a clearly-marked discontinuity rather than a silent corruption.
+- Every drop site (saturated-window port drop, IPC-cap drop, batched bytes discarded with a closing port) also records into a bounded per-terminal drop tally in the pty-host, surfaced as `droppedBytes`/`dropCount`/`lastDropAt` on each terminal in the on-demand flow-control snapshot (`get-flow-control-snapshot`) — so a support bundle can attribute WHOSE scrollback has a gap, not just that bytes were dropped process-wide. Entries are cleared on terminal exit.
 
 ## Notes
 

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -124,6 +124,7 @@ interface InspectableBackpressureManager {
 
 interface InspectableIpcQueueManager {
   queuedBytes: Map<string, number>;
+  deps: { emitReliabilityMetric?: (payload: Record<string, unknown>) => void } | undefined;
   clearQueue: TestMock;
   removeBytes: TestMock;
   tryResume: TestMock;
@@ -150,6 +151,8 @@ interface InspectablePortBatcher {
   dispose: TestMock;
   flushTerminal: TestMock;
   write: TestMock;
+  pendingSnapshot: Array<{ id: string; bytes: number }>;
+  getPendingByteSnapshot: TestMock;
 }
 
 const hostState = vi.hoisted(() => ({
@@ -163,6 +166,7 @@ const hostState = vi.hoisted(() => ({
   batchers: [] as InspectablePortBatcher[],
   resourceGovernorDeps: null as {
     getDropSnapshot: () => { droppedBytesDelta: number; dataLossCountDelta: number };
+    getPausedDurationsSnapshot: () => Array<{ terminalId: string; heldDurationMs: number }>;
   } | null,
   reset() {
     this.currentParentPort = null;
@@ -345,6 +349,15 @@ vi.mock("../pty-host/index.js", async () => {
     private terminalStatuses = new Map<string, string>();
     emitReliabilityMetric = vi.fn();
 
+    // Accessors the diagnostics (flow-control snapshot) handler reads.
+    get terminalStatusesMap(): Map<string, string> {
+      return this.terminalStatuses;
+    }
+
+    get suspendedSet(): Set<string> {
+      return this.suspended;
+    }
+
     constructor(
       private readonly deps: {
         getPauseCoordinator: (id: string) => InspectablePauseCoordinator | undefined;
@@ -514,8 +527,11 @@ vi.mock("../pty-host/index.js", async () => {
     getUtilization = vi.fn(() => 0);
     applyBackpressure = vi.fn();
     dispose = vi.fn();
+    getQueueSnapshot = vi.fn(() => ({ totalPendingBytes: 0, perTerminal: [] }));
+    deps: { emitReliabilityMetric?: (payload: Record<string, unknown>) => void } | undefined;
 
-    constructor() {
+    constructor(deps?: { emitReliabilityMetric?: (payload: Record<string, unknown>) => void }) {
+      this.deps = deps;
       hostState.ipcQueueManagers.push(this);
     }
   }
@@ -529,6 +545,7 @@ vi.mock("../pty-host/index.js", async () => {
       private readonly deps: {
         getPauseCoordinator: (id: string) => InspectablePauseCoordinator | undefined;
         pauseToken?: string;
+        emitReliabilityMetric?: (payload: Record<string, unknown>) => void;
       }
     ) {
       this.pauseToken = deps.pauseToken ?? "port-queue";
@@ -537,6 +554,7 @@ vi.mock("../pty-host/index.js", async () => {
 
     removeBytes = vi.fn();
     tryResume = vi.fn();
+    getQueueSnapshot = vi.fn(() => ({ totalPendingBytes: 0, perTerminal: [] }));
     clearQueue = vi.fn((id: string) => {
       this.pausedIds.delete(id);
     });
@@ -556,6 +574,14 @@ vi.mock("../pty-host/index.js", async () => {
     markPaused(id: string): void {
       this.pausedIds.add(id);
       this.deps.getPauseCoordinator(id)?.pause(this.pauseToken);
+      // Mirror the real manager: a pause-start rides the reliability-metric
+      // funnel, registering this window as a pause SOURCE in the host's
+      // per-source tracking map (pausedTerminals closure in pty-host.ts).
+      this.deps.emitReliabilityMetric?.({
+        terminalId: id,
+        metricType: "pause-start",
+        timestamp: Date.now(),
+      });
     }
   }
 
@@ -563,6 +589,10 @@ vi.mock("../pty-host/index.js", async () => {
     dispose = vi.fn();
     flushTerminal = vi.fn();
     write = vi.fn(() => false);
+    // Buffered-but-unflushed bytes, seeded by tests to simulate data batched
+    // for a port that is about to close.
+    pendingSnapshot: Array<{ id: string; bytes: number }> = [];
+    getPendingByteSnapshot = vi.fn(() => this.pendingSnapshot);
 
     constructor() {
       hostState.batchers.push(this);
@@ -572,9 +602,17 @@ vi.mock("../pty-host/index.js", async () => {
   class MockResourceGovernor {
     start = vi.fn();
     dispose = vi.fn();
+    getSnapshot = vi.fn(() => ({
+      isThrottling: false,
+      isWarning: false,
+      activeProfile: "balanced",
+      smoothedUtilizationPercent: null,
+      throttleDurationMs: 0,
+    }));
 
     constructor(deps: {
       getDropSnapshot: () => { droppedBytesDelta: number; dataLossCountDelta: number };
+      getPausedDurationsSnapshot: () => Array<{ terminalId: string; heldDurationMs: number }>;
     }) {
       hostState.resourceGovernorDeps = deps;
     }
@@ -1831,5 +1869,161 @@ describe("pty-host adversarial", () => {
       droppedBytesDelta: 22,
       dataLossCountDelta: 1,
     });
+  });
+
+  // Helper: flow-control snapshots sent to Main (diagnostics pull).
+  function flowControlSnapshots(parentPort: MockParentPort): Array<Record<string, unknown>> {
+    return parentPort.postMessage.mock.calls
+      .map((c: unknown[]) => c[0])
+      .filter(
+        (m: unknown): m is Record<string, unknown> =>
+          typeof m === "object" &&
+          m !== null &&
+          (m as { type?: string }).type === "flow-control-snapshot"
+      );
+  }
+
+  it("DISCONNECT_ACCOUNTS_BATCHER_PENDING_AS_DROPPED", async () => {
+    // Bytes batched for a closing port die with it — dispose() discards them
+    // silently, so disconnectWindow must account them as data loss first.
+    // Before this accounting, a port-replace mid-flood erased up to a full
+    // batch window per terminal from the drop ledger.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+
+    const port = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [port] });
+    await flushMicrotasks();
+
+    const batcher = hostState.batchers[0];
+    batcher.pendingSnapshot = [
+      { id: "t1", bytes: 120 },
+      { id: "t2", bytes: 40 },
+    ];
+
+    parentPort.emit("message", { type: "disconnect-port", windowId: 1 });
+    await flushMicrotasks();
+
+    expect(batcher.dispose).toHaveBeenCalledTimes(1);
+    expect(hostState.resourceGovernorDeps?.getDropSnapshot()).toEqual({
+      droppedBytesDelta: 160,
+      dataLossCountDelta: 2,
+    });
+  });
+
+  it("DISCONNECT_CLEARS_WINDOW_PAUSE_SOURCE_TRACKING", async () => {
+    // The pre-fix ordering called resumeAll() (which clears the manager's
+    // pause map) BEFORE iterating getPausedTerminalIds() — a live iterator
+    // over that same map — so the removePauseSource loop visited nothing and
+    // the window's pause-source entries leaked: the pause-duration gauge kept
+    // reporting heldDurationMs for a window that no longer existed.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+
+    const port = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [port] });
+    await flushMicrotasks();
+
+    // Window 1's port queue pauses t1 — the pause-start rides the funnel and
+    // registers source "port-1" in the host's tracking map.
+    hostState.portQueueManagers[0].markPaused("t1");
+    expect(hostState.resourceGovernorDeps?.getPausedDurationsSnapshot()).toEqual([
+      expect.objectContaining({ terminalId: "t1" }),
+    ]);
+
+    parentPort.emit("message", { type: "disconnect-port", windowId: 1 });
+    await flushMicrotasks();
+
+    expect(hostState.resourceGovernorDeps?.getPausedDurationsSnapshot()).toEqual([]);
+  });
+
+  it("DISCONNECT_PRESERVES_OTHER_SOURCE_PAUSE_TRACKING", async () => {
+    // Multi-source attribution: a terminal paused by BOTH this window's port
+    // queue AND the IPC queue must keep its held-duration tracking when just
+    // the window disconnects — only the "port-1" source is removed.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+
+    const port = createRendererPort();
+    parentPort.emit("message", { data: { type: "connect-port", windowId: 1 }, ports: [port] });
+    await flushMicrotasks();
+
+    hostState.portQueueManagers[0].markPaused("t1");
+    // The IPC queue also pauses t1 (source "ipc" via its own funnel wiring).
+    hostState.ipcQueueManagers[0].deps?.emitReliabilityMetric?.({
+      terminalId: "t1",
+      metricType: "pause-start",
+      timestamp: Date.now(),
+    });
+
+    parentPort.emit("message", { type: "disconnect-port", windowId: 1 });
+    await flushMicrotasks();
+
+    // The IPC hold keeps t1 in the tracking map after the window is gone.
+    expect(hostState.resourceGovernorDeps?.getPausedDurationsSnapshot()).toEqual([
+      expect.objectContaining({ terminalId: "t1" }),
+    ]);
+  });
+
+  it("FLOW_SNAPSHOT_REPORTS_PER_TERMINAL_DROP_TALLY", async () => {
+    // Two IPC-cap drops on the same terminal must surface as a cumulative
+    // per-terminal tally in the flow-control snapshot — the streaming
+    // data-loss gauge only carries process-wide deltas, so without the tally
+    // a support bundle can't tell WHOSE scrollback has the gap.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    const ipcQueue = hostState.ipcQueueManagers[0];
+    ipcQueue.isAtCapacity.mockReturnValue(true);
+    ipcQueue.getUtilization.mockReturnValue(100);
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(50));
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "b".repeat(30));
+    await flushMicrotasks();
+
+    parentPort.postMessage.mockClear();
+    parentPort.emit("message", { type: "get-flow-control-snapshot", requestId: "req-drop" });
+    await flushMicrotasks();
+
+    const snapshots = flowControlSnapshots(parentPort);
+    expect(snapshots).toHaveLength(1);
+    const terminals = (snapshots[0].snapshot as { terminals: Array<Record<string, unknown>> })
+      .terminals;
+    const t1 = terminals.find((t) => t.terminalId === "t1");
+    expect(t1).toMatchObject({ droppedBytes: 80, dropCount: 2 });
+    expect(typeof t1?.lastDropAt).toBe("number");
+  });
+
+  it("EXIT_CLEARS_DROP_TALLY", async () => {
+    // The tally entry dies with the terminal so the bounded map can't grow
+    // across long sessions and the snapshot only reports live terminals.
+    const parentPort = await loadHost();
+    hostState.terminals.set("t1", createTerminal("t1"));
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    const ipcQueue = hostState.ipcQueueManagers[0];
+    ipcQueue.isAtCapacity.mockReturnValue(true);
+    ipcQueue.getUtilization.mockReturnValue(100);
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(50));
+    await flushMicrotasks();
+
+    (hostState.currentPtyManager as MiniEmitter).emit("exit", "t1", 0);
+    await flushMicrotasks();
+
+    parentPort.postMessage.mockClear();
+    parentPort.emit("message", { type: "get-flow-control-snapshot", requestId: "req-exit" });
+    await flushMicrotasks();
+
+    const snapshots = flowControlSnapshots(parentPort);
+    const terminals = (snapshots[0].snapshot as { terminals: Array<Record<string, unknown>> })
+      .terminals;
+    expect(terminals.find((t) => t.terminalId === "t1" && (t.droppedBytes as number) > 0)).toBe(
+      undefined
+    );
   });
 });

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -279,6 +279,48 @@ import { isLoadBearingReliabilityMetric } from "./pty-host/loadBearingMetrics.js
 // false "regression" on the first emit after the gate opens.
 let dropAccumulator = { droppedBytes: 0, dataLossCount: 0 };
 
+// Per-terminal drop attribution for the on-demand flow-control snapshot
+// ("why is this terminal slow / missing output?"). The streaming
+// `data-loss-count` gauge only carries process-wide deltas, so a support
+// bundle could see THAT bytes were dropped but not WHOSE. Bounded: entries
+// are removed on terminal exit and the map is capped by evicting the
+// oldest-drop entry — a diagnostic tally must never become its own leak.
+// Updated only at drop sites (rare by construction), so it costs nothing on
+// the healthy hot path.
+interface TerminalDropTally {
+  droppedBytes: number;
+  dropCount: number;
+  lastDropAt: number;
+}
+const MAX_DROP_TALLY_TERMINALS = 256;
+const terminalDropTallies = new Map<string, TerminalDropTally>();
+
+function recordTerminalDrop(terminalId: string, droppedBytes: number): void {
+  const existing = terminalDropTallies.get(terminalId);
+  if (existing) {
+    existing.droppedBytes += droppedBytes;
+    existing.dropCount += 1;
+    existing.lastDropAt = Date.now();
+    return;
+  }
+  if (terminalDropTallies.size >= MAX_DROP_TALLY_TERMINALS) {
+    let oldestId: string | null = null;
+    let oldestAt = Number.POSITIVE_INFINITY;
+    for (const [id, tally] of terminalDropTallies) {
+      if (tally.lastDropAt < oldestAt) {
+        oldestAt = tally.lastDropAt;
+        oldestId = id;
+      }
+    }
+    if (oldestId !== null) terminalDropTallies.delete(oldestId);
+  }
+  terminalDropTallies.set(terminalId, {
+    droppedBytes,
+    dropCount: 1,
+    lastDropAt: Date.now(),
+  });
+}
+
 /**
  * Canonical funnel for terminal reliability-metric events. Wraps the
  * `backpressureManager.emitReliabilityMetric` call (which is wired into
@@ -485,8 +527,23 @@ function disconnectWindow(windowId: number, reason: string): void {
   } catch {
     // ignore
   }
+  // Batched-but-unflushed bytes die with the port — account them as data loss
+  // (they were headed to a renderer that will never receive them; the wake/
+  // restore snapshot is the recovery path). dispose() below discards the
+  // chunks without any bookkeeping of its own.
+  for (const { id, bytes } of conn.batcher.getPendingByteSnapshot()) {
+    dropAccumulator.droppedBytes += bytes;
+    dropAccumulator.dataLossCount += 1;
+    recordTerminalDrop(id, bytes);
+  }
   // Dispose batcher (drops buffered data — port is closing)
   conn.batcher.dispose();
+  // Snapshot the paused set BEFORE resumeAll: resumeAll clears the manager's
+  // pause map, and `getPausedTerminalIds()` is a live iterator over that map —
+  // iterating it after resumeAll visits nothing, leaking this window's
+  // per-source pause-tracking entries (stale `heldDurationMs` gauges for a
+  // window that no longer exists).
+  const pausedByThisWindow = [...conn.portQueueManager.getPausedTerminalIds()];
   // Release port-queue pause holds before disposing
   conn.portQueueManager.resumeAll();
   // Clear this window's per-source pause-tracking entries. Multi-source
@@ -495,7 +552,7 @@ function disconnectWindow(windowId: number, reason: string): void {
   // disconnects — `removePauseSource` keeps the entry alive while the
   // IPC path still holds. The renderer is informed via the queue
   // manager's own resume flow + tier-changed message.
-  for (const terminalId of conn.portQueueManager.getPausedTerminalIds()) {
+  for (const terminalId of pausedByThisWindow) {
     removePauseSource(terminalId, `port-${windowId}` as PauseSource);
   }
   conn.portQueueManager.dispose();
@@ -756,6 +813,7 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
           // metrics are gated off (mirrors the IPC at-capacity path).
           dropAccumulator.droppedBytes += byteCount;
           dropAccumulator.dataLossCount += 1;
+          recordTerminalDrop(id, byteCount);
           try {
             conn.port.postMessage({
               type: "terminal-status",
@@ -963,6 +1021,7 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
       // gated separately in ResourceGovernor.emitDataLossCount.
       dropAccumulator.droppedBytes += dataBytes;
       dropAccumulator.dataLossCount += 1;
+      recordTerminalDrop(id, dataBytes);
       // `ipc-cap-drop` is a data-path telemetry pulse, not a pause-source
       // transition — the funnel forwards it to the wire without touching
       // the per-source tracking map (a `suspend`/`pause-end` with `null`
@@ -1057,6 +1116,10 @@ ptyManager.on("exit", (id: string, exitCode: number, signal?: number) => {
 
   // Clean up IPC data mirror state
   ipcDataMirrorTerminals.delete(id);
+
+  // Drop-tally entry dies with the terminal — the flow-control snapshot only
+  // reports live terminals, and the map stays bounded across long sessions.
+  terminalDropTallies.delete(id);
 
   sendEvent({ type: "exit", id, exitCode, signal });
 });
@@ -1380,6 +1443,13 @@ const hostContext: HostContext = {
   resumePausedTerminal,
   createPortQueueManager,
   getPausedDurationsSnapshot,
+  getDropTallySnapshot: () =>
+    Array.from(terminalDropTallies, ([terminalId, tally]) => ({
+      terminalId,
+      droppedBytes: tally.droppedBytes,
+      dropCount: tally.dropCount,
+      lastDropAt: tally.lastDropAt,
+    })),
 };
 
 const dispatchMessage = createPtyHostMessageDispatcher(hostContext);

--- a/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
+++ b/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
@@ -369,4 +369,55 @@ describe("IpcQueueManager adversarial", () => {
       expect(mgr.getTotalQueuedBytes()).toBe(IPC_MAX_QUEUE_BYTES + 1);
     });
   });
+
+  describe("aggregate sweep on non-ack drains", () => {
+    // A terminal paused by the aggregate watermark with an empty queue of its
+    // own receives no acks, so removeBytes never runs for it. The other two
+    // aggregate-shrinking paths — safety-timeout force-resume and clearQueue —
+    // must run the same resume sweep, or the terminal stays stranded until its
+    // own 10s safety timeout.
+    const BIG = HIGH_BYTES + 1;
+
+    function pauseEightBigProducers() {
+      for (let i = 1; i <= 8; i++) {
+        mgr.addBytes(`big${i}`, BIG);
+        mgr.applyBackpressure(`big${i}`, mgr.getUtilization(`big${i}`));
+        expect(mgr.isPaused(`big${i}`)).toBe(true);
+      }
+    }
+
+    it("safety-timeout force-resume sweeps aggregate-paused siblings", () => {
+      // Eight big producers (own-watermark pauses at T=0) push the aggregate
+      // over its 16MB gate.
+      pauseEightBigProducers();
+
+      // t0 pauses via the aggregate gate 1s later; its own timeout is at
+      // T+11s, strictly after the big producers' timeouts at T+10s.
+      vi.advanceTimersByTime(1000);
+      mgr.addBytes("t0", 1000);
+      mgr.applyBackpressure("t0", mgr.getUtilization("t0"));
+      expect(mgr.isPaused("t0")).toBe(true);
+      mgr.removeBytes("t0", 1000);
+      expect(mgr.isPaused("t0")).toBe(true);
+
+      // At T+10s the big producers force-resume and drop their bytes — t0
+      // must resume in the same tick via the sweep, not at T+11s.
+      vi.advanceTimersByTime(IPC_MAX_PAUSE_MS - 1000);
+      expect(mgr.isPaused("t0")).toBe(false);
+    });
+
+    it("clearQueue (terminal teardown) sweeps aggregate-paused siblings", () => {
+      pauseEightBigProducers();
+      mgr.addBytes("t0", 1000);
+      mgr.applyBackpressure("t0", mgr.getUtilization("t0"));
+      mgr.removeBytes("t0", 1000);
+      expect(mgr.isPaused("t0")).toBe(true);
+
+      for (let i = 1; i <= 8; i++) {
+        mgr.clearQueue(`big${i}`);
+      }
+
+      expect(mgr.isPaused("t0")).toBe(false);
+    });
+  });
 });

--- a/electron/pty-host/__tests__/portBatcher.test.ts
+++ b/electron/pty-host/__tests__/portBatcher.test.ts
@@ -756,6 +756,37 @@ describe("PortBatcher", () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
+    it("getPendingByteSnapshot reports per-terminal buffered bytes and empties after flush", () => {
+      const deps = createDeps();
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("aaaa"), 4);
+      batcher.write("t1", bytes("bb"), 2);
+      batcher.write("t2", bytes("ccc"), 3);
+
+      // Buffered-but-unflushed bytes are visible per terminal — this is what
+      // disconnectWindow accounts as dropped when the port closes with data
+      // still batched.
+      const snapshot = batcher.getPendingByteSnapshot();
+      const byId = new Map(snapshot.map((e) => [e.id, e.bytes]));
+      expect(byId.get("t1")).toBe(6);
+      expect(byId.get("t2")).toBe(3);
+
+      vi.runAllTimers();
+      expect(batcher.getPendingByteSnapshot()).toEqual([]);
+    });
+
+    it("getPendingByteSnapshot is empty after dispose", () => {
+      const deps = createDeps();
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("aaaa"), 4);
+      expect(batcher.getPendingByteSnapshot()).toHaveLength(1);
+
+      batcher.dispose();
+      expect(batcher.getPendingByteSnapshot()).toEqual([]);
+    });
+
     it("flushTerminal cancels only the target's timer, leaving siblings pending", () => {
       const deps = createDeps();
       const batcher = new PortBatcher(deps);

--- a/electron/pty-host/__tests__/portPipeline.stress.test.ts
+++ b/electron/pty-host/__tests__/portPipeline.stress.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PortBatcher, setPortBatchThroughputDelayMs } from "../portBatcher.js";
+import { PortQueueManager } from "../portQueue.js";
+import { PtyPauseCoordinator } from "../PtyPauseCoordinator.js";
+import {
+  IPC_MAX_QUEUE_BYTES,
+  IPC_HIGH_WATERMARK_PERCENT,
+  IPC_LOW_WATERMARK_PERCENT,
+  PORT_BATCH_THRESHOLD_BYTES,
+  PORT_BATCH_THROUGHPUT_DELAY_MS,
+} from "../../services/pty/types.js";
+import type { TerminalReliabilityMetricPayload } from "../../../shared/types/pty-host.js";
+
+/**
+ * Deterministic stress tests over the REAL per-window output pipeline —
+ * PortBatcher → PortQueueManager → PtyPauseCoordinator wired exactly like
+ * `electron/pty-host.ts` wires them per renderer connection. The unit suites
+ * (portBatcher.test.ts, portQueue.test.ts) each mock the other component;
+ * these tests exist to prove the composed behavior under heavy multi-terminal
+ * output: batching preserves per-terminal byte order, the focused pane's
+ * latency privilege survives sibling floods, watermark pauses engage and
+ * ack-driven resume actually releases the PTY, and teardown paths leak
+ * neither bytes nor pause holds.
+ */
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const HIGH_WATERMARK_BYTES = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+const LOW_WATERMARK_BYTES = (IPC_MAX_QUEUE_BYTES * IPC_LOW_WATERMARK_PERCENT) / 100;
+
+interface PostedBatch {
+  id: string;
+  data: Uint8Array;
+  bytes: number;
+}
+
+interface SimulatedWindow {
+  windowId: number;
+  batcher: PortBatcher;
+  queueManager: PortQueueManager;
+  posted: PostedBatch[];
+  statusEvents: Array<{ id: string; status: string }>;
+  metrics: TerminalReliabilityMetricPayload[];
+  /** Simulate the renderer acking one posted batch (xterm write completed). */
+  ack: (batch: PostedBatch) => void;
+}
+
+interface SimulatedTerminal {
+  rawPause: ReturnType<typeof vi.fn>;
+  rawResume: ReturnType<typeof vi.fn>;
+  coordinator: PtyPauseCoordinator;
+}
+
+function createHarness() {
+  const terminals = new Map<string, SimulatedTerminal>();
+  const windows: SimulatedWindow[] = [];
+  let focusedByWindow = new Map<number, string | null>();
+
+  function getOrCreateTerminal(id: string): SimulatedTerminal {
+    let t = terminals.get(id);
+    if (!t) {
+      const rawPause = vi.fn();
+      const rawResume = vi.fn();
+      t = {
+        rawPause,
+        rawResume,
+        coordinator: new PtyPauseCoordinator({ pause: rawPause, resume: rawResume }),
+      };
+      terminals.set(id, t);
+    }
+    return t;
+  }
+
+  function addWindow(windowId: number): SimulatedWindow {
+    const posted: PostedBatch[] = [];
+    const statusEvents: Array<{ id: string; status: string }> = [];
+    const metrics: TerminalReliabilityMetricPayload[] = [];
+    const queueManager = new PortQueueManager({
+      getTerminal: (id) =>
+        terminals.has(id) ? { ptyProcess: { pause: vi.fn(), resume: vi.fn() } } : undefined,
+      getPauseCoordinator: (id) => terminals.get(id)?.coordinator,
+      sendEvent: vi.fn(),
+      metricsEnabled: () => true,
+      emitTerminalStatus: (id, status) => {
+        statusEvents.push({ id, status });
+      },
+      emitReliabilityMetric: (payload) => {
+        metrics.push(payload);
+      },
+      pauseToken: `port-queue-${windowId}`,
+      getFocusedTerminalId: () => focusedByWindow.get(windowId) ?? null,
+    });
+    const batcher = new PortBatcher({
+      portQueueManager: queueManager,
+      getFocusedTerminalId: () => focusedByWindow.get(windowId) ?? null,
+      postMessage: (id, data, bytes) => {
+        posted.push({ id, data, bytes });
+      },
+      onError: (error) => {
+        throw error;
+      },
+    });
+    const win: SimulatedWindow = {
+      windowId,
+      batcher,
+      queueManager,
+      posted,
+      statusEvents,
+      metrics,
+      ack: (batch) => {
+        queueManager.removeBytes(batch.id, batch.bytes);
+        queueManager.tryResume(batch.id);
+      },
+    };
+    windows.push(win);
+    return win;
+  }
+
+  /**
+   * Pump one PTY chunk through the same routing the host's data handler uses:
+   * every window is a target (no project filter in these tests), `owned` is
+   * true only for a sole target, and a rejecting batcher marks the window
+   * saturated. Returns the windows that rejected the chunk.
+   */
+  function pump(id: string, text: string, interactive = false): SimulatedWindow[] {
+    getOrCreateTerminal(id);
+    const chunk = encoder.encode(text);
+    const owned = windows.length === 1;
+    const saturated: SimulatedWindow[] = [];
+    for (const win of windows) {
+      if (!win.batcher.write(id, chunk, chunk.byteLength, owned, interactive)) {
+        saturated.push(win);
+      }
+    }
+    return saturated;
+  }
+
+  return {
+    terminals,
+    windows,
+    addWindow,
+    pump,
+    getOrCreateTerminal,
+    setFocused: (windowId: number, id: string | null) => {
+      focusedByWindow.set(windowId, id);
+    },
+    reset: () => {
+      focusedByWindow = new Map();
+    },
+  };
+}
+
+function concatPosted(posted: PostedBatch[], id: string): string {
+  const parts: Uint8Array[] = posted.filter((p) => p.id === id).map((p) => p.data);
+  const total = parts.reduce((sum, p) => sum + p.byteLength, 0);
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    merged.set(part, offset);
+    offset += part.byteLength;
+  }
+  return decoder.decode(merged);
+}
+
+describe("port pipeline stress (real batcher + queue + coordinator)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setPortBatchThroughputDelayMs(PORT_BATCH_THROUGHPUT_DELAY_MS);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("focused terminal's batch posts ahead of five flooding siblings", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+    harness.setFocused(1, "t-focus");
+
+    // Siblings write first (their per-terminal immediates are scheduled
+    // first); the focused terminal writes LAST. The first flush still posts
+    // the focused entry first.
+    for (let i = 0; i < 5; i++) {
+      harness.pump(`t${i}`, `sibling-${i}-`.repeat(20));
+    }
+    harness.pump("t-focus", "focused-output");
+
+    vi.runAllTimers();
+
+    expect(win.posted.length).toBeGreaterThanOrEqual(6);
+    expect(win.posted[0]!.id).toBe("t-focus");
+    expect(concatPosted(win.posted, "t-focus")).toBe("focused-output");
+  });
+
+  it("interactive echo accelerates the focused batch without reordering its earlier chunks", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+    harness.setFocused(1, "t-focus");
+
+    // Focused terminal escalates to throughput mode (two writes), siblings
+    // flood alongside. The echo write swaps the 16ms timer for an immediate.
+    harness.pump("t-focus", "aaa");
+    harness.pump("t-focus", "bbb");
+    harness.pump("t1", "noise-1");
+    harness.pump("t1", "noise-2");
+    harness.pump("t-focus", "x", true);
+
+    // One macrotask tick — well before the 16ms throughput window.
+    vi.advanceTimersByTime(1);
+
+    const focusedBatches = win.posted.filter((p) => p.id === "t-focus");
+    expect(focusedBatches).toHaveLength(1);
+    // Earlier queued chunks land ahead of the echo byte — accelerated, never
+    // reordered.
+    expect(decoder.decode(focusedBatches[0]!.data)).toBe("aaabbbx");
+    expect(win.posted[0]!.id).toBe("t-focus");
+
+    // The swapped-out throughput timer must not double-post.
+    vi.advanceTimersByTime(PORT_BATCH_THROUGHPUT_DELAY_MS + 1);
+    expect(win.posted.filter((p) => p.id === "t-focus")).toHaveLength(1);
+  });
+
+  it("per-terminal byte order survives an interleaved flood with threshold flushes and odd chunk shapes", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+
+    // Interleave two terminals with adversarial chunk shapes: zero-byte,
+    // 1-byte, multibyte UTF-8, and 64KB slabs that trip the synchronous
+    // threshold flush mid-stream.
+    const written = new Map<string, string>([
+      ["t1", ""],
+      ["t2", ""],
+    ]);
+    const shapes = [
+      "",
+      "x",
+      "⚠…emoji😀",
+      "y".repeat(1024),
+      "z".repeat(PORT_BATCH_THRESHOLD_BYTES),
+      "小さなチャンク",
+      "",
+      "w".repeat(64),
+    ];
+    for (let round = 0; round < 12; round++) {
+      for (const id of ["t1", "t2"]) {
+        const text = `${id}:${round}:${shapes[(round + (id === "t2" ? 3 : 0)) % shapes.length]};`;
+        written.set(id, written.get(id)! + text);
+        harness.pump(id, text);
+      }
+    }
+    vi.runAllTimers();
+
+    // Byte-identical reassembly per terminal — no loss, duplication, or
+    // cross-terminal reordering, regardless of how batches were cut.
+    expect(concatPosted(win.posted, "t1")).toBe(written.get("t1"));
+    expect(concatPosted(win.posted, "t2")).toBe(written.get("t2"));
+
+    // Accounting matches delivery exactly: every posted byte is in the ledger.
+    const postedBytes = win.posted.reduce((sum, p) => sum + p.bytes, 0);
+    expect(win.queueManager.getTotalQueuedBytes()).toBe(postedBytes);
+  });
+
+  it("a sustained flood pauses the PTY once at the watermark and acks resume it", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+
+    // 40 × 64KB = 2.5MB — crosses the ~2MB per-terminal high watermark. Each
+    // 64KB write trips the batcher's synchronous threshold flush, charging
+    // the real ledger as it goes.
+    const chunk = "f".repeat(PORT_BATCH_THRESHOLD_BYTES);
+    for (let i = 0; i < 40; i++) {
+      harness.pump("t1", chunk);
+    }
+    // Advance only past the batch window — running ALL timers would also fire
+    // the 10s safety timeout and force-resume the pause under test.
+    vi.advanceTimersByTime(PORT_BATCH_THROUGHPUT_DELAY_MS + 4);
+
+    const terminal = harness.terminals.get("t1")!;
+    expect(win.queueManager.isPaused("t1")).toBe(true);
+    // The raw PTY pause fired exactly once (coordinator dedupes holds).
+    expect(terminal.rawPause).toHaveBeenCalledTimes(1);
+    expect(terminal.rawResume).not.toHaveBeenCalled();
+    expect(win.statusEvents).toContainEqual({ id: "t1", status: "paused-backpressure" });
+    expect(win.queueManager.getQueuedBytes("t1")).toBeGreaterThan(HIGH_WATERMARK_BYTES);
+
+    // The renderer drains: ack each posted batch in FIFO order. The resume
+    // must fire as soon as the ledger crosses the low watermark.
+    for (const batch of win.posted) {
+      win.ack(batch);
+    }
+    expect(win.queueManager.getQueuedBytes("t1")).toBe(0);
+    expect(win.queueManager.isPaused("t1")).toBe(false);
+    expect(terminal.rawResume).toHaveBeenCalledTimes(1);
+    expect(win.statusEvents).toContainEqual({ id: "t1", status: "running" });
+    expect(win.queueManager.getQueuedBytes("t1")).toBeLessThan(LOW_WATERMARK_BYTES);
+  });
+
+  it("terminal exit with batched data still pending delivers the tail and leaves no holds", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+
+    harness.pump("t1", "final-output-before-exit");
+    // Exit arrives before any flush timer fires — mimic the host's exit
+    // handler: flush the batcher's tail, then clear the queue accounting.
+    win.batcher.flushTerminal("t1");
+    win.queueManager.clearQueue("t1");
+
+    expect(concatPosted(win.posted, "t1")).toBe("final-output-before-exit");
+    expect(win.queueManager.getQueuedBytes("t1")).toBe(0);
+    expect(win.queueManager.getTotalQueuedBytes()).toBe(0);
+    expect(harness.terminals.get("t1")!.coordinator.isPaused).toBe(false);
+  });
+
+  it("a saturated window rejects while its sibling window keeps accepting", () => {
+    const harness = createHarness();
+    const winA = harness.addWindow(1);
+    const winB = harness.addWindow(2);
+
+    // Window B's renderer has stalled: its ledger for t1 sits at capacity.
+    winB.queueManager.addBytes("t1", IPC_MAX_QUEUE_BYTES);
+
+    const saturated = harness.pump("t1", "live-output");
+    vi.runAllTimers();
+
+    // Only window B rejected — exactly the per-window outcome the host uses
+    // to decide who gets the data-loss pulse.
+    expect(saturated.map((w) => w.windowId)).toEqual([2]);
+    expect(concatPosted(winA.posted, "t1")).toBe("live-output");
+    expect(winB.posted).toHaveLength(0);
+
+    // B's renderer recovers (acks its backlog) — the next chunk flows again.
+    winB.queueManager.removeBytes("t1", IPC_MAX_QUEUE_BYTES);
+    const saturatedAfter = harness.pump("t1", "-recovered");
+    vi.runAllTimers();
+    expect(saturatedAfter).toHaveLength(0);
+    expect(concatPosted(winB.posted, "t1")).toBe("-recovered");
+    // Window A received both chunks in order.
+    expect(concatPosted(winA.posted, "t1")).toBe("live-output-recovered");
+  });
+
+  it("a resource-governor hold outlives the port-queue resume (multi-source pause)", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+    const terminal = harness.getOrCreateTerminal("t1");
+
+    // The governor pauses first (memory pressure), then the window's queue
+    // crosses its watermark and takes its own hold.
+    terminal.coordinator.pause("resource-governor");
+    expect(terminal.rawPause).toHaveBeenCalledTimes(1);
+
+    const chunk = "g".repeat(PORT_BATCH_THRESHOLD_BYTES);
+    for (let i = 0; i < 40; i++) {
+      harness.pump("t1", chunk);
+    }
+    vi.advanceTimersByTime(PORT_BATCH_THROUGHPUT_DELAY_MS + 4);
+    expect(win.queueManager.isPaused("t1")).toBe(true);
+    // Second hold on an already-paused coordinator does not double-pause.
+    expect(terminal.rawPause).toHaveBeenCalledTimes(1);
+
+    // The renderer drains fully — the port-queue hold releases, but the PTY
+    // must stay paused (governor still holds) and no "running" status leaks.
+    for (const batch of win.posted) {
+      win.ack(batch);
+    }
+    expect(win.queueManager.isPaused("t1")).toBe(false);
+    expect(terminal.rawResume).not.toHaveBeenCalled();
+    expect(terminal.coordinator.isPaused).toBe(true);
+    expect(win.statusEvents).not.toContainEqual({ id: "t1", status: "running" });
+
+    // Governor pressure clears — NOW the PTY resumes.
+    terminal.coordinator.resume("resource-governor");
+    expect(terminal.rawResume).toHaveBeenCalledTimes(1);
+  });
+
+  it("window teardown mid-pause releases the PTY and surfaces the release", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+
+    const chunk = "d".repeat(PORT_BATCH_THRESHOLD_BYTES);
+    for (let i = 0; i < 40; i++) {
+      harness.pump("t1", chunk);
+    }
+    vi.advanceTimersByTime(PORT_BATCH_THROUGHPUT_DELAY_MS + 4);
+    const terminal = harness.terminals.get("t1")!;
+    expect(win.queueManager.isPaused("t1")).toBe(true);
+
+    // LRU eviction / project close: the window goes away with acks pending.
+    // Mimic disconnectWindow: resumeAll, then dispose.
+    win.queueManager.resumeAll();
+    win.queueManager.dispose();
+    win.batcher.dispose();
+
+    expect(terminal.rawResume).toHaveBeenCalledTimes(1);
+    expect(terminal.coordinator.isPaused).toBe(false);
+    // The release is surfaced (stuck-pill regression) with a pause-end metric.
+    expect(win.statusEvents).toContainEqual({ id: "t1", status: "running" });
+    expect(win.metrics.some((m) => m.terminalId === "t1" && m.metricType === "pause-end")).toBe(
+      true
+    );
+    expect(win.queueManager.getTotalQueuedBytes()).toBe(0);
+  });
+
+  it("32 terminals flooding one window: every byte accounted, aggregate gate holds, sweep releases", () => {
+    const harness = createHarness();
+    const win = harness.addWindow(1);
+    harness.setFocused(1, "t0");
+
+    // 32 terminals × 40 × 16KB ≈ 20MB across the window — far over the 16MB
+    // aggregate gate. Terminals stay below their OWN ~2MB watermark (640KB
+    // each), so every pause in this test is aggregate-driven.
+    const chunk = "m".repeat(16 * 1024);
+    for (let round = 0; round < 40; round++) {
+      for (let t = 0; t < 32; t++) {
+        harness.pump(`t${t}`, chunk);
+      }
+    }
+    vi.advanceTimersByTime(PORT_BATCH_THROUGHPUT_DELAY_MS + 4);
+
+    // The focused terminal is exempt from the aggregate gate.
+    expect(win.queueManager.isPaused("t0")).toBe(false);
+    const pausedCount = [...Array(32).keys()].filter((t) =>
+      win.queueManager.isPaused(`t${t}`)
+    ).length;
+    expect(pausedCount).toBeGreaterThan(0);
+
+    // Nothing was lost on the way in: ledger total equals posted total.
+    const postedBytes = win.posted.reduce((sum, p) => sum + p.bytes, 0);
+    expect(win.queueManager.getTotalQueuedBytes()).toBe(postedBytes);
+
+    // The renderer acks everything — every pause releases, every raw PTY
+    // resume fires, the ledger returns to zero.
+    for (const batch of win.posted) {
+      win.ack(batch);
+    }
+    expect(win.queueManager.getTotalQueuedBytes()).toBe(0);
+    for (let t = 0; t < 32; t++) {
+      expect(win.queueManager.isPaused(`t${t}`)).toBe(false);
+      expect(harness.terminals.get(`t${t}`)!.coordinator.isPaused).toBe(false);
+    }
+  });
+});

--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -575,6 +575,189 @@ describe("PortQueueManager", () => {
     });
   });
 
+  describe("aggregate sweep on non-ack drains", () => {
+    // The drain event that frees a swamped window is not always an ack:
+    // safety-timeout force-resumes and terminal teardown (clearQueue) also
+    // shrink the aggregate. A terminal paused by the window-level gate with an
+    // empty queue of its own receives no acks, so those paths MUST run the
+    // same resume sweep as removeBytes or it stays stranded until its own
+    // 10s safety timeout.
+    const BIG = 2.05 * 1024 * 1024; // over the ~2MB per-terminal watermark
+
+    function pauseEightBigProducers(mgr: PortQueueManager) {
+      for (let i = 1; i <= 8; i++) {
+        mgr.addBytes(`big${i}`, BIG);
+        mgr.applyBackpressure(`big${i}`, mgr.getUtilization(`big${i}`));
+        expect(mgr.isPaused(`big${i}`)).toBe(true);
+      }
+    }
+
+    it("safety-timeout force-resume sweeps aggregate-paused siblings", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      // Eight big producers pause on their own watermark at T=0 and push the
+      // aggregate over 16MB.
+      pauseEightBigProducers(mgr);
+      expect(mgr.getTotalQueuedBytes()).toBeGreaterThan(IPC_TOTAL_QUEUE_HIGH_WATERMARK_BYTES);
+
+      // t0 pauses via the aggregate gate 1s later — its safety timeout is at
+      // T+11s, strictly after the big producers' timeouts at T+10s.
+      vi.advanceTimersByTime(1000);
+      mgr.addBytes("t0", 1000);
+      mgr.applyBackpressure("t0", mgr.getUtilization("t0"));
+      expect(mgr.isPaused("t0")).toBe(true);
+
+      // t0's own queue drains fully; the aggregate is still swamped.
+      mgr.removeBytes("t0", 1000);
+      expect(mgr.isPaused("t0")).toBe(true);
+
+      // Advance to exactly T+10s: the big producers' safety timeouts fire and
+      // drop their byte accounting. t0 must resume in the SAME tick via the
+      // sweep — not 1s later when its own timeout fires.
+      vi.advanceTimersByTime(IPC_MAX_PAUSE_MS - 1000);
+      expect(mgr.isPaused("t0")).toBe(false);
+      expect(deps.getPauseCoordinator("t0")!.resume).toHaveBeenCalledWith("port-queue");
+    });
+
+    it("clearQueue (terminal teardown) sweeps aggregate-paused siblings", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      pauseEightBigProducers(mgr);
+      mgr.addBytes("t0", 1000);
+      mgr.applyBackpressure("t0", mgr.getUtilization("t0"));
+      mgr.removeBytes("t0", 1000);
+      expect(mgr.isPaused("t0")).toBe(true);
+
+      // The big producers exit (kill/trash) — no acks will ever arrive for
+      // their bytes. Clearing them must free t0 as soon as the aggregate
+      // crosses the low watermark.
+      for (let i = 1; i <= 8; i++) {
+        mgr.clearQueue(`big${i}`);
+      }
+
+      expect(mgr.isPaused("t0")).toBe(false);
+      expect(deps.getPauseCoordinator("t0")!.resume).toHaveBeenCalledWith("port-queue");
+    });
+  });
+
+  describe("resumeAll surfaces the release (stuck-pill regression)", () => {
+    it("emits running + pause-end for each released terminal", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+      mgr.addBytes("t1", highWatermark + 1);
+      mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+      expect(mgr.isPaused("t1")).toBe(true);
+
+      const emitStatus = deps.emitTerminalStatus as ReturnType<typeof vi.fn>;
+      const emitMetric = deps.emitReliabilityMetric as ReturnType<typeof vi.fn>;
+      emitStatus.mockClear();
+      emitMetric.mockClear();
+
+      vi.advanceTimersByTime(1500);
+      mgr.resumeAll();
+
+      // Without the emission, the shared status map keeps "paused-backpressure"
+      // and any other window still showing the terminal wears a stale pill
+      // until an unrelated transition overwrites it.
+      expect(emitStatus).toHaveBeenCalledWith("t1", "running", expect.any(Number), 1500);
+      expect(emitMetric).toHaveBeenCalledWith(
+        expect.objectContaining({
+          terminalId: "t1",
+          metricType: "pause-end",
+          durationMs: 1500,
+        })
+      );
+      expect(mgr.isPaused("t1")).toBe(false);
+      expect(deps.getPauseCoordinator("t1")!.resume).toHaveBeenCalledWith("port-queue");
+    });
+
+    it("suppresses the running status while another source still holds the pause", () => {
+      const deps = createMockDeps();
+      const heldCoordinator: Pick<PtyPauseCoordinator, "pause" | "resume" | "isPaused"> = {
+        pause: vi.fn(),
+        resume: vi.fn(),
+        get isPaused() {
+          // Still held by e.g. the ipc-queue token after this manager resumes.
+          return true;
+        },
+      };
+      deps.getPauseCoordinator = vi.fn(() => heldCoordinator as PtyPauseCoordinator);
+      const mgr = new PortQueueManager(deps);
+
+      const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+      mgr.addBytes("t1", highWatermark + 1);
+      mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+
+      const emitStatus = deps.emitTerminalStatus as ReturnType<typeof vi.fn>;
+      const emitMetric = deps.emitReliabilityMetric as ReturnType<typeof vi.fn>;
+      emitStatus.mockClear();
+      emitMetric.mockClear();
+
+      mgr.resumeAll();
+
+      // Terminal is NOT running (another hold remains) — no running status,
+      // but the pause-end metric still fires so per-source tracking clears.
+      expect(emitStatus).not.toHaveBeenCalledWith(
+        "t1",
+        "running",
+        expect.anything(),
+        expect.anything()
+      );
+      expect(emitMetric).toHaveBeenCalledWith(
+        expect.objectContaining({ terminalId: "t1", metricType: "pause-end" })
+      );
+    });
+
+    it("a throwing emitter cannot abort the release or leave pause state stale", () => {
+      // resumeAll runs during window teardown, where sendEvent can race a
+      // dying parent channel. A throw from either emitter must not stop the
+      // remaining terminals from being released or leave the pause maps
+      // populated (a stale map would strand coordinator holds forever).
+      const deps = createMockDeps();
+      let channelDead = false;
+      deps.emitTerminalStatus = vi.fn(() => {
+        if (channelDead) throw new Error("channel closing");
+      });
+      const mgr = new PortQueueManager(deps);
+
+      const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+      mgr.addBytes("t1", highWatermark + 1);
+      mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+      mgr.addBytes("t2", highWatermark + 1);
+      mgr.applyBackpressure("t2", mgr.getUtilization("t2"));
+      expect(mgr.isPaused("t1")).toBe(true);
+      expect(mgr.isPaused("t2")).toBe(true);
+
+      // The parent channel dies just as the window tears down.
+      channelDead = true;
+      expect(() => mgr.resumeAll()).not.toThrow();
+
+      expect(mgr.isPaused("t1")).toBe(false);
+      expect(mgr.isPaused("t2")).toBe(false);
+      const coordinator = deps.getPauseCoordinator("t1");
+      expect(coordinator!.resume).toHaveBeenCalledWith("port-queue");
+    });
+
+    it("second resumeAll is a no-op (disconnect then dispose)", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+      mgr.addBytes("t1", highWatermark + 1);
+      mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+      mgr.resumeAll();
+
+      const emitMetric = deps.emitReliabilityMetric as ReturnType<typeof vi.fn>;
+      emitMetric.mockClear();
+      mgr.resumeAll();
+      expect(emitMetric).not.toHaveBeenCalled();
+    });
+  });
+
   describe("focused-terminal prioritization (#10878)", () => {
     function fillBelowPerTerminalWatermark(mgr: PortQueueManager, count: number, bytes: number) {
       for (let i = 0; i < count; i++) {

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -79,6 +79,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
     getPausedDurationsSnapshot: vi.fn(() => []),
+    getDropTallySnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/__tests__/connection.test.ts
+++ b/electron/pty-host/handlers/__tests__/connection.test.ts
@@ -60,6 +60,7 @@ function makeCtx(stateRef: {
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
     getPausedDurationsSnapshot: vi.fn(() => []),
+    getDropTallySnapshot: vi.fn(() => []),
   };
 }
 

--- a/electron/pty-host/handlers/__tests__/diagnostics.test.ts
+++ b/electron/pty-host/handlers/__tests__/diagnostics.test.ts
@@ -69,6 +69,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
     getPausedDurationsSnapshot: vi.fn(() => []),
+    getDropTallySnapshot: vi.fn(() => []),
     ...overrides,
   };
 }
@@ -239,6 +240,41 @@ describe("get-flow-control-snapshot handler", () => {
 
     stats.suspendCount = 99;
     expect(snapshot.stats.suspendCount).toBe(1); // detached copy
+  });
+
+  it("merges per-terminal drop tallies and unions tally-only ids", () => {
+    const ctx = makeCtx({
+      backpressureManager: {
+        terminalStatusesMap: new Map([["a", "running"]]),
+        suspendedSet: new Set(),
+        isSuspended: vi.fn(() => false),
+        getActivityTier: vi.fn(() => "active"),
+        stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+      } as unknown as HostContext["backpressureManager"],
+      // "dropped-only" is known ONLY to the drop tally — a terminal whose
+      // output was dropped but which never paused must still appear, or the
+      // scrollback-gap explanation is invisible in the support bundle.
+      getDropTallySnapshot: vi.fn(() => [
+        { terminalId: "a", droppedBytes: 512, dropCount: 2, lastDropAt: 1111 },
+        { terminalId: "dropped-only", droppedBytes: 64, dropCount: 1, lastDropAt: 2222 },
+      ]),
+    });
+
+    const snapshot = runSnapshot(ctx);
+    const a = snapshot.terminals.find((t) => t.terminalId === "a");
+    expect(a).toMatchObject({ droppedBytes: 512, dropCount: 2, lastDropAt: 1111 });
+    const droppedOnly = snapshot.terminals.find((t) => t.terminalId === "dropped-only");
+    expect(droppedOnly).toMatchObject({ droppedBytes: 64, dropCount: 1, lastDropAt: 2222 });
+    // A terminal with no recorded drops reports explicit zero/null, not undefined.
+    const clean = makeCtx({
+      pauseCoordinators: new Map([["t1", {} as never]]),
+    });
+    const cleanSnapshot = runSnapshot(clean);
+    expect(cleanSnapshot.terminals[0]).toMatchObject({
+      droppedBytes: 0,
+      dropCount: 0,
+      lastDropAt: null,
+    });
   });
 
   it("embeds the resource-governor snapshot verbatim", () => {

--- a/electron/pty-host/handlers/__tests__/dispatcher.test.ts
+++ b/electron/pty-host/handlers/__tests__/dispatcher.test.ts
@@ -94,6 +94,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
     getPausedDurationsSnapshot: vi.fn(() => []),
+    getDropTallySnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -97,6 +97,7 @@ function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
     getPausedDurationsSnapshot: vi.fn(() => []),
+    getDropTallySnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
+++ b/electron/pty-host/handlers/__tests__/terminalInfo.test.ts
@@ -38,6 +38,7 @@ function createCtx(overrides: Partial<HostContext> = {}): HostContext {
     resumePausedTerminal: vi.fn(),
     createPortQueueManager: vi.fn(),
     getPausedDurationsSnapshot: vi.fn(() => []),
+    getDropTallySnapshot: vi.fn(() => []),
     ...overrides,
   };
 }

--- a/electron/pty-host/handlers/diagnostics.ts
+++ b/electron/pty-host/handlers/diagnostics.ts
@@ -21,6 +21,7 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
     rendererConnections,
     getPauseCoordinator,
     getPausedDurationsSnapshot,
+    getDropTallySnapshot,
     sendEvent,
   } = ctx;
 
@@ -37,6 +38,18 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
         heldDurationById.set(terminalId, heldDurationMs);
       }
 
+      // Per-terminal drop attribution: which terminals have had bytes
+      // intentionally dropped (saturated port, IPC cap, disconnected batcher)
+      // and how much. This is the "missing output" half of "why is this
+      // terminal slow?" — pause state alone can't explain a scrollback gap.
+      const dropTallyById = new Map<
+        string,
+        { droppedBytes: number; dropCount: number; lastDropAt: number }
+      >();
+      for (const { terminalId, ...tally } of getDropTallySnapshot()) {
+        dropTallyById.set(terminalId, tally);
+      }
+
       // Union every terminal id known to any flow-control map so a terminal
       // that is paused/suspended/held but has no recorded status still appears.
       const ids = new Set<string>();
@@ -44,9 +57,11 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
       for (const id of backpressureManager.suspendedSet) ids.add(id);
       for (const id of heldDurationById.keys()) ids.add(id);
       for (const id of pauseCoordinators.keys()) ids.add(id);
+      for (const id of dropTallyById.keys()) ids.add(id);
 
       const terminals: FlowControlTerminalSnapshot[] = [];
       for (const id of ids) {
+        const dropTally = dropTallyById.get(id);
         terminals.push({
           terminalId: id,
           flowStatus: backpressureManager.terminalStatusesMap.get(id) ?? null,
@@ -54,6 +69,9 @@ export function createDiagnosticsHandlers(ctx: HostContext): HandlerMap {
           isSuspended: backpressureManager.isSuspended(id),
           activityTier: backpressureManager.getActivityTier(id),
           pausedDurationMs: heldDurationById.get(id) ?? null,
+          droppedBytes: dropTally?.droppedBytes ?? 0,
+          dropCount: dropTally?.dropCount ?? 0,
+          lastDropAt: dropTally?.lastDropAt ?? null,
         });
       }
       terminals.sort((a, b) => a.terminalId.localeCompare(b.terminalId));

--- a/electron/pty-host/handlers/types.ts
+++ b/electron/pty-host/handlers/types.ts
@@ -76,6 +76,18 @@ export interface HostContext {
    * paths keep their start times outside `backpressureManager.pauseStartTimes`.
    */
   getPausedDurationsSnapshot: () => Array<{ terminalId: string; heldDurationMs: number }>;
+  /**
+   * Per-terminal cumulative drop attribution (saturated-window port drops,
+   * IPC-cap drops, batched bytes discarded with a closing port). Bounded map,
+   * cleared per terminal on exit. Consumed by the flow-control snapshot so a
+   * support bundle can tell WHOSE bytes were dropped, not just that some were.
+   */
+  getDropTallySnapshot: () => Array<{
+    terminalId: string;
+    droppedBytes: number;
+    dropCount: number;
+    lastDropAt: number;
+  }>;
 }
 
 export type PtyHostHandler = (msg: any, ports?: MessagePort[]) => void | Promise<void>;

--- a/electron/pty-host/ipcQueue.ts
+++ b/electron/pty-host/ipcQueue.ts
@@ -64,17 +64,26 @@ export class IpcQueueManager {
     }
     const previousTotal = this.totalQueuedBytes;
     this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
-    // Aggregate-gate resume sweep — mirrors PortQueueManager.removeBytes: a
-    // terminal paused by the aggregate watermark may receive no further acks
-    // of its own, so re-check every paused terminal when the total drains
-    // below the low watermark.
+    this.sweepAggregateResume(previousTotal);
+  }
+
+  /**
+   * Aggregate-gate resume sweep — mirrors PortQueueManager: a terminal paused
+   * by the aggregate watermark may receive no further acks of its own, so
+   * re-check every paused terminal whenever the total drains below the low
+   * watermark. Runs on acks (removeBytes), the safety-timeout force-resume,
+   * and clearQueue — any of them can be the drain event, and sweeping only on
+   * acks left aggregate-paused siblings stranded until their own timeouts.
+   */
+  private sweepAggregateResume(previousTotal: number): void {
     if (
-      previousTotal >= IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES &&
-      this.totalQueuedBytes < IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES
+      previousTotal < IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES ||
+      this.totalQueuedBytes >= IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES
     ) {
-      for (const pausedId of [...this.pausedTerminals.keys()]) {
-        this.tryResume(pausedId);
-      }
+      return;
+    }
+    for (const pausedId of [...this.pausedTerminals.keys()]) {
+      this.tryResume(pausedId);
     }
   }
 
@@ -162,6 +171,7 @@ export class IpcQueueManager {
         // (mirrors the port-path fix in #6244).
         const droppedBytes = this.queuedBytes.get(id) ?? 0;
         this.queuedBytes.delete(id);
+        const previousTotal = this.totalQueuedBytes;
         this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - droppedBytes);
 
         const coordinator = this.deps.getPauseCoordinator(id);
@@ -181,6 +191,10 @@ export class IpcQueueManager {
             bufferUtilization: currentUtilization,
           });
         }
+
+        // Dropping this terminal's bytes may have drained the aggregate below
+        // its low watermark — re-check siblings paused by the aggregate gate.
+        this.sweepAggregateResume(previousTotal);
       }, IPC_MAX_PAUSE_MS);
 
       this.pausedTerminals.set(id, safetyTimeout);
@@ -254,9 +268,14 @@ export class IpcQueueManager {
     }
     const removed = this.queuedBytes.get(id) ?? 0;
     this.queuedBytes.delete(id);
+    const previousTotal = this.totalQueuedBytes;
     this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
     this.pausedTerminals.delete(id);
     this.pauseStartTimes.delete(id);
+    // A cleared terminal (exit, force-resume) can be the one holding most of
+    // the aggregate — sweep so aggregate-paused siblings resume now instead of
+    // waiting out their safety timeouts.
+    this.sweepAggregateResume(previousTotal);
   }
 
   dispose(): void {

--- a/electron/pty-host/portBatcher.ts
+++ b/electron/pty-host/portBatcher.ts
@@ -200,6 +200,21 @@ export class PortBatcher {
     return true;
   }
 
+  /**
+   * Per-terminal buffered-but-unflushed byte counts. Read by the host's
+   * `disconnectWindow` before `dispose()` so bytes about to be dropped with
+   * the closing port are accounted as data loss instead of vanishing
+   * silently — dispose() discards `pendingChunks` without any drop
+   * bookkeeping of its own.
+   */
+  getPendingByteSnapshot(): Array<{ id: string; bytes: number }> {
+    const out: Array<{ id: string; bytes: number }> = [];
+    for (const [id, entry] of this.pendingChunks) {
+      if (entry.bytes > 0) out.push({ id, bytes: entry.bytes });
+    }
+    return out;
+  }
+
   flushTerminal(id: string): void {
     const entry = this.pendingChunks.get(id);
     if (!entry) return;

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -76,28 +76,40 @@ export class PortQueueManager {
     }
     const previousTotal = this.totalQueuedBytes;
     this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
-    // Aggregate-gate resume sweep: a terminal paused by the window-level
-    // watermark may have an empty queue of its own, so no further acks (and
-    // therefore no tryResume calls) ever arrive for it. When the aggregate
-    // crosses back below the low watermark, re-check every paused terminal.
+    this.sweepAggregateResume(previousTotal);
+  }
+
+  /**
+   * Aggregate-gate resume sweep: a terminal paused by the window-level
+   * watermark may have an empty queue of its own, so no further acks (and
+   * therefore no tryResume calls) ever arrive for it. When the aggregate
+   * crosses back below the low watermark, re-check every paused terminal.
+   * Called from every path that shrinks the aggregate — acks (removeBytes),
+   * the safety-timeout force-resume, and clearQueue — because any of them can
+   * be the drain event that frees the window; sweeping only on acks left
+   * aggregate-paused siblings stranded until their own safety timeouts when
+   * the drain came from a timeout or a terminal teardown instead.
+   */
+  private sweepAggregateResume(previousTotal: number): void {
     if (
-      previousTotal >= IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES &&
-      this.totalQueuedBytes < IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES
+      previousTotal < IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES ||
+      this.totalQueuedBytes >= IPC_TOTAL_QUEUE_LOW_WATERMARK_BYTES
     ) {
-      // Resume the focused terminal first so the pane the user is watching
-      // recovers ahead of its siblings. tryResume reads only totalQueuedBytes
-      // and per-terminal bytes (neither mutated by a resume), so visiting the
-      // focused id first is order-independent for correctness — it only changes
-      // which coordinator.resume() fires first. Every other paused terminal is
-      // still swept, so no producer is starved (#7030).
-      const focusedId = this.deps.getFocusedTerminalId?.() ?? null;
-      if (focusedId !== null && this.pausedTerminals.has(focusedId)) {
-        this.tryResume(focusedId);
-      }
-      for (const pausedId of [...this.pausedTerminals.keys()]) {
-        if (pausedId === focusedId) continue;
-        this.tryResume(pausedId);
-      }
+      return;
+    }
+    // Resume the focused terminal first so the pane the user is watching
+    // recovers ahead of its siblings. tryResume reads only totalQueuedBytes
+    // and per-terminal bytes (neither mutated by a resume), so visiting the
+    // focused id first is order-independent for correctness — it only changes
+    // which coordinator.resume() fires first. Every other paused terminal is
+    // still swept, so no producer is starved (#7030).
+    const focusedId = this.deps.getFocusedTerminalId?.() ?? null;
+    if (focusedId !== null && this.pausedTerminals.has(focusedId)) {
+      this.tryResume(focusedId);
+    }
+    for (const pausedId of [...this.pausedTerminals.keys()]) {
+      if (pausedId === focusedId) continue;
+      this.tryResume(pausedId);
     }
   }
 
@@ -208,6 +220,7 @@ export class PortQueueManager {
         // and the pause loop wedges across the entire renderer reload (#6244).
         const droppedBytes = this.queuedBytes.get(id) ?? 0;
         this.queuedBytes.delete(id);
+        const previousTotal = this.totalQueuedBytes;
         this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - droppedBytes);
 
         const coordinator = this.deps.getPauseCoordinator(id);
@@ -227,6 +240,13 @@ export class PortQueueManager {
             bufferUtilization: currentUtilization,
           });
         }
+
+        // The force-resume dropped this terminal's byte accounting — if that
+        // took the aggregate below its low watermark, siblings paused by the
+        // window-level gate (with empty queues of their own, so no acks are
+        // coming) must be re-checked here or they stay stranded until each of
+        // their own safety timeouts fires.
+        this.sweepAggregateResume(previousTotal);
       }, IPC_MAX_PAUSE_MS);
 
       this.pausedTerminals.set(id, safetyTimeout);
@@ -302,17 +322,49 @@ export class PortQueueManager {
     }
     const removed = this.queuedBytes.get(id) ?? 0;
     this.queuedBytes.delete(id);
+    const previousTotal = this.totalQueuedBytes;
     this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
     this.pausedTerminals.delete(id);
     this.pauseStartTimes.delete(id);
+    // A cleared terminal (exit, force-resume) can be the terminal holding most
+    // of the window aggregate — sweep so aggregate-paused siblings don't wait
+    // out their safety timeouts for bytes that will never be acked.
+    this.sweepAggregateResume(previousTotal);
   }
 
   resumeAll(): void {
     for (const [id, safetyTimeout] of this.pausedTerminals) {
       clearTimeout(safetyTimeout);
       const coordinator = this.deps.getPauseCoordinator(id);
-      if (coordinator) {
-        coordinator.resume(this.pauseToken);
+      if (!coordinator) continue;
+      coordinator.resume(this.pauseToken);
+      // Surface the release. resumeAll runs when this manager's window goes
+      // away (disconnect/replace/dispose) — without an emission here the
+      // shared status map keeps "paused-backpressure" and any other window
+      // still showing this terminal wears a stale paused pill until some
+      // unrelated transition overwrites it. The pause-end metric also clears
+      // this window's entry in the host's per-source pause-duration tracking
+      // (the funnel maps this manager's metrics to its own `port-<windowId>`
+      // source), so multi-source attribution survives: a terminal also held
+      // by the IPC queue stays tracked by that source. Emission is
+      // best-effort: this path runs during window teardown where sendEvent
+      // can race a dying parent channel, and a throw here must not abort the
+      // remaining releases or leave the pause maps stale.
+      try {
+        const pauseStart = this.pauseStartTimes.get(id);
+        const pauseDuration = pauseStart ? Date.now() - pauseStart : undefined;
+        if (!coordinator.isPaused) {
+          this.deps.emitTerminalStatus(id, "running", this.getUtilization(id), pauseDuration);
+        }
+        this.deps.emitReliabilityMetric({
+          terminalId: id,
+          metricType: "pause-end",
+          timestamp: Date.now(),
+          durationMs: pauseDuration,
+          bufferUtilization: this.getUtilization(id),
+        });
+      } catch (error) {
+        console.warn(`[PtyHost] resumeAll emission failed for ${id}:`, error);
       }
     }
     this.pausedTerminals.clear();

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -252,6 +252,16 @@ export interface FlowControlTerminalSnapshot {
   activityTier: PtyHostActivityTier;
   /** Wall-clock ms the terminal has been paused, or null when not paused. */
   pausedDurationMs: number | null;
+  /**
+   * Cumulative bytes intentionally dropped for this terminal (saturated-window
+   * port drops, IPC-cap drops, batched bytes discarded with a closing port)
+   * since spawn. 0 when nothing was ever dropped.
+   */
+  droppedBytes: number;
+  /** Number of distinct drop events behind {@link droppedBytes}. */
+  dropCount: number;
+  /** Timestamp of the most recent drop, or null when nothing was dropped. */
+  lastDropAt: number | null;
 }
 
 /** Per-transport queue-depth entry in a {@link FlowControlSnapshot}. */

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -521,6 +521,72 @@ describe("terminalClient MessagePort data routing", () => {
     });
   });
 
+  it("port replacement clears the pending-ack FIFO — stale entries never debit the fresh generation", () => {
+    // Generation A: two chunks delivered live, FIFO holds [10, 20]. The host
+    // side of this port (its PortQueueManager ledger) dies with the
+    // replacement, so these entries describe bytes no live ledger holds.
+    const portA = acquirePort();
+    terminalClient.onData("term-1", () => {});
+    portA.postMessage({ type: "data", id: "term-1", data: "aaaaaaaaaa", bytes: 10 });
+    portA.postMessage({ type: "data", id: "term-1", data: "bbbbbbbbbbbbbbbbbbbb", bytes: 20 });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        // Generation B replaces the port, then delivers one fresh chunk (7
+        // bytes). Without the activation-time clear, the xterm write
+        // completion for a NEW chunk would shift generation A's 10-byte entry
+        // and post a wrong-sized ack against B's fresh ledger.
+        const portB = acquirePort();
+        portB.postMessage({ type: "data", id: "term-1", data: "ccccccc", bytes: 7 });
+
+        setTimeout(() => {
+          const acks: Record<string, unknown>[] = [];
+          portB.addEventListener("message", (event: MessageEvent) => {
+            const msg = event.data as Record<string, unknown>;
+            if (msg?.type === "ack" && msg.id === "term-1") acks.push(msg);
+          });
+          portB.start();
+
+          terminalClient.acknowledgePortData("term-1", 999);
+          // FIFO now empty — generation A's entries are gone, not queued behind.
+          terminalClient.acknowledgePortData("term-1", 999, 5);
+
+          setTimeout(() => {
+            expect(acks).toEqual([{ type: "ack", id: "term-1", bytes: 7 }]);
+            resolve();
+          }, 100);
+        }, 50);
+      }, 50);
+    });
+  });
+
+  it("write completions that fire after a port replacement degrade to no-op acks", () => {
+    const portA = acquirePort();
+    terminalClient.onData("term-1", () => {});
+    portA.postMessage({ type: "data", id: "term-1", data: "old-data", bytes: 42 });
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        const portB = acquirePort();
+        const acks: Record<string, unknown>[] = [];
+        portB.addEventListener("message", (event: MessageEvent) => {
+          const msg = event.data as Record<string, unknown>;
+          if (msg?.type === "ack") acks.push(msg);
+        });
+        portB.start();
+
+        // The stale chunk's write completion arrives AFTER the replacement:
+        // its FIFO entry was cleared at activation, so nothing is posted.
+        terminalClient.acknowledgePortData("term-1", 42);
+
+        setTimeout(() => {
+          expect(acks).toEqual([]);
+          resolve();
+        }, 100);
+      }, 50);
+    });
+  });
+
   it("dispatches to correct terminal only", () => {
     const port = acquirePort();
     const received1: string[] = [];

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -160,6 +160,15 @@ function activatePort(port: MessagePort): void {
   if (messagePort) {
     messagePort.close();
   }
+  // Port-generation boundary: the pending-ack FIFO describes chunks delivered
+  // on the OUTGOING port, whose host-side ledger is being torn down with it
+  // (disconnectWindow disposes that window's PortQueueManager). Carrying the
+  // entries across would let stale xterm write completions settle them against
+  // the NEW port's ledger — debiting bytes the fresh generation actually has
+  // in flight and permanently misaligning the per-chunk FIFO. Stale write
+  // callbacks that fire after this clear degrade to no-op acks instead
+  // (acknowledgePortData shifts at most what is queued).
+  pendingPortAckBytes.clear();
   messagePort = port;
   installPortDataHandler(port);
   port.addEventListener("close", () => {

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -172,7 +172,7 @@ class TerminalInstanceService {
 
     this.restoreController = new TerminalRestoreController({
       getInstance: (id) => this.instances.get(id),
-      writeData: (id, data) => this.writeToTerminal(id, data),
+      writeData: (id, data, chunkCount) => this.writeToTerminal(id, data, chunkCount),
     });
 
     this.writeController = new TerminalWriteController({

--- a/src/services/terminal/TerminalRestoreController.ts
+++ b/src/services/terminal/TerminalRestoreController.ts
@@ -23,7 +23,10 @@ function classifyRestoreError(error: unknown): TerminalScrollbackRestoreError {
 
 export interface RestoreControllerDeps {
   getInstance: (id: string) => ManagedTerminal | undefined;
-  writeData: (id: string, data: string | Uint8Array) => void;
+  // chunkCount travels with each replayed deferred batch: the batch's pending
+  // port-ack FIFO entries were deliberately NOT settled at defer time, so the
+  // replay write must settle exactly them (see TerminalWriteController).
+  writeData: (id: string, data: string | Uint8Array, chunkCount: number) => void;
 }
 
 // Slice a chunk without splitting a UTF-16 surrogate pair. xterm 6's parser
@@ -49,6 +52,27 @@ export class TerminalRestoreController {
 
   constructor(deps: RestoreControllerDeps) {
     this.deps = deps;
+  }
+
+  /**
+   * Replay everything deferred while a restore was in progress. Deferred
+   * entries carry live ledger charges (port-ack FIFO, IPC ledger, ingest
+   * inFlightBytes) that only the replay write settles, so EVERY terminal
+   * restore attempt must end in exactly one of: this replay (success OR
+   * failure — a failed restore with a live tail beats a frozen pane), a
+   * newer restore generation taking ownership of the entries, or full
+   * terminal teardown (destroyTerminal discards the FIFO and ingest queue).
+   * A path that drops deferredOutput outside those three strands the ingest
+   * ledger: inFlightBytes stays charged, the queue stops draining at its
+   * watermark, and the watchdog reads the hold as healthy (#9910 class).
+   */
+  private replayDeferred(id: string, managed: ManagedTerminal): void {
+    if (managed.deferredOutput.length === 0) return;
+    const deferred = managed.deferredOutput;
+    managed.deferredOutput = [];
+    for (const entry of deferred) {
+      this.deps.writeData(id, entry.data, entry.chunkCount);
+    }
   }
 
   restoreFromSerialized(id: string, serializedState: string): boolean {
@@ -83,18 +107,16 @@ export class TerminalRestoreController {
         }
 
         current.isSerializedRestoreInProgress = false;
-
-        const deferred = current.deferredOutput;
-        current.deferredOutput = [];
-        for (const data of deferred) {
-          this.deps.writeData(id, data);
-        }
+        this.replayDeferred(id, current);
       });
       return true;
     } catch (error) {
       managed.isSerializedRestoreInProgress = false;
       managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to restore terminal ${id}`, error);
+      // The restore died synchronously (reset/write threw) — release anything
+      // already deferred so its ledger charges settle and live output resumes.
+      this.replayDeferred(id, managed);
       return false;
     }
   }
@@ -186,13 +208,7 @@ export class TerminalRestoreController {
           }
 
           managed.isSerializedRestoreInProgress = false;
-
-          const deferredData = managed.deferredOutput;
-          managed.deferredOutput = [];
-
-          for (const data of deferredData) {
-            this.deps.writeData(id, data);
-          }
+          this.replayDeferred(id, managed);
         }
       }
     };
@@ -204,6 +220,17 @@ export class TerminalRestoreController {
       // failure instead of silently marking the restore "done".
       managed.lastScrollbackRestoreError = classifyRestoreError(err);
       logError(`Write chain error for ${id}`, err);
+      // task's finally never ran either: clear the defer gate and release the
+      // held output ourselves (only while this generation still owns it), or
+      // every subsequent chunk defers forever behind a restore that will
+      // never complete.
+      if (
+        this.deps.getInstance(id) === managed &&
+        managed.restoreGeneration === restoreGeneration
+      ) {
+        managed.isSerializedRestoreInProgress = false;
+        this.replayDeferred(id, managed);
+      }
       return false;
     });
 
@@ -250,16 +277,38 @@ export class TerminalRestoreController {
       const result = await this.restoreFetchedState(id, serializedState);
       if (!result) {
         managed.isSerializedRestoreInProgress = false;
+        // The restore never ran (null state) or failed — release anything
+        // deferred while we awaited the snapshot. replayDeferred empties the
+        // array, so a failure path that already replayed makes this a no-op.
+        if (managed.restoreGeneration === restoreGeneration) {
+          this.replayDeferred(id, managed);
+        }
       }
       return result;
     } catch (error) {
       managed.isSerializedRestoreInProgress = false;
       managed.lastScrollbackRestoreError = classifyRestoreError(error);
       logError(`Failed to fetch state for terminal ${id}`, error);
+      // Output deferred during the failed snapshot fetch must not stay
+      // stranded — settle its ledger charges by replaying it live.
+      if (
+        this.deps.getInstance(id) === managed &&
+        managed.restoreGeneration === restoreGeneration
+      ) {
+        this.replayDeferred(id, managed);
+      }
       return false;
     }
   }
 
+  /**
+   * Valid ONLY inside full terminal teardown (TerminalInstanceService's
+   * destroy path): dropping deferredOutput here discards entries whose ledger
+   * charges are settled by the teardown that follows — discardPortAcks drains
+   * the pending port-ack FIFO and resetForTerminal drops the ingest queue.
+   * Calling this outside that path would strand those ledgers (see
+   * replayDeferred).
+   */
   destroy(id: string): void {
     const managed = this.deps.getInstance(id);
     if (!managed) return;

--- a/src/services/terminal/TerminalWriteController.ts
+++ b/src/services/terminal/TerminalWriteController.ts
@@ -180,10 +180,19 @@ export class TerminalWriteController {
     }
 
     if (managed.isSerializedRestoreInProgress) {
-      managed.deferredOutput.push(data);
-      const deferredBytes = typeof data === "string" ? data.length : data.byteLength;
-      this.deps.acknowledgePortData(id, deferredBytes, chunkCount);
-      this.deps.notifyWriteComplete(id, deferredBytes);
+      // Defer WITHOUT settling any ledger. The batch's pending port-ack FIFO
+      // entries, the host's queued-byte ledger, and the ingest inFlightBytes
+      // all stay charged until the replay write (post-restore) completes and
+      // runs the normal bookkeeping below. This is load-bearing twice over:
+      // (1) acking here and again at replay double-debited the FIFO — each
+      // replayed chunk stole an entry belonging to a chunk that arrived after
+      // the restore, leaving the host ledger permanently inflated and every
+      // subsequent backpressure pause degraded to its 10s safety timeout;
+      // (2) holding the charge means the host's own watermarks pace the PTY
+      // while the restore runs, so a flooding agent can no longer grow
+      // deferredOutput without bound — the transport backpressure IS the cap,
+      // and no bytes are dropped to enforce it.
+      managed.deferredOutput.push({ data, chunkCount });
       return;
     }
 

--- a/src/services/terminal/__tests__/TerminalRestoreController.test.ts
+++ b/src/services/terminal/__tests__/TerminalRestoreController.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/utils/logger", () => ({
 describe("TerminalRestoreController", () => {
   let controller: TerminalRestoreController;
   let instances: Map<string, ManagedTerminal>;
-  let writeDataSpy: (id: string, data: string | Uint8Array) => void;
+  let writeDataSpy: (id: string, data: string | Uint8Array, chunkCount: number) => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockTerminal: Record<string, any>;
   let writeCallbacks: Map<number, () => void>;
@@ -75,7 +75,7 @@ describe("TerminalRestoreController", () => {
     };
 
     instances = new Map();
-    writeDataSpy = vi.fn<(id: string, data: string | Uint8Array) => void>();
+    writeDataSpy = vi.fn<(id: string, data: string | Uint8Array, chunkCount: number) => void>();
 
     controller = new TerminalRestoreController({
       getInstance: (id) => instances.get(id),
@@ -158,19 +158,24 @@ describe("TerminalRestoreController", () => {
 
     it("flushes deferred output after restore", async () => {
       const managed = makeManagedTerminal();
-      managed.deferredOutput = ["deferred1", "deferred2"];
+      managed.deferredOutput = [
+        { data: "deferred1", chunkCount: 1 },
+        { data: "deferred2", chunkCount: 3 },
+      ];
       instances.set("t1", managed);
 
       controller.restoreFromSerialized("t1", "small-state");
       await flushMicrotasks();
 
-      expect(writeDataSpy).toHaveBeenCalledWith("t1", "deferred1");
-      expect(writeDataSpy).toHaveBeenCalledWith("t1", "deferred2");
+      // Each replayed batch carries its own chunkCount so the write settles
+      // exactly the pending port-ack FIFO entries the batch owns.
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "deferred1", 1);
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "deferred2", 3);
     });
 
     it("does not apply callback when destroyed mid-write", async () => {
       const managed = makeManagedTerminal({
-        deferredOutput: ["should-not-flush"],
+        deferredOutput: [{ data: "should-not-flush", chunkCount: 1 }],
       });
       instances.set("t1", managed);
 
@@ -187,7 +192,7 @@ describe("TerminalRestoreController", () => {
 
     it("does not apply first callback when a second restore starts before callback fires", async () => {
       const managed = makeManagedTerminal({
-        deferredOutput: ["first-deferred"],
+        deferredOutput: [{ data: "first-deferred", chunkCount: 1 }],
       });
       instances.set("t1", managed);
 
@@ -195,14 +200,14 @@ describe("TerminalRestoreController", () => {
       controller.restoreFromSerialized("t1", "first-state");
 
       // Second restore before first callback fires
-      managed.deferredOutput = ["second-deferred"];
+      managed.deferredOutput = [{ data: "second-deferred", chunkCount: 2 }];
       controller.restoreFromSerialized("t1", "second-state");
 
       await flushMicrotasks();
 
       // Only the second restore's deferred output should have been flushed
       expect(writeDataSpy).toHaveBeenCalledTimes(1);
-      expect(writeDataSpy).toHaveBeenCalledWith("t1", "second-deferred");
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "second-deferred", 2);
       expect(managed.restoreGeneration).toBe(2);
     });
 
@@ -358,7 +363,7 @@ describe("TerminalRestoreController", () => {
       instances.set("t1", managed);
       const data = "x".repeat(INCREMENTAL_RESTORE_CONFIG.chunkBytes * 2);
 
-      managed.deferredOutput = ["deferred-data"];
+      managed.deferredOutput = [{ data: "deferred-data", chunkCount: 1 }];
 
       const promise = controller.restoreFromSerializedIncremental("t1", data);
       await flushMicrotasks();
@@ -368,7 +373,7 @@ describe("TerminalRestoreController", () => {
       }
       await promise;
 
-      expect(writeDataSpy).toHaveBeenCalledWith("t1", "deferred-data");
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "deferred-data", 1);
     });
 
     it("clears all timeout handles after successful multi-chunk restore", async () => {
@@ -494,13 +499,117 @@ describe("TerminalRestoreController", () => {
       expect(result).toBe(false);
       expect(managed.isSerializedRestoreInProgress).toBe(false);
     });
+
+    it("replays output deferred during the fetch when the state comes back null", async () => {
+      // Deferred entries carry unsettled ledger charges (port-ack FIFO, IPC
+      // ledger, ingest inFlightBytes) — a restore that never runs must still
+      // release them by replaying, or the ingest queue strands invisibly
+      // (getStalledBytes reads inFlightBytes>0 as healthy).
+      const { terminalClient } = await import("@/clients");
+      let resolveFetch!: (value: string | null) => void;
+      vi.mocked(terminalClient.getSerializedState).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = resolve;
+          })
+      );
+
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      const promise = controller.fetchAndRestore("t1");
+      await flushMicrotasks();
+
+      // Live output arrives while the snapshot fetch is in flight.
+      managed.deferredOutput.push({ data: "mid-fetch-output", chunkCount: 2 });
+
+      resolveFetch(null);
+      const result = await promise;
+
+      expect(result).toBe(false);
+      expect(managed.isSerializedRestoreInProgress).toBe(false);
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "mid-fetch-output", 2);
+      expect(managed.deferredOutput).toHaveLength(0);
+    });
+
+    it("replays output deferred during the fetch when the fetch rejects", async () => {
+      const { terminalClient } = await import("@/clients");
+      let rejectFetch!: (err: Error) => void;
+      vi.mocked(terminalClient.getSerializedState).mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            rejectFetch = reject;
+          })
+      );
+
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      const promise = controller.fetchAndRestore("t1");
+      await flushMicrotasks();
+
+      managed.deferredOutput.push({ data: "mid-fetch-output", chunkCount: 1 });
+
+      rejectFetch(new Error("host gone"));
+      const result = await promise;
+
+      expect(result).toBe(false);
+      expect(managed.isSerializedRestoreInProgress).toBe(false);
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "mid-fetch-output", 1);
+      expect(managed.deferredOutput).toHaveLength(0);
+    });
+
+    it("does NOT replay on a stale-generation fetch failure — the newer restore owns the entries", async () => {
+      const { terminalClient } = await import("@/clients");
+      let rejectFetch!: (err: Error) => void;
+      vi.mocked(terminalClient.getSerializedState).mockImplementation(
+        () =>
+          new Promise((_, reject) => {
+            rejectFetch = reject;
+          })
+      );
+
+      const managed = makeManagedTerminal();
+      instances.set("t1", managed);
+
+      const promise = controller.fetchAndRestore("t1");
+      await flushMicrotasks();
+      managed.deferredOutput.push({ data: "held-for-next-gen", chunkCount: 1 });
+
+      // A newer restore supersedes this one before the fetch settles.
+      managed.restoreGeneration++;
+      rejectFetch(new Error("host gone"));
+      await promise;
+
+      expect(writeDataSpy).not.toHaveBeenCalled();
+      expect(managed.deferredOutput).toHaveLength(1);
+    });
+  });
+
+  describe("failure-path deferred replay (synchronous restore)", () => {
+    it("replays deferred output when terminal.reset throws mid-restore", () => {
+      const managed = makeManagedTerminal({
+        deferredOutput: [{ data: "held", chunkCount: 3 }],
+      });
+      instances.set("t1", managed);
+      mockTerminal.reset.mockImplementationOnce(() => {
+        throw new Error("core torn down");
+      });
+
+      const result = controller.restoreFromSerialized("t1", "small-state");
+
+      expect(result).toBe(false);
+      expect(managed.isSerializedRestoreInProgress).toBe(false);
+      expect(writeDataSpy).toHaveBeenCalledWith("t1", "held", 3);
+      expect(managed.deferredOutput).toHaveLength(0);
+    });
   });
 
   describe("destroy", () => {
     it("bumps restore generation and clears restore state", () => {
       const managed = makeManagedTerminal({
         isSerializedRestoreInProgress: true,
-        deferredOutput: ["data"],
+        deferredOutput: [{ data: "data", chunkCount: 1 }],
       });
       instances.set("t1", managed);
 

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -119,19 +119,48 @@ describe("TerminalWriteController.write", () => {
     expect((managed.terminal as unknown as MockTerminal).write).not.toHaveBeenCalled();
   });
 
-  it("serialized-restore path: defers output and acks port data, never the IPC ledger", () => {
+  it("serialized-restore path: defers output without settling ANY ledger", () => {
     managed.isSerializedRestoreInProgress = true;
     controller.write("t1", "abc");
-    controller.write("t1", new Uint8Array([0x61, 0x62]));
+    controller.write("t1", new Uint8Array([0x61, 0x62]), 3);
 
-    expect(managed.deferredOutput).toEqual(["abc", new Uint8Array([0x61, 0x62])]);
-    expect(deps.acknowledgePortData).toHaveBeenNthCalledWith(1, "t1", 3, 1);
-    expect(deps.acknowledgePortData).toHaveBeenNthCalledWith(2, "t1", 2, 1);
-    // Deferred chunks are replayed through the normal path once restore
-    // finishes, which acks the IPC ledger then — acking here too would
-    // double-drain the host ledger.
+    // The batch's chunkCount travels with the deferred entry so the replay
+    // write can settle exactly the FIFO entries the batch owns.
+    expect(managed.deferredOutput).toEqual([
+      { data: "abc", chunkCount: 1 },
+      { data: new Uint8Array([0x61, 0x62]), chunkCount: 3 },
+    ]);
+    // No ledger moves at defer time. Deferred chunks are replayed through the
+    // normal path once restore finishes, and ALL bookkeeping (port-ack FIFO,
+    // IPC ledger, ingest inFlightBytes) happens on the replay write's
+    // completion. Acking here AND at replay double-debited the port-ack FIFO:
+    // each replayed chunk stole an entry belonging to a chunk that arrived
+    // after the restore, permanently inflating the host's queued-byte ledger
+    // (every later pause then degrades to its 10s safety timeout). Holding the
+    // charge also keeps the host's watermarks pacing the PTY while the restore
+    // runs, bounding mid-restore buffering without dropping bytes.
+    expect(deps.acknowledgePortData).not.toHaveBeenCalled();
     expect(deps.acknowledgeData).not.toHaveBeenCalled();
+    expect(deps.notifyWriteComplete).not.toHaveBeenCalled();
     expect((managed.terminal as unknown as MockTerminal).write).not.toHaveBeenCalled();
+  });
+
+  it("replaying a deferred batch settles its own FIFO entries exactly once", () => {
+    // End-to-end defer→replay: the ONLY acknowledgement for a deferred batch
+    // is the one its replay write produces, with the original chunkCount.
+    managed.isSerializedRestoreInProgress = true;
+    controller.write("t1", new Uint8Array([1, 2, 3]), 2);
+    expect(deps.acknowledgePortData).not.toHaveBeenCalled();
+
+    managed.isSerializedRestoreInProgress = false;
+    const [entry] = managed.deferredOutput;
+    managed.deferredOutput = [];
+    controller.write("t1", entry!.data, entry!.chunkCount);
+
+    expect(deps.acknowledgePortData).toHaveBeenCalledTimes(1);
+    expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 3, 2);
+    expect(deps.notifyWriteComplete).toHaveBeenCalledTimes(1);
+    expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 3);
   });
 
   it("normal path: writes to terminal, acks both data and port data, increments unseen", () => {
@@ -196,12 +225,12 @@ describe("TerminalWriteController.write", () => {
 
     it("deferred-restore path: never acks the IPC ledger even for non-ASCII strings", () => {
       // The IPC ledger is drained when the deferred chunk replays through the
-      // normal path after restore. Acking here would double-drain it. The port
-      // ack stays in UTF-16 code units (1 for the single box-drawing char).
+      // normal path after restore. Acking here would double-drain it. The
+      // port-ack FIFO is equally untouched (settled by the replay write).
       managed.isSerializedRestoreInProgress = true;
       controller.write("t1", "│");
 
-      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 1, 1);
+      expect(deps.acknowledgePortData).not.toHaveBeenCalled();
       expect(deps.acknowledgeData).not.toHaveBeenCalled();
     });
   });
@@ -219,10 +248,11 @@ describe("TerminalWriteController.write", () => {
       expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 2, 2);
     });
 
-    it("deferred-restore path: forwards the chunk count when acking held batches", () => {
+    it("deferred-restore path: preserves the chunk count on the held batch", () => {
       managed.isSerializedRestoreInProgress = true;
       controller.write("t1", new Uint8Array([1, 2]), 2);
-      expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 2, 2);
+      expect(deps.acknowledgePortData).not.toHaveBeenCalled();
+      expect(managed.deferredOutput).toEqual([{ data: new Uint8Array([1, 2]), chunkCount: 2 }]);
     });
   });
 

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -199,7 +199,12 @@ export interface ManagedTerminal {
   writeChain: Promise<void>;
   restoreGeneration: number;
   isSerializedRestoreInProgress: boolean;
-  deferredOutput: Array<string | Uint8Array>;
+  // Output that arrived mid-restore, replayed once the restore settles. Each
+  // entry keeps the ingest batch's chunkCount so the replay write can settle
+  // the SAME pending port-ack FIFO entries the batch owns — the entries are
+  // deliberately NOT settled at defer time (see TerminalWriteController), so
+  // the host's flow control keeps pacing the PTY while the restore runs.
+  deferredOutput: Array<{ data: string | Uint8Array; chunkCount: number }>;
 
   // Background scrollback restore state — prevents double-restore and tracks
   // lifecycle. Restores are queued ("pending"), replay asynchronously


### PR DESCRIPTION
This branch hardens the terminal output pipeline against heavy agent output. I wrote deterministic stress tests around the failure modes first, and they surfaced a cluster of flow-control accounting bugs. This is the main one.

### Double-acking deferred output during scrollback restore

When a serialized restore is in progress, live output is deferred and replayed once the restore settles. That deferred output was being acknowledged twice against the host's byte ledger: once at defer time, and again when the replay went back through the normal write path. Each replayed chunk stole a pending-ack FIFO entry belonging to a chunk that arrived after the restore, so the host's queued-byte ledger ended up permanently inflated and every later backpressure pause degraded to the 10 second safety timeout.

Deferred output now settles its accounting exactly once, on replay (`TerminalWriteController`, `TerminalRestoreController`). Each deferred entry carries its original `chunkCount` so the replay settles exactly the FIFO entries the batch owns. A nice side effect is that the host's watermarks now pace the PTY while a restore runs, so mid-restore buffering is bounded by the transport itself and no bytes get dropped to enforce it.

Every failed restore path (snapshot fetch rejecting, null serialized state, a synchronous restore throw, a poisoned write chain) now still replays held output, so a pane can't freeze behind a restore that never completes.

### Other fixes

- Terminals paused by the window-level aggregate watermark stayed stranded until their own safety timeout when the queue drained through a timeout or terminal teardown instead of acks. Those paths now run the same resume sweep as acks, in both `portQueue.ts` and `ipcQueue.ts`.
- The window disconnect cleanup in `pty-host.ts` iterated a live iterator after `resumeAll()` had already cleared the map it read from, so the loop never ran and per-window pause tracking entries leaked. The paused set is now snapshotted first, and `resumeAll()` emits the release so other windows don't wear a stale paused pill.
- Bytes still batched when a window's port closed were silently dropped with no accounting. They're now counted as data loss.
- After a port replacement, stale ack entries from the previous port generation could debit the fresh ledger. The pending-ack FIFO is now cleared at port activation, and stale write completions degrade to no-op acks.

### Diagnostics

The flow-control snapshot now carries a bounded per-terminal drop tally (`droppedBytes` / `dropCount` / `lastDropAt`), so a support bundle can attribute which terminal lost output instead of only knowing that some bytes were dropped process-wide. Entries are capped at 256 terminals and cleared on exit.

### Tests

Around 40 new tests, including a new integration stress suite (`electron/pty-host/__tests__/portPipeline.stress.test.ts`) that exercises the real `PortBatcher`, `PortQueueManager` and `PtyPauseCoordinator` together: focused-terminal priority under sibling floods, watermark pause and ack-driven resume, multi-source pause holds, saturated-window isolation, and byte-exact reassembly across threshold flushes with adversarial chunk shapes. A second-opinion review caught the stranded-restore edge case, which is now covered too.

Typecheck, lint ratchet and 649 targeted tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
