### PR TITLE
fix(dock): make docked terminal title bar a drag handle

### DIFF
--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
 import type { PanelInstance } from "@shared/types/panel";
 import type { DragData } from "./DndProvider";
-import { DragHandleProvider } from "./DragHandleContext";
+import { DragHandleProvider, type DragHandleContextValue } from "./DragHandleContext";
 import { useDockPanelDragHandleRegistration } from "@/components/Layout/dockPanelPortalContext";
 
 interface SortableDockItemProps {
@@ -77,10 +77,35 @@ export function SortableDockItem({
   // so a fresh `groupPanelIds` array on an unrelated render doesn't re-fire this.
   const registerDragHandle = useDockPanelDragHandleRegistration();
   const dragHandleIdKey = groupPanelIds?.join(",");
+
+  // dnd-kit re-creates `listeners` on every shared-DndContext render — which is
+  // effectively every drag frame anywhere in the app (DndProvider churns
+  // placeholder/over state, and its inline sensor options defeat useSensor
+  // memoization). Registering the raw `{ listeners, setActivatorNodeRef }` would
+  // make this effect re-fire and re-render DockPanelOffscreenContainer on every
+  // such frame — the exact drag-perf regression this dock path is hardened
+  // against. So keep the latest handle in a ref and register a STABLE proxy that
+  // reads through it, keyed only on the (stable) id set. The bridged header
+  // re-reads the proxy each time it opens, so it always sees live listeners.
+  const handleRef = useRef<DragHandleContextValue>({ listeners, setActivatorNodeRef });
+  useEffect(() => {
+    handleRef.current = { listeners, setActivatorNodeRef };
+  });
+  const bridgedHandle = useMemo<DragHandleContextValue>(
+    () => ({
+      get listeners() {
+        return handleRef.current.listeners;
+      },
+      get setActivatorNodeRef() {
+        return handleRef.current.setActivatorNodeRef;
+      },
+    }),
+    []
+  );
   useEffect(() => {
     const ids = dragHandleIdKey ? dragHandleIdKey.split(",") : [terminal.id];
-    return registerDragHandle(ids, { listeners, setActivatorNodeRef });
-  }, [registerDragHandle, terminal.id, dragHandleIdKey, listeners, setActivatorNodeRef]);
+    return registerDragHandle(ids, bridgedHandle);
+  }, [registerDragHandle, terminal.id, dragHandleIdKey, bridgedHandle]);
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
@@ -6,6 +7,7 @@ import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/
 import type { PanelInstance } from "@shared/types/panel";
 import type { DragData } from "./DndProvider";
 import { DragHandleProvider } from "./DragHandleContext";
+import { useDockPanelDragHandleRegistration } from "@/components/Layout/dockPanelPortalContext";
 
 interface SortableDockItemProps {
   terminal: PanelInstance;
@@ -65,6 +67,20 @@ export function SortableDockItem({
     const overMid = over.rect.left + over.rect.width / 2;
     dropDirection = draggedMid < overMid ? "before" : "after";
   }
+
+  // Publish this dock item's drag handle so the portaled panel body (a React
+  // sibling rendered by DockPanelOffscreenContainer, out of this provider's
+  // subtree) can make its PanelHeader a drag handle too — grid parity (#10990).
+  // Register under every group member id so whichever tab is active resolves the
+  // group's shared handle; fall back to the panel's own id for a single item.
+  // Keyed on the joined id string (a primitive) rather than the array reference,
+  // so a fresh `groupPanelIds` array on an unrelated render doesn't re-fire this.
+  const registerDragHandle = useDockPanelDragHandleRegistration();
+  const dragHandleIdKey = groupPanelIds?.join(",");
+  useEffect(() => {
+    const ids = dragHandleIdKey ? dragHandleIdKey.split(",") : [terminal.id];
+    return registerDragHandle(ids, { listeners, setActivatorNodeRef });
+  }, [registerDragHandle, terminal.id, dragHandleIdKey, listeners, setActivatorNodeRef]);
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
@@ -3,6 +3,10 @@ import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { SortableDockItem } from "../SortableDockItem";
 import { useDragHandle } from "../DragHandleContext";
+import {
+  DockPanelContext,
+  type DockPanelContextValue,
+} from "@/components/Layout/dockPanelPortalContext";
 import type { PanelInstance } from "@shared/types/panel";
 
 interface MockSortableState {
@@ -102,6 +106,70 @@ describe("SortableDockItem", () => {
     expect(captured).not.toBeNull();
     expect(captured!.setActivatorNodeRef).toBe(mockSetActivatorNodeRef);
     expect(captured!.listeners).toBeDefined();
+  });
+
+  it("registers its drag handle under the panel's own id for a single dock item (#10990)", () => {
+    mockState = { isDragging: false };
+    const registerDragHandle = vi.fn(() => vi.fn());
+    const ctx: DockPanelContextValue = {
+      moveToDestination: vi.fn(),
+      registerDragHandle,
+    };
+    render(
+      <DockPanelContext.Provider value={ctx}>
+        <SortableDockItem terminal={terminal} sourceIndex={0}>
+          <div />
+        </SortableDockItem>
+      </DockPanelContext.Provider>
+    );
+    expect(registerDragHandle).toHaveBeenCalledTimes(1);
+    const [ids, handle] = registerDragHandle.mock.calls[0]!;
+    expect(ids).toEqual([terminal.id]);
+    expect(handle.setActivatorNodeRef).toBe(mockSetActivatorNodeRef);
+    expect(handle.listeners).toBeDefined();
+  });
+
+  it("registers under every group member id for a grouped dock item (#10990)", () => {
+    mockState = { isDragging: false };
+    const registerDragHandle = vi.fn(() => vi.fn());
+    const ctx: DockPanelContextValue = {
+      moveToDestination: vi.fn(),
+      registerDragHandle,
+    };
+    render(
+      <DockPanelContext.Provider value={ctx}>
+        <SortableDockItem
+          terminal={terminal}
+          sourceIndex={0}
+          groupId="g1"
+          groupPanelIds={["t2", "t3", "t4"]}
+        >
+          <div />
+        </SortableDockItem>
+      </DockPanelContext.Provider>
+    );
+    expect(registerDragHandle).toHaveBeenCalledTimes(1);
+    expect(registerDragHandle.mock.calls[0]![0]).toEqual(["t2", "t3", "t4"]);
+  });
+
+  it("disposes its registration on unmount", () => {
+    mockState = { isDragging: false };
+    const dispose = vi.fn();
+    const registerDragHandle = vi.fn(() => dispose);
+    const ctx: DockPanelContextValue = {
+      moveToDestination: vi.fn(),
+      registerDragHandle,
+    };
+    const { unmount } = render(
+      <DockPanelContext.Provider value={ctx}>
+        <SortableDockItem terminal={terminal} sourceIndex={0}>
+          <div />
+        </SortableDockItem>
+      </DockPanelContext.Provider>
+    );
+    expect(dispose).not.toHaveBeenCalled();
+    unmount();
+    expect(dispose).toHaveBeenCalledTimes(1);
   });
 
   it("renders no insertion indicator when idle", () => {

--- a/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
@@ -172,6 +172,56 @@ describe("SortableDockItem", () => {
     expect(dispose).toHaveBeenCalledTimes(1);
   });
 
+  it("registers only once across re-renders despite churning listeners identity and array refs", () => {
+    // The useSortable mock returns a fresh `listeners` object on every render,
+    // mirroring how the real shared DndContext re-creates listeners on every
+    // drag frame. Combined with a fresh `groupPanelIds` array reference (same
+    // ids), the registration must NOT re-fire — a re-fire would re-render
+    // DockPanelOffscreenContainer on every drag frame app-wide.
+    mockState = { isDragging: false };
+    const dispose = vi.fn();
+    const registerDragHandle = vi.fn(() => dispose);
+    const ctx: DockPanelContextValue = {
+      moveToDestination: vi.fn(),
+      registerDragHandle,
+    };
+    const { rerender } = render(
+      <DockPanelContext.Provider value={ctx}>
+        <SortableDockItem
+          terminal={terminal}
+          sourceIndex={0}
+          groupId="g1"
+          groupPanelIds={["t2", "t3"]}
+        >
+          <div />
+        </SortableDockItem>
+      </DockPanelContext.Provider>
+    );
+    expect(registerDragHandle).toHaveBeenCalledTimes(1);
+
+    // Re-render twice with a NEW array reference holding the SAME ids and a
+    // changed sourceIndex (forces a real re-render + fresh mock listeners).
+    for (const idx of [1, 2]) {
+      rerender(
+        <DockPanelContext.Provider value={ctx}>
+          <SortableDockItem
+            terminal={terminal}
+            sourceIndex={idx}
+            groupId="g1"
+            groupPanelIds={["t2", "t3"]}
+          >
+            <div />
+          </SortableDockItem>
+        </DockPanelContext.Provider>
+      );
+    }
+
+    // The joined id-key ("t2,t3") is unchanged, so the id set never changed —
+    // still a single registration, no dispose.
+    expect(registerDragHandle).toHaveBeenCalledTimes(1);
+    expect(dispose).not.toHaveBeenCalled();
+  });
+
   it("renders no insertion indicator when idle", () => {
     mockState = { isDragging: false };
     const { container } = render(

--- a/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableDockItem.test.tsx
@@ -110,7 +110,7 @@ describe("SortableDockItem", () => {
 
   it("registers its drag handle under the panel's own id for a single dock item (#10990)", () => {
     mockState = { isDragging: false };
-    const registerDragHandle = vi.fn(() => vi.fn());
+    const registerDragHandle = vi.fn<DockPanelContextValue["registerDragHandle"]>(() => vi.fn());
     const ctx: DockPanelContextValue = {
       moveToDestination: vi.fn(),
       registerDragHandle,
@@ -131,7 +131,7 @@ describe("SortableDockItem", () => {
 
   it("registers under every group member id for a grouped dock item (#10990)", () => {
     mockState = { isDragging: false };
-    const registerDragHandle = vi.fn(() => vi.fn());
+    const registerDragHandle = vi.fn<DockPanelContextValue["registerDragHandle"]>(() => vi.fn());
     const ctx: DockPanelContextValue = {
       moveToDestination: vi.fn(),
       registerDragHandle,
@@ -155,7 +155,7 @@ describe("SortableDockItem", () => {
   it("disposes its registration on unmount", () => {
     mockState = { isDragging: false };
     const dispose = vi.fn();
-    const registerDragHandle = vi.fn(() => dispose);
+    const registerDragHandle = vi.fn<DockPanelContextValue["registerDragHandle"]>(() => dispose);
     const ctx: DockPanelContextValue = {
       moveToDestination: vi.fn(),
       registerDragHandle,
@@ -180,7 +180,7 @@ describe("SortableDockItem", () => {
     // DockPanelOffscreenContainer on every drag frame app-wide.
     mockState = { isDragging: false };
     const dispose = vi.fn();
-    const registerDragHandle = vi.fn(() => dispose);
+    const registerDragHandle = vi.fn<DockPanelContextValue["registerDragHandle"]>(() => dispose);
     const ctx: DockPanelContextValue = {
       moveToDestination: vi.fn(),
       registerDragHandle,

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useCallback, useState, useRef } from "react";
+import { useEffect, useLayoutEffect, useCallback, useMemo, useState, useRef } from "react";
 import { canDuplicatePanelKind } from "@/services/terminal/panelDuplicationService";
 import { createPortal } from "react-dom";
 import { useShallow } from "zustand/react/shallow";
@@ -9,7 +9,21 @@ import { DockedPanel } from "@/components/Terminal/DockedPanel";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { logError } from "@/utils/logger";
 import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
+import {
+  DragHandleProvider,
+  type DragHandleContextValue,
+} from "@/components/DragDrop/DragHandleContext";
 import { DockPanelContext, type DockPanelContextValue } from "./dockPanelPortalContext";
+
+// Stable "no drag handle" value. The portaled dock panel body is ALWAYS wrapped
+// in a DragHandleProvider (so the provider element type never toggles and the
+// xterm-hosting subtree never remounts); parked/inactive panels receive this
+// shared empty value so their PanelHeader renders exactly as before — no
+// listeners, no keyboard activator, no spurious tab stop.
+const EMPTY_DRAG_HANDLE: DragHandleContextValue = {
+  listeners: undefined,
+  setActivatorNodeRef: undefined,
+};
 
 interface DockPanelOffscreenContainerProps {
   children: React.ReactNode;
@@ -26,6 +40,35 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
   // Mirror into state so JSX doesn't read the ref during render (React Compiler).
   // The ref remains the authoritative source; state snapshots it for render.
   const [wrappers, setWrappers] = useState<Map<string, HTMLElement>>(() => new Map());
+
+  // Drag-handle bridge (#10990). SortableDockItem publishes its dnd-kit handle
+  // here (keyed by panel id, or every member id for a group) so the portaled
+  // panel body — a React sibling of the sortable — can consume it. Same ref +
+  // state-snapshot shape as `wrappers` above: the ref is authoritative, state
+  // snapshots it so render never reads the ref. Registration happens once per
+  // dock item mount (dnd-kit's listeners/setActivatorNodeRef are referentially
+  // stable), so this does not re-render on drag frames.
+  const dragHandlesRef = useRef<Map<string, DragHandleContextValue>>(new Map());
+  const [dragHandles, setDragHandles] = useState<Map<string, DragHandleContextValue>>(
+    () => new Map()
+  );
+
+  const registerDragHandle = useCallback((panelIds: string[], handle: DragHandleContextValue) => {
+    for (const id of panelIds) dragHandlesRef.current.set(id, handle);
+    setDragHandles(new Map(dragHandlesRef.current));
+    return () => {
+      let changed = false;
+      for (const id of panelIds) {
+        // Only clear our own entry — a newer registration for the same id
+        // (e.g. a remounted chip) must win over this stale disposer.
+        if (dragHandlesRef.current.get(id) === handle) {
+          dragHandlesRef.current.delete(id);
+          changed = true;
+        }
+      }
+      if (changed) setDragHandles(new Map(dragHandlesRef.current));
+    };
+  }, []);
 
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
   const activeDockTerminalId = usePanelStore((s) => s.activeDockTerminalId);
@@ -205,9 +248,13 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
     }
   }, []);
 
-  const contextValue: DockPanelContextValue = {
-    moveToDestination,
-  };
+  // Both callbacks are referentially stable, so the context value stays stable
+  // across renders — consumers (SortableDockItem, dock chips) never re-run their
+  // effects just because this container re-rendered.
+  const contextValue = useMemo<DockPanelContextValue>(
+    () => ({ moveToDestination, registerDragHandle }),
+    [moveToDestination, registerDragHandle]
+  );
 
   return (
     <DockPanelContext.Provider value={contextValue}>
@@ -253,6 +300,19 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         const existingGroup = getPanelGroup(terminal.id);
         const isSinglePanel = !existingGroup || existingGroup.panelIds.length <= 1;
 
+        // Re-provide the dock sortable's drag handle across the portal boundary
+        // (#10990) so this panel's PanelHeader becomes a drag handle, matching
+        // the grid. Gate on the active dock panel: only the one open popover's
+        // header receives live listeners + the keyboard activator ref, so parked
+        // headers never claim a group's shared setActivatorNodeRef and no
+        // offscreen header becomes a stray drag/tab target. The provider is
+        // ALWAYS present (empty value when inactive) so its element type never
+        // toggles — the xterm-hosting DockedPanel subtree is never remounted.
+        const bridgedDragHandle =
+          terminal.id === activeDockTerminalId
+            ? (dragHandles.get(terminal.id) ?? EMPTY_DRAG_HANDLE)
+            : EMPTY_DRAG_HANDLE;
+
         // Wrap the portaled panel body in DockPopoverChildProvider so any
         // Radix overlay opened from inside the docked panel (e.g.
         // TerminalContextMenu via ContentPanel, panel header dropdowns,
@@ -262,27 +322,29 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         // item — see #8161.
         const content = (
           <DockPopoverChildProvider>
-            <div
-              data-dock-panel-id={terminal.id}
-              className="dock-panel-slot"
-              style={{
-                width: "100%",
-                height: "100%",
-                display: "flex",
-                flexDirection: "column",
-              }}
-            >
-              <DockedPanel
-                terminal={terminal}
-                onPopoverClose={handlePopoverClose}
-                onAddTab={
-                  isSinglePanel && canDuplicatePanelKind(terminal.kind)
-                    ? () => handleAddTabForPanel(terminal)
-                    : undefined
-                }
-                showRestoreControl={isSinglePanel}
-              />
-            </div>
+            <DragHandleProvider value={bridgedDragHandle}>
+              <div
+                data-dock-panel-id={terminal.id}
+                className="dock-panel-slot"
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <DockedPanel
+                  terminal={terminal}
+                  onPopoverClose={handlePopoverClose}
+                  onAddTab={
+                    isSinglePanel && canDuplicatePanelKind(terminal.kind)
+                      ? () => handleAddTabForPanel(terminal)
+                      : undefined
+                  }
+                  showRestoreControl={isSinglePanel}
+                />
+              </div>
+            </DragHandleProvider>
           </DockPopoverChildProvider>
         );
 

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -45,9 +45,9 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
   // here (keyed by panel id, or every member id for a group) so the portaled
   // panel body — a React sibling of the sortable — can consume it. Same ref +
   // state-snapshot shape as `wrappers` above: the ref is authoritative, state
-  // snapshots it so render never reads the ref. Registration happens once per
-  // dock item mount (dnd-kit's listeners/setActivatorNodeRef are referentially
-  // stable), so this does not re-render on drag frames.
+  // snapshots it so render never reads the ref. SortableDockItem registers a
+  // STABLE handle proxy (see its comment), so this map mutates only on dock-item
+  // mount/unmount — never on drag frames despite dnd-kit churning listeners.
   const dragHandlesRef = useRef<Map<string, DragHandleContextValue>>(new Map());
   const [dragHandles, setDragHandles] = useState<Map<string, DragHandleContextValue>>(
     () => new Map()

--- a/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
+++ b/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
@@ -307,6 +307,60 @@ describe("DockPanelOffscreenContainer drag-handle bridge (#10990)", () => {
     expect(panel.getAttribute("data-has-listeners")).toBe("true");
   });
 
+  it("keeps a parked group member empty while a different member is active (gate ≠ 'any active')", () => {
+    // Two panels registered under one shared group handle; only panel-1 is
+    // active. The active member lights up; the parked member must NOT — else a
+    // parked header would claim the group's shared setActivatorNodeRef.
+    setPanels([makePanel({ id: "panel-1" }), makePanel({ id: "panel-2" })]);
+    mockState.activeDockTerminalId = "panel-1";
+    renderWithRegister();
+
+    const groupHandle = {
+      listeners: { onPointerDown: vi.fn(), onKeyDown: vi.fn() },
+      setActivatorNodeRef: vi.fn(),
+    };
+    act(() => {
+      capturedRegister!(["panel-1", "panel-2"], groupHandle);
+    });
+
+    const active = document.querySelector('[data-testid="docked-panel"][data-pid="panel-1"]')!;
+    const parked = document.querySelector('[data-testid="docked-panel"][data-pid="panel-2"]')!;
+    expect(active.getAttribute("data-has-listeners")).toBe("true");
+    expect(parked.getAttribute("data-has-listeners")).toBe("false");
+    expect(parked.getAttribute("data-has-activator")).toBe("false");
+  });
+
+  it("flips the header's listeners off on popover close WITHOUT remounting the panel node", () => {
+    mockState.activeDockTerminalId = "panel-1";
+    const { rerender } = renderWithRegister();
+
+    const handle = {
+      listeners: { onPointerDown: vi.fn(), onKeyDown: vi.fn() },
+      setActivatorNodeRef: vi.fn(),
+    };
+    act(() => {
+      capturedRegister!(["panel-1"], handle);
+    });
+    const openNode = document.querySelector('[data-testid="docked-panel"]')!;
+    expect(openNode.getAttribute("data-has-listeners")).toBe("true");
+
+    // Close the popover (active id clears); the provider element type never
+    // toggles, so only the context value flips empty — same portaled node.
+    mockState.activeDockTerminalId = null;
+    act(() => {
+      rerender(
+        <DockPanelOffscreenContainer>
+          <CaptureRegister />
+        </DockPanelOffscreenContainer>
+      );
+    });
+
+    const closedNode = document.querySelector('[data-testid="docked-panel"]')!;
+    expect(closedNode).toBe(openNode); // no remount — xterm subtree preserved
+    expect(closedNode.getAttribute("data-has-listeners")).toBe("false");
+    expect(closedNode.getAttribute("data-has-activator")).toBe("false");
+  });
+
   it("a stale disposer does not clear a newer registration for the same id", () => {
     mockState.activeDockTerminalId = "panel-1";
     renderWithRegister();

--- a/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
+++ b/src/components/Layout/__tests__/DockPanelOffscreenContainer.test.tsx
@@ -32,11 +32,25 @@ vi.mock("@/store/helpPanelStore", () => ({
     selector({ terminalId: null }),
 }));
 
-vi.mock("@/components/Terminal/DockedPanel", () => ({
-  DockedPanel: ({ terminal }: { terminal: PtyPanelData }) => (
-    <div data-testid="docked-panel" data-pid={terminal.id} />
-  ),
-}));
+// Mock the panel body but keep it a REAL consumer of DragHandleContext, so the
+// bridge tests below prove the drag handle actually crosses the createPortal
+// boundary (#10990) rather than asserting against a mocked hook.
+vi.mock("@/components/Terminal/DockedPanel", async () => {
+  const { useDragHandle } = await import("@/components/DragDrop/DragHandleContext");
+  return {
+    DockedPanel: ({ terminal }: { terminal: PtyPanelData }) => {
+      const dragHandle = useDragHandle();
+      return (
+        <div
+          data-testid="docked-panel"
+          data-pid={terminal.id}
+          data-has-listeners={dragHandle?.listeners ? "true" : "false"}
+          data-has-activator={dragHandle?.setActivatorNodeRef ? "true" : "false"}
+        />
+      );
+    },
+  };
+});
 
 vi.mock("@/services/terminal/panelDuplicationService", () => ({
   buildPanelDuplicateOptions: vi.fn(),
@@ -52,7 +66,11 @@ vi.mock("@/components/ui/DockPopoverChildContext", () => ({
 }));
 
 import { DockPanelOffscreenContainer } from "../DockPanelOffscreenContainer";
-import { useDockPanelPortal } from "../dockPanelPortalContext";
+import {
+  useDockPanelPortal,
+  useDockPanelDragHandleRegistration,
+  type DockPanelContextValue,
+} from "../dockPanelPortalContext";
 
 function makePanel(overrides: Partial<PtyPanelData> = {}): PtyPanelData {
   return {
@@ -86,6 +104,12 @@ function setPanels(panels: PtyPanelData[]) {
 let captured: ((panelId: string, destination: HTMLElement | null) => void) | null = null;
 function Capture() {
   captured = useDockPanelPortal();
+  return null;
+}
+
+let capturedRegister: DockPanelContextValue["registerDragHandle"] | null = null;
+function CaptureRegister() {
+  capturedRegister = useDockPanelDragHandleRegistration();
   return null;
 }
 
@@ -202,5 +226,107 @@ describe("DockPanelOffscreenContainer stable-wrapper relocation (#9927)", () => 
     act(() => captured!("panel-1", target));
     expect(moveBefore).not.toHaveBeenCalled();
     expect(wrapper.parentElement).toBe(target);
+  });
+});
+
+describe("DockPanelOffscreenContainer drag-handle bridge (#10990)", () => {
+  beforeEach(() => {
+    closeDockTerminalMock.mockClear();
+    setPanels([makePanel({ id: "panel-1" })]);
+    capturedRegister = null;
+  });
+
+  function renderWithRegister() {
+    capturedRegister = null;
+    return render(
+      <DockPanelOffscreenContainer>
+        <CaptureRegister />
+      </DockPanelOffscreenContainer>
+    );
+  }
+
+  it("re-provides the registered handle to the active dock panel's portaled body", () => {
+    mockState.activeDockTerminalId = "panel-1";
+    renderWithRegister();
+
+    // Before any registration the portaled body sees the empty handle.
+    const before = document.querySelector('[data-testid="docked-panel"]')!;
+    expect(before.getAttribute("data-has-listeners")).toBe("false");
+    expect(before.getAttribute("data-has-activator")).toBe("false");
+
+    const handle = {
+      listeners: { onPointerDown: vi.fn(), onKeyDown: vi.fn() },
+      setActivatorNodeRef: vi.fn(),
+    };
+    act(() => {
+      capturedRegister!(["panel-1"], handle);
+    });
+
+    // The portaled body now receives the live listeners + keyboard activator —
+    // grid parity across the createPortal boundary.
+    const after = document.querySelector('[data-testid="docked-panel"]')!;
+    expect(after.getAttribute("data-has-listeners")).toBe("true");
+    expect(after.getAttribute("data-has-activator")).toBe("true");
+  });
+
+  it("does NOT provide the handle to a parked (non-active) dock panel", () => {
+    mockState.activeDockTerminalId = null; // no popover open
+    renderWithRegister();
+
+    const handle = {
+      listeners: { onPointerDown: vi.fn() },
+      setActivatorNodeRef: vi.fn(),
+    };
+    act(() => {
+      capturedRegister!(["panel-1"], handle);
+    });
+
+    // Registered, but gated off because the panel is not the active dock panel:
+    // its offscreen header must not become a stray drag/tab target.
+    const panel = document.querySelector('[data-testid="docked-panel"]')!;
+    expect(panel.getAttribute("data-has-listeners")).toBe("false");
+    expect(panel.getAttribute("data-has-activator")).toBe("false");
+  });
+
+  it("resolves a group member id to the group's shared handle when that member is active", () => {
+    // Two panels; only panel-1 is rendered by this container in the single-panel
+    // fixture, so register the group handle under both member ids and make
+    // panel-1 active — it must resolve the shared handle.
+    mockState.activeDockTerminalId = "panel-1";
+    renderWithRegister();
+
+    const groupHandle = {
+      listeners: { onPointerDown: vi.fn(), onKeyDown: vi.fn() },
+      setActivatorNodeRef: vi.fn(),
+    };
+    act(() => {
+      capturedRegister!(["panel-0", "panel-1"], groupHandle);
+    });
+
+    const panel = document.querySelector('[data-testid="docked-panel"]')!;
+    expect(panel.getAttribute("data-has-listeners")).toBe("true");
+  });
+
+  it("a stale disposer does not clear a newer registration for the same id", () => {
+    mockState.activeDockTerminalId = "panel-1";
+    renderWithRegister();
+
+    const first = { listeners: { onPointerDown: vi.fn() }, setActivatorNodeRef: vi.fn() };
+    const second = { listeners: { onPointerDown: vi.fn() }, setActivatorNodeRef: vi.fn() };
+
+    let disposeFirst!: () => void;
+    act(() => {
+      disposeFirst = capturedRegister!(["panel-1"], first);
+    });
+    act(() => {
+      capturedRegister!(["panel-1"], second);
+    });
+    // `second` now owns the id; the first disposer must be a no-op.
+    act(() => {
+      disposeFirst();
+    });
+
+    const panel = document.querySelector('[data-testid="docked-panel"]')!;
+    expect(panel.getAttribute("data-has-listeners")).toBe("true");
   });
 });

--- a/src/components/Layout/dockPanelPortalContext.ts
+++ b/src/components/Layout/dockPanelPortalContext.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from "react";
+import type { DragHandleContextValue } from "@/components/DragDrop/DragHandleContext";
 
 export interface DockPanelContextValue {
   // Relocate a dock panel's stable wrapper element into `destination` (the
@@ -7,6 +8,16 @@ export interface DockPanelContextValue {
   // container — React never sees it change identity — so the panel subtree is
   // never unmounted/remounted across open/close or tab switches.
   moveToDestination: (panelId: string, destination: HTMLElement | null) => void;
+  // Publish the dock sortable's drag handle (dnd-kit listeners + activator ref)
+  // for the given panel ids so DockPanelOffscreenContainer can re-provide it to
+  // the portaled panel body across the createPortal boundary (grid parity —
+  // #10990). SortableDockItem is the sole owner of the dock useSortable()
+  // registration, but the popover body is a React *sibling* of that sortable
+  // (portaled from here), so useDragHandle() would otherwise resolve to null and
+  // the docked PanelHeader never becomes a drag handle. Returns a disposer. For
+  // a tab group, pass every member id so whichever tab is active resolves the
+  // group's shared handle.
+  registerDragHandle: (panelIds: string[], handle: DragHandleContextValue) => () => void;
 }
 
 // Defined in its own module (no component exports) so Vite Fast Refresh never
@@ -23,4 +34,16 @@ export function useDockPanelPortal() {
     throw new Error("useDockPanelPortal must be used within DockPanelOffscreenContainer");
   }
   return context.moveToDestination;
+}
+
+// Stable no-op so SortableDockItem — which renders standalone in unit tests
+// without the container — can register unconditionally without a null guard.
+const NOOP_REGISTER: DockPanelContextValue["registerDragHandle"] = () => () => {};
+
+// Non-throwing counterpart to useDockPanelPortal: outside the container this
+// returns a stable no-op registrar rather than throwing, since a dock chip can
+// legitimately render without the offscreen container present (unit tests,
+// isolated stories).
+export function useDockPanelDragHandleRegistration(): DockPanelContextValue["registerDragHandle"] {
+  return useContext(DockPanelContext)?.registerDragHandle ?? NOOP_REGISTER;
 }


### PR DESCRIPTION
## Summary

- Docked terminal panels get a title bar when opened in the dock popover, but unlike the grid, that title bar can't be dragged.
- Root cause: `SortableTerminal` (the grid wrapper) provides a `DragHandleProvider` via React context, giving the panel header its drag listeners. The docked panel body is rendered through a portal by `DockPanelOffscreenContainer`, as a sibling of the dock item `SortableDockItem` rather than a descendant, so `useDragHandle()` resolves to `null` in the header and the already-coded `location === "dock"` drag branch never gets wired up.
- Fix bridges the single dnd-kit handle owned by `SortableDockItem` across the portal boundary, so the docked title bar becomes a real drag handle like the grid's.

Resolves #10990

## Changes

- `SortableDockItem` publishes its `listeners` and `setActivatorNodeRef` through a new `registerDragHandle` function added to the dock portal context, keyed by panel id (or every member id when the dock item is a tab group).
- `DockPanelOffscreenContainer` always wraps the portaled content in a `DragHandleProvider`, but only supplies live listeners when that panel is the currently active/open one in the dock. Parked (non-open) tab members never grab a shared handle, and always having the provider present avoids remounting the terminal subtree.
- Registration uses a stable getter-proxy so dnd-kit's per-frame listener churn during an active drag doesn't cause extra re-renders of the container.
- Files: `src/components/Layout/dockPanelPortalContext.ts`, `src/components/Layout/DockPanelOffscreenContainer.tsx`, `src/components/DragDrop/SortableDockItem.tsx`, plus their `__tests__` files.

## Testing

- 166 targeted tests pass locally, covering the bridge itself, register-once behavior across churn, parked tab members getting an empty handle, and no remount of the terminal on dock close.
- Own changed files are clean under prettier and eslint, zero errors.