### PR TITLE
perf(memory): cut steady-state footprint across renderers and utility hosts

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -145,10 +145,15 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
-// V8 tuning for renderer processes: heap limits and GC exposure
+// V8 tuning for renderer processes: heap limits and GC exposure.
+// Semi-space 16 MB: the young generation commits up to ~2× the semi-space per
+// renderer, and with one renderer per project view the slack multiplies. 64 MB
+// (up to ~128 MB committed nursery per view under terminal streaming) bought
+// scavenge frequency we don't need — terminal churn is short-lived garbage
+// with a tiny live set, so scavenges stay sub-millisecond at 16 MB.
 app.commandLine.appendSwitch(
   "js-flags",
-  "--max-old-space-size=768 --max-semi-space-size=64 --expose-gc"
+  "--max-old-space-size=768 --max-semi-space-size=16 --expose-gc"
 );
 
 // Allow autoplay without user gesture (voice input, media panels).

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -638,6 +638,10 @@ export class WorkspaceHostProcess extends EventEmitter {
           // host OOM-loop (#10729). 512 MB raises the headroom while the slow-OOM
           // detector above surfaces any genuine leak instead of looping silently.
           "--max-old-space-size=512",
+          // Cap the young generation: git-status polling churns short-lived
+          // strings per poll; an uncapped nursery (RAM-scaled by V8) commits
+          // slack per project's host. One host per project multiplies it.
+          "--max-semi-space-size=8",
           `--diagnostic-dir=${app.getPath("logs")}`,
           "--report-exclude-env",
         ],

