### PR TITLE
Add a generation-safe lifecycle ledger for agent terminals

### DIFF
--- a/docs/architecture/terminal-lifecycle.md
+++ b/docs/architecture/terminal-lifecycle.md
@@ -2,6 +2,14 @@
 
 This document describes the runtime lifecycle state for terminals across renderer, main, and PTY host.
 
+## Lifecycle ledger (generation safety)
+
+`AgentTerminalLifecycleLedger` (`shared/utils/agentLifecycleLedger.ts`) is a bounded, in-memory audit ledger instantiated once per process: main (`electron/services/pty/lifecycleLedger.ts`, the authority), the pty-host (a `PtyManager` member), and the renderer (`src/services/terminal/lifecycleLedger.ts`). Main mints a monotonic `launchGeneration` per terminal id in `PtyClient.spawn` — every spawn path (fresh, restart, resume, respawn-after-host-crash) funnels through it — and stamps it on the spawn options; the pty-host adopts it and echoes it on `exit` and `agent-session-captured` events so cross-process completions key to the same incarnation.
+
+The ledger records immutable launch facts per generation (launch/detected agent ids, cwd/project/worktree attribution with explicit-vs-inferred provenance, model/preset/flags, env provenance as sorted key names + content hash — never values — and initial/first-attach geometry) and validates lifecycle operations in two regimes: live-state ops (resize, restore, attach, detection) apply only to the CURRENT generation, while terminal-final ops (close, journal) are exactly-once PER generation and tolerate past generations, so a kill's journal write landing after a same-id respawn is neither dropped nor attributed to the successor.
+
+Load-bearing gates wired on it: `journalAgentSession` (`electron/services/pty/agentSessionJournal.ts`) is the single funnel for all four session-journal close paths (trash expiry, kill, gracefulKill, shutdown) and drops duplicate records per (terminalId, generation); `PtyManager` stamps buffered pre-spawn resizes with the generation current at buffering time and drops stale ones at the next spawn instead of booting the successor at dead geometry; the renderer's `addPanel` rejects spawn resolutions and hydration/reconnect merges that no longer belong to the live incarnation (stale persisted snapshots must not overwrite fresh launch metadata); and inferred (cwd-derived) worktree attribution never overwrites a differing explicit one. Rejections land in a bounded anomaly ring surfaced as the `lifecycleLedger` section of the diagnostics bundle (`DiagnosticsCollector`). The ledger is diagnostic-grade and never persisted — it is not a user-facing history.
+
 ## Runtime status model
 
 `TerminalRuntimeStatus` is a lightweight, runtime-only view used by the renderer store:

--- a/e2e/full/resilience/agent-lifecycle-ledger.spec.ts
+++ b/e2e/full/resilience/agent-lifecycle-ledger.spec.ts
@@ -1,0 +1,335 @@
+/**
+ * Agent-terminal lifecycle integrity across LRU eviction (lifecycle ledger).
+ *
+ * Launches a recipe terminal with caller-resolved env and a recipe cwd, cycles
+ * projects to force LRU eviction of its view, revives it, and verifies the
+ * LIVE PTY retained its launch identity (cwd + env) rather than merely its
+ * scrollback. Then closes it and asserts the main-process lifecycle ledger's
+ * diagnostics section carries the launch facts (env provenance as key names,
+ * never values) and no stale-generation / duplicate-journal anomalies.
+ */
+
+import { test, expect } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo, createFixtureRepoWithRecipes } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { addAndSwitchToProject, selectExistingProjectAndRefresh } from "../../helpers/workflows";
+import {
+  runTerminalCommand,
+  waitForTerminalText,
+  getTerminalTextById,
+} from "../../helpers/terminal";
+import { getGridPanelIds, getPanelById } from "../../helpers/panels";
+import { dismissBlockingPalette } from "../../helpers/overlays";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../../helpers/timeouts";
+
+// Project name stems — waitForActiveProject matches against the
+// `daintree-e2e-<stem>-XXXX` fixture directory basename via substring, so
+// these must equal the fixture repo names passed to createFixtureRepo*.
+const PROJECT_A = "ledger-a";
+const PROJECT_B = "ledger-b";
+const PROJECT_C = "ledger-c";
+
+const RECIPE_NAME = "Ledger Recipe";
+const RECIPE_ID = "inrepo-ledger-recipe";
+const ENV_KEY = "LEDGER_E2E_MARKER";
+const ENV_VALUE = "ledger-e2e-value";
+const CACHE_LIMIT = 2;
+
+let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
+let repoABasename = "";
+let projectIdA = "";
+let projectIdC = "";
+let recipePanelId = "";
+
+// The identity probes use POSIX shell expansion (`$VAR`, `$(basename …)`);
+// the resilience bucket also runs on Windows, where the default shell is
+// PowerShell/cmd. The lifecycle paths under test are platform-independent —
+// skip rather than fork per-shell probe syntax. Called at the top of every
+// test (the suite is serial and each test depends on the probes).
+const POSIX_SKIP_REASON = "POSIX shell probes are not portable to the Windows default shell";
+function skipOnWindows(): void {
+  test.info().annotations.push({ type: "platform-skip", description: POSIX_SKIP_REASON });
+  test.skip(process.platform === "win32", POSIX_SKIP_REASON);
+}
+
+async function configurePvm(app: AppContext["app"], limit: number): Promise<void> {
+  await app.evaluate((_electron, n) => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const pvm = getPvm?.() as
+      | {
+          setCachedViewLimit: (n: number) => void;
+          setLowMemoryFreeThresholdMb?: (mb: number | null) => void;
+        }
+      | null
+      | undefined;
+    pvm?.setLowMemoryFreeThresholdMb?.(null);
+    pvm?.setCachedViewLimit(n);
+  }, limit);
+}
+
+async function readPvmState(app: AppContext["app"]): Promise<{
+  viewCount: number;
+  projectIds: string[];
+  activeProjectId: string | null;
+}> {
+  return app.evaluate(() => {
+    const g = globalThis as Record<string, unknown>;
+    const getPvm = g.__daintreeGetPvm as (() => unknown) | undefined;
+    const pvm = getPvm?.() as
+      | {
+          getAllViews: () => Array<{ projectId: string }>;
+          getActiveProjectId: () => string | null;
+        }
+      | null
+      | undefined;
+    if (!pvm) return { viewCount: -1, projectIds: [], activeProjectId: null };
+    const views = pvm.getAllViews();
+    return {
+      viewCount: views.length,
+      projectIds: views.map((v) => v.projectId),
+      activeProjectId: pvm.getActiveProjectId(),
+    };
+  });
+}
+
+async function requireActiveProjectId(app: AppContext["app"], label: string): Promise<string> {
+  const state = await readPvmState(app);
+  if (!state.activeProjectId) {
+    throw new Error(`[lifecycle-ledger] expected active project id after opening ${label}`);
+  }
+  return state.activeProjectId;
+}
+
+async function dispatchAction(window: Page, actionId: string, args?: unknown): Promise<void> {
+  await window.evaluate(
+    (payload) => {
+      const dispatch = (
+        window as unknown as {
+          __daintreeDispatchAction?: (
+            id: string,
+            a?: unknown,
+            opts?: { source?: string; confirmed?: boolean }
+          ) => Promise<unknown>;
+        }
+      ).__daintreeDispatchAction;
+      if (typeof dispatch !== "function") {
+        throw new Error("__daintreeDispatchAction is not available");
+      }
+      return dispatch(payload.actionId, payload.args, { source: "menu", confirmed: true });
+    },
+    { actionId, args }
+  );
+}
+
+// Opens and closes the project-settings Recipes tab — the canonical trigger
+// for recipeStore.loadRecipes so the in-repo recipe is available to run.
+async function loadRecipesViaSettings(window: Page): Promise<void> {
+  await dismissBlockingPalette(window).catch(() => undefined);
+  await window.locator(SEL.toolbar.projectSwitcherTrigger).click();
+  const palette = window.locator(SEL.projectSwitcher.palette);
+  await expect(palette).toBeVisible({ timeout: T_MEDIUM });
+  await palette.locator(SEL.projectSwitcher.projectSettings).click();
+  await expect(window.locator(SEL.projectSettings.heading)).toBeVisible({ timeout: T_MEDIUM });
+  await window.locator(SEL.projectSettings.recipesTab).click();
+  await window.waitForTimeout(T_SETTLE);
+  await window.locator(SEL.projectSettings.closeButton).click();
+  await expect(window.locator(SEL.projectSettings.heading)).not.toBeVisible({ timeout: T_SHORT });
+}
+
+async function findPanelContaining(window: Page, text: string): Promise<string> {
+  let foundId = "";
+  await expect
+    .poll(
+      async () => {
+        const ids = await getGridPanelIds(window);
+        for (const id of ids) {
+          const content = await getTerminalTextById(window, id).catch(() => "");
+          if (content.includes(text)) {
+            foundId = id;
+            return true;
+          }
+        }
+        return false;
+      },
+      { timeout: T_LONG, intervals: [250, 500, 1000, 2000] }
+    )
+    .toBe(true);
+  return foundId;
+}
+
+test.describe
+  .serial("Agent lifecycle ledger: recipe launch → LRU eviction → revive → close", () => {
+  test.beforeAll(async () => {
+    test.setTimeout(300_000);
+
+    const repoA = createFixtureRepoWithRecipes({
+      name: "ledger-a",
+      inRepoRecipes: [
+        {
+          name: RECIPE_NAME,
+          terminals: [
+            {
+              type: "terminal",
+              title: "Ledger Term",
+              command: "echo LEDGER_RECIPE_READY",
+              env: { [ENV_KEY]: ENV_VALUE },
+            },
+          ],
+        },
+      ],
+    });
+    const repoB = createFixtureRepo({ name: "ledger-b" });
+    const repoC = createFixtureRepo({ name: "ledger-c" });
+    fixtureCleanups = [repoA.cleanup, repoB.cleanup, repoC.cleanup];
+    // The fixture dir carries a random mkdtemp suffix — derive the expected
+    // `basename $PWD` from the real path instead of assuming the stem.
+    repoABasename = repoA.dir.split("/").pop() ?? "";
+
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA.dir, PROJECT_A);
+    projectIdA = await requireActiveProjectId(ctx.app, PROJECT_A);
+
+    await configurePvm(ctx.app, CACHE_LIMIT);
+
+    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoB.dir, PROJECT_B);
+    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoC.dir, PROJECT_C);
+    projectIdC = await requireActiveProjectId(ctx.app, PROJECT_C);
+
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) {
+      await configurePvm(ctx.app, 5).catch(() => undefined);
+      await closeApp(ctx.app);
+    }
+    for (const cleanup of fixtureCleanups) cleanup();
+  });
+
+  test("recipe terminal launches with its caller-resolved env and recipe cwd", async () => {
+    skipOnWindows();
+    test.slow();
+
+    await loadRecipesViaSettings(ctx.window);
+    await dispatchAction(ctx.window, "recipe.run", { recipeId: RECIPE_ID });
+
+    recipePanelId = await findPanelContaining(ctx.window, "LEDGER_RECIPE_READY");
+    const panel: Locator = getPanelById(ctx.window, recipePanelId);
+
+    // Live identity probes — expansion happens in the spawned shell, so the
+    // expected strings can only come from PTY output, never the echoed input.
+    await runTerminalCommand(ctx.window, panel, `echo "MARKER:$${ENV_KEY}"`);
+    await waitForTerminalText(panel, `MARKER:${ENV_VALUE}`);
+
+    await runTerminalCommand(ctx.window, panel, 'echo "CWD:$(basename "$PWD")"');
+    await waitForTerminalText(panel, `CWD:${repoABasename}`);
+  });
+
+  test("live PTY keeps env and cwd identity across LRU eviction and revival", async () => {
+    skipOnWindows();
+    test.slow();
+
+    // A→B→C with cache=2 evicts A's view; poll until it is really gone so the
+    // return is a genuine cold start.
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_B);
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_C);
+    await expect
+      .poll(
+        async () => {
+          const state = await readPvmState(ctx.app);
+          return (
+            state.activeProjectId === projectIdC &&
+            !state.projectIds.includes(projectIdA) &&
+            state.viewCount >= 1 &&
+            state.viewCount <= CACHE_LIMIT
+          );
+        },
+        { timeout: T_LONG, intervals: [200, 400, 800, 1600] }
+      )
+      .toBe(true);
+
+    ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PROJECT_A);
+
+    // The revived view rehydrates the panel with restored scrollback — find it
+    // by the marker that only ever existed in PTY output.
+    const revivedId = await findPanelContaining(ctx.window, "LEDGER_RECIPE_READY");
+    const revivedPanel = getPanelById(ctx.window, revivedId);
+
+    // Fresh probes against the LIVE pty: identity must hold on the reattached
+    // process, not just in restored scrollback.
+    await runTerminalCommand(ctx.window, revivedPanel, `echo "MARKER2:$${ENV_KEY}"`);
+    await waitForTerminalText(revivedPanel, `MARKER2:${ENV_VALUE}`);
+
+    await runTerminalCommand(ctx.window, revivedPanel, 'echo "CWD2:$(basename "$PWD")"');
+    await waitForTerminalText(revivedPanel, `CWD2:${repoABasename}`);
+
+    recipePanelId = revivedId;
+  });
+
+  test("close is clean and the lifecycle ledger reports coherent facts with no anomalies", async () => {
+    skipOnWindows();
+    test.slow();
+
+    // Hard kill so the close reaches the PTY (trash would keep it alive under
+    // the TTL) — the exit event is what stamps the main ledger's close.
+    await dispatchAction(ctx.window, "terminal.kill", {
+      terminalId: recipePanelId,
+      confirmed: true,
+    });
+    await expect
+      .poll(async () => (await getGridPanelIds(ctx.window)).includes(recipePanelId), {
+        timeout: T_LONG,
+        intervals: [200, 400, 800],
+      })
+      .toBe(false);
+
+    // Main-process lifecycle ledger: launch facts are auditable in the support
+    // bundle — env as key names only, never values — and the whole flow
+    // (spawn, LRU cycle, revive, close) produced no stale-generation or
+    // duplicate-journal rejections for this terminal. Poll: panel removal in
+    // the renderer can precede the main-side exit event that stamps the close.
+    interface LedgerSection {
+      terminals: Array<{
+        terminalId: string;
+        facts: { env?: { keys: string[] }; worktreeId?: string };
+        closedAt?: number;
+      }>;
+      anomalies: Array<{ terminalId: string; reason: string }>;
+    }
+    const collectLedger = (): Promise<LedgerSection> =>
+      ctx.window.evaluate(async () => {
+        const review = await (
+          window as unknown as {
+            electron: {
+              system: {
+                collectDiagnosticsForReview: () => Promise<{ payload: Record<string, unknown> }>;
+              };
+            };
+          }
+        ).electron.system.collectDiagnosticsForReview();
+        return review.payload.lifecycleLedger as LedgerSection;
+      });
+
+    await expect
+      .poll(
+        async () => {
+          const ledger = await collectLedger();
+          const entry = ledger.terminals.find((t) => t.terminalId === recipePanelId);
+          return entry?.closedAt !== undefined;
+        },
+        { timeout: T_LONG, intervals: [500, 1000, 2000] }
+      )
+      .toBe(true);
+
+    const ledger = await collectLedger();
+    const entry = ledger.terminals.find((t) => t.terminalId === recipePanelId);
+    expect(entry?.facts.env?.keys).toContain(ENV_KEY);
+    expect(JSON.stringify(ledger)).not.toContain(ENV_VALUE);
+    expect(ledger.anomalies.filter((a) => a.terminalId === recipePanelId)).toEqual([]);
+  });
+});

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -6,8 +6,7 @@ import { CHANNELS } from "../../channels.js";
 import { broadcastToProjectRenderers, broadcastToRenderer } from "../../utils.js";
 import { events, type DaintreeEventMap } from "../../../services/events.js";
 import { mcpPaneConfigService } from "../../../services/McpPaneConfigService.js";
