### PR TITLE
fix(window): paint persisted project identity on initial host skeleton

### DIFF
--- a/electron/services/persistence/readLastProjectId.ts
+++ b/electron/services/persistence/readLastProjectId.ts
@@ -1,10 +1,11 @@
-// eager-import-allow: reads the last-active project id from SQLite synchronously before the window opens
+// eager-import-allow: reads last-active project state from SQLite synchronously before the window opens
 /**
- * Synchronous, standalone reader for the last-active projectId.
+ * Synchronous, standalone readers for the last-active project.
  *
- * Called BEFORE app.whenReady() to determine the correct session partition
- * for the initial WebContentsView. Uses its own read-only better-sqlite3
- * connection — does not depend on getSharedDb() or ProjectStore.initialize().
+ * Called BEFORE app.whenReady() / on the early-renderer boot path. Each uses its
+ * own read-only better-sqlite3 connection — they do not depend on getSharedDb()
+ * or ProjectStore.initialize() (the shared DB is not open yet at this point in
+ * boot, and opening it would run migrations on the loadURL-dispatch path).
  *
  * Returns null on first launch, corrupt DB, or any error (safe fallback).
  */
@@ -13,6 +14,7 @@ import Database from "better-sqlite3";
 import { app } from "electron";
 import fs from "node:fs";
 import path from "path";
