### PR TITLE
fix(toolbar): dedupe persisted button ids so forge pills don't render duplicated (#10937)

### DIFF
--- a/eslint-warnings-baseline.json
+++ b/eslint-warnings-baseline.json
@@ -1,9 +1,9 @@
 {
-  "count": 1127,
+  "count": 1128,
   "byRule": {
     "@typescript-eslint/no-explicit-any": 52,
     "@typescript-eslint/no-floating-promises": 86,
-    "@typescript-eslint/no-unsafe-type-assertion": 494,
+    "@typescript-eslint/no-unsafe-type-assertion": 495,
     "no-restricted-imports": 5,
     "no-restricted-syntax": 376,
     "no-useless-assignment": 19,
@@ -11,5 +11,5 @@
     "react-compiler/react-compiler": 15,
     "react-hooks/exhaustive-deps": 38
   },
-  "updatedAt": "2026-07-03T06:34:36.196Z"
+  "updatedAt": "2026-07-03T09:37:28.145Z"
 }

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1113,16 +1113,22 @@ export function Toolbar({
 
   const effectiveLeftButtons = useMemo(
     () =>
-      toolbarLayout.leftButtons.filter((id) =>
+      // Dedupe defensively so a persisted list holding a repeated id never
+      // renders duplicate pills (#10937) — the store also heals this, this is
+      // belt-and-suspenders at the render boundary.
+      Array.from(new Set(toolbarLayout.leftButtons)).filter((id) =>
         isToolbarButtonVisible(id, pinnedButtons, effectiveAgentSettings, agentAvailability)
       ),
     [toolbarLayout.leftButtons, pinnedButtons, effectiveAgentSettings, agentAvailability]
   );
 
   const effectiveRightButtons = useMemo(() => {
-    const existing = new Set(toolbarLayout.rightButtons);
+    // Dedupe the persisted base before appending plugin extras, so duplicate
+    // ids (e.g. repeated `forge-stats`, #10937) can't render twice.
+    const base = Array.from(new Set(toolbarLayout.rightButtons));
+    const existing = new Set(base);
     const extra = pluginButtonIds.filter((id) => !existing.has(id));
-    return [...toolbarLayout.rightButtons, ...extra].filter((id) =>
+    return [...base, ...extra].filter((id) =>
       isToolbarButtonVisible(id, pinnedButtons, effectiveAgentSettings, agentAvailability)
     );
   }, [

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -746,6 +746,19 @@ describe("toolbarPreferencesStore", () => {
       expect(layout.rightButtons).toContain("copy-tree");
     });
 
+    it("sanitizeButtonList dedupes repeated ids when set via setRightButtons (#10937)", async () => {
+      const store = await loadStore();
+
+      store
+        .getState()
+        .setRightButtons(["settings", "forge-stats" as never, "forge-stats" as never, "copy-tree"]);
+
+      const { rightButtons } = store.getState().layout;
+      expect(rightButtons.filter((id) => id === "forge-stats")).toHaveLength(1);
+      // First occurrence keeps its slot: dedup preserves order.
+      expect(rightButtons.indexOf("settings")).toBeLessThan(rightButtons.indexOf("forge-stats"));
+    });
+
     it("v4→v5 handles missing layout without throwing", async () => {
       storageMock.setItem(
         STORAGE_KEY,
@@ -1031,6 +1044,96 @@ describe("toolbarPreferencesStore", () => {
         const store = await loadStore();
         expect(store.getState().layout.pinnedButtons).toEqual({ "forge-stats": false });
         expect(store.getState().layout.rightButtons).toContain("forge-stats");
+      });
+
+      it("dedupes a v9 rename collision so only one forge-stats survives (#10937)", async () => {
+        // A v9 profile holding both `forge-stats` and the legacy `github-stats`
+        // would, under the bare-`.map()` v10 rename, produce two `forge-stats`
+        // entries. The dedup guard collapses them to one, keeping the first slot.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal"],
+                rightButtons: ["forge-stats", "settings", "github-stats", "problems"],
+                pinnedButtons: {},
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 9,
+          })
+        );
+
+        const store = await loadStore();
+        const { rightButtons } = store.getState().layout;
+        expect(rightButtons.filter((id) => id === "forge-stats")).toHaveLength(1);
+        expect(rightButtons).not.toContain("github-stats");
+        // First occurrence wins: forge-stats keeps its original slot ahead of settings.
+        expect(rightButtons.indexOf("forge-stats")).toBeLessThan(rightButtons.indexOf("settings"));
+      });
+    });
+
+    describe("v10→v11 deduplicates button ids", () => {
+      it("collapses repeated ids in both arrays while leaving pinnedButtons untouched", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "terminal", "browser"],
+                rightButtons: [
+                  "voice-recording",
+                  "forge-stats",
+                  "forge-stats",
+                  "forge-stats",
+                  "settings",
+                ],
+                pinnedButtons: { "forge-stats": false },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 10,
+          })
+        );
+
+        const store = await loadStore();
+        const { leftButtons, rightButtons, pinnedButtons } = store.getState().layout;
+        expect(leftButtons.filter((id) => id === "terminal")).toHaveLength(1);
+        expect(rightButtons.filter((id) => id === "forge-stats")).toHaveLength(1);
+        // Survivor order is preserved (existing entries never reorder).
+        expect(rightButtons.indexOf("voice-recording")).toBeLessThan(
+          rightButtons.indexOf("forge-stats")
+        );
+        expect(rightButtons.indexOf("forge-stats")).toBeLessThan(rightButtons.indexOf("settings"));
+        // The pin map is a Record — unique keys by construction, left untouched.
+        expect(pinnedButtons).toEqual({ "forge-stats": false });
+      });
+
+      it("heals duplicates on an already-current v11 blob via merge() (#10937)", async () => {
+        // The durable guard lives in `sanitizeButtonList`, run on every
+        // hydration through `merge()` — not only the version-gated migration —
+        // so a blob already stamped v11 that still carries duplicates (a stale
+        // dev build re-corrupting a shared profile) is repaired regardless.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal"],
+                rightButtons: ["forge-stats", "forge-stats", "settings"],
+                pinnedButtons: {},
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 11,
+          })
+        );
+
+        const store = await loadStore();
+        expect(
+          store.getState().layout.rightButtons.filter((id) => id === "forge-stats")
+        ).toHaveLength(1);
       });
     });
   });

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -749,9 +749,7 @@ describe("toolbarPreferencesStore", () => {
     it("sanitizeButtonList dedupes repeated ids when set via setRightButtons (#10937)", async () => {
       const store = await loadStore();
 
-      store
-        .getState()
-        .setRightButtons(["settings", "forge-stats" as never, "forge-stats" as never, "copy-tree"]);
+      store.getState().setRightButtons(["settings", "forge-stats", "forge-stats", "copy-tree"]);
 
       const { rightButtons } = store.getState().layout;
       expect(rightButtons.filter((id) => id === "forge-stats")).toHaveLength(1);

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -755,8 +755,10 @@ describe("toolbarPreferencesStore", () => {
 
       const { rightButtons } = store.getState().layout;
       expect(rightButtons.filter((id) => id === "forge-stats")).toHaveLength(1);
-      // First occurrence keeps its slot: dedup preserves order.
+      // Non-duplicated ids all survive, in first-occurrence order.
+      expect(rightButtons).toContain("copy-tree");
       expect(rightButtons.indexOf("settings")).toBeLessThan(rightButtons.indexOf("forge-stats"));
+      expect(rightButtons.indexOf("forge-stats")).toBeLessThan(rightButtons.indexOf("copy-tree"));
     });
 
     it("v4→v5 handles missing layout without throwing", async () => {

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -44,7 +44,15 @@ const DEFAULT_PREFERENCES: ToolbarPreferences = {
 const FIXED_BUTTON_IDS: ToolbarButtonId[] = ["sidebar-toggle", "assistant-toggle", "portal-toggle"];
 
 function sanitizeButtonList(buttons: AnyToolbarButtonId[]): AnyToolbarButtonId[] {
-  return buttons.filter((id) => !FIXED_BUTTON_IDS.includes(id as ToolbarButtonId));
+  const filtered = buttons.filter((id) => !FIXED_BUTTON_IDS.includes(id as ToolbarButtonId));
+  // Dedupe by first occurrence. A persisted list can accumulate repeated ids —
+  // chiefly duplicate `forge-stats` when the v10 `renameForgeStats` migration
+  // collapses `github-stats` onto a list that already held `forge-stats`,
+  // compounded by shared dev-profile round-trips (#10937). Every hydration
+  // routes through here via `mergeButtonList`, and `setLeftButtons`/
+  // `setRightButtons` do too, so this is the durable, version-independent guard
+  // against duplicate pills (`merge()` runs every load; `migrate()` does not).
+  return Array.from(new Set(filtered));
 }
 
 /**
@@ -186,7 +194,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 10,
+      version: 11,
       storage: createSafeJSONStorage(),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
@@ -357,6 +365,25 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
           }
           if (Array.isArray(layout?.rightButtons)) {
             layout.rightButtons = layout.rightButtons.map(renameForgeStats);
+          }
+        }
+        if (version < 11) {
+          // One-time heal for profiles that accumulated duplicate button ids —
+          // chiefly repeated `forge-stats` from the v10 rename landing on a list
+          // that already held one, compounded by shared dev-profile round-trips
+          // (#10937). The v10 `renameForgeStats` step above used a bare `.map()`
+          // with no dedup, unlike the v3 `renameAgentSetup` precedent. `merge()`
+          // (via `sanitizeButtonList`) already dedupes on every load; this makes
+          // the repair explicit and matches the per-version migration
+          // convention. `pinnedButtons` is a map, so its keys can't duplicate.
+          const layout = state.layout as
+            | { leftButtons?: string[]; rightButtons?: string[] }
+            | undefined;
+          const dedupe = (buttons?: string[]) =>
+            Array.isArray(buttons) ? Array.from(new Set(buttons)) : buttons;
+          if (layout) {
+            layout.leftButtons = dedupe(layout.leftButtons);
+            layout.rightButtons = dedupe(layout.rightButtons);
           }
         }
         return state as unknown as ToolbarPreferencesState;

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -144,7 +144,13 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
           toList.splice(toIndex, 0, buttonId);
 
           return {
-            layout: { ...state.layout, leftButtons, rightButtons },
+            layout: {
+              ...state.layout,
+              // Sanitize both sides so a cross-side move onto a list that
+              // already held the id can't leave a duplicate behind (#10937).
+              leftButtons: sanitizeButtonList(leftButtons),
+              rightButtons: sanitizeButtonList(rightButtons),
+            },
           };
         }),
       toggleButtonVisibility: (buttonId, _side) =>


### PR DESCRIPTION
## Summary

In dev mode the forge status pills (issues, pull requests, commits) were rendering 2 or 3 times, stacked directly on top of each other. The persisted Zustand store `daintree-toolbar-preferences` had the id `forge-stats` repeated in `layout.rightButtons`, and the render layer just maps one pill per array entry with no dedup, so every duplicate in the array became a duplicate pill on screen.

Two compounding causes. The v10 `renameForgeStats` migration in `toolbarPreferencesStore.ts` renames `github-stats` to `forge-stats` with a plain `.map()` and no dedup, unlike the v3 `renameAgentSetup` migration, which sets the precedent by deduping with `Array.from(new Set(...))`. On top of that, `mergeButtonList` re-inserts the legacy `github-stats` id whenever a stale dev build hydrates the shared `daintree-dev` profile, and the next develop-build migration renames that reinserted id into another `forge-stats` copy. Repeat the old-build/new-build cycle and the count keeps climbing.

Resolves #10937

## Changes

Three layers of defense, in order of durability:

1. `sanitizeButtonList` now dedups by first occurrence. This is the version-independent guard: `merge()` routes every hydration through it, and so do the `setLeftButtons`, `setRightButtons`, and `moveButton` write paths.
2. Added a v11 migration that dedups `leftButtons` and `rightButtons` as a one-time explicit repair, matching the file's existing per-version migration convention. `pinnedButtons` is a `Record`, so its keys are already unique and needed no change.
3. `effectiveLeftButtons` and `effectiveRightButtons` in `Toolbar.tsx` now dedup the base arrays at the render boundary, as a final belt-and-suspenders layer.

This is likely also the root cause behind #10806, where two side-by-side pills showed up after rapid project-view switching. That was diagnosed at the time as an orphaned `ProjectViewManager` `WebContentsView`, but it's plausible that was actually this same bug at 2x. No `ProjectViewManager` changes were needed here, so treat that connection as a theory, not a confirmed fix.

Production is unaffected. It uses a separate profile that's only ever touched by builds `v0.19` and later, so the old-schema writer that drives the compounding never runs there.

Files changed:
- `src/store/toolbarPreferencesStore.ts`
- `src/components/Layout/Toolbar.tsx`
- `src/store/__tests__/toolbarPreferencesStore.test.ts`

## Testing

Added 5 new store tests covering dedup via `merge()`, the v9 to v10 rename collision, the v10 to v11 migration, and healing an already-current v11 blob via `merge()`. Store suite (52 tests) and Toolbar suite (124 tests) both pass locally.
