### PR TITLE
Worktree card and review hub readiness polish

### DIFF
--- a/src/components/Worktree/ReviewHub/ReadinessRail.tsx
+++ b/src/components/Worktree/ReviewHub/ReadinessRail.tsx
@@ -57,16 +57,19 @@ export function ReadinessRail({ summary, onCta }: ReadinessRailProps) {
   const level = LEVEL_CONFIG[summary.level];
   const ordered = [...summary.blockers, ...summary.warnings, ...summary.infos];
   const visible = ordered.slice(0, MAX_VISIBLE_ITEMS);
-  const hiddenCount = ordered.length - visible.length;
+  const hidden = ordered.slice(MAX_VISIBLE_ITEMS);
 
   return (
     <div
       data-testid="review-readiness-rail"
+      role="group"
+      aria-label="Review readiness"
       className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-1.5 border-b border-divider bg-overlay-subtle text-[11px]"
     >
       <span
         data-testid="review-readiness-level"
         data-level={summary.level}
+        role="status"
         className={cn(
           "inline-flex items-center gap-1.5 px-1.5 py-0.5 rounded border font-medium shrink-0",
           level.chipClass
@@ -78,9 +81,14 @@ export function ReadinessRail({ summary, onCta }: ReadinessRailProps) {
       {visible.map((item) => (
         <RailItem key={item.id} item={item} onCta={onCta} />
       ))}
-      {hiddenCount > 0 && (
-        <span data-testid="review-readiness-overflow" className="text-daintree-text/40 shrink-0">
-          +{hiddenCount} more
+      {hidden.length > 0 && (
+        <span
+          data-testid="review-readiness-overflow"
+          className="text-daintree-text/40 shrink-0 cursor-help"
+          title={hidden.map((item) => item.label).join("\n")}
+          aria-label={`${hidden.length} more: ${hidden.map((item) => item.label).join(", ")}`}
+        >
+          +{hidden.length} more
         </span>
       )}
     </div>

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -35,6 +35,7 @@ import {
 } from "lucide-react";
 import { isProtectedBranch } from "@shared/utils/gitConstants";
 import { useUIStore } from "@/store/uiStore";
+import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 import { getCIStatusVisual } from "@/lib/worktreeCIStatus";
 import { Skeleton, SkeletonBone, SkeletonHint } from "@/components/ui/Skeleton";
@@ -1189,6 +1190,16 @@ export function ReviewHubContent({
     await runPush();
   }, [runPush]);
 
+  // Push from the clean-tree state, where no CommitPanel (and thus no local
+  // push confirm) is mounted. Routes through the same D2 preview dialog the
+  // git.push action uses, then reuses runPush so progress and error banners
+  // stay on the hub's existing paths.
+  const handlePushClean = useCallback(async () => {
+    const confirmed = await useGitPushConfirmStore.getState().requestConfirmation(worktreePath);
+    if (!confirmed) return;
+    await runPush();
+  }, [worktreePath, runPush]);
+
   const handleFocusBlocker = useCallback(
     (blocker: "conflicts" | "staged-files") => {
       // Conflict warning + Staged + Unstaged sections live inside the
@@ -1969,7 +1980,31 @@ export function ReviewHubContent({
                 <div className="flex flex-col items-center justify-center py-12 text-daintree-text/50">
                   <CheckSquare className="w-8 h-8 mb-2 text-daintree-text/30" />
                   <p className="text-sm">Working tree clean</p>
-                  <p className="text-xs mt-1">No changes to commit</p>
+                  {status.hasRemote && (aheadCount ?? 0) > 0 ? (
+                    <>
+                      <p className="text-xs mt-1" data-testid="review-hub-clean-unpushed">
+                        {aheadCount} commit{aheadCount !== 1 ? "s" : ""} not pushed
+                      </p>
+                      {readinessSummary.pushReady && (
+                        <button
+                          type="button"
+                          onClick={() => void handlePushClean()}
+                          disabled={isPushing}
+                          data-testid="review-hub-clean-push"
+                          className={cn(
+                            "mt-3 px-2.5 py-1 rounded text-xs font-medium transition-colors",
+                            "bg-filter-selected-bg-soft hover:bg-tint/[0.14] text-daintree-text/80",
+                            "disabled:opacity-50 disabled:cursor-not-allowed",
+                            "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
+                          )}
+                        >
+                          {isPushing ? "Pushing…" : "Push"}
+                        </button>
+                      )}
+                    </>
+                  ) : (
+                    <p className="text-xs mt-1">No changes to commit</p>
+                  )}
                 </div>
               ) : status ? (
                 <div>

--- a/src/components/Worktree/ReviewHub/__tests__/ReadinessRail.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReadinessRail.test.tsx
@@ -57,6 +57,42 @@ describe("ReadinessRail", () => {
     expect(screen.getByTestId("review-readiness-overflow").textContent).toBe("+2 more");
   });
 
+  it("discloses the hidden items' labels on the overflow indicator", () => {
+    const summary = makeSummary({
+      level: "blocked",
+      blockers: [item({ id: "conflicts", severity: "blocker" })],
+      warnings: [
+        item({ id: "behind-remote", severity: "warning" }),
+        item({ id: "ci-failing", severity: "warning" }),
+      ],
+      infos: [
+        item({ id: "no-remote", label: "No remote configured" }),
+        item({ id: "pr-missing", label: "No pull request for this branch" }),
+      ],
+    });
+    render(<ReadinessRail summary={summary} onCta={vi.fn()} />);
+    const overflow = screen.getByTestId("review-readiness-overflow");
+    expect(overflow.getAttribute("title")).toBe(
+      "No remote configured\nNo pull request for this branch"
+    );
+    expect(overflow.getAttribute("aria-label")).toBe(
+      "2 more: No remote configured, No pull request for this branch"
+    );
+  });
+
+  it("labels the rail as a group and announces level changes via a status region", () => {
+    const { rerender } = render(
+      <ReadinessRail summary={makeSummary({ level: "ready" })} onCta={vi.fn()} />
+    );
+    const rail = screen.getByTestId("review-readiness-rail");
+    expect(rail.getAttribute("role")).toBe("group");
+    expect(rail.getAttribute("aria-label")).toBe("Review readiness");
+    const chip = screen.getByTestId("review-readiness-level");
+    expect(chip.getAttribute("role")).toBe("status");
+    rerender(<ReadinessRail summary={makeSummary({ level: "blocked" })} onCta={vi.fn()} />);
+    expect(screen.getByTestId("review-readiness-level").textContent).toBe("Blocked");
+  });
+
   it("renders detail inline after the label", () => {
     const summary = makeSummary({
       level: "needs-review",

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -332,6 +332,7 @@ vi.mock("@/components/ui/EmptyState", () => ({
 
 import { ReviewHub } from "../ReviewHub";
 import { useUIStore } from "@/store/uiStore";
+import { useGitPushConfirmStore } from "@/store/gitPushConfirmStore";
 import { usePreferencesStore } from "@/store/preferencesStore";
 
 const WORKTREE_PATH = "/home/user/project";
@@ -4463,6 +4464,98 @@ describe("ReviewHub", () => {
 
       await waitFor(() => screen.getByTestId("readiness-item-conflicts"));
       expect((stagedFilter as HTMLInputElement).value).toBe("index");
+    });
+  });
+
+  describe("clean-tree push affordance", () => {
+    afterEach(() => {
+      // The real (unmocked) confirm store is shared suite-wide — resolve any
+      // request a failing test left pending so it can't bleed forward.
+      useGitPushConfirmStore.getState().resolveConfirmation(false);
+    });
+
+    function setWorktreeDivergence(overrides: Record<string, unknown>) {
+      const existing = worktreeStoreData.current.get("main-wt")!;
+      worktreeStoreData.current.set("main-wt", { ...existing, ...overrides });
+    }
+
+    function renderCleanHub(divergence: Record<string, unknown>, hasRemote = true) {
+      setWorktreeDivergence(divergence);
+      getStagingStatusMock.mockResolvedValue(
+        makeStatus({ staged: [], unstaged: [], hasRemote, repoState: "CLEAN" })
+      );
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    }
+
+    it("names the unpushed commits and gates Push behind the D2 preview dialog", async () => {
+      renderCleanHub({ aheadCount: 2, behindCount: 0 });
+      await waitFor(() => screen.getByText("Working tree clean"));
+
+      expect(screen.getByTestId("review-hub-clean-unpushed").textContent).toBe(
+        "2 commits not pushed"
+      );
+
+      act(() => void fireEvent.click(screen.getByTestId("review-hub-clean-push")));
+      // The click only requests the push confirmation — nothing reaches the
+      // IPC until the globally-mounted preview dialog resolves it.
+      expect(pushMock).not.toHaveBeenCalled();
+      expect(useGitPushConfirmStore.getState().pendingConfirm?.cwd).toBe(WORKTREE_PATH);
+
+      await act(async () => {
+        useGitPushConfirmStore.getState().resolveConfirmation(true);
+      });
+      await waitFor(() => expect(pushMock).toHaveBeenCalledWith(WORKTREE_PATH));
+    });
+
+    it("does not push when the preview dialog is declined", async () => {
+      renderCleanHub({ aheadCount: 1, behindCount: 0 });
+      await waitFor(() => screen.getByText("Working tree clean"));
+
+      act(() => void fireEvent.click(screen.getByTestId("review-hub-clean-push")));
+      await act(async () => {
+        useGitPushConfirmStore.getState().resolveConfirmation(false);
+      });
+      expect(pushMock).not.toHaveBeenCalled();
+    });
+
+    it("names the unpushed commits but offers no Push while divergence is unknown", async () => {
+      // behindCount undefined — an unknown divergence state must never read
+      // as pushable (mirrors deriveReviewReadiness.pushReady).
+      renderCleanHub({ aheadCount: 3, behindCount: undefined });
+      await waitFor(() => screen.getByText("Working tree clean"));
+
+      expect(screen.getByTestId("review-hub-clean-unpushed").textContent).toBe(
+        "3 commits not pushed"
+      );
+      expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
+    });
+
+    it("offers no Push while behind the remote", async () => {
+      renderCleanHub({ aheadCount: 2, behindCount: 1 });
+      await waitFor(() => screen.getByText("Working tree clean"));
+      // The unpushed copy proves the divergence fixture reached the component
+      // — without it the missing button would pass vacuously.
+      expect(screen.getByTestId("review-hub-clean-unpushed").textContent).toBe(
+        "2 commits not pushed"
+      );
+      expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
+    });
+
+    it("keeps the quiet no-changes copy when there is nothing to push", async () => {
+      renderCleanHub({ aheadCount: 0, behindCount: 0 });
+      await waitFor(() => screen.getByText("Working tree clean"));
+
+      expect(screen.getByText("No changes to commit")).toBeDefined();
+      expect(screen.queryByTestId("review-hub-clean-unpushed")).toBeNull();
+      expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
+    });
+
+    it("keeps the quiet copy when unpushed commits exist but there is no remote", async () => {
+      renderCleanHub({ aheadCount: 2, behindCount: 0 }, false);
+      await waitFor(() => screen.getByText("Working tree clean"));
+
+      expect(screen.getByText("No changes to commit")).toBeDefined();
+      expect(screen.queryByTestId("review-hub-clean-push")).toBeNull();
     });
   });
 });

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -822,7 +822,6 @@ export function WorktreeCard({
               <TooltipContent side="right" align="start" className="text-xs">
                 {
                   {
-                    approval: "Agent waiting for approval",
                     waiting: "Agent waiting for input",
                     cleanup: "Ready for cleanup",
                     complete: "Complete: in review",

--- a/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
@@ -104,6 +104,32 @@ interface WorktreeActionsToolbarProps {
   handleLaunchAgent: (agentId: string) => void;
 }
 
+// APG toolbar keyboard support: arrow keys move focus between the toolbar's
+// buttons (wrapping), Home/End jump to the ends. Handled only while focus is
+// on a toolbar button, and stopped from bubbling so card/grid-level arrow-key
+// domains don't also react. Dropdown content is portaled, so menu keystrokes
+// never reach this handler.
+function handleToolbarKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+  if (e.key !== "ArrowLeft" && e.key !== "ArrowRight" && e.key !== "Home" && e.key !== "End") {
+    return;
+  }
+  const buttons = Array.from(
+    e.currentTarget.querySelectorAll<HTMLButtonElement>("button:not([disabled])")
+  );
+  const active = document.activeElement;
+  const currentIndex = buttons.findIndex((button) => button === active);
+  if (currentIndex === -1 || buttons.length < 2) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const nextIndex =
+    e.key === "Home"
+      ? 0
+      : e.key === "End"
+        ? buttons.length - 1
+        : (currentIndex + (e.key === "ArrowRight" ? 1 : -1) + buttons.length) % buttons.length;
+  buttons[nextIndex]?.focus();
+}
+
 export function WorktreeActionsToolbar({
   isCollapsed,
   isActive,
@@ -122,6 +148,7 @@ export function WorktreeActionsToolbar({
       data-worktree-row-toolbar=""
       role="toolbar"
       aria-label="Worktree actions"
+      onKeyDown={handleToolbarKeyDown}
       className={cn(
         "flex items-center gap-0.5 shrink-0 transition-opacity duration-150",
         isCollapsed

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -140,7 +140,11 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
   }, [changedFileCount, prefersReducedMotion, animate, countScope]);
 
   const isConflicted = reviewState === "conflicted";
-  const showReviewHubButton = !!onOpenReviewHub && hasChanges;
+  // A clean tree with unpushed commits still has a Review Hub next step —
+  // push — so the opener stays visible; only the label shifts to match.
+  const isUnpushedClean = reviewState === "unpushed-clean" && !hasChanges;
+  const showReviewHubButton = !!onOpenReviewHub && (hasChanges || isUnpushedClean);
+  const reviewHubButtonLabel = isUnpushedClean ? "Review & Push" : "Review & Commit";
   const rightButtonGroupShown = showReviewHubButton;
 
   const lifecycleState = worktree.lifecycleStatus?.state;
@@ -452,12 +456,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                         "rounded-r-[var(--radius-lg)]",
                         "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
                       )}
-                      aria-label="Open Review & Commit"
+                      aria-label={`Open ${reviewHubButtonLabel}`}
                     >
                       <GitCommitHorizontal className="w-3.5 h-3.5" />
                     </button>
                   </TooltipTrigger>
-                  <TooltipContent side="bottom">Review & Commit</TooltipContent>
+                  <TooltipContent side="bottom">{reviewHubButtonLabel}</TooltipContent>
                 </Tooltip>
               )}
             </div>

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeActionsToolbar.keyboard.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeActionsToolbar.keyboard.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { WorktreeState } from "@shared/types";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { WorktreeActionsToolbar } from "../WorktreeActionsToolbar";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+const noop = () => {};
+
+const baseWorktree: WorktreeState = {
+  id: "test-wt",
+  worktreeId: "test-wt",
+  path: "/tmp/test-wt",
+  name: "test-branch",
+  branch: "feature/test",
+  isCurrent: false,
+  isMainWorktree: false,
+  worktreeChanges: null,
+  lastActivityTimestamp: null,
+};
+
+const baseMenu = {
+  launchAgents: [],
+  recipes: [],
+  runningRecipeId: null,
+  counts: { grid: 0, dock: 0, active: 0, completed: 0, all: 0, waiting: 0, working: 0 },
+  onCopyContextFull: noop,
+  onCopyContextModified: noop,
+  onCopyPath: noop,
+  onOpenEditor: noop,
+  onRevealInFinder: noop,
+  onRunRecipe: noop,
+  onDockAll: noop,
+  onMaximizeAll: noop,
+  onCloseAll: noop,
+  onTerminateAll: noop,
+  onClearHistory: noop,
+  onResetRenderers: noop,
+  onSelectAllAgents: noop,
+  onSelectWaitingAgents: noop,
+  onSelectWorkingAgents: noop,
+};
+
+function renderToolbar() {
+  return render(
+    <TooltipProvider>
+      <WorktreeActionsToolbar
+        isCollapsed={false}
+        isActive={false}
+        onCleanupWorktree={noop}
+        canCollapse={true}
+        onToggleCollapse={noop}
+        contentId="content-id"
+        menu={baseMenu}
+        worktree={baseWorktree}
+        isPinned={false}
+        handleLaunchAgent={noop}
+      />
+    </TooltipProvider>
+  );
+}
+
+function toolbarButtons(): HTMLButtonElement[] {
+  const toolbar = screen.getByRole("toolbar");
+  return Array.from(toolbar.querySelectorAll<HTMLButtonElement>("button:not([disabled])"));
+}
+
+describe("WorktreeActionsToolbar keyboard navigation", () => {
+  it("moves focus with ArrowRight and wraps past the last button", () => {
+    renderToolbar();
+    const buttons = toolbarButtons();
+    expect(buttons.length).toBeGreaterThanOrEqual(3);
+
+    buttons[0]!.focus();
+    fireEvent.keyDown(buttons[0]!, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(buttons[1]);
+
+    buttons[buttons.length - 1]!.focus();
+    fireEvent.keyDown(buttons[buttons.length - 1]!, { key: "ArrowRight" });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("moves focus with ArrowLeft and wraps before the first button", () => {
+    renderToolbar();
+    const buttons = toolbarButtons();
+
+    buttons[1]!.focus();
+    fireEvent.keyDown(buttons[1]!, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(buttons[0]);
+
+    fireEvent.keyDown(buttons[0]!, { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+  });
+
+  it("jumps to the ends with Home and End", () => {
+    renderToolbar();
+    const buttons = toolbarButtons();
+
+    buttons[1]!.focus();
+    fireEvent.keyDown(buttons[1]!, { key: "End" });
+    expect(document.activeElement).toBe(buttons[buttons.length - 1]);
+
+    fireEvent.keyDown(buttons[buttons.length - 1]!, { key: "Home" });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("stops handled arrow keys from reaching card-level key domains", () => {
+    const outerKeyDown = vi.fn();
+    render(
+      <TooltipProvider>
+        <div onKeyDown={outerKeyDown}>
+          <WorktreeActionsToolbar
+            isCollapsed={false}
+            isActive={false}
+            onCleanupWorktree={noop}
+            canCollapse={true}
+            onToggleCollapse={noop}
+            contentId="content-id"
+            menu={baseMenu}
+            worktree={baseWorktree}
+            isPinned={false}
+            handleLaunchAgent={noop}
+          />
+        </div>
+      </TooltipProvider>
+    );
+    const buttons = toolbarButtons();
+
+    buttons[0]!.focus();
+    fireEvent.keyDown(buttons[0]!, { key: "ArrowRight" });
+    expect(outerKeyDown).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(buttons[0]!, { key: "Enter" });
+    expect(outerKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves arrow keys alone when focus is outside the toolbar's buttons", () => {
+    const outerKeyDown = vi.fn();
+    render(
+      <TooltipProvider>
+        <div onKeyDown={outerKeyDown}>
+          <WorktreeActionsToolbar
+            isCollapsed={false}
+            isActive={false}
+            onCleanupWorktree={noop}
+            canCollapse={true}
+            onToggleCollapse={noop}
+            contentId="content-id"
+            menu={baseMenu}
+            worktree={baseWorktree}
+            isPinned={false}
+            handleLaunchAgent={noop}
+          />
+        </div>
+      </TooltipProvider>
+    );
+    const toolbar = screen.getByRole("toolbar");
+    const buttons = toolbarButtons();
+
+    // No toolbar button focused — the handler must neither steal focus nor
+    // swallow the key from surrounding key domains.
+    fireEvent.keyDown(toolbar, { key: "ArrowRight" });
+    expect(document.activeElement).not.toBe(buttons[0]);
+    expect(outerKeyDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -120,7 +120,7 @@ describe("WorktreeCard row affordances polish (issue #8099)", () => {
 
   it("Review & Commit button uses inset outline (-2px offset) for its flush rounded-r edge", () => {
     expect(detailsSource).toMatch(
-      /rounded-r-\[var\(--radius-lg\)\][\s\S]{0,200}focus-visible:outline-offset-\[-2px\][\s\S]{0,400}aria-label="Open Review & Commit"/
+      /rounded-r-\[var\(--radius-lg\)\][\s\S]{0,200}focus-visible:outline-offset-\[-2px\][\s\S]{0,400}aria-label=\{`Open \$\{reviewHubButtonLabel\}`\}/
     );
   });
 

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -316,11 +316,13 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     expect(onOpenReviewHub).toHaveBeenCalledTimes(1);
   });
 
-  it('renders no commit-side button when reviewState is "unpushed-clean"', () => {
+  it('renders a Review & Push button when reviewState is "unpushed-clean"', () => {
+    const onOpenReviewHub = vi.fn();
     renderSection({
       reviewState: "unpushed-clean",
       hasChanges: false,
       computedSubtitle: { text: "fix: stuff", tone: "muted" },
+      onOpenReviewHub,
       worktree: {
         ...baseWorktree,
         worktreeChanges: {
@@ -333,6 +335,27 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     expect(screen.queryByLabelText("Open Review & Commit")).toBeNull();
     expect(screen.queryByText("Conflicts need review")).toBeNull();
     expect(screen.getByText("fix: stuff")).toBeDefined();
+    const button = screen.getByLabelText("Open Review & Push");
+    fireEvent.click(button);
+    expect(onOpenReviewHub).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no review-hub button when the tree is clean with nothing to push", () => {
+    renderSection({
+      reviewState: null,
+      hasChanges: false,
+      computedSubtitle: { text: "fix: stuff", tone: "muted" },
+      onOpenReviewHub: vi.fn(),
+      worktree: {
+        ...baseWorktree,
+        worktreeChanges: {
+          ...baseWorktree.worktreeChanges,
+          changedFileCount: 0,
+        } as WorktreeChanges,
+      },
+    });
+    expect(screen.queryByLabelText("Open Review & Commit")).toBeNull();
+    expect(screen.queryByLabelText("Open Review & Push")).toBeNull();
   });
 });
 

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeStatus.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeStatus.test.tsx
@@ -647,6 +647,24 @@ describe("useWorktreeStatus — computedSubtitle", () => {
       { text: "No recent activity", tone: "muted" }
     );
   });
+
+  it('shows "Checking status…" instead of a false all-clear while git status is unresolved', () => {
+    expect(getSubtitle({ worktreeChanges: null })).toEqual({
+      text: "Checking status…",
+      tone: "muted",
+    });
+  });
+
+  it("still prefers an open PR title while git status is unresolved", () => {
+    expect(
+      getSubtitle({
+        worktreeChanges: null,
+        prTitle: "feat: dark mode",
+        prState: "open",
+        ...prLinked({ prState: "open", prTitle: "feat: dark mode" }),
+      })
+    ).toEqual({ text: "feat: dark mode", tone: "muted" });
+  });
 });
 
 describe("useWorktreeStatus — reviewState", () => {

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts
@@ -162,6 +162,13 @@ export function useWorktreeStatus({
       return { text: prTitle, tone: "muted" };
     }
 
+    // Distinguish "git status hasn't resolved yet" from a genuinely quiet
+    // worktree — "No recent activity" on a not-yet-indexed worktree reads as
+    // an all-clear the data can't support.
+    if (worktree.worktreeChanges == null) {
+      return { text: "Checking status…", tone: "muted" };
+    }
+
     return { text: "No recent activity", tone: "muted" };
   })();
 


### PR DESCRIPTION
This is a UX polish pass over the worktree cards and the review hub. The goal is to make it easier to scan a project and see which worktrees are actually ready to review or ship.

* While git status hasn't resolved yet, the card subtitle shows "Checking status…" instead of "No recent activity", so a not-yet-indexed worktree doesn't read as an all-clear.
* The card's review button now also appears for worktrees with committed but unpushed work, labelled "Review & Push". Previously those cards offered nothing, even though the review hub is where push lives.
* The review hub's clean-tree empty state now names the number of unpushed commits and offers a Push button instead of dead-ending on "No changes to commit". The button only appears when the divergence state affirmatively allows a push (ahead, not behind, remote known).
* The readiness rail's "+N more" overflow now lists the hidden items on hover, so the tail of the readiness summary is inspectable. The rail also picked up proper group/status ARIA semantics.
* The card's action toolbar can now be navigated with arrow keys (Left/Right wrap, Home/End jump), matching its `role="toolbar"`.
* Removed a dead "approval" entry from the card's chip tooltip map.

The new Push button reuses the existing `GitPushConfirmDialog` via `useGitPushConfirmStore`, so this doesn't add any new destructive paths. It also keeps the hub's existing push progress and error banner handling.

Tests cover the new states: unresolved status, unpushed-clean cards, the gated push flow (confirm, decline, unknown divergence, behind remote, no remote), the overflow disclosure, and toolbar keyboard navigation. Full `npm run check` is green.
