### PR TITLE
Micro-animation polish across the UI

### DIFF
--- a/docs/themes/interaction-state-recipes.md
+++ b/docs/themes/interaction-state-recipes.md
@@ -187,8 +187,10 @@ This document maps each interactive component role to its canonical Tailwind cla
 | Color/bg/border changes | `transition-colors` | Covers color, background-color, border-color for most interactive states |
 | Width/height changes | `transition-[width]` / `transition-[height]` | Layout-impacting properties should be explicit |
 | Opacity changes | `transition-opacity` | Visual fades only |
-| Transform changes | `transition-transform` | Animations, scale effects |
-| Multiple props | `transition-[color,background-color,transform]` | Explicit is better than `transition-all` — forces all props to interpolate |
+| Transform changes | `transition-transform` | Covers `transform`, `translate`, `scale`, `rotate` — safe for all transform utilities |
+| Multiple props | `transition-[color,background-color,translate]` | Explicit is better than `transition-all` — forces all props to interpolate |
+
+**Tailwind v4 trap:** `translate-*`, `scale-*`, and `rotate-*` utilities emit the individual `translate`/`scale`/`rotate` CSS properties, NOT `transform`. An arbitrary list like `transition-[opacity,transform]` silently skips them (the motion snaps while only the fade runs). In arbitrary lists, name the individual properties you animate (`transition-[opacity,translate,scale]`); only an inline `style={{ transform: ... }}` string is covered by `transform`. Same for reduced-motion neutralizers: `transform-none` does not reset `translate`/`scale` — use `translate-none` / `scale-none`.
 
 ---
 

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -96,7 +96,7 @@ function ModeChip({ label, isVisible, id }: ModeChipProps) {
       className={cn(
         "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-[var(--radius-sm)]",
         "bg-overlay-subtle text-xs text-daintree-text/70 select-none shrink-0 origin-left",
-        "transition-[opacity,transform] motion-reduce:transition-opacity motion-reduce:scale-100",
+        "transition-[opacity,scale] motion-reduce:transition-opacity motion-reduce:scale-100",
         isVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"
       )}
       style={{

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import {
   Moon,
   Layers,
@@ -12,7 +12,9 @@ import {
 import { useShallow } from "zustand/react/shallow";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useExitLaggedCount } from "@/hooks/useExitLaggedCount";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store";
@@ -245,138 +247,152 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
     setKillConfirmId(null);
   }, [killConfirmId, removePanel, terminals]);
 
-  if (terminals.length === 0) return null;
-
   const count = terminals.length;
+  // Lagged count keeps the label stable while the pill fades out via the
+  // .dock-status-pill exit transition instead of flashing "(0)".
+  const displayCount = useExitLaggedCount(count);
   const triggerLabel =
-    waitingCount > 0 ? `Background (${count} · ${waitingCount} waiting)` : `Background (${count})`;
+    waitingCount > 0
+      ? `Background (${displayCount} · ${waitingCount} waiting)`
+      : `Background (${displayCount})`;
+
+  useEffect(() => {
+    if (count === 0) {
+      setIsOpen(false);
+      setKillConfirmId(null);
+    }
+  }, [count]);
 
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="pill"
-          size="sm"
-          className={cn(
-            compact ? "px-1.5 min-w-0" : "px-3",
-            isOpen && "bg-overlay-emphasis border-border-default"
-          )}
-          aria-haspopup="dialog"
-          aria-expanded={isOpen}
-          aria-controls="background-container-popover"
-          aria-label={triggerLabel}
-        >
-          <span className="relative">
-            <Moon className="w-3.5 h-3.5 text-daintree-text/50" aria-hidden="true" />
-            {compact && count > 0 && (
-              <span
-                className={cn(
-                  "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm",
-                  waitingCount > 0
-                    ? "bg-state-waiting text-daintree-bg"
-                    : "bg-daintree-text/20 text-daintree-text"
-                )}
-              >
-                {count > 9 ? "9+" : count}
-              </span>
+    <span className="dock-status-pill" data-visible={count > 0 ? "true" : "false"}>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="pill"
+            size="sm"
+            className={cn(
+              compact ? "px-1.5 min-w-0" : "px-3",
+              isOpen && "bg-overlay-emphasis border-border-default"
             )}
-          </span>
-          {!compact && (
-            <span className="font-medium tabular-nums">
-              Background ({count}
-              {waitingCount > 0 && (
-                <>
-                  {" · "}
-                  <span className="text-state-waiting">{waitingCount} waiting</span>
-                </>
+            aria-haspopup="dialog"
+            aria-expanded={isOpen}
+            aria-controls="background-container-popover"
+            aria-label={triggerLabel}
+          >
+            <span className="relative">
+              <Moon className="w-3.5 h-3.5 text-daintree-text/50" aria-hidden="true" />
+              {compact && displayCount > 0 && (
+                <span
+                  className={cn(
+                    "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm",
+                    waitingCount > 0
+                      ? "bg-state-waiting text-daintree-bg"
+                      : "bg-daintree-text/20 text-daintree-text"
+                  )}
+                >
+                  <AnimatedLabel label={displayCount > 9 ? "9+" : String(displayCount)} />
+                </span>
               )}
-              )
             </span>
-          )}
-        </Button>
-      </PopoverTrigger>
-
-      <PopoverContent
-        id="background-container-popover"
-        role="dialog"
-        aria-label="Backgrounded panels"
-        className="w-96 p-0"
-        side="top"
-        align="end"
-        sideOffset={8}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onPointerDownOutside={(e) => {
-          // Keep the popover anchored while the kill confirm dialog is open;
-          // AppDialog is a react-dom portal with no Radix marker on its root,
-          // so we gate on local state rather than a DOM selector.
-          if (killConfirmId !== null) e.preventDefault();
-        }}
-        onInteractOutside={(e) => {
-          if (killConfirmId !== null) e.preventDefault();
-        }}
-        onEscapeKeyDown={(e) => {
-          if (killConfirmId !== null) e.preventDefault();
-        }}
-      >
-        <div className="flex flex-col">
-          <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
-            <span className="text-xs font-medium text-daintree-text/70">Background panels</span>
-            {waitingCount > 0 && (
-              <span className="text-[10px] font-medium text-state-waiting tabular-nums">
-                {waitingCount} waiting
+            {!compact && (
+              <span className="font-medium tabular-nums">
+                Background (<AnimatedLabel label={String(displayCount)} />
+                {waitingCount > 0 && (
+                  <>
+                    {" · "}
+                    <span className="text-state-waiting">
+                      <AnimatedLabel label={String(waitingCount)} /> waiting
+                    </span>
+                  </>
+                )}
+                )
               </span>
             )}
-          </div>
+          </Button>
+        </PopoverTrigger>
 
-          <div className="p-1 flex flex-col gap-1 max-h-[360px] overflow-y-auto">
-            {displayItems.map((item) => {
-              if (item.type === "group") {
+        <PopoverContent
+          id="background-container-popover"
+          role="dialog"
+          aria-label="Backgrounded panels"
+          className="w-96 p-0"
+          side="top"
+          align="end"
+          sideOffset={8}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => {
+            // Keep the popover anchored while the kill confirm dialog is open;
+            // AppDialog is a react-dom portal with no Radix marker on its root,
+            // so we gate on local state rather than a DOM selector.
+            if (killConfirmId !== null) e.preventDefault();
+          }}
+          onInteractOutside={(e) => {
+            if (killConfirmId !== null) e.preventDefault();
+          }}
+          onEscapeKeyDown={(e) => {
+            if (killConfirmId !== null) e.preventDefault();
+          }}
+        >
+          <div className="flex flex-col">
+            <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
+              <span className="text-xs font-medium text-daintree-text/70">Background panels</span>
+              {waitingCount > 0 && (
+                <span className="text-[10px] font-medium text-state-waiting tabular-nums">
+                  {waitingCount} waiting
+                </span>
+              )}
+            </div>
+
+            <div className="p-1 flex flex-col gap-1 max-h-[360px] overflow-y-auto">
+              {displayItems.map((item) => {
+                if (item.type === "group") {
+                  return (
+                    <BackgroundGroupItem
+                      key={item.groupRestoreId}
+                      groupRestoreId={item.groupRestoreId}
+                      groupMetadata={item.groupMetadata}
+                      terminals={item.terminals}
+                      worktreeMap={worktreeMap}
+                      watchedPanels={watchedPanels}
+                      onRestoreGroup={handleRestoreGroup}
+                      onRestoreSingle={handleRestoreSingle}
+                      onWatchToggle={handleWatchToggle}
+                      onKill={(id) => setKillConfirmId(id)}
+                    />
+                  );
+                }
+                const worktreeName = item.terminal.worktreeId
+                  ? worktreeMap.get(item.terminal.worktreeId)?.name
+                  : undefined;
                 return (
-                  <BackgroundGroupItem
-                    key={item.groupRestoreId}
-                    groupRestoreId={item.groupRestoreId}
-                    groupMetadata={item.groupMetadata}
-                    terminals={item.terminals}
-                    worktreeMap={worktreeMap}
-                    watchedPanels={watchedPanels}
-                    onRestoreGroup={handleRestoreGroup}
-                    onRestoreSingle={handleRestoreSingle}
+                  <BackgroundSingleItem
+                    key={item.terminal.id}
+                    terminal={item.terminal}
+                    worktreeName={worktreeName}
+                    isWatched={watchedPanels.has(item.terminal.id)}
+                    onRestore={handleRestoreSingle}
                     onWatchToggle={handleWatchToggle}
                     onKill={(id) => setKillConfirmId(id)}
                   />
                 );
-              }
-              const worktreeName = item.terminal.worktreeId
-                ? worktreeMap.get(item.terminal.worktreeId)?.name
-                : undefined;
-              return (
-                <BackgroundSingleItem
-                  key={item.terminal.id}
-                  terminal={item.terminal}
-                  worktreeName={worktreeName}
-                  isWatched={watchedPanels.has(item.terminal.id)}
-                  onRestore={handleRestoreSingle}
-                  onWatchToggle={handleWatchToggle}
-                  onKill={(id) => setKillConfirmId(id)}
-                />
-              );
-            })}
+              })}
+            </div>
           </div>
-        </div>
-      </PopoverContent>
+        </PopoverContent>
 
-      <ConfirmDialog
-        isOpen={killConfirmId !== null}
-        onClose={() => setKillConfirmId(null)}
-        title={KILL_TERMINAL_TITLE}
-        description={killTerminalDescription(killTarget?.title || undefined)}
-        variant="destructive"
-        confirmLabel={KILL_TERMINAL_CONFIRM_LABEL}
-        onConfirm={handleKillConfirm}
-      />
-    </Popover>
+        <ConfirmDialog
+          isOpen={killConfirmId !== null}
+          onClose={() => setKillConfirmId(null)}
+          title={KILL_TERMINAL_TITLE}
+          description={killTerminalDescription(killTarget?.title || undefined)}
+          variant="destructive"
+          confirmLabel={KILL_TERMINAL_CONFIRM_LABEL}
+          onConfirm={handleKillConfirm}
+        />
+      </Popover>
+    </span>
   );
 }
 

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -406,7 +406,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
         </div>
 
         <PopoverContent
-          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
+          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
           style={{ height: popoverHeight }}
           side="top"
           align="start"

--- a/src/components/Layout/ForgeStatusIndicator.tsx
+++ b/src/components/Layout/ForgeStatusIndicator.tsx
@@ -32,7 +32,7 @@ export function ForgeStatusIndicator({
   return (
     <div
       className={cn(
-        "absolute bottom-0 left-0 right-0 h-[1px] rounded-b-[var(--radius-md)]",
+        "absolute bottom-0 left-0 right-0 h-[1px] rounded-b-[var(--radius-md)] transition-opacity duration-150",
         internalStatus === "idle" && "opacity-0 pointer-events-none",
         internalStatus === "loading" && "overflow-hidden forge-status-loading",
         internalStatus === "success" && "forge-status-success",

--- a/src/components/Layout/StatusContainer.tsx
+++ b/src/components/Layout/StatusContainer.tsx
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PanelBottom, PanelTopClose } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import { cn } from "@/lib/utils";
+import { useExitLaggedCount } from "@/hooks/useExitLaggedCount";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
@@ -51,117 +53,126 @@ export function StatusContainer({ config, terminals, compact = false }: StatusCo
       trackTerminalFocus: state.trackTerminalFocus,
     }))
   );
-  if (terminals.length === 0) return null;
-
   const count = terminals.length;
+  // Lagged count keeps the label stable while the pill fades out via the
+  // .dock-status-pill exit transition instead of flashing "(0)".
+  const displayCount = useExitLaggedCount(count);
   const Icon = config.icon;
 
+  useEffect(() => {
+    if (count === 0) setIsOpen(false);
+  }, [count]);
+
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="pill"
-          size="sm"
-          className={cn(
-            compact ? "px-1.5 min-w-0" : "px-3",
-            isOpen && "bg-overlay-emphasis border-border-default"
-          )}
-          aria-haspopup="dialog"
-          aria-expanded={isOpen}
-          aria-controls={config.contentId}
-          aria-label={`${config.buttonLabel}: ${count} agent${count === 1 ? "" : "s"}`}
-        >
-          <span className="relative">
-            <Icon className={cn("w-3.5 h-3.5", config.iconColor)} aria-hidden="true" />
-            {compact && count > 0 && (
-              <span
-                className={cn(
-                  "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm",
-                  config.badgeColor,
-                  config.badgeTextColor
-                )}
-              >
-                {count > 9 ? "9+" : count}
+    <span className="dock-status-pill" data-visible={count > 0 ? "true" : "false"}>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="pill"
+            size="sm"
+            className={cn(
+              compact ? "px-1.5 min-w-0" : "px-3",
+              isOpen && "bg-overlay-emphasis border-border-default"
+            )}
+            aria-haspopup="dialog"
+            aria-expanded={isOpen}
+            aria-controls={config.contentId}
+            aria-label={`${config.buttonLabel}: ${displayCount} agent${displayCount === 1 ? "" : "s"}`}
+          >
+            <span className="relative">
+              <Icon className={cn("w-3.5 h-3.5", config.iconColor)} aria-hidden="true" />
+              {compact && displayCount > 0 && (
+                <span
+                  className={cn(
+                    "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm",
+                    config.badgeColor,
+                    config.badgeTextColor
+                  )}
+                >
+                  <AnimatedLabel label={displayCount > 9 ? "9+" : String(displayCount)} />
+                </span>
+              )}
+            </span>
+            {!compact && (
+              <span className="font-medium tabular-nums">
+                {config.buttonLabel} (<AnimatedLabel label={String(displayCount)} />)
               </span>
             )}
-          </span>
-          {!compact && (
-            <span className="font-medium tabular-nums">
-              {config.buttonLabel} ({count})
-            </span>
-          )}
-        </Button>
-      </PopoverTrigger>
+          </Button>
+        </PopoverTrigger>
 
-      <PopoverContent
-        id={config.contentId}
-        role="dialog"
-        aria-label={config.contentAriaLabel}
-        className="w-96 p-0"
-        side="top"
-        align="end"
-        sideOffset={8}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-      >
-        <div className="flex flex-col">
-          <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
-            <span className="text-xs font-medium text-daintree-text/70">{config.headerLabel}</span>
-          </div>
+        <PopoverContent
+          id={config.contentId}
+          role="dialog"
+          aria-label={config.contentAriaLabel}
+          className="w-96 p-0"
+          side="top"
+          align="end"
+          sideOffset={8}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <div className="flex flex-col">
+            <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
+              <span className="text-xs font-medium text-daintree-text/70">
+                {config.headerLabel}
+              </span>
+            </div>
 
-          <div className="p-1 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
-            {terminals.map((terminal) => (
-              <button
-                key={terminal.id}
-                type="button"
-                onClick={() => {
-                  const worktreeId = terminal.worktreeId?.trim();
-                  if (worktreeId && worktreeId !== activeWorktreeId) {
-                    trackTerminalFocus(worktreeId, terminal.id);
-                    selectWorktree(worktreeId);
-                  }
-                  activateTerminal(terminal.id);
-                  pingTerminal(terminal.id);
-                  setIsOpen(false);
-                }}
-                className="flex items-center justify-between gap-2.5 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] transition-colors group text-left outline-hidden hover:bg-tint/5 focus:bg-tint/5"
-              >
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                  <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
-                    <TerminalIcon
-                      kind={terminal.kind}
-                      chrome={deriveTerminalChrome(terminal)}
-                      className="h-3 w-3"
-                    />
+            <div className="p-1 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
+              {terminals.map((terminal) => (
+                <button
+                  key={terminal.id}
+                  type="button"
+                  onClick={() => {
+                    const worktreeId = terminal.worktreeId?.trim();
+                    if (worktreeId && worktreeId !== activeWorktreeId) {
+                      trackTerminalFocus(worktreeId, terminal.id);
+                      selectWorktree(worktreeId);
+                    }
+                    activateTerminal(terminal.id);
+                    pingTerminal(terminal.id);
+                    setIsOpen(false);
+                  }}
+                  className="flex items-center justify-between gap-2.5 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] transition-colors group text-left outline-hidden hover:bg-tint/5 focus:bg-tint/5"
+                >
+                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
+                      <TerminalIcon
+                        kind={terminal.kind}
+                        chrome={deriveTerminalChrome(terminal)}
+                        className="h-3 w-3"
+                      />
+                    </div>
+                    <span className="text-xs truncate font-medium text-daintree-text/70 group-hover:text-daintree-text transition-colors">
+                      {terminal.title}
+                    </span>
                   </div>
-                  <span className="text-xs truncate font-medium text-daintree-text/70 group-hover:text-daintree-text transition-colors">
-                    {terminal.title}
-                  </span>
-                </div>
 
-                <div className="flex items-center gap-2.5 shrink-0">
-                  <Icon
-                    className={cn("w-3 h-3", config.iconColor)}
-                    aria-label={config.statusAriaLabel}
-                  />
+                  <div className="flex items-center gap-2.5 shrink-0">
+                    <Icon
+                      className={cn("w-3 h-3", config.iconColor)}
+                      aria-label={config.statusAriaLabel}
+                    />
 
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors">
-                        {getLocationIcon(terminal.location)}
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      {terminal.location === "dock" ? "Docked" : "On Grid"}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              </button>
-            ))}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="text-muted-foreground/40 group-hover:text-muted-foreground/60 transition-colors">
+                          {getLocationIcon(terminal.location)}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {terminal.location === "dock" ? "Docked" : "On Grid"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                </button>
+              ))}
+            </div>
           </div>
-        </div>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+    </span>
   );
 }

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1440,7 +1440,7 @@ export function Toolbar({
             <div
               data-fullscreen={isFullscreen ? "true" : undefined}
               className={cn(
-                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-[120ms]",
+                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
                 isFullscreen ? "w-0" : "w-16"
               )}
             />
@@ -1658,7 +1658,7 @@ export function Toolbar({
               aria-hidden="true"
               data-fullscreen={isFullscreen ? "true" : undefined}
               className={cn(
-                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-[120ms]",
+                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
                 isFullscreen && "w-0"
               )}
               style={

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -1,8 +1,10 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { ChevronDown, ChevronRight, Layers, OctagonX } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
+import { useExitLaggedCount } from "@/hooks/useExitLaggedCount";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
@@ -178,113 +180,124 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
     setKillConfirmId(null);
   }, [killConfirmId, removePanel, terminals]);
 
-  if (terminals.length === 0) return null;
-
   const count = terminals.length;
+  // Lagged count keeps the label stable while the pill fades out via the
+  // .dock-status-pill exit transition instead of flashing "(0)".
+  const displayCount = useExitLaggedCount(count);
   const WaitingIcon = STATE_ICONS.waiting;
 
+  useEffect(() => {
+    if (count === 0) {
+      setIsOpen(false);
+      setKillConfirmId(null);
+    }
+  }, [count]);
+
   return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="pill"
-          size="sm"
-          className={cn(
-            compact ? "px-1.5 min-w-0" : "px-3",
-            isOpen && "bg-overlay-emphasis border-border-default"
-          )}
-          aria-haspopup="dialog"
-          aria-expanded={isOpen}
-          aria-controls="waiting-container-popover"
-          aria-label={`Waiting (${count})`}
-        >
-          <span className="relative">
-            <WaitingIcon className="w-3.5 h-3.5 text-state-waiting" aria-hidden="true" />
-            {compact && count > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm bg-state-waiting text-daintree-bg">
-                {count > 9 ? "9+" : count}
+    <span className="dock-status-pill" data-visible={count > 0 ? "true" : "false"}>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="pill"
+            size="sm"
+            className={cn(
+              compact ? "px-1.5 min-w-0" : "px-3",
+              isOpen && "bg-overlay-emphasis border-border-default"
+            )}
+            aria-haspopup="dialog"
+            aria-expanded={isOpen}
+            aria-controls="waiting-container-popover"
+            aria-label={`Waiting (${displayCount})`}
+          >
+            <span className="relative">
+              <WaitingIcon className="w-3.5 h-3.5 text-state-waiting" aria-hidden="true" />
+              {compact && displayCount > 0 && (
+                <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm bg-state-waiting text-daintree-bg">
+                  <AnimatedLabel label={displayCount > 9 ? "9+" : String(displayCount)} />
+                </span>
+              )}
+            </span>
+            {!compact && (
+              <span className="font-medium tabular-nums">
+                Waiting (
+                <AnimatedLabel label={String(displayCount)} textClassName="text-state-waiting" />)
               </span>
             )}
-          </span>
-          {!compact && (
-            <span className="font-medium tabular-nums">
-              Waiting (<span className="text-state-waiting">{count}</span>)
-            </span>
-          )}
-        </Button>
-      </PopoverTrigger>
+          </Button>
+        </PopoverTrigger>
 
-      <PopoverContent
-        id="waiting-container-popover"
-        role="dialog"
-        aria-label="Waiting panels"
-        className="w-96 p-0"
-        side="top"
-        align="end"
-        sideOffset={8}
-        onOpenAutoFocus={(e) => e.preventDefault()}
-        onCloseAutoFocus={(e) => e.preventDefault()}
-        onPointerDownOutside={(e) => {
-          if (killConfirmId !== null) e.preventDefault();
-        }}
-        onInteractOutside={(e) => {
-          if (killConfirmId !== null) e.preventDefault();
-        }}
-        onEscapeKeyDown={(e) => {
-          if (killConfirmId !== null) e.preventDefault();
-        }}
-      >
-        <div className="flex flex-col">
-          <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
-            <span className="text-xs font-medium text-daintree-text/70">Waiting for input</span>
-            <span className="text-[10px] font-medium text-state-waiting tabular-nums">
-              {count} {count === 1 ? "agent" : "agents"}
-            </span>
-          </div>
+        <PopoverContent
+          id="waiting-container-popover"
+          role="dialog"
+          aria-label="Waiting panels"
+          className="w-96 p-0"
+          side="top"
+          align="end"
+          sideOffset={8}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => {
+            if (killConfirmId !== null) e.preventDefault();
+          }}
+          onInteractOutside={(e) => {
+            if (killConfirmId !== null) e.preventDefault();
+          }}
+          onEscapeKeyDown={(e) => {
+            if (killConfirmId !== null) e.preventDefault();
+          }}
+        >
+          <div className="flex flex-col">
+            <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
+              <span className="text-xs font-medium text-daintree-text/70">Waiting for input</span>
+              <span className="text-[10px] font-medium text-state-waiting tabular-nums">
+                {count} {count === 1 ? "agent" : "agents"}
+              </span>
+            </div>
 
-          <div className="flex flex-col max-h-[360px] overflow-y-auto">
-            {displayItems.map((item) => {
-              if (item.type === "group") {
+            <div className="flex flex-col max-h-[360px] overflow-y-auto">
+              {displayItems.map((item) => {
+                if (item.type === "group") {
+                  return (
+                    <WaitingGroupItem
+                      key={item.group.id}
+                      group={item.group}
+                      waitingTerminals={item.waitingTerminals}
+                      worktreeMap={worktreeMap}
+                      onActivate={handleActivate}
+                      onKill={(id) => setKillConfirmId(id)}
+                    />
+                  );
+                }
+                const worktreeName = item.terminal.worktreeId
+                  ? worktreeMap.get(item.terminal.worktreeId)?.name
+                  : undefined;
                 return (
-                  <WaitingGroupItem
-                    key={item.group.id}
-                    group={item.group}
-                    waitingTerminals={item.waitingTerminals}
-                    worktreeMap={worktreeMap}
+                  <WaitingSingleItem
+                    key={item.terminal.id}
+                    terminal={item.terminal}
+                    groupId={item.groupId}
+                    worktreeName={worktreeName}
                     onActivate={handleActivate}
                     onKill={(id) => setKillConfirmId(id)}
                   />
                 );
-              }
-              const worktreeName = item.terminal.worktreeId
-                ? worktreeMap.get(item.terminal.worktreeId)?.name
-                : undefined;
-              return (
-                <WaitingSingleItem
-                  key={item.terminal.id}
-                  terminal={item.terminal}
-                  groupId={item.groupId}
-                  worktreeName={worktreeName}
-                  onActivate={handleActivate}
-                  onKill={(id) => setKillConfirmId(id)}
-                />
-              );
-            })}
+              })}
+            </div>
           </div>
-        </div>
-      </PopoverContent>
+        </PopoverContent>
 
-      <ConfirmDialog
-        isOpen={killConfirmId !== null}
-        onClose={() => setKillConfirmId(null)}
-        title={KILL_TERMINAL_TITLE}
-        description={killTerminalDescription(killTarget?.title || undefined)}
-        variant="destructive"
-        confirmLabel={KILL_TERMINAL_CONFIRM_LABEL}
-        onConfirm={handleKillConfirm}
-      />
-    </Popover>
+        <ConfirmDialog
+          isOpen={killConfirmId !== null}
+          onClose={() => setKillConfirmId(null)}
+          title={KILL_TERMINAL_TITLE}
+          description={killTerminalDescription(killTarget?.title || undefined)}
+          variant="destructive"
+          confirmLabel={KILL_TERMINAL_CONFIRM_LABEL}
+          onConfirm={handleKillConfirm}
+        />
+      </Popover>
+    </span>
   );
 }
 

--- a/src/components/Layout/__tests__/BackgroundContainer.test.tsx
+++ b/src/components/Layout/__tests__/BackgroundContainer.test.tsx
@@ -210,9 +210,19 @@ beforeEach(() => {
 });
 
 describe("BackgroundContainer", () => {
-  it("renders nothing when there are no backgrounded terminals", () => {
+  it("stays mounted but hidden when there are no backgrounded terminals", () => {
+    // The pill keeps its DOM node so the .dock-status-pill CSS can run the
+    // display/opacity exit transition; visibility is gated by data-visible.
     const { container } = render(<BackgroundContainer />);
-    expect(container.textContent).toBe("");
+    const pill = container.querySelector(".dock-status-pill");
+    expect(pill).not.toBeNull();
+    expect(pill?.getAttribute("data-visible")).toBe("false");
+  });
+
+  it("marks the pill visible once a terminal is backgrounded", () => {
+    mockTerminals = [makeTerminal({ id: "t1", agentState: "idle" })];
+    const { container } = render(<BackgroundContainer />);
+    expect(container.querySelector(".dock-status-pill")?.getAttribute("data-visible")).toBe("true");
   });
 
   describe("trigger label", () => {

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -231,7 +231,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
 
     it("uses Tier 3 panel timing (200ms restore / 120ms collapse), not Tier 1", () => {
       expect(source).toMatch(
-        /transition-\[width\]\s+duration-200\s+data-\[fullscreen=true\]:duration-\[120ms\]/
+        /transition-\[width\]\s+duration-200\s+data-\[fullscreen=true\]:duration-120/
       );
       expect(source).not.toContain("duration-150");
     });
@@ -241,7 +241,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
 
     it("applies the Tier 3 timing to both the macOS and Windows spacers", () => {
-      const tier3 = /duration-200 data-\[fullscreen=true\]:duration-\[120ms\]/g;
+      const tier3 = /duration-200 data-\[fullscreen=true\]:duration-120/g;
       expect((source.match(tier3) ?? []).length).toBeGreaterThanOrEqual(2);
     });
 

--- a/src/components/Layout/__tests__/WaitingContainer.test.tsx
+++ b/src/components/Layout/__tests__/WaitingContainer.test.tsx
@@ -201,9 +201,19 @@ beforeEach(() => {
 });
 
 describe("WaitingContainer", () => {
-  it("renders nothing when there are no waiting terminals", () => {
+  it("stays mounted but hidden when there are no waiting terminals", () => {
+    // The pill keeps its DOM node so the .dock-status-pill CSS can run the
+    // display/opacity exit transition; visibility is gated by data-visible.
     const { container } = render(<WaitingContainer />);
-    expect(container.textContent).toBe("");
+    const pill = container.querySelector(".dock-status-pill");
+    expect(pill).not.toBeNull();
+    expect(pill?.getAttribute("data-visible")).toBe("false");
+  });
+
+  it("marks the pill visible once a terminal is waiting", () => {
+    mockTerminals = [makeTerminal({ id: "t1" })];
+    const { container } = render(<WaitingContainer />);
+    expect(container.querySelector(".dock-status-pill")?.getAttribute("data-visible")).toBe("true");
   });
 
   describe("trigger", () => {

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1140,7 +1140,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               "shadow-[var(--theme-shadow-floating)]",
               "text-[11px] font-medium text-daintree-text/80",
               "hover:text-daintree-text hover:bg-overlay-raised",
-              "transition-[transform,opacity] motion-reduce:transition-none",
+              "transition-[translate,opacity] motion-reduce:transition-none",
               showJumpPill
                 ? "opacity-100 translate-y-0 pointer-events-auto"
                 : "opacity-0 translate-y-2 pointer-events-none"

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -172,8 +172,8 @@ export function GettingStartedChecklist({
           "rounded-[var(--radius-sm)] border",
           "text-sm text-daintree-text",
           "shadow-[var(--theme-shadow-floating)]",
-          "transition-[transform,opacity,background-color,border-color] duration-200 ease-out",
-          "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
+          "transition-[translate,opacity,background-color,border-color] duration-200 ease-out",
+          "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:translate-none",
           isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
           allComplete
             ? "bg-surface-panel border-border-default"

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -869,7 +869,7 @@ function PanelHeaderComponent({
                     onAddTab();
                   }}
                   onPointerDown={(e) => e.stopPropagation()}
-                  className="shrink-0 p-1.5 opacity-0 group-hover:opacity-100 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                  className="shrink-0 p-1.5 opacity-0 group-hover:opacity-100 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-[opacity,color,background-color] focus-visible:opacity-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
                   aria-label="Duplicate panel as new tab"
                   aria-keyshortcuts={duplicateAriaShortcut}
                   type="button"

--- a/src/components/Plugin/PluginManagerView.tsx
+++ b/src/components/Plugin/PluginManagerView.tsx
@@ -459,7 +459,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
               aria-hidden="true"
               data-fullscreen={isFullscreen ? "true" : undefined}
               className={cn(
-                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-[120ms]",
+                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
                 isFullscreen ? "w-0" : "w-16"
               )}
             />
@@ -492,7 +492,7 @@ export function PluginManagerView({ deepLinkIntent, onDeepLinkConsumed }: Plugin
               aria-hidden="true"
               data-fullscreen={isFullscreen ? "true" : undefined}
               className={cn(
-                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-[120ms]",
+                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-120",
                 isFullscreen && "w-0"
               )}
               style={

--- a/src/components/Project/GeneralTab.tsx
+++ b/src/components/Project/GeneralTab.tsx
@@ -354,7 +354,7 @@ export function GeneralTab({
                 type="text"
                 value={name}
                 onChange={(e) => onNameChange(e.target.value)}
-                className="w-full bg-transparent border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-placeholder"
+                className="w-full bg-transparent border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition-[border-color,box-shadow] placeholder:text-text-placeholder"
                 placeholder="My Awesome Project"
               />
             </div>
@@ -381,7 +381,7 @@ export function GeneralTab({
                 aria-label={`Set project color to ${PRESET_SWATCHES[i]!.label}`}
                 onClick={() => onColorChange(hex)}
                 className={cn(
-                  "h-7 w-7 rounded-full transition border-2 shrink-0",
+                  "h-7 w-7 rounded-full transition-[border-color,scale,box-shadow] border-2 shrink-0",
                   color === hex
                     ? "border-daintree-text scale-110 shadow-sm"
                     : "border-transparent hover:border-daintree-border hover:scale-105"

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1402,7 +1402,7 @@ function SearchResults({
             </div>
             <ChevronRight
               className={cn(
-                "w-4 h-4 text-daintree-text/20 shrink-0 transition-[color,transform] duration-150",
+                "w-4 h-4 text-daintree-text/20 shrink-0 transition-[color,translate] duration-150",
                 index === activeIndex
                   ? "text-daintree-text/40 translate-x-0.5"
                   : "group-hover:text-daintree-text/40"

--- a/src/components/Terminal/AutocompleteMenu.tsx
+++ b/src/components/Terminal/AutocompleteMenu.tsx
@@ -2,6 +2,14 @@ import { forwardRef, useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
+import {
+  getUiPaletteTransitionDuration,
+  UI_PALETTE_ENTER_DURATION,
+  UI_PALETTE_EXIT_DURATION,
+  UI_ENTER_EASING,
+  UI_EXIT_EASING,
+} from "@/lib/animationUtils";
 
 function getDescriptionSnippet(description: string, maxLength = 60): string {
   const cleaned = description.replace(/\s+/g, " ").trim();
@@ -51,6 +59,13 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
     ref
   ) => {
     const listRef = useRef<HTMLDivElement | null>(null);
+    // Palette-tier presence (150ms enter / 100ms exit) so the menu rises in
+    // and fades out like its sibling overlays instead of popping on every
+    // `/` or `@` keystroke.
+    const { isVisible, shouldRender } = useAnimatedPresence({
+      isOpen,
+      animationDuration: getUiPaletteTransitionDuration("exit"),
+    });
 
     useEffect(() => {
       if (!isOpen) return;
@@ -58,7 +73,7 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
       selected?.scrollIntoView?.({ block: "nearest" });
     }, [isOpen, selectedIndex, items]);
 
-    if (!isOpen) return null;
+    if (!shouldRender) return null;
 
     const isEmpty = !isLoading && items.length === 0;
 
@@ -67,9 +82,20 @@ export const AutocompleteMenu = forwardRef<HTMLDivElement, AutocompleteMenuProps
         ref={ref}
         className={cn(
           "absolute bottom-full mb-0 w-[420px] max-w-[calc(100vw-16px)] overflow-hidden rounded-lg border border-tint/10 bg-surface shadow-[var(--theme-shadow-floating)]",
-          "z-50"
+          "z-50 origin-bottom",
+          "transition-[opacity,translate,scale]",
+          "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:translate-none motion-reduce:scale-none",
+          isVisible
+            ? "opacity-100 translate-y-0 scale-100"
+            : "opacity-0 translate-y-0.5 scale-[0.99]"
         )}
-        style={style}
+        style={{
+          ...style,
+          transitionDuration: isVisible
+            ? `${UI_PALETTE_ENTER_DURATION}ms`
+            : `${UI_PALETTE_EXIT_DURATION}ms`,
+          transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
+        }}
         role={isEmpty ? undefined : "listbox"}
         aria-label={ariaLabel ?? title ?? "Autocomplete"}
         aria-busy={isLoading || isStale || undefined}

--- a/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
@@ -155,7 +155,7 @@ export function WorktreeActionsToolbar({
           ? "opacity-100"
           : isActive
             ? "opacity-100"
-            : "opacity-50 delay-0 group-hover/card:opacity-100 group-hover/card:delay-[75ms] group-has-[:focus-visible]/card:opacity-100 group-has-[:focus-visible]/card:delay-0 group-has-[[data-state=open]]/card:opacity-100 group-has-[[data-state=open]]/card:delay-0"
+            : "opacity-50 delay-0 group-hover/card:opacity-100 group-hover/card:delay-75 group-has-[:focus-visible]/card:opacity-100 group-has-[:focus-visible]/card:delay-0 group-has-[[data-state=open]]/card:opacity-100 group-has-[[data-state=open]]/card:delay-0"
       )}
     >
       {onCleanupWorktree && (

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -100,7 +100,7 @@ describe("WorktreeCard row affordances polish (issue #8099)", () => {
   });
 
   it("toolbar hover reveal is delayed 75ms but keyboard focus bypasses the delay", () => {
-    expect(toolbarSource).toContain("group-hover/card:delay-[75ms]");
+    expect(toolbarSource).toContain("group-hover/card:delay-75");
     expect(toolbarSource).toContain("group-has-[:focus-visible]/card:delay-0");
     expect(toolbarSource).toContain("group-has-[[data-state=open]]/card:delay-0");
   });

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -45,7 +45,7 @@ function FilterSection({
           onClick={() => setIsOpen(!isOpen)}
           aria-expanded={isOpen}
           aria-controls={contentId}
-          className="flex flex-1 items-center justify-between px-3 py-2 text-xs font-medium text-daintree-text/70 hover:bg-overlay-soft"
+          className="flex flex-1 items-center justify-between px-3 py-2 text-xs font-medium text-daintree-text/70 transition-colors hover:bg-overlay-soft"
         >
           <span className="flex items-center gap-1.5">
             {title}
@@ -77,11 +77,24 @@ function FilterSection({
           </button>
         )}
       </div>
-      {isOpen && (
-        <div id={contentId} className="px-3 pb-3 pt-1">
-          {children}
+      {/* Animated reveal so the body honors what the rotating chevron
+       * promises — same grid-rows idiom as LocalCommitsDropdown. Content
+       * stays mounted; `inert` keeps collapsed chips out of tab order. */}
+      <div
+        aria-hidden={!isOpen}
+        inert={!isOpen}
+        data-animated-reveal
+        className={cn(
+          "grid transition-[grid-template-rows] duration-150 ease-out motion-reduce:transition-none",
+          isOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        )}
+      >
+        <div className="overflow-hidden">
+          <div id={contentId} className="px-3 pb-3 pt-1">
+            {children}
+          </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/components/Worktree/__tests__/ScrollIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/ScrollIndicator.test.tsx
@@ -139,10 +139,13 @@ describe("ScrollIndicator", () => {
     expect(screen.getByLabelText("Scroll down, 4 more below")).toBeTruthy();
   });
 
-  it("uses scoped transition-[opacity,transform] instead of bare transition", () => {
+  it("uses scoped transition-[opacity,translate] instead of bare transition", () => {
+    // `translate` (not `transform`) because Tailwind v4 translate-* utilities
+    // emit the individual `translate` property, which a `transform` entry in
+    // the transition list does not cover.
     render(<ScrollIndicator direction="below" count={1} onClick={onClick} />);
     const button = screen.getByRole("button");
-    expect(button.className).toContain("transition-[opacity,transform]");
+    expect(button.className).toContain("transition-[opacity,translate]");
     expect(button.className.split(/\s+/)).not.toContain("transition");
   });
 });

--- a/src/components/ui/AppDialog.tsx
+++ b/src/components/ui/AppDialog.tsx
@@ -377,8 +377,11 @@ export function AppDialog({
             maxHeight,
             sizeClasses[size],
             "w-full",
-            "transition-[opacity,transform]",
-            "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
+            // Tailwind v4 translate-*/scale-* emit the individual `translate`
+            // and `scale` properties, which `transform` in a transition list
+            // does NOT cover — list them explicitly or the rise/zoom snaps.
+            "transition-[opacity,translate,scale]",
+            "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:translate-none motion-reduce:scale-none",
             isVisible
               ? "opacity-100 translate-y-0 scale-100"
               : "opacity-0 translate-y-1 scale-[0.98]",

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -205,7 +205,10 @@ export function AppPaletteDialog({
         tabIndex={-1}
         className={cn(
           "w-full max-w-xl mx-4 bg-surface-dialog border border-border-default rounded-[var(--radius-xl)] shadow-[var(--theme-shadow-dialog)] overflow-hidden origin-top",
-          "transition-[opacity,transform]",
+          // Tailwind v4 scale-* emits the individual `scale` property, which
+          // `transform` in a transition list does NOT cover — the palette
+          // zoom only animates when `scale` is listed explicitly.
+          "transition-[opacity,scale]",
           "motion-reduce:transition-opacity motion-reduce:scale-100",
           isVisible ? "opacity-100 scale-100" : "opacity-0 scale-[0.96]",
           className

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -209,7 +209,7 @@ export function EmptyState(props: EmptyStateProps) {
             // `aria-hidden` alone leaves it focusable via keyboard.
             inert
             className={cn(
-              "[grid-area:1/1] flex flex-col items-center pointer-events-none motion-safe:animate-out motion-safe:fade-out motion-safe:duration-[100ms]",
+              "[grid-area:1/1] flex flex-col items-center pointer-events-none motion-safe:animate-out motion-safe:fade-out motion-safe:duration-100",
               outgoing.scale === "canvas" ? "gap-3 @max-[280px]/empty-state:gap-2" : "gap-2"
             )}
             onAnimationEnd={handleExitEnd}

--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -80,7 +80,10 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
           "text-sm text-daintree-text",
           "shadow-[var(--theme-shadow-floating)]",
           "ring-1 ring-inset ring-tint/[0.05]",
-          "transition-[transform,opacity] duration-300 ease-out",
+          // Tailwind v4 translate-* emits the individual `translate` property,
+          // which `transform` in a transition list does NOT cover — list it
+          // explicitly or the slide-in snaps and only the fade animates.
+          "transition-[translate,opacity] duration-300 ease-out",
           "motion-reduce:transition-none motion-reduce:duration-0",
           isVisible ? "translate-x-0 opacity-100" : "translate-x-8 opacity-0",
           accentClass

--- a/src/components/ui/ScrollPill.tsx
+++ b/src/components/ui/ScrollPill.tsx
@@ -40,8 +40,11 @@ export const ScrollPill = forwardRef<HTMLButtonElement, ScrollPillProps>(
           "bg-daintree-bg/90 border border-daintree-border/40 text-daintree-text shadow-[var(--theme-shadow-floating)]",
           "text-xs font-medium cursor-pointer",
           "hover:bg-daintree-bg hover:border-daintree-border/60",
-          "transition-[opacity,transform] duration-150",
-          "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
+          // Tailwind v4 translate-* emits the individual `translate` property,
+          // which `transform` in a transition list does NOT cover — list it
+          // explicitly or the slide snaps and only the fade animates.
+          "transition-[opacity,translate] duration-150",
+          "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:translate-none",
           "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1",
           isVisible ? "opacity-100 translate-y-0" : hiddenTransform,
           className

--- a/src/components/ui/__tests__/ScrollPill.test.tsx
+++ b/src/components/ui/__tests__/ScrollPill.test.tsx
@@ -27,14 +27,17 @@ describe("ScrollPill", () => {
     expect(screen.getByRole("button").getAttribute("type")).toBe("button");
   });
 
-  it("uses scoped transition-[opacity,transform] and not bare transition", () => {
+  it("uses scoped transition-[opacity,translate] and not bare transition", () => {
+    // `translate` (not `transform`) because Tailwind v4 translate-* utilities
+    // emit the individual `translate` property, which a `transform` entry in
+    // the transition list does not cover.
     render(
       <ScrollPill isVisible translateDirection="down">
         hi
       </ScrollPill>
     );
     const button = screen.getByRole("button");
-    expect(button.className).toContain("transition-[opacity,transform]");
+    expect(button.className).toContain("transition-[opacity,translate]");
     expect(button.className.split(/\s+/)).not.toContain("transition");
   });
 

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -659,8 +659,13 @@ describe("animate-skeleton-shimmer CSS contract", () => {
   });
 
   it("hides the ::after sweep under body[data-performance-mode]", () => {
+    // The rule is a selector list shared with the Pulse skeleton shimmer, so
+    // allow the sibling selector between ::after and the declaration block.
     expect(css).toMatch(
-      /body\[data-performance-mode="true"\]\s+\.animate-skeleton-shimmer::after\s*\{[^}]*display:\s*none/
+      /body\[data-performance-mode="true"\]\s+\.animate-skeleton-shimmer::after[^{]*\{[^}]*display:\s*none/
+    );
+    expect(css).toMatch(
+      /body\[data-performance-mode="true"\]\s+\.pulse-skeleton-shimmer::after[^{]*\{[^}]*display:\s*none/
     );
   });
 });

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -196,7 +196,7 @@ const ContextMenuSubContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}
@@ -233,7 +233,7 @@ const ContextMenuContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-context-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -235,7 +235,7 @@ const DropdownMenuSubContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}
@@ -272,7 +272,7 @@ const DropdownMenuContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-dropdown-menu-content-transform-origin)", ...style }}
         className={cn(
           "relative z-[var(--z-popover)] min-w-[10rem] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto rounded-[var(--radius-lg)] surface-overlay shadow-overlay p-1 text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}

--- a/src/components/ui/fixed-dropdown.tsx
+++ b/src/components/ui/fixed-dropdown.tsx
@@ -218,8 +218,11 @@ export function FixedDropdown({
       ref={contentRef}
       className={cn(
         "absolute pointer-events-auto overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
-        "transition-[opacity,transform]",
-        "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
+        // Tailwind v4 translate-*/scale-* emit the individual `translate` and
+        // `scale` properties, which `transform` in a transition list does NOT
+        // cover — list them explicitly or the rise/zoom snaps.
+        "transition-[opacity,translate,scale]",
+        "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:translate-none motion-reduce:scale-none",
         isVisible
           ? "opacity-100 translate-y-0 scale-100"
           : "opacity-0 -translate-y-0.5 scale-[0.99]",

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -233,7 +233,7 @@ const PopoverContent = React.forwardRef<
         style={{ transformOrigin: "var(--radix-popover-content-transform-origin)", ...style }}
         className={cn(
           "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
-          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
           className
         )}
         {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -220,7 +220,7 @@ const SelectContent = React.forwardRef<
           style={{ transformOrigin: "var(--radix-select-content-transform-origin)", ...style }}
           className={cn(
             "relative z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-lg)] surface-overlay shadow-overlay text-daintree-text",
-            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
             position === "popper" &&
               "min-w-[var(--radix-select-trigger-width)] max-h-[var(--radix-select-content-available-height)]",
             className

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -246,7 +246,7 @@ const TooltipContent = React.forwardRef<
           style={{ transformOrigin: "var(--radix-tooltip-content-transform-origin)", ...style }}
           className={cn(
             "z-[var(--z-popover)] max-w-xs overflow-hidden rounded-[var(--radius-md)] surface-overlay shadow-overlay px-3 py-1.5 text-xs text-daintree-text",
-            "animate-in fade-in-0 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-[100ms] data-[state=closed]:fade-out-0 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
+            "animate-in fade-in-0 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=closed]:fade-out-0 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
             className
           )}
           {...props}

--- a/src/hooks/useExitLaggedCount.ts
+++ b/src/hooks/useExitLaggedCount.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Holds the last non-zero count so an element fading out via a presence
+ * transition (e.g. `.dock-status-pill`) keeps showing its final value
+ * instead of flashing "(0)" during the exit fade. Returns the live count
+ * whenever it is non-zero.
+ */
+export function useExitLaggedCount(count: number): number {
+  const [lastNonZero, setLastNonZero] = useState(count);
+
+  useEffect(() => {
+    if (count > 0) setLastNonZero(count);
+  }, [count]);
+
+  return count > 0 ? count : lastNonZero;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
 @import "./styles/components/pulse.css";
 @import "./styles/components/sidebar.css";
 @import "./styles/components/panels.css";
+@import "./styles/components/dock.css";
 
 /* Reduced-motion variant — composes OS-level `prefers-reduced-motion: reduce`
  * with the Daintree "Reduce UI animations" toggle (`body[data-reduce-animations="true"]`).

--- a/src/index.css
+++ b/src/index.css
@@ -2561,7 +2561,8 @@ body[data-performance-mode="true"] .surface-stale {
 /* The global wildcard above kills the shimmer animation but the ::after
  * pseudo-element still paints its static gradient stripe — hide it.
  */
-body[data-performance-mode="true"] .animate-skeleton-shimmer::after {
+body[data-performance-mode="true"] .animate-skeleton-shimmer::after,
+body[data-performance-mode="true"] .pulse-skeleton-shimmer::after {
   display: none !important;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1880,6 +1880,13 @@ body,
     transition: none !important;
   }
 
+  /* Grid-rows expand/collapse reveals (filter sections et al.) — height
+   * interpolation is spatial motion; the content still snaps open/closed.
+   * WCAG 2.3.3. */
+  [data-animated-reveal] {
+    transition: none !important;
+  }
+
   *:focus-visible {
     transition: none !important;
   }

--- a/src/styles/components/dock.css
+++ b/src/styles/components/dock.css
@@ -1,0 +1,48 @@
+/* Dock status pills (Background / Waiting / Errors in ContentDock).
+ *
+ * ── Pill entrance / exit ──
+ * The pills exist only while agents occupy those states. Without an
+ * animation the first waiting/errored agent makes the pill pop in and the
+ * last one clearing makes it vanish, unlike every toolbar badge. Same
+ * technique as [data-toolbar-overflow-trigger] in toolbar.css: opacity-only
+ * (these are full-size buttons — scale would read as a glitch) with
+ * @starting-style + allow-discrete driving entry and exit in pure CSS. The
+ * wrapper stays mounted and toggles data-visible, going display:none when
+ * empty so it reclaims its layout slot and drops out of the a11y tree.
+ * Tier 2 timing from animationUtils.ts: 200ms enter (UI_ENTER_DURATION),
+ * 120ms exit (UI_EXIT_DURATION). The Button inside owns its own hover/press
+ * transitions; this wrapper only carries presence.
+ */
+.dock-status-pill {
+  display: none;
+  opacity: 0;
+  transition:
+    display 120ms allow-discrete,
+    opacity 120ms ease;
+}
+
+.dock-status-pill[data-visible="true"] {
+  display: inline-flex;
+  opacity: 1;
+  transition:
+    display 200ms allow-discrete,
+    opacity 200ms ease;
+
+  @starting-style {
+    opacity: 0;
+  }
+}
+
+/* ── Reduced motion ──
+ * The fade is already opacity-only (WCAG 2.3.3-safe). Keep a timed (not
+ * `none`) display swap so the discrete show/hide still completes
+ * (lesson #6182); mirror the [data-toolbar-overflow-trigger] treatment.
+ */
+@variant reduce-motion {
+  .dock-status-pill,
+  .dock-status-pill[data-visible="true"] {
+    transition:
+      display 0s,
+      opacity 200ms ease;
+  }
+}

--- a/src/styles/components/pulse.css
+++ b/src/styles/components/pulse.css
@@ -1,9 +1,18 @@
+/* Compositor-friendly sweep: the ::after overlay rides translateX instead of
+ * animating background-position, which repaints every bone on the main thread
+ * for the whole loading window (same rationale as .animate-skeleton-shimmer
+ * in src/index.css, #4738). Geometry preserves the original look exactly:
+ * the overlay is 7 element-widths wide, tiles the theme gradient at its
+ * authored 2-width period (700% / 3.5 = 200% of the element), and slides two
+ * full periods (4/7 of its width) per cycle — so the loop stays seamless, the
+ * highlight passes twice per 1.8s, and the element is never uncovered while
+ * the ease-in-out dwells at the endpoints. */
 @keyframes pulse-skeleton-shimmer {
   0% {
-    background-position: -200% 0;
+    transform: translateX(0);
   }
   100% {
-    background-position: 200% 0;
+    transform: translateX(calc(400% / 7));
   }
 }
 
@@ -76,6 +85,18 @@
 }
 
 .pulse-skeleton-shimmer {
+  position: relative;
+  overflow: hidden;
+  background: var(--pulse-empty-bg, var(--theme-surface-panel));
+}
+
+.pulse-skeleton-shimmer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -500%;
+  width: 700%;
   background: var(
     --pulse-skeleton-gradient,
     linear-gradient(
@@ -85,8 +106,9 @@
       var(--pulse-empty-bg, var(--theme-surface-panel)) 75%
     )
   );
-  background-size: 200% 100%;
+  background-size: calc(200% / 7) 100%;
   animation: pulse-skeleton-shimmer 1.8s ease-in-out infinite;
+  will-change: transform;
 }
 
 /* WCAG 2.3.3 — kill the sweep AND fall back to a flat surface so the static
@@ -94,7 +116,11 @@
  * query and the Daintree-level "Reduce UI animations" toggle. */
 @variant reduce-motion {
   .pulse-skeleton-shimmer {
-    animation: none;
     background: var(--pulse-empty-bg, var(--theme-surface-panel));
+  }
+
+  .pulse-skeleton-shimmer::after {
+    display: none;
+    will-change: auto;
   }
 }


### PR DESCRIPTION
This is a micro-animation polish pass across the UI, broken into six focused commits.

## The headline fix: translate/scale were never transitioning

Since the Tailwind v4 migration, nine overlay surfaces have listed only `transform` in their `transition-property` lists. Tailwind v4's translate and scale utilities don't emit `transform`; they emit the individual `translate` and `scale` CSS properties. So dialog rise (`AppDialog`), palette zoom (`AppPaletteDialog` and the `ActionPalette` status chip), dropdown rise (`fixed-dropdown`), the scroll pill slides, the notification jump pill, the re-entry summary slide-in, the settings-result chevron nudge and the onboarding checklist rise were all fade-only snaps. The fix is to list `translate` and `scale` explicitly. The toaster keeps `transform` because it composes an inline transform string, which `transform` does cover.

## Animate the dock status pills

The Background, Waiting and Errors pills popped in and out with no transition and hard-swapped their counts. They now fade in over 200ms and out over 120ms using `@starting-style` and `allow-discrete` (the same technique as the toolbar overflow trigger), and the counts crossfade through `AnimatedLabel`. The displayed count lags on exit so the label never flashes "(0)" mid-fade, and the popover closes itself when the last agent clears since the pill no longer unmounts.

## Animate the composer autocomplete

The slash-command and mention menu mounted and unmounted instantly while every sibling overlay animates. It now rises out of the input and fades away at the palette tier (150ms enter, 100ms exit) via `useAnimatedPresence`.

## Animate the filter section reveal

The worktree filter popover rotated its chevron over 150ms but hard-mounted the body it promised. Sections now animate their reveal with the grid-rows idiom from `LocalCommitsDropdown`, with `inert` keeping collapsed chips out of the tab order. The header hover also picked up its missing `transition-colors`.

## Move the Pulse shimmer onto the compositor

The Pulse skeleton bones animated `background-position`, repainting every bone on the main thread for the whole loading window. The sweep is now a `::after` overlay riding `translateX`, with geometry that reproduces the original look exactly (same theme gradients, same two passes per 1.8s cycle, seamless loop).

## Consistency pass

Promotes the `duration-[120ms]`/`duration-[100ms]`/`delay-[75ms]` literals to their `duration-120`/`duration-100`/`delay-75` tokens, folds the select's one-off `zoom-98` into the family-standard `zoom-97`, gives the forge status strip a 150ms fade back to idle, and narrows three bare `transition` utilities to the properties they actually animate.

Everything respects reduced motion (both the OS preference and the in-app toggle) and performance mode. Tests are updated and passing, and `npm run check` is green.
