### PR TITLE
perf(worktree): cut create→agent-ready latency

### DIFF
--- a/e2e/full/worktree/worktree-agent-ready-perf.spec.ts
+++ b/e2e/full/worktree/worktree-agent-ready-perf.spec.ts
@@ -1,0 +1,814 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window bridges are untyped in Playwright evaluate() */
+import { test, expect } from "@playwright/test";
+import { chmodSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { execSync } from "child_process";
+import path from "path";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo, removePathSync } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { SEL } from "../../helpers/selectors";
+import { T_LONG } from "../../helpers/timeouts";
+
+// Latency harness for the core product loop: create a git worktree, switch to
+// it, and launch an agent in it — then tear the worktree down again. Three
+// measured blocks, split into separate serial tests so a mid-run crash (e.g.
+// environmental renderer churn) can't lose every block's samples:
+//
+//   1. Single-flow rounds — the dialog's exact sequence, headless:
+//      `worktree.create` dispatch → create resolved → worktree card visible,
+//      then (after switching to the new worktree) `recipe.run` dispatch →
+//      panel → xterm → agent first output (READY token), then teardown:
+//      `terminal.kill` + `worktree.delete` → delete resolved → card gone.
+//   2. Step-attribution rounds — the pre-create IPC hops the headless
+//      `worktree.createWithRecipe` flow pays (`getAvailableBranch`,
+//      `getDefaultPath`) timed individually.
+//   3. Burst rounds — N concurrent `worktree.create` dispatches (the fleet /
+//      bulk-create shape), per-create resolve times + wall clock, then N
+//      concurrent deletes. Where the cost scales with N.
+//
+// A fake `claude` CLI (instant banner + READY token) removes real-CLI boot
+// variance so the numbers isolate app overhead.
+//
+// Opt-in only — a measurement harness for local A/B runs, not a CI gate.
+//   RUN_PERF_WORKTREE_AGENT_READY=1 npx playwright test --project=full-worktree \
+//     e2e/full/worktree/worktree-agent-ready-perf.spec.ts
+const ROUNDS = Math.max(1, Math.floor(Number(process.env.PERF_WORKTREE_ROUNDS) || 10));
+const ATTRIB_ROUNDS = 3;
+const BURST_SIZES = (process.env.PERF_WORKTREE_BURST_SIZES ?? "5,20")
+  .split(",")
+  .map((s) => Math.floor(Number(s.trim())))
+  .filter((n) => Number.isFinite(n) && n > 0);
+// Idle gap between measured rounds so teardown of one sample (panel close,
+// monitor removal, persist flushes) can't bleed into the next.
+const SETTLE_MS = Number(process.env.PERF_WORKTREE_SETTLE_MS ?? 750);
+const OUT_PATH = process.env.PERF_WORKTREE_OUT ?? "";
+const READY_TOKEN = "FAKE_AGENT_READY";
+// In-repo recipe ids are rewritten to opaque UUIDs at load time, so the
+// runtime id is resolved by name via `recipe.list` in beforeAll.
+const RECIPE_NAME = "Agent Ready Perf";
+let recipeId: string;
+
+let ctx: AppContext;
+let fixtureDir: string;
+let fakeBinDir: string;
+let metricsPath: string;
+let fixtureCleanup: (() => void) | undefined;
+let worktreeParentDirs: Set<string>;
+
+interface CreateSample {
+  round: number;
+  createResolvedMs: number;
+  cardMs: number;
+  worktreeId: string | null;
+  error?: string;
+}
+
+interface AgentSample {
+  recipeResolvedMs: number;
+  panelMs: number;
+  xtermMs: number;
+  firstTextMs: number;
+  outputMs: number;
+  panelId: string | null;
+  error?: string;
+}
+
+interface DeleteSample {
+  deleteResolvedMs: number;
+  cardGoneMs: number;
+  error?: string;
+}
+
+interface RoundSample {
+  round: number;
+  create: CreateSample;
+  agent: AgentSample;
+  del: DeleteSample;
+}
+
+interface AttribSample {
+  round: number;
+  getAvailableBranchMs: number;
+  getDefaultPathMs: number;
+}
+
+interface BurstSample {
+  n: number;
+  rep: number;
+  createWallMs: number;
+  createResolvedMs: number[];
+  cardsAllVisibleMs: number;
+  deleteWallMs: number;
+  errors: string[];
+}
+
+const samples: RoundSample[] = [];
+const attribSamples: AttribSample[] = [];
+const burstSamples: BurstSample[] = [];
+
+// Rewrite the whole (small) results file after every sample so a crashed
+// later block still leaves everything measured so far on disk.
+function persistResults(): void {
+  if (!OUT_PATH) return;
+  writeFileSync(
+    OUT_PATH,
+    JSON.stringify(
+      { rounds: ROUNDS, settleMs: SETTLE_MS, samples, attribSamples, burstSamples },
+      null,
+      2
+    )
+  );
+}
+
+function prepareFixture(): void {
+  const { dir, cleanup } = createFixtureRepo({ name: "worktree-agent-ready-perf" });
+  fixtureDir = dir;
+  fixtureCleanup = cleanup;
+  worktreeParentDirs = new Set();
+  fakeBinDir = path.join(fixtureDir, ".e2e-bin");
+  mkdirSync(fakeBinDir, { recursive: true });
+  metricsPath = path.join(fixtureDir, "perf-metrics.ndjson");
+
+  const implName = process.platform === "win32" ? "claude.js" : "claude";
+  const fakeClaude = path.join(fakeBinDir, implName);
+  // Instant-boot fake agent: prints a banner + READY immediately, then idles.
+  writeFileSync(
+    fakeClaude,
+    [
+      "#!/usr/bin/env node",
+      "if (process.argv.includes('--version')) {",
+      "  console.log('claude code v9.9.9');",
+      "  process.exit(0);",
+      "}",
+      // One single write so READY cannot land in a later chunk than the
+      // banner — keeps the first-output milestone a single observable event.
+      `process.stdout.write('╭─ fake claude ─╮\\n│ benchmarking │\\n╰──────────────╯\\n' + ${JSON.stringify(READY_TOKEN)} + '\\n');`,
+      "process.stdin.resume();",
+      "process.stdin.setEncoding('utf8');",
+      "const keepAlive = setInterval(() => {}, 1000);",
+      "const shutdown = () => { clearInterval(keepAlive); process.exit(0); };",
+      "process.on('SIGINT', shutdown);",
+      "process.on('SIGTERM', shutdown);",
+      "",
+    ].join("\n")
+  );
+  chmodSync(fakeClaude, 0o755);
+  if (process.platform === "win32") {
+    writeFileSync(
+      path.join(fakeBinDir, "claude.cmd"),
+      ["@echo off", 'node "%~dp0claude.js" %*', ""].join("\r\n")
+    );
+  }
+
+  // In-repo recipe with a single agent terminal — the create-worktree flow's
+  // "launch an agent in it" half.
+  const recipesDir = path.join(fixtureDir, ".daintree", "recipes");
+  mkdirSync(recipesDir, { recursive: true });
+  writeFileSync(
+    path.join(recipesDir, "agent-ready-perf.json"),
+    JSON.stringify(
+      {
+        id: "inrepo-agent-ready-perf",
+        name: RECIPE_NAME,
+        terminals: [{ type: "claude", title: "Perf Agent" }],
+        createdAt: 1700000000000,
+        showInEmptyState: false,
+      },
+      null,
+      2
+    ) + "\n"
+  );
+
+  writeFileSync(
+    path.join(fixtureDir, "package.json"),
+    JSON.stringify(
+      { name: "worktree-agent-ready-perf", version: "1.0.0", private: true },
+      null,
+      2
+    ) + "\n"
+  );
+  execSync("git add -A && git commit -m worktree-agent-ready-perf-fixture", {
+    cwd: fixtureDir,
+    stdio: "ignore",
+  });
+}
+
+function pct(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function stats(label: string, arr: number[]): string {
+  if (arr.length === 0) return `${label}: n=0`;
+  const mean = arr.reduce((a, b) => a + b, 0) / arr.length;
+  return `${label}: n=${arr.length} p50=${pct(arr, 50).toFixed(1)}ms p95=${pct(arr, 95).toFixed(1)}ms mean=${mean.toFixed(1)}ms min=${Math.min(...arr).toFixed(1)}ms max=${Math.max(...arr).toFixed(1)}ms`;
+}
+
+async function resolveDefaultPath(branch: string): Promise<string> {
+  const p = await ctx.window.evaluate(
+    ({ rootPath, branch }) =>
+      (window as any).electron.worktree.getDefaultPath(rootPath, branch) as Promise<string>,
+    { rootPath: fixtureDir, branch }
+  );
+  worktreeParentDirs.add(path.dirname(p));
+  return p;
+}
+
+async function measureCreate(round: number, branch: string): Promise<CreateSample> {
+  const wtPath = await resolveDefaultPath(branch);
+  const sample = await ctx.window.evaluate(
+    async ({ rootPath, branch, wtPath }) => {
+      const dispatch = (window as any).__daintreeDispatchAction as
+        | ((id: string, args?: unknown, opts?: unknown) => Promise<any>)
+        | undefined;
+      if (!dispatch) {
+        return {
+          createResolvedMs: -1,
+          cardMs: -1,
+          worktreeId: null,
+          error: "__daintreeDispatchAction missing",
+        };
+      }
+      const cardSel = `[data-worktree-branch="${branch}"]`;
+      const t0 = performance.now();
+      let createResolvedMs = -1;
+      let worktreeId: string | null = null;
+      let error: string | undefined;
+      const dispatched = dispatch(
+        "worktree.create",
+        { rootPath, options: { baseBranch: "main", newBranch: branch, path: wtPath } },
+        { source: "test" }
+      ).then(
+        (r: any) => {
+          createResolvedMs = performance.now() - t0;
+          worktreeId = r?.ok ? (r.result as string) : null;
+          if (!r?.ok) error = `create failed: ${r?.error?.message ?? "unknown"}`;
+        },
+        (e: unknown) => {
+          createResolvedMs = -2;
+          error = `create rejected: ${String(e)}`;
+        }
+      );
+      let cardMs = -1;
+      const deadline = t0 + 30_000;
+      while (performance.now() < deadline) {
+        if (cardMs < 0 && document.querySelector(cardSel)) {
+          cardMs = performance.now() - t0;
+        }
+        if (createResolvedMs !== -1 && (cardMs >= 0 || error)) break;
+        await new Promise((r) => requestAnimationFrame(r));
+      }
+      await dispatched;
+      return { createResolvedMs, cardMs, worktreeId, error };
+    },
+    { rootPath: fixtureDir, branch, wtPath }
+  );
+  return { round, ...sample };
+}
+
+async function measureAgent(branch: string, worktreeId: string): Promise<AgentSample> {
+  const page = ctx.window;
+  // Switch to the new worktree first (the dialog flow does the same); the
+  // switch itself is covered by the worktree-switch marks/benchmarks, so
+  // it's deliberately outside this sample's timed window. Dispatch
+  // `worktree.select` rather than clicking the sidebar card — right after
+  // creation the branch can transiently match two cards (sidebar +
+  // dashboard), which trips strict-mode locators.
+  await page.evaluate(async (worktreeId) => {
+    const dispatch = (window as any).__daintreeDispatchAction;
+    await dispatch?.("worktree.select", { worktreeId }, { source: "test" });
+  }, worktreeId);
+  await expect.poll(() => page.locator(SEL.panel.gridPanel).count(), { timeout: T_LONG }).toBe(0);
+
+  return await page.evaluate(
+    async ({ recipeId, worktreeId, readyToken }) => {
+      const dispatch = (window as any).__daintreeDispatchAction as (
+        id: string,
+        args?: unknown,
+        opts?: unknown
+      ) => Promise<any>;
+      const gridSel = '[data-panel-location="grid"]';
+      const before = new Set(
+        Array.from(document.querySelectorAll(gridSel)).map(
+          (el) => el.getAttribute("data-panel-id") ?? ""
+        )
+      );
+      const t0 = performance.now();
+      let recipeResolvedMs = -1;
+      let error: string | undefined;
+      const dispatched = dispatch("recipe.run", { recipeId, worktreeId }, { source: "test" }).then(
+        (r: any) => {
+          recipeResolvedMs = performance.now() - t0;
+          if (!r?.ok) error = `recipe.run failed: ${r?.error?.message ?? "unknown"}`;
+        },
+        (e: unknown) => {
+          recipeResolvedMs = -2;
+          error = `recipe.run rejected: ${String(e)}`;
+        }
+      );
+
+      let panelMs = -1;
+      let xtermMs = -1;
+      let firstTextMs = -1;
+      let outputMs = -1;
+      let panelId: string | null = null;
+      const deadline = t0 + 30_000;
+      while (performance.now() < deadline) {
+        const now = performance.now();
+        if (panelId === null) {
+          for (const el of Array.from(document.querySelectorAll(gridSel))) {
+            const id = el.getAttribute("data-panel-id");
+            if (id && !before.has(id)) {
+              panelId = id;
+              panelMs = now - t0;
+              break;
+            }
+          }
+        }
+        if (panelId !== null) {
+          const panelEl = document.querySelector(`[data-panel-id="${panelId}"]`);
+          if (panelEl) {
+            if (xtermMs < 0) {
+              const x = panelEl.querySelector(".xterm");
+              if (x && (x as HTMLElement).clientWidth > 0) xtermMs = now - t0;
+            }
+            if (xtermMs >= 0 && outputMs < 0) {
+              const rows = panelEl.querySelector(".xterm-rows");
+              const text = rows?.textContent ?? "";
+              if (firstTextMs < 0 && text.trim().length > 0) firstTextMs = now - t0;
+              if (text.includes(readyToken)) {
+                outputMs = now - t0;
+                break;
+              }
+            }
+          }
+        }
+        if (error) break;
+        await new Promise((r) => requestAnimationFrame(r));
+      }
+      await dispatched;
+      if (outputMs < 0 && !error) {
+        const rows = panelId
+          ? document.querySelector(`[data-panel-id="${panelId}"] .xterm-rows`)
+          : null;
+        error = `READY not rendered; text="${(rows?.textContent ?? "").trim().slice(0, 300)}"`;
+      }
+      return { recipeResolvedMs, panelMs, xtermMs, firstTextMs, outputMs, panelId, error };
+    },
+    { recipeId, worktreeId, readyToken: READY_TOKEN }
+  );
+}
+
+async function measureDelete(branch: string, worktreeId: string): Promise<DeleteSample> {
+  const page = ctx.window;
+  // Kill panels first (unconfirmed kills of running agents open a confirm
+  // dialog that would pollute later rounds), then time the delete itself.
+  await page.evaluate(async () => {
+    const dispatch = (window as any).__daintreeDispatchAction;
+    const ids = Array.from(document.querySelectorAll('[data-panel-location="grid"]'))
+      .map((el) => el.getAttribute("data-panel-id"))
+      .filter((id): id is string => !!id);
+    for (const id of ids) {
+      await dispatch?.("terminal.kill", { terminalId: id, confirmed: true }, { source: "test" });
+      await dispatch?.("terminal.close", { terminalId: id }, { source: "test" });
+    }
+  });
+  return await page.evaluate(
+    async ({ branch, worktreeId }) => {
+      const dispatch = (window as any).__daintreeDispatchAction as (
+        id: string,
+        args?: unknown,
+        opts?: unknown
+      ) => Promise<any>;
+      const cardSel = `[data-worktree-branch="${branch}"]`;
+      const t0 = performance.now();
+      let deleteResolvedMs = -1;
+      let error: string | undefined;
+      const dispatched = dispatch(
+        "worktree.delete",
+        { worktreeId, force: true, deleteBranch: true, closeTerminals: true },
+        { source: "test" }
+      ).then(
+        (r: any) => {
+          deleteResolvedMs = performance.now() - t0;
+          if (!r?.ok) error = `delete failed: ${r?.error?.message ?? "unknown"}`;
+        },
+        (e: unknown) => {
+          deleteResolvedMs = -2;
+          error = `delete rejected: ${String(e)}`;
+        }
+      );
+      let cardGoneMs = -1;
+      const deadline = t0 + 30_000;
+      while (performance.now() < deadline) {
+        if (cardGoneMs < 0 && !document.querySelector(cardSel)) {
+          cardGoneMs = performance.now() - t0;
+        }
+        if (deleteResolvedMs !== -1 && (cardGoneMs >= 0 || error)) break;
+        await new Promise((r) => requestAnimationFrame(r));
+      }
+      await dispatched;
+      return { deleteResolvedMs, cardGoneMs, error };
+    },
+    { branch, worktreeId }
+  );
+}
+
+const perfDescribe = process.env.RUN_PERF_WORKTREE_AGENT_READY
+  ? test.describe.serial
+  : test.describe.skip;
+
+perfDescribe("Perf: worktree create → agent-ready → delete", () => {
+  test.beforeAll(async () => {
+    prepareFixture();
+    // Agent terminals launch through a login shell (`-lic`), which sources the
+    // user's zprofile/zshrc — on a machine with a real `claude` install those
+    // rc files prepend its directory and the fake CLI loses the PATH race.
+    // Point ZDOTDIR at an empty dir so no user rc files run: path_helper still
+    // reorders PATH but keeps the fake bin dir, making resolution
+    // deterministic.
+    const emptyZdotdir = path.join(fixtureDir, ".e2e-zdotdir");
+    mkdirSync(emptyZdotdir, { recursive: true });
+    ctx = await launchApp({
+      env: {
+        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        ZDOTDIR: emptyZdotdir,
+        DAINTREE_CLI_PATH_PREPEND: fakeBinDir,
+        DAINTREE_IDENTITY_DEBUG_PASS: "1",
+        DAINTREE_PERF_CAPTURE: "1",
+        DAINTREE_PERF_METRICS_FILE: metricsPath,
+      },
+    });
+    ctx.window = await openAndOnboardProject(
+      ctx.app,
+      ctx.window,
+      fixtureDir,
+      "Worktree Agent Ready Perf"
+    );
+
+    // Let post-onboarding work (worktree load, availability probes, pool
+    // warmup) settle so round 1 measures the flow, not app startup residue.
+    await ctx.window.waitForTimeout(3_000);
+    // Seed the renderer perf-mark consumer buffer (see agent-launch-perf).
+    await ctx.window.evaluate(() => {
+      (window as any).__DAINTREE_PERF_MARKS__ ||= [];
+    });
+    // Recipes only load when recipe UI mounts (dialog open / recipes tab) —
+    // open and close the New Worktree dialog once, exactly like a real
+    // pre-create session, so `.daintree/recipes/*.json` is in the store.
+    await ctx.window.evaluate(async () => {
+      const dispatch = (window as any).__daintreeDispatchAction;
+      await dispatch?.("worktree.createDialog.open", undefined, { source: "test" });
+    });
+    await expect(ctx.window.locator(SEL.worktree.newDialog)).toBeVisible({ timeout: T_LONG });
+    await ctx.window.keyboard.press("Escape");
+    await expect(ctx.window.locator(SEL.worktree.newDialog)).not.toBeVisible({ timeout: T_LONG });
+
+    // Resolve the runtime recipe id by name (in-repo ids are rewritten to
+    // opaque UUIDs at load time).
+    recipeId = await ctx.window.evaluate(async (name) => {
+      const dispatch = (window as any).__daintreeDispatchAction;
+      let last: unknown = null;
+      for (let i = 0; i < 40; i++) {
+        const r = await dispatch?.("recipe.list", {}, { source: "test" });
+        last = r;
+        const found = r?.ok ? (r.result?.recipes ?? []).find((x: any) => x.name === name) : null;
+        if (found) return found.id as string;
+        await new Promise((res) => setTimeout(res, 500));
+      }
+      throw new Error(
+        `recipe '${name}' never appeared in recipe.list; last=${JSON.stringify(last)}`
+      );
+    }, RECIPE_NAME);
+  });
+
+  test.afterAll(async () => {
+    // Marks: renderer buffer + host ndjson (best-effort — the window may be
+    // gone after a crash).
+    try {
+      const markRecords: unknown[] = await ctx.window.evaluate(
+        () => (window as any).__DAINTREE_PERF_MARKS__ ?? []
+      );
+      if (existsSync(metricsPath)) {
+        for (const line of readFileSync(metricsPath, "utf8").trim().split("\n")) {
+          if (!line) continue;
+          try {
+            const rec = JSON.parse(line);
+            if (
+              /^(terminal_|pty_pool_|agentlaunch\.|wtcreate\.|wtdelete\.)/.test(String(rec.mark))
+            ) {
+              markRecords.push(rec);
+            }
+          } catch {
+            // Skip lines truncated mid-write.
+          }
+        }
+      }
+      if (OUT_PATH) {
+        writeFileSync(
+          OUT_PATH,
+          JSON.stringify(
+            {
+              rounds: ROUNDS,
+              settleMs: SETTLE_MS,
+              samples,
+              attribSamples,
+              burstSamples,
+              markRecords,
+            },
+            null,
+            2
+          )
+        );
+        console.log(`results written to ${OUT_PATH}`);
+      }
+    } catch {
+      persistResults();
+    }
+    if (ctx?.app) await closeApp(ctx.app);
+    // `git worktree add` targets live in a sibling `<repo>-worktrees` dir the
+    // fixture cleanup doesn't know about.
+    for (const dir of worktreeParentDirs ?? []) {
+      try {
+        removePathSync(dir);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+    fixtureCleanup?.();
+  });
+
+  test("single-flow rounds: create → card → agent output → delete", async () => {
+    test.slow();
+    test.setTimeout(600_000);
+
+    for (let i = 1; i <= ROUNDS; i++) {
+      const branch = `perf-agent-ready-r${i}`;
+      const create = await measureCreate(i, branch);
+      let agent: AgentSample = {
+        recipeResolvedMs: -1,
+        panelMs: -1,
+        xtermMs: -1,
+        firstTextMs: -1,
+        outputMs: -1,
+        panelId: null,
+        error: create.error ? "skipped: create failed" : undefined,
+      };
+      let del: DeleteSample = {
+        deleteResolvedMs: -1,
+        cardGoneMs: -1,
+        error: create.error ? "skipped: create failed" : undefined,
+      };
+      if (!create.error && create.worktreeId) {
+        agent = await measureAgent(branch, create.worktreeId);
+        del = await measureDelete(branch, create.worktreeId);
+      }
+      samples.push({ round: i, create, agent, del });
+      persistResults();
+      await ctx.window.waitForTimeout(SETTLE_MS);
+    }
+
+    // Every milestone must have fired — a round where e.g. the sidebar card
+    // never appeared (cardMs -1) is a regression, not a valid sample.
+    const ok = samples.filter(
+      (s) =>
+        !s.create.error &&
+        !s.agent.error &&
+        !s.del.error &&
+        s.create.createResolvedMs >= 0 &&
+        s.create.cardMs >= 0 &&
+        s.agent.panelMs >= 0 &&
+        s.agent.xtermMs >= 0 &&
+        s.agent.outputMs >= 0 &&
+        s.del.deleteResolvedMs >= 0 &&
+        s.del.cardGoneMs >= 0
+    );
+    console.log("──────── worktree create → agent-ready → delete (single flow) ────────");
+    console.log(`rounds=${ROUNDS} ok=${ok.length} settleMs=${SETTLE_MS}`);
+    console.log(
+      stats(
+        "create dispatch→resolved ",
+        ok.map((s) => s.create.createResolvedMs)
+      )
+    );
+    console.log(
+      stats(
+        "create dispatch→card     ",
+        ok.map((s) => s.create.cardMs)
+      )
+    );
+    console.log(
+      stats(
+        "recipe dispatch→panel    ",
+        ok.map((s) => s.agent.panelMs)
+      )
+    );
+    console.log(
+      stats(
+        "recipe dispatch→xterm    ",
+        ok.map((s) => s.agent.xtermMs)
+      )
+    );
+    console.log(
+      stats(
+        "recipe dispatch→output   ",
+        ok.map((s) => s.agent.outputMs)
+      )
+    );
+    console.log(
+      stats(
+        "create+agent (sum)       ",
+        ok.map((s) => s.create.createResolvedMs + s.agent.outputMs)
+      )
+    );
+    console.log(
+      stats(
+        "delete dispatch→resolved ",
+        ok.map((s) => s.del.deleteResolvedMs)
+      )
+    );
+    console.log(
+      stats(
+        "delete dispatch→card gone",
+        ok.map((s) => s.del.cardGoneMs)
+      )
+    );
+    console.log("───────────────────────────────────────────────────────────────────────");
+
+    // Reliability invariants only — latency itself is reported, not gated.
+    expect(ok.length, "every round completed the full loop").toBe(ROUNDS);
+  });
+
+  test("step attribution: pre-create IPC hops", async () => {
+    test.setTimeout(120_000);
+    for (let i = 1; i <= ATTRIB_ROUNDS; i++) {
+      const sample = await ctx.window.evaluate(
+        async ({ rootPath, branch }) => {
+          const api = (window as any).electron.worktree;
+          const t0 = performance.now();
+          const availableBranch = await api.getAvailableBranch(rootPath, branch);
+          const t1 = performance.now();
+          await api.getDefaultPath(rootPath, availableBranch);
+          const t2 = performance.now();
+          return { getAvailableBranchMs: t1 - t0, getDefaultPathMs: t2 - t1 };
+        },
+        { rootPath: fixtureDir, branch: `perf-attrib-r${i}` }
+      );
+      attribSamples.push({ round: i, ...sample });
+      persistResults();
+    }
+    console.log(
+      stats(
+        "attrib getAvailableBranch",
+        attribSamples.map((s) => s.getAvailableBranchMs)
+      )
+    );
+    console.log(
+      stats(
+        "attrib getDefaultPath    ",
+        attribSamples.map((s) => s.getDefaultPathMs)
+      )
+    );
+    expect(attribSamples.length).toBe(ATTRIB_ROUNDS);
+  });
+
+  test("burst scaling: N concurrent creates then deletes", async () => {
+    test.slow();
+    test.setTimeout(600_000);
+    const page = ctx.window;
+
+    for (const n of BURST_SIZES) {
+      for (let rep = 1; rep <= 2; rep++) {
+        const branches = Array.from({ length: n }, (_, k) => `perf-burst-n${n}-r${rep}-i${k}`);
+        const paths: string[] = [];
+        for (const b of branches) paths.push(await resolveDefaultPath(b));
+
+        const burst = await page.evaluate(
+          async ({ rootPath, branches, paths }) => {
+            const dispatch = (window as any).__daintreeDispatchAction as (
+              id: string,
+              args?: unknown,
+              opts?: unknown
+            ) => Promise<any>;
+            const errors: string[] = [];
+            const t0 = performance.now();
+            const resolved: number[] = new Array(branches.length).fill(-1);
+            const ids: (string | null)[] = new Array(branches.length).fill(null);
+            await Promise.all(
+              branches.map((branch, k) =>
+                dispatch(
+                  "worktree.create",
+                  {
+                    rootPath,
+                    options: { baseBranch: "main", newBranch: branch, path: paths[k] },
+                  },
+                  { source: "test" }
+                ).then(
+                  (r: any) => {
+                    resolved[k] = performance.now() - t0;
+                    if (r?.ok) ids[k] = r.result as string;
+                    else errors.push(`create ${branch}: ${r?.error?.message ?? "unknown"}`);
+                  },
+                  (e: unknown) => errors.push(`create ${branch} rejected: ${String(e)}`)
+                )
+              )
+            );
+            const createWallMs = performance.now() - t0;
+
+            // Store-arrival probe via worktree.list (the sidebar is
+            // virtualized, so DOM card queries undercount at N=20).
+            let cardsAllVisibleMs = -1;
+            const deadline = t0 + 120_000;
+            while (performance.now() < deadline) {
+              const listed = await dispatch("worktree.list", undefined, { source: "test" });
+              const known = new Set(
+                listed?.ok ? (listed.result?.worktrees ?? []).map((w: any) => w.branch) : []
+              );
+              if (branches.every((b) => known.has(b))) {
+                cardsAllVisibleMs = performance.now() - t0;
+                break;
+              }
+              await new Promise((r) => setTimeout(r, 50));
+            }
+
+            const tDel = performance.now();
+            await Promise.all(
+              ids.map((id, k) =>
+                id
+                  ? dispatch(
+                      "worktree.delete",
+                      { worktreeId: id, force: true, deleteBranch: true },
+                      { source: "test" }
+                    ).then(
+                      (r: any) => {
+                        if (!r?.ok)
+                          errors.push(`delete ${branches[k]}: ${r?.error?.message ?? "unknown"}`);
+                      },
+                      (e: unknown) => errors.push(`delete ${branches[k]} rejected: ${String(e)}`)
+                    )
+                  : Promise.resolve()
+              )
+            );
+            const deleteWallMs = performance.now() - tDel;
+            return {
+              createWallMs,
+              createResolvedMs: resolved,
+              cardsAllVisibleMs,
+              deleteWallMs,
+              errors,
+            };
+          },
+          { rootPath: fixtureDir, branches, paths }
+        );
+        burstSamples.push({ n, rep, ...burst });
+        persistResults();
+        // Best-effort inter-rep hygiene: wait for this rep's worktrees to
+        // leave the store. Reps use unique branch names, so a straggler (e.g.
+        // a failed delete) is recorded in `errors` without wedging later reps.
+        await expect
+          .poll(
+            () =>
+              page.evaluate(async (bs: string[]) => {
+                const dispatch = (window as any).__daintreeDispatchAction;
+                const listed = await dispatch?.("worktree.list", undefined, { source: "test" });
+                const known = new Set(
+                  listed?.ok ? (listed.result?.worktrees ?? []).map((w: any) => w.branch) : []
+                );
+                return bs.filter((b) => known.has(b)).length;
+              }, branches),
+            { timeout: T_LONG }
+          )
+          .toBe(0)
+          .catch(() => {
+            console.warn(`burst n=${n} rep=${rep}: leftover worktrees in store after delete`);
+          });
+        await page.waitForTimeout(SETTLE_MS);
+      }
+    }
+
+    for (const b of burstSamples) {
+      console.log(
+        `burst n=${b.n} rep=${b.rep}: createWall=${b.createWallMs.toFixed(0)}ms lastResolve=${Math.max(...b.createResolvedMs).toFixed(0)}ms cardsAll=${b.cardsAllVisibleMs.toFixed(0)}ms deleteWall=${b.deleteWallMs.toFixed(0)}ms errors=${b.errors.length}`
+      );
+    }
+    for (const b of burstSamples) {
+      const createErrors = b.errors.filter((e) => e.startsWith("create "));
+      expect(createErrors, `burst n=${b.n} rep=${b.rep} creates succeeded`).toEqual([]);
+      expect(
+        b.cardsAllVisibleMs,
+        `burst n=${b.n} rep=${b.rep} all worktrees reached the store`
+      ).toBeGreaterThan(0);
+      // Delete failures under bulk churn are reported, not gated — they track
+      // a known monitor-loss bug at high N, and gating them would leave the
+      // latency harness permanently red for an unrelated defect.
+      const deleteErrors = b.errors.filter((e) => !e.startsWith("create "));
+      if (deleteErrors.length > 0) {
+        console.warn(
+          `burst n=${b.n} rep=${b.rep}: ${deleteErrors.length} delete error(s), e.g. ${deleteErrors[0]}`
+        );
+      }
+    }
+  });
+});

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -86,6 +86,7 @@ vi.mock("../../utils.js", () => {
   return {
     checkRateLimit: checkRateLimitMock,
     waitForRateLimitSlot: waitForRateLimitSlotMock,
+    waitForBurstRateLimitSlot: waitForRateLimitSlotMock,
     typedHandle,
     typedHandleWithContext,
     typedHandleValidated: (

--- a/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
@@ -6,6 +6,7 @@ const ipcMainMock = vi.hoisted(() => ({
 }));
 
 const waitForRateLimitSlotMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const waitForBurstRateLimitSlotMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const checkRateLimitMock = vi.hoisted(() => vi.fn());
 
 vi.mock("electron", () => ({
@@ -53,6 +54,7 @@ vi.mock("../../utils.js", () => {
   return {
     checkRateLimit: checkRateLimitMock,
     waitForRateLimitSlot: waitForRateLimitSlotMock,
+    waitForBurstRateLimitSlot: waitForBurstRateLimitSlotMock,
     typedHandle,
     typedHandleWithContext,
     typedHandleValidated: (
@@ -159,19 +161,19 @@ describe("worktree rate limiting", () => {
   });
 
   describe("worktree:create", () => {
-    it("calls waitForRateLimitSlot with dedicated key and parameters", async () => {
+    it("calls waitForBurstRateLimitSlot with dedicated key, interval, and burst allowance", async () => {
       const handler = getInvokeHandler(CHANNELS.WORKTREE_CREATE);
       await handler({} as never, {
         rootPath: "/test/project",
         options: { baseBranch: "main", newBranch: "feat-1", path: "/test/worktrees/feat-1" },
       });
 
-      expect(waitForRateLimitSlotMock).toHaveBeenCalledWith("worktreeCreate", 1_000);
+      expect(waitForBurstRateLimitSlotMock).toHaveBeenCalledWith("worktreeCreate", 1_000, 30);
       expect(mockWorktreeService.createWorktree).toHaveBeenCalled();
     });
 
     it("rejects without calling createWorktree when rate limit slot rejects", async () => {
-      waitForRateLimitSlotMock.mockRejectedValueOnce(new Error("Spawn queue full"));
+      waitForBurstRateLimitSlotMock.mockRejectedValueOnce(new Error("Spawn queue full"));
       const handler = getInvokeHandler(CHANNELS.WORKTREE_CREATE);
 
       await expect(

--- a/electron/ipc/handlers/worktree/constants.ts
+++ b/electron/ipc/handlers/worktree/constants.ts
@@ -1,8 +1,16 @@
 export const WORKTREE_RATE_LIMIT_KEY = "worktreeCreate";
-// Strict-interval leaky bucket: one worktree creation released every 1s.
-// Prior sliding-window approach (2 per 2s) released both slots simultaneously
-// when the window rolled, producing a feast/famine burst pattern. See #5098.
-// Interval reduced from 6s to 1s in #5161 — 1 per second is safe for git lock
-// contention on any repo size and brings 30-worktree batches down from ~180s
-// to ~30s without regressing the burst-pattern fix.
+// Token bucket: up to WORKTREE_RATE_LIMIT_BURST creates pass with no wait
+// after an idle stretch, then sustained callers drain at one per second.
+// History: #5098 replaced a feast/famine sliding window with a strict
+// 1s-interval leaky bucket; #5161 cut the interval 6s → 1s. Both were about
+// keeping concurrent `git worktree add` runs off the same repo — that
+// property is now enforced structurally by the workspace-host's per-repo
+// create queue (WorkspaceService.enqueueCreateWorktree), which runs creates
+// strictly one-at-a-time back to back. With git safety no longer depending
+// on wall-clock spacing, the burst allowance exists purely as runaway-
+// automation backpressure: 30 covers the bulk-create batches #5161 sized
+// for (a 30-worktree batch used to take ~30s of pure pacing; it now runs at
+// real git speed), while sustained abuse still settles to 1/s with the
+// 50-deep queue-full rejection unchanged.
 export const WORKTREE_RATE_LIMIT_INTERVAL_MS = 1_000;
+export const WORKTREE_RATE_LIMIT_BURST = 30;

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -17,9 +17,13 @@ import {
   WorktreeCreatePayloadSchema,
   WorktreeSetActivePayloadSchema,
 } from "../../../schemas/ipc.js";
-import { checkRateLimit, waitForRateLimitSlot } from "../../utils.js";
+import { checkRateLimit, waitForBurstRateLimitSlot } from "../../utils.js";
 import { validateBranchName } from "../../../../shared/utils/pathPattern.js";
-import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
+import {
+  WORKTREE_RATE_LIMIT_KEY,
+  WORKTREE_RATE_LIMIT_INTERVAL_MS,
+  WORKTREE_RATE_LIMIT_BURST,
+} from "./constants.js";
 
 type SoundId = keyof typeof SoundServiceModule.SOUND_FILES;
 
@@ -73,7 +77,11 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     if (!branchValidation.valid) {
       throw new Error(branchValidation.error ?? "Invalid branch name");
     }
-    await waitForRateLimitSlot(WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS);
+    await waitForBurstRateLimitSlot(
+      WORKTREE_RATE_LIMIT_KEY,
+      WORKTREE_RATE_LIMIT_INTERVAL_MS,
+      WORKTREE_RATE_LIMIT_BURST
+    );
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
     }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -41,10 +41,12 @@ import { WorktreeListService } from "./WorktreeListService.js";
 import { PRIntegrationService, type PRIntegrationCallbacks } from "./PRIntegrationService.js";
 import { RepoFetchCoordinator } from "./RepoFetchCoordinator.js";
 import { waitForPathExists } from "../utils/fs.js";
+import { markHostPerformance } from "../utils/hostPerformance.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import {
   parseCheckedOutBranches,
   nextAvailableBranchName,
+  isBranchAlreadyExistsError,
   ensureNoteFile,
   assertWorktreePathContained,
 } from "./worktreeUtils.js";
@@ -281,6 +283,12 @@ export class WorkspaceService {
   // are no-ops while paused/disabled via scheduleTopologyReconcile's guards.
   private periodicSafetyTimer: ReturnType<typeof setInterval> | null = null;
   private readonly inFlightWorktreeCreates = new Map<string, Promise<string>>();
+  // Per-repo create chain: distinct creates on the same root run strictly
+  // one-at-a-time, back to back. This enforces the no-concurrent-`git worktree
+  // add` property (#5098 git lock contention) at the actual git boundary, so
+  // the IPC layer's rate limit can grant a burst allowance without wall-clock
+  // pacing every create 1s apart.
+  private readonly createWorktreeQueues = new Map<string, Promise<unknown>>();
 
   /**
    * Host-run identity, minted once per WorkspaceService instance — i.e. once
@@ -2378,7 +2386,7 @@ export class WorkspaceService {
       return;
     }
 
-    const createPromise = this.performCreateWorktree(rootPath, options);
+    const createPromise = this.enqueueCreateWorktree(rootPath, options);
     this.inFlightWorktreeCreates.set(createKey, createPromise);
 
     try {
@@ -2401,6 +2409,21 @@ export class WorkspaceService {
         this.inFlightWorktreeCreates.delete(createKey);
       }
     }
+  }
+
+  private enqueueCreateWorktree(rootPath: string, options: CreateWorktreeOptions): Promise<string> {
+    const queueKey = this.normalizeCreateWorktreeKeyPath(pathResolve(rootPath));
+    const prev = this.createWorktreeQueues.get(queueKey) ?? Promise.resolve();
+    const run = prev.then(() => this.performCreateWorktree(rootPath, options));
+    // A failed create must not poison the chain for the next caller.
+    const tail = run.catch(() => {});
+    this.createWorktreeQueues.set(queueKey, tail);
+    void tail.then(() => {
+      if (this.createWorktreeQueues.get(queueKey) === tail) {
+        this.createWorktreeQueues.delete(queueKey);
+      }
+    });
+    return run;
   }
 
   private getCreateWorktreeInFlightKey(rootPath: string, options: CreateWorktreeOptions): string {
@@ -2428,6 +2451,7 @@ export class WorkspaceService {
     // absoluteCreatePath is block-scoped to the try.
     let pendingCreateKey: string | null = null;
     try {
+      markHostPerformance("wtcreate.host-start", { branch: options.newBranch });
       const git = await createHardenedGit(rootPath);
       const { baseBranch, path } = options;
       let { newBranch } = options;
@@ -2467,27 +2491,69 @@ export class WorkspaceService {
         await mkdir(parentDir, { recursive: true });
       }
 
-      // #6463: when not explicitly reusing a branch, guard against a stale
-      // local branch with the same name. Without this, `git worktree add -b`
-      // hits "fatal: a branch named '...' already exists" whenever a previous
-      // worktree was deleted but its branch was kept. Two recoveries:
-      // (a) branch exists but is not checked out anywhere → reuse it (drop
-      //     -b, switch to the useExistingBranch arg form);
-      // (b) branch is live in another worktree → suffix -2/-3/... and create
-      //     a fresh branch.
-      // Inlined (not behind a helper) so the happy-path microtask timing
-      // matches the pre-fix behavior — the next await is still the worktree
-      // add, not a wrapper-promise resolution.
-      if (!useExistingBranch) {
-        let localBranches: string[] = [];
-        try {
-          localBranches = (await git.branchLocal()).all;
-        } catch {
-          // Best-effort: if branch listing fails, fall through and let the
-          // actual worktree command surface its own error.
-        }
+      // Mark the metadata-subdir basename pending so the watcher event our own
+      // `git worktree add` produces is recognized and dropped — without
+      // blanket-suppressing concurrent external `git worktree remove` events.
+      pendingCreateKey = this.topologyMetadataKey(absoluteCreatePath);
+      this.topologyMarkPending(pendingCreateKey, this.topologyPendingCreate);
 
-        if (localBranches.includes(newBranch)) {
+      // `--end-of-options` after the subcommand flags so any leading-dash ref
+      // or path that slipped past validation is treated as positional.
+      const addReusingBranch = () =>
+        git.raw(["worktree", "add", "--end-of-options", path, newBranch]);
+      // --no-track: local-base branches shouldn't auto-track a local ref even
+      // when the user has branch.autoSetupMerge=always. Skipping tracking also
+      // avoids a .git/config.lock acquisition, cutting contention under bulk
+      // creation. PR-mode (fromRemote) keeps --track — ahead/behind badges
+      // at WorktreeMonitor.ts:1092 depend on @{u} resolving.
+      const addNewBranch = () =>
+        git.raw([
+          "worktree",
+          "add",
+          "-b",
+          newBranch,
+          fromRemote ? "--track" : "--no-track",
+          "--end-of-options",
+          path,
+          baseBranch,
+        ]);
+
+      markHostPerformance("wtcreate.git-add:start", { branch: newBranch });
+      if (useExistingBranch) {
+        await addReusingBranch();
+      } else {
+        try {
+          await addNewBranch();
+        } catch (addError) {
+          // #6463: a stale local branch with the same name makes `worktree add
+          // -b` fail with "a branch named '...' already exists" whenever a
+          // previous worktree was deleted but its branch was kept. That add
+          // failure is atomic — git refuses before creating the directory or
+          // registering any worktree metadata — so collision detection rides
+          // the add itself instead of charging every create a pre-flight
+          // `git branchLocal` spawn. Recovery outcomes are unchanged:
+          // (a) branch exists but is not checked out anywhere → reuse it (drop
+          //     -b, switch to the useExistingBranch arg form);
+          // (b) branch is live in another worktree → suffix -2/-3/... and
+          //     create a fresh branch.
+          if (!isBranchAlreadyExistsError(addError)) throw addError;
+
+          // The failed add produced no watcher event to suppress; release the
+          // pending mark while the recovery probes run so an external create
+          // of the same basename in this window isn't silently dropped, then
+          // re-mark just before the retry add below.
+          this.topologyClearPending(pendingCreateKey);
+
+          let localBranches: string[];
+          try {
+            localBranches = (await git.branchLocal()).all;
+          } catch {
+            // Can't inspect branches to recover; surface the original git
+            // failure (same outcome as the old pre-flight, whose listing
+            // failure fell through to this add error).
+            throw addError;
+          }
+
           let checkedOut = new Set<string>();
           let listFailed = false;
           try {
@@ -2505,57 +2571,21 @@ export class WorkspaceService {
           // a fresh tracking branch is created.
           const canReuse = !listFailed && !fromRemote && !checkedOut.has(newBranch);
 
+          this.topologyMarkPending(pendingCreateKey, this.topologyPendingCreate);
           if (canReuse) {
             useExistingBranch = true;
             // The -b path tracks baseBranch; reuse drops that. Stale local
             // branches typically retain their original config, so this is
             // the right tradeoff vs. failing the user-visible create.
             fromRemote = false;
+            await addReusingBranch();
           } else {
             newBranch = nextAvailableBranchName(newBranch, new Set(localBranches));
+            await addNewBranch();
           }
         }
       }
-
-      // `--end-of-options` after the subcommand flags so any leading-dash ref
-      // or path that slipped past validation is treated as positional.
-
-      // Mark the metadata-subdir basename pending so the watcher event our own
-      // `git worktree add` produces is recognized and dropped — without
-      // blanket-suppressing concurrent external `git worktree remove` events.
-      pendingCreateKey = this.topologyMetadataKey(absoluteCreatePath);
-      this.topologyMarkPending(pendingCreateKey, this.topologyPendingCreate);
-
-      if (useExistingBranch) {
-        await git.raw(["worktree", "add", "--end-of-options", path, newBranch]);
-      } else if (fromRemote) {
-        await git.raw([
-          "worktree",
-          "add",
-          "-b",
-          newBranch,
-          "--track",
-          "--end-of-options",
-          path,
-          baseBranch,
-        ]);
-      } else {
-        // --no-track: local-base branches shouldn't auto-track a local ref even
-        // when the user has branch.autoSetupMerge=always. Skipping tracking also
-        // avoids a .git/config.lock acquisition, cutting contention under bulk
-        // creation. PR-mode (fromRemote) keeps --track — ahead/behind badges
-        // at WorktreeMonitor.ts:1092 depend on @{u} resolving.
-        await git.raw([
-          "worktree",
-          "add",
-          "-b",
-          newBranch,
-          "--no-track",
-          "--end-of-options",
-          path,
-          baseBranch,
-        ]);
-      }
+      markHostPerformance("wtcreate.git-add:end", { branch: newBranch });
 
       const absolutePath = isAbsolute(path) ? pathResolve(path) : pathResolve(rootPath, path);
       // 500ms is ample: git returns after the directory exists; the polling
@@ -2567,6 +2597,7 @@ export class WorkspaceService {
         initialRetryDelayMs: 50,
         maxRetryDelayMs: 800,
       });
+      markHostPerformance("wtcreate.path-verified", { branch: newBranch });
 
       // Build the Worktree object directly from known inputs instead of
       // shelling out to `git worktree list --porcelain` — the per-create list
@@ -2598,6 +2629,7 @@ export class WorkspaceService {
       // We bypass syncMonitors here because syncMonitors treats its array as
       // authoritative and would remove every other non-main monitor.
       await this.addNewWorktreeMonitor(createdWorktree, isActive, true);
+      markHostPerformance("wtcreate.monitor-registered", { branch: newBranch });
 
       // Monitor is registered. Drop the pending entry now: any still-buffered
       // create event for this name will be matched by the next drain (the
@@ -2700,6 +2732,7 @@ export class WorkspaceService {
           details: stack,
         });
       });
+      markHostPerformance("wtcreate.host-end", { branch: newBranch });
       return canonicalWorktreeId;
     } catch (error) {
       // Create failed — drop any pending entry so a real external change to
@@ -2821,6 +2854,7 @@ export class WorkspaceService {
     // is block-scoped to the try.
     let pendingDeleteKey: string | null = null;
     try {
+      markHostPerformance("wtdelete.host-start", { worktreeId });
       const monitor = this.monitors.get(worktreeId);
       if (!monitor) {
         // Replay path: the monitor was cleaned up by the original successful
@@ -2919,7 +2953,9 @@ export class WorkspaceService {
           // `--end-of-options` so a leading-dash worktree path is treated as
           // positional rather than parsed as a flag.
           args.push("--end-of-options", monitor.path);
+          markHostPerformance("wtdelete.git-remove:start", { worktreeId });
           const removeResult = await this.removeGitWorktreeWithRetry(this.git, args, monitor.path);
+          markHostPerformance("wtdelete.git-remove:end", { worktreeId });
           if (removeResult === "stale") {
             try {
               await this.git.raw(["worktree", "prune"]);
@@ -2994,6 +3030,7 @@ export class WorkspaceService {
       // a second delete — the operation completed once, the renderer just
       // missed the live ack.
       if (mutationId) this.recordAcknowledgedMutation(mutationId);
+      markHostPerformance("wtdelete.host-end", { worktreeId });
       this.sendEvent({ type: "delete-worktree-result", requestId, success: true });
     } catch (error) {
       // Delete failed — drop any pending entry so a real external change to

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -132,6 +132,36 @@ function flushAsyncTail(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+/**
+ * Collision plumbing for the optimistic-add order: the first `worktree add -b
+ * <branch>` rejects with git's stale-branch error (what a real repo produces),
+ * `worktree list --porcelain` returns the given output (or rejects), and every
+ * other git call resolves. Recovery behavior itself is asserted per test.
+ */
+function mockCollidingAdd(
+  raw: ReturnType<typeof vi.fn>,
+  branch: string,
+  porcelain: string[] | Error
+): void {
+  raw.mockImplementation((args: string[]) => {
+    if (args[0] === "worktree" && args[1] === "add" && args[2] === "-b" && args[3] === branch) {
+      return Promise.reject(new Error(`fatal: a branch named '${branch}' already exists`));
+    }
+    if (args[0] === "worktree" && args[1] === "list") {
+      return porcelain instanceof Error
+        ? Promise.reject(porcelain)
+        : Promise.resolve(porcelain.join("\n"));
+    }
+    return Promise.resolve(undefined);
+  });
+}
+
+/** The last `worktree add` argv issued — recovery retries follow the failed optimistic add. */
+function lastWorktreeAddCall(raw: ReturnType<typeof vi.fn>): string[] | undefined {
+  const calls = raw.mock.calls.filter((call) => call[0][0] === "worktree" && call[0][1] === "add");
+  return calls.at(-1)?.[0];
+}
+
 describe("WorkspaceService.createWorktree", () => {
   let service: WorkspaceService;
   let waitForPathExists: any;
@@ -539,16 +569,15 @@ describe("WorkspaceService.createWorktree", () => {
       branches: {},
       detached: false,
     });
-    // git worktree list --porcelain — only main is checked out, the stale
+    // The optimistic `-b` add fails with git's stale-branch error; the
+    // worktree list shows only main checked out, so the stale
     // bugfix/issue-6463 branch has no live worktree.
-    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
-      if (args[0] === "worktree" && args[1] === "list") {
-        return Promise.resolve(
-          ["worktree /test/root", "HEAD abc123", "branch refs/heads/main", ""].join("\n")
-        );
-      }
-      return Promise.resolve(undefined);
-    });
+    mockCollidingAdd(mockSimpleGit.raw, "bugfix/issue-6463", [
+      "worktree /test/root",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+    ]);
 
     await service.createWorktree("req-stale-reuse", "/test/root", {
       baseBranch: "main",
@@ -556,12 +585,23 @@ describe("WorkspaceService.createWorktree", () => {
       path: "/test/worktree-reuse",
     });
 
-    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+    // Recovery is failure-driven: the FIRST add must be the optimistic -b
+    // attempt (a reintroduced pre-flight would issue the reuse form first).
+    const addCalls = mockSimpleGit.raw.mock.calls.filter(
       (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
-    expect(worktreeAddCall).toBeDefined();
+    expect(addCalls[0]![0]).toEqual([
+      "worktree",
+      "add",
+      "-b",
+      "bugfix/issue-6463",
+      "--no-track",
+      "--end-of-options",
+      "/test/worktree-reuse",
+      "main",
+    ]);
     // No -b — reuse path, like the explicit useExistingBranch caller.
-    expect(worktreeAddCall![0]).toEqual([
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)).toEqual([
       "worktree",
       "add",
       "--end-of-options",
@@ -587,23 +627,16 @@ describe("WorkspaceService.createWorktree", () => {
       branches: {},
       detached: false,
     });
-    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
-      if (args[0] === "worktree" && args[1] === "list") {
-        return Promise.resolve(
-          [
-            "worktree /test/root",
-            "HEAD abc123",
-            "branch refs/heads/main",
-            "",
-            "worktree /test/foo-existing",
-            "HEAD def456",
-            "branch refs/heads/feature/foo",
-            "",
-          ].join("\n")
-        );
-      }
-      return Promise.resolve(undefined);
-    });
+    mockCollidingAdd(mockSimpleGit.raw, "feature/foo", [
+      "worktree /test/root",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /test/foo-existing",
+      "HEAD def456",
+      "branch refs/heads/feature/foo",
+      "",
+    ]);
 
     await service.createWorktree("req-checked-out", "/test/root", {
       baseBranch: "main",
@@ -611,11 +644,7 @@ describe("WorkspaceService.createWorktree", () => {
       path: "/test/worktree-foo",
     });
 
-    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      (call) => call[0][0] === "worktree" && call[0][1] === "add"
-    );
-    expect(worktreeAddCall).toBeDefined();
-    expect(worktreeAddCall![0]).toEqual([
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)).toEqual([
       "worktree",
       "add",
       "-b",
@@ -642,26 +671,19 @@ describe("WorkspaceService.createWorktree", () => {
       branches: {},
       detached: false,
     });
-    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
-      if (args[0] === "worktree" && args[1] === "list") {
-        // feature/foo is live; feature/foo-2 and feature/foo-3 are stale
-        // local branches but the requested name is feature/foo (live), so
-        // we must suffix past every existing local name.
-        return Promise.resolve(
-          [
-            "worktree /test/root",
-            "HEAD abc",
-            "branch refs/heads/main",
-            "",
-            "worktree /test/foo-live",
-            "HEAD def",
-            "branch refs/heads/feature/foo",
-            "",
-          ].join("\n")
-        );
-      }
-      return Promise.resolve(undefined);
-    });
+    // feature/foo is live; feature/foo-2 and feature/foo-3 are stale local
+    // branches but the requested name is feature/foo (live), so we must
+    // suffix past every existing local name.
+    mockCollidingAdd(mockSimpleGit.raw, "feature/foo", [
+      "worktree /test/root",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+      "worktree /test/foo-live",
+      "HEAD def",
+      "branch refs/heads/feature/foo",
+      "",
+    ]);
 
     await service.createWorktree("req-suffix-skip", "/test/root", {
       baseBranch: "main",
@@ -669,10 +691,7 @@ describe("WorkspaceService.createWorktree", () => {
       path: "/test/worktree-foo-new",
     });
 
-    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      (call) => call[0][0] === "worktree" && call[0][1] === "add"
-    );
-    expect(worktreeAddCall![0]).toEqual([
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)).toEqual([
       "worktree",
       "add",
       "-b",
@@ -695,12 +714,11 @@ describe("WorkspaceService.createWorktree", () => {
       branches: {},
       detached: false,
     });
-    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
-      if (args[0] === "worktree" && args[1] === "list") {
-        return Promise.reject(new Error("fatal: unable to read .git/index"));
-      }
-      return Promise.resolve(undefined);
-    });
+    mockCollidingAdd(
+      mockSimpleGit.raw,
+      "feature/foo",
+      new Error("fatal: unable to read .git/index")
+    );
 
     await service.createWorktree("req-list-failed", "/test/root", {
       baseBranch: "main",
@@ -708,10 +726,7 @@ describe("WorkspaceService.createWorktree", () => {
       path: "/test/worktree-foo-fail",
     });
 
-    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      (call) => call[0][0] === "worktree" && call[0][1] === "add"
-    );
-    expect(worktreeAddCall![0]).toEqual([
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)).toEqual([
       "worktree",
       "add",
       "-b",
@@ -734,16 +749,14 @@ describe("WorkspaceService.createWorktree", () => {
       branches: {},
       detached: false,
     });
-    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
-      if (args[0] === "worktree" && args[1] === "list") {
-        // pr-9999-feature is NOT checked out — would normally trigger reuse,
-        // but fromRemote suppresses that.
-        return Promise.resolve(
-          ["worktree /test/root", "HEAD abc", "branch refs/heads/main", ""].join("\n")
-        );
-      }
-      return Promise.resolve(undefined);
-    });
+    // pr-9999-feature is NOT checked out — would normally trigger reuse,
+    // but fromRemote suppresses that.
+    mockCollidingAdd(mockSimpleGit.raw, "pr-9999-feature", [
+      "worktree /test/root",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+    ]);
 
     await service.createWorktree("req-fromremote-stale", "/test/root", {
       baseBranch: "origin/pr-9999-feature",
@@ -752,10 +765,13 @@ describe("WorkspaceService.createWorktree", () => {
       fromRemote: true,
     });
 
-    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
+    // Failure-driven: the optimistic --track add for the original name runs
+    // first; the suffixed retry keeps --track.
+    const addCalls = mockSimpleGit.raw.mock.calls.filter(
       (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
-    expect(worktreeAddCall![0]).toEqual([
+    expect(addCalls[0]![0][3]).toBe("pr-9999-feature");
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)).toEqual([
       "worktree",
       "add",
       "-b",
@@ -776,23 +792,16 @@ describe("WorkspaceService.createWorktree", () => {
       branches: {},
       detached: false,
     });
-    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
-      if (args[0] === "worktree" && args[1] === "list") {
-        return Promise.resolve(
-          [
-            "worktree /test/root",
-            "HEAD abc",
-            "branch refs/heads/main",
-            "",
-            "worktree /test/foo-live",
-            "HEAD def",
-            "branch refs/heads/feature/foo",
-            "",
-          ].join("\n")
-        );
-      }
-      return Promise.resolve(undefined);
-    });
+    mockCollidingAdd(mockSimpleGit.raw, "feature/foo", [
+      "worktree /test/root",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+      "worktree /test/foo-live",
+      "HEAD def",
+      "branch refs/heads/feature/foo",
+      "",
+    ]);
 
     await service.createWorktree("req-suffix-gap", "/test/root", {
       baseBranch: "main",
@@ -800,10 +809,7 @@ describe("WorkspaceService.createWorktree", () => {
       path: "/test/worktree-foo-gap",
     });
 
-    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      (call) => call[0][0] === "worktree" && call[0][1] === "add"
-    );
-    expect(worktreeAddCall![0][3]).toBe("feature/foo-11");
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)![3]).toBe("feature/foo-11");
   });
 
   it("escapes regex metacharacters in branch names when computing suffixes", async () => {
@@ -817,23 +823,16 @@ describe("WorkspaceService.createWorktree", () => {
       branches: {},
       detached: false,
     });
-    mockSimpleGit.raw.mockImplementationOnce((args: string[]) => {
-      if (args[0] === "worktree" && args[1] === "list") {
-        return Promise.resolve(
-          [
-            "worktree /test/root",
-            "HEAD abc",
-            "branch refs/heads/main",
-            "",
-            "worktree /test/live",
-            "HEAD def",
-            "branch refs/heads/bugfix/foo(6463)",
-            "",
-          ].join("\n")
-        );
-      }
-      return Promise.resolve(undefined);
-    });
+    mockCollidingAdd(mockSimpleGit.raw, "bugfix/foo(6463)", [
+      "worktree /test/root",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+      "worktree /test/live",
+      "HEAD def",
+      "branch refs/heads/bugfix/foo(6463)",
+      "",
+    ]);
 
     await service.createWorktree("req-regex-escape", "/test/root", {
       baseBranch: "main",
@@ -841,23 +840,13 @@ describe("WorkspaceService.createWorktree", () => {
       path: "/test/worktree-regex",
     });
 
-    const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
-      (call) => call[0][0] === "worktree" && call[0][1] === "add"
-    );
-    expect(worktreeAddCall![0][3]).toBe("bugfix/foo(6463)-3");
+    expect(lastWorktreeAddCall(mockSimpleGit.raw)![3]).toBe("bugfix/foo(6463)-3");
   });
 
-  it("proceeds with the original -b path when the branch does not exist locally", async () => {
-    // Baseline: the guard is a no-op when there's no collision. Argv must
-    // match the pre-fix shape exactly so the issue-mode --no-track contract
-    // is preserved.
-    mockSimpleGit.branchLocal.mockResolvedValueOnce({
-      all: ["main", "develop"],
-      current: "main",
-      branches: {},
-      detached: false,
-    });
-
+  it("proceeds with the original -b path and zero probe spawns when the branch does not exist locally", async () => {
+    // Baseline: recovery is failure-driven, so a collision-free create issues
+    // exactly one git call — the add itself. Argv must match the issue-mode
+    // --no-track contract exactly.
     await service.createWorktree("req-no-collision", "/test/root", {
       baseBranch: "main",
       newBranch: "feature/brand-new",
@@ -874,11 +863,161 @@ describe("WorkspaceService.createWorktree", () => {
       "/test/worktree-new",
       "main",
     ]);
-    // Never queried the worktree list — short-circuit when branch is free.
+    // No pre-flight branch listing and no worktree-list probe on the happy
+    // path — the old order charged every create a branchLocal spawn.
+    expect(mockSimpleGit.branchLocal).not.toHaveBeenCalled();
     const listCall = mockSimpleGit.raw.mock.calls.find(
       (call) => call[0][0] === "worktree" && call[0][1] === "list"
     );
     expect(listCall).toBeUndefined();
+  });
+
+  it("surfaces the original add error when branch listing fails during recovery", async () => {
+    mockSimpleGit.raw.mockImplementation((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "add") {
+        return Promise.reject(new Error("fatal: a branch named 'feature/foo' already exists"));
+      }
+      return Promise.resolve(undefined);
+    });
+    mockSimpleGit.branchLocal.mockRejectedValueOnce(new Error("fatal: bad repo"));
+
+    await service.createWorktree("req-recovery-blind", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "/test/worktree-foo-blind",
+    });
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-recovery-blind",
+        success: false,
+        error: "fatal: a branch named 'feature/foo' already exists",
+      })
+    );
+    // Only the single failed add — no reuse/suffix retries were attempted.
+    const addCalls = mockSimpleGit.raw.mock.calls.filter(
+      (call) => call[0][0] === "worktree" && call[0][1] === "add"
+    );
+    expect(addCalls).toHaveLength(1);
+  });
+
+  it("does not run branch-collision recovery for non-collision add failures", async () => {
+    // `worktree add` reports an existing target *path* with a similar
+    // "already exists" phrase; that must surface as-is, not trigger the
+    // stale-branch recovery.
+    mockSimpleGit.raw.mockImplementation((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "add") {
+        return Promise.reject(new Error("fatal: '/test/worktree-dup' already exists"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-path-exists", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "/test/worktree-dup",
+    });
+
+    expect(mockSimpleGit.branchLocal).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-path-exists",
+        success: false,
+        error: "fatal: '/test/worktree-dup' already exists",
+      })
+    );
+  });
+
+  it("runs concurrent distinct creates on the same root strictly one at a time", async () => {
+    // The per-root create queue is what lets the IPC rate limit grant a burst
+    // allowance: git adds must never overlap on one repo (#5098), enforced
+    // structurally here rather than by wall-clock pacing.
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    mockSimpleGit.raw.mockImplementation(async (args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "add") {
+        order.push(`add:${args[3]}`);
+        if (args[3] === "serial-a") await firstGate;
+      }
+      return undefined;
+    });
+
+    const first = service.createWorktree("req-serial-1", "/test/root", {
+      baseBranch: "main",
+      newBranch: "serial-a",
+      path: "/test/worktree-serial-a",
+    });
+    const second = service.createWorktree("req-serial-2", "/test/root", {
+      baseBranch: "main",
+      newBranch: "serial-b",
+      path: "/test/worktree-serial-b",
+    });
+
+    for (let i = 0; i < 25 && order.length === 0; i++) {
+      await flushAsyncTail();
+    }
+    // First add is in flight (gated); the second create must not have
+    // started its git work.
+    expect(order).toEqual(["add:serial-a"]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["add:serial-a", "add:serial-b"]);
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-serial-1",
+        success: true,
+      })
+    );
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-serial-2",
+        success: true,
+      })
+    );
+  });
+
+  it("keeps serving creates after a failed create earlier in the queue", async () => {
+    mockSimpleGit.raw.mockImplementation((args: string[]) => {
+      if (args[0] === "worktree" && args[1] === "add" && args[3] === "fail-first") {
+        return Promise.reject(new Error("fatal: could not create work tree dir"));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await service.createWorktree("req-fail-first", "/test/root", {
+      baseBranch: "main",
+      newBranch: "fail-first",
+      path: "/test/worktree-fail-first",
+    });
+    await service.createWorktree("req-after-fail", "/test/root", {
+      baseBranch: "main",
+      newBranch: "after-fail",
+      path: "/test/worktree-after-fail",
+    });
+
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-fail-first",
+        success: false,
+      })
+    );
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-after-fail",
+        success: true,
+      })
+    );
   });
 
   it("skips the pre-flight guard entirely when useExistingBranch is true", async () => {

--- a/electron/workspace-host/worktreeUtils.ts
+++ b/electron/workspace-host/worktreeUtils.ts
@@ -11,6 +11,7 @@ import {
 } from "path";
 import { getGitDir } from "../utils/gitUtils.js";
 import { getGitLocaleEnv } from "../utils/hardenedGit.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { NOTE_PATH } from "./types.js";
 
 // Hard ceiling on the `git lfs version` probe. `git` is already on PATH, so a
@@ -87,6 +88,18 @@ export function parseCheckedOutBranches(porcelainOutput: string): Set<string> {
     }
   }
   return branches;
+}
+
+/**
+ * Matches git's refusal when `worktree add -b` names a branch that already
+ * exists ("fatal: a branch named 'x' already exists"). Deliberately anchored
+ * on "branch named" — `worktree add` reports an existing target *path* with a
+ * similar "already exists" phrase, and that failure must not trigger branch
+ * collision recovery. Git output is locale-pinned to C/English by the
+ * hardened factory's env, so message matching is stable.
+ */
+export function isBranchAlreadyExistsError(error: unknown): boolean {
+  return /branch named .* already exists/i.test(formatErrorMessage(error, ""));
 }
 
 export function nextAvailableBranchName(baseName: string, existing: Set<string>): string {


### PR DESCRIPTION
This PR speeds up the core product loop of creating a git worktree and getting an agent running inside it, with the biggest wins on bulk creation. It adds an opt-in benchmark that measures the whole sequence — `worktree.create` dispatch → create resolved → sidebar card → agent panel → xterm → agent first output → `worktree.delete` — plus a burst block (N concurrent creates) for the fleet/bulk-create shape, then uses it to drive two changes.

### Before and after

Measured with the new harness on macOS, 12 single-flow rounds per run, 2 runs per variant, against a fake instant-boot `claude` CLI so the numbers isolate app overhead rather than agent startup. Baseline is unmodified `develop`. Bursts are N concurrent `worktree.create` dispatches from an idle start.

| Metric (p50, n=24 rounds / 4 burst reps) | develop | this PR |
| --- | --- | --- |
| `worktree.create` dispatch → resolved | 58ms | 46ms |
| `worktree.create` dispatch → sidebar card | 64ms | 58ms |
| create → agent first output (full loop) | 289ms | 165ms |
| `worktree.delete` dispatch → resolved | 83ms | 80ms |
| burst n=5: all creates resolved | 4.12s | 0.20s |
| burst n=20: all creates resolved (idle start) | 19.12s | 0.84s |

The single-create win (−12ms) is the removed `branchLocal` spawn; the burst rows are the rate-limit rework (a burst-of-5's median per-create resolve went 2.12s → 123ms). The full-loop delta overstates the app-side win — much of it is node-boot variance in the fake CLI between sessions; the attributable app-side movement is the create side plus a few ms on panel/xterm. Delete is intentionally untouched (measured, nothing indicted: ~80ms is two git spawns plus teardown checks).

New `wtcreate.*` / `wtdelete.*` host perf marks (emitted only under `DAINTREE_PERF_CAPTURE`) attribute the create time per phase. Post-change, the host-side create is ~43ms: ~30ms is `git worktree add` itself, ~12ms is git-dir resolution + monitor registration, everything else sub-millisecond.

### What changed

1. **Worktree-create rate limit: strict 1/s leaky bucket → token bucket (burst 30), backed by real serialization instead of wall-clock pacing.** The 1/s pacing existed to keep concurrent `git worktree add` runs off the same repo (#5098, #5161) — a burst of N creates paid 0/1/2/…/N−1 seconds of pure queueing, which is why burst n=20 took 19s on develop. That git-safety property is now enforced structurally: the workspace host chains distinct creates per repo root (`enqueueCreateWorktree`), so they run strictly one-at-a-time back to back at real git speed, and the IPC limiter's only remaining job is runaway-automation backpressure (burst 30 covers the 30-worktree batches #5161 sized for; sustained abuse still settles to 1/s with the 50-deep queue-full rejection unchanged). The serialization is also a small safety improvement over develop, where two creates issued more than 1s apart could still overlap if the first took longer than a second.
2. **Dropped the pre-flight `git branchLocal` spawn from every create.** The #6463 stale-branch guard ran a branch listing before every `worktree add` to decide reuse-vs-suffix up front. `git worktree add -b` fails atomically when the branch exists (verified: no directory created, no worktree metadata registered), so the add is now attempted optimistically and the identical recovery (reuse if not checked out anywhere, else suffix `-2`/`-3`/…) runs only on the actual collision error. Detection matches git's "a branch named '…' already exists" message, which is stable because the hardened git env pins `LC_MESSAGES=C`; the similar path-collision phrase ("'<path>' already exists") deliberately does not match and surfaces as-is. Happy path: one git spawn instead of two. Collision path (rare): one extra failed spawn on top of what develop did.

A third candidate — resolving the git dir by parsing the worktree's `.git` gitfile instead of spawning `git rev-parse` (~10ms/create) — was implemented, benchmarked, and withdrawn: seeding the resolution changed monitor-registration timing enough that the new worktree's monitor was dropped and the agent terminal never received output (reproducible, bisected to the seed). Not worth a subtle behavior change for 10ms; noted here so the next person doesn't re-derive it blind.

### The benchmark

```
RUN_PERF_WORKTREE_AGENT_READY=1 npx playwright test --project=full-worktree \
  e2e/full/worktree/worktree-agent-ready-perf.spec.ts
```

Opt-in only, skipped in CI (same pattern as `agent-launch-perf.spec.ts` from #10972 — perf budgets deliberately stay out of PR CI). Three serial tests so a mid-run crash can't lose every block's samples, with results persisted incrementally (`PERF_WORKTREE_OUT`): single-flow rounds (create → card → agent READY → delete), step attribution for the pre-create IPC hops (`getAvailableBranch` ~13ms, `getDefaultPath` ~0.5ms), and burst scaling (default n=5,20, two reps each; store-arrival is probed via `worktree.list` because the sidebar is virtualized at N=20). A fake `claude` CLI removes real-CLI boot variance; `ZDOTDIR` points at an empty dir so a machine's real `claude` install can't win the login-shell PATH race.

### Observations for follow-up

- On one baseline run, ~100s after a 20-deep create burst, all 20 worktree monitors had disappeared from the workspace host and every delete failed with "Worktree not found". It didn't reproduce across later runs; the benchmark records burst delete errors without gating on them so the latency harness stays usable while that's investigated.
- A second consecutive n=20 burst lands in the token bucket's sustained-rate regime (~1/s refill after the first 30). That's intended backpressure for repeated mass creation; if fleets legitimately need repeated 20+ batches within a minute, the burst constant is the knob.

### Accepted trade-offs

- A stale-branch collision now costs one extra (failed) `git worktree add` spawn compared to develop's pre-flight detection. Collisions are rare (deleted worktree with a kept branch, same name reused) and the recovery outcome is identical, so charging the rare path instead of every create is the right direction.
- With a localized git that ignores `LC_MESSAGES` (not a configuration the hardened env produces), a collision would surface git's error instead of auto-recovering — the same outcome develop had whenever its pre-flight `branchLocal` failed.

### Testing

- `npm run check` passes; full typecheck composite passes.
- `WorkspaceService.createWorktree` suite reworked for the optimistic-add order (same behavioral assertions: reuse form, suffix selection, fromRemote suffixing, probe-failure fallback) plus new coverage: zero probe spawns on the happy path, original-error surfacing when recovery can't inspect branches, no recovery on path-collision errors, strict per-root serialization of concurrent creates, and the queue surviving a failed create.
- Rate-limit handler tests updated to pin the token-bucket call (`worktreeCreate`, 1s, burst 30).
- The perf spec's reliability invariants (every round completes create → agent READY → delete; burst creates all succeed and reach the store) pass 12/12 rounds × 2 runs on the changed build.
