### PR TITLE
refactor(pty): split PtyClient routing, RPC, and signal aggregation

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -684,16 +684,6 @@ export class PtyClient extends EventEmitter {
     return this.placementRouter.peekPlacementKey(projectId);
   }
 
-  /**
-   * Placement with admission: existing shard or override wins; a brand-new
-   * project beyond the shard cap is pinned to the default shard for the rest
-   * of the session (stable placement — a project never flip-flops between
-   * shards while it has live terminals).
-   */
-  private resolvePlacementKey(projectId: string | null | undefined): string {
-    return this.placementRouter.resolvePlacementKey(projectId);
-  }
-
   private ensureShardForProject(projectId: string | null | undefined): PtyShard {
     return this.placementRouter.ensureShardForProject(projectId);
   }

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -74,6 +74,10 @@ import { helpSessionJobService } from "./HelpSessionJobService.js";
 import { getLifecycleLedger, ledgerFactsFromSpawnOptions } from "./pty/lifecycleLedger.js";
 import { BrokerError } from "./rpc/index.js";
 import { routeHostEvent, type PtyEventRouterDeps } from "./pty/PtyEventRouter.js";
+import { sendPtyHostRpc } from "./pty/PtyHostRpcFacade.js";
+import { mergeFlowControlSnapshots, mergeMemoryRollups } from "./pty/rollupMerge.js";
+import { HostSignalAggregator, type HostMemoryWarningPayload } from "./pty/HostSignalAggregator.js";
+import { ShardPlacementRouter } from "./pty/ShardPlacementRouter.js";
 import { PtyShard } from "./pty/PtyShard.js";
 import {
   DEFAULT_SHARD_KEY,
@@ -92,10 +96,8 @@ import type {
   CrashType,
   SpawnResult,
   FlowControlSnapshot,
-  FlowControlShardSnapshot,
   HostThrottlePayload,
   MemoryRollup,
-  MemoryRollupProject,
   GracefulKillResult,
   PtyHostWorkerGovernanceSnapshot,
 } from "../../shared/types/pty-host.js";
@@ -243,6 +245,8 @@ export class PtyClient extends EventEmitter {
   private readonly shards = new Map<string, PtyShard>();
   /** The boot shard — always exists, never retired; the only shard when the fabric is off. */
   private readonly defaultShard: PtyShard;
+  /** Placement lookups over the maps below — constructed once `defaultShard` exists. */
+  private readonly placementRouter: ShardPlacementRouter;
   /** Per-shard router deps, built once per shard (broker + emitter proxy are shard-scoped). */
   private readonly shardRouterDeps = new WeakMap<PtyShard, PtyEventRouterDeps>();
   private shardCallbacksCache: ConstructorParameters<typeof PtyShard>[1] | null = null;
@@ -267,10 +271,9 @@ export class PtyClient extends EventEmitter {
   // treat the payload as THE terminal backend's state, so with multiple shards a
   // healthy sibling's release must not clear a struggling shard's warning — the
   // fabric ORs the per-shard booleans and only forwards aggregate transitions.
-  private readonly throttledShards = new Set<string>();
-  private aggregateThrottled = false;
-  private readonly memoryWarningShards = new Set<string>();
-  private aggregateMemoryWarning = false;
+  private readonly signalAggregator = new HostSignalAggregator({
+    emit: (event, payload) => this.emit(event, payload),
+  });
   /** Mirrors the system-sleep watchdog pause so shards created mid-sleep stay quiet. */
   private healthChecksPaused = false;
 
@@ -368,6 +371,18 @@ export class PtyClient extends EventEmitter {
     this.electronDir = path.basename(__dirname) === "chunks" ? path.dirname(__dirname) : __dirname;
 
     this.defaultShard = this.ensureShard(DEFAULT_SHARD_KEY);
+    this.placementRouter = new ShardPlacementRouter({
+      fabricEnabled: this.fabricEnabled,
+      projectShardCap: this.projectShardCap,
+      defaultShard: this.defaultShard,
+      shards: this.shards,
+      terminalOwners: this.terminalOwners,
+      projectShardOverrides: this.projectShardOverrides,
+      windowPortShard: this.windowPortShard,
+      windowProjectContexts: this.windowProjectContexts,
+      ensureShard: (key) => this.ensureShard(key),
+      logWarn,
+    });
 
     if (!this.config.deferStart) {
       this.start();
@@ -569,27 +584,11 @@ export class PtyClient extends EventEmitter {
   }
 
   private emitAggregatedThrottle(shard: PtyShard, payload: HostThrottlePayload): boolean {
-    if (payload.isThrottled) {
-      this.throttledShards.add(shard.key);
-    } else {
-      this.throttledShards.delete(shard.key);
-    }
-    const aggregate = this.throttledShards.size > 0;
-    if (aggregate === this.aggregateThrottled) return false;
-    this.aggregateThrottled = aggregate;
-    return this.emit("host-throttled", { ...payload, isThrottled: aggregate });
+    return this.signalAggregator.recordThrottle(shard.key, payload);
   }
 
   private emitAggregatedMemoryWarning(shard: PtyShard, payload: HostMemoryWarningPayload): boolean {
-    if (payload.isWarning) {
-      this.memoryWarningShards.add(shard.key);
-    } else {
-      this.memoryWarningShards.delete(shard.key);
-    }
-    const aggregate = this.memoryWarningShards.size > 0;
-    if (aggregate === this.aggregateMemoryWarning) return false;
-    this.aggregateMemoryWarning = aggregate;
-    return this.emit("host-memory-warning", { ...payload, isWarning: aggregate });
+    return this.signalAggregator.recordMemoryWarning(shard.key, payload);
   }
 
   /**
@@ -621,28 +620,7 @@ export class PtyClient extends EventEmitter {
    * not pin "throttled"/"memory warning" on forever.
    */
   private dropShardSignals(shardKey: string): void {
-    if (this.throttledShards.delete(shardKey)) {
-      const aggregate = this.throttledShards.size > 0;
-      if (aggregate !== this.aggregateThrottled) {
-        this.aggregateThrottled = aggregate;
-        this.emit("host-throttled", {
-          isThrottled: aggregate,
-          reason: "host-shard-gone",
-          timestamp: Date.now(),
-        });
-      }
-    }
-    if (this.memoryWarningShards.delete(shardKey)) {
-      const aggregate = this.memoryWarningShards.size > 0;
-      if (aggregate !== this.aggregateMemoryWarning) {
-        this.aggregateMemoryWarning = aggregate;
-        this.emit("host-memory-warning", {
-          isWarning: aggregate,
-          utilizationPercent: 0,
-          timestamp: Date.now(),
-        });
-      }
-    }
+    this.signalAggregator.dropShard(shardKey);
   }
 
   /**
@@ -694,17 +672,16 @@ export class PtyClient extends EventEmitter {
 
   /** Owner shard key for a terminal id; unknown ids fall back to the default shard. */
   private ownerKey(id: string): string {
-    return this.terminalOwners.get(id) ?? DEFAULT_SHARD_KEY;
+    return this.placementRouter.ownerKey(id);
   }
 
   private shardForTerminal(id: string): PtyShard {
-    return this.shards.get(this.ownerKey(id)) ?? this.defaultShard;
+    return this.placementRouter.shardForTerminal(id);
   }
 
   /** Pure placement lookup — never creates shards or records overrides. */
   private peekPlacementKey(projectId: string | null | undefined): string {
-    if (!this.fabricEnabled || !projectId) return DEFAULT_SHARD_KEY;
-    return this.projectShardOverrides.get(projectId) ?? projectId;
+    return this.placementRouter.peekPlacementKey(projectId);
   }
 
   /**
@@ -714,55 +691,31 @@ export class PtyClient extends EventEmitter {
    * shards while it has live terminals).
    */
   private resolvePlacementKey(projectId: string | null | undefined): string {
-    if (!this.fabricEnabled || !projectId) return DEFAULT_SHARD_KEY;
-    const override = this.projectShardOverrides.get(projectId);
-    if (override) return override;
-    if (this.shards.has(projectId)) return projectId;
-    const projectShardCount = this.shards.size - (this.shards.has(DEFAULT_SHARD_KEY) ? 1 : 0);
-    if (projectShardCount >= this.projectShardCap) {
-      logWarn(
-        `[PtyClient] Project shard cap (${this.projectShardCap}) reached; project ${projectId} co-locates on the default shard`
-      );
-      this.projectShardOverrides.set(projectId, DEFAULT_SHARD_KEY);
-      return DEFAULT_SHARD_KEY;
-    }
-    return projectId;
+    return this.placementRouter.resolvePlacementKey(projectId);
   }
 
   private ensureShardForProject(projectId: string | null | undefined): PtyShard {
-    return this.ensureShard(this.resolvePlacementKey(projectId));
+    return this.placementRouter.ensureShardForProject(projectId);
   }
 
   /** Shard that owns a project's terminals (for queries/kills) — never creates. */
   private shardForProjectQuery(projectId: string): PtyShard {
-    return this.shards.get(this.peekPlacementKey(projectId)) ?? this.defaultShard;
+    return this.placementRouter.shardForProjectQuery(projectId);
   }
 
   /** Shard key a window's port should route to, from its current project context. */
   private shardKeyForWindowContext(windowId: number): string {
-    return this.resolvePlacementKey(this.windowProjectContexts.get(windowId)?.projectId ?? null);
+    return this.placementRouter.shardKeyForWindowContext(windowId);
   }
 
   /** Shard that receives window-scoped messages (focus): the port holder, else the context owner. */
   private shardForWindow(windowId: number): PtyShard {
-    const portKey = this.windowPortShard.get(windowId);
-    if (portKey !== undefined) {
-      const shard = this.shards.get(portKey);
-      if (shard) return shard;
-    }
-    return (
-      this.shards.get(
-        this.peekPlacementKey(this.windowProjectContexts.get(windowId)?.projectId ?? null)
-      ) ?? this.defaultShard
-    );
+    return this.placementRouter.shardForWindow(windowId);
   }
 
   /** Shards to fan aggregate queries over. Falls back to the default shard so callers keep the legacy timeout→sentinel path when nothing is ready. */
   private fanOutShards(): PtyShard[] {
-    const ready = [...this.shards.values()].filter(
-      (shard) => !shard.retired && shard.lifecycle.isInitialized && shard.lifecycle.child !== null
-    );
-    return ready.length > 0 ? ready : [this.defaultShard];
+    return this.placementRouter.fanOutShards();
   }
 
   // ── Shard lifecycle ──────────────────────────────────────────────────────
@@ -1766,12 +1719,12 @@ export class PtyClient extends EventEmitter {
 
   async gracefulKill(id: string): Promise<string | null> {
     const shard = this.shardForTerminal(id);
-    const requestId = shard.broker.generateId(`graceful-kill-${id}`);
-    const promise = shard.broker.register<GracefulKillResult>(requestId, {
-      method: "graceful-kill",
-      timeoutMs: PTY_TIMEOUTS["graceful-kill"],
-    });
-    shard.send({ type: "graceful-kill", id, requestId });
+    const promise = sendPtyHostRpc<GracefulKillResult>(
+      shard,
+      `graceful-kill-${id}`,
+      (requestId) => ({ type: "graceful-kill", id, requestId }),
+      { method: "graceful-kill", timeoutMs: PTY_TIMEOUTS["graceful-kill"] }
+    );
     const result = await promise.catch((error: unknown) => {
       // Sending a kill to a host that isn't there only mutates local bookkeeping.
       // Skip whenever the host is known to be gone — either because the broker
@@ -1795,33 +1748,30 @@ export class PtyClient extends EventEmitter {
     options?: { preserveSession?: boolean }
   ): Promise<Array<{ id: string; agentSessionId: string | null }>> {
     const shard = this.shardForProjectQuery(projectId);
-    const requestId = shard.broker.generateId(`graceful-kill-by-project-${projectId}`);
-    const promise = shard.broker.register<Array<{ id: string; agentSessionId: string | null }>>(
-      requestId,
-      {
-        method: "graceful-kill-by-project",
-        timeoutMs: PTY_TIMEOUTS["graceful-kill-by-project"],
-      }
+    const promise = sendPtyHostRpc<Array<{ id: string; agentSessionId: string | null }>>(
+      shard,
+      `graceful-kill-by-project-${projectId}`,
+      (requestId) => ({
+        type: "graceful-kill-by-project",
+        projectId,
+        requestId,
+        ...(options?.preserveSession !== undefined
+          ? { preserveSession: options.preserveSession }
+          : {}),
+      }),
+      { method: "graceful-kill-by-project", timeoutMs: PTY_TIMEOUTS["graceful-kill-by-project"] }
     );
-    shard.send({
-      type: "graceful-kill-by-project",
-      projectId,
-      requestId,
-      ...(options?.preserveSession !== undefined
-        ? { preserveSession: options.preserveSession }
-        : {}),
-    });
     return promise.catch(() => []);
   }
 
   async killByProject(projectId: string): Promise<number> {
     const shard = this.shardForProjectQuery(projectId);
-    const requestId = shard.broker.generateId(`kill-by-project-${projectId}`);
-    const promise = shard.broker.register<number>(requestId, {
-      method: "kill-by-project",
-      timeoutMs: PTY_TIMEOUTS["kill-by-project"],
-    });
-    shard.send({ type: "kill-by-project", projectId, requestId });
+    const promise = sendPtyHostRpc<number>(
+      shard,
+      `kill-by-project-${projectId}`,
+      (requestId) => ({ type: "kill-by-project", projectId, requestId }),
+      { method: "kill-by-project", timeoutMs: PTY_TIMEOUTS["kill-by-project"] }
+    );
     return promise.catch(() => 0);
   }
 
@@ -1831,13 +1781,15 @@ export class PtyClient extends EventEmitter {
     terminalTypes: Record<string, number>;
   }> {
     const shard = this.shardForProjectQuery(projectId);
-    const requestId = shard.broker.generateId(`project-stats-${projectId}`);
-    const promise = shard.broker.register<{
+    const promise = sendPtyHostRpc<{
       terminalCount: number;
       processIds: number[];
       terminalTypes: Record<string, number>;
-    }>(requestId);
-    shard.send({ type: "get-project-stats", projectId, requestId });
+    }>(shard, `project-stats-${projectId}`, (requestId) => ({
+      type: "get-project-stats",
+      projectId,
+      requestId,
+    }));
     return promise.catch(() => ({ terminalCount: 0, processIds: [], terminalTypes: {} }));
   }
 
@@ -1853,9 +1805,10 @@ export class PtyClient extends EventEmitter {
     const rollups = (
       await Promise.all(
         shards.map((shard) => {
-          const requestId = shard.broker.generateId("memory-rollup");
-          const promise = shard.broker.register<MemoryRollup>(requestId);
-          shard.send({ type: "get-memory-rollup", requestId });
+          const promise = sendPtyHostRpc<MemoryRollup>(shard, "memory-rollup", (requestId) => ({
+            type: "get-memory-rollup",
+            requestId,
+          }));
           return promise.catch(() => null);
         })
       )
@@ -1899,18 +1852,22 @@ export class PtyClient extends EventEmitter {
   /** Get terminal IDs for a specific project */
   async getTerminalsForProjectAsync(projectId: string): Promise<string[]> {
     const shard = this.shardForProjectQuery(projectId);
-    const requestId = shard.broker.generateId(`terminals-${projectId}`);
-    const promise = shard.broker.register<string[]>(requestId);
-    shard.send({ type: "get-terminals-for-project", projectId, requestId });
+    const promise = sendPtyHostRpc<string[]>(shard, `terminals-${projectId}`, (requestId) => ({
+      type: "get-terminals-for-project",
+      projectId,
+      requestId,
+    }));
     return promise.catch(() => []);
   }
 
   /** Get terminal info by ID */
   async getTerminalAsync(id: string): Promise<TerminalInfoResponse | null> {
     const shard = this.shardForTerminal(id);
-    const requestId = shard.broker.generateId(`terminal-${id}`);
-    const promise = shard.broker.register<TerminalInfoResponse | null>(requestId);
-    shard.send({ type: "get-terminal", id, requestId });
+    const promise = sendPtyHostRpc<TerminalInfoResponse | null>(
+      shard,
+      `terminal-${id}`,
+      (requestId) => ({ type: "get-terminal", id, requestId })
+    );
     return promise.catch(() => null);
   }
 
@@ -1918,9 +1875,11 @@ export class PtyClient extends EventEmitter {
   async getAvailableTerminalsAsync(): Promise<TerminalInfoResponse[]> {
     const results = await Promise.all(
       this.fanOutShards().map((shard) => {
-        const requestId = shard.broker.generateId("available-terminals");
-        const promise = shard.broker.register<TerminalInfoResponse[]>(requestId);
-        shard.send({ type: "get-available-terminals", requestId });
+        const promise = sendPtyHostRpc<TerminalInfoResponse[]>(
+          shard,
+          "available-terminals",
+          (requestId) => ({ type: "get-available-terminals", requestId })
+        );
         return promise.catch(() => [] as TerminalInfoResponse[]);
       })
     );
@@ -1933,9 +1892,11 @@ export class PtyClient extends EventEmitter {
   ): Promise<TerminalInfoResponse[]> {
     const results = await Promise.all(
       this.fanOutShards().map((shard) => {
-        const requestId = shard.broker.generateId(`terminals-by-state-${state}`);
-        const promise = shard.broker.register<TerminalInfoResponse[]>(requestId);
-        shard.send({ type: "get-terminals-by-state", state, requestId });
+        const promise = sendPtyHostRpc<TerminalInfoResponse[]>(
+          shard,
+          `terminals-by-state-${state}`,
+          (requestId) => ({ type: "get-terminals-by-state", state, requestId })
+        );
         return promise.catch(() => [] as TerminalInfoResponse[]);
       })
     );
@@ -1946,9 +1907,11 @@ export class PtyClient extends EventEmitter {
   async getAllTerminalsAsync(): Promise<TerminalInfoResponse[]> {
     const results = await Promise.all(
       this.fanOutShards().map((shard) => {
-        const requestId = shard.broker.generateId("all-terminals");
-        const promise = shard.broker.register<TerminalInfoResponse[]>(requestId);
-        shard.send({ type: "get-all-terminals", requestId });
+        const promise = sendPtyHostRpc<TerminalInfoResponse[]>(
+          shard,
+          "all-terminals",
+          (requestId) => ({ type: "get-all-terminals", requestId })
+        );
         return promise.catch(() => [] as TerminalInfoResponse[]);
       })
     );
@@ -1969,9 +1932,11 @@ export class PtyClient extends EventEmitter {
     const results = (
       await Promise.all(
         shards.map((shard) => {
-          const requestId = shard.broker.generateId("flow-control-snapshot");
-          const promise = shard.broker.register<FlowControlSnapshot>(requestId);
-          shard.send({ type: "get-flow-control-snapshot", requestId });
+          const promise = sendPtyHostRpc<FlowControlSnapshot>(
+            shard,
+            "flow-control-snapshot",
+            (requestId) => ({ type: "get-flow-control-snapshot", requestId })
+          );
           return promise.then(
             (snapshot) => ({ shardKey: shard.key, snapshot }),
             () => null
@@ -2018,9 +1983,11 @@ export class PtyClient extends EventEmitter {
     const snapshots = (
       await Promise.all(
         this.fanOutShards().map((shard) => {
-          const requestId = shard.broker.generateId("worker-governance-snapshot");
-          const promise = shard.broker.register<PtyHostWorkerGovernanceSnapshot>(requestId);
-          shard.send({ type: "get-worker-governance-snapshot", requestId });
+          const promise = sendPtyHostRpc<PtyHostWorkerGovernanceSnapshot>(
+            shard,
+            "worker-governance-snapshot",
+            (requestId) => ({ type: "get-worker-governance-snapshot", requestId })
+          );
           return promise.catch(() => null);
         })
       )
@@ -2050,12 +2017,14 @@ export class PtyClient extends EventEmitter {
   ): Promise<import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]> {
     const results = await Promise.all(
       this.fanOutShards().map((shard) => {
-        const requestId = shard.broker.generateId("semantic-search");
-        const promise =
-          shard.broker.register<import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]>(
-            requestId
-          );
-        shard.send({ type: "search-semantic-buffers", query, isRegex, requestId });
+        const promise = sendPtyHostRpc<
+          import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]
+        >(shard, "semantic-search", (requestId) => ({
+          type: "search-semantic-buffers",
+          query,
+          isRegex,
+          requestId,
+        }));
         return promise.catch(
           () => [] as import("../../shared/types/ipc/terminal.js").SemanticSearchMatch[]
         );
@@ -2067,9 +2036,12 @@ export class PtyClient extends EventEmitter {
   /** Replay terminal history */
   async replayHistoryAsync(id: string, maxLines: number = 100): Promise<number> {
     const shard = this.shardForTerminal(id);
-    const requestId = shard.broker.generateId(`replay-${id}`);
-    const promise = shard.broker.register<number>(requestId);
-    shard.send({ type: "replay-history", id, maxLines, requestId });
+    const promise = sendPtyHostRpc<number>(shard, `replay-${id}`, (requestId) => ({
+      type: "replay-history",
+      id,
+      maxLines,
+      requestId,
+    }));
     return promise.catch(() => 0);
   }
 
@@ -2081,13 +2053,13 @@ export class PtyClient extends EventEmitter {
    */
   async getSerializedStateAsync(id: string): Promise<string | null> {
     const shard = this.shardForTerminal(id);
-    const requestId = shard.broker.generateId(`serialize-${id}`);
     // Extended timeout for large terminals with lots of scrollback (see PTY_TIMEOUTS).
-    const promise = shard.broker.register<string | null>(requestId, {
-      method: "get-serialized-state",
-      timeoutMs: PTY_TIMEOUTS["get-serialized-state"],
-    });
-    shard.send({ type: "get-serialized-state", id, requestId });
+    const promise = sendPtyHostRpc<string | null>(
+      shard,
+      `serialize-${id}`,
+      (requestId) => ({ type: "get-serialized-state", id, requestId }),
+      { method: "get-serialized-state", timeoutMs: PTY_TIMEOUTS["get-serialized-state"] }
+    );
     return promise.catch(() => {
       console.warn(`[PtyClient] getSerializedState timeout for ${id}`);
       return null;
@@ -2101,23 +2073,23 @@ export class PtyClient extends EventEmitter {
     id: string
   ): Promise<import("../../shared/types/ipc.js").TerminalInfoPayload | null> {
     const shard = this.shardForTerminal(id);
-    const requestId = shard.broker.generateId(`terminal-info-${id}`);
-    const promise = shard.broker.register<
-      import("../../shared/types/ipc.js").TerminalInfoPayload | null
-    >(requestId);
-    shard.send({ type: "get-terminal-info", id, requestId });
+    const promise = sendPtyHostRpc<import("../../shared/types/ipc.js").TerminalInfoPayload | null>(
+      shard,
+      `terminal-info-${id}`,
+      (requestId) => ({ type: "get-terminal-info", id, requestId })
+    );
     return promise.catch(() => null);
   }
 
   /** Get a snapshot of terminal state (async due to IPC) */
   async getTerminalSnapshot(id: string): Promise<TerminalSnapshot | null> {
     const shard = this.shardForTerminal(id);
-    const requestId = shard.broker.generateId(`snapshot-${id}`);
-    const promise = shard.broker.register<TerminalSnapshot | null>(requestId, {
-      method: "get-snapshot",
-      timeoutMs: PTY_TIMEOUTS["get-snapshot"],
-    });
-    shard.send({ type: "get-snapshot", id, requestId });
+    const promise = sendPtyHostRpc<TerminalSnapshot | null>(
+      shard,
+      `snapshot-${id}`,
+      (requestId) => ({ type: "get-snapshot", id, requestId }),
+      { method: "get-snapshot", timeoutMs: PTY_TIMEOUTS["get-snapshot"] }
+    );
     return promise.catch(() => null);
   }
 
@@ -2125,12 +2097,12 @@ export class PtyClient extends EventEmitter {
   async getAllTerminalSnapshots(): Promise<TerminalSnapshot[]> {
     const results = await Promise.all(
       this.fanOutShards().map((shard) => {
-        const requestId = shard.broker.generateId("all-snapshots");
-        const promise = shard.broker.register<TerminalSnapshot[]>(requestId, {
-          method: "get-all-snapshots",
-          timeoutMs: PTY_TIMEOUTS["get-all-snapshots"],
-        });
-        shard.send({ type: "get-all-snapshots", requestId });
+        const promise = sendPtyHostRpc<TerminalSnapshot[]>(
+          shard,
+          "all-snapshots",
+          (requestId) => ({ type: "get-all-snapshots", requestId }),
+          { method: "get-all-snapshots", timeoutMs: PTY_TIMEOUTS["get-all-snapshots"] }
+        );
         return promise.catch(() => [] as TerminalSnapshot[]);
       })
     );
@@ -2153,20 +2125,20 @@ export class PtyClient extends EventEmitter {
     spawnedAt?: number
   ): Promise<boolean> {
     const shard = this.shardForTerminal(id);
-    const requestId = shard.broker.generateId(`transition-${id}`);
-    const promise = shard.broker.register<boolean>(requestId, {
-      method: "transition-state",
-      timeoutMs: PTY_TIMEOUTS["transition-state"],
-    });
-    shard.send({
-      type: "transition-state",
-      id,
-      requestId,
-      event,
-      trigger,
-      confidence,
-      spawnedAt,
-    });
+    const promise = sendPtyHostRpc<boolean>(
+      shard,
+      `transition-${id}`,
+      (requestId) => ({
+        type: "transition-state",
+        id,
+        requestId,
+        event,
+        trigger,
+        confidence,
+        spawnedAt,
+      }),
+      { method: "transition-state", timeoutMs: PTY_TIMEOUTS["transition-state"] }
+    );
     return promise.catch(() => false);
   }
 
@@ -2250,8 +2222,7 @@ export class PtyClient extends EventEmitter {
     this.terminalOwners.clear();
     this.projectShardOverrides.clear();
     this.windowPortShard.clear();
-    this.throttledShards.clear();
-    this.memoryWarningShards.clear();
+    this.signalAggregator.clear();
     this.removeAllListeners();
 
     console.log("[PtyClient] Disposed");
@@ -2290,17 +2261,6 @@ export class PtyClient extends EventEmitter {
   }
 }
 
-/** Payload shape the event router emits for `host-memory-warning`. */
-interface HostMemoryWarningPayload {
-  isWarning: boolean;
-  utilizationPercent: number;
-  heapMb?: number;
-  externalMb?: number;
-  workerHeapMb?: number;
-  workerExternalMb?: number;
-  timestamp: number;
-}
-
 /**
  * Per-shard emitter handed to the event router: every `emit` the router (or
  * the events bridge callbacks) performs is redirected into the fabric's
@@ -2316,92 +2276,6 @@ class ShardEventEmitter extends EventEmitter {
   override emit(event: string | symbol, ...args: unknown[]): boolean {
     return this.forward(String(event), args);
   }
-}
-
-/**
- * Merge per-shard memory rollups into one app-wide rollup. The fabric places
- * a project on exactly one shard, so per-project rows never overlap across
- * shards — the by-key merge below is defensive (and collapses the null-project
- * row if it ever appears on more than one shard). `available` is a global
- * claim ("the process table was read"), so one failed shard marks the merged
- * rollup unavailable rather than silently under-reporting.
- */
-function mergeMemoryRollups(rollups: MemoryRollup[]): MemoryRollup {
-  const byKey = new Map<string | null, MemoryRollupProject>();
-  for (const rollup of rollups) {
-    for (const row of rollup.byProject) {
-      const existing = byKey.get(row.projectId);
-      if (!existing) {
-        byKey.set(row.projectId, { ...row, topProcesses: [...row.topProcesses] });
-        continue;
-      }
-      existing.terminalCount += row.terminalCount;
-      existing.processCount += row.processCount;
-      existing.memoryKb += row.memoryKb;
-      existing.topProcesses = [...existing.topProcesses, ...row.topProcesses]
-        .sort((a, b) => b.memoryKb - a.memoryKb)
-        .slice(0, 5);
-    }
-  }
-  return {
-    byProject: [...byKey.values()],
-    totalMemoryKb: rollups.reduce((sum, r) => sum + r.totalMemoryKb, 0),
-    totalProcessCount: rollups.reduce((sum, r) => sum + r.totalProcessCount, 0),
-    terminalCount: rollups.reduce((sum, r) => sum + r.terminalCount, 0),
-    available: rollups.every((r) => r.available),
-    sampledAt: Math.max(...rollups.map((r) => r.sampledAt)),
-  };
-}
-
-/**
- * Merge per-shard flow-control snapshots. Terminal rows and queue depths
- * concatenate (terminals are disjoint across shards); counters sum; the
- * top-level governor/event-loop fields carry the worst-shard view so single-
- * number diagnostics ("is the terminal backend throttled", "PTY host lag
- * p99") stay meaningful; `shards` carries the per-shard breakdown.
- */
-function mergeFlowControlSnapshots(
-  entries: Array<{ shardKey: string; snapshot: FlowControlSnapshot }>
-): FlowControlSnapshot {
-  const snapshots = entries.map((e) => e.snapshot);
-  const smoothed = snapshots
-    .map((s) => s.resourceGovernor.smoothedUtilizationPercent)
-    .filter((v): v is number => v !== null);
-  const eventLoops = snapshots
-    .map((s) => s.eventLoop)
-    .filter((v): v is NonNullable<FlowControlSnapshot["eventLoop"]> => v !== null);
-  const worstEventLoop =
-    eventLoops.length > 0
-      ? eventLoops.reduce((worst, current) => (current.p99Ms > worst.p99Ms ? current : worst))
-      : null;
-  const shards: FlowControlShardSnapshot[] = entries.map(({ shardKey, snapshot }) => ({
-    shardKey,
-    terminalCount: snapshot.terminals.length,
-    totalPendingBytes: snapshot.totalPendingBytes,
-    resourceGovernor: snapshot.resourceGovernor,
-    eventLoop: snapshot.eventLoop,
-  }));
-  return {
-    timestamp: Math.max(...snapshots.map((s) => s.timestamp)),
-    terminals: snapshots.flatMap((s) => s.terminals),
-    queueDepth: snapshots.flatMap((s) => s.queueDepth),
-    totalPendingBytes: snapshots.reduce((sum, s) => sum + s.totalPendingBytes, 0),
-    stats: {
-      pauseCount: snapshots.reduce((sum, s) => sum + s.stats.pauseCount, 0),
-      resumeCount: snapshots.reduce((sum, s) => sum + s.stats.resumeCount, 0),
-      suspendCount: snapshots.reduce((sum, s) => sum + s.stats.suspendCount, 0),
-      forceResumeCount: snapshots.reduce((sum, s) => sum + s.stats.forceResumeCount, 0),
-    },
-    resourceGovernor: {
-      isThrottling: snapshots.some((s) => s.resourceGovernor.isThrottling),
-      isWarning: snapshots.some((s) => s.resourceGovernor.isWarning),
-      activeProfile: snapshots[0].resourceGovernor.activeProfile,
-      smoothedUtilizationPercent: smoothed.length > 0 ? Math.max(...smoothed) : null,
-      throttleDurationMs: Math.max(...snapshots.map((s) => s.resourceGovernor.throttleDurationMs)),
-    },
-    eventLoop: worstEventLoop,
-    shards,
-  };
 }
 
 let ptyClientInstance: PtyClient | null = null;

--- a/electron/services/pty/HostSignalAggregator.ts
+++ b/electron/services/pty/HostSignalAggregator.ts
@@ -1,0 +1,96 @@
+/**
+ * HostSignalAggregator - OR-aggregation of process-scoped PTY host signals
+ * (`host-throttled`, `host-memory-warning`) across every live shard.
+ *
+ * Consumers of these events treat the payload as THE terminal backend's
+ * state, so with multiple shards a healthy sibling's release must not clear
+ * a struggling shard's warning — this aggregates the per-shard booleans and
+ * only forwards a transition when the aggregate actually flips. Extracted
+ * verbatim from PtyClient.ts (#11007) — no behavior changes.
+ */
+
+import type { HostThrottlePayload } from "../../../shared/types/pty-host.js";
+
+/** Payload shape the event router emits for `host-memory-warning`. */
+export interface HostMemoryWarningPayload {
+  isWarning: boolean;
+  utilizationPercent: number;
+  heapMb?: number;
+  externalMb?: number;
+  workerHeapMb?: number;
+  workerExternalMb?: number;
+  timestamp: number;
+}
+
+export interface HostSignalAggregatorDeps {
+  emit: (event: string, payload: unknown) => boolean;
+}
+
+export class HostSignalAggregator {
+  private readonly throttledShards = new Set<string>();
+  private aggregateThrottled = false;
+  private readonly memoryWarningShards = new Set<string>();
+  private aggregateMemoryWarning = false;
+
+  constructor(private readonly deps: HostSignalAggregatorDeps) {}
+
+  recordThrottle(shardKey: string, payload: HostThrottlePayload): boolean {
+    if (payload.isThrottled) {
+      this.throttledShards.add(shardKey);
+    } else {
+      this.throttledShards.delete(shardKey);
+    }
+    const aggregate = this.throttledShards.size > 0;
+    if (aggregate === this.aggregateThrottled) return false;
+    this.aggregateThrottled = aggregate;
+    return this.deps.emit("host-throttled", { ...payload, isThrottled: aggregate });
+  }
+
+  recordMemoryWarning(shardKey: string, payload: HostMemoryWarningPayload): boolean {
+    if (payload.isWarning) {
+      this.memoryWarningShards.add(shardKey);
+    } else {
+      this.memoryWarningShards.delete(shardKey);
+    }
+    const aggregate = this.memoryWarningShards.size > 0;
+    if (aggregate === this.aggregateMemoryWarning) return false;
+    this.aggregateMemoryWarning = aggregate;
+    return this.deps.emit("host-memory-warning", { ...payload, isWarning: aggregate });
+  }
+
+  /**
+   * Drop a departed shard's attribution from the aggregated signals and emit
+   * the release edge if the aggregate flipped — a retired/crashed shard must
+   * not pin "throttled"/"memory warning" on forever.
+   */
+  dropShard(shardKey: string): void {
+    if (this.throttledShards.delete(shardKey)) {
+      const aggregate = this.throttledShards.size > 0;
+      if (aggregate !== this.aggregateThrottled) {
+        this.aggregateThrottled = aggregate;
+        this.deps.emit("host-throttled", {
+          isThrottled: aggregate,
+          reason: "host-shard-gone",
+          timestamp: Date.now(),
+        });
+      }
+    }
+    if (this.memoryWarningShards.delete(shardKey)) {
+      const aggregate = this.memoryWarningShards.size > 0;
+      if (aggregate !== this.aggregateMemoryWarning) {
+        this.aggregateMemoryWarning = aggregate;
+        this.deps.emit("host-memory-warning", {
+          isWarning: aggregate,
+          utilizationPercent: 0,
+          timestamp: Date.now(),
+        });
+      }
+    }
+  }
+
+  /** Reset all aggregation state — called from PtyClient.dispose(). */
+  clear(): void {
+    this.throttledShards.clear();
+    this.memoryWarningShards.clear();
+  }
+}

--- a/electron/services/pty/PtyHostRpcFacade.ts
+++ b/electron/services/pty/PtyHostRpcFacade.ts
@@ -1,0 +1,38 @@
+/**
+ * PtyHostRpcFacade - Thin wrapper for the repeated
+ * `generateId -> register -> send` triad every PtyClient RPC method performs
+ * against a {@link PtyShard}'s broker.
+ *
+ * Deliberately does NOT own fallback/error-handling policy: callers keep
+ * their own `.catch()`/`.then()` on the returned promise. Fallback behavior
+ * differs per call site (e.g. `PtyClient.gracefulKill`'s forced-kill
+ * escalation on a live-host timeout vs. every other method's plain
+ * `.catch(() => defaultValue)`), so flattening it into this facade would
+ * silently change behavior. See #11007.
+ */
+
+import type { PtyHostRequest } from "../../../shared/types/pty-host.js";
+import type { RegisterOptions } from "../rpc/index.js";
+import type { PtyShard } from "./PtyShard.js";
+
+/**
+ * Generate a request id (via `shard.broker.generateId(idSuffix)`), register
+ * it with the broker, send the built request, and return the broker's
+ * promise. Register-before-send ordering is preserved exactly — the host can
+ * resolve synchronously on some paths, so listeners must be live before the
+ * message is sent (#5434).
+ */
+export function sendPtyHostRpc<T>(
+  shard: PtyShard,
+  idSuffix: string,
+  buildRequest: (requestId: string) => PtyHostRequest,
+  registerOptions?: RegisterOptions
+): Promise<T> {
+  const requestId = shard.broker.generateId(idSuffix);
+  // Always pass an options object (never omit the arg) to stay on the
+  // `options: RegisterOptions` overload — `register<T>(id, {})` normalizes
+  // identically to the zero-arg call (both yield method/timeoutMs undefined).
+  const promise = shard.broker.register<T>(requestId, registerOptions ?? {});
+  shard.send(buildRequest(requestId));
+  return promise;
+}

--- a/electron/services/pty/ShardPlacementRouter.ts
+++ b/electron/services/pty/ShardPlacementRouter.ts
@@ -1,0 +1,128 @@
+/**
+ * ShardPlacementRouter - Cross-shard placement lookups for the PTY fabric.
+ *
+ * Fabric invariant: one project -> one shard. A project's terminals never
+ * split across shards, so per-project ops (kill-by-project, rollup rows,
+ * pool warm) stay single-shard.
+ *
+ * State stays centralized in PtyClient — this router takes the
+ * placement-relevant maps by reference (mirrors the PtyEventRouter
+ * shared-state convention) plus a live accessor (`ensureShard`, which can
+ * fork a new shard) so the "owner entry lives until no incarnation remains"
+ * lifetime invariants stay in one place. Extracted verbatim from
+ * PtyClient.ts (#11007) — no behavior changes.
+ */
+
+import { DEFAULT_SHARD_KEY } from "./fabricConfig.js";
+import type { PtyShard } from "./PtyShard.js";
+
+export interface ShardPlacementWindowContext {
+  projectId: string | null;
+  projectPath?: string;
+  mode: "active" | "switch";
+}
+
+export interface ShardPlacementRouterDeps {
+  /** Whether the PTY fabric (per-project host shards) is active. */
+  fabricEnabled: boolean;
+  /** Max concurrent project shards; overflow projects co-locate on the default shard. */
+  projectShardCap: number;
+  /** The boot shard — always exists, never retired. */
+  defaultShard: PtyShard;
+  /** Live shards by key, shared by reference with PtyClient. */
+  shards: Map<string, PtyShard>;
+  /** terminalId -> owning shard key, shared by reference with PtyClient. */
+  terminalOwners: Map<string, string>;
+  /** projectId -> forced shard key, shared by reference with PtyClient. */
+  projectShardOverrides: Map<string, string>;
+  /** windowId -> shard key currently holding (or pending) that window's MessagePort. */
+  windowPortShard: Map<number, string>;
+  /** windowId -> current project context, shared by reference with PtyClient. */
+  windowProjectContexts: Map<number, ShardPlacementWindowContext>;
+  /** Get or create the shard for a key. Forks immediately once start() has been requested. */
+  ensureShard: (key: string) => PtyShard;
+  logWarn: (message: string) => void;
+}
+
+export class ShardPlacementRouter {
+  constructor(private readonly deps: ShardPlacementRouterDeps) {}
+
+  /** Owner shard key for a terminal id; unknown ids fall back to the default shard. */
+  ownerKey(id: string): string {
+    return this.deps.terminalOwners.get(id) ?? DEFAULT_SHARD_KEY;
+  }
+
+  shardForTerminal(id: string): PtyShard {
+    return this.deps.shards.get(this.ownerKey(id)) ?? this.deps.defaultShard;
+  }
+
+  /** Pure placement lookup — never creates shards or records overrides. */
+  peekPlacementKey(projectId: string | null | undefined): string {
+    if (!this.deps.fabricEnabled || !projectId) return DEFAULT_SHARD_KEY;
+    return this.deps.projectShardOverrides.get(projectId) ?? projectId;
+  }
+
+  /**
+   * Placement with admission: existing shard or override wins; a brand-new
+   * project beyond the shard cap is pinned to the default shard for the rest
+   * of the session (stable placement — a project never flip-flops between
+   * shards while it has live terminals).
+   */
+  resolvePlacementKey(projectId: string | null | undefined): string {
+    if (!this.deps.fabricEnabled || !projectId) return DEFAULT_SHARD_KEY;
+    const override = this.deps.projectShardOverrides.get(projectId);
+    if (override) return override;
+    if (this.deps.shards.has(projectId)) return projectId;
+    const projectShardCount =
+      this.deps.shards.size - (this.deps.shards.has(DEFAULT_SHARD_KEY) ? 1 : 0);
+    if (projectShardCount >= this.deps.projectShardCap) {
+      this.deps.logWarn(
+        `[PtyClient] Project shard cap (${this.deps.projectShardCap}) reached; project ${projectId} co-locates on the default shard`
+      );
+      this.deps.projectShardOverrides.set(projectId, DEFAULT_SHARD_KEY);
+      return DEFAULT_SHARD_KEY;
+    }
+    return projectId;
+  }
+
+  ensureShardForProject(projectId: string | null | undefined): PtyShard {
+    return this.deps.ensureShard(this.resolvePlacementKey(projectId));
+  }
+
+  /** Shard that owns a project's terminals (for queries/kills) — never creates. */
+  shardForProjectQuery(projectId: string): PtyShard {
+    return this.deps.shards.get(this.peekPlacementKey(projectId)) ?? this.deps.defaultShard;
+  }
+
+  /** Shard key a window's port should route to, from its current project context. */
+  shardKeyForWindowContext(windowId: number): string {
+    return this.resolvePlacementKey(
+      this.deps.windowProjectContexts.get(windowId)?.projectId ?? null
+    );
+  }
+
+  /** Shard that receives window-scoped messages (focus): the port holder, else the context owner. */
+  shardForWindow(windowId: number): PtyShard {
+    const portKey = this.deps.windowPortShard.get(windowId);
+    if (portKey !== undefined) {
+      const shard = this.deps.shards.get(portKey);
+      if (shard) return shard;
+    }
+    return (
+      this.deps.shards.get(
+        this.peekPlacementKey(this.deps.windowProjectContexts.get(windowId)?.projectId ?? null)
+      ) ?? this.deps.defaultShard
+    );
+  }
+
+  /**
+   * Shards to fan aggregate queries over. Falls back to the default shard so
+   * callers keep the legacy timeout->sentinel path when nothing is ready.
+   */
+  fanOutShards(): PtyShard[] {
+    const ready = [...this.deps.shards.values()].filter(
+      (shard) => !shard.retired && shard.lifecycle.isInitialized && shard.lifecycle.child !== null
+    );
+    return ready.length > 0 ? ready : [this.deps.defaultShard];
+  }
+}

--- a/electron/services/pty/__tests__/PtyHostRpcFacade.test.ts
+++ b/electron/services/pty/__tests__/PtyHostRpcFacade.test.ts
@@ -13,7 +13,7 @@ function makeShard(overrides: { registerResult?: unknown; registerError?: Error 
         calls.push("generateId");
         return suffix ? `req-1-${suffix}` : "req-1";
       }),
-      register: vi.fn((requestId: string, options?: unknown) => {
+      register: vi.fn((_requestId: string, options?: unknown) => {
         calls.push("register");
         registerArgs.push(options);
         if (overrides.registerError) {

--- a/electron/services/pty/__tests__/PtyHostRpcFacade.test.ts
+++ b/electron/services/pty/__tests__/PtyHostRpcFacade.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest";
+import { sendPtyHostRpc } from "../PtyHostRpcFacade.js";
+import type { PtyShard } from "../PtyShard.js";
+
+/** Minimal shard double — the facade only touches `broker` and `send`. */
+function makeShard(overrides: { registerResult?: unknown; registerError?: Error } = {}) {
+  const calls: string[] = [];
+  const registerArgs: unknown[] = [];
+  const sentRequests: unknown[] = [];
+  const shard = {
+    broker: {
+      generateId: vi.fn((suffix?: string) => {
+        calls.push("generateId");
+        return suffix ? `req-1-${suffix}` : "req-1";
+      }),
+      register: vi.fn((requestId: string, options?: unknown) => {
+        calls.push("register");
+        registerArgs.push(options);
+        if (overrides.registerError) {
+          return Promise.reject(overrides.registerError);
+        }
+        return Promise.resolve(overrides.registerResult);
+      }),
+    },
+    send: vi.fn((request: unknown) => {
+      calls.push("send");
+      sentRequests.push(request);
+    }),
+  };
+  return { shard: shard as unknown as PtyShard, calls, registerArgs, sentRequests };
+}
+
+describe("sendPtyHostRpc", () => {
+  it("generates the request id via the suffix, registers, then sends — in that order", async () => {
+    const { shard, calls, sentRequests } = makeShard({ registerResult: { ok: true } });
+
+    const result = await sendPtyHostRpc<{ ok: boolean }>(shard, "my-suffix", (requestId) => ({
+      type: "get-terminal",
+      id: "t1",
+      requestId,
+    }));
+
+    expect(result).toEqual({ ok: true });
+    expect(shard.broker.generateId).toHaveBeenCalledWith("my-suffix");
+    // Register must be called before send — the host can resolve synchronously
+    // on some paths, so listeners must be live before the message goes out (#5434).
+    expect(calls).toEqual(["generateId", "register", "send"]);
+    expect(sentRequests).toEqual([
+      { type: "get-terminal", id: "t1", requestId: "req-1-my-suffix" },
+    ]);
+  });
+
+  it("threads the generated request id into the built request", async () => {
+    const { shard, sentRequests } = makeShard({ registerResult: [] });
+
+    await sendPtyHostRpc(shard, "terminals-proj-1", (requestId) => ({
+      type: "get-terminals-for-project",
+      projectId: "proj-1",
+      requestId,
+    }));
+
+    expect(sentRequests).toEqual([
+      {
+        type: "get-terminals-for-project",
+        projectId: "proj-1",
+        requestId: "req-1-terminals-proj-1",
+      },
+    ]);
+  });
+
+  it("forwards register options (method/timeoutMs) to the broker", async () => {
+    const { shard, registerArgs } = makeShard({ registerResult: null });
+
+    await sendPtyHostRpc(
+      shard,
+      "graceful-kill-t1",
+      (requestId) => ({ type: "graceful-kill", id: "t1", requestId }),
+      { method: "graceful-kill", timeoutMs: 5000 }
+    );
+
+    expect(registerArgs).toEqual([{ method: "graceful-kill", timeoutMs: 5000 }]);
+  });
+
+  it("normalizes a missing options arg to an empty object rather than omitting it", async () => {
+    const { shard, registerArgs } = makeShard({ registerResult: null });
+
+    await sendPtyHostRpc(shard, "no-options", (requestId) => ({
+      type: "get-project-stats",
+      projectId: "p",
+      requestId,
+    }));
+
+    expect(registerArgs).toEqual([{}]);
+  });
+
+  it("leaves rejection handling to the caller — does not swallow broker errors", async () => {
+    const { shard } = makeShard({ registerError: new Error("boom") });
+
+    await expect(
+      sendPtyHostRpc(shard, "will-fail", (requestId) => ({
+        type: "get-terminal",
+        id: "t1",
+        requestId,
+      }))
+    ).rejects.toThrow("boom");
+  });
+});

--- a/electron/services/pty/__tests__/rollupMerge.test.ts
+++ b/electron/services/pty/__tests__/rollupMerge.test.ts
@@ -186,13 +186,13 @@ describe("mergeFlowControlSnapshots", () => {
       {
         shardKey: "main",
         snapshot: makeFlowControlSnapshot({
-          eventLoop: { p50Ms: 1, p95Ms: 2, p99Ms: 5, maxMs: 10, sampleCount: 100 },
+          eventLoop: { p99Ms: 5, maxMs: 10, utilization: 0.1 },
         }),
       },
       {
         shardKey: "proj-a",
         snapshot: makeFlowControlSnapshot({
-          eventLoop: { p50Ms: 1, p95Ms: 2, p99Ms: 40, maxMs: 50, sampleCount: 100 },
+          eventLoop: { p99Ms: 40, maxMs: 50, utilization: 0.4 },
         }),
       },
     ]);

--- a/electron/services/pty/__tests__/rollupMerge.test.ts
+++ b/electron/services/pty/__tests__/rollupMerge.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { mergeFlowControlSnapshots, mergeMemoryRollups } from "../rollupMerge.js";
+import type {
+  FlowControlSnapshot,
+  MemoryRollup,
+  TerminalResourceProcess,
+} from "../../../../shared/types/pty-host.js";
+
+function makeProcess(overrides: Partial<TerminalResourceProcess> = {}): TerminalResourceProcess {
+  return { pid: 1, comm: "node", cpuPercent: 0, memoryKb: 100, ...overrides };
+}
+
+function makeRollup(overrides: Partial<MemoryRollup> = {}): MemoryRollup {
+  return {
+    byProject: [],
+    totalMemoryKb: 0,
+    totalProcessCount: 0,
+    terminalCount: 0,
+    available: true,
+    sampledAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeFlowControlSnapshot(
+  overrides: Partial<FlowControlSnapshot> = {}
+): FlowControlSnapshot {
+  return {
+    timestamp: 1000,
+    terminals: [],
+    queueDepth: [],
+    totalPendingBytes: 0,
+    stats: { pauseCount: 0, resumeCount: 0, suspendCount: 0, forceResumeCount: 0 },
+    resourceGovernor: {
+      isThrottling: false,
+      isWarning: false,
+      activeProfile: "balanced",
+      smoothedUtilizationPercent: null,
+      throttleDurationMs: 0,
+    },
+    eventLoop: null,
+    ...overrides,
+  };
+}
+
+describe("mergeMemoryRollups", () => {
+  it("sums per-project rows that appear on only one shard", () => {
+    const merged = mergeMemoryRollups([
+      makeRollup({
+        byProject: [
+          {
+            projectId: "a",
+            terminalCount: 1,
+            processCount: 2,
+            memoryKb: 500,
+            topProcesses: [makeProcess({ memoryKb: 500 })],
+          },
+        ],
+        totalMemoryKb: 500,
+        totalProcessCount: 2,
+        terminalCount: 1,
+        sampledAt: 100,
+      }),
+      makeRollup({
+        byProject: [
+          {
+            projectId: "b",
+            terminalCount: 1,
+            processCount: 1,
+            memoryKb: 300,
+            topProcesses: [makeProcess({ memoryKb: 300 })],
+          },
+        ],
+        totalMemoryKb: 300,
+        totalProcessCount: 1,
+        terminalCount: 1,
+        sampledAt: 200,
+      }),
+    ]);
+
+    expect(merged.byProject).toHaveLength(2);
+    expect(merged.totalMemoryKb).toBe(800);
+    expect(merged.totalProcessCount).toBe(3);
+    expect(merged.terminalCount).toBe(2);
+    // Newest sample wins for the merged timestamp.
+    expect(merged.sampledAt).toBe(200);
+  });
+
+  it("merges duplicate project rows across shards and keeps only the top 5 processes", () => {
+    const bigProcesses = Array.from({ length: 4 }, (_, i) =>
+      makeProcess({ pid: i + 1, memoryKb: 1000 + i })
+    );
+    const merged = mergeMemoryRollups([
+      makeRollup({
+        byProject: [
+          {
+            projectId: "shared",
+            terminalCount: 1,
+            processCount: 4,
+            memoryKb: 4006,
+            topProcesses: bigProcesses,
+          },
+        ],
+      }),
+      makeRollup({
+        byProject: [
+          {
+            projectId: "shared",
+            terminalCount: 1,
+            processCount: 2,
+            memoryKb: 300,
+            topProcesses: [
+              makeProcess({ pid: 5, memoryKb: 200 }),
+              makeProcess({ pid: 6, memoryKb: 100 }),
+            ],
+          },
+        ],
+      }),
+    ]);
+
+    expect(merged.byProject).toHaveLength(1);
+    const row = merged.byProject[0];
+    expect(row.terminalCount).toBe(2);
+    expect(row.processCount).toBe(6);
+    expect(row.memoryKb).toBe(4306);
+    // 6 candidate processes total, capped at the top 5 by memory.
+    expect(row.topProcesses).toHaveLength(5);
+    expect(row.topProcesses[0].memoryKb).toBe(1003);
+  });
+
+  it("marks the merged rollup unavailable when any shard's rollup was unavailable", () => {
+    const merged = mergeMemoryRollups([
+      makeRollup({ available: true }),
+      makeRollup({ available: false }),
+    ]);
+    expect(merged.available).toBe(false);
+  });
+});
+
+describe("mergeFlowControlSnapshots", () => {
+  it("concatenates terminal/queue arrays and sums the backpressure counters", () => {
+    const merged = mergeFlowControlSnapshots([
+      {
+        shardKey: "main",
+        snapshot: makeFlowControlSnapshot({
+          terminals: [
+            {
+              terminalId: "t1",
+              flowStatus: null,
+              heldTokens: [],
+              isSuspended: false,
+              activityTier: "active",
+              pausedDurationMs: null,
+              droppedBytes: 0,
+              dropCount: 0,
+              lastDropAt: null,
+            },
+          ],
+          stats: { pauseCount: 1, resumeCount: 2, suspendCount: 0, forceResumeCount: 0 },
+          totalPendingBytes: 10,
+        }),
+      },
+      {
+        shardKey: "proj-a",
+        snapshot: makeFlowControlSnapshot({
+          stats: { pauseCount: 3, resumeCount: 1, suspendCount: 1, forceResumeCount: 2 },
+          totalPendingBytes: 20,
+        }),
+      },
+    ]);
+
+    expect(merged.terminals).toHaveLength(1);
+    expect(merged.totalPendingBytes).toBe(30);
+    expect(merged.stats).toEqual({
+      pauseCount: 4,
+      resumeCount: 3,
+      suspendCount: 1,
+      forceResumeCount: 2,
+    });
+    expect(merged.shards).toHaveLength(2);
+    expect(merged.shards?.map((s) => s.shardKey)).toEqual(["main", "proj-a"]);
+  });
+
+  it("carries the worst (highest p99) event-loop reading across shards", () => {
+    const merged = mergeFlowControlSnapshots([
+      {
+        shardKey: "main",
+        snapshot: makeFlowControlSnapshot({
+          eventLoop: { p50Ms: 1, p95Ms: 2, p99Ms: 5, maxMs: 10, sampleCount: 100 },
+        }),
+      },
+      {
+        shardKey: "proj-a",
+        snapshot: makeFlowControlSnapshot({
+          eventLoop: { p50Ms: 1, p95Ms: 2, p99Ms: 40, maxMs: 50, sampleCount: 100 },
+        }),
+      },
+    ]);
+
+    expect(merged.eventLoop?.p99Ms).toBe(40);
+  });
+
+  it("treats a null event loop on every shard as null overall, never crashing on empty input", () => {
+    const merged = mergeFlowControlSnapshots([
+      { shardKey: "main", snapshot: makeFlowControlSnapshot({ eventLoop: null }) },
+    ]);
+    expect(merged.eventLoop).toBeNull();
+  });
+
+  it("resolves throttling/warning as true if any shard reports true", () => {
+    const merged = mergeFlowControlSnapshots([
+      {
+        shardKey: "main",
+        snapshot: makeFlowControlSnapshot({
+          resourceGovernor: {
+            isThrottling: false,
+            isWarning: false,
+            activeProfile: "balanced",
+            smoothedUtilizationPercent: null,
+            throttleDurationMs: 0,
+          },
+        }),
+      },
+      {
+        shardKey: "proj-a",
+        snapshot: makeFlowControlSnapshot({
+          resourceGovernor: {
+            isThrottling: true,
+            isWarning: true,
+            activeProfile: "performance",
+            smoothedUtilizationPercent: 80,
+            throttleDurationMs: 500,
+          },
+        }),
+      },
+    ]);
+
+    expect(merged.resourceGovernor.isThrottling).toBe(true);
+    expect(merged.resourceGovernor.isWarning).toBe(true);
+    expect(merged.resourceGovernor.smoothedUtilizationPercent).toBe(80);
+    expect(merged.resourceGovernor.throttleDurationMs).toBe(500);
+  });
+});

--- a/electron/services/pty/rollupMerge.ts
+++ b/electron/services/pty/rollupMerge.ts
@@ -1,0 +1,98 @@
+/**
+ * rollupMerge - Pure functions for merging per-shard PTY host aggregates into
+ * one app-wide view. Extracted verbatim from PtyClient.ts (#11007) — no
+ * behavior changes.
+ */
+
+import type {
+  FlowControlShardSnapshot,
+  FlowControlSnapshot,
+  MemoryRollup,
+  MemoryRollupProject,
+} from "../../../shared/types/pty-host.js";
+
+/**
+ * Merge per-shard memory rollups into one app-wide rollup. The fabric places
+ * a project on exactly one shard, so per-project rows never overlap across
+ * shards — the by-key merge below is defensive (and collapses the null-project
+ * row if it ever appears on more than one shard). `available` is a global
+ * claim ("the process table was read"), so one failed shard marks the merged
+ * rollup unavailable rather than silently under-reporting.
+ */
+export function mergeMemoryRollups(rollups: MemoryRollup[]): MemoryRollup {
+  const byKey = new Map<string | null, MemoryRollupProject>();
+  for (const rollup of rollups) {
+    for (const row of rollup.byProject) {
+      const existing = byKey.get(row.projectId);
+      if (!existing) {
+        byKey.set(row.projectId, { ...row, topProcesses: [...row.topProcesses] });
+        continue;
+      }
+      existing.terminalCount += row.terminalCount;
+      existing.processCount += row.processCount;
+      existing.memoryKb += row.memoryKb;
+      existing.topProcesses = [...existing.topProcesses, ...row.topProcesses]
+        .sort((a, b) => b.memoryKb - a.memoryKb)
+        .slice(0, 5);
+    }
+  }
+  return {
+    byProject: [...byKey.values()],
+    totalMemoryKb: rollups.reduce((sum, r) => sum + r.totalMemoryKb, 0),
+    totalProcessCount: rollups.reduce((sum, r) => sum + r.totalProcessCount, 0),
+    terminalCount: rollups.reduce((sum, r) => sum + r.terminalCount, 0),
+    available: rollups.every((r) => r.available),
+    sampledAt: Math.max(...rollups.map((r) => r.sampledAt)),
+  };
+}
+
+/**
+ * Merge per-shard flow-control snapshots. Terminal rows and queue depths
+ * concatenate (terminals are disjoint across shards); counters sum; the
+ * top-level governor/event-loop fields carry the worst-shard view so single-
+ * number diagnostics ("is the terminal backend throttled", "PTY host lag
+ * p99") stay meaningful; `shards` carries the per-shard breakdown.
+ */
+export function mergeFlowControlSnapshots(
+  entries: Array<{ shardKey: string; snapshot: FlowControlSnapshot }>
+): FlowControlSnapshot {
+  const snapshots = entries.map((e) => e.snapshot);
+  const smoothed = snapshots
+    .map((s) => s.resourceGovernor.smoothedUtilizationPercent)
+    .filter((v): v is number => v !== null);
+  const eventLoops = snapshots
+    .map((s) => s.eventLoop)
+    .filter((v): v is NonNullable<FlowControlSnapshot["eventLoop"]> => v !== null);
+  const worstEventLoop =
+    eventLoops.length > 0
+      ? eventLoops.reduce((worst, current) => (current.p99Ms > worst.p99Ms ? current : worst))
+      : null;
+  const shards: FlowControlShardSnapshot[] = entries.map(({ shardKey, snapshot }) => ({
+    shardKey,
+    terminalCount: snapshot.terminals.length,
+    totalPendingBytes: snapshot.totalPendingBytes,
+    resourceGovernor: snapshot.resourceGovernor,
+    eventLoop: snapshot.eventLoop,
+  }));
+  return {
+    timestamp: Math.max(...snapshots.map((s) => s.timestamp)),
+    terminals: snapshots.flatMap((s) => s.terminals),
+    queueDepth: snapshots.flatMap((s) => s.queueDepth),
+    totalPendingBytes: snapshots.reduce((sum, s) => sum + s.totalPendingBytes, 0),
+    stats: {
+      pauseCount: snapshots.reduce((sum, s) => sum + s.stats.pauseCount, 0),
+      resumeCount: snapshots.reduce((sum, s) => sum + s.stats.resumeCount, 0),
+      suspendCount: snapshots.reduce((sum, s) => sum + s.stats.suspendCount, 0),
+      forceResumeCount: snapshots.reduce((sum, s) => sum + s.stats.forceResumeCount, 0),
+    },
+    resourceGovernor: {
+      isThrottling: snapshots.some((s) => s.resourceGovernor.isThrottling),
+      isWarning: snapshots.some((s) => s.resourceGovernor.isWarning),
+      activeProfile: snapshots[0].resourceGovernor.activeProfile,
+      smoothedUtilizationPercent: smoothed.length > 0 ? Math.max(...smoothed) : null,
+      throttleDurationMs: Math.max(...snapshots.map((s) => s.resourceGovernor.throttleDurationMs)),
+    },
+    eventLoop: worstEventLoop,
+    shards,
+  };
+}


### PR DESCRIPTION
## Summary

- Mechanical refactor of `electron/services/PtyClient.ts`, the main-process router for the PTY fabric. It's a large file, and it was accumulating a lot of cross-shard RPC boilerplate, so this splits three concerns out into sibling modules under `electron/services/pty/`.
- The ~19 RPC methods that share a `generateId` → `register` → `send` → `catch` shape now go through a thin wrapper, `PtyHostRpcFacade.ts`. Every call site's fallback behavior is preserved exactly, including the forced-kill escalation branch in `gracefulKill`.
- Host-throttle/memory-warning OR-aggregation moved to `HostSignalAggregator.ts`, shard placement lookups (`ownerKey`, `shardForTerminal`, `resolvePlacementKey`, `fanOutShards`) moved to `ShardPlacementRouter.ts`, and the two pure merge helpers (`mergeMemoryRollups`, `mergeFlowControlSnapshots`) moved to `rollupMerge.ts`.

Resolves #11007

## Changes

- `electron/services/pty/PtyHostRpcFacade.ts`: thin RPC wrapper for the cross-shard calls.
- `electron/services/pty/HostSignalAggregator.ts`: host-throttle and memory-warning OR-aggregation.
- `electron/services/pty/ShardPlacementRouter.ts`: shard placement lookups. Takes `PtyClient`'s state maps by reference, so the existing "owner entry lives until no incarnation remains" lifetime invariants stay centralized in `PtyClient` rather than splitting across modules.
- `electron/services/pty/rollupMerge.ts`: the two standalone pure merge helpers.
- `PtyClient` keeps its original private method names as thin delegates to the new modules, so no call sites elsewhere in the codebase changed.
- Deliberately deferred extracting `ShardRespawnCoordinator`, `OrphanedPtyReaper`, and `ShardRetirementScheduler`, which the issue also flagged as candidates. They're tightly coupled to crash-recovery and ledger-generation logic, where extraction risk outweighs the benefit for a mechanical, behavior-preserving refactor. The three modules landed here match the issue title directly: routing, RPC, and signal aggregation.

## Testing

- Added unit tests for the two pure/near-pure extractions, `rollupMerge` and `PtyHostRpcFacade`.
- All 9 existing `PtyClient.*.test.ts` files (154 tests) plus the 2 new test files pass.
- eslint and prettier clean on all touched files. No public API or behavior changes.
