### PR TITLE
perf(project-switch): deterministic warm wake + concurrent worktree load

### DIFF
--- a/e2e/full/resilience/project-switch-perf.spec.ts
+++ b/e2e/full/resilience/project-switch-perf.spec.ts
@@ -1,0 +1,302 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window.electron is untyped in Playwright evaluate() */
+import { test, expect } from "@playwright/test";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { launchApp, closeApp, getActiveAppWindow, type AppContext } from "../../helpers/launch";
+import { createFixtureRepos } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { openTerminal } from "../../helpers/panels";
+
+// A/B latency harness for project switching. Unlike the stress spec (which
+// hammers switches to prove the app never wedges), this one measures two
+// user-facing latencies per switch, sequentially and gently, so runs are
+// comparable across branches:
+//   - round-trip: `window.electron.project.switch()` resolve time, measured
+//     inside the calling renderer — the full main-process handler including
+//     the view swap AND the worktree/git load ("switch fully settled").
+//   - reveal: the app's own projectview.coldstart/warm-swap `visibleMs`
+//     telemetry — time until the incoming view is actually on screen.
+// Cold switches rotate through more projects than the e2e cached-view limit
+// (4) so every target was LRU-evicted; warm switches toggle A<->B so the
+// target is always cached.
+const PROJECT_COUNT = Number(process.env.PERF_SWITCH_PROJECTS ?? 6);
+const COLD_ROUNDS = Number(process.env.PERF_SWITCH_COLD_ROUNDS ?? 3);
+const WARM_TOGGLES = Number(process.env.PERF_SWITCH_WARM_TOGGLES ?? 12);
+const TERMINAL_PROJECTS = Number(process.env.PERF_SWITCH_TERMINALS ?? 2);
+// Idle gap between measured switches so deferred post-switch work (LRU
+// eviction, persist flushes) from one sample can't bleed into the next.
+const SETTLE_MS = 400;
+
+let ctx: AppContext;
+let cleanups: Array<() => void> = [];
+
+interface ProjectInfo {
+  id: string;
+  name: string;
+  path: string;
+}
+
+interface ColdReveal {
+  visibleMs: number;
+  loadToPaintMs: number;
+}
+
+/** Pull projectview reveal telemetry from the app's own log, scoped by time. */
+function readRevealTelemetry(logPath: string, sinceMs: number) {
+  const cold: ColdReveal[] = [];
+  const warm: number[] = [];
+  if (!existsSync(logPath)) return { cold, warm };
+  const log = readFileSync(logPath, "utf8");
+  const re = /\[([^\]]+)\]\s+\[INFO\]\s+projectview\.(coldstart|warm-swap)\s*(\{[\s\S]*?\})/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(log)) !== null) {
+    const atMs = Date.parse(m[1]);
+    if (!Number.isFinite(atMs) || atMs < sinceMs) continue;
+    let payload: any;
+    try {
+      payload = JSON.parse(m[3]);
+    } catch {
+      continue;
+    }
+    if (typeof payload?.visibleMs !== "number") continue;
+    if (m[2] === "coldstart") {
+      cold.push({
+        visibleMs: payload.visibleMs,
+        loadToPaintMs: typeof payload.loadToPaintMs === "number" ? payload.loadToPaintMs : NaN,
+      });
+    } else {
+      warm.push(payload.visibleMs);
+    }
+  }
+  return { cold, warm };
+}
+
+function countMatches(logPath: string, sinceMs: number, needle: RegExp): number {
+  if (!existsSync(logPath)) return 0;
+  const log = readFileSync(logPath, "utf8");
+  let count = 0;
+  for (const line of log.split(/\r?\n/)) {
+    const tsMatch = line.match(/^\[([^\]]+)\]/);
+    if (!tsMatch) continue;
+    const atMs = Date.parse(tsMatch[1]);
+    if (Number.isFinite(atMs) && atMs >= sinceMs && needle.test(line)) count++;
+  }
+  return count;
+}
+
+function pct(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function stats(label: string, arr: number[]): string {
+  if (arr.length === 0) return `${label}: n=0`;
+  return `${label}: n=${arr.length} p50=${pct(arr, 50)}ms p95=${pct(arr, 95)}ms max=${Math.max(...arr)}ms`;
+}
+
+// Opt-in only — a measurement harness for local A/B runs, not a CI gate.
+// Latency numbers are machine-dependent, so asserting budgets here would
+// flake across runners; the assertions below are reliability invariants only.
+//   RUN_PERF_SWITCH=1 npx playwright test --project=full-resilience \
+//     e2e/full/resilience/project-switch-perf.spec.ts
+const perfDescribe =
+  process.env.RUN_PERF_SWITCH || process.env.RUN_PERF_STRESS
+    ? test.describe.serial
+    : test.describe.skip;
+
+perfDescribe("Resilience: project-switch latency measurement", () => {
+  test.beforeAll(async () => {
+    const fixtures = createFixtureRepos(PROJECT_COUNT);
+    cleanups = fixtures.map((f) => f.cleanup);
+    const repos = fixtures.map((f) => f.dir);
+
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repos[0]);
+
+    for (let i = 1; i < repos.length; i++) {
+      await ctx.window.evaluate((p) => (window as any).electron.project.add(p), repos[i]);
+    }
+    await ctx.window.waitForTimeout(1500);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    for (const c of cleanups) c();
+  });
+
+  test("measures cold and warm switch round-trip and reveal latency", async () => {
+    test.slow();
+    test.setTimeout(600_000);
+
+    const logPath = path.join(ctx.userDataDir, "logs", "daintree.log");
+
+    const projects: ProjectInfo[] = await ctx.window.evaluate(() =>
+      (window as any).electron.project.getAll()
+    );
+    expect(projects.length).toBeGreaterThanOrEqual(PROJECT_COUNT);
+
+    // Read the attached (topmost live) project view's id from the main process.
+    const getAttachedProjectId = async (): Promise<string | null> =>
+      ctx.app.evaluate(async ({ BrowserWindow }) => {
+        const win = BrowserWindow.getAllWindows()[0];
+        if (!win || win.isDestroyed()) return null;
+        const views = (win.contentView?.children ?? []) as Electron.WebContentsView[];
+        for (let i = views.length - 1; i >= 0; i--) {
+          const wc = views[i]?.webContents;
+          if (!wc || wc.isDestroyed()) continue;
+          const id = await wc
+            .executeJavaScript("window.__DAINTREE_INITIAL_PROJECT__?.id ?? null", true)
+            .catch(() => null);
+          if (typeof id === "string" && id.length > 0) return id;
+        }
+        return null;
+      });
+
+    // Run `project.switch(target)` inside the topmost live project view and
+    // time the IPC round-trip in the renderer. Resolves -1 on failure so one
+    // bad sample can't hang the harness.
+    const timedSwitch = async (targetId: string): Promise<number> => {
+      const roundTrip = await ctx.app.evaluate(async ({ BrowserWindow }, id) => {
+        const win = BrowserWindow.getAllWindows()[0];
+        if (!win || win.isDestroyed()) return -1;
+        const views = (win.contentView?.children ?? []) as Electron.WebContentsView[];
+        for (let i = views.length - 1; i >= 0; i--) {
+          const wc = views[i]?.webContents;
+          if (!wc || wc.isDestroyed()) continue;
+          const isProjectView = await wc
+            .executeJavaScript("!!(window.electron && window.electron.project)", true)
+            .catch(() => false);
+          if (!isProjectView) continue;
+          const timeout = new Promise<number>((resolve) => setTimeout(() => resolve(-1), 60_000));
+          const run = wc
+            .executeJavaScript(
+              `(async () => {
+                 const t0 = performance.now();
+                 await window.electron.project.switch(${JSON.stringify(id)});
+                 return Math.round(performance.now() - t0);
+               })()`,
+              true
+            )
+            .catch(() => -1) as Promise<number>;
+          return Promise.race([run, timeout]);
+        }
+        return -1;
+      }, targetId);
+
+      // The handler resolves after the swap, so the attached view should
+      // already be the target; poll briefly to absorb scheduling noise.
+      const deadline = Date.now() + 15_000;
+      while (Date.now() < deadline) {
+        if ((await getAttachedProjectId()) === targetId) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      return roundTrip;
+    };
+
+    const settle = () => new Promise((r) => setTimeout(r, SETTLE_MS));
+
+    // Seed terminals in the first projects so switches carry PTY restore +
+    // warm wake work, matching real usage.
+    for (let i = 0; i < Math.min(TERMINAL_PROJECTS, projects.length); i++) {
+      await timedSwitch(projects[i].id);
+      const page = await getActiveAppWindow(ctx.app, 60_000, { requireProject: true });
+      await openTerminal(page);
+      await page.waitForTimeout(300);
+    }
+    await settle();
+
+    // ── Cold phase: rotate through all projects; each target was evicted ──
+    const coldStart = Date.now();
+    const coldRoundTrips: number[] = [];
+    for (let round = 0; round < COLD_ROUNDS; round++) {
+      for (const proj of projects) {
+        if ((await getAttachedProjectId()) === proj.id) continue;
+        coldRoundTrips.push(await timedSwitch(proj.id));
+        await settle();
+      }
+    }
+    const coldTele = readRevealTelemetry(logPath, coldStart);
+
+    // ── Warm phase: toggle between the two terminal-seeded projects ──
+    const a = projects[0].id;
+    const b = projects[1].id;
+    await timedSwitch(a);
+    await settle();
+    await timedSwitch(b);
+    await settle();
+    const warmStart = Date.now();
+    const warmRoundTrips: number[] = [];
+    for (let i = 0; i < WARM_TOGGLES; i++) {
+      warmRoundTrips.push(await timedSwitch(i % 2 === 0 ? a : b));
+      await settle();
+    }
+    const warmTele = readRevealTelemetry(logPath, warmStart);
+
+    const rendererGone = countMatches(
+      logPath,
+      coldStart,
+      /render-process-gone|Renderer process gone|Renderer crashed|Crash loop detected/
+    );
+    const hardTimeouts = countMatches(
+      logPath,
+      coldStart,
+      /projectview\.(paintgate|warmpaintgate)\.hardtimeout/
+    );
+
+    console.log("──────── project-switch latency results ────────");
+    console.log(
+      `projects=${projects.length} coldRounds=${COLD_ROUNDS} warmToggles=${WARM_TOGGLES} terminals=${Math.min(TERMINAL_PROJECTS, projects.length)}`
+    );
+    console.log(
+      stats(
+        "cold round-trip (switch IPC settled)",
+        coldRoundTrips.filter((v) => v >= 0)
+      )
+    );
+    console.log(
+      stats(
+        "cold reveal (visibleMs)",
+        coldTele.cold.map((c) => c.visibleMs)
+      )
+    );
+    console.log(
+      stats(
+        "cold load->paint gap",
+        coldTele.cold.map((c) => c.loadToPaintMs).filter((v) => Number.isFinite(v))
+      )
+    );
+    console.log(
+      stats(
+        "warm round-trip (switch IPC settled)",
+        warmRoundTrips.filter((v) => v >= 0)
+      )
+    );
+    console.log(stats("warm reveal (visibleMs)", warmTele.warm));
+    console.log(
+      `phase telemetry mix: cold-phase cold=${coldTele.cold.length} warm=${coldTele.warm.length} | warm-phase warm=${warmTele.warm.length} cold=${warmTele.cold.length}`
+    );
+    console.log(`reliability: renderer-gone=${rendererGone} paint-hard-timeouts=${hardTimeouts}`);
+    console.log("─────────────────────────────────────────────────");
+
+    // Reliability invariants only — latency itself is reported, not gated.
+    expect(rendererGone, "no renderer crashes during measurement").toBe(0);
+    // A paint-gate hard timeout means a switch revealed by falling through its
+    // grace period instead of by the renderer's signal — the exact failure
+    // mode behind warm swaps stalling at ~1500ms (every warm swap hard-timed-
+    // out before the APP_VIEW_WARM_ACTIVATED wake trigger existed). Not a
+    // machine-dependent latency budget: on a healthy build this is always 0.
+    expect(hardTimeouts, "no paint-gate hard timeouts").toBe(0);
+    for (const rt of [...coldRoundTrips, ...warmRoundTrips]) {
+      expect(rt, "every measured switch resolved").toBeGreaterThanOrEqual(0);
+    }
+    // The phases must have exercised the paths they claim to measure.
+    expect(coldTele.cold.length, "cold phase produced cold switches").toBeGreaterThanOrEqual(
+      Math.floor(COLD_ROUNDS * PROJECT_COUNT * 0.8)
+    );
+    expect(warmTele.warm.length, "warm phase produced warm switches").toBeGreaterThanOrEqual(
+      Math.floor(WARM_TOGGLES * 0.8)
+    );
+  });
+});

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -165,6 +165,7 @@ export const CHANNELS = {
   APP_VIEW_PAINTED: "app:view-painted",
   APP_VIEW_WARM_PAINTED: "app:view-warm-painted",
   APP_VIEW_REVEALED: "app:view-revealed",
+  APP_VIEW_WARM_ACTIVATED: "app:view-warm-activated",
   APP_VIEW_CACHED: "app:view-cached",
   APP_DISMISS_ROSETTA_WARNING: "app:dismiss-rosetta-warning",
   MENU_ACTION: "menu:action",

--- a/electron/ipc/handlers/__tests__/project.switch.test.ts
+++ b/electron/ipc/handlers/__tests__/project.switch.test.ts
@@ -719,6 +719,182 @@ describe("project:switch worktree-load-status (#8400)", () => {
   });
 });
 