+import type { Project } from "../../../shared/types/project.js";
 
 export function readLastActiveProjectIdSync(): string | null {
   try {
@@ -34,6 +36,43 @@ export function readLastActiveProjectIdSync(): string | null {
   } catch {
     // Any error (corrupt DB, missing table, etc.) — fall back to default session.
     // The full DB init in setupWindowServices will handle recovery.
+    return null;
+  }
+}
+
+/**
+ * Synchronous, standalone reader for the last-active project's skeleton
+ * identity (name, emoji, accent color). Used by the initial host window's boot
+ * skeleton so it paints the destination project's accent + name/emoji and
+ * matches a cold project switch (#10942). Like readLastActiveProjectIdSync,
+ * reads via its own throwaway read-only connection so the shared DB never has
+ * to be open — and never gets force-opened — on the boot path.
+ *
+ * Returns null when the id is missing, the project row is gone (deleted), or
+ * anything throws; the anonymous gray skeleton remains the fallback.
+ */
+export function readLastActiveProjectIdentitySync(
+  projectId: string
+): Pick<Project, "name" | "emoji" | "color"> | null {
+  try {
+    const dbPath = path.join(app.getPath("userData"), "daintree.db");
+
+    if (!fs.existsSync(dbPath)) {
+      return null; // First launch — no database yet
+    }
+
+    const sqlite = new Database(dbPath, { readonly: true });
+    try {
+      const row = sqlite
+        .prepare("SELECT name, emoji, color FROM projects WHERE id = ?")
+        .get(projectId) as { name: string; emoji: string; color: string | null } | undefined;
+      if (!row) return null;
+      return { name: row.name, emoji: row.emoji, color: row.color ?? undefined };
+    } finally {
+      sqlite.close();
+    }
+  } catch {
+    // Corrupt DB, missing column, etc. — anonymous skeleton is the fallback.
     return null;
   }
 }

--- a/electron/window/__tests__/windowShowSequence.test.ts
+++ b/electron/window/__tests__/windowShowSequence.test.ts
@@ -304,10 +304,11 @@ describe("window show sequence", () => {
     loadRenderer("startup", "proj-1");
 
     // The project is resolved before the CSS precompute, threaded in alongside
-    // the pre-read themeConfig. The boot path must NOT pass instantReveal — the
-    // 400ms Doherty gate belongs on the initial launch (3rd arg undefined).
+    // the pre-read themeConfig. The boot path passes exactly two args — project
+    // + themeConfig — and NO instantReveal option, so the 400ms Doherty gate
+    // stays on the initial launch (toHaveBeenCalledWith already pins arity).
     expect(buildSkeletonCss).toHaveBeenCalledWith(project, expect.anything());
-    expect(buildSkeletonCss.mock.calls[0][2]).toBeUndefined();
+    expect(buildSkeletonCss.mock.calls[0]).toHaveLength(2);
     expect(readLastActiveProjectIdentity).toHaveBeenCalledWith("proj-1");
 
     const domReadyHandlers = listeners.get("dom-ready") ?? [];

--- a/electron/window/__tests__/windowShowSequence.test.ts
+++ b/electron/window/__tests__/windowShowSequence.test.ts
@@ -39,9 +39,15 @@ interface SetupArgs {
   win: ReturnType<typeof createMockWindow>;
   appView: ReturnType<typeof createMockAppView>;
   windowBg: string;
-  buildSkeletonCss?: () => string;
+  buildSkeletonCss?: (
+    project: unknown | null,
+    themeConfig?: unknown,
+    options?: { instantReveal?: boolean }
+  ) => string;
   insertSkeletonCss?: (wc: unknown, css: string) => void;
-  injectSkeletonCss?: (wc: unknown) => void;
+  injectSkeletonCss?: (wc: unknown, project: unknown | null) => void;
+  injectSkeletonProjectIdentity?: (wc: unknown, project: unknown | null) => void;
+  readLastActiveProjectIdentity?: (projectId: string) => unknown | null;
 }
 
 const SHOW_FALLBACK_MS = 5_000;
@@ -58,24 +64,36 @@ function buildLoadRenderer({
   buildSkeletonCss = () => "precomputed",
   insertSkeletonCss = vi.fn(),
   injectSkeletonCss = vi.fn(),
+  injectSkeletonProjectIdentity = vi.fn(),
+  readLastActiveProjectIdentity = () => null,
 }: SetupArgs) {
   appView.setBackgroundColor(windowBg);
   const appWebContents = appView.webContents;
+  const themeConfig = {}; // fixture — production holds the pre-read appTheme config
 
   let rendererLoadRequested = false;
-  return (reason: string): void => {
+  return (reason: string, projectId?: string): void => {
     if (win.isDestroyed() || rendererLoadRequested) return;
     rendererLoadRequested = true;
 
-    const precomputedSkeletonCss = buildSkeletonCss();
+    // Resolve the persisted last-active project's identity via the standalone
+    // read-only reader so the boot skeleton matches a cold project switch
+    // (#10942). Mirrors createWindow.ts.
+    const initialProject = projectId ? readLastActiveProjectIdentity(projectId) : null;
+    const precomputedSkeletonCss = buildSkeletonCss(initialProject, themeConfig);
     let firstDomReady = true;
     appWebContents.on("dom-ready", () => {
-      if (firstDomReady) {
-        firstDomReady = false;
+      const crashReload = !firstDomReady;
+      // Re-read on crash auto-reload so a renamed/recolored project stays fresh.
+      const project =
+        crashReload && projectId ? readLastActiveProjectIdentity(projectId) : initialProject;
+      firstDomReady = false;
+      if (!crashReload) {
         insertSkeletonCss(appWebContents, precomputedSkeletonCss);
       } else {
-        injectSkeletonCss(appWebContents);
+        injectSkeletonCss(appWebContents, project);
       }
+      injectSkeletonProjectIdentity(appWebContents, project);
     });
 
     let shown = false;
@@ -254,10 +272,140 @@ describe("window show sequence", () => {
     persistentCssHandler();
 
     // First parse uses the precomputed string; the crash-reload re-resolves
-    // theme/sidebar/focus state via the full injection path.
+    // theme/sidebar/focus state via the full injection path, threading the
+    // (null here — no projectId supplied) project through.
     expect(insertSkeletonCss).toHaveBeenCalledOnce();
     expect(injectSkeletonCss).toHaveBeenCalledOnce();
-    expect(injectSkeletonCss).toHaveBeenCalledWith(appView.webContents);
+    expect(injectSkeletonCss).toHaveBeenCalledWith(appView.webContents, null);
+  });
+
+  it("threads the persisted project's accent + identity into the boot skeleton (#10942)", () => {
+    const listeners: ListenerMap = new Map();
+    const win = createMockWindow();
+    const appView = createMockAppView(listeners);
+    const project = { name: "Daintree", emoji: "🌳", color: "#11a06b" };
+    const buildSkeletonCss = vi.fn((p: unknown | null) =>
+      p ? "css-with-project-accent" : "css-anonymous"
+    );
+    const insertSkeletonCss = vi.fn();
+    const injectSkeletonProjectIdentity = vi.fn();
+    const readLastActiveProjectIdentity = vi.fn((id: string) => (id === "proj-1" ? project : null));
+
+    const loadRenderer = buildLoadRenderer({
+      win,
+      appView,
+      windowBg: "#0e0e0d",
+      buildSkeletonCss,
+      insertSkeletonCss,
+      injectSkeletonProjectIdentity,
+      readLastActiveProjectIdentity,
+    });
+
+    loadRenderer("startup", "proj-1");
+
+    // The project is resolved before the CSS precompute, threaded in alongside
+    // the pre-read themeConfig. The boot path must NOT pass instantReveal — the
+    // 400ms Doherty gate belongs on the initial launch (3rd arg undefined).
+    expect(buildSkeletonCss).toHaveBeenCalledWith(project, expect.anything());
+    expect(buildSkeletonCss.mock.calls[0][2]).toBeUndefined();
+    expect(readLastActiveProjectIdentity).toHaveBeenCalledWith("proj-1");
+
+    const domReadyHandlers = listeners.get("dom-ready") ?? [];
+    domReadyHandlers[0]();
+
+    // First parse inserts the project-accented precomputed CSS and paints identity.
+    expect(insertSkeletonCss).toHaveBeenCalledWith(appView.webContents, "css-with-project-accent");
+    expect(injectSkeletonProjectIdentity).toHaveBeenCalledWith(appView.webContents, project);
+  });
+
+  it("keeps the anonymous skeleton when no persisted project id is present (#10942)", () => {
+    const listeners: ListenerMap = new Map();
+    const win = createMockWindow();
+    const appView = createMockAppView(listeners);
+    const buildSkeletonCss = vi.fn((p: unknown | null) =>
+      p ? "css-with-project-accent" : "css-anonymous"
+    );
+    const readLastActiveProjectIdentity = vi.fn();
+
+    const loadRenderer = buildLoadRenderer({
+      win,
+      appView,
+      windowBg: "#0e0e0d",
+      buildSkeletonCss,
+      readLastActiveProjectIdentity,
+    });
+
+    loadRenderer("startup"); // no projectId — first launch / no last-active project
+
+    expect(readLastActiveProjectIdentity).not.toHaveBeenCalled();
+    expect(buildSkeletonCss).toHaveBeenCalledWith(null, expect.anything());
+  });
+
+  it("keeps the anonymous skeleton when the persisted project is no longer in the DB", () => {
+    const listeners: ListenerMap = new Map();
+    const win = createMockWindow();
+    const appView = createMockAppView(listeners);
+    const buildSkeletonCss = vi.fn((p: unknown | null) =>
+      p ? "css-with-project-accent" : "css-anonymous"
+    );
+
+    const loadRenderer = buildLoadRenderer({
+      win,
+      appView,
+      windowBg: "#0e0e0d",
+      buildSkeletonCss,
+      readLastActiveProjectIdentity: () => null, // project row gone (deleted)
+    });
+
+    loadRenderer("startup", "proj-1");
+
+    expect(buildSkeletonCss).toHaveBeenCalledWith(null, expect.anything());
+  });
+
+  it("re-reads fresh project identity + accent on a renderer-crash reload (#10942)", () => {
+    const listeners: ListenerMap = new Map();
+    const win = createMockWindow();
+    const appView = createMockAppView(listeners);
+    const initial = { name: "Beta", emoji: "β", color: "#ff0000" };
+    const renamed = { name: "Beta Renamed", emoji: "🟢", color: "#00ff00" };
+    const buildSkeletonCss = vi.fn((p: unknown | null) =>
+      p ? "css-with-project-accent" : "css-anonymous"
+    );
+    const insertSkeletonCss = vi.fn();
+    const injectSkeletonCss = vi.fn();
+    const injectSkeletonProjectIdentity = vi.fn();
+    let readCount = 0;
+    const readLastActiveProjectIdentity = vi.fn(() => (readCount++ === 0 ? initial : renamed));
+
+    const loadRenderer = buildLoadRenderer({
+      win,
+      appView,
+      windowBg: "#0e0e0d",
+      buildSkeletonCss,
+      insertSkeletonCss,
+      injectSkeletonCss,
+      injectSkeletonProjectIdentity,
+      readLastActiveProjectIdentity,
+    });
+
+    loadRenderer("startup", "proj-1");
+
+    // One read at boot for the precomputed CSS.
+    expect(readLastActiveProjectIdentity).toHaveBeenCalledTimes(1);
+
+    const persistentCssHandler = (listeners.get("dom-ready") ?? [])[0];
+    persistentCssHandler(); // initial parse
+    persistentCssHandler(); // crash auto-reload
+
+    // Initial parse uses the boot-read project's precomputed CSS + identity.
+    expect(insertSkeletonCss).toHaveBeenCalledWith(appView.webContents, "css-with-project-accent");
+    expect(injectSkeletonProjectIdentity).toHaveBeenCalledWith(appView.webContents, initial);
+
+    // Crash reload re-reads (now renamed) and rebuilds via the injection path,
+    // so a renamed/recolored project stays current instead of going stale.
+    expect(readLastActiveProjectIdentity).toHaveBeenCalledTimes(2);
+    expect(injectSkeletonCss).toHaveBeenCalledWith(appView.webContents, renamed);
+    expect(injectSkeletonProjectIdentity).toHaveBeenLastCalledWith(appView.webContents, renamed);
   });
 
   it("shows the window via the 5s fallback timer when dom-ready never fires", () => {

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -31,12 +31,14 @@ import {
   buildSkeletonCss,
   insertSkeletonCss,
   injectSkeletonCss,
+  injectSkeletonProjectIdentity,
   resolveInitialColorSchemeId,
   resolveE2EPreloadArgs,
   resolveInstanceRole,
   INITIAL_COLOR_SCHEME_ARG,
   INSTANCE_ROLE_ARG,
 } from "./skeletonCss.js";
+import { readLastActiveProjectIdentitySync } from "../services/persistence/readLastProjectId.js";
 import { attachRendererConsoleCapture } from "./rendererConsoleCapture.js";
 import { markPerformance } from "../utils/performance.js";
 import { registerProtocolsForSession, getDistPath } from "../setup/protocols.js";
@@ -370,15 +372,36 @@ export function setupBrowserWindow(
     // skips the synchronous config.json re-reads; later dom-ready events
     // (crash auto-reloads) rebuild it so the skeleton reflects current
     // theme/sidebar/focus state.
-    const precomputedSkeletonCss = buildSkeletonCss(undefined, themeConfig);
+    // Resolve the persisted last-active project so the initial host skeleton
+    // paints that project's accent + name/emoji, matching a cold project switch
+    // (#10942). readLastActiveProjectIdentitySync reads via its own throwaway
+    // read-only sqlite connection — the shared DB is NOT open yet on the
+    // early-renderer boot path (and opening it would run migrations on the
+    // loadURL-dispatch path), so projectStore.getProjectById can't be used here.
+    // When the id is missing, the project row is gone, or the read fails, the
+    // anonymous gray skeleton (the prior behavior) remains the fallback. Mirrors
+    // the cold-switch handler in ProjectViewManager, minus instantReveal (the
+    // 400ms Doherty gate belongs on the initial launch).
+    const initialProject = projectId ? readLastActiveProjectIdentitySync(projectId) : null;
+    const precomputedSkeletonCss = buildSkeletonCss(initialProject, themeConfig);
     let firstDomReady = true;
     appWebContents.on("dom-ready", () => {
-      if (firstDomReady) {
-        firstDomReady = false;
+      const crashReload = !firstDomReady;
+      // Re-read on crash auto-reload so a renamed/recolored project stays
+      // current (mirrors ProjectViewManager's re-read inside its dom-ready
+      // handler). The first parse reuses the boot-path value captured above.
+      const project =
+        crashReload && projectId ? readLastActiveProjectIdentitySync(projectId) : initialProject;
+      firstDomReady = false;
+      if (!crashReload) {
         insertSkeletonCss(appWebContents, precomputedSkeletonCss);
       } else {
-        injectSkeletonCss(appWebContents);
+        // Rebuild fresh so the skeleton reflects current theme/sidebar/focus
+        // state, keeping the persisted project's accent.
+        injectSkeletonCss(appWebContents, project);
       }
+      // Repaint name/emoji on every parse so crash reloads stay identified.
+      injectSkeletonProjectIdentity(appWebContents, project);
     });
 
     // Gate win.show() on the skeleton markup being parsed so the OS never


### PR DESCRIPTION
## Summary

- The initial host window showed a plain gray anonymous skeleton on cold boot, while cold project switches painted the destination project's accent, name and emoji. Opening a project and switching into the same project looked different.
- The boot path now resolves the persisted last-active project's identity and threads its accent into the precomputed skeleton CSS, with name and emoji injected on every `dom-ready` so renderer-crash reloads stay identified.
- Cold-switch and warm/LRU paths are untouched, and the 400ms Doherty entry gate stays on the boot path. The anonymous gray skeleton remains the fallback when the id is missing, the project row is gone, or the read fails.

Resolves #10942

## Changes

- New `readLastActiveProjectIdentitySync` in `electron/services/persistence/readLastProjectId.ts`, opening its own throwaway read-only sqlite connection. Mirrors the existing `readLastActiveProjectIdSync`. The shared DB is not open on the early `loadURL` boot path, and opening it there would run migrations on the dispatch path.
- `electron/window/createWindow.ts` resolves the project before precomputing the boot skeleton CSS, then re-reads on crash-reload so a renamed or recolored project stays fresh. `instantReveal` is deliberately not passed; the Doherty gate belongs on initial launch.
- `windowShowSequence` tests extended to cover the new flow.

## Testing

- `electron/window/__tests__/windowShowSequence.test.ts` now covers: project accent and identity threaded into the boot skeleton, the no-persisted-projectId fallback, the deleted-project fallback, the no-`instantReveal` boot invariant (400ms Doherty gate preserved), and crash-reload identity freshness.