### PR TITLE
feat(assistant): add a Stop control to end the Daintree Assistant terminal

### DIFF
--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -2,6 +2,7 @@ import { CHANNELS } from "../ipc/channels.js";
 import { typedBroadcast } from "../ipc/utils.js";
 import { events } from "./events.js";
 import { projectStore } from "./ProjectStore.js";
+import { getAgentAvailabilityStore } from "./AgentAvailabilityStore.js";
 import type { PtyClient } from "./PtyClient.js";
 import type { ProjectStatusMap } from "../../shared/types/ipc/project.js";
 import { MutableDisposable, toDisposable, type IDisposable } from "../utils/lifecycle.js";
@@ -143,14 +144,36 @@ export class ProjectStatsService {
       if (this.generation !== gen) return;
 
       const agentCounts = new Map<string, { active: number; waiting: number }>();
+      // Per-project count of Daintree Assistant "help" PTYs. The PTY host tallies
+      // them into `terminalCount`, but the assistant is tooling-internal — it must
+      // be netted out of `processCount` and never appear in the agent counts the
+      // switcher shows (#10989).
+      const helpProcessCounts = new Map<string, number>();
       for (const id of projectIds) {
         agentCounts.set(id, { active: 0, waiting: 0 });
+        helpProcessCounts.set(id, 0);
       }
+      const availability = getAgentAvailabilityStore();
       for (const terminal of allTerminals) {
         if (!terminal.projectId) continue;
         const counts = agentCounts.get(terminal.projectId);
         if (!counts) continue;
         if (terminal.isTrashed) continue;
+
+        // The assistant help terminal is a real PTY but tooling-internal: skip it
+        // for the agent counts, and — when it's a live PTY the host actually
+        // counted (mirroring TerminalRegistry.getProjectStats: non-exited,
+        // non-trashed) — record it so `processCount` can subtract it below.
+        if (availability.isHelpTerminal(terminal.id)) {
+          if (terminal.hasPty !== false) {
+            helpProcessCounts.set(
+              terminal.projectId,
+              (helpProcessCounts.get(terminal.projectId) ?? 0) + 1
+            );
+          }
+          continue;
+        }
+
         if (terminal.kind === "dev-preview") continue;
         if (terminal.hasPty === false) continue;
         // Runtime identity wins; launch intent is only a boot-window fallback
@@ -173,8 +196,11 @@ export class ProjectStatsService {
         if (entry.status === "fulfilled") {
           const [id, ptyStats] = entry.value;
           const counts = agentCounts.get(id) ?? { active: 0, waiting: 0 };
+          const helpCount = helpProcessCounts.get(id) ?? 0;
           statusMap[id] = {
-            processCount: ptyStats.terminalCount,
+            // Net out the assistant help PTY the host counted but the switcher
+            // must not show; clamp in case stats momentarily lag (#10989).
+            processCount: Math.max(0, ptyStats.terminalCount - helpCount),
             activeAgentCount: counts.active,
             waitingAgentCount: counts.waiting,
           };

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -162,9 +162,21 @@ describe("ProjectStatsService adversarial", () => {
     availabilityMock.isHelpTerminal.mockImplementation((id: string) => id === "help-1");
     ptyClient.getAllTerminalsAsync.mockResolvedValue([
       // The assistant help terminal — a real agent PTY, but tooling-internal.
-      { id: "help-1", projectId: "p1", kind: "terminal", launchAgentId: "daintree-assistant", agentState: "waiting" },
+      {
+        id: "help-1",
+        projectId: "p1",
+        kind: "terminal",
+        launchAgentId: "daintree-assistant",
+        agentState: "waiting",
+      },
       // A genuine user agent — must still count.
-      { id: "t-2", projectId: "p1", kind: "terminal", launchAgentId: "claude", agentState: "working" },
+      {
+        id: "t-2",
+        projectId: "p1",
+        kind: "terminal",
+        launchAgentId: "claude",
+        agentState: "working",
+      },
     ]);
     // PTY host counts both PTYs (it has no help awareness).
     ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 2 });
@@ -190,8 +202,20 @@ describe("ProjectStatsService adversarial", () => {
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }, { id: "p2" }]);
     availabilityMock.isHelpTerminal.mockImplementation((id: string) => id === "help-p1");
     ptyClient.getAllTerminalsAsync.mockResolvedValue([
-      { id: "help-p1", projectId: "p1", kind: "terminal", launchAgentId: "daintree-assistant", agentState: "idle" },
-      { id: "t-p2", projectId: "p2", kind: "terminal", launchAgentId: "claude", agentState: "working" },
+      {
+        id: "help-p1",
+        projectId: "p1",
+        kind: "terminal",
+        launchAgentId: "daintree-assistant",
+        agentState: "idle",
+      },
+      {
+        id: "t-p2",
+        projectId: "p2",
+        kind: "terminal",
+        launchAgentId: "claude",
+        agentState: "working",
+      },
     ]);
     ptyClient.getProjectStats.mockImplementation(async (id: string) => ({
       projectId: id,
@@ -225,7 +249,13 @@ describe("ProjectStatsService adversarial", () => {
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
     availabilityMock.isHelpTerminal.mockImplementation((id: string) => id === "help-1");
     ptyClient.getAllTerminalsAsync.mockResolvedValue([
-      { id: "help-1", projectId: "p1", kind: "terminal", launchAgentId: "daintree-assistant", agentState: "idle" },
+      {
+        id: "help-1",
+        projectId: "p1",
+        kind: "terminal",
+        launchAgentId: "daintree-assistant",
+        agentState: "idle",
+      },
     ]);
     // Stats lag: main process sees the help PTY but the host reports 0.
     ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 0 });
@@ -249,7 +279,13 @@ describe("ProjectStatsService adversarial", () => {
     ptyClient.getAllTerminalsAsync.mockResolvedValue([
       // Trashed → the PTY host already excludes it from terminalCount, so it
       // must not be subtracted (double-counting would drive processCount negative).
-      { id: "help-trashed", projectId: "p1", isTrashed: true, kind: "terminal", agentState: "idle" },
+      {
+        id: "help-trashed",
+        projectId: "p1",
+        isTrashed: true,
+        kind: "terminal",
+        agentState: "idle",
+      },
       // No live PTY → likewise not part of terminalCount.
       { id: "help-nopty", projectId: "p1", hasPty: false, kind: "terminal", agentState: "idle" },
     ]);

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -204,10 +204,16 @@ describe("ProjectStatsService adversarial", () => {
 
     const [, payload] = broadcastMock.mock.calls.at(-1) as [
       string,
-      { p1: { processCount: number }; p2: { processCount: number; activeAgentCount: number } },
+      {
+        p1: { processCount: number; activeAgentCount: number; waitingAgentCount: number };
+        p2: { processCount: number; activeAgentCount: number };
+      },
     ];
-    // p1's only PTY is the help terminal → 1 − 1 = 0.
+    // p1's only PTY is the help terminal → 1 − 1 = 0, and it never surfaces in
+    // the agent counts.
     expect(payload.p1.processCount).toBe(0);
+    expect(payload.p1.activeAgentCount).toBe(0);
+    expect(payload.p1.waitingAgentCount).toBe(0);
     // p2 is untouched — its help count is 0.
     expect(payload.p2.processCount).toBe(1);
     expect(payload.p2.activeAgentCount).toBe(1);

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -20,12 +20,19 @@ const eventEmitter = vi.hoisted(() => {
   };
 });
 
+const availabilityMock = vi.hoisted(() => ({
+  isHelpTerminal: vi.fn<(id: string) => boolean>(() => false),
+}));
+
 vi.mock("../../ipc/utils.js", () => ({
   typedBroadcast: broadcastMock,
 }));
 
 vi.mock("../events.js", () => ({ events: eventEmitter }));
 vi.mock("../ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+vi.mock("../AgentAvailabilityStore.js", () => ({
+  getAgentAvailabilityStore: () => availabilityMock,
+}));
 
 import { ProjectStatsService } from "../ProjectStatsService.js";
 
@@ -50,6 +57,8 @@ beforeEach(() => {
   vi.setSystemTime(1_830_001);
   eventEmitter._reset();
   projectStoreMock.getAllProjects.mockReturnValue([]);
+  availabilityMock.isHelpTerminal.mockReset();
+  availabilityMock.isHelpTerminal.mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -144,6 +153,112 @@ describe("ProjectStatsService adversarial", () => {
     ];
     expect(payload.p1.activeAgentCount).toBe(2);
     expect(payload.p1.waitingAgentCount).toBe(1);
+    svc.stop();
+  });
+
+  it("excludes the Daintree Assistant help terminal from agent counts and subtracts it from processCount (#10989)", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    availabilityMock.isHelpTerminal.mockImplementation((id: string) => id === "help-1");
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      // The assistant help terminal — a real agent PTY, but tooling-internal.
+      { id: "help-1", projectId: "p1", kind: "terminal", launchAgentId: "daintree-assistant", agentState: "waiting" },
+      // A genuine user agent — must still count.
+      { id: "t-2", projectId: "p1", kind: "terminal", launchAgentId: "claude", agentState: "working" },
+    ]);
+    // PTY host counts both PTYs (it has no help awareness).
+    ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 2 });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const [, payload] = broadcastMock.mock.calls.at(-1) as [
+      string,
+      { p1: { activeAgentCount: number; waitingAgentCount: number; processCount: number } },
+    ];
+    // The waiting help terminal is not surfaced; only the real working agent.
+    expect(payload.p1.activeAgentCount).toBe(1);
+    expect(payload.p1.waitingAgentCount).toBe(0);
+    // processCount nets out the help PTY: 2 counted − 1 help = 1.
+    expect(payload.p1.processCount).toBe(1);
+    svc.stop();
+  });
+
+  it("only subtracts help terminals from their own project's processCount (#10989)", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }, { id: "p2" }]);
+    availabilityMock.isHelpTerminal.mockImplementation((id: string) => id === "help-p1");
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      { id: "help-p1", projectId: "p1", kind: "terminal", launchAgentId: "daintree-assistant", agentState: "idle" },
+      { id: "t-p2", projectId: "p2", kind: "terminal", launchAgentId: "claude", agentState: "working" },
+    ]);
+    ptyClient.getProjectStats.mockImplementation(async (id: string) => ({
+      projectId: id,
+      terminalCount: id === "p1" ? 1 : 1,
+    }));
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const [, payload] = broadcastMock.mock.calls.at(-1) as [
+      string,
+      { p1: { processCount: number }; p2: { processCount: number; activeAgentCount: number } },
+    ];
+    // p1's only PTY is the help terminal → 1 − 1 = 0.
+    expect(payload.p1.processCount).toBe(0);
+    // p2 is untouched — its help count is 0.
+    expect(payload.p2.processCount).toBe(1);
+    expect(payload.p2.activeAgentCount).toBe(1);
+    svc.stop();
+  });
+
+  it("clamps processCount to zero if the PTY-host count momentarily lags the help count (#10989)", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    availabilityMock.isHelpTerminal.mockImplementation((id: string) => id === "help-1");
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      { id: "help-1", projectId: "p1", kind: "terminal", launchAgentId: "daintree-assistant", agentState: "idle" },
+    ]);
+    // Stats lag: main process sees the help PTY but the host reports 0.
+    ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 0 });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const [, payload] = broadcastMock.mock.calls.at(-1) as [
+      string,
+      { p1: { processCount: number } },
+    ];
+    expect(payload.p1.processCount).toBe(0);
+    svc.stop();
+  });
+
+  it("does not subtract a trashed or hasPty:false help terminal from processCount (#10989)", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    availabilityMock.isHelpTerminal.mockReturnValue(true);
+    ptyClient.getAllTerminalsAsync.mockResolvedValue([
+      // Trashed → the PTY host already excludes it from terminalCount, so it
+      // must not be subtracted (double-counting would drive processCount negative).
+      { id: "help-trashed", projectId: "p1", isTrashed: true, kind: "terminal", agentState: "idle" },
+      // No live PTY → likewise not part of terminalCount.
+      { id: "help-nopty", projectId: "p1", hasPty: false, kind: "terminal", agentState: "idle" },
+    ]);
+    ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 3 });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const [, payload] = broadcastMock.mock.calls.at(-1) as [
+      string,
+      { p1: { processCount: number } },
+    ];
+    // Neither help terminal was live-counted, so nothing is subtracted.
+    expect(payload.p1.processCount).toBe(3);
     svc.stop();
   });
 

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -143,6 +143,7 @@ export function HelpPanel({
     if (!isVisible) setHasDomFocus(false);
   }, [isVisible]);
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
+  const [showEndSessionConfirm, setShowEndSessionConfirm] = useState(false);
   const [showAgentSwitchConfirm, setShowAgentSwitchConfirm] = useState(false);
   // Tracks the last preferredAgentId the switch effect acted on so a single
   // preference change drives at most one switch attempt (the effect re-runs
