### PR TITLE
feat(pty-host): per-project PTY host fabric behind DAINTREE_PTY_FABRIC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ From there, follow the architecture doc nearest the surface you're changing. Eac
 | [dev-preview-event-routing.md](./architecture/dev-preview-event-routing.md) | Per-event routing audit for dev-preview lifecycle signals. |
 | [terminal-identity.md](./architecture/terminal-identity.md) | The single PTY-backed panel shape — plain vs agent terminal as runtime states. |
 | [terminal-lifecycle.md](./architecture/terminal-lifecycle.md) | Runtime lifecycle status for terminals across renderer, main, and PTY host. |
+| [pty-host-fabric.md](./architecture/pty-host-fabric.md) | Per-project PTY host shards behind `DAINTREE_PTY_FABRIC` — placement, port routing, crash isolation, idle retirement. |
 | [agent-activity-monitoring.md](./architecture/agent-activity-monitoring.md) | How a live agent terminal is judged working / waiting / completed / exited. |
 | [agent-state-tracking-strategy.md](./architecture/agent-state-tracking-strategy.md) | Why activity is tracked via passive PTY observation, and the rubric for new proposals. |
 | [resource-governance.md](./architecture/resource-governance.md) | Adaptive profiles, memory pressure, view eviction, and PTY hibernation. |

--- a/docs/architecture/pty-host-fabric.md
+++ b/docs/architecture/pty-host-fabric.md
@@ -1,0 +1,51 @@
+# PTY Host Fabric
+
+The PTY fabric dissolves the app-global singleton `daintree-pty-host` into a pool of **host shards** — one full pty-host UtilityProcess per open project — routed by `PtyClient` behind its unchanged public interface. Each shard owns a disjoint subset of terminals on its own event loop, its own RAM-scaled V8 heap, and its own `ResourceGovernor`, so one project's output flood, memory pressure, or native crash can no longer pause, throttle, or kill every other project's terminals.
+
+## Status & flag
+
+**Default: OFF.** The fabric ships behind `DAINTREE_PTY_FABRIC=1` (or `true`); with the flag unset, `PtyClient` runs exactly one shard (`main`) with the legacy singleton behavior — same service name, same fixed 512 MB heap, same restart/replay semantics — verified by the pre-existing PtyClient suites running unchanged. `PtyClientConfig.fabric` / `PtyClientConfig.maxProjectShards` override the env flag and shard cap for tests.
+
+Phases landed (spec: "The Terminal Data-Plane Fabric"): **Phase 0** (fabric seam behind the `PtyClient` interface, shard-count 1 parity) and **Phase 1** (per-project shards, crash isolation, shard-bound terminal lifecycle), plus the Phase 2 slices that fall out structurally (per-shard governors with RAM-scaled budgets; no cross-project stop-the-world). Not yet landed: spill-to-disk / durable agent sessions (Phase 3), per-shard in-thread analysis (Phase 4), bounded-N packing (Phase 5).
+
+## Architecture
+
+- `electron/services/PtyClient.ts` — the router. Owns placement (`projectId → shard`), terminal ownership (`terminalId → shard`), window-port routing (`windowId → shard`), cross-shard aggregation, and the public API. Pure bookkeeping + port plumbing: terminal bytes flow renderer↔shard directly over `MessageChannelMain`, never through main.
+- `electron/services/pty/PtyShard.ts` — one shard: `PtyHostLifecycle` (fork/restart/backoff, per-shard `serviceName`), `PtyHealthWatchdog`, a per-shard `RequestResponseBroker` (a crashing shard rejects only its own pending requests), pending MessagePorts, and the respawn/resync flags.
+- `electron/services/pty/fabricConfig.ts` — pure policy: flag parsing, shard cap (`clamp(cores − 2, 1, 8)`), RAM-scaled heap budget (`clamp(totalMem/32, 512, 2048)` MB), shard service names (`daintree-pty-host:<key>-<hash>`; the default shard keeps the legacy name).
+- The pty-host process itself is unchanged: every shard runs the same binary, and its governor/pool/analysis machinery is already per-process. `ResourceGovernor` now reads `DAINTREE_PTY_HEAP_BUDGET_MB` (set by `PtyHostLifecycle` from the same value as `--max-old-space-size`) so its thresholds track the real heap cap instead of a hardcoded 512.
+
+## Placement invariants
+
+- **One project → one shard.** A project's terminals never split across shards, so per-project ops (kill-by-project, stats, rollup rows, pool warm) stay single-shard. Future bounded-N packing (spec Phase 5) must preserve this invariant.
+- Projectless terminals (help sessions, smoke tests) live on the default shard.
+- Placement is **session-sticky**: a project past the shard cap, or whose shard exhausted its crash budget, is pinned to the default shard via `projectShardOverrides` and never flip-flops back mid-session.
+- The default shard always exists, is never retired, and is the boot/ready gate (`waitForReady`, `isReady`).
+
+## Window ports
+
+Each window has one PTY MessagePort, connected to the shard owning the window's **active project**. `connectMessagePort` derives the target from the window's project context; if the port previously lived on another shard, that shard gets `disconnect-port` (tearing down its per-window queue/batcher). When a project switch moves a window to a different shard, `rerouteWindowPortIfNeeded` re-mints the channel via the targeted port-refresh callback (`setPortRefreshCallback` now takes an optional `windowId`; `perWindowInit` refreshes just that window). Background projects' terminals stream via the IPC fallback exactly as before — same as the pre-fabric behavior for non-active projects.
+
+## Cross-shard invariants (re-provided by the router)
+
+- **Memory rollup** (`getMemoryRollup`) — fan-out + merge; totals sum, `available` is AND-ed, per-project rows never overlap (placement invariant).
+- **Flow-control snapshot** (`getFlowControlSnapshotAsync`) — terminals/queues concatenate, counters sum, the top-level governor/event-loop fields carry the **worst-shard** view ("PTY host lag p99" = worst shard), and the new optional `FlowControlSnapshot.shards` array carries the per-shard breakdown for why-slow diagnostics.
+- **Host signals** (`host-throttled`, `host-memory-warning`) — consumers treat these as THE backend's state, so the router ORs per-shard booleans and forwards only aggregate edges; a healthy shard's release can't clear a struggling sibling's warning, and a departed shard's stale hold is dropped (with a release edge) on crash/retirement.
+- **Global controls** (pause-all/resume-all on sleep, trim-state, resource profile, monitoring, session-persist suppression, log levels, plugin-agent registry) — cached and fanned out to every shard; a shard forked mid-session receives the full cache on its first `ready`.
+- **Fleet broadcast** (`broadcastWrite`, `batchDoubleEscape`) — grouped per owning shard, one message per shard.
+- **Lifecycle ledger** — generations mint/close exactly as before; migration and per-shard respawn each mint a fresh incarnation so the session journal's exactly-once gate holds across shards.
+
+## Failure containment
+
+- **Shard crash** — only that shard's terminals die; orphan-PID cleanup is scoped to its terminals (killing by owner map, never a sibling's PTY trees); its broker rejects only its own requests; its pending spawns respawn on the restarted shard with fresh generations; only its windows get a port refresh. `host-crash-details` (which drives the renderer's global "backend recovering" state) is emitted only for the default shard / singleton path — a project shard's crash is contained to a log plus its own targeted recovery, because unrelated windows would never receive the `terminal:backend-ready` that clears the recovering state.
+- **Fork failure** — a project shard whose `utilityProcess.fork()` throws follows the same containment as a crash loop (deferred one tick so an in-flight spawn registration lands first): its project pins to the default shard and its terminals respawn there. Only a default-shard fork failure emits the global `host-crash`.
+- **Crash loop** (3 crashes / 30 min, same budget as the singleton) — a _project_ shard's terminals migrate to the default shard (graceful degradation toward the singleton, never dropped terminals) with no global `host-crash`; the _default_ shard exhausting its budget still emits `host-crash` (global banner), as before.
+- **Partial aggregates** — if any fanned-out shard fails/times out, `getMemoryRollup` marks the merged rollup `available: false` (consumers gate memory displays on it), and `getFlowControlSnapshotAsync` routes through the merge so the `shards` breakdown makes the missing shard observable.
+- **Idle retirement** — a project shard with no terminals, no pending spawns, and no window on its project lingers `PTY_SHARD_IDLE_LINGER_MS` (45 s) and then exits, releasing all its FDs and heap. This binds terminal-tier resource lifetime to the shard instead of the renderer view — the structural fix for LRU view eviction leaking PTY FDs/RSS into a shared host.
+- **Per-shard host files** — each shard writes its own emergency log (`pty-host-<shard>.log`; the default shard keeps `pty-host.log`) since the size-check-then-truncate rotation is not cross-process safe. Session snapshots stay safe unmodified: they are keyed per terminal id and a terminal lives on exactly one shard.
+
+## Testing
+
+- `electron/services/__tests__/PtyClient.fabric.test.ts` — placement, port routing/reroute, ready replay, crash isolation (scoped orphan cleanup, per-shard respawn), crash-loop migration, default-shard crash budget, idle retirement, cap overflow, aggregated signals, rollup/flow-control/all-terminals merges, fan-out controls.
+- `electron/services/pty/__tests__/fabricConfig.test.ts` — policy clamps and service-name uniqueness.
+- Singleton parity: the entire pre-existing `PtyClient.*` suite (adversarial, handshake, watchdog, multiPort, deferStart, projectId, lifecycleLedger, ipc.integration) runs unchanged with the flag off.

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -101,23 +101,35 @@ export interface ResourceGovernorDeps {
   };
 }
 
-// Process memory budget for the combined heap + external signal. The pty-host
-// is forked with --max-old-space-size matching PtyClient's DEFAULT_CONFIG
-// memoryLimitMb (512) — keep HEAP_BUDGET_MB in sync with it. That flag bounds
-// only the V8 heap; ArrayBuffer backing stores (queued PTY output slabs,
-// xterm typed arrays) are allocated outside it and show up in
+// Process memory budget for the combined heap + external signal. The host is
+// forked with a --max-old-space-size that the parent mirrors into
+// DAINTREE_PTY_HEAP_BUDGET_MB (PtyHostLifecycle sets both from the same
+// memoryLimitMb), so the governor's budget tracks the real V8 cap: 512 on the
+// legacy singleton path, RAM-scaled per shard under the PTY fabric. That cap
+// bounds only the V8 heap; ArrayBuffer backing stores (queued PTY output
+// slabs, xterm typed arrays) are allocated outside it and show up in
 // process.memoryUsage().external, so the governor budgets them separately.
 //
 // Analysis worker_threads inherit the same execArgv, so each worker ISOLATE
-// carries its own 512MB old-space cap — HEAP_BUDGET_MB doubles as the
-// per-isolate binding constraint for the worker-heap term below. The total
-// budget stays process-scoped: it bounded all mirror buffers when they lived
-// on this thread, and it bounds the same memory now that #10920 moved them
-// into worker isolates. Deliberately independent of pool size — idle worker
+// carries its own old-space cap — HEAP_BUDGET_MB doubles as the per-isolate
+// binding constraint for the worker-heap term below. The total budget stays
+// process-scoped: it bounded all mirror buffers when they lived on this
+// thread, and it bounds the same memory now that #10920 moved them into
+// worker isolates. Deliberately independent of pool size — idle worker
 // baselines (~5-20MB each) are real process memory and count against it, so an
 // oversized DAINTREE_ANALYSIS_WORKERS override spends its own headroom.
-const HEAP_BUDGET_MB = 512;
-const EXTERNAL_HEADROOM_MB = 256;
+function resolveHeapBudgetMb(): number {
+  const raw = Number(process.env.DAINTREE_PTY_HEAP_BUDGET_MB);
+  if (Number.isFinite(raw) && raw >= 256 && raw <= 8192) return Math.floor(raw);
+  return 512;
+}
+const HEAP_BUDGET_MB = resolveHeapBudgetMb();
+// External headroom scales with the heap budget (heap/2, floor 256) so the
+// heap-vs-total ratio stays ~67% at every shard size — a fixed 256 on a
+// 2048MB fabric shard would let the heap term dominate and effectively stop
+// budgeting ArrayBuffer growth. At the legacy 512 budget this is exactly the
+// historical 256.
+const EXTERNAL_HEADROOM_MB = Math.max(256, Math.floor(HEAP_BUDGET_MB / 2));
 const TOTAL_PROCESS_BUDGET_MB = HEAP_BUDGET_MB + EXTERNAL_HEADROOM_MB;
 // Worker memory samples older than this contribute 0 to the utilization
 // signal (same stale-contributes-0 discipline as ResourceProfileService's

--- a/electron/pty-host/emergencyLog.ts
+++ b/electron/pty-host/emergencyLog.ts
@@ -7,6 +7,16 @@ const MAX_LOG_SIZE = 1024 * 1024; // 1MB
 export function getEmergencyLogPath(): string {
   const userData = process.env.DAINTREE_USER_DATA;
   const logDir = userData ? path.join(userData, "logs") : path.join(process.cwd(), "logs");
+  // Under the PTY fabric each shard is its own process; the size-check-then-
+  // truncate rotation below is not cross-process safe, so shards get their own
+  // file. The default shard (and the legacy singleton) keeps `pty-host.log`.
+  const service = process.env.DAINTREE_PTY_SHARD_SERVICE;
+  if (service && service !== "daintree-pty-host") {
+    const suffix = service.replace(/^daintree-pty-host:?/, "").replace(/[^a-zA-Z0-9_-]/g, "");
+    if (suffix) {
+      return path.join(logDir, `pty-host-${suffix}.log`);
+    }
+  }
   return path.join(logDir, "pty-host.log");
 }
 

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -8,25 +8,40 @@
  * all operations to the Pty Host (UtilityProcess) via IPC, keeping the Main
  * thread responsive.
  *
- * Architecture (post-#6690 split):
+ * Fabric architecture: PtyClient is the router of the PTY fabric — a pool of
+ * host shards ({@link PtyShard}), each a full pty-host UtilityProcess owning a
+ * disjoint subset of terminals on its own event loop, heap, and resource
+ * governor. With `DAINTREE_PTY_FABRIC` off (the default) there is exactly one
+ * shard ("main") and behavior is byte-for-byte the legacy singleton host. With
+ * the fabric on, each project gets its own shard: placement is per-project
+ * (one project never spans shards), window MessagePorts route to the shard
+ * owning the window's active project, and cross-shard invariants (memory
+ * rollup, flow-control snapshots, host-throttle/memory-warning signals) are
+ * aggregated here. PtyClient stays pure bookkeeping + port plumbing — terminal
+ * bytes flow renderer↔shard directly over MessageChannelMain, never through
+ * this class.
+ *
+ * Per-shard machinery (owned by each {@link PtyShard}):
  * - {@link PtyHostLifecycle} (`pty/PtyHostLifecycle.ts`) — UtilityProcess fork,
  *   exit handling, restart backoff, child-process-gone race, host log
  *   forwarding, and `readyPromise` lifecycle.
  * - {@link PtyHealthWatchdog} (`pty/PtyHealthWatchdog.ts`) — heartbeat watchdog,
  *   sleep/wake handshake, RTT observability.
+ * - {@link RequestResponseBroker} — request/response correlation, per shard so
+ *   a crashing shard rejects only its own pending requests.
+ *
+ * Shared routing plumbing:
  * - {@link routeHostEvent} (`pty/PtyEventRouter.ts`) — pure-function router for
- *   transport-level host events. Eliminates `event as any` casts via the
- *   {@link PtyHostResponseEvent} sub-union.
+ *   transport-level host events, invoked with per-shard deps.
  * - {@link bridgePtyEvent} (`pty/PtyEventsBridge.ts`) — domain event bridge to
  *   the internal event bus. Called first by the router.
- * - {@link RequestResponseBroker} — request/response correlation.
  *
- * PtyClient itself owns the cross-cutting business state (broker, pending
- * spawns/kills, MessagePort plumbing, project context, log-level overrides)
- * and the public API.
+ * PtyClient itself owns the cross-shard business state (placement, terminal
+ * ownership, pending spawns/kills, MessagePort routing, project context,
+ * log-level overrides) and the public API.
  *
  * Why this pattern:
- * - Manages critical child process (UtilityProcess) requiring explicit lifecycle control
+ * - Manages critical child processes (UtilityProcess) requiring explicit lifecycle control
  * - Constructor accepts configuration: must be instantiated with specific options
  * - Needs coordination with other services (MessagePort distribution, error handlers)
  * - Lifecycle tied to app lifecycle: created in main.ts, passed to IPC handlers
@@ -40,6 +55,7 @@
 
 import { MessagePortMain } from "electron";
 import { EventEmitter } from "events";
+import os from "os";
 import path from "path";
 import { spawnSync } from "child_process";
 import { fileURLToPath } from "url";
@@ -56,19 +72,30 @@ import { getTrashedPidTracker } from "./TrashedPidTracker.js";
 import { helpSessionService } from "./HelpSessionService.js";
 import { helpSessionJobService } from "./HelpSessionJobService.js";
 import { getLifecycleLedger, ledgerFactsFromSpawnOptions } from "./pty/lifecycleLedger.js";
-import { RequestResponseBroker, BrokerError } from "./rpc/index.js";
+import { BrokerError } from "./rpc/index.js";
 import { routeHostEvent, type PtyEventRouterDeps } from "./pty/PtyEventRouter.js";
-import { PtyHealthWatchdog } from "./pty/PtyHealthWatchdog.js";
-import { PtyHostLifecycle } from "./pty/PtyHostLifecycle.js";
+import { PtyShard } from "./pty/PtyShard.js";
+import {
+  DEFAULT_SHARD_KEY,
+  PTY_SHARD_IDLE_LINGER_MS,
+  isPtyFabricEnabled,
+  maxProjectShards,
+  shardHeapBudgetMb,
+  shardServiceName,
+} from "./pty/fabricConfig.js";
+import type { PtyHealthWatchdog } from "./pty/PtyHealthWatchdog.js";
+import type { PtyHostLifecycle } from "./pty/PtyHostLifecycle.js";
 import type {
-  PtyHostRequest,
   PtyHostEvent,
   PtyHostSpawnOptions,
   PtyHostActivityTier,
   CrashType,
   SpawnResult,
   FlowControlSnapshot,
+  FlowControlShardSnapshot,
+  HostThrottlePayload,
   MemoryRollup,
+  MemoryRollupProject,
   GracefulKillResult,
   PtyHostWorkerGovernanceSnapshot,
 } from "../../shared/types/pty-host.js";
@@ -126,7 +153,11 @@ export interface PtyClientConfig {
   healthCheckIntervalMs?: number;
   /** Whether to show dialog on crash */
   showCrashDialog?: boolean;
-  /** Memory limit in MB for PTY Host process (default: 512) */
+  /**
+   * Memory limit in MB for PTY Host process (default: 512). Applies to the
+   * legacy singleton path; with the PTY fabric enabled every shard instead
+   * gets a RAM-scaled budget from {@link shardHeapBudgetMb}.
+   */
   memoryLimitMb?: number;
   /**
    * When true the constructor wires up the host lifecycle but does NOT fork the
@@ -137,9 +168,18 @@ export interface PtyClientConfig {
    * construct-and-fork behavior.
    */
   deferStart?: boolean;
+  /**
+   * Force the PTY fabric (per-project host shards) on or off, overriding the
+   * DAINTREE_PTY_FABRIC environment flag. Primarily a test hook.
+   */
+  fabric?: boolean;
+  /** Override the concurrent project-shard cap. Primarily a test hook. */
+  maxProjectShards?: number;
 }
 