+describe("project:switch concurrent worktree load", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setup(opts: {
+    switchTo: () => Promise<{ view: unknown; isNew: boolean }>;
+    loadProject?: () => Promise<void>;
+    previousProject?: { id: string; name: string; path: string } | null;
+  }) {
+    const pvm = {
+      switchTo: vi.fn(opts.switchTo),
+      getProjectIdForWebContents: vi.fn(),
+    };
+
+    mockGetWindowForWebContents.mockReturnValue({ id: 7, isDestroyed: () => false });
+
+    const previous =
+      opts.previousProject === undefined
+        ? { id: "proj-old", name: "Old Project", path: "/projects/old" }
+        : opts.previousProject;
+    projectStoreMock.getCurrentProjectId.mockReturnValue(previous?.id ?? null);
+    projectStoreMock.getProjectById.mockImplementation((id: string) => {
+      if (id === "proj-new") {
+        return { id: "proj-new", name: "New Project", path: "/projects/new" };
+      }
+      if (previous && id === previous.id) return previous;
+      return null;
+    });
+    projectStoreMock.setCurrentProject.mockResolvedValue(undefined);
+
+    const worktreeService = {
+      loadProject: vi.fn(opts.loadProject ?? (async () => undefined)),
+      attachDirectPort: vi.fn(),
+      getHostForProject: vi.fn(() => null),
+      resumeProject: vi.fn(),
+      pauseProject: vi.fn(),
+      unregisterWindow: vi.fn(),
+    };
+
+    const deps = {
+      mainWindow: { id: 7 } as unknown,
+      projectViewManager: pvm,
+      worktreeService: worktreeService as never,
+    } as unknown as HandlerDependencies;
+
+    registerProjectCrudHandlers(deps);
+
+    const handleMap = new Map<string, (...args: unknown[]) => unknown>();
+    for (const call of (ipcMain.handle as ReturnType<typeof vi.fn>).mock.calls) {
+      handleMap.set(call[0] as string, call[1] as (...args: unknown[]) => unknown);
+    }
+
+    const invoke = () =>
+      handleMap.get(CHANNELS.PROJECT_SWITCH)!({ sender: { id: 300 } }, "proj-new");
+
+    return { invoke, pvm, worktreeService };
+  }
+
+  it("starts the worktree git load before the view swap resolves", async () => {
+    let resolveSwap: (v: { view: unknown; isNew: boolean }) => void = () => {};
+    const swapGate = new Promise<{ view: unknown; isNew: boolean }>((resolve) => {
+      resolveSwap = resolve;
+    });
+    const { invoke, worktreeService } = setup({ switchTo: () => swapGate });
+
+    const handlerPromise = invoke();
+
+    // The load must be in flight while the swap still is — running them
+    // serially re-adds the full host-spawn + git-enumeration time (hundreds of
+    // ms on a cold host) to every switch's resolve time.
+    await vi.waitFor(() => expect(worktreeService.loadProject).toHaveBeenCalled());
+    expect(worktreeService.loadProject).toHaveBeenCalledWith("/projects/new", 7);
+    expect(worktreeService.resumeProject).toHaveBeenCalledWith("/projects/new");
+
+    resolveSwap({
+      view: { webContents: { id: 300, isDestroyed: () => false, send: vi.fn() } },
+      isNew: false,
+    });
+    await handlerPromise;
+  });
+
+  it("re-points the worktree mapping at the previous project when the swap fails", async () => {
+    const { invoke, worktreeService } = setup({
+      switchTo: async () => {
+        throw new Error("load timeout");
+      },
+    });
+
+    await expect(invoke()).rejects.toThrow("load timeout");
+
+    // The early load already flipped windowToProject to the failed target while
+    // the previous view stays visible — exactly the cross-project contamination
+    // loadProject exists to prevent. The handler must restore the mapping.
+    await vi.waitFor(() =>
+      expect(worktreeService.loadProject).toHaveBeenCalledWith("/projects/old", 7)
+    );
+  });
+
+  it("releases the window mapping when the swap fails with no previous project", async () => {
+    const { invoke, worktreeService } = setup({
+      switchTo: async () => {
+        throw new Error("load timeout");
+      },
+      previousProject: null,
+    });
+
+    await expect(invoke()).rejects.toThrow("load timeout");
+
+    // First switch from the welcome view: there is nothing to restore, so the
+    // early load's attachment (and windowToProject mapping) must be released —
+    // pausing alone would leave the window routed at the failed target.
+    await vi.waitFor(() => expect(worktreeService.unregisterWindow).toHaveBeenCalledWith(7));
+    // With nothing to restore, the mapping must not be re-loaded anywhere else.
+    expect(worktreeService.loadProject).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the failure restore when a newer switch claimed the window meanwhile", async () => {
+    let rejectSwap: (err: Error) => void = () => {};
+    const failingSwap = new Promise<{ view: unknown; isNew: boolean }>((_resolve, reject) => {
+      rejectSwap = reject;
+    });
+    let call = 0;
+    const { invoke, worktreeService } = setup({
+      switchTo: () => {
+        call++;
+        if (call === 1) return failingSwap;
+        return Promise.resolve({
+          view: { webContents: { id: 300, isDestroyed: () => false, send: vi.fn() } },
+          isNew: false,
+        });
+      },
+    });
+
+    const first = invoke();
+    // Let the first handler reach its awaited swap before the second starts.
+    await vi.waitFor(() => expect(worktreeService.loadProject).toHaveBeenCalledTimes(1));
+
+    // A second switch claims the window (bumps the epoch) and completes.
+    await invoke();
+
+    // Now the first swap fails. Its deferred restore must see the stale epoch
+    // and do nothing — re-loading the old project here would clobber the
+    // mapping the second switch just established.
+    rejectSwap(new Error("load timeout"));
+    await expect(first).rejects.toThrow("load timeout");
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(worktreeService.loadProject).not.toHaveBeenCalledWith("/projects/old", 7);
+    expect(worktreeService.unregisterWindow).not.toHaveBeenCalled();
+  });
+
+  it("does not surface a worktree load failure through a successful swap", async () => {
+    const sendMock = vi.fn();
+    const { invoke } = setup({
+      switchTo: async () => ({
+        view: { webContents: { id: 300, isDestroyed: () => false, send: sendMock } },
+        isNew: false,
+      }),
+      loadProject: async () => {
+        throw new Error("Not a git repository");
+      },
+    });
+
+    // Forward-fail (#8400): the load rejection — even though it now starts
+    // before the swap — must resolve the switch and surface as the targeted
+    // worktree-load-status, not reject the handler.
+    await invoke();
+
+    expect(sendMock).toHaveBeenCalledWith(CHANNELS.PROJECT_WORKTREE_LOAD_STATUS, {
+      projectId: "proj-new",
+      worktreeLoadError: "Not a git repository",
+    });
+  });
+});
+
 describe("project:switch PROJECT_ON_SWITCH notification", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/electron/ipc/handlers/projectCrud/switch.ts
+++ b/electron/ipc/handlers/projectCrud/switch.ts
@@ -8,6 +8,7 @@ import { scratchStore } from "../../../services/ScratchStore.js";
 import { ProjectSwitchService } from "../../../services/ProjectSwitchService.js";
 import { broadcastProjectSwitchUpdates } from "../../projectSwitchBroadcast.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { logInfo } from "../../../utils/logger.js";
 import {
   sanitizeTerminals,
   sanitizeTerminalSizes,
@@ -144,6 +145,13 @@ export function registerProjectSwitchHandlers(deps: HandlerDependencies): () => 
   return () => handlers.forEach((cleanup) => cleanup());
 }
 
+// Monotonic per-window switch epoch. A swap-failure restore (below) is
+// deferred until the failed target's early worktree load settles; by then a
+// newer switch may own the window, and restoring the old mapping would
+// clobber it. Bumped at every activateProjectView entry; the restore only
+// runs if its epoch is still current.
+const windowSwitchEpochs = new Map<number, number>();
+
 const pendingOutgoingPersists = new Map<string, Promise<void>>();
 
 function trackOutgoingPersist(projectId: string | null, persist: Promise<void>): void {
@@ -221,8 +229,79 @@ async function activateProjectView(
   project: Project,
   options: ActivateOptions
 ): Promise<void> {
+  const activateStart = performance.now();
+  const senderWindow = getWindowForWebContents(event.sender);
+  const windowId = senderWindow?.id ?? deps.mainWindow?.id;
+
+  let switchEpoch = 0;
+  if (windowId !== undefined) {
+    switchEpoch = (windowSwitchEpochs.get(windowId) ?? 0) + 1;
+    windowSwitchEpochs.set(windowId, switchEpoch);
+  }
+
+  // Start the workspace-host git load CONCURRENTLY with the view swap. The two
+  // have no data dependency (loadProject takes explicit path + windowId), and
+  // running them serially added the full load — several hundred ms when the
+  // target's host is cold (spawn + worktree enumeration) — to every switch's
+  // resolve time. Window-routed worktree sends already target the incoming
+  // view for the whole swap (registerAppView flips at attach), so an early
+  // windowToProject flip routes to the right renderer. Failures are NOT
+  // surfaced here: the await below owns forward-fail (#8400). Reopen requires
+  // the host to be resumed BEFORE loadProject so it is ready to accept
+  // worktree IPC from the newly-active view.
+  let loadWorktrees: Promise<void> | null = null;
+  if (deps.worktreeService && windowId !== undefined) {
+    if (options.resumeWorkspace) {
+      deps.worktreeService.resumeProject(project.path);
+    }
+    loadWorktrees = deps.worktreeService.loadProject(project.path, windowId);
+    // Observed at the await below; without this a load rejection while the
+    // swap is still in flight would be an unhandled rejection.
+    loadWorktrees.catch(() => {});
+  }
+
   // Multi-view path: swap WebContentsViews instead of resetting stores
-  const { view, isNew } = await pvm.switchTo(projectId, project.path);
+  let swapResult: { view: Electron.WebContentsView; isNew: boolean };
+  try {
+    swapResult = await pvm.switchTo(projectId, project.path);
+  } catch (error) {
+    // The swap failed and rolled back to the previous view, but the early
+    // loadProject may have already pointed windowToProject at the failed
+    // target — the exact cross-project contamination loadProject exists to
+    // prevent. Once the failed load settles (and only if no newer switch has
+    // claimed the window since), re-point the mapping at the still-visible
+    // previous project (cheap for its warm host); with no previous project to
+    // restore (first switch from the welcome view, or the previous project
+    // was deleted mid-switch) release the window's mapping entirely, undoing
+    // the early load's attachment.
+    if (loadWorktrees && deps.worktreeService && windowId !== undefined) {
+      const worktreeService = deps.worktreeService;
+      const previousPath = (() => {
+        const previousId = projectStore.getCurrentProjectId();
+        return previousId ? projectStore.getProjectById(previousId)?.path : undefined;
+      })();
+      void loadWorktrees
+        .catch(() => {})
+        .then(() => {
+          if (windowSwitchEpochs.get(windowId) !== switchEpoch) return undefined;
+          if (previousPath === project.path) return undefined; // mapping already correct
+          if (previousPath) {
+            return worktreeService.loadProject(previousPath, windowId);
+          }
+          worktreeService.unregisterWindow(windowId);
+          return undefined;
+        })
+        .catch((restoreError) => {
+          console.error(
+            `${options.logPrefix} Failed to restore worktree mapping after swap failure:`,
+            restoreError
+          );
+        });
+    }
+    throw error;
+  }
+  const { view, isNew } = swapResult;
+  const swapMs = Math.round(performance.now() - activateStart);
 
   // Mutually exclusive with scratch: switching to a project clears any
   // active scratch pointer + notifies renderers so palette/UI state stays
@@ -274,15 +353,6 @@ async function activateProjectView(
     });
   }
 
-  // Reopen requires the workspace host to be resumed BEFORE loadProject so
-  // the host is ready to accept worktree IPC from the newly-active view.
-  if (options.resumeWorkspace && deps.worktreeService) {
-    deps.worktreeService.resumeProject(project.path);
-  }
-
-  const senderWindow = getWindowForWebContents(event.sender);
-  const windowId = senderWindow?.id ?? deps.mainWindow?.id;
-
   // Notify the PTY host of the active project and distribute a fresh
   // MessagePort to the reactivated view BEFORE the worktree git load. On warm
   // switches `loadProject` below can take several hundred ms (prune/list/status
@@ -318,13 +388,14 @@ async function activateProjectView(
     }
   }
 
