### PR TITLE
refactor(terminal): reduce hybrid input bar friction points

### DIFF
--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -21,9 +21,14 @@ export interface AutocompleteMenuProps {
   items: AutocompleteItem[];
   selectedIndex: number;
   isLoading?: boolean;
+  /** Results were produced for an earlier query and a refresh is pending;
+   *  rows render dimmed so they don't read as matches for the current text. */
+  isStale?: boolean;
   onSelect: (item: AutocompleteItem) => void;
   style?: React.CSSProperties;
   title?: string;
+  /** Compact keyboard hint rendered opposite the title, e.g. "↵ run · ⇥ complete". */
+  keyHint?: string;
   ariaLabel?: string;
   emptyMessage: string;
 }
@@ -35,14 +40,24 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
       items,
       selectedIndex,
       isLoading = false,
+      isStale = false,
       onSelect,
       style,
       title,
+      keyHint,
       ariaLabel,
       emptyMessage,
     },
     ref
   ) => {
+    const listRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      if (!isOpen) return;
+      const selected = listRef.current?.querySelector('[aria-selected="true"]');
+      selected?.scrollIntoView?.({ block: "nearest" });
+    }, [isOpen, selectedIndex, items]);
+
     if (!isOpen) return null;
 
     const isEmpty = !isLoading && items.length === 0;
@@ -57,10 +72,18 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
         style={style}
         role={isEmpty ? undefined : "listbox"}
         aria-label={ariaLabel ?? title ?? "Autocomplete"}
+        aria-busy={isLoading || isStale || undefined}
       >
-        {title && (
-          <div className="border-b border-tint/5 px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-daintree-text/40">
-            {title}
+        {(title || keyHint) && (
+          <div className="flex items-center justify-between gap-2 border-b border-tint/5 px-2 py-1.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-daintree-text/40">
+              {title}
+            </span>
+            {keyHint && (
+              <span aria-hidden="true" className="shrink-0 text-[10px] text-daintree-text/30">
+                {keyHint}
+              </span>
+            )}
           </div>
         )}
         <ScrollShadow className="max-h-64" scrollClassName="p-1">
@@ -79,46 +102,58 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
             </div>
           )}
 
