### PR TITLE
Reduce notification and diagnostics noise

### DIFF
--- a/docs/architecture/crash-recovery-and-safe-mode.md
+++ b/docs/architecture/crash-recovery-and-safe-mode.md
@@ -202,7 +202,7 @@ This is the **most-urgent global banner** (top of the priority list) because the
 
 ## 6. Global banner coordination & local-error suppression
 
-All six top-of-app recovery banners compete for a **single slot**. `useGlobalBannerPriority` (`src/components/Recovery/useGlobalBannerPriority.ts`) computes the winner; `GlobalBannerCoordinator` (mounted once in `App.tsx`) renders exactly one and **unmounts** the rest (so e.g. `RestoreConfirmationBanner`'s auto-dismiss timer only runs while visible).
+All seven top-of-app recovery banners compete for a **single slot**. `useGlobalBannerPriority` (`src/components/Recovery/useGlobalBannerPriority.ts`) computes the winner; `GlobalBannerCoordinator` (mounted once in `App.tsx`) renders exactly one and **unmounts** the rest (so e.g. `RestoreConfirmationBanner`'s auto-dismiss timer only runs while visible).
 
 Precedence (high → low):
 
@@ -211,8 +211,9 @@ host-crash         backendStatus !== "connected"   — backend unusable now
 watchdog-disabled  watchdogStatus === "disabled"    — deadlock detector gone
 safe-mode          safeMode && !dismissed           — panels held back after a crash loop
 restore-confirmation                                — informational "session recovered"
-github-token                                        — expired credentials
+forge-token                                         — expired forge credentials
 cloud-sync                                          — synced-folder warning
+rosetta                                             — x64 build translated on Apple Silicon
 ```
 
 Watchdog ranks below host-crash (a live failure beats a downed monitor) and above safe-mode (the watchdog protects against the _next_ crash; safe-mode is a consequence of the _previous_ one).

--- a/docs/architecture/notification-system.md
+++ b/docs/architecture/notification-system.md
@@ -143,12 +143,14 @@ safe-mode           safeMode && !dismissed                (panels not restored a
   ↓
 restore-confirmation restoreVisible                       (session-recovered, auto-dismiss timer)
   ↓
-github-token        tokenUnhealthy                        (expired creds; GitHub data broken now)
+forge-token         tokenUnhealthy                        (expired creds; forge data broken now)
   ↓
 cloud-sync          cloudSyncService !== null             (environmental warning)
+  ↓
+rosetta             rosettaVisible                        (x64 build translated on Apple Silicon)
 ```
 
-Rationale for the order lives inline in `useGlobalBannerPriority.ts`: watchdog sits below host-crash (a live host failure outranks a downed monitor) and above safe-mode (the watchdog protects against the _next_ crash; safe-mode is a consequence of the _previous_ one); `restore-confirmation` stays above `github-token` because its auto-dismiss timer only runs while mounted, so it must keep that window; `github-token` outranks `cloud-sync` because an expired token is an active failure while cloud-sync is a persistent environmental condition.
+Rationale for the order lives inline in `useGlobalBannerPriority.ts`: watchdog sits below host-crash (a live host failure outranks a downed monitor) and above safe-mode (the watchdog protects against the _next_ crash; safe-mode is a consequence of the _previous_ one); `restore-confirmation` stays above `forge-token` because its auto-dismiss timer only runs while mounted, so it must keep that window; `forge-token` outranks `cloud-sync` because an expired token is an active failure while cloud-sync is a persistent environmental condition; `rosetta` sits last because nothing in the app can change it — any more actionable banner deserves the slot first.
 
 **Suppressed banners unmount — they are not CSS-hidden.** The coordinator returns exactly one component; the losers are removed from the tree. This is deliberate: mount-driven effects (most notably `RestoreConfirmationBanner`'s auto-dismiss timer) must not run while the banner is invisible. A CSS-hide would leave those timers ticking behind a higher-priority banner.
 

--- a/src/components/Diagnostics/WhySlowContent.tsx
+++ b/src/components/Diagnostics/WhySlowContent.tsx
@@ -21,6 +21,64 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function formatSnapshotAge(ageMs: number): string {
+  if (ageMs < 10_000) return "just now";
+  if (ageMs < 60_000) return `${Math.floor(ageMs / 1000)}s ago`;
+  const minutes = Math.floor(ageMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ago`;
+}
+
+// Shared by the PTY-lag tile tone and isAllClear so the calm summary can never
+// disagree with a warn-toned tile over the same number.
+const PTY_LAG_WARN_THRESHOLD_MS = 50;
+
+/**
+ * True when nothing in the snapshot would render a warn/alert tone — the same
+ * conditions the tiles and badges below use, so the calm summary line can
+ * never contradict a highlighted metric next to it. The resource and pty
+ * sections must be present: a section degraded to null means "unknown", and
+ * claiming all-clear over missing data would be false calm. `worktrees` may be
+ * null legitimately (no workspace open), so it only vetoes when present, as do
+ * renderer samples (an empty push cache just means no view has reported yet).
+ */
+export function isAllClear(snapshot: WhySlowSnapshot): boolean {
+  const r = snapshot.resource;
+  if (!r) return false;
+  if (
+    r.currentProfile !== "performance" ||
+    r.targetProfile !== "performance" ||
+    r.reasons.length > 0 ||
+    r.lagPressureActive ||
+    r.interactiveOverrideActive ||
+    r.isOnBattery ||
+    (r.thermalState !== "unknown" && r.thermalState !== "nominal") ||
+    r.speedLimit < 100
+  ) {
+    return false;
+  }
+  if (snapshot.focusThrottle.throttled) return false;
+  // Any view on the DOM fallback renders the WebGL tile in warn tone.
+  if (snapshot.rendererTerminals.some((s) => s.webglMode === "dom")) return false;
+  const p = snapshot.pty;
+  if (!p) return false;
+  if (p.totalPendingBytes > 0 || p.pausedCount > 0) return false;
+  if (p.eventLoopP99Ms !== null && p.eventLoopP99Ms > PTY_LAG_WARN_THRESHOLD_MS) return false;
+  if (snapshot.worktrees && snapshot.worktrees.fetchInFlightCount > 0) return false;
+  return true;
+}
+
+/**
+ * Bottleneck-first ordering: the largest pressure contribution is the likeliest
+ * answer to "why am I slow?", so it leads the list. Stable sort keeps the
+ * collector's declaration order for ties.
+ */
+export function sortReasonsByContribution<T extends { contribution: number }>(
+  reasons: readonly T[]
+): T[] {
+  return [...reasons].sort((a, b) => b.contribution - a.contribution);
+}
+
 function profileTone(profile: string): MetricTone {
   if (profile === "efficiency") return "alert";
   if (profile === "balanced") return "warn";
@@ -99,6 +157,7 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const mountedRef = useRef(true);
   const inFlightRef = useRef(false);
+  const failStreakRef = useRef(0);
 
   const refresh = useCallback(async () => {
     // Skip if a fetch is already in flight so the poll interval can't stack
@@ -111,9 +170,17 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
       if (!mountedRef.current) return;
       setSnapshot(next);
       setError(false);
+      failStreakRef.current = 0;
     } catch (err) {
       if (!mountedRef.current) return;
-      logError("Failed to load why-slow snapshot", err);
+      // Log only the first failure of a streak — the poll retries every 5s
+      // indefinitely, so a persistently-dead collector would otherwise write
+      // an identical error line on every tick. The streak resets on success
+      // so a fresh outage still logs.
+      failStreakRef.current += 1;
+      if (failStreakRef.current === 1) {
+        logError("Failed to load why-slow snapshot", err);
+      }
       setError(true);
     } finally {
       inFlightRef.current = false;
@@ -135,6 +202,8 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
 
   const renderer = snapshot ? aggregateRenderer(snapshot) : null;
   const resource = snapshot?.resource ?? null;
+  const snapshotAgeMs = snapshot ? Math.max(0, Date.now() - snapshot.timestamp) : 0;
+  const sortedReasons = resource ? sortReasonsByContribution(resource.reasons) : [];
 
   return (
     <div className={cn("h-full overflow-auto p-3 text-sm text-daintree-text", className)}>
@@ -143,19 +212,46 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
           <Gauge className="w-4 h-4 text-daintree-text/60" />
           <span className="font-medium">Why am I slow?</span>
         </div>
-        <button
-          onClick={() => void refresh()}
-          disabled={isRefreshing}
-          className="flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-md)] text-xs text-daintree-text/70 hover:text-daintree-text hover:bg-tint/[0.06] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent disabled:opacity-50"
-          aria-label="Refresh diagnostics snapshot"
-        >
-          <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
-          Refresh
-        </button>
+        <div className="flex items-center gap-2">
+          {snapshot ? (
+            error ? (
+              <span
+                data-testid="why-slow-stale-note"
+                className="text-[10px] text-status-warning/80 tabular-nums"
+              >
+                Refresh failed · data from {formatSnapshotAge(snapshotAgeMs)}
+              </span>
+            ) : (
+              <span
+                data-testid="why-slow-updated-note"
+                className="text-[10px] text-daintree-text/40 tabular-nums"
+              >
+                Updated {formatSnapshotAge(snapshotAgeMs)}
+              </span>
+            )
+          ) : null}
+          <button
+            onClick={() => void refresh()}
+            disabled={isRefreshing}
+            className="flex items-center gap-1.5 px-2 py-1 rounded-[var(--radius-md)] text-xs text-daintree-text/70 hover:text-daintree-text hover:bg-tint/[0.06] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent disabled:opacity-50"
+            aria-label="Refresh diagnostics snapshot"
+          >
+            <RefreshCw className={cn("w-3.5 h-3.5", isRefreshing && "animate-spin")} />
+            Refresh
+          </button>
+        </div>
       </div>
 
       {error && !snapshot ? (
         <div className="text-status-error text-xs">Couldn't load the diagnostics snapshot.</div>
+      ) : null}
+
+      {/* Suppressed while a refresh is failing: "right now" from stale data
+          would contradict the stale note in the header. */}
+      {snapshot && !error && isAllClear(snapshot) ? (
+        <p data-testid="why-slow-all-clear" className="text-xs text-daintree-text/55 mb-3">
+          Nothing is slowing Daintree down right now
+        </p>
       ) : null}
 
       {snapshot ? (
@@ -204,15 +300,22 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
                     <Badge tone="warn">thermal {resource.thermalState}</Badge>
                   ) : null}
                 </div>
-                {resource.reasons.length > 0 ? (
+                {sortedReasons.length > 0 ? (
                   <ul className="flex flex-col gap-1 mt-1">
-                    {resource.reasons.map((r) => (
+                    {sortedReasons.map((r, index) => (
                       <li
                         key={r.signal}
-                        className="flex items-center justify-between text-xs text-daintree-text/75 font-mono"
+                        className={cn(
+                          "flex items-center justify-between text-xs font-mono",
+                          // Bottleneck-first: the top contributor is the likely
+                          // answer, so it reads at full strength; the rest recede.
+                          index === 0 && sortedReasons.length > 1
+                            ? "text-daintree-text font-medium"
+                            : "text-daintree-text/75"
+                        )}
                       >
                         <span>{r.detail}</span>
-                        <span className="text-daintree-text/45">+{r.contribution}</span>
+                        <span className="text-daintree-text/45 font-normal">+{r.contribution}</span>
                       </li>
                     ))}
                   </ul>
@@ -290,7 +393,8 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
                   snapshot.pty?.eventLoopP99Ms != null ? `${snapshot.pty.eventLoopP99Ms}ms` : "—"
                 }
                 tone={
-                  snapshot.pty?.eventLoopP99Ms != null && snapshot.pty.eventLoopP99Ms > 50
+                  snapshot.pty?.eventLoopP99Ms != null &&
+                  snapshot.pty.eventLoopP99Ms > PTY_LAG_WARN_THRESHOLD_MS
                     ? "warn"
                     : "default"
                 }

--- a/src/components/Diagnostics/__tests__/WhySlowContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/WhySlowContent.test.tsx
@@ -27,6 +27,39 @@ function makeSnapshot(overrides?: Partial<WhySlowSnapshot>): WhySlowSnapshot {
   };
 }
 
+function makeQuietResource(): NonNullable<WhySlowSnapshot["resource"]> {
+  return {
+    currentProfile: "performance",
+    targetProfile: "performance",
+    pressureScore: 0,
+    reasons: [],
+    lagPressureActive: false,
+    lagEscalatedActive: false,
+    interactiveOverrideActive: false,
+    thermalState: "nominal",
+    isOnBattery: false,
+    speedLimit: 100,
+  };
+}
+
+function makeQuietPty(): NonNullable<WhySlowSnapshot["pty"]> {
+  return {
+    totalPendingBytes: 0,
+    terminalCount: 2,
+    pausedCount: 0,
+    suspendedCount: 0,
+    maxPausedDurationMs: 0,
+    eventLoopP99Ms: 3,
+    eventLoopMaxMs: 6,
+    eventLoopUtilization: 0.1,
+  };
+}
+
+const quietWorktrees: NonNullable<WhySlowSnapshot["worktrees"]> = {
+  monitorCount: 3,
+  fetchInFlightCount: 0,
+};
+
 describe("WhySlowContent", () => {
   beforeEach(() => {
     getWhySlowSnapshot.mockReset();
@@ -135,5 +168,178 @@ describe("WhySlowContent", () => {
     });
 
     expect(logError).not.toHaveBeenCalled();
+  });
+
+  it("marks the snapshot stale when a refresh fails, and recovers on the next success", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(60_000);
+    getWhySlowSnapshot.mockResolvedValueOnce(makeSnapshot({ timestamp: 60_000 }));
+
+    render(<WhySlowContent />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByTestId("why-slow-updated-note").textContent).toBe("Updated just now");
+
+    // Poll ticks fail → the old snapshot stays visible but is flagged stale.
+    getWhySlowSnapshot.mockRejectedValue(new Error("collector down"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(screen.getByTestId("why-slow-stale-note").textContent).toBe(
+      "Refresh failed · data from 15s ago"
+    );
+    expect(screen.queryByTestId("why-slow-updated-note")).toBeNull();
+
+    // The poll keeps retrying; the next success clears the stale note.
+    getWhySlowSnapshot.mockResolvedValue(makeSnapshot({ timestamp: 80_000 }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(screen.queryByTestId("why-slow-stale-note")).toBeNull();
+    expect(screen.getByTestId("why-slow-updated-note")).toBeTruthy();
+  });
+
+  it("logs only the first failure of a streak, then again after recovery", async () => {
+    vi.useFakeTimers();
+    getWhySlowSnapshot.mockRejectedValue(new Error("collector down"));
+
+    render(<WhySlowContent />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(logError).toHaveBeenCalledTimes(1);
+
+    // Repeated failing poll ticks stay silent — no error loop in the log.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+    expect(logError).toHaveBeenCalledTimes(1);
+
+    // Success resets the streak; a fresh outage logs once more.
+    getWhySlowSnapshot.mockResolvedValueOnce(makeSnapshot());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    getWhySlowSnapshot.mockRejectedValue(new Error("down again"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(logError).toHaveBeenCalledTimes(2);
+  });
+
+  it("lists pressure reasons bottleneck-first, keeping collector order for ties", async () => {
+    getWhySlowSnapshot.mockResolvedValue(
+      makeSnapshot({
+        resource: {
+          currentProfile: "efficiency",
+          targetProfile: "efficiency",
+          pressureScore: 5,
+          reasons: [
+            { signal: "memory", contribution: 1, detail: "app memory 2.1 GB" },
+            { signal: "fleetSize", contribution: 3, detail: "24 active agents" },
+            { signal: "systemMemory", contribution: 1, detail: "system memory low" },
+          ],
+          lagPressureActive: false,
+          lagEscalatedActive: false,
+          interactiveOverrideActive: false,
+          thermalState: "nominal",
+          isOnBattery: false,
+          speedLimit: 100,
+        },
+      })
+    );
+
+    render(<WhySlowContent />);
+
+    const items = await screen.findAllByRole("listitem");
+    const texts = items.map((li) => li.textContent);
+    // fleetSize (+3) leads despite the collector emitting memory (+1) first;
+    // the tied +1 reasons keep their collector order (stable sort).
+    expect(texts[0]).toContain("24 active agents");
+    expect(texts[1]).toContain("app memory 2.1 GB");
+    expect(texts[2]).toContain("system memory low");
+  });
+
+  it("shows the all-clear line only when every section is present and quiet", async () => {
+    getWhySlowSnapshot.mockResolvedValue(
+      makeSnapshot({
+        resource: makeQuietResource(),
+        pty: makeQuietPty(),
+        worktrees: quietWorktrees,
+      })
+    );
+
+    render(<WhySlowContent />);
+
+    expect(await screen.findByTestId("why-slow-all-clear")).toBeTruthy();
+  });
+
+  it("does not claim all-clear when the resource section degraded to null", async () => {
+    // Partial payload: resource section missing — "unknown" must not read as healthy.
+    getWhySlowSnapshot.mockResolvedValue(makeSnapshot({ pty: makeQuietPty() }));
+
+    render(<WhySlowContent />);
+
+    expect(await screen.findByText("Resource profile unavailable.")).toBeTruthy();
+    expect(screen.queryByTestId("why-slow-all-clear")).toBeNull();
+  });
+
+  it("does not claim all-clear when the pty section degraded to null", async () => {
+    getWhySlowSnapshot.mockResolvedValue(makeSnapshot({ resource: makeQuietResource() }));
+
+    render(<WhySlowContent />);
+
+    await screen.findByText("Resource profile");
+    expect(screen.queryByTestId("why-slow-all-clear")).toBeNull();
+  });
+
+  it("does not claim all-clear when a warn tone is visible (focus throttle, pty lag)", async () => {
+    getWhySlowSnapshot.mockResolvedValue(
+      makeSnapshot({
+        resource: makeQuietResource(),
+        pty: makeQuietPty(),
+        focusThrottle: { throttled: true, pollMultiplier: 4 },
+      })
+    );
+
+    const { unmount } = render(<WhySlowContent />);
+    await screen.findByText("Resource profile");
+    expect(screen.queryByTestId("why-slow-all-clear")).toBeNull();
+    unmount();
+
+    // PTY host lag above the warn threshold vetoes all-clear on its own.
+    getWhySlowSnapshot.mockResolvedValue(
+      makeSnapshot({
+        resource: makeQuietResource(),
+        pty: { ...makeQuietPty(), eventLoopP99Ms: 80 },
+      })
+    );
+
+    render(<WhySlowContent />);
+    await screen.findByText("Resource profile");
+    expect(screen.queryByTestId("why-slow-all-clear")).toBeNull();
+  });
+
+  it("hides the all-clear line while a refresh is failing", async () => {
+    vi.useFakeTimers();
+    getWhySlowSnapshot.mockResolvedValueOnce(
+      makeSnapshot({ resource: makeQuietResource(), pty: makeQuietPty() })
+    );
+
+    render(<WhySlowContent />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByTestId("why-slow-all-clear")).toBeTruthy();
+
+    // The snapshot on screen still says all-clear, but it is stale now — the
+    // calm line must not present old data as "right now" next to the stale note.
+    getWhySlowSnapshot.mockRejectedValue(new Error("collector down"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(screen.getByTestId("why-slow-stale-note")).toBeTruthy();
+    expect(screen.queryByTestId("why-slow-all-clear")).toBeNull();
   });
 });

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -376,57 +376,59 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     return entries.filter((e) => e.archivedAt === null && !e.seenAsToast && !isSnoozed(e));
   }, [entries, filter, frozenUnreadIds, snoozedThreads]);
 
-  const { needsAttentionGroups, chronoSections, dividerGroupId } = useMemo(() => {
-    const now = Date.now();
-    const isSnoozedGroup = (g: ThreadGroup): boolean => {
-      if (!g.correlationId) return false;
-      const until = snoozedThreads[g.correlationId];
-      return typeof until === "number" && until > now;
-    };
-    // Pinned reflects the global unread severe-threads set so it stays the
-    // same in All and Unread filter views. Hidden in Archived and Snoozed —
-    // pinned is for active, attention-required items only. Snoozed threads
-    // are an explicit defer so they must drop out of the pinned rail.
-    const pinned =
-      filter === "archived" || filter === "snoozed"
-        ? []
-        : groupByCorrelationId(entries.filter((e) => e.archivedAt === null))
-            .filter((g) => {
-              if (isSnoozedGroup(g)) return false;
-              if (!isUnreadGroup(g)) return false;
-              const sev = getWorstSeverity(g.entries);
-              return sev === "error" || sev === "warning";
-            })
-            .sort((a, b) => {
-              const sevDiff =
-                SEVERITY_WEIGHTS[getWorstSeverity(b.entries)] -
-                SEVERITY_WEIGHTS[getWorstSeverity(a.entries)];
-              if (sevDiff !== 0) return sevDiff;
-              return b.latestTimestamp - a.latestTimestamp;
-            })
-            .slice(0, NEEDS_ATTENTION_CAP);
+  const { needsAttentionGroups, needsAttentionOverflow, chronoSections, dividerGroupId } =
+    useMemo(() => {
+      const now = Date.now();
+      const isSnoozedGroup = (g: ThreadGroup): boolean => {
+        if (!g.correlationId) return false;
+        const until = snoozedThreads[g.correlationId];
+        return typeof until === "number" && until > now;
+      };
+      // Pinned reflects the global unread severe-threads set so it stays the
+      // same in All and Unread filter views. Hidden in Archived and Snoozed —
+      // pinned is for active, attention-required items only. Snoozed threads
+      // are an explicit defer so they must drop out of the pinned rail.
+      const severeUnread =
+        filter === "archived" || filter === "snoozed"
+          ? []
+          : groupByCorrelationId(entries.filter((e) => e.archivedAt === null))
+              .filter((g) => {
+                if (isSnoozedGroup(g)) return false;
+                if (!isUnreadGroup(g)) return false;
+                const sev = getWorstSeverity(g.entries);
+                return sev === "error" || sev === "warning";
+              })
+              .sort((a, b) => {
+                const sevDiff =
+                  SEVERITY_WEIGHTS[getWorstSeverity(b.entries)] -
+                  SEVERITY_WEIGHTS[getWorstSeverity(a.entries)];
+                if (sevDiff !== 0) return sevDiff;
+                return b.latestTimestamp - a.latestTimestamp;
+              });
+      const pinned = severeUnread.slice(0, NEEDS_ATTENTION_CAP);
 
-    const chronoGroups = groupByCorrelationId(filteredEntries);
-    const sections: ContextSection[] = groupByContext
-      ? partitionByContext(chronoGroups)
-      : [{ key: "all", groups: chronoGroups }];
+      const chronoGroups = groupByCorrelationId(filteredEntries);
+      const sections: ContextSection[] = groupByContext
+        ? partitionByContext(chronoGroups)
+        : [{ key: "all", groups: chronoGroups }];
 
-    let divider: string | null = null;
-    if (lastClosedAt > 0 && filter !== "archived" && filter !== "snoozed") {
-      for (const g of chronoGroups) {
-        if (g.latestTimestamp > lastClosedAt) {
-          divider = g.correlationId ?? g.entries[0]?.id ?? null;
-          break;
+      let divider: string | null = null;
+      if (lastClosedAt > 0 && filter !== "archived" && filter !== "snoozed") {
+        for (const g of chronoGroups) {
+          if (g.latestTimestamp > lastClosedAt) {
+            divider = g.correlationId ?? g.entries[0]?.id ?? null;
+            break;
+          }
         }
       }
-    }
 
-    return {
-      needsAttentionGroups: pinned,
-      chronoSections: sections,
-      dividerGroupId: divider,
-    };
-  }, [entries, filteredEntries, groupByContext, lastClosedAt, filter, snoozedThreads]);
+      return {
+        needsAttentionGroups: pinned,
+        needsAttentionOverflow: severeUnread.length - pinned.length,
+        chronoSections: sections,
+        dividerGroupId: divider,
+      };
+    }, [entries, filteredEntries, groupByContext, lastClosedAt, filter, snoozedThreads]);
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
@@ -1074,6 +1076,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               {needsAttentionGroups.length > 0 && (
                 <NeedsAttentionSection
                   groups={needsAttentionGroups}
+                  overflowCount={needsAttentionOverflow}
                   indexOffset={0}
                   focusedIndex={focusedIndex}
                   setRowRef={setRowRef}
@@ -1166,6 +1169,7 @@ interface RovingSectionProps {
 
 function NeedsAttentionSection({
   groups,
+  overflowCount,
   indexOffset,
   focusedIndex,
   setRowRef,
@@ -1181,6 +1185,8 @@ function NeedsAttentionSection({
   onUnsnoozeRow,
 }: {
   groups: ThreadGroup[];
+  /** Severe unread threads beyond the pinned cap — they remain in the chronological list below. */
+  overflowCount: number;
   onDismiss: (id: string) => void;
   onDismissThread: (correlationId: string) => void;
   snoozePendingIndex: number | null;
@@ -1224,6 +1230,14 @@ function NeedsAttentionSection({
           );
         })}
       </div>
+      {overflowCount > 0 && (
+        <div
+          data-testid="needs-attention-overflow"
+          className="px-3 pb-2 text-[10px] text-daintree-text/45"
+        >
+          +{overflowCount} more below
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1068,6 +1068,48 @@ describe("NotificationCenter — Needs attention pinned section", () => {
     expect(messages).toHaveLength(5);
   });
 
+  it("shows a '+N more below' note when severe unread threads exceed the pinned cap", async () => {
+    const baseT = Date.now();
+    setEntries(
+      Array.from({ length: 7 }, (_, i) =>
+        makeEntry({
+          id: `failure-${i}`,
+          type: "error",
+          message: `Failure ${i}`,
+          timestamp: baseT - i,
+          seenAsToast: false,
+        })
+      )
+    );
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    // 7 severe unread threads, 5 pinned → the remaining 2 are acknowledged,
+    // not silently dropped; "below" must be literally true — the overflowed
+    // entries stay reachable in the chronological list.
+    expect(screen.getByTestId("needs-attention-overflow").textContent).toBe("+2 more below");
+    const chrono = screen.getByTestId("chrono-section");
+    expect(within(chrono).getByText("Failure 5")).toBeTruthy();
+    expect(within(chrono).getByText("Failure 6")).toBeTruthy();
+
+    // The pinned rail is computed from the global unread set, so the note
+    // (and the reachable rows) survive switching to the Unread filter.
+    await act(async () => {
+      fireEvent.click(screen.getByText("Unread"));
+    });
+    expect(screen.getByTestId("needs-attention-overflow").textContent).toBe("+2 more below");
+    expect(within(screen.getByTestId("chrono-section")).getByText("Failure 6")).toBeTruthy();
+  });
+
+  it("omits the overflow note when severe unread threads fit within the cap", () => {
+    setEntries([makeEntry({ type: "error", message: "Build failed", seenAsToast: false })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("needs-attention-section")).toBeTruthy();
+    expect(screen.queryByTestId("needs-attention-overflow")).toBeNull();
+  });
+
   it("stays consistent across All and Unread filter views for mixed read/unread threads", async () => {
     const correlationId = "thread-mixed";
     const t = Date.now();

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -3216,6 +3216,63 @@ describe("notify() — thread re-promotion (#9008)", () => {
       expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeDefined();
     });
 
+    it("clears the snooze when a snoozed thread escalates while blurred (no toast)", () => {
+      // The toast stays focus-gated (#10056), but the escalation must still
+      // un-snooze the thread: otherwise an error lands hidden behind a snooze
+      // the user set on a milder thread and never reaches the unread badge.
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      useNotificationHistoryStore.setState({
+        snoozedThreads: { build: Date.now() + 60_000 },
+      });
+      notify({
+        type: "error",
+        correlationId: "build",
+        message: "Build failed",
+        priority: "low",
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeUndefined();
+      const escalation = useNotificationHistoryStore
+        .getState()
+        .entries.find((e) => e.message === "Build failed");
+      expect(escalation?.seenAsToast).toBe(false);
+      expect(useNotificationHistoryStore.getState().unreadCount).toBe(1);
+    });
+
+    it("keeps the snooze on a routine same-severity update while blurred", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      const until = Date.now() + 60_000;
+      useNotificationHistoryStore.setState({ snoozedThreads: { build: until } });
+      notify({
+        type: "info",
+        correlationId: "build",
+        message: "Still building",
+        priority: "low",
+      });
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBe(until);
+    });
+
+    it("watch-priority update on a snoozed thread clears the snooze even while blurred", () => {
+      // `watch` bypasses the focus gate entirely, so the thread is actively
+      // toasting — keeping its inbox rows hidden behind the snooze would
+      // contradict the visible toast.
+      vi.spyOn(document, "hasFocus").mockReturnValue(false);
+      seedThread([seedEntry({ type: "info", correlationId: "build" })]);
+      useNotificationHistoryStore.setState({
+        snoozedThreads: { build: Date.now() + 60_000 },
+      });
+      notify({
+        type: "info",
+        correlationId: "build",
+        message: "Watch update",
+        priority: "watch",
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationHistoryStore.getState().snoozedThreads["build"]).toBeUndefined();
+    });
+
     it("grid-bar path clears the snooze when the same predicate would re-promote", () => {
       seedThread([seedEntry({ type: "info", correlationId: "build" })]);
       useNotificationHistoryStore.setState({

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -967,20 +967,31 @@ export function notify(payload: NotifyPayload): string {
   // escalation from the unread badge and re-entry summary. Blurred
   // escalations stay inbox-only (`seenAsToast: false`) so they surface on
   // refocus; `urgent` bypasses quiet hours and rate limiting, not focus.
-  const shouldToastThread =
-    !shouldToast && isFocused && correlationId && !payload.transient
+  const wouldRePromoteThread =
+    correlationId && !payload.transient
       ? shouldReToast(type, getEntriesByCorrelationId(correlationId), payload.urgent)
       : false;
+  const shouldToastThread = !shouldToast && isFocused && wouldRePromoteThread;
   const effectiveShouldToast = shouldToast || shouldToastThread;
 
-  // Auto-resurface: a snoozed thread that re-toasts (escalated severity,
+  // Auto-resurface: a snoozed thread that re-promotes (escalated severity,
   // urgent, or full un-snooze) must clear its snooze before `addEntry`
   // lands the new history row. Running this before the write keeps the
   // store atomically consistent — observers never see an unread badge that
   // counts the new entry while still hiding its thread behind the snooze
-  // filter. Routine same-severity updates do not pass `shouldReToast` and
-  // therefore stay snoozed, preserving the user's defer choice.
-  if (effectiveShouldToast && correlationId) {
+  // filter. Routine same-severity updates that would otherwise route
+  // inbox-only do not pass `shouldReToast` and therefore stay snoozed,
+  // preserving the user's defer choice; an update that clears the normal
+  // toast gate (`effectiveShouldToast`) un-snoozes regardless, because a
+  // thread actively toasting must not keep its inbox row hidden.
+  //
+  // `wouldRePromoteThread` is included alongside `effectiveShouldToast` so a
+  // blurred escalation still un-snoozes: the toast stays focus-gated
+  // (#10056), but the escalated entry must land unread and count toward the
+  // badge rather than staying hidden behind a snooze the user set on a
+  // milder thread. Mirrors the grid-bar path, which already clears the
+  // snooze off `shouldReToast` regardless of focus.
+  if ((effectiveShouldToast || wouldRePromoteThread) && correlationId) {
     useNotificationHistoryStore.getState().clearSnooze(correlationId);
   }
 


### PR DESCRIPTION
This PR reduces notification and diagnostics noise without adding any new UI surfaces.

## Fix snooze on escalation while unfocused

There's a bug in `notify.ts` where a snoozed thread that escalates in severity while the app window is unfocused keeps its snooze. The escalated error stays hidden from the unread badge until the snooze expires.

The fix clears the snooze on escalation, but keeps the toast gated on window focus. This is how the grid-bar path already behaves.

## '+N more below' for pinned threads

The 'Needs attention' section has a cap of 5 pinned threads, and silently dropped the extras. Now it shows a "+N more below" note, and the overflow stays reachable in the chronological list underneath.

## 'Why slow?' diagnostics improvements

* Show an "Updated Xs ago" caption in the header.
* If a poll fails, show a "Refresh failed" note with the age of the data. Previously, stale data was shown silently.
* Sort pressure reasons by contribution, so the likely bottleneck is always first.
* Show a calm all-clear line when every subsystem is present and quiet.
* Log repeated collection failures only once per failure streak. Previously a dead collector logged every 5 seconds.

## Fix global banner docs

The global banner docs listed six banners with a `github-token` slot. The code actually has seven slots, including `forge-token` and `rosetta`.

## Tests

There are tests covering all the new behaviour: blurred escalation and snooze interactions, the overflow note across filters, the stale note lifecycle, bottleneck-first ordering, and the all-clear vetoes. Everything passes locally, including the notification center and diagnostics Playwright specs.