@@ -837,6 +838,26 @@ export function HelpPanel({
     setShowNewSessionConfirm(false);
   }, []);
 
+  // Stop reuses the same "something to lose" gate as +New session — confirm
+  // only when a working agent or an engaged conversation would be discarded.
+  const handleEndSession = useCallback(() => {
+    if (!terminalId || !agentId) return;
+    if (shouldConfirmNewSession) {
+      setShowEndSessionConfirm(true);
+      return;
+    }
+    controller.endSession();
+  }, [controller, terminalId, agentId, shouldConfirmNewSession]);
+
+  const handleConfirmEndSession = useCallback(() => {
+    setShowEndSessionConfirm(false);
+    controller.endSession();
+  }, [controller]);
+
+  const handleCancelEndSession = useCallback(() => {
+    setShowEndSessionConfirm(false);
+  }, []);
+
   const handleConfirmAgentSwitch = useCallback(() => {
     setShowAgentSwitchConfirm(false);
     // Guard against the preference having moved back to the running agent (or
@@ -1032,7 +1053,9 @@ export function HelpPanel({
       <HelpPanelHeader
         agentState={terminalPty?.agentState}
         canStartNewSession={Boolean(terminalId && agentId)}
+        canEndSession={Boolean(terminalId && agentId)}
         onNewSession={handleNewSession}
+        onEndSession={handleEndSession}
         onOpenDocs={handleOpenAssistantDocs}
         onClose={handleClose}
         isFocused={isHighlighted}
@@ -1362,6 +1385,15 @@ export function HelpPanel({
         confirmLabel="Start new session"
         onConfirm={handleConfirmNewSession}
         onClose={handleCancelNewSession}
+        variant="destructive"
+      />
+      <ConfirmDialog
+        isOpen={showEndSessionConfirm}
+        title="Stop assistant?"
+        description="The assistant will stop and the conversation will be discarded"
+        confirmLabel="Stop assistant"
+        onConfirm={handleConfirmEndSession}
+        onClose={handleCancelEndSession}
         variant="destructive"
       />
       <ConfirmDialog

--- a/src/components/HelpPanel/HelpPanelHeader.tsx
+++ b/src/components/HelpPanel/HelpPanelHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, CircleHelp, Plus } from "lucide-react";
+import { ChevronRight, CircleHelp, CircleStop, Plus } from "lucide-react";
 import { SpinnerCircle, HollowCircle, InteractingCircle } from "@/components/icons";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { cn } from "@/lib/utils";
@@ -58,7 +58,9 @@ function AssistantHeaderStateIndicator({
 interface HelpPanelHeaderProps {
   agentState: AgentState | null | undefined;
   canStartNewSession: boolean;
+  canEndSession: boolean;
   onNewSession: () => void;
+  onEndSession: () => void;
   onOpenDocs: () => void;
   onClose: () => void;
   isFocused?: boolean;
@@ -67,7 +69,9 @@ interface HelpPanelHeaderProps {
 export function HelpPanelHeader({
   agentState,
   canStartNewSession,
+  canEndSession,
   onNewSession,
+  onEndSession,
   onOpenDocs,
   onClose,
   isFocused = false,
@@ -111,6 +115,16 @@ export function HelpPanelHeader({
           aria-label="Start new session"
         >
           <Plus className="w-3.5 h-3.5" />
+        </button>
+      )}
+      {canEndSession && (
+        <button
+          type="button"
+          onClick={onEndSession}
+          className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          aria-label="Stop Daintree Assistant"
+        >
+          <CircleStop className="w-3.5 h-3.5" />
         </button>
       )}
       <button

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2298,7 +2298,11 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
     // …the persisted hibernate entry is dropped so a stop can't be resumed…
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
     // …and, unlike + New session, no fresh agent is launched.
-    expect(mockDispatch).not.toHaveBeenCalledWith("agent.launch", expect.anything(), expect.anything());
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.anything(),
+      expect.anything()
+    );
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
     // Stop ends the session but keeps the panel open (it is not "hide").
     expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
@@ -2353,7 +2357,11 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
-    expect(mockDispatch).not.toHaveBeenCalledWith("agent.launch", expect.anything(), expect.anything());
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.anything(),
+      expect.anything()
+    );
     // Confirmed stop keeps the panel open — restart is one click away.
     expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
   });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2244,6 +2244,117 @@ describe("HelpPanel — + New session destructive reset", () => {
   });
 });
 
+describe("HelpPanel — Stop assistant (end session, #10989)", () => {
+  function setupBoundTerminal(opts: {
+    agentState?: string;
+    conversationTouched?: boolean;
+    sessionId?: string | null;
+  }) {
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.sessionId = opts.sessionId ?? "sess-bound";
+    helpPanelState.conversationTouched = opts.conversationTouched ?? false;
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+        agentState: opts.agentState ?? "idle",
+      },
+    };
+  }
+
+  it("hides the stop button when there is no live terminal", () => {
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    const { container } = render(<HelpPanel width={380} />);
+    expect(container.querySelector('button[aria-label="Stop Daintree Assistant"]')).toBeNull();
+  });
+
+  it("keeps the stop button distinct from the hide button", () => {
+    setupBoundTerminal({ agentState: "idle" });
+    const { container } = render(<HelpPanel width={380} />);
+    expect(container.querySelector('button[aria-label="Stop Daintree Assistant"]')).toBeTruthy();
+    expect(container.querySelector('button[aria-label="Hide Daintree Assistant"]')).toBeTruthy();
+  });
+
+  it("ends immediately without a confirm and does NOT relaunch when idle and untouched", () => {
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+
+    const { container, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Stop Daintree Assistant"]')!);
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    // Teardown ran…
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    expect(helpPanelState.clearFigures).toHaveBeenCalled();
+    // …the persisted hibernate entry is dropped so a stop can't be resumed…
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    // …and, unlike + New session, no fresh agent is launched.
+    expect(mockDispatch).not.toHaveBeenCalledWith("agent.launch", expect.anything(), expect.anything());
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+  });
+
+  it("shows the Stop assistant confirm when the agent is working (no teardown yet)", () => {
+    setupBoundTerminal({ agentState: "working", conversationTouched: false });
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Stop Daintree Assistant"]')!);
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.clearTerminal).not.toHaveBeenCalled();
+    expect(getByTestId("dialog-title").textContent).toBe("Stop assistant?");
+    expect(getByTestId("dialog-confirm").textContent).toBe("Stop assistant");
+    expect(getByTestId("dialog-description").textContent).toContain(
+      "the conversation will be discarded"
+    );
+  });
+
+  it("shows the confirm when the conversation has been touched even while idle", () => {
+    setupBoundTerminal({ agentState: "idle", conversationTouched: true });
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Stop Daintree Assistant"]')!);
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(getByTestId("dialog-title").textContent).toBe("Stop assistant?");
+  });
+
+  it("keeps the session intact when the user cancels the confirm", () => {
+    setupBoundTerminal({ agentState: "working" });
+
+    const { container, getByTestId, queryByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Stop Daintree Assistant"]')!);
+    fireEvent.click(getByTestId("dialog-cancel"));
+
+    expect(queryByTestId("confirm-dialog")).toBeNull();
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(mockRevokeSession).not.toHaveBeenCalled();
+    expect(helpPanelState.clearTerminal).not.toHaveBeenCalled();
+  });
+
+  it("tears down and does not relaunch when the user confirms the stop", () => {
+    setupBoundTerminal({ agentState: "working", conversationTouched: true });
+
+    const { container, getByTestId } = render(<HelpPanel width={380} />);
+    fireEvent.click(container.querySelector('button[aria-label="Stop Daintree Assistant"]')!);
+    fireEvent.click(getByTestId("dialog-confirm"));
+
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(mockDispatch).not.toHaveBeenCalledWith("agent.launch", expect.anything(), expect.anything());
+  });
+});
+
 // The footer pinned-context indicator is a quiet, neutral ambient signal — it
 // never paints the row red or parks a destructive "Start new session" button
 // just because no live grid terminal remains (#10792). Closing every grid

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2300,6 +2300,8 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
     // …and, unlike + New session, no fresh agent is launched.
     expect(mockDispatch).not.toHaveBeenCalledWith("agent.launch", expect.anything(), expect.anything());
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    // Stop ends the session but keeps the panel open (it is not "hide").
+    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
   });
 
   it("shows the Stop assistant confirm when the agent is working (no teardown yet)", () => {
@@ -2352,6 +2354,55 @@ describe("HelpPanel — Stop assistant (end session, #10989)", () => {
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
     expect(mockDispatch).not.toHaveBeenCalledWith("agent.launch", expect.anything(), expect.anything());
+    // Confirmed stop keeps the panel open — restart is one click away.
+    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
+  });
+
+  it("aborts a relaunch in flight so a late-settling dispatch never binds a fresh session", async () => {
+    // Regression: user hits Stop while a + New session relaunch is mid-flight.
+    // endSession() bumps the launch generation so the superseded _executeLaunch
+    // bails at its post-dispatch gen-check instead of binding the fresh session.
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "sess-fresh",
+      sessionPath: "/sessions/fresh",
+      token: "tok-fresh",
+      tier: "action",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    let resolveDispatch: (value: unknown) => void = () => {};
+    mockDispatch.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveDispatch = r;
+        })
+    );
+
+    const { container } = render(<HelpPanel width={380} />);
+    // Start the relaunch (idle + untouched → immediate, no confirm); dispatch hangs.
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
+    });
+    const reservedId = (mockDispatch.mock.calls[0]?.[1] as { requestedId?: string } | undefined)
+      ?.requestedId;
+    expect(reservedId).toMatch(/^terminal-/);
+    (helpPanelState.setTerminal as ReturnType<typeof vi.fn>).mockClear();
+
+    // Stop the assistant while the relaunch is still provisioning.
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Stop Daintree Assistant"]')!);
+    });
+
+    // The hung dispatch finally resolves with the reserved terminal.
+    await act(async () => {
+      resolveDispatch({ ok: true, result: { terminalId: reservedId } });
+    });
+
+    // The superseded launch bailed: it never bound the fresh session and cleaned
+    // up the orphaned terminal instead.
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalledWith(reservedId, "claude", "sess-fresh");
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith(reservedId);
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanelHeader.test.tsx
@@ -1,35 +1,38 @@
 // @vitest-environment jsdom
