### PR TITLE
Fix 45-60s renderer lockup when revealing a project view with backlogged terminals

### DIFF
--- a/src/services/terminal/TerminalResizeController.ts
+++ b/src/services/terminal/TerminalResizeController.ts
@@ -2,7 +2,7 @@ import { Terminal } from "@xterm/xterm";
 import { terminalClient } from "@/clients";
 import { TerminalRefreshTier } from "@/types";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
-import { logError } from "@/utils/logger";
+import { logError, logWarn } from "@/utils/logger";
 import type { ManagedTerminal } from "./types";
 import type { TerminalOutputIngestService } from "./TerminalOutputIngestService";
 
@@ -10,6 +10,24 @@ const START_DEBOUNCING_THRESHOLD = 200;
 const RESIZE_DEBOUNCE_MS = 100;
 const RESIZE_LOCK_TTL_MS = 5000;
 const SETTLED_RESIZE_DELAY_MS = 500;
+
+/**
+ * Max held ingest bytes a resize may force-flush into xterm synchronously.
+ * `terminal.resize()` parses xterm's ENTIRE write buffer in one unyielding
+ * main-thread task before reflowing (`CoreTerminal.resize` →
+ * `WriteBuffer.flushSync`), so the pre-resize `flushForTerminal` — which
+ * deliberately bypasses the ingest in-flight watermark — must stay bounded. A
+ * project view hidden for minutes accumulates its agents' entire output in
+ * the ingest queue (hidden-page timer throttling stalls xterm's parse pump
+ * while MessagePort chunks keep arriving), and the reveal-time
+ * ResizeObserver resize then detonated that backlog as a 45-60s renderer
+ * lockup (2026-07-06: UI dead, MCP dispatches through the active view timing
+ * out). Past this budget the backlog skips the flush and drains watermarked
+ * at the new grid instead — the same wrap outcome as output arriving just
+ * after a resize, without the synchronous parse; the PTY SIGWINCH repaint
+ * corrects any TUI framing either way.
+ */
+export const RESIZE_FLUSH_SYNC_BUDGET_BYTES = 1024 * 1024;
 
 /** Narrow structural type for the private xterm.js internals we access. */
 interface XtermCoreRenderDimensions {
@@ -487,8 +505,7 @@ export class TerminalResizeController {
       return;
     }
 
-    this.deps.dataBuffer.flushForTerminal(id);
-    this.deps.dataBuffer.resetForTerminal(id);
+    const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
 
     if (this.getResizeStrategy(managed) === "settled") {
       // For settled agents, defer xterm.js resize to fire atomically
@@ -503,9 +520,35 @@ export class TerminalResizeController {
       this.sendPtyResize(id, cols, rows);
     }
 
+    if (!flushedHeldBytes) {
+      this.deps.dataBuffer.resumeFlush(id);
+    }
+
     if (managed.latestWasAtBottom && !managed.isUserScrolledBack) {
       managed.terminal.scrollToBottom();
     }
+  }
+
+  /**
+   * Bounded pre-resize flush. Returns true when held ingest bytes were
+   * flushed into xterm (they parse at the outgoing grid inside `resize()`'s
+   * flushSync); false when the backlog exceeded
+   * {@link RESIZE_FLUSH_SYNC_BUDGET_BYTES} and was left queued — the caller
+   * must `resumeFlush` after the resize so the backlog drains watermarked at
+   * the new grid. The reset only runs on the flush path: `resetForTerminal`
+   * deletes the queue, so resetting a held backlog would drop output.
+   */
+  private flushHeldBytesBeforeResize(id: string): boolean {
+    const queuedBytes = this.deps.dataBuffer.getQueuedBytes(id);
+    if (queuedBytes > RESIZE_FLUSH_SYNC_BUDGET_BYTES) {
+      logWarn(
+        `[TerminalResizeController] ${id}: ${queuedBytes} held ingest bytes exceed the pre-resize flush budget — draining watermarked at the new grid instead`
+      );
+      return false;
+    }
+    this.deps.dataBuffer.flushForTerminal(id);
+    this.deps.dataBuffer.resetForTerminal(id);
+    return true;
   }
 
   clearResizeJob(managed: ManagedTerminal): void {
@@ -591,10 +634,12 @@ export class TerminalResizeController {
             const current = this.deps.getInstance(id);
             if (current) {
               current.resizeJob = undefined;
-              this.deps.dataBuffer.flushForTerminal(id);
-              this.deps.dataBuffer.resetForTerminal(id);
+              const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
               this.resizeTerminal(current, current.latestCols, current.latestRows);
               this.sendPtyResize(id, current.latestCols, current.latestRows);
+              if (!flushedHeldBytes) {
+                this.deps.dataBuffer.resumeFlush(id);
+              }
             }
           },
           { priority: "background", signal: controller.signal }
@@ -608,10 +653,12 @@ export class TerminalResizeController {
         const current = this.deps.getInstance(id);
         if (current) {
           current.resizeDebounceTimer = undefined;
-          this.deps.dataBuffer.flushForTerminal(id);
-          this.deps.dataBuffer.resetForTerminal(id);
+          const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
           this.resizeTerminal(current, current.latestCols, current.latestRows);
           this.sendPtyResize(id, current.latestCols, current.latestRows);
+          if (!flushedHeldBytes) {
+            this.deps.dataBuffer.resumeFlush(id);
+          }
         }
       }, 0) as unknown as number;
       managed.resizeDebounceTimer = timerId;
@@ -630,10 +677,12 @@ export class TerminalResizeController {
         // and we must not write mid-transition. The lock release path will
         // requeue via batchResize when it ends.
         if (this.isResizeLocked(id)) return;
-        this.deps.dataBuffer.flushForTerminal(id);
-        this.deps.dataBuffer.resetForTerminal(id);
+        const flushedHeldBytes = this.flushHeldBytesBeforeResize(id);
         this.resizeTerminal(current, cols, rows);
         this.sendPtyResize(id, cols, rows);
+        if (!flushedHeldBytes) {
+          this.deps.dataBuffer.resumeFlush(id);
+        }
       }
     }, RESIZE_DEBOUNCE_MS) as unknown as number;
     managed.resizeDebounceTimer = timeoutId;

