### PR TITLE
feat(panels): allow file viewer panels to dock

### DIFF
--- a/e2e/full/panels/core-file-panel.spec.ts
+++ b/e2e/full/panels/core-file-panel.spec.ts
@@ -190,4 +190,34 @@ test.describe.serial("Core: File viewer panel (dialog + panel)", () => {
     const result = await dispatchAction(ctx.window, "file.read", { path: "spec.md" });
     expect(JSON.stringify(result)).toContain("Markdown E2E Spec");
   });
+
+  test("file panel moves to the dock, previews from the chip, and restores to the grid", async () => {
+    const panel = ctx.window
+      .locator(SEL.panel.gridPanel)
+      .filter({ has: ctx.window.locator('[data-testid="file-pane-body"]') })
+      .first();
+
+    // The docked panel stays mounted in the offscreen parking container, so
+    // count GRID membership rather than total pane instances.
+    const gridFilePanels = ctx.window
+      .locator(SEL.panel.gridPanel)
+      .filter({ has: ctx.window.locator('[data-testid="file-pane-body"]') });
+
+    await panel.locator('[data-testid="panel-move-to-dock"]').click();
+    await expect(gridFilePanels).toHaveCount(2, { timeout: T_MEDIUM });
+
+    // The chip carries the file name; clicking opens the dock popover with the
+    // panel's live content relocated into it.
+    const chip = ctx.window.locator("[data-dock-item]", { hasText: "spec.md" });
+    await expect(chip).toBeVisible({ timeout: T_MEDIUM });
+    await chip.click();
+    await expect(
+      ctx.window.locator('[data-dock-portal-target] [data-testid="file-pane-body"]')
+    ).toBeVisible({ timeout: T_LONG });
+
+    // Double-click restores the panel to the grid.
+    await chip.dblclick();
+    await expect(gridFilePanels).toHaveCount(3, { timeout: T_MEDIUM });
+    await expect(chip).not.toBeVisible({ timeout: T_MEDIUM });
+  });
 });

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -9,6 +9,7 @@ import {
   onPanelKindRegistered,
   onPanelKindUnregistered,
   panelKindUsesTerminalUi,
+  panelKindIsDockable,
   registerPanelKind,
   unregisterPluginPanelKinds,
   clearPanelKindRegistry,
@@ -527,5 +528,25 @@ describe("getFirstRenderPreloadSeeds", () => {
     // getFirstRenderSeeds stays panel-only; the app root lives solely in the
     // combined accessor so the registry contract test above keeps its exact shape.
     expect(getFirstRenderSeeds()).not.toContain(FIRST_RENDER_ROOT_SEED);
+  });
+});
+
+describe("panelKindIsDockable", () => {
+  it("PTY kinds are always dockable", () => {
+    expect(panelKindIsDockable("terminal")).toBe(true);
+  });
+
+  it("file panels opt in via the dockable capability", () => {
+    expect(panelKindIsDockable("file")).toBe(true);
+  });
+
+  it("non-PTY kinds without the capability are not dockable", () => {
+    expect(panelKindIsDockable("browser")).toBe(false);
+    expect(panelKindIsDockable("dev-preview")).toBe(false);
+    expect(panelKindIsDockable("review")).toBe(false);
+  });
+
+  it("unknown kinds are not dockable", () => {
+    expect(panelKindIsDockable("no-such-kind")).toBe(false);
   });
 });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -102,6 +102,14 @@ export interface PanelKindConfig {
   canRestart: boolean;
   /** Whether this panel kind can convert to/from other types */
   canConvert: boolean;
+  /**
+   * Whether a non-PTY kind can live in the dock. PTY kinds are always
+   * dockable; setting this opts a non-PTY kind into dock membership. The
+   * dock render path must have a chip for the kind (see `ContentDock`) —
+   * `DockPanelData` in shared/types/panel.ts is the type-level twin of this
+   * flag and the two must stay in sync.
+   */
+  dockable?: boolean;
   /** Whether this panel kind uses the standard terminal UI */
   usesTerminalUi?: boolean;
   /** Whether this panel kind should keep its runtime alive across project switches */
@@ -231,6 +239,7 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     hasPty: false,
     canRestart: false,
     canConvert: false,
+    dockable: true,
     usesTerminalUi: false,
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
@@ -489,6 +498,20 @@ export function getPanelKindColor(kind: PanelKind, agentId?: string): string {
 export function panelKindHasPty(kind: PanelKind): boolean {
   const config = getPanelKindConfig(kind);
   return config?.hasPty ?? false;
+}
+
+/**
+ * Check if a panel kind can live in the dock. PTY kinds always can; non-PTY
+ * kinds opt in via `dockable` (the dock chip row and offscreen host render
+ * them through `isDockPanel`).
+ *
+ * @param kind - The panel kind to check
+ * @returns True if panels of this kind can be moved to the dock
+ */
+export function panelKindIsDockable(kind: PanelKind): boolean {
+  const config = getPanelKindConfig(kind);
+  if (!config) return false;
+  return config.hasPty || config.dockable === true;
 }
 
 /**

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -630,6 +630,17 @@ export function isFilePanel(panel: PanelInstance | TerminalInstance): panel is F
 }
 
 /**
+ * Panels that can live in the dock. Type-level twin of the registry's
+ * `dockable` capability (`panelKindIsDockable`) — extend both together when a
+ * new kind gains dock support, along with a chip branch in `ContentDock`.
+ */
+export type DockPanelData = PtyPanelData | FilePanelData;
+
+export function isDockPanel(panel: PanelInstance | TerminalInstance): panel is DockPanelData {
+  return isPtyPanel(panel) || isFilePanel(panel);
+}
+
+/**
  * Legacy interface for backward compatibility with persisted state.
  * New code should use the PanelInstance discriminated union.
  *

--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -7,10 +7,16 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePanelStore, useProjectStore, useWorktreeSelectionStore } from "@/store";
-import { isPtyPanel, type PanelInstance, type PtyPanelData } from "@shared/types/panel";
+import {
+  isDockPanel,
+  isPtyPanel,
+  type DockPanelData,
+  type PanelInstance,
+} from "@shared/types/panel";
 import { getNarrowPanel } from "@/store/slices/panelRegistry/selectors";
 import type { TrashedTerminal } from "@/store/slices";
 import { DockedTerminalItem } from "./DockedTerminalItem";
+import { DockedFilePanelItem } from "./DockedFilePanelItem";
 import { DockedTabGroup } from "./DockedTabGroup";
 import { TrashContainer } from "./TrashContainer";
 import { WaitingContainer } from "./WaitingContainer";
@@ -75,7 +81,7 @@ export type { DockDensity } from "@/store/preferencesStore";
 // Stable empty refs so the narrowed dock subscriptions below can bail under
 // `useShallow` when the dock is empty instead of yielding a fresh `[]`.
 const EMPTY_DOCK_SIGNATURE: readonly string[] = [];
-const EMPTY_DOCK_TERMINALS: readonly PtyPanelData[] = [];
+const EMPTY_DOCK_TERMINALS: readonly DockPanelData[] = [];
 
 interface ContentDockProps {
   density?: DockDensity;
@@ -100,10 +106,10 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   // Narrow dock subscriptions (#10908). Subscribing to the whole `panelsById`
   // re-rendered the dock on every panel's rAF status-buffer flush — including
   // grid agents that never appear here. Both selectors below react only to dock
-  // panels. The dock is intentionally PTY-only: its chrome (output preview,
-  // restart, agent state) is built on terminal affordances, so `getNarrowPanel`
-  // + `isPtyPanel` is the correct gate (NOT the #10512 grid render-eligibility
-  // predicate, which deliberately does not apply to the dock).
+  // panels. Membership is `isDockPanel` (PTY panels plus the dockable file
+  // kind — #10985); each member kind has its own chip below. This is NOT the
+  // #10512 grid render-eligibility predicate, which deliberately does not
+  // apply to the dock.
   //
   // `dockPanelSignature` is a structural `${id}:${worktreeId}` list that stays
   // referentially stable across status-buffer flushes, so the (activity-agnostic)
@@ -119,7 +125,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
         const terminal = getNarrowPanel(state.panelsById, id);
         if (
           terminal &&
-          isPtyPanel(terminal) &&
+          isDockPanel(terminal) &&
           terminal.location === "dock" &&
           !state.trashedTerminals.has(terminal.id)
         ) {
@@ -135,12 +141,12 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
   // fires when a *dock* panel's reference changes, not on grid-agent churn.
   const dockTerminalsRaw = usePanelStore(
     useShallow((state) => {
-      const result: PtyPanelData[] = [];
+      const result: DockPanelData[] = [];
       for (const id of state.panelIds) {
         const terminal = getNarrowPanel(state.panelsById, id);
         if (
           terminal &&
-          isPtyPanel(terminal) &&
+          isDockPanel(terminal) &&
           terminal.location === "dock" &&
           !state.trashedTerminals.has(terminal.id)
         ) {
@@ -168,11 +174,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     helpTerminalId,
   ]);
 
-  const dockTerminals = useMemo<PtyPanelData[]>(() => {
-    // `dockTerminalsRaw` already narrows to dock/pty/non-trashed panels; apply
-    // the help-panel and active-worktree filters here (external stores the
-    // store selector can't read).
-    const result: PtyPanelData[] = [];
+  const dockTerminals = useMemo<DockPanelData[]>(() => {
+    // `dockTerminalsRaw` already narrows to dock/dockable/non-trashed panels;
+    // apply the help-panel and active-worktree filters here (external stores
+    // the store selector can't read).
+    const result: DockPanelData[] = [];
     for (const terminal of dockTerminalsRaw) {
       if (
         terminal.id !== helpTerminalId &&
@@ -471,7 +477,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             <div
               ref={combinedRef}
               role="toolbar"
-              aria-label="Docked terminals"
+              aria-label="Docked panels"
               aria-orientation="horizontal"
               aria-busy={isDndActive || undefined}
               onKeyDown={handleDockKeyDown}
@@ -494,17 +500,23 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                     <SortableDockPlaceholder />
                   ) : (
                     dockItems.map(({ group, panels }, index) => {
-                      // Single-panel group: render DockedTerminalItem directly
+                      // Single-panel group: render the kind's chip directly
                       if (panels.length === 1) {
                         const terminal = panels[0]!;
                         return (
                           <SortableDockItem key={group.id} terminal={terminal} sourceIndex={index}>
-                            <DockedTerminalItem terminal={terminal} />
+                            {isPtyPanel(terminal) ? (
+                              <DockedTerminalItem terminal={terminal} />
+                            ) : (
+                              <DockedFilePanelItem panel={terminal} />
+                            )}
                           </SortableDockItem>
                         );
                       }
 
-                      // Multi-panel group: pass group context for group-aware DnD
+                      // Multi-panel group: pass group context for group-aware DnD.
+                      // Groups resolve through the isPtyPanel filter above, so
+                      // the runtime narrow below never drops a panel.
                       const firstPanel = panels[0]!;
                       return (
                         <SortableDockItem
@@ -514,7 +526,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
                           groupId={group.id}
                           groupPanelIds={group.panelIds}
                         >
-                          <DockedTabGroup group={group} panels={panels} />
+                          <DockedTabGroup group={group} panels={panels.filter(isPtyPanel)} />
                         </SortableDockItem>
                       );
                     })

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -3,7 +3,7 @@ import { canDuplicatePanelKind } from "@/services/terminal/panelDuplicationServi
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelStore, useWorktreeSelectionStore } from "@/store";
-import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import { isDockPanel, type DockPanelData } from "@shared/types/panel";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { DockedPanel } from "@/components/Terminal/DockedPanel";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
@@ -32,12 +32,12 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
   const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
   const dockTerminals = usePanelStore(
     useShallow((s) => {
-      const result: PtyPanelData[] = [];
+      const result: DockPanelData[] = [];
       for (const id of s.panelIds) {
         const t = s.panelsById[id];
         if (
           t &&
-          isPtyPanel(t) &&
+          isDockPanel(t) &&
           t.location === "dock" &&
           !s.trashedTerminals.has(t.id) &&
           t.id !== helpTerminalId &&
@@ -75,7 +75,7 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
 
   // Handler for adding a new tab to a single panel (creates a tab group)
   const handleAddTabForPanel = useCallback(
-    async (panel: PtyPanelData) => {
+    async (panel: DockPanelData) => {
       let groupId: string;
       let createdNewGroup = false;
       let newPanelId: string | null = null;

--- a/src/components/Layout/DockedFilePanelItem.tsx
+++ b/src/components/Layout/DockedFilePanelItem.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useDndMonitor } from "@dnd-kit/core";
+import type { DraggableSyntheticListeners } from "@dnd-kit/core";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
+import { cn } from "@/lib/utils";
+import { usePanelStore, useFocusStore } from "@/store";
+import type { FilePanelData } from "@shared/types/panel";
+import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { useDockPanelPortal } from "./dockPanelPortalContext";
+import { useDockPopoverResize } from "./useDockPopoverResize";
+import { DockPopoverResizeHandle } from "./DockPopoverResizeHandle";
+import {
+  handleDockInteractOutside,
+  handleDockEscapeKeyDown,
+  handleDockFocusOutside,
+} from "./dockPopoverGuard";
+import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
+
+interface DockedFilePanelItemProps {
+  panel: FilePanelData;
+}
+
+/**
+ * Dock chip for a file viewer panel. Mirrors DockedTerminalItem's popover +
+ * stable-wrapper relocation flow, minus everything PTY: no renderer policies,
+ * no xterm fit, no agent state. The panel's React subtree lives in
+ * DockPanelOffscreenContainer and is moved (not remounted) into this popover,
+ * so scroll position and view mode survive open/close.
+ */
+export function DockedFilePanelItem({ panel }: DockedFilePanelItemProps) {
+  // Pointer/touch drag listeners only — dnd-kit's keyboard handler would
+  // preventDefault() this button's activation click (see DockedTerminalItem).
+  const dragHandle = useDragHandle();
+  const dragPointerListeners: DraggableSyntheticListeners = dragHandle?.listeners
+    ? Object.fromEntries(
+        Object.entries(dragHandle.listeners).filter(([name]) => name !== "onKeyDown")
+      )
+    : undefined;
+  const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
+  const openDockTerminal = usePanelStore((s) => s.openDockTerminal);
+  const closeDockTerminal = usePanelStore((s) => s.closeDockTerminal);
+  const moveTerminalToGrid = usePanelStore((s) => s.moveTerminalToGrid);
+
+  const isOpen = activeDockTerminalId === panel.id;
+
+  const sidebarHidden = useFocusStore((s) => s.gestureSidebarHidden);
+  const collisionPadding = useMemo(() => {
+    const basePadding = 32;
+    return {
+      top: basePadding,
+      left: sidebarHidden ? 8 : basePadding,
+      bottom: basePadding,
+      right: basePadding,
+    };
+  }, [sidebarHidden]);
+
+  const moveToDestination = useDockPanelPortal();
+  const portalContainerElementRef = useRef<HTMLDivElement | null>(null);
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
+  const portalContainerRef = useCallback((node: HTMLDivElement | null) => {
+    portalContainerElementRef.current = node;
+    setPortalContainer(node);
+  }, []);
+
+  // Relocate the panel's stable wrapper into the popover on open, back to the
+  // offscreen parking container on close (same contract as terminals).
+  useEffect(() => {
+    if (isOpen && portalContainer) {
+      moveToDestination(panel.id, portalContainer);
+    } else {
+      moveToDestination(panel.id, null);
+    }
+    return () => {
+      moveToDestination(panel.id, null);
+    };
+  }, [isOpen, portalContainer, panel.id, moveToDestination]);
+
+  // Auto-close popover when drag starts for this panel
+  useDndMonitor({
+    onDragStart: ({ active }) => {
+      if (active.id === panel.id && isOpen) {
+        closeDockTerminal();
+      }
+    },
+  });
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        openDockTerminal(panel.id);
+      } else {
+        closeDockTerminal();
+      }
+    },
+    [panel.id, openDockTerminal, closeDockTerminal]
+  );
+
+  const handleMoveToGrid = useCallback(() => {
+    const moved = moveTerminalToGrid(panel.id);
+    if (moved) closeDockTerminal();
+  }, [panel.id, moveTerminalToGrid, closeDockTerminal]);
+
+  const chrome = useMemo(() => deriveTerminalChrome({ kind: panel.kind }), [panel.kind]);
+
+  // File name beats the generic kind title in the chip, mirroring the pane's
+  // own title layering (a user-locked rename still wins).
+  const fileName = panel.filePath?.split(/[/\\]/).filter(Boolean).pop();
+  const displayTitle = panel.titleMode === "user" ? panel.title : (fileName ?? panel.title);
+
+  const { height: popoverHeight, isResizing, handleProps } = useDockPopoverResize();
+
+  return (
+    <DockPopoverChildProvider>
+      <Popover open={isOpen} onOpenChange={handleOpenChange}>
+        <div className="relative flex items-center">
+          <TerminalContextMenu terminalId={panel.id} forceLocation="dock">
+            <PopoverTrigger asChild>
+              <button
+                {...dragPointerListeners}
+                data-dock-item=""
+                className={cn(
+                  "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
+                  "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
+                  "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+                  "cursor-grab active:cursor-grabbing",
+                  isOpen &&
+                    "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30"
+                )}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (e.detail >= 2) return;
+                  if (isOpen) {
+                    closeDockTerminal();
+                  } else {
+                    openDockTerminal(panel.id);
+                  }
+                }}
+                onDoubleClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleMoveToGrid();
+                }}
+                aria-label={`${displayTitle} - Click to preview, double-click to move to grid, drag to reorder`}
+              >
+                <div className="flex items-center justify-center shrink-0">
+                  <TerminalIcon kind={panel.kind} chrome={chrome} className="w-3.5 h-3.5" />
+                </div>
+                <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
+                  {displayTitle}
+                </span>
+              </button>
+            </PopoverTrigger>
+          </TerminalContextMenu>
+        </div>
+
+        <PopoverContent
+          className="w-[700px] max-w-[90vw] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-120 data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-97 data-[state=open]:zoom-in-97 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1"
+          style={{ height: popoverHeight }}
+          side="top"
+          align="start"
+          sideOffset={10}
+          collisionPadding={collisionPadding}
+          onInteractOutside={(e) => handleDockInteractOutside(e, portalContainerElementRef.current)}
+          onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainerElementRef.current)}
+          onFocusOutside={handleDockFocusOutside}
+          onOpenAutoFocus={(event) => {
+            // No terminal to hand focus to — keep focus on the chip so Escape
+            // closes without a focus jump.
+            event.preventDefault();
+          }}
+        >
+          <div className="relative w-full h-full group">
+            <DockPopoverResizeHandle handleProps={handleProps} isResizing={isResizing} />
+            {/* Portal target — content renders in DockPanelOffscreenContainer
+                and is relocated here on open. */}
+            <div
+              ref={portalContainerRef}
+              className="w-full h-full flex flex-col"
+              data-dock-portal-target={panel.id}
+            />
+          </div>
+        </PopoverContent>
+      </Popover>
+    </DockPopoverChildProvider>
+  );
+}

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -156,7 +156,7 @@ describe("ContentDock regression test", () => {
       const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
 
       expect(content).toContain('role="toolbar"');
-      expect(content).toContain('aria-label="Docked terminals"');
+      expect(content).toContain('aria-label="Docked panels"');
       expect(content).toContain('aria-orientation="horizontal"');
     });
 

