### PR TITLE
True memory accounting for terminal workloads

### DIFF
--- a/docs/architecture/resource-governance.md
+++ b/docs/architecture/resource-governance.md
@@ -10,7 +10,7 @@ This doc is the map for that machinery: the signals, the profile state machine a
 
 Two loops, different time constants:
 
-- **Slow loop — `ResourceProfileService`** (`electron/services/ResourceProfileService.ts`, ~818 LOC). Runs in the main process on a 30 s aligned interval. Aggregates memory, thermal, battery, CPU-speed-limit, fleet-size, and system-available-memory signals into a `pressureScore`, maps the score to a profile, applies asymmetric hysteresis, and pushes the resulting `ResourceProfileConfig` to every consumer. This is **policy** — it changes cadences and budgets, never pauses anyone.
+- **Slow loop — `ResourceProfileService`** (`electron/services/ResourceProfileService.ts`, ~818 LOC). Runs in the main process on a 30 s aligned interval. Aggregates memory, thermal, battery, CPU-speed-limit, fleet-size, system-available-memory, and terminal-workload-memory signals into a `pressureScore`, maps the score to a profile, applies asymmetric hysteresis, and pushes the resulting `ResourceProfileConfig` to every consumer. This is **policy** — it changes cadences and budgets, never pauses anyone.
 - **Fast loop — `ResourceGovernor`** (`electron/pty-host/ResourceGovernor.ts`, ~525 LOC). Runs in the **PTY host process** on a 2 s interval, watching its own V8 heap. When the heap approaches its limit it pauses terminal output (the `paused-resource-governor` flow state) and resumes when pressure clears. The profile service feeds it one input — `setResourceProfile(profile)` — which lowers the governor's thresholds under `efficiency`; otherwise the governor is autonomous.
 
 Bridging the two: a third fast path lives **inside** `ResourceProfileService` — an event-loop-lag monitor (5 s interval) that can force the whole app into `efficiency` immediately, bypassing the slow loop's hysteresis, when the JS thread is genuinely saturated.
@@ -44,6 +44,7 @@ The profile is intentionally **coarse**. There are only three states, so every c
 | CPU speed limit (macOS & Windows) | `powerMonitor` `speed-limit-change` | `+2` below 50, `+1` below 100 |
 | Active-agent fleet size | cached count from `PtyClient.getAllTerminalsAsync()`, filtered | `+3` ≥ 24, `+2` ≥ 16, `+1` ≥ 8 |
 | System-available memory | `process.getSystemMemoryInfo()` (free + purgeable on macOS, free elsewhere) | `+2` below 0.1 × RAM, `+1` below 0.2 × RAM |
+| Terminal-workload memory | cached `PtyClient.getMemoryRollup()` (descendant RSS from the pty-host `ProcessTreeCache`, PID-deduplicated, via `electron/services/memoryAccounting.ts`) | `+2` above 0.4 × RAM, `+1` above 0.25 × RAM — only from a fresh (≤ 60 s), successful process-table sweep; stale/unavailable data contributes 0. Per-tier 10% exit band. Bounded at +2 so terminal workloads alone can never latch `efficiency`. |
 
 Mapping (`ResourceProfileService.ts:669`): `score >= 3 → efficiency`, `score === 0 → performance`, otherwise `balanced`.
 
@@ -194,6 +195,7 @@ Resource governance is deliberately **quiet**. Per `CLAUDE.md`'s runtime-signal 
 | --- | --- |
 | Profile state machine, signals, lag monitor, fan-out | `electron/services/ResourceProfileService.ts` |
 | Profile config table + types | `shared/types/resourceProfile.ts` |