-          {items.map((item, idx) => {
-            const descriptionSnippet = item.description
-              ? getDescriptionSnippet(item.description)
-              : undefined;
+          <div
+            ref={listRef}
+            className={cn(
+              "transition-opacity duration-150 ease-out",
+              isStale && items.length > 0 && "opacity-50"
+            )}
+          >
+            {items.map((item, idx) => {
+              const descriptionSnippet = item.description
+                ? getDescriptionSnippet(item.description)
+                : undefined;
 
-            return (
-              <Tooltip key={item.key}>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={idx === selectedIndex}
-                    className={cn(
-                      "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors",
-                      idx === selectedIndex
-                        ? "bg-overlay-soft text-daintree-text"
-                        : "text-daintree-text/70 hover:bg-tint/[0.05] hover:text-daintree-text"
-                    )}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={() => onSelect(item)}
-                  >
-                    <span className="shrink-0 font-mono text-xs leading-4">{item.label}</span>
-                    {descriptionSnippet && (
-                      <span
-                        className={cn(
-                          "min-w-0 truncate text-[10px] leading-4",
-                          idx === selectedIndex ? "text-daintree-text/80" : "text-daintree-text/30"
-                        )}
-                      >
-                        {descriptionSnippet}
+              return (
+                <Tooltip key={item.key}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={idx === selectedIndex}
+                      className={cn(
+                        "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors",
+                        idx === selectedIndex
+                          ? "bg-overlay-soft text-daintree-text"
+                          : "text-daintree-text/70 hover:bg-tint/[0.05] hover:text-daintree-text"
+                      )}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => onSelect(item)}
+                    >
+                      <span className="min-w-0 flex-none max-w-full truncate font-mono text-xs leading-4">
+                        {item.label}
                       </span>
-                    )}
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  {item.description ? `${item.label} — ${item.description}` : item.label}
-                </TooltipContent>
-              </Tooltip>
-            );
-          })}
+                      {descriptionSnippet && (
+                        <span
+                          className={cn(
+                            "min-w-0 truncate text-[10px] leading-4",
+                            idx === selectedIndex
+                              ? "text-daintree-text/80"
+                              : "text-daintree-text/30"
+                          )}
+                        >
+                          {descriptionSnippet}
+                        </span>
+                      )}
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {item.description ? `${item.label} — ${item.description}` : item.label}
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </div>
         </ScrollShadow>
       </div>
     );

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -88,6 +88,7 @@ interface LatestState {
   activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
   isAutocompleteOpen: boolean;
   autocompleteItems: AutocompleteItem[];
+  isResultsStale: boolean;
   selectedIndex: number;
   value: string;
   atContext: AtFileContext | null;
@@ -329,12 +330,22 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               : null;
     const isAutocompleteOpen = activeMode !== null && !disabled;
 
-    const { files: autocompleteFiles, isLoading: isAutocompleteLoading } = useFileAutocomplete({
+    const {
+      files: autocompleteFiles,
+      isLoading: isAutocompleteLoading,
+      resultsQuery: fileResultsQuery,
+    } = useFileAutocomplete({
       cwd,
       query: atContext?.queryForSearch ?? "",
       enabled: isAutocompleteOpen && activeMode === "file",
       limit: 50,
     });
+
+    // File search is debounced + async; every other mode filters synchronously.
+    // While the visible results belong to an earlier query they are "stale":
+    // rendered dimmed, and never accepted by Enter/Tab (the literal text wins).
+    const isResultsStale =
+      activeMode === "file" && fileResultsQuery !== (atContext?.queryForSearch ?? "");
 
     const { items: autocompleteCommands, isLoading: isCommandsLoading } =
       useSlashCommandAutocomplete({
@@ -368,6 +379,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         activeMode,
         isAutocompleteOpen,
         autocompleteItems,
+        isResultsStale,
         selectedIndex,
         value,
         atContext,
@@ -677,6 +689,8 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       setAtContext,
       setSlashContext,
       setDiffContext,
+      setTerminalContext,
+      setSelectionContext,
       setIsExpanded,
       setSelectedIndex,
     });
@@ -696,6 +710,8 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       setAtContext,
       setSlashContext,
       setDiffContext,
+      setTerminalContext,
+      setSelectionContext,
     });
 
     useEditorFactory({
@@ -775,8 +791,10 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
       "--ib-accent": inputBarColors.accent,
     } as React.CSSProperties;
 
-    const isSpecialState = isVoiceActiveForPanel || isDragOverFiles;
+    const isSpecialState = isVoiceActiveForPanel || isDragOverFiles || isFleetPrimary;
 
+    // Fleet-primary uses the same amber family as FleetDraftingPill so the
+    // shell itself says "Enter broadcasts" at the point of typing.
     const specialStyle: React.CSSProperties | undefined = isVoiceActiveForPanel
       ? {
           borderColor: `color-mix(in oklab, ${inputBarColors.accent} 60%, transparent)`,
@@ -789,7 +807,14 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
             backgroundColor: inputBarColors.shellBg,
             boxShadow: `0 0 0 1px color-mix(in oklab, ${inputBarColors.accent} 30%, transparent)`,
           }
-        : undefined;
+        : isFleetPrimary
+          ? {
+              borderColor: "color-mix(in oklab, var(--color-category-amber) 55%, transparent)",
+              backgroundColor: inputBarColors.shellBg,
+              boxShadow:
+                "0 0 0 1px color-mix(in oklab, var(--color-category-amber) 22%, transparent)",
+            }
+          : undefined;
 
     const barContent = (
       <div
@@ -810,6 +835,7 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               disabled && "opacity-60"
             )}
             data-voice-active={isVoiceActiveForPanel ? "true" : undefined}
+            data-fleet-armed={isFleetPrimary ? "true" : undefined}
             style={specialStyle}
             onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
@@ -824,8 +850,21 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               items={autocompleteItems}
               selectedIndex={selectedIndex}
               isLoading={isLoading}
+              isStale={isResultsStale}
               onSelect={handleAutocompleteSelect}
               style={{ left: `${menuLeftPx}px` }}
+              title={
+                activeMode === "command"
+                  ? "Commands"
+                  : activeMode === "terminal"
+                    ? "Terminal output"
+                    : activeMode === "selection"
+                      ? "Terminal selection"
+                      : activeMode === "diff"
+                        ? "Diffs"
+                        : "Files"
+              }
+              keyHint={activeMode === "command" ? "↵ run · ⇥ complete" : "↵ insert"}
               ariaLabel={
                 activeMode === "command"
                   ? "Command autocomplete"
@@ -853,8 +892,13 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
               </div>
             )}
             {isVoiceSubmitting && (
-              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-md bg-daintree-bg/80 pointer-events-none">
+              <div
+                role="status"
+                aria-live="polite"
+                className="absolute inset-0 z-10 flex items-center justify-center gap-2 rounded-md bg-daintree-bg/80 pointer-events-none"
+              >
                 <Loader2 className="h-4 w-4 animate-spin text-daintree-accent" />
+                <span className="text-xs text-daintree-text/70">Finishing dictation…</span>
               </div>
             )}
             <button

--- a/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
+++ b/src/components/Terminal/__tests__/AutocompleteMenu.test.tsx
@@ -86,4 +86,106 @@ describe("AutocompleteMenu", () => {
     expect(screen.getAllByRole("option")).toHaveLength(2);
     expect(screen.queryByRole("status")).toBeNull();
   });
+
+  it("renders a header with title and key hint when provided", () => {
+    render(
+      <AutocompleteMenu
+        isOpen={true}
+        items={[{ key: "a", label: "alpha", value: "alpha" }]}
+        selectedIndex={0}
+        onSelect={noop}
+        title="Commands"
+        keyHint="↵ run · ⇥ complete"
+        emptyMessage="No matches"
+      />
+    );
+
+    expect(screen.getByText("Commands")).toBeTruthy();
+    expect(screen.getByText("↵ run · ⇥ complete")).toBeTruthy();
+  });
+
+  it("marks the listbox busy while results are stale or loading", () => {
+    const items: AutocompleteItem[] = [{ key: "a", label: "alpha", value: "alpha" }];
+
+    const { rerender } = render(
+      <AutocompleteMenu
+        isOpen={true}
+        items={items}
+        selectedIndex={0}
+        isStale={true}
+        onSelect={noop}
+        emptyMessage="No matches"
+      />
+    );
+    expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBe("true");
+
+    rerender(
+      <AutocompleteMenu
+        isOpen={true}
+        items={items}
+        selectedIndex={0}
+        isStale={false}
+        isLoading={true}
+        onSelect={noop}
+        emptyMessage="No matches"
+      />
+    );
+    expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBe("true");
+
+    rerender(
+      <AutocompleteMenu
+        isOpen={true}
+        items={items}
+        selectedIndex={0}
+        isStale={false}
+        isLoading={false}
+        onSelect={noop}
+        emptyMessage="No matches"
+      />
+    );
+    expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBeNull();
+  });
+
+  it("scrolls the keyboard-selected option into view as selection moves", () => {
+    const scrollSpy = vi.fn();
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollSpy;
+    try {
+      const items: AutocompleteItem[] = [
+        { key: "a", label: "alpha", value: "alpha" },
+        { key: "b", label: "beta", value: "beta" },
+        { key: "c", label: "gamma", value: "gamma" },
+      ];
+
+      const { rerender } = render(
+        <AutocompleteMenu
+          isOpen={true}
+          items={items}
+          selectedIndex={0}
+          onSelect={noop}
+          emptyMessage="No matches"
+        />
+      );
+      const callsAfterMount = scrollSpy.mock.calls.length;
+
+      rerender(
+        <AutocompleteMenu
+          isOpen={true}
+          items={items}
+          selectedIndex={2}
+          onSelect={noop}
+          emptyMessage="No matches"
+        />
+      );
+
+      expect(scrollSpy.mock.calls.length).toBeGreaterThan(callsAfterMount);
+      expect(scrollSpy).toHaveBeenLastCalledWith({ block: "nearest" });
+    } finally {
+      if (original === undefined) {
+        delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+      } else {
+        Element.prototype.scrollIntoView = original;
+      }
+    }
+  });
 });

