### PR TITLE
fix(terminal): spawn overlay panes at their real grid and guard mid-stream re-wraps

### DIFF
--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -2,6 +2,7 @@ import { Terminal } from "@xterm/xterm";
 import { TerminalRefreshTier } from "@/types";
 import { isSidebarMeasurementLocked } from "@/lib/layoutTransitionLock";
 import { logDebug, logWarn } from "@/utils/logger";
+import { REVEAL_REWRAP_QUIESCENT_MS } from "./TerminalResizeController";
 import type { ManagedTerminal } from "./types";
 
 // Sweep cadence. Matches the TerminalReflowController heartbeat — slow enough
@@ -428,7 +429,18 @@ export class TerminalReconciliationWatchdog {
           // Breaker tripped: stop re-wrapping this pane's scrollback. Fall through so
           // the cheaper render-pause / WebGL layers below still reconcile — the
           // breaker disables only the expensive geometry repair, not the whole chain.
-          if (!managed.geometryRepairGaveUp) {
+          // A main-buffer pane that wrote within the reveal quiescence window
+          // will have its reconcile deferred by reconcileGeometryFresh's
+          // streaming gate (#10863) — that's a deferred tick, not a failed
+          // convergence, so don't issue the repair or burn a breaker attempt
+          // on it; retry once the stream pauses. Main-buffer only: the gate in
+          // reconcileGeometryFresh sits after the alt-buffer early-return, so
+          // an alt-buffer reconcile is never deferred by writes. Fall through
+          // (not return) so the render-pause / WebGL layers below still run —
+          // a streaming pane with a paused renderer needs that unpause.
+          const streamingDeferred =
+            !managed.isAltBuffer && now - (managed.lastWriteAt ?? 0) < REVEAL_REWRAP_QUIESCENT_MS;
+          if (!managed.geometryRepairGaveUp && !streamingDeferred) {
             const attempts = managed.geometryRepairAttempts ?? 0;
             if (attempts >= WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS) {
               managed.geometryRepairGaveUp = true;

--- a/src/services/terminal/TerminalReconciliationWatchdog.ts
+++ b/src/services/terminal/TerminalReconciliationWatchdog.ts
@@ -2,7 +2,7 @@ import { Terminal } from "@xterm/xterm";
 import { TerminalRefreshTier } from "@/types";
 import { isSidebarMeasurementLocked } from "@/lib/layoutTransitionLock";
 import { logDebug, logWarn } from "@/utils/logger";
-import { REVEAL_REWRAP_QUIESCENT_MS } from "./TerminalResizeController";
+import { hasStreamingWrites } from "./TerminalResizeController";
 import type { ManagedTerminal } from "./types";
 
 // Sweep cadence. Matches the TerminalReflowController heartbeat — slow enough
@@ -348,6 +348,17 @@ export class TerminalReconciliationWatchdog {
     const inSynchronizedBlock = managed.terminal.modes?.synchronizedOutputMode === true;
     const element = managed.terminal.element;
 
+    // A streaming main-buffer pane (recent or still-parsing writes) will have
+    // any grid-changing reconcile deferred by reconcileGeometryFresh's
+    // quiescence gate (#10863). Issuing a geometry repair anyway would stamp
+    // the 6s repair cooldown and spend heavy budget on a guaranteed no-op, so
+    // both geometry branches below skip the attempt and fall through to the
+    // cheaper render-pause / WebGL layers, retrying once the stream pauses.
+    // Main-buffer only: the gate in reconcileGeometryFresh sits after the
+    // alt-buffer early-return, so an alt-buffer reconcile is never deferred
+    // by writes.
+    const streamingDeferred = !managed.isAltBuffer && hasStreamingWrites(managed, now);
+
     // Reveal-pending guaranteed redraw (#10632). The project-switch suppression
     // window cleared while this host was still detached/occluded, so its one-shot
     // resetRenderer was deferred to the watchdog rather than spent on a zero-box
@@ -358,6 +369,9 @@ export class TerminalReconciliationWatchdog {
     // by the attachGeneration it was armed under: a later re-attach that already
     // re-ran its own reveal supersedes it. Cleared ONLY on a successful reconcile
     // (false = unmeasurable/occluded box → keep the flag and retry next tick).
+    // A streaming-deferred tick keeps the obligation armed WITHOUT issuing the
+    // repair (no cooldown stamp, no heavy budget) and falls through to the
+    // cheaper layers below.
     if (managed.revealPendingRepair && !inSynchronizedBlock) {
       if (
         managed.revealPendingGeneration !== undefined &&
@@ -367,7 +381,7 @@ export class TerminalReconciliationWatchdog {
         // the id) — the obligation can't belong to this incarnation; drop it.
         managed.revealPendingRepair = false;
         managed.revealPendingGeneration = undefined;
-      } else {
+      } else if (!streamingDeferred) {
         if (heavyBudget <= 0) return 0;
         managed.lastWatchdogRepairAt = now;
         logWarn(
@@ -429,17 +443,11 @@ export class TerminalReconciliationWatchdog {
           // Breaker tripped: stop re-wrapping this pane's scrollback. Fall through so
           // the cheaper render-pause / WebGL layers below still reconcile — the
           // breaker disables only the expensive geometry repair, not the whole chain.
-          // A main-buffer pane that wrote within the reveal quiescence window
-          // will have its reconcile deferred by reconcileGeometryFresh's
-          // streaming gate (#10863) — that's a deferred tick, not a failed
-          // convergence, so don't issue the repair or burn a breaker attempt
-          // on it; retry once the stream pauses. Main-buffer only: the gate in
-          // reconcileGeometryFresh sits after the alt-buffer early-return, so
-          // an alt-buffer reconcile is never deferred by writes. Fall through
-          // (not return) so the render-pause / WebGL layers below still run —
-          // a streaming pane with a paused renderer needs that unpause.
-          const streamingDeferred =
-            !managed.isAltBuffer && now - (managed.lastWriteAt ?? 0) < REVEAL_REWRAP_QUIESCENT_MS;
+          // A streaming-deferred tick is not a failed convergence — don't
+          // issue the repair or burn a breaker attempt on it (see the
+          // streamingDeferred declaration above); the render-pause / WebGL
+          // layers below still run so a streaming pane with a paused renderer
+          // gets its unpause.
           if (!managed.geometryRepairGaveUp && !streamingDeferred) {
             const attempts = managed.geometryRepairAttempts ?? 0;
             if (attempts >= WATCHDOG_MAX_GEOMETRY_REPAIR_ATTEMPTS) {

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -65,6 +65,15 @@ export interface ResizeControllerDeps {
   dataBuffer: TerminalOutputIngestService;
 }
 
+/**
+ * How long a main-buffer pane must be write-quiescent before the reveal-path
+ * reconcile ({@link TerminalResizeController.reconcileGeometryFresh}) may apply
+ * a grid-changing resize. A resize that lands while a main-buffer CLI is still
+ * streaming re-wraps its committed scrollback under the app's cursor-relative
+ * sticky-region repaint and duplicates/garbles the block (#10863).
+ */
+export const REVEAL_REWRAP_QUIESCENT_MS = 300;
+
 export class TerminalResizeController {
   private resizeLocks = new Map<string, number>();
   private settledResizeTimers = new Map<string, number>();
@@ -402,6 +411,23 @@ export class TerminalResizeController {
       if (!cellDims) return false;
       cols = Math.max(2, Math.floor(rect.width / cellDims.width));
       rows = Math.max(1, Math.floor(rect.height / cellDims.height));
+    }
+
+    // Never re-wrap a main-buffer pane out from under a CLI that is still
+    // streaming (#10863). xterm's resize() reflows committed scrollback while
+    // an Ink-style CLI repaints its sticky region with cursor-relative erase
+    // math sized for the old grid — a reveal that lands mid-paint duplicates
+    // or garbles the block it is painting. Report "not paintable yet" (before
+    // touching the dim caches, so applyDeferredResize's cache==current check
+    // stays truthful) and let the reveal sweep retry once the pane has been
+    // write-quiescent; the reconciliation watchdog backstops a pane that
+    // never goes quiet. A no-drift pass falls through: the PTY re-assert
+    // below is dedupe-safe and never re-wraps.
+    if (
+      (managed.terminal.cols !== cols || managed.terminal.rows !== rows) &&
+      Date.now() - (managed.lastWriteAt ?? 0) < REVEAL_REWRAP_QUIESCENT_MS
+    ) {
+      return false;
     }
 
     managed.lastWidth = rect.width;

--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -74,6 +74,23 @@ export interface ResizeControllerDeps {
  */
 export const REVEAL_REWRAP_QUIESCENT_MS = 300;
 
+/**
+ * True while the pane is still streaming for re-wrap purposes (#10863). Either
+ * signal means streaming: `lastWriteAt` is stamped only when a batch finishes
+ * PARSING (the write-buffer callback), so recency alone misses a queued batch
+ * that is still parsing — including a pane's very FIRST batch, where
+ * `lastWriteAt` is unset entirely; `pendingWrites` covers exactly that
+ * in-flight window. The reveal-path quiescence gate and the watchdog's
+ * deferred-tick accounting must agree on this predicate, or a deferred
+ * reconcile burns geometry-breaker attempts — share it, never inline it.
+ */
+export function hasStreamingWrites(managed: ManagedTerminal, now: number): boolean {
+  return (
+    (managed.pendingWrites ?? 0) > 0 ||
+    now - (managed.lastWriteAt ?? 0) < REVEAL_REWRAP_QUIESCENT_MS
+  );
+}
+
 export class TerminalResizeController {
   private resizeLocks = new Map<string, number>();
   private settledResizeTimers = new Map<string, number>();
@@ -419,13 +436,13 @@ export class TerminalResizeController {
     // math sized for the old grid — a reveal that lands mid-paint duplicates
     // or garbles the block it is painting. Report "not paintable yet" (before
     // touching the dim caches, so applyDeferredResize's cache==current check
-    // stays truthful) and let the reveal sweep retry once the pane has been
-    // write-quiescent; the reconciliation watchdog backstops a pane that
-    // never goes quiet. A no-drift pass falls through: the PTY re-assert
-    // below is dedupe-safe and never re-wraps.
+    // stays truthful) and let the reveal sweep retry; the reconciliation
+    // watchdog picks up a pane that outlasts the sweep at its first quiet
+    // tick. A no-drift pass falls through: the PTY re-assert below is
+    // dedupe-safe and never re-wraps.
     if (
       (managed.terminal.cols !== cols || managed.terminal.rows !== rows) &&
-      Date.now() - (managed.lastWriteAt ?? 0) < REVEAL_REWRAP_QUIESCENT_MS
+      hasStreamingWrites(managed, Date.now())
     ) {
       return false;
     }

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -742,6 +742,29 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(managed.geometryRepairAttempts).toBe(1);
     });
 
+    it("does not count a still-parsing tick (pendingWrites) as a repair attempt", () => {
+      // Same deferral as the lastWriteAt case, via the other streaming signal:
+      // a queued-but-unparsed batch means reconcileGeometryFresh would defer,
+      // so the watchdog must not issue the repair or spend a breaker attempt.
+      const managed = makeManaged({ isAltBuffer: false });
+      setRenderPaused(managed, false);
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      managed.pendingWrites = 1;
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(managed.geometryRepairAttempts ?? 0).toBe(0);
+
+      // The batch lands (and its lastWriteAt stamp ages out) — next tick repairs.
+      managed.pendingWrites = 0;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(1);
+      expect(managed.geometryRepairAttempts).toBe(1);
+    });
+
     it("falls through to the paused-render recovery on a streaming-deferred tick", () => {
       // Deferring the geometry repair must not starve the cheaper layers: a
       // streaming pane whose renderer is paused still needs the unpause reflow.
@@ -824,6 +847,37 @@ describe("TerminalReconciliationWatchdog", () => {
       vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
       expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("t1");
       expect(managed.revealPendingRepair).toBe(true);
+    });
+
+    it("defers the reveal-pending redraw for a streaming main-buffer pane without stamping the cooldown", () => {
+      // Issuing the reveal repair on a streaming pane is a guaranteed no-op
+      // (reconcileGeometryFresh's quiescence gate defers it), so it must not
+      // stamp the 6s cooldown or spend heavy budget — the obligation stays
+      // armed and the very next quiet tick repairs.
+      const managed = makeManaged({ isAltBuffer: false });
+      managed.revealPendingRepair = true;
+      managed.revealPendingGeneration = managed.attachGeneration;
+      // Diverged grid: the exact case where reconcileGeometryFresh's streaming
+      // gate WOULD defer the re-wrap, making the issued repair a no-op.
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      managed.pendingWrites = 1;
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(managed.revealPendingRepair).toBe(true);
+      expect(managed.lastWatchdogRepairAt).toBeUndefined();
+      // The fall-through geometry-convergence branch must defer too — no
+      // breaker attempt spent on the same streaming tick.
+      expect(managed.geometryRepairAttempts ?? 0).toBe(0);
+
+      // The stream drains — the next tick issues the repair and clears the flag.
+      managed.pendingWrites = 0;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledWith("t1");
+      expect(managed.revealPendingRepair).toBe(false);
     });
 
     it("defers the reveal-pending redraw while a synchronized-output block is open", () => {

--- a/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
+++ b/src/services/terminal/__tests__/TerminalReconciliationWatchdog.test.ts
@@ -715,6 +715,64 @@ describe("TerminalReconciliationWatchdog", () => {
       expect(deferred?.geometryRepairAttempts).toBe(0);
     });
 
+    it("does not count a streaming-deferred tick as a repair attempt (#10863)", () => {
+      // Main-buffer: the quiescence gate exists for main-buffer CLIs whose
+      // committed scrollback a reconcile would re-wrap mid-paint.
+      const managed = makeManaged({ isAltBuffer: false });
+      setRenderPaused(managed, false);
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      // The pane writes continuously: keep lastWriteAt inside the quiescence
+      // window at every tick. reconcileGeometryFresh would defer these, so the
+      // watchdog must neither issue the repair nor spend a breaker attempt.
+      for (let i = 0; i < 12; i++) {
+        managed.lastWriteAt = Date.now() + WATCHDOG_INTERVAL_MS;
+        vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      }
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(managed.geometryRepairAttempts ?? 0).toBe(0);
+      expect(managed.geometryRepairGaveUp).toBeFalsy();
+
+      // The stream pauses — the very next tick repairs normally.
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(1);
+      expect(managed.geometryRepairAttempts).toBe(1);
+    });
+
+    it("falls through to the paused-render recovery on a streaming-deferred tick", () => {
+      // Deferring the geometry repair must not starve the cheaper layers: a
+      // streaming pane whose renderer is paused still needs the unpause reflow.
+      const managed = makeManaged({ isAltBuffer: false });
+      setRenderPaused(managed, true);
+      setGrid(managed, { cols: 137, rows: 40 }, { cols: 100, rows: 40 });
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      managed.lastWriteAt = Date.now() + WATCHDOG_INTERVAL_MS;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).not.toHaveBeenCalled();
+      expect(deps.forceReflow).toHaveBeenCalledWith(managed.terminal.element);
+    });
+
+    it("still repairs a streaming ALT-buffer pane (quiescence gate is main-buffer only)", () => {
+      // reconcileGeometryFresh never re-wraps an alt-buffer pane (its guard
+      // returns before the quiescence gate), so deferring alt-buffer repairs
+      // for writes would only starve the reveal repair with no safety gain.
+      const managed = makeDivergedTerminal();
+      instances.set("t1", managed);
+      const deps = makeDeps(instances);
+      watchdog = new TerminalReconciliationWatchdog(deps);
+
+      managed.lastWriteAt = Date.now() + WATCHDOG_INTERVAL_MS;
+      vi.advanceTimersByTime(WATCHDOG_INTERVAL_MS);
+      expect(deps.reconcileRevealGeometry).toHaveBeenCalledTimes(1);
+      expect(managed.geometryRepairAttempts).toBe(1);
+    });
+
     it("neither advances nor resets the breaker while a synchronized-output block stays open", () => {
       const managed = makeManaged({ isAltBuffer: true });
       (

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -23,6 +23,7 @@ vi.mock("@shared/config/agentRegistry", async (importOriginal) => {
 import {
   TerminalResizeController,
   getXtermCellDimensions,
+  REVEAL_REWRAP_QUIESCENT_MS,
   type ResizeControllerDeps,
 } from "../TerminalResizeController";
 
@@ -1293,6 +1294,66 @@ describe("TerminalResizeController", () => {
       expect(ok).toBe(true);
       expect(managed.terminal.resize).not.toHaveBeenCalled();
       expect(resizeMock).not.toHaveBeenCalled();
+    });
+
+    it("defers a grid-changing reflow while the pane is still streaming output (#10863)", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      // A write landed just now — the CLI is mid-paint.
+      (managed as { lastWriteAt?: number }).lastWriteAt = Date.now();
+
+      const controller = makeController(managed);
+      const before = {
+        latestCols: managed.latestCols,
+        latestRows: managed.latestRows,
+        lastWidth: managed.lastWidth,
+        lastHeight: managed.lastHeight,
+      };
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      // Reports "not paintable yet" so the reveal sweep retries later, and
+      // must not have re-wrapped xterm, resized the PTY, or poisoned the dim
+      // caches (applyDeferredResize's cache==current check relies on them).
+      expect(ok).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+      expect(managed.latestCols).toBe(before.latestCols);
+      expect(managed.latestRows).toBe(before.latestRows);
+      expect(managed.lastWidth).toBe(before.lastWidth);
+      expect(managed.lastHeight).toBe(before.lastHeight);
+    });
+
+    it("applies the deferred reflow once the pane has gone write-quiescent", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      (managed as { lastWriteAt?: number }).lastWriteAt = Date.now();
+
+      const controller = makeController(managed);
+      expect(controller.reconcileGeometryFresh("term-1")).toBe(false);
+
+      vi.advanceTimersByTime(REVEAL_REWRAP_QUIESCENT_MS + 1);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(100, 30);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
+    });
+
+    it("still re-asserts the PTY during streaming when the grid has not drifted", () => {
+      const managed = createManagedTerminal();
+      managed.terminal.cols = 100;
+      managed.terminal.rows = 30;
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      (managed as { lastWriteAt?: number }).lastWriteAt = Date.now();
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      // No re-wrap is involved, so streaming doesn't defer the dedupe-safe
+      // PTY re-assert.
+      expect(ok).toBe(true);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 100, 30);
     });
 
     it("ignores an active resize lock without clearing it (the reveal exception)", () => {

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -1323,6 +1323,22 @@ describe("TerminalResizeController", () => {
       expect(managed.lastHeight).toBe(before.lastHeight);
     });
 
+    it("defers a grid-changing reflow while a write batch is still parsing (pendingWrites)", () => {
+      const managed = createManagedTerminal();
+      managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));
+      // First-ever batch queued but not yet parsed: lastWriteAt is unset (its
+      // stamp rides the write-buffer completion callback), so recency alone
+      // would wave this through and re-wrap mid-first-paint.
+      (managed as { pendingWrites?: number }).pendingWrites = 1;
+
+      const controller = makeController(managed);
+      const ok = controller.reconcileGeometryFresh("term-1");
+
+      expect(ok).toBe(false);
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(resizeMock).not.toHaveBeenCalled();
+    });
+
     it("applies the deferred reflow once the pane has gone write-quiescent", () => {
       const managed = createManagedTerminal();
       managed.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 100, rows: 30 }));

--- a/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
+++ b/src/store/__tests__/panelStore.assistantFocusGuard.test.ts
@@ -39,6 +39,9 @@ vi.mock("@/clients", () => ({
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
+    // No attached renderer xterm in these tests — spawn falls back to the
+    // default/estimated dims path.
+    get: vi.fn(() => null),
     cleanup: vi.fn(),
     destroy: vi.fn(),
     detachForProjectSwitch: vi.fn(),

--- a/src/store/slices/__tests__/gridCapacity.test.ts
+++ b/src/store/slices/__tests__/gridCapacity.test.ts
@@ -33,6 +33,9 @@ vi.mock("@/clients", () => ({
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
+    // No attached renderer xterm in these tests — spawn falls back to the
+    // default/estimated dims path.
+    get: vi.fn(() => null),
     destroy: vi.fn(),
     applyRendererPolicy: vi.fn(),
     onPanelBackgrounded: vi.fn(),

--- a/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelSpawnDims.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for spawn-time PTY geometry (#10863).
+ *
+ * The PTY must boot at the grid the renderer is actually showing. The overlay
+ * (help panel) XtermAdapter mounts without waiting for spawnStatus, so its
+ * xterm can be attached and fitted before the queued spawn runs — booting the
+ * PTY at the legacy 80×24 default made the assistant CLI paint its startup
+ * banner at a width the renderer wasn't wrapping at, duplicating/garbling the
+ * committed output. Three orderings are covered:
+ *  - attach before spawn → spawn uses the live attached grid
+ *  - attach during the spawn IPC → the dropped fit resize is re-asserted
+ *  - no attach yet (overlay) → spawn uses the panel-derived estimate
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+    waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(() => null),
+  },
+}));
+
+vi.mock("@/store/helpPanelStore", () => ({
+  useHelpPanelStore: {
+    getState: () => ({ width: 500 }),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    innerHeight: 900,
+    electron: {
+      globalEnv: {
+        get: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+
+function makeAttachedManaged(cols: number, rows: number) {
+  return {
+    terminal: { cols, rows, element: { isConnected: true } },
+  };
+}
+
+async function drainMicrotasks(iterations = 100): Promise<void> {
+  for (let i = 0; i < iterations; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("spawn-time PTY geometry (#10863)", () => {
+  beforeEach(async () => {
+    const { reset } = usePanelStore.getState();
+    await reset();
+
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn>; resize: ReturnType<typeof vi.fn> };
+    };
+    terminalClient.spawn.mockReset();
+    terminalClient.spawn.mockImplementation(async ({ id }: { id?: string }) => id ?? "spawn-id");
+    terminalClient.resize.mockReset();
+
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    vi.mocked(terminalInstanceService.get).mockReset();
+    vi.mocked(terminalInstanceService.get).mockReturnValue(null as never);
+    vi.mocked(terminalInstanceService.sendPtyResize).mockReset();
+  });
+
+  it("spawns at the live grid when the xterm attached before the queued spawn ran", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    vi.mocked(terminalInstanceService.get).mockReturnValue(makeAttachedManaged(54, 40) as never);
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "dims-1",
+      cwd: "/",
+      bypassLimits: true,
+    });
+    await drainMicrotasks();
+
+    expect(terminalClient.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "dims-1", cols: 54, rows: 40 })
+    );
+    // Spawn dims already match the live grid — no compensating re-assert.
+    const { terminalClient: tc } = (await import("@/clients")) as unknown as {
+      terminalClient: { resize: ReturnType<typeof vi.fn> };
+    };
+    expect(tc.resize).not.toHaveBeenCalledWith("dims-1", 54, 40);
+    expect(terminalInstanceService.sendPtyResize).not.toHaveBeenCalledWith("dims-1", 54, 40);
+  });
+
+  it("re-asserts the fitted grid when the attach landed while the spawn IPC was in flight", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn>; resize: ReturnType<typeof vi.fn> };
+    };
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+
+    // Not attached when the spawn dims are read; attached (and fitted to
+    // 54×40) by the time the spawn IPC resolves. The fit's own PTY resize was
+    // dropped by the pty-host during this window, so addPanel must re-assert.
+    vi.mocked(terminalInstanceService.get)
+      .mockReturnValueOnce(null as never)
+      .mockReturnValue(makeAttachedManaged(54, 40) as never);
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "dims-2",
+      cwd: "/",
+      bypassLimits: true,
+    });
+    await drainMicrotasks();
+
+    expect(terminalClient.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "dims-2", cols: 80, rows: 24 })
+    );
+    // Direct PTY-only resize — sendPtyResize would defer 500ms for a
+    // settled-strategy agent, exactly the window the CLI paints its banner in.
+    expect(terminalClient.resize).toHaveBeenCalledWith("dims-2", 54, 40);
+    expect(terminalInstanceService.sendPtyResize).not.toHaveBeenCalledWith("dims-2", 54, 40);
+  });
+
+  it("boots an overlay panel at the panel-derived estimate, never the 80×24 default", async () => {
+    const { terminalClient } = (await import("@/clients")) as unknown as {
+      terminalClient: { spawn: ReturnType<typeof vi.fn> };
+    };
+
+    const { addPanel } = usePanelStore.getState();
+    await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "dims-3",
+      cwd: "/",
+      location: "overlay",
+      bypassLimits: true,
+    });
+    await drainMicrotasks();
+
+    const spawnArgs = terminalClient.spawn.mock.calls.find(
+      (call) => (call[0] as { id?: string }).id === "dims-3"
+    )?.[0] as { cols: number; rows: number };
+    expect(spawnArgs).toBeDefined();
+    // The estimate derives from the persisted panel width/viewport, so pin
+    // only the invariants: not the legacy default, and consistent with the
+    // committed panel record (the grid every other consumer sees).
+    expect(spawnArgs.cols).not.toBe(80);
+    expect(spawnArgs.rows).not.toBe(24);
+    const panel = usePanelStore.getState().panelsById["dims-3"] as PtyPanelData;
+    expect(spawnArgs.cols).toBe(panel.cols);
+    expect(spawnArgs.rows).toBe(panel.rows);
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelTitleMode.test.ts
@@ -54,6 +54,9 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     setInputLocked: vi.fn(),
     sendPtyResize: vi.fn(),
     waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+    // No attached renderer xterm in these tests — spawn falls back to the
+    // default/estimated dims path.
+    get: vi.fn(() => null),
   },
 }));
 

--- a/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockActivateOnCreate.test.ts
@@ -77,6 +77,9 @@ vi.mock("@/clients", () => ({
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
+    // No attached renderer xterm in these tests — spawn falls back to the
+    // default/estimated dims path.
+    get: vi.fn(() => null),
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
     onPanelBackgrounded: vi.fn(),

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -47,6 +47,9 @@ vi.mock("@/clients", () => ({
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
+    // No attached renderer xterm in these tests — spawn falls back to the
+    // default/estimated dims path.
+    get: vi.fn(() => null),
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
     onPanelBackgrounded: vi.fn(),

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -54,6 +54,9 @@ vi.mock("@/services/TerminalInstanceService", () => ({
     setInputLocked: vi.fn(),
     sendPtyResize: vi.fn(),
     waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+    // No attached renderer xterm in these tests — spawn falls back to the
+    // default/estimated dims path.
+    get: vi.fn(() => null),
   },
 }));
 

--- a/src/store/slices/panelRegistry/__tests__/updateTitleOwnership.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/updateTitleOwnership.test.ts
@@ -46,6 +46,9 @@ vi.mock("@/clients", () => ({
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
+    // No attached renderer xterm in these tests — spawn falls back to the
+    // default/estimated dims path.
+    get: vi.fn(() => null),
     cleanup: vi.fn(),
     applyRendererPolicy: vi.fn(),
     onPanelBackgrounded: vi.fn(),

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -18,6 +18,7 @@ import { getScrollbackForType, PERFORMANCE_MODE_SCROLLBACK } from "@/utils/scrol
 import { getXtermOptions, calculateTerminalDimensions } from "@/config/xtermConfig";
 import { deriveTerminalRuntimeIdentity } from "@/utils/terminalChrome";
 import { getWorktreeSelectionSnapshot } from "@/store/storeAccessors";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelLimitStore, evaluatePanelLimit } from "@/store/panelLimitStore";
 import { notify } from "@/lib/notify";
 import { saveNormalized } from "./persistence";
@@ -56,6 +57,54 @@ function countNonTrashTerminals(state: PanelRegistrySlice): number {
 }
 
 const TERMINAL_STARTUP_ATTACH_TIMEOUT_MS = 2500;
+
+// Chrome allowance for the overlay (help panel) grid estimate: horizontal =
+// panel border + terminal-host inset; vertical = header + banners + hybrid
+// input bar + footer. Rough is fine — the estimate only has to be close
+// enough that a CLI painting before the first real fit lands near the final
+// wrap width instead of the legacy 80×24 spawn default.
+const OVERLAY_CHROME_X_PX = 16;
+const OVERLAY_CHROME_Y_PX = 240;
+
+/**
+ * Live grid of an ATTACHED renderer xterm. Returns null until the instance is
+ * mounted in the real DOM — a prewarmed (never-attached) instance still holds
+ * its construction-default grid, which must not be mistaken for a fitted
+ * measurement.
+ */
+function getAttachedGridDims(id: string): { cols: number; rows: number } | null {
+  const managed = terminalInstanceService.get(id);
+  if (!managed?.terminal.element?.isConnected) return null;
+  return { cols: managed.terminal.cols, rows: managed.terminal.rows };
+}
+
+/**
+ * Estimated grid for an overlay (help panel) terminal, derived from the
+ * persisted panel width and the current viewport. The overlay's XtermAdapter
+ * mounts without waiting for spawnStatus, but historically both the prewarmed
+ * xterm and the PTY booted at the 80×24 spawn default, so the assistant CLI
+ * painted its banner at 80 cols and the first real fit re-wrapped (or, when
+ * the fit's PTY resize raced the spawn and was dropped, permanently desynced)
+ * the committed output — the duplicated/garbled assistant startup (#10863).
+ */
+function estimateOverlayGridDims(fontSize: number): { cols: number; rows: number } | null {
+  const panelWidth = useHelpPanelStore.getState().width;
+  const viewportHeight = window.innerHeight;
+  // NaN/∞ would flow into the panel record, the xterm constructor, and the
+  // spawn payload — fall back to the legacy defaults instead of estimating.
+  if (
+    !Number.isFinite(panelWidth) ||
+    !Number.isFinite(viewportHeight) ||
+    !Number.isFinite(fontSize)
+  ) {
+    return null;
+  }
+  return calculateTerminalDimensions(
+    Math.max(200, panelWidth - OVERLAY_CHROME_X_PX),
+    Math.max(240, viewportHeight - OVERLAY_CHROME_Y_PX),
+    fontSize
+  );
+}
 
 class TerminalStartupQueue {
   private readonly tasks: Array<() => Promise<void>> = [];
@@ -316,6 +365,16 @@ export const createAddPanelActions = (
     // Reconnects don't go through a fresh spawn — mark them "ready" directly.
     const spawnStatus: "spawning" | "ready" | "failed" = isReconnect ? "ready" : "spawning";
 
+    // Overlay terminals boot at ~their real grid instead of the 80×24 spawn
+    // default so the assistant CLI never paints its startup banner at a width
+    // the first fit then re-wraps (#10863). Grid/dock keep the legacy default:
+    // their XtermAdapter attaches only after spawnStatus flips "ready", so the
+    // fit's PTY resize always lands on a live PTY.
+    const overlayDims =
+      location === "overlay" && !isReconnect
+        ? estimateOverlayGridDims(getTerminalAppearanceSnapshot().fontSize)
+        : null;
+
     const terminal = {
       id,
       kind,
@@ -328,8 +387,8 @@ export const createAddPanelActions = (
       ...(options.titleMode && { titleMode: options.titleMode }),
       worktreeId: options.worktreeId,
       cwd: options.cwd ?? "",
-      cols: 80,
-      rows: 24,
+      cols: overlayDims?.cols ?? 80,
+      rows: overlayDims?.rows ?? 24,
       agentState,
       lastStateChange,
       location,
@@ -540,6 +599,13 @@ export const createAddPanelActions = (
         theme: appearance.effectiveTheme,
         screenReaderMode: appearance.screenReaderMode,
       });
+      // Overlay panes are BORN at their estimated grid (xterm constructor
+      // cols/rows) so pre-attach CLI output wraps near the final width — a
+      // prewarmed-but-unattached xterm otherwise sits at the 80×24 default
+      // until the help panel's XtermAdapter mounts (#10863).
+      const prewarmOptions = overlayDims
+        ? { ...terminalOptions, cols: overlayDims.cols, rows: overlayDims.rows }
+        : terminalOptions;
 
       // Prewarm ALL terminal types to ensure the managed instance and data
       // listeners exist before the backend PTY can emit output. Do not attach
@@ -556,7 +622,7 @@ export const createAddPanelActions = (
         // Awaited so the managed instance and its PTY data listener exist before
         // the queued spawn runs — prewarmTerminal is async now that the lazy
         // Unicode11 addon is loaded during terminal construction (#10840).
-        await terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
+        await terminalInstanceService.prewarmTerminal(id, launchAgentId, prewarmOptions, {
           offscreen: false,
           widthPx: location === "dock" ? DOCK_PREWARM_WIDTH_PX : DOCK_TERM_WIDTH,
           heightPx: location === "dock" ? DOCK_PREWARM_HEIGHT_PX : DOCK_TERM_HEIGHT,
@@ -570,7 +636,7 @@ export const createAddPanelActions = (
         // Awaited so the instance exists before the sendPtyResize below targets
         // it — prewarmTerminal is async now that the lazy Unicode11 addon is
         // loaded during terminal construction (#10840).
-        await terminalInstanceService.prewarmTerminal(id, launchAgentId, terminalOptions, {
+        await terminalInstanceService.prewarmTerminal(id, launchAgentId, prewarmOptions, {
           offscreen: false,
           widthPx,
           heightPx,
@@ -579,9 +645,16 @@ export const createAddPanelActions = (
         // Only send explicit resize for active grid spawns. Background/dock
         // terminals can boot at the spawn default and will be resized on reveal.
         // Cell metrics come from calculateTerminalDimensions so the lineHeight
-        // assumption stays in sync with xtermConfig.
-        if (!isDockOrInactive) {
-          const { cols, rows } = calculateTerminalDimensions(widthPx, heightPx, fontSize);
+        // assumption stays in sync with xtermConfig. An overlay panel that
+        // reaches this branch (no active worktree) must use its own estimate —
+        // the DOCK_TERM-derived dims would re-poison the grid the overlay
+        // spawn path just fixed (#10863), and for a settled-strategy agent
+        // this call arms a 500ms timer that can land AFTER the spawn. When the
+        // estimate is unavailable (non-finite inputs), skip entirely and let
+        // the spawn-time dims own overlay geometry.
+        if (!isDockOrInactive && (location !== "overlay" || overlayDims)) {
+          const { cols, rows } =
+            overlayDims ?? calculateTerminalDimensions(widthPx, heightPx, fontSize);
           terminalInstanceService.sendPtyResize(id, cols, rows);
         }
       }
@@ -681,13 +754,22 @@ export const createAddPanelActions = (
         if (!_p1 || !isPtyPanel(_p1) || _p1.spawnStatus !== "spawning") return;
 
         const commandToExecute = options.skipCommandExecution ? undefined : options.command;
+        // Spawn the PTY at the grid the renderer is actually showing. The
+        // overlay XtermAdapter mounts without waiting for spawnStatus, so by
+        // now the xterm may already be attached and fitted — a PTY resize it
+        // sent before this spawn resolved was silently dropped by the
+        // pty-host (no terminal yet), and booting at 80×24 anyway left the
+        // CLI painting a width the renderer wasn't wrapping at (#10863).
+        const attachedDims = getAttachedGridDims(id);
+        const spawnCols = attachedDims?.cols ?? overlayDims?.cols ?? 80;
+        const spawnRows = attachedDims?.rows ?? overlayDims?.rows ?? 24;
         await terminalClient.spawn({
           id,
           projectId: capturedProjectId,
           cwd: options.cwd,
           shell: options.shell,
-          cols: 80,
-          rows: 24,
+          cols: spawnCols,
+          rows: spawnRows,
           command: commandToExecute,
           kind,
           launchAgentId,
@@ -732,6 +814,20 @@ export const createAddPanelActions = (
               error: killError,
             });
           });
+        } else {
+          // Recover the attach-during-spawn race: a fit that ran while the
+          // spawn IPC was in flight had its PTY resize dropped (no terminal
+          // existed yet), which would strand the CLI at the spawn dims while
+          // xterm renders the fitted grid — the assistant's progressively
+          // garbled prompt (#10863). Re-assert the live grid now that the PTY
+          // exists. PTY-only and direct: xterm already shows these dims, and
+          // sendPtyResize would defer 500ms for a settled-strategy agent —
+          // exactly the window in which the CLI paints its banner at the
+          // stale spawn width. The backend dedupes when nothing drifted.
+          const settledDims = getAttachedGridDims(id);
+          if (settledDims && (settledDims.cols !== spawnCols || settledDims.rows !== spawnRows)) {
+            terminalClient.resize(id, settledDims.cols, settledDims.rows);
+          }
         }
 
         if (mountedPanel && shouldWaitForVisibleAttach) {


### PR DESCRIPTION
This PR fixes a fairly nasty issue with the Daintree Assistant sidebar. On launch you'd get garbled loading output (stray SGR fragments painted over the logo), the banner and footer duplicated, and the whole thing got progressively worse the more you typed. The same CLI worked fine in a standalone terminal, which pointed the finger squarely at our terminal layer.

## Root cause

Every PTY spawns hardcoded at 80x24 (`addPanel.ts`). Grid terminals get away with this because their `XtermAdapter` only mounts after `spawnStatus` flips to `ready`, so the attach-fit's PTY resize always lands on a live PTY. The assistant sidebar mounts its terminal without waiting, so its attach-fit can run while the spawn IPC is still in flight. The pty-host silently drops a resize for a terminal that doesn't exist yet, and the PTY then boots at 80x24 while xterm is already fitted to roughly 55 columns. The CLI paints at 80 columns into a 55 column grid, and every sticky-region repaint on keystroke compounds the damage. That's the whole symptom set from #10863's remaining tail (the earlier fix in `5272596ab` only removed the redundant reveal cascade on switch-back; this initial-open path was never covered).

## The fix

- Spawn the PTY at the live attached xterm grid when one exists, falling back to an estimate derived from the persisted panel width for overlay panels, then the legacy 80x24. The overlay's prewarmed xterm is also born at the estimated size so pre-attach output wraps near the final width.
- After the spawn IPC resolves, re-assert the live grid with a direct PTY-only resize. This recovers the dropped-resize race, and deliberately bypasses `sendPtyResize` because its 500ms settled-strategy deferral is exactly the window the CLI paints its banner in.
- `reconcileGeometryFresh()` now defers a grid-changing reflow while the pane has written within `REVEAL_REWRAP_QUIESCENT_MS` (300ms). Re-wrapping committed main-buffer scrollback under a CLI that's mid-paint is what duplicated the blocks; the reveal sweep retries once the stream pauses.
- The reconciliation watchdog treats those streaming-deferred passes as untried rather than failed, so it doesn't burn its circuit-breaker attempts on them. The gate is main-buffer only and falls through to the render-pause/WebGL layers, so a streaming pane with a paused renderer still gets unpaused.

## Test coverage

- New `addPanelSpawnDims.test.ts`: spawn uses live attached dims, the attach-during-spawn race triggers the post-spawn re-assert, and overlay panels never boot at the 80x24 default.
- `TerminalResizeController.test.ts`: the quiescence gate defers while streaming, applies once quiescent, doesn't poison the dim caches on defer, and still re-asserts the PTY when nothing drifted.
- `TerminalReconciliationWatchdog.test.ts`: streaming-deferred ticks spend no breaker attempts, alt-buffer panes are never deferred, and the paused-render recovery still runs on deferred ticks.

Closes the remaining part of #10863. Reviewed over two rounds, with the second round catching a watchdog starvation issue and a settled-strategy timing hole in the first version of the fix.