--- a/src/components/Layout/__tests__/dockRenderItems.test.ts
+++ b/src/components/Layout/__tests__/dockRenderItems.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PtyPanelData } from "@shared/types/panel";
+import type { FilePanelData, PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 import { buildDockRenderItems } from "../dockRenderItems";
 
@@ -25,7 +25,42 @@ function group(panelIds: string[], activeTabId = panelIds[0] ?? ""): TabGroup {
   };
 }
 
+function filePanel(id: string): FilePanelData {
+  return {
+    id,
+    title: id,
+    kind: "file",
+    location: "dock",
+    isVisible: false,
+    filePath: `/repo/${id}.md`,
+  } as FilePanelData;
+}
+
 describe("buildDockRenderItems", () => {
+  it("renders a docked file panel as a standalone chip", () => {
+    const items = buildDockRenderItems([], () => [], null, [filePanel("spec")]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.panels[0]?.kind).toBe("file");
+    expect(items[0]?.group.panelIds).toEqual(["spec"]);
+  });
+
+  it("renders a file panel standalone even when its stored group only resolves PTY panels", () => {
+    // A grid tab group containing a terminal and a file panel moved to the
+    // dock: groups resolve PTY-only, so the file panel falls through to the
+    // flat membership list and must not vanish.
+    const items = buildDockRenderItems(
+      [group(["term-1", "spec"], "term-1")],
+      () => [terminal("term-1")],
+      null,
+      [terminal("term-1"), filePanel("spec")]
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]?.group.panelIds).toEqual(["term-1"]);
+    expect(items[1]?.panels[0]?.id).toBe("spec");
+  });
+
   it("drops stale groups whose panels no longer resolve to dock terminals", () => {
     const items = buildDockRenderItems([group(["closed-panel"])], () => []);
 

--- a/src/components/Layout/dockRenderItems.ts
+++ b/src/components/Layout/dockRenderItems.ts
@@ -1,19 +1,20 @@
-import type { PtyPanelData } from "@shared/types/panel";
+import type { DockPanelData, PtyPanelData } from "@shared/types/panel";
 import type { TabGroup } from "@/types";
 
 export interface DockRenderItem {
   group: TabGroup;
-  panels: PtyPanelData[];
+  panels: DockPanelData[];
 }
 
 export function buildDockRenderItems(
   tabGroups: TabGroup[],
+  // Tab groups stay PTY-only — file panels dock as standalone chips.
   resolvePanels: (groupId: string) => PtyPanelData[],
   excludedPanelId?: string | null,
-  dockTerminals: PtyPanelData[] = []
+  dockTerminals: DockPanelData[] = []
 ): DockRenderItem[] {
   const renderedPanelIds = new Set<string>();
-  const items = tabGroups.flatMap((group) => {
+  const items: DockRenderItem[] = tabGroups.flatMap((group) => {
     const panels = resolvePanels(group.id).filter((panel) => panel.id !== excludedPanelId);
     if (panels.length === 0) return [];
 

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -77,7 +77,11 @@ import {
 import { TabButton, type TabInfo } from "./TabButton";
 import { SortableTabButton } from "./SortableTabButton";
 
-import { panelKindCanRestart, panelKindHasPty } from "@shared/config/panelKindRegistry";
+import {
+  panelKindCanRestart,
+  panelKindHasPty,
+  panelKindIsDockable,
+} from "@shared/config/panelKindRegistry";
 import { isPtyPanel } from "@shared/types/panel";
 import { actionService } from "@/services/ActionService";
 import { fireWatchNotification } from "@/lib/watchNotification";
@@ -307,10 +311,11 @@ function PanelHeaderComponent({
   const isHibernated = useIsHibernated(id);
 
   // Whether the overflow "..." menu has any items to show.
-  // Dock rendering is PTY-only (`ContentDock` / `DockPanelOffscreenContainer`
-  // filter via `isPtyPanel`); offering the move-to-dock affordance for
-  // browser/dev-preview/review panels would silently strand them.
-  const showMoveToDock = !!onMinimize && !isMaximized && location !== "dock" && hasPty;
+  // Dock membership is capability-gated: PTY kinds plus non-PTY kinds that
+  // opt in via the registry's `dockable` flag (file panels — #10985).
+  // Offering the affordance for any other kind would silently strand it.
+  const showMoveToDock =
+    !!onMinimize && !isMaximized && location !== "dock" && panelKindIsDockable(kind);
   const hasOverflowItems = true;
 
   // Restart handler for Radix DropdownMenu onSelect

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -9,7 +9,7 @@ import { useWorktrees } from "@/hooks/useWorktrees";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { panelKindHasPty, panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import {
   isBrowserPanel,
   isDevPreviewPanel,
@@ -543,6 +543,9 @@ export function TerminalContextMenu({
         </ContextMenuItem>
       )}
       <ContextMenuItem
+        // Move-to-grid is always safe; move-to-dock only for kinds the dock
+        // renders (PTY + dockable non-PTY like file panels).
+        disabled={currentLocation === "grid" && !panelKindIsDockable(terminal.kind ?? "terminal")}
         onSelect={() => handleAction(currentLocation === "grid" ? "move-to-dock" : "move-to-grid")}
       >
         {currentLocation === "grid" ? (

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -174,6 +174,7 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Diagnostics/TelemetryContent.tsx",
     "src/components/Fleet/FleetArmingRibbon.tsx",
     "src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx",
+    "src/components/Layout/DockedFilePanelItem.tsx",
     "src/components/Layout/DockedTabGroup.tsx",
     "src/components/Layout/DockedTerminalItem.tsx",
     "src/components/Layout/Sidebar.tsx",

--- a/src/services/actions/definitions/terminalLayoutActions.ts
+++ b/src/services/actions/definitions/terminalLayoutActions.ts
@@ -5,7 +5,7 @@ import { computeGridColumns } from "@/lib/terminalLayout";
 import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 export function registerTerminalLayoutActions(
   actions: ActionRegistry,
   callbacks: ActionCallbacks
@@ -29,10 +29,10 @@ export function registerTerminalLayoutActions(
         if (!terminal) {
           return;
         }
-        // Dock rendering is PTY-only (see ContentDock + DockPanelOffscreenContainer).
-        // Reject browser / dev-preview / review panels so they don't silently
+        // Dock membership is capability-gated (PTY kinds + dockable non-PTY
+        // kinds like file panels). Reject the rest so they don't silently
         // disappear into a dock slot that won't render them.
-        if (!panelKindHasPty(terminal.kind)) {
+        if (!panelKindIsDockable(terminal.kind ?? "terminal")) {
           return;
         }
 
@@ -266,6 +266,9 @@ export function registerTerminalLayoutActions(
       if (terminal.location === "dock") {
         state.moveTerminalToGrid(focusedId);
       } else {
+        // Same dockability gate as terminal.moveToDock — a non-dockable kind
+        // toggled dockward would strand invisibly.
+        if (!panelKindIsDockable(terminal.kind ?? "terminal")) return;
         state.moveTerminalToDock(focusedId);
         state.openDockTerminal(focusedId);
       }

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -27,7 +27,12 @@ import {
   isAgentReady,
 } from "./slices";
 import type { TerminalRefreshTier, AddPanelFocusPolicy } from "@shared/types";
-import { isGridPanelLocation, isPtyPanel, type PtyPanelData } from "@shared/types/panel";
+import {
+  isGridPanelLocation,
+  isDockPanel,
+  isPtyPanel,
+  type PtyPanelData,
+} from "@shared/types/panel";
 import { TerminalRefreshTier as TerminalRefreshTierEnum } from "@/types";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
@@ -761,7 +766,7 @@ export const usePanelStore = create<PanelGridState>()(
         const restoredPanel = get().panelsById[id];
         if (!restoredPanel) return;
         const previousFocusedId = get().focusedId;
-        const landsInDock = restoredPanel.location === "dock" && isPtyPanel(restoredPanel);
+        const landsInDock = restoredPanel.location === "dock" && isDockPanel(restoredPanel);
         set({
           focusedId: id,
           // Open the dock popover when the panel landed back in the dock so
@@ -809,7 +814,7 @@ export const usePanelStore = create<PanelGridState>()(
         if (!focusId) return;
         const restoredPanel = get().panelsById[focusId]!;
         const previousFocusedId = get().focusedId;
-        const landsInDock = restoredPanel.location === "dock" && isPtyPanel(restoredPanel);
+        const landsInDock = restoredPanel.location === "dock" && isDockPanel(restoredPanel);
         set({
           focusedId: focusId,
           // Match the restored panel's location so a docked group reopens the

--- a/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/dockGridTransitions.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { PtyPanelData, TabGroup } from "@shared/types/panel";
+import type { PanelInstance, PtyPanelData, TabGroup } from "@shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -114,6 +114,34 @@ describe("dock ↔ grid transitions", () => {
       expect(updated!.location).toBe("dock");
       expect(updated!.isVisible).toBe(false);
       expect(updated!.runtimeStatus).toBe("background");
+    });
+
+    it("moves a file panel to the dock and back without PTY-only fields", () => {
+      usePanelStore.setState((state) => ({
+        panelsById: {
+          ...state.panelsById,
+          "file-1": {
+            id: "file-1",
+            kind: "file",
+            title: "spec.md",
+            location: "grid",
+            isVisible: true,
+            filePath: "/repo/spec.md",
+          } as PanelInstance,
+        },
+        panelIds: [...state.panelIds, "file-1"],
+      }));
+
+      usePanelStore.getState().moveTerminalToDock("file-1");
+      let updated = usePanelStore.getState().panelsById["file-1"];
+      expect(updated!.location).toBe("dock");
+      expect(updated!.isVisible).toBe(false);
+
+      const moved = usePanelStore.getState().moveTerminalToGrid("file-1");
+      expect(moved).toBe(true);
+      updated = usePanelStore.getState().panelsById["file-1"];
+      expect(updated!.location).toBe("grid");
+      expect(updated!.isVisible).toBe(true);
     });
   });
 

--- a/src/store/slices/panelRegistry/selectors.ts
+++ b/src/store/slices/panelRegistry/selectors.ts
@@ -4,6 +4,7 @@ import {
   isDevPreviewPanel,
   isPtyPanel,
   isReviewPanel,
+  isFilePanel,
   type PanelInstance,
   type PanelKind,
 } from "@shared/types/panel";
@@ -45,6 +46,7 @@ export function getNarrowPanel(
   if (isBrowserPanel(panel)) return panel;
   if (isDevPreviewPanel(panel)) return panel;
   if (isReviewPanel(panel)) return panel;
+  if (isFilePanel(panel)) return panel;
   if (isPtyPanel(panel)) return panel;
   return undefined;
 }

--- a/src/store/slices/terminalBulkActionsSlice.ts
+++ b/src/store/slices/terminalBulkActionsSlice.ts
@@ -1,4 +1,5 @@
 import PQueue from "p-queue";
+import { panelKindIsDockable } from "@shared/config/panelKindRegistry";
 import type { StateCreator } from "zustand";
 import { isPtyPanel, type PtyPanelData } from "@shared/types/panel";
 import type { AgentState } from "@/types";
@@ -281,7 +282,9 @@ export const createTerminalBulkActionsSlice = (
       const gridTerminals = terminals.filter(
         (t) =>
           (t.location === "grid" || t.location === undefined) &&
-          (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined)
+          (t.worktreeId ?? undefined) === (activeWorktreeId ?? undefined) &&
+          // Never bulk-move a kind the dock can't render.
+          panelKindIsDockable(t.kind ?? "terminal")
       );
       gridTerminals.forEach((t) => moveTerminalToDock(t.id));
     },


### PR DESCRIPTION
This adds dock support for the new file viewer panels. Closes #10985. Until now, the dock only supported terminal panels.

This adds a `dockable` capability flag to the panel kind registry, and widens dock membership with a new `DockPanelData` type. It also adds a new dock chip component for file panels (`DockedFilePanelItem`), which reuses the existing offscreen wrapper relocation so the panel stays mounted as the dock popover is opened and closed: scroll position and view mode survive.

The move to dock button, the keyboard action (`terminal.moveToDock`), the dock toggle action, bulk move, and the context menu item all check the new capability before offering to move a panel.

In the process, review caught two pre-existing bugs that are fixed here:

* `terminal.toggleDock` and `bulkMoveToDock` had no kind gate at all, so they could strand a browser, dev preview, or review panel invisibly in a dock that never renders it. The shared context menu offered the same trap.
* `getNarrowPanel` silently dropped file panels: it enumerates the built-in kinds explicitly and never learned about the `file` kind, so any consumer of the narrowed read path lost them.

Tab groups in the dock stay terminal only. If you move a tab group that contains a file panel, the file panel renders as a standalone chip. Browser, dev preview, and review panels remain non-dockable for now; the same widening would unlock them later.

## Validation

* `npm run check` passes
* ~8,400 unit tests pass, including new coverage for the capability, dock render items, and the dock/grid round trip
* 8 end to end tests pass, including a new test that moves a file panel to the dock, previews it from the chip, and restores it to the grid

Replaces #10986, which GitHub closed when its base branch was deleted after #10982 merged. Rebased onto `develop` at `b63399e20`.