-  // Always call loadProject so the WorkspaceClient's windowToProject
-  // mapping points to the correct project.  Without this, reactivating a
-  // cached view leaves the mapping pointing at the *previous* project,
-  // causing sendToEntryWindows to route the old project's IPC events to
-  // the newly-active view (cross-project worktree contamination).
+  // Settle the worktree load started alongside the swap. Calling loadProject
+  // on every switch keeps the WorkspaceClient's windowToProject mapping
+  // pointing at the correct project — without it, reactivating a cached view
+  // leaves the mapping on the *previous* project, causing sendToEntryWindows
+  // to route the old project's IPC events to the newly-active view
+  // (cross-project worktree contamination).
   if (deps.worktreeService) {
-    if (windowId !== undefined) {
+    if (loadWorktrees && windowId !== undefined) {
       // Forward-fail: the view swap already committed to the new project, so a
       // load failure surfaces as a Tier 3 recovery banner rather than reverting
       // (#8400). Send a targeted status to *this* view only (broadcastToRenderer
@@ -332,7 +403,7 @@ async function activateProjectView(
       // stale banner when a previously-failed view is reactivated successfully.
       let worktreeLoadError: string | null = null;
       try {
-        await deps.worktreeService.loadProject(project.path, windowId);
+        await loadWorktrees;
 
         // Always attach a direct MessagePort.  For new views this is the
         // first port; for cached views it re-establishes the relay after a
@@ -363,4 +434,14 @@ async function activateProjectView(
       deps.windowRegistry.registerAppViewWebContents(senderWindow.id, view.webContents.id);
     }
   }
+
+  // Switch-settle telemetry: `swapMs` is the view swap (reveal path), the
+  // remainder to `totalMs` is the post-swap tail — now dominated by however
+  // much of the concurrent worktree load outlived the swap.
+  logInfo("projectswitch.settled", {
+    projectId,
+    isNew,
+    swapMs,
+    totalMs: Math.round(performance.now() - activateStart),
+  });
 }

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1512,6 +1512,8 @@ function buildElectronApi(): ElectronAPI {
       onConfigReloaded: (callback: () => void) => _typedOn(CHANNELS.APP_CONFIG_RELOADED, callback),
 
       onViewRevealed: (callback: () => void) => _typedOn(CHANNELS.APP_VIEW_REVEALED, callback),
+      onViewWarmActivated: (callback: () => void) =>
+        _typedOn(CHANNELS.APP_VIEW_WARM_ACTIVATED, callback),
       onViewCached: (callback: () => void) => _typedOn(CHANNELS.APP_VIEW_CACHED, callback),
     },
 

--- a/electron/services/__tests__/WorkspaceClient.loadOrder.test.ts
+++ b/electron/services/__tests__/WorkspaceClient.loadOrder.test.ts
@@ -1,0 +1,201 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHosts, MockWorkspaceHostProcess } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { EventEmitter } = require("events") as typeof import("events");
+
+  const mockHosts: any[] = [];
+
+  class MockWorkspaceHostProcess extends EventEmitter {
+    projectPath: string;
+    private _isReady = false;
+    private _isDisposed = false;
+    private readyResolve: (() => void) | null = null;
+    private readyPromise: Promise<void>;
+    private responseHandlers = new Map<string, (result: any) => void>();
+    private responseRejects = new Map<string, (error: Error) => void>();
+
+    constructor(projectPath: string) {
+      super();
+      this.projectPath = projectPath;
+      this.readyPromise = new Promise((resolve) => {
+        this.readyResolve = resolve;
+      });
+      mockHosts.push(this);
+    }
+
+    waitForReady(): Promise<void> {
+      return this.readyPromise;
+    }
+
+    isReady(): boolean {
+      return this._isReady && !this._isDisposed;
+    }
+
+    generateRequestId(): string {
+      return `req-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+    }
+
+    send = vi.fn(() => true);
+
+    sendWithResponse = vi.fn(<T>(request: { requestId: string; type: string }): Promise<T> => {
+      return new Promise<T>((resolve, reject) => {
+        this.responseHandlers.set(request.requestId, resolve);
+        this.responseRejects.set(request.requestId, reject);
+      });
+    });
+
+    pauseHealthCheck = vi.fn();
+    resumeHealthCheck = vi.fn();
+    dispose = vi.fn(() => {
+      this._isDisposed = true;
+    });
+
+    setLogLevelOverrides = vi.fn();
+    relayFetchThrottle = vi.fn();
+
+    simulateReady(): void {
+      this._isReady = true;
+      if (this.readyResolve) {
+        this.readyResolve();
+        this.readyResolve = null;
+      }
+    }
+
+    resolveRequest(requestId: string, result: any = {}): void {
+      const handler = this.responseHandlers.get(requestId);
+      if (handler) {
+        this.responseHandlers.delete(requestId);
+        handler(result);
+      }
+    }
+
+    getLastRequest(): { requestId: string; type: string; [key: string]: any } | undefined {
+      const calls = this.sendWithResponse.mock.calls;
+      if (calls.length === 0) return undefined;
+      return calls[calls.length - 1][0] as any;
+    }
+  }
+
+  return { mockHosts, MockWorkspaceHostProcess };
+});
+
+vi.mock("../WorkspaceHostProcess.js", () => ({
+  WorkspaceHostProcess: MockWorkspaceHostProcess,
+}));
+
+vi.mock("electron", () => {
+  return {
+    BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  };
+});
+
+vi.mock("../events.js", () => ({
+  events: { emit: vi.fn() },
+}));
+
+vi.mock("../ProjectStore.js", () => ({
+  projectStore: { getProjectSettings: vi.fn().mockResolvedValue({ runCommands: [] }) },
+}));
+
+vi.mock("../../store.js", () => ({
+  store: { get: vi.fn().mockReturnValue(null), set: vi.fn() },
+}));
+
+import { WorkspaceClient } from "../WorkspaceClient.js";
+
+type MockHost = InstanceType<typeof MockWorkspaceHostProcess>;
+
+// The project-switch IPC handler starts loadProject concurrently with the view
+// swap, so rapid switches can have several loads in flight per window at once.
+// The pool's windowToProject mapping must be "last REQUESTED wins" — a slow
+// early load completing after a later one must not steal the mapping back.
+describe("WorkspaceClient.loadProject request ordering", () => {
+  let client: WorkspaceClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockHosts.length = 0;
+    client = new WorkspaceClient({
+      maxRestartAttempts: 3,
+      showCrashDialog: false,
+      healthCheckIntervalMs: 1000,
+      maxWarmEntries: 3,
+    });
+  });
+
+  afterEach(() => {
+    client.dispose();
+    vi.useRealTimers();
+  });
+
+  function h(index: number): MockHost {
+    return mockHosts[index];
+  }
+
+  async function readyAndResolveLoad(hostIndex: number): Promise<void> {
+    h(hostIndex).simulateReady();
+    await vi.advanceTimersByTimeAsync(0);
+    const req = h(hostIndex).getLastRequest()!;
+    h(hostIndex).resolveRequest(req.requestId);
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  it("a superseded load completing late does not steal the window mapping (A→B→C)", async () => {
+    const loadA = client.loadProject("/project-a", 1);
+    await readyAndResolveLoad(0);
+    await loadA;
+    expect(client.getHostForWindow(1)).toBe(h(0));
+
+    // Rapid A→B→C: both loads in flight; C's host becomes ready FIRST.
+    const loadB = client.loadProject("/project-b", 1);
+    const loadC = client.loadProject("/project-c", 1);
+
+    await readyAndResolveLoad(2);
+    await loadC;
+    expect(client.getHostForWindow(1)).toBe(h(2));
+
+    // B's slow host finishes last — the stale completion must not flip the
+    // mapping back to B while the window displays C.
+    await readyAndResolveLoad(1);
+    await loadB;
+
+    expect(client.getHostForWindow(1)).toBe(h(2));
+    // The superseded host stays warm for a future switch-back but is demoted
+    // to background polling, mirroring a switch-away.
+    expect(h(1).send).toHaveBeenCalledWith({ type: "background" });
+  });
+
+  it("a same-project re-request does not strand the winning attachment", async () => {
+    const loadA = client.loadProject("/project-a", 1);
+    await readyAndResolveLoad(0);
+    await loadA;
+
+    // Two loads for the SAME project race (e.g. a switch retried while the
+    // first cold spawn is still in flight). Whatever the completion order,
+    // the window must stay attached to the project's host and the host must
+    // not be reaped as dormant.
+    const first = client.loadProject("/project-b", 1);
+    const second = client.loadProject("/project-b", 1);
+    await readyAndResolveLoad(1);
+    await Promise.all([first, second]);
+
+    expect(client.getHostForWindow(1)).toBe(h(1));
+
+    // Far past the dormant grace period: the winning attachment's host must
+    // survive (a stale-undo that stranded it would have scheduled cleanup).
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(h(1).dispose).not.toHaveBeenCalled();
+  });
+
+  it("a load completing after the window released does not resurrect the mapping", async () => {
+    const load = client.loadProject("/project-b", 1);
+    client.unregisterWindow(1);
+
+    await readyAndResolveLoad(0);
+    await load;
+
+    expect(client.getHostForWindow(1)).toBeUndefined();
+  });
+});

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -87,6 +87,17 @@ export class WorkspaceHostPool {
   readonly windowToProject = new Map<number, string>();
   readonly worktreePathToProject = new Map<string, string>();
 
+  /**
+   * Monotonic per-window `loadProject` request sequence — makes the mapping
+   * "last requested wins" instead of "last completion wins". The switch IPC
+   * handler starts the git load concurrently with the view swap, so two rapid
+   * switches (A→B→C) can have loads in flight at once; without this, a slow
+   * cold host for the superseded B could complete after C and flip
+   * `windowToProject` back to B while the window displays C, routing B's
+   * worktree events into C's view.
+   */
+  private windowLoadSeq = new Map<number, number>();
+
   private logLevelOverridesCache: Record<string, string> = readPersistedLogOverrides();
 
   /** Last GitHub fetch-throttle multiplier relayed from main — seeded into
@@ -209,6 +220,10 @@ export class WorkspaceHostPool {
 
   async loadProject(rootPath: string, windowId: number): Promise<void> {
     const normalizedPath = this.normalizeProjectPath(rootPath);
+    const seq = (this.windowLoadSeq.get(windowId) ?? 0) + 1;
+    this.windowLoadSeq.set(windowId, seq);
+    const isStale = () => this.windowLoadSeq.get(windowId) !== seq;
+
     const oldProjectPath = this.windowToProject.get(windowId);
     const isSwitching = oldProjectPath !== undefined && oldProjectPath !== normalizedPath;
 
@@ -218,6 +233,10 @@ export class WorkspaceHostPool {
         () => false,
         () => true
       );
+      // Superseded while waiting on the entry's readiness — the newer request
+      // owns the mapping and all attachment bookkeeping (including disposing a
+      // ready-failed entry, which it detects itself on the same code path).
+      if (isStale()) return;
       if (isReadyFailed) {
         existingEntry.host.dispose();
         this.entries.delete(normalizedPath);
@@ -286,6 +305,26 @@ export class WorkspaceHostPool {
         newEntry.host.dispose();
       }
       throw error;
+    }
+
+    if (isStale()) {
+      // Superseded while the host was spawning. Keep the now-warm host for a
+      // future switch-back, but undo this window's attachment and leave the
+      // mapping to the newer request. Skip the undo when the winning request
+      // landed on this same project — it re-owns the existing attachment
+      // rather than adding its own, so releasing here would strand it.
+      if (
+        this.entries.get(normalizedPath) === newEntry &&
+        this.windowToProject.get(windowId) !== normalizedPath
+      ) {
+        newEntry.windowIds.delete(windowId);
+        newEntry.refCount--;
+        if (newEntry.refCount <= 0) {
+          newEntry.host.send({ type: "background" });
+          this.scheduleDormantCleanup(normalizedPath, newEntry);
+        }
+      }
+      return;
     }
 
     this.windowToProject.set(windowId, normalizedPath);
@@ -357,6 +396,10 @@ export class WorkspaceHostPool {
   }
 
   releaseWindow(windowId: number): void {
+    // Invalidate any in-flight loadProject for this window so a late
+    // completion can't resurrect the mapping after the window released it.
+    this.windowLoadSeq.delete(windowId);
+
     const projectPath = this.windowToProject.get(windowId);
     if (!projectPath) return;
 
@@ -637,5 +680,6 @@ export class WorkspaceHostPool {
     this.entries.clear();
     this.windowToProject.clear();
     this.worktreePathToProject.clear();
+    this.windowLoadSeq.clear();
   }
 }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -508,6 +508,17 @@ export class ProjectViewManager {
             hardMs: warmHardMs,
           }
         );
+        // Deterministic wake trigger: a detached + setVisible(false) cached
+        // view never gets `visibilitychange`, and `resume` only fires when the
+        // Efficiency profile actually froze it — so on most reactivations the
+        // renderer had NO signal to run its wake fan-out and the warm gate sat
+        // until the hard timeout (~1.5s per warm switch). Main knows exactly
+        // when it re-attaches a cached view, so tell the renderer directly;
+        // the visibility/resume listeners remain as fallbacks. Sent after the
+        // gate is armed so the wake's completion signal can't slip past it.
+        if (!cached.view.webContents.isDestroyed()) {
+          cached.view.webContents.send(CHANNELS.APP_VIEW_WARM_ACTIVATED);
+        }
         const gateResult = await warmGate;
         if (gateResult === "hard-timeout") {
           logWarn("projectview.warmpaintgate.hardtimeout", {
@@ -530,6 +541,12 @@ export class ProjectViewManager {
         // No outgoing view to bridge through (e.g. first-run with no welcome
         // view) — nothing to flash past, so reveal the cached view immediately.
         this.activateView(cached);
+        // Same deterministic wake trigger as the bridged path: the reattach
+        // emits no visibility/resume event, so the terminals' refit/repaint
+        // fan-out needs an explicit signal here too.
+        if (!cached.view.webContents.isDestroyed()) {
+          cached.view.webContents.send(CHANNELS.APP_VIEW_WARM_ACTIVATED);
+        }
       }
 
       const visibleMs = Math.round(performance.now() - warmStart);

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -813,6 +813,54 @@ describe("ProjectViewManager — paint gate (cold-start visible swap)", () => {
     expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
   });
 
+  it("warm reactivation sends the wake trigger to the cached view while the bridge is up", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const firstSwitch = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(incomingWc.id);
+    await firstSwitch;
+
+    win.contentView.removeChildView.mockClear();
+    initialWc.send.mockClear();
+
+    const switchBack = manager.switchTo("proj-a", "/path/a");
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+
+    // The explicit wake trigger is the renderer's only reliable signal to run
+    // its wake fan-out (a detached setVisible(false) view gets no
+    // visibilitychange/resume on reattach), so it must arrive while the bridge
+    // is still up — before the gate resolves — or the fan-out that releases
+    // the gate never runs and every warm swap rides the hard timeout.
+    expect(
+      initialWc.send.mock.calls.filter(([c]) => c === CHANNELS.APP_VIEW_WARM_ACTIVATED)
+    ).toHaveLength(1);
+    expect(win.contentView.removeChildView).not.toHaveBeenCalled();
+
+    manager.signalWarmViewPainted(initialWc.id);
+    await switchBack;
+    expect(win.contentView.removeChildView).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send the warm wake trigger on a cold switch", async () => {
+    const incomingWc = createMockWebContents();
+    wcQueue.push(incomingWc);
+
+    const switchPromise = manager.switchTo("proj-b", "/path/b");
+    await Promise.resolve();
+    await Promise.resolve();
+    manager.signalViewPainted(incomingWc.id);
+    await switchPromise;
+
+    // Cold-started renderers drive their own boot-time wake; the warm trigger
+    // targeting them would be meaningless (no cached terminals to refit).
+    expect(
+      incomingWc.send.mock.calls.filter(([c]) => c === CHANNELS.APP_VIEW_WARM_ACTIVATED)
+    ).toHaveLength(0);
+  });
+
   it("warm bridge falls through to the hard timeout when no warm signal arrives", async () => {
     vi.useFakeTimers();
     try {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -455,6 +455,17 @@ export interface ElectronAPI extends GeneratedElectronAPI {
      * visibilitychange/resume ran while the view was still occluded.
      */
     onViewRevealed(callback: () => void): () => void;
+    /**
+     * Subscribe to the warm-activation wake signal. Main fires this the moment
+     * it re-attaches a cached view behind the anti-flash bridge (or reveals it
+     * directly when there is no bridge). A detached `setVisible(false)` view
+     * never receives `visibilitychange`/`resume` on reattach, so without this
+     * explicit trigger the wake fan-out — and the `notifyWarmViewPainted` gate
+     * release it ends with — only ran when Chromium happened to emit a
+     * lifecycle event (the Efficiency-profile freeze path), and every other
+     * warm swap stalled until the warm paint gate's hard timeout.
+     */
+    onViewWarmActivated(callback: () => void): () => void;
     onViewCached(callback: () => void): () => void;
   };
   // menu is generated — see GeneratedElectronAPI.

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1828,6 +1828,11 @@ export interface IpcEventMap {
   // visibilitychange/resume ran while the view was still occluded, where
   // Chromium culls the paint, so it can fail to stick until the user clicks.
   "app:view-revealed": void;
+  // Fired by ProjectViewManager the moment it re-attaches a cached view (warm
+  // switch). A detached setVisible(false) view receives no visibilitychange or
+  // resume event on reattach, so this is the renderer's deterministic trigger
+  // to run the wake fan-out whose completion releases the warm paint gate.
+  "app:view-warm-activated": void;
   "app:view-cached": void;
 
   // Privacy events

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -822,6 +822,24 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     }
     cleanups.push(clearRevealBackstops);
 
+    // Deterministic warm-activation wake (#9679 hardening): main fires this the
+    // moment it re-attaches this cached view behind the anti-flash bridge. The
+    // visibilitychange/resume listeners above never fire for a plain
+    // detach/reattach (no lifecycle event is emitted for a `setVisible(false)`
+    // WebContentsView, and `resume` needs an actual freeze), so on most warm
+    // switches the wake fan-out — whose completion releases main's warm paint
+    // gate via notifyWarmViewPainted — had no trigger and the gate always ran
+    // to its hard timeout. Routed through scheduleWake so it coalesces with any
+    // visibility/resume-triggered wake and inherits the same double-rAF settle.
+    // Deliberately NO entry-time visibility guard: this is the one trigger main
+    // asserts is valid, and dropping it here would re-open the hard-timeout
+    // stall; scheduleWake re-checks visibility at execution and APP_VIEW_CACHED
+    // cancels a pending wake if the view is switched away mid-schedule.
+    const offViewWarmActivated = window.electron?.app?.onViewWarmActivated?.(() => {
+      scheduleWake();
+    });
+    if (offViewWarmActivated) cleanups.push(offViewWarmActivated);
+
     const offViewRevealed = window.electron?.app?.onViewRevealed?.(() => {
       if (document.visibilityState !== "visible") return;
       scheduleRepaint();

--- a/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.scheduleWake.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/store/wakeActiveWorktreeTerminals", () => ({
 }));
 
 let viewRevealedCb: (() => void) | null = null;
+let viewWarmActivatedCb: (() => void) | null = null;
 let viewCachedCb: (() => void) | null = null;
 
 vi.mock("@/lib/notify", () => ({ notify: vi.fn(() => "notif-id") }));
@@ -42,6 +43,7 @@ beforeEach(() => {
   wakeMock.mockClear();
   repaintMock.mockClear();
   viewRevealedCb = null;
+  viewWarmActivatedCb = null;
   viewCachedCb = null;
   globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
     const id = ++rafIdCounter;
@@ -74,6 +76,12 @@ beforeEach(() => {
         viewRevealedCb = cb;
         return () => {
           viewRevealedCb = null;
+        };
+      },
+      onViewWarmActivated: (cb: () => void) => {
+        viewWarmActivatedCb = cb;
+        return () => {
+          viewWarmActivatedCb = null;
         };
       },
       onViewCached: (cb: () => void) => {
@@ -395,6 +403,83 @@ describe("WorktreeStoreProvider — wake fan-out scheduling (#10362)", () => {
     act(() => vi.advanceTimersByTime(5000));
     flushRepaintGate();
     expect(repaintMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the wake fan-out on the warm-activation signal through the double-rAF gate", async () => {
+    await renderProvider();
+    // Drain the mount-scheduled missed-event wake first.
+    act(() => flushFrame());
+    act(() => flushFrame());
+    wakeMock.mockClear();
+    expect(viewWarmActivatedCb).not.toBeNull();
+
+    // A detached setVisible(false) view receives no visibilitychange/resume on
+    // reattach, so main's explicit warm-activation send is the only trigger
+    // this path can rely on — it must drive the same deferred wake fan-out.
+    act(() => viewWarmActivatedCb?.());
+    act(() => flushFrame());
+    expect(wakeMock).not.toHaveBeenCalled();
+
+    act(() => flushFrame());
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces a warm-activation signal with a same-turn lifecycle event into one wake", async () => {
+    await renderProvider();
+    act(() => flushFrame());
+    act(() => flushFrame());
+    wakeMock.mockClear();
+    expect(viewWarmActivatedCb).not.toBeNull();
+
+    // When Chromium DOES emit lifecycle events (e.g. the Efficiency-profile
+    // freeze path fires `resume`), the explicit trigger must dedupe with them
+    // rather than double-running the fan-out.
+    act(() => {
+      viewWarmActivatedCb?.();
+      document.dispatchEvent(new Event("resume"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    act(() => flushFrame());
+    act(() => flushFrame());
+
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a warm-activation wake when the view is hidden by execution time", async () => {
+    await renderProvider();
+    act(() => flushFrame());
+    act(() => flushFrame());
+    wakeMock.mockClear();
+    expect(viewWarmActivatedCb).not.toBeNull();
+
+    // The trigger itself has no entry-time visibility guard (main asserts the
+    // activation), but scheduleWake's execution-time re-check still applies:
+    // a view hidden again before the second frame must not run the fan-out.
+    setVisibilityState("hidden");
+    act(() => viewWarmActivatedCb?.());
+    act(() => flushFrame());
+    act(() => flushFrame());
+
+    expect(wakeMock).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending warm-activation wake when the view is cached mid-schedule", async () => {
+    await renderProvider();
+    act(() => flushFrame());
+    act(() => flushFrame());
+    wakeMock.mockClear();
+    expect(viewWarmActivatedCb).not.toBeNull();
+    expect(viewCachedCb).not.toBeNull();
+
+    // Rapid A→B→A→B: the warm activation schedules a wake, but the view is
+    // cached again (superseding switch) before the second frame — the pending
+    // rAF must be cancelled so the fan-out can't run against an occluded view.
+    act(() => viewWarmActivatedCb?.());
+    act(() => flushFrame());
+    act(() => viewCachedCb?.());
+    act(() => flushFrame());
+
+    expect(wakeMock).not.toHaveBeenCalled();
   });
 
   it("ignores visibilitychange dispatched while hidden", async () => {


### PR DESCRIPTION
This PR makes project switching meaningfully faster, with before and after numbers from a new opt-in e2e measurement harness.

### Renderer wake on warm switches

Switching to a cached view should be nearly instant, but every warm switch was stalling at the warm paint gate's 1500ms hard timeout. The renderer's terminal wake fan-out (which releases the gate via `notifyWarmViewPainted`) was only triggered by `visibilitychange`/`resume` events, and in Electron 42 a detached `setVisible(false)` view never receives either on reattach. The view reports `visibilityState === "visible"` the entire time it sits in the cache, so nothing ever fired the wake.

The main process knows exactly when it reactivates a cached view, so it now sends an explicit `app:view-warm-activated` event right after arming the gate. The renderer routes it into the existing `scheduleWake()` coalescer, and the visibility/resume listeners stay in place as fallbacks.

### Concurrent worktree load

`activateProjectView` was running the workspace-host git load strictly after the view swap, adding the full load (host spawn plus worktree enumeration, hundreds of ms on a cold host) to every switch's round trip. The load now starts alongside the swap. Forward-fail semantics (#8400) and the PTY port ordering (#10075) are unchanged.

### Results

From `e2e/full/resilience/project-switch-perf.spec.ts` (run with `RUN_PERF_SWITCH=1`), same machine, develop vs this branch:

| Metric | develop | this branch |
| --- | --- | --- |
| Warm reveal p50 | 1502ms | 66 to 200ms |
| Warm round trip p50 | 1506ms | 70 to 200ms |
| Cold round trip p50 | 294ms | ~180ms |
| Paint gate hard timeouts | 14 | 0 |

Warm reveals are now signal-driven instead of timeout-bound. The spec asserts `hardTimeouts === 0`, which fails on develop.

### Hardening

Review turned up some rapid-switch races, mostly pre-existing but widened by the concurrent load:

- `WorkspaceHostPool.loadProject` is now "last requested wins" per window. A superseded slow load completing late can't flip `windowToProject` back and route the wrong project's events into the active view.
- The swap-failure restore is epoch-guarded so it can't clobber a newer switch, and a failed first switch (no previous project) now releases the window mapping instead of leaving it pointed at the failed target.

### Testing

- New unit tests: warm-activated send ordering in `ProjectViewManager.paintGate.test.ts`, concurrent load and failure restore in `project.switch.test.ts`, load ordering races in `WorkspaceClient.loadOrder.test.ts`, and the new wake trigger in `WorktreeStoreContext.scheduleWake.test.tsx`.
- `core-project-switch-race.spec.ts` and the project-switch stress spec both pass locally, with the stress storm now running at zero hard timeouts.
- `npm run check` is green.