--- a/src/services/terminal/__tests__/TerminalResizeController.test.ts
+++ b/src/services/terminal/__tests__/TerminalResizeController.test.ts
@@ -24,6 +24,7 @@ import {
   TerminalResizeController,
   getXtermCellDimensions,
   REVEAL_REWRAP_QUIESCENT_MS,
+  RESIZE_FLUSH_SYNC_BUDGET_BYTES,
   type ResizeControllerDeps,
 } from "../TerminalResizeController";
 
@@ -137,6 +138,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -164,6 +167,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -190,6 +195,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -222,6 +229,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -255,6 +264,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -274,6 +285,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal,
         resetForTerminal,
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -285,6 +298,99 @@ describe("TerminalResizeController", () => {
     expect(resizeMock).toHaveBeenCalledWith("term-1", 132, 41);
   });
 
+  describe("pre-resize flush budget", () => {
+    function makeBudgetDeps(queuedBytes: number) {
+      return {
+        flushForTerminal: vi.fn(),
+        resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => queuedBytes),
+        resumeFlush: vi.fn(),
+      };
+    }
+
+    it("flushes and resets when held bytes are at the budget", () => {
+      const managed = createManagedTerminal();
+      const dataBuffer = makeBudgetDeps(RESIZE_FLUSH_SYNC_BUDGET_BYTES);
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: dataBuffer as any,
+      });
+
+      controller.applyResize("term-1", 132, 41);
+
+      expect(dataBuffer.flushForTerminal).toHaveBeenCalledWith("term-1");
+      expect(dataBuffer.resetForTerminal).toHaveBeenCalledWith("term-1");
+      expect(dataBuffer.resumeFlush).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledWith(132, 41);
+    });
+
+    it("skips the flush AND the reset past the budget, still resizes, then resumes the watermarked drain", () => {
+      // A queue-deleting reset without the flush would drop the held output —
+      // the skip path must leave the backlog queued for resumeFlush.
+      const managed = createManagedTerminal();
+      const dataBuffer = makeBudgetDeps(RESIZE_FLUSH_SYNC_BUDGET_BYTES + 1);
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: dataBuffer as any,
+      });
+
+      controller.applyResize("term-1", 132, 41);
+
+      expect(dataBuffer.flushForTerminal).not.toHaveBeenCalled();
+      expect(dataBuffer.resetForTerminal).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalledWith(132, 41);
+      expect(resizeMock).toHaveBeenCalledWith("term-1", 132, 41);
+      expect(dataBuffer.resumeFlush).toHaveBeenCalledWith("term-1");
+    });
+
+    it("resumes the drain on the skip path even when the xterm resize is settled-deferred", () => {
+      const managed = createManagedTerminal();
+      managed.launchAgentId = "codex";
+      managed.runtimeAgentId = "codex";
+      getEffectiveAgentConfigMock.mockReturnValue({
+        capabilities: { resizeStrategy: "settled" },
+      });
+      const dataBuffer = makeBudgetDeps(RESIZE_FLUSH_SYNC_BUDGET_BYTES + 1);
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: dataBuffer as any,
+      });
+
+      controller.applyResize("term-1", 132, 41);
+
+      // The settled timer owns the xterm+PTY resize, but the held backlog must
+      // not wait 500ms to start draining.
+      expect(dataBuffer.flushForTerminal).not.toHaveBeenCalled();
+      expect(dataBuffer.resumeFlush).toHaveBeenCalledWith("term-1");
+      vi.advanceTimersByTime(500);
+      expect(managed.terminal.resize).toHaveBeenCalledWith(132, 41);
+    });
+
+    it("applies the budget on the debounced resize path", () => {
+      const managed = createManagedTerminal();
+      Object.assign(managed.terminal, {
+        _core: { _renderService: { dimensions: { css: { cell: { width: 10, height: 20 } } } } },
+      });
+      const dataBuffer = makeBudgetDeps(RESIZE_FLUSH_SYNC_BUDGET_BYTES + 1);
+      const controller = new TerminalResizeController({
+        getInstance: vi.fn(() => managed),
+        dataBuffer: dataBuffer as any,
+      });
+
+      // Unfocused + visible + deep buffer → resize() takes the debounce path
+      // instead of applyResize.
+      managed.isFocused = false;
+      managed.terminal.buffer.active.length = 5000;
+      controller.resize("term-1", 1600, 800);
+      vi.advanceTimersByTime(200);
+
+      expect(dataBuffer.flushForTerminal).not.toHaveBeenCalled();
+      expect(dataBuffer.resetForTerminal).not.toHaveBeenCalled();
+      expect(managed.terminal.resize).toHaveBeenCalled();
+      expect(dataBuffer.resumeFlush).toHaveBeenCalledWith("term-1");
+    });
+  });
+
   it("lockResize with custom TTL expires after specified duration", () => {
     const managed = createManagedTerminal();
     const controller = new TerminalResizeController({
@@ -292,6 +398,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -312,6 +420,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -332,6 +442,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -354,6 +466,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -379,6 +493,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -401,6 +517,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -428,6 +546,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -465,6 +585,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -495,6 +617,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -515,6 +639,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as unknown as ResizeControllerDeps["dataBuffer"],
     });
 
@@ -537,6 +663,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as unknown as ResizeControllerDeps["dataBuffer"],
     });
 