-import { persistAgentSession } from "../../../services/pty/agentSessionHistory.js";
-import { getAgentSessionRetentionDays } from "../../../services/pty/agentSessionRetention.js";
+import { journalAgentSession } from "../../../services/pty/agentSessionJournal.js";
 import type {
   SpawnResult,
   BroadcastWriteResultPayload,
@@ -154,29 +153,17 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
   // Resume records captured by the pty-host (trash expiry). Main is the
   // journal's single writer — the pty-host writing the file itself would race
   // main's own close-path writes (two processes, two write queues, one file)
-  // — so persist here with the real retention setting, then signal renderers.
+  // — so persist here through the exactly-once journal funnel, keyed by the
+  // capture's terminal generation, then signal renderers.
   const unsubSessionCaptured = events.on(
     "agent-session:captured",
     (payload: DaintreeEventMap["agent-session:captured"]) => {
-      void (async () => {
-        try {
-          const { app } = await import("electron");
-          await persistAgentSession(
-            payload.record,
-            app.getPath("userData"),
-            getAgentSessionRetentionDays()
-          );
-          // Signal AFTER the write lands so a refetch it triggers sees the record.
-          events.emit("agent-session:recorded", {
-            sessionId: payload.record.sessionId,
-            worktreeId: payload.record.worktreeId ?? null,
-            projectId: payload.record.projectId ?? null,
-            timestamp: Date.now(),
-          });
-        } catch (err) {
-          console.error("[TerminalEvents] Failed to persist captured agent session:", err);
-        }
-      })();
+      void journalAgentSession(payload.record, {
+        terminalId: payload.terminalId,
+        generation: payload.launchGeneration,
+      }).catch((err) => {
+        console.error("[TerminalEvents] Failed to persist captured agent session:", err);
+      });
     }
   );
   handlers.push(unsubSessionCaptured);

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -30,7 +30,6 @@ import {
   SettingTemplateError,
   substituteSettingsTemplates,
 } from "../../../services/settingsTemplateResolver.js";
-import { events } from "../../../services/events.js";
 import type * as PluginServiceModule from "../../../services/PluginService.js";
 
 type ValidatedTerminalSpawnOptions = z.output<typeof TerminalSpawnOptionsSchema>;
@@ -83,10 +82,11 @@ async function getPluginService(): Promise<PluginServiceSingleton> {
 import {
   listAgentSessions,
   clearAgentSessions,
-  persistAgentSession,
   pruneAgentSessions,
 } from "../../../services/pty/agentSessionHistory.js";
 import { getAgentSessionRetentionDays } from "../../../services/pty/agentSessionRetention.js";
+import { journalAgentSession } from "../../../services/pty/agentSessionJournal.js";
+import { getLifecycleLedger } from "../../../services/pty/lifecycleLedger.js";
 import type { WorkspaceClient } from "../../../services/WorkspaceClient.js";
 import { getDefaultShell } from "../../../services/pty/terminalShell.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
@@ -619,13 +619,17 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
   // expiry capture, the fourth close path that already journals.
   const persistCloseRecord = async (
     info: Awaited<ReturnType<typeof ptyClient.getTerminalAsync>>,
-    sessionId: string | null
+    sessionId: string | null,
+    generation?: number
   ): Promise<void> => {
     if (!sessionId || !info?.launchAgentId) return;
     try {
       const branch = await resolveBranchForMain(info.worktreeId, deps.worktreeService);
-      const { app } = await import("electron");
-      await persistAgentSession(
+      // journalAgentSession is the exactly-once funnel: it gates on the
+      // lifecycle ledger's (terminalId, generation) key — dropping a record a
+      // concurrent close path already journaled — persists with the real
+      // retention setting, and emits agent-session:recorded after the write.
+      await journalAgentSession(
         {
           sessionId,
           agentId: info.launchAgentId,
@@ -644,17 +648,8 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           cwd: info.cwd ?? undefined,
           branch,
         },
-        app.getPath("userData"),
-        getAgentSessionRetentionDays()
+        { terminalId: info.id, generation }
       );
-      // Signal AFTER the write lands so a refetch it triggers sees the record.
-      // Bridged to every renderer for live resume-list refresh.
-      events.emit("agent-session:recorded", {
-        sessionId,
-        worktreeId: info.worktreeId ?? null,
-        projectId: info.projectId ?? null,
-        timestamp: Date.now(),
-      });
     } catch (err) {
       console.warn("[TerminalLifecycle] Failed to persist agent session on close:", err);
     }
@@ -671,8 +666,12 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       // terminals through it. Plain terminals keep the original hard kill.
       const info = await ptyClient.getTerminalAsync(id).catch(() => null);
       if (info?.launchAgentId) {
+        // Freeze the generation BEFORE the kill: a restart can respawn this id
+        // while gracefulKill is in flight, and the record must stay attributed
+        // to the incarnation that produced it, not the successor.
+        const generation = getLifecycleLedger().currentGeneration(id);
         const sessionId = await ptyClient.gracefulKill(id);
-        await persistCloseRecord(info, sessionId);
+        await persistCloseRecord(info, sessionId, generation);
       } else {
         ptyClient.kill(id);
       }
@@ -687,8 +686,9 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       throw new Error("Invalid terminal ID: must be a string");
     }
     const info = await ptyClient.getTerminalAsync(id).catch(() => null);
+    const generation = getLifecycleLedger().currentGeneration(id);
     const sessionId = await ptyClient.gracefulKill(id);
-    await persistCloseRecord(info, sessionId);
+    await persistCloseRecord(info, sessionId, generation);
     return sessionId;
   };
 

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -3,8 +3,8 @@ import { app, dialog } from "electron";
 import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
 import { projectStore } from "../services/ProjectStore.js";
-import { persistAgentSession } from "../services/pty/agentSessionHistory.js";
-import { getAgentSessionRetentionDays } from "../services/pty/agentSessionRetention.js";
+import { journalAgentSession } from "../services/pty/agentSessionJournal.js";
+import { getLifecycleLedger } from "../services/pty/lifecycleLedger.js";
 import { getActiveAgentCount, showQuitWarning } from "../utils/quitWarning.js";
 import {
   disposeAgentAvailabilityStore,
@@ -176,6 +176,13 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         } catch {
           // Snapshot is best-effort; journaling below skips when info is absent.
         }
+        // Freeze each terminal's launch generation alongside the info snapshot,
+        // before any kill — the journal write below must stay attributed to the
+        // incarnation being shut down.
+        const ledger = getLifecycleLedger();
+        const generationById = new Map<string, number | undefined>(
+          [...terminalInfoById.keys()].map((id) => [id, ledger.currentGeneration(id)])
+        );
 
         const allProjects = projectStore.getAllProjects();
         const projectIds = allProjects.map((p) => p.id);
@@ -257,10 +264,12 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
             })
           );
 
-          const userData = app.getPath("userData");
           for (const { result, info } of capturedAgents) {
             try {
-              await persistAgentSession(
+              // Exactly-once funnel: the ledger key (terminalId, generation)
+              // drops a record another close path (e.g. a user kill landing
+              // mid-shutdown) already journaled for this incarnation.
+              await journalAgentSession(
                 {
                   sessionId: result.agentSessionId as string,
                   agentId: info.launchAgentId as string,
@@ -278,8 +287,7 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
                   cwd: info.cwd ?? undefined,
                   branch: info.worktreeId ? branchByWorktree.get(info.worktreeId) : undefined,
                 },
-                userData,
-                getAgentSessionRetentionDays()
+                { terminalId: result.id, generation: generationById.get(result.id) }
               );
             } catch (err) {
               console.warn("[MAIN] Failed to journal agent session on shutdown:", err);

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -1100,47 +1100,50 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
   }
 });
 
