### PR TITLE
perf(terminal): cut agent-terminal launch latency

### DIFF
--- a/e2e/full/terminal/agent-launch-perf.spec.ts
+++ b/e2e/full/terminal/agent-launch-perf.spec.ts
@@ -1,0 +1,359 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window bridges are untyped in Playwright evaluate() */
+import { test, expect } from "@playwright/test";
+import { chmodSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { execSync } from "child_process";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { SEL } from "../../helpers/selectors";
+import { T_LONG } from "../../helpers/timeouts";
+
+// A/B latency harness for agent-terminal launch. Measures, inside the
+// renderer, the time from dispatching `agent.launch` (the exact path the
+// toolbar/tray buttons take) to three user-facing milestones:
+//   - panel:  the optimistic panel element appears in the grid DOM
+//   - xterm:  the xterm element is attached and visible (terminal chrome up)
+//   - output: the agent CLI's first output is rendered in the terminal
+// A fake `claude` CLI (instant banner + READY token) removes real-CLI boot
+// variance so the numbers isolate app overhead. Round 1 is reported as cold
+// (first terminal pays lazy imports / pty-pool miss); later rounds as warm.
+//
+// Opt-in only — a measurement harness for local A/B runs, not a CI gate.
+//   RUN_PERF_AGENT_LAUNCH=1 npx playwright test --project=full-terminal \
+//     e2e/full/terminal/agent-launch-perf.spec.ts
+const ROUNDS = Math.max(1, Math.floor(Number(process.env.PERF_AGENT_LAUNCH_ROUNDS) || 12));
+// Idle gap between measured rounds so teardown of one sample (panel close,
+// persist flushes, pool re-warm) can't bleed into the next.
+const SETTLE_MS = Number(process.env.PERF_AGENT_LAUNCH_SETTLE_MS ?? 750);
+const OUT_PATH = process.env.PERF_AGENT_LAUNCH_OUT ?? "";
+const READY_TOKEN = "FAKE_AGENT_READY";
+
+let ctx: AppContext;
+let fixtureDir: string;
+let fakeBinDir: string;
+let metricsPath: string;
+let fixtureCleanup: (() => void) | undefined;
+
+interface RoundSample {
+  round: number;
+  dispatchResolvedMs: number;
+  panelMs: number;
+  xtermMs: number;
+  firstTextMs: number;
+  outputMs: number;
+  panelId: string | null;
+  error?: string;
+}
+
+function prepareFixture(): void {
+  const { dir, cleanup } = createFixtureRepo({ name: "agent-launch-perf" });
+  fixtureDir = dir;
+  fixtureCleanup = cleanup;
+  fakeBinDir = path.join(fixtureDir, ".e2e-bin");
+  mkdirSync(fakeBinDir, { recursive: true });
+  metricsPath = path.join(fixtureDir, "perf-metrics.ndjson");
+
+  const implName = process.platform === "win32" ? "claude.js" : "claude";
+  const fakeClaude = path.join(fakeBinDir, implName);
+  // Instant-boot fake agent: prints a banner + READY immediately, then idles.
+  // No trust prompt — this harness measures app launch overhead, not
+  // interaction; CLI boot time is a constant (~node startup) on both variants.
+  writeFileSync(
+    fakeClaude,
+    [
+      "#!/usr/bin/env node",
+      "if (process.argv.includes('--version')) {",
+      "  console.log('claude code v9.9.9');",
+      "  process.exit(0);",
+      "}",
+      // One single write so READY cannot land in a later chunk than the
+      // banner — keeps the first-output milestone a single observable event.
+      `process.stdout.write('╭─ fake claude ─╮\\n│ benchmarking │\\n╰──────────────╯\\n' + ${JSON.stringify(READY_TOKEN)} + '\\n');`,
+      "process.stdin.resume();",
+      "process.stdin.setEncoding('utf8');",
+      "const keepAlive = setInterval(() => {}, 1000);",
+      "const shutdown = () => { clearInterval(keepAlive); process.exit(0); };",
+      "process.on('SIGINT', shutdown);",
+      "process.on('SIGTERM', shutdown);",
+      "",
+    ].join("\n")
+  );
+  chmodSync(fakeClaude, 0o755);
+  if (process.platform === "win32") {
+    writeFileSync(
+      path.join(fakeBinDir, "claude.cmd"),
+      ["@echo off", 'node "%~dp0claude.js" %*', ""].join("\r\n")
+    );
+  }
+
+  writeFileSync(
+    path.join(fixtureDir, "package.json"),
+    JSON.stringify({ name: "agent-launch-perf", version: "1.0.0", private: true }, null, 2) + "\n"
+  );
+  execSync("git add -A && git commit -m agent-launch-perf-fixture", {
+    cwd: fixtureDir,
+    stdio: "ignore",
+  });
+}
+
+function pct(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function stats(label: string, arr: number[]): string {
+  if (arr.length === 0) return `${label}: n=0`;
+  const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+  return `${label}: n=${arr.length} p50=${pct(arr, 50).toFixed(1)}ms p95=${pct(arr, 95).toFixed(1)}ms mean=${mean.toFixed(1)}ms min=${Math.min(...arr).toFixed(1)}ms max=${Math.max(...arr).toFixed(1)}ms`;
+}
+
+const perfDescribe = process.env.RUN_PERF_AGENT_LAUNCH ? test.describe.serial : test.describe.skip;
+
+perfDescribe("Perf: agent-terminal launch latency", () => {
+  test.beforeAll(async () => {
+    prepareFixture();
+    ctx = await launchApp({
+      env: {
+        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        DAINTREE_CLI_PATH_PREPEND: fakeBinDir,
+        DAINTREE_IDENTITY_DEBUG_PASS: "1",
+        DAINTREE_PERF_CAPTURE: "1",
+        DAINTREE_PERF_METRICS_FILE: metricsPath,
+      },
+    });
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Agent Launch Perf");
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("measures dispatch → panel → xterm → first-output latency", async () => {
+    test.slow();
+    test.setTimeout(600_000);
+    const { window: page } = ctx;
+
+    // Let post-onboarding work (worktree load, availability probes, pool
+    // warmup) settle so round 1 measures launch, not app startup residue.
+    await page.waitForTimeout(3_000);
+
+    // Seed the renderer perf-mark consumer buffer: markRendererPerformance
+    // records into window.__DAINTREE_PERF_MARKS__ whenever the array exists,
+    // independent of the build-time DAINTREE_PERF_CAPTURE gate. Reading the
+    // buffer directly avoids depending on the 15s steady-state flush.
+    await page.evaluate(() => {
+      (window as any).__DAINTREE_PERF_MARKS__ ||= [];
+    });
+
+    const measureRound = async (round: number): Promise<RoundSample> => {
+      const sample = await page.evaluate(
+        async ({ readyToken }) => {
+          const gridSel = '[data-panel-location="grid"]';
+          const before = new Set(
+            Array.from(document.querySelectorAll(gridSel)).map(
+              (el) => el.getAttribute("data-panel-id") ?? ""
+            )
+          );
+          const dispatch = (window as any).__daintreeDispatchAction as
+            | ((id: string, args?: unknown, opts?: unknown) => Promise<unknown>)
+            | undefined;
+          if (!dispatch) {
+            return {
+              dispatchResolvedMs: -1,
+              panelMs: -1,
+              xtermMs: -1,
+              outputMs: -1,
+              panelId: null,
+              error: "__daintreeDispatchAction missing",
+            };
+          }
+
+          // Long tasks overlapping the launch window explain paint stalls the
+          // milestone marks can't see (commit lands in 1ms; first paint waits
+          // out whatever is hogging the main thread).
+          const longTasks: Array<{ startMs: number; durMs: number }> = [];
+          let observer: PerformanceObserver | undefined;
+          try {
+            observer = new PerformanceObserver((list) => {
+              for (const e of list.getEntries()) {
+                longTasks.push({ startMs: e.startTime, durMs: e.duration });
+              }
+            });
+            observer.observe({ type: "longtask", buffered: false });
+          } catch {
+            // longtask unsupported — probe is best-effort
+          }
+
+          const t0 = performance.now();
+          let dispatchResolvedMs = -1;
+          const dispatched = dispatch(
+            "agent.launch",
+            { agentId: "claude" },
+            { source: "test" }
+          ).then(
+            (r) => {
+              dispatchResolvedMs = performance.now() - t0;
+              return r;
+            },
+            () => {
+              dispatchResolvedMs = -2;
+              return null;
+            }
+          );
+
+          let panelMs = -1;
+          let xtermMs = -1;
+          let firstTextMs = -1;
+          let outputMs = -1;
+          let panelId: string | null = null;
+          const deadline = t0 + 30_000;
+          while (performance.now() < deadline) {
+            const now = performance.now();
+            if (panelId === null) {
+              for (const el of Array.from(document.querySelectorAll(gridSel))) {
+                const id = el.getAttribute("data-panel-id");
+                if (id && !before.has(id)) {
+                  panelId = id;
+                  panelMs = now - t0;
+                  break;
+                }
+              }
+            }
+            if (panelId !== null) {
+              const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`);
+              if (panelEl) {
+                if (xtermMs < 0) {
+                  const x = panelEl.querySelector(".xterm");
+                  if (x && (x as HTMLElement).clientWidth > 0) xtermMs = now - t0;
+                }
+                if (xtermMs >= 0 && outputMs < 0) {
+                  const rows = panelEl.querySelector(".xterm-rows");
+                  const text = rows?.textContent ?? "";
+                  if (firstTextMs < 0 && text.trim().length > 0) firstTextMs = now - t0;
+                  if (text.includes(readyToken)) {
+                    outputMs = now - t0;
+                    break;
+                  }
+                }
+              }
+            }
+            await new Promise((r) => requestAnimationFrame(r));
+          }
+          await dispatched;
+          observer?.disconnect();
+          const tasks = longTasks
+            .filter((lt) => lt.startMs + lt.durMs >= t0)
+            .map((lt) => ({ atMs: Math.round(lt.startMs - t0), durMs: Math.round(lt.durMs) }));
+          return { dispatchResolvedMs, panelMs, xtermMs, firstTextMs, outputMs, panelId, tasks };
+        },
+        { readyToken: READY_TOKEN }
+      );
+
+      // Tear down EVERY grid panel — not just the one the sample identified —
+      // so a selector miss or a mid-round failure can't leak a running fake
+      // agent into later rounds. `confirmed: true` matters: an unconfirmed
+      // kill of a running-agent panel doesn't kill — it opens a pending
+      // destructive-action confirm that lingers over the app and pollutes
+      // subsequent rounds with overlay renders. The close is a fallback for
+      // a panel the kill already removed (no-op) or an already-exited agent.
+      await page.evaluate(async () => {
+        const dispatch = (window as any).__daintreeDispatchAction;
+        const ids = Array.from(document.querySelectorAll('[data-panel-location="grid"]'))
+          .map((el) => el.getAttribute("data-panel-id"))
+          .filter((id): id is string => !!id);
+        for (const id of ids) {
+          await dispatch?.(
+            "terminal.kill",
+            { terminalId: id, confirmed: true },
+            { source: "test" }
+          );
+          await dispatch?.("terminal.close", { terminalId: id }, { source: "test" });
+        }
+      });
+      await expect
+        .poll(() => page.locator(SEL.panel.gridPanel).count(), { timeout: T_LONG })
+        .toBe(0);
+
+      return { round, ...sample };
+    };
+
+    const samples: RoundSample[] = [];
+    for (let i = 1; i <= ROUNDS; i++) {
+      samples.push(await measureRound(i));
+      await page.waitForTimeout(SETTLE_MS);
+    }
+
+    // Renderer marks: read the consumer buffer directly. Host (pty-host)
+    // marks land in the ndjson file synchronously via fs.appendFileSync.
+    const markRecords: unknown[] = await page.evaluate(
+      () => (window as any).__DAINTREE_PERF_MARKS__ ?? []
+    );
+    if (existsSync(metricsPath)) {
+      for (const line of readFileSync(metricsPath, "utf8").trim().split("\n")) {
+        if (!line) continue;
+        try {
+          const rec = JSON.parse(line);
+          if (/^(terminal_|pty_pool_|agentlaunch\.)/.test(String(rec.mark))) markRecords.push(rec);
+        } catch {
+          // Skip lines truncated mid-write.
+        }
+      }
+    }
+
+    const ok = samples.filter((s) => !s.error && s.outputMs >= 0);
+    const cold = ok.filter((s) => s.round === 1);
+    const warm = ok.filter((s) => s.round > 1);
+
+    console.log("──────── agent-terminal launch latency results ────────");
+    console.log(`rounds=${ROUNDS} ok=${ok.length} settleMs=${SETTLE_MS}`);
+    for (const s of cold) {
+      console.log(
+        `cold (round 1): panel=${s.panelMs.toFixed(1)}ms xterm=${s.xtermMs.toFixed(1)}ms output=${s.outputMs.toFixed(1)}ms dispatchResolved=${s.dispatchResolvedMs.toFixed(1)}ms`
+      );
+    }
+    console.log(
+      stats(
+        "warm dispatch→panel   ",
+        warm.map((s) => s.panelMs)
+      )
+    );
+    console.log(
+      stats(
+        "warm dispatch→xterm   ",
+        warm.map((s) => s.xtermMs)
+      )
+    );
+    console.log(
+      stats(
+        "warm dispatch→output  ",
+        warm.map((s) => s.outputMs)
+      )
+    );
+    console.log("────────────────────────────────────────────────────────");
+
+    if (OUT_PATH) {
+      writeFileSync(
+        OUT_PATH,
+        JSON.stringify({ rounds: ROUNDS, settleMs: SETTLE_MS, samples, markRecords }, null, 2)
+      );
+      console.log(`results written to ${OUT_PATH}`);
+    }
+
+    // Reliability invariants only — latency itself is reported, not gated.
+    expect(ok.length, "every round produced a rendered agent terminal").toBe(ROUNDS);
+    for (const s of samples) {
+      expect(s.error ?? "", `round ${s.round} dispatched cleanly`).toBe("");
+      expect(
+        s.dispatchResolvedMs,
+        `round ${s.round} agent.launch dispatch resolved`
+      ).toBeGreaterThanOrEqual(0);
+      expect(s.panelMs, `round ${s.round} panel appeared`).toBeGreaterThanOrEqual(0);
+      expect(s.xtermMs, `round ${s.round} xterm attached`).toBeGreaterThanOrEqual(0);
+      expect(s.outputMs, `round ${s.round} agent output rendered`).toBeGreaterThanOrEqual(0);
+    }
+  });
+});

--- a/electron/ipc/__tests__/utils.test.ts
+++ b/electron/ipc/__tests__/utils.test.ts
@@ -57,6 +57,7 @@ import {
   typedSend,
   checkRateLimit,
   waitForRateLimitSlot,
+  waitForBurstRateLimitSlot,
   drainRateLimitQueues,
   armRestoreQuota,
   consumeRestoreQuota,
@@ -712,6 +713,107 @@ describe("waitForRateLimitSlot (leaky bucket, 2-arg)", () => {
     const before = Date.now();
     await waitForRateLimitSlot("lb-reset", 5_000);
     expect(Date.now()).toBe(before);
+  });
+});
+
+describe("waitForBurstRateLimitSlot (token bucket)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    _resetRateLimitQueuesForTest();
+  });
+
+  afterEach(() => {
+    _resetRateLimitQueuesForTest();
+    vi.useRealTimers();
+  });
+
+  it("releases up to the burst allowance instantly, then spaces at the interval", async () => {
+    const INTERVAL = 1_000;
+    const BURST = 6;
+    const resolvedAt: number[] = [];
+    const start = Date.now();
+
+    const promises = Array.from({ length: BURST + 2 }, (_, i) =>
+      waitForBurstRateLimitSlot("tb-burst", INTERVAL, BURST).then(() => {
+        resolvedAt.push(Date.now() - start);
+        return i;
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    // Exactly the burst allowance passes with zero wait — not one more.
+    expect(resolvedAt).toEqual(Array.from({ length: BURST }, () => 0));
+
+    // Callers beyond the burst drain at the leaky-bucket cadence.
+    await vi.advanceTimersByTimeAsync(INTERVAL);
+    expect(resolvedAt).toEqual([...Array.from({ length: BURST }, () => 0), INTERVAL]);
+    await vi.advanceTimersByTimeAsync(INTERVAL);
+    expect(resolvedAt).toEqual([...Array.from({ length: BURST }, () => 0), INTERVAL, 2 * INTERVAL]);
+
+    await Promise.all(promises);
+  });
+
+  it("re-banks burst capacity while idle instead of releasing more than the burst", async () => {
+    const INTERVAL = 1_000;
+    const BURST = 3;
+
+    // Exhaust the burst.
+    for (let i = 0; i < BURST; i++) {
+      await waitForBurstRateLimitSlot("tb-refill", INTERVAL, BURST);
+    }
+
+    // One interval of idle re-banks exactly one slot.
+    await vi.advanceTimersByTimeAsync(INTERVAL);
+    const afterRefill = Date.now();
+    await waitForBurstRateLimitSlot("tb-refill", INTERVAL, BURST);
+    expect(Date.now()).toBe(afterRefill);
+
+    // The very next caller has no banked slot and must wait a full interval.
+    const resolved: number[] = [];
+    const p = waitForBurstRateLimitSlot("tb-refill", INTERVAL, BURST).then(() => {
+      resolved.push(Date.now() - afterRefill);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toEqual([]);
+    await vi.advanceTimersByTimeAsync(INTERVAL);
+    expect(resolved).toEqual([INTERVAL]);
+    await p;
+  });
+
+  it("burst of 1 behaves exactly like the plain leaky bucket", async () => {
+    const INTERVAL = 2_000;
+    await waitForBurstRateLimitSlot("tb-one", INTERVAL, 1);
+
+    const resolved: number[] = [];
+    const start = Date.now();
+    const p = waitForBurstRateLimitSlot("tb-one", INTERVAL, 1).then(() => {
+      resolved.push(Date.now() - start);
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toEqual([]);
+    await vi.advanceTimersByTimeAsync(INTERVAL);
+    expect(resolved).toEqual([INTERVAL]);
+    await p;
+  });
+
+  it("rejects pending callers past MAX_QUEUE_DEPTH like the leaky bucket", async () => {
+    const INTERVAL = 1_000;
+    const BURST = 2;
+    const pending: Promise<void>[] = [];
+    // Burst passes instantly (no pending count) …
+    for (let i = 0; i < BURST; i++) {
+      await waitForBurstRateLimitSlot("tb-overflow", INTERVAL, BURST);
+    }
+    // … then 50 waiting callers fill the queue.
+    for (let i = 0; i < 50; i++) {
+      pending.push(waitForBurstRateLimitSlot("tb-overflow", INTERVAL, BURST));
+    }
+    await expect(waitForBurstRateLimitSlot("tb-overflow", INTERVAL, BURST)).rejects.toThrow(
+      "Spawn queue full"
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await Promise.all(pending);
   });
 });
 

--- a/electron/ipc/handlers/terminal/__tests__/commandLaunch.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/commandLaunch.test.ts
@@ -119,15 +119,17 @@ describe("buildCommandLaunchShell", () => {
       expect(result?.args[1]).toContain("exec '/bin/zsh' -l");
     });
 
-    it("defers the macOS interactive shell with a sleep wrapper", () => {
+    it("launches macOS through the same direct -lic form as Linux (no sleep wrapper)", () => {
       setPlatform("darwin");
 
       const result = buildCommandLaunchShell("claude", "/bin/zsh");
 
       expect(result).not.toBeNull();
-      expect(result?.args[0]).toBe("-c");
-      expect(result?.args[1]).toContain("sleep 0.05");
-      expect(result?.args[1]).toContain("exec '/bin/zsh'");
+      expect(result?.args[0]).toBe("-lic");
+      expect(result?.args[1]).not.toContain("sleep");
+      expect(result?.args[1]).toContain("trap : INT");
+      expect(result?.args[1]).toContain("claude");
+      expect(result?.args[1]).toContain("exec '/bin/zsh' -l");
     });
 
     it("uses -i -c for plain /bin/sh on Linux", () => {

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.shellReady.test.ts
@@ -37,6 +37,7 @@ type SafeParseable = {
 
 vi.mock("../../../utils.js", () => ({
   waitForRateLimitSlot: vi.fn(async () => {}),
+  waitForBurstRateLimitSlot: vi.fn(async () => {}),
   consumeRestoreQuota: vi.fn(() => false),
   typedHandle: (channel: string, handler: unknown) => {
     ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -19,6 +19,7 @@ const { mockGetCurrentProject, mockGetProjectById, mockGetProjectSettings } = vi
 }));
 
 const waitForRateLimitSlotMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const waitForBurstRateLimitSlotMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const consumeRestoreQuotaMock = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock("../../../../services/ProjectStore.js", () => ({
@@ -57,6 +58,7 @@ type SafeParseable = {
 
 vi.mock("../../../utils.js", () => ({
   waitForRateLimitSlot: waitForRateLimitSlotMock,
+  waitForBurstRateLimitSlot: waitForBurstRateLimitSlotMock,
   consumeRestoreQuota: consumeRestoreQuotaMock,
   typedHandle: (channel: string, handler: unknown) => {
     ipcMainMock.handle(channel, (_e: unknown, ...args: unknown[]) =>
@@ -641,20 +643,12 @@ describe("terminal spawn shell-injection hardening (#6065)", () => {
 
       // Lock the security-critical inner script template against structural
       // regressions. The shell path must be single-quoted and the user command
-      // must appear verbatim between the trap markers.
-      if (process.platform === "darwin") {
-        expect(spawnArgs.args[0]).toBe("-c");
-        expect(spawnArgs.args[1]).toContain("sleep 0.05");
-        expect(spawnArgs.args[1]).toContain("exec '/bin/zsh' -lic");
-        expect(spawnArgs.args[1]).toContain("trap : INT");
-        expect(spawnArgs.args[1]).toContain(command);
-        expect(spawnArgs.args[1]).toContain("trap - INT");
-      } else {
-        expect(spawnArgs.args).toEqual([
-          "-lic",
-          `trap : INT\n${command}\ntrap - INT\nexec '/bin/zsh' -l`,
-        ]);
-      }
+      // must appear verbatim between the trap markers. macOS and Linux share
+      // the direct -lic form (the macOS sleep-deferral wrapper is gone).
+      expect(spawnArgs.args).toEqual([
+        "-lic",
+        `trap : INT\n${command}\ntrap - INT\nexec '/bin/zsh' -l`,
+      ]);
     }
   );
 
@@ -678,11 +672,7 @@ describe("terminal spawn shell-injection hardening (#6065)", () => {
       );
 
       const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-      if (process.platform === "darwin") {
-        expect(spawnArgs.args[1]).toContain("exec '/tmp/o'\\''hare/zsh' -lic");
-      } else {
-        expect(spawnArgs.args[1]).toContain("exec '/tmp/o'\\''hare/zsh' -l");
-      }
+      expect(spawnArgs.args[1]).toContain("exec '/tmp/o'\\''hare/zsh' -l");
     }
   );
 });
@@ -697,6 +687,7 @@ describe("terminal spawn rate limiting (#5352)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     waitForRateLimitSlotMock.mockResolvedValue(undefined);
+    waitForBurstRateLimitSlotMock.mockResolvedValue(undefined);
     consumeRestoreQuotaMock.mockReturnValue(false);
     ptyClient = {
       spawn: vi.fn(),
@@ -708,23 +699,23 @@ describe("terminal spawn rate limiting (#5352)", () => {
     mockGetProjectSettings.mockResolvedValue({});
   });
 
-  it("uses the leaky-bucket form so batch spawns drain at a smooth 1/sec cadence", async () => {
+  it("uses the burst token bucket so interactive bursts pass instantly and batches drain at 1/sec", async () => {
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
 
     const handler = getSpawnHandler();
     await handler({} as Electron.IpcMainInvokeEvent, { cols: 80, rows: 24 });
 
-    // Exactly ("terminalSpawn", 1_000) — 2 args, not 3. The 3-arg overload
-    // silently picks the sliding-window implementation and reintroduces the
-    // every-10-terminals stall described in #5352.
-    expect(waitForRateLimitSlotMock).toHaveBeenCalledWith("terminalSpawn", 1_000);
-    expect(waitForRateLimitSlotMock.mock.calls[0]).toHaveLength(2);
+    // The burst variant keeps the leaky-bucket cadence after the burst —
+    // NOT the sliding-window overload, whose every-10-terminals stall #5352
+    // ruled out for batch spawns.
+    expect(waitForBurstRateLimitSlotMock).toHaveBeenCalledWith("terminalSpawn", 1_000, 6);
+    expect(waitForRateLimitSlotMock).not.toHaveBeenCalled();
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
   });
 
   it("rejects without calling ptyClient.spawn when the rate-limit slot rejects", async () => {
-    waitForRateLimitSlotMock.mockRejectedValueOnce(new Error("Spawn queue full"));
+    waitForBurstRateLimitSlotMock.mockRejectedValueOnce(new Error("Spawn queue full"));
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
@@ -753,7 +744,7 @@ describe("terminal spawn rate limiting (#5352)", () => {
       } as unknown as Parameters<typeof handler>[1]
     );
 
-    expect(waitForRateLimitSlotMock).not.toHaveBeenCalled();
+    expect(waitForBurstRateLimitSlotMock).not.toHaveBeenCalled();
     expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/ipc/handlers/terminal/commandLaunch.ts
+++ b/electron/ipc/handlers/terminal/commandLaunch.ts
@@ -30,8 +30,6 @@
 import { getDefaultShell } from "../../../services/pty/terminalShell.js";
 import { isCmdShell, isPowerShellShell } from "../../../../shared/utils/shellEscape.js";
 
-const MACOS_COMMAND_LAUNCH_STARTUP_DELAY_SECONDS = "0.05";
-
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
@@ -114,22 +112,14 @@ export function buildCommandLaunchShell(
   // Use a no-op trap rather than SIG_IGN so child CLIs don't inherit ignored
   // SIGINT.
   const script = `trap : INT\n${command}\ntrap - INT\n${execInteractiveShell}`;
-  const interactiveArgs =
-    name.includes("zsh") || name.includes("bash")
-      ? `-lic ${shellQuote(script)}`
-      : `-i -c ${shellQuote(script)}`;
-  // macOS CI can emit the first shell/agent bytes before node-pty returns
-  // from spawn. Defer the interactive shell by one tick so the PTY data
-  // handoff listener is installed before startup output begins.
+  // The historical macOS `sleep 0.05` deferral wrapper (added when early
+  // shell/agent bytes could race the PTY data listeners) is gone: fresh
+  // spawns attach a BufferedPtyDataHandoff synchronously with pty.spawn and
+  // the renderer registers its data callback at prewarm, before the spawn
+  // IPC is even sent — no consumer attaches late any more, and the wrapper
+  // taxed every agent launch 50ms plus an extra shell exec.
   const args =
-    process.platform === "darwin"
-      ? [
-          "-c",
-          `sleep ${MACOS_COMMAND_LAUNCH_STARTUP_DELAY_SECONDS}\nexec ${shellQuote(shell)} ${interactiveArgs}`,
-        ]
-      : name.includes("zsh") || name.includes("bash")
-        ? ["-lic", script]
-        : ["-i", "-c", script];
+    name.includes("zsh") || name.includes("bash") ? ["-lic", script] : ["-i", "-c", script];
 
   return { shell, args };
 }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -6,7 +6,7 @@ import crypto from "crypto";
 import os from "os";
 import { z } from "zod";
 import { CHANNELS } from "../../channels.js";
-import { waitForRateLimitSlot, consumeRestoreQuota } from "../../utils.js";
+import { waitForBurstRateLimitSlot, consumeRestoreQuota } from "../../utils.js";
 import { defineIpcNamespace, op, opValidated } from "../../define.js";
 import { projectStore } from "../../../services/ProjectStore.js";
 import type * as McpServerServiceModule from "../../../services/McpServerService.js";
@@ -111,7 +111,12 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
     const bypassedRateLimit = validatedOptions.restore === true && consumeRestoreQuota();
     if (!bypassedRateLimit) {
-      await waitForRateLimitSlot("terminalSpawn", 1_000);
+      // Burst-tolerant token bucket: a user launching several agents
+      // back-to-back (fleet launch, "up to 4 in parallel" MCP guidance) gets
+      // up to 6 instant spawns, then the schedule falls back to the smooth
+      // 1/sec leaky-bucket cadence that #5352 chose for batch spawns — the
+      // sliding-window overload and its every-N-terminals stall stay out.
+      await waitForBurstRateLimitSlot("terminalSpawn", 1_000, 6);
     }
 
     const cols = Math.max(1, Math.min(500, Math.floor(validatedOptions.cols) || 80));

--- a/electron/ipc/utils.ts
+++ b/electron/ipc/utils.ts
@@ -208,7 +208,24 @@ export async function waitForRateLimitSlot(
   return waitForSlidingWindowSlot(key, maxCallsOrInterval, windowMs);
 }
 
-async function waitForLeakyBucketSlot(key: string, intervalMs: number): Promise<void> {
+/**
+ * Token-bucket variant of the leaky bucket: `burst` callers may pass with no
+ * wait after an idle stretch, then sustained callers drain at one per
+ * `intervalMs` (identical to the leaky bucket). A burst allowance of 1 IS the
+ * leaky bucket. Use for interactive operations where a small user-driven
+ * burst (e.g. launching several agents back-to-back) must not serialize onto
+ * the sustained cadence, while runaway automation still hits the same
+ * long-run rate.
+ */
+export async function waitForBurstRateLimitSlot(
+  key: string,
+  intervalMs: number,
+  burst: number
+): Promise<void> {
+  return waitForLeakyBucketSlot(key, intervalMs, burst);
+}
+
+async function waitForLeakyBucketSlot(key: string, intervalMs: number, burst = 1): Promise<void> {
   if (intervalMs <= 0) return;
 
   const state = getOrCreateLeakyState(key);
@@ -226,8 +243,14 @@ async function waitForLeakyBucketSlot(key: string, intervalMs: number): Promise<
   // concurrent callers each claim a unique sequential slot. If this advance
   // happened after an await, two simultaneous callers could both read the
   // same `nextAvailableMs` and end up scheduled for the same instant.
+  //
+  // The burst allowance banks idle time: clamping the reserved slot from
+  // below at `now - (burst - 1) * intervalMs` lets up to `burst` reservations
+  // land at-or-before `now` (zero wait) before the schedule pushes into the
+  // future, after which callers space out at `intervalMs` exactly like the
+  // plain leaky bucket.
   const now = Date.now();
-  const slotMs = Math.max(now, state.nextAvailableMs);
+  const slotMs = Math.max(now - (Math.max(1, burst) - 1) * intervalMs, state.nextAvailableMs);
   state.nextAvailableMs = slotMs + intervalMs;
   const waitMs = slotMs - now;
 

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -2,6 +2,7 @@ import { parseSpawnError } from "../index.js";
 import type { AgentEvent } from "../../services/AgentStateMachine.js";
 import type { SpawnResult } from "../../../shared/types/pty-host.js";
 import type { HandlerMap, HostContext } from "./types.js";
+import { markHostPerformance } from "../../utils/hostPerformance.js";
 
 /** A PTY PID is usable only once it is a positive integer. */
 function isValidPid(pid: number | undefined): pid is number {
@@ -44,6 +45,7 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
 
   return {
     spawn: (msg) => {
+      markHostPerformance("agentlaunch.host-spawn:start", { terminalId: msg.id });
       let spawnResult: SpawnResult;
       try {
         // Remove stale coordinator before spawn (handles ID respawn)
@@ -109,6 +111,10 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
         }
       }
 
+      markHostPerformance("agentlaunch.host-spawn:end", {
+        terminalId: msg.id,
+        success: spawnResult.success,
+      });
       sendEvent({ type: "spawn-result", id: msg.id, result: spawnResult });
     },
 

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -477,6 +477,15 @@ export interface PtyPanelData extends BasePanelData {
    */
   spawnStatus?: "spawning" | "ready" | "missing-cli" | "failed";
   /**
+   * Live-only render hint: mount the visible xterm immediately instead of
+   * waiting for spawnStatus to flip "ready". Stamped at creation for a
+   * single active-grid launch (startup queue idle), where realizing the
+   * xterm concurrently with the spawn IPC shaves the round-trip off the
+   * time-to-visible path. Burst spawns (queue non-idle) stay gated so many
+   * panels never realize in the same frame. Never serialized.
+   */
+  eagerAttach?: boolean;
+  /**
    * Original user-selected preset ID. Set on first spawn, never overwritten
    * when a fallback activates. Used to display "was {original} → {active}".
    */

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -456,6 +456,7 @@ function TerminalPaneComponent({
         exitBehavior: pty?.exitBehavior,
         isTrashedOrRemoved: terminal?.location === "trash" || terminal === undefined,
         spawnStatus: pty?.spawnStatus,
+        eagerAttach: pty?.eagerAttach ?? false,
         sessionLostOnRestore: pty?.sessionLostOnRestore ?? false,
       };
     })
@@ -468,6 +469,7 @@ function TerminalPaneComponent({
     exitBehavior,
     isTrashedOrRemoved,
     spawnStatus,
+    eagerAttach,
     sessionLostOnRestore,
   } = terminalState;
   // Fleet-scope mounts pass `isInputLocked: true` to render the panel as a
@@ -1411,7 +1413,7 @@ function TerminalPaneComponent({
             detail={getPanelCliDetail() ?? { state: "missing", resolvedPath: null, via: null }}
             onRunAnyway={handleRunAnyway}
           />
-        ) : spawnStatus === "spawning" ? (
+        ) : spawnStatus === "spawning" && !eagerAttach ? (
           <TerminalStartupPlaceholder agentId={agentId} onCancel={() => onClose()} />
         ) : spawnStatus === "failed" ? (
           <div className="flex-1 min-h-0 bg-daintree-bg flex items-center justify-center">

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -12,6 +12,7 @@ import { isElectronAvailable } from "./useElectron";
 import { systemClient } from "@/clients";
 import { useHomeDir } from "@/hooks/app/useHomeDir";
 import { logError, logWarn } from "@/utils/logger";
+import { markRendererPerformance } from "@/utils/performance";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
@@ -302,6 +303,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
       // useRef avoids the react batching window that useState would have.
       if (launchingAgentsRef.current.has(agentId)) return null;
       launchingAgentsRef.current.add(agentId);
+      markRendererPerformance("agentlaunch.begin", { agentId });
 
       try {
         const targetWorktreeId = launchOptions?.worktreeId ?? activeWorktreeId;
@@ -677,6 +679,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         }
 
         try {
+          markRendererPerformance("agentlaunch.addpanel", { agentId });
           const terminalId = await addPanel(options);
           if (!terminalId) return null;
           const rawLocation = usePanelStore.getState().panelsById[terminalId]?.location ?? "grid";

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -73,6 +73,8 @@ const PTY_FIELD_CLASSIFICATION = {
   sessionTokens: false,
   spawnError: false,
   spawnStatus: false,
+  // Live-only render hint for single-launch eager xterm mount; never persisted.
+  eagerAttach: false,
   activityHeadline: false,
   activityStatus: false,
   activityType: false,

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -136,6 +136,8 @@ describe("optimistic panel spawn (#5789)", () => {
     const panel = getPtyPanel("opt-1");
     expect(panel).toBeDefined();
     expect(panel?.spawnStatus).toBe("spawning");
+    // A single active-grid launch mounts its xterm eagerly (startup queue idle).
+    expect(panel?.eagerAttach).toBe(true);
     expect(panel?.runtimeIdentity).toMatchObject({
       kind: "agent",
       agentId: "claude",
@@ -208,6 +210,14 @@ describe("optimistic panel spawn (#5789)", () => {
       expect(state.panelIds).toContain(id);
     }
 
+    // Only the first launch of the burst gets the eager xterm mount; the
+    // reservation taken at its eager decision hides the still-empty queue
+    // from the rest, so they keep the one-per-frame realization gate.
+    expect((state.panelsById["concurrent-0"] as PtyPanelData | undefined)?.eagerAttach).toBe(true);
+    for (const id of ids.slice(1)) {
+      expect((state.panelsById[id] as PtyPanelData | undefined)?.eagerAttach).toBeUndefined();
+    }
+
     // Only the first PTY spawn is allowed to start while the startup job is blocked.
     expect(terminalClient.spawn).toHaveBeenCalledTimes(1);
     expect(terminalClient.spawn.mock.calls[0]?.[0]).toMatchObject({ id: "concurrent-0" });
@@ -227,6 +237,23 @@ describe("optimistic panel spawn (#5789)", () => {
     for (const id of ids) {
       expect((after.panelsById[id] as PtyPanelData | undefined)?.spawnStatus).toBe("ready");
     }
+  });
+
+  it("does not stamp eagerAttach on dock launches", async () => {
+    const { addPanel } = usePanelStore.getState();
+    const id = await addPanel({
+      kind: "terminal",
+      launchAgentId: "claude",
+      command: "claude",
+      requestedId: "dock-eager",
+      cwd: "/",
+      location: "dock",
+      bypassLimits: true,
+    });
+
+    expect(id).toBe("dock-eager");
+    expect(getPtyPanel("dock-eager")?.eagerAttach).toBeUndefined();
+    await drainMicrotasks();
   });
 
   it("keeps the panel with spawnStatus 'failed' when the background spawn rejects", async () => {

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -30,6 +30,7 @@ import {
   DOCK_PREWARM_HEIGHT_PX,
 } from "./helpers";
 import { logDebug, logWarn, logError } from "@/utils/logger";
+import { markRendererPerformance } from "@/utils/performance";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { collectPanelIdForBatch, isHydrationBatchActive } from "./hydrationBatch";
 import { addToWorktreeIndex, transferBetweenWorktreeIndex } from "./worktreeIndex";
@@ -111,8 +112,26 @@ function estimateOverlayGridDims(fontSize: number): { cols: number; rows: number
 class TerminalStartupQueue {
   private readonly tasks: Array<() => Promise<void>> = [];
   private isDraining = false;
+  private reservations = 0;
+
+  /** True when an enqueued task would start immediately (single-launch fast path). */
+  get isIdle(): boolean {
+    return this.tasks.length === 0 && !this.isDraining && this.reservations === 0;
+  }
+
+  /**
+   * Claim a pending slot between the synchronous eager-attach decision and
+   * the (post-await) enqueue. Concurrent addPanel calls — a recipe's
+   * Promise.allSettled burst — would otherwise all observe an idle queue and
+   * every panel would stamp eagerAttach, realizing many xterms in the same
+   * frame (the exact burst #5789 gates against). Released on enqueue.
+   */
+  reserve(): void {
+    this.reservations++;
+  }
 
   enqueue(task: () => Promise<void>): void {
+    if (this.reservations > 0) this.reservations--;
     this.tasks.push(task);
     void this.drain();
   }
@@ -405,6 +424,18 @@ export const createAddPanelActions = (
         ? estimateOverlayGridDims(getTerminalAppearanceSnapshot().fontSize)
         : null;
 
+    // Single active-grid launches mount their visible xterm immediately
+    // (TerminalPane skips the spawnStatus gate), overlapping xterm.open()
+    // and the first fit with the env fetch + spawn IPC below. Decided at
+    // commit time — the flag must be in the first committed panel record
+    // because TerminalPane reads it on first render. Burst spawns (queue
+    // busy) keep the gate so panels realize one at a time (#5789).
+    const eagerAttach =
+      !isReconnect && location === "grid" && isInActiveWorktree && terminalStartupQueue.isIdle;
+    // Every non-reconnect PTY panel reaches the enqueue below (prewarm and
+    // dock-wake failures are caught), so each reserve pairs with one enqueue.
+    if (!isReconnect) terminalStartupQueue.reserve();
+
     const terminal = {
       id,
       kind,
@@ -453,8 +484,9 @@ export const createAddPanelActions = (
       // Caller-resolved launch env captured so a restored session replays the
       // SAME provider environment it launched with (#10922). This is the
       // launcher's merged env (agent global + preset/recipe + caller layers); the
-      // ambient global/project env is still re-fetched fresh at spawn time below
-      // and layered UNDER this, so only the launch-resolved layer is frozen here.
+      // ambient global/project env is fetched when the panel is added (the
+      // prefetch below, overlapping prewarm and any queue wait) and layered
+      // UNDER this, so only the launch-resolved layer is frozen here.
       ...(options.env && { env: options.env }),
       isUsingFallback: options.isUsingFallback,
       fallbackChainIndex: options.fallbackChainIndex,
@@ -467,6 +499,7 @@ export const createAddPanelActions = (
       removeOnExit: options.removeOnExit,
       startedAt: Date.now(),
       spawnStatus,
+      ...(eagerAttach && { eagerAttach: true }),
       // Preserve the saved `lastActiveAt` from the snapshot so the
       // post-hydration focus picker in `useAppHydration` can pick
       // the active worktree's most-recently-focused panel (#9933).
@@ -620,6 +653,8 @@ export const createAddPanelActions = (
       });
     }
 
+    markRendererPerformance("agentlaunch.committed", { id });
+
     // Mint the panel's launch generation atomically with the commit above (no
     // await between id reservation and here). Every async completion below —
     // env fetch, spawn IPC, attach settle — re-validates against it so a
@@ -647,6 +682,51 @@ export const createAddPanelActions = (
       // can tell an idempotent re-merge from a clobbering one.
       agentLifecycleLedger.recordRestoreApplied(id, launchGeneration);
     }
+
+    // Start the ambient env fetch now so its IPC round-trips overlap the
+    // prewarm below and any queue wait, instead of serializing ahead of the
+    // spawn IPC inside the startup task. Same merge semantics as before —
+    // global env under project env under the caller's launch env. The
+    // promise never rejects (every branch resolves a fallback), so an
+    // early-returning startup task cannot leave an unhandled rejection.
+    const spawnEnvPromise: Promise<Record<string, string> | undefined> = (() => {
+      if (isReconnect) return Promise.resolve(options.env);
+      try {
+        return Promise.all([
+          globalEnvClient.get().catch((error: unknown) => {
+            logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
+            return {} as Record<string, string>;
+          }),
+          capturedProjectId
+            ? projectClient.getSettings(capturedProjectId).then(
+                (s) => s?.environmentVariables ?? ({} as Record<string, string>),
+                (error: unknown) => {
+                  logWarn("[TerminalStore] Failed to fetch project environment variables", {
+                    error,
+                  });
+                  return {} as Record<string, string>;
+                }
+              )
+            : Promise.resolve({} as Record<string, string>),
+        ]).then(
+          ([globalEnvVars, projectEnvVars]) => {
+            const hasGlobal = Object.keys(globalEnvVars).length > 0;
+            const hasProject = Object.keys(projectEnvVars).length > 0;
+            if (hasGlobal || hasProject) {
+              return { ...globalEnvVars, ...projectEnvVars, ...options.env };
+            }
+            return options.env;
+          },
+          (error: unknown) => {
+            logWarn("[TerminalStore] Failed to fetch environment variables", { error });
+            return options.env;
+          }
+        );
+      } catch (error) {
+        logWarn("[TerminalStore] Failed to fetch environment variables", { error });
+        return Promise.resolve(options.env);
+      }
+    })();
 
     // Prewarm renderer-side xterm immediately so we never drop startup output/ANSI while hidden.
     // earlyDataBuffer in terminalClient buffers any data that arrives before the
@@ -733,6 +813,7 @@ export const createAddPanelActions = (
     } catch (error) {
       logWarn("[TerminalStore] Failed to prewarm terminal", { id, error });
     }
+    markRendererPerformance("agentlaunch.prewarmed", { id });
 
     // Determine if terminal should start backgrounded:
     // 1. Dock terminals are always backgrounded (offscreen)
@@ -791,37 +872,12 @@ export const createAddPanelActions = (
     terminalStartupQueue.enqueue(async () => {
       const _p0 = get().panelsById[id];
       if (!_p0 || !isPtyPanel(_p0) || _p0.spawnStatus !== "spawning") return;
+      markRendererPerformance("agentlaunch.task-start", { id });
 
       try {
-        let mergedEnv: Record<string, string> | undefined = options.env;
-        try {
-          const [globalEnvVars, projectEnvVars] = await Promise.all([
-            globalEnvClient.get().catch((error: unknown) => {
-              logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
-              return {} as Record<string, string>;
-            }),
-            capturedProjectId
-              ? projectClient.getSettings(capturedProjectId).then(
-                  (s) => s?.environmentVariables ?? ({} as Record<string, string>),
-                  (error: unknown) => {
-                    logWarn("[TerminalStore] Failed to fetch project environment variables", {
-                      error,
-                    });
-                    return {} as Record<string, string>;
-                  }
-                )
-              : Promise.resolve({} as Record<string, string>),
-          ]);
+        const mergedEnv = await spawnEnvPromise;
 
-          const hasGlobal = Object.keys(globalEnvVars).length > 0;
-          const hasProject = Object.keys(projectEnvVars).length > 0;
-          if (hasGlobal || hasProject) {
-            mergedEnv = { ...globalEnvVars, ...projectEnvVars, ...options.env };
-          }
-        } catch (error) {
-          logWarn("[TerminalStore] Failed to fetch environment variables", { error });
-        }
-
+        markRendererPerformance("agentlaunch.env-ready", { id });
         const _p1 = get().panelsById[id];
         if (!_p1 || !isPtyPanel(_p1) || _p1.spawnStatus !== "spawning") return;
 
@@ -860,6 +916,8 @@ export const createAddPanelActions = (
           // consumes it for that agent and ignores it otherwise.
           actionContext: options.actionContext,
         });
+
+        markRendererPerformance("agentlaunch.spawn-ipc-resolved", { id });
 
         // Reject a spawn resolution that no longer belongs to this incarnation:
         // if a restart or hydration replay re-launched the id while our IPC was
@@ -907,6 +965,7 @@ export const createAddPanelActions = (
             });
           });
         } else {
+          if (mountedPanel) markRendererPerformance("agentlaunch.ready", { id });
           // Recover the attach-during-spawn race: a fit that ran while the
           // spawn IPC was in flight had its PTY resize dropped (no terminal
           // existed yet), which would strand the CLI at the spawn dims while


### PR DESCRIPTION
This PR speeds up launching an agent terminal. It adds an opt-in benchmark that measures the time from dispatching `agent.launch` (the exact path the toolbar and tray buttons take) to the terminal being visible, and to the agent's first output rendering, then uses it to drive four changes.

### Before and after

Interleaved A/B runs against `develop`, 20 rounds per run, using a fake instant-boot `claude` CLI so the numbers isolate app overhead rather than agent startup time. Median warm launches on macOS:

| Milestone | develop | this PR |
| --- | --- | --- |
| Terminal visible (xterm mounted) | 133ms | 25ms |
| Agent's first output rendered | 258ms | 168ms |

Cold first launches improve too: first output went from 327-590ms down to roughly 300ms across runs.

### What changed

1. **Eager xterm mount for single launches.** `TerminalPane` used to hold the startup placeholder until the spawn IPC round trip resolved, so `terminal.open()`, the first fit, and addon setup all ran after the PTY existed. A single active-grid launch now stamps `eagerAttach` on the panel and mounts `XtermAdapter` immediately, overlapping all of that with the spawn. Burst launches (a busy startup queue, e.g. recipes) keep the old one-at-a-time gate, enforced with a reservation on the queue so concurrent `addPanel` calls can't all observe it idle. Side benefit: the PTY now spawns at the fitted dimensions instead of the 80x24 default, so the CLI paints its banner at the real width.
2. **Env fetch overlaps the spawn path.** The global/project environment fetch used to run inside the startup task, serialized ahead of the spawn IPC. It now starts at panel-add time and the task just awaits the prefetched result. Same merge semantics as before.
3. **Removed the macOS `sleep 0.05` command-launch wrapper.** Every agent launch on macOS paid a flat 50ms plus an extra shell exec. The race it guarded against can't happen any more: fresh spawns attach a `BufferedPtyDataHandoff` synchronously with `pty.spawn`, and the renderer registers its data callback at prewarm, before the spawn IPC is even sent. macOS now uses the same direct `-lic` form as Linux. Validated locally against `terminal-agent-state-status.spec.ts`.
4. **Burst-tolerant spawn rate limit.** `terminalSpawn` was a strict one-per-second leaky bucket, so launching four agents back to back cost 0/1/2/3 seconds of queueing. It's now a token bucket (`waitForBurstRateLimitSlot`): up to 6 instant launches, then the same smooth 1/sec cadence that #5352 picked for batch spawns.

### The benchmark

```
RUN_PERF_AGENT_LAUNCH=1 npx playwright test --project=full-terminal \
  e2e/full/terminal/agent-launch-perf.spec.ts
```

Opt-in only, skipped in CI. It dispatches `agent.launch` in-renderer, rAF-polls for the panel, the xterm, and the READY token, and writes per-round samples plus perf marks to a JSON file (`PERF_AGENT_LAUNCH_OUT`) for offline diffing. New `agentlaunch.*` perf marks along the launch path (all gated behind perf capture) give per-phase attribution.

### Accepted trade-off

With the eager mount there's a ~100ms window where the terminal is focused but the PTY doesn't exist yet, and keystrokes typed there are dropped. The old placeholder didn't deliver input either (keystrokes fell through to global shortcuts), so this isn't a regression, just a different failure mode for input nobody realistically types that fast.

### Testing

- `npm run check` passes.
- New unit coverage: token-bucket burst/refill/queue-depth cases in `electron/ipc/__tests__/utils.test.ts`, `eagerAttach` stamping (single, burst, dock) in `optimisticPanelSpawn.test.ts`.
- Updated the command-launch template tests to pin the new direct `-lic` form on macOS.
- `terminal-agent-state-status.spec.ts` (the fake-agent e2e spec that exercises command launch and early output) passes locally on macOS with the sleep removed.