@@ -554,6 +682,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as unknown as ResizeControllerDeps["dataBuffer"],
     });
 
@@ -578,6 +708,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -608,6 +740,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -631,6 +765,8 @@ describe("TerminalResizeController", () => {
       dataBuffer: {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as any,
     });
 
@@ -652,6 +788,8 @@ describe("TerminalResizeController", () => {
     const dataBuffer = {
       flushForTerminal: vi.fn(),
       resetForTerminal: vi.fn(),
+      getQueuedBytes: vi.fn(() => 0),
+      resumeFlush: vi.fn(),
     } as unknown as ResizeControllerDeps["dataBuffer"];
 
     getEffectiveAgentConfigMock.mockReturnValue({
@@ -681,6 +819,8 @@ describe("TerminalResizeController", () => {
     const dataBuffer = {
       flushForTerminal: vi.fn(),
       resetForTerminal: vi.fn(),
+      getQueuedBytes: vi.fn(() => 0),
+      resumeFlush: vi.fn(),
     } as unknown as ResizeControllerDeps["dataBuffer"];
 
     const controller = new TerminalResizeController({
@@ -799,6 +939,8 @@ describe("TerminalResizeController", () => {
       return {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as unknown as ResizeControllerDeps["dataBuffer"];
     }
 
@@ -1002,6 +1144,8 @@ describe("TerminalResizeController", () => {
       return {
         flushForTerminal: vi.fn(),
         resetForTerminal: vi.fn(),
+        getQueuedBytes: vi.fn(() => 0),
+        resumeFlush: vi.fn(),
       } as unknown as ResizeControllerDeps["dataBuffer"];
     }
 
@@ -1143,6 +1287,8 @@ describe("TerminalResizeController", () => {
         dataBuffer: {
           flushForTerminal: vi.fn(),
           resetForTerminal: vi.fn(),
+          getQueuedBytes: vi.fn(() => 0),
+          resumeFlush: vi.fn(),
         } as any,
       });
     }
@@ -1302,6 +1448,8 @@ describe("TerminalResizeController", () => {
         dataBuffer: {
           flushForTerminal: vi.fn(),
           resetForTerminal: vi.fn(),
+          getQueuedBytes: vi.fn(() => 0),
+          resumeFlush: vi.fn(),
         } as any,
       });
     }
@@ -1572,7 +1720,12 @@ describe("TerminalResizeController", () => {
     function makeCtl(managed: ReturnType<typeof createManagedTerminal>) {
       return new TerminalResizeController({
         getInstance: vi.fn(() => managed),
-        dataBuffer: { flushForTerminal: vi.fn(), resetForTerminal: vi.fn() } as any,
+        dataBuffer: {
+          flushForTerminal: vi.fn(),
+          resetForTerminal: vi.fn(),
+          getQueuedBytes: vi.fn(() => 0),
+          resumeFlush: vi.fn(),
+        } as any,
       });
     }
 


### PR DESCRIPTION
When I switched back to a project view that had been hidden for about six minutes while four agent terminals kept streaming, the entire interface locked up for 45 to 60 seconds at a time. Main process and pty-host were completely healthy the whole time (no backpressure pauses, no pending bytes), so this was purely a renderer main-thread wedge. Diagnosed from a diagnostics capture taken during the hang plus the app and MCP logs: every MCP call routed through the active view stalled the instant the view was revealed, which is what made the timeline so clear.

The mechanism has two halves:

1. **Accumulate.** While a view is hidden, Chromium throttles page timers, which stalls xterm's `setTimeout`-driven parse pump. MessagePort chunks keep arriving, so output piles up in the `TerminalOutputIngestService` queue. The queue is unbounded, and acks are parse-gated, so minutes of agent output just sit there.
2. **Detonate.** On reveal, the grid re-layout fires `applyResize`, which called `flushForTerminal()` (a force-drain that deliberately bypasses the 128KB in-flight watermark) and then `terminal.resize()`. xterm's `CoreTerminal.resize()` calls `WriteBuffer.flushSync()`, which parses everything just dumped in one unyielding main-thread task, then reflows the whole buffer. Multiply by five terminals and the view is dead for the better part of a minute.

The fix caps the pre-resize flush at `RESIZE_FLUSH_SYNC_BUDGET_BYTES` (1MB) across all four call sites in `TerminalResizeController`. Past the budget we skip the flush and the queue-deleting `resetForTerminal()` (resetting a held backlog would drop output), let the resize proceed (its `flushSync` then only sees the watermark-bounded in-flight bytes), and kick `resumeFlush()` so the backlog drains incrementally with scheduler yields at the new grid. That's the same wrap outcome as output arriving just after a resize, without the synchronous parse. No data loss, and the skip logs a warning so the next occurrence is visible.

Worst case reveal now costs roughly 50 to 250ms per pane instead of a frozen minute, and the catch-up parse interleaves with input and MCP dispatches instead of blocking them.

Testing: four new unit tests (budget boundary, skip preserves the queue, settled-strategy skip still resumes the drain, debounced path), all 78 `TerminalResizeController` tests pass, 142 adjacent terminal suites pass, and `npm run check` is green.

Deliberately out of scope: bounding the hidden-view ingest queue itself and parse-while-hidden pacing. Those belong to the data-plane work landing separately.