-ptyManager.on("exit", (id: string, exitCode: number, signal?: number) => {
-  // Release all pause holds and remove coordinator for this terminal
-  const coordinator = pauseCoordinators.get(id);
-  if (coordinator) {
-    coordinator.forceReleaseAll();
-    pauseCoordinators.delete(id);
-  }
-
-  // Drop any tracked pause-duration sources for this terminal so the next
-  // `pause-duration-gauge` tick doesn't emit a stale `heldDurationMs`
-  // for a terminal that no longer exists. Cleanup paths (this one,
-  // `disconnectWindow`, `clearQueue`, `dispose`) bypass the funnel
-  // because they don't carry a wire emission — a disconnected window
-  // or torn-down queue manager shouldn't trigger a "pause-end" wire
-  // event. The renderer is informed separately via terminal-exit /
-  // disconnect flows.
-  clearAllPauseSources(id);
-
-  // Clean up any active backpressure monitoring for this terminal
-  backpressureManager.cleanupTerminal(id);
-
-  // Flush pending batched data for exiting terminal, then clean up backpressure state
-  ipcQueueManager.clearQueue(id);
-  for (const conn of rendererConnections.values()) {
-    try {
-      conn.batcher.flushTerminal(id);
-    } catch {
-      // Port may already be closed — safe to ignore
+ptyManager.on(
+  "exit",
+  (id: string, exitCode: number, signal?: number, launchGeneration?: number) => {
+    // Release all pause holds and remove coordinator for this terminal
+    const coordinator = pauseCoordinators.get(id);
+    if (coordinator) {
+      coordinator.forceReleaseAll();
+      pauseCoordinators.delete(id);
     }
-    conn.portQueueManager.clearQueue(id);
+
+    // Drop any tracked pause-duration sources for this terminal so the next
+    // `pause-duration-gauge` tick doesn't emit a stale `heldDurationMs`
+    // for a terminal that no longer exists. Cleanup paths (this one,
+    // `disconnectWindow`, `clearQueue`, `dispose`) bypass the funnel
+    // because they don't carry a wire emission — a disconnected window
+    // or torn-down queue manager shouldn't trigger a "pause-end" wire
+    // event. The renderer is informed separately via terminal-exit /
+    // disconnect flows.
+    clearAllPauseSources(id);
+
+    // Clean up any active backpressure monitoring for this terminal
+    backpressureManager.cleanupTerminal(id);
+
+    // Flush pending batched data for exiting terminal, then clean up backpressure state
+    ipcQueueManager.clearQueue(id);
+    for (const conn of rendererConnections.values()) {
+      try {
+        conn.batcher.flushTerminal(id);
+      } catch {
+        // Port may already be closed — safe to ignore
+      }
+      conn.portQueueManager.clearQueue(id);
+    }
+
+    // Clean up IPC data mirror state
+    ipcDataMirrorTerminals.delete(id);
+
+    // Drop-tally entry dies with the terminal — the flow-control snapshot only
+    // reports live terminals, and the map stays bounded across long sessions.
+    terminalDropTallies.delete(id);
+
+    sendEvent({ type: "exit", id, exitCode, signal, launchGeneration });
   }
-
-  // Clean up IPC data mirror state
-  ipcDataMirrorTerminals.delete(id);
-
-  // Drop-tally entry dies with the terminal — the flow-control snapshot only
-  // reports live terminals, and the map stays bounded across long sessions.
-  terminalDropTallies.delete(id);
-
-  sendEvent({ type: "exit", id, exitCode, signal });
-});
+);
 
 ptyManager.on("error", (id: string, error: string) => {
   sendEvent({ type: "error", id, error });
@@ -1308,6 +1311,8 @@ events.on("terminal:restored", (payload) => {
 events.on("agent-session:captured", (payload) => {
   sendEvent({
     type: "agent-session-captured",
+    terminalId: payload.terminalId,
+    launchGeneration: payload.launchGeneration,
     record: payload.record,
   });
 });

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -54,7 +54,11 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
         }
 
         ptyManager.spawn(msg.id, msg.options);
-        spawnResult = { success: true, id: msg.id };
+        spawnResult = {
+          success: true,
+          id: msg.id,
+          launchGeneration: msg.options.launchGeneration,
+        };
 
         // Eagerly create coordinator so all subsystems can pause from the start
         getOrCreatePauseCoordinator(msg.id);
@@ -73,6 +77,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
         spawnResult = {
           success: false,
           id: msg.id,
+          launchGeneration: msg.options.launchGeneration,
           error: parseSpawnError(error),
         };
 

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -453,6 +453,31 @@ async function collectFlowControl(ptyClient?: PtyClient) {
   }
 }
 
+/**
+ * Agent-terminal lifecycle ledger snapshot: per-terminal launch facts
+ * (identity, provenance, generations) plus the anomaly ring buffer — the
+ * rejected stale/duplicate lifecycle operations. Secret-free by construction
+ * (env is key names + hash only) and cwd is sanitized like `collectTerminals`.
+ */
+async function collectLifecycleLedger() {
+  try {
+    const { getLifecycleLedger } = await import("./pty/lifecycleLedger.js");
+    const diagnostics = getLifecycleLedger().getDiagnostics();
+    return {
+      anomalies: diagnostics.anomalies,
+      terminals: diagnostics.terminals.map((t) => ({
+        ...t,
+        facts: {
+          ...t.facts,
+          cwd: t.facts.cwd ? sanitizePath(t.facts.cwd) : undefined,
+        },
+      })),
+    };
+  } catch {
+    return { error: "Failed to get lifecycle ledger snapshot" };
+  }
+}
+
 async function collectLogs() {
   try {
     const entries = logBuffer.getAll();
@@ -851,6 +876,7 @@ export async function collectDiagnosticsWithKeys(
     { key: "config", fn: collectStoreConfig },
     { key: "terminals", fn: () => collectTerminals(deps.ptyClient) },
     { key: "flowControl", fn: () => collectFlowControl(deps.ptyClient) },
+    { key: "lifecycleLedger", fn: collectLifecycleLedger },
     { key: "projectViews", fn: () => collectProjectViews(deps) },
     { key: "rendererMemory", fn: collectRendererMemory },
     { key: "memoryTrends", fn: collectMemoryTrends },

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -55,6 +55,7 @@ const logWarn = (msg: string, ctx?: Record<string, unknown>) =>
 import { getTrashedPidTracker } from "./TrashedPidTracker.js";
 import { helpSessionService } from "./HelpSessionService.js";
 import { helpSessionJobService } from "./HelpSessionJobService.js";
+import { getLifecycleLedger, ledgerFactsFromSpawnOptions } from "./pty/lifecycleLedger.js";
 import { RequestResponseBroker, BrokerError } from "./rpc/index.js";
 import { routeHostEvent, type PtyEventRouterDeps } from "./pty/PtyEventRouter.js";
 import { PtyHealthWatchdog } from "./pty/PtyHealthWatchdog.js";
@@ -338,6 +339,28 @@ export class PtyClient extends EventEmitter {
             helpSessionJobService.attachHelpSessionPid(pid);
           }
         },
+        // Lifecycle-ledger bookkeeping. Exits carry the host-adopted
+        // launchGeneration so a stale exit arriving after a same-id respawn
+        // closes its own incarnation, never the successor.
+        onTerminalExit: (id, exitCode, launchGeneration) => {
+          const ledger = getLifecycleLedger();
+          const generation = launchGeneration ?? ledger.currentGeneration(id);
+          if (generation !== undefined && ledger.currentGeneration(id) !== undefined) {
+            ledger.recordClose(id, generation, "exit", exitCode);
+          }
+        },
+        onSpawnResult: (id, result) => {
+          const ledger = getLifecycleLedger();
+          // Prefer the generation echoed by the host: a stale result from a
+          // killed predecessor must record against its own incarnation (where
+          // the ledger rejects it as stale), never the live successor's.
+          const generation = result.launchGeneration ?? ledger.currentGeneration(id);
+          if (generation === undefined || ledger.currentGeneration(id) === undefined) return;
+          const resolved = ledger.recordSpawnResolved(id, generation, result.success);
+          if (resolved.accepted && !result.success) {
+            ledger.recordClose(id, generation, `spawn-failed:${result.error?.code ?? "UNKNOWN"}`);
+          }
+        },
       },
       logWarn: (message) => console.warn(message),
     };
@@ -468,10 +491,24 @@ export class PtyClient extends EventEmitter {
       this.onPortRefresh();
     }
 
-    // Respawn terminals that were active when host crashed
+    // Respawn terminals that were active when host crashed. Each replay is a
+    // NEW incarnation — the previous PTY died with the host — so close the old
+    // generation and mint a fresh one. Without this, a session captured before
+    // the crash and one captured after would share a generation and the
+    // journal's exactly-once gate would drop the second record. (The initial
+    // host-ready replay in handleReady keeps its generation: nothing was ever
+    // delivered, so it is the same incarnation.)
+    const ledger = getLifecycleLedger();
     for (const [id, options] of this.pendingSpawns) {
       console.log(`[PtyClient] Respawning terminal: ${id}`);
-      this.send({ type: "spawn", id, options });
+      const previousGeneration = options.launchGeneration ?? ledger.currentGeneration(id);
+      if (previousGeneration !== undefined && ledger.currentGeneration(id) !== undefined) {
+        ledger.recordClose(id, previousGeneration, "pty-host-crash");
+      }
+      const generation = ledger.recordLaunch(id, ledgerFactsFromSpawnOptions(options));
+      const stamped: PtyHostSpawnOptions = { ...options, launchGeneration: generation };
+      this.pendingSpawns.set(id, stamped);
+      this.send({ type: "spawn", id, options: stamped });
     }
 
     // Re-enable IPC data mirrors that were active before crash
@@ -725,8 +762,21 @@ export class PtyClient extends EventEmitter {
         : undefined;
 
     const resolvedProjectId = normalizedProjectId ?? activeProjectId;
-    const resolvedOptions =
+    const projectResolvedOptions: PtyHostSpawnOptions =
       resolvedProjectId !== undefined ? { ...options, projectId: resolvedProjectId } : options;
+    // Mint the launch generation here — every spawn (fresh, restart, resume)
+    // funnels through this method, so the ledger sees each incarnation exactly
+    // once. The pty-host adopts the stamped generation and echoes it on exits
+    // and session captures, which is what lets close/journal events reject
+    // stale or duplicate completions instead of relying on timing.
+    const generation = getLifecycleLedger().recordLaunch(
+      id,
+      ledgerFactsFromSpawnOptions(projectResolvedOptions)
+    );
+    const resolvedOptions: PtyHostSpawnOptions = {
+      ...projectResolvedOptions,
+      launchGeneration: generation,
+    };
 
     this.pendingSpawns.set(id, resolvedOptions);
     this.send({ type: "spawn", id, options: resolvedOptions });

--- a/electron/services/PtyManager.ts
+++ b/electron/services/PtyManager.ts
@@ -33,6 +33,8 @@ import {
 import { computeSpawnContext, acquirePtyProcess } from "./pty/terminalSpawn.js";
 import { disposeTerminalSerializerService } from "./pty/TerminalSerializerService.js";
 import { deleteSessionFile } from "./pty/terminalSessionPersistence.js";
+import { ledgerFactsFromSpawnOptions } from "./pty/lifecycleLedger.js";
+import { AgentTerminalLifecycleLedger } from "../../shared/utils/agentLifecycleLedger.js";
 import { events } from "./events.js";
 import { getGitBranch } from "../utils/gitUtils.js";
 import type { GracefulKillResult, TerminalRetentionState } from "../../shared/types/pty-host.js";
@@ -75,7 +77,26 @@ export class PtyManager extends EventEmitter {
   // Applied as initial dims at spawn so the PTY boots at the correct size
   // (no SIGWINCH-after-start), avoiding the race between the renderer's
   // ResizeObserver/MessagePort resize and the slower spawn IPC round-trip.
-  private pendingResizes = new Map<string, { cols: number; rows: number }>();
+  // Each entry is stamped with the ledger generation current at buffering
+  // time (null = id never launched here): a resize buffered against a killed
+  // incarnation must not become the initial dims of its successor.
+  private pendingResizes = new Map<
+    string,
+    { cols: number; rows: number; generation: number | null }
+  >();
+  // Host-local lifecycle ledger. Adopts the generation Main stamped on spawn
+  // options so both processes key each incarnation identically; guards the
+  // pendingResizes buffer across same-id respawns and provides the audit
+  // trail for stale completions inside the host.
+  private lifecycleLedger = new AgentTerminalLifecycleLedger({
+    onAnomaly: (anomaly) => {
+      if (process.env.NODE_ENV === "production") return;
+      logWarn(
+        `Lifecycle invariant rejected: ${anomaly.op} on ${anomaly.terminalId} ` +
+          `(gen ${anomaly.generation ?? "?"} vs current ${anomaly.currentGeneration ?? "?"}): ${anomaly.reason}`
+      );
+    },
+  });
 
   constructor() {
     super();
@@ -338,12 +359,6 @@ export class PtyManager extends EventEmitter {
    */
   spawn(id: string, options: PtySpawnOptions): void {
     const pendingResize = this.pendingResizes.get(id);
-    if (pendingResize) {
-      options = { ...options, cols: pendingResize.cols, rows: pendingResize.rows };
-      // Defer the delete until spawn definitively succeeds (just before
-      // registry.add) so a thrown acquirePtyProcess / TerminalProcess
-      // constructor preserves the buffered dims for a caller retry.
-    }
 
     if (this.registry.has(id)) {
       const existing = this.registry.get(id);
@@ -356,6 +371,36 @@ export class PtyManager extends EventEmitter {
     logInfo(
       `Spawning terminal ${id} (kind: ${options.kind}, launchAgentId: ${options.launchAgentId})`
     );
+
+    // Adopt Main's generation (or mint locally for direct callers/tests) BEFORE
+    // consuming any buffered resize, so the staleness check below compares the
+    // buffered stamp against this incarnation.
+    this.lifecycleLedger.recordLaunch(id, ledgerFactsFromSpawnOptions(options), {
+      generation: options.launchGeneration,
+    });
+
+    if (pendingResize) {
+      // A null stamp is the classic pre-first-spawn race (renderer resize beat
+      // the spawn IPC) — apply as initial dims. A non-null stamp belongs to a
+      // previous incarnation of this id; recordResize rejects it as stale so
+      // it never becomes the successor's boot geometry.
+      const applies =
+        pendingResize.generation === null ||
+        this.lifecycleLedger.recordResize(
+          id,
+          pendingResize.generation,
+          pendingResize.cols,
+          pendingResize.rows
+        ).accepted;
+      if (applies) {
+        options = { ...options, cols: pendingResize.cols, rows: pendingResize.rows };
+        // Defer the delete until spawn definitively succeeds (just before
+        // registry.add) so a thrown acquirePtyProcess / TerminalProcess
+        // constructor preserves the buffered dims for a caller retry.
+      } else {
+        this.pendingResizes.delete(id);
+      }
+    }
 
     const spawnContext = computeSpawnContext(id, options);
     const acquired = acquirePtyProcess(
@@ -386,7 +431,7 @@ export class PtyManager extends EventEmitter {
             if (this.registry.get(termId) !== terminalProcess) {
               return;
             }
-            this.emit("exit", termId, exitCode, signal);
+            this.emit("exit", termId, exitCode, signal, options.launchGeneration);
             if (!terminalProcess.shouldPreserveOnExit(exitCode)) {
               this.registry.delete(termId);
             }
@@ -505,7 +550,14 @@ export class PtyManager extends EventEmitter {
       terminal.resize(cols, rows);
     } else {
       // Buffer the dims and apply them at spawn time. Coalesces last-write-wins.
-      this.pendingResizes.set(id, { cols, rows });
+      // Stamp the current ledger generation (null = never launched) so a
+      // resize buffered against a killed incarnation is dropped at the next
+      // spawn instead of becoming its initial dims.
+      this.pendingResizes.set(id, {
+        cols,
+        rows,
+        generation: this.lifecycleLedger.currentGeneration(id) ?? null,
+      });
       logDebug(`Terminal ${id} not yet registered, buffering resize ${cols}x${rows}`);
     }
   }
@@ -577,6 +629,8 @@ export class PtyManager extends EventEmitter {
             // real retention setting. Forwarded by the pty-host entry, bridged
             // onto the main bus, persisted in the terminal event handlers.
             events.emit("agent-session:captured", {
+              terminalId: termId,
+              launchGeneration: info.launchGeneration,
               record: {
                 sessionId,
                 agentId: info.launchAgentId,
@@ -1032,6 +1086,7 @@ export class PtyManager extends EventEmitter {
 
     this.registry.dispose();
     this.pendingResizes.clear();
+    this.lifecycleLedger.clear();
     this.removeAllListeners();
 
     disposeTerminalSerializerService();

--- a/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyClient.lifecycleLedger.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { EventEmitter } from "events";
+import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+
+const shared = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+  const appEmitter = new EventEmitter();
+  const appMock = Object.assign(appEmitter, {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+  });
+  return {
+    forkMock: vi.fn(),
+    tracker: {
+      removeTrashed: vi.fn(),
+      persistTrashed: vi.fn(),
+      clearAll: vi.fn(),
+    },
+    appMock,
+  };
+});
+
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: shared.forkMock,
+  },
+  UtilityProcess: EventEmitter,
+  MessagePortMain: class {},
+  app: shared.appMock,
+}));
+
+vi.mock("../TrashedPidTracker.js", () => ({
+  getTrashedPidTracker: () => shared.tracker,
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  isValidLogOverrideLevel: vi.fn(() => true),
+}));
+
+interface MockUtilityProcess extends EventEmitter {
+  postMessage: Mock;
+  kill: Mock;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  pid?: number;
+}
+
+function createMockChild(): MockUtilityProcess {
+  return Object.assign(new EventEmitter(), {
+    postMessage: vi.fn(),
+    kill: vi.fn(),
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    pid: 321,
+  });
+}
+
+function spawnMessages(
+  child: MockUtilityProcess
+): Array<{ id: string; options: PtyHostSpawnOptions }> {
+  return child.postMessage.mock.calls
+    .map(
+      (call: unknown[]) => call[0] as { type?: string; id?: string; options?: PtyHostSpawnOptions }
+    )
+    .filter((msg) => msg?.type === "spawn")
+    .map((msg) => ({ id: msg.id!, options: msg.options! }));
+}
+
+describe("PtyClient lifecycle ledger", () => {
+  let mockChild: MockUtilityProcess;
+  let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
+  let getLifecycleLedger: typeof import("../pty/lifecycleLedger.js").getLifecycleLedger;
+  let disposeLifecycleLedger: typeof import("../pty/lifecycleLedger.js").disposeLifecycleLedger;
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.clearAllMocks();
+    shared.appMock.removeAllListeners();
+    mockChild = createMockChild();
+    shared.forkMock.mockReturnValue(mockChild);
+
+    ({ PtyClient: PtyClientClass } = await import("../PtyClient.js"));
+    ({ getLifecycleLedger, disposeLifecycleLedger } = await import("../pty/lifecycleLedger.js"));
+    disposeLifecycleLedger();
+  });
+
+  afterEach(() => {
+    disposeLifecycleLedger();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function createReadyClient(): import("../PtyClient.js").PtyClient {
+    const client = new PtyClientClass();
+    mockChild.emit("message", { type: "ready" });
+    return client;
+  }
+
+  const baseOptions: PtyHostSpawnOptions = {
+    cwd: "/repo/wt-a",
+    cols: 80,
+    rows: 24,
+    launchAgentId: "claude",
+    agentModelId: "opus",
+    worktreeId: "wt-a",
+    env: { ANTHROPIC_BASE_URL: "https://proxy.example" },
+  };
+
+  it("mints and stamps launchGeneration on every spawn of an id", () => {
+    const client = createReadyClient();
+
+    client.spawn("t1", baseOptions);
+    client.kill("t1");
+    client.spawn("t1", baseOptions);
+
+    const spawns = spawnMessages(mockChild);
+    expect(spawns.map((s) => s.options.launchGeneration)).toEqual([1, 2]);
+    expect(getLifecycleLedger().currentGeneration("t1")).toBe(2);
+
+    // Launch facts recorded with env provenance, never values.
+    const entry = getLifecycleLedger().getEntry("t1");
+    expect(entry?.facts).toMatchObject({
+      launchAgentId: "claude",
+      agentModelId: "opus",
+      worktreeId: "wt-a",
+      worktreeSource: "explicit",
+    });
+    expect(entry?.facts.env?.keys).toEqual(["ANTHROPIC_BASE_URL"]);
+    expect(JSON.stringify(entry)).not.toContain("proxy.example");
+  });
+
+  it("replays crashed-host spawns under fresh generations and closes the old ones", () => {
+    const client = createReadyClient();
+    const ledger = getLifecycleLedger();
+    client.spawn("t1", baseOptions);
+    expect(ledger.currentGeneration("t1")).toBe(1);
+
+    const restartedChild = createMockChild();
+    shared.forkMock.mockReturnValue(restartedChild);
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    mockChild.emit("exit", 1);
+    vi.advanceTimersByTime(200);
+    restartedChild.emit("message", { type: "ready" });
+
+    const replayed = spawnMessages(restartedChild);
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0]?.options.launchGeneration).toBe(2);
+    expect(ledger.currentGeneration("t1")).toBe(2);
+
+    // Old incarnation closed as a host crash; its journal slot is independent
+    // of the replayed generation's.
+    expect(ledger.recordClose("t1", 1, "late")).toMatchObject({
+      accepted: false,
+      reason: "duplicate-close",
+    });
+    expect(ledger.recordJournal("t1", 1, "sess-before-crash").accepted).toBe(true);
+    expect(ledger.recordJournal("t1", 2, "sess-after-crash").accepted).toBe(true);
+  });
+
+  it("keeps the same generation for the initial-ready replay (nothing was delivered)", () => {
+    // Deferred start: spawn before the host is ready.
+    const client = new PtyClientClass({ deferStart: true });
+    client.start();
+    client.spawn("t1", baseOptions);
+    mockChild.emit("message", { type: "ready" });
+
+    const spawns = spawnMessages(mockChild);
+    // One replayed spawn on ready (the pre-ready send is dropped by transport,
+    // but both stamped messages carry the SAME generation — same incarnation).
+    expect(spawns.length).toBeGreaterThanOrEqual(1);
+    for (const spawn of spawns) {
+      expect(spawn.options.launchGeneration).toBe(1);
+    }
+    expect(getLifecycleLedger().currentGeneration("t1")).toBe(1);
+  });
+
+  it("attributes exit events to the generation they carry, not the successor", () => {
+    const client = createReadyClient();
+    const ledger = getLifecycleLedger();
+
+    client.spawn("t1", baseOptions);
+    client.kill("t1");
+    client.spawn("t1", baseOptions); // restart reuses the id → generation 2
+
+    // The killed incarnation's exit arrives late, stamped with generation 1.
+    mockChild.emit("message", { type: "exit", id: "t1", exitCode: 137, launchGeneration: 1 });
+
+    const entry = ledger.getEntry("t1");
+    expect(entry?.generation).toBe(2);
+    expect(entry?.closedAt).toBeUndefined();
+
+    // The live incarnation's own exit still closes it.
+    mockChild.emit("message", { type: "exit", id: "t1", exitCode: 0, launchGeneration: 2 });
+    expect(ledger.getEntry("t1")?.closedAt).toBeDefined();
+    expect(ledger.getEntry("t1")?.exitCode).toBe(0);
+  });
+
+  it("records spawn failures as resolved+closed for the failing generation", () => {
+    const client = createReadyClient();
+    const ledger = getLifecycleLedger();
+
+    client.spawn("t1", baseOptions);
+    mockChild.emit("message", {
+      type: "spawn-result",
+      id: "t1",
+      result: { success: false, id: "t1", error: { code: "ENOENT", message: "no shell" } },
+    });
+
+    const entry = ledger.getEntry("t1");
+    expect(entry?.spawnOk).toBe(false);
+    expect(entry?.closedAt).toBeDefined();
+    expect(entry?.closeReason).toBe("spawn-failed:ENOENT");
+  });
+
+  it("a stale spawn failure from a killed predecessor cannot clear the successor", () => {
+    const client = createReadyClient();
+    const ledger = getLifecycleLedger();
+
+    client.spawn("t1", baseOptions); // generation 1
+    client.kill("t1");
+    client.spawn("t1", baseOptions); // generation 2, live
+
+    // The predecessor's failure result arrives late, stamped with its own
+    // generation. It must neither drop the successor's pendingSpawns entry
+    // (host-crash replay would lose the terminal) nor close its ledger entry.
+    mockChild.emit("message", {
+      type: "spawn-result",
+      id: "t1",
+      result: {
+        success: false,
+        id: "t1",
+        launchGeneration: 1,
+        error: { code: "ENOENT", message: "no shell" },
+      },
+    });
+
+    expect(client.hasTerminal("t1")).toBe(true);
+    const entry = ledger.getEntry("t1");
+    expect(entry?.generation).toBe(2);
+    expect(entry?.closedAt).toBeUndefined();
+    expect(entry?.spawnOk).toBeUndefined();
+  });
+
+  it("records successful spawn resolution", () => {
+    const client = createReadyClient();
+    client.spawn("t1", baseOptions);
+    mockChild.emit("message", {
+      type: "spawn-result",
+      id: "t1",
+      result: { success: true, id: "t1" },
+    });
+    expect(getLifecycleLedger().getEntry("t1")?.spawnOk).toBe(true);
+  });
+});

--- a/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
+++ b/electron/services/__tests__/PtyManager.lifecycleLedger.test.ts
@@ -1,0 +1,309 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+
+const shared = vi.hoisted(() => ({
+  terminals: new Map<string, MockTerminalProcess>(),
+  created: [] as MockTerminalProcess[],
+  trashCallbacks: new Map<string, (id: string) => void>(),
+  eventsEmit: vi.fn(),
+  computeSpawnContext: vi.fn(),
+  acquirePtyProcess: vi.fn(),
+  agentTransitionState: vi.fn(),
+  agentEmitKilled: vi.fn(),
+  disposeSerializer: vi.fn(),
+  deleteSessionFile: vi.fn(),
+  getGitBranch: vi.fn(),
+}));
+
+type MockPtyProcess = Pick<IPty, "kill" | "pid" | "cols" | "rows" | "process">;
+
+interface TerminalCallbacks {
+  emitData: (id: string, data: string | Uint8Array) => void;
+  onExit: (id: string, exitCode: number) => void;
+}
+
+class MockTerminalProcess {
+  id: string;
+  options: PtyHostSpawnOptions;
+  callbacks: TerminalCallbacks;
+  sessionId: string | null = null;
+  info: {
+    id: string;
+    cwd: string;
+    cols: number;
+    rows: number;
+    kind?: string;
+    launchAgentId?: string;
+    launchGeneration?: number;
+    projectId?: string;
+    worktreeId?: string;
+    title?: string;
+    titleMode?: string;
+    lastObservedTitle?: string;
+    agentLaunchFlags?: string[];
+    agentModelId?: string;
+    spawnedAt: number;
+    isExited: boolean;
+    wasKilled: boolean;
+    outputBuffer: string;
+    semanticBuffer: string[];
+    restartCount: number;
+  };
+  kill = vi.fn(() => {
+    this.info.wasKilled = true;
+  });
+  resize = vi.fn((cols: number, rows: number) => {
+    this.info.cols = cols;
+    this.info.rows = rows;
+  });
+  setSabModeEnabled = vi.fn();
+  dispose = vi.fn();
+  getActivityTier = vi.fn(() => "active" as const);
+
+  constructor(
+    id: string,
+    options: PtyHostSpawnOptions,
+    callbacks: TerminalCallbacks,
+    _deps: unknown,
+    _spawnContext: unknown,
+    _ptyProcess: MockPtyProcess
+  ) {
+    this.id = id;
+    this.options = options;
+    this.callbacks = callbacks;
+    this.info = {
+      id,
+      cwd: options.cwd,
+      cols: options.cols,
+      rows: options.rows,
+      kind: options.kind,
+      launchAgentId: options.launchAgentId,
+      launchGeneration: options.launchGeneration,
+      projectId: options.projectId,
+      worktreeId: options.worktreeId,
+      title: options.title,
+      agentLaunchFlags: options.agentLaunchFlags,
+      agentModelId: options.agentModelId,
+      spawnedAt: Date.now(),
+      isExited: false,
+      wasKilled: false,
+      outputBuffer: "",
+      semanticBuffer: [],
+      restartCount: 0,
+    };
+    shared.created.push(this);
+  }
+
+  getInfo() {
+    return this.info;
+  }
+
+  shouldPreserveOnExit(): boolean {
+    return false;
+  }
+
+  gracefulShutdown(): Promise<string | null> {
+    return Promise.resolve(this.sessionId);
+  }
+}
+
+class MockTerminalRegistry {
+  add(id: string, terminal: MockTerminalProcess): void {
+    shared.terminals.set(id, terminal);
+  }
+  get(id: string): MockTerminalProcess | undefined {
+    return shared.terminals.get(id);
+  }
+  delete(id: string): void {
+    shared.terminals.delete(id);
+  }
+  has(id: string): boolean {
+    return shared.terminals.has(id);
+  }
+  getAll(): MockTerminalProcess[] {
+    return Array.from(shared.terminals.values());
+  }
+  getAllIds(): string[] {
+    return Array.from(shared.terminals.keys());
+  }
+  entries(): IterableIterator<[string, MockTerminalProcess]> {
+    return shared.terminals.entries();
+  }
+  trash(id: string, onExpire: (id: string) => void): void {
+    shared.trashCallbacks.set(id, onExpire);
+  }
+  clearTrashTimeout(_id: string): void {}
+  isInTrash(_id: string): boolean {
+    return false;
+  }
+  getTrashExpiresAt(_id: string): number | undefined {
+    return undefined;
+  }
+  dispose(): void {
+    shared.terminals.clear();
+  }
+}
+
+class MockAgentStateService {
+  transitionState = shared.agentTransitionState;
+  emitAgentKilled = shared.agentEmitKilled;
+}
+
+vi.mock("../pty/terminalSpawn.js", () => ({
+  computeSpawnContext: shared.computeSpawnContext,
+  acquirePtyProcess: shared.acquirePtyProcess,
+}));
+
+vi.mock("../pty/index.js", () => ({
+  TerminalRegistry: MockTerminalRegistry,
+  AgentStateService: MockAgentStateService,
+  TerminalProcess: MockTerminalProcess,
+  TerminalSnapshot: class {},
+  MAX_PRESERVED_TERMINAL_SNAPSHOTS: 20,
+}));
+
+vi.mock("../events.js", () => ({
+  events: {
+    emit: shared.eventsEmit,
+  },
+}));
+
+vi.mock("../pty/TerminalSerializerService.js", () => ({
+  disposeTerminalSerializerService: shared.disposeSerializer,
+}));
+
+vi.mock("../pty/terminalSessionPersistence.js", () => ({
+  deleteSessionFile: shared.deleteSessionFile,
+}));
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitBranch: shared.getGitBranch,
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  createLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+const { PtyManager } = await import("../PtyManager.js");
+
+function createPtyProcess(): MockPtyProcess {
+  return {
+    kill: vi.fn(),
+    pid: 123,
+    cols: 80,
+    rows: 24,
+    process: "zsh",
+  };
+}
+
+function spawnOptions(overrides?: Partial<PtyHostSpawnOptions>): PtyHostSpawnOptions {
+  return {
+    cwd: "/repo",
+    cols: 80,
+    rows: 24,
+    kind: "terminal",
+    ...overrides,
+  };
+}
+
+describe("PtyManager lifecycle ledger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shared.terminals.clear();
+    shared.created.length = 0;
+    shared.trashCallbacks.clear();
+    shared.computeSpawnContext.mockReturnValue({
+      env: {},
+      shell: "/bin/zsh",
+      args: ["-l"],
+    });
+    shared.acquirePtyProcess.mockImplementation(() => ({
+      ptyProcess: createPtyProcess(),
+      prelude: "",
+      dataHandoff: undefined,
+    }));
+    shared.agentTransitionState.mockReturnValue(true);
+    shared.deleteSessionFile.mockResolvedValue(undefined);
+    shared.getGitBranch.mockResolvedValue("feature/x");
+  });
+
+  it("applies a pre-first-spawn buffered resize as initial dims", () => {
+    const manager = new PtyManager();
+
+    // Renderer resize beats the spawn IPC — the classic race the buffer serves.
+    manager.resize("t1", 132, 43);
+    manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
+
+    expect(shared.created[0]?.options.cols).toBe(132);
+    expect(shared.created[0]?.options.rows).toBe(43);
+  });
+
+  it("drops a buffered resize stamped by a previous incarnation", () => {
+    const manager = new PtyManager();
+
+    manager.spawn("t1", spawnOptions({ launchGeneration: 1 }));
+    manager.kill("t1");
+    shared.created[0]!.callbacks.onExit("t1", 0);
+
+    // Stale resize from the killed incarnation lands after the kill removed
+    // the pendingResizes entry but before the respawn — buffered, stamped
+    // with generation 1.
+    manager.resize("t1", 500, 2);
+
+    manager.spawn("t1", spawnOptions({ launchGeneration: 2 }));
+
+    // The successor boots at its own spawn dims, not the stale geometry.
+    expect(shared.created[1]?.options.cols).toBe(80);
+    expect(shared.created[1]?.options.rows).toBe(24);
+  });
+
+  it("still applies a buffered resize when spawn adopts a fresh external generation", () => {
+    const manager = new PtyManager();
+
+    manager.resize("t1", 100, 30);
+    manager.spawn("t1", spawnOptions({ launchGeneration: 7 }));
+
+    expect(shared.created[0]?.options.cols).toBe(100);
+    expect(shared.created[0]?.options.rows).toBe(30);
+  });
+
+  it("stamps terminalId and launchGeneration on trash-expiry session captures", async () => {
+    const manager = new PtyManager();
+
+    manager.spawn(
+      "t1",
+      spawnOptions({
+        launchAgentId: "claude",
+        launchGeneration: 3,
+        worktreeId: "wt-a",
+        agentModelId: "opus",
+      })
+    );
+    shared.created[0]!.sessionId = "sess-1";
+    shared.created[0]!.info.title = "Claude";
+
+    manager.trash("t1");
+    shared.trashCallbacks.get("t1")!("t1");
+    await vi.waitFor(() => {
+      expect(shared.eventsEmit).toHaveBeenCalledWith(
+        "agent-session:captured",
+        expect.objectContaining({
+          terminalId: "t1",
+          launchGeneration: 3,
+          record: expect.objectContaining({
+            sessionId: "sess-1",
+            agentId: "claude",
+            worktreeId: "wt-a",
+            agentModelId: "opus",
+          }),
+        })
+      );
+    });
+  });
+});

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -757,6 +757,10 @@ export type DaintreeEventMap = {
    * `agent-session:recorded`.
    */
   "agent-session:captured": {
+    /** Terminal whose close produced the record — keys ledger dedupe. */
+    terminalId: string;
+    /** Launch generation of that terminal incarnation, when known. */
+    launchGeneration?: number;
     record: Omit<
       import("../../shared/types/ipc/agentSessionHistory.js").AgentSessionRecord,
       "savedAt"

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -66,6 +66,17 @@ export interface PtyEventRouterCallbacks {
    * pure side effect.
    */
   onTerminalPid?: (id: string, pid: number) => void;
+  /**
+   * Optional. Fires on every `exit` event so the lifecycle ledger can record
+   * the close against the exiting incarnation's generation. Pure side effect.
+   */
+  onTerminalExit?: (id: string, exitCode: number, launchGeneration?: number) => void;
+  /**
+   * Optional. Fires on every `spawn-result` (after `pendingSpawns` cleanup on
+   * failure) so the lifecycle ledger can record spawn resolution. Pure side
+   * effect.
+   */
+  onSpawnResult?: (id: string, result: SpawnResult) => void;
 }
 
 export interface PtyEventRouterDeps {
@@ -147,6 +158,13 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
         state.pendingSpawns.delete(event.id);
       }
       state.terminalPids.delete(event.id);
+      if (callbacks.onTerminalExit) {
+        try {
+          callbacks.onTerminalExit(event.id, event.exitCode, event.launchGeneration);
+        } catch (err) {
+          deps.logWarn(`[PtyClient] onTerminalExit threw for ${event.id}: ${String(err)}`);
+        }
+      }
       emitter.emit("exit", event.id, event.exitCode, event.signal);
       return true;
     }
@@ -266,8 +284,29 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
     case "spawn-result": {
       const spawnResultEvent: { id: string; result: SpawnResult } = event;
       if (!spawnResultEvent.result.success) {
-        // Remove from pending spawns since spawn failed
-        state.pendingSpawns.delete(spawnResultEvent.id);
+        // Remove from pending spawns since spawn failed — but only when the
+        // failure belongs to the entry we still hold. A stale failure from a
+        // killed predecessor (same id, older launchGeneration) must not clear
+        // the live successor's replay entry.
+        const pending = state.pendingSpawns.get(spawnResultEvent.id);
+        const resultGeneration = spawnResultEvent.result.launchGeneration;
+        if (
+          pending === undefined ||
+          resultGeneration === undefined ||
+          pending.launchGeneration === undefined ||
+          pending.launchGeneration === resultGeneration
+        ) {
+          state.pendingSpawns.delete(spawnResultEvent.id);
+        }
+      }
+      if (callbacks.onSpawnResult) {
+        try {
+          callbacks.onSpawnResult(spawnResultEvent.id, spawnResultEvent.result);
+        } catch (err) {
+          deps.logWarn(
+            `[PtyClient] onSpawnResult threw for ${spawnResultEvent.id}: ${String(err)}`
+          );
+        }
       }
       emitter.emit("spawn-result", spawnResultEvent.id, spawnResultEvent.result);
       return true;

--- a/electron/services/pty/PtyEventsBridge.ts
+++ b/electron/services/pty/PtyEventsBridge.ts
@@ -161,7 +161,11 @@ export function bridgePtyEvent(event: PtyHostEvent, config?: PtyEventsBridgeConf
       return true;
 
     case "agent-session-captured":
-      events.emit("agent-session:captured", { record: event.record });
+      events.emit("agent-session:captured", {
+        terminalId: event.terminalId,
+        launchGeneration: event.launchGeneration,
+        record: event.record,
+      });
       return true;
 
     case "terminal-status": {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -452,6 +452,7 @@ export class TerminalProcess {
       agentPresetId: options.agentPresetId,
       agentPresetColor: options.agentPresetColor,
       originalAgentPresetId: options.originalAgentPresetId ?? options.agentPresetId,
+      launchGeneration: options.launchGeneration,
       spawnArgs,
     };
 

--- a/electron/services/pty/__tests__/PtyEventsBridge.test.ts
+++ b/electron/services/pty/__tests__/PtyEventsBridge.test.ts
@@ -189,16 +189,25 @@ describe("bridgePtyEvent", () => {
   });
 
   it("re-emits a pty-host captured session onto the main bus for persistence", () => {
-    const payloads: Array<{ sessionId: string; worktreeId: string | null }> = [];
+    const payloads: Array<{
+      sessionId: string;
+      worktreeId: string | null;
+      terminalId: string;
+      launchGeneration: number | undefined;
+    }> = [];
     events.on("agent-session:captured", (payload) => {
       payloads.push({
         sessionId: payload.record.sessionId,
         worktreeId: payload.record.worktreeId,
+        terminalId: payload.terminalId,
+        launchGeneration: payload.launchGeneration,
       });
     });
 
     const handled = bridgePtyEvent({
       type: "agent-session-captured",
+      terminalId: "term-9",
+      launchGeneration: 3,
       record: {
         sessionId: "sess-1",
         agentId: "claude",
@@ -210,7 +219,9 @@ describe("bridgePtyEvent", () => {
     });
 
     expect(handled).toBe(true);
-    expect(payloads).toEqual([{ sessionId: "sess-1", worktreeId: null }]);
+    expect(payloads).toEqual([
+      { sessionId: "sess-1", worktreeId: null, terminalId: "term-9", launchGeneration: 3 },
+    ]);
   });
 
   it("returns false for unhandled event types", () => {

--- a/electron/services/pty/__tests__/agentSessionJournal.test.ts
+++ b/electron/services/pty/__tests__/agentSessionJournal.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+let userDataDir = "";
+
+vi.mock("electron", () => ({
+  app: { getPath: vi.fn(() => userDataDir) },
+}));
+
+vi.mock("../../../store.js", () => ({
+  store: { get: vi.fn(() => ({ retentionDays: 30 })) },
+}));
+
+vi.mock("../../../utils/logger.js", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { journalAgentSession } from "../agentSessionJournal.js";
+import { readSessionHistory } from "../agentSessionHistory.js";
+import { getLifecycleLedger, disposeLifecycleLedger } from "../lifecycleLedger.js";
+import { events } from "../../events.js";
+
+function makeRecord(sessionId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId,
+    agentId: "claude",
+    worktreeId: "wt-1" as string | null,
+    title: "Claude: fix auth" as string | null,
+    projectId: "proj-1" as string | null,
+    ...overrides,
+  };
+}
+
+describe("journalAgentSession", () => {
+  const previousUserData = process.env.DAINTREE_USER_DATA;
+  let recordedEvents: Array<{ sessionId: string }>;
+  let unsubscribe: () => void;
+
+  beforeEach(async () => {
+    userDataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "daintree-session-journal-"));
+    process.env.DAINTREE_USER_DATA = userDataDir;
+    disposeLifecycleLedger();
+    recordedEvents = [];
+    unsubscribe = events.on("agent-session:recorded", (payload) => {
+      recordedEvents.push({ sessionId: payload.sessionId });
+    });
+  });
+
+  afterEach(async () => {
+    unsubscribe();
+    disposeLifecycleLedger();
+    process.env.DAINTREE_USER_DATA = previousUserData;
+    await fsp.rm(userDataDir, { recursive: true, force: true });
+  });
+
+  it("persists a record and emits agent-session:recorded after the write", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+
+    const written = await journalAgentSession(makeRecord("sess-1"), {
+      terminalId: "term-1",
+      generation,
+    });
+
+    expect(written).toBe(true);
+    const records = await readSessionHistory(userDataDir);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ sessionId: "sess-1", agentId: "claude" });
+    expect(recordedEvents).toEqual([{ sessionId: "sess-1" }]);
+  });
+
+  it("journals exactly once per terminal generation across overlapping close paths", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+
+    // Kill path and trash-expiry capture race for the same incarnation.
+    const first = await journalAgentSession(makeRecord("sess-1"), {
+      terminalId: "term-1",
+      generation,
+    });
+    const second = await journalAgentSession(makeRecord("sess-1"), {
+      terminalId: "term-1",
+      generation,
+    });
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(await readSessionHistory(userDataDir)).toHaveLength(1);
+    expect(recordedEvents).toHaveLength(1);
+  });
+
+  it("dedupes even when the duplicate capture carries a different sessionId", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+
+    await journalAgentSession(makeRecord("sess-1"), { terminalId: "term-1", generation });
+    const dup = await journalAgentSession(makeRecord("sess-1b"), {
+      terminalId: "term-1",
+      generation,
+    });
+
+    expect(dup).toBe(false);
+    const records = await readSessionHistory(userDataDir);
+    expect(records.map((r) => r.sessionId)).toEqual(["sess-1"]);
+  });
+
+  it("journals a past generation's record after the terminal id respawned", async () => {
+    const ledger = getLifecycleLedger();
+    const oldGeneration = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+    // Restart respawns the same id while the kill's journal write is in flight.
+    ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+
+    const written = await journalAgentSession(makeRecord("sess-old"), {
+      terminalId: "term-1",
+      generation: oldGeneration,
+    });
+
+    expect(written).toBe(true);
+    expect(await readSessionHistory(userDataDir)).toHaveLength(1);
+  });
+
+  it("fails open for terminals the ledger never saw", async () => {
+    const written = await journalAgentSession(makeRecord("sess-unknown"), {
+      terminalId: "term-unseen",
+    });
+    expect(written).toBe(true);
+    expect(await readSessionHistory(userDataDir)).toHaveLength(1);
+    // No anomaly for the fail-open path — it is not an invariant violation.
+    expect(getLifecycleLedger().getAnomalies()).toEqual([]);
+  });
+
+  it("falls back to the current ledger generation when none is supplied", async () => {
+    const ledger = getLifecycleLedger();
+    ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+
+    expect(await journalAgentSession(makeRecord("sess-1"), { terminalId: "term-1" })).toBe(true);
+    expect(await journalAgentSession(makeRecord("sess-1"), { terminalId: "term-1" })).toBe(false);
+    expect(await readSessionHistory(userDataDir)).toHaveLength(1);
+  });
+
+  it("releases the journal reservation when the write fails, so a retry still lands", async () => {
+    const ledger = getLifecycleLedger();
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+
+    // Force the first write to fail: point the journal at a path where the
+    // history file location is a directory, so the atomic write rejects.
+    const filePath = path.join(userDataDir, "agent-session-history.json");
+    await fsp.mkdir(filePath, { recursive: true });
+
+    await expect(
+      journalAgentSession(makeRecord("sess-1"), { terminalId: "term-1", generation })
+    ).rejects.toThrow();
+
+    await fsp.rm(filePath, { recursive: true, force: true });
+
+    // The failed attempt must not have consumed the generation's journal slot.
+    const retried = await journalAgentSession(makeRecord("sess-1"), {
+      terminalId: "term-1",
+      generation,
+    });
+    expect(retried).toBe(true);
+    expect(await readSessionHistory(userDataDir)).toHaveLength(1);
+  });
+
+  it("applies retention on the main-side write", async () => {
+    const ledger = getLifecycleLedger();
+
+    // Seed a record far older than the mocked 30-day retention window.
+    const stale = {
+      sessionId: "sess-stale",
+      agentId: "claude",
+      worktreeId: "wt-1",
+      title: null,
+      projectId: null,
+      savedAt: Date.now() - 90 * 24 * 60 * 60 * 1000,
+    };
+    const filePath = path.join(userDataDir, "agent-session-history.json");
+    await fsp.writeFile(filePath, JSON.stringify([stale]));
+
+    const generation = ledger.recordLaunch("term-1", { launchAgentId: "claude" });
+    await journalAgentSession(makeRecord("sess-fresh"), { terminalId: "term-1", generation });
+
+    const records = await readSessionHistory(userDataDir);
+    expect(records.map((r) => r.sessionId)).toEqual(["sess-fresh"]);
+  });
+});

--- a/electron/services/pty/agentSessionJournal.ts
+++ b/electron/services/pty/agentSessionJournal.ts
@@ -1,0 +1,78 @@
+import { persistAgentSession, type AgentSessionRecord } from "./agentSessionHistory.js";
+import { getAgentSessionRetentionDays } from "./agentSessionRetention.js";
+import { getLifecycleLedger } from "./lifecycleLedger.js";
+import { events } from "../events.js";
+import { createLogger } from "../../utils/logger.js";
+
+const logger = createLogger("main:AgentSessionJournal");
+
+export interface JournalCloseContext {
+  /** Terminal whose close produced this record. */
+  terminalId: string;
+  /**
+   * Launch generation of the closing incarnation. Capture it BEFORE initiating
+   * the kill: a restart can respawn the same terminal id mid-close, and the
+   * record must stay attributed to the generation that produced it. Falls back
+   * to the ledger's current generation when omitted.
+   */
+  generation?: number;
+}
+
+/**
+ * Journal one resumable agent session, exactly once per terminal generation.
+ *
+ * Single funnel for every close path (trash expiry via `agent-session:captured`,
+ * IPC kill / gracefulKill, app shutdown). Main is the journal's only writer;
+ * the lifecycle ledger provides the idempotency key `(terminalId, generation)`
+ * so overlapping close paths (a user kill landing mid-shutdown, a trash expiry
+ * racing an explicit kill) produce one record instead of relying on
+ * sessionId-dedupe timing at eviction.
+ *
+ * Fail-open: a terminal the ledger never saw (spawned before this process
+ * instance, ledger evicted) is journaled without gating — losing a resume
+ * record is worse than a rare duplicate, which sessionId-dedupe still catches.
+ *
+ * Returns true when a record was written.
+ */
+export async function journalAgentSession(
+  record: Omit<AgentSessionRecord, "savedAt">,
+  ctx: JournalCloseContext
+): Promise<boolean> {
+  const ledger = getLifecycleLedger();
+  const generation = ctx.generation ?? ledger.currentGeneration(ctx.terminalId);
+  const gatedGeneration =
+    generation !== undefined && ledger.currentGeneration(ctx.terminalId) !== undefined
+      ? generation
+      : undefined;
+  if (gatedGeneration !== undefined) {
+    const verdict = ledger.recordJournal(ctx.terminalId, gatedGeneration, record.sessionId);
+    if (!verdict.accepted) {
+      logger.debug(
+        `Skipping duplicate journal for ${ctx.terminalId} gen ${gatedGeneration}: ${verdict.reason}`
+      );
+      return false;
+    }
+  }
+
+  try {
+    const { app } = await import("electron");
+    await persistAgentSession(record, app.getPath("userData"), getAgentSessionRetentionDays());
+  } catch (err) {
+    // The mark is a reservation, not a receipt — release it so a retry or a
+    // concurrent close path can still journal this generation. Losing the
+    // record outright is strictly worse than the duplicate the gate prevents.
+    if (gatedGeneration !== undefined) {
+      ledger.rescindJournal(ctx.terminalId, gatedGeneration);
+    }
+    throw err;
+  }
+
+  // Signal AFTER the write lands so a refetch it triggers sees the record.
+  events.emit("agent-session:recorded", {
+    sessionId: record.sessionId,
+    worktreeId: record.worktreeId ?? null,
+    projectId: record.projectId ?? null,
+    timestamp: Date.now(),
+  });
+  return true;
+}

--- a/electron/services/pty/lifecycleLedger.ts
+++ b/electron/services/pty/lifecycleLedger.ts
@@ -1,0 +1,61 @@
+import {
+  AgentTerminalLifecycleLedger,
+  computeEnvProvenance,
+  type LedgerAnomaly,
+  type LedgerLaunchFacts,
+} from "../../../shared/utils/agentLifecycleLedger.js";
+import type { PtyHostSpawnOptions } from "../../../shared/types/pty-host.js";
+import { createLogger } from "../../utils/logger.js";
+
+const logger = createLogger("pty:LifecycleLedger");
+
+/**
+ * Per-process lifecycle ledger singleton (Pattern C — see PtyManager). Main
+ * and the pty-host each get their own instance; Main's is the authority for
+ * journal dedupe and the diagnostics surface, the pty-host's guards buffered
+ * resizes across incarnations.
+ *
+ * Anomalies are always recorded in the bounded ring buffer for diagnostics;
+ * outside production they are also logged loudly so lifecycle races fail
+ * visibly in development and tests.
+ */
+function logAnomaly(anomaly: LedgerAnomaly): void {
+  if (process.env.NODE_ENV === "production") return;
+  logger.warn(
+    `Lifecycle invariant rejected: ${anomaly.op} on ${anomaly.terminalId} ` +
+      `(gen ${anomaly.generation ?? "?"} vs current ${anomaly.currentGeneration ?? "?"}): ` +
+      `${anomaly.reason}${anomaly.detail ? ` — ${anomaly.detail}` : ""}`
+  );
+}
+
+let ledgerInstance: AgentTerminalLifecycleLedger | null = null;
+
+export function getLifecycleLedger(): AgentTerminalLifecycleLedger {
+  if (!ledgerInstance) {
+    ledgerInstance = new AgentTerminalLifecycleLedger({ onAnomaly: logAnomaly });
+  }
+  return ledgerInstance;
+}
+
+export function disposeLifecycleLedger(): void {
+  ledgerInstance?.clear();
+  ledgerInstance = null;
+}
+
+/** Launch facts for the ledger from spawn options — env reduced to provenance. */
+export function ledgerFactsFromSpawnOptions(options: PtyHostSpawnOptions): LedgerLaunchFacts {
+  return {
+    launchAgentId: options.launchAgentId,
+    cwd: options.cwd,
+    projectId: options.projectId,
+    worktreeId: options.worktreeId,
+    worktreeSource: options.worktreeId !== undefined ? "explicit" : undefined,
+    agentModelId: options.agentModelId,
+    agentPresetId: options.agentPresetId,
+    originalPresetId: options.originalAgentPresetId ?? options.agentPresetId,
+    agentLaunchFlags: options.agentLaunchFlags,
+    env: computeEnvProvenance(options.env),
+    initialCols: options.cols,
+    initialRows: options.rows,
+  };
+}

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -104,6 +104,11 @@ export interface TerminalPublicState {
   agentPresetColor?: string;
   /** User-originally-selected preset ID; immutable across fallback hops. */
   originalAgentPresetId?: string;
+  /**
+   * Launch generation adopted from Main's lifecycle ledger at spawn. Echoed on
+   * `agent-session-captured` so Main can journal exactly-once per incarnation.
+   */
+  launchGeneration?: number;
 }
 
 /**
@@ -193,7 +198,7 @@ export interface TerminalInfo extends TerminalPublicState {
 
 export interface PtyManagerEvents {
   data: (id: string, data: string | Uint8Array) => void;
-  exit: (id: string, exitCode: number, signal?: number) => void;
+  exit: (id: string, exitCode: number, signal?: number, launchGeneration?: number) => void;
   error: (id: string, error: string) => void;
 }
 

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -18,6 +18,14 @@ export interface AddPanelOptionsBase {
   /** How the title is owned. Absent defaults to "default". */
   titleMode?: PanelTitleMode;
   worktreeId?: string;
+  /**
+   * How `worktreeId` was determined: `"explicit"` (caller/user chose it, the
+   * default when omitted) or `"inferred"` (derived from cwd prefix matching —
+   * orphan reconnects, journal resume). Recorded in the lifecycle ledger,
+   * whose invariant is that inferred attribution never overwrites a differing
+   * explicit one.
+   */
+  worktreeIdSource?: "explicit" | "inferred";
   cwd?: string;
   location?: PanelLocation;
   /** If provided, request a stable ID when spawning a new backend process */

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -78,6 +78,14 @@ export interface PtyHostSpawnOptions {
   agentPresetColor?: string;
   /** Original user-selected preset ID; unchanged across fallback hops for revert UX. */
   originalAgentPresetId?: string;
+  /**
+   * Launch generation minted by Main's lifecycle ledger (see
+   * `shared/utils/agentLifecycleLedger.ts`). Monotonic per terminal id;
+   * a respawn after a pty-host crash mints a fresh generation. The pty-host
+   * adopts it and echoes it on `agent-session-captured` so Main can dedupe
+   * session journaling exactly-once per terminal incarnation.
+   */
+  launchGeneration?: number;
 }
 
 /** Per-project terminal-workload memory, deduplicated by PID. */
@@ -421,7 +429,9 @@ export type PtyHostEvent =
   // same xterm (terminalClient.onData subscribes to both the port and IPC
   // paths on the strength of the one-visual-path invariant).
   | { type: "data-mirror"; id: string; data: string }
-  | { type: "exit"; id: string; exitCode: number; signal?: number }
+  // `launchGeneration` attributes the exit to one terminal incarnation so a
+  // stale exit arriving after a same-id respawn can't close the successor.
+  | { type: "exit"; id: string; exitCode: number; signal?: number; launchGeneration?: number }
   | { type: "error"; id: string; error: string }
   | { type: "spawn-result"; id: string; result: SpawnResult }
   | { type: "kill-by-project-result"; requestId: string; killed: number }
@@ -516,9 +526,13 @@ export type PtyHostEvent =
        * Trash expiry captured a resumable session in the pty-host. The record
        * is shipped to Main for persistence — Main is the journal's single
        * writer, so cross-process read-modify-write races on the file can't
-       * drop records, and the real retention setting applies.
+       * drop records, and the real retention setting applies. `terminalId` +
+       * `launchGeneration` key the capture to one terminal incarnation so
+       * Main's lifecycle ledger can journal it exactly once.
        */
       type: "agent-session-captured";
+      terminalId: string;
+      launchGeneration?: number;
       record: Omit<AgentSessionRecord, "savedAt">;
     }
   | { type: "terminal-pid"; id: string; pid: number }
@@ -763,6 +777,12 @@ export type SpawnErrorCode =
 export interface SpawnResult {
   success: boolean;
   id: string;
+  /**
+   * Launch generation echoed from the spawn options so a stale result
+   * arriving after a same-id respawn can't clear the successor's pending
+   * spawn entry or mis-record its ledger resolution.
+   */
+  launchGeneration?: number;
   error?: SpawnError;
 }
 

--- a/shared/utils/__tests__/agentLifecycleLedger.test.ts
+++ b/shared/utils/__tests__/agentLifecycleLedger.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  AgentTerminalLifecycleLedger,
+  computeEnvProvenance,
+  type LedgerAnomaly,
+} from "../agentLifecycleLedger.js";
+
+function makeLedger(overrides: ConstructorParameters<typeof AgentTerminalLifecycleLedger>[0] = {}) {
+  let tick = 1000;
+  return new AgentTerminalLifecycleLedger({ now: () => tick++, ...overrides });
+}
+
+describe("computeEnvProvenance", () => {
+  it("returns undefined for missing env", () => {
+    expect(computeEnvProvenance(undefined)).toBeUndefined();
+  });
+
+  it("captures sorted key names and never values", () => {
+    const provenance = computeEnvProvenance({
+      ZED_TOKEN: "secret-value",
+      ANTHROPIC_BASE_URL: "https://proxy.example",
+    });
+    expect(provenance?.keys).toEqual(["ANTHROPIC_BASE_URL", "ZED_TOKEN"]);
+    expect(JSON.stringify(provenance)).not.toContain("secret-value");
+  });
+
+  it("hashes independently of key insertion order", () => {
+    const a = computeEnvProvenance({ A: "1", B: "2" });
+    const b = computeEnvProvenance({ B: "2", A: "1" });
+    expect(a?.hash).toBe(b?.hash);
+  });
+
+  it("changes hash when a value changes", () => {
+    const a = computeEnvProvenance({ A: "1" });
+    const b = computeEnvProvenance({ A: "2" });
+    expect(a?.hash).not.toBe(b?.hash);
+  });
+});
+
+describe("recordLaunch / generations", () => {
+  it("mints monotonic generations per terminal id", () => {
+    const ledger = makeLedger();
+    expect(ledger.recordLaunch("t1", {})).toBe(1);
+    expect(ledger.recordLaunch("t1", {})).toBe(2);
+    expect(ledger.recordLaunch("t2", {})).toBe(1);
+    expect(ledger.currentGeneration("t1")).toBe(2);
+  });
+
+  it("adopts an externally minted generation", () => {
+    const ledger = makeLedger();
+    expect(ledger.recordLaunch("t1", {}, { generation: 7 })).toBe(7);
+    expect(ledger.currentGeneration("t1")).toBe(7);
+  });
+
+  it("resets per-generation state on relaunch", () => {
+    const ledger = makeLedger();
+    const gen1 = ledger.recordLaunch("t1", { agentModelId: "opus" });
+    ledger.recordFirstAttach("t1", gen1, 120, 40);
+    const gen2 = ledger.recordLaunch("t1", { agentModelId: "sonnet" });
+    const entry = ledger.getEntry("t1");
+    expect(entry?.generation).toBe(gen2);
+    expect(entry?.facts.agentModelId).toBe("sonnet");
+    expect(entry?.firstAttachCols).toBeUndefined();
+  });
+});
+
+describe("live-state generation gating", () => {
+  it("rejects operations for unknown terminals", () => {
+    const ledger = makeLedger();
+    const verdict = ledger.recordResize("nope", 1, 80, 24);
+    expect(verdict).toMatchObject({ accepted: false, reason: "unknown-terminal" });
+  });
+
+  it("rejects stale-generation completions after a relaunch", () => {
+    const ledger = makeLedger();
+    const gen1 = ledger.recordLaunch("t1", {});
+    ledger.recordLaunch("t1", {});
+    expect(ledger.recordResize("t1", gen1, 100, 30)).toMatchObject({
+      accepted: false,
+      reason: "stale-generation",
+    });
+    expect(ledger.recordRestoreApplied("t1", gen1)).toMatchObject({
+      accepted: false,
+      reason: "stale-generation",
+    });
+    expect(ledger.recordSpawnResolved("t1", gen1, true)).toMatchObject({
+      accepted: false,
+      reason: "stale-generation",
+    });
+  });
+
+  it("rejects future generations", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    expect(ledger.recordResize("t1", gen + 1, 80, 24)).toMatchObject({
+      accepted: false,
+      reason: "future-generation",
+    });
+  });
+
+  it("accepts current-generation operations", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    expect(ledger.recordResize("t1", gen, 120, 40).accepted).toBe(true);
+    expect(ledger.recordSpawnResolved("t1", gen, true).accepted).toBe(true);
+    expect(ledger.recordRestoreApplied("t1", gen).accepted).toBe(true);
+    const entry = ledger.getEntry("t1");
+    expect(entry?.spawnOk).toBe(true);
+    expect(entry?.restoredAt).toBeDefined();
+  });
+});
+
+describe("first attach", () => {
+  it("records only the first attach geometry", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", { initialCols: 80, initialRows: 24 });
+    expect(ledger.recordFirstAttach("t1", gen, 132, 43).accepted).toBe(true);
+    expect(ledger.recordFirstAttach("t1", gen, 200, 50).accepted).toBe(true);
+    const entry = ledger.getEntry("t1");
+    expect(entry?.firstAttachCols).toBe(132);
+    expect(entry?.firstAttachRows).toBe(43);
+  });
+});
+
+describe("detected-agent evolution", () => {
+  it("tracks evolution, deduping consecutive repeats and bounding length", () => {
+    const ledger = makeLedger({ maxDetectedAgents: 3 });
+    const gen = ledger.recordLaunch("t1", { launchAgentId: "claude" });
+    ledger.recordDetectedAgent("t1", gen, "claude");
+    ledger.recordDetectedAgent("t1", gen, "claude");
+    ledger.recordDetectedAgent("t1", gen, "codex");
+    ledger.recordDetectedAgent("t1", gen, "claude");
+    ledger.recordDetectedAgent("t1", gen, "gemini");
+    expect(ledger.getEntry("t1")?.detectedAgentIds).toEqual(["codex", "claude", "gemini"]);
+  });
+});
+
+describe("worktree attribution", () => {
+  it("lets explicit attribution move the terminal", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", { worktreeId: "wt-a", worktreeSource: "explicit" });
+    expect(ledger.recordWorktreeAttribution("t1", gen, "wt-b", "explicit").accepted).toBe(true);
+    expect(ledger.getEntry("t1")?.facts.worktreeId).toBe("wt-b");
+  });
+
+  it("never lets cwd inference overwrite a differing explicit worktree", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", { worktreeId: "wt-a", worktreeSource: "explicit" });
+    const verdict = ledger.recordWorktreeAttribution("t1", gen, "wt-b", "inferred");
+    expect(verdict).toMatchObject({ accepted: false, reason: "inferred-worktree-overwrite" });
+    expect(ledger.getEntry("t1")?.facts.worktreeId).toBe("wt-a");
+    expect(ledger.getEntry("t1")?.facts.worktreeSource).toBe("explicit");
+  });
+
+  it("accepts inference when it agrees with the explicit id or none exists", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    expect(ledger.recordWorktreeAttribution("t1", gen, "wt-a", "inferred").accepted).toBe(true);
+    expect(ledger.getEntry("t1")?.facts.worktreeSource).toBe("inferred");
+    const gen2 = ledger.recordLaunch("t2", { worktreeId: "wt-a", worktreeSource: "explicit" });
+    expect(ledger.recordWorktreeAttribution("t2", gen2, "wt-a", "inferred").accepted).toBe(true);
+  });
+});
+
+describe("close: exactly-once per generation", () => {
+  it("accepts one close per generation and rejects duplicates", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    expect(ledger.recordClose("t1", gen, "exit", 0).accepted).toBe(true);
+    expect(ledger.recordClose("t1", gen, "exit", 0)).toMatchObject({
+      accepted: false,
+      reason: "duplicate-close",
+    });
+    expect(ledger.getEntry("t1")?.exitCode).toBe(0);
+  });
+
+  it("accepts a close for a PAST generation after the id respawned", () => {
+    const ledger = makeLedger();
+    const gen1 = ledger.recordLaunch("t1", {});
+    const gen2 = ledger.recordLaunch("t1", {});
+    // Stale exit from the killed incarnation arrives after the restart.
+    expect(ledger.recordClose("t1", gen1, "exit", 137).accepted).toBe(true);
+    // It must not touch the live successor's entry.
+    expect(ledger.getEntry("t1")?.closedAt).toBeUndefined();
+    expect(ledger.getEntry("t1")?.generation).toBe(gen2);
+    // And the successor's own close still lands.
+    expect(ledger.recordClose("t1", gen2, "exit", 0).accepted).toBe(true);
+    expect(ledger.getEntry("t1")?.exitCode).toBe(0);
+  });
+
+  it("rejects closes for future generations and unknown terminals", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    expect(ledger.recordClose("t1", gen + 5, "exit")).toMatchObject({
+      accepted: false,
+      reason: "future-generation",
+    });
+    expect(ledger.recordClose("ghost", 1, "exit")).toMatchObject({
+      accepted: false,
+      reason: "unknown-terminal",
+    });
+  });
+});
+
+describe("journal: exactly-once per generation", () => {
+  it("accepts one journal per generation and rejects duplicates", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    expect(ledger.recordJournal("t1", gen, "sess-1").accepted).toBe(true);
+    expect(ledger.recordJournal("t1", gen, "sess-1")).toMatchObject({
+      accepted: false,
+      reason: "duplicate-journal",
+    });
+    // A different sessionId for the same generation is still a duplicate —
+    // the incarnation was already journaled.
+    expect(ledger.recordJournal("t1", gen, "sess-2")).toMatchObject({
+      accepted: false,
+      reason: "duplicate-journal",
+    });
+  });
+
+  it("rescindJournal releases the reservation so a retry can journal", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    expect(ledger.recordJournal("t1", gen, "sess-1").accepted).toBe(true);
+    ledger.rescindJournal("t1", gen);
+    expect(ledger.getEntry("t1")?.journaledSessionId).toBeUndefined();
+    expect(ledger.recordJournal("t1", gen, "sess-1").accepted).toBe(true);
+    // Rescinding an unreserved generation is a no-op.
+    ledger.rescindJournal("t1", gen + 10);
+    ledger.rescindJournal("ghost", 1);
+  });
+
+  it("journals each generation independently across respawns", () => {
+    const ledger = makeLedger();
+    const gen1 = ledger.recordLaunch("t1", {});
+    const gen2 = ledger.recordLaunch("t1", {});
+    // Kill-path journal for the old incarnation lands after the respawn.
+    expect(ledger.recordJournal("t1", gen1, "sess-old").accepted).toBe(true);
+    expect(ledger.recordJournal("t1", gen2, "sess-new").accepted).toBe(true);
+    expect(ledger.recordJournal("t1", gen1, "sess-old")).toMatchObject({
+      accepted: false,
+      reason: "duplicate-journal",
+    });
+    expect(ledger.getEntry("t1")?.journaledSessionId).toBe("sess-new");
+  });
+});
+
+describe("anomalies", () => {
+  it("records rejections in a bounded ring buffer and invokes onAnomaly", () => {
+    const seen: LedgerAnomaly[] = [];
+    const ledger = makeLedger({ maxAnomalies: 3, onAnomaly: (a) => seen.push(a) });
+    const gen1 = ledger.recordLaunch("t1", {});
+    ledger.recordLaunch("t1", {});
+    for (let i = 0; i < 5; i++) {
+      ledger.recordResize("t1", gen1, 80 + i, 24);
+    }
+    expect(seen).toHaveLength(5);
+    const anomalies = ledger.getAnomalies();
+    expect(anomalies).toHaveLength(3);
+    expect(anomalies[0]).toMatchObject({
+      terminalId: "t1",
+      op: "resize",
+      reason: "stale-generation",
+      generation: gen1,
+      currentGeneration: 2,
+    });
+    // Ring keeps the newest entries.
+    expect(anomalies[2]?.detail).toBe("84x24");
+  });
+});
+
+describe("bounds and eviction", () => {
+  it("evicts closed entries first, then oldest live", () => {
+    const ledger = makeLedger({ maxTerminals: 2 });
+    const gen1 = ledger.recordLaunch("t1", {});
+    ledger.recordClose("t1", gen1, "exit");
+    ledger.recordLaunch("t2", {});
+    ledger.recordLaunch("t3", {});
+    expect(ledger.getEntry("t1")).toBeUndefined();
+    expect(ledger.getEntry("t2")).toBeDefined();
+    expect(ledger.getEntry("t3")).toBeDefined();
+
+    ledger.recordLaunch("t4", {});
+    // No closed entries — oldest live (t2) goes.
+    expect(ledger.getEntry("t2")).toBeUndefined();
+    expect(ledger.getEntry("t3")).toBeDefined();
+    expect(ledger.getEntry("t4")).toBeDefined();
+  });
+
+  it("bounds the generation-mark map", () => {
+    const ledger = makeLedger({ maxGenerationMarks: 2 });
+    const genA = ledger.recordLaunch("a", {});
+    const genB = ledger.recordLaunch("b", {});
+    const genC = ledger.recordLaunch("c", {});
+    ledger.recordJournal("a", genA, "s-a");
+    ledger.recordJournal("b", genB, "s-b");
+    ledger.recordJournal("c", genC, "s-c");
+    // "a"'s mark was evicted (FIFO), so a re-journal is accepted again —
+    // bounded memory trades away dedupe only for the oldest marks.
+    expect(ledger.recordJournal("a", genA, "s-a").accepted).toBe(true);
+  });
+});
+
+describe("diagnostics", () => {
+  it("returns a defensive snapshot without env values", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {
+      launchAgentId: "claude",
+      env: computeEnvProvenance({ SECRET_KEY: "hunter2" }),
+    });
+    ledger.recordDetectedAgent("t1", gen, "claude");
+    const diagnostics = ledger.getDiagnostics();
+    expect(diagnostics.terminals).toHaveLength(1);
+    expect(JSON.stringify(diagnostics)).not.toContain("hunter2");
+    expect(JSON.stringify(diagnostics)).toContain("SECRET_KEY");
+
+    // Mutating the snapshot must not affect ledger state.
+    diagnostics.terminals[0]!.detectedAgentIds.push("evil");
+    diagnostics.terminals[0]!.facts.worktreeId = "evil";
+    expect(ledger.getEntry("t1")?.detectedAgentIds).toEqual(["claude"]);
+    expect(ledger.getEntry("t1")?.facts.worktreeId).toBeUndefined();
+  });
+
+  it("clear() resets entries, marks, and anomalies", () => {
+    const ledger = makeLedger();
+    const gen = ledger.recordLaunch("t1", {});
+    ledger.recordJournal("t1", gen, "s");
+    ledger.recordResize("ghost", 1, 80, 24);
+    ledger.clear();
+    expect(ledger.getDiagnostics()).toEqual({ terminals: [], anomalies: [] });
+    // Marks cleared too: the same journal is accepted again after clear+relaunch.
+    const gen2 = ledger.recordLaunch("t1", {}, { generation: gen });
+    expect(ledger.recordJournal("t1", gen2, "s").accepted).toBe(true);
+  });
+});
+
+describe("uses injected clock", () => {
+  it("stamps launchedAt/closedAt from the injected now()", () => {
+    const now = vi.fn(() => 42);
+    const ledger = new AgentTerminalLifecycleLedger({ now });
+    const gen = ledger.recordLaunch("t1", {});
+    ledger.recordClose("t1", gen, "exit");
+    const entry = ledger.getEntry("t1");
+    expect(entry?.launchedAt).toBe(42);
+    expect(entry?.closedAt).toBe(42);
+  });
+});

