### PR TITLE
perf(store): stop git-status polls fanning out into whole-app re-renders

### DIFF
--- a/e2e/full/panels/store-fanout-perf.spec.ts
+++ b/e2e/full/panels/store-fanout-perf.spec.ts
@@ -224,7 +224,13 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
       const fixture = prepareFixture(scale);
       let ctx: AppContext | undefined;
       try {
+        // enableWebgl keeps the GPU process out-of-process (and matches
+        // production rendering). The local-macOS default of --disable-gpu
+        // --in-process-gpu makes a compositor fault under sustained terminal
+        // streaming fatal to the whole app — observed as a mid-flip
+        // "graceful shutdown" cascade that killed the measured view.
         ctx = await launchApp({
+          enableWebgl: true,
           env: {
             PATH: `${fixture.fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
             DAINTREE_CLI_PATH_PREPEND: fixture.fakeBinDir,
@@ -329,6 +335,16 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         const queueSettleMs = Math.max(5_000, (scale - 6) * 1_100 + 4_000);
         await page.waitForTimeout(queueSettleMs);
 
+        // Reload sentinel: a renderer crash/reload mid-scale reinstalls a fresh
+        // probe and silently truncates captured commits — fail loudly instead.
+        await page.evaluate(() => {
+          (window as any).__FANOUT_SESSION_MARKER__ = true;
+        });
+        const assertNoReload = async (where: string) => {
+          const alive = await page.evaluate(() => !!(window as any).__FANOUT_SESSION_MARKER__);
+          expect(alive, `renderer view survived without reload (${where})`).toBe(true);
+        };
+
         const ptyWrite = async (data: string) => {
           await page.evaluate(
             ([id, payload]) => (window as any).electron.terminal.write(id, payload),
@@ -418,21 +434,23 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         // working->waiting rides the ~8s idle debounce. Both directions are
         // bracketed around the observed data-agent-state attribute change.
         const flips: EventSample[] = [];
+        // Node-side polling with short evaluates (~±100ms flip-time precision,
+        // well within the ±500ms attribution brackets). A single long-running
+        // in-page evaluate would die unrecoverably if the view reloads.
         const waitForState = async (state: string, timeoutMs: number): Promise<number> => {
-          const flipAt = await page.evaluate(
-            async ([panelId, want, timeout]) => {
-              const el = document.querySelector(`[data-panel-id="${panelId}"]`);
-              if (!el) return -1;
-              const deadline = performance.now() + Number(timeout);
-              while (performance.now() < deadline) {
-                if (el.getAttribute("data-agent-state") === want) return performance.now();
-                await new Promise((r) => requestAnimationFrame(r));
-              }
-              return -1;
-            },
-            [flipPanelId!, state, String(timeoutMs)] as const
-          );
-          return flipAt as number;
+          const deadline = Date.now() + timeoutMs;
+          while (Date.now() < deadline) {
+            const found = await page.evaluate(
+              ([panelId, want]) => {
+                const el = document.querySelector(`[data-panel-id="${panelId}"]`);
+                return el?.getAttribute("data-agent-state") === want ? performance.now() : -1;
+              },
+              [flipPanelId!, state] as const
+            );
+            if (found > 0) return found;
+            await page.waitForTimeout(100);
+          }
+          return -1;
         };
 
         await probeStart();
@@ -468,6 +486,7 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         const streamCommits = (await probeStop()) as any[];
         await ptyWrite(`${IDLE_TOKEN}\r`);
         const stream = [collectWindow(streamCommits, streamT0, streamT1)];
+        await assertNoReload("after workloads");
 
         const scaleResult: ScaleResult = {
           scale,

--- a/e2e/full/panels/store-fanout-perf.spec.ts
+++ b/e2e/full/panels/store-fanout-perf.spec.ts
@@ -1,0 +1,538 @@
+/* eslint-disable @typescript-eslint/no-explicit-any -- window bridges are untyped in Playwright evaluate() */
+import { test, expect } from "@playwright/test";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "fs";
+import { execSync } from "child_process";
+import path from "path";
+import { tmpdir } from "os";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { openAndOnboardProject } from "../../helpers/project";
+import { T_LONG } from "../../helpers/timeouts";
+
+// Store-update fanout harness: how many React components re-render — and how
+// many milliseconds of render work run — per git-status tick and per
+// agent-state flip, as worktree/panel count scales. Reads per-commit render
+// counts and self durations from window.__DAINTREE_RENDER_PROBE__
+// (src/utils/renderFanoutProbe.ts), which only exists in a bench build:
+//
+//   npm run build:e2e:bench
+//   RUN_PERF_STORE_FANOUT=1 npx playwright test --project=full-panels \
+//     e2e/full/panels/store-fanout-perf.spec.ts
+//
+// Four workloads per scale, each in a fresh app instance:
+//   tick-quiet:  force a git-status poll of one worktree with NO file changes
+//   tick-change: dirty/clean a file, then force the poll (real status delta)
+//   flip:        drive one agent working<->waiting via a fake claude CLI
+//   stream:      one agent streams output for a fixed window (ambient fanout)
+//
+// Opt-in only — a measurement harness for local A/B runs, never a CI gate
+// (perf budgets deliberately stay out of PR CI pre-1.0).
+const SCALES = (process.env.PERF_STORE_FANOUT_SCALES ?? "1,5,20,50")
+  .split(",")
+  .map((s) => Math.max(1, Math.floor(Number(s.trim()))))
+  .filter((n) => Number.isFinite(n) && n > 0);
+const TICKS = Math.max(3, Math.floor(Number(process.env.PERF_STORE_FANOUT_TICKS) || 15));
+const CHANGE_TICKS = Math.max(3, Math.floor(Number(process.env.PERF_STORE_FANOUT_CHANGE_TICKS) || 10));
+const FLIP_CYCLES = Math.max(2, Math.floor(Number(process.env.PERF_STORE_FANOUT_FLIP_CYCLES) || 5));
+const STREAM_SECONDS = Math.max(3, Math.floor(Number(process.env.PERF_STORE_FANOUT_STREAM_SECONDS) || 10));
+const OUT_PATH = process.env.PERF_STORE_FANOUT_OUT ?? "";
+
+const READY_TOKEN = "FAKE_CLAUDE_READY";
+const WORK_TOKEN = "__DAINTREE_FAKE_WORK__";
+const IDLE_TOKEN = "__DAINTREE_FAKE_IDLE__";
+
+interface EventSample {
+  /** commits observed in the event window */
+  commits: number;
+  /** component fibers rendered across those commits */
+  renders: number;
+  /** total self render ms across those commits */
+  selfMs: number;
+  /** per-component rollup for the window */
+  byComponent: Record<string, { n: number; ms: number }>;
+  /** wall ms from trigger to last attributed commit (diagnostic) */
+  windowMs: number;
+}
+
+interface WorkloadResult {
+  name: string;
+  events: EventSample[];
+}
+
+interface ScaleResult {
+  scale: number;
+  panelCount: number;
+  ambientCommitsPer10s: number;
+  ambientRendersPer10s: number;
+  workloads: WorkloadResult[];
+}
+
+function pct(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor((p / 100) * sorted.length));
+  return sorted[idx];
+}
+
+function fmtRow(name: string, events: EventSample[]): string {
+  const renders = events.map((e) => e.renders);
+  const selfMs = events.map((e) => e.selfMs);
+  const commits = events.map((e) => e.commits);
+  return (
+    `${name.padEnd(12)} n=${String(events.length).padStart(3)}` +
+    ` renders p50=${String(pct(renders, 50)).padStart(5)} p95=${String(pct(renders, 95)).padStart(5)}` +
+    ` selfMs p50=${pct(selfMs, 50).toFixed(2).padStart(8)} p95=${pct(selfMs, 95).toFixed(2).padStart(8)}` +
+    ` commits p50=${String(pct(commits, 50)).padStart(3)}`
+  );
+}
+
+function topComponents(events: EventSample[], limit = 12): Array<{ name: string; n: number; ms: number }> {
+  const merged = new Map<string, { n: number; ms: number }>();
+  for (const e of events) {
+    for (const [name, v] of Object.entries(e.byComponent)) {
+      const entry = merged.get(name) ?? { n: 0, ms: 0 };
+      entry.n += v.n;
+      entry.ms += v.ms;
+      merged.set(name, entry);
+    }
+  }
+  return [...merged.entries()]
+    .map(([name, v]) => ({ name, ...v }))
+    .sort((a, b) => b.ms - a.ms)
+    .slice(0, limit);
+}
+
+function git(cmd: string, cwd: string): void {
+  execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
+}
+
+interface Fixture {
+  dir: string;
+  worktreeDirs: string[];
+  fakeBinDir: string;
+  cleanup: () => void;
+}
+
+// Fresh repo + (scale-1) sibling git worktrees + a fake `claude` CLI that
+// boots instantly (no trust prompt) and flips working/idle on stdin tokens.
+// The OSC 9;4 heartbeat drives the working state viewport-independently
+// (#8753); WORK mode also streams a short line every 150ms so the stream
+// workload exercises the real output->activity->status-buffer path.
+function prepareFixture(scale: number): Fixture {
+  const dir = mkdtempSync(path.join(tmpdir(), `daintree-e2e-store-fanout-${scale}-`));
+  git("init -b main", dir);
+  git('config user.email "test@daintree.dev"', dir);
+  git('config user.name "Daintree Test"', dir);
+  writeFileSync(path.join(dir, "README.md"), `# store-fanout-${scale}\n`);
+  writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: `store-fanout-${scale}`, version: "1.0.0", private: true }, null, 2) + "\n"
+  );
+
+  const fakeBinDir = path.join(dir, ".e2e-bin");
+  mkdirSync(fakeBinDir, { recursive: true });
+  const implName = process.platform === "win32" ? "claude.js" : "claude";
+  writeFileSync(
+    path.join(fakeBinDir, implName),
+    [
+      "#!/usr/bin/env node",
+      "if (process.argv.includes('--version')) {",
+      "  console.log('claude code v9.9.9');",
+      "  process.exit(0);",
+      "}",
+      `const WORK = ${JSON.stringify(WORK_TOKEN)};`,
+      `const IDLE = ${JSON.stringify(IDLE_TOKEN)};`,
+      "const OSC_WORKING = '\\u001b]9;4;1;0\\u0007';",
+      "const OSC_IDLE = '\\u001b]9;4;0;0\\u0007';",
+      `process.stdout.write('╭─ fake claude ─╮\\n│ fanout bench │\\n╰──────────────╯\\n' + ${JSON.stringify(READY_TOKEN)} + '\\n');`,
+      "process.stdin.resume();",
+      "process.stdin.setEncoding('utf8');",
+      "let oscTimer = null;",
+      "let streamTimer = null;",
+      "let tick = 0;",
+      "const startWork = () => {",
+      "  if (oscTimer) return;",
+      "  process.stdout.write(OSC_WORKING);",
+      "  oscTimer = setInterval(() => process.stdout.write(OSC_WORKING), 1000);",
+      "  streamTimer = setInterval(() => {",
+      "    tick++;",
+      "    process.stdout.write('working... step ' + tick + '\\n');",
+      "  }, 150);",
+      "};",
+      "const stopWork = () => {",
+      "  if (oscTimer) { clearInterval(oscTimer); oscTimer = null; }",
+      "  if (streamTimer) { clearInterval(streamTimer); streamTimer = null; }",
+      "  process.stdout.write(OSC_IDLE);",
+      "};",
+      "const keepAlive = setInterval(() => {}, 1000);",
+      "const shutdown = () => { stopWork(); clearInterval(keepAlive); process.exit(0); };",
+      "process.stdin.on('data', (chunk) => {",
+      "  const input = String(chunk);",
+      "  if (input.includes(WORK)) startWork();",
+      "  else if (input.includes(IDLE)) stopWork();",
+      "});",
+      "process.on('SIGINT', shutdown);",
+      "process.on('SIGTERM', shutdown);",
+      "",
+    ].join("\n")
+  );
+  chmodSync(path.join(fakeBinDir, implName), 0o755);
+  if (process.platform === "win32") {
+    writeFileSync(
+      path.join(fakeBinDir, "claude.cmd"),
+      ["@echo off", 'node "%~dp0claude.js" %*', ""].join("\r\n")
+    );
+  }
+
+  git("add -A", dir);
+  git('commit -m "store-fanout fixture"', dir);
+
+  const worktreeRoot = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+  mkdirSync(worktreeRoot, { recursive: true });
+  const worktreeDirs: string[] = [];
+  for (let i = 1; i < scale; i++) {
+    const branch = `wt-${String(i).padStart(2, "0")}`;
+    const wtDir = path.join(worktreeRoot, branch);
+    git(`worktree add -b ${branch} ${JSON.stringify(wtDir)} main`, dir);
+    worktreeDirs.push(wtDir);
+  }
+
+  const cleanup = () => {
+    try {
+      rmSync(worktreeRoot, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  };
+  return { dir, worktreeDirs, fakeBinDir, cleanup };
+}
+
+const perfDescribe = process.env.RUN_PERF_STORE_FANOUT ? test.describe.serial : test.describe.skip;
+
+perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", () => {
+  const results: ScaleResult[] = [];
+
+  for (const scale of SCALES) {
+    test(`fanout at ${scale} worktree(s)`, async () => {
+      test.slow();
+      test.setTimeout(900_000);
+
+      const fixture = prepareFixture(scale);
+      let ctx: AppContext | undefined;
+      try {
+        ctx = await launchApp({
+          env: {
+            PATH: `${fixture.fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            DAINTREE_CLI_PATH_PREPEND: fixture.fakeBinDir,
+            DAINTREE_IDENTITY_DEBUG_PASS: "1",
+          },
+        });
+        ctx.window = await openAndOnboardProject(
+          ctx.app,
+          ctx.window,
+          fixture.dir,
+          `Store Fanout ${scale}`
+        );
+        const page = ctx.window;
+
+        // The probe only exists in bench builds — fail loudly otherwise.
+        const probeState = await page.evaluate(() => {
+          const probe = (window as any).__DAINTREE_RENDER_PROBE__;
+          return { installed: !!probe?.installed };
+        });
+        expect(
+          probeState.installed,
+          "render probe missing — build with `npm run build:e2e:bench` first"
+        ).toBe(true);
+
+        // All worktrees discovered by the workspace scan.
+        await expect
+          .poll(
+            async () =>
+              await page.evaluate(async () => {
+                const all = await (window as any).electron.worktree.getAll();
+                return Array.isArray(all) ? all.length : 0;
+              }),
+            { timeout: 120_000, intervals: [500, 1000] }
+          )
+          .toBeGreaterThanOrEqual(scale);
+
+        const worktrees: Array<{ id: string; path: string; isMain: boolean }> = await page.evaluate(
+          async () => {
+            const all = await (window as any).electron.worktree.getAll();
+            return all.map((w: any) => ({
+              id: w.id,
+              path: w.path,
+              isMain: !!(w.isMain ?? w.isMainWorktree),
+            }));
+          }
+        );
+        expect(worktrees.length).toBeGreaterThanOrEqual(scale);
+        const mainWt = worktrees.find((w) => w.isMain) ?? worktrees[0];
+
+        // Let post-onboarding work (availability probes, pool warmup) settle
+        // before the first launch — `agent.launch` returns null while the
+        // fake claude hasn't been probed as installed yet.
+        await page.waitForTimeout(3_000);
+
+        // One fake agent per worktree. Launches beyond the spawn token bucket
+        // (6) queue at 1/s — dispatch sequentially and let the queue drain.
+        // Retried because the very first dispatch can race the availability
+        // probe on slow starts.
+        const launched: string[] = [];
+        for (const wt of worktrees.slice(0, scale)) {
+          let terminalId: string | null = null;
+          for (let attempt = 0; attempt < 20 && !terminalId; attempt++) {
+            terminalId = await page.evaluate(async (worktreeId) => {
+              const dispatch = (window as any).__daintreeDispatchAction;
+              // dispatch returns the ActionDispatchResult envelope, not the
+              // action's raw result.
+              const envelope = await dispatch(
+                "agent.launch",
+                { agentId: "claude", worktreeId, focusPolicy: "preserve" },
+                { source: "test" }
+              );
+              return envelope?.ok ? (envelope.result?.terminalId ?? null) : null;
+            }, wt.id);
+            if (!terminalId) await page.waitForTimeout(1_500);
+          }
+          expect(terminalId, `agent launch in ${wt.id}`).toBeTruthy();
+          launched.push(terminalId!);
+        }
+
+        // Deterministic focus across scales: the main worktree is active, so
+        // the visible grid panel (and flip target) is always main's agent.
+        await page.evaluate(
+          (id) => (window as any).electron.worktree.setActive(id),
+          mainWt.id
+        );
+        await page.waitForTimeout(1_000);
+
+        // The active worktree's agent is the one we flip; find its grid panel.
+        const gridPanel = page.locator('[data-panel-location="grid"]').first();
+        await expect(gridPanel).toBeVisible({ timeout: T_LONG });
+        const flipPanelId = await gridPanel.getAttribute("data-panel-id");
+        expect(flipPanelId).toBeTruthy();
+
+        // Wait for the visible agent to be detected and READY, then let the
+        // background spawn queue + availability probes fully settle.
+        await expect
+          .poll(() => gridPanel.getAttribute("data-detected-agent-id"), {
+            timeout: 120_000,
+            intervals: [500, 1000],
+          })
+          .toBe("claude");
+        const queueSettleMs = Math.max(5_000, (scale - 6) * 1_100 + 4_000);
+        await page.waitForTimeout(queueSettleMs);
+
+        const ptyWrite = async (data: string) => {
+          await page.evaluate(
+            ([id, payload]) => (window as any).electron.terminal.write(id, payload),
+            [flipPanelId!, data]
+          );
+        };
+
+        const probeStart = () =>
+          page.evaluate(() => (window as any).__DAINTREE_RENDER_PROBE__.start());
+        const probeStop = () =>
+          page.evaluate(() => (window as any).__DAINTREE_RENDER_PROBE__.stop());
+
+        // Attribute captured commits to [t0, t1] windows on the page clock.
+        const collectWindow = (
+          commits: Array<{ t: number; renders: number; selfMs: number; byComponent: any }>,
+          t0: number,
+          t1: number
+        ): EventSample => {
+          const inWindow = commits.filter((c) => c.t >= t0 && c.t <= t1);
+          const byComponent: Record<string, { n: number; ms: number }> = {};
+          for (const c of inWindow) {
+            for (const [name, v] of Object.entries(
+              c.byComponent as Record<string, { n: number; ms: number }>
+            )) {
+              const entry = (byComponent[name] ??= { n: 0, ms: 0 });
+              entry.n += v.n;
+              entry.ms += v.ms;
+            }
+          }
+          const last = inWindow.length > 0 ? inWindow[inWindow.length - 1].t : t0;
+          return {
+            commits: inWindow.length,
+            renders: inWindow.reduce((a, c) => a + c.renders, 0),
+            selfMs: inWindow.reduce((a, c) => a + c.selfMs, 0),
+            byComponent,
+            windowMs: last - t0,
+          };
+        };
+
+        // ── Ambient noise floor: 10s with nothing happening ──
+        await probeStart();
+        await page.waitForTimeout(10_000);
+        const ambient = (await probeStop()) as Array<{ t: number; renders: number; selfMs: number; byComponent: any }>;
+        const ambientCommits = ambient.length;
+        const ambientRenders = ambient.reduce((a, c) => a + c.renders, 0);
+
+        // ── Workload: tick-quiet — forced git poll, zero file changes ──
+        const tickQuiet: EventSample[] = [];
+        await probeStart();
+        const quietWindows: Array<{ t0: number; t1: number }> = [];
+        for (let k = 0; k < TICKS; k++) {
+          const t0 = await page.evaluate(() => performance.now());
+          await page.evaluate(
+            (id) => (window as any).electron.worktree.refresh(id),
+            mainWt.id
+          );
+          await page.waitForTimeout(450);
+          const t1 = await page.evaluate(() => performance.now());
+          quietWindows.push({ t0, t1 });
+        }
+        const quietCommits = (await probeStop()) as any[];
+        for (const w of quietWindows) tickQuiet.push(collectWindow(quietCommits, w.t0, w.t1));
+
+        // ── Workload: tick-change — alternate dirty/clean, forced poll ──
+        const tickChange: EventSample[] = [];
+        const churnFile = path.join(mainWt.path, "fanout-churn.txt");
+        await probeStart();
+        const changeWindows: Array<{ t0: number; t1: number }> = [];
+        for (let k = 0; k < CHANGE_TICKS; k++) {
+          if (k % 2 === 0) writeFileSync(churnFile, `dirty ${k}\n`);
+          else rmSync(churnFile, { force: true });
+          const t0 = await page.evaluate(() => performance.now());
+          await page.evaluate(
+            (id) => (window as any).electron.worktree.refresh(id),
+            mainWt.id
+          );
+          await page.waitForTimeout(500);
+          const t1 = await page.evaluate(() => performance.now());
+          changeWindows.push({ t0, t1 });
+        }
+        rmSync(churnFile, { force: true });
+        const changeCommits = (await probeStop()) as any[];
+        for (const w of changeWindows) tickChange.push(collectWindow(changeCommits, w.t0, w.t1));
+
+        // ── Workload: flip — working<->waiting on the visible agent ──
+        // waiting->working flips on the first OSC heartbeat (fast);
+        // working->waiting rides the ~8s idle debounce. Both directions are
+        // bracketed around the observed data-agent-state attribute change.
+        const flips: EventSample[] = [];
+        const waitForState = async (state: string, timeoutMs: number): Promise<number> => {
+          const flipAt = await page.evaluate(
+            async ([panelId, want, timeout]) => {
+              const el = document.querySelector(`[data-panel-id="${panelId}"]`);
+              if (!el) return -1;
+              const deadline = performance.now() + Number(timeout);
+              while (performance.now() < deadline) {
+                if (el.getAttribute("data-agent-state") === want) return performance.now();
+                await new Promise((r) => requestAnimationFrame(r));
+              }
+              return -1;
+            },
+            [flipPanelId!, state, String(timeoutMs)] as const
+          );
+          return flipAt as number;
+        };
+
+        await probeStart();
+        const flipWindows: Array<{ t0: number; t1: number; ok: boolean }> = [];
+        for (let cycle = 0; cycle < FLIP_CYCLES; cycle++) {
+          // -> working (fast)
+          const tSend = await page.evaluate(() => performance.now());
+          await ptyWrite(`${WORK_TOKEN}\r`);
+          const tWorking = await waitForState("working", 20_000);
+          await page.waitForTimeout(400);
+          flipWindows.push({ t0: tSend, t1: tWorking + 400, ok: tWorking > 0 });
+
+          // -> waiting (debounced). Bracket around the observed flip so the
+          // ~8s debounce dead-time doesn't pollute the sample.
+          await ptyWrite(`${IDLE_TOKEN}\r`);
+          const tWaiting = await waitForState("waiting", 40_000);
+          await page.waitForTimeout(400);
+          flipWindows.push({ t0: tWaiting - 600, t1: tWaiting + 400, ok: tWaiting > 0 });
+        }
+        const flipCommits = (await probeStop()) as any[];
+        for (const w of flipWindows) {
+          if (w.ok) flips.push(collectWindow(flipCommits, w.t0, w.t1));
+        }
+
+        // ── Workload: stream — one agent streams for STREAM_SECONDS ──
+        await ptyWrite(`${WORK_TOKEN}\r`);
+        await waitForState("working", 20_000);
+        await page.waitForTimeout(1_000);
+        await probeStart();
+        const streamT0 = await page.evaluate(() => performance.now());
+        await page.waitForTimeout(STREAM_SECONDS * 1_000);
+        const streamT1 = await page.evaluate(() => performance.now());
+        const streamCommits = (await probeStop()) as any[];
+        await ptyWrite(`${IDLE_TOKEN}\r`);
+        const stream = [collectWindow(streamCommits, streamT0, streamT1)];
+
+        const scaleResult: ScaleResult = {
+          scale,
+          panelCount: launched.length,
+          ambientCommitsPer10s: ambientCommits,
+          ambientRendersPer10s: ambientRenders,
+          workloads: [
+            { name: "tick-quiet", events: tickQuiet },
+            { name: "tick-change", events: tickChange },
+            { name: "flip", events: flips },
+            { name: "stream", events: stream },
+          ],
+        };
+        results.push(scaleResult);
+
+        console.log(`──── store fanout @ ${scale} worktree(s), ${launched.length} agents ────`);
+        console.log(
+          `ambient (10s quiet): commits=${ambientCommits} renders=${ambientRenders}`
+        );
+        for (const w of scaleResult.workloads) console.log(fmtRow(w.name, w.events));
+        for (const w of scaleResult.workloads) {
+          const top = topComponents(w.events, 8);
+          if (top.length > 0) {
+            console.log(
+              `top ${w.name}: ` +
+                top
+                  .map((t) => `${t.name}×${t.n}(${t.ms.toFixed(1)}ms)`)
+                  .join(" ")
+            );
+          }
+        }
+
+        // Reliability invariants only — fanout itself is reported, not gated.
+        expect(flips.length, "observed both flip directions").toBeGreaterThanOrEqual(
+          FLIP_CYCLES
+        );
+        expect(
+          tickQuiet.length + tickChange.length,
+          "all git ticks completed"
+        ).toBe(TICKS + CHANGE_TICKS);
+      } finally {
+        if (ctx?.app) await closeApp(ctx.app);
+        fixture.cleanup();
+      }
+    });
+  }
+
+  test.afterAll(() => {
+    if (OUT_PATH && results.length > 0) {
+      writeFileSync(
+        OUT_PATH,
+        JSON.stringify(
+          {
+            scales: SCALES,
+            ticks: TICKS,
+            changeTicks: CHANGE_TICKS,
+            flipCycles: FLIP_CYCLES,
+            streamSeconds: STREAM_SECONDS,
+            results,
+          },
+          null,
+          2
+        )
+      );
+      console.log(`store-fanout results written to ${OUT_PATH}`);
+    }
+  });
+});

--- a/e2e/full/panels/store-fanout-perf.spec.ts
+++ b/e2e/full/panels/store-fanout-perf.spec.ts
@@ -26,14 +26,29 @@ import { T_LONG } from "../../helpers/timeouts";
 //
 // Opt-in only — a measurement harness for local A/B runs, never a CI gate
 // (perf budgets deliberately stay out of PR CI pre-1.0).
+//
+// Machines running PARALLEL e2e sessions (agent fleets): every launchApp
+// reaps stray e2e Electrons machine-wide via
+// `pkill -f "node_modules/electron.*daintree-e2e"`, which kills a long
+// benchmark run mid-flight. Immunize this run by pointing it at an Electron
+// dist clone outside node_modules (official electron override):
+//   cp -Rc node_modules/electron/dist .bench-electron/dist   # APFS clone
+//   ELECTRON_OVERRIDE_DIST_PATH=$PWD/.bench-electron/dist RUN_PERF_STORE_FANOUT=1 ...
+// Leaked bench apps then need manual cleanup: pkill -f ".bench-electron".
 const SCALES = (process.env.PERF_STORE_FANOUT_SCALES ?? "1,5,20,50")
   .split(",")
   .map((s) => Math.max(1, Math.floor(Number(s.trim()))))
   .filter((n) => Number.isFinite(n) && n > 0);
 const TICKS = Math.max(3, Math.floor(Number(process.env.PERF_STORE_FANOUT_TICKS) || 15));
-const CHANGE_TICKS = Math.max(3, Math.floor(Number(process.env.PERF_STORE_FANOUT_CHANGE_TICKS) || 10));
+const CHANGE_TICKS = Math.max(
+  3,
+  Math.floor(Number(process.env.PERF_STORE_FANOUT_CHANGE_TICKS) || 10)
+);
 const FLIP_CYCLES = Math.max(2, Math.floor(Number(process.env.PERF_STORE_FANOUT_FLIP_CYCLES) || 5));
-const STREAM_SECONDS = Math.max(3, Math.floor(Number(process.env.PERF_STORE_FANOUT_STREAM_SECONDS) || 10));
+const STREAM_SECONDS = Math.max(
+  3,
+  Math.floor(Number(process.env.PERF_STORE_FANOUT_STREAM_SECONDS) || 10)
+);
 const OUT_PATH = process.env.PERF_STORE_FANOUT_OUT ?? "";
 
 const READY_TOKEN = "FAKE_CLAUDE_READY";
@@ -85,7 +100,10 @@ function fmtRow(name: string, events: EventSample[]): string {
   );
 }
 
-function topComponents(events: EventSample[], limit = 12): Array<{ name: string; n: number; ms: number }> {
+function topComponents(
+  events: EventSample[],
+  limit = 12
+): Array<{ name: string; n: number; ms: number }> {
   const merged = new Map<string, { n: number; ms: number }>();
   for (const e of events) {
     for (const [name, v] of Object.entries(e.byComponent)) {
@@ -125,7 +143,8 @@ function prepareFixture(scale: number): Fixture {
   writeFileSync(path.join(dir, "README.md"), `# store-fanout-${scale}\n`);
   writeFileSync(
     path.join(dir, "package.json"),
-    JSON.stringify({ name: `store-fanout-${scale}`, version: "1.0.0", private: true }, null, 2) + "\n"
+    JSON.stringify({ name: `store-fanout-${scale}`, version: "1.0.0", private: true }, null, 2) +
+      "\n"
   );
 
   const fakeBinDir = path.join(dir, ".e2e-bin");
@@ -312,10 +331,7 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
 
         // Deterministic focus across scales: the main worktree is active, so
         // the visible grid panel (and flip target) is always main's agent.
-        await page.evaluate(
-          (id) => (window as any).electron.worktree.setActive(id),
-          mainWt.id
-        );
+        await page.evaluate((id) => (window as any).electron.worktree.setActive(id), mainWt.id);
         await page.waitForTimeout(1_000);
 
         // The active worktree's agent is the one we flip; find its grid panel.
@@ -387,7 +403,12 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         // ── Ambient noise floor: 10s with nothing happening ──
         await probeStart();
         await page.waitForTimeout(10_000);
-        const ambient = (await probeStop()) as Array<{ t: number; renders: number; selfMs: number; byComponent: any }>;
+        const ambient = (await probeStop()) as Array<{
+          t: number;
+          renders: number;
+          selfMs: number;
+          byComponent: any;
+        }>;
         const ambientCommits = ambient.length;
         const ambientRenders = ambient.reduce((a, c) => a + c.renders, 0);
 
@@ -397,10 +418,7 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         const quietWindows: Array<{ t0: number; t1: number }> = [];
         for (let k = 0; k < TICKS; k++) {
           const t0 = await page.evaluate(() => performance.now());
-          await page.evaluate(
-            (id) => (window as any).electron.worktree.refresh(id),
-            mainWt.id
-          );
+          await page.evaluate((id) => (window as any).electron.worktree.refresh(id), mainWt.id);
           await page.waitForTimeout(450);
           const t1 = await page.evaluate(() => performance.now());
           quietWindows.push({ t0, t1 });
@@ -417,10 +435,7 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
           if (k % 2 === 0) writeFileSync(churnFile, `dirty ${k}\n`);
           else rmSync(churnFile, { force: true });
           const t0 = await page.evaluate(() => performance.now());
-          await page.evaluate(
-            (id) => (window as any).electron.worktree.refresh(id),
-            mainWt.id
-          );
+          await page.evaluate((id) => (window as any).electron.worktree.refresh(id), mainWt.id);
           await page.waitForTimeout(500);
           const t1 = await page.evaluate(() => performance.now());
           changeWindows.push({ t0, t1 });
@@ -503,30 +518,22 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         results.push(scaleResult);
 
         console.log(`──── store fanout @ ${scale} worktree(s), ${launched.length} agents ────`);
-        console.log(
-          `ambient (10s quiet): commits=${ambientCommits} renders=${ambientRenders}`
-        );
+        console.log(`ambient (10s quiet): commits=${ambientCommits} renders=${ambientRenders}`);
         for (const w of scaleResult.workloads) console.log(fmtRow(w.name, w.events));
         for (const w of scaleResult.workloads) {
           const top = topComponents(w.events, 8);
           if (top.length > 0) {
             console.log(
-              `top ${w.name}: ` +
-                top
-                  .map((t) => `${t.name}×${t.n}(${t.ms.toFixed(1)}ms)`)
-                  .join(" ")
+              `top ${w.name}: ` + top.map((t) => `${t.name}×${t.n}(${t.ms.toFixed(1)}ms)`).join(" ")
             );
           }
         }
 
         // Reliability invariants only — fanout itself is reported, not gated.
-        expect(flips.length, "observed both flip directions").toBeGreaterThanOrEqual(
-          FLIP_CYCLES
+        expect(flips.length, "observed both flip directions").toBeGreaterThanOrEqual(FLIP_CYCLES);
+        expect(tickQuiet.length + tickChange.length, "all git ticks completed").toBe(
+          TICKS + CHANGE_TICKS
         );
-        expect(
-          tickQuiet.length + tickChange.length,
-          "all git ticks completed"
-        ).toBe(TICKS + CHANGE_TICKS);
       } finally {
         if (ctx?.app) await closeApp(ctx.app);
         fixture.cleanup();

--- a/e2e/full/panels/store-fanout-perf.spec.ts
+++ b/e2e/full/panels/store-fanout-perf.spec.ts
@@ -137,6 +137,21 @@ interface Fixture {
 // workload exercises the real output->activity->status-buffer path.
 function prepareFixture(scale: number): Fixture {
   const dir = mkdtempSync(path.join(tmpdir(), `daintree-e2e-store-fanout-${scale}-`));
+  try {
+    return buildFixture(scale, dir);
+  } catch (error) {
+    // A failed git/chmod step would otherwise leak the temp repo and the
+    // sibling worktree root.
+    rmSync(path.join(path.dirname(dir), path.basename(dir) + "-worktrees"), {
+      recursive: true,
+      force: true,
+    });
+    rmSync(dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function buildFixture(scale: number, dir: string): Fixture {
   git("init -b main", dir);
   git('config user.email "test@daintree.dev"', dir);
   git('config user.name "Daintree Test"', dir);
@@ -186,9 +201,13 @@ function prepareFixture(scale: number): Fixture {
       "const shutdown = () => { stopWork(); clearInterval(keepAlive); process.exit(0); };",
       "process.stdin.on('data', (chunk) => {",
       "  const input = String(chunk);",
-      "  if (input.includes(WORK)) startWork();",
-      "  else if (input.includes(IDLE)) stopWork();",
+      "  const wi = input.lastIndexOf(WORK);",
+      "  const ii = input.lastIndexOf(IDLE);",
+      "  if (wi >= 0 && wi > ii) startWork();",
+      "  else if (ii >= 0) stopWork();",
       "});",
+      "process.stdin.on('end', shutdown);",
+      "process.stdin.on('close', shutdown);",
       "process.on('SIGINT', shutdown);",
       "process.on('SIGTERM', shutdown);",
       "",
@@ -230,7 +249,9 @@ function prepareFixture(scale: number): Fixture {
   return { dir, worktreeDirs, fakeBinDir, cleanup };
 }
 
-const perfDescribe = process.env.RUN_PERF_STORE_FANOUT ? test.describe.serial : test.describe.skip;
+// Exact-value gate: "0"/"false" must not enable a multi-minute benchmark.
+const perfDescribe =
+  process.env.RUN_PERF_STORE_FANOUT === "1" ? test.describe.serial : test.describe.skip;
 
 perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", () => {
   const results: ScaleResult[] = [];
@@ -469,26 +490,38 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         };
 
         await probeStart();
-        const flipWindows: Array<{ t0: number; t1: number; ok: boolean }> = [];
+        const flipWindows: Array<{ t0: number; t1: number; ok: boolean; direction: string }> = [];
         for (let cycle = 0; cycle < FLIP_CYCLES; cycle++) {
           // -> working (fast)
           const tSend = await page.evaluate(() => performance.now());
           await ptyWrite(`${WORK_TOKEN}\r`);
           const tWorking = await waitForState("working", 20_000);
           await page.waitForTimeout(400);
-          flipWindows.push({ t0: tSend, t1: tWorking + 400, ok: tWorking > 0 });
+          flipWindows.push({
+            t0: tSend,
+            t1: tWorking + 400,
+            ok: tWorking > 0,
+            direction: "working",
+          });
 
           // -> waiting (debounced). Bracket around the observed flip so the
           // ~8s debounce dead-time doesn't pollute the sample.
           await ptyWrite(`${IDLE_TOKEN}\r`);
           const tWaiting = await waitForState("waiting", 40_000);
           await page.waitForTimeout(400);
-          flipWindows.push({ t0: tWaiting - 600, t1: tWaiting + 400, ok: tWaiting > 0 });
+          flipWindows.push({
+            t0: tWaiting - 600,
+            t1: tWaiting + 400,
+            ok: tWaiting > 0,
+            direction: "waiting",
+          });
         }
         const flipCommits = (await probeStop()) as any[];
         for (const w of flipWindows) {
           if (w.ok) flips.push(collectWindow(flipCommits, w.t0, w.t1));
         }
+        const okWorkingFlips = flipWindows.filter((w) => w.direction === "working" && w.ok).length;
+        const okWaitingFlips = flipWindows.filter((w) => w.direction === "waiting" && w.ok).length;
 
         // ── Workload: stream — one agent streams for STREAM_SECONDS ──
         await ptyWrite(`${WORK_TOKEN}\r`);
@@ -530,7 +563,13 @@ perfDescribe("Perf: store-update fanout (renders per git tick / agent flip)", ()
         }
 
         // Reliability invariants only — fanout itself is reported, not gated.
-        expect(flips.length, "observed both flip directions").toBeGreaterThanOrEqual(FLIP_CYCLES);
+        // Per-direction so a failed WORK write can't be masked by the panel
+        // already sitting in waiting when the IDLE wait polls it.
+        expect(okWorkingFlips, "every ->working flip observed").toBe(FLIP_CYCLES);
+        expect(
+          okWaitingFlips,
+          "->waiting flips observed (one debounce straggler allowed)"
+        ).toBeGreaterThanOrEqual(FLIP_CYCLES - 1);
         expect(tickQuiet.length + tickChange.length, "all git ticks completed").toBe(
           TICKS + CHANGE_TICKS
         );

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "watch:main": "node scripts/build-main.mjs --watch",
     "build": "tsc && vite build && npm run build:main",
     "build:e2e": "tsc && vite build && cross-env NODE_ENV=test node scripts/build-main.mjs",
+    "build:e2e:bench": "tsc && cross-env DAINTREE_RENDER_PROBE=1 vite build && cross-env NODE_ENV=test node scripts/build-main.mjs",
     "package": "npm run build && electron-builder",
     "package:mac": "npm run build && electron-builder --mac",
     "package:win": "npm run build && electron-builder --win appx nsis",

--- a/scripts/perf/render-fanout-probe.js
+++ b/scripts/perf/render-fanout-probe.js
@@ -44,6 +44,12 @@
     var stack = [root.current];
     while (stack.length > 0) {
       var fiber = stack.pop();
+      // Subtree pruning (mirrors React DevTools): when React bails out above a
+      // subtree it reuses the existing child fibers wholesale, so the child
+      // pointer matches the alternate's — nothing below rendered this commit.
+      // Without this check, retained fibers still carrying PerformedWork from
+      // OLDER commits are re-counted on every walk (~1000x over-count).
+      var descend = fiber.alternate === null || fiber.child !== fiber.alternate.child;
       if ((fiber.flags & PERFORMED_WORK) !== 0 && COMPONENT_TAGS[fiber.tag] === true) {
         renders++;
         var self = fiber.actualDuration || 0;
@@ -59,7 +65,9 @@
         entry.n++;
         entry.ms += self;
       }
-      for (var c = fiber.child; c !== null; c = c.sibling) stack.push(c);
+      if (descend) {
+        for (var c = fiber.child; c !== null; c = c.sibling) stack.push(c);
+      }
     }
 
     if (renders > 0) {

--- a/scripts/perf/render-fanout-probe.js
+++ b/scripts/perf/render-fanout-probe.js
@@ -17,8 +17,11 @@
   // react-reconciler ReactFiberFlags.PerformedWork — set on a fiber only when
   // its render function actually ran this commit (bailouts keep it clear).
   var PERFORMED_WORK = 0b1;
-  // WorkTags that execute user component code: FunctionComponent,
-  // ClassComponent, ForwardRef, MemoComponent, SimpleMemoComponent.
+  // WorkTags counted as renders: FunctionComponent, ClassComponent,
+  // ForwardRef, MemoComponent, SimpleMemoComponent. Deliberately component
+  // fibers only — ContextConsumer (tag 9) render props and host/provider/
+  // fragment wrappers are excluded, so "renders" reads as "component
+  // functions/classes that executed".
   var COMPONENT_TAGS = { 0: true, 1: true, 11: true, 14: true, 15: true };
 
   var capturing = false;
@@ -54,9 +57,13 @@
         renders++;
         var self = fiber.actualDuration || 0;
         for (var child = fiber.child; child !== null; child = child.sibling) {
-          // Subtract only children that rendered this commit — bailed-out
-          // children retain stale actualDuration from earlier commits.
-          if ((child.flags & PERFORMED_WORK) !== 0) self -= child.actualDuration || 0;
+          // Subtract every child's actualDuration (mirrors react-dom's own
+          // profiler semantics): a rendered fiber reconciles all its children,
+          // so each child is a fresh clone whose actualDuration is either 0
+          // (bailed) or this commit's time — including non-component wrappers
+          // (providers/fragments) that carry rendered-descendant time which
+          // would otherwise be double-attributed to this fiber's self time.
+          self -= child.actualDuration || 0;
         }
         if (self < 0) self = 0;
         selfMs += self;

--- a/scripts/perf/render-fanout-probe.js
+++ b/scripts/perf/render-fanout-probe.js
@@ -1,0 +1,122 @@
+// React render-fanout probe, inlined into index.html as a classic <head>
+// script by renderFanoutProbePlugin (vite.config.ts) — ONLY when the build
+// runs with DAINTREE_RENDER_PROBE=1 (`npm run build:e2e:bench`). Classic
+// inline scripts execute during HTML parse, before any deferred module
+// script, so the DevTools hook below is guaranteed to exist before react-dom
+// evaluates and registers with it.
+//
+// Registers a minimal __REACT_DEVTOOLS_GLOBAL_HOOK__ and, on every commit,
+// walks the fiber tree counting component fibers that performed work plus
+// their self durations (requires the react-dom/profiling bundle, which the
+// bench build aliases in). Consumed by
+// e2e/full/panels/store-fanout-perf.spec.ts via window.__DAINTREE_RENDER_PROBE__.
+(function installRenderFanoutProbe() {
+  "use strict";
+  if (window.__REACT_DEVTOOLS_GLOBAL_HOOK__) return;
+
+  // react-reconciler ReactFiberFlags.PerformedWork — set on a fiber only when
+  // its render function actually ran this commit (bailouts keep it clear).
+  var PERFORMED_WORK = 0b1;
+  // WorkTags that execute user component code: FunctionComponent,
+  // ClassComponent, ForwardRef, MemoComponent, SimpleMemoComponent.
+  var COMPONENT_TAGS = { 0: true, 1: true, 11: true, 14: true, 15: true };
+
+  var capturing = false;
+  var commits = [];
+
+  function componentName(type) {
+    if (typeof type === "function") return type.displayName || type.name || "Anonymous";
+    if (type && typeof type === "object") {
+      if (type.displayName) return type.displayName;
+      if (type.render) return type.render.displayName || type.render.name || "ForwardRef";
+      if (type.type) return componentName(type.type);
+    }
+    return "Anonymous";
+  }
+
+  function recordCommit(root) {
+    if (!capturing) return;
+    var t = performance.now();
+    var renders = 0;
+    var selfMs = 0;
+    var byComponent = {};
+
+    var stack = [root.current];
+    while (stack.length > 0) {
+      var fiber = stack.pop();
+      if ((fiber.flags & PERFORMED_WORK) !== 0 && COMPONENT_TAGS[fiber.tag] === true) {
+        renders++;
+        var self = fiber.actualDuration || 0;
+        for (var child = fiber.child; child !== null; child = child.sibling) {
+          // Subtract only children that rendered this commit — bailed-out
+          // children retain stale actualDuration from earlier commits.
+          if ((child.flags & PERFORMED_WORK) !== 0) self -= child.actualDuration || 0;
+        }
+        if (self < 0) self = 0;
+        selfMs += self;
+        var name = componentName(fiber.type);
+        var entry = byComponent[name] || (byComponent[name] = { n: 0, ms: 0 });
+        entry.n++;
+        entry.ms += self;
+      }
+      for (var c = fiber.child; c !== null; c = c.sibling) stack.push(c);
+    }
+
+    if (renders > 0) {
+      commits.push({
+        t: t,
+        renders: renders,
+        selfMs: selfMs,
+        commitMs: root.current.actualDuration || 0,
+        byComponent: byComponent,
+      });
+    }
+  }
+
+  // Shape react-dom's injectInternals expects; everything must be
+  // exception-safe — a throw here would corrupt React's commit phase.
+  var hook = {
+    isDisabled: false,
+    supportsFiber: true,
+    supportsFlight: false,
+    renderers: new Map(),
+    inject: function () {
+      return 1;
+    },
+    onScheduleFiberRoot: function () {},
+    onCommitFiberRoot: function (_id, root) {
+      try {
+        recordCommit(root);
+      } catch (e) {
+        // Never let probe bugs break the app's commit phase.
+      }
+    },
+    onCommitFiberUnmount: function () {},
+    onPostCommitFiberRoot: function () {},
+    checkDCE: function () {},
+  };
+
+  Object.defineProperty(window, "__REACT_DEVTOOLS_GLOBAL_HOOK__", {
+    value: hook,
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  });
+
+  window.__DAINTREE_RENDER_PROBE__ = {
+    installed: true,
+    start: function () {
+      commits = [];
+      capturing = true;
+    },
+    stop: function () {
+      capturing = false;
+      var out = commits;
+      commits = [];
+      return out;
+    },
+    peek: function () {
+      return commits.slice();
+    },
+  };
+})();

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -81,6 +81,7 @@ function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): Wo
 function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
   const store = createStore<WorktreeViewState & WorktreeViewActions>(() => ({
     worktrees,
+    statusCheckedAt: new Map(),
     manualAssociations: new Map(),
     version: { epoch: "", seq: 0 },
     tombstones: new Map(),

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -648,13 +648,18 @@ export function WorktreeCard({
     hoverWorktreeIdRef.current = worktree.id;
   }, [worktree.id]);
 
+  // Freshness lives in the store's statusCheckedAt side map, not on the
+  // snapshot — the snapshot field only reflects the last content change (see
+  // createWorktreeStore). Per-id primitive selector: this card re-renders only
+  // when ITS worktree's stamp advances.
+  const lastGitStatusCheckedAt = useWorktreeStore((s) => s.statusCheckedAt.get(worktree.id));
+
   const handleRevalidate = useCallback(() => {
     const id = hoverWorktreeIdRef.current;
     if (
       isActive ||
       !isRevalidationAllowed(id) ||
-      (worktree.lastGitStatusCheckedAt &&
-        Date.now() - worktree.lastGitStatusCheckedAt < REVALIDATE_FRESHNESS_GATE)
+      (lastGitStatusCheckedAt && Date.now() - lastGitStatusCheckedAt < REVALIDATE_FRESHNESS_GATE)
     ) {
       return;
     }
@@ -665,16 +670,16 @@ export function WorktreeCard({
         inFlightRevalidates.delete(id);
       })
       .catch(() => {});
-  }, [isActive, worktree.lastGitStatusCheckedAt]);
+  }, [isActive, lastGitStatusCheckedAt]);
 
   const handlePointerEnter = useCallback(() => {
-    if (isActive || !worktree.lastGitStatusCheckedAt) return;
+    if (isActive || !lastGitStatusCheckedAt) return;
     if (hoverTimerRef.current) clearTimeout(hoverTimerRef.current);
     hoverTimerRef.current = setTimeout(() => {
       hoverTimerRef.current = null;
       handleRevalidate();
     }, HOVER_REVALIDATE_DELAY);
-  }, [isActive, worktree.lastGitStatusCheckedAt, handleRevalidate]);
+  }, [isActive, lastGitStatusCheckedAt, handleRevalidate]);
 
   const handlePointerLeave = useCallback(() => {
     if (hoverTimerRef.current) {
@@ -937,7 +942,7 @@ export function WorktreeCard({
                 resourceEndpoint={worktree.resourceStatus?.endpoint}
                 resourceLastCheckedAt={worktree.resourceStatus?.lastCheckedAt}
                 devServerSession={devServerSession}
-                lastGitStatusCheckedAt={worktree.lastGitStatusCheckedAt}
+                lastGitStatusCheckedAt={lastGitStatusCheckedAt}
                 onRevalidateGitStatus={handleRevalidate}
                 onCheckResourceStatus={hasStatusCommand ? handleResourceStatus : undefined}
                 onCleanupWorktree={

--- a/src/hooks/__tests__/useQuickSwitcher.test.tsx
+++ b/src/hooks/__tests__/useQuickSwitcher.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { renderHook, act } from "@testing-library/react";
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { usePanelStore } from "@/store/panelStore";
 
 const { useWorktreeStoreMock } = vi.hoisted(() => ({
@@ -24,6 +24,7 @@ vi.mock("@/store", async () => {
 });
 
 import { useQuickSwitcher } from "../useQuickSwitcher";
+import { usePaletteStore } from "@/store/paletteStore";
 
 type MockWorktreeState = {
   worktrees: Map<string, unknown>;
@@ -98,6 +99,14 @@ describe("useQuickSwitcher MRU prune", () => {
   beforeEach(() => {
     usePanelStore.setState({ panelsById: {}, panelIds: [], mruList: [] });
     useWorktreeStoreMock.mockReset();
+    // Panel/worktree subscriptions (and therefore pruning) are gated on the
+    // palette being open — these tests exercise the hydration guards, so run
+    // them against an open palette.
+    usePaletteStore.setState({ activePaletteId: "quick-switcher" });
+  });
+
+  afterEach(() => {
+    usePaletteStore.setState({ activePaletteId: null });
   });
 
   it("does not prune while the item set is empty (panels still hydrating) (#9922)", () => {

--- a/src/hooks/app/useAccessibilityAnnouncements.ts
+++ b/src/hooks/app/useAccessibilityAnnouncements.ts
@@ -124,7 +124,6 @@ function basePanelId(debounceKey: string): string {
 }
 
 export function useAccessibilityAnnouncements() {
-  const isFirstMount = useRef(true);
   const previousStatesRef = useRef<Map<string, TerminalStateSnapshot>>(new Map());
   const debounceTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   // Per-terminal hibernation subscriptions. Hibernation lives on
@@ -133,246 +132,280 @@ export function useAccessibilityAnnouncements() {
   const hibernationUnsubsRef = useRef<Map<string, () => void>>(new Map());
   const hibernationStateRef = useRef<Map<string, boolean>>(new Map());
 
-  const focusedId = usePanelStore((s) => s.focusedId);
-  const panelsById = usePanelStore((s) => s.panelsById);
-  const panelIds = usePanelStore((s) => s.panelIds);
-  const commandQueueCountById = usePanelStore((s) => s.commandQueueCountById);
-  const maximizedId = usePanelStore((s) => s.maximizedId);
-  // Sentinel `undefined` distinguishes the first render (skip) from a genuine
-  // `null` maximize state (nothing maximized) — see the maximize effect below.
-  const prevMaximizedIdRef = useRef<string | null | undefined>(undefined);
-
-  // Panel focus announcements
+  // This hook renders nothing — every consumer below is an effect. It
+  // observes the store with a transient subscription instead of reactive
+  // selectors: a live `panelsById` selector re-rendered the hosting component
+  // (App) on every panel-map identity change, i.e. on every agent-state flip
+  // and every rAF status flush.
   useEffect(() => {
-    if (isFirstMount.current) {
-      isFirstMount.current = false;
-      return;
-    }
+    const prevFocusedIdRef = { current: usePanelStore.getState().focusedId };
+    // `null` means "nothing maximized"; seeding from live state mirrors the
+    // old undefined-sentinel first-render skip.
+    const prevMaximizedIdRef = { current: usePanelStore.getState().maximizedId };
+    const lastDiffInputsRef = {
+      current: null as null | {
+        panelsById: unknown;
+        panelIds: unknown;
+        commandQueueCountById: unknown;
+      },
+    };
 
-    if (!focusedId) return;
+    // Per-pane badge state announcements (#9204).
+    //
+    // Each previously had its own `aria-live="polite"` region; in a multi-pane
+    // fleet that produced competing live regions that NVDA/VoiceOver coalesce
+    // or drop. Routing through the single global announcer with a pane-title
+    // prefix gives screen-reader users a serialized stream with spatial
+    // context.
+    //
+    // Debounce keys are namespaced per badge (`${id}:flow`, `${id}:queue`,
+    // `${id}:exit`) so a rapid queue-then-flow transition in the same pane
+    // does not cancel its sibling. The unsuffixed `${id}` slot is reserved for
+    // the agent-state announcer — leaving it untouched preserves the #8937
+    // cancellation-on-removal guarantee.
+    const diffPanels = (state: ReturnType<typeof usePanelStore.getState>) => {
+      const { panelsById, panelIds, commandQueueCountById } = state;
+      const last = lastDiffInputsRef.current;
+      if (
+        last &&
+        last.panelsById === panelsById &&
+        last.panelIds === panelIds &&
+        last.commandQueueCountById === commandQueueCountById
+      ) {
+        return;
+      }
+      lastDiffInputsRef.current = { panelsById, panelIds, commandQueueCountById };
 
-    const terminal = panelsById[focusedId];
-    if (!terminal) return;
+      const prevStates = previousStatesRef.current;
+      const newStates = new Map<string, TerminalStateSnapshot>();
 
-    useAnnouncerStore.getState().announce(`${terminal.title} panel focused`);
-  }, [focusedId]); // eslint-disable-line react-hooks/exhaustive-deps
+      for (const id of panelIds) {
+        const terminal = panelsById[id];
+        if (!terminal) continue;
 
-  // Per-pane badge state announcements (#9204).
-  //
-  // Each previously had its own `aria-live="polite"` region; in a multi-pane
-  // fleet that produced competing live regions that NVDA/VoiceOver coalesce or
-  // drop. Routing through the single global announcer with a pane-title prefix
-  // gives screen-reader users a serialized stream with spatial context.
-  //
-  // Debounce keys are namespaced per badge (`${id}:flow`, `${id}:queue`,
-  // `${id}:exit`) so a rapid queue-then-flow transition in the same pane does
-  // not cancel its sibling. The unsuffixed `${id}` slot is reserved for the
-  // existing agent-state announcer below — leaving it untouched preserves the
-  // #8937 cancellation-on-removal guarantee.
-  useEffect(() => {
-    const prevStates = previousStatesRef.current;
-    const newStates = new Map<string, TerminalStateSnapshot>();
+        const prev = prevStates.get(terminal.id);
+        // `location` lives on every panel kind (it's on BasePanelData), so it is
+        // captured outside the PTY guard below — browser/dev-preview/review panes
+        // can be minimized and restored too.
+        const nextSnapshot: TerminalStateSnapshot = {
+          location: terminal.location,
+        };
 
-    for (const id of panelIds) {
-      const terminal = panelsById[id];
-      if (!terminal) continue;
+        // PTY-only badge state (agent state, flow, queue, exit, hibernation).
+        // Non-PTY panels have none of these fields, so the whole block is gated.
+        if (isPtyPanel(terminal)) {
+          nextSnapshot.agentState = terminal.agentState;
+          nextSnapshot.stateChangeConfidence = terminal.stateChangeConfidence;
+          nextSnapshot.flowStatus = terminal.flowStatus;
+          nextSnapshot.exitCode = terminal.exitCode;
+          nextSnapshot.hasExited = terminal.exitCode != null;
+          nextSnapshot.queueCount = commandQueueCountById[terminal.id] ?? 0;
 
-      const prev = prevStates.get(terminal.id);
-      // `location` lives on every panel kind (it's on BasePanelData), so it is
-      // captured outside the PTY guard below — browser/dev-preview/review panes
-      // can be minimized and restored too.
-      const nextSnapshot: TerminalStateSnapshot = {
-        location: terminal.location,
-      };
+          // Agent-state transitions — original behavior preserved.
+          if (terminal.agentState && prev?.agentState !== terminal.agentState) {
+            const lowConfidence =
+              terminal.stateChangeConfidence !== undefined && terminal.stateChangeConfidence < 0.7;
 
-      // PTY-only badge state (agent state, flow, queue, exit, hibernation).
-      // Non-PTY panels have none of these fields, so the whole block is gated.
-      if (isPtyPanel(terminal)) {
-        nextSnapshot.agentState = terminal.agentState;
-        nextSnapshot.stateChangeConfidence = terminal.stateChangeConfidence;
-        nextSnapshot.flowStatus = terminal.flowStatus;
-        nextSnapshot.exitCode = terminal.exitCode;
-        nextSnapshot.hasExited = terminal.exitCode != null;
-        nextSnapshot.queueCount = commandQueueCountById[terminal.id] ?? 0;
+            // Skip low-confidence heuristic transitions — keep the previous state
+            // so a later high-confidence confirmation of this state will still trigger.
+            if (prev && lowConfidence) {
+              nextSnapshot.agentState = prev.agentState;
+              nextSnapshot.stateChangeConfidence = prev.stateChangeConfidence;
+            } else if (prev) {
+              // State changed with sufficient confidence — announce.
+              const announcement = getAgentStateMessage(
+                terminal.title,
+                terminal.agentState,
+                terminal.waitingReason
+              );
+              if (announcement) {
+                const { msg, priority } = announcement;
+                const key = terminal.id;
+                const existing = debounceTimersRef.current.get(key);
+                if (existing) clearTimeout(existing);
+                const timer = setTimeout(() => {
+                  useAnnouncerStore.getState().announce(msg, priority);
+                  debounceTimersRef.current.delete(key);
+                }, BADGE_DEBOUNCE_MS);
+                debounceTimersRef.current.set(key, timer);
+              }
+            }
+          }
 
-        // Agent-state transitions — original behavior preserved.
-        if (terminal.agentState && prev?.agentState !== terminal.agentState) {
-          const lowConfidence =
-            terminal.stateChangeConfidence !== undefined && terminal.stateChangeConfidence < 0.7;
-
-          // Skip low-confidence heuristic transitions — keep the previous state
-          // so a later high-confidence confirmation of this state will still trigger.
-          if (prev && lowConfidence) {
-            nextSnapshot.agentState = prev.agentState;
-            nextSnapshot.stateChangeConfidence = prev.stateChangeConfidence;
-          } else if (prev) {
-            // State changed with sufficient confidence — announce.
-            const announcement = getAgentStateMessage(
+          if (prev) {
+            // Flow status transitions (paused/suspended/resumed).
+            const flowMsg = getFlowStatusMessage(
               terminal.title,
-              terminal.agentState,
-              terminal.waitingReason
+              prev.flowStatus,
+              terminal.flowStatus
             );
-            if (announcement) {
-              const { msg, priority } = announcement;
-              const key = terminal.id;
+            if (flowMsg) {
+              const key = `${terminal.id}:flow`;
               const existing = debounceTimersRef.current.get(key);
               if (existing) clearTimeout(existing);
               const timer = setTimeout(() => {
-                useAnnouncerStore.getState().announce(msg, priority);
+                useAnnouncerStore.getState().announce(flowMsg, "polite");
+                debounceTimersRef.current.delete(key);
+              }, BADGE_DEBOUNCE_MS);
+              debounceTimersRef.current.set(key, timer);
+            }
+
+            // Queue-count threshold transitions (0→N, N→0).
+            const queueMsg = getQueueCountMessage(
+              terminal.title,
+              prev.queueCount ?? 0,
+              nextSnapshot.queueCount ?? 0
+            );
+            if (queueMsg) {
+              const key = `${terminal.id}:queue`;
+              const existing = debounceTimersRef.current.get(key);
+              if (existing) clearTimeout(existing);
+              const timer = setTimeout(() => {
+                useAnnouncerStore.getState().announce(queueMsg, "polite");
+                debounceTimersRef.current.delete(key);
+              }, BADGE_DEBOUNCE_MS);
+              debounceTimersRef.current.set(key, timer);
+            }
+
+            // Exit code badge — fires when exitCode flips from undefined to a number.
+            if (!prev.hasExited && nextSnapshot.hasExited) {
+              const exitMsg = getExitMessage(terminal.title, terminal.exitCode);
+              const key = `${terminal.id}:exit`;
+              const existing = debounceTimersRef.current.get(key);
+              if (existing) clearTimeout(existing);
+              const timer = setTimeout(() => {
+                useAnnouncerStore.getState().announce(exitMsg, "polite");
                 debounceTimersRef.current.delete(key);
               }, BADGE_DEBOUNCE_MS);
               debounceTimersRef.current.set(key, timer);
             }
           }
-        }
 
-        if (prev) {
-          // Flow status transitions (paused/suspended/resumed).
-          const flowMsg = getFlowStatusMessage(
-            terminal.title,
-            prev.flowStatus,
-            terminal.flowStatus
-          );
-          if (flowMsg) {
-            const key = `${terminal.id}:flow`;
-            const existing = debounceTimersRef.current.get(key);
-            if (existing) clearTimeout(existing);
-            const timer = setTimeout(() => {
-              useAnnouncerStore.getState().announce(flowMsg, "polite");
-              debounceTimersRef.current.delete(key);
-            }, BADGE_DEBOUNCE_MS);
-            debounceTimersRef.current.set(key, timer);
-          }
-
-          // Queue-count threshold transitions (0→N, N→0).
-          const queueMsg = getQueueCountMessage(
-            terminal.title,
-            prev.queueCount ?? 0,
-            nextSnapshot.queueCount ?? 0
-          );
-          if (queueMsg) {
-            const key = `${terminal.id}:queue`;
-            const existing = debounceTimersRef.current.get(key);
-            if (existing) clearTimeout(existing);
-            const timer = setTimeout(() => {
-              useAnnouncerStore.getState().announce(queueMsg, "polite");
-              debounceTimersRef.current.delete(key);
-            }, BADGE_DEBOUNCE_MS);
-            debounceTimersRef.current.set(key, timer);
-          }
-
-          // Exit code badge — fires when exitCode flips from undefined to a number.
-          if (!prev.hasExited && nextSnapshot.hasExited) {
-            const exitMsg = getExitMessage(terminal.title, terminal.exitCode);
-            const key = `${terminal.id}:exit`;
-            const existing = debounceTimersRef.current.get(key);
-            if (existing) clearTimeout(existing);
-            const timer = setTimeout(() => {
-              useAnnouncerStore.getState().announce(exitMsg, "polite");
-              debounceTimersRef.current.delete(key);
-            }, BADGE_DEBOUNCE_MS);
-            debounceTimersRef.current.set(key, timer);
+          // Hibernation: subscribe once per panel; the listener fires on
+          // hibernate/unhibernate. Snapshot is read inline so the cb sees the
+          // current value without closure staleness.
+          if (!hibernationUnsubsRef.current.has(terminal.id)) {
+            const panelId = terminal.id;
+            // Seed initial state so the first event reflects a true transition.
+            hibernationStateRef.current.set(panelId, terminalInstanceService.isHibernated(panelId));
+            const unsubscribe = terminalInstanceService.subscribeHibernation(panelId, () => {
+              const prevHib = hibernationStateRef.current.get(panelId) ?? false;
+              const nextHib = terminalInstanceService.isHibernated(panelId);
+              if (prevHib === nextHib) return;
+              hibernationStateRef.current.set(panelId, nextHib);
+              const current = usePanelStore.getState().panelsById[panelId];
+              const title = current?.title ?? "Terminal";
+              const msg = nextHib ? `${title}: hibernated` : `${title}: woke up`;
+              useAnnouncerStore.getState().announce(msg, "polite");
+            });
+            hibernationUnsubsRef.current.set(panelId, unsubscribe);
           }
         }
 
-        // Hibernation: subscribe once per panel; the listener fires on
-        // hibernate/unhibernate. Snapshot is read inline so the cb sees the
-        // current value without closure staleness.
-        if (!hibernationUnsubsRef.current.has(terminal.id)) {
-          const panelId = terminal.id;
-          // Seed initial state so the first event reflects a true transition.
-          hibernationStateRef.current.set(panelId, terminalInstanceService.isHibernated(panelId));
-          const unsubscribe = terminalInstanceService.subscribeHibernation(panelId, () => {
-            const prevHib = hibernationStateRef.current.get(panelId) ?? false;
-            const nextHib = terminalInstanceService.isHibernated(panelId);
-            if (prevHib === nextHib) return;
-            hibernationStateRef.current.set(panelId, nextHib);
-            const current = usePanelStore.getState().panelsById[panelId];
-            const title = current?.title ?? "Terminal";
-            const msg = nextHib ? `${title}: hibernated` : `${title}: woke up`;
-            useAnnouncerStore.getState().announce(msg, "polite");
-          });
-          hibernationUnsubsRef.current.set(panelId, unsubscribe);
+        // Location transitions (grid ↔ dock) for all panel kinds. These are
+        // discrete user actions (minimize/restore), so they announce immediately
+        // — no debounce (WCAG 4.1.3). overlay/background/trash are internal moves
+        // that never warrant an announcement, so only grid↔dock is reported.
+        if (prev && prev.location !== terminal.location) {
+          if (prev.location === "grid" && terminal.location === "dock") {
+            useAnnouncerStore.getState().announce(`${terminal.title} minimized to dock`, "polite");
+          } else if (prev.location === "dock" && terminal.location === "grid") {
+            useAnnouncerStore.getState().announce(`${terminal.title} restored to grid`, "polite");
+          }
+        }
+
+        newStates.set(terminal.id, nextSnapshot);
+      }
+
+      // Cancel pending debounce timers for panels that have left panelIds.
+      // Without this, a state-change timer scheduled just before removal would
+      // fire and announce for a panel that is no longer in the store. Keys are
+      // namespaced (`${id}`, `${id}:flow`, …), so we split off the base id.
+      for (const [key, timer] of debounceTimersRef.current) {
+        if (!newStates.has(basePanelId(key))) {
+          clearTimeout(timer);
+          debounceTimersRef.current.delete(key);
         }
       }
 
-      // Location transitions (grid ↔ dock) for all panel kinds. These are
-      // discrete user actions (minimize/restore), so they announce immediately
-      // — no debounce (WCAG 4.1.3). overlay/background/trash are internal moves
-      // that never warrant an announcement, so only grid↔dock is reported.
-      if (prev && prev.location !== terminal.location) {
-        if (prev.location === "grid" && terminal.location === "dock") {
-          useAnnouncerStore.getState().announce(`${terminal.title} minimized to dock`, "polite");
-        } else if (prev.location === "dock" && terminal.location === "grid") {
-          useAnnouncerStore.getState().announce(`${terminal.title} restored to grid`, "polite");
+      // Tear down hibernation subscriptions for removed panels.
+      for (const [id, unsubscribe] of hibernationUnsubsRef.current) {
+        if (!newStates.has(id)) {
+          unsubscribe();
+          hibernationUnsubsRef.current.delete(id);
+          hibernationStateRef.current.delete(id);
         }
       }
 
-      newStates.set(terminal.id, nextSnapshot);
-    }
+      previousStatesRef.current = newStates;
+    };
 
-    // Cancel pending debounce timers for panels that have left panelIds.
-    // Without this, a state-change timer scheduled just before removal would
-    // fire and announce for a panel that is no longer in the store. Keys are
-    // namespaced (`${id}`, `${id}:flow`, …), so we split off the base id.
-    for (const [key, timer] of debounceTimersRef.current) {
-      if (!newStates.has(basePanelId(key))) {
-        clearTimeout(timer);
-        debounceTimersRef.current.delete(key);
+    // Panel focus announcements
+    const diffFocus = (state: ReturnType<typeof usePanelStore.getState>) => {
+      const prev = prevFocusedIdRef.current;
+      if (state.focusedId === prev) return;
+      prevFocusedIdRef.current = state.focusedId;
+      if (!state.focusedId) return;
+      const terminal = state.panelsById[state.focusedId];
+      if (!terminal) return;
+      useAnnouncerStore.getState().announce(`${terminal.title} panel focused`);
+    };
+
+    // Maximize / unmaximize announcements (#9932). `maximizedId` lives in the
+    // focus slice (not on the panel record). It announces immediately
+    // (discrete user action, no debounce). The baseline seeded above keeps a
+    // panel that was already maximized at mount silent.
+    const diffMaximize = (state: ReturnType<typeof usePanelStore.getState>) => {
+      const prev = prevMaximizedIdRef.current;
+      if (prev === state.maximizedId) return;
+      prevMaximizedIdRef.current = state.maximizedId;
+
+      const currentPanels = state.panelsById;
+      if (state.maximizedId !== null) {
+        const title = currentPanels[state.maximizedId]?.title ?? "Panel";
+        useAnnouncerStore.getState().announce(`${title} maximized`, "polite");
+      } else if (prev !== null) {
+        const title = currentPanels[prev]?.title ?? "Panel";
+        useAnnouncerStore.getState().announce(`${title} unmaximized`, "polite");
       }
-    }
+    };
 
-    // Tear down hibernation subscriptions for removed panels.
-    for (const [id, unsubscribe] of hibernationUnsubsRef.current) {
-      if (!newStates.has(id)) {
-        unsubscribe();
-        hibernationUnsubsRef.current.delete(id);
-        hibernationStateRef.current.delete(id);
+    // Seed the diff baselines from the mount-time state without announcing —
+    // matches the old effects' first-render behavior (prev === undefined
+    // suppressed every announcement path; hibernation subscriptions were
+    // still established).
+    diffPanels(usePanelStore.getState());
+
+    // Synchronous per-notification processing keeps the documented
+    // announce-immediately contract for focus/location/maximize (#9932,
+    // WCAG 4.1.3); agent/flow/queue/exit announcements stay debounced by
+    // their own timers. The listener never throws into the writer's
+    // setState — announcements are best-effort.
+    const unsubscribe = usePanelStore.subscribe((state) => {
+      try {
+        diffFocus(state);
+        diffPanels(state);
+        diffMaximize(state);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("[useAccessibilityAnnouncements] announcement pass failed:", error);
       }
-    }
+    });
 
-    previousStatesRef.current = newStates;
-  }, [panelsById, panelIds, commandQueueCountById]);
-
-  // Maximize / unmaximize announcements (#9932). `maximizedId` lives in the
-  // focus slice (not on the panel record), so it can't be diffed inside the
-  // panelsById effect above — a maximize toggle doesn't mutate `panelsById`.
-  // It announces immediately (discrete user action, no debounce). The first
-  // render is skipped via the `undefined` sentinel so a panel that was already
-  // maximized at mount stays silent.
-  useEffect(() => {
-    const prev = prevMaximizedIdRef.current;
-    prevMaximizedIdRef.current = maximizedId;
-
-    if (prev === undefined) return; // first render — establish baseline only
-    if (prev === maximizedId) return;
-
-    // Read titles from the freshest store state — the closure's `panelsById`
-    // can lag a render behind if a panel is removed in the same tick it is
-    // unmaximized, which would otherwise drop the title to the fallback.
-    const currentPanels = usePanelStore.getState().panelsById;
-    if (maximizedId !== null) {
-      const title = currentPanels[maximizedId]?.title ?? "Panel";
-      useAnnouncerStore.getState().announce(`${title} maximized`, "polite");
-    } else if (prev !== null) {
-      const title = currentPanels[prev]?.title ?? "Panel";
-      useAnnouncerStore.getState().announce(`${title} unmaximized`, "polite");
-    }
-  }, [maximizedId, panelsById]);
-
-  // Cleanup debounce timers and hibernation subscriptions on unmount
-  useEffect(() => {
     const timers = debounceTimersRef.current;
     const hibUnsubs = hibernationUnsubsRef.current;
+    const hibStates = hibernationStateRef.current;
     return () => {
+      unsubscribe();
       for (const timer of timers.values()) {
         clearTimeout(timer);
       }
       timers.clear();
-      for (const unsubscribe of hibUnsubs.values()) {
-        unsubscribe();
+      for (const unsub of hibUnsubs.values()) {
+        unsub();
       }
       hibUnsubs.clear();
+      hibStates.clear();
     };
   }, []);
 }

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -126,8 +126,6 @@ export function cancelContextInjection(): void {
 
 export function useContextInjection(targetTerminalId?: string): UseContextInjectionReturn {
   const [error, setError] = useState<string | null>(null);
-  const focusedId = usePanelStore((state) => state.focusedId);
-  const panelsById = usePanelStore((state) => state.panelsById);
   const addError = useErrorStore((state) => state.addError);
   const removeError = useErrorStore((state) => state.removeError);
 
@@ -226,7 +224,12 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
 
   const inject = useCallback(
     async (worktreeId: string, terminalId?: string, selectedPaths?: string[]) => {
-      const activeTerminal = terminalId || focusedId;
+      // Read focus/panel state at call time instead of holding reactive
+      // subscriptions: this hook is mounted in App AND in every TerminalPane,
+      // and a live `panelsById` selector re-rendered all of them on every
+      // panel-map identity change (each agent-state flip and each rAF status
+      // flush). getState() is also fresher than a render-captured snapshot.
+      const activeTerminal = terminalId || usePanelStore.getState().focusedId;
 
       if (!activeTerminal) {
         setError("No terminal selected");
@@ -239,7 +242,7 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
         return;
       }
 
-      let terminal = panelsById[activeTerminal];
+      let terminal = usePanelStore.getState().panelsById[activeTerminal];
       if (!terminal) {
         setError(`Terminal not found: ${activeTerminal}`);
         return;
@@ -458,7 +461,7 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
         }
       }
     },
-    [focusedId, panelsById, addError, removeError]
+    [addError, removeError]
   );
 
   const cancel = useCallback(() => {

--- a/src/hooks/usePanelPalette.ts
+++ b/src/hooks/usePanelPalette.ts
@@ -10,6 +10,7 @@ import {
 import { useUserAgentRegistryStore } from "@/store/userAgentRegistryStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import type { WorktreeSnapshot } from "@shared/types";
 import { useProjectStore } from "@/store/projectStore";
 import { usePaletteStore } from "@/store/paletteStore";
 import { useSearchablePalette, type UseSearchablePaletteReturn } from "./useSearchablePalette";
@@ -78,6 +79,8 @@ const PANEL_FUSE_OPTIONS: IFuseOptions<PanelKindOption> = {
 
 export const MORE_AGENTS_PANEL_ID = "more-agents";
 
+const EMPTY_WORKTREES: Map<string, WorktreeSnapshot> = new Map();
+
 export function usePanelPalette(): UsePanelPaletteReturn {
   const userRegistry = useUserAgentRegistryStore((state) => state.registry);
   const availability = useCliAvailabilityStore((state) => state.availability);
@@ -90,8 +93,13 @@ export function usePanelPalette(): UsePanelPaletteReturn {
   // Journal fetch gated on open; refreshed live when a close path journals a
   // new record, so a just-expired session appears without reopening.
   const { sessions: resumeSessions } = useAgentSessionRecords(paletteIsOpen);
-  // Live per-view worktree map: drives stale-entry detection and location labels.
-  const worktrees = useWorktreeStore((state) => state.worktrees);
+  // Per-view worktree map: drives stale-entry detection and location labels.
+  // Open-gated like the journal fetch — this hook is always mounted in App,
+  // and a live map subscription re-rendered the whole App on every
+  // worktree-map identity change while the palette was closed.
+  const worktrees = useWorktreeStore((state) =>
+    paletteIsOpen ? state.worktrees : EMPTY_WORKTREES
+  );
   // Scope the browsable resume list to the current project's own history.
   const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
   // Re-render when a plugin loads/unloads mid-session so agent icon/name/color

--- a/src/hooks/useQuickSwitcher.ts
+++ b/src/hooks/useQuickSwitcher.ts
@@ -6,6 +6,7 @@ import { useWorktrees } from "./useWorktrees";
 import { useWorktreeSelectionStore } from "@/store";
 import { isPtyPanel, type PanelKind } from "@shared/types/panel";
 import { useSearchablePalette } from "./useSearchablePalette";
+import { usePaletteStore } from "@/store/paletteStore";
 import { deriveTerminalChrome, type TerminalChromeDescriptor } from "@/utils/terminalChrome";
 
 export type QuickSwitcherItemType = "terminal" | "worktree";
@@ -51,11 +52,23 @@ const FUSE_OPTIONS: IFuseOptions<QuickSwitcherItem> = {
 const MAX_RESULTS = 20;
 const MRU_BOOST_FACTOR = 0.05;
 
+const EMPTY_PANEL_IDS: string[] = [];
+const EMPTY_PANELS_BY_ID: ReturnType<typeof usePanelStore.getState>["panelsById"] = {};
+const EMPTY_MRU: string[] = [];
+
 export function useQuickSwitcher(): UseQuickSwitcherReturn {
-  const panelIds = usePanelStore((state) => state.panelIds);
-  const panelsById = usePanelStore((state) => state.panelsById);
+  // Always mounted in App: subscribe to the panel/worktree data only while the
+  // palette is open, else every agent-state flip and status flush re-rendered
+  // the whole App through this hook. Stable empty sentinels keep the memos
+  // below inert while closed; opening flips the selectors live in the same
+  // render, so the palette never shows stale items.
+  const paletteIsOpen = usePaletteStore((state) => state.activePaletteId === "quick-switcher");
+  const panelIds = usePanelStore((state) => (paletteIsOpen ? state.panelIds : EMPTY_PANEL_IDS));
+  const panelsById = usePanelStore((state) =>
+    paletteIsOpen ? state.panelsById : EMPTY_PANELS_BY_ID
+  );
   const setFocused = usePanelStore((state) => state.setFocused);
-  const mruList = usePanelStore((state) => state.mruList);
+  const mruList = usePanelStore((state) => (paletteIsOpen ? state.mruList : EMPTY_MRU));
   const pruneMru = usePanelStore((state) => state.pruneMru);
 
   const {
@@ -63,7 +76,7 @@ export function useQuickSwitcher(): UseQuickSwitcherReturn {
     worktreeMap,
     isInitialized: worktreesInitialized,
     error: worktreeError,
-  } = useWorktrees();
+  } = useWorktrees({ enabled: paletteIsOpen });
   const { selectWorktree } = useWorktreeSelectionStore(
     useShallow((state) => ({
       selectWorktree: state.selectWorktree,

--- a/src/hooks/useResumeSessionsPalette.ts
+++ b/src/hooks/useResumeSessionsPalette.ts
@@ -6,6 +6,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { usePaletteStore, type PaletteId } from "@/store/paletteStore";
 import { useAgentSessionRecords } from "@/hooks/useAgentSessionRecords";
 import { buildResumeSessionItems, type ResumeSessionItem } from "@/services/resumeSessionItems";
+import type { WorktreeSnapshot } from "@shared/types";
 
 const RESUME_PALETTE_ID: PaletteId = "resume-sessions";
 
@@ -37,14 +38,18 @@ const RESUME_FUSE_OPTIONS: IFuseOptions<ResumeSessionItem> = {
  * Browsing is a flat, newest-first list paged by {@link RESUME_PAGE_SIZE};
  * searching is flat and relevance-ordered over the full journal.
  */
-export function useResumeSessionsPalette() {
-  const worktrees = useWorktreeStore((state) => state.worktrees);
-  const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
+const EMPTY_WORKTREES: Map<string, WorktreeSnapshot> = new Map();
 
+export function useResumeSessionsPalette() {
   // Open state read straight from the shared palette store — the same source
-  // useSearchablePalette derives its isOpen from — so the journal fetch can be
-  // gated on it without a circular items → palette → isOpen dependency.
+  // useSearchablePalette derives its isOpen from — so the journal fetch (and
+  // the worktree-map subscription below) can be gated on it without a
+  // circular items → palette → isOpen dependency. The map subscription is
+  // open-gated because this hook is always mounted in App: a live selector
+  // re-rendered the whole App on every worktree-map identity change.
   const isOpen = usePaletteStore((state) => state.activePaletteId === RESUME_PALETTE_ID);
+  const worktrees = useWorktreeStore((state) => (isOpen ? state.worktrees : EMPTY_WORKTREES));
+  const currentProjectId = useProjectStore((state) => state.currentProject?.id ?? null);
   const { sessions, isLoading } = useAgentSessionRecords(isOpen);
 
   const items = useMemo(

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -99,10 +99,16 @@ function sendSelectionToTarget(targetId: string): void {
 
 const MAX_RESULTS = 20;
 
+const EMPTY_PANEL_IDS: string[] = [];
+const EMPTY_PANELS_BY_ID: ReturnType<typeof usePanelStore.getState>["panelsById"] = {};
+
 export function useSendToAgentPalette() {
-  const panelIds = usePanelStore((state) => state.panelIds);
-  const panelsById = usePanelStore((state) => state.panelsById);
+  // Always mounted in App: subscribe to the panel map only while open — a
+  // live selector here re-rendered the whole App on every agent-state flip
+  // and status flush. The open() helpers above already read via getState().
   const isOpen = usePaletteStore((state) => state.activePaletteId === "send-to-agent");
+  const panelIds = usePanelStore((state) => (isOpen ? state.panelIds : EMPTY_PANEL_IDS));
+  const panelsById = usePanelStore((state) => (isOpen ? state.panelsById : EMPTY_PANELS_BY_ID));
   const showAgentTaskTitles = usePreferencesStore((s) => s.showAgentTaskTitles);
 
   const items = useMemo<SendToAgentItem[]>(() => {

--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -59,8 +59,16 @@ function getNormalized(worktreeMap: Map<string, WorktreeSnapshot>): {
   return cached;
 }
 
-export function useWorktrees(): UseWorktreesReturn {
-  const worktreeMap = useWorktreeStore((state) => state.worktrees);
+// Stable sentinel for gated consumers — getNormalized caches per Map identity,
+// so a disabled subscription yields the same empty outputs every render.
+const EMPTY_WORKTREES = new Map<string, WorktreeSnapshot>();
+
+export function useWorktrees(options?: { enabled?: boolean }): UseWorktreesReturn {
+  // `enabled: false` swaps the Map subscription for a stable empty sentinel so
+  // always-mounted consumers that only need the data while visible (e.g. the
+  // quick switcher while open) stop re-rendering on every worktree-map change.
+  const enabled = options?.enabled ?? true;
+  const worktreeMap = useWorktreeStore((state) => (enabled ? state.worktrees : EMPTY_WORKTREES));
   const isLoading = useWorktreeStore((state) => state.isLoading);
   const isInitialized = useWorktreeStore((state) => state.isInitialized);
   const isReconnecting = useWorktreeStore((state) => state.isReconnecting);

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -521,6 +521,7 @@ describe("destructive-action danger metadata", () => {
       worktrees: new Map<string, WorktreeSnapshot>([
         ["wt-placeholder", { id: "wt-placeholder", hasTeardownCommand: true } as WorktreeSnapshot],
       ]),
+      statusCheckedAt: new Map(),
       manualAssociations: new Map(),
       version: { epoch: "test", seq: 1 },
       tombstones: new Map(),

--- a/src/store/__tests__/createWorktreeStore.statusCheckedAt.test.ts
+++ b/src/store/__tests__/createWorktreeStore.statusCheckedAt.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { WorktreeSnapshot, WorktreeEventVersion } from "@shared/types";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+
+// Freshness (lastGitStatusCheckedAt) advances on EVERY completed host poll —
+// including polls where nothing user-visible changed. It is tracked in the
+// statusCheckedAt side map so a quiet poll can't churn the worktrees Map
+// identity and fan out to every whole-map subscriber.
+
+const TEST_EPOCH = "test-epoch";
+let _seq = 0;
+function nextV(): WorktreeEventVersion {
+  return { epoch: TEST_EPOCH, seq: ++_seq };
+}
+
+function makeSnapshot(id: string, extra: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    name: id,
+    branch: "main",
+    path: `/repo/${id}`,
+    isCurrent: false,
+    isMainWorktree: false,
+    modifiedCount: 0,
+    changes: [],
+    summary: "",
+    mood: null,
+    gitDir: "",
+    ...extra,
+  } as unknown as WorktreeSnapshot;
+}
+
+describe("createWorktreeStore — statusCheckedAt freshness side map", () => {
+  it("a freshness-only update advances statusCheckedAt without a new worktrees Map identity", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { lastGitStatusCheckedAt: 1_000 }), nextV());
+    const mapBefore = store.getState().worktrees;
+    const snapshotBefore = store.getState().worktrees.get("wt-1");
+
+    // Same content, newer freshness stamp — the quiet-poll shape.
+    store.getState().applyUpdate(makeSnapshot("wt-1", { lastGitStatusCheckedAt: 2_000 }), nextV());
+
+    expect(store.getState().worktrees).toBe(mapBefore);
+    expect(store.getState().worktrees.get("wt-1")).toBe(snapshotBefore);
+    expect(store.getState().statusCheckedAt.get("wt-1")).toBe(2_000);
+  });
+
+  it("a content change still produces a new Map identity and records freshness", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { lastGitStatusCheckedAt: 1_000 }), nextV());
+    const mapBefore = store.getState().worktrees;
+
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { modifiedCount: 3, lastGitStatusCheckedAt: 2_000 }),
+        nextV()
+      );
+
+    expect(store.getState().worktrees).not.toBe(mapBefore);
+    expect(store.getState().worktrees.get("wt-1")?.modifiedCount).toBe(3);
+    expect(store.getState().statusCheckedAt.get("wt-1")).toBe(2_000);
+  });
+
+  it("an identical freshness stamp keeps the statusCheckedAt identity stable", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { lastGitStatusCheckedAt: 1_000 }), nextV());
+    const freshnessBefore = store.getState().statusCheckedAt;
+
+    store.getState().applyUpdate(makeSnapshot("wt-1", { lastGitStatusCheckedAt: 1_000 }), nextV());
+
+    expect(store.getState().statusCheckedAt).toBe(freshnessBefore);
+  });
+
+  it("applySnapshot rebuilds freshness for all worktrees and prunes removed ids", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot(
+        [
+          makeSnapshot("wt-1", { lastGitStatusCheckedAt: 1_000 }),
+          makeSnapshot("wt-2", { lastGitStatusCheckedAt: 1_500 }),
+        ],
+        nextV()
+      );
+    expect(store.getState().statusCheckedAt.get("wt-1")).toBe(1_000);
+    expect(store.getState().statusCheckedAt.get("wt-2")).toBe(1_500);
+
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { lastGitStatusCheckedAt: 2_000 })], nextV());
+    expect(store.getState().statusCheckedAt.get("wt-1")).toBe(2_000);
+    expect(store.getState().statusCheckedAt.has("wt-2")).toBe(false);
+  });
+
+  it("a value-equal snapshot with fresher stamps updates freshness but not the worktrees identity", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { lastGitStatusCheckedAt: 1_000 })], nextV());
+    const mapBefore = store.getState().worktrees;
+
+    store
+      .getState()
+      .applySnapshot([makeSnapshot("wt-1", { lastGitStatusCheckedAt: 2_000 })], nextV());
+
+    expect(store.getState().worktrees).toBe(mapBefore);
+    expect(store.getState().statusCheckedAt.get("wt-1")).toBe(2_000);
+  });
+
+  it("applyRemove drops the worktree's freshness entry", () => {
+    const store = createWorktreeStore();
+    store.getState().applyUpdate(makeSnapshot("wt-1", { lastGitStatusCheckedAt: 1_000 }), nextV());
+    expect(store.getState().statusCheckedAt.has("wt-1")).toBe(true);
+
+    store.getState().applyRemove("wt-1", nextV());
+
+    expect(store.getState().statusCheckedAt.has("wt-1")).toBe(false);
+    expect(store.getState().worktrees.has("wt-1")).toBe(false);
+  });
+});

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -207,6 +207,18 @@ function isConnectivityError(message: string): boolean {
 
 export interface WorktreeViewState {
   worktrees: Map<string, WorktreeSnapshot>;
+  /**
+   * `worktreeId → lastGitStatusCheckedAt` (epoch ms), tracked outside the
+   * snapshot map on purpose: the host advances this stamp on every completed
+   * poll — including polls where nothing user-visible changed — so comparing
+   * it in `snapshotsEqual` forced a new `worktrees` Map identity per poll and
+   * fanned every quiet tick out to every whole-map subscriber. Freshness
+   * consumers (the WorktreeHeader pill, WorktreeCard's revalidate gate) read
+   * this map per-id instead. The `lastGitStatusCheckedAt` field still present
+   * on stored snapshots reflects the last content change, not the last poll —
+   * always read freshness from here.
+   */
+  statusCheckedAt: Map<string, number>;
   manualAssociations: Map<string, ManualIssueAssociation>;
   /**
    * Host-minted `(epoch, seq)` stamp of the most recently applied event.
@@ -351,6 +363,7 @@ export type WorktreeViewStoreApi = StoreApi<WorktreeViewStore>;
 export function createWorktreeStore(): WorktreeViewStoreApi {
   return createStore<WorktreeViewStore>((set, get) => ({
     worktrees: new Map(),
+    statusCheckedAt: new Map(),
     manualAssociations: new Map(),
     version: { epoch: "", seq: 0 },
     tombstones: new Map(),
@@ -392,6 +405,24 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         mergeIssueState(s, prev.worktrees.get(s.id), manual.get(s.id))
       );
 
+      // Rebuild the freshness map from the authoritative snapshot (also prunes
+      // removed ids), keeping the previous identity when every stamp matches
+      // so freshness-only subscribers see no spurious notify.
+      let nextStatusCheckedAt = prev.statusCheckedAt;
+      {
+        const rebuilt = new Map<string, number>();
+        for (const s of merged) {
+          if (s.lastGitStatusCheckedAt !== undefined) {
+            rebuilt.set(s.id, s.lastGitStatusCheckedAt);
+          }
+        }
+        const unchanged =
+          rebuilt.size === prev.statusCheckedAt.size &&
+          [...rebuilt].every(([id, t]) => prev.statusCheckedAt.get(id) === t);
+        if (!unchanged) nextStatusCheckedAt = rebuilt;
+      }
+      const statusCheckedAtChanged = nextStatusCheckedAt !== prev.statusCheckedAt;
+
       // Once hydrated, suppress redundant Map identity churn when every
       // incoming snapshot is value-equal to its existing counterpart. Cold
       // starts always rebuild so `isInitialized` flips correctly even when
@@ -411,6 +442,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           error: null,
           isReconnecting: false,
           reconnectingAt: null,
+          ...(statusCheckedAtChanged ? { statusCheckedAt: nextStatusCheckedAt } : {}),
           ...(tombstonesChanged ? { tombstones: new Map() } : {}),
           ...(associationsChanged ? { manualAssociations: manual } : {}),
         });
@@ -425,6 +457,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         error: null,
         isReconnecting: false,
         reconnectingAt: null,
+        ...(statusCheckedAtChanged ? { statusCheckedAt: nextStatusCheckedAt } : {}),
         ...(tombstonesChanged ? { tombstones: new Map() } : {}),
         ...(associationsChanged ? { manualAssociations: manual } : {}),
       });
@@ -460,13 +493,36 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       const tombstonesChanged = tombstones !== prevState.tombstones;
 
       const merged = mergeIssueState(state, existing, prevState.manualAssociations.get(state.id));
+
+      // Freshness stamp advances on every completed poll; track it in the
+      // side map so a poll that changed nothing else doesn't churn the
+      // snapshot Map identity below.
+      let statusCheckedAt = prevState.statusCheckedAt;
+      if (
+        merged.lastGitStatusCheckedAt !== undefined &&
+        statusCheckedAt.get(state.id) !== merged.lastGitStatusCheckedAt
+      ) {
+        statusCheckedAt = new Map(statusCheckedAt);
+        statusCheckedAt.set(state.id, merged.lastGitStatusCheckedAt);
+      }
+      const statusCheckedAtChanged = statusCheckedAt !== prevState.statusCheckedAt;
+
       if (existing && snapshotsEqual(existing, merged)) {
-        set({ version, ...(tombstonesChanged ? { tombstones } : {}) });
+        set({
+          version,
+          ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
+          ...(tombstonesChanged ? { tombstones } : {}),
+        });
         return;
       }
       const next = new Map(prev);
       next.set(state.id, merged);
-      set({ worktrees: next, version, ...(tombstonesChanged ? { tombstones } : {}) });
+      set({
+        worktrees: next,
+        version,
+        ...(statusCheckedAtChanged ? { statusCheckedAt } : {}),
+        ...(tombstonesChanged ? { tombstones } : {}),
+      });
     },
 
     applyIssueNotFound(worktreeId: string, issueNumber: number) {
@@ -532,6 +588,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       tombstones.set(worktreeId, now);
 
       const hadWorktree = prevState.worktrees.has(worktreeId);
+      const hadStatusCheckedAt = prevState.statusCheckedAt.has(worktreeId);
       const hadDeletingId = prevState.deletingIds.has(worktreeId);
       const hadDeleteError = prevState.deleteErrors.has(worktreeId);
       const hadDeleteErrorArgs = prevState.deleteErrorArgs.has(worktreeId);
@@ -541,6 +598,10 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
 
       const nextWorktrees = hadWorktree ? new Map(prevState.worktrees) : prevState.worktrees;
       if (hadWorktree) nextWorktrees.delete(worktreeId);
+      const nextStatusCheckedAt = hadStatusCheckedAt
+        ? new Map(prevState.statusCheckedAt)
+        : prevState.statusCheckedAt;
+      if (hadStatusCheckedAt) nextStatusCheckedAt.delete(worktreeId);
       const nextDeletingIds = hadDeletingId
         ? new Set(prevState.deletingIds)
         : prevState.deletingIds;
@@ -575,6 +636,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
 
       set({
         worktrees: nextWorktrees,
+        statusCheckedAt: nextStatusCheckedAt,
         deletingIds: nextDeletingIds,
         deleteErrors: nextDeleteErrors,
         deleteErrorArgs: nextDeleteErrorArgs,
@@ -1544,8 +1606,11 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.baseAheadCount === b.baseAheadCount &&
     a.baseBehindCount === b.baseBehindCount &&
     a.baseMatchesUpstream === b.baseMatchesUpstream &&
+    // lastGitStatusCheckedAt is deliberately NOT compared (like `timestamp`):
+    // it advances on every completed poll, so comparing it here would force a
+    // new worktrees Map identity per quiet tick. Freshness lives in the
+    // store's `statusCheckedAt` side map instead.
     a.lastFetchedAt === b.lastFetchedAt &&
-    a.lastGitStatusCheckedAt === b.lastGitStatusCheckedAt &&
     a.fetchAuthFailed === b.fetchAuthFailed &&
     a.fetchNetworkFailed === b.fetchNetworkFailed &&
     a.isFetchInFlight === b.isFetchInFlight &&

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -355,6 +355,12 @@ function renderFanoutProbePlugin(state: ImportMapBuildState): Plugin {
     apply: "build",
     transformIndexHtml() {
       if (process.env.DAINTREE_RENDER_PROBE !== "1") return;
+      // Loud on purpose: a globally exported DAINTREE_RENDER_PROBE=1 would
+      // otherwise silently turn a packaging build into a bench build
+      // (inline probe + profiling react-dom + no minification).
+      console.warn(
+        "[render-fanout-probe] BENCH BUILD: inlining render probe, profiling react-dom, minify off — never ship this build"
+      );
       const source = readFileSync(
         path.join(process.cwd(), "scripts", "perf", "render-fanout-probe.js"),
         "utf8"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -340,6 +340,44 @@ function inlineSkeletonScriptsPlugin(state: ImportMapBuildState): Plugin {
   };
 }
 
+// Bench builds only (DAINTREE_RENDER_PROBE=1, `npm run build:e2e:bench`):
+// inlines scripts/perf/render-fanout-probe.js as a classic <head> script so
+// the React DevTools hook it installs exists before any deferred module
+// script evaluates react-dom. Classic-inline is the only placement that
+// guarantees that ordering regardless of chunking; a src/ module import would
+// also be vulnerable to sideEffects-based tree-shaking. The script hash rides
+// state.skeletonScriptHashes so the meta CSP and the HTTP-header sidecar both
+// allow it. Never active for shipped builds — the env var is only set by the
+// bench build script.
+function renderFanoutProbePlugin(state: ImportMapBuildState): Plugin {
+  return {
+    name: "render-fanout-probe",
+    apply: "build",
+    transformIndexHtml() {
+      if (process.env.DAINTREE_RENDER_PROBE !== "1") return;
+      const source = readFileSync(
+        path.join(process.cwd(), "scripts", "perf", "render-fanout-probe.js"),
+        "utf8"
+      );
+      if (source.includes("</script>")) {
+        throw new Error(
+          '[render-fanout-probe] scripts/perf/render-fanout-probe.js contains "</script>" and cannot be inlined'
+        );
+      }
+      state.skeletonScriptHashes.push(
+        `'sha256-${createHash("sha256").update(source, "utf8").digest("base64")}'`
+      );
+      return [
+        {
+          tag: "script",
+          injectTo: "head-prepend" as const,
+          children: source,
+        },
+      ];
+    },
+  };
+}
+
 // `HOST_IMPORTMAP_SPECIFIERS` (imported from @daintreehq/plugin-vite above) is
 // the set of specifiers exposed to externalized plugin bundles. In production
 // each bare specifier points at the same `vendor-react` chunk because Rolldown
@@ -916,6 +954,11 @@ export default defineConfig(({ command, mode }) => {
       // transformIndexHtml hooks (registration order), and the CSP transform
       // reads the skeleton hashes this plugin stores in shared state.
       inlineSkeletonScriptsPlugin(importMapState),
+      // Bench-only (no-op unless DAINTREE_RENDER_PROBE=1). Must sit between
+      // inlineSkeletonScriptsPlugin (buildStart resets the hash list) and
+      // cspTransformPlugin (reads it) — all three use default-order
+      // transformIndexHtml hooks, so registration order is execution order.
+      renderFanoutProbePlugin(importMapState),
       cspTransformPlugin(importMapState),
       compilerReportPlugin,
       rendererBundleSizePlugin(),
@@ -1119,6 +1162,14 @@ export default defineConfig(({ command, mode }) => {
     },
     resolve: {
       alias: {
+        // Bench builds (DAINTREE_RENDER_PROBE=1, see build:bench) swap in the
+        // profiling react-dom bundle so the render-fanout probe
+        // (src/utils/renderFanoutProbe.ts) gets per-fiber actualDuration.
+        // Production semantics are otherwise identical (no StrictMode
+        // double-render); never set for shipped builds.
+        ...(process.env.DAINTREE_RENDER_PROBE === "1"
+          ? { "react-dom/client": "react-dom/profiling" }
+          : {}),
         "@": path.resolve(__dirname, "./src"),
         "@shared": path.resolve(__dirname, "./shared"),
         // refractor/core eagerly imports parse-entities, whose browser-condition

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -975,6 +975,10 @@ export default defineConfig(({ command, mode }) => {
     base: "./",
     build: {
       target: "chrome148",
+      // Bench builds skip minification so the render-fanout probe reports
+      // readable component names (only explicit displayNames survive the
+      // minifier). Never set for shipped builds.
+      ...(process.env.DAINTREE_RENDER_PROBE === "1" ? { minify: false } : {}),
       modulePreload: { polyfill: false },
       outDir: "dist",
       emptyOutDir: true,


### PR DESCRIPTION
This PR adds an opt-in benchmark that measures how many React components re-render (and how many milliseconds of render work run) per git-status poll and per agent-state change, at 1, 5, 20, and 50 worktrees. It then uses those numbers to remove wasteful store subscriptions. This is the multiplier on everything else: every poll and state flip we can't eliminate still costs whatever the renderer fanout makes it cost, and #10915 already showed this bug class is fertile ground.

The headline: a quiet git poll (nothing changed on disk, the most common event in the app) used to re-render ~1,385 components at 50 worktrees. It now re-renders ~48. Idle re-rendering at 50 worktrees dropped 75%.

### Before and after

Medians over 15 quiet polls, 10 change polls, and 10 state flips per scale, one fresh app instance per scale, fake instant-boot `claude` agents (one per worktree) so the numbers isolate app overhead. Render counts are deterministic run to run (three baseline runs reproduced the same medians); milliseconds move with machine load, so treat counts as the primary signal.

**Components re-rendered per event (median)**

| Workload | Scale | develop | this PR | change |
| --- | --- | --- | --- | --- |
| Quiet git poll | 1 wt | 523 | 39 | -93% |
| Quiet git poll | 5 wt | 965 | 43 | -96% |
| Quiet git poll | 20 wt | 1,385 | 53 | -96% |
| Quiet git poll | 50 wt | 1,385 | 48 | -97% |
| Change git poll | 1 wt | 1,077 | 593 | -45% |
| Change git poll | 5 wt | 1,955 | 1,061 | -46% |
| Change git poll | 20 wt | 1,479 | 1,479 | +0% |
| Change git poll | 50 wt | 2,775 | 1,444 | -48% |
| Agent-state flip | 1 wt | 641 | 641 | +0% |
| Agent-state flip | 50 wt | 1,845 | 1,845 | +0% |

**Render self-time per event, ms (median)**

| Workload | Scale | develop | this PR | change |
| --- | --- | --- | --- | --- |
| Quiet git poll | 1 wt | 24.8 | 1.9 | -93% |
| Quiet git poll | 50 wt | 47.8 | 1.8 | -96% |
| Change git poll | 1 wt | 59.0 | 48.1 | -18% |
| Change git poll | 50 wt | 98.6 | 75.0 | -24% |
| Agent-state flip | 50 wt | 114.3 | 112.6 | -2% |

**Ambient renders per 10s, idle app**

| Scale | develop | this PR | change |
| --- | --- | --- | --- |
| 1 wt | 712 | 712 | +0% |
| 5 wt | 4,581 | 4,627 | +1% |
| 20 wt | 15,558 | 15,515 | -0% |
| 50 wt | 46,902 | 11,780 | -75% |

Agent-state flips didn't improve, and the per-component attribution explains why: the flip event includes agent output, which advances the worktree's `lastActivityTimestamp`. That's a legitimate content change (it drives the sidebar recency sort), and `App` consumes the worktree map directly for JSX, so the App chain plus the per-row sidebar wrappers re-render. Narrowing App's own `useWorktrees` subscription is a structural refactor and future work. The identical render counts with unchanged medians across three runs also confirm the flip path never went through the subscriptions this PR removed.

### What changed

1. **Freshness stamps moved out of the snapshot equality check.** The workspace host advances `lastGitStatusCheckedAt` on every completed poll, including polls where nothing user-visible changed. `snapshotsEqual` compared it, so every quiet poll minted a new `worktrees` Map identity and re-rendered all ~20 whole-map subscribers, App chain included. The stamp now lives in a `statusCheckedAt` side map on the store; freshness consumers (the `WorktreeHeader` pill, `WorktreeCard`'s hover-revalidate gate) subscribe per-id, so a quiet poll re-renders exactly one card. This is the quiet-poll and idle win.
2. **`useContextInjection` stopped subscribing to the panel map.** The hook is mounted in `App` and in every `TerminalPane`, and its live `panelsById`/`focusedId` selectors re-rendered all of them on every panel-map identity change. `inject()` now reads both via `getState()` at call time, which is also fresher than a render-captured snapshot.
3. **`useAccessibilityAnnouncements` observes the store outside React.** Everything this hook does is an announcement effect; it renders nothing. Five reactive selectors became one transient `usePanelStore.subscribe`, with the same diff logic driven from refs. Announce-immediately semantics for focus/location/maximize are preserved (WCAG 4.1.3), agent/flow/queue/exit stay debounced, and all 36 existing tests pass unchanged.
4. **Palette hooks only subscribe while open.** The quick-switcher, send-to-agent, panel, and resume-sessions palettes are always mounted in `App`, and their `panelsById`/`panelIds`/`mruList`/`worktrees` selectors re-rendered the whole App on every flip, flush, and worktree change while closed. Each now reads through stable empty sentinels until its palette opens, following the open-gating precedent `usePanelPalette` already used for its journal fetch. `useWorktrees` gains an optional `{ enabled }` flag for the same pattern. This is most of the change-poll win.

### The benchmark

```
npm run build:e2e:bench
RUN_PERF_STORE_FANOUT=1 npx playwright test --project=full-panels \
  e2e/full/panels/store-fanout-perf.spec.ts
```

A classic inline `<head>` script (injected only when the build runs with `DAINTREE_RENDER_PROBE=1`) installs a minimal React DevTools hook before `react-dom` evaluates, walks each commit's fiber tree with the same reused-subtree pruning DevTools uses, and reports per-component render counts and self-durations. The bench build also aliases `react-dom/client` to `react-dom/profiling` and skips minification so attribution stays readable. Four workloads per scale: quiet poll (forced via `worktree.refresh`), change poll (dirty/clean a file first), agent flip (fake `claude` driven working/waiting through OSC 9;4 plus the idle debounce), and a streaming window. Results land in `PERF_STORE_FANOUT_OUT` as JSON for offline diffing.

Opt-in only and deliberately not wired into PR CI, matching the pre-1.0 stance on perf budgets. It's the standing regression tripwire for the next O(worktrees) subscription: run it before and after any change to store subscription patterns.

One note on the tables above: after those runs were recorded, review tightened the probe's per-component self-time subtraction (it now subtracts every reconciled child's `actualDuration`, matching react-dom's own profiler semantics, instead of only children that performed work). Render counts, the primary signal, are unaffected.

### Accepted trade-offs

- The `lastGitStatusCheckedAt` field still exists on stored snapshots but only reflects the last content change. Freshness must be read from the side map; the store comment and the per-id hook make that the obvious path, and nothing else consumed the field (grep plus the full suite agree).
- Quick-switcher MRU pruning now happens when the palette opens instead of continuously in the background. The pruned list is only consumed while the palette is open, so the observable behavior is identical; the two MRU tests now run against an open palette.
- Announcement processing runs per store notification instead of per committed render batch. Same-tick flapping could in principle announce transitions the old batching coalesced, but no product path writes opposing transitions synchronously, and the per-key 300ms debounce still covers rapid sequences.

### Testing

- `npm run check` passes.
- Full local vitest suite passes.
- New unit coverage: `createWorktreeStore.statusCheckedAt.test.ts` pins the freshness-only-update contract (stable Map identity, side-map update, snapshot rebuild pruning, `applyRemove` cleanup).
- Targeted suites for every touched area pass: accessibility announcements (36), context injection, palette hooks (50), Sidebar, Worktree, and store suites (3,709 tests in the combined run).
- Reviewed by Codex in two passes. The product-code pass confirmed the behavior-preservation claims (first-mount silence, debounce cancellation, hibernation teardown, tombstone paths) with no findings; the bench-infra pass produced six hardening fixes that were applied: react-dom-matching self-time subtraction, an exact-value `RUN_PERF_STORE_FANOUT === "1"` gate, per-direction flip invariants, fixture cleanup on setup failure, fake-CLI stdin `end`/`close` shutdown, and a loud bench-build warning in the Vite plugin.
