### PR TITLE
fix(workspace-host): stream git changes from agent-active worktrees and fix external worktree discovery

### DIFF
--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -128,6 +128,12 @@ async function handleWorktreePortRequest(
         break;
       }
 
+      case "set-agent-activity": {
+        workspaceService.setAgentActivity(msg.payload.worktreeIds);
+        result = { ok: true };
+        break;
+      }
+
       case "refresh": {
         const requestId = `port-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
         // Forward the host's bounded outcome so a watchdog-tripped refresh

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -11,13 +11,19 @@ const MAX_RESETS_PER_SESSION = 3;
 const WATCHER_WORKTREE_MIN_DEBOUNCE_MS = 250;
 const WATCHER_WORKTREE_MAX_DEBOUNCE_MS = 800;
 const WATCHER_WORKTREE_MAX_WAIT_MS = 1500;
-const WATCHER_FOCUS_DOWNGRADE_DELAY_MS = 3_000;
+const WATCHER_ELEVATION_DOWNGRADE_DELAY_MS = 3_000;
 
 export type WatcherMode = "none" | "git-only" | "recursive";
 
 export interface WatcherControllerHost {
   readonly isRunning: boolean;
-  readonly isCurrent: boolean;
+  /**
+   * Whether this worktree deserves the recursive (working-tree) watcher:
+   * true when it's the focused worktree or an agent is actively working in
+   * it. The controller only cares about the tier, not which signal produced
+   * it.
+   */
+  readonly isElevated: boolean;
   readonly gitWatchEnabled: boolean;
   readonly gitWatchDebounceMs: number;
   readonly worktreeId: string;
@@ -44,11 +50,12 @@ export interface WatcherControllerHost {
 
 /**
  * Manages the git file watcher lifecycle for a single worktree. Tiers
- * granularity by focus state: focused worktrees get the recursive watcher;
- * background worktrees stay on the cheap `.git/`-only watch. Recovers from
- * runtime failures by reconstructing in `git-only` mode and retrying the
- * recursive arm on a backoff. Coordinates self-triggered refreshes via a
- * pending-flag protocol so concurrent updates don't pile up.
+ * granularity by elevation: elevated worktrees (focused, or with an agent
+ * actively working) get the recursive watcher; the rest stay on the cheap
+ * `.git/`-only watch. Recovers from runtime failures by reconstructing in
+ * `git-only` mode and retrying the recursive arm on a backoff. Coordinates
+ * self-triggered refreshes via a pending-flag protocol so concurrent updates
+ * don't pile up.
  */
 export class WatcherController {
   private gitWatcher = new MutableDisposable<IDisposable>();
@@ -89,15 +96,15 @@ export class WatcherController {
   }
 
   desiredMode(): "git-only" | "recursive" {
-    return this.host.isCurrent ? "recursive" : "git-only";
+    return this.host.isElevated ? "recursive" : "git-only";
   }
 
   /**
    * Poll cadence is mode-aware. Recursive coverage drops the heartbeat to
    * 5min — the watcher catches every working-tree edit, so the timer is
    * just a safety net for OS suspend/wake and rare watcher-ghost cases.
-   * Git-only on the active worktree tightens to 60s so mid-edit changes
-   * that bypass .git/ are still picked up reasonably; background git-only
+   * Git-only on an elevated worktree tightens to 60s so mid-edit changes
+   * that bypass .git/ are still picked up reasonably; non-elevated git-only
    * shares the 5min fallback. No watcher falls back to the supplied
    * adaptive interval.
    */
@@ -106,7 +113,7 @@ export class WatcherController {
       case "recursive":
         return WATCHER_FALLBACK_POLL_INTERVAL_MS;
       case "git-only":
-        return this.host.isCurrent
+        return this.host.isElevated
           ? WATCHER_GIT_ONLY_ACTIVE_POLL_INTERVAL_MS
           : WATCHER_FALLBACK_POLL_INTERVAL_MS;
       case "none":
@@ -116,11 +123,11 @@ export class WatcherController {
   }
 
   /**
-   * Start the git file watcher. The mode is tiered by `host.isCurrent`:
-   * focused worktrees get the recursive watcher; background worktrees get
-   * only the cheap .git/ watchers. On recursive failure (e.g. ENOSPC at
-   * startup), the per-file .git/ watchers are preserved by immediately
-   * reconstructing in "git-only" mode.
+   * Start the git file watcher. The mode is tiered by `host.isElevated`:
+   * elevated worktrees get the recursive watcher; the rest get only the
+   * cheap .git/ watchers. On recursive failure (e.g. ENOSPC at startup),
+   * the per-file .git/ watchers are preserved by immediately reconstructing
+   * in "git-only" mode.
    */
   start(mode: "git-only" | "recursive" = this.desiredMode()): void {
     if (this.disposed) return;
@@ -186,9 +193,9 @@ export class WatcherController {
           if (!this.hasWatcher) {
             this.start("git-only");
           }
-          // Background worktrees don't want recursive at all, so don't keep
-          // poking at it; the next focus flip re-arms via the focus change.
-          if (this.host.isCurrent) {
+          // Non-elevated worktrees don't want recursive at all, so don't keep
+          // poking at it; the next elevation flip re-arms via the change.
+          if (this.host.isElevated) {
             this.scheduleRetry();
           }
         }
@@ -259,10 +266,11 @@ export class WatcherController {
 
   /**
    * Reconcile watcher state. Stop if disabled while running; start if
-   * enabled and not yet armed; rotate if granularity disagrees with focus.
-   * Skips the granularity rotation when a focus-driven downgrade timer is
-   * pending — otherwise periodic reconciliation (e.g. updateWorktrees) would
-   * defeat the hysteresis the moment a focused worktree turns background.
+   * enabled and not yet armed; rotate if granularity disagrees with
+   * elevation. Skips the granularity rotation when an elevation-driven
+   * downgrade timer is pending — otherwise periodic reconciliation (e.g.
+   * updateWorktrees) would defeat the hysteresis the moment a worktree
+   * loses elevation.
    */
   ensureState(): void {
     if (!this.host.gitWatchEnabled && this.hasWatcher) {
@@ -276,9 +284,9 @@ export class WatcherController {
       this.gitWatcherMode !== this.desiredMode() &&
       this.downgradeTimer === null
     ) {
-      // Existing watcher granularity disagrees with focus state — re-arm
-      // so the active worktree gets the recursive watcher and background
-      // worktrees stay on the cheap .git/-only watch.
+      // Existing watcher granularity disagrees with elevation — re-arm so
+      // elevated worktrees get the recursive watcher and the rest stay on
+      // the cheap .git/-only watch.
       this.update();
     }
   }
@@ -290,23 +298,24 @@ export class WatcherController {
   }
 
   /**
-   * React to a focus-tier change. Upgrades (background → focused) re-arm the
-   * recursive watcher immediately so the user sees fresh state right after
-   * switching to a worktree. Downgrades (focused → background) settle for
-   * `WATCHER_FOCUS_DOWNGRADE_DELAY_MS` to absorb rapid focus toggles before
-   * tearing down the recursive arm — this avoids inotify churn on quick
-   * back-and-forth and keeps the watcher alive through transient passes.
+   * React to an elevation-tier change (focus flip or agent activity flip).
+   * Upgrades re-arm the recursive watcher immediately so fresh state streams
+   * right after switching to a worktree or an agent starting work.
+   * Downgrades settle for `WATCHER_ELEVATION_DOWNGRADE_DELAY_MS` to absorb
+   * rapid toggles before tearing down the recursive arm — this avoids
+   * inotify churn on quick back-and-forth and keeps the watcher alive
+   * through transient passes.
    *
    * Returns `true` when an immediate rotation occurred (caller should
    * re-derive poll cadence); `false` when the change was deferred or had no
    * effect on the current granularity.
    */
-  handleFocusChange(isCurrent: boolean): boolean {
+  handleElevationChange(elevated: boolean): boolean {
     if (this.disposed || !this.host.isRunning || !this.host.gitWatchEnabled) {
       return false;
     }
 
-    if (isCurrent) {
+    if (elevated) {
       if (this.downgradeTimer) {
         clearTimeout(this.downgradeTimer);
         this.downgradeTimer = null;
@@ -336,13 +345,13 @@ export class WatcherController {
         this.disposed ||
         !this.host.isRunning ||
         !this.host.gitWatchEnabled ||
-        this.host.isCurrent ||
+        this.host.isElevated ||
         this.gitWatcherMode !== "recursive"
       ) {
         return;
       }
       this.update();
-    }, WATCHER_FOCUS_DOWNGRADE_DELAY_MS).unref();
+    }, WATCHER_ELEVATION_DOWNGRADE_DELAY_MS).unref();
     return false;
   }
 
@@ -446,7 +455,7 @@ export class WatcherController {
   /**
    * Recursive watcher reported a runtime failure. Preserve the cheap .git/
    * watchers by reconstructing in "git-only" mode, then schedule a retry of
-   * the recursive arm on the active worktree only.
+   * the recursive arm on elevated worktrees only.
    */
   private handleWatcherFailed(): void {
     if (this.disposed) return;
@@ -459,7 +468,7 @@ export class WatcherController {
     this.gitWatcher.clear();
     this.gitWatcherMode = "none";
     this.start("git-only");
-    if (this.host.isCurrent) {
+    if (this.host.isElevated) {
       this.scheduleRetry();
     }
   }
@@ -470,7 +479,7 @@ export class WatcherController {
       !this.host.isRunning ||
       !this.host.gitWatchEnabled ||
       this.watcherRetryTimer ||
-      !this.host.isCurrent
+      !this.host.isElevated
     ) {
       return;
     }
@@ -486,7 +495,7 @@ export class WatcherController {
         !this.disposed &&
         this.host.isRunning &&
         this.host.gitWatchEnabled &&
-        this.host.isCurrent &&
+        this.host.isElevated &&
         this.gitWatcherMode !== "recursive"
       ) {
         // Drop any current git-only instance so start()'s idempotent

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1,7 +1,7 @@
 import os from "os";
 import { randomUUID } from "node:crypto";
 import PQueue from "p-queue";
-import { existsSync } from "fs";
+import { existsSync, watch as fsWatch, type FSWatcher } from "fs";
 import { stat, readFile, access, mkdir } from "fs/promises";
 import { resolve as pathResolve, isAbsolute, dirname, basename } from "path";
 import { validateBranchName } from "../../shared/utils/pathPattern.js";
@@ -178,6 +178,14 @@ export class WorkspaceService {
   // worktree is never present here. Mutated via lruTouch/lruRemove; budget
   // enforced by applyWatcherBudget().
   private readonly backgroundGitWatcherLru = new Map<string, true>();
+  // Worktree IDs the renderer reports as having an actively working agent
+  // (via the `set-agent-activity` port action). Agent-active monitors are
+  // elevated to the recursive watcher tier and exempted from the background
+  // watcher budget, exactly like the focused worktree — the ENOSPC/EMFILE
+  // degradation path bounds the worst case on constrained kernels. Kept as a
+  // set (not per-monitor only) so worktrees discovered *after* the broadcast
+  // (e.g. an agent's own `git worktree add`) inherit the flag on creation.
+  private agentActiveWorktreeIds = new Set<string>();
   // Provider hostname-matcher table relayed from main's forge registry.
   // Empty until the first relay lands (after plugin load), so monitors start
   // unmatched and re-resolve when the table arrives or changes.
@@ -228,6 +236,13 @@ export class WorkspaceService {
   // Topology watcher — watches `.git/worktrees/` for external worktree
   // create/delete and triggers serialized reconciliation.
   private topologyWatcherSubscription = new MutableDisposable();
+  // Cheap fs.watch on the common git dir, armed only while `.git/worktrees/`
+  // doesn't exist (project with zero linked worktrees). Without it the first
+  // external `git worktree add` of a session is only discovered by the 90s
+  // safety reconcile — startTopologyWatcher() no-ops on an absent dir and
+  // nothing re-invoked it. Fires once when the dir appears, then hands off
+  // to the real parcel watcher and an immediate reconcile.
+  private topologyMetadataSentinel: FSWatcher | null = null;
   // No constructor `timeout` here: this queue's task wraps runTopologyReconcile
   // in withTimeout itself (and always resolves via its own try/catch/finally),
   // so it can never pin the single slot. A p-queue constructor timeout would
@@ -995,6 +1010,10 @@ export class WorkspaceService {
     monitor.stop();
     this.monitors.delete(id);
     this.lruRemove(id);
+    // Drop the agent-active flag with the monitor — a same-path worktree
+    // recreated later must not inherit a stale elevation. The renderer's
+    // next broadcast re-adds it if an agent really is working there.
+    this.agentActiveWorktreeIds.delete(id);
     this.recoverWatcherIfNoMonitorsRemain();
 
     clearGitDirCache(monitor.path);
@@ -1093,15 +1112,24 @@ export class WorkspaceService {
    * run AFTER any sync/focus mutation that could re-arm watchers.
    */
   private applyWatcherBudget(): void {
-    // Reconcile LRU membership against live monitors: the active worktree must
-    // never be in the pool; every other running monitor must be present.
+    // Reconcile LRU membership against live monitors: the active worktree and
+    // agent-active worktrees must never be in the pool; every other running
+    // monitor must be present.
     for (const id of [...this.backgroundGitWatcherLru.keys()]) {
-      if (!this.monitors.has(id) || id === this.activeWorktreeId) {
+      if (
+        !this.monitors.has(id) ||
+        id === this.activeWorktreeId ||
+        this.agentActiveWorktreeIds.has(id)
+      ) {
         this.backgroundGitWatcherLru.delete(id);
       }
     }
     for (const id of this.monitors.keys()) {
-      if (id !== this.activeWorktreeId && !this.backgroundGitWatcherLru.has(id)) {
+      if (
+        id !== this.activeWorktreeId &&
+        !this.agentActiveWorktreeIds.has(id) &&
+        !this.backgroundGitWatcherLru.has(id)
+      ) {
         this.backgroundGitWatcherLru.set(id, true);
       }
     }
@@ -1118,9 +1146,48 @@ export class WorkspaceService {
     if (this.activeWorktreeId) {
       this.monitors.get(this.activeWorktreeId)?.setGitWatchBudgetAllowed(true);
     }
+    // Worktrees with an actively working agent always keep theirs too —
+    // streaming those changes is the product's core loop; the watcher-failure
+    // degradation path (ENOSPC/EMFILE → git-only) bounds the worst case.
+    for (const id of this.agentActiveWorktreeIds) {
+      this.monitors.get(id)?.setGitWatchBudgetAllowed(true);
+    }
     // Grant the surviving MRU tail.
     for (let i = cutoff; i < ids.length; i++) {
       this.monitors.get(ids[i])?.setGitWatchBudgetAllowed(true);
+    }
+  }
+
+  /**
+   * Applies the renderer's agent-activity broadcast: the set of worktree IDs
+   * that currently have an agent producing work (working/directing). Elevates
+   * matching monitors to the recursive watcher tier (see
+   * `WorktreeMonitor.agentActive`) and re-runs the watcher budget so they are
+   * exempted from background eviction. The set is retained so monitors
+   * created later — including worktrees the agent itself just created —
+   * inherit the flag before their watcher first arms.
+   */
+  setAgentActivity(worktreeIds: string[]): void {
+    // Port payloads are typed but not runtime-validated; a malformed request
+    // must not silently clear every elevation (`new Set(undefined)` is empty).
+    if (!Array.isArray(worktreeIds)) return;
+    const next = new Set(worktreeIds.filter((id): id is string => typeof id === "string"));
+    const previous = this.agentActiveWorktreeIds;
+    this.agentActiveWorktreeIds = next;
+
+    let membershipChanged = false;
+    for (const [id, monitor] of this.monitors) {
+      const active = next.has(id);
+      if (monitor.agentActive !== active) {
+        monitor.agentActive = active;
+        membershipChanged = true;
+      }
+    }
+    // A worktree that left the set re-enters the LRU pool at the MRU tail
+    // (freshest) via applyWatcherBudget's membership reconcile, and newly
+    // active ones leave it — either way the budget must be re-enforced.
+    if (membershipChanged || previous.size !== next.size) {
+      this.applyWatcherBudget();
     }
   }
 
@@ -1224,9 +1291,18 @@ export class WorkspaceService {
       monitor.setGitWatchBudgetAllowed(false);
     }
 
+    // Inherit the agent-activity flag before start so a worktree the agent
+    // just created (its monitor arriving via topology reconcile after the
+    // renderer's broadcast) arms the recursive watcher and runs its initial
+    // status immediately, instead of starting as a cold background monitor.
+    if (this.agentActiveWorktreeIds.has(wt.id)) {
+      monitor.agentActive = true;
+      monitor.setGitWatchBudgetAllowed(true);
+    }
+
     this.monitors.set(wt.id, monitor);
 
-    if (isActive) {
+    if (isActive || this.agentActiveWorktreeIds.has(wt.id)) {
       this.lruRemove(wt.id);
     } else {
       this.lruTouch(wt.id);
@@ -1617,7 +1693,6 @@ export class WorkspaceService {
     const generationAtStart = this.topologyWatcherGeneration;
     const metadataDir = await this.worktreeMetadataDirPath();
     if (!metadataDir) return;
-    if (!existsSync(metadataDir)) return;
     // Re-validate after the async commondir resolution: a stop (pause,
     // project switch, dispose) bumps the generation, and a concurrent start
     // that won the race either holds the subscription already or bumped the
@@ -1629,6 +1704,16 @@ export class WorkspaceService {
     ) {
       return;
     }
+    if (!existsSync(metadataDir)) {
+      // No linked worktrees yet — `.git/worktrees/` is created by the first
+      // `git worktree add`. Watch for it so that add is discovered in
+      // milliseconds instead of by the 90s safety reconcile.
+      this.armTopologyMetadataSentinel(metadataDir);
+      return;
+    }
+    // The real watcher takes over from here; a sentinel left over from an
+    // earlier no-dir phase would just fire redundantly.
+    this.disarmTopologyMetadataSentinel();
 
     const generation = ++this.topologyWatcherGeneration;
     const drain = () => this.drainTopologyEventBuffer();
@@ -1688,6 +1773,71 @@ export class WorkspaceService {
       });
   }
 
+  /**
+   * Arm the fs.watch sentinel that waits for `.git/worktrees/` to appear.
+   * Non-persistent and filtered to the single directory entry, so it costs
+   * one watch handle on the common git dir. On failure (exotic filesystems,
+   * watch limits) discovery falls back to the 90s safety reconcile.
+   */
+  private armTopologyMetadataSentinel(metadataDir: string): void {
+    if (this.topologyMetadataSentinel) return;
+    const commonDir = dirname(metadataDir);
+    try {
+      const sentinel = fsWatch(commonDir, { persistent: false }, (_eventType, name) => {
+        // Only the `worktrees` entry matters — the common dir churns
+        // constantly (index, HEAD, refs). A null name can't be classified,
+        // so fall through to the existence check.
+        if (name && name.toString().replaceAll("\\", "/") !== "worktrees") return;
+        if (this.topologyMetadataSentinel !== sentinel) return;
+        if (!existsSync(metadataDir)) return;
+        this.disarmTopologyMetadataSentinel();
+        void this.startTopologyWatcher();
+        this.scheduleTopologyReconcile();
+      });
+      sentinel.on("error", () => {
+        if (this.topologyMetadataSentinel === sentinel) {
+          this.disarmTopologyMetadataSentinel();
+        }
+      });
+      this.topologyMetadataSentinel = sentinel;
+    } catch {
+      // fs.watch unavailable — the periodic safety reconcile still discovers
+      // the first worktree, just slower.
+    }
+  }
+
+  private disarmTopologyMetadataSentinel(): void {
+    if (!this.topologyMetadataSentinel) return;
+    const sentinel = this.topologyMetadataSentinel;
+    this.topologyMetadataSentinel = null;
+    try {
+      sentinel.close();
+    } catch {
+      // Stale handle on Windows — ignore.
+    }
+  }
+
+  /**
+   * Post-reconcile self-heal for the topology watcher. Two silent-death
+   * cases need it: (1) `.git/worktrees/` was deleted (last linked worktree
+   * removed) — the parcel subscription stops reporting without erroring;
+   * (2) the dir appeared while neither watcher nor sentinel was live (e.g.
+   * the sentinel failed to arm). Runs after the worktree list has been
+   * re-verified, so rebuilding here can't mask a missed event.
+   */
+  private async ensureTopologyWatcherAlive(): Promise<void> {
+    if (!this.topologyWatcherEnabled || !this.pollingEnabled) return;
+    if (this.topologyWatcherSubscription.value) {
+      const metadataDir = await this.worktreeMetadataDirPath();
+      if (!metadataDir || existsSync(metadataDir)) return;
+      // Watch root vanished — drop the dead subscription and fall through
+      // to re-arm via the sentinel path.
+      this.topologyWatcherGeneration++;
+      this.topologyWatcherSubscription.value = undefined;
+    }
+    await this.startTopologyWatcher();
+  }
+
   private stopTopologyWatcher(): void {
     // Tearing the watcher down clears the dark state — there's no longer a
     // watcher whose silence matters. Emit recovery (only if dark) so a
@@ -1697,6 +1847,7 @@ export class WorkspaceService {
     this.handleTopologyWatcherRecovered();
     this.topologyWatcherGeneration++;
     this.topologyWatcherSubscription.value = undefined;
+    this.disarmTopologyMetadataSentinel();
     if (this.topologyDebounceTimer) {
       clearTimeout(this.topologyDebounceTimer);
       this.topologyDebounceTimer = null;
@@ -1852,6 +2003,8 @@ export class WorkspaceService {
     // state is resolved — recover here rather than on watcher re-arm, since
     // re-subscribing doesn't prove the topology is current (#8516/#8558).
     this.handleTopologyWatcherRecovered();
+
+    await this.ensureTopologyWatcherAlive();
 
     // Auto-switch to main if the previously-active worktree was removed.
     // syncMonitors nulls activeWorktreeId when pruning the active monitor,
@@ -3340,6 +3493,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     }
     this.monitors.clear();
     this.backgroundGitWatcherLru.clear();
+    this.agentActiveWorktreeIds.clear();
     // Drop in-flight fetch chains and per-repo failure state — the next
     // project's monitors get a clean coordinator and stale completions are
     // discarded by the generation guard.
@@ -3473,6 +3627,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     }
     this.monitors.clear();
     this.backgroundGitWatcherLru.clear();
+    this.agentActiveWorktreeIds.clear();
     this.fetchCoordinator.destroy();
     this.authFailureConfirmedNotified.clear();
     this.pollQueue.clear();

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1687,7 +1687,11 @@ export class WorkspaceService {
   }
 
   private async startTopologyWatcher(): Promise<void> {
-    if (!this.topologyWatcherEnabled) return;
+    // The pollingEnabled gate keeps a paused service dark: without it, an
+    // ensureTopologyWatcherAlive() that entered its await before the pause
+    // would arm a fresh watcher/sentinel right after stopTopologyWatcher()
+    // tore everything down. Resume re-invokes this symmetrically.
+    if (!this.topologyWatcherEnabled || !this.pollingEnabled) return;
     if (this.topologyWatcherSubscription.value) return;
 
     const generationAtStart = this.topologyWatcherGeneration;
@@ -1700,6 +1704,7 @@ export class WorkspaceService {
     if (
       generationAtStart !== this.topologyWatcherGeneration ||
       !this.topologyWatcherEnabled ||
+      !this.pollingEnabled ||
       this.topologyWatcherSubscription.value
     ) {
       return;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -65,6 +65,14 @@ const STATUS_INITIAL_DELAY_MAX_MS = 5_000;
 // stably record absence (packed-refs, detached HEAD's branch ref) and still
 // match on the next stat pass without forcing a real git check.
 const STAT_ABSENT_SENTINEL = -1;
+// Ceiling on how long the stat pre-check may keep skipping full git-status
+// passes while the working tree is NOT covered by a recursive watcher. The
+// four statted files are all .git metadata, so pure working-tree edits (an
+// agent editing sources without staging) never perturb the baseline — without
+// this bound they would stay invisible indefinitely on git-only/unwatched
+// worktrees. Recursive-watched worktrees are exempt: their watcher observes
+// every working-tree write and forces a refresh itself.
+const FULL_STATUS_MAX_AGE_MS = 120_000;
 
 // FNV-1a 32-bit offset basis. Also the digest of an empty change list, which
 // makes it the natural initial value for `previousStateHash` (see below).
@@ -131,6 +139,11 @@ export class WorktreeMonitor {
   private _branch: string | undefined;
   private _gitDir: string | undefined;
   private _isCurrent: boolean;
+  // True while an agent is actively producing work in this worktree (set by
+  // WorkspaceService from the renderer's agent-activity broadcast). Feeds the
+  // elevation tier alongside `_isCurrent` so agent worktrees keep recursive
+  // working-tree watching while backgrounded.
+  private _agentActive: boolean = false;
   private _isMainWorktree: boolean;
 
   // State
@@ -217,6 +230,10 @@ export class WorktreeMonitor {
   // simple-git fork-exec. null = no baseline yet (first poll, or post-error).
   private lastStatBaseline: GitFileStatBaseline | null = null;
   private lastStatBaselineAt: number = 0;
+  // Timestamp of the last completed FULL status pass (one that actually ran
+  // git, not a stat-skip). Bounds how long stat-skips may mask working-tree
+  // edits on worktrees without recursive coverage (FULL_STATUS_MAX_AGE_MS).
+  private lastFullStatusAt: number = 0;
   private lastBaseDivergenceKey: string | null = null;
   private lastBaseDivergenceResult: BaseDivergence | null = null;
   private cachedCommonDir: string | null = null;
@@ -390,8 +407,8 @@ export class WorktreeMonitor {
       get isRunning() {
         return monitor._isRunning;
       },
-      get isCurrent() {
-        return monitor._isCurrent;
+      get isElevated() {
+        return monitor._isCurrent || monitor._agentActive;
       },
       get gitWatchEnabled() {
         // Combined gate: the per-view watcher budget can suppress the watcher
@@ -617,9 +634,10 @@ export class WorktreeMonitor {
     // immediately so the focused worktree gets the recursive watcher right
     // away; downgrades settle behind a short delay inside the controller to
     // absorb rapid focus toggles. Only re-derive poll cadence when the
-    // controller actually rotated synchronously.
+    // controller actually rotated synchronously. Elevation combines focus
+    // with agent activity, so losing focus while an agent works is a no-op.
     if (changed && this._isRunning && this.gitWatchEnabled) {
-      const rotatedImmediately = this.watcherController.handleFocusChange(value);
+      const rotatedImmediately = this.watcherController.handleElevationChange(this.isElevated);
       if (rotatedImmediately && this.pollingTimer) {
         clearTimeout(this.pollingTimer);
         this.pollingTimer = null;
@@ -638,6 +656,46 @@ export class WorktreeMonitor {
     // worktree that hadn't been actively fetched.
     if (changed && this._isRunning) {
       this.fetchScheduler.reschedule(true);
+    }
+  }
+
+  get isElevated(): boolean {
+    return this._isCurrent || this._agentActive;
+  }
+
+  get agentActive(): boolean {
+    return this._agentActive;
+  }
+
+  /**
+   * Marks whether an agent is actively producing work in this worktree.
+   * Elevation (focus OR agent activity) drives watcher granularity, so a
+   * background worktree with a working agent streams working-tree changes
+   * like the focused one. Both edges also force a status refresh: on start
+   * so the card baselines right away, on stop so the agent's final state
+   * lands without waiting for a poll.
+   */
+  set agentActive(value: boolean) {
+    const changed = this._agentActive !== value;
+    this._agentActive = value;
+    if (!changed || !this._isRunning) {
+      return;
+    }
+    if (this.gitWatchEnabled) {
+      const rotatedImmediately = this.watcherController.handleElevationChange(this.isElevated);
+      if (rotatedImmediately && this.pollingTimer) {
+        clearTimeout(this.pollingTimer);
+        this.pollingTimer = null;
+        this.scheduleNextPoll();
+      }
+    }
+    if (value) {
+      // Agent work incoming — reset the idle backoff so the poll fallback
+      // returns to base cadence, mirroring the focus-gain path.
+      this.pollingStrategy.recordStateChange();
+    }
+    if (this._hasInitialStatus) {
+      this.triggerRefreshIfUpdating();
     }
   }
 
@@ -969,12 +1027,13 @@ export class WorktreeMonitor {
       this.watcherController.start();
     }
 
-    // Foreground monitors run the initial git status synchronously — the
-    // user is looking at this card and expects fresh data on app launch.
+    // Elevated monitors (focused, or agent already working — e.g. a worktree
+    // the agent just created and immediately started editing) run the initial
+    // git status synchronously so the card has fresh data right away.
     // Background monitors defer through a 2-5s jitter so N monitors started
     // together don't all fork git at t=0. The fetch scheduler already has
     // its own initial jitter on a separate cadence.
-    if (this._isCurrent) {
+    if (this.isElevated) {
       await this.updateGitStatus(true);
 
       if (this._isRunning && this.pollingEnabled) {
@@ -1090,7 +1149,7 @@ export class WorktreeMonitor {
     if (this.pollingStrategy.isCircuitBreakerTripped()) {
       this.pollingStrategy.reset();
     }
-    if (this._isCurrent && this.gitWatchEnabled) {
+    if (this.isElevated && this.gitWatchEnabled) {
       const budgetReset = this.watcherController.resetRetryBudget();
       if (budgetReset) {
         this.watcherController.update();
@@ -1406,7 +1465,7 @@ export class WorktreeMonitor {
       if (this.pollQueue) {
         await this.pollQueue.add(run, {
           signal: this._pollAbortController.signal,
-          priority: this._isCurrent ? 1 : 0,
+          priority: this.isElevated ? 1 : 0,
         });
       } else {
         await run();
@@ -1448,10 +1507,11 @@ export class WorktreeMonitor {
       const queueDelayMs = Math.max(0, startTime - queuedAt);
 
       try {
-        // Force a status refresh when the active worktree lacks recursive
-        // coverage — both no-watcher and git-only modes can miss mid-edit
-        // changes that haven't reached .git/ yet.
-        const forceRefresh = this._isCurrent && this.watcherController.currentMode !== "recursive";
+        // Force a status refresh when an elevated worktree (focused or
+        // agent-active) lacks recursive coverage — both no-watcher and
+        // git-only modes can miss mid-edit changes that haven't reached
+        // .git/ yet.
+        const forceRefresh = this.isElevated && this.watcherController.currentMode !== "recursive";
         // Watchdog the whole pass: if any await inside updateGitStatus hangs
         // past the ceiling, treat it as a failure and move on rather than let
         // this monitor's loop (and, via the shared pollQueue slot, the whole
@@ -1478,7 +1538,7 @@ export class WorktreeMonitor {
     const runPoll = this.pollQueue
       ? this.pollQueue.add(() => executePoll(), {
           signal: this._pollAbortController.signal,
-          priority: this._isCurrent ? 1 : 0,
+          priority: this.isElevated ? 1 : 0,
         })
       : executePoll();
 
@@ -1584,7 +1644,22 @@ export class WorktreeMonitor {
       // The baseline only exists after the first real check, so this branch
       // is a no-op on the very first poll. Forced refreshes (watcher events,
       // user actions) always run the full check.
-      if (!forceRefresh && gitDir && this._hasInitialStatus && this.lastStatBaseline !== null) {
+      //
+      // The skip is only trustworthy for working-tree freshness while the
+      // recursive watcher covers the tree (its events force refreshes). In
+      // git-only/unwatched modes the four statted files can't reflect pure
+      // working-tree edits, so cap how long skips may stack up: past
+      // FULL_STATUS_MAX_AGE_MS the poll falls through to a real git check.
+      const skipTrustworthy =
+        this.watcherController.currentMode === "recursive" ||
+        Date.now() - this.lastFullStatusAt < FULL_STATUS_MAX_AGE_MS;
+      if (
+        !forceRefresh &&
+        gitDir &&
+        this._hasInitialStatus &&
+        this.lastStatBaseline !== null &&
+        skipTrustworthy
+      ) {
         const baselineAt = this.lastStatBaselineAt;
         const checkStartedAt = Date.now();
         try {
@@ -1842,6 +1917,9 @@ export class WorktreeMonitor {
       // baseline so the next non-forced poll falls through to a full check
       // rather than skipping against a snapshot that predates the failure.
       if (checkSucceeded && gitDir) {
+        // A full pass ran git and landed cleanly — reset the stat-skip
+        // staleness budget alongside the baseline rebuild.
+        this.lastFullStatusAt = Date.now();
         try {
           const commonDir = await this.resolveCommonDirAsync(gitDir);
           const fresh = await this.buildStatBaseline(gitDir, commonDir);

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -60,7 +60,7 @@ async function settle(): Promise<void> {
 
 interface MutableHost {
   isRunning: boolean;
-  isCurrent: boolean;
+  isElevated: boolean;
   gitWatchEnabled: boolean;
   gitWatchDebounceMs: number;
   worktreeId: string;
@@ -77,7 +77,7 @@ interface MutableHost {
 function makeHost(overrides: Partial<MutableHost> = {}): MutableHost {
   return {
     isRunning: true,
-    isCurrent: true,
+    isElevated: true,
     gitWatchEnabled: true,
     gitWatchDebounceMs: 300,
     worktreeId: "/test/worktree",
@@ -133,7 +133,7 @@ describe("WatcherController", () => {
 
   it("starts in recursive mode for focused worktrees", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -147,7 +147,7 @@ describe("WatcherController", () => {
 
   it("starts in git-only mode for background worktrees", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: false });
+    const host = makeHost({ isElevated: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -162,7 +162,7 @@ describe("WatcherController", () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     mockWatcherStartFiresFailure = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -175,7 +175,7 @@ describe("WatcherController", () => {
   it("schedules a recursive retry after a failed recursive start (focused only)", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -191,7 +191,7 @@ describe("WatcherController", () => {
 
   it("does not fire onWatcherRecovered on a clean cold start", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -204,7 +204,7 @@ describe("WatcherController", () => {
   it("fires onWatcherRecovered once when the recursive arm recovers via retry", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -226,7 +226,7 @@ describe("WatcherController", () => {
     // so onWatcherRecovered must not fire.
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -248,7 +248,7 @@ describe("WatcherController", () => {
     // this way must still signal recovery when recursive finally arms.
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -269,7 +269,7 @@ describe("WatcherController", () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     mockWatcherStartFiresFailure = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -288,7 +288,7 @@ describe("WatcherController", () => {
   it("does not schedule a retry for background worktrees", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: false });
+    const host = makeHost({ isElevated: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     // Background goes straight to git-only with no retry budget.
@@ -305,7 +305,7 @@ describe("WatcherController", () => {
   it("respects the WATCHER_MAX_RETRIES (5) budget", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -324,7 +324,7 @@ describe("WatcherController", () => {
   it("update() rotates without resetting the retry budget", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -347,7 +347,7 @@ describe("WatcherController", () => {
   it("stop(true) resets the retry budget — restart allows a full 5-retry budget", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     // Burn 3 retries on the first run.
@@ -373,7 +373,7 @@ describe("WatcherController", () => {
   it("stop(false) preserves the retry budget — exhausted budget stays exhausted across rotation", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     // Exhaust the entire 5-retry budget on the first run.
@@ -436,7 +436,7 @@ describe("WatcherController", () => {
 
   it("ensureState() rotates when granularity disagrees with focus", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -444,7 +444,7 @@ describe("WatcherController", () => {
     await settle();
     expect(ctrl.currentMode).toBe("recursive");
 
-    host.isCurrent = false;
+    host.isElevated = false;
     ctrl.ensureState();
     await settle();
     expect(ctrl.currentMode).toBe("git-only");
@@ -536,7 +536,7 @@ describe("WatcherController", () => {
   it("clearRetryTimer() cancels the retry without disposing the watcher", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -569,7 +569,7 @@ describe("WatcherController", () => {
   it("stop(true) cancels pending retry timers", async () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
@@ -597,7 +597,7 @@ describe("WatcherController", () => {
 
   it("uses the 250ms worktree min-debounce floor", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
     await settle();
@@ -605,17 +605,17 @@ describe("WatcherController", () => {
     expect(capturedWatcherOptions).toMatchObject({ worktreeMinDebounceMs: 250 });
   });
 
-  it("handleFocusChange(false) defers the downgrade by the settle delay", async () => {
+  it("handleElevationChange(false) defers the downgrade by the settle delay", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
     await settle();
     expect(ctrl.currentMode).toBe("recursive");
     const startsBeforeFlip = watcherStartCallCount;
 
-    host.isCurrent = false;
-    const rotated = ctrl.handleFocusChange(false);
+    host.isElevated = false;
+    const rotated = ctrl.handleElevationChange(false);
     await settle();
 
     expect(rotated).toBe(false);
@@ -629,22 +629,22 @@ describe("WatcherController", () => {
     expect(ctrl.currentMode).toBe("git-only");
   });
 
-  it("handleFocusChange(true) cancels a pending downgrade and keeps recursive", async () => {
+  it("handleElevationChange(true) cancels a pending downgrade and keeps recursive", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
     await settle();
     const startsBeforeFlip = watcherStartCallCount;
 
-    host.isCurrent = false;
-    ctrl.handleFocusChange(false);
+    host.isElevated = false;
+    ctrl.handleElevationChange(false);
     await settle();
 
     // Re-focus before the settle window elapses.
     await vi.advanceTimersByTimeAsync(1_500);
-    host.isCurrent = true;
-    const rotated = ctrl.handleFocusChange(true);
+    host.isElevated = true;
+    const rotated = ctrl.handleElevationChange(true);
     await settle();
 
     // Already recursive — no rotation needed.
@@ -656,17 +656,17 @@ describe("WatcherController", () => {
     expect(ctrl.currentMode).toBe("recursive");
   });
 
-  it("handleFocusChange(true) immediately upgrades a git-only watcher and reports rotation", async () => {
+  it("handleElevationChange(true) immediately upgrades a git-only watcher and reports rotation", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: false });
+    const host = makeHost({ isElevated: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
     await settle();
     expect(ctrl.currentMode).toBe("git-only");
     const startsBeforeFlip = watcherStartCallCount;
 
-    host.isCurrent = true;
-    const rotated = ctrl.handleFocusChange(true);
+    host.isElevated = true;
+    const rotated = ctrl.handleElevationChange(true);
     await settle();
 
     expect(rotated).toBe(true);
@@ -676,14 +676,14 @@ describe("WatcherController", () => {
 
   it("stop() cancels a pending downgrade timer", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
     await settle();
     const startsBeforeFlip = watcherStartCallCount;
 
-    host.isCurrent = false;
-    ctrl.handleFocusChange(false);
+    host.isElevated = false;
+    ctrl.handleElevationChange(false);
     await settle();
     ctrl.stop(true);
 
@@ -732,18 +732,18 @@ describe("WatcherController", () => {
 
   it("ensureState() does not bypass a pending downgrade timer", async () => {
     mockWatcherStartResult = true;
-    const host = makeHost({ isCurrent: true });
+    const host = makeHost({ isElevated: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
     await settle();
     expect(ctrl.currentMode).toBe("recursive");
     const startsBeforeFlip = watcherStartCallCount;
 
-    // Simulate WorkspaceService.updateWorktrees: set isCurrent then call
+    // Simulate WorkspaceService.updateWorktrees: set isElevated then call
     // ensureState. The downgrade timer must keep the recursive watcher
     // alive through the periodic reconciliation pass.
-    host.isCurrent = false;
-    ctrl.handleFocusChange(false);
+    host.isElevated = false;
+    ctrl.handleElevationChange(false);
     await settle();
     ctrl.ensureState();
     await settle();
@@ -757,12 +757,12 @@ describe("WatcherController", () => {
     expect(watcherStartCallCount).toBe(startsBeforeFlip + 1);
   });
 
-  it("handleFocusChange(true) starts a watcher when none exists", async () => {
+  it("handleElevationChange(true) starts a watcher when none exists", async () => {
     // Simulate: a previous start failed (mode 'none', no watcher), then
     // the user focuses this worktree via setActiveWorktree. The watcher
     // must be re-attempted, not silently skipped.
     mockWatcherStartResult = false;
-    const host = makeHost({ isCurrent: false });
+    const host = makeHost({ isElevated: false });
     const ctrl = new WatcherController(host as WatcherControllerHost);
     ctrl.start();
     await settle();
@@ -771,8 +771,8 @@ describe("WatcherController", () => {
     const startsBeforeFlip = watcherStartCallCount;
 
     mockWatcherStartResult = true;
-    host.isCurrent = true;
-    const rotated = ctrl.handleFocusChange(true);
+    host.isElevated = true;
+    const rotated = ctrl.handleElevationChange(true);
     await settle();
 
     expect(rotated).toBe(true);
@@ -801,7 +801,7 @@ describe("WatcherController", () => {
     it("resets exhausted budget so subsequent failure schedules a retry", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
-      const host = makeHost({ isCurrent: true });
+      const host = makeHost({ isElevated: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
@@ -826,7 +826,7 @@ describe("WatcherController", () => {
     });
 
     it("no-ops when watcherRetryCount is zero (does not consume cap)", async () => {
-      const host = makeHost({ isCurrent: true });
+      const host = makeHost({ isElevated: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
       const result = ctrl.resetRetryBudget();
       expect(result).toBe(false);
@@ -845,7 +845,7 @@ describe("WatcherController", () => {
     it("capped at MAX_RESETS_PER_SESSION (3)", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
-      const host = makeHost({ isCurrent: true });
+      const host = makeHost({ isElevated: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
@@ -872,7 +872,7 @@ describe("WatcherController", () => {
     it("clears a pending retry timer", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
-      const host = makeHost({ isCurrent: true });
+      const host = makeHost({ isElevated: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
@@ -894,7 +894,7 @@ describe("WatcherController", () => {
     it("stop(true) resets both the retry budget and the session cap", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
-      const host = makeHost({ isCurrent: true });
+      const host = makeHost({ isElevated: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();
@@ -928,7 +928,7 @@ describe("WatcherController", () => {
     it("stop(false) preserves both the retry count and the session cap", async () => {
       mockRecursiveStartResult = false;
       mockGitOnlyStartResult = true;
-      const host = makeHost({ isCurrent: true });
+      const host = makeHost({ isElevated: true });
       const ctrl = new WatcherController(host as WatcherControllerHost);
 
       ctrl.start();

--- a/electron/workspace-host/__tests__/WorkspaceService.activeWorktreeEvents.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.activeWorktreeEvents.test.ts
@@ -34,6 +34,9 @@ vi.mock("../../utils/git.js", () => ({
 
 vi.mock("../../utils/gitUtils.js", () => ({
   getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  // null → the post-reconcile watcher self-heal (ensureTopologyWatcherAlive)
+  // no-ops, keeping these tests focused on event ordering.
+  getGitCommonDir: vi.fn().mockResolvedValue(null),
   clearGitDirCache: vi.fn(),
   clearGitCommonDirCache: vi.fn(),
 }));

--- a/electron/workspace-host/__tests__/WorkspaceService.agentActivity.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.agentActivity.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { resolve as pathResolve } from "path";
+import type { WorkspaceService } from "../WorkspaceService.js";
+import type { WorktreeMonitor } from "../WorktreeMonitor.js";
+import type { Worktree } from "../../../shared/types/worktree.js";
+
+// Records each GitFileWatcher construction so tests can assert which tier
+// (recursive vs git-only) the controller armed after an agent-activity flip.
+const watcherArms: Array<{ watchWorktree: boolean }> = [];
+
+vi.mock("../../utils/gitFileWatcher.js", () => ({
+  GitFileWatcher: class {
+    constructor(opts: { watchWorktree?: boolean } & Record<string, unknown>) {
+      watcherArms.push({ watchWorktree: opts.watchWorktree === true });
+    }
+    start() {
+      return Promise.resolve(true);
+    }
+    dispose() {}
+  },
+}));
+
+const mockSimpleGit = {
+  raw: vi.fn().mockResolvedValue(undefined),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+};
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  createWslHardenedGit: vi.fn(() => mockSimpleGit),
+  validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
+}));
+
+vi.mock("../../utils/git.js", () => ({
+  invalidateGitStatusCache: vi.fn(),
+  getWorktreeChangesWithStats: vi.fn().mockResolvedValue({
+    head: "abc123",
+    isDirty: false,
+    changedFileCount: 0,
+    changes: [],
+  }),
+}));
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue(null),
+  getGitCommonDir: vi.fn().mockReturnValue(null),
+  clearGitDirCache: vi.fn(),
+  clearGitCommonDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/worktree/mood.js", () => ({
+  categorizeWorktree: vi.fn().mockReturnValue("stable"),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../services/worktree/index.js", () => ({
+  AdaptivePollingStrategy: vi.fn(function () {
+    return {
+      getCurrentInterval: vi.fn().mockReturnValue(2000),
+      updateInterval: vi.fn(),
+      reportActivity: vi.fn(),
+      updateConfig: vi.fn(),
+      isCircuitBreakerTripped: vi.fn().mockReturnValue(false),
+      reset: vi.fn(),
+      setBaseInterval: vi.fn(),
+      calculateNextInterval: vi.fn().mockReturnValue(2000),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      recordNoChange: vi.fn(),
+      recordStateChange: vi.fn(),
+    };
+  }),
+  NoteFileReader: vi.fn(function () {
+    return { read: vi.fn().mockResolvedValue({}) };
+  }),
+}));
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: {
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    refresh: vi.fn(),
+    getStatus: vi.fn().mockReturnValue({
+      state: "idle",
+      isPolling: false,
+      candidateCount: 0,
+      resolvedCount: 0,
+      isEnabled: true,
+    }),
+  },
+}));
+
+const mockEvents = new EventEmitter();
+vi.mock("../../services/events.js", () => ({
+  events: mockEvents,
+}));
+
+vi.mock("fs/promises", () => ({
+  stat: vi.fn().mockResolvedValue({ birthtimeMs: 1000, ctimeMs: 1000 }),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  access: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  cp: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function wtPath(name: string): string {
+  return pathResolve(`/test/${name}`);
+}
+
+function createTestWorktree(name: string, overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: wtPath(name),
+    path: wtPath(name),
+    name,
+    branch: name,
+    isCurrent: false,
+    isMainWorktree: false,
+    gitDir: `${wtPath(name)}/.git`,
+    ...overrides,
+  };
+}
+
+describe("WorkspaceService agent-activity elevation", () => {
+  let service: WorkspaceService;
+  let WorktreeMonitorClass: typeof WorktreeMonitor;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    watcherArms.length = 0;
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(vi.fn() as any);
+    const WorktreeMonitorModule = await import("../WorktreeMonitor.js");
+    WorktreeMonitorClass = WorktreeMonitorModule.WorktreeMonitor;
+
+    service["projectRootPath"] = "/test/root";
+    service["git"] = mockSimpleGit as any;
+    service["gitWatchEnabled"] = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function registerMonitor(name: string, isCurrent = false): WorktreeMonitor {
+    const wt = createTestWorktree(name, { isCurrent });
+    const monitor = new WorktreeMonitorClass(
+      wt,
+      {
+        basePollingInterval: 10000,
+        adaptiveBackoff: false,
+        pollIntervalMax: 30000,
+        circuitBreakerThreshold: 3,
+        gitWatchEnabled: true,
+      },
+      { onUpdate: vi.fn() },
+      "main"
+    );
+    service["monitors"].set(wt.id, monitor);
+    monitor.startWithoutGitStatus();
+    return monitor;
+  }
+
+  function setActive(name: string): void {
+    service["activeWorktreeId"] = wtPath(name);
+  }
+
+  it("elevates a background monitor to the recursive watcher tier", () => {
+    const a = registerMonitor("a");
+    service["applyWatcherBudget"]();
+    expect(watcherArms.at(-1)).toEqual({ watchWorktree: false });
+
+    service.setAgentActivity([a.id]);
+
+    expect(a.agentActive).toBe(true);
+    // The elevation change rebuilt the watcher with recursive coverage.
+    expect(watcherArms.at(-1)).toEqual({ watchWorktree: true });
+  });
+
+  it("exempts agent-active worktrees from background budget eviction", () => {
+    service["backgroundGitWatcherCap"] = 1;
+    const active = registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    const c = registerMonitor("c");
+    setActive("active");
+    // Recency: a (LRU) → b → c (MRU). Under cap 1 only c would survive.
+    service["lruTouch"](a.id);
+    service["lruTouch"](b.id);
+    service["lruTouch"](c.id);
+
+    service.setAgentActivity([a.id]);
+
+    expect(active.hasWatcher).toBe(true);
+    expect(a.hasWatcher).toBe(true); // agent-active: exempt despite LRU-oldest
+    expect(b.hasWatcher).toBe(false); // pays the cap for the pool
+    expect(c.hasWatcher).toBe(true); // MRU keeps the single slot
+    expect(service["backgroundGitWatcherLru"].has(a.id)).toBe(false);
+  });
+
+  it("deactivation returns the worktree to the budget pool", () => {
+    service["backgroundGitWatcherCap"] = 1;
+    registerMonitor("active", true);
+    const a = registerMonitor("a");
+    const b = registerMonitor("b");
+    setActive("active");
+    service["lruTouch"](a.id);
+    service["lruTouch"](b.id);
+    service.setAgentActivity([a.id]);
+    expect(a.hasWatcher).toBe(true);
+    expect(service["backgroundGitWatcherLru"].has(a.id)).toBe(false);
+
+    service.setAgentActivity([]);
+
+    expect(a.agentActive).toBe(false);
+    // Re-enters the pool; as the freshest entry it holds the single slot and
+    // the older b stays evicted.
+    expect(service["backgroundGitWatcherLru"].has(a.id)).toBe(true);
+    expect(a.hasWatcher).toBe(true);
+    expect(b.hasWatcher).toBe(false);
+  });
+
+  it("monitors created after the broadcast inherit the agent-active flag", async () => {
+    service.setAgentActivity([wtPath("agent-made")]);
+
+    await service["addNewWorktreeMonitor"](createTestWorktree("agent-made"), false, true);
+
+    const monitor = service["monitors"].get(wtPath("agent-made"));
+    expect(monitor).toBeDefined();
+    expect(monitor!.agentActive).toBe(true);
+    expect(monitor!.hasWatcher).toBe(true);
+    // Armed recursive from the start — not a cold background git-only arm.
+    expect(watcherArms.at(-1)).toEqual({ watchWorktree: true });
+    expect(service["backgroundGitWatcherLru"].has(wtPath("agent-made"))).toBe(false);
+  });
+
+  it("setAgentActivity for an unknown worktree id is retained but harmless", () => {
+    const a = registerMonitor("a");
+    service.setAgentActivity([wtPath("not-yet-discovered")]);
+
+    expect(a.agentActive).toBe(false);
+    expect(service["agentActiveWorktreeIds"].has(wtPath("not-yet-discovered"))).toBe(true);
+  });
+
+  it("removing a monitor drops its agent-active flag (no stale elevation on recreate)", () => {
+    const a = registerMonitor("a");
+    service.setAgentActivity([a.id]);
+    expect(service["agentActiveWorktreeIds"].has(a.id)).toBe(true);
+
+    service["removeMonitor"](a.id);
+
+    expect(service["agentActiveWorktreeIds"].has(a.id)).toBe(false);
+  });
+
+  it("ignores malformed payloads instead of clearing every elevation", () => {
+    const a = registerMonitor("a");
+    service.setAgentActivity([a.id]);
+    expect(a.agentActive).toBe(true);
+
+    service.setAgentActivity(undefined as unknown as string[]);
+    expect(a.agentActive).toBe(true);
+
+    service.setAgentActivity([42, a.id] as unknown as string[]);
+    expect(a.agentActive).toBe(true);
+    expect(service["agentActiveWorktreeIds"].size).toBe(1);
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -644,17 +644,25 @@ describe("WorkspaceService external worktree removal", () => {
         .spyOn(service as any, "discoverAndSyncWorktrees")
         .mockResolvedValue(undefined);
 
-      service["setPollingEnabled"](false);
-
+      // Arm while enabled, then pause — the teardown races a late event from
+      // the (now dead) subscription, which must not reconcile.
       service["startTopologyWatcher"]();
       await vi.runAllTimersAsync();
+      const armedCallbacks = parcelWatcherCallbacks.length;
+      expect(armedCallbacks).toBeGreaterThan(0);
+      service["setPollingEnabled"](false);
 
-      parcelWatcherCallbacks[0]!(null, [
+      parcelWatcherCallbacks[armedCallbacks - 1]!(null, [
         { type: "delete", path: "/test/root/.git/worktrees/wt-1" },
       ]);
       await vi.advanceTimersByTimeAsync(350);
-
       expect(discoverSpy).not.toHaveBeenCalled();
+
+      // And a paused service never arms a watcher in the first place.
+      service["startTopologyWatcher"]();
+      await vi.runAllTimersAsync();
+      expect(parcelWatcherCallbacks.length).toBe(armedCallbacks);
+
       vi.useRealTimers();
     });
 

--- a/electron/workspace-host/__tests__/WorkspaceService.topologySentinel.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.topologySentinel.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+import { mkdtempSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { WorkspaceService } from "../WorkspaceService.js";
+
+// Real fs.watch drives the sentinel; only the parcel watcher (native FSEvents
+// subscription for the steady-state topology watcher) is stubbed.
+const parcelSubscriptions: Array<{ dir: string; unsubscribed: boolean }> = [];
+
+vi.mock("@parcel/watcher", () => ({
+  default: {
+    subscribe: vi.fn((dir: string) => {
+      const entry = { dir, unsubscribed: false };
+      parcelSubscriptions.push(entry);
+      return Promise.resolve({
+        unsubscribe: () => {
+          entry.unsubscribed = true;
+          return Promise.resolve();
+        },
+      });
+    }),
+  },
+}));
+
+const mockSimpleGit = {
+  raw: vi.fn().mockResolvedValue(undefined),
+  branch: vi.fn().mockResolvedValue({ current: "main" }),
+};
+
+vi.mock("simple-git", () => ({
+  simpleGit: vi.fn(() => mockSimpleGit),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: vi.fn(() => mockSimpleGit),
+  createWslHardenedGit: vi.fn(() => mockSimpleGit),
+  validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
+}));
+
+// getGitCommonDir points the metadata-dir resolution at the temp repo.
+let commonDir: string;
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: vi.fn().mockReturnValue(null),
+  getGitCommonDir: vi.fn(() => Promise.resolve(commonDir)),
+  clearGitDirCache: vi.fn(),
+  clearGitCommonDirCache: vi.fn(),
+}));
+
+vi.mock("../../services/PullRequestService.js", () => ({
+  pullRequestService: {
+    initialize: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    reset: vi.fn(),
+    refresh: vi.fn(),
+    getStatus: vi.fn().mockReturnValue({
+      state: "idle",
+      isPolling: false,
+      candidateCount: 0,
+      resolvedCount: 0,
+      isEnabled: true,
+    }),
+  },
+}));
+
+const mockEvents = new EventEmitter();
+vi.mock("../../services/events.js", () => ({
+  events: mockEvents,
+}));
+
+describe("WorkspaceService topology metadata sentinel", () => {
+  let service: WorkspaceService;
+  let tempRoot: string;
+  let metadataDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    parcelSubscriptions.length = 0;
+    tempRoot = mkdtempSync(join(tmpdir(), "daintree-topo-sentinel-"));
+    commonDir = join(tempRoot, ".git");
+    mkdirSync(commonDir, { recursive: true });
+    metadataDir = join(commonDir, "worktrees");
+
+    const WorkspaceServiceModule = await import("../WorkspaceService.js");
+    service = new WorkspaceServiceModule.WorkspaceService(vi.fn() as any);
+    service["projectRootPath"] = tempRoot;
+    service["git"] = mockSimpleGit as any;
+  });
+
+  afterEach(() => {
+    service["stopTopologyWatcher"]();
+    rmSync(tempRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("arms the sentinel instead of subscribing when .git/worktrees is absent", async () => {
+    await service["startTopologyWatcher"]();
+
+    expect(service["topologyMetadataSentinel"]).not.toBeNull();
+    expect(service["topologyWatcherSubscription"].value).toBeUndefined();
+    expect(parcelSubscriptions).toHaveLength(0);
+  });
+
+  it("hands off to the real watcher and schedules a reconcile when the dir appears", async () => {
+    const reconcileSpy = vi
+      .spyOn(service, "scheduleTopologyReconcile")
+      .mockImplementation(() => {});
+    await service["startTopologyWatcher"]();
+    expect(service["topologyMetadataSentinel"]).not.toBeNull();
+
+    // The first external `git worktree add` creates the metadata dir.
+    mkdirSync(metadataDir);
+
+    await vi.waitFor(
+      () => {
+        expect(reconcileSpy).toHaveBeenCalled();
+        expect(parcelSubscriptions).toHaveLength(1);
+      },
+      { timeout: 5000, interval: 25 }
+    );
+    expect(parcelSubscriptions[0]!.dir).toBe(metadataDir);
+    expect(service["topologyMetadataSentinel"]).toBeNull();
+  });
+
+  it("subscribes directly (no sentinel) when the dir already exists", async () => {
+    mkdirSync(metadataDir);
+
+    await service["startTopologyWatcher"]();
+    await vi.waitFor(() => {
+      expect(service["topologyWatcherSubscription"].value).toBeDefined();
+    });
+
+    expect(service["topologyMetadataSentinel"]).toBeNull();
+    expect(parcelSubscriptions).toHaveLength(1);
+  });
+
+  it("stopTopologyWatcher disarms a live sentinel", async () => {
+    await service["startTopologyWatcher"]();
+    expect(service["topologyMetadataSentinel"]).not.toBeNull();
+
+    service["stopTopologyWatcher"]();
+
+    expect(service["topologyMetadataSentinel"]).toBeNull();
+  });
+
+  it("ensureTopologyWatcherAlive drops a dead subscription once the dir vanished and re-arms the sentinel", async () => {
+    mkdirSync(metadataDir);
+    await service["startTopologyWatcher"]();
+    await vi.waitFor(() => {
+      expect(service["topologyWatcherSubscription"].value).toBeDefined();
+    });
+
+    // Last linked worktree removed → watch root gone; the parcel
+    // subscription goes silent without erroring.
+    rmSync(metadataDir, { recursive: true });
+
+    await service["ensureTopologyWatcherAlive"]();
+
+    expect(service["topologyWatcherSubscription"].value).toBeUndefined();
+    expect(service["topologyMetadataSentinel"]).not.toBeNull();
+  });
+
+  it("ensureTopologyWatcherAlive keeps a healthy subscription untouched", async () => {
+    mkdirSync(metadataDir);
+    await service["startTopologyWatcher"]();
+    await vi.waitFor(() => {
+      expect(service["topologyWatcherSubscription"].value).toBeDefined();
+    });
+    const before = service["topologyWatcherSubscription"].value;
+
+    await service["ensureTopologyWatcherAlive"]();
+
+    expect(service["topologyWatcherSubscription"].value).toBe(before);
+    expect(parcelSubscriptions).toHaveLength(1);
+  });
+});

--- a/electron/workspace-host/__tests__/WorkspaceService.topologySentinel.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.topologySentinel.test.ts
@@ -163,6 +163,25 @@ describe("WorkspaceService topology metadata sentinel", () => {
     expect(service["topologyMetadataSentinel"]).not.toBeNull();
   });
 
+  it("arms nothing while polling is paused (backgrounded app)", async () => {
+    mkdirSync(metadataDir);
+    service["pollingEnabled"] = false;
+
+    await service["startTopologyWatcher"]();
+    expect(service["topologyWatcherSubscription"].value).toBeUndefined();
+    expect(service["topologyMetadataSentinel"]).toBeNull();
+    expect(parcelSubscriptions).toHaveLength(0);
+
+    // The sentinel path is equally gated: absent dir + paused → no sentinel.
+    rmSync(metadataDir, { recursive: true });
+    await service["startTopologyWatcher"]();
+    expect(service["topologyMetadataSentinel"]).toBeNull();
+
+    await service["ensureTopologyWatcherAlive"]();
+    expect(service["topologyWatcherSubscription"].value).toBeUndefined();
+    expect(service["topologyMetadataSentinel"]).toBeNull();
+  });
+
   it("ensureTopologyWatcherAlive keeps a healthy subscription untouched", async () => {
     mkdirSync(metadataDir);
     await service["startTopologyWatcher"]();

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -1165,6 +1165,98 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
+    it("agentActive flip false→true upgrades a background watcher to recursive and forces a refresh", async () => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+      await flushInitialStatus();
+
+      expect(capturedWatcherOptions).toMatchObject({ watchWorktree: false });
+      const startsBeforeFlip = capturedWatcherOptionsHistory.length;
+      const statusCallsBefore = mockGetWorktreeChangesWithStats.mock.calls.length;
+
+      monitor.agentActive = true;
+
+      // Immediate upgrade — an agent's edits must stream without waiting.
+      expect(capturedWatcherOptionsHistory.length).toBe(startsBeforeFlip + 1);
+      expect(capturedWatcherOptionsHistory.at(-1)).toMatchObject({ watchWorktree: true });
+
+      // Activation also forces a status refresh so the card baselines now.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockGetWorktreeChangesWithStats.mock.calls.length).toBe(statusCallsBefore + 1);
+
+      monitor.stop();
+    });
+
+    it("losing focus while an agent works keeps the recursive watcher (elevation held)", async () => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(ACTIVE_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+      monitor.agentActive = true;
+      await vi.advanceTimersByTimeAsync(0);
+
+      const startsBeforeFlip = capturedWatcherOptionsHistory.length;
+      monitor.isCurrent = false;
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      // No rebuild: the working agent holds the elevation.
+      expect(capturedWatcherOptionsHistory.length).toBe(startsBeforeFlip);
+      expect(capturedWatcherOptionsHistory.at(-1)).toMatchObject({ watchWorktree: true });
+
+      monitor.stop();
+    });
+
+    it("agentActive set before start arms recursive and runs the initial status synchronously", async () => {
+      mockWatcherStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      // WorkspaceService.addNewWorktreeMonitor applies the retained
+      // agent-activity set before start() — e.g. a worktree the agent itself
+      // just created.
+      monitor.agentActive = true;
+      await monitor.start();
+
+      expect(capturedWatcherOptions).toMatchObject({ watchWorktree: true });
+      // Elevated start skips the 2-5s background jitter.
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      const startsBeforeFlip = capturedWatcherOptionsHistory.length;
+      monitor.agentActive = false;
+
+      // Downgrade settles behind the same delay as focus loss.
+      expect(capturedWatcherOptionsHistory.length).toBe(startsBeforeFlip);
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(capturedWatcherOptionsHistory.at(-1)).toMatchObject({ watchWorktree: false });
+
+      monitor.stop();
+    });
+
     it("watcher start failure schedules retry on active worktree", async () => {
       mockWatcherStartResult = false;
       mockGetWorktreeChangesWithStats.mockResolvedValue({
@@ -3210,6 +3302,59 @@ describe("WorktreeMonitor", () => {
       // cleared the baseline so the stat pre-check can't short-circuit.
       await monitor.updateGitStatus(false);
       expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(2);
+
+      monitor.stop();
+    });
+
+    it("forces a real check once the full-status budget expires without recursive coverage", async () => {
+      vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+      const callbacks = makeCallbacks();
+      // TEST_CONFIG has gitWatchEnabled: false — no watcher covers the
+      // working tree, the exact mode where the four statted .git files can
+      // never reflect an agent's unstaged edits.
+      const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, callbacks, "main");
+
+      await monitor.start();
+      await flushInitialStatus();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      // Within the budget the skip still applies…
+      await monitor.updateGitStatus(false);
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      // …but once the last FULL pass ages past the ceiling, a matching
+      // baseline no longer suppresses the real git check.
+      (monitor as unknown as { lastFullStatusAt: number }).lastFullStatusAt = Date.now() - 120_001;
+      await monitor.updateGitStatus(false);
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(2);
+
+      // The full pass reset the budget — the next poll skips again.
+      await monitor.updateGitStatus(false);
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(2);
+
+      monitor.stop();
+    });
+
+    it("an expired full-status budget does not bypass the skip under recursive coverage", async () => {
+      vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+      mockWatcherStartResult = true;
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(
+        { ...TEST_WORKTREE, isCurrent: true },
+        { ...TEST_CONFIG, gitWatchEnabled: true },
+        callbacks,
+        "main"
+      );
+
+      // Active monitors run the initial status synchronously in start().
+      await monitor.start();
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+
+      (monitor as unknown as { lastFullStatusAt: number }).lastFullStatusAt = Date.now() - 120_001;
+      await monitor.updateGitStatus(false);
+      // The recursive watcher observes every working-tree write and forces
+      // its own refreshes, so the stat skip stays trustworthy indefinitely.
+      expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
 
       monitor.stop();
     });

--- a/shared/types/worktree-port.ts
+++ b/shared/types/worktree-port.ts
@@ -48,6 +48,15 @@ export interface WorktreePortProtocol {
     payload: { worktreeId: string };
     result: { ok: true };
   };
+  // Full-replacement set of worktree IDs that currently have an agent
+  // actively producing work (agentState working/directing). The host elevates
+  // these monitors to the recursive watcher tier so their working-tree edits
+  // stream to the dashboard while backgrounded. Sent debounced by the
+  // renderer whenever the set changes, and re-sent after host restart.
+  "set-agent-activity": {
+    payload: { worktreeIds: string[] };
+    result: { ok: true };
+  };
   refresh: {
     payload: { worktreeId?: string };
     // `ok: false` (+ message) when the host's bounded refresh trips its overall

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ import {
   useThemeBrowserSettingsBridge,
   useErrorRetry,
   useActiveWorktreeSync,
+  useAgentActivityBroadcast,
 } from "./hooks/app";
 import { useResourceProfile } from "./hooks/useResourceProfile";
 import { AppLayout } from "./components/Layout";
@@ -584,6 +585,7 @@ function AppInner() {
   );
 
   const { activeWorktree, defaultTerminalCwd } = useActiveWorktreeSync();
+  useAgentActivityBroadcast();
   const resumeSession = useResumeAgentSession();
 
   const worktreePalette = useWorktreePalette({ worktrees });

--- a/src/hooks/app/__tests__/useAgentActivityBroadcast.test.tsx
+++ b/src/hooks/app/__tests__/useAgentActivityBroadcast.test.tsx
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { AgentState } from "@shared/types/agent";
+
+interface StubPanel {
+  id: string;
+  kind: string;
+  location?: string;
+  agentState?: AgentState;
+}
+
+interface StubState {
+  panelIdsByWorktreeId: Record<string, string[]>;
+  panelsById: Record<string, StubPanel>;
+}
+
+let storeState: StubState = { panelIdsByWorktreeId: {}, panelsById: {} };
+const storeListeners = new Set<() => void>();
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => storeState,
+    subscribe: (cb: () => void) => {
+      storeListeners.add(cb);
+      return () => storeListeners.delete(cb);
+    },
+  },
+}));
+
+import { useAgentActivityBroadcast } from "../useAgentActivityBroadcast";
+
+function setPanels(
+  panels: Array<{ worktreeId: string; agentState?: AgentState; location?: string; kind?: string }>
+): void {
+  const panelIdsByWorktreeId: Record<string, string[]> = {};
+  const panelsById: Record<string, StubPanel> = {};
+  panels.forEach((p, i) => {
+    const id = `panel-${i}`;
+    (panelIdsByWorktreeId[p.worktreeId] ??= []).push(id);
+    panelsById[id] = {
+      id,
+      kind: p.kind ?? "terminal",
+      location: p.location,
+      agentState: p.agentState,
+    };
+  });
+  storeState = { panelIdsByWorktreeId, panelsById };
+  storeListeners.forEach((cb) => cb());
+}
+
+const requestMock = vi.fn(() => Promise.resolve({ ok: true as const }));
+let readyCallback: (() => void) | null = null;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  requestMock.mockClear();
+  readyCallback = null;
+  storeState = { panelIdsByWorktreeId: {}, panelsById: {} };
+  storeListeners.clear();
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      request: requestMock,
+      onReady: (cb: () => void) => {
+        readyCallback = cb;
+        return () => {
+          readyCallback = null;
+        };
+      },
+    },
+  } as unknown as Window["electron"];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useAgentActivityBroadcast", () => {
+  it("broadcasts worktrees with working agents after the activation debounce", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([
+        { worktreeId: "/wt/b", agentState: "working" },
+        { worktreeId: "/wt/a", agentState: "directing" },
+        { worktreeId: "/wt/idle", agentState: "idle" },
+      ]);
+    });
+    expect(requestMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    expect(requestMock).toHaveBeenCalledExactlyOnceWith("set-agent-activity", {
+      worktreeIds: ["/wt/a", "/wt/b"],
+    });
+  });
+
+  it("ignores trashed panels and the unassigned bucket", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([
+        { worktreeId: "/wt/a", agentState: "working", location: "trash" },
+        { worktreeId: "__none__", agentState: "working" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it("a short working→waiting flap never reaches the host", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "working" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    // Permission prompt: working → waiting → (approved) → working, faster
+    // than the deactivation settle.
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "waiting" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "working" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+
+    expect(requestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("deactivation settles before broadcasting the removal", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "working" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "completed" }]);
+    });
+    // Not yet — the settle window absorbs flaps.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_000);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    expect(requestMock).toHaveBeenLastCalledWith("set-agent-activity", { worktreeIds: [] });
+  });
+
+  it("a second deactivation resets the settle window instead of riding the first one's tail", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([
+        { worktreeId: "/wt/a", agentState: "working" },
+        { worktreeId: "/wt/b", agentState: "working" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setPanels([
+        { worktreeId: "/wt/a", agentState: "completed" },
+        { worktreeId: "/wt/b", agentState: "working" },
+      ]);
+    });
+    // 4.9s into a's settle window, b also deactivates — it must get its own
+    // full window, not fire 100ms later on a's timer.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_900);
+    });
+    act(() => {
+      setPanels([
+        { worktreeId: "/wt/a", agentState: "completed" },
+        { worktreeId: "/wt/b", agentState: "waiting" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_900);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    expect(requestMock).toHaveBeenLastCalledWith("set-agent-activity", { worktreeIds: [] });
+  });
+
+  it("unrelated store churn does not reset a pending deactivation's settle window", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "working" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "completed" }]);
+    });
+    // Unrelated mutations every second (focus moves, pings) leave the busy
+    // set unchanged — the settle window must not restart each time.
+    for (let i = 0; i < 4; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+      act(() => {
+        setPanels([{ worktreeId: "/wt/a", agentState: "completed" }]);
+      });
+    }
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_100);
+    });
+
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    expect(requestMock).toHaveBeenLastCalledWith("set-agent-activity", { worktreeIds: [] });
+  });
+
+  it("retries a failed send without needing another store change", async () => {
+    requestMock.mockRejectedValueOnce(new Error("port timeout"));
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "working" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    // No further panel-store activity — the retry must self-schedule.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    expect(requestMock).toHaveBeenLastCalledWith("set-agent-activity", {
+      worktreeIds: ["/wt/a"],
+    });
+  });
+
+  it("unmount cancels pending sends and unsubscribes", async () => {
+    const { unmount } = renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "working" }]);
+    });
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    act(() => {
+      setPanels([{ worktreeId: "/wt/b", agentState: "working" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it("re-sends the current set when the port reconnects (host restart)", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([{ worktreeId: "/wt/a", agentState: "working" }]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    // Host restart: fresh epoch holds an empty agent-activity set.
+    act(() => {
+      readyCallback?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    expect(requestMock).toHaveBeenLastCalledWith("set-agent-activity", {
+      worktreeIds: ["/wt/a"],
+    });
+  });
+});

--- a/src/hooks/app/__tests__/useAgentActivityBroadcast.test.tsx
+++ b/src/hooks/app/__tests__/useAgentActivityBroadcast.test.tsx
@@ -287,6 +287,43 @@ describe("useAgentActivityBroadcast", () => {
     expect(requestMock).not.toHaveBeenCalled();
   });
 
+  it("port reconnect during a deactivation settle re-elevates on the fast path", async () => {
+    renderHook(() => useAgentActivityBroadcast());
+
+    act(() => {
+      setPanels([
+        { worktreeId: "/wt/a", agentState: "working" },
+        { worktreeId: "/wt/b", agentState: "working" },
+      ]);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(requestMock).toHaveBeenCalledTimes(1);
+
+    // a deactivates — a 5s settle timer is now pending for the reduced set.
+    act(() => {
+      setPanels([
+        { worktreeId: "/wt/a", agentState: "completed" },
+        { worktreeId: "/wt/b", agentState: "working" },
+      ]);
+    });
+    // Host restarts mid-settle. The fresh host holds an empty set, so the
+    // still-working b is an ACTIVATION now — it must not ride out the
+    // remaining settle window unelevated.
+    act(() => {
+      readyCallback?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    expect(requestMock).toHaveBeenLastCalledWith("set-agent-activity", {
+      worktreeIds: ["/wt/b"],
+    });
+  });
+
   it("re-sends the current set when the port reconnects (host restart)", async () => {
     renderHook(() => useAgentActivityBroadcast());
 

--- a/src/hooks/app/index.ts
+++ b/src/hooks/app/index.ts
@@ -17,6 +17,7 @@ export { useAppEventListeners } from "./useAppEventListeners";
 export { useThemeBrowserSettingsBridge } from "./useThemeBrowserSettingsBridge";
 export { useErrorRetry } from "./useErrorRetry";
 export { useActiveWorktreeSync } from "./useActiveWorktreeSync";
+export { useAgentActivityBroadcast } from "./useAgentActivityBroadcast";
 export { useOrchestrationMilestones } from "./useOrchestrationMilestones";
 export { useAgentWaitingNudge } from "./useAgentWaitingNudge";
 export { useForgeEnableRecommendation } from "./useForgeEnableRecommendation";

--- a/src/hooks/app/useAgentActivityBroadcast.ts
+++ b/src/hooks/app/useAgentActivityBroadcast.ts
@@ -43,8 +43,23 @@ function computeBusyWorktreeIds(): string[] {
  */
 export function useAgentActivityBroadcast(): void {
   useEffect(() => {
+    // Keys are JSON-encoded sorted id arrays — collision-safe for any path
+    // characters (a newline join would let pathological ids alias a set).
+    const EMPTY_KEY = JSON.stringify([]);
+    const keyToIds = (key: string): string[] => {
+      const raw = key.startsWith("unsent:") ? key.slice("unsent:".length) : key;
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        return Array.isArray(parsed)
+          ? parsed.filter((id): id is string => typeof id === "string")
+          : [];
+      } catch {
+        return [];
+      }
+    };
+
     // The host starts every session/epoch with an empty set.
-    let lastSentKey = "";
+    let lastSentKey = EMPTY_KEY;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let timerKind: "activation" | "deactivation" | null = null;
     // The busy-set key the pending timer was scheduled for. Re-evaluations
@@ -67,7 +82,7 @@ export function useAgentActivityBroadcast(): void {
       clearTimer();
       if (disposed) return;
       const ids = computeBusyWorktreeIds();
-      const key = ids.join("\n");
+      const key = JSON.stringify(ids);
       if (key === lastSentKey) return;
       lastSentKey = key;
       window.electron.worktreePort.request("set-agent-activity", { worktreeIds: ids }).catch(() => {
@@ -100,7 +115,8 @@ export function useAgentActivityBroadcast(): void {
     };
 
     const evaluate = () => {
-      const key = computeBusyWorktreeIds().join("\n");
+      const ids = computeBusyWorktreeIds();
+      const key = JSON.stringify(ids);
       if (key === lastSentKey) {
         clearTimer();
         return;
@@ -109,15 +125,19 @@ export function useAgentActivityBroadcast(): void {
       if (timer && pendingKey === key) {
         return;
       }
-      const lastIds = new Set(lastSentKey.split("\n").filter(Boolean));
-      const hasActivation = key.split("\n").some((id) => id !== "" && !lastIds.has(id));
+      const lastIds = new Set(keyToIds(lastSentKey));
+      const hasActivation = ids.some((id) => !lastIds.has(id));
       scheduleSend(hasActivation ? "activation" : "deactivation", key);
     };
 
     const unsubscribe = usePanelStore.subscribe(evaluate);
     const offReady = window.electron.worktreePort.onReady(() => {
-      // Fresh host epoch — its agent-activity set is empty again.
-      lastSentKey = "";
+      // Fresh host epoch — its agent-activity set is empty again. Drop any
+      // pending timer too: relative to the empty host, every still-busy
+      // worktree is an activation and must go out on the fast path, not ride
+      // out the tail of a pre-restart deactivation settle.
+      lastSentKey = EMPTY_KEY;
+      clearTimer();
       evaluate();
     });
     evaluate();

--- a/src/hooks/app/useAgentActivityBroadcast.ts
+++ b/src/hooks/app/useAgentActivityBroadcast.ts
@@ -1,0 +1,132 @@
+import { useEffect } from "react";
+import { usePanelStore } from "@/store/panelStore";
+import { isPtyPanel } from "@shared/types/panel";
+import { NO_WORKTREE } from "@/store/slices/panelRegistry/worktreeIndex";
+
+// Fleet launches start several agents within a beat of each other — a short
+// leading debounce coalesces them into one port request.
+const ACTIVATION_DEBOUNCE_MS = 250;
+// Agents flap working ↔ waiting on permission prompts. Keeping a worktree
+// elevated through short pauses avoids watcher teardown/re-arm churn in the
+// host; the deactivation refresh (which lands the agent's final diff) is
+// delayed by at most this settle.
+const DEACTIVATION_SETTLE_MS = 5_000;
+
+function computeBusyWorktreeIds(): string[] {
+  const state = usePanelStore.getState();
+  const busy: string[] = [];
+  for (const [worktreeId, panelIds] of Object.entries(state.panelIdsByWorktreeId)) {
+    if (worktreeId === NO_WORKTREE) continue;
+    for (const id of panelIds) {
+      const panel = state.panelsById[id];
+      if (!panel || !isPtyPanel(panel)) continue;
+      if (panel.location === "trash") continue;
+      if (panel.agentState === "working" || panel.agentState === "directing") {
+        busy.push(worktreeId);
+        break;
+      }
+    }
+  }
+  return busy.sort();
+}
+
+/**
+ * Streams the set of worktrees with actively working agents to the
+ * workspace-host (`set-agent-activity`). The host elevates those monitors to
+ * the recursive file-watcher tier so their working-tree edits reach the
+ * dashboard in near-real-time while backgrounded — without this, an agent's
+ * uncommitted edits in a non-focused worktree are invisible to the `.git/`-
+ * only watcher and can sit stale for minutes.
+ *
+ * Activations flush fast; deactivations settle so permission-prompt flaps
+ * don't churn watchers. Re-sends after a host restart via `onReady`.
+ */
+export function useAgentActivityBroadcast(): void {
+  useEffect(() => {
+    // The host starts every session/epoch with an empty set.
+    let lastSentKey = "";
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let timerKind: "activation" | "deactivation" | null = null;
+    // The busy-set key the pending timer was scheduled for. Re-evaluations
+    // that land on the same key leave the timer alone — otherwise unrelated
+    // panel-store churn (focus moves, pings) would keep resetting a pending
+    // deactivation's settle window and starve the send.
+    let pendingKey: string | null = null;
+    let disposed = false;
+
+    const clearTimer = () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      timerKind = null;
+      pendingKey = null;
+    };
+
+    const send = () => {
+      clearTimer();
+      if (disposed) return;
+      const ids = computeBusyWorktreeIds();
+      const key = ids.join("\n");
+      if (key === lastSentKey) return;
+      lastSentKey = key;
+      window.electron.worktreePort.request("set-agent-activity", { worktreeIds: ids }).catch(() => {
+        if (disposed || lastSentKey !== key) return;
+        // Host restarting or transiently unreachable. Mark unsent so the
+        // comparison can't believe the host holds this state, and retry on
+        // our own clock — a quiet store never re-evaluates otherwise.
+        lastSentKey = `unsent:${key}`;
+        scheduleSend("deactivation", key);
+      });
+    };
+
+    const scheduleSend = (kind: "activation" | "deactivation", key: string) => {
+      if (timer) {
+        // A pending activation timer is the soonest send possible and its
+        // send() recomputes the full set, so it covers any later change.
+        if (timerKind === "activation") return;
+        // Pending deactivation: an activation upgrades it to the fast path;
+        // a DIFFERENT deactivation resets the settle window so every removal
+        // gets the full flap-absorption interval, not the tail of an
+        // earlier removal's window.
+        clearTimeout(timer);
+      }
+      timerKind = kind;
+      pendingKey = key;
+      timer = setTimeout(
+        send,
+        kind === "activation" ? ACTIVATION_DEBOUNCE_MS : DEACTIVATION_SETTLE_MS
+      );
+    };
+
+    const evaluate = () => {
+      const key = computeBusyWorktreeIds().join("\n");
+      if (key === lastSentKey) {
+        clearTimer();
+        return;
+      }
+      // A live timer already targeting this exact state needs no reschedule.
+      if (timer && pendingKey === key) {
+        return;
+      }
+      const lastIds = new Set(lastSentKey.split("\n").filter(Boolean));
+      const hasActivation = key.split("\n").some((id) => id !== "" && !lastIds.has(id));
+      scheduleSend(hasActivation ? "activation" : "deactivation", key);
+    };
+
+    const unsubscribe = usePanelStore.subscribe(evaluate);
+    const offReady = window.electron.worktreePort.onReady(() => {
+      // Fresh host epoch — its agent-activity set is empty again.
+      lastSentKey = "";
+      evaluate();
+    });
+    evaluate();
+
+    return () => {
+      disposed = true;
+      clearTimer();
+      unsubscribe();
+      offReady();
+    };
+  }, []);
+}


### PR DESCRIPTION
I noticed git status updates were slow, and in the worst case a worktree an agent had just created never showed its changes at all. I spent some time digging through the whole watching/monitoring pipeline and found three separate problems all contributing to it.

## Unstaged agent edits in background worktrees never surfaced

Only the focused worktree gets a recursive working-tree watcher. Background worktrees get a cheap `.git/`-only watcher, which is fine for commits and staging, but plain file edits never touch `.git`. The 300s fallback poll should have caught those, except the stat pre-check in `WorktreeMonitor.updateGitStatus()` only stats four `.git` metadata files (`index`, `HEAD`, `refs/heads/<branch>`, `packed-refs`). Unstaged edits change none of them, so every poll skipped the real `git status` forever. An agent editing files in a background worktree was invisible until it staged or committed something.

## The first external `git worktree add` took up to 90 seconds to appear

`startTopologyWatcher()` no-ops when `.git/worktrees/` doesn't exist yet, which is exactly the state of a project with zero linked worktrees. Nothing ever re-invoked it, so when an agent ran `git worktree add`, discovery fell back to the 90s safety reconcile for the entire session. This is the "create a new branch and worktree" case that started this investigation.

## Nothing connected agent activity to git monitoring

The host had no idea which worktrees had agents actively producing work, so it couldn't prioritise them. Watching agents work across worktrees is the core loop of the product, and the freshest data went to the one worktree the user was focused on instead.

## The fix

The watcher tier is now driven by elevation, meaning focused OR agent-active. The renderer broadcasts which worktrees have agents in `working`/`directing` state over the existing worktree MessagePort (new `set-agent-activity` action, debounced 250ms on activation, 5s settle on deactivation so permission-prompt flaps don't churn watchers). The host gives those worktrees the same recursive watcher as the focused one, exempt from the background watcher budget, and forces a status refresh on both activity edges so the final diff lands the moment an agent finishes. The set is retained, so a worktree the agent just created inherits the flag before its monitor first arms.

For discovery, a cheap `fs.watch` sentinel on the common git dir now waits for `.git/worktrees/` to appear, then hands off to the real parcel watcher and reconciles immediately. `ensureTopologyWatcherAlive()` runs after every reconcile to catch the reverse case too (watch root deleted when the last worktree is removed leaves the subscription silently dead).

As a backstop for anything still unwatched, the stat fast path can now only mask working-tree edits for 120s (`FULL_STATUS_MAX_AGE_MS`). Recursive-watched worktrees are exempt since their watcher observes every write.

## No main-thread offloading needed

I went in expecting to move git work off the main thread, but it's already done right: everything runs in the per-project workspace-host utility process, and snapshots go straight to the renderer over dedicated MessagePorts without touching main. So there was nothing to offload, the latency was all watcher tiering and the stat-skip hole.

## Tests

Added coverage for the elevation logic (`WorktreeMonitor`, `WatcherController`, `WorkspaceService` budget exemption and inheritance), the bounded-staleness rule, the topology sentinel lifecycle, and the renderer broadcast hook (debounce, settle-window reset, retry on failure, unmount cleanup). Full `npm run check` and the workspace-host suite (33 files, 712 tests) are green.