+| Composite memory snapshot (Electron + terminal-workload slices, freshness) | `electron/services/memoryAccounting.ts`, `shared/types/memoryAccounting.ts` |
 | PTY-host heap governor (cross-process) | `electron/pty-host/ResourceGovernor.ts` |
 | Worker-governance aggregation + trim fan-out | `electron/services/WorkerGovernanceService.ts` |
 | Worker snapshot shape + pure policy | `shared/types/workerGovernance.ts`, `shared/utils/workerGovernancePolicy.ts` |

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -125,6 +125,7 @@ export const CHANNELS = {
   SYSTEM_GET_RESOURCE_PROFILE_SNAPSHOT: "system:get-resource-profile-snapshot",
   SYSTEM_REQUEST_INTERACTIVE_OVERRIDE: "system:request-interactive-override",
   SYSTEM_GET_WHY_SLOW_SNAPSHOT: "system:get-why-slow-snapshot",
+  SYSTEM_GET_MEMORY_SNAPSHOT: "system:get-memory-snapshot",
   SYSTEM_REPORT_TERMINAL_RENDERER_DIAGNOSTICS: "system:report-terminal-renderer-diagnostics",
   DIAGNOSTICS_GET_PROCESS_METRICS: "diagnostics:get-process-metrics",
   DIAGNOSTICS_GET_HEAP_STATS: "diagnostics:get-heap-stats",

--- a/electron/ipc/handlers/__tests__/whySlow.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/whySlow.handlers.test.ts
@@ -38,6 +38,9 @@ vi.mock("../../utils.js", () => utilsMock);
 const collectorMock = vi.hoisted(() => ({ collectWhySlowSnapshot: vi.fn() }));
 vi.mock("../../../services/DiagnosticsCollector.js", () => collectorMock);
 
+const memoryAccountingMock = vi.hoisted(() => ({ getCompositeMemorySnapshot: vi.fn() }));
+vi.mock("../../../services/memoryAccounting.js", () => memoryAccountingMock);
+
 const cacheMock = vi.hoisted(() => ({ recordRendererTerminalDiagnostics: vi.fn() }));
 vi.mock("../../../services/RendererTerminalDiagnosticsCache.js", () => cacheMock);
 
@@ -72,6 +75,7 @@ describe("registerWhySlowHandlers — getWhySlowSnapshot", () => {
       pty: null,
       worktrees: null,
       workers: null,
+      memory: null,
     };
     collectorMock.collectWhySlowSnapshot.mockResolvedValue(snapshot);
 
@@ -79,7 +83,18 @@ describe("registerWhySlowHandlers — getWhySlowSnapshot", () => {
     const result = await getRegistered("system:get-why-slow-snapshot")(null);
 
     expect(result).toEqual(snapshot);
-    expect(collectorMock.collectWhySlowSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves the composite memory snapshot, defaulting a missing ptyClient to null", async () => {
+    const snapshot = { timestamp: 1, electron: {}, terminalWorkloads: {} };
+    memoryAccountingMock.getCompositeMemorySnapshot.mockResolvedValue(snapshot);
+
+    registerWhySlowHandlers({} as never);
+    const result = await getRegistered("system:get-memory-snapshot")(null);
+
+    expect(result).toEqual(snapshot);
+    expect(memoryAccountingMock.getCompositeMemorySnapshot).toHaveBeenCalledWith(null);
+    expect(collectorMock.collectWhySlowSnapshot).not.toHaveBeenCalled();
   });
 });
 

--- a/electron/ipc/handlers/whySlow.preload.ts
+++ b/electron/ipc/handlers/whySlow.preload.ts
@@ -2,6 +2,7 @@ import type { IpcInvokeMap } from "../../types/index.js";
 
 export const WHY_SLOW_METHOD_CHANNELS = {
   getWhySlowSnapshot: "system:get-why-slow-snapshot",
+  getMemorySnapshot: "system:get-memory-snapshot",
   reportTerminalRendererDiagnostics: "system:report-terminal-renderer-diagnostics",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 

--- a/electron/ipc/handlers/whySlow.ts
+++ b/electron/ipc/handlers/whySlow.ts
@@ -2,8 +2,10 @@ import { z } from "zod";
 import { defineIpcNamespace, op, opValidated } from "../define.js";
 import type { HandlerDependencies } from "../types.js";
 import type { WhySlowSnapshot } from "../../../shared/types/whySlow.js";
+import type { CompositeMemorySnapshot } from "../../../shared/types/memoryAccounting.js";
 import { WHY_SLOW_METHOD_CHANNELS } from "./whySlow.preload.js";
 import { collectWhySlowSnapshot } from "../../services/DiagnosticsCollector.js";
+import { getCompositeMemorySnapshot } from "../../services/memoryAccounting.js";
 import { recordRendererTerminalDiagnostics } from "../../services/RendererTerminalDiagnosticsCache.js";
 
 // Renderer-pushed terminal-rendering state (#10910). Bounded so a compromised
@@ -32,6 +34,14 @@ export function registerWhySlowHandlers(deps: HandlerDependencies): () => void {
       getWhySlowSnapshot: op(
         WHY_SLOW_METHOD_CHANNELS.getWhySlowSnapshot,
         async (): Promise<WhySlowSnapshot> => collectWhySlowSnapshot(deps)
+      ),
+      // Composite memory snapshot (Electron working-set + terminal descendant
+      // RSS by project) for the resource badge popover. Reads go through
+      // shared TTL caches, so popover-cadence polling stays cheap.
+      getMemorySnapshot: op(
+        WHY_SLOW_METHOD_CHANNELS.getMemorySnapshot,
+        async (): Promise<CompositeMemorySnapshot> =>
+          getCompositeMemorySnapshot(deps.ptyClient ?? null)
       ),
       // Fire-and-forget renderer push: cache the sender's terminal WebGL/tier
       // state by webContents id. Ignored once the sender is torn down, mirroring

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -14,6 +14,7 @@ import { getRendererTerminalDiagnosticsSamples } from "./RendererTerminalDiagnos
 import type { HandlerDependencies } from "../ipc/types.js";
 import type {
   WhySlowFocusThrottleSnapshot,
+  WhySlowMemorySnapshot,
   WhySlowPtySummary,
   WhySlowResourceSnapshot,
   WhySlowSnapshot,
@@ -573,6 +574,19 @@ async function collectMemoryTrends() {
   }
 }
 
+// Composite memory attribution for support exports: Electron working-set +
+// terminal descendant RSS grouped by project, each with freshness metadata.
+// The rollup exposes only process basenames (`comm`), never command lines or
+// paths; the final redactDeep pass covers the rest.
+async function collectMemoryAttribution(deps: HandlerDependencies) {
+  try {
+    const { getCompositeMemorySnapshot } = await import("./memoryAccounting.js");
+    return await getCompositeMemorySnapshot(deps.ptyClient ?? null);
+  } catch {
+    return { error: "Failed to collect memory attribution" };
+  }
+}
+
 // Hibernation + resource-profile runtime state. Both are global singletons
 // reached via their own getters — not threaded through HandlerDependencies.
 async function collectResourceState() {
@@ -731,6 +745,44 @@ async function collectWhySlowWorkers(): Promise<WhySlowWorkerSummary | null> {
   }
 }
 
+// Cap the per-project attribution: the top handful answers "which project is
+// heavy?" without turning the snapshot into a full process inventory.
+const WHY_SLOW_TOP_PROJECTS = 5;
+
+async function collectWhySlowMemory(ptyClient?: PtyClient): Promise<WhySlowMemorySnapshot | null> {
+  try {
+    const { getCompositeMemorySnapshot } = await import("./memoryAccounting.js");
+    const snapshot = await getCompositeMemorySnapshot(ptyClient ?? null);
+    const workloads = snapshot.terminalWorkloads;
+    const topProjects = [...workloads.byProject]
+      .sort((a, b) => b.memoryMb - a.memoryMb)
+      .slice(0, WHY_SLOW_TOP_PROJECTS)
+      .map((p) => ({
+        projectId: p.projectId,
+        memoryMb: p.memoryMb,
+        terminalCount: p.terminalCount,
+        processCount: p.processCount,
+        // Basenames only — the rollup never carries command lines, but keep
+        // the export contract explicit at the boundary too.
+        topProcessNames: p.topProcesses.map((proc) => proc.comm),
+      }));
+    return {
+      appMemoryMb: snapshot.electron.available ? snapshot.electron.totalWorkingSetMb : null,
+      terminalWorkloads: {
+        available: workloads.available,
+        stale: workloads.stale,
+        ageMs: workloads.ageMs,
+        totalMemoryMb: workloads.totalMemoryMb,
+        processCount: workloads.processCount,
+        terminalCount: workloads.terminalCount,
+        topProjects,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
 async function collectWhySlowWorktrees(): Promise<WhySlowWorktreeSummary | null> {
   try {
     const { getWorkspaceClientRef } = await import("../window/serviceRefs.js");
@@ -760,11 +812,12 @@ export async function collectWhySlowSnapshot(deps: HandlerDependencies): Promise
   // section in withTimeout, but the live dock pull calls this directly. A hung
   // pty-host or workspace-host must not wedge the very snapshot meant to explain
   // a slowdown — degrade the stuck section to null instead.
-  const [resource, pty, worktrees, workers] = await Promise.all([
+  const [resource, pty, worktrees, workers, memory] = await Promise.all([
     withTimeout(collectWhySlowResource(), WHY_SLOW_ASYNC_TIMEOUT_MS, null),
     withTimeout(collectWhySlowPty(deps.ptyClient), WHY_SLOW_ASYNC_TIMEOUT_MS, null),
     withTimeout(collectWhySlowWorktrees(), WHY_SLOW_ASYNC_TIMEOUT_MS, null),
     withTimeout(collectWhySlowWorkers(), WHY_SLOW_ASYNC_TIMEOUT_MS, null),
+    withTimeout(collectWhySlowMemory(deps.ptyClient), WHY_SLOW_ASYNC_TIMEOUT_MS, null),
   ]);
   return {
     timestamp: Date.now(),
@@ -774,6 +827,7 @@ export async function collectWhySlowSnapshot(deps: HandlerDependencies): Promise
     pty,
     worktrees,
     workers,
+    memory,
   };
 }
 
@@ -800,6 +854,7 @@ export async function collectDiagnosticsWithKeys(
     { key: "projectViews", fn: () => collectProjectViews(deps) },
     { key: "rendererMemory", fn: collectRendererMemory },
     { key: "memoryTrends", fn: collectMemoryTrends },
+    { key: "memoryAttribution", fn: () => collectMemoryAttribution(deps) },
     { key: "resourceState", fn: collectResourceState },
     { key: "workerGovernance", fn: collectWorkerGovernance },
     { key: "whySlow", fn: () => collectWhySlowSnapshot(deps) },

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -12,6 +12,7 @@ import { getFocusThrottlePollMultiplier } from "../window/focusThrottleState.js"
 import { logInfo } from "../utils/logger.js";
 import { setAlignedInterval } from "../utils/setAlignedInterval.js";
 import { getAppMetricsSnapshot } from "../utils/appMetricsSnapshot.js";
+import { getCachedMemoryRollup } from "./memoryAccounting.js";
 import type { PtyClient } from "./PtyClient.js";
 import type { WorkspaceClient } from "./WorkspaceClient.js";
 import type { HibernationService } from "./HibernationService.js";
@@ -131,6 +132,28 @@ const FLEET_AGENTS_PER_GB_CRITICAL = FLEET_COUNT_CRITICAL / 16;
 const SYS_AVAILABLE_HIGH_FRACTION = 0.2;
 const SYS_AVAILABLE_LOW_FRACTION = 0.1;
 
+// Terminal-workload signal: summed RSS of every live terminal's descendant
+// tree (agent CLIs, dev servers, language servers, test runners) from the
+// pty-host memory rollup. These are the largest real consumers in Daintree
+// sessions and invisible to app.getAppMetrics(). Fractions of total RAM like
+// the other memory signals, sitting well above the app-private bands because
+// RSS double-counts shared pages across the fleet — this is a generous
+// pressure heuristic, not a unique-footprint budget. Bounded at +2 so
+// terminal workloads alone can reach `balanced` but can never latch
+// `efficiency` (score ≥ 3) without a second corroborating signal; like every
+// score input it only tunes cadences and budgets — it never pauses, kills,
+// or hibernates a live workload.
+const TERMINAL_WORKLOAD_HIGH_FRACTION = 0.4;
+const TERMINAL_WORKLOAD_LOW_FRACTION = 0.25;
+// Per-tier exit band: once a tier is engaged it releases at 90% of its entry
+// threshold, so a workload hovering at a boundary can't flap the score (and
+// with it the candidate-profile hold timers) on every 30s tick.
+const TERMINAL_WORKLOAD_EXIT_RATIO = 0.9;
+// Contributions are taken only from a successful process-table sweep newer
+// than this (2 eval ticks). A huge-but-stale reading — ps wedged, pty-host
+// unresponsive — must never hold the profile down; no measurement, no score.
+const TERMINAL_WORKLOAD_FRESH_MS = 60_000;
+
 export interface ResourceProfileDeps {
   getPtyClient: () => PtyClient | null;
   getWorkspaceClient: () => WorkspaceClient | null;
@@ -174,6 +197,21 @@ export class ResourceProfileService {
   private readonly memoryThresholdLowMb: number;
   private readonly sysMemThresholdHighMb: number;
   private readonly sysMemThresholdLowMb: number;
+  private readonly terminalWorkloadHighMb: number;
+  private readonly terminalWorkloadLowMb: number;
+  // Latest terminal-workload rollup sample; null until the first successful
+  // async refresh. Read synchronously by the scoring path, mirroring the
+  // cachedActiveAgentCount pattern.
+  private cachedTerminalWorkload: {
+    totalMemoryMb: number;
+    available: boolean;
+    sampledAt: number;
+  } | null = null;
+  // Engaged contribution tier (0/1/2) for the exit-band hysteresis.
+  private terminalWorkloadTier = 0;
+  // Monotonic generation for the workload refresh, independent of the fleet
+  // counter so neither refresh path can invalidate the other's in-flight work.
+  private workloadRefreshGeneration = 0;
   private readonly fleetCountHigh: number;
   private readonly fleetCountVeryHigh: number;
   private readonly fleetCountCritical: number;
@@ -197,6 +235,8 @@ export class ResourceProfileService {
     this.memoryThresholdLowMb = totalRamMb * LOW_FRACTION;
     this.sysMemThresholdHighMb = totalRamMb * SYS_AVAILABLE_HIGH_FRACTION;
     this.sysMemThresholdLowMb = totalRamMb * SYS_AVAILABLE_LOW_FRACTION;
+    this.terminalWorkloadHighMb = totalRamMb * TERMINAL_WORKLOAD_HIGH_FRACTION;
+    this.terminalWorkloadLowMb = totalRamMb * TERMINAL_WORKLOAD_LOW_FRACTION;
     const totalRamGb = totalRamMb / 1024;
     this.fleetCountHigh = Math.max(
       FLEET_COUNT_HIGH,
@@ -335,10 +375,15 @@ export class ResourceProfileService {
     // (or any earlier refresh in this lifecycle) will see a stale generation
     // in its .then() and drop its result.
     this.refreshGeneration += 1;
+    // Same reset for the terminal-workload sample and its hysteresis latch.
+    this.cachedTerminalWorkload = null;
+    this.terminalWorkloadTier = 0;
+    this.workloadRefreshGeneration += 1;
 
     logInfo("resource-profile-service-started", { profile: this.currentProfile });
 
     this.refreshFleetState();
+    this.refreshTerminalWorkloadState();
 
     powerMonitor.on("thermal-state-change", this.onThermalStateChange);
     powerMonitor.on("speed-limit-change", this.onSpeedLimitChange);
@@ -354,6 +399,7 @@ export class ResourceProfileService {
 
     this.evalCleanup = setAlignedInterval(() => {
       this.refreshFleetState();
+      this.refreshTerminalWorkloadState();
       this.evaluate();
     }, EVAL_INTERVAL_MS);
 
@@ -652,6 +698,42 @@ export class ResourceProfileService {
       });
   }
 
+  /**
+   * Async refresh of the terminal-workload memory sample, mirroring
+   * refreshFleetState: fire-and-forget each tick, cached result read
+   * synchronously by the scoring path. Reads through the shared rollup TTL
+   * cache in memoryAccounting so this adds at most one pty-host round-trip
+   * per 5s across all snapshot consumers.
+   */
+  private refreshTerminalWorkloadState(): void {
+    if (this.disposed) return;
+    // Under sustained event-loop saturation, skip optional async work — the
+    // cached sample is used until it ages past the freshness gate.
+    if (this.lagEscalatedActive) return;
+
+    const ptyClient = this.deps.getPtyClient();
+    if (!ptyClient) return;
+
+    this.workloadRefreshGeneration += 1;
+    const generation = this.workloadRefreshGeneration;
+
+    getCachedMemoryRollup(ptyClient)
+      .then((rollup) => {
+        if (this.disposed || rollup === null) return;
+        if (generation !== this.workloadRefreshGeneration) return;
+        this.cachedTerminalWorkload = {
+          totalMemoryMb: rollup.totalMemoryKb / 1024,
+          available: rollup.available,
+          sampledAt: rollup.sampledAt,
+        };
+      })
+      .catch(() => {
+        // A PtyClient without the rollup surface (test doubles) or an
+        // unexpected throw: leave the cache untouched — no measurement,
+        // no contribution.
+      });
+  }
+
   private countActiveAgentTerminals(terminals: ActiveAgentTerminalLike[]): number {
     let count = 0;
     for (const t of terminals) {
@@ -726,6 +808,8 @@ export class ResourceProfileService {
     this.lagPreviousElu = null;
     this.clearLagPressure();
     this.interactiveOverrideUntil = 0;
+    this.cachedTerminalWorkload = null;
+    this.terminalWorkloadTier = 0;
     this.thermalState = "unknown";
     this.isOnBattery = false;
     this.speedLimit = 100;
@@ -908,6 +992,51 @@ export class ResourceProfileService {
           detail: `system available ${Math.round(sysAvailMb)}MB`,
         });
       }
+    }
+
+    // Terminal-workload signal. Gated on a fresh, successful process-table
+    // sweep: an unavailable rollup (ps/PowerShell failed, pty-host down) or a
+    // sample past the freshness bound contributes nothing, whatever its
+    // magnitude, and drops the hysteresis latch. Tier recomputation is
+    // idempotent for a given sample, so the why-slow read path sharing this
+    // code can't skew it.
+    const workload = this.cachedTerminalWorkload;
+    // Negative age = the clock moved backwards (suspend correction, fake
+    // timers): reject as not-fresh rather than letting an old sample read as
+    // "from the future" and contribute until the clock catches up.
+    const workloadAgeMs = workload === null ? null : Date.now() - workload.sampledAt;
+    const workloadFresh =
+      workload !== null &&
+      workload.available &&
+      workload.sampledAt > 0 &&
+      workloadAgeMs !== null &&
+      workloadAgeMs >= 0 &&
+      workloadAgeMs <= TERMINAL_WORKLOAD_FRESH_MS;
+    if (workloadFresh) {
+      const workloadMb = workload.totalMemoryMb;
+      const highBar =
+        this.terminalWorkloadTier >= 2
+          ? this.terminalWorkloadHighMb * TERMINAL_WORKLOAD_EXIT_RATIO
+          : this.terminalWorkloadHighMb;
+      const lowBar =
+        this.terminalWorkloadTier >= 1
+          ? this.terminalWorkloadLowMb * TERMINAL_WORKLOAD_EXIT_RATIO
+          : this.terminalWorkloadLowMb;
+      this.terminalWorkloadTier = workloadMb > highBar ? 2 : workloadMb > lowBar ? 1 : 0;
+      if (this.terminalWorkloadTier > 0) {
+        pressureScore += this.terminalWorkloadTier;
+        reasons.push({
+          signal: "terminalWorkloads",
+          contribution: this.terminalWorkloadTier,
+          detail: `terminal workloads ${Math.round(workloadMb)}MB`,
+        });
+      }
+    } else {
+      // Hysteresis only spans consecutive fresh readings. A stale/unavailable
+      // gap drops the latch so a post-gap sample re-qualifies at the full
+      // entry threshold — otherwise a tier engaged before the gap would let a
+      // below-entry value ride the 0.9× exit band back to a higher score.
+      this.terminalWorkloadTier = 0;
     }
 
     return { pressureScore, reasons };

--- a/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
+++ b/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
@@ -729,6 +729,75 @@ describe("DiagnosticsCollector adversarial", () => {
     expect(snap.focusThrottle).toEqual({ throttled: false, pollMultiplier: 1 });
   });
 
+  it("WHY_SLOW_MEMORY_ATTRIBUTION_LEAKS_NO_COMMAND_LINES_OR_PATHS", async () => {
+    // Terminal workload memory must reach both the whySlow snapshot and the
+    // memoryAttribution export as process BASENAMES only — a command line or
+    // cwd here would leak paths, tokens, and branch names into support bundles.
+    const deps = {
+      ptyClient: {
+        getAllTerminalsAsync: async () => [],
+        getMemoryRollup: async () => ({
+          byProject: [
+            {
+              projectId: "proj-1",
+              terminalCount: 2,
+              processCount: 3,
+              memoryKb: 2_048_000,
+              topProcesses: [
+                { pid: 101, comm: "node", cpuPercent: 12, memoryKb: 1_024_000 },
+                { pid: 102, comm: "vite", cpuPercent: 3, memoryKb: 512_000 },
+              ],
+            },
+          ],
+          totalMemoryKb: 2_048_000,
+          totalProcessCount: 3,
+          terminalCount: 2,
+          available: true,
+          sampledAt: Date.now() - 4_000,
+        }),
+      },
+    } as unknown as import("../../ipc/types.js").HandlerDependencies;
+
+    const payload = (await diagnostics.collectDiagnostics(deps)) as {
+      whySlow: {
+        memory: {
+          terminalWorkloads: {
+            available: boolean;
+            stale: boolean;
+            totalMemoryMb: number;
+            topProjects: Array<Record<string, unknown>>;
+          };
+        } | null;
+      };
+      memoryAttribution: {
+        terminalWorkloads: {
+          byProject: Array<{ topProcesses: Array<Record<string, unknown>> }>;
+        };
+      };
+    };
+
+    const workloads = payload.whySlow.memory!.terminalWorkloads;
+    expect(workloads.available).toBe(true);
+    expect(workloads.stale).toBe(false);
+    expect(workloads.totalMemoryMb).toBe(2000);
+    expect(workloads.topProjects[0].topProcessNames).toEqual(["node", "vite"]);
+    // Structural no-leak contract: exactly these keys, nothing carrying a
+    // command line or path can ride along unnoticed.
+    expect(Object.keys(workloads.topProjects[0]).sort()).toEqual([
+      "memoryMb",
+      "processCount",
+      "projectId",
+      "terminalCount",
+      "topProcessNames",
+    ]);
+    const topProcess = payload.memoryAttribution.terminalWorkloads.byProject[0].topProcesses[0];
+    expect(Object.keys(topProcess).sort()).toEqual(["comm", "cpuPercent", "memoryKb", "pid"]);
+    const serialized =
+      JSON.stringify(payload.memoryAttribution) + JSON.stringify(payload.whySlow.memory);
+    expect(serialized).not.toContain("command");
+    expect(serialized).not.toContain("cwd");
+  });
+
   it("PROJECT_VIEWS_ISOLATE_PER_WINDOW_FAILURE (#10500)", async () => {
     const goodPvm = {
       getViewInventory: () => [

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -50,6 +50,8 @@ import { broadcastToRenderer } from "../../ipc/utils.js";
 import { ResourceProfileService, type ResourceProfileDeps } from "../ResourceProfileService.js";
 import { RESOURCE_PROFILE_CONFIGS } from "../../../shared/types/resourceProfile.js";
 import { resetAppMetricsSnapshotForTesting } from "../../utils/appMetricsSnapshot.js";
+import { resetMemoryAccountingForTesting } from "../memoryAccounting.js";
+import type { MemoryRollup } from "../../../shared/types/pty-host.js";
 
 const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
@@ -1911,6 +1913,239 @@ describe("ResourceProfileService", () => {
       expect(snap.pressureScore).toBe(3);
       expect(snap.targetProfile).toBe("efficiency");
       expect(snap.isOnBattery).toBe(true);
+
+      service.stop();
+    });
+  });
+
+  describe("terminal-workload pressure signal", () => {
+    // At the pinned 8 GB: LOW band = 2048 MB (0.25 × RAM), HIGH band = 3276.8 MB (0.4 × RAM).
+    const setWorkload = (
+      service: ResourceProfileService,
+      totalMemoryMb: number,
+      opts?: { available?: boolean; ageMs?: number }
+    ): void => {
+      (
+        service as unknown as {
+          cachedTerminalWorkload: {
+            totalMemoryMb: number;
+            available: boolean;
+            sampledAt: number;
+          } | null;
+        }
+      ).cachedTerminalWorkload = {
+        totalMemoryMb,
+        available: opts?.available ?? true,
+        sampledAt: Date.now() - (opts?.ageMs ?? 1_000),
+      };
+    };
+
+    beforeEach(() => {
+      resetMemoryAccountingForTesting();
+    });
+
+    it("contributes +1 above the low band from a fresh measurement", () => {
+      const service = new ResourceProfileService(createDeps());
+      setWorkload(service, 2_500);
+
+      const snap = service.getWhySlowResourceSnapshot();
+
+      const reason = snap.reasons.find((r) => r.signal === "terminalWorkloads");
+      expect(reason).toBeDefined();
+      expect(reason?.contribution).toBe(1);
+      expect(reason?.detail).toBe("terminal workloads 2500MB");
+      expect(snap.pressureScore).toBe(1);
+      expect(snap.targetProfile).toBe("balanced");
+    });
+
+    it("is bounded at +2 — terminal workloads alone can never latch efficiency", () => {
+      const service = new ResourceProfileService(createDeps());
+      // 6 GB of descendants on an 8 GB machine — as extreme as it gets.
+      setWorkload(service, 6_000);
+
+      const snap = service.getWhySlowResourceSnapshot();
+
+      const reason = snap.reasons.find((r) => r.signal === "terminalWorkloads");
+      expect(reason?.contribution).toBe(2);
+      expect(snap.pressureScore).toBe(2);
+      expect(snap.targetProfile).toBe("balanced");
+    });
+
+    it("reaches efficiency only with a second corroborating signal", () => {
+      const service = new ResourceProfileService(createDeps());
+      mockIsOnBatteryPower.mockReturnValue(true);
+      (service as unknown as { isOnBattery: boolean }).isOnBattery = true;
+      setWorkload(service, 3_400);
+
+      const snap = service.getWhySlowResourceSnapshot();
+
+      expect(snap.pressureScore).toBe(3);
+      expect(snap.targetProfile).toBe("efficiency");
+    });
+
+    it("ignores a huge-but-stale sample", () => {
+      const service = new ResourceProfileService(createDeps());
+      setWorkload(service, 6_000, { ageMs: 61_000 });
+
+      const snap = service.getWhySlowResourceSnapshot();
+
+      expect(snap.reasons.find((r) => r.signal === "terminalWorkloads")).toBeUndefined();
+      expect(snap.pressureScore).toBe(0);
+      expect(snap.targetProfile).toBe("performance");
+    });
+
+    it("ignores an unavailable rollup regardless of magnitude", () => {
+      const service = new ResourceProfileService(createDeps());
+      setWorkload(service, 6_000, { available: false });
+
+      const snap = service.getWhySlowResourceSnapshot();
+
+      expect(snap.reasons.find((r) => r.signal === "terminalWorkloads")).toBeUndefined();
+      expect(snap.pressureScore).toBe(0);
+    });
+
+    it("ignores a sample stamped in the future (clock moved backwards)", () => {
+      const service = new ResourceProfileService(createDeps());
+      // Negative age: the sample claims to be from an hour ahead of now.
+      setWorkload(service, 6_000, { ageMs: -3_600_000 });
+
+      const snap = service.getWhySlowResourceSnapshot();
+
+      expect(snap.reasons.find((r) => r.signal === "terminalWorkloads")).toBeUndefined();
+      expect(snap.pressureScore).toBe(0);
+    });
+
+    it("drops the hysteresis latch across a stale gap", () => {
+      const service = new ResourceProfileService(createDeps());
+
+      // Engage tier 2 above the 3276.8 MB band.
+      setWorkload(service, 3_300);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(2);
+
+      // The sample goes stale — contribution drops AND the latch releases.
+      setWorkload(service, 3_300, { ageMs: 120_000 });
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(0);
+
+      // Fresh data returns below the tier-2 entry threshold: it must score as
+      // a cold +1 evaluation, not inherit the pre-gap tier's 0.9× exit band.
+      setWorkload(service, 3_000);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(1);
+    });
+
+    it("holds an engaged tier through the 10% exit band, releasing below it", () => {
+      const service = new ResourceProfileService(createDeps());
+
+      // Engage tier 1 above the 2048 MB band.
+      setWorkload(service, 2_100);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(1);
+
+      // Dip below entry but above the exit bar (2048 × 0.9 = 1843.2) — held.
+      setWorkload(service, 1_900);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(1);
+
+      // Below the exit bar — released.
+      setWorkload(service, 1_800);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(0);
+    });
+
+    it("steps an engaged high tier down through both exit bands", () => {
+      const service = new ResourceProfileService(createDeps());
+
+      // Engage tier 2 above the 3276.8 MB band.
+      setWorkload(service, 3_300);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(2);
+
+      // Above the tier-2 exit bar (3276.8 × 0.9 ≈ 2949) — held at +2.
+      setWorkload(service, 3_000);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(2);
+
+      // Below the tier-2 exit bar but well above the low band — steps to +1.
+      setWorkload(service, 2_900);
+      expect(service.getWhySlowResourceSnapshot().pressureScore).toBe(1);
+    });
+
+    it("populates the cached sample from the pty-host rollup on start", async () => {
+      const rollupBase: MemoryRollup = {
+        byProject: [],
+        totalMemoryKb: 2_500 * 1024,
+        totalProcessCount: 4,
+        terminalCount: 2,
+        available: true,
+        sampledAt: 0,
+      };
+      const ptyClient = {
+        setResourceProfile: vi.fn(),
+        getAllTerminalsAsync: vi.fn().mockResolvedValue([]),
+        getMemoryRollup: vi
+          .fn()
+          .mockImplementation(() => Promise.resolve({ ...rollupBase, sampledAt: Date.now() })),
+      };
+      const service = new ResourceProfileService(
+        createDeps({
+          getPtyClient: () => ptyClient as unknown as import("../PtyClient.js").PtyClient,
+        })
+      );
+      service.start();
+      await flushAsync();
+
+      const snap = service.getWhySlowResourceSnapshot();
+      const reason = snap.reasons.find((r) => r.signal === "terminalWorkloads");
+      expect(reason?.contribution).toBe(1);
+      expect(reason?.detail).toBe("terminal workloads 2500MB");
+
+      service.stop();
+    });
+
+    it("recovers from efficiency when the workload data goes unavailable", async () => {
+      const rollupBase: MemoryRollup = {
+        byProject: [],
+        totalMemoryKb: 3_500 * 1024,
+        totalProcessCount: 6,
+        terminalCount: 3,
+        available: true,
+        sampledAt: 0,
+      };
+      const ptyClient = {
+        setResourceProfile: vi.fn(),
+        getAllTerminalsAsync: vi.fn().mockResolvedValue([]),
+        getMemoryRollup: vi
+          .fn()
+          .mockImplementation(() => Promise.resolve({ ...rollupBase, sampledAt: Date.now() })),
+      };
+      const service = new ResourceProfileService(
+        createDeps({
+          getPtyClient: () => ptyClient as unknown as import("../PtyClient.js").PtyClient,
+        })
+      );
+      // Battery +1 corroborates the workload +2 → score 3 → efficiency.
+      mockIsOnBatteryPower.mockReturnValue(true);
+      service.start();
+      await flushAsync();
+
+      // Warmup (2 ticks), first scoring tick starts the candidate, downgrade
+      // hold (30s) applies it on the following tick.
+      for (let i = 0; i < 4; i += 1) {
+        vi.advanceTimersByTime(30_000);
+        await flushAsync();
+      }
+      expect(service.getProfile()).toBe("efficiency");
+
+      // The process table wedges: unavailable rollup with even bigger numbers.
+      // The contribution must drop to 0, leaving battery (+1) → balanced after
+      // the 90s upgrade hold — huge-but-unmeasurable data can't pin efficiency.
+      ptyClient.getMemoryRollup.mockImplementation(() =>
+        Promise.resolve({
+          ...rollupBase,
+          totalMemoryKb: 6_000 * 1024,
+          available: false,
+          sampledAt: Date.now(),
+        })
+      );
+      for (let i = 0; i < 6; i += 1) {
+        vi.advanceTimersByTime(30_000);
+        await flushAsync();
+      }
+      expect(service.getProfile()).toBe("balanced");
 
       service.stop();
     });

--- a/electron/services/__tests__/memoryAccounting.test.ts
+++ b/electron/services/__tests__/memoryAccounting.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import type { PtyClient } from "../PtyClient.js";
+import type { MemoryRollup } from "../../../shared/types/pty-host.js";
+
+vi.mock("electron", () => ({
+  app: {
+    getAppMetrics: vi.fn(() => []),
+  },
+}));
+
+import { app } from "electron";
+import {
+  composeMemorySnapshot,
+  getCachedMemoryRollup,
+  getCompositeMemorySnapshot,
+  resetMemoryAccountingForTesting,
+} from "../memoryAccounting.js";
+import { resetAppMetricsSnapshotForTesting } from "../../utils/appMetricsSnapshot.js";
+import { TERMINAL_WORKLOAD_STALE_MS } from "../../../shared/types/memoryAccounting.js";
+
+const mockGetAppMetrics = app.getAppMetrics as Mock;
+
+const NOW = 1_000_000;
+
+function makeMetric(workingSetKb: number): Electron.ProcessMetric {
+  return {
+    pid: Math.floor(Math.random() * 10000),
+    type: "Tab",
+    creationTime: NOW,
+    cpu: { percentCPUUsage: 0, idleWakeupsPerSecond: 0 },
+    memory: {
+      workingSetSize: workingSetKb,
+      peakWorkingSetSize: workingSetKb,
+      privateBytes: 0,
+    },
+    sandboxed: false,
+    integrityLevel: "untrusted",
+  } as unknown as Electron.ProcessMetric;
+}
+
+function makeRollup(overrides?: Partial<MemoryRollup>): MemoryRollup {
+  return {
+    byProject: [
+      {
+        projectId: "proj-a",
+        terminalCount: 2,
+        processCount: 5,
+        memoryKb: 512_000,
+        topProcesses: [{ pid: 42, comm: "node", cpuPercent: 3.5, memoryKb: 200_000 }],
+      },
+    ],
+    totalMemoryKb: 512_000,
+    totalProcessCount: 5,
+    terminalCount: 2,
+    available: true,
+    sampledAt: NOW - 2_000,
+    ...overrides,
+  };
+}
+
+describe("composeMemorySnapshot", () => {
+  it("composes Electron metrics alone when no rollup source exists", () => {
+    const snapshot = composeMemorySnapshot(
+      [makeMetric(100 * 1024), makeMetric(50 * 1024)],
+      NOW - 1_000,
+      null,
+      NOW
+    );
+
+    expect(snapshot.electron).toEqual({
+      available: true,
+      totalWorkingSetMb: 150,
+      processCount: 2,
+      sampledAt: NOW - 1_000,
+    });
+    expect(snapshot.terminalWorkloads).toEqual({
+      available: false,
+      stale: false,
+      ageMs: null,
+      sampledAt: 0,
+      totalMemoryMb: 0,
+      processCount: 0,
+      terminalCount: 0,
+      byProject: [],
+    });
+  });
+
+  it("marks the Electron slice unavailable when the metrics sweep failed", () => {
+    const snapshot = composeMemorySnapshot(null, 0, makeRollup(), NOW);
+    expect(snapshot.electron.available).toBe(false);
+    expect(snapshot.electron.totalWorkingSetMb).toBe(0);
+    // The workload slice is independent — a metrics failure must not degrade it.
+    expect(snapshot.terminalWorkloads.available).toBe(true);
+    expect(snapshot.terminalWorkloads.totalMemoryMb).toBe(500);
+  });
+
+  it("preserves last-good workload values on an unavailable rollup instead of zeroing", () => {
+    const snapshot = composeMemorySnapshot(
+      [],
+      NOW,
+      makeRollup({ available: false, sampledAt: NOW - 40_000 }),
+      NOW
+    );
+
+    expect(snapshot.terminalWorkloads.available).toBe(false);
+    expect(snapshot.terminalWorkloads.stale).toBe(true);
+    expect(snapshot.terminalWorkloads.ageMs).toBe(40_000);
+    // The pty-host aggregates over its retained cache even when ps fails —
+    // the numbers survive, explicitly flagged rather than dropped to 0.
+    expect(snapshot.terminalWorkloads.totalMemoryMb).toBe(500);
+    expect(snapshot.terminalWorkloads.byProject).toHaveLength(1);
+  });
+
+  it("passes very high terminal descendant memory through without clamping", () => {
+    const snapshot = composeMemorySnapshot(
+      [],
+      NOW,
+      makeRollup({ totalMemoryKb: 64 * 1024 * 1024, sampledAt: NOW - 1_000 }),
+      NOW
+    );
+    expect(snapshot.terminalWorkloads.available).toBe(true);
+    expect(snapshot.terminalWorkloads.stale).toBe(false);
+    expect(snapshot.terminalWorkloads.totalMemoryMb).toBe(64 * 1024);
+  });
+
+  it("flags huge-but-stale process-tree data as stale while keeping the values", () => {
+    const age = TERMINAL_WORKLOAD_STALE_MS + 5_000;
+    const snapshot = composeMemorySnapshot(
+      [],
+      NOW,
+      makeRollup({ totalMemoryKb: 32 * 1024 * 1024, sampledAt: NOW - age }),
+      NOW
+    );
+    expect(snapshot.terminalWorkloads.available).toBe(true);
+    expect(snapshot.terminalWorkloads.stale).toBe(true);
+    expect(snapshot.terminalWorkloads.ageMs).toBe(age);
+    expect(snapshot.terminalWorkloads.totalMemoryMb).toBe(32 * 1024);
+  });
+
+  it("reports a never-sampled rollup as ageless rather than infinitely stale", () => {
+    const snapshot = composeMemorySnapshot([], NOW, makeRollup({ sampledAt: 0 }), NOW);
+    expect(snapshot.terminalWorkloads.ageMs).toBeNull();
+    expect(snapshot.terminalWorkloads.stale).toBe(false);
+  });
+
+  it("clamps a negative age (clock skew) to zero", () => {
+    const snapshot = composeMemorySnapshot([], NOW, makeRollup({ sampledAt: NOW + 10_000 }), NOW);
+    expect(snapshot.terminalWorkloads.ageMs).toBe(0);
+    expect(snapshot.terminalWorkloads.stale).toBe(false);
+  });
+
+  it("maps per-project attribution to MB and keeps only process basenames", () => {
+    const snapshot = composeMemorySnapshot([], NOW, makeRollup(), NOW);
+    const project = snapshot.terminalWorkloads.byProject[0];
+    expect(project).toEqual({
+      projectId: "proj-a",
+      terminalCount: 2,
+      processCount: 5,
+      memoryMb: 500,
+      topProcesses: [{ pid: 42, comm: "node", cpuPercent: 3.5, memoryKb: 200_000 }],
+    });
+    expect(JSON.stringify(project)).not.toContain("command");
+  });
+});
+
+describe("getCachedMemoryRollup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    resetMemoryAccountingForTesting();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makePtyClient(rollup: MemoryRollup): { client: PtyClient; fetch: Mock } {
+    const fetch = vi.fn().mockResolvedValue(rollup);
+    return { client: { getMemoryRollup: fetch } as unknown as PtyClient, fetch };
+  }
+
+  it("returns null without a PtyClient", async () => {
+    await expect(getCachedMemoryRollup(null)).resolves.toBeNull();
+  });
+
+  it("serves repeat reads within the TTL from cache", async () => {
+    const { client, fetch } = makePtyClient(makeRollup());
+    await getCachedMemoryRollup(client);
+    await getCachedMemoryRollup(client);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(NOW + 6_000);
+    await getCachedMemoryRollup(client);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("dedupes concurrent reads onto one in-flight request", async () => {
+    const { client, fetch } = makePtyClient(makeRollup());
+    const [a, b] = await Promise.all([
+      getCachedMemoryRollup(client),
+      getCachedMemoryRollup(client),
+    ]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+  });
+
+  it("treats a backwards clock as a stale cache", async () => {
+    const { client, fetch } = makePtyClient(makeRollup());
+    await getCachedMemoryRollup(client);
+    vi.setSystemTime(NOW - 60_000);
+    await getCachedMemoryRollup(client);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("getCompositeMemorySnapshot", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    vi.clearAllMocks();
+    resetMemoryAccountingForTesting();
+    resetAppMetricsSnapshotForTesting();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("degrades the Electron slice when app.getAppMetrics throws", async () => {
+    mockGetAppMetrics.mockImplementation(() => {
+      throw new Error("metrics unavailable");
+    });
+    const client = {
+      getMemoryRollup: vi.fn().mockResolvedValue(makeRollup({ sampledAt: NOW - 1_000 })),
+    } as unknown as PtyClient;
+
+    const snapshot = await getCompositeMemorySnapshot(client);
+    expect(snapshot.electron.available).toBe(false);
+    expect(snapshot.terminalWorkloads.available).toBe(true);
+    expect(snapshot.terminalWorkloads.totalMemoryMb).toBe(500);
+  });
+
+  it("combines both slices with independent timestamps", async () => {
+    mockGetAppMetrics.mockReturnValue([makeMetric(200 * 1024)]);
+    const client = {
+      getMemoryRollup: vi.fn().mockResolvedValue(makeRollup({ sampledAt: NOW - 3_000 })),
+    } as unknown as PtyClient;
+
+    const snapshot = await getCompositeMemorySnapshot(client);
+    expect(snapshot.timestamp).toBe(NOW);
+    expect(snapshot.electron).toMatchObject({
+      available: true,
+      totalWorkingSetMb: 200,
+      sampledAt: NOW,
+    });
+    expect(snapshot.terminalWorkloads).toMatchObject({
+      available: true,
+      sampledAt: NOW - 3_000,
+      ageMs: 3_000,
+    });
+  });
+});

--- a/electron/services/memoryAccounting.ts
+++ b/electron/services/memoryAccounting.ts
@@ -1,0 +1,152 @@
+import {
+  getAppMetricsSnapshot,
+  getAppMetricsSnapshotTimestamp,
+} from "../utils/appMetricsSnapshot.js";
+import type { PtyClient } from "./PtyClient.js";
+import type { MemoryRollup } from "../../shared/types/pty-host.js";
+import {
+  TERMINAL_WORKLOAD_STALE_MS,
+  type CompositeMemorySnapshot,
+  type ElectronMemorySlice,
+  type TerminalWorkloadSlice,
+} from "../../shared/types/memoryAccounting.js";
+
+/**
+ * Read-through cache for the cross-process memory rollup, aligned with the
+ * appMetricsSnapshot TTL so the badge popover (4s), the why-slow dock (5s),
+ * and the resource-profile eval (30s) share one pty-host round-trip per
+ * window instead of stacking their own.
+ */
+const ROLLUP_TTL_MS = 5_000;
+
+let cachedRollup: MemoryRollup | null = null;
+let cachedRollupAt = 0;
+let rollupInflight: Promise<MemoryRollup> | null = null;
+
+/**
+ * Fetch the terminal-workload memory rollup through the shared TTL cache.
+ * Never rejects: PtyClient.getMemoryRollup already resolves to an
+ * `available: false` rollup on IPC failure. Returns null only when no
+ * PtyClient is wired (tests, early startup).
+ */
+export async function getCachedMemoryRollup(
+  ptyClient: PtyClient | null
+): Promise<MemoryRollup | null> {
+  // Structural guard for partial doubles (tests, degraded startup wiring):
+  // a missing rollup surface reads as "no source" — an unavailable slice —
+  // rather than a rejection every consumer would have to fence.
+  if (!ptyClient || typeof ptyClient.getMemoryRollup !== "function") return null;
+  const age = Date.now() - cachedRollupAt;
+  // Negative age = clock moved backwards (suspend correction, fake timers) —
+  // treat the cache as stale rather than trusting it.
+  if (cachedRollup !== null && age >= 0 && age <= ROLLUP_TTL_MS) {
+    return cachedRollup;
+  }
+  if (rollupInflight) return rollupInflight;
+  rollupInflight = ptyClient
+    .getMemoryRollup()
+    .then((rollup) => {
+      cachedRollup = rollup;
+      cachedRollupAt = Date.now();
+      return rollup;
+    })
+    .finally(() => {
+      rollupInflight = null;
+    });
+  return rollupInflight;
+}
+
+/**
+ * Pure composition of the two slices — the seam unit tests exercise. Either
+ * input may be null/unavailable; the output always represents that explicitly
+ * instead of collapsing to a plausible-looking zero.
+ */
+export function composeMemorySnapshot(
+  metrics: Electron.ProcessMetric[] | null,
+  metricsSampledAt: number,
+  rollup: MemoryRollup | null,
+  now: number
+): CompositeMemorySnapshot {
+  let electron: ElectronMemorySlice;
+  if (metrics === null) {
+    electron = { available: false, totalWorkingSetMb: 0, processCount: 0, sampledAt: 0 };
+  } else {
+    let totalKb = 0;
+    for (const proc of metrics) {
+      // workingSetSize is the only cross-platform field — privateBytes is
+      // Windows-only and reports 0 (not undefined) on macOS/Linux (lesson #8646).
+      totalKb += proc.memory.workingSetSize;
+    }
+    electron = {
+      available: true,
+      totalWorkingSetMb: Math.round(totalKb / 1024),
+      processCount: metrics.length,
+      sampledAt: metricsSampledAt,
+    };
+  }
+
+  let terminalWorkloads: TerminalWorkloadSlice;
+  if (rollup === null) {
+    terminalWorkloads = {
+      available: false,
+      stale: false,
+      ageMs: null,
+      sampledAt: 0,
+      totalMemoryMb: 0,
+      processCount: 0,
+      terminalCount: 0,
+      byProject: [],
+    };
+  } else {
+    // sampledAt is the last SUCCESSFUL process-table sweep. An unavailable
+    // rollup still carries the previous sweep's numbers (the pty-host
+    // aggregates over its retained cache), so last-good values survive a ps
+    // failure — flagged, never silently presented as fresh.
+    const hasSample = rollup.sampledAt > 0;
+    const ageMs = hasSample ? Math.max(0, now - rollup.sampledAt) : null;
+    terminalWorkloads = {
+      available: rollup.available,
+      stale: hasSample ? ageMs! > TERMINAL_WORKLOAD_STALE_MS : false,
+      ageMs,
+      sampledAt: rollup.sampledAt,
+      totalMemoryMb: Math.round(rollup.totalMemoryKb / 1024),
+      processCount: rollup.totalProcessCount,
+      terminalCount: rollup.terminalCount,
+      byProject: rollup.byProject.map((p) => ({
+        projectId: p.projectId,
+        terminalCount: p.terminalCount,
+        processCount: p.processCount,
+        memoryMb: Math.round(p.memoryKb / 1024),
+        topProcesses: p.topProcesses,
+      })),
+    };
+  }
+
+  return { timestamp: now, electron, terminalWorkloads };
+}
+
+/**
+ * The unified memory snapshot: Electron working-set + terminal descendant RSS,
+ * grouped by project, with per-slice freshness. Both reads go through their
+ * TTL caches, so pulling this on a popover/diagnostics cadence costs at most
+ * one metrics sweep and one pty-host round-trip per 5s across all consumers.
+ */
+export async function getCompositeMemorySnapshot(
+  ptyClient: PtyClient | null
+): Promise<CompositeMemorySnapshot> {
+  let metrics: Electron.ProcessMetric[] | null;
+  try {
+    metrics = getAppMetricsSnapshot();
+  } catch {
+    metrics = null;
+  }
+  const rollup = await getCachedMemoryRollup(ptyClient);
+  return composeMemorySnapshot(metrics, getAppMetricsSnapshotTimestamp(), rollup, Date.now());
+}
+
+/** Drop the rollup cache so tests with mocked PtyClients stay isolated. */
+export function resetMemoryAccountingForTesting(): void {
+  cachedRollup = null;
+  cachedRollupAt = 0;
+  rollupInflight = null;
+}

--- a/electron/utils/appMetricsSnapshot.ts
+++ b/electron/utils/appMetricsSnapshot.ts
@@ -39,6 +39,15 @@ export function refreshAppMetricsSnapshot(): Electron.ProcessMetric[] {
   return metrics;
 }
 
+/**
+ * Wall-clock time of the cached sweep, or 0 when none has succeeded yet.
+ * Lets composite consumers report the true sample time instead of overstating
+ * freshness with their own read time.
+ */
+export function getAppMetricsSnapshotTimestamp(): number {
+  return cachedAt;
+}
+
 /** Drop the cached snapshot so tests with mocked metrics stay isolated. */
 export function resetAppMetricsSnapshotForTesting(): void {
   cachedMetrics = null;

--- a/shared/types/ipc/generated-api.ts
+++ b/shared/types/ipc/generated-api.ts
@@ -618,6 +618,9 @@ export interface GeneratedElectronAPI {
     ): Promise<IpcInvokeMap["slash-commands:list"]["result"]>;
   };
   system: {
+    getMemorySnapshot(
+      ...args: IpcInvokeMap["system:get-memory-snapshot"]["args"]
+    ): Promise<IpcInvokeMap["system:get-memory-snapshot"]["result"]>;
     getResourceProfile(
       ...args: IpcInvokeMap["system:get-resource-profile"]["args"]
     ): Promise<IpcInvokeMap["system:get-resource-profile"]["result"]>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1269,6 +1269,10 @@ export interface GeneratedIpcInvokeMap {
     args: [];
     result: void;
   };
+  "system:get-memory-snapshot": {
+    args: [];
+    result: import("../memoryAccounting.js").CompositeMemorySnapshot;
+  };
   "system:get-resource-profile": {
     args: [];
     result: import("../resourceProfile.js").ResourceProfilePayload;

--- a/shared/types/memoryAccounting.ts
+++ b/shared/types/memoryAccounting.ts
@@ -1,0 +1,68 @@
+// Composite memory accounting: the memory users actually care about is
+// Electron-owned processes PLUS the descendant trees their terminals spawned
+// (agent CLIs, dev servers, language servers, test runners). The two sources
+// have independent sampling pipelines and failure modes, so each slice carries
+// its own timestamp and availability flag — stale process-tree data must never
+// read as a real zero.
+
+import type { TerminalResourceProcess } from "./pty-host.js";
+
+/**
+ * A terminal-workload sample older than this is flagged stale. The
+ * ProcessTreeCache polls at 2–5s with adaptive backoff capped at 15s, so a
+ * healthy cache is never older than the ceiling; 2× the ceiling separates
+ * "adaptive backoff" from "the ps/PowerShell path is wedged".
+ */
+export const TERMINAL_WORKLOAD_STALE_MS = 30_000;
+
+/** Working-set summary of Daintree's own Electron processes (app.getAppMetrics()). */
+export interface ElectronMemorySlice {
+  /** False when the metrics sweep threw — totals are 0 and must not be shown as data. */
+  available: boolean;
+  /** Summed working-set across all Electron processes, in MB (shared pages double-count). */
+  totalWorkingSetMb: number;
+  processCount: number;
+  /** Wall-clock time of the underlying metrics sweep (0 = never sampled). */
+  sampledAt: number;
+}
+
+/** Per-project terminal workload attribution, PID-deduplicated within the project. */
+export interface TerminalWorkloadProject {
+  /** Resolved project id, or null for terminals not attributable to a project. */
+  projectId: string | null;
+  terminalCount: number;
+  processCount: number;
+  /** Summed RSS (MB) across the project's terminal process trees. */
+  memoryMb: number;
+  /** Highest-RSS processes — basenames only, never command lines or paths. */
+  topProcesses: TerminalResourceProcess[];
+}
+
+/**
+ * RSS rollup across every live terminal's process subtree, sourced from the
+ * pty-host's ProcessTreeCache. Sums resident set size, so shared pages are
+ * counted per process — a pressure heuristic, not unique footprint.
+ */
+export interface TerminalWorkloadSlice {
+  /** False when the OS process table couldn't be read (ps/PowerShell failed or pty-host unreachable). */
+  available: boolean;
+  /** True when the last successful process-table sweep is older than {@link TERMINAL_WORKLOAD_STALE_MS}. */
+  stale: boolean;
+  /** Age of the last successful sweep at snapshot time; null when never sampled. */
+  ageMs: number | null;
+  /** Wall-clock time of the last successful process-table sweep (0 = never). */
+  sampledAt: number;
+  /** Summed RSS (MB), globally PID-deduplicated across overlapping trees. */
+  totalMemoryMb: number;
+  processCount: number;
+  terminalCount: number;
+  byProject: TerminalWorkloadProject[];
+}
+
+/** The unified snapshot combining both slices, each with independent freshness. */
+export interface CompositeMemorySnapshot {
+  /** When this snapshot was assembled (not when either slice was sampled). */
+  timestamp: number;
+  electron: ElectronMemorySlice;
+  terminalWorkloads: TerminalWorkloadSlice;
+}

--- a/shared/types/whySlow.ts
+++ b/shared/types/whySlow.ts
@@ -23,7 +23,8 @@ export interface WhySlowResourceReason {
     | "cpuSpeedLimit"
     | "fleetSize"
     | "rendererSaturation"
-    | "systemMemory";
+    | "systemMemory"
+    | "terminalWorkloads";
   /** Additive pressure-score contribution (efficiency latches at total ≥ 3). */
   contribution: number;
   /** Human-readable detail, e.g. "12 active agents" or "thermal serious". */
@@ -113,6 +114,40 @@ export interface WhySlowWorktreeSummary {
   fetchInFlightCount: number;
 }
 
+/** A high-memory project in the terminal-workload attribution (basenames only). */
+export interface WhySlowTerminalWorkloadProject {
+  /** Resolved project id, or null for terminals not attributable to a project. */
+  projectId: string | null;
+  memoryMb: number;
+  terminalCount: number;
+  processCount: number;
+  /** Process basenames of the project's heaviest processes — never command lines or paths. */
+  topProcessNames: string[];
+}
+
+/**
+ * Memory split for "is Daintree large, or are my terminal workloads large?" —
+ * Electron working-set vs terminal descendant RSS, with the freshness metadata
+ * needed to tell a genuine 0 from an unreadable process table.
+ */
+export interface WhySlowMemorySnapshot {
+  /** Summed Electron working-set (MB), or null when the metrics sweep failed. */
+  appMemoryMb: number | null;
+  terminalWorkloads: {
+    /** False when the OS process table couldn't be read. */
+    available: boolean;
+    /** True when the last successful sweep is older than the staleness bound. */
+    stale: boolean;
+    /** Age of the last successful sweep, or null when never sampled. */
+    ageMs: number | null;
+    totalMemoryMb: number;
+    processCount: number;
+    terminalCount: number;
+    /** Highest-memory projects, descending. */
+    topProjects: WhySlowTerminalWorkloadProject[];
+  };
+}
+
 /** The full "why am I slow?" snapshot. */
 export interface WhySlowSnapshot {
   timestamp: number;
@@ -123,6 +158,8 @@ export interface WhySlowSnapshot {
   worktrees: WhySlowWorktreeSummary | null;
   /** Persistent-worker pressure summary (queue depth, degraded subsystems), or null. */
   workers: WhySlowWorkerSummary | null;
+  /** App vs terminal-workload memory split; null when collection failed. */
+  memory: WhySlowMemorySnapshot | null;
 }
 
 /** Renderer-pushed payload for {@link WhySlowRendererTerminalSample} (id + freshness added main-side). */

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -61,6 +61,10 @@ export const systemClient = {
     return window.electron.system.getWhySlowSnapshot();
   },
 
+  getMemorySnapshot: (): ReturnType<typeof window.electron.system.getMemorySnapshot> => {
+    return window.electron.system.getMemorySnapshot();
+  },
+
   getTmpDir: (): Promise<string> => {
     if (cachedTmpDir !== null) return Promise.resolve(cachedTmpDir);
     if (tmpDirInflight) return tmpDirInflight;

--- a/src/components/Diagnostics/WhySlowContent.tsx
+++ b/src/components/Diagnostics/WhySlowContent.tsx
@@ -204,6 +204,15 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
   const resource = snapshot?.resource ?? null;
   const snapshotAgeMs = snapshot ? Math.max(0, Date.now() - snapshot.timestamp) : 0;
   const sortedReasons = resource ? sortReasonsByContribution(resource.reasons) : [];
+  const memory = snapshot?.memory ?? null;
+  const memoryWorkloads = memory?.terminalWorkloads ?? null;
+  // "Has data" = a live measurement, or retained nonzero values from a prior
+  // successful sweep. A never-sampled slice must render as "—", not a fake 0.
+  const workloadsHaveData =
+    memoryWorkloads !== null &&
+    (memoryWorkloads.available ||
+      (memoryWorkloads.ageMs !== null &&
+        (memoryWorkloads.totalMemoryMb > 0 || memoryWorkloads.processCount > 0)));
 
   return (
     <div className={cn("h-full overflow-auto p-3 text-sm text-daintree-text", className)}>
@@ -368,6 +377,49 @@ export function WhySlowContent({ className }: WhySlowContentProps) {
               <p className="text-xs text-daintree-text/45 mt-2">
                 No terminal renderer reports yet.
               </p>
+            )}
+          </section>
+
+          {/* Memory: Daintree's own processes vs terminal descendant workloads */}
+          <section>
+            <h3 className="text-[10px] uppercase tracking-wide text-daintree-text/55 font-medium mb-2">
+              Memory
+            </h3>
+            {memory && memoryWorkloads ? (
+              <div className="flex flex-col gap-2">
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                  <MetricTile
+                    label="Daintree app"
+                    value={memory.appMemoryMb !== null ? String(memory.appMemoryMb) : "—"}
+                    unit={memory.appMemoryMb !== null ? "MB" : undefined}
+                  />
+                  <MetricTile
+                    label="Terminal workloads"
+                    value={workloadsHaveData ? String(memoryWorkloads.totalMemoryMb) : "—"}
+                    unit={workloadsHaveData ? "MB" : undefined}
+                  />
+                  <MetricTile
+                    label="Workload processes"
+                    value={workloadsHaveData ? String(memoryWorkloads.processCount) : "—"}
+                  />
+                  <MetricTile
+                    label="Workload terminals"
+                    value={workloadsHaveData ? String(memoryWorkloads.terminalCount) : "—"}
+                  />
+                </div>
+                {!memoryWorkloads.available || memoryWorkloads.stale ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {!memoryWorkloads.available ? (
+                      <Badge tone="warn">process table unavailable</Badge>
+                    ) : null}
+                    {memoryWorkloads.stale ? (
+                      <Badge tone="warn">workload sample stale</Badge>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-xs text-daintree-text/45">Memory attribution unavailable.</p>
             )}
           </section>
 

--- a/src/components/Diagnostics/__tests__/WhySlowContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/WhySlowContent.test.tsx
@@ -23,6 +23,7 @@ function makeSnapshot(overrides?: Partial<WhySlowSnapshot>): WhySlowSnapshot {
     pty: null,
     worktrees: null,
     workers: null,
+    memory: null,
     ...overrides,
   };
 }
@@ -134,6 +135,93 @@ describe("WhySlowContent", () => {
 
     expect(await screen.findByText("Worker queue")).toBeTruthy();
     expect(screen.queryByText(/^degraded:/)).toBeNull();
+  });
+
+  it("renders the app vs terminal-workload memory split", async () => {
+    getWhySlowSnapshot.mockResolvedValue(
+      makeSnapshot({
+        memory: {
+          appMemoryMb: 512,
+          terminalWorkloads: {
+            available: true,
+            stale: false,
+            ageMs: 2_000,
+            totalMemoryMb: 2048,
+            processCount: 12,
+            terminalCount: 4,
+            topProjects: [],
+          },
+        },
+      })
+    );
+
+    render(<WhySlowContent />);
+
+    expect(await screen.findByText("Terminal workloads")).toBeTruthy();
+    expect(screen.getByText("512")).toBeTruthy(); // Daintree app MB
+    expect(screen.getByText("2048")).toBeTruthy(); // workload MB
+    expect(screen.getByText("12")).toBeTruthy(); // workload processes
+    expect(screen.queryByText("process table unavailable")).toBeNull();
+    expect(screen.queryByText("workload sample stale")).toBeNull();
+  });
+
+  it("flags unavailable and stale workload samples without hiding last-good totals", async () => {
+    getWhySlowSnapshot.mockResolvedValue(
+      makeSnapshot({
+        memory: {
+          appMemoryMb: null,
+          terminalWorkloads: {
+            available: false,
+            stale: true,
+            ageMs: 90_000,
+            totalMemoryMb: 3100,
+            processCount: 9,
+            terminalCount: 3,
+            topProjects: [],
+          },
+        },
+      })
+    );
+
+    render(<WhySlowContent />);
+
+    expect(await screen.findByText("process table unavailable")).toBeTruthy();
+    expect(screen.getByText("workload sample stale")).toBeTruthy();
+    // The last-good total still shows, flagged rather than zeroed.
+    expect(screen.getByText("3100")).toBeTruthy();
+  });
+
+  it("renders dashes, not zeros, when workloads were never sampled", async () => {
+    getWhySlowSnapshot.mockResolvedValue(
+      makeSnapshot({
+        memory: {
+          appMemoryMb: 512,
+          terminalWorkloads: {
+            available: false,
+            stale: false,
+            ageMs: null,
+            totalMemoryMb: 0,
+            processCount: 0,
+            terminalCount: 0,
+            topProjects: [],
+          },
+        },
+      })
+    );
+
+    render(<WhySlowContent />);
+
+    expect(await screen.findByText("process table unavailable")).toBeTruthy();
+    // A never-sampled slice must not imply a measured empty workload.
+    expect(screen.queryByText("0")).toBeNull();
+  });
+
+  it("degrades the memory section when collection failed", async () => {
+    getWhySlowSnapshot.mockResolvedValue(makeSnapshot());
+
+    render(<WhySlowContent />);
+
+    expect(await screen.findByText("Memory attribution unavailable.")).toBeTruthy();
   });
 
   it("does not start overlapping refreshes while one is in flight", async () => {

--- a/src/components/Project/ProjectResourceBadge.tsx
+++ b/src/components/Project/ProjectResourceBadge.tsx
@@ -6,6 +6,10 @@ import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { logError } from "@/utils/logger";
 import type { ProcessMetricEntry, HeapStats, DiagnosticsInfo } from "@shared/types/ipc/system";
 import type { BulkProjectStatsEntry } from "@shared/types/ipc/project";
+import type {
+  CompositeMemorySnapshot,
+  TerminalWorkloadSlice,
+} from "@shared/types/memoryAccounting";
 import type { Project } from "@shared/types";
 import {
   type MemoryState,
@@ -105,23 +109,54 @@ function MemoryRow({ label, value }: { label: string; value: string }) {
 
 function MemorySummary({
   appMemoryMB,
-  workloadMB,
+  workloads,
+  lastGoodWorkloads,
   systemAvailableMB,
 }: {
   appMemoryMB: number;
-  workloadMB: number | null;
+  /** Current terminal-workload slice, or null when no snapshot has arrived. */
+  workloads: TerminalWorkloadSlice | null;
+  /** Most recent slice that was actually measured, kept across unavailable reads. */
+  lastGoodWorkloads: TerminalWorkloadSlice | null;
   systemAvailableMB: number | null;
 }) {
+  // Prefer the live measurement. On an unavailable read fall back to the
+  // retained values the pty-host kept from its last successful sweep (present
+  // even on the first open after a ps failure), then to the last slice this
+  // renderer saw measured — never a fake 0, never a silently-dropped row.
+  const measured = workloads?.available ? workloads : null;
+  const retained =
+    measured === null &&
+    workloads !== null &&
+    workloads.sampledAt > 0 &&
+    (workloads.totalMemoryMb > 0 || workloads.processCount > 0)
+      ? workloads
+      : null;
+  const shown = measured ?? retained ?? lastGoodWorkloads;
+  const workloadNote = measured?.stale
+    ? `Last sampled ${Math.max(1, Math.round((measured.ageMs ?? 0) / 1000))}s ago`
+    : measured === null && shown !== null
+      ? "Process table unavailable — showing last reading"
+      : workloads !== null && !workloads.available
+        ? "Process table unavailable"
+        : null;
+
   return (
     <div className="space-y-1">
-      <MemoryRow label="Daintree app" value={formatMemory(appMemoryMB)} />
-      {workloadMB !== null && (
-        <MemoryRow label="Terminal workloads" value={formatMemory(workloadMB)} />
+      <MemoryRow label="Daintree app memory" value={formatMemory(appMemoryMB)} />
+      {(workloads !== null || shown !== null) && (
+        <MemoryRow
+          label="Terminal workloads"
+          value={shown !== null ? formatMemory(shown.totalMemoryMb) : "Unavailable"}
+        />
+      )}
+      {workloadNote !== null && (
+        <div className="text-[9px] text-status-warning/70 leading-tight">{workloadNote}</div>
       )}
       {systemAvailableMB !== null && (
         <MemoryRow label="System available" value={formatMemory(systemAvailableMB)} />
       )}
-      {workloadMB !== null && (
+      {shown !== null && (
         <div className="text-[9px] text-daintree-text/25 leading-tight">
           Workloads = dev servers, agents, and tools your terminals launched
         </div>
@@ -165,6 +200,8 @@ function ProjectBreakdown({
 
   if (entries.length === 0) return null;
 
+  const hasEstimates = entries.some((entry) => entry.stats!.terminalMemoryMB === undefined);
+
   return (
     <div className="space-y-1">
       <div className="text-[10px] text-daintree-text/50 font-medium">Projects</div>
@@ -196,6 +233,11 @@ function ProjectBreakdown({
           );
         })}
       </div>
+      {hasEstimates && (
+        <div className="text-[9px] text-daintree-text/25 leading-tight">
+          ~ estimated from terminal count, not measured
+        </div>
+      )}
     </div>
   );
 }
@@ -253,6 +295,11 @@ export function ProjectResourceBadge() {
   const [isLoading, setIsLoading] = useState(true);
   const [open, setOpen] = useState(false);
   const [popoverData, setPopoverData] = useState<PopoverData | null>(null);
+  const [memorySnapshot, setMemorySnapshot] = useState<CompositeMemorySnapshot | null>(null);
+  // Last workload slice that was actually measured — survives unavailable
+  // reads so the popover degrades to "showing last reading" instead of
+  // dropping to a fake 0 or hiding a previously-shown row.
+  const [lastGoodWorkloads, setLastGoodWorkloads] = useState<TerminalWorkloadSlice | null>(null);
   const [popoverSampledAt, setPopoverSampledAt] = useState<number | null>(null);
   const [nowTs, setNowTs] = useState(() => Date.now());
   const [thresholds, setThresholds] = useState<MemoryThresholds>(FALLBACK_THRESHOLDS);
@@ -264,21 +311,6 @@ export function ProjectResourceBadge() {
   const trend = getTrendDirection(samples, SAMPLES_PER_MIN);
   const projectIdsKey = useMemo(() => stats.projects.map((p) => p.id).join(","), [stats.projects]);
 
-  // Sum measured terminal-tree memory across projects for the popover summary.
-  // Null when no project reported a measurement (OS table unreadable) so the
-  // row hides rather than implying a real 0.
-  const workloadMB = useMemo(() => {
-    if (!popoverData) return null;
-    let sum = 0;
-    let measured = false;
-    for (const entry of Object.values(popoverData.projectStats)) {
-      if (typeof entry.terminalMemoryMB === "number") {
-        sum += entry.terminalMemoryMB;
-        measured = true;
-      }
-    }
-    return measured ? sum : null;
-  }, [popoverData]);
   const systemAvailableMB = popoverData?.diagnosticsInfo.systemAvailableMB ?? null;
   const ageSec =
     popoverSampledAt !== null ? Math.max(0, Math.round((nowTs - popoverSampledAt) / 1000)) : null;
@@ -409,10 +441,13 @@ export function ProjectResourceBadge() {
 
     const fetchPopoverData = async () => {
       try {
-        const [processMetrics, heapStats, diagnosticsInfo] = await Promise.all([
+        const [processMetrics, heapStats, diagnosticsInfo, snapshot] = await Promise.all([
           systemClient.getProcessMetrics(),
           systemClient.getHeapStats(),
           systemClient.getDiagnosticsInfo(),
+          // Isolate a snapshot failure: the rest of the popover still updates,
+          // and the memory rows degrade to their last-good/unavailable states.
+          systemClient.getMemorySnapshot().catch(() => null),
         ]);
 
         const projectIds = projectIdsKey ? projectIdsKey.split(",") : [];
@@ -421,6 +456,13 @@ export function ProjectResourceBadge() {
 
         if (!cancelled) {
           setPopoverData({ processMetrics, heapStats, diagnosticsInfo, projectStats });
+          // A failed snapshot poll clears the live slice so old readings can't
+          // masquerade as current; last-good values still render via
+          // lastGoodWorkloads with their "showing last reading" note.
+          setMemorySnapshot(snapshot);
+          if (snapshot?.terminalWorkloads.available) {
+            setLastGoodWorkloads(snapshot.terminalWorkloads);
+          }
           setPopoverSampledAt(Date.now());
         }
       } catch (error) {
@@ -476,8 +518,13 @@ export function ProjectResourceBadge() {
           {popoverData ? (
             <>
               <MemorySummary
-                appMemoryMB={stats.totalMemoryMB}
-                workloadMB={workloadMB}
+                appMemoryMB={
+                  memorySnapshot?.electron.available
+                    ? memorySnapshot.electron.totalWorkingSetMb
+                    : stats.totalMemoryMB
+                }
+                workloads={memorySnapshot?.terminalWorkloads ?? null}
+                lastGoodWorkloads={lastGoodWorkloads}
                 systemAvailableMB={systemAvailableMB}
               />
               <ProjectBreakdown projects={stats.projects} projectStats={popoverData.projectStats} />

--- a/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
+++ b/src/components/Project/__tests__/ProjectResourceBadge.popover.test.tsx
@@ -1,0 +1,285 @@
+// @vitest-environment jsdom
+/**
+ * ProjectResourceBadge — popover memory honesty.
+ *
+ * The popover must label measured vs estimated memory truthfully: measured
+ * workload totals come from the composite memory snapshot, unavailable reads
+ * preserve the last good value with an explicit note (never a fake 0), and
+ * per-project estimates carry the `~` legend.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { act } from "react";
+
+vi.mock("@/clients", () => ({
+  projectClient: {
+    getAll: vi.fn(),
+    getBulkStats: vi.fn(),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn(),
+    getHardwareInfo: vi.fn(),
+    getProcessMetrics: vi.fn(),
+    getHeapStats: vi.fn(),
+    getDiagnosticsInfo: vi.fn(),
+    getMemorySnapshot: vi.fn(),
+  },
+}));
+
+const statsStoreState: { stats: Record<string, { processCount: number }> } = { stats: {} };
+vi.mock("@/store/projectStatsStore", () => ({
+  useProjectStatsStore: {
+    getState: () => statsStoreState,
+  },
+}));
+
+// Controlled-popover stub: the component drives `open` through onOpenChange, so
+// any click inside the wrapper opens it and the content always renders.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => <div onClickCapture={() => onOpenChange?.(true)}>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { projectClient, systemClient } from "@/clients";
+import type { Project } from "@shared/types";
+import type { BulkProjectStatsEntry } from "@shared/types/ipc/project";
+import type {
+  CompositeMemorySnapshot,
+  TerminalWorkloadSlice,
+} from "@shared/types/memoryAccounting";
+import { ProjectResourceBadge } from "../ProjectResourceBadge";
+
+const mockGetAll = vi.mocked(projectClient.getAll);
+const mockGetBulkStats = vi.mocked(projectClient.getBulkStats);
+const mockGetAppMetrics = vi.mocked(systemClient.getAppMetrics);
+const mockGetHardwareInfo = vi.mocked(systemClient.getHardwareInfo);
+const mockGetProcessMetrics = vi.mocked(systemClient.getProcessMetrics);
+const mockGetHeapStats = vi.mocked(systemClient.getHeapStats);
+const mockGetDiagnosticsInfo = vi.mocked(systemClient.getDiagnosticsInfo);
+const mockGetMemorySnapshot = vi.mocked(systemClient.getMemorySnapshot);
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: "p1",
+    name: "Proj One",
+    path: "/tmp/test",
+    emoji: "🚀",
+    color: "blue",
+    status: "active",
+    lastOpened: 0,
+    ...overrides,
+  };
+}
+
+function makeWorkloads(overrides: Partial<TerminalWorkloadSlice> = {}): TerminalWorkloadSlice {
+  return {
+    available: true,
+    stale: false,
+    ageMs: 2_000,
+    sampledAt: Date.now() - 2_000,
+    totalMemoryMb: 900,
+    processCount: 6,
+    terminalCount: 2,
+    byProject: [],
+    ...overrides,
+  };
+}
+
+function makeMemorySnapshot(
+  workloadOverrides: Partial<TerminalWorkloadSlice> = {}
+): CompositeMemorySnapshot {
+  return {
+    timestamp: Date.now(),
+    electron: {
+      available: true,
+      totalWorkingSetMb: 300,
+      processCount: 4,
+      sampledAt: Date.now(),
+    },
+    terminalWorkloads: makeWorkloads(workloadOverrides),
+  };
+}
+
+function makeBulkStatsEntry(overrides: Partial<BulkProjectStatsEntry> = {}): BulkProjectStatsEntry {
+  return {
+    processCount: 2,
+    terminalCount: 2,
+    estimatedMemoryMB: 100,
+    terminalTypes: {},
+    processIds: [],
+    activeAgentCount: 0,
+    waitingAgentCount: 0,
+    ...overrides,
+  };
+}
+
+async function renderOpenBadge(): Promise<HTMLElement> {
+  const { container } = render(<ProjectResourceBadge />);
+  // Flush the initial badge poll so the trigger renders.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  const trigger = container.querySelector("button");
+  expect(trigger).not.toBeNull();
+  await act(async () => {
+    fireEvent.click(trigger!);
+  });
+  // Flush the popover fetch fan-out.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return container;
+}
+
+describe("ProjectResourceBadge — popover memory honesty", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetAll.mockReset().mockResolvedValue([makeProject()]);
+    mockGetBulkStats.mockReset().mockResolvedValue({
+      p1: makeBulkStatsEntry({
+        terminalMemoryMB: 750,
+        topProcess: { name: "node", memoryMB: 400 },
+      }),
+    });
+    mockGetAppMetrics.mockReset().mockResolvedValue({ totalMemoryMB: 290 });
+    mockGetHardwareInfo.mockReset().mockResolvedValue({
+      totalMemoryBytes: 8 * 1024 * 1024 * 1024,
+      logicalCpuCount: 8,
+    });
+    mockGetProcessMetrics.mockReset().mockResolvedValue([]);
+    mockGetHeapStats
+      .mockReset()
+      .mockResolvedValue({ usedMB: 100, limitMB: 200, percent: 50, externalMB: 10 });
+    mockGetDiagnosticsInfo
+      .mockReset()
+      .mockResolvedValue({ uptimeSeconds: 60, eventLoopP99Ms: 10, systemAvailableMB: 4096 });
+    mockGetMemorySnapshot.mockReset().mockResolvedValue(makeMemorySnapshot());
+    statsStoreState.stats = { p1: { processCount: 1 } };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("labels measured app and workload memory from the composite snapshot", async () => {
+    const container = await renderOpenBadge();
+
+    expect(container.textContent).toContain("Daintree app memory");
+    expect(container.textContent).toContain("300MB");
+    expect(container.textContent).toContain("Terminal workloads");
+    expect(container.textContent).toContain("900MB");
+    // Measured per-project value renders without the estimate marker or legend.
+    expect(container.textContent).toContain("750MB");
+    expect(container.textContent).not.toContain("~");
+    expect(container.textContent).not.toContain("estimated from terminal count");
+  });
+
+  it("shows Unavailable instead of a fake zero when nothing was ever measured", async () => {
+    mockGetMemorySnapshot.mockResolvedValue(
+      makeMemorySnapshot({
+        available: false,
+        ageMs: null,
+        sampledAt: 0,
+        totalMemoryMb: 0,
+        processCount: 0,
+        terminalCount: 0,
+      })
+    );
+
+    const container = await renderOpenBadge();
+
+    expect(container.textContent).toContain("Terminal workloads");
+    expect(container.textContent).toContain("Unavailable");
+    expect(container.textContent).toContain("Process table unavailable");
+    expect(container.textContent).not.toContain("Terminal workloads0MB");
+  });
+
+  it("preserves the last good workload reading across an unavailable poll", async () => {
+    const container = await renderOpenBadge();
+    expect(container.textContent).toContain("900MB");
+
+    // The next popover poll finds the process table unreadable; the rollup
+    // degrades to available:false with zeroed fresh values.
+    mockGetMemorySnapshot.mockResolvedValue(
+      makeMemorySnapshot({ available: false, totalMemoryMb: 0, processCount: 0 })
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+
+    expect(container.textContent).toContain("900MB");
+    expect(container.textContent).toContain("showing last reading");
+    expect(container.textContent).not.toContain("Unavailable —");
+  });
+
+  it("shows host-retained values on first open when the process table is already wedged", async () => {
+    // The pty-host aggregates over its retained cache even when ps fails, so
+    // the very first snapshot this renderer sees can be unavailable yet carry
+    // real last-good numbers — they must render, flagged, not as Unavailable.
+    mockGetMemorySnapshot.mockResolvedValue(
+      makeMemorySnapshot({
+        available: false,
+        stale: false,
+        ageMs: 10_000,
+        sampledAt: Date.now() - 10_000,
+        totalMemoryMb: 900,
+      })
+    );
+
+    const container = await renderOpenBadge();
+
+    expect(container.textContent).toContain("900MB");
+    expect(container.textContent).toContain("showing last reading");
+    expect(container.textContent).not.toContain("Unavailable");
+  });
+
+  it("keeps the last good reading when the snapshot poll itself fails", async () => {
+    const container = await renderOpenBadge();
+    expect(container.textContent).toContain("900MB");
+
+    // The snapshot IPC rejects outright on the next poll; the stale-guarded
+    // fallback must show the last good value with its note, not the previous
+    // slice masquerading as a fresh measurement.
+    mockGetMemorySnapshot.mockRejectedValue(new Error("ipc down"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+
+    expect(container.textContent).toContain("900MB");
+    expect(container.textContent).toContain("showing last reading");
+  });
+
+  it("flags a stale-but-available workload sample with its age", async () => {
+    mockGetMemorySnapshot.mockResolvedValue(
+      makeMemorySnapshot({ stale: true, ageMs: 45_000, sampledAt: Date.now() - 45_000 })
+    );
+
+    const container = await renderOpenBadge();
+
+    expect(container.textContent).toContain("900MB");
+    expect(container.textContent).toContain("Last sampled 45s ago");
+  });
+
+  it("marks per-project estimates with the ~ legend when unmeasured", async () => {
+    mockGetBulkStats.mockResolvedValue({
+      p1: makeBulkStatsEntry({ terminalCount: 3, estimatedMemoryMB: 150 }),
+    });
+
+    const container = await renderOpenBadge();
+
+    expect(container.textContent).toContain("~150MB");
+    expect(container.textContent).toContain("estimated from terminal count, not measured");
+  });
+});


### PR DESCRIPTION
Users don't really care how much memory our Electron processes are using. They care what the app is costing them overall, which is Electron plus all the process trees spawned inside terminals: agent CLIs, dev servers, language servers, test runners. The bottom-left readout was based on `app.getAppMetrics()` working-set totals, so it missed the biggest real consumers entirely.

This adds a single cached composite memory snapshot in the main process (`electron/services/memoryAccounting.ts`) that combines the Electron working-set totals with the pty-host per-project RSS rollup. Each side carries its own timestamp and availability flag, so stale process-table data never shows up as a real zero.

The snapshot feeds three surfaces:

- **Resource badge popover (bottom left).** Honest "Daintree app memory" and "Terminal workloads" rows, a `~` marker plus legend on the per-project `terminalCount * 50MB` estimates, and it keeps the last good reading with a note when the OS process table can't be read, instead of dropping to zero or silently hiding the row.
- **Why-am-I-slow diagnostics dock.** A new memory section that splits app memory from terminal workloads, so "Daintree renderers are large" and "my dev servers are large" are finally distinguishable.
- **Support exports.** A `memoryAttribution` section with per-project attribution, process basenames only. No command lines, no paths.

`ResourceProfileService` also gains a terminal-workload pressure signal. It's bounded at +2 so it can never latch the `efficiency` profile on its own, gated on a fresh successful process-table sweep (stale or unavailable data contributes nothing, whatever its magnitude), and has a 10% exit band so values hovering at a threshold don't flap the score. Like every other score input it only tunes cadences and budgets. Nothing gets killed or hibernated.

A review pass caught a few real edge cases: a future-stamped sample (clock moved backwards) counting as fresh, the hysteresis tier surviving a stale gap so a below-threshold value could ride the exit band back to a higher score, failed snapshot polls letting old readings masquerade as fresh in the popover, and fake zeros in the dock when nothing was ever sampled. All fixed with regression tests.

Tests cover the snapshot composition (unavailable, stale, and huge-but-stale rollups), freshness gating and hysteresis in the profile service, the badge display states, and export sanitization. I deliberately left out a nightly E2E extension for this. Spawning real memory-heavy child processes in CI is flaky, and the unit coverage exercises the same seams.