### PR TITLE
fix(panels): show inline "Move to grid" button on docked file panels

### DIFF
--- a/e2e/full/panels/core-file-panel.spec.ts
+++ b/e2e/full/panels/core-file-panel.spec.ts
@@ -215,6 +215,13 @@ test.describe.serial("Core: File viewer panel (dialog + panel)", () => {
       ctx.window.locator('[data-dock-portal-target] [data-testid="file-pane-body"]')
     ).toBeVisible({ timeout: T_LONG });
 
+    // #10991: a single docked file panel exposes the inline "Move to grid"
+    // button in its header (matching docked terminals), not just the overflow
+    // menu.
+    await expect(
+      ctx.window.locator('[data-dock-portal-target] [data-testid="panel-move-to-grid"]')
+    ).toBeVisible({ timeout: T_SHORT });
+
     // Double-click restores the panel to the grid.
     await chip.dblclick();
     await expect(gridFilePanels).toHaveCount(3, { timeout: T_MEDIUM });

--- a/src/panels/file/FilePane.tsx
+++ b/src/panels/file/FilePane.tsx
@@ -227,6 +227,7 @@ export function FilePane({
   onTitleChange,
   onMinimize,
   onRestore,
+  showRestoreControl,
   tabs,
   onTabClick,
   onTabClose,
@@ -468,6 +469,7 @@ export function FilePane({
       onTitleChange={onTitleChange}
       onMinimize={onMinimize}
       onRestore={onRestore}
+      showRestoreControl={showRestoreControl}
       toolbar={toolbar}
       tabs={tabs}
       onTabClick={onTabClick}

--- a/src/panels/file/__tests__/FilePane.test.tsx
+++ b/src/panels/file/__tests__/FilePane.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// FilePane forwards a fixed prop list to ContentPanel; #10991 was a dropped
+// `showRestoreControl`, which hid the inline "Move to grid" button on a docked
+// single file panel. Stub ContentPanel to capture what FilePane forwards, and
+// mock the heavy store/client/viewer surface so we render only FilePane's own
+// wiring — the seam that shipped the bug.
+const contentPanelProps: Array<Record<string, unknown>> = [];
+
+vi.mock("@/components/Panel/ContentPanel", () => ({
+  ContentPanel: (props: Record<string, unknown>) => {
+    contentPanelProps.push(props);
+    return null;
+  },
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: (selector: (state: unknown) => unknown) =>
+    selector({ panelsById: {}, setFileViewMode: vi.fn(), setFilePanelPath: vi.fn() }),
+}));
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (state: unknown) => unknown) => selector({ currentProject: null }),
+}));
+vi.mock("@/store/preferencesStore", () => ({
+  usePreferencesStore: (selector: (state: unknown) => unknown) =>
+    selector({ markdownWrapLines: false, setMarkdownWrapLines: vi.fn() }),
+}));
+vi.mock("@/hooks/useWorktreeStore", () => ({
+  useWorktreeStore: (selector: (state: unknown) => unknown) => selector({ worktrees: new Map() }),
+}));
+vi.mock("@/store/accessibilityAnnouncerStore", () => ({
+  useAnnouncerStore: { getState: () => ({ announce: vi.fn() }) },
+}));
+vi.mock("@/clients/filesClient", () => ({
+  filesClient: {
+    read: vi.fn().mockResolvedValue({ content: "" }),
+    search: vi.fn().mockResolvedValue({ files: [] }),
+  },
+}));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock("@/components/Markdown/MarkdownViewer", () => ({ MarkdownViewer: () => null }));
+vi.mock("@/components/FileViewer/CodeViewer", () => ({ CodeViewer: () => null }));
+
+import { FilePane } from "../FilePane";
+
+function lastContentPanelProps(): Record<string, unknown> {
+  const props = contentPanelProps.at(-1);
+  if (!props) throw new Error("ContentPanel was not rendered");
+  return props;
+}
+
+afterEach(() => {
+  contentPanelProps.length = 0;
+});
+
+describe("FilePane restore-control wiring", () => {
+  it("forwards showRestoreControl so a single docked file panel shows the inline restore button", () => {
+    render(
+      <FilePane
+        id="file-1"
+        title="spec.md"
+        isFocused={false}
+        location="dock"
+        onFocus={() => {}}
+        onClose={() => {}}
+        onRestore={() => {}}
+        showRestoreControl={true}
+      />
+    );
+
+    const props = lastContentPanelProps();
+    expect(props.showRestoreControl).toBe(true);
+    expect(props.onRestore).toBeTypeOf("function");
+  });
+
+  it("forwards showRestoreControl=false so grouped docked panels keep the inline button hidden", () => {
+    render(
+      <FilePane
+        id="file-2"
+        title="spec.md"
+        isFocused={false}
+        location="dock"
+        onFocus={() => {}}
+        onClose={() => {}}
+        onRestore={() => {}}
+        showRestoreControl={false}
+      />
+    );
+
+    expect(lastContentPanelProps().showRestoreControl).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Docked single file panels were missing the inline "Move to grid" button that docked terminal panels show in their header, so restoring one meant digging through the overflow menu.
- Root cause: `FilePane` destructured its props but dropped `showRestoreControl`, so it never reached `ContentPanel` and then `PanelHeader`, whose inline restore button only renders when both `onRestore` and `showRestoreControl` are set.
- `TerminalPane` already forwards `showRestoreControl` correctly; `FilePane` now matches it.

Resolves #10991

## Changes
- `src/panels/file/FilePane.tsx` now forwards `showRestoreControl` to `ContentPanel`.
- Added `src/panels/file/__tests__/FilePane.test.tsx`, asserting the prop is forwarded for both single (`true`) and grouped (`false`) dock states.
- Updated `e2e/full/panels/core-file-panel.spec.ts` to assert the inline move-to-grid button is visible in the docked file-panel header.

## Testing
- `FilePane`, `PanelHeader`, and registry fallback unit tests all pass locally (72 tests).
- Prettier and eslint clean on all three changed files.
- Browser and dev-preview panes share the same non-forwarding pattern, but they're not dockable (only terminal and file kinds are), so that's intentionally out of scope here.