--- a/shared/utils/agentLifecycleLedger.ts
+++ b/shared/utils/agentLifecycleLedger.ts
@@ -1,0 +1,518 @@
+/**
+ * AgentTerminalLifecycleLedger — bounded, in-memory audit ledger for agent
+ * terminal lifecycle integrity (spawn → attach → resize → restore → close →
+ * journal → resume).
+ *
+ * Each process that participates in the terminal lifecycle (renderer, main,
+ * pty-host) owns its own instance; generations are monotonic per terminal id,
+ * minted locally or adopted from the spawning process so cross-process events
+ * (e.g. pty-host session captures) key to the same generation main minted.
+ *
+ * The ledger is a diagnostic/audit aid with one load-bearing duty: mutators
+ * validate against the recorded generation and REJECT stale or duplicate
+ * completions instead of applying them, so callers gate side effects (journal
+ * writes, buffered resizes, restore merges) on the returned verdict rather
+ * than on timing luck. Two validation regimes:
+ *
+ * - Live-state ops (resize, restore, attach, detection) apply only to the
+ *   CURRENT generation — a stale completion must never touch a successor.
+ * - Terminal-final ops (close, journal) are exactly-once PER generation and
+ *   tolerate past generations — a kill's journal write may legitimately land
+ *   after the same terminal id respawned, and must neither be dropped nor
+ *   attributed to the successor.
+ *
+ * It never stores env values or terminal content — env is captured as sorted
+ * key names plus a content hash (`computeEnvProvenance`), so diagnostics can
+ * show provider provenance without exposing secrets.
+ */
+
+export type LedgerWorktreeSource = "explicit" | "inferred";
+
+export interface LedgerEnvProvenance {
+  /** Sorted env var names from the caller-resolved launch env. Never values. */
+  keys: string[];
+  /** FNV-1a hash over sorted `key=value` pairs — change detection, not content. */
+  hash: string;
+}
+
+/** Immutable facts recorded once per launch generation. */
+export interface LedgerLaunchFacts {
+  launchAgentId?: string;
+  cwd?: string;
+  projectId?: string;
+  worktreeId?: string;
+  worktreeSource?: LedgerWorktreeSource;
+  agentModelId?: string;
+  agentPresetId?: string;
+  originalPresetId?: string;
+  agentLaunchFlags?: string[];
+  env?: LedgerEnvProvenance;
+  initialCols?: number;
+  initialRows?: number;
+  spawnedBy?: string;
+  /** Session id this launch resumes, when relaunched from the journal. */
+  resumedFromSessionId?: string;
+}
+
+export type LedgerRejectReason =
+  | "unknown-terminal"
+  | "stale-generation"
+  | "future-generation"
+  | "duplicate-journal"
+  | "duplicate-close"
+  | "inferred-worktree-overwrite";
+
+export type LedgerVerdict =
+  | { accepted: true }
+  | { accepted: false; reason: LedgerRejectReason; detail?: string };
+
+export interface LedgerAnomaly {
+  terminalId: string;
+  /** Generation the stale/duplicate operation carried, when known. */
+  generation: number | null;
+  /** Generation the ledger held when the operation was rejected. */
+  currentGeneration: number | null;
+  op: string;
+  reason: LedgerRejectReason;
+  detail?: string;
+  at: number;
+}
+
+export interface LedgerEntrySnapshot {
+  terminalId: string;
+  generation: number;
+  facts: LedgerLaunchFacts;
+  launchedAt: number;
+  /** Detected-agent evolution for this generation, oldest first (bounded). */
+  detectedAgentIds: string[];
+  spawnResolvedAt?: number;
+  spawnOk?: boolean;
+  firstAttachCols?: number;
+  firstAttachRows?: number;
+  restoredAt?: number;
+  closedAt?: number;
+  closeReason?: string;
+  exitCode?: number | null;
+  journaledSessionId?: string;
+  journaledAt?: number;
+}
+
+export interface LedgerDiagnostics {
+  terminals: LedgerEntrySnapshot[];
+  anomalies: LedgerAnomaly[];
+}
+
+export interface AgentLifecycleLedgerOptions {
+  /** Max tracked terminals; closed entries are evicted first. Default 256. */
+  maxTerminals?: number;
+  /** Max retained anomalies (ring buffer). Default 128. */
+  maxAnomalies?: number;
+  /** Max retained close/journal generation marks (FIFO). Default 1024. */
+  maxGenerationMarks?: number;
+  /** Max retained detected-agent evolution entries per generation. Default 8. */
+  maxDetectedAgents?: number;
+  /**
+   * Invoked on every rejected operation. Wire to a dev/test-only logger for
+   * loud invariant checks; production callers rely on the returned verdict.
+   */
+  onAnomaly?: (anomaly: LedgerAnomaly) => void;
+  /** Clock override for tests. */
+  now?: () => number;
+}
+
+type LedgerEntry = LedgerEntrySnapshot;
+
+/** Exactly-once bookkeeping for terminal-final ops, keyed per generation. */
+interface GenerationMark {
+  closed?: boolean;
+  closeReason?: string;
+  journaledSessionId?: string;
+}
+
+/** FNV-1a 32-bit over sorted `key=value` pairs. Stable, cheap, non-cryptographic. */
+export function computeEnvProvenance(
+  env: Record<string, string> | undefined
+): LedgerEnvProvenance | undefined {
+  if (!env) return undefined;
+  const keys = Object.keys(env).sort();
+  let hash = 0x811c9dc5;
+  for (const key of keys) {
+    const pair = `${key}=${env[key]}\n`;
+    for (let i = 0; i < pair.length; i++) {
+      hash ^= pair.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+  }
+  return { keys, hash: hash.toString(16).padStart(8, "0") };
+}
+
+export class AgentTerminalLifecycleLedger {
+  private entries = new Map<string, LedgerEntry>();
+  private generationMarks = new Map<string, GenerationMark>();
+  private anomalies: LedgerAnomaly[] = [];
+  private readonly maxTerminals: number;
+  private readonly maxAnomalies: number;
+  private readonly maxGenerationMarks: number;
+  private readonly maxDetectedAgents: number;
+  private readonly onAnomaly?: (anomaly: LedgerAnomaly) => void;
+  private readonly now: () => number;
+
+  constructor(options: AgentLifecycleLedgerOptions = {}) {
+    this.maxTerminals = options.maxTerminals ?? 256;
+    this.maxAnomalies = options.maxAnomalies ?? 128;
+    this.maxGenerationMarks = options.maxGenerationMarks ?? 1024;
+    this.maxDetectedAgents = options.maxDetectedAgents ?? 8;
+    this.onAnomaly = options.onAnomaly;
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Record a new launch of `terminalId` and mint (or adopt) its generation.
+   * A relaunch of a known id (restart, respawn-after-host-crash) increments
+   * the generation and resets per-generation state; live-state completions
+   * carrying the previous generation are rejected from here on.
+   *
+   * `generation` adopts an externally minted token (the pty-host adopts
+   * main's) instead of minting locally, so both processes key the same
+   * incarnation identically.
+   */
+  recordLaunch(
+    terminalId: string,
+    facts: LedgerLaunchFacts,
+    options?: { generation?: number }
+  ): number {
+    const previous = this.entries.get(terminalId);
+    const generation = options?.generation ?? (previous?.generation ?? 0) + 1;
+    // Re-insert so Map iteration order stays oldest-first for eviction.
+    this.entries.delete(terminalId);
+    this.entries.set(terminalId, {
+      terminalId,
+      generation,
+      facts: { ...facts },
+      launchedAt: this.now(),
+      detectedAgentIds: [],
+    });
+    this.evictIfNeeded();
+    return generation;
+  }
+
+  currentGeneration(terminalId: string): number | undefined {
+    return this.entries.get(terminalId)?.generation;
+  }
+
+  isCurrent(terminalId: string, generation: number): boolean {
+    return this.entries.get(terminalId)?.generation === generation;
+  }
+
+  recordSpawnResolved(terminalId: string, generation: number, ok: boolean): LedgerVerdict {
+    return this.withCurrent("spawn-resolved", terminalId, generation, (entry) => {
+      entry.spawnResolvedAt = this.now();
+      entry.spawnOk = ok;
+      return { accepted: true };
+    });
+  }
+
+  /** First live attach dims — recorded once; later attaches are no-ops, not anomalies. */
+  recordFirstAttach(
+    terminalId: string,
+    generation: number,
+    cols: number,
+    rows: number
+  ): LedgerVerdict {
+    return this.withCurrent("first-attach", terminalId, generation, (entry) => {
+      if (entry.firstAttachCols === undefined) {
+        entry.firstAttachCols = cols;
+        entry.firstAttachRows = rows;
+      }
+      return { accepted: true };
+    });
+  }
+
+  /**
+   * Validate that a resize recorded under `generation` may apply to the
+   * current generation. A resize buffered before a terminal was killed must
+   * not become the initial dims of its successor.
+   */
+  recordResize(terminalId: string, generation: number, cols: number, rows: number): LedgerVerdict {
+    return this.withCurrent(
+      "resize",
+      terminalId,
+      generation,
+      () => ({ accepted: true }),
+      `${cols}x${rows}`
+    );
+  }
+
+  recordDetectedAgent(terminalId: string, generation: number, agentId: string): LedgerVerdict {
+    return this.withCurrent("detected-agent", terminalId, generation, (entry) => {
+      const last = entry.detectedAgentIds[entry.detectedAgentIds.length - 1];
+      if (last !== agentId) {
+        entry.detectedAgentIds.push(agentId);
+        if (entry.detectedAgentIds.length > this.maxDetectedAgents) {
+          entry.detectedAgentIds.shift();
+        }
+      }
+      return { accepted: true };
+    });
+  }
+
+  /**
+   * Update worktree attribution. Inferred attribution (derived from cwd) never
+   * overwrites a differing explicit worktreeId recorded at launch or later.
+   */
+  recordWorktreeAttribution(
+    terminalId: string,
+    generation: number,
+    worktreeId: string,
+    source: LedgerWorktreeSource
+  ): LedgerVerdict {
+    return this.withCurrent("worktree-attribution", terminalId, generation, (entry) => {
+      if (
+        source === "inferred" &&
+        entry.facts.worktreeSource === "explicit" &&
+        entry.facts.worktreeId !== undefined &&
+        entry.facts.worktreeId !== worktreeId
+      ) {
+        return {
+          accepted: false,
+          reason: "inferred-worktree-overwrite",
+          detail: `explicit ${entry.facts.worktreeId} vs inferred ${worktreeId}`,
+        };
+      }
+      entry.facts.worktreeId = worktreeId;
+      entry.facts.worktreeSource = source;
+      return { accepted: true };
+    });
+  }
+
+  /**
+   * Validate that a restore completion (session rehydration, metadata merge)
+   * recorded under `generation` may still apply. A restore resolved after a
+   * newer launch took the id must not overwrite the newer launch's metadata.
+   */
+  recordRestoreApplied(terminalId: string, generation: number): LedgerVerdict {
+    return this.withCurrent("restore", terminalId, generation, (entry) => {
+      entry.restoredAt = this.now();
+      return { accepted: true };
+    });
+  }
+
+  /**
+   * At-most-once close per (terminalId, generation). Past generations are
+   * accepted — an exit event for a killed terminal may arrive after the same
+   * id respawned (restart flow) and still belongs to its own generation.
+   */
+  recordClose(
+    terminalId: string,
+    generation: number,
+    reason?: string,
+    exitCode?: number | null
+  ): LedgerVerdict {
+    return this.withGenerationMark("close", terminalId, generation, (mark, entry) => {
+      if (mark.closed) {
+        return { accepted: false, reason: "duplicate-close", detail: mark.closeReason };
+      }
+      mark.closed = true;
+      mark.closeReason = reason;
+      if (entry) {
+        entry.closedAt = this.now();
+        entry.closeReason = reason;
+        if (exitCode !== undefined) entry.exitCode = exitCode;
+      }
+      return { accepted: true };
+    });
+  }
+
+  /**
+   * At-most-once session journaling per (terminalId, generation). Callers MUST
+   * gate the journal write on this verdict — it is the exactly-once mechanism
+   * for agent session history across the trash-expiry / kill / graceful-kill /
+   * shutdown close paths. Past generations are accepted (see recordClose).
+   *
+   * The mark is a RESERVATION taken before the durable write; a failed write
+   * must release it via {@link rescindJournal} or a later retry (and every
+   * other close path for the generation) would be dropped as a duplicate.
+   * Production journaling goes through `journalAgentSession`, which owns that
+   * reserve/rollback pairing — do not call this directly from close paths.
+   */
+  recordJournal(terminalId: string, generation: number, sessionId: string): LedgerVerdict {
+    return this.withGenerationMark("journal", terminalId, generation, (mark, entry) => {
+      if (mark.journaledSessionId !== undefined) {
+        return {
+          accepted: false,
+          reason: "duplicate-journal",
+          detail: `already journaled ${mark.journaledSessionId}`,
+        };
+      }
+      mark.journaledSessionId = sessionId;
+      if (entry) {
+        entry.journaledSessionId = sessionId;
+        entry.journaledAt = this.now();
+      }
+      return { accepted: true };
+    });
+  }
+
+  /**
+   * Release a journal reservation after a failed durable write so a retry (or
+   * another close path) can journal the generation. No-op when nothing is
+   * reserved.
+   */
+  rescindJournal(terminalId: string, generation: number): void {
+    const mark = this.generationMarks.get(`${terminalId}#${generation}`);
+    if (mark) {
+      mark.journaledSessionId = undefined;
+    }
+    const entry = this.entries.get(terminalId);
+    if (entry && entry.generation === generation) {
+      entry.journaledSessionId = undefined;
+      entry.journaledAt = undefined;
+    }
+  }
+
+  getEntry(terminalId: string): LedgerEntrySnapshot | undefined {
+    const entry = this.entries.get(terminalId);
+    return entry ? this.snapshotEntry(entry) : undefined;
+  }
+
+  getAnomalies(): LedgerAnomaly[] {
+    return [...this.anomalies];
+  }
+
+  /** Secret-free snapshot for diagnostics/support bundles. */
+  getDiagnostics(): LedgerDiagnostics {
+    return {
+      terminals: [...this.entries.values()].map((entry) => this.snapshotEntry(entry)),
+      anomalies: this.getAnomalies(),
+    };
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.generationMarks.clear();
+    this.anomalies = [];
+  }
+
+  private snapshotEntry(entry: LedgerEntry): LedgerEntrySnapshot {
+    return {
+      ...entry,
+      facts: { ...entry.facts },
+      detectedAgentIds: [...entry.detectedAgentIds],
+    };
+  }
+
+  /** Live-state ops: only the current generation may apply. */
+  private withCurrent(
+    op: string,
+    terminalId: string,
+    generation: number,
+    apply: (entry: LedgerEntry) => LedgerVerdict,
+    detail?: string
+  ): LedgerVerdict {
+    const entry = this.entries.get(terminalId);
+    if (!entry) {
+      return this.reject(op, terminalId, generation, null, "unknown-terminal", detail);
+    }
+    if (generation < entry.generation) {
+      return this.reject(op, terminalId, generation, entry.generation, "stale-generation", detail);
+    }
+    if (generation > entry.generation) {
+      return this.reject(op, terminalId, generation, entry.generation, "future-generation", detail);
+    }
+    const verdict = apply(entry);
+    if (!verdict.accepted) {
+      this.pushAnomaly({
+        terminalId,
+        generation,
+        currentGeneration: entry.generation,
+        op,
+        reason: verdict.reason,
+        detail: verdict.detail ?? detail,
+        at: this.now(),
+      });
+    }
+    return verdict;
+  }
+
+  /** Terminal-final ops: exactly-once per generation, past generations allowed. */
+  private withGenerationMark(
+    op: string,
+    terminalId: string,
+    generation: number,
+    apply: (mark: GenerationMark, entry: LedgerEntry | undefined) => LedgerVerdict
+  ): LedgerVerdict {
+    const entry = this.entries.get(terminalId);
+    if (!entry) {
+      return this.reject(op, terminalId, generation, null, "unknown-terminal");
+    }
+    if (generation > entry.generation) {
+      return this.reject(op, terminalId, generation, entry.generation, "future-generation");
+    }
+    const key = `${terminalId}#${generation}`;
+    let mark = this.generationMarks.get(key);
+    if (!mark) {
+      mark = {};
+      this.generationMarks.set(key, mark);
+      if (this.generationMarks.size > this.maxGenerationMarks) {
+        const oldest = this.generationMarks.keys().next().value;
+        if (oldest !== undefined) this.generationMarks.delete(oldest);
+      }
+    }
+    const verdict = apply(mark, generation === entry.generation ? entry : undefined);
+    if (!verdict.accepted) {
+      this.pushAnomaly({
+        terminalId,
+        generation,
+        currentGeneration: entry.generation,
+        op,
+        reason: verdict.reason,
+        detail: verdict.detail,
+        at: this.now(),
+      });
+    }
+    return verdict;
+  }
+
+  private reject(
+    op: string,
+    terminalId: string,
+    generation: number,
+    currentGeneration: number | null,
+    reason: LedgerRejectReason,
+    detail?: string
+  ): LedgerVerdict {
+    this.pushAnomaly({
+      terminalId,
+      generation,
+      currentGeneration,
+      op,
+      reason,
+      detail,
+      at: this.now(),
+    });
+    return { accepted: false, reason, detail };
+  }
+
+  private pushAnomaly(anomaly: LedgerAnomaly): void {
+    this.anomalies.push(anomaly);
+    if (this.anomalies.length > this.maxAnomalies) {
+      this.anomalies.splice(0, this.anomalies.length - this.maxAnomalies);
+    }
+    this.onAnomaly?.(anomaly);
+  }
+
+  private evictIfNeeded(): void {
+    if (this.entries.size <= this.maxTerminals) return;
+    // Prefer evicting closed entries (oldest first); fall back to oldest live.
+    for (const [id, entry] of this.entries) {
+      if (entry.closedAt !== undefined) {
+        this.entries.delete(id);
+        if (this.entries.size <= this.maxTerminals) return;
+      }
+    }
+    for (const id of this.entries.keys()) {
+      this.entries.delete(id);
+      if (this.entries.size <= this.maxTerminals) return;
+    }
+  }
+}

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -33,6 +33,7 @@ import { TerminalRestoreController } from "./TerminalRestoreController";
 import { TerminalReflowController, forceXtermReflow } from "./TerminalReflowController";
 import { TerminalReconciliationWatchdog } from "./TerminalReconciliationWatchdog";
 import { TerminalWriteController } from "./TerminalWriteController";
+import { agentLifecycleLedger } from "./lifecycleLedger";
 import { reportFileLinkFailure } from "./FileLinksAddon";
 import {
   installTerminalBoundListeners,
@@ -1813,6 +1814,22 @@ class TerminalInstanceService {
     const managed = this.instances.get(id);
     const deferredWake = managed?.pendingVisibilityWake === true;
     if (managed) managed.pendingVisibilityWake = false;
+
+    // Record the first live-attach geometry in the lifecycle ledger (once per
+    // launch generation — recordFirstAttach ignores later attaches). Pairs
+    // with the 80x24 initial dims stamped at launch so a support bundle can
+    // show whether a pane ever converged from boot geometry.
+    if (managed) {
+      const generation = agentLifecycleLedger.currentGeneration(id);
+      if (generation !== undefined) {
+        agentLifecycleLedger.recordFirstAttach(
+          id,
+          generation,
+          managed.terminal.cols,
+          managed.terminal.rows
+        );
+      }
+    }
 
     const waiters = this.attachSettledWaiters.get(id);
     if (waiters) {

--- a/src/services/terminal/lifecycleLedger.ts
+++ b/src/services/terminal/lifecycleLedger.ts
@@ -1,0 +1,28 @@
+import {
+  AgentTerminalLifecycleLedger,
+  type LedgerAnomaly,
+} from "@shared/utils/agentLifecycleLedger";
+import { logWarn } from "@/utils/logger";
+
+/**
+ * Renderer-side lifecycle ledger. The panel store has no generation counter of
+ * its own — `spawnStatus` plus existence re-checks were the only guards — so
+ * this ledger provides the per-panel launch epoch that async completions
+ * (spawn resolve, hydration/reconnect merges, worktree inference) validate
+ * against before touching panel state. Complements, not replaces, the
+ * instance-scoped guards (`attachGeneration`, `restoreGeneration`), which die
+ * with the ManagedTerminal while the panel row and its id survive.
+ *
+ * Per project view (one instance per renderer context), diagnostic-grade and
+ * bounded; main's ledger remains the authority for journal dedupe.
+ */
+function logAnomaly(anomaly: LedgerAnomaly): void {
+  if (import.meta.env?.PROD) return;
+  logWarn(
+    `[LifecycleLedger] ${anomaly.op} rejected on ${anomaly.terminalId} ` +
+      `(gen ${anomaly.generation ?? "?"} vs current ${anomaly.currentGeneration ?? "?"}): ${anomaly.reason}` +
+      (anomaly.detail ? ` — ${anomaly.detail}` : "")
+  );
+}
+
+export const agentLifecycleLedger = new AgentTerminalLifecycleLedger({ onAnomaly: logAnomaly });

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -11,6 +11,7 @@ import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
 import { reduceAgentDetected, reduceAgentExited } from "./identityReducer";
 import { logIdentityDebugDev, recordIdentityEventDev } from "./identityDiagnostics";
+import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 
 // Per-terminal baseline of `changedFileCount` captured the first time an
 // agent enters "working" in a session. Compared against the count at
@@ -243,6 +244,21 @@ export function setupIdentityListeners(): DisposableStore {
             `[IdentityDebug] detected IGNORED term=${terminalId.slice(-8)} reason=no-icon-and-no-agent`
           );
           return;
+        }
+
+        // Audit the detected-agent evolution for this launch generation
+        // (bounded per generation; duplicate consecutive detections no-op).
+        // Gated on a live panel so a late detection for a removed terminal
+        // doesn't keep writing into its retired ledger entry.
+        if (nextDetectedAgentId && usePanelStore.getState().panelsById[terminalId]) {
+          const ledgerGeneration = agentLifecycleLedger.currentGeneration(terminalId);
+          if (ledgerGeneration !== undefined) {
+            agentLifecycleLedger.recordDetectedAgent(
+              terminalId,
+              ledgerGeneration,
+              nextDetectedAgentId
+            );
+          }
         }
 
         usePanelStore.setState((state) => {

--- a/src/store/slices/panelRegistry/__tests__/addPanelLifecycleLedger.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelLifecycleLedger.test.ts
@@ -86,12 +86,32 @@ function getPtyPanel(id: string): PtyPanelData | undefined {
   return usePanelStore.getState().panelsById[id] as PtyPanelData | undefined;
 }
 
+// Drain microtasks: the spawn task chains through Promise.all (env fetch) →
+// terminalClient.spawn → set ready → waitForAttachSettled, all microtask-fast
+// under mocked IPC. Mirrors the optimisticPanelSpawn test (#5789), which uses
+// the same spawn flow and passes reliably under CI. vi.waitFor's macrotask
+// polling adds OS-scheduler jitter that can race the spawn task under load.
+async function drainMicrotasks(iterations = 100): Promise<void> {
+  for (let i = 0; i < iterations; i++) {
+    await Promise.resolve();
+  }
+}
+
 describe("addPanel lifecycle ledger", () => {
   beforeEach(async () => {
     await usePanelStore.getState().reset();
     agentLifecycleLedger.clear();
     terminalClient.spawn.mockReset().mockResolvedValue(undefined);
     terminalClient.kill.mockReset().mockResolvedValue(undefined);
+    // Explicitly reset waitForAttachSettled so the spawn task's post-ready
+    // await resolves immediately. The mock factory sets mockResolvedValue but
+    // a prior test's mockImplementation (or vitest's mock state under load)
+    // can survive into the next test if not explicitly cleared — mirrors the
+    // optimisticPanelSpawn test's beforeEach.
+    const { terminalInstanceService } = await import("@/services/TerminalInstanceService");
+    const waitForAttachSettledMock = vi.mocked(terminalInstanceService.waitForAttachSettled);
+    waitForAttachSettledMock.mockReset();
+    waitForAttachSettledMock.mockResolvedValue(undefined);
   });
 
   it("records launch facts, spawn resolution, and env provenance", async () => {
@@ -108,9 +128,8 @@ describe("addPanel lifecycle ledger", () => {
     });
 
     expect(id).toBe("term-facts");
-    await vi.waitFor(() => {
-      expect(getPtyPanel("term-facts")?.spawnStatus).toBe("ready");
-    });
+    await drainMicrotasks();
+    expect(getPtyPanel("term-facts")?.spawnStatus).toBe("ready");
 
     const entry = agentLifecycleLedger.getEntry("term-facts");
     expect(entry?.generation).toBe(1);
@@ -144,9 +163,8 @@ describe("addPanel lifecycle ledger", () => {
     expect(id).toBe("term-race");
 
     // Wait until the startup queue has issued the spawn IPC.
-    await vi.waitFor(() => {
-      expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
-    });
+    await drainMicrotasks();
+    expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
 
     // User closes the panel while the spawn IPC is still in flight.
     usePanelStore.getState().removePanel("term-race");
@@ -156,9 +174,8 @@ describe("addPanel lifecycle ledger", () => {
 
     // Spawn resolves late — the orphaned PTY must be compensating-killed.
     resolveSpawn();
-    await vi.waitFor(() => {
-      expect(terminalClient.kill.mock.calls.length).toBeGreaterThan(killsAtRemoval);
-    });
+    await drainMicrotasks();
+    expect(terminalClient.kill.mock.calls.length).toBeGreaterThan(killsAtRemoval);
     expect(usePanelStore.getState().panelsById["term-race"]).toBeUndefined();
   });
 
@@ -174,9 +191,8 @@ describe("addPanel lifecycle ledger", () => {
       location: "grid",
       bypassLimits: true,
     });
-    await vi.waitFor(() => {
-      expect(getPtyPanel("term-live")?.spawnStatus).toBe("ready");
-    });
+    await drainMicrotasks();
+    expect(getPtyPanel("term-live")?.spawnStatus).toBe("ready");
 
     // A hydration replay for the same id arrives late, carrying a stale
     // persisted snapshot with different launch metadata.

--- a/src/store/slices/panelRegistry/__tests__/addPanelLifecycleLedger.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/addPanelLifecycleLedger.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Generation-safety tests for the panel-store lifecycle ledger wiring:
+ * close-before-spawn resolution, stale hydration replay over a live launch,
+ * and idempotent double-hydration re-merge.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PtyPanelData } from "@shared/types/panel";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    onPanelBackgrounded: vi.fn(),
+    destroy: vi.fn(),
+    prewarmTerminal: vi.fn(),
+    setInputLocked: vi.fn(),
+    sendPtyResize: vi.fn(),
+    waitForAttachSettled: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(() => null),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  (globalThis as { window?: unknown }).window = {
+    electron: {
+      globalEnv: {
+        get: vi.fn().mockResolvedValue({}),
+      },
+    },
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+const { agentLifecycleLedger } = await import("@/services/terminal/lifecycleLedger");
+const { terminalClient } = (await import("@/clients")) as unknown as {
+  terminalClient: {
+    spawn: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
+  };
+};
+
+function getPtyPanel(id: string): PtyPanelData | undefined {
+  return usePanelStore.getState().panelsById[id] as PtyPanelData | undefined;
+}
+
+describe("addPanel lifecycle ledger", () => {
+  beforeEach(async () => {
+    await usePanelStore.getState().reset();
+    agentLifecycleLedger.clear();
+    terminalClient.spawn.mockReset().mockResolvedValue(undefined);
+    terminalClient.kill.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("records launch facts, spawn resolution, and env provenance", async () => {
+    const id = await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      requestedId: "term-facts",
+      cwd: "/repo/wt-a",
+      worktreeId: "wt-a",
+      launchAgentId: "claude",
+      agentModelId: "opus",
+      env: { ANTHROPIC_API_KEY: "sk-secret" },
+      location: "grid",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("term-facts");
+    await vi.waitFor(() => {
+      expect(getPtyPanel("term-facts")?.spawnStatus).toBe("ready");
+    });
+
+    const entry = agentLifecycleLedger.getEntry("term-facts");
+    expect(entry?.generation).toBe(1);
+    expect(entry?.facts).toMatchObject({
+      launchAgentId: "claude",
+      agentModelId: "opus",
+      worktreeId: "wt-a",
+      worktreeSource: "explicit",
+    });
+    expect(entry?.spawnOk).toBe(true);
+    expect(entry?.facts.env?.keys).toEqual(["ANTHROPIC_API_KEY"]);
+    expect(JSON.stringify(entry)).not.toContain("sk-secret");
+  });
+
+  it("close-before-spawn: removal mid-spawn closes the generation and compensates with a kill", async () => {
+    let resolveSpawn!: () => void;
+    terminalClient.spawn.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSpawn = resolve;
+        })
+    );
+
+    const id = await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      requestedId: "term-race",
+      cwd: "/repo",
+      location: "grid",
+      bypassLimits: true,
+    });
+    expect(id).toBe("term-race");
+
+    // Wait until the startup queue has issued the spawn IPC.
+    await vi.waitFor(() => {
+      expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
+    });
+
+    // User closes the panel while the spawn IPC is still in flight.
+    usePanelStore.getState().removePanel("term-race");
+    expect(agentLifecycleLedger.getEntry("term-race")?.closedAt).toBeDefined();
+    expect(agentLifecycleLedger.getEntry("term-race")?.closeReason).toBe("removed");
+    const killsAtRemoval = terminalClient.kill.mock.calls.length;
+
+    // Spawn resolves late — the orphaned PTY must be compensating-killed.
+    resolveSpawn();
+    await vi.waitFor(() => {
+      expect(terminalClient.kill.mock.calls.length).toBeGreaterThan(killsAtRemoval);
+    });
+    expect(usePanelStore.getState().panelsById["term-race"]).toBeUndefined();
+  });
+
+  it("stale hydration replay cannot overwrite a live fresh launch", async () => {
+    // Fresh user launch owns the id.
+    await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      requestedId: "term-live",
+      cwd: "/repo/wt-a",
+      worktreeId: "wt-a",
+      launchAgentId: "claude",
+      agentModelId: "opus",
+      location: "grid",
+      bypassLimits: true,
+    });
+    await vi.waitFor(() => {
+      expect(getPtyPanel("term-live")?.spawnStatus).toBe("ready");
+    });
+
+    // A hydration replay for the same id arrives late, carrying a stale
+    // persisted snapshot with different launch metadata.
+    const replayId = await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      existingId: "term-live",
+      cwd: "/repo/old-path",
+      launchAgentId: "codex",
+      agentModelId: "stale-model",
+      location: "grid",
+      bypassLimits: true,
+    });
+
+    // The call reports the id (panel exists) but the live panel is untouched.
+    expect(replayId).toBe("term-live");
+    const panel = getPtyPanel("term-live");
+    expect(panel?.launchAgentId).toBe("claude");
+    expect(panel?.agentModelId).toBe("opus");
+    expect(panel?.cwd).toBe("/repo/wt-a");
+
+    // The rejection is auditable.
+    const anomalies = agentLifecycleLedger.getAnomalies();
+    expect(anomalies.some((a) => a.op === "restore" && a.terminalId === "term-live")).toBe(true);
+  });
+
+  it("allows an idempotent re-merge when the panel itself is restore-born", async () => {
+    // First hydration pass creates the reconnect panel.
+    await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      existingId: "term-restored",
+      cwd: "/repo/wt-a",
+      launchAgentId: "claude",
+      agentModelId: "opus",
+      location: "grid",
+      bypassLimits: true,
+    });
+    expect(getPtyPanel("term-restored")).toBeDefined();
+    expect(agentLifecycleLedger.getEntry("term-restored")?.restoredAt).toBeDefined();
+
+    // Double hydration re-merges the same snapshot — allowed and applied.
+    await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      existingId: "term-restored",
+      cwd: "/repo/wt-a",
+      launchAgentId: "claude",
+      agentModelId: "opus-4.1",
+      location: "grid",
+      bypassLimits: true,
+    });
+
+    expect(getPtyPanel("term-restored")?.agentModelId).toBe("opus-4.1");
+    expect(agentLifecycleLedger.currentGeneration("term-restored")).toBe(2);
+  });
+
+  it("stamps inferred worktree provenance from AddPanelOptions", async () => {
+    await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      requestedId: "term-inferred",
+      cwd: "/repo/wt-b/sub",
+      worktreeId: "wt-b",
+      worktreeIdSource: "inferred",
+      location: "grid",
+      bypassLimits: true,
+    });
+
+    const entry = agentLifecycleLedger.getEntry("term-inferred");
+    expect(entry?.facts.worktreeSource).toBe("inferred");
+
+    // A later explicit move wins; a later divergent inference is rejected.
+    const generation = entry!.generation;
+    expect(
+      agentLifecycleLedger.recordWorktreeAttribution(
+        "term-inferred",
+        generation,
+        "wt-c",
+        "explicit"
+      ).accepted
+    ).toBe(true);
+    expect(
+      agentLifecycleLedger.recordWorktreeAttribution(
+        "term-inferred",
+        generation,
+        "wt-d",
+        "inferred"
+      ).accepted
+    ).toBe(false);
+  });
+});

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -33,6 +33,8 @@ import { logDebug, logWarn, logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { collectPanelIdForBatch, isHydrationBatchActive } from "./hydrationBatch";
 import { addToWorktreeIndex, transferBetweenWorktreeIndex } from "./worktreeIndex";
+import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
+import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
 
 // Lazy accessor to break circular dependency: addPanel -> projectStore -> panelPersistence -> addPanel.
 // Resolved on first call (after app init), then cached.
@@ -362,6 +364,30 @@ export const createAddPanelActions = (
       ? options.lastStateChange
       : (options.lastStateChange ?? (agentState !== undefined ? Date.now() : undefined));
 
+    // Stale-restore guard: a reconnect/hydration replay must never overwrite a
+    // LIVE fresh launch that already owns this id. The ledger distinguishes the
+    // two owners of an existing panel: an earlier restore pass stamped
+    // `restoredAt` (double hydration — merging the same snapshot again is
+    // idempotent and allowed), while a fresh launch did not (its metadata —
+    // launchAgentId, model, preset, env — is newer than the snapshot and the
+    // merge below would clobber it). Generation 0 = "persisted snapshot,
+    // predates every launch this session", so the rejection lands in the
+    // anomaly ring for diagnostics.
+    if (isReconnect) {
+      const preexisting = get().panelsById[id];
+      const ledgerEntry = preexisting ? agentLifecycleLedger.getEntry(id) : undefined;
+      if (
+        preexisting &&
+        ledgerEntry &&
+        ledgerEntry.closedAt === undefined &&
+        ledgerEntry.restoredAt === undefined
+      ) {
+        agentLifecycleLedger.recordRestoreApplied(id, 0);
+        logWarn("[TerminalStore] Rejected stale restore over a live launch", { id });
+        return id;
+      }
+    }
+
     // PTY-backed plugin-contributed kinds are rare today, but stamp pluginId
     // if the registry has an entry so the panel survives plugin removal.
     const ptyKindConfig = getPanelKindConfig(kind);
@@ -594,6 +620,34 @@ export const createAddPanelActions = (
       });
     }
 