--- a/electron/services/mainHeapCompaction.ts
+++ b/electron/services/mainHeapCompaction.ts
@@ -1,0 +1,35 @@
+import {
+  IdleHeapCompactor,
+  resolveExposedGc,
+  IDLE_HEAP_COMPACT_CHECK_INTERVAL_MS,
+} from "./pty/analysis/idleHeapCompactor.js";
+
+/**
+ * Idle heap compaction for the MAIN isolate. Boot, project switches, config
+ * parses, and IPC broadcast bursts churn transient garbage through main's V8
+ * heap, and nothing drives the idle memory reducer afterwards — the committed
+ * slack lingers exactly like it did in the pty-host before its compactor.
+ *
+ * Activity signal: heap growth. User-input idle (powerMonitor) is wrong here —
+ * overnight agent fleets keep main busy while the user is away, and Playwright
+ * -driven e2e input never registers. A heapUsed delta above the threshold
+ * between polls means main is doing real work; when the heap stops moving, one
+ * compacting GC runs and the latch holds until growth resumes. A GC's own
+ * shrink is a negative delta, so compaction never re-triggers itself.
+ */
+const HEAP_GROWTH_ACTIVITY_BYTES = 2 * 1024 * 1024;
+
+export function startMainIdleHeapCompaction(): () => void {
+  const compactor = new IdleHeapCompactor(resolveExposedGc());
+  let lastHeapUsed = process.memoryUsage().heapUsed;
+  const timer = setInterval(() => {
+    const heapUsed = process.memoryUsage().heapUsed;
+    if (heapUsed - lastHeapUsed > HEAP_GROWTH_ACTIVITY_BYTES) {
+      compactor.noteActivity();
+    }
+    lastHeapUsed = heapUsed;
+    compactor.maybeCompact();
+  }, IDLE_HEAP_COMPACT_CHECK_INTERVAL_MS);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -334,6 +334,11 @@ export class PtyHostLifecycle {
         // utility process CWD (homedir).
         execArgv: [
           `--max-old-space-size=${this.config.memoryLimitMb}`,
+          // Cap the young generation: PTY relay churns short-lived strings with
+          // a tiny live set, so an uncapped nursery (V8 scales it with machine
+          // RAM) just commits slack pages per shard. 8 MB keeps scavenges
+          // sub-millisecond at this allocation profile.
+          "--max-semi-space-size=8",
           `--diagnostic-dir=${app.getPath("logs")}`,
           "--report-exclude-env",
         ],

--- a/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.agentDetection.test.ts
@@ -6,6 +6,7 @@ import type { ProcessTreeCache } from "../../ProcessTreeCache.js";
 import type { DetectionResult } from "../../ProcessDetector.js";
 import { makeAgentResult, makeNoAgentResult } from "../../ProcessDetector.js";
 import { events } from "../../events.js";
+import { DEFAULT_SCROLLBACK } from "../types.js";
 
 vi.mock("node-pty", () => {
   return { spawn: vi.fn() };
@@ -507,16 +508,14 @@ describe("TerminalProcess.handleAgentDetection — polling loop teardown", () =>
 });
 
 // Issue #5776: spawn-sealed agent behaviours on runtime-promoted panels.
-// Plain terminals spawned with kind="terminal" inherit DEFAULT_SCROLLBACK (1k);
-// when runtime detection sees an agent appear, the headless detection buffer
-// must grow to AGENT_SCROLLBACK (10k) so the buffer carries enough history for
-// the agent's longer output. Cold agent terminals already start at 10k and
-// must be untouched.
+// Every PTY starts at DEFAULT_SCROLLBACK (the tiered agent-vs-plain split was
+// retired); the invariant under test is that runtime agent detection never
+// changes the headless mirror's scrollback, in either direction.
 describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback", () => {
   it("plain terminal starts at DEFAULT_SCROLLBACK and agent detection does not change it", () => {
     const terminal = createPlainTerminal();
     try {
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
 
       callHandleAgentDetection(
         terminal,
@@ -524,7 +523,7 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
         getSpawnedAt(terminal)
       );
 
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
     } finally {
       terminal.dispose();
     }
@@ -538,14 +537,14 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
         makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
 
       callHandleAgentDetection(
         terminal,
         makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
     } finally {
       terminal.dispose();
     }
@@ -555,7 +554,7 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
     const terminal = createAgentTerminal();
     try {
       // Cold-spawned agent already starts at AGENT_SCROLLBACK.
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
 
       callHandleAgentDetection(
         terminal,
@@ -563,7 +562,7 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
         getSpawnedAt(terminal)
       );
 
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
     } finally {
       terminal.dispose();
     }
@@ -572,9 +571,9 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
   it("growScrollback never shrinks", () => {
     const terminal = createAgentTerminal();
     try {
-      expect(getScrollback(terminal)).toBe(10000);
-      terminal.growScrollback(5000);
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
+      terminal.growScrollback(Math.floor(DEFAULT_SCROLLBACK / 2));
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
     } finally {
       terminal.dispose();
     }
@@ -588,14 +587,14 @@ describe("TerminalProcess.handleAgentDetection — runtime promotion scrollback"
         makeAgentResult({ agentType: "claude" as const, processIconId: "claude" }),
         getSpawnedAt(terminal)
       );
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
 
       callHandleAgentDetection(
         terminal,
         makeAgentResult({ agentType: "gemini" as const, processIconId: "gemini" }),
         getSpawnedAt(terminal)
       );
-      expect(getScrollback(terminal)).toBe(10000);
+      expect(getScrollback(terminal)).toBe(DEFAULT_SCROLLBACK);
     } finally {
       terminal.dispose();
     }

--- a/electron/services/pty/analysis/AnalysisWorkerPool.ts
+++ b/electron/services/pty/analysis/AnalysisWorkerPool.ts
@@ -129,7 +129,13 @@ export class AnalysisWorkerPool implements AnalysisPoolHost {
   constructor(
     private readonly size: number = defaultAnalysisPoolSize(),
     private readonly spawnWorker: () => WorkerLike = () => {
-      const worker = new Worker(resolveAnalysisWorkerPath());
+      // Young-generation cap only (maps to --max-semi-space-size): headless
+      // xterm parsing churns short-lived strings, so an uncapped nursery
+      // commits slack pages per worker isolate. No old-gen cap — exceeding a
+      // resourceLimits old-gen budget terminates the worker.
+      const worker = new Worker(resolveAnalysisWorkerPath(), {
+        resourceLimits: { maxYoungGenerationSizeMb: 8 },
+      });
       worker.unref();
       return worker;
     }

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -277,11 +277,13 @@ export const WRITE_MAX_CHUNK_SIZE = 50;
 export const WRITE_INTERVAL_MS = 5;
 
 // Scrollback configuration
-// All PTY panels get a generous scrollback; there is no "agent tier" scrollback
-// decision any more. The headless analysis buffer is small because only recent
-// output is needed for state detection; the renderer-visible scrollback is
-// larger so long agent runs don't truncate.
-export const DEFAULT_SCROLLBACK = 10000;
+// All PTY panels get the same scrollback; there is no "agent tier" scrollback
+// decision any more. Capped at the renderer's hard display ceiling (AGENT_POLICY
+// maxLines in src/utils/scrollbackConfig.ts — 5000 even for "unlimited") so the
+// headless analysis mirror never retains lines no renderer can show and no
+// consumer can read (terminal.getOutput caps at 1000). At ~12 bytes/cell this
+// halves the worst-case mirror cost per terminal versus the previous 10000.
+export const DEFAULT_SCROLLBACK = 5000;
 
 // Preserved-snapshot eviction (issue #10839)
 // Agent terminals that exit cleanly retain their full serialized scrollback

--- a/electron/utils/__tests__/webContentsLifecycle.test.ts
+++ b/electron/utils/__tests__/webContentsLifecycle.test.ts
@@ -5,6 +5,7 @@ import {
   unfreezeWebContents,
   throttleCpuWebContents,
   unthrottleCpuWebContents,
+  purgeMemoryWebContents,
 } from "../webContentsLifecycle.js";
 
 interface MockDebugger {
@@ -281,6 +282,60 @@ describe("webContentsLifecycle", () => {
     it("never throws when wc.debugger is missing entirely (unthrottle)", async () => {
       const wc = { isDestroyed: vi.fn(() => false) } as unknown as Electron.WebContents;
       await expect(unthrottleCpuWebContents(wc)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("purgeMemoryWebContents", () => {
+    it("sends the pressure notification before the HeapProfiler GC sequence", async () => {
+      const wc = createMockWc();
+      await purgeMemoryWebContents(wc as unknown as Electron.WebContents);
+      const methods = wc.debugger.sendCommand.mock.calls.map((c: unknown[]) => c[0]);
+      expect(methods).toEqual([
+        "Memory.simulatePressureNotification",
+        "HeapProfiler.enable",
+        "HeapProfiler.collectGarbage",
+        "HeapProfiler.disable",
+      ]);
+      expect(wc.debugger.sendCommand.mock.calls[0][1]).toEqual({ level: "critical" });
+    });
+
+    it("never sends Memory.forciblyPurgeJavaScriptMemory (SIGSEGVs throttled hidden views)", async () => {
+      const wc = createMockWc();
+      await purgeMemoryWebContents(wc as unknown as Electron.WebContents);
+      const methods = wc.debugger.sendCommand.mock.calls.map((c: unknown[]) => c[0]);
+      expect(methods).not.toContain("Memory.forciblyPurgeJavaScriptMemory");
+    });
+
+    it("skips entirely when Windows E2E disables cached-view CDP throttles", async () => {
+      vi.stubEnv("DAINTREE_E2E_DISABLE_CACHED_VIEW_CPU_THROTTLE", "1");
+      const wc = createMockWc();
+      await purgeMemoryWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.attach).not.toHaveBeenCalled();
+      expect(wc.debugger.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it("returns early when wc is destroyed", async () => {
+      const wc = createMockWc({ destroyed: true });
+      await purgeMemoryWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.sendCommand).not.toHaveBeenCalled();
+    });
+
+    it("swallows expected CDP errors silently", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Target closed"));
+      await expect(
+        purgeMemoryWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("warns once for an unexpected CDP error", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockRejectedValueOnce(new Error("boom"));
+      await expect(
+        purgeMemoryWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
       expect(warnSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/electron/utils/webContentsLifecycle.ts
+++ b/electron/utils/webContentsLifecycle.ts
@@ -91,3 +91,32 @@ export function throttleCpuWebContents(wc: Electron.WebContents): Promise<void> 
 export function unthrottleCpuWebContents(wc: Electron.WebContents): Promise<void> {
   return setCpuThrottlingRate(wc, ACTIVE_VIEW_CPU_THROTTLE_RATE);
 }
+
+/**
+ * Compact a cached renderer's V8 heap, main-side over CDP (works even when
+ * the renderer is CPU-throttled — the renderer-side `window.gc()` idle
+ * callback cannot make that guarantee). `HeapProfiler.collectGarbage` is the
+ * DevTools "collect garbage" button: a full last-resort GC that compacts and
+ * returns committed-but-free pages, while leaving JIT code, WebGL contexts,
+ * and compositor state intact. Do NOT swap in the Memory-domain purges here:
+ * both `Memory.forciblyPurgeJavaScriptMemory` and
+ * `Memory.simulatePressureNotification` SIGSEGV a CPU-throttled hidden
+ * WebContentsView on Electron 42/Chromium 148 (measured: exit code 11,
+ * reproducibly, seconds after the command lands). Per-target, so the active
+ * view is untouched. Shares the Windows-CI e2e opt-out with the CPU throttle:
+ * both ride the same debugger session Playwright owns there.
+ */
+export async function purgeMemoryWebContents(wc: Electron.WebContents): Promise<void> {
+  if (getIsE2EDisableCachedViewCpuThrottle()) return;
+  if (wc.isDestroyed()) return;
+  try {
+    ensureAttached(wc);
+    await wc.debugger.sendCommand("HeapProfiler.enable");
+    await wc.debugger.sendCommand("HeapProfiler.collectGarbage");
+    await wc.debugger.sendCommand("HeapProfiler.disable");
+  } catch (err) {
+    const message = formatErrorMessage(err, "CDP memory purge failed");
+    if (EXPECTED_CDP_ERRORS.some((s) => message.includes(s))) return;
+    console.warn("[webContentsLifecycle] purgeMemoryWebContents failed:", message);
+  }
+}

--- a/electron/utils/webContentsLifecycle.ts
+++ b/electron/utils/webContentsLifecycle.ts
@@ -93,24 +93,27 @@ export function unthrottleCpuWebContents(wc: Electron.WebContents): Promise<void
 }
 
 /**
- * Compact a cached renderer's V8 heap, main-side over CDP (works even when
- * the renderer is CPU-throttled — the renderer-side `window.gc()` idle
- * callback cannot make that guarantee). `HeapProfiler.collectGarbage` is the
- * DevTools "collect garbage" button: a full last-resort GC that compacts and
- * returns committed-but-free pages, while leaving JIT code, WebGL contexts,
- * and compositor state intact. Do NOT swap in the Memory-domain purges here:
- * both `Memory.forciblyPurgeJavaScriptMemory` and
- * `Memory.simulatePressureNotification` SIGSEGV a CPU-throttled hidden
- * WebContentsView on Electron 42/Chromium 148 (measured: exit code 11,
- * reproducibly, seconds after the command lands). Per-target, so the active
- * view is untouched. Shares the Windows-CI e2e opt-out with the CPU throttle:
- * both ride the same debugger session Playwright owns there.
+ * Purge a cached renderer's reclaimable memory, main-side over CDP (works
+ * even when the renderer is CPU-throttled — the renderer-side `window.gc()`
+ * idle callback cannot make that guarantee). The critical pressure
+ * notification is the same `NotifyMemoryPressure(CRITICAL)` Blink's own
+ * MemoryPurgeManager fires after backgrounding/freeze: it drops Blink
+ * discardable caches (fonts, decoded images, backing stores) and triggers a
+ * V8 memory-pressure GC. `HeapProfiler.collectGarbage` (the DevTools
+ * "collect garbage" button) then compacts and returns the freed pages.
+ * Do NOT add `Memory.forciblyPurgeJavaScriptMemory`: it reproducibly
+ * SIGSEGVs a CPU-throttled hidden WebContentsView on Electron 42/Chromium
+ * 148 (exit code 11 ~instantly; isolated in an A/B probe — the pressure
+ * notification alone is stable). Per-target, so the active view is
+ * untouched. Shares the Windows-CI e2e opt-out with the CPU throttle: both
+ * ride the same debugger session Playwright owns there.
  */
 export async function purgeMemoryWebContents(wc: Electron.WebContents): Promise<void> {
   if (getIsE2EDisableCachedViewCpuThrottle()) return;
   if (wc.isDestroyed()) return;
   try {
     ensureAttached(wc);
+    await wc.debugger.sendCommand("Memory.simulatePressureNotification", { level: "critical" });
     await wc.debugger.sendCommand("HeapProfiler.enable");
     await wc.debugger.sendCommand("HeapProfiler.collectGarbage");
     await wc.debugger.sendCommand("HeapProfiler.disable");

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -55,6 +55,7 @@ import {
   unfreezeWebContents,
   throttleCpuWebContents,
   unthrottleCpuWebContents,
+  purgeMemoryWebContents,
 } from "../utils/webContentsLifecycle.js";
 import { ACTIVE_AGENT_STATES, type AgentState } from "../../shared/types/agent.js";
 import {
@@ -112,6 +113,14 @@ const DEFAULT_WARM_PAINT_GATE_HARD_TIMEOUT_MS = 1_500;
  * sample period without a new timer.
  */
 const CACHED_VIEW_MEMORY_SAMPLE_INTERVAL_MS = 30_000;
+
+// Cached-view memory purge cadence. The delay keeps the likely next-switch
+// target (a just-cached view) fully warm so fast switch-back pays nothing;
+// the interval re-purges long-cached views whose background work (agent
+// output, worktree events) keeps re-accumulating garbage. Purge is per-target
+// CDP — the active view is never touched.
+const CACHED_VIEW_PURGE_DELAY_MS = 20_000;
+const CACHED_VIEW_PURGE_INTERVAL_MS = 60_000;
 
 type ViewState = "loading" | "active" | "cached";
 
@@ -172,6 +181,11 @@ interface ViewEntry {
   state: ViewState;
   crashTimestamps: number[];
   cleanupHandlers: () => void;
+  /**
+   * Delayed/periodic CDP memory purge while cached (see schedulePurge).
+   * Cleared on activation and teardown so a live view is never purged.
+   */
+  purgeTimer?: NodeJS.Timeout;
   /**
    * Cold-start preload (`preload.cts`) evaluation cost in ms, self-reported by
    * the view's preload via PERF_FLUSH_RENDERER_MARKS (#9770). Set once per view
@@ -1453,6 +1467,37 @@ export class ProjectViewManager {
       ) {
         void freezeWebContents(webContents);
       }
+
+      this.schedulePurge(current, CACHED_VIEW_PURGE_DELAY_MS);
+    }
+  }
+
+  /**
+   * Delayed + periodic memory purge for a cached view. The renderer-side
+   * `requestIdleCallback(gc)` above is best-effort inside a throttled
+   * renderer; this is the guaranteed main-side counterpart (works throttled
+   * or frozen) and additionally purges Blink's discardable caches. Purging
+   * does not stop timers, ports, or agent output processing — it only drops
+   * reclaimable memory — so it is safe for cached views with live agents.
+   */
+  private schedulePurge(entry: ViewEntry, delayMs: number): void {
+    this.clearPurgeTimer(entry);
+    const timer = setTimeout(() => {
+      const live = this.views.get(entry.projectId);
+      if (live !== entry || entry.state !== "cached") return;
+      const wc = entry.view.webContents;
+      if (!wc || wc.isDestroyed()) return;
+      void purgeMemoryWebContents(wc);
+      this.schedulePurge(entry, CACHED_VIEW_PURGE_INTERVAL_MS);
+    }, delayMs);
+    timer.unref?.();
+    entry.purgeTimer = timer;
+  }
+
+  private clearPurgeTimer(entry: ViewEntry): void {
+    if (entry.purgeTimer) {
+      clearTimeout(entry.purgeTimer);
+      entry.purgeTimer = undefined;
     }
   }
 
@@ -1504,6 +1549,8 @@ export class ProjectViewManager {
   }
 
   private activateView(entry: ViewEntry, insertBehind = false): void {
+    // A view being activated must never take a scheduled cache purge.
+    this.clearPurgeTimer(entry);
     registerAppView(this.win, entry.view);
 
     // Restore visibility BEFORE unfreezing: deactivateEntry() called
@@ -2151,6 +2198,8 @@ export class ProjectViewManager {
   private cleanupEntry(projectId: string): void {
     const entry = this.views.get(projectId);
     if (!entry) return;
+
+    this.clearPurgeTimer(entry);
 
     // Detach persistent webContents listeners before close() so any queued
     // event (did-finish-load, render-process-gone, etc.) cannot fire against

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -164,6 +164,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.backgroundResize.test.ts
@@ -122,6 +122,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -154,6 +154,7 @@ vi.mock("../rendererConsoleCapture.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.focusIntent.test.ts
@@ -166,6 +166,7 @@ vi.mock("../rendererConsoleCapture.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -685,9 +685,11 @@ describe("ProjectViewManager — cached-view memory purge", () => {
 
     vi.advanceTimersByTime(60_000);
     expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(purgeMemoryWebContents).mock.calls.every((c) => c[0] === initialWc)).toBe(
-      true
-    );
+    expect(
+      vi
+        .mocked(purgeMemoryWebContents)
+        .mock.calls.every((c) => c[0] === (initialWc as unknown as Electron.WebContents))
+    ).toBe(true);
   });
 
   it("never purges a view that was reactivated before the delay", async () => {

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -118,6 +118,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),
@@ -126,7 +127,11 @@ vi.mock("../../utils/webContentsLifecycle.js", () => ({
 
 import { ProjectViewManager } from "../ProjectViewManager.js";
 import { events } from "../../services/events.js";
-import { freezeWebContents, unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
+import {
+  freezeWebContents,
+  unfreezeWebContents,
+  purgeMemoryWebContents,
+} from "../../utils/webContentsLifecycle.js";
 import {
   registerCachedViewWebContents,
   unregisterCachedViewWebContents,
@@ -631,5 +636,77 @@ describe("ProjectViewManager — memory sampler jitter", () => {
 
     vi.advanceTimersByTime(30_000);
     expect(sample).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("ProjectViewManager — cached-view memory purge", () => {
+  let manager: ProjectViewManager;
+  let win: ReturnType<typeof createMockWindow>;
+  let initialWc: ReturnType<typeof createMockWebContents>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    nextWebContentsId = 100;
+    win = createMockWindow();
+    manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+      paintGateTimeoutMs: 0,
+      paintGateHardTimeoutMs: 0,
+    });
+    (manager as unknown as { waitForPaint: () => Promise<string> }).waitForPaint = () =>
+      Promise.resolve("signal");
+    initialWc = createMockWebContents();
+    const initialView = { webContents: initialWc, setBounds: vi.fn() };
+    manager.registerInitialView(initialView as never, "proj-a", "/path/a");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("purges a cached view only after the delay elapses", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    expect(vi.mocked(purgeMemoryWebContents)).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(19_999);
+    expect(vi.mocked(purgeMemoryWebContents)).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledWith(initialWc);
+  });
+
+  it("re-purges a long-cached view on the periodic interval", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    vi.advanceTimersByTime(20_000);
+    expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(60_000);
+    expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(purgeMemoryWebContents).mock.calls.every((c) => c[0] === initialWc)).toBe(
+      true
+    );
+  });
+
+  it("never purges a view that was reactivated before the delay", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    vi.advanceTimersByTime(10_000);
+
+    await manager.switchTo("proj-a", "/path/a");
+    vi.advanceTimersByTime(120_000);
+
+    expect(vi.mocked(purgeMemoryWebContents)).not.toHaveBeenCalledWith(initialWc);
+  });
+
+  it("stops purging once the view is torn down", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    vi.advanceTimersByTime(20_000);
+    expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledTimes(1);
+
+    initialWc.isDestroyed.mockReturnValue(true);
+    vi.advanceTimersByTime(120_000);
+    expect(vi.mocked(purgeMemoryWebContents)).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -114,6 +114,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.lifecycle.test.ts
@@ -206,6 +206,7 @@ vi.mock("../rendererConsoleCapture.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.paintGate.test.ts
@@ -197,6 +197,7 @@ vi.mock("../rendererConsoleCapture.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.preload.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.preload.test.ts
@@ -147,6 +147,7 @@ vi.mock("../rendererConsoleCapture.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -162,6 +162,7 @@ vi.mock("../../services/ProjectStore.js", () => ({
 }));
 
 vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  purgeMemoryWebContents: vi.fn().mockResolvedValue(undefined),
   freezeWebContents: vi.fn().mockResolvedValue(undefined),
   unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
   throttleCpuWebContents: vi.fn().mockResolvedValue(undefined),

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -35,6 +35,7 @@ import {
   startEventLoopLagMonitor,
   startProcessMemoryMonitor,
 } from "../utils/performance.js";
+import { startMainIdleHeapCompaction } from "../services/mainHeapCompaction.js";
 import {
   startAppMetricsMonitor,
   hasSustainedRendererSaturation,
@@ -373,6 +374,13 @@ export async function initGlobalServices(
       if (process.env.DAINTREE_PERF_CAPTURE === "1" && !getStopProcessMemoryMonitor()) {
         setStopProcessMemoryMonitor(startProcessMemoryMonitor());
       }
+    },
+  });
+
+  registerDeferredTask({
+    name: "main-idle-heap-compaction",
+    run: () => {
+      startMainIdleHeapCompaction();
     },
   });
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -36,6 +36,11 @@ import { initForgeBridge } from "./workspace-host/forgeBridge.js";
 import { fanoutEventToWorktreePorts } from "./workspace-host/worktreePortFanout.js";
 import { PERF_MARKS } from "../shared/perf/marks.js";
 import { markHostPerformance } from "./utils/hostPerformance.js";
+import {
+  IdleHeapCompactor,
+  resolveExposedGc,
+  IDLE_HEAP_COMPACT_CHECK_INTERVAL_MS,
+} from "./services/pty/analysis/idleHeapCompactor.js";
 
 // First user-code statement after all imports settle. ESM hoists native
 // module dlopen (better-sqlite3 via WorkspaceService, @parcel/watcher) ahead
@@ -311,8 +316,21 @@ process.on("unhandledRejection", (reason) => {
   setImmediate(() => process.exit(1));
 });
 
+// Idle heap compaction for this isolate: git polling churns transient strings
+// and diff/status structures every cycle, and a utility process has nothing
+// driving V8's idle memory reducer, so committed-but-free heap pages linger
+// for minutes after a burst (same problem the pty-host compactor fixes).
+// Activity = any inbound request or outbound event; the latch inside the
+// compactor means at most one compacting GC per quiet period.
+const idleHeapCompactor = new IdleHeapCompactor(resolveExposedGc());
+const idleHeapCompactTimer = setInterval(() => {
+  idleHeapCompactor.maybeCompact();
+}, IDLE_HEAP_COMPACT_CHECK_INTERVAL_MS);
+idleHeapCompactTimer.unref?.();
+
 // Helper to send events to Main process (and directly to renderers for spontaneous events)
 function sendEvent(event: WorkspaceHostEvent): void {
+  idleHeapCompactor.noteActivity();
   try {
     port.postMessage(event);
   } catch (error) {
@@ -362,6 +380,7 @@ const forgeBridge = initForgeBridge(sendEvent);
 
 // Handle requests from Main
 port.on("message", async (rawMsg: any) => {
+  idleHeapCompactor.noteActivity();
   const msg =
     rawMsg && typeof rawMsg === "object" && "data" in rawMsg
       ? (rawMsg as { data: unknown }).data


### PR DESCRIPTION
This PR implements a series of optimizations to reduce Daintree's steady-state memory footprint, using the kitchen-sink memory benchmark from #10973 as the yardstick. All five changes are scrollback-neutral and have no user-visible effect.

1. Cached background project views now receive a delayed (20s) and periodic (60s) memory purge over CDP, driven from the main process so it works even when the renderer is CPU-throttled. The purge is cancelled the moment a view is reactivated, so fast switch-back stays warm.
2. The headless analysis mirror's scrollback drops from 10000 to 5000 lines. 5000 is the renderer's hard display ceiling (`AGENT_POLICY` maxLines, even for the "unlimited" setting), and `terminal.getOutput` caps at 1000 lines, so nothing above 5000 was ever reachable.
3. The renderer V8 semi-space is reduced from 64 MB to 16 MB. Terminal churn is short-lived garbage with a tiny live set, so the big nursery bought scavenge frequency we don't need while committing up to ~128 MB per project view.
4. The pty-host and workspace-host utility processes get `--max-semi-space-size=8`, and the analysis workers get a matching `resourceLimits.maxYoungGenerationSizeMb` cap.
5. The `IdleHeapCompactor` is extended to the workspace-host (message/event activity signal) and the main process (heap-growth activity signal), matching the proven pty-host pattern.

## Results

Five full app lifecycles per arm, 4 projects x 3 terminals, all views alive in every sample in both arms (no evictions, no crashes). Idle retained footprint:

| Metric | baseline | optimized | Δ mean | Δ p95 |
|---|---|---|---|---|
| app RSS | 2662.9 MB | 2576.1 MB | -3.3% | -3.5% |
| utility footprint | 507.8 MB | 433.1 MB | -14.7% | -14.8% |
| pty-host working set | 448.0 MB | 398.0 MB | -11.2% | -13.2% |
| renderer footprint | 614.1 MB | 588.3 MB | -4.2% | -5.7% |
| renderer JS heap | 207.8 MB | 197.2 MB | -5.1% | -3.5% |

The aggregate `appFootprint` metric turned out to be unusable for A/B on this machine: the GPU process flips between ~0.8 GB and ~1.8 GB of macOS purgeable IOSurface memory between runs (baseline stddev was ±573 MB), which swamps everything else. The per-class metrics above are stable across both optimized runs I did.

## Hazards

While testing this I found that the CDP command `Memory.forciblyPurgeJavaScriptMemory` reliably segfaults a CPU-throttled hidden `WebContentsView` on Electron 42 / Chromium 148 (exit code 11, roughly 200ms after the command lands, isolated in an A/B probe). The purge instead uses `Memory.simulatePressureNotification` at critical level, which is the same `NotifyMemoryPressure(CRITICAL)` path Blink's own `MemoryPurgeManager` fires after backgrounding, plus `HeapProfiler.collectGarbage` to compact. A unit test now guards against anyone reintroducing the crashing command.

## Validation

- Two full kitchen-sink benchmark A/B runs (plus three short probe runs to isolate the segfault)
- `npm run check` green
- All affected unit suites pass (2192 tests: ProjectViewManager, webContentsLifecycle, pty, analysis workers, WorkspaceHostProcess)
