### PR TITLE
fix(ci): raise tsc heap limit in Marketing Screenshots build

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -100,6 +100,8 @@ jobs:
         run: node scripts/ci/verify-electron-install.mjs
 
       - name: Build app
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
         run: npm run build
 
       - name: Install Claude Code


### PR DESCRIPTION
The **Marketing Screenshots** workflow's `Build app` step runs `npm run build` (which invokes `tsc`) at Node's default ~2GB old-space ceiling. On the `v0.22.0` tag it OOMed:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
sh: line 1: tsc  Abort trap: 6  (exit 134)
```

The log shows ~2042 MB used right at the heap limit — the codebase has grown enough that this step no longer fits in the default heap. This is deterministic, not a flake, and will keep recurring.

Fix: set `NODE_OPTIONS=--max-old-space-size=6144` on the build step, matching what the gating release workflows (`release-macos/linux/windows.yml`) already do.

Note: this workflow doesn't gate the release — the v0.22.0 R2 publish is unaffected.