### PR TITLE
fix(dnd): allow dock-to-grid drops to target any grid slot

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -892,6 +892,9 @@ export function DndProvider({ children }: DndProviderProps) {
 
       // Capture state before clearing
       const dropContainer = overContainer;
+      // Capture the drag-over hysteresis verdict before it is cleared so the
+      // commit can honor the same before/after decision the placeholder previewed.
+      const gridInsertMemo = gridInsertMemoRef.current;
 
       setActiveId(null);
       setActiveData(null);
@@ -998,11 +1001,17 @@ export function DndProvider({ children }: DndProviderProps) {
         const isAccordionOver = parseAccordionDragId(overId) !== null;
         // For a single-terminal dock→grid drop landing directly on an existing
         // panel (not the placeholder), resolve before/after by rect geometry so
-        // it commits to the same slot the placeholder previewed. Drops onto the
-        // placeholder already flow the correct index via sortable.index.
+        // it commits to the same slot the placeholder previewed. Reuse the
+        // hysteresis verdict for the same hover target so a drop inside the
+        // dead-zone commits where the preview showed. Drops onto the placeholder
+        // already flow the correct index via sortable.index.
         const dockToGridGeometry =
           sourceLocation === "dock" && targetContainer === "grid" && !isGroupDrag
-            ? { activeRect: active.rect.current.translated, overRect: over.rect }
+            ? {
+                activeRect: active.rect.current.translated,
+                overRect: over.rect,
+                previousIndex: gridInsertMemo?.overId === overId ? gridInsertMemo.index : undefined,
+              }
             : undefined;
         const targetIndex = resolveTargetIndex(
           freshTerminalsById,

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -104,6 +104,7 @@ import {
   detectTargetContainer,
   resolveTargetIndex,
   resolveGroupPlacementIndex,
+  resolveGridInsertionIndexFromRects,
   findGroupIndex,
   type OverDropData,
 } from "./dropResolution";
@@ -608,6 +609,11 @@ export function DndProvider({ children }: DndProviderProps) {
   // undefined before handleDragEnd fires.
   const activeWorktreeSortDataRef = useRef<Record<string, unknown> | null>(null);
 
+  // Last before/after placeholder index resolved for a given hover target during
+  // a dock→grid drag. Threaded back into the geometry helper as its previous
+  // verdict so the hysteresis dead-zone can damp per-frame oscillation.
+  const gridInsertMemoRef = useRef<{ overId: string; index: number } | null>(null);
+
   const [isCancelDrop, setIsCancelDrop] = useState(false);
 
   // Configure sensors with activation constraint so clicks work for popovers.
@@ -697,6 +703,7 @@ export function DndProvider({ children }: DndProviderProps) {
 
     setActiveId(dragId);
     terminalInstanceService.lockResize(terminalId, true);
+    gridInsertMemoRef.current = null;
 
     // Clear any pending stabilization timers from previous drags
     if (stabilizationTimerRef.current) {
@@ -717,6 +724,7 @@ export function DndProvider({ children }: DndProviderProps) {
     if (!over) {
       setOverContainer(null);
       setPlaceholderIndex(null);
+      gridInsertMemoRef.current = null;
       return;
     }
 
@@ -767,12 +775,22 @@ export function DndProvider({ children }: DndProviderProps) {
 
       const overId = over.id as string;
 
+      // A multi-panel tab group dragged as a unit still commits through the
+      // before-biased group path in handleDragEnd, so keep its placeholder on
+      // that same path to avoid a placeholder/drop mismatch. Only single
+      // docked terminals get the before/after geometry treatment below.
+      const isGroupDrag =
+        !!activeDataCurrent?.groupId &&
+        !!activeDataCurrent?.groupPanelIds &&
+        activeDataCurrent.groupPanelIds.length > 1;
+
       // Determine group index based on what we're hovering over
       let groupIndex = -1;
 
       if (overId === GRID_PLACEHOLDER_ID) {
         // Hovering over the placeholder itself - use sortable.index if available
-        // (this can happen during drag oscillation)
+        // (this can happen during drag oscillation). Keep the memoized geometry
+        // verdict so drifting back onto the panel resumes with hysteresis.
         if (overData?.sortable?.index !== undefined) {
           groupIndex = Math.min(Math.max(0, overData.sortable.index), tabGroups.length);
         } else {
@@ -791,12 +809,32 @@ export function DndProvider({ children }: DndProviderProps) {
             // Dropping on empty grid or container itself - append to end
             groupIndex = tabGroups.length;
           }
+          gridInsertMemoRef.current = null;
+        } else if (!isGroupDrag) {
+          // Directly over an existing panel: use pointer/rect geometry to allow
+          // landing AFTER it, not only before. Without this a single full-surface
+          // panel leaves no whitespace to hover, so every drop resolved to index 0.
+          const previousIndex =
+            gridInsertMemoRef.current?.overId === overId
+              ? gridInsertMemoRef.current.index
+              : undefined;
+          groupIndex = resolveGridInsertionIndexFromRects(
+            groupIndex,
+            active.rect.current.translated,
+            over.rect,
+            previousIndex
+          );
+          groupIndex = Math.min(Math.max(0, groupIndex), tabGroups.length);
+          gridInsertMemoRef.current = { overId, index: groupIndex };
+        } else {
+          gridInsertMemoRef.current = null;
         }
       }
 
       setPlaceholderIndex(groupIndex);
     } else {
       setPlaceholderIndex(null);
+      gridInsertMemoRef.current = null;
     }
   }, []);
 
@@ -859,6 +897,7 @@ export function DndProvider({ children }: DndProviderProps) {
       setActiveData(null);
       setOverContainer(null);
       setPlaceholderIndex(null);
+      gridInsertMemoRef.current = null;
 
       // ALWAYS unlock resize regardless of drop target - fixes stuck resize locks
       // when dropping outside droppable areas (over === null)
@@ -957,6 +996,14 @@ export function DndProvider({ children }: DndProviderProps) {
           "grid";
 
         const isAccordionOver = parseAccordionDragId(overId) !== null;
+        // For a single-terminal dock→grid drop landing directly on an existing
+        // panel (not the placeholder), resolve before/after by rect geometry so
+        // it commits to the same slot the placeholder previewed. Drops onto the
+        // placeholder already flow the correct index via sortable.index.
+        const dockToGridGeometry =
+          sourceLocation === "dock" && targetContainer === "grid" && !isGroupDrag
+            ? { activeRect: active.rect.current.translated, overRect: over.rect }
+            : undefined;
         const targetIndex = resolveTargetIndex(
           freshTerminalsById,
           freshTerminalIds,
@@ -964,7 +1011,8 @@ export function DndProvider({ children }: DndProviderProps) {
           targetContainer,
           overId,
           overData?.sortable?.index,
-          isAccordionOver
+          isAccordionOver,
+          dockToGridGeometry
         );
 
         // Scrollable panel grid (#8805) — no grid-full rejection, the grid
@@ -1265,6 +1313,7 @@ export function DndProvider({ children }: DndProviderProps) {
     setActiveData(null);
     setOverContainer(null);
     setPlaceholderIndex(null);
+    gridInsertMemoRef.current = null;
     setIsWorktreeSortActive(false);
     setActiveSortWorktree(null);
     // No explicit refresh needed - terminals return to original state (no layout change)

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -609,10 +609,12 @@ export function DndProvider({ children }: DndProviderProps) {
   // undefined before handleDragEnd fires.
   const activeWorktreeSortDataRef = useRef<Record<string, unknown> | null>(null);
 
-  // Last before/after placeholder index resolved for a given hover target during
-  // a dock→grid drag. Threaded back into the geometry helper as its previous
-  // verdict so the hysteresis dead-zone can damp per-frame oscillation.
-  const gridInsertMemoRef = useRef<{ overId: string; index: number } | null>(null);
+  // Last before/after verdict for a given hover target during a dock→grid drag.
+  // Stored as a space-agnostic decision (after vs before the target) rather than
+  // an absolute index so it reconstructs correctly against both the group-space
+  // baseIndex in handleDragOver and the terminal-space baseIndex at commit. Fed
+  // back into the geometry helper's hysteresis to damp per-frame oscillation.
+  const gridInsertMemoRef = useRef<{ overId: string; after: boolean } | null>(null);
 
   const [isCancelDrop, setIsCancelDrop] = useState(false);
 
@@ -814,18 +816,21 @@ export function DndProvider({ children }: DndProviderProps) {
           // Directly over an existing panel: use pointer/rect geometry to allow
           // landing AFTER it, not only before. Without this a single full-surface
           // panel leaves no whitespace to hover, so every drop resolved to index 0.
+          const baseGroupIndex = groupIndex;
           const previousIndex =
             gridInsertMemoRef.current?.overId === overId
-              ? gridInsertMemoRef.current.index
+              ? gridInsertMemoRef.current.after
+                ? baseGroupIndex + 1
+                : baseGroupIndex
               : undefined;
           groupIndex = resolveGridInsertionIndexFromRects(
-            groupIndex,
+            baseGroupIndex,
             active.rect.current.translated,
             over.rect,
             previousIndex
           );
           groupIndex = Math.min(Math.max(0, groupIndex), tabGroups.length);
-          gridInsertMemoRef.current = { overId, index: groupIndex };
+          gridInsertMemoRef.current = { overId, after: groupIndex === baseGroupIndex + 1 };
         } else {
           gridInsertMemoRef.current = null;
         }
@@ -1010,7 +1015,7 @@ export function DndProvider({ children }: DndProviderProps) {
             ? {
                 activeRect: active.rect.current.translated,
                 overRect: over.rect,
-                previousIndex: gridInsertMemo?.overId === overId ? gridInsertMemo.index : undefined,
+                previousAfter: gridInsertMemo?.overId === overId ? gridInsertMemo.after : undefined,
               }
             : undefined;
         const targetIndex = resolveTargetIndex(

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -299,15 +299,16 @@ describe("resolveTargetIndex", () => {
     ).toBe(2);
   });
 
-  it("honors previousIndex so the commit matches the previewed slot in the dead-zone", () => {
+  it("honors previousAfter so the commit matches the previewed slot in the dead-zone", () => {
     // Hovering "b" (idx 1), center just left of midpoint (raw = before = 1), but the
-    // preview held after (2); passing previousIndex keeps the commit at 2.
+    // preview held after; previousAfter reconstructs the after-index (2) in
+    // terminal-space so the commit lands where the placeholder previewed.
     const active = makeRect(38, 40, 20, 20); // center x = 48, dist 2 < 8
     expect(
       resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false, {
         activeRect: active,
         overRect: over,
-        previousIndex: 2,
+        previousAfter: true,
       })
     ).toBe(2);
     // Without the memoized verdict the raw geometry would commit before (1).
@@ -315,6 +316,19 @@ describe("resolveTargetIndex", () => {
       resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false, {
         activeRect: active,
         overRect: over,
+      })
+    ).toBe(1);
+  });
+
+  it("reconstructs previousAfter=false as the before-index for the hovered terminal", () => {
+    // Hovering "b" (idx 1), center just right of midpoint (raw = after = 2), but the
+    // preview held before; previousAfter=false reconstructs idx (1).
+    const active = makeRect(42, 40, 20, 20); // center x = 52, dist 2 < 8
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false, {
+        activeRect: active,
+        overRect: over,
+        previousAfter: false,
       })
     ).toBe(1);
   });

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -262,8 +262,8 @@ describe("resolveTargetIndex", () => {
     ).toBe(2);
   });
 
-  it("exact grid match with missing rects biases after (append)", () => {
-    // First panel "a" (idx 0); null rects → after → 1, satisfying default-to-last
+  it("exact grid match with missing rects biases after the hovered panel, not before", () => {
+    // Hovering "a" (idx 0) with null rects → after → 1 (not the before-biased 0)
     expect(
       resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "a", undefined, false, {
         activeRect: null,
@@ -278,6 +278,17 @@ describe("resolveTargetIndex", () => {
     );
   });
 
+  it("does not apply geometry when the exact-match branch is skipped (skipAccordionOver)", () => {
+    // skipAccordionOver=true bypasses the findIndex branch entirely, so the
+    // right-half geometry (which would give idx+1=2) must NOT apply; falls to sortableIndex.
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", 0, true, {
+        activeRect: makeRect(60, 40, 20, 20),
+        overRect: over,
+      })
+    ).toBe(0);
+  });
+
   it("ignores geometry when overId misses (falls to sortableIndex)", () => {
     const active = makeRect(60, 40, 20, 20);
     expect(
@@ -286,6 +297,26 @@ describe("resolveTargetIndex", () => {
         overRect: over,
       })
     ).toBe(2);
+  });
+
+  it("honors previousIndex so the commit matches the previewed slot in the dead-zone", () => {
+    // Hovering "b" (idx 1), center just left of midpoint (raw = before = 1), but the
+    // preview held after (2); passing previousIndex keeps the commit at 2.
+    const active = makeRect(38, 40, 20, 20); // center x = 48, dist 2 < 8
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false, {
+        activeRect: active,
+        overRect: over,
+        previousIndex: 2,
+      })
+    ).toBe(2);
+    // Without the memoized verdict the raw geometry would commit before (1).
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false, {
+        activeRect: active,
+        overRect: over,
+      })
+    ).toBe(1);
   });
 });
 
@@ -308,6 +339,20 @@ describe("resolveGridInsertionIndexFromRects", () => {
     expect(resolveGridInsertionIndexFromRects(0, makeRect(40, 40, Number.NaN, 20), over)).toBe(1);
   });
 
+  it("biases after for a finite-size rect with a non-finite position", () => {
+    // width/height are valid but left is NaN → centerX is NaN; must still fall
+    // back to after, not silently resolve before.
+    const active = {
+      left: Number.NaN,
+      top: 40,
+      width: 20,
+      height: 20,
+      right: Number.NaN,
+      bottom: 60,
+    };
+    expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(1);
+  });
+
   it("returns before when the center is above the target row", () => {
     const active = makeRect(40, -60, 20, 20); // center y = -50 < 0
     expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(0);
@@ -316,6 +361,18 @@ describe("resolveGridInsertionIndexFromRects", () => {
   it("returns after when the center is below the target row", () => {
     const active = makeRect(40, 120, 20, 20); // center y = 130 >= 100
     expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(1);
+  });
+
+  it("treats center exactly at the top edge as in-band (splits horizontally)", () => {
+    // center y = 0 == over.top; `< top` is false → same band, right half → after
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(60, -10, 20, 20), over)).toBe(1);
+    // same edge, left half → before
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(20, -10, 20, 20), over)).toBe(0);
+  });
+
+  it("treats center exactly at the bottom edge as after (>= bottom), even on the left", () => {
+    // center y = 100 == over.bottom → after regardless of x
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(20, 90, 20, 20), over)).toBe(1);
   });
 
   it("returns after below the row even when x is far left (reading order)", () => {
@@ -348,6 +405,11 @@ describe("resolveGridInsertionIndexFromRects", () => {
   it("lets the raw verdict win once the center leaves the dead-zone", () => {
     const active = makeRect(60, 40, 20, 20); // center x = 70, dist 20 > 8
     expect(resolveGridInsertionIndexFromRects(0, active, over, 0)).toBe(1);
+  });
+
+  it("does not hold at exactly the dead-zone boundary (distance == hysteresisPx)", () => {
+    // center x = 42, dist exactly 8; `< 8` is false so the hold does not engage → raw before
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(32, 40, 20, 20), over, 1)).toBe(0);
   });
 
   it("ignores a previousIndex that does not belong to this base index", () => {

--- a/src/components/DragDrop/__tests__/dropResolution.test.ts
+++ b/src/components/DragDrop/__tests__/dropResolution.test.ts
@@ -5,10 +5,16 @@ import {
   detectTargetContainer,
   resolveTargetIndex,
   resolveGroupPlacementIndex,
+  resolveGridInsertionIndexFromRects,
   findGroupIndex,
+  type ClientRectLike,
 } from "../dropResolution";
 import type { PanelInstance } from "@shared/types/panel";
 import type { TabGroup } from "@shared/types";
+
+function makeRect(left: number, top: number, width: number, height: number): ClientRectLike {
+  return { left, top, width, height, right: left + width, bottom: top + height };
+}
 
 function makeTerminal(id: string, location: "grid" | "dock", worktreeId?: string): PanelInstance {
   return {
@@ -230,6 +236,130 @@ describe("resolveTargetIndex", () => {
     const ids = [...panelIds, "d"];
     // "d" is wt2 and won't appear when filtering for wt1
     expect(resolveTargetIndex(byId, ids, "wt1", "grid", "d", undefined, false)).toBe(3);
+  });
+
+  // Geometry-aware branch (dock→grid single-terminal drops). Over rect spans
+  // x:[0,100] y:[0,100]; the active center decides before ("b" → 1) vs after → 2.
+  const over = makeRect(0, 0, 100, 100);
+
+  it("exact grid match with geometry left-of-midpoint keeps before-index", () => {
+    const active = makeRect(20, 40, 20, 20); // center (30, 50) → left half
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false, {
+        activeRect: active,
+        overRect: over,
+      })
+    ).toBe(1);
+  });
+
+  it("exact grid match with geometry right-of-midpoint advances to after-index", () => {
+    const active = makeRect(60, 40, 20, 20); // center (70, 50) → right half
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "b", undefined, false, {
+        activeRect: active,
+        overRect: over,
+      })
+    ).toBe(2);
+  });
+
+  it("exact grid match with missing rects biases after (append)", () => {
+    // First panel "a" (idx 0); null rects → after → 1, satisfying default-to-last
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "a", undefined, false, {
+        activeRect: null,
+        overRect: null,
+      })
+    ).toBe(1);
+  });
+
+  it("exact grid match without geometry keeps the original before-index", () => {
+    expect(resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "a", undefined, false)).toBe(
+      0
+    );
+  });
+
+  it("ignores geometry when overId misses (falls to sortableIndex)", () => {
+    const active = makeRect(60, 40, 20, 20);
+    expect(
+      resolveTargetIndex(terminalsById, panelIds, "wt1", "grid", "ghost", 2, false, {
+        activeRect: active,
+        overRect: over,
+      })
+    ).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveGridInsertionIndexFromRects
+// ---------------------------------------------------------------------------
+describe("resolveGridInsertionIndexFromRects", () => {
+  const over = makeRect(0, 0, 100, 100); // midX = 50, band y:[0,100)
+
+  it("biases after when the active rect is missing", () => {
+    expect(resolveGridInsertionIndexFromRects(0, null, over)).toBe(1);
+  });
+
+  it("biases after when the over rect is missing", () => {
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(40, 40, 20, 20), null)).toBe(1);
+  });
+
+  it("biases after for degenerate (zero/NaN) rect dimensions", () => {
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(40, 40, 0, 20), over)).toBe(1);
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(40, 40, Number.NaN, 20), over)).toBe(1);
+  });
+
+  it("returns before when the center is above the target row", () => {
+    const active = makeRect(40, -60, 20, 20); // center y = -50 < 0
+    expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(0);
+  });
+
+  it("returns after when the center is below the target row", () => {
+    const active = makeRect(40, 120, 20, 20); // center y = 130 >= 100
+    expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(1);
+  });
+
+  it("returns after below the row even when x is far left (reading order)", () => {
+    const active = makeRect(0, 120, 20, 20); // center (10, 130)
+    expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(1);
+  });
+
+  it("splits on the horizontal midpoint within the same row", () => {
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(20, 40, 20, 20), over)).toBe(0); // cx 30
+    expect(resolveGridInsertionIndexFromRects(0, makeRect(60, 40, 20, 20), over)).toBe(1); // cx 70
+  });
+
+  it("biases after on an exact horizontal tie", () => {
+    const active = makeRect(40, 40, 20, 20); // center x = 50 == midX
+    expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(1);
+  });
+
+  it("holds the previous 'after' verdict inside the hysteresis dead-zone", () => {
+    const active = makeRect(38, 40, 20, 20); // center x = 48, dist 2 < 8, raw = before
+    expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(0); // no memory → raw
+    expect(resolveGridInsertionIndexFromRects(0, active, over, 1)).toBe(1); // holds after
+  });
+
+  it("holds the previous 'before' verdict inside the hysteresis dead-zone", () => {
+    const active = makeRect(42, 40, 20, 20); // center x = 52, dist 2 < 8, raw = after
+    expect(resolveGridInsertionIndexFromRects(0, active, over)).toBe(1); // no memory → raw
+    expect(resolveGridInsertionIndexFromRects(0, active, over, 0)).toBe(0); // holds before
+  });
+
+  it("lets the raw verdict win once the center leaves the dead-zone", () => {
+    const active = makeRect(60, 40, 20, 20); // center x = 70, dist 20 > 8
+    expect(resolveGridInsertionIndexFromRects(0, active, over, 0)).toBe(1);
+  });
+
+  it("ignores a previousIndex that does not belong to this base index", () => {
+    const active = makeRect(38, 40, 20, 20); // center x = 48 (would hold if adjacent)
+    // previousIndex 5 is not baseIndex(0) or baseIndex+1(1) → recompute raw = before
+    expect(resolveGridInsertionIndexFromRects(0, active, over, 5)).toBe(0);
+  });
+
+  it("honors hysteresis relative to a non-zero base index", () => {
+    const active = makeRect(38, 40, 20, 20); // raw = before = 2
+    expect(resolveGridInsertionIndexFromRects(2, active, over, 3)).toBe(3); // holds after
+    expect(resolveGridInsertionIndexFromRects(2, active, over, 0)).toBe(2); // 0 not adjacent → raw
   });
 });
 

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -31,6 +31,9 @@ export const GRID_INSERTION_HYSTERESIS_PX = 8;
 function isUsableRect(rect: ClientRectLike | null | undefined): rect is ClientRectLike {
   return (
     !!rect &&
+    Number.isFinite(rect.left) &&
+    Number.isFinite(rect.top) &&
+    Number.isFinite(rect.bottom) &&
     Number.isFinite(rect.width) &&
     Number.isFinite(rect.height) &&
     rect.width > 0 &&

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -165,7 +165,14 @@ export function resolveTargetIndex(
   geometry?: {
     activeRect?: ClientRectLike | null;
     overRect?: ClientRectLike | null;
-    previousIndex?: number;
+    /**
+     * The drag-over hysteresis verdict (after vs before the hovered target),
+     * space-agnostic so it reconstructs against this terminal-space index. Kept
+     * as a boolean rather than an absolute index because the placeholder preview
+     * resolves in group-space, which diverges from terminal-space when an
+     * earlier multi-panel group shifts the flat indices.
+     */
+    previousAfter?: boolean;
   }
 ): number {
   const containerTerminals = filterTerminalsByContainer(
@@ -179,11 +186,13 @@ export function resolveTargetIndex(
     const idx = containerTerminals.findIndex((t) => t.id === overId);
     if (idx !== -1) {
       if (geometry) {
+        const previousIndex =
+          geometry.previousAfter === undefined ? undefined : geometry.previousAfter ? idx + 1 : idx;
         return resolveGridInsertionIndexFromRects(
           idx,
           geometry.activeRect,
           geometry.overRect,
-          geometry.previousIndex
+          previousIndex
         );
       }
       return idx;

--- a/src/components/DragDrop/dropResolution.ts
+++ b/src/components/DragDrop/dropResolution.ts
@@ -10,6 +10,81 @@ export interface OverDropData {
   worktreeId?: string;
 }
 
+/** Minimal shape of a dnd-kit `ClientRect` — the fields the geometry math reads. */
+export interface ClientRectLike {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Dead-zone (px) around a slot's horizontal midpoint where the before/after
+ * decision holds its previous value. Inserting the placeholder shifts the
+ * hovered panel's rect under MeasuringStrategy.Always, which would otherwise
+ * flip the verdict frame-to-frame and flicker the placeholder.
+ */
+export const GRID_INSERTION_HYSTERESIS_PX = 8;
+
+function isUsableRect(rect: ClientRectLike | null | undefined): rect is ClientRectLike {
+  return (
+    !!rect &&
+    Number.isFinite(rect.width) &&
+    Number.isFinite(rect.height) &&
+    rect.width > 0 &&
+    rect.height > 0
+  );
+}
+
+/**
+ * Decide whether a dragged item lands before or after the slot it hovers,
+ * returning `baseIndex` (before) or `baseIndex + 1` (after). Reading-order
+ * geometry for a 2-D grid: a drag center above the target row inserts before,
+ * below the row inserts after, and within the row the horizontal midpoint
+ * splits before/after. Missing/degenerate geometry and exact horizontal ties
+ * bias toward after (append) so a dock→grid drop with no clear slot lands last,
+ * not first.
+ *
+ * `previousIndex` (the last resolved index for the same hover target) engages a
+ * hysteresis dead-zone at the horizontal midpoint so the verdict does not
+ * oscillate as the placeholder reflows the target's rect. It is honored only
+ * when it belongs to this target (adjacent to `baseIndex`).
+ */
+export function resolveGridInsertionIndexFromRects(
+  baseIndex: number,
+  activeRect: ClientRectLike | null | undefined,
+  overRect: ClientRectLike | null | undefined,
+  previousIndex?: number,
+  hysteresisPx: number = GRID_INSERTION_HYSTERESIS_PX
+): number {
+  const before = baseIndex;
+  const after = baseIndex + 1;
+
+  if (!isUsableRect(activeRect) || !isUsableRect(overRect)) return after;
+
+  const centerX = activeRect.left + activeRect.width / 2;
+  const centerY = activeRect.top + activeRect.height / 2;
+
+  // Different row than the target: reading order decides outright.
+  if (centerY < overRect.top) return before;
+  if (centerY >= overRect.bottom) return after;
+
+  // Same row: split on the horizontal midpoint, exact ties bias after.
+  const midX = overRect.left + overRect.width / 2;
+  const raw = centerX >= midX ? after : before;
+
+  if (
+    (previousIndex === before || previousIndex === after) &&
+    Math.abs(centerX - midX) < hysteresisPx
+  ) {
+    return previousIndex;
+  }
+
+  return raw;
+}
+
 /** Map dnd-kit container ID strings ("grid-container", "dock-container") to containers. */
 export function resolveContainerId(containerId: string): "grid" | "dock" | null {
   if (containerId === "grid-container") return "grid";
@@ -70,6 +145,11 @@ export function detectTargetContainer(
 /**
  * Compute target insertion index within a container.
  * Falls back: exact terminal match → sortable.index → append-to-end.
+ *
+ * When `geometry` is supplied (dock→grid single-terminal drops), an exact
+ * terminal match resolves before/after the hovered panel via rect geometry
+ * instead of always landing before it, so any slot — including after a single
+ * existing panel — is reachable in one drag.
  */
 export function resolveTargetIndex(
   terminalsById: Record<string, CarrierPanel | undefined>,
@@ -78,7 +158,12 @@ export function resolveTargetIndex(
   targetContainer: "grid" | "dock",
   overId: string,
   sortableIndex: number | undefined,
-  skipAccordionOver: boolean
+  skipAccordionOver: boolean,
+  geometry?: {
+    activeRect?: ClientRectLike | null;
+    overRect?: ClientRectLike | null;
+    previousIndex?: number;
+  }
 ): number {
   const containerTerminals = filterTerminalsByContainer(
     terminalsById,
@@ -89,7 +174,17 @@ export function resolveTargetIndex(
 
   if (!skipAccordionOver) {
     const idx = containerTerminals.findIndex((t) => t.id === overId);
-    if (idx !== -1) return idx;
+    if (idx !== -1) {
+      if (geometry) {
+        return resolveGridInsertionIndexFromRects(
+          idx,
+          geometry.activeRect,
+          geometry.overRect,
+          geometry.previousIndex
+        );
+      }
+      return idx;
+    }
   }
 
   if (sortableIndex !== undefined) return sortableIndex;


### PR DESCRIPTION
## Summary

- With a single panel in the grid, dragging a docked terminal in could only ever land in the first position. Getting it into the second slot took two drags: drop it first, then pick it back up and drag it again.
- Dock-to-grid drags can now target any slot, before or after an existing panel, in one drag.
- The default landing position (when no specific slot is targeted) is now the last slot instead of the first.

Resolves #10995

## Changes

- Added `resolveGridInsertionIndexFromRects` to `src/components/DragDrop/dropResolution.ts`, a pure geometry helper that decides before/after the hovered panel by comparing the dragged rect to the target rect: above is before, below is after, same row uses the horizontal midpoint, biased toward after on ties or missing geometry.
- `handleDragOver` in `src/components/DragDrop/DndProvider.tsx` calls it (gated to a single terminal dragged from dock to grid) to position the placeholder, backed by a per-hover-target hysteresis dead-zone so the placeholder doesn't flicker between positions under `MeasuringStrategy.Always`.
- `handleDragEnd` mirrors the same decision through `resolveTargetIndex`, so dropping directly on a panel commits to whatever slot the placeholder was previewing.
- The before/after verdict is stored as a space-agnostic boolean so it reconstructs correctly against both group-space indices (preview) and terminal-space indices (commit).
- The existing trashed-dock-terminal restore path (`restoreTerminal`, `panelIds`) is structurally isolated from this change and untouched.

Files: `src/components/DragDrop/dropResolution.ts`, `src/components/DragDrop/DndProvider.tsx`, `src/components/DragDrop/__tests__/dropResolution.test.ts` (19 new unit test cases).

## Testing

Ran locally: `dropResolution` test suite (59 tests), full `DragDrop` suite (188 tests), and `dockGridTransitions` suite (14 tests), all green. Own changed files are prettier-clean and pass eslint with 0 errors.