-const DEFAULT_CONFIG: Required<PtyClientConfig> = {
+type ResolvedPtyClientConfig = Required<Omit<PtyClientConfig, "fabric" | "maxProjectShards">>;
+
+const DEFAULT_CONFIG: ResolvedPtyClientConfig = {
   // 5s heartbeat. Watchdog checks the missed-pong count before incrementing,
   // so SIGKILL fires on the tick after 3 consecutive missed pongs — ~20s
   // worst-case detection. Was 30s (~90s detection), which left users staring
@@ -189,22 +229,59 @@ function readPersistedOverrides(): Record<string, string> {
 }
 
 export class PtyClient extends EventEmitter {
-  private config: Required<PtyClientConfig>;
+  private config: ResolvedPtyClientConfig;
   private isDisposed = false;
-  private readonly lifecycle: PtyHostLifecycle;
-  private readonly healthWatchdog: PtyHealthWatchdog;
-  private readonly routerDeps: PtyEventRouterDeps;
+
+  /** Whether the PTY fabric (per-project host shards) is active. */
+  private readonly fabricEnabled: boolean;
+  /** Max concurrent project shards; overflow projects co-locate on the default shard. */
+  private readonly projectShardCap: number;
+  /** Per-shard V8 heap budget (RAM-scaled under the fabric, config value otherwise). */
+  private readonly shardMemoryLimitMb: number;
+  private readonly electronDir: string;
+  /** Live shards by key: "main" plus one per project under the fabric. */
+  private readonly shards = new Map<string, PtyShard>();
+  /** The boot shard — always exists, never retired; the only shard when the fabric is off. */
+  private readonly defaultShard: PtyShard;
+  /** Per-shard router deps, built once per shard (broker + emitter proxy are shard-scoped). */
+  private readonly shardRouterDeps = new WeakMap<PtyShard, PtyEventRouterDeps>();
+  private shardCallbacksCache: ConstructorParameters<typeof PtyShard>[1] | null = null;
+  /**
+   * terminalId → owning shard key. Set at spawn admission, retargeted on
+   * crash-loop migration, and dropped once no incarnation of the id remains
+   * (final exit / failed spawn). The single source of truth for routing
+   * per-terminal requests to the shard that actually holds the terminal.
+   */
+  private readonly terminalOwners = new Map<string, string>();
+  /**
+   * projectId → forced shard key. Written when a project shard exhausts its
+   * crash budget (its terminals migrate to the default shard and stay there
+   * for the rest of the session — no crash-loop ping-pong) and when the
+   * project-shard cap overflows.
+   */
+  private readonly projectShardOverrides = new Map<string, string>();
+  /** windowId → shard key currently holding (or pending) that window's MessagePort. */
+  private readonly windowPortShard = new Map<number, string>();
+  private readonly shardRetirementTimers = new Map<string, NodeJS.Timeout>();
+  // Aggregated host signals. Consumers of "host-throttled" / "host-memory-warning"
+  // treat the payload as THE terminal backend's state, so with multiple shards a
+  // healthy sibling's release must not clear a struggling shard's warning — the
+  // fabric ORs the per-shard booleans and only forwards aggregate transitions.
+  private readonly throttledShards = new Set<string>();
+  private aggregateThrottled = false;
+  private readonly memoryWarningShards = new Set<string>();
+  private aggregateMemoryWarning = false;
+  /** Mirrors the system-sleep watchdog pause so shards created mid-sleep stay quiet. */
+  private healthChecksPaused = false;
 
   private pendingSpawns: Map<string, PtyHostSpawnOptions> = new Map();
   private ipcDataMirrorIds = new Set<string>();
   private pendingKillCount: Map<string, number> = new Map();
-  private needsRespawn = false;
   private activeProjectId: string | null = null;
   private windowProjectContexts = new Map<
     number,
     { projectId: string | null; projectPath?: string; mode: "active" | "switch" }
   >();
-  private shouldResyncProjectContext = false;
   // Per-window UI-focused terminal id. Cached so it can be replayed to the host
   // on port reconnect (page reload clears the host's map on port-replace) and on
   // host restart (#5534) — the renderer only re-sends on an actual focus change,
@@ -213,19 +290,18 @@ export class PtyClient extends EventEmitter {
   private windowFocusedTerminals = new Map<number, string | null>();
   private deferInitialPoolWarm = false;
   private hostStartRequested = false;
-  private pendingMessagePorts = new Map<number, MessagePortMain>();
   private terminalPids: Map<string, number> = new Map();
   private resourceMonitoringEnabled = false;
   private sessionPersistSuppressed = false;
-  // Cached for replay in respawnPending(): both sends are fire-and-forget, so
-  // a restarted host would otherwise boot on balanced governor thresholds and
+  // Cached for replay in respawnPendingForShard(): both sends are fire-and-forget,
+  // so a restarted host would otherwise boot on balanced governor thresholds and
   // the ProcessTreeCache constructor default until the next profile change.
   private lastResourceProfile: ResourceProfile | null = null;
   private lastProcessTreePollIntervalMs: number | null = null;
 
   /**
    * Cap on pendingSpawns to prevent restart-storm amplification. If the host
-   * crashes during spawn and respawnPending() replays the map, an unbounded map
+   * crashes during spawn and the respawn replay walks the map, an unbounded map
    * lets the next crash grow the replay burst. Capping admission keeps the
    * respawn fan-out bounded under repeated crashes.
    */
@@ -239,17 +315,13 @@ export class PtyClient extends EventEmitter {
    */
   private readonly MAX_PENDING_KILLS = 500;
 
-  /** Unified request/response broker for all async operations */
-  private broker = new RequestResponseBroker({
-    defaultTimeoutMs: 5000,
-    idPrefix: "pty",
-    onTimeout: (requestId, method) => {
-      console.warn(`[PtyClient] Request timeout: ${method ? `${method} ` : ""}(${requestId})`);
-    },
-  });
-
-  /** Callback to notify renderer when MessagePort needs to be refreshed */
-  private onPortRefresh: (() => void) | null = null;
+  /**
+   * Callback to notify renderer when MessagePorts need to be refreshed. Called
+   * with a windowId to refresh one window (fabric shard restart / port
+   * reroute) or with no argument to refresh every window (legacy host
+   * restart).
+   */
+  private onPortRefresh: ((windowId?: number) => void) | null = null;
 
   /** Cached log-level overrides. Replayed on every host spawn/restart via the
    * `ready` event, which is the first moment the child's message listener is
@@ -258,78 +330,167 @@ export class PtyClient extends EventEmitter {
    * user's saved configuration without waiting for renderer IPC. */
   private logLevelOverridesCache: Record<string, string> = readPersistedOverrides();
 
+  /**
+   * Default-shard accessors. Internal code uses these wherever the singleton
+   * client used its single lifecycle/watchdog (ready gate, boot wait); the
+   * adversarial/watchdog test suites also reach them via casts, so keep the
+   * names stable.
+   */
+  private get lifecycle(): PtyHostLifecycle {
+    return this.defaultShard.lifecycle;
+  }
+
+  /** @internal Default-shard watchdog — kept for the watchdog/handshake test suites. */
+  get healthWatchdog(): PtyHealthWatchdog {
+    return this.defaultShard.watchdog;
+  }
+
   constructor(config: PtyClientConfig = {}) {
     super();
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    const { fabric, maxProjectShards: shardCapOverride, ...baseConfig } = config;
+    this.config = { ...DEFAULT_CONFIG, ...baseConfig };
+    this.fabricEnabled = fabric ?? isPtyFabricEnabled();
+    this.projectShardCap = shardCapOverride ?? maxProjectShards(os.cpus().length);
+    this.shardMemoryLimitMb = this.fabricEnabled
+      ? shardHeapBudgetMb(os.totalmem())
+      : this.config.memoryLimitMb;
 
     // SharedArrayBuffer cannot be sent to Electron UtilityProcess via postMessage
     // ("An object could not be cloned"). This is a Chromium structured clone limitation
     // that affects all platforms. Use IPC fallback for terminal I/O.
     console.log("[PtyClient] Using IPC mode (SharedArrayBuffer not supported in UtilityProcess)");
+    if (this.fabricEnabled) {
+      console.log(
+        `[PtyClient] PTY fabric enabled: per-project host shards (cap ${this.projectShardCap}, heap ${this.shardMemoryLimitMb}MB/shard)`
+      );
+    }
 
-    const electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
+    this.electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
 
-    this.healthWatchdog = new PtyHealthWatchdog({
-      intervalMs: this.config.healthCheckIntervalMs,
-      maxMissedHeartbeats: MAX_MISSED_HEARTBEATS,
-      getChild: () => this.lifecycle.child,
-      isHostInitialized: () => this.lifecycle.isInitialized,
-      send: (request) => this.send(request),
-      emitCrashDetails: (payload) => {
-        this.emit("host-crash-details", payload);
-      },
-    });
+    this.defaultShard = this.ensureShard(DEFAULT_SHARD_KEY);
 
-    this.lifecycle = new PtyHostLifecycle(
+    if (!this.config.deferStart) {
+      this.start();
+    }
+  }
+
+  /** Get or create the shard for a key. Forks immediately once start() has been requested. */
+  private ensureShard(key: string): PtyShard {
+    this.cancelShardRetirement(key);
+    const existing = this.shards.get(key);
+    if (existing) return existing;
+
+    const shard = new PtyShard(
       {
-        memoryLimitMb: this.config.memoryLimitMb,
-        electronDir,
-        deferInitialPoolWarm: () => this.deferInitialPoolWarm,
+        key,
+        serviceName: shardServiceName(key),
+        memoryLimitMb: this.shardMemoryLimitMb,
+        electronDir: this.electronDir,
+        healthCheckIntervalMs: this.config.healthCheckIntervalMs,
+        maxMissedHeartbeats: MAX_MISSED_HEARTBEATS,
+        // Project shards always defer the boot-time homedir pool warm: their
+        // first project context immediately drains the pool to the project
+        // path, so a homedir warm would only spawn shells for the drain to
+        // kill. The default shard keeps the boot-restore deferral flag (#10393).
+        deferInitialPoolWarm:
+          key === DEFAULT_SHARD_KEY ? () => this.deferInitialPoolWarm : () => true,
+        resyncContextOnFirstReady: key !== DEFAULT_SHARD_KEY,
       },
-      {
-        onMessage: (event) => this.handleHostEvent(event),
-        onExitSync: ({ wasReady: _wasReady, fallbackCrashType }) => {
-          this.healthWatchdog.stop();
-          if (this.isDisposed) {
-            return;
-          }
-          this.cleanupOrphanedPtys(fallbackCrashType);
-          this.broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
-          this.shouldResyncProjectContext = true;
-        },
-        onCrashClassified: ({ crashType, payload }) => {
-          this.cleanupOrphanedPtys(crashType);
-          if (payload) {
-            this.emit("host-crash-details", payload);
-          }
-        },
-        onMaxRestartsReached: (code) => {
-          this.emit("host-crash", code);
-        },
-        onForkFailed: () => {
-          this.emit("host-crash", -1);
-        },
-        onBeforeRestart: () => {
-          this.needsRespawn = true;
-        },
-        isDisposed: () => this.isDisposed,
-        logInfo: (message) => logInfo(message),
-        logWarn: (message) => logWarn(message),
-      }
+      this.shardCallbacks()
     );
+    this.shards.set(key, shard);
+    if (key !== DEFAULT_SHARD_KEY) {
+      console.log(`[PtyClient] Created PTY shard '${key}' (${shard.serviceName})`);
+    }
+    if (this.hostStartRequested) {
+      shard.start();
+    }
+    return shard;
+  }
 
-    this.routerDeps = {
-      isDisposed: () => this.isDisposed,
-      broker: this.broker,
-      emitter: this,
+  private shardCallbacks(): ConstructorParameters<typeof PtyShard>[1] {
+    if (this.shardCallbacksCache) return this.shardCallbacksCache;
+    this.shardCallbacksCache = {
+      onMessage: (shard, event) => this.handleShardEvent(shard, event),
+      onExitSync: (shard, { fallbackCrashType }) => {
+        shard.watchdog.stop();
+        if (this.isDisposed) {
+          return;
+        }
+        this.cleanupOrphanedPtysForShard(shard, fallbackCrashType);
+        shard.broker.clear(new BrokerError("HOST_EXITED", "Pty host exited"));
+        shard.shouldResyncProjectContext = true;
+        // The crashed shard's throttle/memory-warning holds are gone with the
+        // process; recompute the aggregate so a sibling-free release isn't
+        // stuck behind a dead shard's stale hold.
+        this.dropShardSignals(shard.key);
+      },
+      onCrashClassified: (shard, { crashType, payload }) => {
+        this.cleanupOrphanedPtysForShard(shard, crashType);
+        if (payload) {
+          this.emitCrashDetailsForShard(shard, payload);
+        }
+      },
+      onMaxRestartsReached: (shard, code) => {
+        if (shard.key === DEFAULT_SHARD_KEY || !this.fabricEnabled) {
+          this.emit("host-crash", code);
+          return;
+        }
+        this.migrateShardTerminalsToDefault(shard, code);
+      },
+      onForkFailed: (shard) => {
+        if (shard.key === DEFAULT_SHARD_KEY || !this.fabricEnabled) {
+          this.emit("host-crash", -1);
+          return;
+        }
+        // fork() throws synchronously — possibly mid-spawn/ensureShard, before
+        // the caller has registered the terminal it was placing here. Defer the
+        // containment one tick so the in-flight registration lands first and
+        // the migration replays it on the default shard. No restart is ever
+        // scheduled after a fork failure, so without this the project's
+        // terminals would route to a permanently dead shard while every window
+        // showed a global backend-crashed banner.
+        setImmediate(() => {
+          if (this.isDisposed || shard.retired) return;
+          this.migrateShardTerminalsToDefault(shard, -1);
+        });
+      },
+      emitCrashDetails: (shard, payload) => {
+        this.emitCrashDetailsForShard(shard, payload);
+      },
+      onBrokerTimeout: (_shard, requestId, method) => {
+        console.warn(`[PtyClient] Request timeout: ${method ? `${method} ` : ""}(${requestId})`);
+      },
+      isClientDisposed: () => this.isDisposed,
+      logInfo: (message) => logInfo(message),
+      logWarn: (message) => logWarn(message),
+    };
+    return this.shardCallbacksCache;
+  }
+
+  private handleShardEvent(shard: PtyShard, event: PtyHostEvent): void {
+    if (shard.retired) return;
+    let deps = this.shardRouterDeps.get(shard);
+    if (!deps) {
+      deps = this.buildRouterDeps(shard);
+      this.shardRouterDeps.set(shard, deps);
+    }
+    routeHostEvent(event, deps);
+  }
+
+  private buildRouterDeps(shard: PtyShard): PtyEventRouterDeps {
+    return {
+      isDisposed: () => this.isDisposed || shard.retired,
+      broker: shard.broker,
+      emitter: new ShardEventEmitter((event, args) => this.emitFromShard(shard, event, args)),
       state: {
         pendingSpawns: this.pendingSpawns,
         pendingKillCount: this.pendingKillCount,
         terminalPids: this.terminalPids,
       },
       callbacks: {
-        onReady: () => this.handleReady(),
-        onPong: () => this.healthWatchdog.recordPong(),
+        onReady: () => this.handleShardReady(shard),
+        onPong: () => shard.watchdog.recordPong(),
         onTerminalRemovedFromTrash: (id) => getTrashedPidTracker().removeTrashed(id),
         // #7526: filter help-session PTYs into the Windows Job Object so the
         // OS reaps the agent tree on a hard Daintree crash. No-op on
@@ -364,27 +525,143 @@ export class PtyClient extends EventEmitter {
       },
       logWarn: (message) => console.warn(message),
     };
+  }
 
-    if (!this.config.deferStart) {
-      this.start();
+  /**
+   * Every event the per-shard router would emit funnels through here so the
+   * fabric can do cross-shard bookkeeping before forwarding on the public
+   * emitter: terminal-owner cleanup on final exits, idle-shard sweeps, and
+   * OR-aggregation of the process-scoped host signals.
+   */
+  private emitFromShard(shard: PtyShard, event: string, args: unknown[]): boolean {
+    if (event === "exit") {
+      const id = args[0] as string;
+      // Owner entries live until no incarnation of the id remains: a kill
+      // followed by a same-id respawn keeps the entry (retargeted by spawn),
+      // while the final exit releases it.
+      if (!this.pendingSpawns.has(id) && !this.pendingKillCount.has(id)) {
+        this.terminalOwners.delete(id);
+      }
+      const emitted = this.emit(event, ...args);
+      this.scheduleIdleSweep();
+      return emitted;
+    }
+    if (event === "spawn-result") {
+      const result = args[1] as SpawnResult;
+      if (!result.success) {
+        const id = args[0] as string;
+        if (!this.pendingSpawns.has(id) && !this.pendingKillCount.has(id)) {
+          this.terminalOwners.delete(id);
+        }
+        const emitted = this.emit(event, ...args);
+        this.scheduleIdleSweep();
+        return emitted;
+      }
+      return this.emit(event, ...args);
+    }
+    if (event === "host-throttled") {
+      return this.emitAggregatedThrottle(shard, args[0] as HostThrottlePayload);
+    }
+    if (event === "host-memory-warning") {
+      return this.emitAggregatedMemoryWarning(shard, args[0] as HostMemoryWarningPayload);
+    }
+    return this.emit(event, ...args);
+  }
+
+  private emitAggregatedThrottle(shard: PtyShard, payload: HostThrottlePayload): boolean {
+    if (payload.isThrottled) {
+      this.throttledShards.add(shard.key);
+    } else {
+      this.throttledShards.delete(shard.key);
+    }
+    const aggregate = this.throttledShards.size > 0;
+    if (aggregate === this.aggregateThrottled) return false;
+    this.aggregateThrottled = aggregate;
+    return this.emit("host-throttled", { ...payload, isThrottled: aggregate });
+  }
+
+  private emitAggregatedMemoryWarning(shard: PtyShard, payload: HostMemoryWarningPayload): boolean {
+    if (payload.isWarning) {
+      this.memoryWarningShards.add(shard.key);
+    } else {
+      this.memoryWarningShards.delete(shard.key);
+    }
+    const aggregate = this.memoryWarningShards.size > 0;
+    if (aggregate === this.aggregateMemoryWarning) return false;
+    this.aggregateMemoryWarning = aggregate;
+    return this.emit("host-memory-warning", { ...payload, isWarning: aggregate });
+  }
+
+  /**
+   * `host-crash-details` drives the renderer's global "backend recovering"
+   * state (`terminal:backend-recovering` broadcast to every window), and that
+   * state is only cleared by a `terminal:backend-ready` — which the fabric
+   * sends targeted, to the crashed shard's windows alone. Broadcasting a
+   * project shard's crash would therefore wedge every unrelated window in
+   * "recovering" forever. Keep the global event for the default shard (and
+   * the singleton path) and contain project-shard crashes to a log; their
+   * recovery is the shard restart + targeted port refresh.
+   */
+  private emitCrashDetailsForShard(
+    shard: PtyShard,
+    payload: Parameters<ConstructorParameters<typeof PtyShard>[1]["emitCrashDetails"]>[1]
+  ): void {
+    if (shard.key === DEFAULT_SHARD_KEY || !this.fabricEnabled) {
+      this.emit("host-crash-details", payload);
+      return;
+    }
+    logWarn(
+      `[PtyClient] PTY shard '${shard.key}' crashed (${payload.crashType}, code ${payload.code}); recovering shard-locally`
+    );
+  }
+
+  /**
+   * Drop a departed shard's attribution from the aggregated signals and emit
+   * the release edge if the aggregate flipped — a retired/crashed shard must
+   * not pin "throttled"/"memory warning" on forever.
+   */
+  private dropShardSignals(shardKey: string): void {
+    if (this.throttledShards.delete(shardKey)) {
+      const aggregate = this.throttledShards.size > 0;
+      if (aggregate !== this.aggregateThrottled) {
+        this.aggregateThrottled = aggregate;
+        this.emit("host-throttled", {
+          isThrottled: aggregate,
+          reason: "host-shard-gone",
+          timestamp: Date.now(),
+        });
+      }
+    }
+    if (this.memoryWarningShards.delete(shardKey)) {
+      const aggregate = this.memoryWarningShards.size > 0;
+      if (aggregate !== this.aggregateMemoryWarning) {
+        this.aggregateMemoryWarning = aggregate;
+        this.emit("host-memory-warning", {
+          isWarning: aggregate,
+          utilizationPercent: 0,
+          timestamp: Date.now(),
+        });
+      }
     }
   }
 
   /**
-   * Fork the PTY host. Called automatically from the constructor unless
+   * Fork the PTY host shards. Called automatically from the constructor unless
    * `deferStart` was set, in which case the caller invokes this once the early
    * PATH refresh has resolved so node-pty inherits the user's full PATH
    * (#8625/#8827). Idempotent — a second call once the host has already been
    * requested is a no-op, so the multi-window boot path can call it
-   * unconditionally. Auto-restarts go through `lifecycle.start()` directly and
-   * are unaffected by this guard.
+   * unconditionally. Auto-restarts go through each shard's `lifecycle.start()`
+   * directly and are unaffected by this guard.
    */
   start(): void {
     if (this.hostStartRequested) {
       return;
     }
     this.hostStartRequested = true;
-    this.lifecycle.start();
+    for (const shard of this.shards.values()) {
+      shard.start();
+    }
     console.log("[PtyClient] Pty Host started");
   }
 
@@ -405,25 +682,105 @@ export class PtyClient extends EventEmitter {
     this.deferInitialPoolWarm = defer;
   }
 
-  /** Wait for the host to be ready */
+  /** Wait for the (default-shard) host to be ready — the boot gate. */
   async waitForReady(): Promise<void> {
     return this.lifecycle.waitForReady();
   }
 
-  private handleHostEvent(event: PtyHostEvent): void {
-    routeHostEvent(event, this.routerDeps);
+  // ── Placement ────────────────────────────────────────────────────────────
+  // Fabric invariant: one project → one shard. A project's terminals never
+  // split across shards, so per-project ops (kill-by-project, rollup rows,
+  // pool warm) stay single-shard and (A)→(B) packing evolutions stay internal.
+
+  /** Owner shard key for a terminal id; unknown ids fall back to the default shard. */
+  private ownerKey(id: string): string {
+    return this.terminalOwners.get(id) ?? DEFAULT_SHARD_KEY;
   }
 
-  private handleReady(): void {
-    if (!this.lifecycle.markReady()) {
+  private shardForTerminal(id: string): PtyShard {
+    return this.shards.get(this.ownerKey(id)) ?? this.defaultShard;
+  }
+
+  /** Pure placement lookup — never creates shards or records overrides. */
+  private peekPlacementKey(projectId: string | null | undefined): string {
+    if (!this.fabricEnabled || !projectId) return DEFAULT_SHARD_KEY;
+    return this.projectShardOverrides.get(projectId) ?? projectId;
+  }
+
+  /**
+   * Placement with admission: existing shard or override wins; a brand-new
+   * project beyond the shard cap is pinned to the default shard for the rest
+   * of the session (stable placement — a project never flip-flops between
+   * shards while it has live terminals).
+   */
+  private resolvePlacementKey(projectId: string | null | undefined): string {
+    if (!this.fabricEnabled || !projectId) return DEFAULT_SHARD_KEY;
+    const override = this.projectShardOverrides.get(projectId);
+    if (override) return override;
+    if (this.shards.has(projectId)) return projectId;
+    const projectShardCount = this.shards.size - (this.shards.has(DEFAULT_SHARD_KEY) ? 1 : 0);
+    if (projectShardCount >= this.projectShardCap) {
+      logWarn(
+        `[PtyClient] Project shard cap (${this.projectShardCap}) reached; project ${projectId} co-locates on the default shard`
+      );
+      this.projectShardOverrides.set(projectId, DEFAULT_SHARD_KEY);
+      return DEFAULT_SHARD_KEY;
+    }
+    return projectId;
+  }
+
+  private ensureShardForProject(projectId: string | null | undefined): PtyShard {
+    return this.ensureShard(this.resolvePlacementKey(projectId));
+  }
+
+  /** Shard that owns a project's terminals (for queries/kills) — never creates. */
+  private shardForProjectQuery(projectId: string): PtyShard {
+    return this.shards.get(this.peekPlacementKey(projectId)) ?? this.defaultShard;
+  }
+
+  /** Shard key a window's port should route to, from its current project context. */
+  private shardKeyForWindowContext(windowId: number): string {
+    return this.resolvePlacementKey(this.windowProjectContexts.get(windowId)?.projectId ?? null);
+  }
+
+  /** Shard that receives window-scoped messages (focus): the port holder, else the context owner. */
+  private shardForWindow(windowId: number): PtyShard {
+    const portKey = this.windowPortShard.get(windowId);
+    if (portKey !== undefined) {
+      const shard = this.shards.get(portKey);
+      if (shard) return shard;
+    }
+    return (
+      this.shards.get(
+        this.peekPlacementKey(this.windowProjectContexts.get(windowId)?.projectId ?? null)
+      ) ?? this.defaultShard
+    );
+  }
+
+  /** Shards to fan aggregate queries over. Falls back to the default shard so callers keep the legacy timeout→sentinel path when nothing is ready. */
+  private fanOutShards(): PtyShard[] {
+    const ready = [...this.shards.values()].filter(
+      (shard) => !shard.retired && shard.lifecycle.isInitialized && shard.lifecycle.child !== null
+    );
+    return ready.length > 0 ? ready : [this.defaultShard];
+  }
+
+  // ── Shard lifecycle ──────────────────────────────────────────────────────
+
+  private handleShardReady(shard: PtyShard): void {
+    if (!shard.lifecycle.markReady()) {
       console.warn("[PtyClient] Ignoring late ready event - host is dead");
       return;
     }
-    console.log("[PtyClient] Pty Host is ready");
+    if (shard.key === DEFAULT_SHARD_KEY) {
+      console.log("[PtyClient] Pty Host is ready");
+    } else {
+      console.log(`[PtyClient] Pty Host shard '${shard.key}' is ready`);
+    }
     // Replay log-level overrides on every ready (initial spawn + restarts).
     // The child's message listener isn't attached until after it receives
     // "ready", so pushing on spawn would race.
-    this.send({
+    shard.send({
       type: "set-log-level-overrides",
       overrides: this.logLevelOverridesCache,
     });
@@ -432,74 +789,93 @@ export class PtyClient extends EventEmitter {
     // detection patterns from the first tick (#10587). Reads the authoritative
     // main-process snapshot directly — no cache needed, and a host restart
     // re-syncs whatever plugins are loaded now.
-    this.send({ type: "set-plugin-agent-registry", registry: getPluginAgentRegistry() });
+    shard.send({ type: "set-plugin-agent-registry", registry: getPluginAgentRegistry() });
+    // A project shard forked mid-session missed every earlier config setter
+    // (resource profile, monitoring, persistence suppression) — those are
+    // host-process-wide, so replay the caches on its first ready. Restart
+    // readies get the same replay from respawnPendingForShard below.
+    if (shard.key !== DEFAULT_SHARD_KEY && !shard.needsRespawn) {
+      this.replayGlobalConfigToShard(shard);
+    }
     // Re-arm the watchdog on every successful ready — covers both the initial
     // boot and every auto-restart cycle. The original code armed it inside
     // startHost() before ready arrived, but the tick was a no-op until
     // isInitialized=true anyway, so deferring to ready is equivalent and
     // avoids a leaked timer when fork itself fails.
-    if (!this.healthWatchdog.isHealthCheckPaused) {
-      this.healthWatchdog.start();
+    if (!this.healthChecksPaused && !shard.watchdog.isHealthCheckPaused) {
+      shard.watchdog.start();
     }
-    if (this.needsRespawn) {
-      this.needsRespawn = false;
-      this.respawnPending();
+    if (shard.needsRespawn) {
+      shard.needsRespawn = false;
+      this.respawnPendingForShard(shard);
     } else if (this.pendingSpawns.size > 0) {
       // Initial host-ready replay (#8827). With deferred start the host forks
       // only after the early PATH refresh, so any spawn requested during that
       // window had its send() dropped — the host's message listener isn't
       // attached until it emits "ready" (also true for the brief construct→
-      // ready window on the non-deferred path). Replay those spawns now so a
-      // terminal launched before the host was ready isn't silently lost.
+      // ready window on the non-deferred path, and for a project shard forked
+      // by the spawn that is being replayed). Replay this shard's spawns now
+      // so a terminal launched before its host was ready isn't silently lost.
       // Double-spawn-safe: on the first "ready" no spawn could have been
       // delivered yet. The restart-only side effects (port refresh, stale-kill
-      // clearing) stay in respawnPending() above.
+      // clearing) stay in respawnPendingForShard() above.
       for (const [id, options] of this.pendingSpawns) {
-        this.send({ type: "spawn", id, options });
+        if (this.ownerKey(id) !== shard.key) continue;
+        shard.send({ type: "spawn", id, options });
       }
     }
-    const pendingPortWindowIds = new Set(this.pendingMessagePorts.keys());
-    this.flushPendingMessagePorts();
-    if (this.shouldResyncProjectContext) {
-      this.shouldResyncProjectContext = false;
-      this.syncProjectContext(pendingPortWindowIds);
+    const pendingPortWindowIds = new Set(shard.pendingMessagePorts.keys());
+    this.flushPendingMessagePortsForShard(shard);
+    if (shard.shouldResyncProjectContext) {
+      shard.shouldResyncProjectContext = false;
+      this.syncProjectContextToShard(shard, pendingPortWindowIds);
     }
   }
 
-  private send(request: PtyHostRequest): void {
-    this.lifecycle.postMessage(request);
-  }
+  private respawnPendingForShard(shard: PtyShard): void {
+    // Kills sent to the crashed shard will never receive "exit" events, so
+    // its pendingKillCount entries are permanently stale. Unlike pendingSpawns
+    // (replayed below to recreate terminals on the new host), they are
+    // cleared — the terminals those kills targeted died with the process.
+    for (const id of [...this.pendingKillCount.keys()]) {
+      if (this.ownerKey(id) === shard.key) {
+        this.pendingKillCount.delete(id);
+      }
+    }
+    // Owner entries without a pending spawn were awaiting an exit event that
+    // died with the shard — nothing will respawn them.
+    for (const [id, owner] of [...this.terminalOwners]) {
+      if (owner === shard.key && !this.pendingSpawns.has(id)) {
+        this.terminalOwners.delete(id);
+      }
+    }
 
-  private respawnPending(): void {
-    // Kills sent to the crashed host will never receive "exit" events, so
-    // pendingKillCount entries from that session are permanently stale.
-    // Unlike pendingSpawns (replayed below to recreate terminals on the new
-    // host), pendingKillCount is cleared — the terminals those kills targeted
-    // died with the host process.
-    this.pendingKillCount.clear();
-
-    // Notify that ports need refresh after host restart
+    // Notify that ports need refresh after the shard restart. Fabric mode
+    // targets only the windows whose port lived on this shard; the legacy
+    // single-host path keeps the refresh-everything behavior.
     if (this.onPortRefresh) {
-      for (const port of this.pendingMessagePorts.values()) {
-        try {
-          port.close();
-        } catch {
-          // ignore
+      shard.closePendingPorts();
+      if (!this.fabricEnabled) {
+        this.onPortRefresh();
+      } else {
+        for (const [windowId, key] of [...this.windowPortShard]) {
+          if (key !== shard.key) continue;
+          this.windowPortShard.delete(windowId);
+          this.onPortRefresh(windowId);
         }
       }
-      this.pendingMessagePorts.clear();
-      this.onPortRefresh();
     }
 
-    // Respawn terminals that were active when host crashed. Each replay is a
-    // NEW incarnation — the previous PTY died with the host — so close the old
-    // generation and mint a fresh one. Without this, a session captured before
-    // the crash and one captured after would share a generation and the
-    // journal's exactly-once gate would drop the second record. (The initial
-    // host-ready replay in handleReady keeps its generation: nothing was ever
-    // delivered, so it is the same incarnation.)
+    // Respawn terminals that were active when the shard crashed. Each replay
+    // is a NEW incarnation — the previous PTY died with the host — so close
+    // the old generation and mint a fresh one. Without this, a session
+    // captured before the crash and one captured after would share a
+    // generation and the journal's exactly-once gate would drop the second
+    // record. (The initial host-ready replay in handleShardReady keeps its
+    // generation: nothing was ever delivered, so it is the same incarnation.)
     const ledger = getLifecycleLedger();
     for (const [id, options] of this.pendingSpawns) {
+      if (this.ownerKey(id) !== shard.key) continue;
       console.log(`[PtyClient] Respawning terminal: ${id}`);
       const previousGeneration = options.launchGeneration ?? ledger.currentGeneration(id);
       if (previousGeneration !== undefined && ledger.currentGeneration(id) !== undefined) {
@@ -508,22 +884,32 @@ export class PtyClient extends EventEmitter {
       const generation = ledger.recordLaunch(id, ledgerFactsFromSpawnOptions(options));
       const stamped: PtyHostSpawnOptions = { ...options, launchGeneration: generation };
       this.pendingSpawns.set(id, stamped);
-      this.send({ type: "spawn", id, options: stamped });
+      shard.send({ type: "spawn", id, options: stamped });
     }
 
     // Re-enable IPC data mirrors that were active before crash
     for (const id of this.ipcDataMirrorIds) {
-      this.send({ type: "set-ipc-data-mirror", id, enabled: true });
+      if (this.ownerKey(id) !== shard.key) continue;
+      shard.send({ type: "set-ipc-data-mirror", id, enabled: true });
     }
 
+    this.replayGlobalConfigToShard(shard);
+  }
+
+  /**
+   * Replay the cached host-process-wide config to one shard: on restarts
+   * (the new process booted with defaults) and on a project shard's first
+   * ready (it missed every earlier live setter).
+   */
+  private replayGlobalConfigToShard(shard: PtyShard): void {
     // Re-enable resource monitoring if it was active
     if (this.resourceMonitoringEnabled) {
-      this.send({ type: "set-resource-monitoring", enabled: true });
+      shard.send({ type: "set-resource-monitoring", enabled: true });
     }
 
     // Replay session persistence suppression if disk space was critical
     if (this.sessionPersistSuppressed) {
-      this.send({ type: "set-session-persist-suppressed", suppressed: true });
+      shard.send({ type: "set-session-persist-suppressed", suppressed: true });
     }
 
     // Replay the resource profile so the new host's governor and process-tree
@@ -531,19 +917,190 @@ export class PtyClient extends EventEmitter {
     // re-sends on transitions. The explicit poll interval (focus throttle)
     // replays after the profile since it was the later writer when both are set.
     if (this.lastResourceProfile !== null) {
-      this.send({ type: "set-resource-profile", profile: this.lastResourceProfile });
+      shard.send({ type: "set-resource-profile", profile: this.lastResourceProfile });
     }
     if (this.lastProcessTreePollIntervalMs !== null) {
-      this.send({ type: "set-process-tree-poll-interval", ms: this.lastProcessTreePollIntervalMs });
+      shard.send({
+        type: "set-process-tree-poll-interval",
+        ms: this.lastProcessTreePollIntervalMs,
+      });
     }
   }
 
-  private cleanupOrphanedPtys(crashType: CrashType): void {
+  /**
+   * A project shard exhausted its crash budget. Instead of declaring a global
+   * host crash (the singleton behavior — its terminals ARE gone, but every
+   * other project's are fine), pin the project to the default shard and
+   * respawn its terminals there: graceful degradation toward the singleton,
+   * never toward dropped terminals. The pin is session-sticky so a
+   * crash-looping project can't ping-pong between a fresh shard and the
+   * default.
+   */
+  private migrateShardTerminalsToDefault(shard: PtyShard, code: number | null): void {
+    logWarn(
+      `[PtyClient] PTY shard '${shard.key}' exceeded its crash budget (code ${code}); migrating its terminals to the default shard`
+    );
+    shard.retired = true;
+    this.shards.delete(shard.key);
+    this.cancelShardRetirement(shard.key);
+    this.projectShardOverrides.set(shard.key, DEFAULT_SHARD_KEY);
+
+    // Kills in flight against the dead shard are moot, and owner entries
+    // without a pending spawn have nothing left to migrate.
+    for (const id of [...this.pendingKillCount.keys()]) {
+      if (this.ownerKey(id) === shard.key) {
+        this.pendingKillCount.delete(id);
+      }
+    }
+    for (const [id, owner] of [...this.terminalOwners]) {
+      if (owner === shard.key && !this.pendingSpawns.has(id)) {
+        this.terminalOwners.delete(id);
+      }
+    }
+
+    // Respawn the shard's live terminals on the default shard — a NEW
+    // incarnation each, exactly like a crash respawn. If the default shard is
+    // itself mid-restart these sends drop and its own ready replay picks the
+    // (now default-owned) spawns up.
+    const target = this.ensureShard(DEFAULT_SHARD_KEY);
+    const ledger = getLifecycleLedger();
+    const migratedIds: string[] = [];
+    for (const [id, options] of this.pendingSpawns) {
+      if (this.ownerKey(id) !== shard.key) continue;
+      console.log(`[PtyClient] Migrating terminal to default shard: ${id}`);
+      const previousGeneration = options.launchGeneration ?? ledger.currentGeneration(id);
+      if (previousGeneration !== undefined && ledger.currentGeneration(id) !== undefined) {
+        ledger.recordClose(id, previousGeneration, "pty-host-crash");
+      }
+      const generation = ledger.recordLaunch(id, ledgerFactsFromSpawnOptions(options));
+      const stamped: PtyHostSpawnOptions = { ...options, launchGeneration: generation };
+      this.pendingSpawns.set(id, stamped);
+      this.terminalOwners.set(id, DEFAULT_SHARD_KEY);
+      migratedIds.push(id);
+      target.send({ type: "spawn", id, options: stamped });
+    }
+    for (const id of migratedIds) {
+      if (this.ipcDataMirrorIds.has(id)) {
+        target.send({ type: "set-ipc-data-mirror", id, enabled: true });
+      }
+    }
+
+    // Undelivered window ports re-route through the normal path (placement
+    // now resolves to the default shard); delivered ports get a targeted
+    // refresh so the renderer reconnects to the new owner.
+    for (const [windowId, port] of [...shard.pendingMessagePorts]) {
+      shard.pendingMessagePorts.delete(windowId);
+      this.connectMessagePort(windowId, port);
+    }
+    for (const [windowId, key] of [...this.windowPortShard]) {
+      if (key !== shard.key) continue;
+      this.windowPortShard.delete(windowId);
+      this.onPortRefresh?.(windowId);
+    }
+
+    shard.dispose();
+    this.dropShardSignals(shard.key);
+  }
+
+  // ── Idle shard retirement ────────────────────────────────────────────────
+  // A project shard's process lives while its project has terminals or a
+  // window; when the last reference drops it lingers briefly, then exits,
+  // releasing every FD and byte of heap it held. This binds terminal-tier
+  // resource lifetime to the shard instead of the renderer view — the
+  // structural fix for eviction leaking PTY FDs/RSS into a shared host.
+
+  private shardIsIdle(key: string): boolean {
+    for (const owner of this.terminalOwners.values()) {
+      if (owner === key) return false;
+    }
+    for (const ctx of this.windowProjectContexts.values()) {
+      if (ctx.projectId !== null && this.peekPlacementKey(ctx.projectId) === key) return false;
+    }
+    for (const portKey of this.windowPortShard.values()) {
+      if (portKey === key) return false;
+    }
+    return true;
+  }
+
+  private scheduleIdleSweep(): void {
+    if (!this.fabricEnabled || this.isDisposed) return;
+    for (const key of this.shards.keys()) {
+      if (key === DEFAULT_SHARD_KEY) continue;
+      this.maybeScheduleShardRetirement(key);
+    }
+  }
+
+  private maybeScheduleShardRetirement(key: string): void {
+    if (!this.shardIsIdle(key)) return;
+    const existing = this.shardRetirementTimers.get(key);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.shardRetirementTimers.delete(key);
+      if (this.isDisposed || !this.shardIsIdle(key)) return;
+      const shard = this.shards.get(key);
+      if (!shard) return;
+      console.log(`[PtyClient] Retiring idle PTY shard '${key}'`);
+      this.shards.delete(key);
+      shard.dispose();
+      this.dropShardSignals(key);
+    }, PTY_SHARD_IDLE_LINGER_MS);
+    timer.unref?.();
+    this.shardRetirementTimers.set(key, timer);
+  }
+
+  private cancelShardRetirement(key: string): void {
+    const timer = this.shardRetirementTimers.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      this.shardRetirementTimers.delete(key);
+    }
+  }
+
+  /**
+   * When a window's project context now places it on a different shard than
+   * the one holding its MessagePort, move the port: an undelivered pending
+   * port transfers directly; a delivered one is re-minted via the targeted
+   * port-refresh callback (a transferred MessagePort cannot be recalled from
+   * a utility process).
+   */
+  private rerouteWindowPortIfNeeded(windowId: number): void {
+    if (!this.fabricEnabled) return;
+    const currentKey = this.windowPortShard.get(windowId);
+    if (currentKey === undefined) return;
+    const targetKey = this.shardKeyForWindowContext(windowId);
+    if (currentKey === targetKey) return;
+    const current = this.shards.get(currentKey);
+    const pendingPort = current?.pendingMessagePorts.get(windowId);
+    if (current && pendingPort) {
+      current.pendingMessagePorts.delete(windowId);
+      this.connectMessagePort(windowId, pendingPort);
+      return;
+    }
+    if (!this.onPortRefresh) return;
+    console.log(
+      `[PtyClient] Rerouting window ${windowId} PTY port: shard '${currentKey}' → '${targetKey}'`
+    );
+    this.onPortRefresh(windowId);
+  }
+
+  private cleanupOrphanedPtysForShard(shard: PtyShard, crashType: CrashType): void {
     if (crashType === "CLEAN_EXIT" || this.terminalPids.size === 0) {
       return;
     }
 
-    const uniquePids = new Set(this.terminalPids.values());
+    // Scope to the crashed shard's terminals — killing a sibling shard's
+    // healthy PTY trees would turn one project's crash into an app-wide one.
+    const ownedIds: string[] = [];
+    const uniquePids = new Set<number>();
+    for (const [id, pid] of this.terminalPids) {
+      if (this.ownerKey(id) !== shard.key) continue;
+      ownedIds.push(id);
+      uniquePids.add(pid);
+    }
+    if (uniquePids.size === 0) {
+      return;
+    }
+
     console.warn(
       `[PtyClient] Attempting to clean up ${uniquePids.size} orphaned PTY process(es) after host crash`
     );
@@ -584,88 +1141,131 @@ export class PtyClient extends EventEmitter {
       }
     }
 
-    this.terminalPids.clear();
+    for (const id of ownedIds) {
+      this.terminalPids.delete(id);
+    }
   }
 
-  /** Set callback for MessagePort refresh (called on host restart) */
-  setPortRefreshCallback(callback: () => void): void {
+  /**
+   * Set callback for MessagePort refresh. Called with no argument on a legacy
+   * full-host restart (refresh every window) and with a windowId when the
+   * fabric restarts or reroutes a single window's shard.
+   */
+  setPortRefreshCallback(callback: (windowId?: number) => void): void {
     this.onPortRefresh = callback;
   }
 
   /**
-   * Update the cached log-level overrides and push immediately if the host is
-   * ready. On every subsequent restart the cached map is replayed via the
+   * Update the cached log-level overrides and push immediately to every ready
+   * shard. On every subsequent restart the cached map is replayed via the
    * `ready` handler — callers don't need to track restarts themselves.
    */
   setLogLevelOverrides(overrides: Record<string, string>): void {
     this.logLevelOverridesCache = { ...overrides };
-    if (this.lifecycle.isInitialized && this.lifecycle.child) {
-      this.send({ type: "set-log-level-overrides", overrides: this.logLevelOverridesCache });
+    for (const shard of this.shards.values()) {
+      if (shard.lifecycle.isInitialized && shard.lifecycle.child) {
+        shard.send({ type: "set-log-level-overrides", overrides: this.logLevelOverridesCache });
+      }
     }
   }
 
   /**
-   * Push the current plugin-agent registry to the host so its activity monitor
-   * can resolve plugin detection patterns (#10587). Called by `PluginService`
-   * after a plugin load/unload changes the registry. Reads the authoritative
-   * main snapshot at call time; on a host restart the registry is replayed from
-   * the `ready` handler, so callers don't track restarts themselves. No-op when
-   * the host isn't ready yet — the ready replay covers that window.
+   * Push the current plugin-agent registry to every ready shard so their
+   * activity monitors can resolve plugin detection patterns (#10587). Called
+   * by `PluginService` after a plugin load/unload changes the registry. Reads
+   * the authoritative main snapshot at call time; on a host restart the
+   * registry is replayed from the `ready` handler, so callers don't track
+   * restarts themselves. No-op for shards that aren't ready yet — the ready
+   * replay covers that window.
    */
   syncPluginAgentRegistry(): void {
-    if (this.lifecycle.isInitialized && this.lifecycle.child) {
-      this.send({ type: "set-plugin-agent-registry", registry: getPluginAgentRegistry() });
+    for (const shard of this.shards.values()) {
+      if (shard.lifecycle.isInitialized && shard.lifecycle.child) {
+        shard.send({ type: "set-plugin-agent-registry", registry: getPluginAgentRegistry() });
+      }
     }
   }
 
-  private flushPendingMessagePorts(): void {
-    if (!this.lifecycle.child || this.pendingMessagePorts.size === 0) {
+  private flushPendingMessagePortsForShard(shard: PtyShard): void {
+    if (!shard.lifecycle.child || shard.pendingMessagePorts.size === 0) {
       return;
     }
 
-    const pending = new Map(this.pendingMessagePorts);
-    this.pendingMessagePorts.clear();
+    const pending = new Map(shard.pendingMessagePorts);
+    shard.pendingMessagePorts.clear();
+    // Re-enter connectMessagePort rather than posting directly: placement may
+    // have moved while the port waited (project switch, crash migration), and
+    // the connect path re-derives the owning shard.
     for (const [windowId, port] of pending) {
       this.connectMessagePort(windowId, port);
     }
   }
 
-  /** Forward MessagePort to Pty Host for direct Renderer↔PtyHost communication */
+  /**
+   * Forward MessagePort to the owning shard for direct Renderer↔PtyHost
+   * communication. The owning shard is derived from the window's current
+   * project context; when the port previously lived on a different shard the
+   * old shard gets an explicit disconnect so it can tear down its per-window
+   * queue/batcher state.
+   */
   connectMessagePort(windowId: number, port: MessagePortMain): void {
-    const existingPending = this.pendingMessagePorts.get(windowId);
+    const targetKey = this.shardKeyForWindowContext(windowId);
+    const target = this.ensureShard(targetKey);
+
+    const previousKey = this.windowPortShard.get(windowId);
+    if (previousKey !== undefined && previousKey !== targetKey) {
+      const previous = this.shards.get(previousKey);
+      if (previous) {
+        const stalePending = previous.pendingMessagePorts.get(windowId);
+        if (stalePending && stalePending !== port) {
+          try {
+            stalePending.close();
+          } catch {
+            // ignore
+          }
+        }
+        previous.pendingMessagePorts.delete(windowId);
+        previous.send({ type: "disconnect-port", windowId });
+      }
+    }
+    this.windowPortShard.set(windowId, targetKey);
+
+    const existingPending = target.pendingMessagePorts.get(windowId);
     if (existingPending && existingPending !== port) {
       try {
         existingPending.close();
       } catch {
         // ignore
       }
-      this.pendingMessagePorts.delete(windowId);
+      target.pendingMessagePorts.delete(windowId);
     }
 
-    if (!this.lifecycle.child) {
+    if (!target.lifecycle.child) {
       console.warn("[PtyClient] Cannot connect MessagePort - host not running, will retry");
-      this.pendingMessagePorts.set(windowId, port);
+      target.pendingMessagePorts.set(windowId, port);
       return;
     }
 
     try {
-      this.lifecycle.child.postMessage({ type: "connect-port", windowId }, [port]);
+      target.lifecycle.child.postMessage({ type: "connect-port", windowId }, [port]);
       if (process.env.DAINTREE_VERBOSE) {
         console.log(`[PtyClient] MessagePort forwarded to Pty Host for window ${windowId}`);
       }
       // Re-send project context for this window (handles page reload case where
-      // disconnectWindow in the host clears windowProjectMap on port-replace)
+      // disconnectWindow in the host clears windowProjectMap on port-replace).
+      // The target IS the owner of this window's project, so the pool-warming
+      // projectPath is included.
       const ctx = this.windowProjectContexts.get(windowId);
       if (ctx) {
         if (ctx.mode === "switch" && ctx.projectId !== null) {
-          this.send({
+          target.send({
             type: "project-switch",
             windowId,
             projectId: ctx.projectId,
             ...(ctx.projectPath ? { projectPath: ctx.projectPath } : {}),
           });
         } else {
-          this.send({
+          target.send({
             type: "set-active-project",
             windowId,
             projectId: ctx.projectId,
@@ -677,20 +1277,28 @@ export class PtyClient extends EventEmitter {
       // on port-replace, and the renderer won't re-fire without a focus change.
       const focusedId = this.windowFocusedTerminals.get(windowId);
       if (focusedId !== undefined) {
-        this.send({ type: "set-focused-terminal", windowId, id: focusedId });
+        target.send({ type: "set-focused-terminal", windowId, id: focusedId });
       }
     } catch (error) {
       console.error("[PtyClient] Failed to forward MessagePort to Pty Host:", error);
-      this.pendingMessagePorts.set(windowId, port);
+      target.pendingMessagePorts.set(windowId, port);
     }
   }
 
-  /** Notify Pty Host that a window's MessagePort should be disconnected */
+  /** Notify the owning shard that a window's MessagePort should be disconnected */
   disconnectMessagePort(windowId: number): void {
-    this.pendingMessagePorts.delete(windowId);
+    for (const shard of this.shards.values()) {
+      shard.pendingMessagePorts.delete(windowId);
+    }
+    const portKey = this.windowPortShard.get(windowId);
+    this.windowPortShard.delete(windowId);
     this.windowProjectContexts.delete(windowId);
     this.windowFocusedTerminals.delete(windowId);
-    this.send({ type: "disconnect-port", windowId });
+    (this.shards.get(portKey ?? DEFAULT_SHARD_KEY) ?? this.defaultShard).send({
+      type: "disconnect-port",
+      windowId,
+    });
+    this.scheduleIdleSweep();
   }
 
   private resolveKeySequence(key: string): string | null {
@@ -778,16 +1386,22 @@ export class PtyClient extends EventEmitter {
       launchGeneration: generation,
     };
 
+    // Placement: the terminal is admitted to its project's shard (the default
+    // shard with the fabric off, for projectless terminals, and for projects
+    // pinned by cap overflow / crash migration). Ownership is recorded before
+    // the send so events and per-terminal requests route consistently.
+    const shard = this.ensureShardForProject(resolvedProjectId);
+    this.terminalOwners.set(id, shard.key);
     this.pendingSpawns.set(id, resolvedOptions);
-    this.send({ type: "spawn", id, options: resolvedOptions });
+    shard.send({ type: "spawn", id, options: resolvedOptions });
   }
 
   write(id: string, data: string, traceId?: string): void {
-    this.send({ type: "write", id, data, traceId });
+    this.shardForTerminal(id).send({ type: "write", id, data, traceId });
   }
 
   submit(id: string, text: string): void {
-    this.send({ type: "submit", id, text });
+    this.shardForTerminal(id).send({ type: "submit", id, text });
   }
 
   /**
@@ -795,7 +1409,7 @@ export class PtyClient extends EventEmitter {
    * no-execute counterpart to {@link submit}; see {@link TerminalProcess.stage}.
    */
   stage(id: string, text: string): void {
-    this.send({ type: "stage", id, text });
+    this.shardForTerminal(id).send({ type: "stage", id, text });
   }
 
   sendKey(id: string, key: string): void {
@@ -817,24 +1431,43 @@ export class PtyClient extends EventEmitter {
     if (!Array.isArray(ids) || ids.length === 0) return;
     const validIds = ids.filter((id) => typeof id === "string" && id.length > 0);
     if (validIds.length === 0) return;
-    this.send({ type: "batch-double-escape", ids: validIds });
+    for (const [shard, shardIds] of this.groupByOwnerShard(validIds)) {
+      shard.send({ type: "batch-double-escape", ids: shardIds });
+    }
   }
 
   /**
-   * Fan one data payload to every id in a single pty-host message. Used by
-   * fleet broadcast: every keystroke becomes one main→host message instead
-   * of N renderer→main IPC hops, cutting fan-out latency on large fleets.
+   * Fan one data payload to every id in a single per-shard pty-host message.
+   * Used by fleet broadcast: every keystroke becomes one main→host message per
+   * shard instead of N renderer→main IPC hops, cutting fan-out latency on
+   * large fleets.
    */
   broadcastWrite(ids: string[], data: string): void {
     if (!Array.isArray(ids) || ids.length === 0 || typeof data !== "string" || data.length === 0)
       return;
     const validIds = ids.filter((id) => typeof id === "string" && id.length > 0);
     if (validIds.length === 0) return;
-    this.send({ type: "broadcast-write", ids: validIds, data });
+    for (const [shard, shardIds] of this.groupByOwnerShard(validIds)) {
+      shard.send({ type: "broadcast-write", ids: shardIds, data });
+    }
+  }
+
+  private groupByOwnerShard(ids: string[]): Map<PtyShard, string[]> {
+    const groups = new Map<PtyShard, string[]>();
+    for (const id of ids) {
+      const shard = this.shardForTerminal(id);
+      const list = groups.get(shard);
+      if (list) {
+        list.push(id);
+      } else {
+        groups.set(shard, [id]);
+      }
+    }
+    return groups;
   }
 
   resize(id: string, cols: number, rows: number): void {
-    this.send({ type: "resize", id, cols, rows });
+    this.shardForTerminal(id).send({ type: "resize", id, cols, rows });
   }
 
   kill(id: string, reason?: string, options?: { escalationDelayMs?: number }): void {
@@ -864,7 +1497,12 @@ export class PtyClient extends EventEmitter {
     }
     // Always send the kill IPC. The host-side handler kills the terminal if
     // it exists and removes any persisted session state for the id.
-    this.send({ type: "kill", id, reason, escalationDelayMs: options?.escalationDelayMs });
+    this.shardForTerminal(id).send({
+      type: "kill",
+      id,
+      reason,
+      escalationDelayMs: options?.escalationDelayMs,
+    });
   }
 
   /** Check if a terminal exists (based on local tracking) */
@@ -888,35 +1526,39 @@ export class PtyClient extends EventEmitter {
       .catch((err) => {
         console.warn("[PtyClient] persistTrashed failed:", err);
       });
-    this.send({ type: "trash", id });
+    this.shardForTerminal(id).send({ type: "trash", id });
   }
 
   /** Restore terminal from trash. Returns true if terminal was tracked. */
   restore(id: string): boolean {
     getTrashedPidTracker().removeTrashed(id);
     const wasTracked = this.pendingSpawns.has(id);
-    this.send({ type: "restore", id });
+    this.shardForTerminal(id).send({ type: "restore", id });
     return wasTracked;
   }
 
   setActivityTier(id: string, tier: PtyHostActivityTier, pollingIntervalMs?: number): void {
-    this.send({ type: "set-activity-tier", id, tier, pollingIntervalMs });
+    this.shardForTerminal(id).send({ type: "set-activity-tier", id, tier, pollingIntervalMs });
   }
 
   /**
    * Report the UI-focused terminal for a window so the host's per-window
    * PortQueueManager/PortBatcher can prioritize it. Cached per window for replay
-   * on port reconnect and host restart. Fire-and-forget — a dropped send only
+   * on port reconnect and host restart. Routed to the shard holding the
+   * window's port — the focused terminal lives on the window's active project,
+   * which is that shard by construction. Fire-and-forget — a dropped send only
    * loses prioritization until the next focus change or replay.
    */
   setFocusedTerminal(windowId: number, id: string | null): void {
     this.windowFocusedTerminals.set(windowId, id);
-    this.send({ type: "set-focused-terminal", windowId, id });
+    this.shardForWindow(windowId).send({ type: "set-focused-terminal", windowId, id });
   }
 
   setResourceMonitoring(enabled: boolean): void {
     this.resourceMonitoringEnabled = enabled;
-    this.send({ type: "set-resource-monitoring", enabled });
+    for (const shard of this.shards.values()) {
+      shard.send({ type: "set-resource-monitoring", enabled });
+    }
   }
 
   setResourceProfile(profile: ResourceProfile): void {
@@ -924,12 +1566,16 @@ export class PtyClient extends EventEmitter {
     // The profile resets the host's process-tree cadence to its baseline; a
     // stale explicit interval must not be replayed over it after a restart.
     this.lastProcessTreePollIntervalMs = null;
-    this.send({ type: "set-resource-profile", profile });
+    for (const shard of this.shards.values()) {
+      shard.send({ type: "set-resource-profile", profile });
+    }
   }
 
   setProcessTreePollInterval(ms: number): void {
     this.lastProcessTreePollIntervalMs = ms;
-    this.send({ type: "set-process-tree-poll-interval", ms });
+    for (const shard of this.shards.values()) {
+      shard.send({ type: "set-process-tree-poll-interval", ms });
+    }
   }
 
   /**
@@ -943,12 +1589,12 @@ export class PtyClient extends EventEmitter {
     } else {
       this.ipcDataMirrorIds.delete(id);
     }
-    this.send({ type: "set-ipc-data-mirror", id, enabled });
+    this.shardForTerminal(id).send({ type: "set-ipc-data-mirror", id, enabled });
   }
 
-  private syncProjectContext(skipWindowIds?: ReadonlySet<number>): void {
-    if (!this.lifecycle.child) {
-      this.shouldResyncProjectContext = true;
+  private syncProjectContextToShard(shard: PtyShard, skipWindowIds?: ReadonlySet<number>): void {
+    if (!shard.lifecycle.child) {
+      shard.shouldResyncProjectContext = true;
       return;
     }
 
@@ -956,19 +1602,27 @@ export class PtyClient extends EventEmitter {
       if (skipWindowIds?.has(windowId)) {
         continue;
       }
+      // Only the shard that owns a window's project receives the projectPath:
+      // the path triggers a pool drain/warm in the host, and a non-owning
+      // shard warming its pool to another project's root is pure churn. The
+      // bare context still lands so the shard's per-window data filter and
+      // tier recompute stay correct.
+      const includePath =
+        ctx.projectPath !== undefined &&
+        (!this.fabricEnabled || this.peekPlacementKey(ctx.projectId) === shard.key);
       if (ctx.mode === "switch" && ctx.projectId !== null) {
-        this.send({
+        shard.send({
           type: "project-switch",
           windowId,
           projectId: ctx.projectId,
-          ...(ctx.projectPath ? { projectPath: ctx.projectPath } : {}),
+          ...(includePath ? { projectPath: ctx.projectPath } : {}),
         });
       } else {
-        this.send({
+        shard.send({
           type: "set-active-project",
           windowId,
           projectId: ctx.projectId,
-          ...(ctx.projectPath ? { projectPath: ctx.projectPath } : {}),
+          ...(includePath ? { projectPath: ctx.projectPath } : {}),
         });
       }
     }
@@ -978,7 +1632,7 @@ export class PtyClient extends EventEmitter {
     // avoid a duplicate send.
     for (const [windowId, focusedId] of this.windowFocusedTerminals) {
       if (skipWindowIds?.has(windowId)) continue;
-      this.send({ type: "set-focused-terminal", windowId, id: focusedId });
+      shard.send({ type: "set-focused-terminal", windowId, id: focusedId });
     }
   }
 
@@ -1001,17 +1655,23 @@ export class PtyClient extends EventEmitter {
     this.activeProjectId = projectId;
     // panelCwds / projectEnv are transient warm hints for the first send only —
     // they are NOT stored in windowProjectContexts. A host restart replays via
-    // syncProjectContext against a freshly-empty pool with no pending restore
-    // spawns, so re-warming saved panel cwds (or refiring the env hash) would
-    // be wasted work.
+    // syncProjectContextToShard against a freshly-empty pool with no pending
+    // restore spawns, so re-warming saved panel cwds (or refiring the env hash)
+    // would be wasted work.
     this.windowProjectContexts.set(windowId, { projectId, projectPath, mode: "active" });
 
-    if (!this.lifecycle.child) {
-      this.shouldResyncProjectContext = true;
+    // Activating a project materializes its shard so the pool warm below runs
+    // in the process the project's terminals will spawn in.
+    const shard = this.ensureShardForProject(projectId);
+
+    if (!shard.lifecycle.child) {
+      shard.shouldResyncProjectContext = true;
+      this.rerouteWindowPortIfNeeded(windowId);
+      this.scheduleIdleSweep();
       return;
     }
 
-    this.send({
+    shard.send({
       type: "set-active-project",
       windowId,
       projectId,
@@ -1019,32 +1679,41 @@ export class PtyClient extends EventEmitter {
       ...(panelCwds && panelCwds.length > 0 ? { panelCwds } : {}),
       ...(projectEnv ? { projectEnv } : {}),
     });
+    this.rerouteWindowPortIfNeeded(windowId);
+    this.scheduleIdleSweep();
   }
 
   onProjectSwitch(windowId: number, projectId: string, projectPath?: string): void {
     this.activeProjectId = projectId;
     this.windowProjectContexts.set(windowId, { projectId, projectPath, mode: "switch" });
 
-    if (!this.lifecycle.child) {
-      this.shouldResyncProjectContext = true;
+    const shard = this.ensureShardForProject(projectId);
+
+    if (!shard.lifecycle.child) {
+      shard.shouldResyncProjectContext = true;
+      this.rerouteWindowPortIfNeeded(windowId);
+      this.scheduleIdleSweep();
       return;
     }
 
-    this.send({
+    shard.send({
       type: "project-switch",
       windowId,
       projectId,
       ...(projectPath ? { projectPath } : {}),
     });
+    this.rerouteWindowPortIfNeeded(windowId);
+    this.scheduleIdleSweep();
   }
 
   async gracefulKill(id: string): Promise<string | null> {
-    const requestId = this.broker.generateId(`graceful-kill-${id}`);
-    const promise = this.broker.register<GracefulKillResult>(requestId, {
+    const shard = this.shardForTerminal(id);
+    const requestId = shard.broker.generateId(`graceful-kill-${id}`);
+    const promise = shard.broker.register<GracefulKillResult>(requestId, {
       method: "graceful-kill",
       timeoutMs: PTY_TIMEOUTS["graceful-kill"],
     });
-    this.send({ type: "graceful-kill", id, requestId });
+    shard.send({ type: "graceful-kill", id, requestId });
     const result = await promise.catch((error: unknown) => {
       // Sending a kill to a host that isn't there only mutates local bookkeeping.
       // Skip whenever the host is known to be gone — either because the broker
@@ -1054,7 +1723,7 @@ export class PtyClient extends EventEmitter {
       // the 5s timeout window). TIMEOUT is excluded: a per-request timeout
       // with a live host should still escalate to a forced kill.
       const isHostGoneBrokerError = error instanceof BrokerError && error.code !== "TIMEOUT";
-      if (isHostGoneBrokerError || !this.lifecycle.child || this.isDisposed) {
+      if (isHostGoneBrokerError || !shard.lifecycle.child || this.isDisposed) {
         return { sessionId: null };
       }
       this.kill(id, "graceful-kill-timeout");
@@ -1067,15 +1736,16 @@ export class PtyClient extends EventEmitter {
     projectId: string,
     options?: { preserveSession?: boolean }
   ): Promise<Array<{ id: string; agentSessionId: string | null }>> {
-    const requestId = this.broker.generateId(`graceful-kill-by-project-${projectId}`);
-    const promise = this.broker.register<Array<{ id: string; agentSessionId: string | null }>>(
+    const shard = this.shardForProjectQuery(projectId);
+    const requestId = shard.broker.generateId(`graceful-kill-by-project-${projectId}`);
+    const promise = shard.broker.register<Array<{ id: string; agentSessionId: string | null }>>(
       requestId,
       {
         method: "graceful-kill-by-project",
         timeoutMs: PTY_TIMEOUTS["graceful-kill-by-project"],
       }
     );
-    this.send({
+    shard.send({
       type: "graceful-kill-by-project",
       projectId,
       requestId,
@@ -1087,12 +1757,13 @@ export class PtyClient extends EventEmitter {
   }
 
   async killByProject(projectId: string): Promise<number> {
-    const requestId = this.broker.generateId(`kill-by-project-${projectId}`);
-    const promise = this.broker.register<number>(requestId, {
+    const shard = this.shardForProjectQuery(projectId);
+    const requestId = shard.broker.generateId(`kill-by-project-${projectId}`);
+    const promise = shard.broker.register<number>(requestId, {
       method: "kill-by-project",
       timeoutMs: PTY_TIMEOUTS["kill-by-project"],
     });
-    this.send({ type: "kill-by-project", projectId, requestId });
+    shard.send({ type: "kill-by-project", projectId, requestId });
     return promise.catch(() => 0);
   }
 
@@ -1101,41 +1772,61 @@ export class PtyClient extends EventEmitter {
     processIds: number[];
     terminalTypes: Record<string, number>;
   }> {
-    const requestId = this.broker.generateId(`project-stats-${projectId}`);
-    const promise = this.broker.register<{
+    const shard = this.shardForProjectQuery(projectId);
+    const requestId = shard.broker.generateId(`project-stats-${projectId}`);
+    const promise = shard.broker.register<{
       terminalCount: number;
       processIds: number[];
       terminalTypes: Record<string, number>;
     }>(requestId);
-    this.send({ type: "get-project-stats", projectId, requestId });
+    shard.send({ type: "get-project-stats", projectId, requestId });
     return promise.catch(() => ({ terminalCount: 0, processIds: [], terminalTypes: {} }));
   }
 
   /**
    * On-demand rollup of resident memory across every live terminal's process
-   * subtree, grouped by project. Reads the warm ProcessTreeCache in the host —
-   * no extra OS sweep. Resolves to an unavailable rollup on IPC failure/timeout
-   * so callers never throw.
+   * subtree, grouped by project. Reads the warm ProcessTreeCache in each shard —
+   * no extra OS sweep — and merges across shards (a project lives on exactly
+   * one shard, so rows never need cross-shard PID dedup). Resolves to an
+   * unavailable rollup on IPC failure/timeout so callers never throw.
    */
   async getMemoryRollup(): Promise<MemoryRollup> {
-    const requestId = this.broker.generateId("memory-rollup");
-    const promise = this.broker.register<MemoryRollup>(requestId);
-    this.send({ type: "get-memory-rollup", requestId });
-    return promise.catch(() => ({
-      byProject: [],
-      totalMemoryKb: 0,
-      totalProcessCount: 0,
-      terminalCount: 0,
-      available: false,
-      sampledAt: Date.now(),
-    }));
+    const shards = this.fanOutShards();
+    const rollups = (
+      await Promise.all(
+        shards.map((shard) => {
+          const requestId = shard.broker.generateId("memory-rollup");
+          const promise = shard.broker.register<MemoryRollup>(requestId);
+          shard.send({ type: "get-memory-rollup", requestId });
+          return promise.catch(() => null);
+        })
+      )
+    ).filter((rollup): rollup is MemoryRollup => rollup !== null);
+    if (rollups.length === 0) {
+      return {
+        byProject: [],
+        totalMemoryKb: 0,
+        totalProcessCount: 0,
+        terminalCount: 0,
+        available: false,
+        sampledAt: Date.now(),
+      };
+    }
+    const merged = rollups.length === 1 ? rollups[0] : mergeMemoryRollups(rollups);
+    // A shard that failed/timed out leaves its terminals unaccounted — the
+    // partial numbers must not masquerade as a complete, trustworthy rollup
+    // (consumers gate per-project memory displays on `available`).
+    if (rollups.length < shards.length) {
+      return { ...merged, available: false };
+    }
+    return merged;
   }
 
   /**
    * Acknowledge data processing for flow control.
    */
   acknowledgeData(id: string, byteCount: number): void {
-    this.send({ type: "acknowledge-data", id, byteCount });
+    this.shardForTerminal(id).send({ type: "acknowledge-data", id, byteCount });
   }
 
   /**
@@ -1144,116 +1835,183 @@ export class PtyClient extends EventEmitter {
    * automatic flow control gets stuck.
    */
   forceResume(id: string): void {
-    this.send({ type: "force-resume", id });
+    this.shardForTerminal(id).send({ type: "force-resume", id });
   }
 
   /** Get terminal IDs for a specific project */
   async getTerminalsForProjectAsync(projectId: string): Promise<string[]> {
-    const requestId = this.broker.generateId(`terminals-${projectId}`);
-    const promise = this.broker.register<string[]>(requestId);
-    this.send({ type: "get-terminals-for-project", projectId, requestId });
+    const shard = this.shardForProjectQuery(projectId);
+    const requestId = shard.broker.generateId(`terminals-${projectId}`);
+    const promise = shard.broker.register<string[]>(requestId);
+    shard.send({ type: "get-terminals-for-project", projectId, requestId });
     return promise.catch(() => []);
   }
 
   /** Get terminal info by ID */
   async getTerminalAsync(id: string): Promise<TerminalInfoResponse | null> {
-    const requestId = this.broker.generateId(`terminal-${id}`);
-    const promise = this.broker.register<TerminalInfoResponse | null>(requestId);
-    this.send({ type: "get-terminal", id, requestId });
+    const shard = this.shardForTerminal(id);
+    const requestId = shard.broker.generateId(`terminal-${id}`);
+    const promise = shard.broker.register<TerminalInfoResponse | null>(requestId);
+    shard.send({ type: "get-terminal", id, requestId });
     return promise.catch(() => null);
   }
 
-  /** Get available terminals (idle or waiting for user input) */
+  /** Get available terminals (idle or waiting for user input), across all shards */
   async getAvailableTerminalsAsync(): Promise<TerminalInfoResponse[]> {
-    const requestId = this.broker.generateId("available-terminals");
-    const promise = this.broker.register<TerminalInfoResponse[]>(requestId);
-    this.send({ type: "get-available-terminals", requestId });
-    return promise.catch(() => []);
+    const results = await Promise.all(
+      this.fanOutShards().map((shard) => {
+        const requestId = shard.broker.generateId("available-terminals");
+        const promise = shard.broker.register<TerminalInfoResponse[]>(requestId);
+        shard.send({ type: "get-available-terminals", requestId });
+        return promise.catch(() => [] as TerminalInfoResponse[]);
+      })
+    );
+    return results.flat();
   }
 
-  /** Get terminals filtered by agent state */
+  /** Get terminals filtered by agent state, across all shards */
   async getTerminalsByStateAsync(
     state: import("../../shared/types/agent.js").AgentState
   ): Promise<TerminalInfoResponse[]> {
-    const requestId = this.broker.generateId(`terminals-by-state-${state}`);
-    const promise = this.broker.register<TerminalInfoResponse[]>(requestId);
-    this.send({ type: "get-terminals-by-state", state, requestId });
-    return promise.catch(() => []);
+    const results = await Promise.all(
+      this.fanOutShards().map((shard) => {
+        const requestId = shard.broker.generateId(`terminals-by-state-${state}`);
+        const promise = shard.broker.register<TerminalInfoResponse[]>(requestId);
+        shard.send({ type: "get-terminals-by-state", state, requestId });
+        return promise.catch(() => [] as TerminalInfoResponse[]);
+      })
+    );
+    return results.flat();
   }
 
-  /** Get all terminals */
+  /** Get all terminals, across all shards */
   async getAllTerminalsAsync(): Promise<TerminalInfoResponse[]> {
-    const requestId = this.broker.generateId("all-terminals");
-    const promise = this.broker.register<TerminalInfoResponse[]>(requestId);
-    this.send({ type: "get-all-terminals", requestId });
-    return promise.catch(() => []);
+    const results = await Promise.all(
+      this.fanOutShards().map((shard) => {
+        const requestId = shard.broker.generateId("all-terminals");
+        const promise = shard.broker.register<TerminalInfoResponse[]>(requestId);
+        shard.send({ type: "get-all-terminals", requestId });
+        return promise.catch(() => [] as TerminalInfoResponse[]);
+      })
+    );
+    return results.flat();
   }
 
   /**
-   * Get an on-demand structured flow-control snapshot from the pty-host
+   * Get an on-demand structured flow-control snapshot from the pty-host fabric
    * (per-terminal flow status, held pause tokens, queue depths, backpressure
-   * stats, and resource-governor state). Used by `DiagnosticsCollector` for
-   * support bundles. Resolves to an empty snapshot on IPC failure/timeout —
-   * the diagnostics caller never throws.
+   * stats, and resource-governor state). With multiple shards the top-level
+   * governor/event-loop fields carry the worst-shard view and `shards` the
+   * per-shard breakdown. Used by `DiagnosticsCollector` for support bundles.
+   * Resolves to an empty snapshot on IPC failure/timeout — the diagnostics
+   * caller never throws.
    */
   async getFlowControlSnapshotAsync(): Promise<FlowControlSnapshot> {
-    const requestId = this.broker.generateId("flow-control-snapshot");
-    const promise = this.broker.register<FlowControlSnapshot>(requestId);
-    this.send({ type: "get-flow-control-snapshot", requestId });
-    return promise.catch(() => ({
-      timestamp: Date.now(),
-      terminals: [],
-      queueDepth: [],
-      totalPendingBytes: 0,
-      stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
-      resourceGovernor: {
-        isThrottling: false,
-        isWarning: false,
-        activeProfile: "balanced",
-        smoothedUtilizationPercent: null,
-        throttleDurationMs: 0,
-      },
-      eventLoop: null,
-    }));
+    const shards = this.fanOutShards();
+    const results = (
+      await Promise.all(
+        shards.map((shard) => {
+          const requestId = shard.broker.generateId("flow-control-snapshot");
+          const promise = shard.broker.register<FlowControlSnapshot>(requestId);
+          shard.send({ type: "get-flow-control-snapshot", requestId });
+          return promise.then(
+            (snapshot) => ({ shardKey: shard.key, snapshot }),
+            () => null
+          );
+        })
+      )
+    ).filter(
+      (entry): entry is { shardKey: string; snapshot: FlowControlSnapshot } => entry !== null
+    );
+    if (results.length === 0) {
+      return {
+        timestamp: Date.now(),
+        terminals: [],
+        queueDepth: [],
+        totalPendingBytes: 0,
+        stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+        resourceGovernor: {
+          isThrottling: false,
+          isWarning: false,
+          activeProfile: "balanced",
+          smoothedUtilizationPercent: null,
+          throttleDurationMs: 0,
+        },
+        eventLoop: null,
+      };
+    }
+    // With every shard reporting and only one shard live, pass the snapshot
+    // through untouched (legacy shape). A partial fan-out (a shard timed out)
+    // always goes through the merge so the `shards` breakdown makes the
+    // missing shard observable to diagnostics instead of silently vanishing.
+    if (results.length === 1 && shards.length === 1) {
+      return results[0].snapshot;
+    }
+    return mergeFlowControlSnapshots(results);
   }
 
   /**
-   * On-demand worker-governance snapshot from the pty-host (per-slot analysis
-   * worker pool state + host process memory). Resolves null on IPC
-   * failure/timeout — the governance caller reports the provider as errored
-   * rather than throwing.
+   * On-demand worker-governance snapshot from the pty-host fabric (per-slot
+   * analysis worker pool state + host process memory, summed across shards).
+   * Resolves null when every shard fails/times out — the governance caller
+   * reports the provider as errored rather than throwing.
    */
   async getWorkerGovernanceSnapshotAsync(): Promise<PtyHostWorkerGovernanceSnapshot | null> {
-    const requestId = this.broker.generateId("worker-governance-snapshot");
-    const promise = this.broker.register<PtyHostWorkerGovernanceSnapshot>(requestId);
-    this.send({ type: "get-worker-governance-snapshot", requestId });
-    return promise.catch(() => null);
+    const snapshots = (
+      await Promise.all(
+        this.fanOutShards().map((shard) => {
+          const requestId = shard.broker.generateId("worker-governance-snapshot");
+          const promise = shard.broker.register<PtyHostWorkerGovernanceSnapshot>(requestId);
+          shard.send({ type: "get-worker-governance-snapshot", requestId });
+          return promise.catch(() => null);
+        })
+      )
+    ).filter((snapshot): snapshot is PtyHostWorkerGovernanceSnapshot => snapshot !== null);
+    if (snapshots.length === 0) return null;
+    if (snapshots.length === 1) return snapshots[0];
+    return {
+      timestamp: Math.max(...snapshots.map((s) => s.timestamp)),
+      workers: snapshots.flatMap((s) => s.workers),
+      hostMemory: {
+        rssBytes: snapshots.reduce((sum, s) => sum + s.hostMemory.rssBytes, 0),
+        heapUsedBytes: snapshots.reduce((sum, s) => sum + s.hostMemory.heapUsedBytes, 0),
+        externalBytes: snapshots.reduce((sum, s) => sum + s.hostMemory.externalBytes, 0),
+      },
+    };
   }
 
   /**
    * Scan every terminal's semantic buffer for `query` and return one
-   * ANSI-stripped snippet per matching terminal. Substring (case-insensitive)
-   * unless `isRegex` is true. Returns an empty array on regex compile error
-   * or IPC failure — UI never throws on bad input.
+   * ANSI-stripped snippet per matching terminal, across all shards. Substring
+   * (case-insensitive) unless `isRegex` is true. Returns an empty array on
+   * regex compile error or IPC failure — UI never throws on bad input.
    */
   async searchSemanticBuffersAsync(
     query: string,
     isRegex: boolean
   ): Promise<import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]> {
-    const requestId = this.broker.generateId("semantic-search");
-    const promise =
-      this.broker.register<import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]>(
-        requestId
-      );
-    this.send({ type: "search-semantic-buffers", query, isRegex, requestId });
-    return promise.catch(() => []);
+    const results = await Promise.all(
+      this.fanOutShards().map((shard) => {
+        const requestId = shard.broker.generateId("semantic-search");
+        const promise =
+          shard.broker.register<import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]>(
+            requestId
+          );
+        shard.send({ type: "search-semantic-buffers", query, isRegex, requestId });
+        return promise.catch(
+          () => [] as import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]
+        );
+      })
+    );
+    return results.flat();
   }
 
   /** Replay terminal history */
   async replayHistoryAsync(id: string, maxLines: number = 100): Promise<number> {
-    const requestId = this.broker.generateId(`replay-${id}`);
-    const promise = this.broker.register<number>(requestId);
-    this.send({ type: "replay-history", id, maxLines, requestId });
+    const shard = this.shardForTerminal(id);
+    const requestId = shard.broker.generateId(`replay-${id}`);
+    const promise = shard.broker.register<number>(requestId);
+    shard.send({ type: "replay-history", id, maxLines, requestId });
     return promise.catch(() => 0);
   }
 
@@ -1264,13 +2022,14 @@ export class PtyClient extends EventEmitter {
    * @returns Serialized state string or null if terminal not found
    */
   async getSerializedStateAsync(id: string): Promise<string | null> {
-    const requestId = this.broker.generateId(`serialize-${id}`);
+    const shard = this.shardForTerminal(id);
+    const requestId = shard.broker.generateId(`serialize-${id}`);
     // Extended timeout for large terminals with lots of scrollback (see PTY_TIMEOUTS).
-    const promise = this.broker.register<string | null>(requestId, {
+    const promise = shard.broker.register<string | null>(requestId, {
       method: "get-serialized-state",
       timeoutMs: PTY_TIMEOUTS["get-serialized-state"],
     });
-    this.send({ type: "get-serialized-state", id, requestId } as PtyHostRequest);
+    shard.send({ type: "get-serialized-state", id, requestId });
     return promise.catch(() => {
       console.warn(`[PtyClient] getSerializedState timeout for ${id}`);
       return null;
@@ -1283,42 +2042,49 @@ export class PtyClient extends EventEmitter {
   async getTerminalInfo(
     id: string
   ): Promise<import("../../shared/types/ipc.js").TerminalInfoPayload | null> {
-    const requestId = this.broker.generateId(`terminal-info-${id}`);
-    const promise = this.broker.register<
+    const shard = this.shardForTerminal(id);
+    const requestId = shard.broker.generateId(`terminal-info-${id}`);
+    const promise = shard.broker.register<
       import("../../shared/types/ipc.js").TerminalInfoPayload | null
     >(requestId);
-    this.send({ type: "get-terminal-info", id, requestId });
+    shard.send({ type: "get-terminal-info", id, requestId });
     return promise.catch(() => null);
   }
 
   /** Get a snapshot of terminal state (async due to IPC) */
   async getTerminalSnapshot(id: string): Promise<TerminalSnapshot | null> {
-    const requestId = this.broker.generateId(`snapshot-${id}`);
-    const promise = this.broker.register<TerminalSnapshot | null>(requestId, {
+    const shard = this.shardForTerminal(id);
+    const requestId = shard.broker.generateId(`snapshot-${id}`);
+    const promise = shard.broker.register<TerminalSnapshot | null>(requestId, {
       method: "get-snapshot",
       timeoutMs: PTY_TIMEOUTS["get-snapshot"],
     });
-    this.send({ type: "get-snapshot", id, requestId });
+    shard.send({ type: "get-snapshot", id, requestId });
     return promise.catch(() => null);
   }
 
-  /** Get snapshots for all terminals (async due to IPC) */
+  /** Get snapshots for all terminals (async due to IPC), across all shards */
   async getAllTerminalSnapshots(): Promise<TerminalSnapshot[]> {
-    const requestId = this.broker.generateId("all-snapshots");
-    const promise = this.broker.register<TerminalSnapshot[]>(requestId, {
-      method: "get-all-snapshots",
-      timeoutMs: PTY_TIMEOUTS["get-all-snapshots"],
-    });
-    this.send({ type: "get-all-snapshots", requestId });
-    return promise.catch(() => []);
+    const results = await Promise.all(
+      this.fanOutShards().map((shard) => {
+        const requestId = shard.broker.generateId("all-snapshots");
+        const promise = shard.broker.register<TerminalSnapshot[]>(requestId, {
+          method: "get-all-snapshots",
+          timeoutMs: PTY_TIMEOUTS["get-all-snapshots"],
+        });
+        shard.send({ type: "get-all-snapshots", requestId });
+        return promise.catch(() => [] as TerminalSnapshot[]);
+      })
+    );
+    return results.flat();
   }
 
   markChecked(id: string): void {
-    this.send({ type: "mark-checked", id });
+    this.shardForTerminal(id).send({ type: "mark-checked", id });
   }
 
   updateObservedTitle(id: string, title: string): void {
-    this.send({ type: "update-observed-title", id, title });
+    this.shardForTerminal(id).send({ type: "update-observed-title", id, title });
   }
 
   async transitionState(
@@ -1328,12 +2094,13 @@ export class PtyClient extends EventEmitter {
     confidence: number,
     spawnedAt?: number
   ): Promise<boolean> {
-    const requestId = this.broker.generateId(`transition-${id}`);
-    const promise = this.broker.register<boolean>(requestId, {
+    const shard = this.shardForTerminal(id);
+    const requestId = shard.broker.generateId(`transition-${id}`);
+    const promise = shard.broker.register<boolean>(requestId, {
       method: "transition-state",
       timeoutMs: PTY_TIMEOUTS["transition-state"],
     });
-    this.send({
+    shard.send({
       type: "transition-state",
       id,
       requestId,
@@ -1345,65 +2112,76 @@ export class PtyClient extends EventEmitter {
     return promise.catch(() => false);
   }
 
-  /** Request PtyHost to trim scrollback on all terminals to reduce memory */
+  /** Request every shard to trim scrollback on all terminals to reduce memory */
   trimState(targetLines: number): void {
-    this.send({ type: "trim-state", targetLines });
+    for (const shard of this.shards.values()) {
+      shard.send({ type: "trim-state", targetLines });
+    }
   }
 
-  /** Suppress or resume terminal session persistence in the PtyHost */
+  /** Suppress or resume terminal session persistence across all shards */
   suppressSessionPersistence(suppressed: boolean): void {
     this.sessionPersistSuppressed = suppressed;
-    this.send({ type: "set-session-persist-suppressed", suppressed });
+    for (const shard of this.shards.values()) {
+      shard.send({ type: "set-session-persist-suppressed", suppressed });
+    }
   }
 
   /** Pause all PTY processes during system sleep to prevent buffer overflow */
   pauseAll(): void {
-    this.send({ type: "pause-all" });
+    for (const shard of this.shards.values()) {
+      shard.send({ type: "pause-all" });
+    }
   }
 
   /** Resume all PTY processes after system wake with incremental stagger */
   resumeAll(): void {
-    this.send({ type: "resume-all" });
+    for (const shard of this.shards.values()) {
+      shard.send({ type: "resume-all" });
+    }
   }
 
-  /** Pause health check during system sleep to prevent time-drift false positives */
+  /** Pause health checks during system sleep to prevent time-drift false positives */
   pauseHealthCheck(): void {
-    this.healthWatchdog.pause();
+    this.healthChecksPaused = true;
+    for (const shard of this.shards.values()) {
+      shard.watchdog.pause();
+    }
   }
 
-  /** Resume health check after system wake with handshake verification */
+  /** Resume health checks after system wake with handshake verification */
   resumeHealthCheck(): void {
-    this.healthWatchdog.resume();
+    this.healthChecksPaused = false;
+    for (const shard of this.shards.values()) {
+      shard.watchdog.resume();
+    }
   }
 
   manualRestart(): void {
-    this.lifecycle.manualRestart();
+    for (const shard of this.shards.values()) {
+      shard.lifecycle.manualRestart();
+    }
   }
 
   dispose(): void {
     if (this.isDisposed) return;
     this.isDisposed = true;
-    this.shouldResyncProjectContext = false;
-    this.needsRespawn = false;
 
     getTrashedPidTracker().clearAll();
     console.log("[PtyClient] Disposing...");
 
-    this.healthWatchdog.dispose();
-    this.lifecycle.dispose();
-
-    for (const port of this.pendingMessagePorts.values()) {
-      try {
-        port.close();
-      } catch {
-        // ignore
-      }
+    for (const timer of this.shardRetirementTimers.values()) {
+      clearTimeout(timer);
     }
-    this.pendingMessagePorts.clear();
+    this.shardRetirementTimers.clear();
 
-    // Clean up all pending requests via broker (rejects pending promises with
+    // Per shard: watchdog, lifecycle (posts `dispose` to the host, force-kills
+    // after 1s), pending ports, and the broker (rejects pending promises with
     // "Broker disposed"; callers convert to sentinel values via .catch()).
-    this.broker.dispose();
+    for (const shard of this.shards.values()) {
+      shard.dispose();
+    }
+    this.shards.clear();
 
     this.pendingSpawns.clear();
     this.pendingKillCount.clear();
@@ -1411,12 +2189,17 @@ export class PtyClient extends EventEmitter {
     this.windowFocusedTerminals.clear();
     this.ipcDataMirrorIds.clear();
     this.terminalPids.clear();
+    this.terminalOwners.clear();
+    this.projectShardOverrides.clear();
+    this.windowPortShard.clear();
+    this.throttledShards.clear();
+    this.memoryWarningShards.clear();
     this.removeAllListeners();
 
     console.log("[PtyClient] Disposed");
   }
 
-  /** Check if host is running and initialized */
+  /** Check if the (default-shard) host is running and initialized */
   isReady(): boolean {
     return this.lifecycle.isRunning();
   }
@@ -1447,6 +2230,120 @@ export class PtyClient extends EventEmitter {
   isSharedBufferEnabled(): boolean {
     return false;
   }
+}
+
+/** Payload shape the event router emits for `host-memory-warning`. */
+interface HostMemoryWarningPayload {
+  isWarning: boolean;
+  utilizationPercent: number;
+  heapMb?: number;
+  externalMb?: number;
+  workerHeapMb?: number;
+  workerExternalMb?: number;
+  timestamp: number;
+}
+
+/**
+ * Per-shard emitter handed to the event router: every `emit` the router (or
+ * the events bridge callbacks) performs is redirected into the fabric's
+ * {@link PtyClient} funnel, which does cross-shard bookkeeping and then
+ * re-emits on the public client emitter. The proxy itself never has
+ * listeners.
+ */
+class ShardEventEmitter extends EventEmitter {
+  constructor(private readonly forward: (event: string, args: unknown[]) => boolean) {
+    super();
+  }
+
+  override emit(event: string | symbol, ...args: unknown[]): boolean {
+    return this.forward(String(event), args);
+  }
+}
+
+/**
+ * Merge per-shard memory rollups into one app-wide rollup. The fabric places
+ * a project on exactly one shard, so per-project rows never overlap across
+ * shards — the by-key merge below is defensive (and collapses the null-project
+ * row if it ever appears on more than one shard). `available` is a global
+ * claim ("the process table was read"), so one failed shard marks the merged
+ * rollup unavailable rather than silently under-reporting.
+ */
+function mergeMemoryRollups(rollups: MemoryRollup[]): MemoryRollup {
+  const byKey = new Map<string | null, MemoryRollupProject>();
+  for (const rollup of rollups) {
+    for (const row of rollup.byProject) {
+      const existing = byKey.get(row.projectId);
+      if (!existing) {
+        byKey.set(row.projectId, { ...row, topProcesses: [...row.topProcesses] });
+        continue;
+      }
+      existing.terminalCount += row.terminalCount;
+      existing.processCount += row.processCount;
+      existing.memoryKb += row.memoryKb;
+      existing.topProcesses = [...existing.topProcesses, ...row.topProcesses]
+        .sort((a, b) => b.memoryKb - a.memoryKb)
+        .slice(0, 5);
+    }
+  }
+  return {
+    byProject: [...byKey.values()],
+    totalMemoryKb: rollups.reduce((sum, r) => sum + r.totalMemoryKb, 0),
+    totalProcessCount: rollups.reduce((sum, r) => sum + r.totalProcessCount, 0),
+    terminalCount: rollups.reduce((sum, r) => sum + r.terminalCount, 0),
+    available: rollups.every((r) => r.available),
+    sampledAt: Math.max(...rollups.map((r) => r.sampledAt)),
+  };
+}
+
+/**
+ * Merge per-shard flow-control snapshots. Terminal rows and queue depths
+ * concatenate (terminals are disjoint across shards); counters sum; the
+ * top-level governor/event-loop fields carry the worst-shard view so single-
+ * number diagnostics ("is the terminal backend throttled", "PTY host lag
+ * p99") stay meaningful; `shards` carries the per-shard breakdown.
+ */
+function mergeFlowControlSnapshots(
+  entries: Array<{ shardKey: string; snapshot: FlowControlSnapshot }>
+): FlowControlSnapshot {
+  const snapshots = entries.map((e) => e.snapshot);
+  const smoothed = snapshots
+    .map((s) => s.resourceGovernor.smoothedUtilizationPercent)
+    .filter((v): v is number => v !== null);
+  const eventLoops = snapshots
+    .map((s) => s.eventLoop)
+    .filter((v): v is NonNullable<FlowControlSnapshot["eventLoop"]> => v !== null);
+  const worstEventLoop =
+    eventLoops.length > 0
+      ? eventLoops.reduce((worst, current) => (current.p99Ms > worst.p99Ms ? current : worst))
+      : null;
+  const shards: FlowControlShardSnapshot[] = entries.map(({ shardKey, snapshot }) => ({
+    shardKey,
+    terminalCount: snapshot.terminals.length,
+    totalPendingBytes: snapshot.totalPendingBytes,
+    resourceGovernor: snapshot.resourceGovernor,
+    eventLoop: snapshot.eventLoop,
+  }));
+  return {
+    timestamp: Math.max(...snapshots.map((s) => s.timestamp)),
+    terminals: snapshots.flatMap((s) => s.terminals),
+    queueDepth: snapshots.flatMap((s) => s.queueDepth),
+    totalPendingBytes: snapshots.reduce((sum, s) => sum + s.totalPendingBytes, 0),
+    stats: {
+      pauseCount: snapshots.reduce((sum, s) => sum + s.stats.pauseCount, 0),
+      resumeCount: snapshots.reduce((sum, s) => sum + s.stats.resumeCount, 0),
+      suspendCount: snapshots.reduce((sum, s) => sum + s.stats.suspendCount, 0),
+      forceResumeCount: snapshots.reduce((sum, s) => sum + s.stats.forceResumeCount, 0),
+    },
+    resourceGovernor: {
+      isThrottling: snapshots.some((s) => s.resourceGovernor.isThrottling),
+      isWarning: snapshots.some((s) => s.resourceGovernor.isWarning),
+      activeProfile: snapshots[0].resourceGovernor.activeProfile,
+      smoothedUtilizationPercent: smoothed.length > 0 ? Math.max(...smoothed) : null,
+      throttleDurationMs: Math.max(...snapshots.map((s) => s.resourceGovernor.throttleDurationMs)),
+    },
+    eventLoop: worstEventLoop,
+    shards,
+  };
 }
 
 let ptyClientInstance: PtyClient | null = null;

--- a/electron/services/__tests__/PtyClient.fabric.test.ts
+++ b/electron/services/__tests__/PtyClient.fabric.test.ts
@@ -1,0 +1,879 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { EventEmitter } from "events";
+
+vi.mock("electron", () => ({
+  utilityProcess: {
+    fork: vi.fn(),
+  },
+  dialog: {
+    showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+  },
+  app: {
+    getPath: vi.fn().mockReturnValue("/mock/user/data"),
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+vi.mock("../TrashedPidTracker.js", () => ({
+  getTrashedPidTracker: () => ({
+    removeTrashed: vi.fn(),
+    persistTrashed: vi.fn().mockResolvedValue(undefined),
+    clearAll: vi.fn(),
+  }),
+}));
+
+interface MockUtilityProcess extends EventEmitter {
+  postMessage: Mock;
+  kill: Mock;
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+}
+
+interface ForkedShard {
+  child: MockUtilityProcess;
+  serviceName: string;
+  execArgv: string[];
+  env: Record<string, string>;
+}
+
+function createMockChild(): MockUtilityProcess {
+  return Object.assign(new EventEmitter(), {
+    postMessage: vi.fn(),
+    kill: vi.fn(),
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+  });
+}
+
+function createMockPort() {
+  return {
+    close: vi.fn(),
+    start: vi.fn(),
+    on: vi.fn(),
+    postMessage: vi.fn(),
+  };
+}
+
+function messagesOfType(child: MockUtilityProcess, type: string): Record<string, unknown>[] {
+  return child.postMessage.mock.calls
+    .map((call: unknown[]) => call[0] as Record<string, unknown>)
+    .filter((msg) => msg?.type === type);
+}
+
+/**
+ * PTY fabric (DAINTREE_PTY_FABRIC) — per-project host shards behind the
+ * PtyClient facade. These tests drive the fabric through the public API with
+ * the flag forced on via config and assert the routing/aggregation/lifecycle
+ * invariants the sharding must re-provide: per-project placement, port
+ * routing + reroute, crash isolation (scoped orphan cleanup), crash-loop
+ * migration to the default shard, idle retirement, cap overflow, and
+ * OR-aggregated host signals.
+ */
+describe("PtyClient fabric", () => {
+  let forks: ForkedShard[];
+  let failNextFork: boolean;
+  let PtyClientClass: typeof import("../PtyClient.js").PtyClient;
+  let fabricConfig: typeof import("../pty/fabricConfig.js");
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    forks = [];
+    failNextFork = false;
+
+    vi.resetModules();
+    vi.doMock("electron", () => ({
+      utilityProcess: {
+        fork: vi.fn((_path: string, _args: string[], opts: Record<string, unknown>) => {
+          if (failNextFork) {
+            failNextFork = false;
+            throw new Error("simulated fork failure");
+          }
+          const child = createMockChild();
+          forks.push({
+            child,
+            serviceName: opts.serviceName as string,
+            execArgv: (opts.execArgv as string[]) ?? [],
+            env: (opts.env as Record<string, string>) ?? {},
+          });
+          return child;
+        }),
+      },
+      dialog: {
+        showMessageBox: vi.fn().mockResolvedValue({ response: 0 }),
+      },
+      app: {
+        getPath: vi.fn().mockReturnValue("/mock/user/data"),
+        on: vi.fn(),
+        off: vi.fn(),
+      },
+    }));
+    vi.doMock("../TrashedPidTracker.js", () => ({
+      getTrashedPidTracker: () => ({
+        removeTrashed: vi.fn(),
+        persistTrashed: vi.fn().mockResolvedValue(undefined),
+        clearAll: vi.fn(),
+      }),
+    }));
+
+    PtyClientClass = (await import("../PtyClient.js")).PtyClient;
+    fabricConfig = await import("../pty/fabricConfig.js");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  const shardByService = (match: (name: string) => boolean): ForkedShard => {
+    const found = forks.find((f) => match(f.serviceName));
+    if (!found)
+      throw new Error(
+        `no fork matching predicate; forks: ${forks.map((f) => f.serviceName).join(", ")}`
+      );
+    return found;
+  };
+
+  const defaultShard = () => shardByService((n) => n === "daintree-pty-host");
+  const projectShard = (projectId: string) =>
+    shardByService((n) => n.startsWith(`daintree-pty-host:${projectId.slice(0, 16)}-`));
+
+  const createFabricClient = (opts?: { maxProjectShards?: number }) => {
+    const client = new PtyClientClass({ fabric: true, ...opts });
+    defaultShard().child.emit("message", { type: "ready" });
+    return client;
+  };
+
+  describe("flag off (singleton parity)", () => {
+    it("keeps a single host with the legacy service name regardless of projectIds", () => {
+      const client = new PtyClientClass({ fabric: false });
+      defaultShard().child.emit("message", { type: "ready" });
+
+      client.spawn("t1", { cwd: "/tmp", cols: 80, rows: 24, projectId: "project-a" });
+      client.spawn("t2", { cwd: "/tmp", cols: 80, rows: 24, projectId: "project-b" });
+
+      expect(forks).toHaveLength(1);
+      expect(forks[0].serviceName).toBe("daintree-pty-host");
+      expect(messagesOfType(forks[0].child, "spawn")).toHaveLength(2);
+      client.dispose();
+    });
+
+    it("forks with the configured 512MB heap and mirrors it into the governor env", () => {
+      const client = new PtyClientClass({ fabric: false });
+      expect(forks[0].execArgv).toContain("--max-old-space-size=512");
+      expect(forks[0].env.DAINTREE_PTY_HEAP_BUDGET_MB).toBe("512");
+      client.dispose();
+    });
+  });
+
+  describe("placement", () => {
+    it("gives each project its own shard and routes terminal ops to the owner", () => {
+      const client = createFabricClient();
+
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      client.spawn("t2", { cwd: "/b", cols: 80, rows: 24, projectId: "project-b" });
+
+      expect(forks).toHaveLength(3);
+      const shardA = projectShard("project-a");
+      const shardB = projectShard("project-b");
+      expect(shardA.serviceName).not.toBe(shardB.serviceName);
+      expect(messagesOfType(shardA.child, "spawn").map((m) => m.id)).toEqual(["t1"]);
+      expect(messagesOfType(shardB.child, "spawn").map((m) => m.id)).toEqual(["t2"]);
+
+      client.write("t1", "echo hi\r");
+      client.write("t2", "ls\r");
+      expect(messagesOfType(shardA.child, "write").map((m) => m.id)).toEqual(["t1"]);
+      expect(messagesOfType(shardB.child, "write").map((m) => m.id)).toEqual(["t2"]);
+
+      // Unknown ids fall back to the default shard.
+      client.write("t-unknown", "x");
+      expect(messagesOfType(defaultShard().child, "write").map((m) => m.id)).toEqual(["t-unknown"]);
+      client.dispose();
+    });
+
+    it("keeps projectless terminals on the default shard", () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/tmp", cols: 80, rows: 24 });
+      expect(forks).toHaveLength(1);
+      expect(messagesOfType(defaultShard().child, "spawn").map((m) => m.id)).toEqual(["t1"]);
+      client.dispose();
+    });
+
+    it("groups fleet broadcast writes per owning shard", () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      client.spawn("t2", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      client.spawn("t3", { cwd: "/b", cols: 80, rows: 24, projectId: "project-b" });
+
+      client.broadcastWrite(["t1", "t2", "t3"], "hello");
+
+      const shardA = projectShard("project-a");
+      const shardB = projectShard("project-b");
+      expect(messagesOfType(shardA.child, "broadcast-write")).toEqual([
+        { type: "broadcast-write", ids: ["t1", "t2"], data: "hello" },
+      ]);
+      expect(messagesOfType(shardB.child, "broadcast-write")).toEqual([
+        { type: "broadcast-write", ids: ["t3"], data: "hello" },
+      ]);
+      expect(messagesOfType(defaultShard().child, "broadcast-write")).toHaveLength(0);
+      client.dispose();
+    });
+
+    it("routes kill-by-project to the owning shard and resolves its broker response", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.killByProject("project-a");
+      const request = messagesOfType(shardA.child, "kill-by-project")[0];
+      expect(request).toBeDefined();
+      expect(messagesOfType(defaultShard().child, "kill-by-project")).toHaveLength(0);
+
+      shardA.child.emit("message", {
+        type: "kill-by-project-result",
+        requestId: request.requestId,
+        killed: 1,
+      });
+      await expect(promise).resolves.toBe(1);
+      client.dispose();
+    });
+
+    it("pins projects beyond the shard cap to the default shard", () => {
+      const client = createFabricClient({ maxProjectShards: 1 });
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      client.spawn("t2", { cwd: "/b", cols: 80, rows: 24, projectId: "project-b" });
+
+      expect(forks).toHaveLength(2); // default + project-a only
+      expect(messagesOfType(defaultShard().child, "spawn").map((m) => m.id)).toEqual(["t2"]);
+
+      // Placement is sticky: subsequent per-project ops for the overflow
+      // project stay on the default shard.
+      client.killByProject("project-b");
+      expect(messagesOfType(defaultShard().child, "kill-by-project")).toHaveLength(1);
+      client.dispose();
+    });
+
+    it("RAM-scales the shard heap budget and mirrors it into the governor env", () => {
+      const client = createFabricClient();
+      const arg = forks[0].execArgv.find((a) => a.startsWith("--max-old-space-size="));
+      const heapMb = Number(arg?.split("=")[1]);
+      expect(heapMb).toBeGreaterThanOrEqual(512);
+      expect(heapMb).toBeLessThanOrEqual(2048);
+      expect(forks[0].env.DAINTREE_PTY_HEAP_BUDGET_MB).toBe(String(heapMb));
+      client.dispose();
+    });
+  });
+
+  describe("shard ready replay", () => {
+    it("replays owned spawns and cached host-wide config on a project shard's first ready", () => {
+      const client = createFabricClient();
+      client.setResourceProfile("efficiency" as never);
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.postMessage.mockClear();
+
+      shardA.child.emit("message", { type: "ready" });
+
+      expect(messagesOfType(shardA.child, "set-log-level-overrides")).toHaveLength(1);
+      expect(messagesOfType(shardA.child, "set-plugin-agent-registry")).toHaveLength(1);
+      expect(messagesOfType(shardA.child, "set-resource-profile")).toHaveLength(1);
+      // The pre-ready spawn send was dropped by the real host; ready replays it.
+      expect(messagesOfType(shardA.child, "spawn").map((m) => m.id)).toEqual(["t1"]);
+      // Only this shard's terminals replay — never siblings'.
+      client.dispose();
+    });
+  });
+
+  describe("crash isolation", () => {
+    it.skipIf(process.platform === "win32")(
+      "scopes orphan-PID cleanup to the crashed shard's terminals",
+      async () => {
+        const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+        try {
+          const client = createFabricClient();
+          client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+          client.spawn("t2", { cwd: "/tmp", cols: 80, rows: 24 });
+          const shardA = projectShard("project-a");
+          shardA.child.emit("message", { type: "ready" });
+          shardA.child.emit("message", { type: "terminal-pid", id: "t1", pid: 11111 });
+          defaultShard().child.emit("message", { type: "terminal-pid", id: "t2", pid: 22222 });
+
+          shardA.child.emit("exit", 1);
+          await vi.advanceTimersByTimeAsync(0);
+
+          const killedPids = killSpy.mock.calls.map((c) => c[0]);
+          expect(killedPids).toContain(-11111);
+          expect(killedPids).not.toContain(-22222);
+          expect(killedPids).not.toContain(22222);
+          client.dispose();
+        } finally {
+          killSpy.mockRestore();
+        }
+      }
+    );
+
+    it("respawns only the crashed shard's terminals on its restarted host", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      client.spawn("t2", { cwd: "/tmp", cols: 80, rows: 24 });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+      const defaultChild = defaultShard().child;
+      defaultChild.postMessage.mockClear();
+      const forkCountBefore = forks.length;
+
+      shardA.child.emit("exit", 1);
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(forks.length).toBe(forkCountBefore + 1);
+      const restarted = forks[forks.length - 1];
+      expect(restarted.serviceName).toBe(shardA.serviceName);
+      restarted.child.emit("message", { type: "ready" });
+
+      const respawns = messagesOfType(restarted.child, "spawn");
+      expect(respawns.map((m) => m.id)).toEqual(["t1"]);
+      // The respawn is a NEW incarnation.
+      expect(
+        (respawns[0].options as { launchGeneration?: number }).launchGeneration
+      ).toBeGreaterThan(1);
+      // The healthy default shard saw no respawn traffic.
+      expect(messagesOfType(defaultChild, "spawn")).toHaveLength(0);
+      client.dispose();
+    });
+
+    it("migrates a crash-looping project shard's terminals to the default shard without a global host-crash", async () => {
+      const client = createFabricClient();
+      const hostCrash = vi.fn();
+      client.on("host-crash", hostCrash);
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      projectShard("project-a").child.emit("message", { type: "ready" });
+
+      // Three crashes inside the window exhaust the shard's restart budget.
+      for (let i = 0; i < 3; i++) {
+        const shardChild = forks[forks.length - 1].child;
+        shardChild.emit("exit", 1);
+        await vi.advanceTimersByTimeAsync(15_000);
+      }
+
+      expect(hostCrash).not.toHaveBeenCalled();
+      const migrated = messagesOfType(defaultShard().child, "spawn");
+      expect(migrated.map((m) => m.id)).toEqual(["t1"]);
+
+      // The project is pinned to the default shard for the session.
+      const forkCount = forks.length;
+      client.spawn("t3", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      expect(forks.length).toBe(forkCount);
+      expect(messagesOfType(defaultShard().child, "spawn").map((m) => m.id)).toEqual(["t1", "t3"]);
+      client.dispose();
+    });
+
+    it("still emits host-crash when the default shard exhausts its restart budget", async () => {
+      const client = createFabricClient();
+      const hostCrash = vi.fn();
+      client.on("host-crash", hostCrash);
+
+      for (let i = 0; i < 3; i++) {
+        const child = forks[forks.length - 1].child;
+        child.emit("exit", 1);
+        await vi.advanceTimersByTimeAsync(15_000);
+      }
+
+      expect(hostCrash).toHaveBeenCalledTimes(1);
+      client.dispose();
+    });
+  });
+
+  describe("window port routing", () => {
+    it("routes a window's port to its active project's shard and disconnects the previous shard", () => {
+      const client = createFabricClient();
+      const refresh = vi.fn();
+      client.setPortRefreshCallback(refresh);
+
+      // No context yet: the port lands on the default shard.
+      const portA = createMockPort();
+      client.connectMessagePort(1, portA as never);
+      expect(messagesOfType(defaultShard().child, "connect-port")).toHaveLength(1);
+
+      // Activating a project on another shard triggers a targeted re-mint.
+      client.setActiveProject(1, "project-a", "/projects/a");
+      expect(refresh).toHaveBeenCalledWith(1);
+
+      const shardA = projectShard("project-a");
+      const portB = createMockPort();
+      client.connectMessagePort(1, portB as never);
+      // Old shard is told to drop its per-window connection state...
+      expect(messagesOfType(defaultShard().child, "disconnect-port")).toEqual([
+        { type: "disconnect-port", windowId: 1 },
+      ]);
+      // ...and the new port lands on the owning shard.
+      const connect = shardA.child.postMessage.mock.calls.find(
+        (c: unknown[]) => (c[0] as { type?: string }).type === "connect-port"
+      );
+      expect(connect).toBeDefined();
+      expect(connect?.[1]).toEqual([portB]);
+
+      // Focus routing follows the port.
+      shardA.child.postMessage.mockClear();
+      client.setFocusedTerminal(1, "t1");
+      expect(messagesOfType(shardA.child, "set-focused-terminal")).toEqual([
+        { type: "set-focused-terminal", windowId: 1, id: "t1" },
+      ]);
+      client.dispose();
+    });
+
+    it("sends the pool-warming projectPath only to the owning shard on context resync", () => {
+      const client = createFabricClient();
+      client.setActiveProject(1, "project-a", "/projects/a");
+      const shardA = projectShard("project-a");
+      shardA.child.postMessage.mockClear();
+
+      // First ready resyncs window contexts (pre-ready sends were dropped).
+      shardA.child.emit("message", { type: "ready" });
+      expect(messagesOfType(shardA.child, "set-active-project")).toEqual([
+        {
+          type: "set-active-project",
+          windowId: 1,
+          projectId: "project-a",
+          projectPath: "/projects/a",
+        },
+      ]);
+
+      // A sibling shard restarting must NOT warm its pool to project-a's path.
+      client.spawn("t2", { cwd: "/b", cols: 80, rows: 24, projectId: "project-b" });
+      const shardB = projectShard("project-b");
+      shardB.child.postMessage.mockClear();
+      shardB.child.emit("message", { type: "ready" });
+      const contextsOnB = messagesOfType(shardB.child, "set-active-project");
+      expect(contextsOnB).toEqual([
+        { type: "set-active-project", windowId: 1, projectId: "project-a" },
+      ]);
+      client.dispose();
+    });
+  });
+
+  describe("idle retirement", () => {
+    it("retires a project shard once its last terminal exits and no window shows the project", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      shardA.child.emit("message", { type: "exit", id: "t1", exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(fabricConfig.PTY_SHARD_IDLE_LINGER_MS + 1);
+
+      // Retirement disposes the shard: host asked to dispose, then force-killed.
+      expect(messagesOfType(shardA.child, "dispose")).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1_100);
+      expect(shardA.child.kill).toHaveBeenCalled();
+
+      // A later spawn for the project gets a fresh shard.
+      const forkCount = forks.length;
+      client.spawn("t2", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      expect(forks.length).toBe(forkCount + 1);
+      client.dispose();
+    });
+
+    it("does not retire a shard while a window still shows its project", async () => {
+      const client = createFabricClient();
+      client.setActiveProject(1, "project-a", "/projects/a");
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      await vi.advanceTimersByTimeAsync(fabricConfig.PTY_SHARD_IDLE_LINGER_MS * 3);
+      expect(messagesOfType(shardA.child, "dispose")).toHaveLength(0);
+      client.dispose();
+    });
+  });
+
+  describe("aggregated host signals", () => {
+    it("ORs host-throttled across shards and only forwards aggregate edges", () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const events: boolean[] = [];
+      client.on("host-throttled", (payload: { isThrottled: boolean }) => {
+        events.push(payload.isThrottled);
+      });
+
+      shardA.child.emit("message", { type: "host-throttled", isThrottled: true, timestamp: 1 });
+      defaultShard().child.emit("message", {
+        type: "host-throttled",
+        isThrottled: true,
+        timestamp: 2,
+      });
+      // Shard A releasing must not clear the aggregate while main still holds.
+      shardA.child.emit("message", { type: "host-throttled", isThrottled: false, timestamp: 3 });
+      defaultShard().child.emit("message", {
+        type: "host-throttled",
+        isThrottled: false,
+        timestamp: 4,
+      });
+
+      expect(events).toEqual([true, false]);
+      client.dispose();
+    });
+
+    it("ORs host-memory-warning across shards", () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const events: boolean[] = [];
+      client.on("host-memory-warning", (payload: { isWarning: boolean }) => {
+        events.push(payload.isWarning);
+      });
+
+      shardA.child.emit("message", {
+        type: "host-memory-warning",
+        isWarning: true,
+        utilizationPercent: 80,
+        timestamp: 1,
+      });
+      defaultShard().child.emit("message", {
+        type: "host-memory-warning",
+        isWarning: false,
+        utilizationPercent: 10,
+        timestamp: 2,
+      });
+      shardA.child.emit("message", {
+        type: "host-memory-warning",
+        isWarning: false,
+        utilizationPercent: 20,
+        timestamp: 3,
+      });
+
+      expect(events).toEqual([true, false]);
+      client.dispose();
+    });
+  });
+
+  describe("cross-shard aggregation", () => {
+    it("merges memory rollups across shards", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.getMemoryRollup();
+      const defaultReq = messagesOfType(defaultShard().child, "get-memory-rollup")[0];
+      const shardAReq = messagesOfType(shardA.child, "get-memory-rollup")[0];
+      expect(defaultReq).toBeDefined();
+      expect(shardAReq).toBeDefined();
+
+      defaultShard().child.emit("message", {
+        type: "memory-rollup",
+        requestId: defaultReq.requestId,
+        rollup: {
+          byProject: [
+            { projectId: null, terminalCount: 1, processCount: 2, memoryKb: 100, topProcesses: [] },
+          ],
+          totalMemoryKb: 100,
+          totalProcessCount: 2,
+          terminalCount: 1,
+          available: true,
+          sampledAt: 10,
+        },
+      });
+      shardA.child.emit("message", {
+        type: "memory-rollup",
+        requestId: shardAReq.requestId,
+        rollup: {
+          byProject: [
+            {
+              projectId: "project-a",
+              terminalCount: 2,
+              processCount: 5,
+              memoryKb: 900,
+              topProcesses: [],
+            },
+          ],
+          totalMemoryKb: 900,
+          totalProcessCount: 5,
+          terminalCount: 2,
+          available: true,
+          sampledAt: 20,
+        },
+      });
+
+      const merged = await promise;
+      expect(merged.totalMemoryKb).toBe(1000);
+      expect(merged.totalProcessCount).toBe(7);
+      expect(merged.terminalCount).toBe(3);
+      expect(merged.available).toBe(true);
+      expect(merged.sampledAt).toBe(20);
+      expect(merged.byProject).toHaveLength(2);
+      client.dispose();
+    });
+
+    it("merges flow-control snapshots with a worst-shard governor view and per-shard breakdown", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.getFlowControlSnapshotAsync();
+      const mkSnapshot = (over: Record<string, unknown>) => ({
+        timestamp: 1,
+        terminals: [],
+        queueDepth: [],
+        totalPendingBytes: 0,
+        stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+        resourceGovernor: {
+          isThrottling: false,
+          isWarning: false,
+          activeProfile: "balanced",
+          smoothedUtilizationPercent: null,
+          throttleDurationMs: 0,
+        },
+        eventLoop: null,
+        ...over,
+      });
+      const defaultReq = messagesOfType(defaultShard().child, "get-flow-control-snapshot")[0];
+      const shardAReq = messagesOfType(shardA.child, "get-flow-control-snapshot")[0];
+      defaultShard().child.emit("message", {
+        type: "flow-control-snapshot",
+        requestId: defaultReq.requestId,
+        snapshot: mkSnapshot({
+          totalPendingBytes: 10,
+          eventLoop: { p99Ms: 5, maxMs: 9, utilization: 0.2 },
+        }),
+      });
+      shardA.child.emit("message", {
+        type: "flow-control-snapshot",
+        requestId: shardAReq.requestId,
+        snapshot: mkSnapshot({
+          totalPendingBytes: 90,
+          resourceGovernor: {
+            isThrottling: true,
+            isWarning: true,
+            activeProfile: "balanced",
+            smoothedUtilizationPercent: 88,
+            throttleDurationMs: 1200,
+          },
+          eventLoop: { p99Ms: 42, maxMs: 60, utilization: 0.9 },
+        }),
+      });
+
+      const merged = await promise;
+      expect(merged.totalPendingBytes).toBe(100);
+      expect(merged.resourceGovernor.isThrottling).toBe(true);
+      expect(merged.resourceGovernor.smoothedUtilizationPercent).toBe(88);
+      expect(merged.eventLoop?.p99Ms).toBe(42);
+      expect(merged.shards).toHaveLength(2);
+      expect(merged.shards?.map((s) => s.shardKey).sort()).toEqual(["main", "project-a"]);
+      client.dispose();
+    });
+
+    it("concatenates get-all-terminals across shards", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.getAllTerminalsAsync();
+      const defaultReq = messagesOfType(defaultShard().child, "get-all-terminals")[0];
+      const shardAReq = messagesOfType(shardA.child, "get-all-terminals")[0];
+      defaultShard().child.emit("message", {
+        type: "all-terminals",
+        requestId: defaultReq.requestId,
+        terminals: [{ id: "t0", cwd: "/", spawnedAt: 1 }],
+      });
+      shardA.child.emit("message", {
+        type: "all-terminals",
+        requestId: shardAReq.requestId,
+        terminals: [{ id: "t1", cwd: "/a", spawnedAt: 2 }],
+      });
+
+      const all = await promise;
+      expect(all.map((t) => t.id).sort()).toEqual(["t0", "t1"]);
+      client.dispose();
+    });
+  });
+
+  describe("fan-out control messages", () => {
+    it("sends pause-all/resume-all and trim-state to every shard", () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+
+      client.pauseAll();
+      client.resumeAll();
+      client.trimState(1000);
+
+      for (const child of [defaultShard().child, shardA.child]) {
+        expect(messagesOfType(child, "pause-all")).toHaveLength(1);
+        expect(messagesOfType(child, "resume-all")).toHaveLength(1);
+        expect(messagesOfType(child, "trim-state")).toEqual([
+          { type: "trim-state", targetLines: 1000 },
+        ]);
+      }
+      client.dispose();
+    });
+  });
+
+  describe("failure containment hardening", () => {
+    it("migrates to the default shard when a project shard's fork fails, without a global host-crash", async () => {
+      const client = createFabricClient();
+      const hostCrash = vi.fn();
+      client.on("host-crash", hostCrash);
+
+      failNextFork = true;
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      // Fork threw synchronously; the containment defers one tick so the
+      // in-flight spawn registration lands before migration replays it.
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(hostCrash).not.toHaveBeenCalled();
+      expect(messagesOfType(defaultShard().child, "spawn").map((m) => m.id)).toEqual(["t1"]);
+
+      // The project is pinned to the default shard — no refork attempts.
+      const forkCount = forks.length;
+      client.spawn("t2", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      expect(forks.length).toBe(forkCount);
+      expect(messagesOfType(defaultShard().child, "spawn").map((m) => m.id)).toEqual(["t1", "t2"]);
+      client.dispose();
+    });
+
+    it("still emits host-crash when the default shard's fork fails", () => {
+      const hostCrash = vi.fn();
+      failNextFork = true;
+      const client = new PtyClientClass({ fabric: true });
+      client.on("host-crash", hostCrash);
+      // Constructor fork already failed; a manual re-fork failure emits too.
+      failNextFork = true;
+      client.manualRestart();
+      expect(hostCrash).toHaveBeenCalledWith(-1);
+      client.dispose();
+    });
+
+    it("does not broadcast host-crash-details for a project shard crash, only for the default shard", async () => {
+      const client = createFabricClient();
+      const crashDetails = vi.fn();
+      client.on("host-crash-details", crashDetails);
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      shardA.child.emit("exit", 1);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(crashDetails).not.toHaveBeenCalled();
+
+      defaultShard().child.emit("exit", 1);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(crashDetails).toHaveBeenCalledTimes(1);
+      client.dispose();
+    });
+
+    it("marks a merged memory rollup unavailable when a shard fails to report", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.getMemoryRollup();
+      const shardAReq = messagesOfType(shardA.child, "get-memory-rollup")[0];
+      shardA.child.emit("message", {
+        type: "memory-rollup",
+        requestId: shardAReq.requestId,
+        rollup: {
+          byProject: [
+            {
+              projectId: "project-a",
+              terminalCount: 1,
+              processCount: 1,
+              memoryKb: 500,
+              topProcesses: [],
+            },
+          ],
+          totalMemoryKb: 500,
+          totalProcessCount: 1,
+          terminalCount: 1,
+          available: true,
+          sampledAt: 5,
+        },
+      });
+      // The default shard never answers — its broker request times out.
+      await vi.advanceTimersByTimeAsync(5_001);
+
+      const rollup = await promise;
+      expect(rollup.totalMemoryKb).toBe(500);
+      expect(rollup.available).toBe(false);
+      client.dispose();
+    });
+
+    it("routes graceful-kill-by-project to the owning shard", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+
+      const promise = client.gracefulKillByProject("project-a");
+      const request = messagesOfType(shardA.child, "graceful-kill-by-project")[0];
+      expect(request).toBeDefined();
+      expect(messagesOfType(defaultShard().child, "graceful-kill-by-project")).toHaveLength(0);
+
+      shardA.child.emit("message", {
+        type: "graceful-kill-by-project-result",
+        requestId: request.requestId,
+        results: [{ id: "t1", agentSessionId: "sess-1" }],
+      });
+      await expect(promise).resolves.toEqual([{ id: "t1", agentSessionId: "sess-1" }]);
+      client.dispose();
+    });
+
+    it("dispose during a pending retirement timer neither throws nor revives the shard", async () => {
+      const client = createFabricClient();
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+      shardA.child.emit("message", { type: "exit", id: "t1", exitCode: 0 });
+
+      client.dispose();
+      await vi.advanceTimersByTimeAsync(fabricConfig.PTY_SHARD_IDLE_LINGER_MS * 2);
+      // Dispose already sent the shard its dispose message; the retirement
+      // timer must not fire a second teardown after dispose cleared it.
+      expect(messagesOfType(shardA.child, "dispose")).toHaveLength(1);
+    });
+
+    it("project switch ping-pong reuses the existing shards", () => {
+      const client = createFabricClient();
+      client.setActiveProject(1, "project-a", "/a");
+      client.setActiveProject(1, "project-b", "/b");
+      const forkCount = forks.length;
+      client.setActiveProject(1, "project-a", "/a");
+      client.setActiveProject(1, "project-b", "/b");
+      expect(forks.length).toBe(forkCount);
+      client.dispose();
+    });
+
+    it("supports deferStart with the fabric: shards fork on start() and replay owned spawns", () => {
+      const client = new PtyClientClass({ fabric: true, deferStart: true });
+      client.spawn("t1", { cwd: "/a", cols: 80, rows: 24, projectId: "project-a" });
+      expect(forks).toHaveLength(0);
+
+      client.start();
+      expect(forks).toHaveLength(2);
+      const shardA = projectShard("project-a");
+      shardA.child.emit("message", { type: "ready" });
+      expect(messagesOfType(shardA.child, "spawn").map((m) => m.id)).toEqual(["t1"]);
+      expect(messagesOfType(defaultShard().child, "spawn")).toHaveLength(0);
+      client.dispose();
+    });
+
+    it("disconnectMessagePort drops a pending port before it was ever delivered", () => {
+      const client = new PtyClientClass({ fabric: true, deferStart: true });
+      const port = createMockPort();
+      client.connectMessagePort(7, port as never);
+      client.disconnectMessagePort(7);
+
+      client.start();
+      defaultShard().child.emit("message", { type: "ready" });
+      expect(messagesOfType(defaultShard().child, "connect-port")).toHaveLength(0);
+      client.dispose();
+    });
+  });
+});

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -120,6 +120,14 @@ export interface PtyHostLifecycleConfig {
   memoryLimitMb: number;
   electronDir: string;
   /**
+   * UtilityProcess serviceName for this host run. Defaults to the legacy
+   * "daintree-pty-host". PTY fabric shards pass a per-project name so crash
+   * attribution (`child-process-gone` details.name) and process listings
+   * identify the owning project; the gone-listener filter matches this exact
+   * name, so a shard never consumes a sibling shard's crash reason.
+   */
+  serviceName?: string;
+  /**
    * Read at each fork. When true the host defers its boot-time homedir pool
    * warm — used on project-restoring boots where the set-active-project that
    * follows ready immediately drains the pool to the project path, so the
@@ -127,6 +135,8 @@ export interface PtyHostLifecycleConfig {
    */
   deferInitialPoolWarm?: () => boolean;
 }
+
+const DEFAULT_SERVICE_NAME = "daintree-pty-host";
 
 export interface PtyHostLifecycleCallbacks {
   /** Forward each message from the child. PtyClient routes these via {@link routeHostEvent}. */
@@ -210,11 +220,23 @@ export class PtyHostLifecycle {
     private readonly config: PtyHostLifecycleConfig,
     private readonly callbacks: PtyHostLifecycleCallbacks
   ) {
-    this.readyPromise = new Promise((resolve, reject) => {
+    this.readyPromise = this.createReadyPromise();
+    this.registerChildProcessGoneListener();
+  }
+
+  /**
+   * Mint a fresh readyPromise for the next fork. The no-op catch marks the
+   * promise handled without consuming the rejection for real awaiters —
+   * fork/pre-ready-crash rejections on a run nobody awaits (restart cycles,
+   * fabric project shards) must not surface as unhandled rejections.
+   */
+  private createReadyPromise(): Promise<void> {
+    const promise = new Promise<void>((resolve, reject) => {
       this.readyResolve = resolve;
       this.readyReject = reject;
     });
-    this.registerChildProcessGoneListener();
+    promise.catch(() => {});
+    return promise;
   }
 
   /** Wait for the host to emit `ready`. Re-creates per fork; safe across restarts. */
@@ -292,10 +314,7 @@ export class PtyHostLifecycle {
     this.pendingChildProcessGoneReason = null;
 
     this.isInitialized = false;
-    this.readyPromise = new Promise((resolve, reject) => {
-      this.readyResolve = resolve;
-      this.readyReject = reject;
-    });
+    this.readyPromise = this.createReadyPromise();
 
     const hostPath = path.join(this.config.electronDir, "pty-host-bootstrap.js");
 
@@ -307,7 +326,7 @@ export class PtyHostLifecycle {
 
     try {
       this.child = utilityProcess.fork(hostPath, [], {
-        serviceName: "daintree-pty-host",
+        serviceName: this.config.serviceName ?? DEFAULT_SERVICE_NAME,
         stdio: "pipe",
         cwd: os.homedir(),
         // `--diagnostic-dir` redirects v8.setHeapSnapshotNearHeapLimit dumps
@@ -321,6 +340,13 @@ export class PtyHostLifecycle {
         env: {
           ...(process.env as Record<string, string>),
           DAINTREE_USER_DATA: app.getPath("userData"),
+          // Keep the host's ResourceGovernor budget in lockstep with the V8
+          // cap above — the fabric RAM-scales the cap per shard, and a
+          // governor still assuming 512 would throttle a 2 GB shard at 25%.
+          DAINTREE_PTY_HEAP_BUDGET_MB: String(this.config.memoryLimitMb),
+          // Shard identity for per-process file scoping (emergency log) —
+          // Electron does not expose serviceName to the child itself.
+          DAINTREE_PTY_SHARD_SERVICE: this.config.serviceName ?? DEFAULT_SERVICE_NAME,
           // Forward packaged-build state to the pty host so dev-only diagnostics
           // (e.g. agent CLI CPU profiling via `DAINTREE_PROFILE_AGENT_STARTUP`)
           // can gate themselves on `!== "0"` without touching `app.isPackaged`.
@@ -425,9 +451,11 @@ export class PtyHostLifecycle {
       if (details.type !== "Utility") return;
       // Electron 41 populates `name` from `serviceName` at runtime, but both
       // fields are typed as optional. Accept either to stay resilient to
-      // future runtime changes or edge cases where only one is set.
-      const matchesHost =
-        details.name === "daintree-pty-host" || details.serviceName === "daintree-pty-host";
+      // future runtime changes or edge cases where only one is set. Matches
+      // this lifecycle's own serviceName exactly so fabric shards never
+      // consume a sibling shard's crash reason.
+      const expectedName = this.config.serviceName ?? DEFAULT_SERVICE_NAME;
+      const matchesHost = details.name === expectedName || details.serviceName === expectedName;
       if (!matchesHost) return;
       this.pendingChildProcessGoneReason = {
         reason: details.reason,

--- a/electron/services/pty/PtyShard.ts
+++ b/electron/services/pty/PtyShard.ts
@@ -1,0 +1,185 @@
+/**
+ * PtyShard - One host shard of the PTY fabric: a single UtilityProcess run of
+ * the pty-host plus everything scoped to it on the main-process side.
+ *
+ * A shard owns exactly what used to live 1:1 inside PtyClient for the
+ * singleton host: the {@link PtyHostLifecycle} (fork/exit/restart/backoff),
+ * the {@link PtyHealthWatchdog} (heartbeat + force-kill), a
+ * {@link RequestResponseBroker} (so a crashing shard rejects only ITS pending
+ * requests, never a sibling's), the pending MessagePorts awaiting a live
+ * child, and the respawn/resync flags consumed on `ready`.
+ *
+ * PtyClient is the router above this: it decides which shard a terminal,
+ * project, or window port belongs to and holds all cross-shard state
+ * (placement, terminal ownership, aggregation). The shard itself is
+ * deliberately dumb — construction wiring plus lifecycle passthroughs — so
+ * the routing policy stays in one place.
+ */
+
+import type { MessagePortMain } from "electron";
+import type {
+  CrashType,
+  HostCrashPayload,
+  PtyHostEvent,
+  PtyHostRequest,
+} from "../../../shared/types/pty-host.js";
+import { RequestResponseBroker } from "../rpc/index.js";
+import { PtyHealthWatchdog } from "./PtyHealthWatchdog.js";
+import { PtyHostLifecycle } from "./PtyHostLifecycle.js";
+
+export interface PtyShardConfig {
+  /** Stable shard key: "main" for the default shard, the projectId otherwise. */
+  key: string;
+  /** UtilityProcess serviceName (see fabricConfig.shardServiceName). */
+  serviceName: string;
+  /** V8 --max-old-space-size for this shard's host process. */
+  memoryLimitMb: number;
+  electronDir: string;
+  healthCheckIntervalMs: number;
+  maxMissedHeartbeats: number;
+  /** Read at each fork; see PtyHostLifecycleConfig.deferInitialPoolWarm. */
+  deferInitialPoolWarm: () => boolean;
+  /**
+   * Project shards start with a pending context resync: their first messages
+   * (project context, config) can be posted between fork and `ready`, where
+   * the child's listener isn't attached yet, so the ready handler must replay
+   * window contexts. The default shard keeps the legacy flag lifecycle
+   * (set on exit / on a context send that finds no child).
+   */
+  resyncContextOnFirstReady: boolean;
+}
+
+export interface PtyShardCallbacks {
+  onMessage: (shard: PtyShard, event: PtyHostEvent) => void;
+  onExitSync: (
+    shard: PtyShard,
+    info: { code: number | null; wasReady: boolean; fallbackCrashType: CrashType }
+  ) => void;
+  onCrashClassified: (
+    shard: PtyShard,
+    info: {
+      reportedCode: number | null;
+      crashType: CrashType;
+      signal: string | null;
+      payload: HostCrashPayload | null;
+    }
+  ) => void;
+  onMaxRestartsReached: (shard: PtyShard, code: number | null) => void;
+  onForkFailed: (shard: PtyShard, error: unknown) => void;
+  emitCrashDetails: (shard: PtyShard, payload: HostCrashPayload) => void;
+  onBrokerTimeout: (shard: PtyShard, requestId: string, method?: string) => void;
+  /** Whether the owning PtyClient has been disposed. */
+  isClientDisposed: () => boolean;
+  logInfo: (message: string) => void;
+  logWarn: (message: string) => void;
+}
+
+export class PtyShard {
+  readonly key: string;
+  readonly serviceName: string;
+  readonly lifecycle: PtyHostLifecycle;
+  readonly watchdog: PtyHealthWatchdog;
+  readonly broker: RequestResponseBroker;
+
+  /** Set by onBeforeRestart; consumed by the ready handler to replay this shard's spawns. */
+  needsRespawn = false;
+  /** Pending window-context resync, consumed on ready. See PtyShardConfig. */
+  shouldResyncProjectContext: boolean;
+  /** True once start() has forked (or requested) this shard's host. */
+  started = false;
+  /**
+   * True once the shard has been removed from the fabric (idle retirement,
+   * crash-loop migration, or client dispose). A retired shard's lifecycle
+   * callbacks all no-op via isDisposed, so late exit/gone events can't
+   * schedule restarts or mutate fabric state.
+   */
+  retired = false;
+  /** MessagePorts awaiting a live child, keyed by windowId. */
+  readonly pendingMessagePorts = new Map<number, MessagePortMain>();
+
+  constructor(config: PtyShardConfig, callbacks: PtyShardCallbacks) {
+    this.key = config.key;
+    this.serviceName = config.serviceName;
+    this.shouldResyncProjectContext = config.resyncContextOnFirstReady;
+
+    this.broker = new RequestResponseBroker({
+      defaultTimeoutMs: 5000,
+      idPrefix: "pty",
+      onTimeout: (requestId, method) => callbacks.onBrokerTimeout(this, requestId, method),
+    });
+
+    this.watchdog = new PtyHealthWatchdog({
+      intervalMs: config.healthCheckIntervalMs,
+      maxMissedHeartbeats: config.maxMissedHeartbeats,
+      getChild: () => this.lifecycle.child,
+      isHostInitialized: () => this.lifecycle.isInitialized,
+      send: (request) => this.send(request),
+      emitCrashDetails: (payload) => callbacks.emitCrashDetails(this, payload),
+    });
+
+    this.lifecycle = new PtyHostLifecycle(
+      {
+        memoryLimitMb: config.memoryLimitMb,
+        electronDir: config.electronDir,
+        serviceName: config.serviceName,
+        deferInitialPoolWarm: config.deferInitialPoolWarm,
+      },
+      {
+        onMessage: (event) => callbacks.onMessage(this, event),
+        onExitSync: (info) => callbacks.onExitSync(this, info),
+        onCrashClassified: (info) => callbacks.onCrashClassified(this, info),
+        onMaxRestartsReached: (code) => callbacks.onMaxRestartsReached(this, code),
+        onForkFailed: (error) => callbacks.onForkFailed(this, error),
+        onBeforeRestart: () => {
+          this.needsRespawn = true;
+        },
+        isDisposed: () => this.retired || callbacks.isClientDisposed(),
+        logInfo: callbacks.logInfo,
+        logWarn: callbacks.logWarn,
+      }
+    );
+  }
+
+  /** Fork this shard's host. Idempotent per shard (mirrors PtyClient.start's guard). */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.lifecycle.start();
+  }
+
+  send(request: PtyHostRequest): void {
+    this.lifecycle.postMessage(request);
+  }
+
+  isRunning(): boolean {
+    return this.lifecycle.isRunning();
+  }
+
+  waitForReady(): Promise<void> {
+    return this.lifecycle.waitForReady();
+  }
+
+  closePendingPorts(): void {
+    for (const port of this.pendingMessagePorts.values()) {
+      try {
+        port.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.pendingMessagePorts.clear();
+  }
+
+  /**
+   * Tear the shard down: watchdog first (no force-kill races the dispose),
+   * then the lifecycle (posts `dispose` to the host, force-kills after 1s),
+   * pending ports, and the broker (rejects this shard's pending requests).
+   */
+  dispose(): void {
+    this.retired = true;
+    this.watchdog.dispose();
+    this.lifecycle.dispose();
+    this.closePendingPorts();
+    this.broker.dispose();
+  }
+}

--- a/electron/services/pty/__tests__/fabricConfig.test.ts
+++ b/electron/services/pty/__tests__/fabricConfig.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_SHARD_KEY,
+  isPtyFabricEnabled,
+  maxProjectShards,
+  shardHeapBudgetMb,
+  shardServiceName,
+} from "../fabricConfig.js";
+
+const GB = 1024 * 1024 * 1024;
+
+describe("fabricConfig", () => {
+  describe("isPtyFabricEnabled", () => {
+    it("is off by default and on only for explicit opt-in values", () => {
+      expect(isPtyFabricEnabled({})).toBe(false);
+      expect(isPtyFabricEnabled({ DAINTREE_PTY_FABRIC: "0" })).toBe(false);
+      expect(isPtyFabricEnabled({ DAINTREE_PTY_FABRIC: "yes" })).toBe(false);
+      expect(isPtyFabricEnabled({ DAINTREE_PTY_FABRIC: "1" })).toBe(true);
+      expect(isPtyFabricEnabled({ DAINTREE_PTY_FABRIC: "true" })).toBe(true);
+    });
+  });
+
+  describe("maxProjectShards", () => {
+    it("reserves headroom for main + renderer and clamps to [1, 8]", () => {
+      expect(maxProjectShards(4)).toBe(2);
+      expect(maxProjectShards(12)).toBe(8);
+      expect(maxProjectShards(32)).toBe(8);
+      expect(maxProjectShards(2)).toBe(1);
+      expect(maxProjectShards(0)).toBe(2);
+      expect(maxProjectShards(Number.NaN)).toBe(2);
+    });
+  });
+
+  describe("shardHeapBudgetMb", () => {
+    it("scales at totalMem/32 clamped to [512, 2048]", () => {
+      expect(shardHeapBudgetMb(8 * GB)).toBe(512); // 256 → floor
+      expect(shardHeapBudgetMb(16 * GB)).toBe(512);
+      expect(shardHeapBudgetMb(32 * GB)).toBe(1024);
+      expect(shardHeapBudgetMb(64 * GB)).toBe(2048);
+      expect(shardHeapBudgetMb(256 * GB)).toBe(2048); // ceiling
+      expect(shardHeapBudgetMb(0)).toBe(512);
+      expect(shardHeapBudgetMb(Number.NaN)).toBe(512);
+    });
+  });
+
+  describe("shardServiceName", () => {
+    it("keeps the legacy name for the default shard", () => {
+      expect(shardServiceName(DEFAULT_SHARD_KEY)).toBe("daintree-pty-host");
+    });
+
+    it("derives distinct, stable names for project shards", () => {
+      const a = shardServiceName("project-a");
+      const b = shardServiceName("project-b");
+      expect(a).toMatch(/^daintree-pty-host:project-a-[0-9a-f]{8}$/);
+      expect(a).not.toBe(b);
+      expect(shardServiceName("project-a")).toBe(a);
+    });
+
+    it("stays unique when sanitized prefixes collide", () => {
+      const a = shardServiceName("проект/one — ✨");
+      const b = shardServiceName("проект/two — ✨");
+      expect(a).not.toBe(b);
+      expect(a.startsWith("daintree-pty-host:")).toBe(true);
+    });
+  });
+});

--- a/electron/services/pty/fabricConfig.ts
+++ b/electron/services/pty/fabricConfig.ts
@@ -1,0 +1,75 @@
+/**
+ * PTY fabric configuration — pure policy helpers for the sharded pty-host.
+ *
+ * The fabric dissolves the single app-global `daintree-pty-host` into a pool
+ * of per-project host shards, each with its own event loop, V8 heap, and
+ * resource governor. Everything here is deterministic and side-effect free so
+ * placement/sizing policy is unit-testable in isolation from PtyClient.
+ *
+ * Kill switch: the fabric is OFF unless `DAINTREE_PTY_FABRIC=1` (or "true").
+ * Off means exactly one shard ("main") with the exact legacy behavior —
+ * fixed 512 MB heap, one process, one governor.
+ */
+
+import { createHash } from "crypto";
+
+/** Shard key for the default shard — also the only shard when the fabric is off. */
+export const DEFAULT_SHARD_KEY = "main";
+
+/** UtilityProcess serviceName of the default shard (unchanged from the singleton host). */
+export const DEFAULT_PTY_HOST_SERVICE_NAME = "daintree-pty-host";
+
+/**
+ * How long a project shard may sit fully idle (no live terminals, no pending
+ * spawns, no window showing its project) before its process is reaped. Long
+ * enough to survive a quick close-and-reopen without a refork; short enough
+ * that cycling across many projects doesn't accumulate idle host processes —
+ * the structural fix for the terminal-tier FD/RSS leak on view eviction.
+ */
+export const PTY_SHARD_IDLE_LINGER_MS = 45_000;
+
+/** Fabric flag: opt-in via DAINTREE_PTY_FABRIC=1. Anything else is the legacy singleton. */
+export function isPtyFabricEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.DAINTREE_PTY_FABRIC;
+  return raw === "1" || raw === "true";
+}
+
+/**
+ * Cap on concurrent project shards (the default shard is not counted).
+ * Matches the core count minus headroom for the main + renderer processes so
+ * shard event loops don't oversubscribe the machine; projects beyond the cap
+ * co-locate on the default shard (graceful degradation toward the singleton).
+ */
+export function maxProjectShards(cpuCount: number): number {
+  if (!Number.isFinite(cpuCount) || cpuCount <= 0) return 2;
+  return Math.min(8, Math.max(1, Math.floor(cpuCount) - 2));
+}
+
+/**
+ * Per-shard V8 heap budget, scaled from machine RAM. The legacy singleton
+ * pinned 512 MB on every machine; with the fabric each shard gets
+ * `totalMem / 32` clamped to [512, 2048] MB — an 8 GB laptop keeps the legacy
+ * 512, a 64 GB workstation gets 2 GB per shard. These are ceilings, not
+ * allocations: V8 only commits what the shard actually uses. The same value
+ * is forwarded to the shard's ResourceGovernor via DAINTREE_PTY_HEAP_BUDGET_MB
+ * so governance thresholds track the real cap instead of a hardcoded 512.
+ */
+export function shardHeapBudgetMb(totalMemBytes: number): number {
+  if (!Number.isFinite(totalMemBytes) || totalMemBytes <= 0) return 512;
+  const totalMemMb = totalMemBytes / (1024 * 1024);
+  return Math.min(2048, Math.max(512, Math.floor(totalMemMb / 32)));
+}
+
+/**
+ * UtilityProcess serviceName for a shard. The default shard keeps the legacy
+ * name (log filters, crash attribution, and tests key off it); project shards
+ * get `daintree-pty-host:<sanitized-key>-<hash>` mirroring the per-project
+ * workspace-host naming so Activity Monitor / crash reports attribute load to
+ * a project. The hash suffix keeps names unique when sanitization collides.
+ */
+export function shardServiceName(shardKey: string): string {
+  if (shardKey === DEFAULT_SHARD_KEY) return DEFAULT_PTY_HOST_SERVICE_NAME;
+  const sanitized = shardKey.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 16) || "project";
+  const hash = createHash("sha1").update(shardKey).digest("hex").slice(0, 8);
+  return `${DEFAULT_PTY_HOST_SERVICE_NAME}:${sanitized}-${hash}`;
+}

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -297,11 +297,20 @@ export async function initPerWindowServices(
         /* non-critical */
       }
     });
-    ptyClient.setPortRefreshCallback(() => {
-      console.log("[MAIN] Pty Host restarted, refreshing ports...");
-      // Refresh ports for ALL registered windows — target the active view
+    ptyClient.setPortRefreshCallback((windowId) => {
+      // Called with no windowId on a full host restart (refresh every window)
+      // and with one when the PTY fabric restarts or reroutes a single
+      // window's shard — refreshing only that window keeps a shard-local
+      // recovery from re-handshaking every healthy window's terminal stream.
+      console.log(
+        windowId === undefined
+          ? "[MAIN] Pty Host restarted, refreshing ports..."
+          : `[MAIN] Pty Host shard changed for window ${windowId}, refreshing its port...`
+      );
+      // Refresh ports for the targeted windows — target the active view
       if (windowRegistry) {
         for (const wCtx of windowRegistry.all()) {
+          if (windowId !== undefined && wCtx.windowId !== windowId) continue;
           if (!wCtx.browserWindow.isDestroyed()) {
             const wc = getAppWebContents(wCtx.browserWindow);
             if (!wc.isDestroyed()) {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -327,6 +327,24 @@ export interface FlowControlSnapshot {
   resourceGovernor: ResourceGovernorSnapshot;
   /** Pty-host loop health since the previous pull; null if unmonitored. */
   eventLoop: PtyHostEventLoopStats | null;
+  /**
+   * Per-shard breakdown when the PTY fabric is running more than one host
+   * shard. In that mode the top-level `resourceGovernor`/`eventLoop` fields
+   * carry the worst-shard view (so "PTY host lag p99" stays meaningful as a
+   * single number) and this array carries the per-shard detail. Absent on the
+   * single-host path.
+   */
+  shards?: FlowControlShardSnapshot[];
+}
+
+/** One PTY fabric shard's slice of a merged {@link FlowControlSnapshot}. */
+export interface FlowControlShardSnapshot {
+  /** Shard key: "main" for the default shard, the owning projectId otherwise. */
+  shardKey: string;
+  terminalCount: number;
+  totalPendingBytes: number;
+  resourceGovernor: ResourceGovernorSnapshot;
+  eventLoop: PtyHostEventLoopStats | null;
 }
 
 /**


### PR DESCRIPTION
## What this is

First slice of the Terminal Data-Plane Fabric: the app-global singleton `daintree-pty-host` becomes a pool of per-project host shards routed by `PtyClient` behind its unchanged public interface. Each shard is a full pty-host UtilityProcess with its own event loop, its own RAM-scaled V8 heap, and its own ResourceGovernor — so one project's output flood, memory pressure, or native crash can't pause, throttle, or kill every other project's terminals.

**Off by default.** Everything is gated behind `DAINTREE_PTY_FABRIC=1`. With the flag unset there is exactly one shard with the legacy service name, the legacy fixed 512 MB heap, and the legacy restart/replay semantics — the entire pre-existing `PtyClient.*` test suite (adversarial, handshake, watchdog, multiPort, deferStart, projectId, lifecycleLedger, ipc.integration — 110 tests) passes unchanged.

This lands spec Phases 0–1 plus the Phase-2 slices that fall out structurally (per-shard governance scope, RAM-scaled budgets). Phases 3–5 (spill-to-disk + durable agent sessions, per-shard in-thread analysis, bounded-N packing) are follow-ups.

## How it works

- `PtyClient` is now the router: placement (`projectId → shard`, one project never spans shards), terminal ownership (`terminalId → shard`), and window-port routing (`windowId → shard`). It stays pure bookkeeping + port plumbing — terminal bytes still flow renderer↔shard directly over `MessageChannelMain`.
- New `PtyShard` owns what used to be 1:1 in the singleton client: `PtyHostLifecycle` (per-shard `serviceName` for crash attribution), `PtyHealthWatchdog`, a per-shard `RequestResponseBroker` (a crashing shard rejects only its own pending requests), pending MessagePorts, and respawn/resync flags.
- New `fabricConfig` holds the pure policy: shard cap `clamp(cores − 2, 1, 8)`, heap budget `clamp(totalMem/32, 512, 2048)` MB. The budget is mirrored into `DAINTREE_PTY_HEAP_BUDGET_MB` so each shard's ResourceGovernor thresholds track the real V8 cap (external headroom scales with it: `max(256, heap/2)` — exactly the historical 256 at the legacy 512).
- Window MessagePorts route to the shard owning the window's active project; cross-shard project switches re-mint the channel via a targeted per-window port refresh (`setPortRefreshCallback` now takes an optional `windowId`), so a shard-local restart no longer re-handshakes every healthy window.
- Cross-shard invariants are re-provided at the router: merged memory rollups (partial fan-outs are marked `available: false`), worst-shard flow-control snapshots with a per-shard `shards` breakdown for why-slow, OR-aggregated `host-throttled`/`host-memory-warning` edges, per-shard-grouped fleet broadcasts, and config replay (profile, monitoring, log levels, plugin registry, persistence suppression) to shards forked mid-session.

## Failure containment

- A shard crash kills only its own terminals: orphan-PID cleanup, broker rejection, spawn replay (fresh lifecycle-ledger generations), and port refresh are all scoped to the crashed shard.
- A project shard that exhausts its crash budget (same 3-in-30-min policy as today) or whose fork fails migrates its terminals to the default shard and pins the project there for the session — graceful degradation toward the singleton, never dropped terminals, and no global `host-crash` banner. Only the default shard escalates globally.
- `host-crash-details` (which drives the renderer's global "backend recovering" state) is emitted only for the default shard — a project shard's crash would otherwise wedge unrelated windows in "recovering", since they never receive the targeted `terminal:backend-ready` that clears it.
- Idle retirement: a project shard with no terminals and no window on its project lingers 45 s and then exits, releasing all its FDs and heap — binding terminal-tier resource lifetime to the shard instead of the renderer view (the structural fix for view eviction leaking PTY FDs/RSS into a shared host).
- Each shard writes its own emergency log (`pty-host-<shard>.log`) since the rotation is not cross-process safe.

## Testing

- New `PtyClient.fabric.test.ts` (24 tests): placement + owner routing, port routing/reroute + previous-shard disconnect, first-ready replay of spawns and cached config, scoped orphan cleanup, per-shard respawn isolation, crash-loop migration, fork-failure migration, default-shard crash budget, crash-details scoping, partial-rollup availability, idle retirement, dispose-during-retirement, cap overflow, project-switch ping-pong, fabric+deferStart, pending-port disconnect, aggregated throttle/memory-warning edges, rollup/flow-control/all-terminals merges, fan-out controls, heap-budget env mirroring.
- New `fabricConfig.test.ts` for the policy clamps and service-name uniqueness.
- Full sweep: `electron/services` + `electron/pty-host` (7,619 tests) and `electron/window` (573 tests) green; `npm run check` green.