+    // Mint the panel's launch generation atomically with the commit above (no
+    // await between id reservation and here). Every async completion below —
+    // env fetch, spawn IPC, attach settle — re-validates against it so a
+    // completion that outlives this incarnation (panel closed, id reused by a
+    // restart or a stale hydration replay) can never write into a successor.
+    const launchGeneration = agentLifecycleLedger.recordLaunch(id, {
+      launchAgentId,
+      cwd: options.cwd,
+      projectId: capturedProjectId,
+      worktreeId: options.worktreeId,
+      worktreeSource:
+        options.worktreeId !== undefined ? (options.worktreeIdSource ?? "explicit") : undefined,
+      agentModelId: options.agentModelId,
+      agentPresetId: options.agentPresetId,
+      originalPresetId: options.originalPresetId ?? options.agentPresetId,
+      agentLaunchFlags: options.agentLaunchFlags,
+      env: computeEnvProvenance(options.env),
+      initialCols: 80,
+      initialRows: 24,
+      spawnedBy: options.spawnedBy,
+      resumedFromSessionId: options.agentSessionId,
+    });
+    if (isReconnect) {
+      // Mark this generation as restore-born so the stale-restore guard above
+      // can tell an idempotent re-merge from a clobbering one.
+      agentLifecycleLedger.recordRestoreApplied(id, launchGeneration);
+    }
+
     // Prewarm renderer-side xterm immediately so we never drop startup output/ANSI while hidden.
     // earlyDataBuffer in terminalClient buffers any data that arrives before the
     // xterm data callback is registered, so prewarming with the pre-assigned id
