### PR TITLE
Performance sweep: hot-path, polling, renderer, and startup efficiency wins

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -24,7 +24,11 @@ const ALLOWED_RENDERER_EVENTS: ReadonlySet<keyof DaintreeEventMap> = new Set(["a
 const EVENT_BUS_BRIDGED_MANIFEST = {
   // Agent lifecycle: emitted on TypedEventBus; relayed here.
   "agent:state-changed": "bus",
-  "agent:state-transition-dropped": "bus",
+  // Diagnostic-only: consumed main-side by the event-inspector buffer; the
+  // renderer never subscribes, so relaying it to every window was pure waste.
+  // Classified "external" to drop it from the relay loop — no producer sends
+  // it on EVENTS_PUSH either, so it has no renderer delivery at all.
+  "agent:state-transition-dropped": "external",
   "agent:all-clear": "bus",
   "agent:detected": "bus",
   "agent:exited": "bus",
@@ -51,7 +55,12 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
 
   // Terminal observability (relayed from TypedEventBus via PtyEventsBridge)
   "terminal:reliability-metric": "bus",
-  "terminal:status": "bus",
+  // Flow-control status reaches the renderer exclusively through the
+  // dedicated project-scoped CHANNELS.TERMINAL_STATUS channel; nothing
+  // subscribes to the bus relay, which fanned every backpressure transition
+  // out to every window. Classified "external" to drop it from the relay
+  // loop — it has no EVENTS_PUSH producer, so no renderer delivery at all.
+  "terminal:status": "external",
 
   // Agent session journaled (relayed from TypedEventBus; emitted by the main
   // close paths and bridged from the pty-host's trash-expiry capture)

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -30,7 +30,10 @@ import {
   fetchWithPrivateHostGuard,
   urlHasCredentials,
 } from "../../utils/pluginDownloadPolicy.js";
-import { isPrivateOrLoopbackHostname, SCOPED_PLUGIN_NAME_PATTERN } from "../../schemas/plugin.js";
+import {
+  isPrivateOrLoopbackHostname,
+  SCOPED_PLUGIN_NAME_PATTERN,
+} from "../../schemas/pluginIdentifiers.js";
 import { scrubSecrets } from "../../../shared/utils/secretScrubber.js";
 import { stableArgsSha256 } from "../../utils/pluginMcpHash.js";
 import { isAuditedHandlerFailure } from "../../utils/pluginAuditMarker.js";

--- a/electron/schemas/index.ts
+++ b/electron/schemas/index.ts
@@ -87,12 +87,9 @@ export {
   type GitWorktreeEntry,
 } from "./external.js";
 
-export {
-  getPluginManifestSchema,
-  PanelContributionSchema,
-  PluginCapabilitySchema,
-  SCOPED_PLUGIN_NAME_PATTERN,
-  type PluginManifest,
-  type PanelContribution,
-  type PluginCapability,
-} from "./plugin.js";
+// `./plugin.js` is deliberately NOT re-exported here: its ~96 zod schemas and
+// `semver` import evaluate at module load, and this barrel sits in the eager
+// boot graph of several IPC handlers. Plugin install/validate consumers import
+// `./plugin.js` directly; boot-path identifier helpers live in
+// `./pluginIdentifiers.js`.
+export { SCOPED_PLUGIN_NAME_PATTERN } from "./pluginIdentifiers.js";

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
-import ipaddr from "ipaddr.js";
 import * as semver from "semver";
 import { z } from "zod";
+import {
+  SAFE_ID_PATTERN,
+  SCOPED_PLUGIN_NAME_PATTERN,
+  isPrivateOrLoopbackHostname,
+} from "./pluginIdentifiers.js";
 import {
   BUILT_IN_PLUGIN_CAPABILITIES,
   PLUGIN_CATEGORY_IDS,
@@ -28,9 +32,11 @@ import type {
   ForgeProviderContribution,
 } from "../../shared/types/forge.js";
 
-export const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
-
-export const SCOPED_PLUGIN_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// Identifier patterns + hostname classification live in the dependency-light
+// `./pluginIdentifiers.ts` so boot-path modules can use them without pulling
+// this file's zod schema construction into the eager graph. Re-exported here
+// because the install/validate consumers of the schemas below use them too.
+export { SAFE_ID_PATTERN, SCOPED_PLUGIN_NAME_PATTERN, isPrivateOrLoopbackHostname };
 
 // The full set of built-in action ids a plugin contribution may reference:
 // `BuiltInActionId = BuiltInKeyAction | BuiltInRuntimeActionId`
@@ -465,76 +471,6 @@ export const AgentContributionSchema = z
   .strict();
 
 export const PluginCapabilitySchema = z.enum(BUILT_IN_PLUGIN_CAPABILITIES);
-
-/**
- * Hostnames that resolve to private/loopback/link-local space and must not
- * appear in a plugin's `scopes.network.allowedUrls`. Literal-string matches
- * only — DNS rebinding (a public hostname that resolves to RFC1918 at
- * request time) is out of scope for manifest-level validation. See #9247.
- */
-// "0.0.0.0" is a Linux/Unix synonym for "any local interface" and routes to
-// loopback on many platforms — it must be rejected alongside "localhost".
-// Trailing-FQDN-dot variants (e.g. "localhost.") are normalized away before
-// the literal check (see `normalizeHostname` below) so we only list bare forms.
-const PRIVATE_LOOPBACK_HOSTNAME_LITERALS = new Set([
-  "localhost",
-  "ip6-localhost",
-  "ip6-loopback",
-  "0.0.0.0",
-]);
-/** IPv4 loopback (127.0.0.0/8). */
-const IPV4_LOOPBACK_REGEX = /^127\./;
-/** IPv4 link-local (169.254.0.0/16). Catches the AWS metadata endpoint. */
-const IPV4_LINK_LOCAL_REGEX = /^169\.254\./;
-/** IPv4 RFC1918 10.0.0.0/8. */
-const IPV4_RFC1918_TEN_REGEX = /^10\./;
-/** IPv4 RFC1918 192.168.0.0/16. */
-const IPV4_RFC1918_192_REGEX = /^192\.168\./;
-/** IPv4 RFC1918 172.16.0.0/12 (172.16.* through 172.31.*). */
-const IPV4_RFC1918_172_REGEX = /^172\.(1[6-9]|2\d|3[0-1])\./;
-
-function normalizeHostname(hostname: string): string {
-  // WHATWG URL parsing preserves trailing FQDN dots (RFC 1034 §3.1): the host
-  // "localhost." is structurally identical to "localhost" but would skip a
-  // literal-set check. Strip the trailing dot before any classification.
-  return hostname.replace(/\.$/, "").toLowerCase();
-}
-
-/**
- * Classify an IPv6 literal. `new URL("https://[::1]").hostname` is `"[::1]"`
- * — WHATWG retains the brackets — so strip them before parsing. Returns true
- * for loopback (::1), link-local (fe80::/10), unique-local (fc00::/7), and
- * IPv4-mapped addresses that unwrap to a blocked IPv4 (e.g. ::ffff:127.0.0.1).
- */
-function isPrivateOrLoopbackIPv6(normalized: string): boolean {
-  const literal =
-    normalized.startsWith("[") && normalized.endsWith("]") ? normalized.slice(1, -1) : normalized;
-  if (!ipaddr.IPv6.isValid(literal)) return false;
-  const addr = ipaddr.IPv6.parse(literal);
-  if (addr.isIPv4MappedAddress()) {
-    return isPrivateOrLoopbackIPv4(addr.toIPv4Address().toString());
-  }
-  const range = addr.range();
-  return range === "loopback" || range === "linkLocal" || range === "uniqueLocal";
-}
-
-function isPrivateOrLoopbackIPv4(value: string): boolean {
-  return (
-    IPV4_LOOPBACK_REGEX.test(value) ||
-    IPV4_LINK_LOCAL_REGEX.test(value) ||
-    IPV4_RFC1918_TEN_REGEX.test(value) ||
-    IPV4_RFC1918_192_REGEX.test(value) ||
-    IPV4_RFC1918_172_REGEX.test(value)
-  );
-}
-
-export function isPrivateOrLoopbackHostname(hostname: string): boolean {
-  const normalized = normalizeHostname(hostname);
-  if (PRIVATE_LOOPBACK_HOSTNAME_LITERALS.has(normalized)) return true;
-  if (isPrivateOrLoopbackIPv4(normalized)) return true;
-  if (isPrivateOrLoopbackIPv6(normalized)) return true;
-  return false;
-}
 
 /**
  * Shared per-entry validator body for manifest URL fields. Each entry must:

--- a/electron/schemas/pluginIdentifiers.ts
+++ b/electron/schemas/pluginIdentifiers.ts
@@ -1,0 +1,85 @@
+import ipaddr from "ipaddr.js";
+
+/**
+ * Dependency-light plugin identifier patterns and hostname classification.
+ *
+ * These live apart from `./plugin.ts` on purpose: several boot-path modules
+ * (deep-link install, plugin IPC handlers, download policy, settings manager)
+ * need only these helpers, and importing them from `plugin.ts` dragged its
+ * ~96 module-eval zod schemas plus `semver` into the eager main-process
+ * graph. Keep this module free of zod/semver.
+ */
+
+export const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+export const SCOPED_PLUGIN_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Hostnames that resolve to private/loopback/link-local space and must not
+ * appear in a plugin's `scopes.network.allowedUrls`. Literal-string matches
+ * only — DNS rebinding (a public hostname that resolves to RFC1918 at
+ * request time) is out of scope for manifest-level validation. See #9247.
+ */
+// "0.0.0.0" is a Linux/Unix synonym for "any local interface" and routes to
+// loopback on many platforms — it must be rejected alongside "localhost".
+// Trailing-FQDN-dot variants (e.g. "localhost.") are normalized away before
+// the literal check (see `normalizeHostname` below) so we only list bare forms.
+const PRIVATE_LOOPBACK_HOSTNAME_LITERALS = new Set([
+  "localhost",
+  "ip6-localhost",
+  "ip6-loopback",
+  "0.0.0.0",
+]);
+/** IPv4 loopback (127.0.0.0/8). */
+const IPV4_LOOPBACK_REGEX = /^127\./;
+/** IPv4 link-local (169.254.0.0/16). Catches the AWS metadata endpoint. */
+const IPV4_LINK_LOCAL_REGEX = /^169\.254\./;
+/** IPv4 RFC1918 10.0.0.0/8. */
+const IPV4_RFC1918_TEN_REGEX = /^10\./;
+/** IPv4 RFC1918 192.168.0.0/16. */
+const IPV4_RFC1918_192_REGEX = /^192\.168\./;
+/** IPv4 RFC1918 172.16.0.0/12 (172.16.* through 172.31.*). */
+const IPV4_RFC1918_172_REGEX = /^172\.(1[6-9]|2\d|3[0-1])\./;
+
+function normalizeHostname(hostname: string): string {
+  // WHATWG URL parsing preserves trailing FQDN dots (RFC 1034 §3.1): the host
+  // "localhost." is structurally identical to "localhost" but would skip a
+  // literal-set check. Strip the trailing dot before any classification.
+  return hostname.replace(/\.$/, "").toLowerCase();
+}
+
+/**
+ * Classify an IPv6 literal. `new URL("https://[::1]").hostname` is `"[::1]"`
+ * — WHATWG retains the brackets — so strip them before parsing. Returns true
+ * for loopback (::1), link-local (fe80::/10), unique-local (fc00::/7), and
+ * IPv4-mapped addresses that unwrap to a blocked IPv4 (e.g. ::ffff:127.0.0.1).
+ */
+function isPrivateOrLoopbackIPv6(normalized: string): boolean {
+  const literal =
+    normalized.startsWith("[") && normalized.endsWith("]") ? normalized.slice(1, -1) : normalized;
+  if (!ipaddr.IPv6.isValid(literal)) return false;
+  const addr = ipaddr.IPv6.parse(literal);
+  if (addr.isIPv4MappedAddress()) {
+    return isPrivateOrLoopbackIPv4(addr.toIPv4Address().toString());
+  }
+  const range = addr.range();
+  return range === "loopback" || range === "linkLocal" || range === "uniqueLocal";
+}
+
+function isPrivateOrLoopbackIPv4(value: string): boolean {
+  return (
+    IPV4_LOOPBACK_REGEX.test(value) ||
+    IPV4_LINK_LOCAL_REGEX.test(value) ||
+    IPV4_RFC1918_TEN_REGEX.test(value) ||
+    IPV4_RFC1918_192_REGEX.test(value) ||
+    IPV4_RFC1918_172_REGEX.test(value)
+  );
+}
+
+export function isPrivateOrLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizeHostname(hostname);
+  if (PRIVATE_LOOPBACK_HOSTNAME_LITERALS.has(normalized)) return true;
+  if (isPrivateOrLoopbackIPv4(normalized)) return true;
+  if (isPrivateOrLoopbackIPv6(normalized)) return true;
+  return false;
+}

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -1,5 +1,6 @@
 import {
   AgentPatternDetector,
+  lastLinesOffset,
   stripAnsi,
   type PatternDetectionConfig,
   type PatternDetectionResult,
@@ -75,6 +76,11 @@ const CPU_LOW_THRESHOLD = 3;
 // throttled, with a trailing-edge run so the final chunk before quiet is
 // still scanned. Downstream consumers debounce at 100ms+ scales.
 const PATTERN_SCAN_THROTTLE_MS = 30;
+
+// Line window for the detector-less esc-interrupt fallback in
+// `scanPatternBuffer` — matches the AgentPatternDetector default so both
+// paths scan the same tail.
+const ESC_FALLBACK_SCAN_LINES = 10;
 
 export interface ProcessStateValidator {
   hasActiveChildren(): boolean;
@@ -484,11 +490,17 @@ export class ActivityMonitor {
 
   private scanPatternBuffer(now: number): void {
     this.lastPatternScanAt = now;
-    const bufferText = stripAnsi(this.patternBuf.getText());
+    const rawBuffer = this.patternBuf.getText();
 
-    // Check for boot-complete patterns in the rolling buffer
+    // Boot-complete patterns may sit anywhere in the rolling buffer, so the
+    // transient boot phase strips it in full and reuses the result below. In
+    // the steady state (boot exited — the rest of the session) detection
+    // windows to the last N lines before stripping, so each 30ms scan strips
+    // only those lines instead of the whole 10KB buffer.
+    let fullStripped: string | undefined;
     if (!this.bootDetector.hasExitedBootState) {
-      if (this.bootDetector.check(bufferText, false, 0, Infinity)) {
+      fullStripped = stripAnsi(rawBuffer);
+      if (this.bootDetector.check(fullStripped, false, 0, Infinity)) {
         // Boot detected via pattern in rolling buffer
         this.fireBootComplete(now);
       }
@@ -496,15 +508,26 @@ export class ActivityMonitor {
 
     // Check for working patterns in the rolling buffer
     const patternResult = this.patternDetector
-      ? this.patternDetector.detect(bufferText, { alreadyStripped: true })
+      ? fullStripped !== undefined
+        ? this.patternDetector.detect(fullStripped, { alreadyStripped: true })
+        : this.patternDetector.detect(rawBuffer)
       : undefined;
     if (patternResult) {
       this.lastPatternResult = patternResult;
       this.lastPatternResultAt = now;
     }
+    // Detector-less fallback: scan the same last-N-lines window the pattern
+    // detector uses. A live interrupt hint is re-emitted on every status-line
+    // repaint, so it is always in the tail; one deeper in the buffer is stale
+    // and shouldn't hold "working" for up to 10KB of scrollback.
     const isWorking = patternResult
       ? patternResult.isWorking
-      : this.isEscInterruptFallback(bufferText.toLowerCase());
+      : this.isEscInterruptFallback(
+          (
+            fullStripped ??
+            stripAnsi(rawBuffer.slice(lastLinesOffset(rawBuffer, ESC_FALLBACK_SCAN_LINES)))
+          ).toLowerCase()
+        );
 
     if (
       isWorking &&

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -2135,8 +2135,10 @@ describe("ActivityMonitor", () => {
       monitor.onData("\nesc to interrupt\n");
       vi.advanceTimersByTime(500);
 
-      // Send a large data burst (>2000 chars) that evicts the working indicator from the pattern buffer
-      monitor.onData("x".repeat(3000));
+      // Send a large data burst that evicts the working indicator from the
+      // pattern buffer — must exceed 2x patternBufferSize (the buffer trims
+      // lazily at 2x capacity) so the trim actually fires.
+      monitor.onData("x".repeat(5000));
 
       // Verify the buffer eviction actually happened
       expect(monitor.getLastPatternResult()?.isWorking).toBe(false);

--- a/electron/services/plugin/PluginSettingsManager.ts
+++ b/electron/services/plugin/PluginSettingsManager.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { SCOPED_PLUGIN_NAME_PATTERN } from "../../schemas/plugin.js";
+import { SCOPED_PLUGIN_NAME_PATTERN } from "../../schemas/pluginIdentifiers.js";
 import { PluginSettingsStore } from "../PluginSettingsStore.js";
 import { projectStore } from "../ProjectStore.js";
 import type {

--- a/electron/services/pty/AgentPatternDetector.ts
+++ b/electron/services/pty/AgentPatternDetector.ts
@@ -90,6 +90,52 @@ export function stripAnsi(text: string): string {
   /* eslint-enable no-control-regex */
 }
 
+function countNewlines(text: string): number {
+  let count = 0;
+  let index = -1;
+  while ((index = text.indexOf("\n", index + 1)) !== -1) count++;
+  return count;
+}
+
+/**
+ * True when a raw-text window starting at `offset` falls inside an OSC
+ * payload — the last `ESC ]` before the offset has no BEL/ST terminator
+ * before it. OSC is the only escape class whose payload may span newlines,
+ * so it is the only one that can pull a naive last-N-lines window off the
+ * visible text.
+ */
+function windowStartsInsideOsc(text: string, offset: number): boolean {
+  if (offset <= 0) return false;
+  const esc = text.lastIndexOf("\x1b", offset - 1);
+  if (esc === -1 || text[esc + 1] !== "]") return false;
+  const bel = text.indexOf("\x07", esc);
+  if (bel !== -1 && bel < offset) return false;
+  const st = text.indexOf("\x1b\\", esc);
+  if (st !== -1 && st < offset) return false;
+  return true;
+}
+
+/**
+ * Find the offset of the last `lineCount` lines within `text` without
+ * allocating a per-line array. Equivalent to
+ * `text.split("\n").slice(-lineCount).join("\n")` but returns a single
+ * slice offset, avoiding the intermediate array and segment strings.
+ */
+export function lastLinesOffset(text: string, lineCount: number): number {
+  let startOffset = 0;
+  let searchFrom = text.length;
+  for (let i = 0; i < lineCount; i++) {
+    const nl = text.lastIndexOf("\n", searchFrom - 1);
+    if (nl === -1) {
+      // Fewer than lineCount lines — scan the whole string.
+      return 0;
+    }
+    startOffset = nl + 1;
+    searchFrom = nl;
+  }
+  return startOffset;
+}
+
 /**
  * Universal patterns that work across all agents.
  * Used when agent-specific patterns aren't configured.
@@ -198,27 +244,6 @@ export class AgentPatternDetector {
   }
 
   /**
-   * Find the offset of the last `scanLineCount` lines within `text` without
-   * allocating a per-line array. Equivalent to
-   * `text.split("\n").slice(-scanLineCount).join("\n")` but returns a single
-   * slice offset, avoiding the intermediate array and segment strings.
-   */
-  private lastLinesOffset(text: string): number {
-    let startOffset = 0;
-    let searchFrom = text.length;
-    for (let i = 0; i < this.scanLineCount; i++) {
-      const nl = text.lastIndexOf("\n", searchFrom - 1);
-      if (nl === -1) {
-        // Fewer than scanLineCount lines — scan the whole string.
-        return 0;
-      }
-      startOffset = nl + 1;
-      searchFrom = nl;
-    }
-    return startOffset;
-  }
-
-  /**
    * Detect working state from terminal output.
    *
    * @param output Terminal output. Raw (may include ANSI codes) unless
@@ -237,11 +262,25 @@ export class AgentPatternDetector {
       };
     }
 
-    // Strip ANSI codes for reliable pattern matching (unless already stripped).
-    const cleanOutput = opts?.alreadyStripped ? output : stripAnsi(output);
-
-    // Scan only the last N lines.
-    const textToScan = cleanOutput.slice(this.lastLinesOffset(cleanOutput));
+    // Window to the last N lines BEFORE stripping, so callers feeding the raw
+    // rolling buffer (per chunk / per 30ms scan) only pay for stripping the
+    // lines actually scanned instead of the whole buffer. CSI/SGR sequences
+    // never contain "\n" so the line window matches the stripped text's —
+    // except OSC payloads, whose content MAY embed newlines. When stripping
+    // shrinks the window below the intended line count (newlines were inside
+    // an OSC payload), widen the raw window once and re-window on the
+    // stripped text, restoring the exact "last N stripped lines" semantics.
+    const offset = lastLinesOffset(output, this.scanLineCount);
+    const windowed = output.slice(offset);
+    let textToScan = opts?.alreadyStripped ? windowed : stripAnsi(windowed);
+    if (
+      !opts?.alreadyStripped &&
+      offset > 0 &&
+      (countNewlines(textToScan) < this.scanLineCount - 1 || windowStartsInsideOsc(output, offset))
+    ) {
+      const widened = stripAnsi(output.slice(lastLinesOffset(output, this.scanLineCount * 4)));
+      textToScan = widened.slice(lastLinesOffset(widened, this.scanLineCount));
+    }
 
     return this.matchPatterns(textToScan);
   }

--- a/electron/services/pty/PatternBuffer.ts
+++ b/electron/services/pty/PatternBuffer.ts
@@ -8,7 +8,12 @@ export class PatternBuffer {
 
   update(data: string): void {
     this.buffer += data;
-    if (this.buffer.length > this.maxSize) {
+    // Trim lazily at 2× capacity: trimming on every over-cap append copies
+    // ~maxSize bytes per chunk under sustained output; deferring to 2× makes
+    // the copy amortized O(1) per byte. Consumers treat the buffer as "at
+    // least the last maxSize chars" (detection windows to the trailing
+    // lines), so briefly retaining up to 2× is harmless.
+    if (this.buffer.length > this.maxSize * 2) {
       this.buffer = this.buffer.slice(-this.maxSize);
     }
   }

--- a/electron/services/pty/PromptDetector.ts
+++ b/electron/services/pty/PromptDetector.ts
@@ -55,8 +55,12 @@ export function detectPrompt(
 
   const scanCount = Math.min(promptScanLineCount, lines.length);
   const scanLines = lines.slice(-scanCount);
+  // Strip each scan line once and reuse in the history loop below — this
+  // runs on the 50ms polling tick, and both loops scan the same lines.
+  const cleanScanLines: string[] = [];
   for (const line of scanLines) {
     const cleanLine = stripAnsi(line);
+    cleanScanLines.push(cleanLine);
     for (const pattern of promptHintPatterns) {
       const match = cleanLine.match(pattern);
       if (match) {
@@ -73,8 +77,7 @@ export function detectPrompt(
     return { isPrompt: false, confidence: 0 };
   }
 
-  for (const line of scanLines) {
-    const cleanLine = stripAnsi(line);
+  for (const cleanLine of cleanScanLines) {
     for (const pattern of promptPatterns) {
       const match = cleanLine.match(pattern);
       if (match) {

--- a/electron/services/pty/__tests__/AgentPatternDetector.test.ts
+++ b/electron/services/pty/__tests__/AgentPatternDetector.test.ts
@@ -805,4 +805,17 @@ wraps to the next line where the escape hint appears: esc to interrupt)`;
       expect(detector.detectFromLines(rows).isWorking).toBe(true);
     });
   });
+
+  describe("raw-window edge cases", () => {
+    it("detects a working indicator followed by an OSC payload with embedded newlines", () => {
+      // detect() windows the RAW buffer to the last N lines before stripping.
+      // Newlines inside an OSC payload inflate the raw line count, so a naive
+      // window could start inside the payload and miss the indicator that
+      // precedes it — the widen-and-rewindow fallback must recover it.
+      const detector = buildTestDetector("claude");
+      const oscWithNewlines = `\x1b]0;${"\n".repeat(20)}\x07`;
+      const output = "line above\n✽ Running tests… (esc to interrupt · 32s)" + oscWithNewlines;
+      expect(detector.detect(output).isWorking).toBe(true);
+    });
+  });
 });

--- a/electron/services/pty/__tests__/PatternBuffer.test.ts
+++ b/electron/services/pty/__tests__/PatternBuffer.test.ts
@@ -15,11 +15,16 @@ describe("PatternBuffer", () => {
     expect(buf.getText()).toBe("hello world");
   });
 
-  it("trims to max size keeping tail", () => {
+  it("retains at least the last maxSize chars within the 2x trim slack", () => {
+    // Trimming is amortized: the buffer may hold up to 2x maxSize before a
+    // trim, but the trailing maxSize chars are always present and a trim
+    // always keeps exactly the tail.
     const buf = new PatternBuffer(10);
     buf.update("abcdefghij");
     buf.update("klmno");
-    expect(buf.getText()).toBe("fghijklmno");
+    expect(buf.getText()).toBe("abcdefghijklmno");
+    buf.update("pqrstu");
+    expect(buf.getText()).toBe("lmnopqrstu");
     expect(buf.getText().length).toBe(10);
   });
 

--- a/electron/services/worktree/NoteFileReader.ts
+++ b/electron/services/worktree/NoteFileReader.ts
@@ -17,6 +17,11 @@ export class NoteFileReader {
   private worktreePath: string;
   private enabled: boolean;
   private filename: string;
+  // Poll-path cache: `read()` runs every full status poll but the note file
+  // rarely changes, so reuse the parsed result while the stat identity
+  // (path, mtime, size) matches and skip the readFile.
+  private cachedKey: string | undefined;
+  private cachedResult: NoteData | undefined;
 
   constructor(
     worktreePath: string,
@@ -33,6 +38,10 @@ export class NoteFileReader {
     if (filename !== undefined) {
       this.filename = filename;
     }
+    // Config changes re-resolve the note path; drop the cache so a stale
+    // (path, mtime, size) key can never serve the previous file's content.
+    this.cachedKey = undefined;
+    this.cachedResult = undefined;
   }
 
   private resolveNotePath(gitDir: string): string | undefined {
@@ -81,20 +90,30 @@ export class NoteFileReader {
       const fileStat = await stat(notePath);
       const timestamp = fileStat.mtimeMs;
 
+      const cacheKey = `${notePath}\n${timestamp}\n${fileStat.size}`;
+      if (cacheKey === this.cachedKey) {
+        return this.cachedResult;
+      }
+
       const content = await readFile(notePath, "utf-8");
       const trimmed = content.trim();
 
-      if (!trimmed) {
-        return undefined;
+      let result: NoteData | undefined;
+      if (trimmed) {
+        const lines = trimmed.split("\n");
+        const lastLine = lines[lines.length - 1].trim();
+        result =
+          lastLine.length > 500
+            ? { content: lastLine.slice(0, 497) + "...", timestamp }
+            : { content: lastLine, timestamp };
       }
 
-      const lines = trimmed.split("\n");
-      const lastLine = lines[lines.length - 1].trim();
-      if (lastLine.length > 500) {
-        return { content: lastLine.slice(0, 497) + "...", timestamp };
-      }
-      return { content: lastLine, timestamp };
+      this.cachedKey = cacheKey;
+      this.cachedResult = result;
+      return result;
     } catch (error) {
+      this.cachedKey = undefined;
+      this.cachedResult = undefined;
       const code = (error as NodeJS.ErrnoException).code;
       if (code && code !== "ENOENT") {
         logWarn("Failed to read AI note file", {

--- a/electron/setup/deepLinkInstall.ts
+++ b/electron/setup/deepLinkInstall.ts
@@ -1,5 +1,5 @@
 import { CHANNELS } from "../ipc/channels.js";
-import { SCOPED_PLUGIN_NAME_PATTERN } from "../schemas/plugin.js";
+import { SCOPED_PLUGIN_NAME_PATTERN } from "../schemas/pluginIdentifiers.js";
 import { getAppWebContents } from "../window/webContentsRegistry.js";
 import {
   clearPendingDaintreeUrls,

--- a/electron/setup/security.ts
+++ b/electron/setup/security.ts
@@ -79,6 +79,26 @@ function bigintSafeReplacer(_key: string, value: unknown): unknown {
   return typeof value === "bigint" ? value.toString() : value;
 }
 
+// Sentinel thrown from `sizeGuardReplacer` to abort the measuring stringify
+// the moment a binary/Map/Set value is encountered — the same payload classes
+// `containsBinary` names, detected during the single serialization pass
+// instead of a separate pre-walk over every invoke's arguments.
+const UNRELIABLE_SIZE_SENTINEL = Symbol("unreliable-json-size");
+
+function sizeGuardReplacer(key: string, value: unknown): unknown {
+  if (value !== null && typeof value === "object") {
+    if (
+      ArrayBuffer.isView(value) ||
+      value instanceof ArrayBuffer ||
+      value instanceof Map ||
+      value instanceof Set
+    ) {
+      throw UNRELIABLE_SIZE_SENTINEL;
+    }
+  }
+  return bigintSafeReplacer(key, value);
+}
+
 export function validateIpcInvokeEnvelope(channel: string, args: unknown[]): void {
   if (args.length > MAX_IPC_ARG_COUNT) {
     throw new AppError({
@@ -89,17 +109,23 @@ export function validateIpcInvokeEnvelope(channel: string, args: unknown[]): voi
     });
   }
 
-  // Binary / Map / Set payloads make `JSON.stringify` an unreliable size
-  // estimator. Skip the byte check and let Mojo's 128 MiB ceiling and the
-  // handler-level caps (clipboard PNG, artifact patch) act as the backstop.
-  if (args.some((arg) => containsBinary(arg))) return;
-
   const category = channelToCategory[channel];
   const budget = category !== undefined ? PAYLOAD_BUDGETS[category] : DEFAULT_PAYLOAD_BUDGET;
 
+  // Binary / Map / Set payloads make `JSON.stringify` an unreliable size
+  // estimator: the replacer aborts the measuring pass on the first one (or on
+  // stringify's own failures, e.g. circular refs), skipping the byte check so
+  // Mojo's 128 MiB ceiling and the handler-level caps (clipboard PNG,
+  // artifact patch) act as the backstop. Folding detection into the
+  // serialization keeps this single-traversal on every invoke instead of a
+  // `containsBinary` pre-walk plus a stringify. Unlike the old pre-walk's
+  // depth>32 bail-out (which SKIPPED the byte gate, letting a deeply nested
+  // oversize payload through unmeasured), deep plain objects are now measured
+  // like wide ones always were; past V8's recursion limit stringify throws
+  // and the catch below fails open, same as before.
   let bytes: number;
   try {
-    bytes = Buffer.byteLength(JSON.stringify(args, bigintSafeReplacer), "utf8");
+    bytes = Buffer.byteLength(JSON.stringify(args, sizeGuardReplacer), "utf8");
   } catch {
     return;
   }

--- a/electron/utils/__tests__/gitRepoOperationState.test.ts
+++ b/electron/utils/__tests__/gitRepoOperationState.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { existsSync } from "fs";
+import { readdirSync } from "fs";
 import { join as pathJoin } from "path";
-import { OPERATION_SENTINEL_NAMES, isRepoOperationInProgress } from "../gitRepoOperationState.js";
+import {
+  OPERATION_SENTINEL_NAMES,
+  isRepoOperationInProgress,
+  getRepoOperationStateSync,
+} from "../gitRepoOperationState.js";
 
 vi.mock("fs", () => ({
-  existsSync: vi.fn(),
+  readdirSync: vi.fn(),
 }));
 
 describe("gitRepoOperationState", () => {
@@ -28,35 +32,61 @@ describe("gitRepoOperationState", () => {
   });
 
   it("returns false when no sentinel files exist", () => {
-    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readdirSync).mockReturnValue(["HEAD", "config", "refs"] as never);
     expect(isRepoOperationInProgress(gitDir)).toBe(false);
   });
 
   for (const sentinel of OPERATION_SENTINEL_NAMES) {
     it(`returns true when ${sentinel} exists`, () => {
-      const expected = pathJoin(gitDir, sentinel);
-      vi.mocked(existsSync).mockImplementation((p) => p === expected);
+      vi.mocked(readdirSync).mockReturnValue(["HEAD", sentinel] as never);
       expect(isRepoOperationInProgress(gitDir)).toBe(true);
     });
   }
 
-  it("short-circuits on the first sentinel match", () => {
-    // MERGE_HEAD is checked first — once it returns true the function should
-    // not stat the remaining sentinel paths.
-    vi.mocked(existsSync).mockImplementation((p) => p === pathJoin(gitDir, "MERGE_HEAD"));
+  it("lists the directory exactly once per call", () => {
+    // The whole point of the readdir approach: one syscall per poll, not one
+    // existsSync per sentinel.
+    vi.mocked(readdirSync).mockReturnValue(["HEAD", "MERGE_HEAD"] as never);
     expect(isRepoOperationInProgress(gitDir)).toBe(true);
-    expect(vi.mocked(existsSync)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(readdirSync)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(readdirSync)).toHaveBeenCalledWith(gitDir);
   });
 
-  it("fails open when existsSync throws — treats sentinel as absent", () => {
+  it("fails open when readdirSync throws — treats sentinels as absent", () => {
     // EPERM or similar permission errors must not propagate; the caller
     // would otherwise stall every poll cycle for the worktree.
-    vi.mocked(existsSync).mockImplementation(() => {
+    vi.mocked(readdirSync).mockImplementation(() => {
       const err = new Error("EPERM") as NodeJS.ErrnoException;
       err.code = "EPERM";
       throw err;
     });
     expect(() => isRepoOperationInProgress(gitDir)).not.toThrow();
     expect(isRepoOperationInProgress(gitDir)).toBe(false);
+    expect(getRepoOperationStateSync(gitDir)).toBeUndefined();
+  });
+
+  describe("getRepoOperationStateSync", () => {
+    it("returns undefined when no sentinel files exist", () => {
+      vi.mocked(readdirSync).mockReturnValue(["HEAD", "config"] as never);
+      expect(getRepoOperationStateSync(gitDir)).toBeUndefined();
+    });
+
+    it.each([
+      ["rebase-merge", "REBASING"],
+      ["rebase-apply", "REBASING"],
+      ["CHERRY_PICK_HEAD", "CHERRY_PICKING"],
+      ["REVERT_HEAD", "REVERTING"],
+      ["MERGE_HEAD", "MERGING"],
+    ])("classifies %s as %s", (sentinel, expected) => {
+      vi.mocked(readdirSync).mockReturnValue(["HEAD", sentinel] as never);
+      expect(getRepoOperationStateSync(gitDir)).toBe(expected);
+    });
+
+    it("prioritizes rebase over merge when both sentinels are present", () => {
+      // An interrupted rebase can leave MERGE_HEAD alongside rebase-merge;
+      // classification order matches the async detectRepoOperationState.
+      vi.mocked(readdirSync).mockReturnValue(["MERGE_HEAD", "rebase-merge"] as never);
+      expect(getRepoOperationStateSync(gitDir)).toBe("REBASING");
+    });
   });
 });

--- a/electron/utils/gitRepoOperationState.ts
+++ b/electron/utils/gitRepoOperationState.ts
@@ -1,6 +1,5 @@
 // eager-import-allow: reads/writes the git-operation lock via sync fs
-import { existsSync } from "fs";
-import { join as pathJoin } from "path";
+import { readdirSync } from "fs";
 import type { RepoState } from "../../shared/types/git.js";
 
 /**
@@ -21,25 +20,34 @@ export const OPERATION_SENTINEL_NAMES = [
 ] as const;
 
 /**
+ * List `gitDir`'s entries once so sentinel checks cost a single syscall
+ * instead of one `existsSync` per sentinel — these run in front of every
+ * status poll for every worktree, where the per-poll fast path is otherwise
+ * a handful of async stats.
+ *
+ * Returns null on filesystem errors (e.g. EPERM) so callers fail open — if we
+ * can't determine the state, let the regular polling/git invocations proceed.
+ * Surfacing a permission error here would stall every poll cycle for the
+ * worktree. Sentinel names are matched exactly as git writes them; git never
+ * varies their case.
+ */
+function readGitDirEntries(gitDir: string): Set<string> | null {
+  try {
+    return new Set(readdirSync(gitDir));
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Returns true if any of the rebase/merge/cherry-pick/revert sentinel files
  * exist in `gitDir`. Synchronous so it's safe to call on hot paths (e.g.
  * before each git status poll) without adding an async round-trip.
- *
- * Fails open on filesystem errors (e.g. EPERM) — if we can't determine
- * the state, let the regular polling/git invocations proceed. Surfacing a
- * permission error here would stall every poll cycle for the worktree.
  */
 export function isRepoOperationInProgress(gitDir: string): boolean {
-  for (const name of OPERATION_SENTINEL_NAMES) {
-    try {
-      if (existsSync(pathJoin(gitDir, name))) {
-        return true;
-      }
-    } catch {
-      // Treat unreadable sentinel paths as absent and continue.
-    }
-  }
-  return false;
+  const entries = readGitDirEntries(gitDir);
+  if (!entries) return false;
+  return OPERATION_SENTINEL_NAMES.some((name) => entries.has(name));
 }
 
 /**
@@ -49,41 +57,21 @@ export function isRepoOperationInProgress(gitDir: string): boolean {
  *
  * Order of checks matches the async `detectRepoOperationState`: rebase first
  * (both merge and apply backends), then cherry-pick, revert, merge.
- *
- * Fails open on filesystem errors — a permission error on any sentinel path
- * is treated as absent so the classifier never blocks polling.
  */
 export function getRepoOperationStateSync(gitDir: string): RepoState | undefined {
-  try {
-    if (
-      existsSync(pathJoin(gitDir, "rebase-merge")) ||
-      existsSync(pathJoin(gitDir, "rebase-apply"))
-    ) {
-      return "REBASING";
-    }
-  } catch {
-    // Treat unreadable as absent.
+  const entries = readGitDirEntries(gitDir);
+  if (!entries) return undefined;
+  if (entries.has("rebase-merge") || entries.has("rebase-apply")) {
+    return "REBASING";
   }
-  try {
-    if (existsSync(pathJoin(gitDir, "CHERRY_PICK_HEAD"))) {
-      return "CHERRY_PICKING";
-    }
-  } catch {
-    // Treat unreadable as absent.
+  if (entries.has("CHERRY_PICK_HEAD")) {
+    return "CHERRY_PICKING";
   }
-  try {
-    if (existsSync(pathJoin(gitDir, "REVERT_HEAD"))) {
-      return "REVERTING";
-    }
-  } catch {
-    // Treat unreadable as absent.
+  if (entries.has("REVERT_HEAD")) {
+    return "REVERTING";
   }
-  try {
-    if (existsSync(pathJoin(gitDir, "MERGE_HEAD"))) {
-      return "MERGING";
-    }
-  } catch {
-    // Treat unreadable as absent.
+  if (entries.has("MERGE_HEAD")) {
+    return "MERGING";
   }
   return undefined;
 }

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -648,7 +648,7 @@ const MAX_REDACT_STRING_CHARS = 2000;
 const MAX_REDACT_ARRAY_ITEMS = 20;
 
 // Scrub content-based secrets BEFORE clamping. The downstream `scrubSecrets`
-// in `writeToLogFile` runs on the already-clamped value, so a secret straddling
+// in `emit`/`emitError` runs on the already-clamped value, so a secret straddling
 // the `MAX_REDACT_STRING_CHARS` boundary would have its high-entropy tail sliced
 // off here first, leaving a surviving prefix too short for the scrubber to match
 // — leaking the leading bytes to disk. Scrubbing first is exactly the upstream
@@ -828,14 +828,17 @@ export async function flushLogFileWritesForTesting(): Promise<void> {
   }
 }
 
+/**
+ * `message` and `contextStr` must already be scrubbed — `emit`/`emitError`
+ * scrub each field once and share the result between the file and console
+ * transports. The composed prefix (timestamp, level) carries no user content.
+ */
 function writeToLogFile(level: string, message: string, contextStr: string): void {
   if (!ENABLE_FILE_LOGGING) return;
   if (getWritesSuppressed()) return;
 
   const timestamp = new Date().toISOString();
-  const logLine = scrubSecrets(
-    `[${timestamp}] [${level}] ${message}${contextStr ? ` ${contextStr}` : ""}\n`
-  );
+  const logLine = `[${timestamp}] [${level}] ${message}${contextStr ? ` ${contextStr}` : ""}\n`;
   const bytes = Buffer.byteLength(logLine, "utf8");
 
   if (level === "ERROR") {
@@ -950,15 +953,18 @@ function emit(source: string, level: LogLevel, message: string, context?: LogCon
   });
 
   sendLogToRenderer(entry);
-  // Stringify once and share between the file and console transports.
+  // Stringify and scrub once, sharing both between the file and console
+  // transports — previously each transport re-scrubbed the same content.
   const contextStr = safeContext ? safeStringify(safeContext) : "";
-  writeToLogFile(level.toUpperCase(), message, contextStr);
+  const scrubbedMessage = scrubSecrets(message);
+  const scrubbedContext = contextStr ? scrubSecrets(contextStr) : "";
+  writeToLogFile(level.toUpperCase(), scrubbedMessage, scrubbedContext);
 
   if (!IS_TEST) {
     const prefix = `[${level.toUpperCase()}] [${source}]`;
     const consoleFn =
       level === "error" ? console.error : level === "warn" ? console.warn : console.log;
-    consoleFn(`${prefix} ${scrubSecrets(message)}`, contextStr ? scrubSecrets(contextStr) : "");
+    consoleFn(`${prefix} ${scrubbedMessage}`, scrubbedContext);
   }
 }
 
@@ -977,15 +983,18 @@ function emitError(source: string, message: string, error?: unknown, context?: L
   });
 
   sendLogToRenderer(entry);
-  // Stringify the merged, redacted context once and share it between the file
-  // and console transports — `safeContext` already folds in `errorDetails`, so
-  // the console path no longer re-serializes/re-scrubs the error and context
-  // separately (and now inherits key-redaction it previously skipped).
+  // Stringify the merged, redacted context once and scrub each field once,
+  // sharing both between the file and console transports — `safeContext`
+  // already folds in `errorDetails`, so the console path no longer
+  // re-serializes/re-scrubs the error and context separately (and inherits
+  // key-redaction it previously skipped).
   const contextStr = safeStringify(safeContext);
-  writeToLogFile("ERROR", message, contextStr);
+  const scrubbedMessage = scrubSecrets(message);
+  const scrubbedContext = scrubSecrets(contextStr);
+  writeToLogFile("ERROR", scrubbedMessage, scrubbedContext);
 
   if (!IS_TEST) {
-    console.error(`[ERROR] [${source}] ${scrubSecrets(message)}`, scrubSecrets(contextStr));
+    console.error(`[ERROR] [${source}] ${scrubbedMessage}`, scrubbedContext);
   }
 }
 

--- a/electron/utils/pluginDownloadPolicy.ts
+++ b/electron/utils/pluginDownloadPolicy.ts
@@ -1,7 +1,7 @@
 import dns from "node:dns/promises";
 import type { net as ElectronNet } from "electron";
 import { MAX_DNTR_BYTES } from "./pluginArchiveConstants.js";
-import { isPrivateOrLoopbackHostname } from "../schemas/plugin.js";
+import { isPrivateOrLoopbackHostname } from "../schemas/pluginIdentifiers.js";
 
 export { MAX_DNTR_BYTES };
 

--- a/shared/utils/__tests__/secretScrubber.test.ts
+++ b/shared/utils/__tests__/secretScrubber.test.ts
@@ -479,6 +479,18 @@ describe("secretScrubber", () => {
         expect(scrubSecrets(input)).toBe(expected);
       });
     }
+
+    // Every pattern must have at least one positive fixture above. The fixtures
+    // assert end-to-end through `scrubSecrets`, so together with this coverage
+    // check they prove the pre-scan probe is sound: a pattern whose `probe`
+    // fragment failed to match its own secrets would return the fixture input
+    // unredacted and fail its `redacts <name>` case.
+    for (const { name, regex } of PATTERNS) {
+      it(`has a positive fixture exercising ${name}`, () => {
+        const stateless = new RegExp(regex.source, regex.flags.replace(/[gy]/g, ""));
+        expect(positive.some(({ input }) => stateless.test(input))).toBe(true);
+      });
+    }
   });
 
   describe("negative cases", () => {

--- a/shared/utils/secretScrubber.ts
+++ b/shared/utils/secretScrubber.ts
@@ -9,7 +9,7 @@
  * Approved call sites:
  *   1. Sentry `beforeSend` (TelemetryService)
  *   2. DiagnosticsCollector string output
- *   3. Logger file-write (`writeToLogFile`) and console-mirror in `emit`/`emitError`
+ *   3. Logger `emit`/`emitError` (scrubbed once, shared by file write + console mirror)
  *   4. Main-process emergency crash log (`emergencyLogMainFatal`)
  *   5. Pty-host emergency crash log (`emergencyLogFatal`)
  *   6. IPC error envelope (`sanitizeErrorForRenderer` in setup/security.ts)
@@ -31,6 +31,18 @@ export interface SecretPattern {
   name: string;
   regex: RegExp;
   replacement: string;
+  /**
+   * Regex-source fragment that matches a substring of EVERY possible match of
+   * `regex` — usually the pattern's literal sigil (`\bghp_`). Fragments are
+   * OR-joined into a single pre-scan probe so `scrubSecrets` can skip all
+   * per-pattern passes on the (overwhelmingly common) secret-free input.
+   * Soundness is enforced end-to-end by the per-pattern fixtures in
+   * `secretScrubber.test.ts`: an over-narrow probe makes `scrubSecrets` return
+   * the fixture input unredacted and the test fails. Omit when no case-stable
+   * anchor exists (e.g. `i`-flagged patterns) — the full pattern source is
+   * folded into the probe instead, which is always sound.
+   */
+  probe?: string;
 }
 
 // Order matters for overlapping sigils: more-specific patterns must run before
@@ -40,11 +52,13 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "github-pat",
     regex: /\bghp_[A-Za-z0-9_]{36,255}\b/g,
+    probe: String.raw`\bghp_`,
     replacement: REDACTED,
   },
   {
     name: "github-fine-grained-pat",
     regex: /\bgithub_pat_[A-Za-z0-9_]{82}\b/g,
+    probe: String.raw`\bgithub_pat_`,
     replacement: REDACTED,
   },
   {
@@ -52,16 +66,19 @@ export const PATTERNS: readonly SecretPattern[] = [
     // Covers `ghs_` (app server-to-server), `ghu_` (user-to-server), and `gho_` (OAuth).
     // All three appear in `gh` CLI output and git-credential-manager logs.
     regex: /\bgh[sou]_[A-Za-z0-9_]{36}\b/g,
+    probe: String.raw`\bgh[sou]_`,
     replacement: REDACTED,
   },
   {
     name: "gitlab-personal-token",
     regex: /\bglpat-[0-9a-zA-Z_-]{20}\b/g,
+    probe: String.raw`\bglpat-`,
     replacement: REDACTED,
   },
   {
     name: "gitlab-deploy-token",
     regex: /\bgldt-[0-9a-zA-Z_-]{20}\b/g,
+    probe: String.raw`\bgldt-`,
     replacement: REDACTED,
   },
   {
@@ -69,6 +86,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // Also covers `sk-ant-oat01-` OAuth setup tokens — the `oat01-` infix is
     // within the `[A-Za-z0-9\-_]` charset and the body length falls inside {90,255}.
     regex: /\bsk-ant-[A-Za-z0-9\-_]{90,255}\b/g,
+    probe: String.raw`\bsk-ant-`,
     replacement: REDACTED,
   },
   {
@@ -76,6 +94,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // MUST precede `openai-api-key` so the shorter `sk-` prefix doesn't
     // greedily consume `sk-proj-`/`sk-svcacct-` and leave the body unredacted.
     regex: /\bsk-(?:proj|svcacct|admin)-[A-Za-z0-9_-]{100,256}\b/g,
+    probe: String.raw`\bsk-(?:proj|svcacct|admin)-`,
     replacement: REDACTED,
   },
   {
@@ -83,21 +102,25 @@ export const PATTERNS: readonly SecretPattern[] = [
     // MUST precede `openai-api-key` so the generic `sk-` prefix doesn't
     // greedily consume `sk-or-v1-` and leave the body unredacted.
     regex: /\bsk-or-v1-[0-9a-f]{55,70}\b/g,
+    probe: String.raw`\bsk-or-v1-`,
     replacement: REDACTED,
   },
   {
     name: "openai-api-key",
     regex: /\bsk-[A-Za-z0-9]{48}\b/g,
+    probe: String.raw`\bsk-`,
     replacement: REDACTED,
   },
   {
     name: "stripe-secret-key",
     regex: /\bsk_(?:live|test)_[0-9a-zA-Z]{24,48}\b/g,
+    probe: String.raw`\bsk_(?:live|test)_`,
     replacement: REDACTED,
   },
   {
     name: "stripe-restricted-key",
     regex: /\brk_(?:live|test)_[0-9a-zA-Z]{24,48}\b/g,
+    probe: String.raw`\brk_(?:live|test)_`,
     replacement: REDACTED,
   },
   {
@@ -106,33 +129,39 @@ export const PATTERNS: readonly SecretPattern[] = [
     // before broader `xoxe-`) AND `slack-token` (`xox[abprs]-` would
     // greedily consume `xox[bp]-` from `xoxe.xox[bp]-` tokens).
     regex: /\bxoxe\.xox[bp]-[A-Za-z0-9-]{160,180}\b/g,
+    probe: String.raw`\bxoxe\.xox[bp]-`,
     replacement: REDACTED,
   },
   {
     name: "slack-refresh-token",
     regex: /\bxoxe-[A-Z0-9-]{140,150}\b/g,
+    probe: String.raw`\bxoxe-`,
     replacement: REDACTED,
   },
   {
     name: "slack-token",
     regex: /\bxox[abprs]-[A-Za-z0-9-]{10,255}\b/g,
+    probe: String.raw`\bxox[abprs]-`,
     replacement: REDACTED,
   },
   {
     name: "slack-app-token",
     // `xapp-` covers Socket Mode and Audit Logs API tokens (post-Dec-2020).
     regex: /\bxapp-[A-Za-z0-9-]{90,140}\b/g,
+    probe: String.raw`\bxapp-`,
     replacement: REDACTED,
   },
   {
     name: "google-api-key",
     regex: /\bAIza[0-9A-Za-z_-]{35}\b/g,
+    probe: String.raw`\bAIza`,
     replacement: REDACTED,
   },
   {
     name: "aws-access-key-id",
     // Covers AKIA (IAM long-term), ASIA (STS short-term), and ABIA (STS variant).
     regex: /\bA[SKB]IA[0-9A-Z]{16}\b/g,
+    probe: String.raw`\bA[SKB]IA`,
     replacement: REDACTED,
   },
   {
@@ -149,12 +178,14 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "npm-token",
     regex: /\bnpm_[A-Za-z0-9]{36}\b/g,
+    probe: String.raw`\bnpm_`,
     replacement: REDACTED,
   },
   {
     name: "digitalocean-token",
     // Covers `dop_v1_` (personal), `doo_v1_` (OAuth), `dor_v1_` (refresh).
     regex: /\bdo[por]_v1_[A-Za-z0-9]{64}\b/g,
+    probe: String.raw`\bdo[por]_v1_`,
     replacement: REDACTED,
   },
   {
@@ -164,6 +195,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // (it would fail to match after a non-word `=` char). Upper bound 512 so
     // unusually long tokens don't leave a tail visible.
     regex: /\bAT[AC]TT3x[A-Za-z0-9+/=_-]{120,512}/g,
+    probe: String.raw`\bAT[AC]TT3x`,
     replacement: REDACTED,
   },
   {
@@ -171,36 +203,43 @@ export const PATTERNS: readonly SecretPattern[] = [
     // `cfat_` (account), `cfut_` (user), `cfk_` (global key). 40-char body
     // followed by an 8-char hex checksum.
     regex: /\bcf(?:at|ut|k)_[A-Za-z0-9]{40}[0-9a-f]{8}\b/g,
+    probe: String.raw`\bcf(?:at|ut|k)_`,
     replacement: REDACTED,
   },
   {
     name: "supabase-key",
     regex: /\bsb_(?:publishable|secret)_[A-Za-z0-9_]{32,64}\b/g,
+    probe: String.raw`\bsb_(?:publishable|secret)_`,
     replacement: REDACTED,
   },
   {
     name: "replicate-api-token",
     regex: /\br8_[A-Za-z0-9]{35,40}\b/g,
+    probe: String.raw`\br8_`,
     replacement: REDACTED,
   },
   {
     name: "huggingface-api-token",
     regex: /\bhf_[A-Za-z0-9]{25,40}\b/g,
+    probe: String.raw`\bhf_`,
     replacement: REDACTED,
   },
   {
     name: "groq-api-key",
     regex: /\bgsk_[A-Za-z0-9]{40,64}\b/g,
+    probe: String.raw`\bgsk_`,
     replacement: REDACTED,
   },
   {
     name: "linear-api-key",
     regex: /\blin_api_[A-Za-z0-9]{35,45}\b/g,
+    probe: String.raw`\blin_api_`,
     replacement: REDACTED,
   },
   {
     name: "notion-api-key",
     regex: /\bntn_[A-Za-z0-9]{40,55}\b/g,
+    probe: String.raw`\bntn_`,
     replacement: REDACTED,
   },
   {
@@ -208,12 +247,14 @@ export const PATTERNS: readonly SecretPattern[] = [
     // Three-segment format: `SG.{22-char ID}.{43-char secret}`. No trailing
     // `\b` because the final segment can end with `-` (non-word char).
     regex: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}/g,
+    probe: String.raw`\bSG\.`,
     replacement: REDACTED,
   },
   {
     name: "azure-connection-string",
     regex:
       /DefaultEndpointsProtocol=https;AccountName=[a-zA-Z0-9]{3,24};AccountKey=[a-zA-Z0-9+/]{86}==/g,
+    probe: "DefaultEndpointsProtocol=",
     replacement: REDACTED,
   },
   {
@@ -225,16 +266,19 @@ export const PATTERNS: readonly SecretPattern[] = [
     // fullchain.pem is typically 4-8KB; multi-issuer bundles can reach
     // tens of KB). `safe-regex2` still passes at this bound.
     regex: /-----BEGIN [A-Z ]{1,64}-----[\s\S]{1,100000}?-----END [A-Z ]{1,64}-----/g,
+    probe: "-----BEGIN ",
     replacement: REDACTED,
   },
   {
     name: "jwt",
     regex: /\beyJ[A-Za-z0-9\-_]{1,8000}\.[A-Za-z0-9\-_]{1,8000}\.[A-Za-z0-9\-_]{1,8000}\b/g,
+    probe: String.raw`\beyJ`,
     replacement: REDACTED,
   },
   {
     name: "bearer-token",
     regex: /Bearer [A-Za-z0-9\-._~+/]{8,4000}={0,2}/g,
+    probe: "Bearer ",
     replacement: `Bearer ${REDACTED}`,
   },
   {
@@ -247,6 +291,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // too noisy to anchor at line starts — plain log lines like
     // `code=42 not found` should not be touched.
     regex: /(^|[?&])(access_token|refresh_token|client_secret)=[^&\s]{1,1000}/gm,
+    probe: "(?:access_token|refresh_token|client_secret)=",
     replacement: `$1$2=${REDACTED}`,
   },
   {
@@ -255,6 +300,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // `?` or `&`. Anchoring at line start would catch unrelated log output like
     // `code=42 not found`.
     regex: /([?&])code=[^&\s]{1,1000}/g,
+    probe: String.raw`[?&]code=`,
     replacement: `$1code=${REDACTED}`,
   },
   {
@@ -272,16 +318,19 @@ export const PATTERNS: readonly SecretPattern[] = [
     name: "vercel-token",
     // Covers `vcp_` (personal), `vci_` (CI), `vca_` (account), `vcr_` (refresh), `vck_` (key).
     regex: /\bvc[piakr]_[A-Za-z0-9]{24,40}\b/g,
+    probe: String.raw`\bvc[piakr]_`,
     replacement: REDACTED,
   },
   {
     name: "perplexity-api-key",
     regex: /\bpplx-[a-f0-9]{48}\b/g,
+    probe: String.raw`\bpplx-`,
     replacement: REDACTED,
   },
   {
     name: "xai-api-key",
     regex: /\bxai-[A-Za-z0-9]{80}\b/g,
+    probe: String.raw`\bxai-`,
     replacement: REDACTED,
   },
   {
@@ -289,11 +338,13 @@ export const PATTERNS: readonly SecretPattern[] = [
     // No trailing `\b` because the body charset includes `-` and `_` (non-word
     // chars), so a token ending in either would silently slip past a boundary.
     regex: /\btgp_v1_[A-Za-z0-9_-]{43}/g,
+    probe: String.raw`\btgp_v1_`,
     replacement: REDACTED,
   },
   {
     name: "resend-api-key",
     regex: /\bre_[A-Za-z0-9]{48}\b/g,
+    probe: String.raw`\bre_[A-Za-z0-9]{48}\b`,
     replacement: REDACTED,
   },
   {
@@ -302,6 +353,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // greedily consume `HRKU-AA` and leave the body visible.
     // No trailing `\b`: body charset includes `-` and `_` (non-word).
     regex: /\bHRKU-AA[0-9a-zA-Z_-]{58}/g,
+    probe: String.raw`\bHRKU-AA`,
     replacement: REDACTED,
   },
   {
@@ -309,6 +361,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // No trailing `\b`: body charset includes `-` and `_` (non-word) so tokens
     // ending in either would silently miss the boundary check.
     regex: /\bHRKU-[A-Za-z0-9_-]{60}/g,
+    probe: String.raw`\bHRKU-`,
     replacement: REDACTED,
   },
   {
@@ -332,16 +385,19 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "pulumi-api-token",
     regex: /\bpul-[a-f0-9]{40}\b/g,
+    probe: String.raw`\bpul-`,
     replacement: REDACTED,
   },
   {
     name: "rubygems-api-token",
     regex: /\brubygems_[a-f0-9]{48}\b/g,
+    probe: String.raw`\brubygems_`,
     replacement: REDACTED,
   },
   {
     name: "readme-api-token",
     regex: /\brdme_[a-z0-9]{70}\b/g,
+    probe: String.raw`\brdme_`,
     replacement: REDACTED,
   },
   {
@@ -349,60 +405,71 @@ export const PATTERNS: readonly SecretPattern[] = [
     // Organization-level tokens use `api_org_` prefix, distinct from user-level
     // `hf_` tokens already covered above.
     regex: /\bapi_org_[A-Za-z]{34}\b/g,
+    probe: String.raw`\bapi_org_`,
     replacement: REDACTED,
   },
   {
     name: "age-secret-key",
     // Base58-encoded (Crockford alphabet) body. Fixed 58-char secret.
     regex: /\bAGE-SECRET-KEY-1[QPZRY9X8GF2TVDW0S3JN54KHCE6MUA7L]{58}\b/g,
+    probe: "AGE-SECRET-KEY-1",
     replacement: REDACTED,
   },
   {
     name: "infracost-api-token",
     regex: /\bico-[A-Za-z0-9]{32}\b/g,
+    probe: String.raw`\bico-`,
     replacement: REDACTED,
   },
   {
     name: "artifactory-api-key",
     regex: /\bAKCp[A-Za-z0-9]{69}\b/g,
+    probe: String.raw`\bAKCp`,
     replacement: REDACTED,
   },
   {
     name: "artifactory-reference-token",
     regex: /\bcmVmd[A-Za-z0-9]{59}\b/g,
+    probe: String.raw`\bcmVmd`,
     replacement: REDACTED,
   },
   {
     name: "grafana-service-account-token",
     // Format: glsa_<32 alnum>_<8 hex>. Trailing `\b` safe because body ends in hex.
     regex: /\bglsa_[A-Za-z0-9]{32}_[A-Fa-f0-9]{8}\b/g,
+    probe: String.raw`\bglsa_`,
     replacement: REDACTED,
   },
   {
     name: "easypost-api-token",
     regex: /\bEZAK[A-Za-z0-9]{54}\b/g,
+    probe: String.raw`\bEZAK`,
     replacement: REDACTED,
   },
   {
     name: "easypost-test-api-token",
     regex: /\bEZTK[A-Za-z0-9]{54}\b/g,
+    probe: String.raw`\bEZTK`,
     replacement: REDACTED,
   },
   {
     name: "maxmind-license-key",
     // Format: <6 alnum>_<29 alnum>_mmk. Trailing `\b` safe because body ends in `k`.
     regex: /\b[A-Za-z0-9]{6}_[A-Za-z0-9]{29}_mmk\b/g,
+    probe: String.raw`_mmk\b`,
     replacement: REDACTED,
   },
   {
     name: "doppler-api-token",
     regex: /\bdp\.pt\.[A-Za-z0-9]{43}\b/g,
+    probe: String.raw`\bdp\.pt\.`,
     replacement: REDACTED,
   },
   {
     name: "scalingo-api-token",
     // No trailing `\b`: body charset includes `-` and `_` (non-word).
     regex: /\btk-us-[A-Za-z0-9_-]{48}/g,
+    probe: String.raw`\btk-us-`,
     replacement: REDACTED,
   },
   {
@@ -417,12 +484,40 @@ export const PATTERNS: readonly SecretPattern[] = [
   },
 ];
 
+// Pre-scan probes: one alternation per case-sensitivity class, OR-joining each
+// pattern's `probe` fragment (falling back to the full pattern source when no
+// fragment is declared). A string that matches neither probe cannot match any
+// pattern, so `scrubSecrets` skips all per-pattern passes — the overwhelmingly
+// common case for log lines. Probes must be a superset of the patterns: false
+// probe hits only cost the full scan; a false miss would leak, which is why
+// fragments fall back to the full source and the fixtures in
+// `secretScrubber.test.ts` assert end-to-end through `scrubSecrets`.
+// Split by case class because a single `i`-flagged alternation defeats V8's
+// fast literal pre-search for the ~56 case-sensitive sigils. The `m` flag
+// keeps any folded-in `^` (e.g. `oauth-query-param`) as broad as the original.
+// No `g`/`y` flags — `.test()` on a `g` regex is stateful (see
+// `findSecretInValue` below).
+function buildProbe(patterns: readonly SecretPattern[], flags: string): RegExp | null {
+  const parts = patterns.map((p) => p.probe ?? p.regex.source);
+  return parts.length > 0 ? new RegExp(parts.join("|"), flags) : null;
+}
+
+const CASE_SENSITIVE_PROBE = buildProbe(
+  PATTERNS.filter((p) => !p.regex.flags.includes("i")),
+  "m"
+);
+const CASE_INSENSITIVE_PROBE = buildProbe(
+  PATTERNS.filter((p) => p.regex.flags.includes("i")),
+  "im"
+);
+
 /**
  * Scrubs known secret sigils from free text. Idempotent — calling twice yields
  * the same result, because the `[REDACTED]` token contains no secret sigil.
  *
  * All patterns are linear-time with bounded quantifiers; total work is O(N·K)
- * where K is the number of patterns. No pre-truncation is applied, because any
+ * where K is the number of patterns, and the probe pre-scan reduces the
+ * secret-free case to O(N). No pre-truncation is applied, because any
  * length cap would have to slice at an arbitrary byte boundary and would leak
  * the leading bytes of a secret that straddled the cut point. Callers that
  * care about payload size apply their own truncation downstream (e.g.
@@ -434,6 +529,9 @@ export const PATTERNS: readonly SecretPattern[] = [
  */
 export function scrubSecrets(value: string): string {
   if (value.length === 0) return value;
+  if (!CASE_SENSITIVE_PROBE?.test(value) && !CASE_INSENSITIVE_PROBE?.test(value)) {
+    return value;
+  }
 
   let out = value;
   for (const { regex, replacement } of PATTERNS) {
@@ -450,18 +548,26 @@ export function scrubSecrets(value: string): string {
  *
  * The shared `PATTERNS` regexes carry the `g` flag, which makes `.test()`
  * stateful (`lastIndex` persists across calls on the same instance and yields
- * non-deterministic false negatives in a loop). Each pattern is cloned with the
- * `g`/`y` flags stripped before testing so detection stays stateless and the
- * module-level catalogue is never mutated.
+ * non-deterministic false negatives in a loop). Each pattern is cloned once at
+ * module load with the `g`/`y` flags stripped so detection stays stateless and
+ * the module-level catalogue is never mutated.
  *
  * @param value arbitrary string, e.g. a recipe env value
  * @returns the first matching `SecretPattern`, or `undefined` when none match
  */
+const STATELESS_PATTERNS: ReadonlyArray<{ pattern: SecretPattern; stateless: RegExp }> =
+  PATTERNS.map((pattern) => ({
+    pattern,
+    stateless: new RegExp(pattern.regex.source, pattern.regex.flags.replace(/[gy]/g, "")),
+  }));
+
 export function findSecretInValue(value: string): SecretPattern | undefined {
   if (value.length === 0) return undefined;
+  if (!CASE_SENSITIVE_PROBE?.test(value) && !CASE_INSENSITIVE_PROBE?.test(value)) {
+    return undefined;
+  }
 
-  for (const pattern of PATTERNS) {
-    const stateless = new RegExp(pattern.regex.source, pattern.regex.flags.replace(/[gy]/g, ""));
+  for (const { pattern, stateless } of STATELESS_PATTERNS) {
     if (stateless.test(value)) return pattern;
   }
 

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -29,7 +29,9 @@ import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
 import { logError } from "@/utils/logger";
 
-export const DIAGNOSTICS_DOCK_REGION_ID = "diagnostics-dock-region";
+import { DIAGNOSTICS_DOCK_REGION_ID } from "./regionIds";
+
+export { DIAGNOSTICS_DOCK_REGION_ID };
 
 interface TabButtonProps {
   tab: DiagnosticsTab;

--- a/src/components/Diagnostics/regionIds.ts
+++ b/src/components/Diagnostics/regionIds.ts
@@ -1,0 +1,6 @@
+// Leaf module so always-mounted toolbar chrome (ToolbarProblemsButton's
+// aria-controls) can reference the dock's region id without statically
+// importing DiagnosticsDock — which would pull the dock and its six content
+// panels into the first-render chunk, defeating the lazy() boundary in
+// AppLayout.
+export const DIAGNOSTICS_DOCK_REGION_ID = "diagnostics-dock-region";

--- a/src/components/Layout/ToolbarProblemsButton.tsx
+++ b/src/components/Layout/ToolbarProblemsButton.tsx
@@ -7,7 +7,7 @@ import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { ToolbarContextMenuItems } from "./ToolbarContextMenuItems";
-import { DIAGNOSTICS_DOCK_REGION_ID } from "@/components/Diagnostics/DiagnosticsDock";
+import { DIAGNOSTICS_DOCK_REGION_ID } from "@/components/Diagnostics/regionIds";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text";
 

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -432,6 +432,17 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
+  // Prefix sums for each section's starting row index — computed in one pass
+  // instead of re-summing all prior sections per section during render.
+  const chronoSectionOffsets: number[] = [];
+  {
+    let offset = 0;
+    for (const s of chronoSections) {
+      chronoSectionOffsets.push(offset);
+      offset += s.groups.length;
+    }
+  }
+
   const markIdsReadWithUndo = (requestedIds: string[], options: { resetLastClosed: boolean }) => {
     if (requestedIds.length === 0) return;
     // Re-filter against live store state so a rapid second click on a stale
@@ -1097,8 +1108,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                   key={section.key}
                   section={section}
                   indexOffset={
-                    needsAttentionGroups.length +
-                    chronoSections.slice(0, sectionIdx).reduce((sum, s) => sum + s.groups.length, 0)
+                    needsAttentionGroups.length + (chronoSectionOffsets[sectionIdx] ?? 0)
                   }
                   focusedIndex={focusedIndex}
                   setRowRef={setRowRef}

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -15,6 +15,7 @@ import { logError, logWarn } from "@/utils/logger";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { addToWorktreeIndex } from "@/store/slices/panelRegistry/worktreeIndex";
 import type {
   AgentSettings,
   CliAvailability,
@@ -641,6 +642,14 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               const next: Partial<typeof state> = {
                 panelsById: { ...state.panelsById, [gateId]: gatePanel },
                 panelIds: [...state.panelIds, gateId],
+                // The gate panel bypasses `addPanel`, so it must join the
+                // per-worktree index here — sidebar summaries and worktree
+                // cycling derive terminal counts from it.
+                panelIdsByWorktreeId: addToWorktreeIndex(
+                  state.panelIdsByWorktreeId,
+                  gatePanel.worktreeId,
+                  gateId
+                ),
               };
               // Atomic dock activation — same race fix as `addPanel`. The gate
               // panel bypasses `addPanel`, so the activation must be folded

--- a/src/lib/__tests__/worktreeCyclingOrder.test.ts
+++ b/src/lib/__tests__/worktreeCyclingOrder.test.ts
@@ -92,6 +92,7 @@ beforeEach(() => {
   usePanelStore.setState({
     panelsById: {},
     panelIds: [],
+    panelIdsByWorktreeId: {},
   });
   resetFilterStore();
 });
@@ -183,6 +184,7 @@ describe("getVisibleWorktreesForCycling", () => {
         } as unknown as ReturnType<typeof usePanelStore.getState>["panelsById"][string],
       },
       panelIds: ["term-working"],
+      panelIdsByWorktreeId: { "wt-working": ["term-working"] },
     } as never);
 
     const ids = getVisibleWorktreesForCycling().map((w) => w.id);
@@ -325,6 +327,7 @@ describe("getVisibleWorktreesForCycling", () => {
         },
       } as unknown as ReturnType<typeof usePanelStore.getState>,
       panelIds: ["term-waiting"],
+      panelIdsByWorktreeId: { "wt-bg": ["term-waiting"] },
     } as never);
     const ids = getVisibleWorktreesForCycling().map((w) => w.id);
     expect(ids).not.toContain("wt-bg");
@@ -350,6 +353,7 @@ describe("getVisibleWorktreesForCycling", () => {
         },
       } as unknown as ReturnType<typeof usePanelStore.getState>,
       panelIds: ["term-waiting"],
+      panelIdsByWorktreeId: { "wt-eph": ["term-waiting"] },
     } as never);
     const ids = getVisibleWorktreesForCycling().map((w) => w.id);
     expect(ids).not.toContain("wt-eph");
@@ -412,6 +416,7 @@ describe("getVisibleWorktreesForCycling", () => {
         },
       } as unknown as ReturnType<typeof usePanelStore.getState>,
       panelIds: ["term-plain"],
+      panelIdsByWorktreeId: { "wt-shell": ["term-plain"] },
     } as never);
     const ids = getVisibleWorktreesForCycling().map((w) => w.id);
     expect(ids).not.toContain("wt-shell");

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -33,7 +33,12 @@ function normalizeSnapshot(snap: WorktreeSnapshot): WorktreeState {
 function buildDerivedMeta(
   worktree: WorktreeState,
   panelsById: ReturnType<typeof usePanelStore.getState>["panelsById"],
-  panelIds: ReturnType<typeof usePanelStore.getState>["panelIds"],
+  // This worktree's bucket from `panelIdsByWorktreeId` — iterating it instead
+  // of every panel keeps the per-worktree rollup O(own panels), matching
+  // `computePanelStateByWorktree` in sidebarPanelDerivation.ts. Bucket
+  // membership is equivalent to the previous `t.worktreeId === worktree.id`
+  // scan over all panel ids.
+  worktreePanelIds: readonly string[] | undefined,
   isInTrash: (id: string) => boolean,
   worktreeIds: Set<string>
 ): DerivedWorktreeMeta {
@@ -44,10 +49,9 @@ function buildDerivedMeta(
   let hasCompletedAgent = false;
   let hasExitedAgent = false;
 
-  for (const id of panelIds) {
+  for (const id of worktreePanelIds ?? []) {
     const t = panelsById[id];
-    if (!t || t.worktreeId !== worktree.id || !isTerminalVisible(t, isInTrash, worktreeIds))
-      continue;
+    if (!t || !isTerminalVisible(t, isInTrash, worktreeIds)) continue;
     terminalCount++;
     if (!isAgentTerminal(t)) continue;
     if (!isPtyPanel(t)) continue;
@@ -169,7 +173,7 @@ export function getVisibleWorktreesForCycling(
       buildDerivedMeta(
         worktree,
         panelState.panelsById,
-        panelState.panelIds,
+        panelState.panelIdsByWorktreeId[worktree.id],
         panelState.isInTrash,
         validWorktreeIds
       )

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -1227,6 +1227,7 @@ describe("worktree cycling respects sidebar order", () => {
         }),
       },
       panelIds: ["term-working"],
+      panelIdsByWorktreeId: { "wt-working": ["term-working"] },
     });
     useWorktreeFilterStore.setState({
       orderBy: "alpha",
@@ -1264,6 +1265,7 @@ describe("worktree cycling respects sidebar order", () => {
         }),
       },
       panelIds: ["term-working"],
+      panelIdsByWorktreeId: { "wt-working": ["term-working"] },
     });
     useWorktreeFilterStore.setState({
       orderBy: "alpha",
@@ -1303,6 +1305,7 @@ describe("worktree cycling respects sidebar order", () => {
         }),
       },
       panelIds: ["term-working"],
+      panelIdsByWorktreeId: { "wt-working": ["term-working"] },
     });
 
     useWorktreeFilterStore.setState({

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -385,6 +385,11 @@ describe("layoutUndoStore", () => {
     expect(state.activeDockTerminalId).toBe("t2");
     expect(state.tabGroups.size).toBe(1);
     expect(state.tabGroups.get("g1")?.panelIds).toEqual(["t1"]);
+    // The per-worktree index must follow the restored worktreeIds — sidebar
+    // summaries and worktree cycling read it, and a stale bucket would leave
+    // the terminals attributed to the pre-undo worktree.
+    expect(state.panelIdsByWorktreeId["w1"]).toEqual(["t1", "t2"]);
+    expect(state.panelIdsByWorktreeId["w2"]).toBeUndefined();
   });
 
   it("multi-step undo/redo traverses history correctly", () => {

--- a/src/store/layoutUndoStore.ts
+++ b/src/store/layoutUndoStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { usePanelStore } from "./panelStore";
 import type { TabGroup } from "@shared/types";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
+import { buildWorktreeIndex } from "@/store/slices/panelRegistry/worktreeIndex";
 
 type CarrierPanel = Parameters<typeof getNarrowPanel>[0][string];
 
@@ -98,6 +99,10 @@ function applySnapshot(snapshot: LayoutSnapshot): boolean {
   usePanelStore.setState({
     panelsById: newTerminalsById,
     panelIds: newTerminalIds,
+    // Bulk restore can change panels' worktreeId, so rebuild the per-worktree
+    // index — sidebar summaries and worktree cycling read it and would
+    // otherwise see stale buckets after an undo of a cross-worktree move.
+    panelIdsByWorktreeId: buildWorktreeIndex(newTerminalIds, newTerminalsById),
     tabGroups: structuredClone(snapshot.tabGroups),
     focusedId: snapshot.focusedId,
     maximizedId: snapshot.maximizedId,

--- a/src/utils/terminalTitleDisplay.ts
+++ b/src/utils/terminalTitleDisplay.ts
@@ -85,7 +85,39 @@ interface ObservedTask {
   isIdentityEcho: boolean;
 }
 
+// Bounded memo over the exact fields `computeObservedTask` reads. Title
+// surfaces (tab strips, headers, dock rows) re-derive titles on every
+// panel-store flush — per animation frame during agent output — while the
+// inputs only change on real title/identity transitions. AGENT_REGISTRY is
+// static, so the six fields fully determine the result. FIFO eviction: the
+// live working set is panels × recent titles, far below the cap.
+const OBSERVED_TASK_CACHE_MAX = 500;
+const observedTaskCache = new Map<string, ObservedTask | null>();
+
 function getObservedTask(panel: TitledPanel): ObservedTask | null {
+  // JSON-encoded tuple: field values are OSC/terminal-controlled strings, so
+  // a delimiter-join could collide across positions; JSON escaping cannot.
+  // null stands in for undefined to keep it distinct from an empty string.
+  const key = JSON.stringify([
+    panel.titleMode ?? "default",
+    panel.detectedAgentId ?? null,
+    panel.agentState === "exited",
+    panel.lastObservedTitle ?? null,
+    panel.title,
+    panel.cwd ?? null,
+  ]);
+  const cached = observedTaskCache.get(key);
+  if (cached !== undefined || observedTaskCache.has(key)) return cached ?? null;
+  const value = computeObservedTask(panel);
+  if (observedTaskCache.size >= OBSERVED_TASK_CACHE_MAX) {
+    const oldest = observedTaskCache.keys().next().value;
+    if (oldest !== undefined) observedTaskCache.delete(oldest);
+  }
+  observedTaskCache.set(key, value);
+  return value;
+}
+
+function computeObservedTask(panel: TitledPanel): ObservedTask | null {
   if ((panel.titleMode ?? "default") === "user") return null;
   if (panel.detectedAgentId === undefined || panel.agentState === "exited") return null;
   const cleaned = cleanTaskTitle(panel.lastObservedTitle);


### PR DESCRIPTION
This was a general performance sweep across the codebase. The goal was a set of small, low-risk efficiency wins that don't change behavior.

### Hot paths

* **Secret scrubber**: added a pre-scan probe so clean log lines skip the ~60 per-pattern regex passes. About 3.5x faster on realistic log lines, and every `scrubSecrets` call site benefits (logger, diagnostics, IPC error envelopes).
* **Logger**: each field is scrubbed once and the result is shared between the file and console transports, instead of re-scrubbing the same content per transport.
* **Agent pattern detection**: `detect()` now windows terminal output to the last 10 lines before stripping ANSI, instead of stripping the whole 10 KB rolling buffer on every 30 ms scan. The boot phase keeps the full-buffer scan. An OSC payload with embedded newlines can pull a raw window off the visible text, so there's a widen-and-rewindow fallback with a regression test.
* **Pattern buffer**: trims lazily at 2x capacity, so sustained output pays an amortized copy instead of a ~10 KB slice per chunk.
* **IPC payload size guard**: folded the `containsBinary` pre-walk into the size-measuring `JSON.stringify` replacer, one traversal per invoke instead of two. This also closes a gap where deeply nested payloads skipped the byte budget entirely.
* **Prompt detector**: scan lines are ANSI-stripped once and reused across both pattern loops on the 50 ms polling tick.

### Polling and events

* **Git status polling**: repo operation state now uses a single `readdirSync` instead of five sequential `existsSync` calls per poll per worktree, on the synchronous path in front of the stat-skip fast path.
* **AI note file reader**: caches the parsed note by path, mtime, and size, so unchanged files skip the `readFile` on every full poll.
* **Bus relay**: `terminal:status` and `agent:state-transition-dropped` are no longer relayed to every window. No renderer ever subscribed to them; flow-control status already reaches the renderer through the dedicated project-scoped channel.

### Renderer

* **Worktree cycling**: `buildDerivedMeta` iterates the per-worktree panel bucket instead of scanning every panel for every worktree on each cycle keypress, matching the sidebar derivation.
* **Terminal titles**: the observed-task derivation behind `getTerminalDisplayTitle` is memoized on its six input fields, so per-frame panel store flushes stop re-running the title pipeline for unchanged tabs.
* **Notification center**: section row offsets use a prefix sum instead of re-summing all prior sections per section.

### Startup

* **Plugin schemas**: extracted `SCOPED_PLUGIN_NAME_PATTERN`, `SAFE_ID_PATTERN`, and the hostname classification into `electron/schemas/pluginIdentifiers.ts`. The ~96 module-eval zod schemas in `schemas/plugin.ts` now leave the eager main-process boot graph and only load with the plugin install/validate paths.
* **Diagnostics dock**: `DIAGNOSTICS_DOCK_REGION_ID` moved to a leaf module so the toolbar button no longer drags the dock and its six content panels into the first-render chunk. Restores the `lazy()` split and cuts ~26 KB gzip from first render (measured against develop).

### Review findings

A Codex review of the diff caught two pre-existing bugs where panels bypassed the per-worktree index that the cycling change now leans on: layout undo restored `panelsById` without rebuilding `panelIdsByWorktreeId`, and the missing-CLI gate panel never joined the index. Both fixed with regression tests. It also flagged the OSC newline edge and a cache-key collision in the title memo, both hardened.

`npm run check` passes, and the touched suites are green (~8k unit tests across the affected areas). The import-budget and first-render-chunk baselines have pre-existing drift on develop; this branch moves both numbers in the right direction but doesn't touch the baselines.
