### PR TITLE
feat(terminal): offer reveal for out-of-root file links

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -95,6 +95,7 @@ export const CHANNELS = {
   SYSTEM_OPEN_EXTERNAL: "system:open-external",
   SYSTEM_OPEN_PATH: "system:open-path",
   SYSTEM_SHOW_ITEM_IN_FOLDER: "system:show-item-in-folder",
+  SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED: "system:show-item-in-folder-unconfined",
   SYSTEM_OPEN_IN_EDITOR: "system:open-in-editor",
   SYSTEM_CHECK_COMMAND: "system:check-command",
   SYSTEM_CHECK_DIRECTORY: "system:check-directory",

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -25,6 +25,9 @@ vi.mock("electron", () => ({
 const fsMock = vi.hoisted(() => ({
   promises: {
     realpath: vi.fn<(p: string) => Promise<string>>((p: string) => Promise.resolve(p)),
+    stat: vi.fn<(p: string) => Promise<{ isFile: () => boolean; isDirectory: () => boolean }>>(() =>
+      Promise.resolve({ isFile: () => true, isDirectory: () => false })
+    ),
   },
 }));
 
@@ -77,6 +80,7 @@ vi.mock("../../utils.js", () => ({
 
 import { CHANNELS } from "../../channels.js";
 import { registerSystemShellHandlers } from "../systemShell.js";
+import { SystemShowItemInFolderUnconfinedPayloadSchema } from "../../../schemas/ipc.js";
 import type { HandlerDependencies } from "../../types.js";
 
 type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
@@ -396,5 +400,118 @@ describe("system path-allowlist: worktree parent dirs", () => {
       handler(fakeEvent, { path: `${WORKTREE_PARENT}-evil${path.sep}secret.txt` })
     ).rejects.toMatchObject({ code: "OUTSIDE_ROOT" });
     expect(shellMock.openPath).not.toHaveBeenCalled();
+  });
+});
+
+describe("system:show-item-in-folder-unconfined (out-of-root reveal recovery)", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsMock.promises.realpath.mockImplementation(realpathEcho);
+    fsMock.promises.stat.mockResolvedValue({ isFile: () => true, isDirectory: () => false });
+    projectStoreMock.getAllProjects.mockReturnValue([{ path: PROJECT_ROOT }]);
+    appMock.getPath.mockImplementation((name: string) => path.join(USERDATA_PARENT, name));
+    storeMock.get.mockReturnValue(undefined);
+    cleanup = registerSystemShellHandlers({} as HandlerDependencies);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // The whole point of this op: an out-of-root path is revealed (no
+  // OUTSIDE_ROOT), because it's the user-initiated recovery for a file link
+  // that resolved outside roots. Roots containment is intentionally skipped.
+  it("reveals an absolute path outside all roots (bypasses containment)", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    const outside = path.join(TEST_ROOT, "etc", "passwd");
+    await handler(fakeEvent, { path: outside });
+    expect(shellMock.showItemInFolder).toHaveBeenCalledWith(outside);
+  });
+
+  it("rejects a non-absolute path with INVALID_PATH", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    await expect(handler(fakeEvent, { path: "relative/file.txt" })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  // Key security distinction from the confined system:show-item-in-folder op
+  // (which relaxes the deny-list for reveal): an out-of-root path is untrusted
+  // terminal output, and historical Windows ShellExecute("open") / Linux
+  // xdg-open fallbacks make reveal a launch surface on some platforms — so the
+  // deny-list stays in force.
+  it("rejects an executable extension even out-of-root (deny-list enforced)", async () => {
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    await expect(
+      handler(fakeEvent, { path: path.join(TEST_ROOT, "dropped", deniedLauncherName) })
+    ).rejects.toMatchObject({ code: "INVALID_PATH" });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("rejects a safe-named symlink whose realpath has a denied extension", async () => {
+    const link = path.join(TEST_ROOT, "etc", "notes.txt");
+    const target = path.join(TEST_ROOT, "dropped", deniedLauncherName);
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      Promise.resolve(path.normalize(p) === path.normalize(link) ? target : path.normalize(p))
+    );
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    await expect(handler(fakeEvent, { path: link })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("rejects a since-deleted path (realpath ENOENT) without revealing", async () => {
+    const missing = path.join(TEST_ROOT, "etc", "gone.txt");
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      path.normalize(p) === path.normalize(missing)
+        ? Promise.reject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }))
+        : realpathEcho(p)
+    );
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    await expect(handler(fakeEvent, { path: missing })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("rejects when stat fails after realpath (INVALID_PATH, no reveal)", async () => {
+    const target = path.join(TEST_ROOT, "etc", "vanished.txt");
+    fsMock.promises.stat.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    await expect(handler(fakeEvent, { path: target })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
+  it("reveals the realpath-resolved target, not the original path", async () => {
+    const link = path.join(TEST_ROOT, "etc", "link.txt");
+    const resolved = path.join(TEST_ROOT, "elsewhere", "real.txt");
+    fsMock.promises.realpath.mockImplementation((p: string) =>
+      Promise.resolve(path.normalize(p) === path.normalize(link) ? resolved : path.normalize(p))
+    );
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    await handler(fakeEvent, { path: link });
+    expect(shellMock.showItemInFolder).toHaveBeenCalledWith(resolved);
+  });
+});
+
+describe("SystemShowItemInFolderUnconfinedPayloadSchema (null-byte guard, lesson #6263)", () => {
+  it("rejects a null byte in the path at the schema boundary", () => {
+    const result = SystemShowItemInFolderUnconfinedPayloadSchema.safeParse({
+      path: "/etc/passwd\x00",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a well-formed absolute path", () => {
+    const result = SystemShowItemInFolderUnconfinedPayloadSchema.safeParse({
+      path: "/etc/passwd",
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/systemShell.handlers.test.ts
@@ -488,6 +488,16 @@ describe("system:show-item-in-folder-unconfined (out-of-root reveal recovery)", 
     expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
   });
 
+  it("rejects a non-file/non-directory node (e.g. socket/device) without revealing", async () => {
+    const target = path.join(TEST_ROOT, "etc", "socket");
+    fsMock.promises.stat.mockResolvedValue({ isFile: () => false, isDirectory: () => false });
+    const handler = getHandler(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED);
+    await expect(handler(fakeEvent, { path: target })).rejects.toMatchObject({
+      code: "INVALID_PATH",
+    });
+    expect(shellMock.showItemInFolder).not.toHaveBeenCalled();
+  });
+
   it("reveals the realpath-resolved target, not the original path", async () => {
     const link = path.join(TEST_ROOT, "etc", "link.txt");
     const resolved = path.join(TEST_ROOT, "elsewhere", "real.txt");
@@ -513,5 +523,10 @@ describe("SystemShowItemInFolderUnconfinedPayloadSchema (null-byte guard, lesson
       path: "/etc/passwd",
     });
     expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty path (.min(1))", () => {
+    const result = SystemShowItemInFolderUnconfinedPayloadSchema.safeParse({ path: "" });
+    expect(result.success).toBe(false);
   });
 });

--- a/electron/ipc/handlers/systemShell.ts
+++ b/electron/ipc/handlers/systemShell.ts
@@ -2,6 +2,7 @@
 import { app, shell } from "electron";
 import os from "os";
 import * as nodePath from "path";
+import * as nodeFs from "fs";
 import { CHANNELS } from "../channels.js";
 import { openExternalUrl } from "../../utils/openExternal.js";
 import { projectStore } from "../../services/ProjectStore.js";
@@ -17,6 +18,7 @@ import {
 import {
   SystemOpenExternalPayloadSchema,
   SystemOpenPathPayloadSchema,
+  SystemShowItemInFolderUnconfinedPayloadSchema,
   SystemOpenInEditorPayloadSchema,
 } from "../../schemas/index.js";
 import type { HandlerDependencies } from "../types.js";
@@ -25,6 +27,7 @@ import { defineIpcNamespace, opValidated } from "../define.js";
 import type {
   SystemOpenExternalPayload,
   SystemOpenPathPayload,
+  SystemShowItemInFolderUnconfinedPayload,
   SystemOpenInEditorPayload,
 } from "../../schemas/ipc.js";
 
@@ -156,6 +159,68 @@ async function assertPathAllowed(
   return realTarget;
 }
 
+/**
+ * Resolve a renderer-supplied path for the UNCONFINED reveal op — the
+ * user-initiated recovery path for a file link that resolved outside project
+ * roots. Unlike {@link assertPathAllowed}, this deliberately skips roots
+ * containment (that's the rejection the user is asking to bypass), but keeps
+ * every other guard: absolute-only, executable deny-list on both the raw
+ * input and the realpath target (defeats a safe-named symlink → Evil.app),
+ * realpath canonicalization (collapses intermediate-component TOCTOU — lesson
+ * #6442), and a stat gate so a since-deleted path surfaces as INVALID_PATH
+ * instead of `shell.showItemInFolder`'s silent no-op. The deny-list is
+ * unconditional here — unlike the confined "editor" flavor, which relaxes it —
+ * because an out-of-root path is untrusted terminal output and the historical
+ * Windows ShellExecute("open") / Linux xdg-open fallbacks make reveal a launch
+ * surface on some platforms.
+ */
+async function resolveRevealTargetUnconfined(targetPath: string): Promise<string> {
+  if (!nodePath.isAbsolute(targetPath)) {
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "Only absolute paths are allowed",
+      context: { targetPath },
+    });
+  }
+
+  assertExtensionAllowed(targetPath);
+
+  let realTarget: string;
+  try {
+    realTarget = await nodeFs.promises.realpath(targetPath);
+  } catch (error) {
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "Could not resolve path",
+      context: { targetPath },
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+
+  assertExtensionAllowed(realTarget);
+
+  try {
+    const stats = await nodeFs.promises.stat(realTarget);
+    if (!stats.isFile() && !stats.isDirectory()) {
+      throw new AppError({
+        code: "INVALID_PATH",
+        message: "Path is not a file or directory",
+        context: { targetPath, realTarget },
+      });
+    }
+  } catch (error) {
+    if (error instanceof AppError) throw error;
+    throw new AppError({
+      code: "INVALID_PATH",
+      message: "Could not stat path",
+      context: { targetPath, realTarget },
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+
+  return realTarget;
+}
+
 export function registerSystemShellHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
@@ -217,6 +282,23 @@ export function registerSystemShellHandlers(_deps: HandlerDependencies): () => v
             shell.showItemInFolder(realTarget);
           } catch (error) {
             console.error("Failed to reveal item in folder:", error);
+            throw error;
+          }
+        }
+      ),
+      // User-initiated reveal of an OUTSIDE_ROOT path (the recovery action on
+      // a file-link toast). Bypasses roots containment but keeps the deny-list,
+      // realpath canonicalization, and a stat gate — see
+      // resolveRevealTargetUnconfined.
+      showItemInFolderUnconfined: opValidated(
+        CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED,
+        SystemShowItemInFolderUnconfinedPayloadSchema,
+        async (payload: SystemShowItemInFolderUnconfinedPayload): Promise<void> => {
+          try {
+            const realTarget = await resolveRevealTargetUnconfined(payload.path);
+            shell.showItemInFolder(realTarget);
+          } catch (error) {
+            console.error("Failed to reveal unconfined item in folder:", error);
             throw error;
           }
         }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1306,6 +1306,9 @@ function buildElectronApi(): ElectronAPI {
       showItemInFolder: (path: string) =>
         _unwrappingInvoke(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER, { path }),
 
+      showItemInFolderUnconfined: (path: string) =>
+        _unwrappingInvoke(CHANNELS.SYSTEM_SHOW_ITEM_IN_FOLDER_UNCONFINED, { path }),
+
       openInEditor: (payload: { path: string; line?: number; col?: number; projectId?: string }) =>
         _unwrappingInvoke(CHANNELS.SYSTEM_OPEN_IN_EDITOR, payload),
 

--- a/electron/schemas/index.ts
+++ b/electron/schemas/index.ts
@@ -27,6 +27,7 @@ export {
   VoiceInputCorrectPayloadSchema,
   SystemOpenExternalPayloadSchema,
   SystemOpenPathPayloadSchema,
+  SystemShowItemInFolderUnconfinedPayloadSchema,
   SystemOpenInEditorPayloadSchema,
   TerminalReplayHistoryPayloadSchema,
   DevPreviewStartPayloadSchema,

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -511,6 +511,7 @@ export const SystemShowItemInFolderUnconfinedPayloadSchema = z.object({
     .string()
     .min(1)
     .max(4096)
+    // eslint-disable-next-line no-control-regex
     .regex(/^[^\x00]*$/, "Null bytes not allowed"),
 });
 

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -501,6 +501,19 @@ export const SystemOpenPathPayloadSchema = z.object({
   path: z.string().min(1).max(4096),
 });
 
+// User-initiated reveal of a path that lives OUTSIDE project roots (the only
+// caller is the OUTSIDE_ROOT recovery action on a file-link toast). Null bytes
+// are rejected at the schema boundary (lesson #6263); roots containment is
+// intentionally NOT applied here — that's the whole point — so the handler
+// must keep the executable deny-list and realpath canonicalization itself.
+export const SystemShowItemInFolderUnconfinedPayloadSchema = z.object({
+  path: z
+    .string()
+    .min(1)
+    .max(4096)
+    .regex(/^[^\x00]*$/, "Null bytes not allowed"),
+});
+
 export const SystemOpenInEditorPayloadSchema = z.object({
   path: z.string().min(1).max(4096),
   line: z.number().int().positive().optional(),
@@ -724,6 +737,9 @@ export type FileReadPayload = z.infer<typeof FileReadPayloadSchema>;
 export type VoiceInputCorrectPayload = z.infer<typeof VoiceInputCorrectPayloadSchema>;
 export type SystemOpenExternalPayload = z.infer<typeof SystemOpenExternalPayloadSchema>;
 export type SystemOpenPathPayload = z.infer<typeof SystemOpenPathPayloadSchema>;
+export type SystemShowItemInFolderUnconfinedPayload = z.infer<
+  typeof SystemShowItemInFolderUnconfinedPayloadSchema
+>;
 export type SystemOpenInEditorPayload = z.infer<typeof SystemOpenInEditorPayloadSchema>;
 export type TerminalReplayHistoryPayload = z.infer<typeof TerminalReplayHistoryPayloadSchema>;
 export type DevPreviewStartPayload = z.infer<typeof DevPreviewStartPayloadSchema>;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -363,6 +363,7 @@ export interface ElectronAPI extends GeneratedElectronAPI {
     openExternal(url: string): Promise<void>;
     openPath(path: string): Promise<void>;
     showItemInFolder(path: string): Promise<void>;
+    showItemInFolderUnconfined(path: string): Promise<void>;
     openInEditor(payload: SystemOpenInEditorPayload & { projectId?: string }): Promise<void>;
     checkCommand(command: string): Promise<boolean>;
     checkDirectory(path: string): Promise<boolean>;

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -1300,6 +1300,10 @@ export interface GeneratedIpcInvokeMap {
     args: [payload: { path: string }];
     result: void;
   };
+  "system:show-item-in-folder-unconfined": {
+    args: [payload: { path: string }];
+    result: void;
+  };
   "telemetry:get": {
     args: [];
     result: { enabled: boolean; hasSeenPrompt: boolean };

--- a/src/clients/systemClient.ts
+++ b/src/clients/systemClient.ts
@@ -26,6 +26,10 @@ export const systemClient = {
     return window.electron.system.showItemInFolder(path);
   },
 
+  showItemInFolderUnconfined: (path: string): Promise<void> => {
+    return window.electron.system.showItemInFolderUnconfined(path);
+  },
+
   openInEditor: (payload: {
     path: string;
     line?: number;

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -28,23 +28,29 @@ export const FILE_LINK_ACTIVATION_COALESCE_KEY = "filelink-activate-fail";
 /**
  * Surface a file-link activation failure to the user as a single sticky,
  * coalesced error toast. The toast auto-promotes to `duration: 0` (sticky)
- * because the `Copy path` action button needs to stay clickable — the
- * toaster's 3s fallback would dismiss it before the user can act.
+ * because its action button needs to stay clickable — the toaster's 3s
+ * fallback would dismiss it before the user can act.
  *
  * The basename (not the full path) goes in the body so toast width stays
  * readable and so we don't echo long absolute paths into the persistent
- * inbox. The full path is only exposed via the clipboard, on explicit user
- * action.
+ * inbox. The full path is only exposed on explicit user action.
+ *
+ * The recovery action branches on the failure code: an OUTSIDE_ROOT failure
+ * offers "Reveal in File Manager" (the file is real, just outside the
+ * project — the user cmd-clicked it with intent, so revealing it in the OS
+ * file manager is the discoverable inverse), while every other failure keeps
+ * "Copy path". Reveal runs through the unconfined IPC op, which skips roots
+ * containment but keeps the executable deny-list.
  *
  * Coalesce caveat: when multiple failures fire inside the 1500ms window,
  * the `buildMessage`/`buildTitle` callbacks only know the *current* call's
  * body, so a coalesced toast can't honestly mix per-failure reasons. The
  * coalesced branch deliberately drops the per-failure body and shows a
  * generic "see inbox for details" message — every coalesced failure still
- * lands as its own inbox row carrying the real reason. The first-failure
- * Copy-path callback is preserved on the live toast (notify() patches with
- * the original `payload.action`), so it always copies a path the user
- * actually clicked.
+ * lands as its own inbox row carrying the real reason. notify() overwrites
+ * the singular `action` with the latest call's on each coalesce tick, so the
+ * key is split by affordance — otherwise a mixed OUTSIDE_ROOT / INVALID_PATH
+ * burst would flip a coalesced toast's button between Reveal and Copy path.
  */
 export function reportFileLinkFailure(reason: string, error: unknown, absolutePath: string): void {
   const code = isClientAppError(error) ? error.code : undefined;
@@ -64,6 +70,31 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
 
   const name = basename(absolutePath) || absolutePath || "file";
   const singleMessage = `${body} (${name})`;
+  const isOutsideRoot = code === "OUTSIDE_ROOT";
+  const coalesceKey = isOutsideRoot
+    ? `${FILE_LINK_ACTIVATION_COALESCE_KEY}:outside-root`
+    : FILE_LINK_ACTIVATION_COALESCE_KEY;
+  const action = isOutsideRoot
+    ? {
+        label: "Reveal in File Manager",
+        onClick: () => {
+          void systemClient.showItemInFolderUnconfined(absolutePath).catch((revealError) => {
+            logError("[FileLinksAddon] Failed to reveal out-of-root file link", revealError, {
+              absolutePath,
+            });
+          });
+        },
+      }
+    : {
+        label: "Copy path",
+        onClick: () => {
+          if (!navigator.clipboard) return;
+          void navigator.clipboard.writeText(absolutePath).catch(() => {
+            /* clipboard unavailable — sticky toast is the durable surface */
+          });
+        },
+      };
+
   notify({
     type: "error",
     title: "Couldn't open file link",
@@ -71,7 +102,7 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
     priority: "high",
     context: { eventKind: "uiFeedback" },
     coalesce: {
-      key: FILE_LINK_ACTIVATION_COALESCE_KEY,
+      key: coalesceKey,
       windowMs: 1500,
       buildTitle: (count) =>
         count <= 1 ? "Couldn't open file link" : `Couldn't open ${count} file links`,
@@ -82,15 +113,7 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
       buildMessage: (count) =>
         count <= 1 ? singleMessage : `Couldn't open ${count} file links — see inbox for details`,
     },
-    action: {
-      label: "Copy path",
-      onClick: () => {
-        if (!navigator.clipboard) return;
-        void navigator.clipboard.writeText(absolutePath).catch(() => {
-          /* clipboard unavailable — sticky toast is the durable surface */
-        });
-      },
-    },
+    action,
   });
 
   logError(`[FileLinksAddon] ${reason}`, error, { absolutePath });

--- a/src/services/terminal/FileLinksAddon.ts
+++ b/src/services/terminal/FileLinksAddon.ts
@@ -74,6 +74,15 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
   const coalesceKey = isOutsideRoot
     ? `${FILE_LINK_ACTIVATION_COALESCE_KEY}:outside-root`
     : FILE_LINK_ACTIVATION_COALESCE_KEY;
+  const copyPathAction = {
+    label: "Copy path",
+    onClick: () => {
+      if (!navigator.clipboard) return;
+      void navigator.clipboard.writeText(absolutePath).catch(() => {
+        /* clipboard unavailable — sticky toast is the durable surface */
+      });
+    },
+  };
   const action = isOutsideRoot
     ? {
         label: "Reveal in File Manager",
@@ -82,18 +91,20 @@ export function reportFileLinkFailure(reason: string, error: unknown, absolutePa
             logError("[FileLinksAddon] Failed to reveal out-of-root file link", revealError, {
               absolutePath,
             });
+            // The reveal was user-initiated, so a silent no-op is the wrong
+            // UX — the file may have been moved/deleted/blocked since the link
+            // was rendered. Surface the failure with Copy path as the recovery.
+            notify({
+              type: "error",
+              title: "Couldn't reveal file",
+              message: `${name} couldn't be revealed in your file manager`,
+              context: { eventKind: "uiFeedback" },
+              action: copyPathAction,
+            });
           });
         },
       }
-    : {
-        label: "Copy path",
-        onClick: () => {
-          if (!navigator.clipboard) return;
-          void navigator.clipboard.writeText(absolutePath).catch(() => {
-            /* clipboard unavailable — sticky toast is the durable surface */
-          });
-        },
-      };
+    : copyPathAction;
 
   notify({
     type: "error",

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -641,7 +641,7 @@ describe("FileLinksAddon", () => {
       expect(outsidePayload.coalesce?.key).not.toBe(invalidPayload.coalesce?.key);
     });
 
-    it("Reveal action catches a rejection without surfacing an unhandled promise", async () => {
+    it("Reveal action catches a rejection and surfaces a recovery toast", async () => {
       reportFileLinkFailure(
         "test",
         new Error(
@@ -658,8 +658,15 @@ describe("FileLinksAddon", () => {
       expect(() => payload.action?.onClick?.()).not.toThrow();
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(systemClient.showItemInFolderUnconfined).toHaveBeenCalledWith("/etc/outside.txt");
-      // Reaching here without an unhandled-rejection failure proves the catch
-      // swallowed the rejected reveal.
+      // The catch surfaced a recovery toast (Copy path) — proving the rejection
+      // was handled, not swallowed into a silent no-op.
+      expect(notify).toHaveBeenCalledTimes(2);
+      const recovery = vi.mocked(notify).mock.calls[1]?.[0] as {
+        title?: string;
+        action?: { label?: string };
+      };
+      expect(recovery.title).toBe("Couldn't reveal file");
+      expect(recovery.action?.label).toBe("Copy path");
     });
   });
 });

--- a/src/services/terminal/__tests__/FileLinksAddon.test.ts
+++ b/src/services/terminal/__tests__/FileLinksAddon.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Terminal, IBufferLine, ILink } from "@xterm/xterm";
-import { FileLinksAddon } from "../FileLinksAddon";
+import { FileLinksAddon, reportFileLinkFailure } from "../FileLinksAddon";
 import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { systemClient } from "@/clients";
@@ -14,7 +14,7 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 vi.mock("@/clients", () => ({
-  systemClient: { openPath: vi.fn(), openInEditor: vi.fn() },
+  systemClient: { openPath: vi.fn(), openInEditor: vi.fn(), showItemInFolderUnconfined: vi.fn() },
 }));
 
 describe("FileLinksAddon", () => {
@@ -385,6 +385,10 @@ describe("FileLinksAddon", () => {
       vi.mocked(actionService.dispatch).mockReset();
       vi.mocked(systemClient.openPath).mockReset();
       vi.mocked(systemClient.openInEditor).mockReset();
+      vi.mocked(systemClient.showItemInFolderUnconfined).mockReset();
+      // The real client returns Promise<void>; give the mock a resolved default
+      // so the Reveal action's fire-and-forget .catch() has a promise to chain.
+      vi.mocked(systemClient.showItemInFolderUnconfined).mockResolvedValue(undefined);
       Object.defineProperty(global.navigator, "clipboard", {
         value: { writeText: vi.fn().mockResolvedValue(undefined) },
         configurable: true,
@@ -436,10 +440,21 @@ describe("FileLinksAddon", () => {
       expect(payload.type).toBe("error");
       expect(payload.title).toBe("Couldn't open file link");
       expect(payload.priority).toBe("high");
-      expect(payload.coalesce?.key).toBe("filelink-activate-fail");
+      expect(payload.coalesce?.key).toBe("filelink-activate-fail:outside-root");
       expect(payload.message).toContain("Path is outside your project roots");
       expect(payload.message).toContain("App.tsx");
-      expect(payload.action?.label).toBe("Copy path");
+      // OUTSIDE_ROOT offers Reveal (the file is real, just outside roots) — not
+      // Copy path. The coalesce key is split so this action can't bleed into a
+      // coalesced INVALID_PATH / generic "Copy path" toast.
+      expect(payload.action?.label).toBe("Reveal in File Manager");
+
+      // Clicking Reveal routes the resolved absolute path (line/col stripped)
+      // through the unconfined IPC op — never auto, always user-initiated.
+      payload.action?.onClick?.();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(systemClient.showItemInFolderUnconfined).toHaveBeenCalledWith(
+        "/home/user/project/src/App.tsx"
+      );
     });
 
     it("surfaces INVALID_PATH (e.g. WSL UNC) using the code-aware message", async () => {
@@ -591,6 +606,60 @@ describe("FileLinksAddon", () => {
       expect(notify).toHaveBeenCalledTimes(1);
       const payload = vi.mocked(notify).mock.calls[0]?.[0] as { message: string };
       expect(payload.message).toContain("Path is not a valid file");
+    });
+
+    it("OUTSIDE_ROOT and INVALID_PATH produce distinct coalesce keys and actions (no bleed)", () => {
+      // notify() overwrites the singular action with the latest call's on each
+      // coalesce tick — a shared key would flip a coalesced toast's button
+      // between Reveal and Copy path across a mixed-code burst. Splitting the
+      // key by affordance keeps each toast honest.
+      reportFileLinkFailure(
+        "test",
+        new Error(
+          "[AppError|OUTSIDE_ROOT|Path is not in a project root] Path is not in a project root"
+        ),
+        "/etc/outside.txt"
+      );
+      reportFileLinkFailure(
+        "test",
+        new Error("[AppError|INVALID_PATH|Path is not a valid file] Path is not a valid file"),
+        "/bad/path.txt"
+      );
+
+      const outsidePayload = vi.mocked(notify).mock.calls[0]?.[0] as {
+        coalesce?: { key: string };
+        action?: { label: string };
+      };
+      const invalidPayload = vi.mocked(notify).mock.calls[1]?.[0] as {
+        coalesce?: { key: string };
+        action?: { label: string };
+      };
+      expect(outsidePayload.coalesce?.key).toBe("filelink-activate-fail:outside-root");
+      expect(outsidePayload.action?.label).toBe("Reveal in File Manager");
+      expect(invalidPayload.coalesce?.key).toBe("filelink-activate-fail");
+      expect(invalidPayload.action?.label).toBe("Copy path");
+      expect(outsidePayload.coalesce?.key).not.toBe(invalidPayload.coalesce?.key);
+    });
+
+    it("Reveal action catches a rejection without surfacing an unhandled promise", async () => {
+      reportFileLinkFailure(
+        "test",
+        new Error(
+          "[AppError|OUTSIDE_ROOT|Path is not in a project root] Path is not in a project root"
+        ),
+        "/etc/outside.txt"
+      );
+      const payload = vi.mocked(notify).mock.calls[0]?.[0] as {
+        action?: { onClick?: () => void };
+      };
+      vi.mocked(systemClient.showItemInFolderUnconfined).mockRejectedValueOnce(new Error("gone"));
+
+      // onClick is synchronous; the reveal is fire-and-forget with a .catch().
+      expect(() => payload.action?.onClick?.()).not.toThrow();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(systemClient.showItemInFolderUnconfined).toHaveBeenCalledWith("/etc/outside.txt");
+      // Reaching here without an unhandled-rejection failure proves the catch
+      // swallowed the rejected reveal.
     });
   });
 });


### PR DESCRIPTION
## Summary

- File links in the terminal that resolve outside the project roots used to dead-end on a `Couldn't open file link` toast with only a `Copy path` button. That failure toast now offers a `Reveal in File Manager` action for those paths.
- Reveal opens Finder on macOS, Explorer on Windows, and the default file manager on Linux, so out-of-root files are reachable without the copy-paste detour.
- The `assertPathAllowed` containment guard stays in force for the confined open and reveal paths, the executable-extension deny-list still applies, and nothing auto-launches. Reveal is strictly user-initiated.

Resolves #10941

## Changes

- New unconfined-reveal IPC channel in `systemShell.ts`, sitting alongside the existing reveal handler that stays on the confined route.
- Schemas and preload wired for the new channel (`electron/schemas/ipc.ts`, `electron/preload.cts`, generated types in `shared/types/ipc/`).
- `FileLinksAddon.ts` surfaces the `Reveal in File Manager` affordance on the out-of-root failure toast and surfaces reveal failures back through `notify`.
- Tests for the new IPC branches and the full guard chain.

## Testing

- `systemShell` handler tests cover the new reveal path, the executable deny-list, and the containment guard.
- `FileLinksAddon` tests cover the new affordance, the out-of-root branch, and failure surfacing.
- Branch test suite green; typecheck, lint, and format clean.