@@ -807,6 +861,26 @@ export const createAddPanelActions = (
           actionContext: options.actionContext,
         });
 
+        // Reject a spawn resolution that no longer belongs to this incarnation:
+        // if a restart or hydration replay re-launched the id while our IPC was
+        // in flight, the successor owns spawnStatus now and its own resolution
+        // manages it. The ledger records the rejection as an anomaly. One
+        // carve-out: when the successor's panel is ALSO gone, the backend PTY
+        // this resolution just created has no owner at all — kill it, exactly
+        // like the orphan path below (killing the shared id is safe only when
+        // no live panel claims it).
+        if (!agentLifecycleLedger.recordSpawnResolved(id, launchGeneration, true).accepted) {
+          if (!get().panelsById[id]) {
+            terminalClient.kill(id).catch((killError) => {
+              logWarn("[TerminalStore] Compensating kill after stale spawn resolution failed", {
+                id,
+                error: killError,
+              });
+            });
+          }
+          return;
+        }
+
         // Promote spawnStatus to "ready" once the PTY is live. If the panel was
         // removed during the spawn window, issue a compensating kill to avoid
         // orphaning the freshly-spawned PTY (removePanel's kill IPC was a no-op
@@ -862,6 +936,11 @@ export const createAddPanelActions = (
         }
       } catch (error) {
         logError("[TerminalStore] Failed to spawn terminal", error);
+        // Same staleness gate as the success path: never stamp a failure onto
+        // a successor incarnation that re-launched this id mid-flight.
+        if (!agentLifecycleLedger.recordSpawnResolved(id, launchGeneration, false).accepted) {
+          return;
+        }
         const current = get().panelsById[id];
         if (!current || !isPtyPanel(current) || current.spawnStatus !== "spawning") return;
 

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -25,9 +25,22 @@ import {
 } from "./hydrationBatch";
 import type { HydrationBatchToken } from "./types";
 import { removeFromWorktreeIndex } from "./worktreeIndex";
+import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
+
+/**
+ * Close out a panel's ledger generation on a user-final removal. Marks
+ * exactly-once per generation; a spawn still in flight for this incarnation
+ * will see the entry closed and route through the compensating-kill path.
+ */
+function recordLedgerClose(id: string, reason: string): void {
+  const generation = agentLifecycleLedger.currentGeneration(id);
+  if (generation !== undefined) {
+    agentLifecycleLedger.recordClose(id, generation, reason);
+  }
+}
 
 /**
  * Reveal a batch's collected panel ids in `panelIds` and persist once. The
@@ -122,6 +135,7 @@ export const createCorePanelActions = (
 
     // Only call PTY operations for PTY-backed terminals
     if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
+      recordLedgerClose(id, "removed");
       terminalClient.kill(id).catch((error) => {
         logError("[TerminalStore] Failed to kill terminal", error);
       });
@@ -199,6 +213,7 @@ export const createCorePanelActions = (
       }
 
       if (panelKindHasPty(terminal.kind ?? "terminal")) {
+        recordLedgerClose(id, "trash-emptied");
         terminalClient.kill(id).catch((error) => {
           logError("[TerminalStore] Failed to kill terminal", error);
         });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -28,6 +28,8 @@ import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { isPtyPanel } from "@shared/types/panel";
+import { agentLifecycleLedger } from "@/services/terminal/lifecycleLedger";
+import { computeEnvProvenance } from "@shared/utils/agentLifecycleLedger";
 import { markTerminalRestarting, unmarkTerminalRestarting } from "@/store/restartExitSuppression";
 import { saveNormalized } from "./persistence";
 import { optimizeForDock } from "./layout";
@@ -626,6 +628,24 @@ export const createRestartActions = (
       // xterm 6.0 does not inherit `disableStdin` across instance recreation.
       terminalInstanceService.setInputLocked(id, true);
 
+      // A restart is a new incarnation of the same panel id — advance the
+      // renderer ledger so post-restart attach/detection/close events record
+      // against the respawned generation, not the killed one.
+      agentLifecycleLedger.recordLaunch(id, {
+        launchAgentId: isAgent ? currentTerminal.launchAgentId : undefined,
+        cwd: currentTerminal.cwd,
+        projectId: capturedProjectId,
+        worktreeId: currentTerminal.worktreeId,
+        worktreeSource: currentTerminal.worktreeId !== undefined ? "explicit" : undefined,
+        agentModelId: isAgent ? currentTerminal.agentModelId : undefined,
+        agentPresetId: nextAgentPresetId,
+        originalPresetId: nextOriginalPresetId ?? nextAgentPresetId,
+        agentLaunchFlags: isAgent ? nextAgentLaunchFlags : undefined,
+        env: computeEnvProvenance(restartEnv),
+        initialCols: spawnCols,
+        initialRows: spawnRows,
+      });
+
       await terminalClient.spawn({
         id,
         projectId: capturedProjectId,
@@ -772,6 +792,13 @@ export const createRestartActions = (
 
     // Terminal is not in a group - move it individually
     let movedToLocation: PanelLocation | null = null;
+
+    // A user-initiated move is explicit worktree attribution — recorded so
+    // later cwd-based inference can never silently overwrite it.
+    const ledgerGeneration = agentLifecycleLedger.currentGeneration(id);
+    if (ledgerGeneration !== undefined) {
+      agentLifecycleLedger.recordWorktreeAttribution(id, ledgerGeneration, worktreeId, "explicit");
+    }
 
     set((state) => {
       // Scrollable grid (#8805): restoring a panel always lands it in the
@@ -1124,6 +1151,23 @@ export const createRestartActions = (
       const capturedProjectId = projectStore.getState().currentProject?.id;
 
       const restartEnv = await buildRestartEnv(capturedProjectId, runtimeSettings.env, "fallback");
+
+      // A fallback hop respawns the id — new renderer ledger incarnation, with
+      // the hopped preset recorded as the active one.
+      agentLifecycleLedger.recordLaunch(id, {
+        launchAgentId: terminal.launchAgentId,
+        cwd: terminal.cwd,
+        projectId: capturedProjectId,
+        worktreeId: terminal.worktreeId,
+        worktreeSource: terminal.worktreeId !== undefined ? "explicit" : undefined,
+        agentModelId: terminal.agentModelId,
+        agentPresetId: nextPreset.id,
+        originalPresetId: originalPresetId,
+        agentLaunchFlags: nextLaunchFlags,
+        env: computeEnvProvenance(restartEnv),
+        initialCols: spawnCols,
+        initialRows: spawnRows,
+      });
 
       await terminalClient.spawn({
         id,

--- a/src/utils/stateHydration/panelRestorePhase.ts
+++ b/src/utils/stateHydration/panelRestorePhase.ts
@@ -544,11 +544,16 @@ export async function restorePanelsPhase(
         // Orphaned backend terminals no longer carry worktreeId — infer it
         // from cwd against the loaded worktrees, then fall back to the
         // active worktree so the panel still appears in the grid filter.
+        // Both are inferred attribution: the lifecycle ledger records the
+        // provenance so cwd inference can never overwrite a worktree the
+        // user explicitly chose later in this panel's life.
         const inferred = inferWorktreeIdFromCwd(terminal.cwd, worktreesForInfer ?? undefined);
         if (inferred) {
           orphanArgs.worktreeId = inferred;
+          orphanArgs.worktreeIdSource = "inferred";
         } else if (activeWorktreeId) {
           orphanArgs.worktreeId = activeWorktreeId;
+          orphanArgs.worktreeIdSource = "inferred";
         }
         const restoredTerminalId = await addPanel(orphanArgs);
 


### PR DESCRIPTION
This PR adds a generation-safe lifecycle ledger for agent terminals. It's a bounded, in-memory audit layer (`shared/utils/agentLifecycleLedger.ts`), instantiated once per process: renderer, main, and pty-host.

Main mints a monotonic `launchGeneration` for each terminal id on every spawn and stamps it onto the spawn options. The pty-host adopts it and echoes it back on `exit` and `agent-session-captured` events, so every cross-process completion keys to the exact incarnation that produced it. Live-state operations (resize, restore, attach) only apply to the current generation. Terminal-final operations (close, journal) are exactly-once per generation and tolerate past generations, so a kill's journal write that lands after a same-id respawn is neither dropped nor pinned on the successor.

What this closes off:

- **Session journaling is exactly-once per terminal generation.** All four close paths (trash expiry, kill, graceful kill, app shutdown) now run through a single funnel, `journalAgentSession`, which gates on the ledger before writing. The mark is a reservation: if the write fails it gets rescinded, so a retry still lands.
- **Buffered pre-spawn resizes can't leak across incarnations.** The pty-host stamps buffered resizes with the generation current at buffering time and drops stale ones at the next spawn, so a killed terminal's geometry never becomes its successor's boot size.
- **Stale spawn results can't clear a live successor.** `spawn-result` now echoes the generation, so a late failure from a killed predecessor no longer deletes the replacement's `pendingSpawns` entry (which would have lost it from host-crash replay).
- **Host-crash respawns are new incarnations.** `respawnPending` closes the old generation and mints a fresh one per replayed terminal. The initial-ready replay keeps its generation, since nothing was ever delivered.
- **The renderer rejects stale completions.** Spawn resolutions and hydration/reconnect merges that no longer belong to the live incarnation are refused, so a stale persisted snapshot can't overwrite the launch metadata (`launchAgentId`, model, preset, env) of a fresh launch. Inferred (cwd-derived) worktree attribution never overwrites an explicit one.

Env is recorded as sorted key names plus a hash, never values. Diagnostics bundles get a new `lifecycleLedger` section with per-terminal launch facts and a bounded anomaly ring buffer, so a support bundle can show lifecycle races instead of us guessing at them.

## Test coverage

- 52 new unit tests: ledger transitions and generation rejection, journal exactly-once plus rescind-on-failure, spawn races (close before spawn resolves, stale spawn results, pty-host restart during replay), buffered-resize staleness, and the stale-hydration guard.
- A new Playwright spec (`e2e/full/resilience/agent-lifecycle-ledger.spec.ts`) launches a recipe terminal with caller-resolved env, forces LRU eviction of its project view, revives it and verifies the live PTY kept its cwd and env identity, then closes it and asserts the ledger reports coherent facts with zero anomalies. Verified locally, 3/3 passing.
- `npm run check` and the surrounding unit suites (roughly 16.9k tests) pass.

This follows the run of one-off lifecycle fixes in #10940, #10927, #10905 and #10811. The ledger makes the next one systematic: stale completions are rejected by generation, not by timing luck.