-import { render } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { render, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
 
 import { HelpPanelHeader } from "../HelpPanelHeader";
 
-function renderHeader(isFocused?: boolean) {
+function renderHeader(overrides: Partial<ComponentProps<typeof HelpPanelHeader>> = {}) {
   return render(
     <HelpPanelHeader
       agentState={null}
       canStartNewSession={false}
+      canEndSession={false}
       onNewSession={vi.fn()}
+      onEndSession={vi.fn()}
       onOpenDocs={vi.fn()}
       onClose={vi.fn()}
-      isFocused={isFocused}
+      {...overrides}
     />
   );
 }
 
 describe("HelpPanelHeader", () => {
   it("renders identically when unfocused and when isFocused is omitted", () => {
-    const { container: a } = renderHeader(false);
-    const { container: b } = renderHeader(undefined);
+    const { container: a } = renderHeader({ isFocused: false });
+    const { container: b } = renderHeader({ isFocused: undefined });
 
     expect(a.firstElementChild!.className).toBe(b.firstElementChild!.className);
   });
 
   it("applies focused-state styling distinct from unfocused", () => {
-    const { container: unfocused } = renderHeader(false);
-    const { container: focused } = renderHeader(true);
+    const { container: unfocused } = renderHeader({ isFocused: false });
+    const { container: focused } = renderHeader({ isFocused: true });
 
     // The exact tokens are a design decision and may shift; we only verify
     // that focused vs unfocused render differently and that the focused
@@ -37,5 +40,31 @@ describe("HelpPanelHeader", () => {
     // focus anchor per CLAUDE.md accent-restraint rules).
     expect(focused.firstElementChild!.className).not.toBe(unfocused.firstElementChild!.className);
     expect([...focused.firstElementChild!.classList].some((c) => c.includes("accent"))).toBe(false);
+  });
+
+  it("shows the stop button only when canEndSession is true", () => {
+    const { queryByLabelText: withoutStop } = renderHeader({ canEndSession: false });
+    expect(withoutStop("Stop Daintree Assistant")).toBeNull();
+
+    const { queryByLabelText: withStop } = renderHeader({ canEndSession: true });
+    expect(withStop("Stop Daintree Assistant")).not.toBeNull();
+  });
+
+  it("uses a stop label distinct from the hide (close) affordance", () => {
+    const { getByLabelText } = renderHeader({ canEndSession: true });
+    // Distinct aria-labels keep the stop and hide buttons independently
+    // targetable — the hide button is "Hide Daintree Assistant".
+    expect(getByLabelText("Stop Daintree Assistant")).not.toBe(
+      getByLabelText("Hide Daintree Assistant")
+    );
+  });
+
+  it("invokes onEndSession when the stop button is clicked", () => {
+    const onEndSession = vi.fn();
+    const { getByLabelText } = renderHeader({ canEndSession: true, onEndSession });
+
+    fireEvent.click(getByLabelText("Stop Daintree Assistant"));
+
+    expect(onEndSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1382,9 +1382,12 @@ export class HelpSessionController {
     previousSessionId: string | null,
     options: { revokePending: boolean }
   ): void {
-    usePanelStore.getState().removePanel(existingTerminalId);
+    // Revoke the bearer(s) BEFORE removing the panel: removePanel fires the PTY
+    // kill IPC, so revoking first ensures any in-flight MCP call 401s before the
+    // teardown reaches the host (#7522), rather than racing the kill.
     revokeHelpSession(previousSessionId);
     if (options.revokePending) this._revokePendingSession();
+    usePanelStore.getState().removePanel(existingTerminalId);
     useHelpPanelStore.getState().clearTerminal();
     useHelpPanelStore.getState().clearFigures();
     this.clearMcpActivity();

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -962,6 +962,62 @@ export class HelpSessionController {
   }
 
   /**
+   * User-facing "Stop assistant" — actually end the running assistant terminal
+   * rather than merely hiding the panel (`handleClose` only flips `isOpen`,
+   * leaving the agent running). Unlike `newSession()` this does NOT relaunch:
+   * it tears the bound session down and leaves the panel open on its empty /
+   * start state so restarting is one click away (D0 inverse). Idempotent — a
+   * no-op when nothing is running and no launch is in flight.
+   */
+  endSession(): void {
+    // Abort any in-flight launch first (mirrors `cancelLaunch`) so a
+    // late-settling provision can't bind a fresh terminal after the user asked
+    // to stop.
+    this._launchGen++;
+    this._isLaunching = false;
+    this._clearLaunchWatchdog();
+
+    const help = useHelpPanelStore.getState();
+    const existingTerminalId = help.terminalId;
+    const previousSessionId = help.sessionId;
+    if (existingTerminalId) {
+      this._teardownBoundSession(existingTerminalId, previousSessionId, {
+        revokePending: true,
+      });
+    } else {
+      // No committed terminal, but a reserved-but-uncommitted session may still
+      // hold a live bearer — drop it so it can't outlive the stop.
+      this._revokePendingSession();
+    }
+
+    // Stop is destructive (not pause): drop the persisted hibernate entry for
+    // this project so the just-ended conversation can't resume on next open,
+    // and disarm any pending hibernate timer.
+    this._clearHibernateTimer();
+    this._hibernateArmedFor = null;
+    const projectId = useProjectStore.getState().currentProject?.id ?? null;
+    if (projectId) {
+      useHelpPanelStore.getState().clearHibernateSession(projectId);
+    }
+
+    // Consume this open cycle's auto-launch budget so a consented auto-launch
+    // (`_maybeAutoLaunch`) doesn't immediately respawn the assistant we just
+    // stopped. Reopening the panel resets this in `_syncInputs`, so the next
+    // open still auto-launches as before.
+    this._hasAutoLaunched = true;
+
+    // Clear session-scoped banners and drop the phase to idle so the panel
+    // lands on a clean empty / start state.
+    this._patch({
+      phase: "idle",
+      showResumeBanner: false,
+      preflightSnapshot: null,
+      tierMismatch: null,
+      sessionRevoked: null,
+    });
+  }
+
+  /**
    * "Run anyway" from the missing-CLI gate — same as `newSession` plus
    * `force: true` so the dispatcher bypasses the missing-CLI guard.
    */
@@ -1040,17 +1096,9 @@ export class HelpSessionController {
       if (existingTerminalId) {
         const panel = usePanelStore.getState().panelsById[existingTerminalId];
         presetEnv = asStringRecord(panel?.extensionState?.presetEnv);
-        usePanelStore.getState().removePanel(existingTerminalId);
-        revokeHelpSession(previousSessionId);
-        if (reservedId) this._revokePendingSession();
-        useHelpPanelStore.getState().clearTerminal();
-        // Replacing the session — clear the prior session's activity row (#9759)
-        // and its figures, since the new help session restarts the figure
-        // counter at 1 in the main process (#9828).
-        useHelpPanelStore.getState().clearFigures();
-        this.clearMcpActivity();
-        this._clearGrantState();
-        this._clearOutcomeAlert();
+        this._teardownBoundSession(existingTerminalId, previousSessionId, {
+          revokePending: reservedId != null,
+        });
       }
       // Discarding the current conversation invalidates any persisted
       // hibernate entry for this project — leaving it would resume the
@@ -1317,6 +1365,31 @@ export class HelpSessionController {
 
   private _resetPhase(): void {
     this._patch({ phase: "idle" });
+  }
+
+  /**
+   * Tear down the currently-bound help session's renderer state in the order
+   * the auth race requires: revoke the session bearer BEFORE removing the PTY
+   * so any in-flight MCP call 401s before teardown reaches the host (#7522);
+   * drop the reserved-but-uncommitted bearer when asked; then clear the
+   * store-side session UI (terminal slot, figures #9828, MCP activity #9759,
+   * grant state #10042, outcome pip #10018). Shared by `launch({
+   * replaceExisting })` and the user-facing `endSession()`. Callers own
+   * presetEnv capture and hibernate cleanup.
+   */
+  private _teardownBoundSession(
+    existingTerminalId: string,
+    previousSessionId: string | null,
+    options: { revokePending: boolean }
+  ): void {
+    usePanelStore.getState().removePanel(existingTerminalId);
+    revokeHelpSession(previousSessionId);
+    if (options.revokePending) this._revokePendingSession();
+    useHelpPanelStore.getState().clearTerminal();
+    useHelpPanelStore.getState().clearFigures();
+    this.clearMcpActivity();
+    this._clearGrantState();
+    this._clearOutcomeAlert();
   }
 
   /**

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1042,7 +1042,7 @@ export class HelpSessionController {
    *
    * Synchronous write order before the first `await` (preserving #6951):
    *   1. Capture live state + bump _launchGen.
-   *   2. If `replaceExisting`, remove existing panel and revoke prior sessions.
+   *   2. If `replaceExisting`, revoke prior sessions then remove the panel.
    *   3. If `requestedId`, set `_pendingNewTerminalId` synchronously, then
    *      write the reservation via `setTerminal(reservedId, agentId, null)`.
    *   4. Only then enter the async provision/dispatch sequence.

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -564,8 +564,8 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
     // an in-flight MCP call 401s before teardown reaches the host. `?? -1` keeps
     // both operands `number`: a missing (never-called) order fails the guards below.
     const revokeOrder =
-      (window.electron.help.revokeSession as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0] ??
-      -1;
+      (window.electron.help.revokeSession as ReturnType<typeof vi.fn>).mock
+        .invocationCallOrder[0] ?? -1;
     const removeOrder =
       (panelStoreState.removePanel as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0] ?? -1;
     expect(revokeOrder).toBeGreaterThanOrEqual(0);

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -554,6 +554,32 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
     expect(ctrl.getSnapshot().phase).toBe("idle");
   });
 
+  it("revokes the bearer before killing the PTY (revoke-before-kill, #7522)", () => {
+    const ctrl = new HelpSessionController();
+    bindLiveSession();
+
+    ctrl.endSession();
+
+    // removePanel fires the PTY kill IPC; the revoke must be dispatched first so
+    // an in-flight MCP call 401s before teardown reaches the host.
+    const revokeOrder = (window.electron.help.revokeSession as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    const removeOrder = (panelStoreState.removePanel as ReturnType<typeof vi.fn>).mock
+      .invocationCallOrder[0];
+    expect(revokeOrder).toBeLessThan(removeOrder);
+  });
+
+  it("revokes a reserved-but-uncommitted bearer even when no terminal is bound", () => {
+    const ctrl = new HelpSessionController();
+    ctrl["_pendingSessionId"] = "sess-pending";
+
+    ctrl.endSession();
+
+    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-pending");
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(ctrl["_pendingSessionId"]).toBeNull();
+  });
+
   it("aborts an in-flight launch by bumping the gen and clearing the guard", () => {
     const ctrl = new HelpSessionController();
     ctrl["_patch"]({ phase: "provisioning" });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -65,6 +65,7 @@ const {
     hibernateSessions: {} as Record<string, unknown>,
     setTerminal: vi.fn(),
     clearTerminal: vi.fn(),
+    clearFigures: vi.fn(),
     setHibernateSession: vi.fn(),
     clearHibernateSession: vi.fn(),
   },
@@ -136,6 +137,7 @@ function resetState() {
   helpPanelState.hibernateSessions = {};
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.clearTerminal = vi.fn();
+  helpPanelState.clearFigures = vi.fn();
   helpPanelState.setHibernateSession = vi.fn();
   helpPanelState.clearHibernateSession = vi.fn();
   panelStoreState.panelIds = [];
@@ -518,6 +520,111 @@ describe("HelpSessionController — syncInputs", () => {
       visibilityEpoch: 0,
     });
     expect(ctrl.getSnapshot().assistantVersionTooOld).toBeNull();
+    ctrl.stop();
+  });
+});
+
+describe("HelpSessionController — endSession (Stop assistant, #10989)", () => {
+  function bindLiveSession() {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    helpPanelState.sessionId = "sess-bound";
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", cwd: "/help" },
+    };
+  }
+
+  it("tears the bound session down without relaunching", () => {
+    const ctrl = new HelpSessionController();
+    ctrl["_patch"]({ phase: "live" });
+    bindLiveSession();
+
+    ctrl.endSession();
+
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
+    expect(window.electron.help.revokeSession).toHaveBeenCalledWith("sess-bound");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    expect(helpPanelState.clearFigures).toHaveBeenCalled();
+    // Stop is destructive, not pause: the persisted hibernate slot is dropped so
+    // the discarded conversation can't resume on next open.
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    // No fresh terminal is reserved — unlike newSession(), stop does not relaunch.
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+  });
+
+  it("aborts an in-flight launch by bumping the gen and clearing the guard", () => {
+    const ctrl = new HelpSessionController();
+    ctrl["_patch"]({ phase: "provisioning" });
+    ctrl["_isLaunching"] = true;
+    const genBefore = ctrl["_launchGen"] as number;
+
+    ctrl.endSession();
+
+    expect(ctrl["_launchGen"]).toBe(genBefore + 1);
+    expect(ctrl["_isLaunching"]).toBe(false);
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+  });
+
+  it("is a no-op teardown when no terminal is bound", () => {
+    const ctrl = new HelpSessionController();
+
+    ctrl.endSession();
+
+    expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+    expect(helpPanelState.clearTerminal).not.toHaveBeenCalled();
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+  });
+
+  it("suppresses an immediate consented auto-relaunch in the same open cycle", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    bindLiveSession();
+
+    ctrl.endSession();
+    expect(ctrl["_hasAutoLaunched"]).toBe(true);
+
+    // clearTerminal ran — the store now reports no bound terminal.
+    helpPanelState.terminalId = null;
+    // The panel is still open with auto-launch consented; without the guard this
+    // would immediately respawn the assistant the user just stopped.
+    ctrl.syncInputs({
+      isOpen: true,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj-1", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: null,
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    });
+
+    expect(ctrl.getSnapshot().phase).toBe("idle");
+    ctrl.stop();
+  });
+
+  it("re-arms auto-launch after the panel closes and reopens", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    bindLiveSession();
+    ctrl.endSession();
+    expect(ctrl["_hasAutoLaunched"]).toBe(true);
+    helpPanelState.terminalId = null;
+
+    // Closing the panel resets the per-open-cycle auto-launch budget.
+    ctrl.syncInputs({
+      isOpen: false,
+      isReadyToLaunch: true,
+      currentProject: { id: "proj-1", path: "/repo" },
+      terminalId: null,
+      preferredAgentId: null,
+      supportedInstalledAgentIds: ["claude"],
+      autoLaunchEnabled: true,
+      visibilityEpoch: 0,
+    });
+
+    expect(ctrl["_hasAutoLaunched"]).toBe(false);
     ctrl.stop();
   });
 });

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -561,12 +561,15 @@ describe("HelpSessionController — endSession (Stop assistant, #10989)", () => 
     ctrl.endSession();
 
     // removePanel fires the PTY kill IPC; the revoke must be dispatched first so
-    // an in-flight MCP call 401s before teardown reaches the host.
-    const revokeOrder = (window.electron.help.revokeSession as ReturnType<typeof vi.fn>).mock
-      .invocationCallOrder[0];
-    const removeOrder = (panelStoreState.removePanel as ReturnType<typeof vi.fn>).mock
-      .invocationCallOrder[0];
-    expect(revokeOrder).toBeLessThan(removeOrder);
+    // an in-flight MCP call 401s before teardown reaches the host. `?? -1` keeps
+    // both operands `number`: a missing (never-called) order fails the guards below.
+    const revokeOrder =
+      (window.electron.help.revokeSession as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0] ??
+      -1;
+    const removeOrder =
+      (panelStoreState.removePanel as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0] ?? -1;
+    expect(revokeOrder).toBeGreaterThanOrEqual(0);
+    expect(removeOrder).toBeGreaterThan(revokeOrder);
   });
 
   it("revokes a reserved-but-uncommitted bearer even when no terminal is bound", () => {


### PR DESCRIPTION
## Summary

The Daintree Assistant runs as a real agent terminal, but there was no way to actually stop it. Closing the panel only hid it (`handleClose` just calls `setOpen(false)`), so the underlying agent kept running and kept showing up in the project switcher as an active or waiting agent. Even `terminal.killAll` deliberately skips it. This adds a real stop.

Resolves #10989

## Changes

- New `HelpSessionController.endSession()` tears down the bound help session: revokes the bearer token before killing the PTY (per #7522), via a newly extracted `_teardownBoundSession` helper shared with `launch({replaceExisting})`. It also clears the persisted hibernate slot, aborts any in-flight launch by bumping the launch generation counter, and suppresses auto-relaunch for the rest of the current open cycle, so a stop actually sticks instead of the assistant relaunching itself. The panel stays open on its empty/start state afterward, so restarting is one click away.
- New `CircleStop` header button in `HelpPanelHeader` (`aria-label="Stop Daintree Assistant"`), shown only when a session is live. It opens a destructive "Stop assistant?" confirm dialog, reusing the existing new-session confirm gate (working agent or touched conversation).
- `ProjectStatsService` now excludes the assistant's help terminal from active/waiting agent counts and nets it out of `processCount` (clamped to not go below zero), scoped per project, so the assistant stops double-counting in the switcher.

## Testing

- `HelpSessionController`: teardown, abort, and auto-relaunch-suppression behavior; revoke-before-kill call ordering; pending-bearer handling; in-flight-relaunch abort.
- `HelpPanelHeader`: button rendering and click handling.
- `HelpPanel`: confirm flow, including that stopping keeps the panel open.
- `ProjectStatsService`: exclusion logic, including per-project isolation and the `processCount` clamp.

One known non-goal for reviewers: there's a brief transient window where a just-spawned assistant PTY can still be counted for one poll cycle before the async help-terminal mark lands. That's pre-existing behavior, self-corrects on the next recompute, and is out of scope here.