--- a/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
+++ b/src/components/Terminal/__tests__/inputEditorExtensions.test.tsx
@@ -719,6 +719,91 @@ describe("fileDropChipField", () => {
     view.destroy();
   });
 
+  it("removes the clicked chip when duplicates point at the same file", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({ doc: "", extensions: [fileDropChipField] }),
+    });
+
+    const text = "@/Users/test/file.ts @/Users/test/file.ts ";
+    view.dispatch({
+      changes: { from: 0, insert: text },
+      effects: [
+        addFileDropChip.of({
+          from: 0,
+          to: 20,
+          filePath: "/Users/test/file.ts",
+          fileName: "file.ts",
+        }),
+        addFileDropChip.of({
+          from: 21,
+          to: 41,
+          filePath: "/Users/test/file.ts",
+          fileName: "file.ts",
+        }),
+      ],
+    });
+
+    const removeButtons = view.dom.querySelectorAll(".cm-file-drop-chip .cm-chip-remove");
+    expect(removeButtons).toHaveLength(2);
+
+    removeButtons[1]!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+    const entries = view.state.field(fileDropChipField);
+    expect(entries).toHaveLength(1);
+    // The first occurrence must survive — only the clicked (second) chip goes.
+    expect(entries[0]!.from).toBe(0);
+    expect(view.state.doc.toString()).toBe("@/Users/test/file.ts ");
+
+    view.destroy();
+    parent.remove();
+  });
+
+  it("removes the clicked chip when duplicates are directly adjacent", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const view = new EditorView({
+      parent,
+      state: EditorState.create({ doc: "", extensions: [fileDropChipField] }),
+    });
+
+    // No separator: the first chip's end equals the second chip's start, so a
+    // closed-interval containment check would match the first entry.
+    const text = "@/Users/test/file.ts@/Users/test/file.ts";
+    view.dispatch({
+      changes: { from: 0, insert: text },
+      effects: [
+        addFileDropChip.of({
+          from: 0,
+          to: 20,
+          filePath: "/Users/test/file.ts",
+          fileName: "file.ts",
+        }),
+        addFileDropChip.of({
+          from: 20,
+          to: 40,
+          filePath: "/Users/test/file.ts",
+          fileName: "file.ts",
+        }),
+      ],
+    });
+
+    const removeButtons = view.dom.querySelectorAll(".cm-file-drop-chip .cm-chip-remove");
+    expect(removeButtons).toHaveLength(2);
+
+    removeButtons[1]!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+
+    const entries = view.state.field(fileDropChipField);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.from).toBe(0);
+    expect(view.state.doc.toString()).toBe("@/Users/test/file.ts");
+
+    view.destroy();
+    parent.remove();
+  });
+
   it("removes file chips when the entire document is cleared", () => {
     const view = makeEditorWithFileChip();
 

--- a/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useAutocompleteItems.test.ts
@@ -36,6 +36,55 @@ describe("useAutocompleteItems", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
+  it("splits file paths into basename label and directory description", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteItems({
+        ...baseParams,
+        activeMode: "file",
+        autocompleteFiles: ["src/components/Button.tsx", "README.md"],
+      })
+    );
+    const [nested, root] = result.current.autocompleteItems;
+    expect(nested!.label).toBe("Button.tsx");
+    expect(nested!.description).toBe("src/components");
+    expect(nested!.value).toBe("src/components/Button.tsx");
+    expect(root!.label).toBe("README.md");
+    expect(root!.description).toBeUndefined();
+    expect(root!.value).toBe("README.md");
+  });
+
+  it("disambiguates duplicate basenames via directory descriptions", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteItems({
+        ...baseParams,
+        activeMode: "file",
+        autocompleteFiles: ["src/a/index.ts", "src/b/index.ts"],
+      })
+    );
+    const items = result.current.autocompleteItems;
+    expect(items[0]!.label).toBe("index.ts");
+    expect(items[1]!.label).toBe("index.ts");
+    expect(items[0]!.description).toBe("src/a");
+    expect(items[1]!.description).toBe("src/b");
+    expect(items[0]!.key).not.toBe(items[1]!.key);
+  });
+
+  it("handles Windows separators and trailing-separator paths", () => {
+    const { result } = renderHook(() =>
+      useAutocompleteItems({
+        ...baseParams,
+        activeMode: "file",
+        autocompleteFiles: ["src\\utils\\log.ts", "src/dir/"],
+      })
+    );
+    const [win, trailing] = result.current.autocompleteItems;
+    expect(win!.label).toBe("log.ts");
+    expect(win!.description).toBe("src\\utils");
+    // Trailing separator yields an empty basename — falls back to the full path.
+    expect(trailing!.label).toBe("src/dir/");
+    expect(trailing!.value).toBe("src/dir/");
+  });
+
   it("returns diff items filtered by partial", () => {
     const { result } = renderHook(() =>
       useAutocompleteItems({

--- a/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useEditorKeymap.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { Compartment } from "@codemirror/state";
+import type { EditorState } from "@codemirror/state";
+import type { Dispatch, SetStateAction } from "react";
+import type {
+  AtFileContext,
+  SlashCommandContext,
+  AtDiffContext,
+  AtTerminalContext,
+  AtSelectionContext,
+} from "../../hybridInputParsing";
+import { useEditorKeymap } from "../useEditorKeymap";
+
+type KeymapParams = Parameters<typeof useEditorKeymap>[0];
+type LatestShape = NonNullable<KeymapParams["latestRef"]["current"]>;
+
+function makeLatest(overrides: Partial<LatestShape> = {}): LatestShape {
+  return {
+    terminalId: "t1",
+    projectId: undefined,
+    disabled: false,
+    isInitializing: false,
+    isInHistoryMode: false,
+    activeMode: "file",
+    isAutocompleteOpen: true,
+    autocompleteItems: [{ key: "src/a.ts", label: "a.ts", value: "src/a.ts" }],
+    isResultsStale: false,
+    selectedIndex: 0,
+    value: "@a",
+    onSendKey: undefined,
+    isVoiceActiveForPanel: false,
+    isExpanded: false,
+    ...overrides,
+  };
+}
+
+describe("useEditorKeymap", () => {
+  let applyAutocompleteSelection: ReturnType<
+    typeof vi.fn<(action: "insert" | "execute") => boolean>
+  >;
+  let sendFromEditor: ReturnType<typeof vi.fn<() => void>>;
+  let cancelVoiceWaitSubmit: ReturnType<typeof vi.fn<() => boolean>>;
+  let setAtContext: ReturnType<typeof vi.fn<Dispatch<SetStateAction<AtFileContext | null>>>>;
+  let setSlashContext: ReturnType<
+    typeof vi.fn<Dispatch<SetStateAction<SlashCommandContext | null>>>
+  >;
+  let setDiffContext: ReturnType<typeof vi.fn<Dispatch<SetStateAction<AtDiffContext | null>>>>;
+  let setTerminalContext: ReturnType<
+    typeof vi.fn<Dispatch<SetStateAction<AtTerminalContext | null>>>
+  >;
+  let setSelectionContext: ReturnType<
+    typeof vi.fn<Dispatch<SetStateAction<AtSelectionContext | null>>>
+  >;
+
+  beforeEach(() => {
+    applyAutocompleteSelection = vi.fn<(action: "insert" | "execute") => boolean>(() => true);
+    sendFromEditor = vi.fn<() => void>();
+    cancelVoiceWaitSubmit = vi.fn<() => boolean>(() => false);
+    setAtContext = vi.fn<Dispatch<SetStateAction<AtFileContext | null>>>();
+    setSlashContext = vi.fn<Dispatch<SetStateAction<SlashCommandContext | null>>>();
+    setDiffContext = vi.fn<Dispatch<SetStateAction<AtDiffContext | null>>>();
+    setTerminalContext = vi.fn<Dispatch<SetStateAction<AtTerminalContext | null>>>();
+    setSelectionContext = vi.fn<Dispatch<SetStateAction<AtSelectionContext | null>>>();
+  });
+
+  function renderKeymap(latest: LatestShape) {
+    const params: KeymapParams = {
+      latestRef: { current: latest },
+      editorViewRef: { current: null },
+      isComposingRef: { current: false },
+      handledEnterRef: { current: false },
+      editableCompartmentRef: { current: new Compartment() },
+      historyPaletteOpenRef: { current: null },
+      applyAutocompleteSelection,
+      handleHistoryNavigation: vi.fn<(direction: "up" | "down") => boolean>(() => false),
+      sendFromEditor,
+      startVoiceWaitSubmit: vi.fn<() => void>(),
+      cancelVoiceWaitSubmit,
+      stashEditorState:
+        vi.fn<(terminalId: string, state: EditorState, projectId?: string) => void>(),
+      popStashedEditorState: vi.fn<
+        (terminalId: string, projectId?: string) => EditorState | undefined
+      >(() => undefined),
+      setAtContext,
+      setSlashContext,
+      setDiffContext,
+      setTerminalContext,
+      setSelectionContext,
+      setIsExpanded: vi.fn<Dispatch<SetStateAction<boolean>>>(),
+      setSelectedIndex: vi.fn<Dispatch<SetStateAction<number>>>(),
+    };
+    const { result } = renderHook(() => useEditorKeymap(params));
+    return { handlers: result.current.handlersRef.current! };
+  }
+
+  describe("Enter", () => {
+    it("accepts the selected item when results are fresh", () => {
+      const { handlers } = renderKeymap(makeLatest());
+      expect(handlers.onEnter()).toBe(true);
+      expect(applyAutocompleteSelection).toHaveBeenCalledWith("insert");
+      expect(sendFromEditor).not.toHaveBeenCalled();
+    });
+
+    it("executes instead of inserting in command mode", () => {
+      const { handlers } = renderKeymap(
+        makeLatest({
+          activeMode: "command",
+          autocompleteItems: [{ key: "/help", label: "/help", value: "/help" }],
+          value: "/he",
+        })
+      );
+      expect(handlers.onEnter()).toBe(true);
+      expect(applyAutocompleteSelection).toHaveBeenCalledWith("execute");
+    });
+
+    it("falls through to the normal send when results are stale", () => {
+      const { handlers } = renderKeymap(makeLatest({ isResultsStale: true }));
+      expect(handlers.onEnter()).toBe(true);
+      expect(applyAutocompleteSelection).not.toHaveBeenCalled();
+      expect(sendFromEditor).toHaveBeenCalledTimes(1);
+    });
+
+    it("routes stale-Enter on empty text to onSendKey", () => {
+      const onSendKey = vi.fn<(key: string) => void>();
+      const { handlers } = renderKeymap(
+        makeLatest({ isResultsStale: true, value: "   ", onSendKey })
+      );
+      expect(handlers.onEnter()).toBe(true);
+      expect(sendFromEditor).not.toHaveBeenCalled();
+      expect(onSendKey).toHaveBeenCalledWith("enter");
+    });
+  });
+
+  describe("Tab", () => {
+    it("inserts the selected item when results are fresh", () => {
+      const { handlers } = renderKeymap(makeLatest());
+      expect(handlers.onTab()).toBe(true);
+      expect(applyAutocompleteSelection).toHaveBeenCalledWith("insert");
+    });
+
+    it("swallows Tab without inserting when results are stale", () => {
+      const { handlers } = renderKeymap(makeLatest({ isResultsStale: true }));
+      expect(handlers.onTab()).toBe(true);
+      expect(applyAutocompleteSelection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Escape", () => {
+    it("clears every autocomplete context, including terminal and selection", () => {
+      const { handlers } = renderKeymap(makeLatest({ activeMode: "terminal" }));
+      expect(handlers.onEscape()).toBe(true);
+      expect(setAtContext).toHaveBeenCalledWith(null);
+      expect(setSlashContext).toHaveBeenCalledWith(null);
+      expect(setDiffContext).toHaveBeenCalledWith(null);
+      expect(setTerminalContext).toHaveBeenCalledWith(null);
+      expect(setSelectionContext).toHaveBeenCalledWith(null);
+    });
+
+    it("cancels a pending voice wait-submit before touching autocomplete", () => {
+      cancelVoiceWaitSubmit.mockReturnValue(true);
+      const { handlers } = renderKeymap(makeLatest());
+      expect(handlers.onEscape()).toBe(true);
+      expect(setAtContext).not.toHaveBeenCalled();
+      expect(setTerminalContext).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/Terminal/hooks/__tests__/useVoiceWaitSubmit.test.ts
+++ b/src/components/Terminal/hooks/__tests__/useVoiceWaitSubmit.test.ts
@@ -1,9 +1,32 @@
+// @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { Compartment } from "@codemirror/state";
 import { useTerminalInputStore } from "@/store/terminalInputStore";
 
 vi.mock("@/services/VoiceRecordingService", () => ({
   voiceRecordingService: { stop: vi.fn().mockResolvedValue(undefined) },
 }));
+
+vi.mock("@/store", () => ({
+  useVoiceRecordingStore: {
+    getState: () => ({
+      activeTarget: { panelId: "test-panel" },
+      status: "recording",
+    }),
+  },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: {
+    getState: () => ({ currentProject: undefined }),
+  },
+}));
+
+import { voiceRecordingService } from "@/services/VoiceRecordingService";
+import { useVoiceWaitSubmit } from "../useVoiceWaitSubmit";
+
+const stopMock = vi.mocked(voiceRecordingService.stop);
 
 const PANEL_ID = "test-panel";
 
@@ -35,5 +58,97 @@ describe("terminalInputStore voiceSubmitting", () => {
     store.setVoiceSubmitting(PANEL_ID, false);
     const after = useTerminalInputStore.getState().voiceSubmittingPanels;
     expect(before).toBe(after);
+  });
+});
+
+describe("useVoiceWaitSubmit", () => {
+  let sendFromEditor: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    useTerminalInputStore.setState({ voiceSubmittingPanels: new Set() });
+    sendFromEditor = vi.fn<() => void>();
+    stopMock.mockReset();
+    stopMock.mockResolvedValue(undefined);
+  });
+
+  function renderWaitSubmit() {
+    return renderHook(() =>
+      useVoiceWaitSubmit({
+        terminalId: PANEL_ID,
+        editorViewRef: { current: null },
+        editableCompartmentRef: { current: new Compartment() },
+        sendFromEditor,
+      })
+    );
+  }
+
+  it("stops the session, sends, and clears the submitting flag", async () => {
+    const { result } = renderWaitSubmit();
+
+    await act(async () => {
+      result.current.startVoiceWaitSubmit();
+    });
+
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(sendFromEditor).toHaveBeenCalledTimes(1);
+    expect(useTerminalInputStore.getState().isVoiceSubmitting(PANEL_ID)).toBe(false);
+  });
+
+  it("does not send when cancelled while the transcript is still finishing", async () => {
+    let resolveStop!: () => void;
+    stopMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStop = resolve;
+        })
+    );
+
+    const { result } = renderWaitSubmit();
+
+    act(() => {
+      result.current.startVoiceWaitSubmit();
+    });
+    expect(useTerminalInputStore.getState().isVoiceSubmitting(PANEL_ID)).toBe(true);
+
+    let cancelled = false;
+    act(() => {
+      cancelled = result.current.cancelVoiceWaitSubmit();
+    });
+    expect(cancelled).toBe(true);
+
+    await act(async () => {
+      resolveStop();
+    });
+
+    expect(sendFromEditor).not.toHaveBeenCalled();
+    expect(useTerminalInputStore.getState().isVoiceSubmitting(PANEL_ID)).toBe(false);
+  });
+
+  it("cancel is a no-op when nothing is waiting", () => {
+    const { result } = renderWaitSubmit();
+    expect(result.current.cancelVoiceWaitSubmit()).toBe(false);
+  });
+
+  it("ignores a second start while one is already waiting", async () => {
+    let resolveStop!: () => void;
+    stopMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStop = resolve;
+        })
+    );
+
+    const { result } = renderWaitSubmit();
+
+    act(() => {
+      result.current.startVoiceWaitSubmit();
+      result.current.startVoiceWaitSubmit();
+    });
+    expect(stopMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveStop();
+    });
+    expect(sendFromEditor).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Terminal/hooks/useAutocompleteItems.ts
+++ b/src/components/Terminal/hooks/useAutocompleteItems.ts
@@ -61,7 +61,19 @@ export function useAutocompleteItems({
       return autocompleteDiffItems;
     }
     if (activeMode === "file") {
-      return autocompleteFiles.map((file) => ({ key: file, label: file, value: file }));
+      // Basename first, directory as the dimmed description — scannable in a
+      // dense list and disambiguates duplicate filenames across directories.
+      return autocompleteFiles.map((file) => {
+        const sep = Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\"));
+        const base = sep >= 0 ? file.slice(sep + 1) : file;
+        const dir = sep >= 0 ? file.slice(0, sep) : "";
+        return {
+          key: file,
+          label: base || file,
+          value: file,
+          description: dir || undefined,
+        };
+      });
     }
     if (activeMode === "command") {
       return autocompleteCommands;

--- a/src/components/Terminal/hooks/useEditorDomHandlers.ts
+++ b/src/components/Terminal/hooks/useEditorDomHandlers.ts
@@ -9,6 +9,7 @@ interface LatestRefShape {
   disabled: boolean;
   isAutocompleteOpen: boolean;
   autocompleteItems: { key: string }[];
+  isResultsStale: boolean;
   activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
   selectedIndex: number;
   value: string;
@@ -30,6 +31,8 @@ interface UseEditorDomHandlersParams {
   setAtContext: (value: null) => void;
   setSlashContext: (value: null) => void;
   setDiffContext: (value: null) => void;
+  setTerminalContext: (value: null) => void;
+  setSelectionContext: (value: null) => void;
 }
 
 export function useEditorDomHandlers({
@@ -45,6 +48,8 @@ export function useEditorDomHandlers({
   setAtContext,
   setSlashContext,
   setDiffContext,
+  setTerminalContext,
+  setSelectionContext,
 }: UseEditorDomHandlersParams) {
   "use no memo";
   const sendFromEditorRef = useRef(sendFromEditor);
@@ -83,7 +88,11 @@ export function useEditorDomHandlers({
             return true;
           }
           if (lastEnterKeydownNewlineRef.current) return false;
-          if (latest.isAutocompleteOpen && latest.autocompleteItems[latest.selectedIndex]) {
+          if (
+            latest.isAutocompleteOpen &&
+            !latest.isResultsStale &&
+            latest.autocompleteItems[latest.selectedIndex]
+          ) {
             event.preventDefault();
             const action = latest.activeMode === "command" ? "execute" : "insert";
             applyAutocompleteSelectionRef.current(action);
@@ -146,6 +155,8 @@ export function useEditorDomHandlers({
           setAtContext(null);
           setSlashContext(null);
           setDiffContext(null);
+          setTerminalContext(null);
+          setSelectionContext(null);
           lastEnterKeydownNewlineRef.current = false;
           handledEnterRef.current = false;
           submitAfterCompositionRef.current = false;

--- a/src/components/Terminal/hooks/useEditorKeymap.ts
+++ b/src/components/Terminal/hooks/useEditorKeymap.ts
@@ -3,7 +3,13 @@ import { EditorView } from "@codemirror/view";
 import { EditorSelection } from "@codemirror/state";
 import type { Compartment } from "@codemirror/state";
 import type { AutocompleteItem } from "../AutocompleteMenu";
-import type { AtFileContext, SlashCommandContext, AtDiffContext } from "../hybridInputParsing";
+import type {
+  AtFileContext,
+  SlashCommandContext,
+  AtDiffContext,
+  AtTerminalContext,
+  AtSelectionContext,
+} from "../hybridInputParsing";
 
 interface LatestRefShape {
   terminalId: string;
@@ -14,6 +20,7 @@ interface LatestRefShape {
   activeMode: "command" | "file" | "diff" | "terminal" | "selection" | null;
   isAutocompleteOpen: boolean;
   autocompleteItems: AutocompleteItem[];
+  isResultsStale: boolean;
   selectedIndex: number;
   value: string;
   onSendKey?: (key: string) => void;
@@ -41,6 +48,8 @@ interface UseEditorKeymapParams {
   setAtContext: Dispatch<SetStateAction<AtFileContext | null>>;
   setSlashContext: Dispatch<SetStateAction<SlashCommandContext | null>>;
   setDiffContext: Dispatch<SetStateAction<AtDiffContext | null>>;
+  setTerminalContext: Dispatch<SetStateAction<AtTerminalContext | null>>;
+  setSelectionContext: Dispatch<SetStateAction<AtSelectionContext | null>>;
   setIsExpanded: Dispatch<SetStateAction<boolean>>;
   setSelectedIndex: Dispatch<SetStateAction<number>>;
 }
@@ -77,6 +86,8 @@ export function useEditorKeymap({
   setAtContext,
   setSlashContext,
   setDiffContext,
+  setTerminalContext,
+  setSelectionContext,
   setIsExpanded,
   setSelectedIndex,
 }: UseEditorKeymapParams) {
@@ -93,7 +104,14 @@ export function useEditorKeymap({
       if (!latest) return false;
       if (isComposingRef.current) return false;
 
-      if (latest.isAutocompleteOpen && latest.autocompleteItems[latest.selectedIndex]) {
+      // Stale results (query changed since they were produced) must not be
+      // accepted by a fast Enter — fall through to the normal send path so
+      // the user's literal text wins over an outdated top match.
+      if (
+        latest.isAutocompleteOpen &&
+        !latest.isResultsStale &&
+        latest.autocompleteItems[latest.selectedIndex]
+      ) {
         const action = latest.activeMode === "command" ? "execute" : "insert";
 
         handledEnterRef.current = true;
@@ -147,6 +165,8 @@ export function useEditorKeymap({
         setAtContext(null);
         setSlashContext(null);
         setDiffContext(null);
+        setTerminalContext(null);
+        setSelectionContext(null);
         return true;
       }
 
@@ -251,6 +271,9 @@ export function useEditorKeymap({
       if (isComposingRef.current) return false;
 
       if (latest.isAutocompleteOpen && latest.autocompleteItems[latest.selectedIndex]) {
+        // Swallow Tab while results are stale — inserting an outdated match
+        // is worse than a no-op, and letting Tab through would move focus.
+        if (latest.isResultsStale) return true;
         applyAutocompleteSelection("insert");
         return true;
       }

--- a/src/components/Terminal/inputEditorExtensions/base.ts
+++ b/src/components/Terminal/inputEditorExtensions/base.ts
@@ -95,6 +95,19 @@ export function buildInputBarTheme(theme: ITheme): Extension {
         color: c.chipColor,
         textDecoration: "underline dotted 1px",
         textUnderlineOffset: "2px",
+        // Long paths ellipsize instead of blowing out narrow panes; the hover
+        // tooltip still shows the full path.
+        maxWidth: "280px",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+        verticalAlign: "bottom",
+      },
+      ".cm-chip-label": {
+        maxWidth: "180px",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
       },
       ".cm-tooltip": {
         background: "transparent",

--- a/src/components/Terminal/inputEditorExtensions/fileDropChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/fileDropChip.ts
@@ -48,6 +48,7 @@ class FileDropChipWidget extends WidgetType {
     span.appendChild(icon);
 
     const label = document.createElement("span");
+    label.className = "cm-chip-label";
     label.setAttribute("aria-hidden", "true");
     label.textContent = this.fileName;
     span.appendChild(label);
@@ -59,9 +60,20 @@ class FileDropChipWidget extends WidgetType {
     removeBtn.addEventListener("mousedown", (e) => {
       e.preventDefault();
       e.stopPropagation();
-      const entry = view.state
-        .field(fileDropChipField, false)
-        ?.find((en) => en.filePath === this.filePath);
+      // Resolve the entry by the widget's document position, not by path \u2014
+      // with duplicate chips for the same file, a path lookup removes the
+      // first occurrence rather than the chip that was clicked. Half-open
+      // containment so an adjacent chip's end boundary can't match first.
+      const entries = view.state.field(fileDropChipField, false);
+      if (!entries) return;
+      let pos = -1;
+      try {
+        pos = view.posAtDOM(span);
+      } catch {
+        // Widget DOM already detached \u2014 fall through to the path match.
+      }
+      const byPos = pos >= 0 ? entries.find((en) => pos >= en.from && pos < en.to) : undefined;
+      const entry = byPos ?? entries.find((en) => en.filePath === this.filePath);
       if (entry) removeChipRange(view, entry.from, entry.to);
     });
     span.appendChild(removeBtn);

--- a/src/components/Terminal/inputEditorExtensions/imageChip.ts
+++ b/src/components/Terminal/inputEditorExtensions/imageChip.ts
@@ -37,6 +37,7 @@ class ImageChipWidget extends WidgetType {
     span.appendChild(img);
 
     const label = document.createElement("span");
+    label.className = "cm-chip-label";
     label.setAttribute("aria-hidden", "true");
     label.textContent = formatChipLabel(this.filePath);
     span.appendChild(label);
@@ -48,9 +49,18 @@ class ImageChipWidget extends WidgetType {
     removeBtn.addEventListener("mousedown", (e) => {
       e.preventDefault();
       e.stopPropagation();
-      const entry = view.state
-        .field(imageChipField, false)
-        ?.find((en) => en.filePath === this.filePath);
+      // Position-based lookup so duplicate chips for the same image remove
+      // the clicked chip, not the first occurrence (mirrors fileDropChip).
+      const entries = view.state.field(imageChipField, false);
+      if (!entries) return;
+      let pos = -1;
+      try {
+        pos = view.posAtDOM(span);
+      } catch {
+        // Widget DOM already detached — fall through to the path match.
+      }
+      const byPos = pos >= 0 ? entries.find((en) => pos >= en.from && pos < en.to) : undefined;
+      const entry = byPos ?? entries.find((en) => en.filePath === this.filePath);
       if (entry) removeChipRange(view, entry.from, entry.to);
     });
     span.appendChild(removeBtn);

--- a/src/hooks/__tests__/useFileAutocomplete.test.ts
+++ b/src/hooks/__tests__/useFileAutocomplete.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+vi.mock("@/clients/filesClient", () => ({
+  filesClient: { search: vi.fn() },
+}));
+
+import { filesClient } from "@/clients/filesClient";
+import { useFileAutocomplete } from "../useFileAutocomplete";
+
+const searchMock = vi.mocked(filesClient.search);
+
+interface Deferred {
+  resolve: (files: string[]) => void;
+  reject: (err: unknown) => void;
+}
+
+function enqueueDeferred(): Deferred {
+  const deferred = {} as Deferred;
+  searchMock.mockImplementationOnce(
+    () =>
+      new Promise((resolve, reject) => {
+        deferred.resolve = (files: string[]) => resolve({ files });
+        deferred.reject = reject;
+      })
+  );
+  return deferred;
+}
+
+describe("useFileAutocomplete", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    searchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("tracks the query that produced the current results", async () => {
+    const first = enqueueDeferred();
+    const { result, rerender } = renderHook(
+      ({ query }) => useFileAutocomplete({ cwd: "/repo", query, enabled: true }),
+      { initialProps: { query: "" } }
+    );
+
+    expect(result.current.resultsQuery).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      first.resolve(["a.ts", "b.ts"]);
+    });
+    expect(result.current.files).toEqual(["a.ts", "b.ts"]);
+    expect(result.current.resultsQuery).toBe("");
+    expect(result.current.isLoading).toBe(false);
+
+    // Query changes: during debounce + in-flight search the old results stay
+    // visible but resultsQuery still names the old query (the stale window).
+    const second = enqueueDeferred();
+    rerender({ query: "src" });
+    expect(result.current.resultsQuery).toBe("");
+    expect(result.current.files).toEqual(["a.ts", "b.ts"]);
+
+    await act(async () => {
+      vi.advanceTimersByTime(80);
+    });
+    expect(result.current.resultsQuery).toBe("");
+
+    await act(async () => {
+      second.resolve(["src/index.ts"]);
+    });
+    expect(result.current.files).toEqual(["src/index.ts"]);
+    expect(result.current.resultsQuery).toBe("src");
+  });
+
+  it("ignores out-of-order resolutions from superseded requests", async () => {
+    const first = enqueueDeferred();
+    const { result, rerender } = renderHook(
+      ({ query }) => useFileAutocomplete({ cwd: "/repo", query, enabled: true }),
+      { initialProps: { query: "a" } }
+    );
+
+    const second = enqueueDeferred();
+    rerender({ query: "ab" });
+    await act(async () => {
+      vi.advanceTimersByTime(80);
+    });
+
+    // Newer request resolves first; the older one lands afterwards and must
+    // not clobber files or resultsQuery.
+    await act(async () => {
+      second.resolve(["ab.ts"]);
+    });
+    expect(result.current.files).toEqual(["ab.ts"]);
+    expect(result.current.resultsQuery).toBe("ab");
+
+    await act(async () => {
+      first.resolve(["a.ts"]);
+    });
+    expect(result.current.files).toEqual(["ab.ts"]);
+    expect(result.current.resultsQuery).toBe("ab");
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("debounces query changes before searching", async () => {
+    enqueueDeferred();
+    const { rerender } = renderHook(
+      ({ query }) => useFileAutocomplete({ cwd: "/repo", query, enabled: true }),
+      { initialProps: { query: "" } }
+    );
+    expect(searchMock).toHaveBeenCalledTimes(1);
+
+    enqueueDeferred();
+    rerender({ query: "src" });
+    await act(async () => {
+      vi.advanceTimersByTime(74);
+    });
+    expect(searchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(searchMock).toHaveBeenCalledTimes(2);
+    expect(searchMock).toHaveBeenLastCalledWith({ cwd: "/repo", query: "src", limit: 50 });
+  });
+
+  it("ignores an in-flight search that resolves after being disabled", async () => {
+    const first = enqueueDeferred();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useFileAutocomplete({ cwd: "/repo", query: "", enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    rerender({ enabled: false });
+
+    await act(async () => {
+      first.resolve(["a.ts"]);
+    });
+    expect(result.current.files).toEqual([]);
+    expect(result.current.resultsQuery).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("treats results from a previous cwd as stale", async () => {
+    const first = enqueueDeferred();
+    const { result, rerender } = renderHook(
+      ({ cwd }) => useFileAutocomplete({ cwd, query: "", enabled: true }),
+      { initialProps: { cwd: "/repo-a" } }
+    );
+
+    await act(async () => {
+      first.resolve(["a.ts"]);
+    });
+    expect(result.current.resultsQuery).toBe("");
+
+    const second = enqueueDeferred();
+    rerender({ cwd: "/repo-b" });
+    // Same query text, different worktree — the old results must not read
+    // as current until the new cwd's search resolves.
+    expect(result.current.resultsQuery).toBeNull();
+
+    await act(async () => {
+      second.resolve(["b.ts"]);
+    });
+    expect(result.current.files).toEqual(["b.ts"]);
+    expect(result.current.resultsQuery).toBe("");
+  });
+
+  it("clears files and resultsQuery when disabled", async () => {
+    const first = enqueueDeferred();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useFileAutocomplete({ cwd: "/repo", query: "", enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    await act(async () => {
+      first.resolve(["a.ts"]);
+    });
+    expect(result.current.files).toEqual(["a.ts"]);
+    expect(result.current.resultsQuery).toBe("");
+
+    rerender({ enabled: false });
+    expect(result.current.files).toEqual([]);
+    expect(result.current.resultsQuery).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("records resultsQuery when a search fails so the empty state is not stale", async () => {
+    const first = enqueueDeferred();
+    const { result } = renderHook(() =>
+      useFileAutocomplete({ cwd: "/repo", query: "zzz", enabled: true })
+    );
+
+    await act(async () => {
+      first.reject(new Error("search failed"));
+    });
+    expect(result.current.files).toEqual([]);
+    expect(result.current.resultsQuery).toBe("zzz");
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/src/hooks/useFileAutocomplete.ts
+++ b/src/hooks/useFileAutocomplete.ts
@@ -35,6 +35,10 @@ export interface UseFileAutocompleteOptions {
 export interface UseFileAutocompleteResult {
   files: string[];
   isLoading: boolean;
+  /** Query the current `files` were produced for; null until the first search
+   *  resolves or when the results belong to a different cwd. Lets callers
+   *  detect stale results while a newer query is debouncing or in flight. */
+  resultsQuery: string | null;
 }
 
 export function useFileAutocomplete({
@@ -44,6 +48,7 @@ export function useFileAutocomplete({
   limit = 50,
 }: UseFileAutocompleteOptions): UseFileAutocompleteResult {
   const [files, setFiles] = useState<string[]>([]);
+  const [resultsFor, setResultsFor] = useState<{ cwd: string; query: string } | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const requestIdRef = useRef(0);
 
@@ -51,14 +56,12 @@ export function useFileAutocomplete({
   const effectiveQuery = useMemo(() => debouncedQuery, [debouncedQuery]);
 
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || !cwd) {
+      // Invalidate any in-flight search so a late resolve can't repopulate
+      // results after the menu closed or the pane lost its cwd.
+      requestIdRef.current++;
       setFiles([]);
-      setIsLoading(false);
-      return;
-    }
-
-    if (!cwd) {
-      setFiles([]);
+      setResultsFor(null);
       setIsLoading(false);
       return;
     }
@@ -71,10 +74,12 @@ export function useFileAutocomplete({
       .then((result) => {
         if (requestIdRef.current !== requestId) return;
         setFiles(result.files);
+        setResultsFor({ cwd, query: effectiveQuery });
       })
       .catch(() => {
         if (requestIdRef.current !== requestId) return;
         setFiles([]);
+        setResultsFor({ cwd, query: effectiveQuery });
       })
       .finally(() => {
         if (requestIdRef.current !== requestId) return;
@@ -82,5 +87,9 @@ export function useFileAutocomplete({
       });
   }, [cwd, enabled, effectiveQuery, limit]);
 
-  return { files, isLoading };
+  // Results produced for another cwd never count as current — a same-text
+  // query in a different worktree must not pass the caller's staleness check.
+  const resultsQuery = resultsFor && resultsFor.cwd === cwd ? resultsFor.query : null;
+
+  return { files, isLoading, resultsQuery };
 }


### PR DESCRIPTION
This PR is a general friction pass on the hybrid input bar composer. No new features, just a set of small changes that make it clearer what will be sent and where it will be sent.

### File autocomplete staleness

File search is debounced and async, so the visible results can lag behind what you've typed. We now track which query and working directory produced the current results. This fixes a few things:

- Pressing Enter or Tab quickly no longer accepts an outdated match. If the results are stale, Enter sends the text you actually typed and Tab does nothing.
- Stale rows render dimmed so they don't read as matches for the current text.
- An in-flight search that resolves after the menu closes, or after the pane's working directory changes, can no longer repopulate the results. The same query text from a different worktree is treated as stale.

### Autocomplete menu

- The menu now has a small header naming the active mode (Files, Commands, Diffs, and so on) with a key hint. `@` can mean files, diffs, terminals or selections, so the menu now says which one you're in.
- Keyboard selection scrolls into view. Previously you could arrow down past the visible rows and lose the selection off-screen.
- File rows show the basename with the directory dimmed, which disambiguates duplicate filenames.
- Long rows truncate instead of overflowing.
- Escape and editor blur now close the `@terminal` and `@selection` menus. These previously stayed open because their contexts were never cleared.

### Chips

- The remove button on duplicate file chips now removes the chip you clicked, not the first chip with the same path. The lookup is position-based, with a path match as fallback.
- Chip labels ellipsize, so long filenames don't blow out narrow panes. The full path is still in the hover tooltip.

### Send state

- The input shell tints amber when fleet broadcast is armed on the focused pane, matching the drafting pill, so it's clear at the point of typing that Enter will broadcast.
- The voice submit overlay now shows a "Finishing dictation" status label instead of a bare spinner.

### Tests

- New suite for the keymap: Enter and Tab against fresh vs stale results, and Escape clearing every context.
- New suite for file search races: the debounce boundary, out-of-order responses, disable mid-flight, and working directory switches.
- Extended the menu, chip and voice tests, including removal of adjacent duplicate chips and cancelling a voice submit mid-wait.

All checks pass, and the hybrid input E2E spec passes locally.
