### PR TITLE
refactor(workspace-host): split WorktreeMonitor.ts into sibling modules

### DIFF
--- a/electron/workspace-host/BaseDivergence.ts
+++ b/electron/workspace-host/BaseDivergence.ts
@@ -1,0 +1,144 @@
+import { join as pathJoin } from "path";
+import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js";
+import type { WslGitInvocation } from "../utils/hardenedGit.js";
+import { getGitDir } from "../utils/gitUtils.js";
+import type { StatPrecheck } from "./StatPrecheck.js";
+
+export interface BaseDivergenceResult {
+  baseBranchName: string | null;
+  aheadCount: number | null;
+  behindCount: number | null;
+  matchesUpstream: boolean;
+}
+
+export interface BaseDivergenceHost {
+  readonly branch: string | undefined;
+  readonly isMainWorktree: boolean;
+  readonly mainBranch: string;
+  readonly linkedPrBaseRef: string | undefined;
+  readonly path: string;
+  readonly wslInvocation: WslGitInvocation | undefined;
+  readonly abortSignal: AbortSignal;
+}
+
+/** Ahead/behind divergence of the current branch against its base branch. */
+export class BaseDivergence {
+  private lastKey: string | null = null;
+  private lastResult: BaseDivergenceResult | null = null;
+
+  constructor(
+    private readonly host: BaseDivergenceHost,
+    private readonly statPrecheck: StatPrecheck
+  ) {}
+
+  async compute(hasUpstream: boolean): Promise<BaseDivergenceResult | null> {
+    const branch = this.host.branch;
+    if (!branch || this.host.isMainWorktree) return null;
+
+    // Pick the branch to diff against. A linked PR's base branch is
+    // authoritative — it's exactly where this worktree's work will merge,
+    // which may differ from the repo's integration branch (e.g. a hotfix
+    // PR targeting `main` in a gitflow repo). Without a PR, fall back to
+    // the repository's main/integration branch.
+    const baseBranch = this.host.linkedPrBaseRef?.trim() || this.host.mainBranch;
+
+    // Divergence only moves when refs move, never on working-tree edits, so
+    // a stat key over the involved refs lets forced passes (watcher-driven
+    // edit storms) reuse the last result without any git spawns.
+    const key = await this.buildKey(branch, baseBranch, hasUpstream);
+    if (key !== null && key === this.lastKey) {
+      return this.lastResult;
+    }
+
+    const wsl = this.host.wslInvocation;
+    const git = wsl
+      ? await createWslHardenedGit(wsl, this.host.abortSignal)
+      : await createHardenedGit(this.host.path, this.host.abortSignal);
+
+    try {
+      // Resolve base ref via the rev-list itself: try origin/<branch> first
+      // (remote ref stays fresh after fetch), fall back to the local branch
+      // for repos without a remote.
+      const remoteRef = `origin/${baseBranch}`;
+      const localRef = baseBranch;
+      const baseBranchName = baseBranch;
+      let resolvedRef = remoteRef;
+      let result: string;
+      try {
+        result = await git.raw(["rev-list", "--count", "--left-right", `${remoteRef}...HEAD`]);
+      } catch {
+        try {
+          result = await git.raw(["rev-list", "--count", "--left-right", `${localRef}...HEAD`]);
+          resolvedRef = localRef;
+        } catch {
+          this.lastKey = null;
+          return null;
+        }
+      }
+      const trimmed = result.trim();
+      const parts = trimmed.split("\t");
+      const behindCount = parts[0] != null && parts[0] !== "" ? parseInt(parts[0], 10) : 0;
+      const aheadCount = parts[1] != null && parts[1] !== "" ? parseInt(parts[1], 10) : 0;
+
+      let matchesUpstream = false;
+      if (hasUpstream) {
+        try {
+          // One invocation resolves both revs — rev-parse prints one OID per
+          // line, and either failing exits non-zero (caught below), matching
+          // the previous two-call error semantics.
+          const out = await git.raw(["rev-parse", "@{u}", resolvedRef]);
+          const [upstreamCommit, baseCommit] = out.trim().split("\n");
+          matchesUpstream = baseCommit !== undefined && upstreamCommit.trim() === baseCommit.trim();
+        } catch {
+          matchesUpstream = false;
+        }
+      }
+
+      const divergence: BaseDivergenceResult = {
+        baseBranchName,
+        aheadCount: Number.isFinite(aheadCount) ? aheadCount : null,
+        behindCount: Number.isFinite(behindCount) ? behindCount : null,
+        matchesUpstream,
+      };
+      this.lastKey = key;
+      this.lastResult = divergence;
+      return divergence;
+    } catch {
+      this.lastKey = null;
+      return null;
+    }
+  }
+
+  /**
+   * Stat-derived cache key for `compute`. Covers every ref the computation
+   * reads: HEAD, this branch's local ref, the base branch's local and
+   * remote refs, the upstream remote ref (the `@{u}` proxy for
+   * `matchesUpstream`), and packed-refs. The remote-ref stats are essential —
+   * `git fetch` writes loose refs under refs/remotes/ without touching
+   * packed-refs, so the stat-baseline fields alone would serve stale
+   * behind-of-base counts after background fetches. Returns `null` (compute,
+   * don't cache) on any stat failure beyond ENOENT.
+   */
+  private async buildKey(
+    branch: string,
+    baseBranch: string,
+    hasUpstream: boolean
+  ): Promise<string | null> {
+    const gitDir = await getGitDir(this.host.path, { cache: true, logErrors: false });
+    if (!gitDir) return null;
+    try {
+      const commonDir = await this.statPrecheck.resolveCommonDirAsync(gitDir);
+      const stats = await Promise.all([
+        this.statPrecheck.statMtime(pathJoin(gitDir, "HEAD")),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "heads", branch)),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "packed-refs")),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "heads", baseBranch)),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", baseBranch)),
+        this.statPrecheck.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", branch)),
+      ]);
+      return [branch, baseBranch, hasUpstream, ...stats].join(" ");
+    } catch {
+      return null;
+    }
+  }
+}

--- a/electron/workspace-host/BaseDivergence.ts
+++ b/electron/workspace-host/BaseDivergence.ts
@@ -4,7 +4,7 @@ import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import { getGitDir } from "../utils/gitUtils.js";
 import type { StatPrecheck } from "./StatPrecheck.js";
 
-export interface BaseDivergenceResult {
+interface BaseDivergenceResult {
   baseBranchName: string | null;
   aheadCount: number | null;
   behindCount: number | null;

--- a/electron/workspace-host/GitStatusPass.ts
+++ b/electron/workspace-host/GitStatusPass.ts
@@ -1,0 +1,579 @@
+import { readFile, access } from "fs/promises";
+import { join as pathJoin } from "path";
+import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js";
+import type { WslGitInvocation } from "../utils/hardenedGit.js";
+import { invalidateGitStatusCache, getWorktreeChangesWithStats } from "../utils/git.js";
+import { getGitDir } from "../utils/gitUtils.js";
+import { getRepoOperationStateSync } from "../utils/gitRepoOperationState.js";
+import { WorktreeRemovedError } from "../utils/errorTypes.js";
+import { categorizeWorktree } from "../services/worktree/mood.js";
+import type { AdaptivePollingStrategy, NoteFileReader } from "../services/worktree/index.js";
+import {
+  extractIssueNumberSync,
+  extractIssueNumber,
+  deriveIssueTitleFromBranch,
+} from "../services/issueExtractor.js";
+import { timeoutSignal, withTimeout } from "../utils/withTimeout.js";
+import type { WorktreeChanges, RepoState } from "../../shared/types/git.js";
+import type { WorktreeMood } from "../../shared/types/worktree.js";
+import type { WatcherController } from "./WatcherController.js";
+import type { StatPrecheck } from "./StatPrecheck.js";
+import type { BaseDivergence } from "./BaseDivergence.js";
+
+const PLAN_FILE_CANDIDATES = ["TODO.md", "PLAN.md", "plan.md", "TASKS.md"] as const;
+
+// Hard ceiling for individual filesystem syscalls on the poll path. On a
+// healthy disk these return in well under a millisecond; on a stalled mount
+// (disconnected NFS/SMB, sleeping external drive) they would otherwise block
+// forever with no abort, pinning a libuv threadpool slot. Passed as an
+// AbortSignal so the syscall is actually cancelled, not merely abandoned.
+const FS_OP_TIMEOUT_MS = 5_000;
+
+// FNV-1a 32-bit offset basis. Also the digest of an empty change list, which
+// makes it the natural initial value for `previousStateHash` (see below).
+const FNV_OFFSET_BASIS = 0x811c9dc5;
+
+export interface GitStatusPassHost {
+  readonly id: string;
+  readonly path: string;
+  readonly name: string;
+  readonly mainBranch: string;
+  readonly isCurrent: boolean;
+  readonly isRunning: boolean;
+  readonly basePollingInterval: number;
+  readonly wslInvocation: WslGitInvocation | undefined;
+  readonly abortSignal: AbortSignal;
+  readonly lastWatcherEventAt: number;
+  readonly prevEmittedIsDetached: boolean;
+  readonly prevEmittedHead: string | undefined;
+  readonly prevEmittedRepoState: RepoState | undefined;
+
+  hasInitialStatus: boolean;
+  repoState: RepoState | undefined;
+  lastGitStatusCompletedAt: number;
+  isUpdating: boolean;
+  branch: string | undefined;
+  issueNumber: number | undefined;
+  branchDerivedTitle: string | undefined;
+  issueTitle: string | undefined;
+  isDetached: boolean;
+  head: string | undefined;
+  mood: WorktreeMood;
+  summary: string | undefined;
+  worktreeChanges: WorktreeChanges | null;
+
+  clearPRInfo(): void;
+  onBranchChanged(branch: string): void;
+  onRemoved(): void;
+  stop(): void;
+  emitUpdate(): void;
+}
+
+/**
+ * Runs the git-status poll pass: single-flight guarded, stat-precheck gated,
+ * detects branch/note/plan-file/upstream/base-divergence changes and emits an
+ * update when anything moved.
+ */
+export class GitStatusPass {
+  // Output state from the last successful pass. Owned here rather than the
+  // host because nothing outside this class and `SnapshotBuilder` (via its
+  // own host getters) reads it.
+  private previousStateHash: number = FNV_OFFSET_BASIS;
+  private worktreeModifiedCount: number = 0;
+  private noteContent: string | undefined;
+  private noteTimestamp: number | undefined;
+  private planFileDetected: boolean = false;
+  private planFilePathValue: string | undefined;
+  private upstreamAheadCount: number | undefined;
+  private upstreamBehindCount: number | undefined;
+  private baseBranchNameValue: string | null | undefined;
+  private baseAheadCountValue: number | null | undefined;
+  private baseBehindCountValue: number | null | undefined;
+  private baseMatchesUpstreamValue: boolean | undefined;
+  private activityTimestamp: number | null = null;
+
+  constructor(
+    private readonly host: GitStatusPassHost,
+    private readonly statPrecheck: StatPrecheck,
+    private readonly baseDivergence: BaseDivergence,
+    private readonly watcherController: WatcherController,
+    private readonly pollingStrategy: AdaptivePollingStrategy,
+    private readonly noteReader: NoteFileReader
+  ) {}
+
+  get modifiedCount(): number {
+    return this.worktreeModifiedCount;
+  }
+
+  get aiNote(): string | undefined {
+    return this.noteContent;
+  }
+
+  get aiNoteTimestamp(): number | undefined {
+    return this.noteTimestamp;
+  }
+
+  get hasPlanFile(): boolean {
+    return this.planFileDetected;
+  }
+
+  get planFilePath(): string | undefined {
+    return this.planFilePathValue;
+  }
+
+  get aheadCount(): number | undefined {
+    return this.upstreamAheadCount;
+  }
+
+  get behindCount(): number | undefined {
+    return this.upstreamBehindCount;
+  }
+
+  get baseBranchName(): string | null | undefined {
+    return this.baseBranchNameValue;
+  }
+
+  get baseAheadCount(): number | null | undefined {
+    return this.baseAheadCountValue;
+  }
+
+  get baseBehindCount(): number | null | undefined {
+    return this.baseBehindCountValue;
+  }
+
+  get baseMatchesUpstream(): boolean | undefined {
+    return this.baseMatchesUpstreamValue;
+  }
+
+  get lastActivityTimestamp(): number | null {
+    return this.activityTimestamp;
+  }
+
+  async run(forceRefresh: boolean = false): Promise<void> {
+    if (this.host.isUpdating) {
+      return;
+    }
+    // Claim the single-flight slot before the first await. Everything below
+    // suspends (git-dir resolution, the stat pre-check), and forced refreshes
+    // bypass both the worktree-changes in-flight cache and the pre-check — so
+    // without the early claim two rapid forced refreshes could pass the guard
+    // together and run duplicate status passes with out-of-order commits.
+    this.host.isUpdating = true;
+
+    // Definite-assignment: assigned as the first statement of the try below;
+    // the status pass (the only later reader) is unreachable unless that try
+    // completed normally, so every read is dominated by the assignment.
+    let gitDir!: string | null;
+    let reachedStatusPass = false;
+    try {
+      // Skip the git status invocation while a rebase/merge/cherry-pick/revert
+      // is in progress — running it would compete with the user's git client
+      // for .git/index.lock. The watcher tracks the same sentinel files, so
+      // it fires when the operation finishes and triggers a fresh refresh.
+      // Polling continues uninterrupted, so the next scheduled poll after
+      // sentinels clear also picks up the change.
+      gitDir = await getGitDir(this.host.path, { cache: true, logErrors: false });
+
+      // Detect blocking git operation state from sentinel files so the renderer
+      // can surface it even when git status is skipped.
+      let opState: RepoState | undefined;
+      if (gitDir) {
+        opState = getRepoOperationStateSync(gitDir);
+        if (opState !== this.host.repoState) {
+          this.host.repoState = opState;
+          if (this.host.hasInitialStatus) {
+            this.host.emitUpdate();
+          }
+        }
+      } else {
+        this.host.repoState = undefined;
+      }
+
+      if (gitDir && opState !== undefined) {
+        // Stamp the completion timestamp before any emit so every snapshot below
+        // carries the advanced value. Git status was skipped, but the sentinel
+        // state was freshly observed above, so the freshness signal is accurate
+        // and the heartbeat-gap detector (which reads this field) won't
+        // false-positive on a long blocking operation. Without this, a
+        // user-triggered refresh during a stuck blocking operation never advances
+        // lastGitStatusCompletedAt, leaving the freshness pill permanently stale
+        // and its Refresh button a no-op (#10715).
+        this.host.lastGitStatusCompletedAt = Date.now();
+        if (!this.host.hasInitialStatus) {
+          // First poll started mid-operation (e.g. app started mid-rebase) — emit
+          // a default snapshot so the renderer can still display the worktree.
+          // Mirrors startWithoutGitStatus()'s contract.
+          this.host.hasInitialStatus = true;
+          this.host.emitUpdate();
+        } else if (forceRefresh) {
+          // The user clicked Refresh on a stale card. Emit so the renderer
+          // receives the advanced timestamp and the freshness pill resets —
+          // otherwise the click is silently dropped. Background polls stamp
+          // silently; the watcher emits a real status once sentinels clear.
+          this.host.emitUpdate();
+        }
+        return;
+      }
+
+      // Cheap stat pre-check: when the four git files we care about haven't
+      // changed since the last baseline and no watcher event has fired since,
+      // the simple-git fork-exec would be redundant. Skip it. This is the
+      // common case on a quiet repo — the per-poll cost drops from ~15-50ms
+      // (fork + git status) to ~1ms (four stat() calls).
+      //
+      // The baseline only exists after the first real check, so this branch
+      // is a no-op on the very first poll. Forced refreshes (watcher events,
+      // user actions) always run the full check.
+      if (
+        !forceRefresh &&
+        gitDir &&
+        this.host.hasInitialStatus &&
+        (await this.statPrecheck.shouldSkip(
+          gitDir,
+          this.host.branch,
+          this.host.lastWatcherEventAt,
+          this.watcherController.currentMode === "recursive"
+        ))
+      ) {
+        // Treat the skip as a no-change observation so the idle backoff
+        // ramps up the next interval. lastGitStatusCompletedAt bumps too,
+        // otherwise the heartbeat-gap check would false-positive on a
+        // long quiet streak that only ran stat-skips.
+        this.pollingStrategy.recordNoChange();
+        this.host.lastGitStatusCompletedAt = Date.now();
+        return;
+      }
+
+      reachedStatusPass = true;
+    } finally {
+      // Early exits (sentinel skip, stat skip, a throw above) release the
+      // claim here and drain any pending watcher flush that queued while it
+      // was held. The status pass below keeps the claim; its own finally is
+      // the release point — and stays the LAST code to touch the flag, so a
+      // flush-triggered synchronous re-entry can't have its claim clobbered.
+      if (!reachedStatusPass) {
+        this.host.isUpdating = false;
+        this.watcherController.flushPendingIfReady(true);
+      }
+    }
+
+    // Tracks whether the try block reached a clean exit point — either the
+    // no-change early return or the post-emit fall-through. The catch block
+    // doesn't flip it (so the finally clears the stale baseline) which means
+    // a flaky git that throws here can't get its old baseline re-stamped and
+    // silently suppress the next retry.
+    let checkSucceeded = false;
+
+    try {
+      if (forceRefresh) {
+        invalidateGitStatusCache(this.host.path);
+      }
+
+      const pollingInterval = this.host.basePollingInterval;
+      const cacheTTL =
+        Number.isFinite(pollingInterval) && pollingInterval > 0
+          ? Math.max(500, pollingInterval - 500)
+          : undefined;
+      const newChanges = await getWorktreeChangesWithStats(this.host.path, {
+        forceRefresh,
+        cacheTTL,
+        wsl: this.host.wslInvocation,
+      });
+
+      if (!this.host.isRunning) {
+        return;
+      }
+
+      // Detect branch changes by reading HEAD directly
+      const currentBranch = await this.readCurrentBranch();
+      const branchChanged = currentBranch !== undefined && currentBranch !== this.host.branch;
+      if (branchChanged) {
+        this.host.branch = currentBranch;
+        const hadPendingRefresh = this.watcherController.takePending();
+        this.watcherController.update();
+        if (hadPendingRefresh) {
+          this.watcherController.markPending();
+        }
+        const syncIssueNumber = extractIssueNumberSync(currentBranch, this.host.name);
+        if (syncIssueNumber) {
+          this.host.issueNumber = syncIssueNumber;
+        } else {
+          this.host.issueNumber = undefined;
+          void this.extractIssueNumberAsync(currentBranch, this.host.name);
+        }
+        this.host.branchDerivedTitle = deriveIssueTitleFromBranch(currentBranch);
+        this.host.issueTitle = undefined;
+        // Clear PR info synchronously in the same emit as the branch change
+        // so the renderer never sees a frame with the new branch but the old
+        // PR (#8079). PullRequestService still emits its own clear downstream;
+        // by then this snapshot already has null PR fields, so that second
+        // emit collapses to a no-op via snapshotsEqual.
+        this.host.clearPRInfo();
+        this.host.onBranchChanged(currentBranch);
+      }
+
+      // Bound the AI-note read: a slow/stalled note file must degrade to "no
+      // note" for this pass, not hang the whole git-status update.
+      const noteData = await withTimeout(
+        this.noteReader.read(),
+        FS_OP_TIMEOUT_MS,
+        `note read: ${this.host.path}`
+      ).catch(() => undefined);
+
+      const hasUpstream = !!newChanges.tracking;
+      const nextAheadCount = hasUpstream ? (newChanges.ahead ?? 0) : undefined;
+      const nextBehindCount = hasUpstream ? (newChanges.behind ?? 0) : undefined;
+
+      // Base-branch divergence — runs in parallel with plan file detection.
+      const baseDivergencePromise = this.baseDivergence.compute(hasUpstream);
+
+      const planResults = await Promise.allSettled(
+        PLAN_FILE_CANDIDATES.map((candidate) =>
+          withTimeout(
+            access(pathJoin(this.host.path, candidate)),
+            FS_OP_TIMEOUT_MS,
+            `plan-file probe: ${candidate}`
+          )
+        )
+      );
+      const detectedPlanFile = PLAN_FILE_CANDIDATES.find(
+        (_, i) => planResults[i].status === "fulfilled"
+      );
+      const nextHasPlanFile = detectedPlanFile !== undefined;
+      const nextPlanFilePath = detectedPlanFile;
+
+      const baseDivergenceResult = await baseDivergencePromise;
+      const nextBaseBranchName = baseDivergenceResult?.baseBranchName ?? undefined;
+      const nextBaseAheadCount = baseDivergenceResult?.aheadCount ?? undefined;
+      const nextBaseBehindCount = baseDivergenceResult?.behindCount ?? undefined;
+      const nextBaseMatchesUpstream = baseDivergenceResult?.matchesUpstream ?? undefined;
+
+      const currentHash = this.calculateStateHash(newChanges);
+      const stateChanged = currentHash !== this.previousStateHash;
+      const noteChanged =
+        noteData?.content !== this.noteContent || noteData?.timestamp !== this.noteTimestamp;
+      const planChanged =
+        nextHasPlanFile !== this.planFileDetected || nextPlanFilePath !== this.planFilePathValue;
+      const upstreamChanged =
+        nextAheadCount !== this.upstreamAheadCount || nextBehindCount !== this.upstreamBehindCount;
+      const baseDivergenceChanged =
+        nextBaseBranchName !== this.baseBranchNameValue ||
+        nextBaseAheadCount !== this.baseAheadCountValue ||
+        nextBaseBehindCount !== this.baseBehindCountValue ||
+        nextBaseMatchesUpstream !== this.baseMatchesUpstreamValue;
+
+      const gitStateChanged =
+        this.host.isDetached !== this.host.prevEmittedIsDetached ||
+        this.host.head !== this.host.prevEmittedHead ||
+        this.host.repoState !== this.host.prevEmittedRepoState;
+
+      const anythingChanged =
+        stateChanged ||
+        noteChanged ||
+        branchChanged ||
+        planChanged ||
+        upstreamChanged ||
+        baseDivergenceChanged ||
+        gitStateChanged;
+
+      // Drive the idle backoff from what the git check actually observed —
+      // a real state change resets, otherwise we count one quiet tick. The
+      // skip path above runs its own recordNoChange so this branch only
+      // sees ticks that paid the full fork-exec cost.
+      if (anythingChanged) {
+        this.pollingStrategy.recordStateChange();
+      } else {
+        this.pollingStrategy.recordNoChange();
+      }
+
+      if (!anythingChanged && !forceRefresh) {
+        checkSucceeded = true;
+        return;
+      }
+
+      // True on initial load OR while the tree has stayed clean — the two are
+      // deliberately indistinguishable (legacy ""-hash semantics).
+      const isInitialLoad = this.previousStateHash === FNV_OFFSET_BASIS;
+      const isNowClean = newChanges.changedFileCount === 0;
+      const hasPendingChanges = newChanges.changedFileCount > 0;
+      const shouldUpdateTimestamp =
+        (stateChanged && !isInitialLoad) || (isInitialLoad && hasPendingChanges);
+
+      if (shouldUpdateTimestamp) {
+        this.activityTimestamp = Date.now();
+      }
+
+      if (isInitialLoad && isNowClean && this.activityTimestamp === null) {
+        this.activityTimestamp = newChanges.lastCommitTimestampMs ?? null;
+      }
+
+      if (
+        isNowClean ||
+        isInitialLoad ||
+        (this.host.worktreeChanges && this.host.worktreeChanges.changedFileCount === 0)
+      ) {
+        this.host.summary = await this.fetchLastCommitMessage(newChanges);
+      }
+
+      let nextMood = this.host.mood;
+      try {
+        nextMood = await categorizeWorktree(
+          {
+            id: this.host.id,
+            path: this.host.path,
+            name: this.host.name,
+            branch: this.host.branch,
+            isCurrent: this.host.isCurrent,
+          },
+          newChanges || undefined,
+          this.host.mainBranch
+        );
+      } catch {
+        nextMood = "error";
+      }
+
+      this.previousStateHash = currentHash;
+      this.host.worktreeChanges = newChanges;
+      this.worktreeModifiedCount = newChanges.changedFileCount;
+      this.host.mood = nextMood;
+      this.noteContent = noteData?.content;
+      this.noteTimestamp = noteData?.timestamp;
+      this.planFileDetected = nextHasPlanFile;
+      this.planFilePathValue = nextPlanFilePath;
+      this.upstreamAheadCount = nextAheadCount;
+      this.upstreamBehindCount = nextBehindCount;
+      this.baseBranchNameValue = nextBaseBranchName;
+      this.baseAheadCountValue = nextBaseAheadCount;
+      this.baseBehindCountValue = nextBaseBehindCount;
+      this.baseMatchesUpstreamValue = nextBaseMatchesUpstream;
+      this.host.hasInitialStatus = true;
+
+      this.host.emitUpdate();
+      checkSucceeded = true;
+    } catch (error) {
+      if (error instanceof WorktreeRemovedError) {
+        this.host.stop();
+        this.host.onRemoved();
+        return;
+      }
+
+      const errorMessage = (error as Error).message || "";
+      if (errorMessage.includes("index.lock")) {
+        this.watcherController.markPending();
+        this.watcherController.scheduleDelayedFlush();
+        return;
+      }
+
+      this.host.mood = "error";
+      this.host.emitUpdate();
+      throw error;
+    } finally {
+      this.host.isUpdating = false;
+      this.host.lastGitStatusCompletedAt = Date.now();
+      // Rebuild the stat baseline only when a real git check finished
+      // cleanly. On failure (anything that didn't set checkSucceeded — git
+      // throw, WorktreeRemovedError, index.lock retry path) we drop the
+      // baseline so the next non-forced poll falls through to a full check
+      // rather than skipping against a snapshot that predates the failure.
+      if (checkSucceeded && gitDir) {
+        await this.statPrecheck.recordFullPass(gitDir, this.host.branch);
+      } else {
+        this.statPrecheck.dropBaseline();
+      }
+      this.watcherController.flushPendingIfReady(true);
+    }
+  }
+
+  private async readCurrentBranch(): Promise<string | undefined> {
+    const gitDir = await getGitDir(this.host.path, { cache: true, logErrors: false });
+    if (!gitDir) {
+      this.host.isDetached = false;
+      this.host.head = undefined;
+      return undefined;
+    }
+
+    const { signal, dispose } = timeoutSignal(FS_OP_TIMEOUT_MS, this.host.abortSignal);
+    try {
+      const headContent = await readFile(pathJoin(gitDir, "HEAD"), { encoding: "utf-8", signal });
+      const trimmed = headContent.trim();
+      const prefix = "ref: refs/heads/";
+      if (trimmed.startsWith(prefix)) {
+        this.host.isDetached = false;
+        this.host.head = undefined;
+        return trimmed.slice(prefix.length);
+      }
+      // Detached HEAD — the file contains a commit SHA
+      if (/^[0-9a-f]{40}$/.test(trimmed)) {
+        this.host.isDetached = true;
+        this.host.head = trimmed;
+      } else {
+        this.host.isDetached = false;
+        this.host.head = undefined;
+      }
+      return undefined;
+    } catch {
+      // Includes a timeout/abort (AbortError) on a stalled filesystem — treat
+      // as "branch unchanged" rather than letting the read hang the poll.
+      this.host.isDetached = false;
+      this.host.head = undefined;
+      return undefined;
+    } finally {
+      dispose();
+    }
+  }
+
+  private async extractIssueNumberAsync(branchName: string, folderName?: string): Promise<void> {
+    try {
+      const issueNum = await extractIssueNumber(branchName, folderName);
+      if (issueNum && this.host.isRunning && this.host.branch === branchName) {
+        this.host.issueNumber = issueNum;
+        if (this.host.hasInitialStatus) {
+          this.host.emitUpdate();
+        }
+      }
+    } catch {
+      // Silently ignore extraction errors
+    }
+  }
+
+  // 32-bit FNV-1a digest instead of the raw joined string: the previous
+  // implementation retained a path+stats concatenation proportional to the
+  // worktree's change count for the monitor's lifetime. A hash collision
+  // (~1 in 2^32 per state pair) suppresses the change event until the next
+  // non-colliding state or a forced refresh.
+  private calculateStateHash(changes: WorktreeChanges): number {
+    const hashInput = changes.changes
+      .map((c) => `${c.path}:${c.status}:${c.insertions ?? 0}:${c.deletions ?? 0}`)
+      .sort()
+      .join("|");
+    let hash = FNV_OFFSET_BASIS;
+    for (let i = 0; i < hashInput.length; i++) {
+      hash = Math.imul(hash ^ hashInput.charCodeAt(i), 0x01000193) >>> 0;
+    }
+    return hash >>> 0;
+  }
+
+  private async fetchLastCommitMessage(changes: WorktreeChanges): Promise<string> {
+    if (changes.lastCommitMessage) {
+      const firstLine = changes.lastCommitMessage.split("\n")[0].trim();
+      return `✅ ${firstLine}`;
+    }
+
+    try {
+      const wsl = this.host.wslInvocation;
+      const git = wsl
+        ? await createWslHardenedGit(wsl, this.host.abortSignal)
+        : await createHardenedGit(this.host.path, this.host.abortSignal);
+      const log = await git.log({ maxCount: 1 });
+      const lastCommitMsg = log.latest?.message;
+
+      if (lastCommitMsg) {
+        const firstLine = lastCommitMsg.split("\n")[0].trim();
+        return `✅ ${firstLine}`;
+      }
+      return "🌱 Ready to get started";
+    } catch {
+      return "🌱 Ready to get started";
+    }
+  }
+}

--- a/electron/workspace-host/GitStatusPass.ts
+++ b/electron/workspace-host/GitStatusPass.ts
@@ -43,7 +43,6 @@ export interface GitStatusPassHost {
   readonly basePollingInterval: number;
   readonly wslInvocation: WslGitInvocation | undefined;
   readonly abortSignal: AbortSignal;
-  readonly lastWatcherEventAt: number;
   readonly prevEmittedIsDetached: boolean;
   readonly prevEmittedHead: string | undefined;
   readonly prevEmittedRepoState: RepoState | undefined;
@@ -230,8 +229,6 @@ export class GitStatusPass {
         this.host.hasInitialStatus &&
         (await this.statPrecheck.shouldSkip(
           gitDir,
-          this.host.branch,
-          this.host.lastWatcherEventAt,
           this.watcherController.currentMode === "recursive"
         ))
       ) {
@@ -476,7 +473,7 @@ export class GitStatusPass {
       // baseline so the next non-forced poll falls through to a full check
       // rather than skipping against a snapshot that predates the failure.
       if (checkSucceeded && gitDir) {
-        await this.statPrecheck.recordFullPass(gitDir, this.host.branch);
+        await this.statPrecheck.recordFullPass(gitDir);
       } else {
         this.statPrecheck.dropBaseline();
       }

--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -1,0 +1,192 @@
+import type {
+  Worktree,
+  WorktreeMood,
+  WorktreeLifecycleStatus,
+  WorktreeLifecyclePhaseResult,
+  WorktreeResourceStatus,
+  WslGitEligibility,
+} from "../../shared/types/worktree.js";
+import type { CIStatusState } from "../../shared/types/forge.js";
+import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
+import type { WorktreeChanges, RepoState } from "../../shared/types/git.js";
+import type { PluginWorktreeLinked } from "../../shared/types/plugin.js";
+
+export interface SnapshotBuilderHost {
+  readonly id: string;
+  readonly path: string;
+  readonly name: string;
+  readonly branch: string | undefined;
+  readonly isCurrent: boolean;
+  readonly isMainWorktree: boolean;
+  readonly gitDir: Worktree["gitDir"];
+  readonly summary: string | undefined;
+  readonly modifiedCount: number | undefined;
+  readonly mood: WorktreeMood | undefined;
+  readonly lastActivityTimestamp: number | null;
+  readonly createdAt: number | undefined;
+  readonly aiNote: string | undefined;
+  readonly aiNoteTimestamp: number | undefined;
+  readonly issueNumber: number | undefined;
+  readonly prNumber: number | undefined;
+  readonly prUrl: string | undefined;
+  readonly prState: import("../../shared/types/forge.js").NormalizedPRState | undefined;
+  readonly prCiStatus: CIStatusState | undefined;
+  readonly prTitle: string | undefined;
+  readonly issueTitle: string | undefined;
+  readonly branchDerivedTitle: string | undefined;
+  readonly sourcePrNumber: number | undefined;
+  readonly prLastUpdatedAt: number | undefined;
+  readonly issueLastUpdatedAt: number | undefined;
+  readonly worktreeChanges: WorktreeChanges | null;
+  readonly lifecycleStatus: WorktreeLifecycleStatus | undefined;
+  readonly lifecyclePhaseResults: readonly WorktreeLifecyclePhaseResult[];
+  readonly resourceStatus: WorktreeResourceStatus | undefined;
+  readonly resourceConnectCommand: string | undefined;
+  readonly resourceProvider: string | undefined;
+  readonly hasResourceConfig: boolean;
+  readonly hasStatusCommand: boolean;
+  readonly hasPauseCommand: boolean;
+  readonly hasResumeCommand: boolean;
+  readonly hasTeardownCommand: boolean;
+  readonly hasProvisionCommand: boolean;
+  readonly worktreeMode: string;
+  readonly worktreeEnvironmentLabel: string | undefined;
+  readonly hasPlanFile: boolean;
+  readonly planFilePath: string | undefined;
+  readonly aheadCount: number | undefined;
+  readonly behindCount: number | undefined;
+  readonly baseBranchName: string | null | undefined;
+  readonly baseAheadCount: number | null | undefined;
+  readonly baseBehindCount: number | null | undefined;
+  readonly baseMatchesUpstream: boolean | undefined;
+  readonly lastFetchedAt: number | null;
+  readonly lastGitStatusCheckedAt: number;
+  readonly fetchAuthFailed: boolean;
+  readonly fetchNetworkFailed: boolean;
+  readonly isFetchInFlight: boolean;
+  readonly matchedForgeProviderId: string | null;
+  readonly isWslPath: boolean;
+  readonly wslDistro: string | undefined;
+  readonly wslPosixPath: string | undefined;
+  readonly wslGitEligible: WslGitEligibility;
+  readonly wslGitOptIn: boolean;
+  readonly wslGitDismissed: boolean;
+  readonly linked: PluginWorktreeLinked | null | undefined;
+  readonly repoState: RepoState | undefined;
+  readonly isDetached: boolean;
+  readonly head: string | undefined;
+}
+
+/** Assembles the IPC-serializable `WorktreeSnapshot` from live monitor state. */
+export class SnapshotBuilder {
+  constructor(private readonly host: SnapshotBuilderHost) {}
+
+  build(): WorktreeSnapshot {
+    let resourceStatus: WorktreeResourceStatus | undefined;
+    if (this.host.resourceStatus) {
+      resourceStatus = { ...this.host.resourceStatus, provider: this.host.resourceProvider };
+    } else if (this.host.resourceProvider) {
+      resourceStatus = { provider: this.host.resourceProvider };
+    }
+
+    // `linked` is the source of truth (#8452). When present, the legacy flat
+    // fields are derived from it; the private flat fields only serve the
+    // legacy/branch-parse path where `_linked` was never populated.
+    const linkedPr = this.host.linked?.pr;
+    const linkedIssue = this.host.linked?.issue;
+    const linkedPrState: "open" | "merged" | "closed" | undefined = linkedPr
+      ? linkedPr.state === "declined"
+        ? "closed"
+        : linkedPr.state
+      : undefined;
+    const linkedPrCiStatus: CIStatusState | undefined =
+      linkedPr?.ciStatus &&
+      (linkedPr.ciStatus.state === "success" ||
+        linkedPr.ciStatus.state === "failure" ||
+        linkedPr.ciStatus.state === "pending")
+        ? linkedPr.ciStatus.state
+        : undefined;
+
+    const snapshot: WorktreeSnapshot = {
+      id: this.host.id,
+      path: this.host.path,
+      name: this.host.name,
+      branch: this.host.branch,
+      isCurrent: this.host.isCurrent,
+      isMainWorktree: this.host.isMainWorktree,
+      gitDir: this.host.gitDir,
+      summary: this.host.summary,
+      modifiedCount: this.host.modifiedCount,
+      mood: this.host.mood,
+      lastActivityTimestamp: this.host.lastActivityTimestamp,
+      createdAt: this.host.createdAt,
+      aiNote: this.host.aiNote,
+      aiNoteTimestamp: this.host.aiNoteTimestamp,
+      issueNumber: linkedIssue?.ref.number ?? this.host.issueNumber,
+      prNumber: linkedPr?.ref.number ?? this.host.prNumber,
+      prUrl: linkedPr?.url ?? this.host.prUrl,
+      prState: linkedPr
+        ? linkedPrState
+        : this.host.prState === "declined"
+          ? "closed"
+          : this.host.prState,
+      prCiStatus: linkedPr ? linkedPrCiStatus : this.host.prCiStatus,
+      prTitle: linkedPr ? linkedPr.title : this.host.prTitle,
+      issueTitle: linkedIssue ? linkedIssue.title : this.host.issueTitle,
+      branchDerivedTitle: this.host.branchDerivedTitle,
+      sourcePrNumber: this.host.sourcePrNumber,
+      prLastUpdatedAt: this.host.prLastUpdatedAt,
+      issueLastUpdatedAt: this.host.issueLastUpdatedAt,
+      worktreeChanges: this.host.worktreeChanges,
+      worktreeId: this.host.id,
+      timestamp: Date.now(),
+      lifecycleStatus: this.host.lifecycleStatus,
+      lifecyclePhaseResults:
+        this.host.lifecyclePhaseResults.length > 0
+          ? [...this.host.lifecyclePhaseResults]
+          : undefined,
+      resourceStatus,
+      resourceConnectCommand: this.host.resourceConnectCommand,
+      hasResourceConfig: this.host.hasResourceConfig || undefined,
+      hasStatusCommand: this.host.hasStatusCommand || undefined,
+      hasPauseCommand: this.host.hasPauseCommand || undefined,
+      hasResumeCommand: this.host.hasResumeCommand || undefined,
+      hasTeardownCommand: this.host.hasTeardownCommand || undefined,
+      hasProvisionCommand: this.host.hasProvisionCommand || undefined,
+      worktreeMode: this.host.worktreeMode !== "local" ? this.host.worktreeMode : undefined,
+      worktreeEnvironmentLabel: this.host.worktreeEnvironmentLabel,
+      hasPlanFile: this.host.hasPlanFile || undefined,
+      planFilePath: this.host.planFilePath,
+      aheadCount: this.host.aheadCount,
+      behindCount: this.host.behindCount,
+      baseBranchName: this.host.baseBranchName ?? undefined,
+      baseAheadCount: this.host.baseAheadCount ?? undefined,
+      baseBehindCount: this.host.baseBehindCount ?? undefined,
+      baseMatchesUpstream: this.host.baseMatchesUpstream ?? undefined,
+      lastFetchedAt: this.host.lastFetchedAt ?? undefined,
+      lastGitStatusCheckedAt: this.host.lastGitStatusCheckedAt,
+      fetchAuthFailed: this.host.fetchAuthFailed || undefined,
+      fetchNetworkFailed: this.host.fetchNetworkFailed || undefined,
+      // Read in-flight state authoritatively at snapshot time (lesson #1700)
+      // so a snapshot emitted between fetch-start and fetch-end always
+      // serializes the correct value, never a stale cached copy.
+      isFetchInFlight: this.host.isFetchInFlight || undefined,
+      matchedForgeProviderId: this.host.matchedForgeProviderId ?? undefined,
+      isWslPath: this.host.isWslPath || undefined,
+      wslDistro: this.host.wslDistro,
+      wslPosixPath: this.host.wslPosixPath,
+      // Emit the three-state value directly for WSL paths so the renderer can
+      // tell "ineligible" (distro mismatch) from "unprobed" (probe pending /
+      // failed). Suppressed for non-WSL worktrees to keep snapshots lean.
+      wslGitEligible: this.host.isWslPath ? this.host.wslGitEligible : undefined,
+      wslGitOptIn: this.host.wslGitOptIn || undefined,
+      wslGitDismissed: this.host.wslGitDismissed || undefined,
+      linked: this.host.linked,
+      repoState: this.host.repoState || undefined,
+      isDetached: this.host.isDetached || undefined,
+      head: this.host.head || undefined,
+    };
+
+    return snapshot;
+  }
+}

--- a/electron/workspace-host/SnapshotBuilder.ts
+++ b/electron/workspace-host/SnapshotBuilder.ts
@@ -20,8 +20,8 @@ export interface SnapshotBuilderHost {
   readonly isMainWorktree: boolean;
   readonly gitDir: Worktree["gitDir"];
   readonly summary: string | undefined;
-  readonly modifiedCount: number | undefined;
-  readonly mood: WorktreeMood | undefined;
+  readonly modifiedCount: number;
+  readonly mood: WorktreeMood;
   readonly lastActivityTimestamp: number | null;
   readonly createdAt: number | undefined;
   readonly aiNote: string | undefined;

--- a/electron/workspace-host/StatPrecheck.ts
+++ b/electron/workspace-host/StatPrecheck.ts
@@ -1,0 +1,220 @@
+import { readFile, stat } from "fs/promises";
+import { isAbsolute, join as pathJoin } from "path";
+import { timeoutSignal, withTimeout } from "../utils/withTimeout.js";
+
+const FS_OP_TIMEOUT_MS = 5_000;
+// Ceiling on how long the stat pre-check may keep skipping full git-status
+// passes while the working tree is NOT covered by a recursive watcher. The
+// four statted files are all .git metadata, so pure working-tree edits (an
+// agent editing sources without staging) never perturb the baseline — without
+// this bound they would stay invisible indefinitely on git-only/unwatched
+// worktrees. Recursive-watched worktrees are exempt: their watcher observes
+// every working-tree write and forces a refresh itself.
+const FULL_STATUS_MAX_AGE_MS = 120_000;
+// Sentinel for "this git path doesn't exist". Used so the baseline can
+// stably record absence (packed-refs, detached HEAD's branch ref) and still
+// match on the next stat pass without forcing a real git check.
+const STAT_ABSENT_SENTINEL = -1;
+
+export interface GitFileStatBaseline {
+  index: number;
+  head: number;
+  refsHead: number;
+  packedRefs: number;
+}
+
+export interface StatPrecheckHost {
+  readonly abortSignal: AbortSignal;
+}
+
+/**
+ * Cheap stat-based pre-check that lets the poll loop skip a full git-status
+ * fork-exec when the four files that would invalidate it (index, HEAD,
+ * refs/heads/<branch>, packed-refs) are unchanged and no watcher event has
+ * fired since the baseline was captured.
+ */
+export class StatPrecheck {
+  private cachedCommonDir: string | null = null;
+  private baseline: GitFileStatBaseline | null = null;
+  private baselineAt: number = 0;
+  private fullStatusAt: number = 0;
+
+  constructor(private readonly host: StatPrecheckHost) {}
+
+  /** Test-only: when the current baseline was captured. */
+  get baselineCapturedAt(): number {
+    return this.baselineAt;
+  }
+
+  /** Test-only: force the full-status budget to a specific timestamp. */
+  set fullStatusCapturedAt(value: number) {
+    this.fullStatusAt = value;
+  }
+
+  /**
+   * Resolve the common git directory for a linked worktree (the `gitDir`
+   * inside `<repo>/.git/worktrees/<name>/` points at `commondir`, which
+   * holds packed-refs and the shared refs/heads tree). Returns `gitDir`
+   * itself for the main worktree, or when the commondir file is missing.
+   * Mirrors `GitFileWatcher.resolveCommonDir`.
+   */
+  async resolveCommonDirAsync(gitDir: string): Promise<string> {
+    // The commondir pointer is immutable for the lifetime of a worktree, so
+    // a successful resolve is cached for the monitor's lifetime. Fallback
+    // paths (missing file, timeout) stay uncached so transient errors retry.
+    if (this.cachedCommonDir !== null) return this.cachedCommonDir;
+    const { signal, dispose } = timeoutSignal(FS_OP_TIMEOUT_MS, this.host.abortSignal);
+    try {
+      const commondirContent = await readFile(pathJoin(gitDir, "commondir"), {
+        encoding: "utf-8",
+        signal,
+      });
+      const trimmed = commondirContent.trim();
+      if (!trimmed) return gitDir;
+      this.cachedCommonDir = isAbsolute(trimmed) ? trimmed : pathJoin(gitDir, trimmed);
+      return this.cachedCommonDir;
+    } catch {
+      // Missing file, timeout, or poll abort — fall back to gitDir. A timeout
+      // here just degrades the next poll to a full git check rather than the
+      // stat fast path; it never freezes the loop.
+      return gitDir;
+    } finally {
+      dispose();
+    }
+  }
+
+  /**
+   * Stat one git path. Returns `STAT_ABSENT_SENTINEL` when the file is
+   * missing (the most common case for packed-refs and unpushed branch
+   * refs) so the baseline can still compare equal on the next pass without
+   * forcing a full git check. Other errors propagate up so the caller
+   * falls back to the full path — a permission flip or filesystem hiccup
+   * should not silently freeze the cached baseline.
+   */
+  async statMtime(filePath: string): Promise<number> {
+    try {
+      // fs.stat has no AbortSignal option (unlike readFile), so it can't be
+      // cancelled — bound the await with withTimeout instead. The timeout
+      // surfaces as a TimeoutError (not ENOENT), so it propagates and
+      // buildStatBaseline falls back to a full git check rather than trusting a
+      // half-captured baseline.
+      const result = await withTimeout(stat(filePath), FS_OP_TIMEOUT_MS, `stat: ${filePath}`);
+      return result.mtimeMs;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "ENOENT") return STAT_ABSENT_SENTINEL;
+      throw error;
+    }
+  }
+
+  /**
+   * Capture mtimeMs for the four git files whose changes would invalidate
+   * the previous status snapshot: index, HEAD, refs/heads/<branch>, and
+   * packed-refs. Returns `null` if any unexpected error occurs (caller
+   * falls back to a full git check). ENOENT is normal for packed-refs and
+   * the branch ref (detached HEAD, or branch not pushed yet) — those paths
+   * return STAT_ABSENT_SENTINEL and the baseline comparison still works.
+   */
+  private async buildStatBaseline(
+    gitDir: string,
+    commonDir: string,
+    branch: string | undefined
+  ): Promise<GitFileStatBaseline | null> {
+    try {
+      const [indexStat, headStat, refsHeadStat, packedRefsStat] = await Promise.all([
+        this.statMtime(pathJoin(gitDir, "index")),
+        this.statMtime(pathJoin(gitDir, "HEAD")),
+        branch
+          ? this.statMtime(pathJoin(commonDir, "refs", "heads", branch))
+          : Promise.resolve(STAT_ABSENT_SENTINEL),
+        this.statMtime(pathJoin(commonDir, "packed-refs")),
+      ]);
+      return {
+        index: indexStat,
+        head: headStat,
+        refsHead: refsHeadStat,
+        packedRefs: packedRefsStat,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private baselinesMatch(a: GitFileStatBaseline, b: GitFileStatBaseline): boolean {
+    return (
+      a.index === b.index &&
+      a.head === b.head &&
+      a.refsHead === b.refsHead &&
+      a.packedRefs === b.packedRefs
+    );
+  }
+
+  private isFullStatusRecent(): boolean {
+    return Date.now() - this.fullStatusAt < FULL_STATUS_MAX_AGE_MS;
+  }
+
+  /**
+   * Whether the caller may skip a full git-status pass. Only trustworthy
+   * while a recursive watcher covers the working tree (its events force
+   * refreshes) or the baseline is still within FULL_STATUS_MAX_AGE_MS of the
+   * last full pass — past that, pure working-tree edits on an
+   * unwatched/git-only worktree would stay invisible indefinitely.
+   */
+  async shouldSkip(
+    gitDir: string,
+    branch: string | undefined,
+    lastWatcherEventAt: number,
+    recursivelyWatched: boolean
+  ): Promise<boolean> {
+    const skipTrustworthy = recursivelyWatched || this.isFullStatusRecent();
+    if (this.baseline === null || !skipTrustworthy) return false;
+
+    const baselineAt = this.baselineAt;
+    const checkStartedAt = Date.now();
+    try {
+      const commonDir = await this.resolveCommonDirAsync(gitDir);
+      const fresh = await this.buildStatBaseline(gitDir, commonDir, branch);
+      if (
+        fresh !== null &&
+        lastWatcherEventAt <= baselineAt &&
+        this.baselinesMatch(this.baseline, fresh)
+      ) {
+        this.baselineAt = checkStartedAt;
+        return true;
+      }
+    } catch {
+      // Unexpected stat error — fall through to the full git check.
+      // Don't poison the baseline; the post-check rebuild will refresh it.
+    }
+    return false;
+  }
+
+  /**
+   * Rebuild the stat baseline after a full pass lands cleanly, resetting the
+   * stat-skip staleness budget alongside it. Drops the baseline on any
+   * failure so the next non-forced poll falls through to a full check
+   * rather than skipping against a snapshot that predates the failure.
+   * Callers must only invoke this when the full pass actually succeeded —
+   * see `dropBaseline()` for the failure path.
+   */
+  async recordFullPass(gitDir: string, branch: string | undefined): Promise<void> {
+    this.fullStatusAt = Date.now();
+    try {
+      const commonDir = await this.resolveCommonDirAsync(gitDir);
+      const fresh = await this.buildStatBaseline(gitDir, commonDir, branch);
+      if (fresh !== null) {
+        this.baseline = fresh;
+        this.baselineAt = Date.now();
+      } else {
+        this.baseline = null;
+      }
+    } catch {
+      this.baseline = null;
+    }
+  }
+
+  /** Drop the cached baseline — called when a git-status pass didn't land cleanly. */
+  dropBaseline(): void {
+    this.baseline = null;
+  }
+}

--- a/electron/workspace-host/StatPrecheck.ts
+++ b/electron/workspace-host/StatPrecheck.ts
@@ -16,7 +16,7 @@ const FULL_STATUS_MAX_AGE_MS = 120_000;
 // match on the next stat pass without forcing a real git check.
 const STAT_ABSENT_SENTINEL = -1;
 
-export interface GitFileStatBaseline {
+interface GitFileStatBaseline {
   index: number;
   head: number;
   refsHead: number;
@@ -25,6 +25,13 @@ export interface GitFileStatBaseline {
 
 export interface StatPrecheckHost {
   readonly abortSignal: AbortSignal;
+  // Live getters, not values snapshotted by the caller: the original inline
+  // implementation read `_branch`/`lastWatcherEventAt` fresh after each
+  // await, so a branch switch or watcher event landing mid-precheck is still
+  // observed. Capturing them once at the `shouldSkip()` call site would miss
+  // events that fire during `resolveCommonDirAsync`/`buildStatBaseline`.
+  readonly branch: string | undefined;
+  readonly lastWatcherEventAt: number;
 }
 
 /**
@@ -160,12 +167,7 @@ export class StatPrecheck {
    * last full pass — past that, pure working-tree edits on an
    * unwatched/git-only worktree would stay invisible indefinitely.
    */
-  async shouldSkip(
-    gitDir: string,
-    branch: string | undefined,
-    lastWatcherEventAt: number,
-    recursivelyWatched: boolean
-  ): Promise<boolean> {
+  async shouldSkip(gitDir: string, recursivelyWatched: boolean): Promise<boolean> {
     const skipTrustworthy = recursivelyWatched || this.isFullStatusRecent();
     if (this.baseline === null || !skipTrustworthy) return false;
 
@@ -173,10 +175,15 @@ export class StatPrecheck {
     const checkStartedAt = Date.now();
     try {
       const commonDir = await this.resolveCommonDirAsync(gitDir);
-      const fresh = await this.buildStatBaseline(gitDir, commonDir, branch);
+      // `branch`/`lastWatcherEventAt` read live from the host — see the
+      // interface comment. A branch switch or watcher event landing during
+      // the awaits above/below must still be observed here, exactly as the
+      // pre-split inline code re-read `this._branch`/`this.lastWatcherEventAt`
+      // fresh at each point rather than snapshotting them once.
+      const fresh = await this.buildStatBaseline(gitDir, commonDir, this.host.branch);
       if (
         fresh !== null &&
-        lastWatcherEventAt <= baselineAt &&
+        this.host.lastWatcherEventAt <= baselineAt &&
         this.baselinesMatch(this.baseline, fresh)
       ) {
         this.baselineAt = checkStartedAt;
@@ -197,11 +204,11 @@ export class StatPrecheck {
    * Callers must only invoke this when the full pass actually succeeded —
    * see `dropBaseline()` for the failure path.
    */
-  async recordFullPass(gitDir: string, branch: string | undefined): Promise<void> {
+  async recordFullPass(gitDir: string): Promise<void> {
     this.fullStatusAt = Date.now();
     try {
       const commonDir = await this.resolveCommonDirAsync(gitDir);
-      const fresh = await this.buildStatBaseline(gitDir, commonDir, branch);
+      const fresh = await this.buildStatBaseline(gitDir, commonDir, this.host.branch);
       if (fresh !== null) {
         this.baseline = fresh;
         this.baselineAt = Date.now();

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1,5 +1,4 @@
 import { access } from "fs/promises";
-import { join as pathJoin } from "path";
 import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import type PQueue from "p-queue";
 import type { WorktreeChanges } from "../../shared/types/git.js";

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1,6 +1,5 @@
-import { readFile, access, stat } from "fs/promises";
-import { isAbsolute, join as pathJoin } from "path";
-import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js";
+import { access } from "fs/promises";
+import { join as pathJoin } from "path";
 import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import type PQueue from "p-queue";
 import type { WorktreeChanges } from "../../shared/types/git.js";
@@ -13,23 +12,17 @@ import type {
 } from "../../shared/types/worktree.js";
 import type { CIStatusState } from "../../shared/types/forge.js";
 import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
-import { invalidateGitStatusCache, getWorktreeChangesWithStats } from "../utils/git.js";
-import { getGitDir } from "../utils/gitUtils.js";
-import { getRepoOperationStateSync } from "../utils/gitRepoOperationState.js";
-import { WorktreeRemovedError } from "../utils/errorTypes.js";
-import { categorizeWorktree } from "../services/worktree/mood.js";
+import { invalidateGitStatusCache } from "../utils/git.js";
 import { AdaptivePollingStrategy, NoteFileReader } from "../services/worktree/index.js";
-import {
-  extractIssueNumberSync,
-  extractIssueNumber,
-  deriveIssueTitleFromBranch,
-} from "../services/issueExtractor.js";
+import { deriveIssueTitleFromBranch } from "../services/issueExtractor.js";
 import { FetchScheduler, type FetchSchedulerHost } from "./FetchScheduler.js";
 import { ResourcePollTimer, type ResourcePollTimerHost } from "./ResourcePollTimer.js";
 import { WatcherController, type WatcherControllerHost } from "./WatcherController.js";
-import { timeoutSignal, withTimeout } from "../utils/withTimeout.js";
-
-const PLAN_FILE_CANDIDATES = ["TODO.md", "PLAN.md", "plan.md", "TASKS.md"] as const;
+import { SnapshotBuilder, type SnapshotBuilderHost } from "./SnapshotBuilder.js";
+import { StatPrecheck, type StatPrecheckHost } from "./StatPrecheck.js";
+import { BaseDivergence, type BaseDivergenceHost } from "./BaseDivergence.js";
+import { GitStatusPass, type GitStatusPassHost } from "./GitStatusPass.js";
+import { withTimeout } from "../utils/withTimeout.js";
 
 // Hard ceiling for individual filesystem syscalls on the poll path. On a
 // healthy disk these return in well under a millisecond; on a stalled mount
@@ -61,40 +54,10 @@ const HEARTBEAT_GAP_CEILING_MS = 360_000;
 // fresh data on app launch.
 const STATUS_INITIAL_DELAY_MIN_MS = 2_000;
 const STATUS_INITIAL_DELAY_MAX_MS = 5_000;
-// Sentinel for "this git path doesn't exist". Used so the baseline can
-// stably record absence (packed-refs, detached HEAD's branch ref) and still
-// match on the next stat pass without forcing a real git check.
-const STAT_ABSENT_SENTINEL = -1;
-// Ceiling on how long the stat pre-check may keep skipping full git-status
-// passes while the working tree is NOT covered by a recursive watcher. The
-// four statted files are all .git metadata, so pure working-tree edits (an
-// agent editing sources without staging) never perturb the baseline — without
-// this bound they would stay invisible indefinitely on git-only/unwatched
-// worktrees. Recursive-watched worktrees are exempt: their watcher observes
-// every working-tree write and forces a refresh itself.
-const FULL_STATUS_MAX_AGE_MS = 120_000;
-
-// FNV-1a 32-bit offset basis. Also the digest of an empty change list, which
-// makes it the natural initial value for `previousStateHash` (see below).
-const FNV_OFFSET_BASIS = 0x811c9dc5;
 
 function randomBetween(minMs: number, maxMs: number): number {
   if (maxMs <= minMs) return minMs;
   return minMs + Math.floor(Math.random() * (maxMs - minMs));
-}
-
-interface GitFileStatBaseline {
-  index: number;
-  head: number;
-  refsHead: number;
-  packedRefs: number;
-}
-
-interface BaseDivergence {
-  baseBranchName: string | null;
-  aheadCount: number | null;
-  behindCount: number | null;
-  matchesUpstream: boolean;
 }
 
 export interface WorktreeMonitorConfig {
@@ -146,35 +109,13 @@ export class WorktreeMonitor {
   private _agentActive: boolean = false;
   private _isMainWorktree: boolean;
 
-  // State
+  // State — `worktreeChanges`/`mood`/`summary` stay here (written from
+  // `poll()`/`scheduleNextPoll()` too, not just the git-status pass); the
+  // rest of the pass's output (modifiedCount, notes, plan file, upstream and
+  // base-branch divergence, activity timestamp) is owned by `gitStatusPass`.
   private worktreeChanges: WorktreeChanges | null = null;
   private mood: WorktreeMood = "stable";
   private summary: string | undefined;
-  private modifiedCount: number = 0;
-  private lastActivityTimestamp: number | null = null;
-  // Seeded with the FNV-1a offset basis — the digest of an empty change list —
-  // mirroring the legacy string implementation where the initial sentinel ""
-  // equaled the clean-tree hash, so a first poll of a clean tree reads as
-  // "no change" exactly as before.
-  private previousStateHash: number = FNV_OFFSET_BASIS;
-
-  // Note state
-  private aiNote: string | undefined;
-  private aiNoteTimestamp: number | undefined;
-
-  // Plan file state
-  private hasPlanFile: boolean = false;
-  private planFilePath: string | undefined;
-
-  // Upstream tracking state
-  private aheadCount: number | undefined;
-  private behindCount: number | undefined;
-
-  // Base-branch divergence state
-  private _baseBranchName: string | null | undefined;
-  private _baseAheadCount: number | null | undefined;
-  private _baseBehindCount: number | null | undefined;
-  private _baseMatchesUpstream: boolean | undefined;
 
   // Issue/PR state
   private _issueNumber: number | undefined;
@@ -224,19 +165,6 @@ export class WorktreeMonitor {
   // whether an event arrived since the baseline was captured — if so, the
   // skip is invalid and we must run the full git check.
   private lastWatcherEventAt: number = 0;
-  // mtime cache for .git/index, HEAD, refs/heads/<branch>, packed-refs.
-  // Populated after every successful git check. When the next poll finds all
-  // four mtimes unchanged AND no watcher event has fired since, we skip the
-  // simple-git fork-exec. null = no baseline yet (first poll, or post-error).
-  private lastStatBaseline: GitFileStatBaseline | null = null;
-  private lastStatBaselineAt: number = 0;
-  // Timestamp of the last completed FULL status pass (one that actually ran
-  // git, not a stat-skip). Bounds how long stat-skips may mask working-tree
-  // edits on worktrees without recursive coverage (FULL_STATUS_MAX_AGE_MS).
-  private lastFullStatusAt: number = 0;
-  private lastBaseDivergenceKey: string | null = null;
-  private lastBaseDivergenceResult: BaseDivergence | null = null;
-  private cachedCommonDir: string | null = null;
   // Timer used to defer the initial `updateGitStatus` call for background
   // monitors so N monitors starting together don't fork git simultaneously.
   // Cleared by `clearTimers()` so `stop()` cancels the deferred poll.
@@ -319,6 +247,19 @@ export class WorktreeMonitor {
   private pollingStrategy: AdaptivePollingStrategy;
   private noteReader: NoteFileReader;
   private pollQueue?: PQueue;
+  private readonly snapshotBuilder: SnapshotBuilder;
+  private readonly statPrecheck: StatPrecheck;
+  private readonly baseDivergence: BaseDivergence;
+  private readonly gitStatusPass: GitStatusPass;
+
+  // Test-only backdoors preserving pre-split field access onto the stat
+  // baseline cache StatPrecheck now owns for real callers.
+  private get lastStatBaselineAt(): number {
+    return this.statPrecheck.baselineCapturedAt;
+  }
+  private set lastFullStatusAt(value: number) {
+    this.statPrecheck.fullStatusCapturedAt = value;
+  }
 
   constructor(
     worktree: Worktree,
@@ -450,6 +391,364 @@ export class WorktreeMonitor {
       onWatcherRecovered: () => monitor.callbacks.onWatcherRecovered?.(monitor.id),
     };
     this.watcherController = new WatcherController(watcherHost);
+
+    const snapshotHost: SnapshotBuilderHost = {
+      get id() {
+        return monitor.id;
+      },
+      get path() {
+        return monitor.path;
+      },
+      get name() {
+        return monitor._name;
+      },
+      get branch() {
+        return monitor._branch;
+      },
+      get isCurrent() {
+        return monitor._isCurrent;
+      },
+      get isMainWorktree() {
+        return monitor._isMainWorktree;
+      },
+      get gitDir() {
+        return monitor._gitDir;
+      },
+      get summary() {
+        return monitor.summary;
+      },
+      get modifiedCount() {
+        return monitor.gitStatusPass.modifiedCount;
+      },
+      get mood() {
+        return monitor.mood;
+      },
+      get lastActivityTimestamp() {
+        return monitor.gitStatusPass.lastActivityTimestamp;
+      },
+      get createdAt() {
+        return monitor._createdAt;
+      },
+      get aiNote() {
+        return monitor.gitStatusPass.aiNote;
+      },
+      get aiNoteTimestamp() {
+        return monitor.gitStatusPass.aiNoteTimestamp;
+      },
+      get issueNumber() {
+        return monitor._issueNumber;
+      },
+      get prNumber() {
+        return monitor.prNumber;
+      },
+      get prUrl() {
+        return monitor.prUrl;
+      },
+      get prState() {
+        return monitor.prState;
+      },
+      get prCiStatus() {
+        return monitor.prCiStatus;
+      },
+      get prTitle() {
+        return monitor.prTitle;
+      },
+      get issueTitle() {
+        return monitor.issueTitle;
+      },
+      get branchDerivedTitle() {
+        return monitor._branchDerivedTitle;
+      },
+      get sourcePrNumber() {
+        return monitor._sourcePrNumber;
+      },
+      get prLastUpdatedAt() {
+        return monitor.prLastUpdatedAt;
+      },
+      get issueLastUpdatedAt() {
+        return monitor.issueLastUpdatedAt;
+      },
+      get worktreeChanges() {
+        return monitor.worktreeChanges;
+      },
+      get lifecycleStatus() {
+        return monitor._lifecycleStatus;
+      },
+      get lifecyclePhaseResults() {
+        return monitor._lifecyclePhaseResults;
+      },
+      get resourceStatus() {
+        return monitor._resourceStatus;
+      },
+      get resourceConnectCommand() {
+        return monitor._resourceConnectCommand;
+      },
+      get resourceProvider() {
+        return monitor._resourceProvider;
+      },
+      get hasResourceConfig() {
+        return monitor._hasResourceConfig;
+      },
+      get hasStatusCommand() {
+        return monitor._hasStatusCommand;
+      },
+      get hasPauseCommand() {
+        return monitor._hasPauseCommand;
+      },
+      get hasResumeCommand() {
+        return monitor._hasResumeCommand;
+      },
+      get hasTeardownCommand() {
+        return monitor._hasTeardownCommand;
+      },
+      get hasProvisionCommand() {
+        return monitor._hasProvisionCommand;
+      },
+      get worktreeMode() {
+        return monitor._worktreeMode;
+      },
+      get worktreeEnvironmentLabel() {
+        return monitor._worktreeEnvironmentLabel;
+      },
+      get hasPlanFile() {
+        return monitor.gitStatusPass.hasPlanFile;
+      },
+      get planFilePath() {
+        return monitor.gitStatusPass.planFilePath;
+      },
+      get aheadCount() {
+        return monitor.gitStatusPass.aheadCount;
+      },
+      get behindCount() {
+        return monitor.gitStatusPass.behindCount;
+      },
+      get baseBranchName() {
+        return monitor.gitStatusPass.baseBranchName;
+      },
+      get baseAheadCount() {
+        return monitor.gitStatusPass.baseAheadCount;
+      },
+      get baseBehindCount() {
+        return monitor.gitStatusPass.baseBehindCount;
+      },
+      get baseMatchesUpstream() {
+        return monitor.gitStatusPass.baseMatchesUpstream;
+      },
+      get lastFetchedAt() {
+        return monitor._lastFetchedAt;
+      },
+      get lastGitStatusCheckedAt() {
+        return monitor.lastGitStatusCompletedAt;
+      },
+      get fetchAuthFailed() {
+        return monitor._fetchAuthFailed;
+      },
+      get fetchNetworkFailed() {
+        return monitor._fetchNetworkFailed;
+      },
+      get isFetchInFlight() {
+        return monitor.fetchScheduler.isFetchInFlight;
+      },
+      get matchedForgeProviderId() {
+        return monitor._matchedForgeProviderId;
+      },
+      get isWslPath() {
+        return monitor._isWslPath;
+      },
+      get wslDistro() {
+        return monitor._wslDistro;
+      },
+      get wslPosixPath() {
+        return monitor._wslPosixPath;
+      },
+      get wslGitEligible() {
+        return monitor._wslGitEligible;
+      },
+      get wslGitOptIn() {
+        return monitor._wslGitOptIn;
+      },
+      get wslGitDismissed() {
+        return monitor._wslGitDismissed;
+      },
+      get linked() {
+        return monitor._linked;
+      },
+      get repoState() {
+        return monitor._repoState;
+      },
+      get isDetached() {
+        return monitor._isDetached;
+      },
+      get head() {
+        return monitor._head;
+      },
+    };
+    this.snapshotBuilder = new SnapshotBuilder(snapshotHost);
+
+    const statPrecheckHost: StatPrecheckHost = {
+      get abortSignal() {
+        return monitor._pollAbortController.signal;
+      },
+    };
+    this.statPrecheck = new StatPrecheck(statPrecheckHost);
+
+    const baseDivergenceHost: BaseDivergenceHost = {
+      get branch() {
+        return monitor._branch;
+      },
+      get isMainWorktree() {
+        return monitor._isMainWorktree;
+      },
+      get mainBranch() {
+        return monitor.mainBranch;
+      },
+      get linkedPrBaseRef() {
+        return monitor._linked?.pr?.baseRef;
+      },
+      get path() {
+        return monitor.path;
+      },
+      get wslInvocation() {
+        return monitor.wslInvocation;
+      },
+      get abortSignal() {
+        return monitor._pollAbortController.signal;
+      },
+    };
+    this.baseDivergence = new BaseDivergence(baseDivergenceHost, this.statPrecheck);
+
+    const gitStatusPassHost: GitStatusPassHost = {
+      get id() {
+        return monitor.id;
+      },
+      get path() {
+        return monitor.path;
+      },
+      get name() {
+        return monitor._name;
+      },
+      get mainBranch() {
+        return monitor.mainBranch;
+      },
+      get isCurrent() {
+        return monitor._isCurrent;
+      },
+      get isRunning() {
+        return monitor._isRunning;
+      },
+      get basePollingInterval() {
+        return monitor.config.basePollingInterval;
+      },
+      get wslInvocation() {
+        return monitor.wslInvocation;
+      },
+      get abortSignal() {
+        return monitor._pollAbortController.signal;
+      },
+      get lastWatcherEventAt() {
+        return monitor.lastWatcherEventAt;
+      },
+      get prevEmittedIsDetached() {
+        return monitor._prevEmittedIsDetached;
+      },
+      get prevEmittedHead() {
+        return monitor._prevEmittedHead;
+      },
+      get prevEmittedRepoState() {
+        return monitor._prevEmittedRepoState;
+      },
+      get hasInitialStatus() {
+        return monitor._hasInitialStatus;
+      },
+      set hasInitialStatus(value: boolean) {
+        monitor._hasInitialStatus = value;
+      },
+      get repoState() {
+        return monitor._repoState;
+      },
+      set repoState(value) {
+        monitor._repoState = value;
+      },
+      get lastGitStatusCompletedAt() {
+        return monitor.lastGitStatusCompletedAt;
+      },
+      set lastGitStatusCompletedAt(value: number) {
+        monitor.lastGitStatusCompletedAt = value;
+      },
+      get isUpdating() {
+        return monitor._isUpdating;
+      },
+      set isUpdating(value: boolean) {
+        monitor._isUpdating = value;
+      },
+      get branch() {
+        return monitor._branch;
+      },
+      set branch(value: string | undefined) {
+        monitor._branch = value;
+      },
+      get issueNumber() {
+        return monitor._issueNumber;
+      },
+      set issueNumber(value: number | undefined) {
+        monitor._issueNumber = value;
+      },
+      get branchDerivedTitle() {
+        return monitor._branchDerivedTitle;
+      },
+      set branchDerivedTitle(value: string | undefined) {
+        monitor._branchDerivedTitle = value;
+      },
+      get issueTitle() {
+        return monitor.issueTitle;
+      },
+      set issueTitle(value: string | undefined) {
+        monitor.issueTitle = value;
+      },
+      get isDetached() {
+        return monitor._isDetached;
+      },
+      set isDetached(value: boolean) {
+        monitor._isDetached = value;
+      },
+      get head() {
+        return monitor._head;
+      },
+      set head(value: string | undefined) {
+        monitor._head = value;
+      },
+      get mood() {
+        return monitor.mood;
+      },
+      set mood(value: WorktreeMood) {
+        monitor.mood = value;
+      },
+      get summary() {
+        return monitor.summary;
+      },
+      set summary(value: string | undefined) {
+        monitor.summary = value;
+      },
+      get worktreeChanges() {
+        return monitor.worktreeChanges;
+      },
+      set worktreeChanges(value: WorktreeChanges | null) {
+        monitor.worktreeChanges = value;
+      },
+      clearPRInfo: () => monitor.clearPRInfo(),
+      onBranchChanged: (branch: string) => monitor.callbacks.onBranchChanged?.(monitor.id, branch),
+      onRemoved: () => monitor.callbacks.onRemoved?.(monitor.id),
+      stop: () => monitor.stop(),
+      emitUpdate: () => monitor.emitUpdate(),
+    };
+    this.gitStatusPass = new GitStatusPass(
+      gitStatusPassHost,
+      this.statPrecheck,
+      this.baseDivergence,
+      this.watcherController,
+      this.pollingStrategy,
+      this.noteReader
+    );
 
     this._isWslPath = Boolean(worktree.isWslPath);
     this._wslDistro = worktree.wslDistro;
@@ -1184,106 +1483,7 @@ export class WorktreeMonitor {
   }
 
   getSnapshot(): WorktreeSnapshot {
-    let resourceStatus: import("../../shared/types/worktree.js").WorktreeResourceStatus | undefined;
-    if (this._resourceStatus) {
-      resourceStatus = { ...this._resourceStatus, provider: this._resourceProvider };
-    } else if (this._resourceProvider) {
-      resourceStatus = { provider: this._resourceProvider };
-    }
-
-    // `linked` is the source of truth (#8452). When present, the legacy flat
-    // fields are derived from it; the private flat fields only serve the
-    // legacy/branch-parse path where `_linked` was never populated.
-    const linkedPr = this._linked?.pr;
-    const linkedIssue = this._linked?.issue;
-    const linkedPrState: "open" | "merged" | "closed" | undefined = linkedPr
-      ? linkedPr.state === "declined"
-        ? "closed"
-        : linkedPr.state
-      : undefined;
-    const linkedPrCiStatus: CIStatusState | undefined =
-      linkedPr?.ciStatus &&
-      (linkedPr.ciStatus.state === "success" ||
-        linkedPr.ciStatus.state === "failure" ||
-        linkedPr.ciStatus.state === "pending")
-        ? linkedPr.ciStatus.state
-        : undefined;
-
-    const snapshot: WorktreeSnapshot = {
-      id: this.id,
-      path: this.path,
-      name: this._name,
-      branch: this._branch,
-      isCurrent: this._isCurrent,
-      isMainWorktree: this._isMainWorktree,
-      gitDir: this._gitDir,
-      summary: this.summary,
-      modifiedCount: this.modifiedCount,
-      mood: this.mood,
-      lastActivityTimestamp: this.lastActivityTimestamp,
-      createdAt: this._createdAt,
-      aiNote: this.aiNote,
-      aiNoteTimestamp: this.aiNoteTimestamp,
-      issueNumber: linkedIssue?.ref.number ?? this._issueNumber,
-      prNumber: linkedPr?.ref.number ?? this.prNumber,
-      prUrl: linkedPr?.url ?? this.prUrl,
-      prState: linkedPr ? linkedPrState : this.prState === "declined" ? "closed" : this.prState,
-      prCiStatus: linkedPr ? linkedPrCiStatus : this.prCiStatus,
-      prTitle: linkedPr ? linkedPr.title : this.prTitle,
-      issueTitle: linkedIssue ? linkedIssue.title : this.issueTitle,
-      branchDerivedTitle: this._branchDerivedTitle,
-      sourcePrNumber: this._sourcePrNumber,
-      prLastUpdatedAt: this.prLastUpdatedAt,
-      issueLastUpdatedAt: this.issueLastUpdatedAt,
-      worktreeChanges: this.worktreeChanges,
-      worktreeId: this.id,
-      timestamp: Date.now(),
-      lifecycleStatus: this._lifecycleStatus,
-      lifecyclePhaseResults:
-        this._lifecyclePhaseResults.length > 0 ? [...this._lifecyclePhaseResults] : undefined,
-      resourceStatus,
-      resourceConnectCommand: this._resourceConnectCommand,
-      hasResourceConfig: this._hasResourceConfig || undefined,
-      hasStatusCommand: this._hasStatusCommand || undefined,
-      hasPauseCommand: this._hasPauseCommand || undefined,
-      hasResumeCommand: this._hasResumeCommand || undefined,
-      hasTeardownCommand: this._hasTeardownCommand || undefined,
-      hasProvisionCommand: this._hasProvisionCommand || undefined,
-      worktreeMode: this._worktreeMode !== "local" ? this._worktreeMode : undefined,
-      worktreeEnvironmentLabel: this._worktreeEnvironmentLabel,
-      hasPlanFile: this.hasPlanFile || undefined,
-      planFilePath: this.planFilePath,
-      aheadCount: this.aheadCount,
-      behindCount: this.behindCount,
-      baseBranchName: this._baseBranchName ?? undefined,
-      baseAheadCount: this._baseAheadCount ?? undefined,
-      baseBehindCount: this._baseBehindCount ?? undefined,
-      baseMatchesUpstream: this._baseMatchesUpstream ?? undefined,
-      lastFetchedAt: this._lastFetchedAt ?? undefined,
-      lastGitStatusCheckedAt: this.lastGitStatusCompletedAt,
-      fetchAuthFailed: this._fetchAuthFailed || undefined,
-      fetchNetworkFailed: this._fetchNetworkFailed || undefined,
-      // Read in-flight state authoritatively at snapshot time (lesson #1700)
-      // so a snapshot emitted between fetch-start and fetch-end always
-      // serializes the correct value, never a stale cached copy.
-      isFetchInFlight: this.fetchScheduler.isFetchInFlight || undefined,
-      matchedForgeProviderId: this._matchedForgeProviderId ?? undefined,
-      isWslPath: this._isWslPath || undefined,
-      wslDistro: this._wslDistro,
-      wslPosixPath: this._wslPosixPath,
-      // Emit the three-state value directly for WSL paths so the renderer can
-      // tell "ineligible" (distro mismatch) from "unprobed" (probe pending /
-      // failed). Suppressed for non-WSL worktrees to keep snapshots lean.
-      wslGitEligible: this._isWslPath ? this._wslGitEligible : undefined,
-      wslGitOptIn: this._wslGitOptIn || undefined,
-      wslGitDismissed: this._wslGitDismissed || undefined,
-      linked: this._linked,
-      repoState: this._repoState || undefined,
-      isDetached: this._isDetached || undefined,
-      head: this._head || undefined,
-    };
-
-    return snapshot;
+    return this.snapshotBuilder.build();
   }
 
   isCircuitBreakerTripped(): boolean {
@@ -1570,674 +1770,7 @@ export class WorktreeMonitor {
   // --- Git status ---
 
   async updateGitStatus(forceRefresh: boolean = false): Promise<void> {
-    if (this._isUpdating) {
-      return;
-    }
-    // Claim the single-flight slot before the first await. Everything below
-    // suspends (git-dir resolution, the stat pre-check), and forced refreshes
-    // bypass both the worktree-changes in-flight cache and the pre-check — so
-    // without the early claim two rapid forced refreshes could pass the guard
-    // together and run duplicate status passes with out-of-order commits.
-    this._isUpdating = true;
-
-    // Definite-assignment: assigned as the first statement of the try below;
-    // the status pass (the only later reader) is unreachable unless that try
-    // completed normally, so every read is dominated by the assignment.
-    let gitDir!: string | null;
-    let reachedStatusPass = false;
-    try {
-      // Skip the git status invocation while a rebase/merge/cherry-pick/revert
-      // is in progress — running it would compete with the user's git client
-      // for .git/index.lock. The watcher tracks the same sentinel files, so
-      // it fires when the operation finishes and triggers a fresh refresh.
-      // Polling continues uninterrupted, so the next scheduled poll after
-      // sentinels clear also picks up the change.
-      gitDir = await getGitDir(this.path, { cache: true, logErrors: false });
-
-      // Detect blocking git operation state from sentinel files so the renderer
-      // can surface it even when git status is skipped.
-      let opState: import("../../shared/types/git.js").RepoState | undefined;
-      if (gitDir) {
-        opState = getRepoOperationStateSync(gitDir);
-        if (opState !== this._repoState) {
-          this._repoState = opState;
-          if (this._hasInitialStatus) {
-            this.emitUpdate();
-          }
-        }
-      } else {
-        this._repoState = undefined;
-      }
-
-      if (gitDir && opState !== undefined) {
-        // Stamp the completion timestamp before any emit so every snapshot below
-        // carries the advanced value. Git status was skipped, but the sentinel
-        // state was freshly observed above, so the freshness signal is accurate
-        // and the heartbeat-gap detector (which reads this field) won't
-        // false-positive on a long blocking operation. Without this, a
-        // user-triggered refresh during a stuck blocking operation never advances
-        // lastGitStatusCompletedAt, leaving the freshness pill permanently stale
-        // and its Refresh button a no-op (#10715).
-        this.lastGitStatusCompletedAt = Date.now();
-        if (!this._hasInitialStatus) {
-          // First poll started mid-operation (e.g. app started mid-rebase) — emit
-          // a default snapshot so the renderer can still display the worktree.
-          // Mirrors startWithoutGitStatus()'s contract.
-          this._hasInitialStatus = true;
-          this.emitUpdate();
-        } else if (forceRefresh) {
-          // The user clicked Refresh on a stale card. Emit so the renderer
-          // receives the advanced timestamp and the freshness pill resets —
-          // otherwise the click is silently dropped. Background polls stamp
-          // silently; the watcher emits a real status once sentinels clear.
-          this.emitUpdate();
-        }
-        return;
-      }
-
-      // Cheap stat pre-check: when the four git files we care about haven't
-      // changed since the last baseline and no watcher event has fired since,
-      // the simple-git fork-exec would be redundant. Skip it. This is the
-      // common case on a quiet repo — the per-poll cost drops from ~15-50ms
-      // (fork + git status) to ~1ms (four stat() calls).
-      //
-      // The baseline only exists after the first real check, so this branch
-      // is a no-op on the very first poll. Forced refreshes (watcher events,
-      // user actions) always run the full check.
-      //
-      // The skip is only trustworthy for working-tree freshness while the
-      // recursive watcher covers the tree (its events force refreshes). In
-      // git-only/unwatched modes the four statted files can't reflect pure
-      // working-tree edits, so cap how long skips may stack up: past
-      // FULL_STATUS_MAX_AGE_MS the poll falls through to a real git check.
-      const skipTrustworthy =
-        this.watcherController.currentMode === "recursive" ||
-        Date.now() - this.lastFullStatusAt < FULL_STATUS_MAX_AGE_MS;
-      if (
-        !forceRefresh &&
-        gitDir &&
-        this._hasInitialStatus &&
-        this.lastStatBaseline !== null &&
-        skipTrustworthy
-      ) {
-        const baselineAt = this.lastStatBaselineAt;
-        const checkStartedAt = Date.now();
-        try {
-          const commonDir = await this.resolveCommonDirAsync(gitDir);
-          const fresh = await this.buildStatBaseline(gitDir, commonDir);
-          if (
-            fresh !== null &&
-            this.lastWatcherEventAt <= baselineAt &&
-            this.statBaselineMatches(this.lastStatBaseline, fresh)
-          ) {
-            // Treat the skip as a no-change observation so the idle backoff
-            // ramps up the next interval. lastGitStatusCompletedAt bumps too,
-            // otherwise the heartbeat-gap check would false-positive on a
-            // long quiet streak that only ran stat-skips.
-            this.pollingStrategy.recordNoChange();
-            this.lastStatBaselineAt = checkStartedAt;
-            this.lastGitStatusCompletedAt = Date.now();
-            return;
-          }
-        } catch {
-          // Unexpected stat error — fall through to the full git check.
-          // Don't poison the baseline; the post-check rebuild will refresh it.
-        }
-      }
-
-      reachedStatusPass = true;
-    } finally {
-      // Early exits (sentinel skip, stat skip, a throw above) release the
-      // claim here and drain any pending watcher flush that queued while it
-      // was held. The status pass below keeps the claim; its own finally is
-      // the release point — and stays the LAST code to touch the flag, so a
-      // flush-triggered synchronous re-entry can't have its claim clobbered.
-      if (!reachedStatusPass) {
-        this._isUpdating = false;
-        this.watcherController.flushPendingIfReady(true);
-      }
-    }
-
-    // Tracks whether the try block reached a clean exit point — either the
-    // no-change early return or the post-emit fall-through. The catch block
-    // doesn't flip it (so the finally clears the stale baseline) which means
-    // a flaky git that throws here can't get its old baseline re-stamped and
-    // silently suppress the next retry.
-    let checkSucceeded = false;
-
-    try {
-      if (forceRefresh) {
-        invalidateGitStatusCache(this.path);
-      }
-
-      const pollingInterval = this.config.basePollingInterval;
-      const cacheTTL =
-        Number.isFinite(pollingInterval) && pollingInterval > 0
-          ? Math.max(500, pollingInterval - 500)
-          : undefined;
-      const newChanges = await getWorktreeChangesWithStats(this.path, {
-        forceRefresh,
-        cacheTTL,
-        wsl: this.wslInvocation,
-      });
-
-      if (!this._isRunning) {
-        return;
-      }
-
-      // Detect branch changes by reading HEAD directly
-      const currentBranch = await this.readCurrentBranch();
-      const branchChanged = currentBranch !== undefined && currentBranch !== this._branch;
-      if (branchChanged) {
-        this._branch = currentBranch;
-        const hadPendingRefresh = this.watcherController.takePending();
-        this.watcherController.update();
-        if (hadPendingRefresh) {
-          this.watcherController.markPending();
-        }
-        const syncIssueNumber = extractIssueNumberSync(currentBranch, this._name);
-        if (syncIssueNumber) {
-          this._issueNumber = syncIssueNumber;
-        } else {
-          this._issueNumber = undefined;
-          void this.extractIssueNumberAsync(currentBranch, this._name);
-        }
-        this._branchDerivedTitle = deriveIssueTitleFromBranch(currentBranch);
-        this.issueTitle = undefined;
-        // Clear PR info synchronously in the same emit as the branch change
-        // so the renderer never sees a frame with the new branch but the old
-        // PR (#8079). PullRequestService still emits its own clear downstream;
-        // by then this snapshot already has null PR fields, so that second
-        // emit collapses to a no-op via snapshotsEqual.
-        this.clearPRInfo();
-        this.callbacks.onBranchChanged?.(this.id, currentBranch);
-      }
-
-      // Bound the AI-note read: a slow/stalled note file must degrade to "no
-      // note" for this pass, not hang the whole git-status update.
-      const noteData = await withTimeout(
-        this.noteReader.read(),
-        FS_OP_TIMEOUT_MS,
-        `note read: ${this.path}`
-      ).catch(() => undefined);
-
-      const hasUpstream = !!newChanges.tracking;
-      const nextAheadCount = hasUpstream ? (newChanges.ahead ?? 0) : undefined;
-      const nextBehindCount = hasUpstream ? (newChanges.behind ?? 0) : undefined;
-
-      // Base-branch divergence — runs in parallel with plan file detection.
-      const baseDivergencePromise = this.computeBaseDivergence(hasUpstream);
-
-      const planResults = await Promise.allSettled(
-        PLAN_FILE_CANDIDATES.map((candidate) =>
-          withTimeout(
-            access(pathJoin(this.path, candidate)),
-            FS_OP_TIMEOUT_MS,
-            `plan-file probe: ${candidate}`
-          )
-        )
-      );
-      const detectedPlanFile = PLAN_FILE_CANDIDATES.find(
-        (_, i) => planResults[i].status === "fulfilled"
-      );
-      const nextHasPlanFile = detectedPlanFile !== undefined;
-      const nextPlanFilePath = detectedPlanFile;
-
-      const baseDivergence = await baseDivergencePromise;
-      const nextBaseBranchName = baseDivergence?.baseBranchName ?? undefined;
-      const nextBaseAheadCount = baseDivergence?.aheadCount ?? undefined;
-      const nextBaseBehindCount = baseDivergence?.behindCount ?? undefined;
-      const nextBaseMatchesUpstream = baseDivergence?.matchesUpstream ?? undefined;
-
-      const currentHash = this.calculateStateHash(newChanges);
-      const stateChanged = currentHash !== this.previousStateHash;
-      const noteChanged =
-        noteData?.content !== this.aiNote || noteData?.timestamp !== this.aiNoteTimestamp;
-      const planChanged =
-        nextHasPlanFile !== this.hasPlanFile || nextPlanFilePath !== this.planFilePath;
-      const upstreamChanged =
-        nextAheadCount !== this.aheadCount || nextBehindCount !== this.behindCount;
-      const baseDivergenceChanged =
-        nextBaseBranchName !== this._baseBranchName ||
-        nextBaseAheadCount !== this._baseAheadCount ||
-        nextBaseBehindCount !== this._baseBehindCount ||
-        nextBaseMatchesUpstream !== this._baseMatchesUpstream;
-
-      const gitStateChanged =
-        this._isDetached !== this._prevEmittedIsDetached ||
-        this._head !== this._prevEmittedHead ||
-        this._repoState !== this._prevEmittedRepoState;
-
-      const anythingChanged =
-        stateChanged ||
-        noteChanged ||
-        branchChanged ||
-        planChanged ||
-        upstreamChanged ||
-        baseDivergenceChanged ||
-        gitStateChanged;
-
-      // Drive the idle backoff from what the git check actually observed —
-      // a real state change resets, otherwise we count one quiet tick. The
-      // skip path above runs its own recordNoChange so this branch only
-      // sees ticks that paid the full fork-exec cost.
-      if (anythingChanged) {
-        this.pollingStrategy.recordStateChange();
-      } else {
-        this.pollingStrategy.recordNoChange();
-      }
-
-      if (!anythingChanged && !forceRefresh) {
-        checkSucceeded = true;
-        return;
-      }
-
-      // True on initial load OR while the tree has stayed clean — the two are
-      // deliberately indistinguishable (legacy ""-hash semantics).
-      const isInitialLoad = this.previousStateHash === FNV_OFFSET_BASIS;
-      const isNowClean = newChanges.changedFileCount === 0;
-      const hasPendingChanges = newChanges.changedFileCount > 0;
-      const shouldUpdateTimestamp =
-        (stateChanged && !isInitialLoad) || (isInitialLoad && hasPendingChanges);
-
-      if (shouldUpdateTimestamp) {
-        this.lastActivityTimestamp = Date.now();
-      }
-
-      if (isInitialLoad && isNowClean && this.lastActivityTimestamp === null) {
-        this.lastActivityTimestamp = newChanges.lastCommitTimestampMs ?? null;
-      }
-
-      if (
-        isNowClean ||
-        isInitialLoad ||
-        (this.worktreeChanges && this.worktreeChanges.changedFileCount === 0)
-      ) {
-        this.summary = await this.fetchLastCommitMessage(newChanges);
-      }
-
-      let nextMood = this.mood;
-      try {
-        nextMood = await categorizeWorktree(
-          {
-            id: this.id,
-            path: this.path,
-            name: this._name,
-            branch: this._branch,
-            isCurrent: this._isCurrent,
-          },
-          newChanges || undefined,
-          this.mainBranch
-        );
-      } catch {
-        nextMood = "error";
-      }
-
-      this.previousStateHash = currentHash;
-      this.worktreeChanges = newChanges;
-      this.modifiedCount = newChanges.changedFileCount;
-      this.mood = nextMood;
-      this.aiNote = noteData?.content;
-      this.aiNoteTimestamp = noteData?.timestamp;
-      this.hasPlanFile = nextHasPlanFile;
-      this.planFilePath = nextPlanFilePath;
-      this.aheadCount = nextAheadCount;
-      this.behindCount = nextBehindCount;
-      this._baseBranchName = nextBaseBranchName;
-      this._baseAheadCount = nextBaseAheadCount;
-      this._baseBehindCount = nextBaseBehindCount;
-      this._baseMatchesUpstream = nextBaseMatchesUpstream;
-      this._hasInitialStatus = true;
-
-      this.emitUpdate();
-      checkSucceeded = true;
-    } catch (error) {
-      if (error instanceof WorktreeRemovedError) {
-        this.stop();
-        this.callbacks.onRemoved?.(this.id);
-        return;
-      }
-
-      const errorMessage = (error as Error).message || "";
-      if (errorMessage.includes("index.lock")) {
-        this.watcherController.markPending();
-        this.watcherController.scheduleDelayedFlush();
-        return;
-      }
-
-      this.mood = "error";
-      this.emitUpdate();
-      throw error;
-    } finally {
-      this._isUpdating = false;
-      this.lastGitStatusCompletedAt = Date.now();
-      // Rebuild the stat baseline only when a real git check finished
-      // cleanly. On failure (anything that didn't set checkSucceeded — git
-      // throw, WorktreeRemovedError, index.lock retry path) we drop the
-      // baseline so the next non-forced poll falls through to a full check
-      // rather than skipping against a snapshot that predates the failure.
-      if (checkSucceeded && gitDir) {
-        // A full pass ran git and landed cleanly — reset the stat-skip
-        // staleness budget alongside the baseline rebuild.
-        this.lastFullStatusAt = Date.now();
-        try {
-          const commonDir = await this.resolveCommonDirAsync(gitDir);
-          const fresh = await this.buildStatBaseline(gitDir, commonDir);
-          if (fresh !== null) {
-            this.lastStatBaseline = fresh;
-            this.lastStatBaselineAt = Date.now();
-          } else {
-            this.lastStatBaseline = null;
-          }
-        } catch {
-          this.lastStatBaseline = null;
-        }
-      } else {
-        this.lastStatBaseline = null;
-      }
-      this.watcherController.flushPendingIfReady(true);
-    }
-  }
-
-  /**
-   * Resolve the common git directory for a linked worktree (the `gitDir`
-   * inside `<repo>/.git/worktrees/<name>/` points at `commondir`, which
-   * holds packed-refs and the shared refs/heads tree). Returns `gitDir`
-   * itself for the main worktree, or when the commondir file is missing.
-   * Mirrors `GitFileWatcher.resolveCommonDir`.
-   */
-  private async resolveCommonDirAsync(gitDir: string): Promise<string> {
-    // The commondir pointer is immutable for the lifetime of a worktree, so
-    // a successful resolve is cached for the monitor's lifetime. Fallback
-    // paths (missing file, timeout) stay uncached so transient errors retry.
-    if (this.cachedCommonDir !== null) return this.cachedCommonDir;
-    const { signal, dispose } = timeoutSignal(FS_OP_TIMEOUT_MS, this._pollAbortController.signal);
-    try {
-      const commondirContent = await readFile(pathJoin(gitDir, "commondir"), {
-        encoding: "utf-8",
-        signal,
-      });
-      const trimmed = commondirContent.trim();
-      if (!trimmed) return gitDir;
-      this.cachedCommonDir = isAbsolute(trimmed) ? trimmed : pathJoin(gitDir, trimmed);
-      return this.cachedCommonDir;
-    } catch {
-      // Missing file, timeout, or poll abort — fall back to gitDir. A timeout
-      // here just degrades the next poll to a full git check rather than the
-      // stat fast path; it never freezes the loop.
-      return gitDir;
-    } finally {
-      dispose();
-    }
-  }
-
-  /**
-   * Capture mtimeMs for the four git files whose changes would invalidate
-   * the previous status snapshot: index, HEAD, refs/heads/<branch>, and
-   * packed-refs. Returns `null` if any unexpected error occurs (caller
-   * falls back to a full git check). ENOENT is normal for packed-refs and
-   * the branch ref (detached HEAD, or branch not pushed yet) — those paths
-   * return STAT_ABSENT_SENTINEL and the baseline comparison still works.
-   */
-  private async buildStatBaseline(
-    gitDir: string,
-    commonDir: string
-  ): Promise<GitFileStatBaseline | null> {
-    try {
-      const [indexStat, headStat, refsHeadStat, packedRefsStat] = await Promise.all([
-        this.statMtime(pathJoin(gitDir, "index")),
-        this.statMtime(pathJoin(gitDir, "HEAD")),
-        this._branch
-          ? this.statMtime(pathJoin(commonDir, "refs", "heads", this._branch))
-          : Promise.resolve(STAT_ABSENT_SENTINEL),
-        this.statMtime(pathJoin(commonDir, "packed-refs")),
-      ]);
-      return {
-        index: indexStat,
-        head: headStat,
-        refsHead: refsHeadStat,
-        packedRefs: packedRefsStat,
-      };
-    } catch {
-      return null;
-    }
-  }
-
-  /**
-   * Stat one git path. Returns `STAT_ABSENT_SENTINEL` when the file is
-   * missing (the most common case for packed-refs and unpushed branch
-   * refs) so the baseline can still compare equal on the next pass without
-   * forcing a full git check. Other errors propagate up so the caller
-   * falls back to the full path — a permission flip or filesystem hiccup
-   * should not silently freeze the cached baseline.
-   */
-  private async statMtime(filePath: string): Promise<number> {
-    try {
-      // fs.stat has no AbortSignal option (unlike readFile), so it can't be
-      // cancelled — bound the await with withTimeout instead. The timeout
-      // surfaces as a TimeoutError (not ENOENT), so it propagates and
-      // buildStatBaseline falls back to a full git check rather than trusting a
-      // half-captured baseline.
-      const result = await withTimeout(stat(filePath), FS_OP_TIMEOUT_MS, `stat: ${filePath}`);
-      return result.mtimeMs;
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException)?.code;
-      if (code === "ENOENT") return STAT_ABSENT_SENTINEL;
-      throw error;
-    }
-  }
-
-  private statBaselineMatches(a: GitFileStatBaseline, b: GitFileStatBaseline): boolean {
-    return (
-      a.index === b.index &&
-      a.head === b.head &&
-      a.refsHead === b.refsHead &&
-      a.packedRefs === b.packedRefs
-    );
-  }
-
-  private async readCurrentBranch(): Promise<string | undefined> {
-    const gitDir = await getGitDir(this.path, { cache: true, logErrors: false });
-    if (!gitDir) {
-      this._isDetached = false;
-      this._head = undefined;
-      return undefined;
-    }
-
-    const { signal, dispose } = timeoutSignal(FS_OP_TIMEOUT_MS, this._pollAbortController.signal);
-    try {
-      const headContent = await readFile(pathJoin(gitDir, "HEAD"), { encoding: "utf-8", signal });
-      const trimmed = headContent.trim();
-      const prefix = "ref: refs/heads/";
-      if (trimmed.startsWith(prefix)) {
-        this._isDetached = false;
-        this._head = undefined;
-        return trimmed.slice(prefix.length);
-      }
-      // Detached HEAD — the file contains a commit SHA
-      if (/^[0-9a-f]{40}$/.test(trimmed)) {
-        this._isDetached = true;
-        this._head = trimmed;
-      } else {
-        this._isDetached = false;
-        this._head = undefined;
-      }
-      return undefined;
-    } catch {
-      // Includes a timeout/abort (AbortError) on a stalled filesystem — treat
-      // as "branch unchanged" rather than letting the read hang the poll.
-      this._isDetached = false;
-      this._head = undefined;
-      return undefined;
-    } finally {
-      dispose();
-    }
-  }
-
-  private async extractIssueNumberAsync(branchName: string, folderName?: string): Promise<void> {
-    try {
-      const issueNum = await extractIssueNumber(branchName, folderName);
-      if (issueNum && this._isRunning && this._branch === branchName) {
-        this._issueNumber = issueNum;
-        if (this._hasInitialStatus) {
-          this.emitUpdate();
-        }
-      }
-    } catch {
-      // Silently ignore extraction errors
-    }
-  }
-
-  private async computeBaseDivergence(hasUpstream: boolean): Promise<BaseDivergence | null> {
-    if (!this._branch || this._isMainWorktree) return null;
-
-    // Pick the branch to diff against. A linked PR's base branch is
-    // authoritative — it's exactly where this worktree's work will merge,
-    // which may differ from the repo's integration branch (e.g. a hotfix
-    // PR targeting `main` in a gitflow repo). Without a PR, fall back to
-    // the repository's main/integration branch.
-    const baseBranch = this._linked?.pr?.baseRef?.trim() || this.mainBranch;
-
-    // Divergence only moves when refs move, never on working-tree edits, so
-    // a stat key over the involved refs lets forced passes (watcher-driven
-    // edit storms) reuse the last result without any git spawns.
-    const key = await this.buildBaseDivergenceKey(baseBranch, hasUpstream);
-    if (key !== null && key === this.lastBaseDivergenceKey) {
-      return this.lastBaseDivergenceResult;
-    }
-
-    const wsl = this.wslInvocation;
-    const git = wsl
-      ? await createWslHardenedGit(wsl, this._pollAbortController.signal)
-      : await createHardenedGit(this.path, this._pollAbortController.signal);
-
-    try {
-      // Resolve base ref via the rev-list itself: try origin/<branch> first
-      // (remote ref stays fresh after fetch), fall back to the local branch
-      // for repos without a remote.
-      const remoteRef = `origin/${baseBranch}`;
-      const localRef = baseBranch;
-      const baseBranchName = baseBranch;
-      let resolvedRef = remoteRef;
-      let result: string;
-      try {
-        result = await git.raw(["rev-list", "--count", "--left-right", `${remoteRef}...HEAD`]);
-      } catch {
-        try {
-          result = await git.raw(["rev-list", "--count", "--left-right", `${localRef}...HEAD`]);
-          resolvedRef = localRef;
-        } catch {
-          this.lastBaseDivergenceKey = null;
-          return null;
-        }
-      }
-      const trimmed = result.trim();
-      const parts = trimmed.split("\t");
-      const behindCount = parts[0] != null && parts[0] !== "" ? parseInt(parts[0], 10) : 0;
-      const aheadCount = parts[1] != null && parts[1] !== "" ? parseInt(parts[1], 10) : 0;
-
-      let matchesUpstream = false;
-      if (hasUpstream) {
-        try {
-          // One invocation resolves both revs — rev-parse prints one OID per
-          // line, and either failing exits non-zero (caught below), matching
-          // the previous two-call error semantics.
-          const out = await git.raw(["rev-parse", "@{u}", resolvedRef]);
-          const [upstreamCommit, baseCommit] = out.trim().split("\n");
-          matchesUpstream = baseCommit !== undefined && upstreamCommit.trim() === baseCommit.trim();
-        } catch {
-          matchesUpstream = false;
-        }
-      }
-
-      const divergence: BaseDivergence = {
-        baseBranchName,
-        aheadCount: Number.isFinite(aheadCount) ? aheadCount : null,
-        behindCount: Number.isFinite(behindCount) ? behindCount : null,
-        matchesUpstream,
-      };
-      this.lastBaseDivergenceKey = key;
-      this.lastBaseDivergenceResult = divergence;
-      return divergence;
-    } catch {
-      this.lastBaseDivergenceKey = null;
-      return null;
-    }
-  }
-
-  /**
-   * Stat-derived cache key for `computeBaseDivergence`. Covers every ref the
-   * computation reads: HEAD, this branch's local ref, the base branch's local
-   * and remote refs, the upstream remote ref (the `@{u}` proxy for
-   * `matchesUpstream`), and packed-refs. The remote-ref stats are essential —
-   * `git fetch` writes loose refs under refs/remotes/ without touching
-   * packed-refs, so the stat-baseline fields alone would serve stale
-   * behind-of-base counts after background fetches. Returns `null` (compute,
-   * don't cache) on any stat failure beyond ENOENT.
-   */
-  private async buildBaseDivergenceKey(
-    baseBranch: string,
-    hasUpstream: boolean
-  ): Promise<string | null> {
-    const branch = this._branch;
-    if (!branch) return null;
-    const gitDir = await getGitDir(this.path, { cache: true, logErrors: false });
-    if (!gitDir) return null;
-    try {
-      const commonDir = await this.resolveCommonDirAsync(gitDir);
-      const stats = await Promise.all([
-        this.statMtime(pathJoin(gitDir, "HEAD")),
-        this.statMtime(pathJoin(commonDir, "refs", "heads", branch)),
-        this.statMtime(pathJoin(commonDir, "packed-refs")),
-        this.statMtime(pathJoin(commonDir, "refs", "heads", baseBranch)),
-        this.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", baseBranch)),
-        this.statMtime(pathJoin(commonDir, "refs", "remotes", "origin", branch)),
-      ]);
-      return [branch, baseBranch, hasUpstream, ...stats].join(" ");
-    } catch {
-      return null;
-    }
-  }
-
-  // 32-bit FNV-1a digest instead of the raw joined string: the previous
-  // implementation retained a path+stats concatenation proportional to the
-  // worktree's change count for the monitor's lifetime. A hash collision
-  // (~1 in 2^32 per state pair) suppresses the change event until the next
-  // non-colliding state or a forced refresh.
-  private calculateStateHash(changes: WorktreeChanges): number {
-    const hashInput = changes.changes
-      .map((c) => `${c.path}:${c.status}:${c.insertions ?? 0}:${c.deletions ?? 0}`)
-      .sort()
-      .join("|");
-    let hash = FNV_OFFSET_BASIS;
-    for (let i = 0; i < hashInput.length; i++) {
-      hash = Math.imul(hash ^ hashInput.charCodeAt(i), 0x01000193) >>> 0;
-    }
-    return hash >>> 0;
-  }
-
-  private async fetchLastCommitMessage(changes: WorktreeChanges): Promise<string> {
-    if (changes.lastCommitMessage) {
-      const firstLine = changes.lastCommitMessage.split("\n")[0].trim();
-      return `✅ ${firstLine}`;
-    }
-
-    try {
-      const wsl = this.wslInvocation;
-      const git = wsl
-        ? await createWslHardenedGit(wsl, this._pollAbortController.signal)
-        : await createHardenedGit(this.path, this._pollAbortController.signal);
-      const log = await git.log({ maxCount: 1 });
-      const lastCommitMsg = log.latest?.message;
-
-      if (lastCommitMsg) {
-        const firstLine = lastCommitMsg.split("\n")[0].trim();
-        return `✅ ${firstLine}`;
-      }
-      return "🌱 Ready to get started";
-    } catch {
-      return "🌱 Ready to get started";
-    }
+    return this.gitStatusPass.run(forceRefresh);
   }
 
   emitUpdate(): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -588,6 +588,12 @@ export class WorktreeMonitor {
       get abortSignal() {
         return monitor._pollAbortController.signal;
       },
+      get branch() {
+        return monitor._branch;
+      },
+      get lastWatcherEventAt() {
+        return monitor.lastWatcherEventAt;
+      },
     };
     this.statPrecheck = new StatPrecheck(statPrecheckHost);
 
@@ -643,9 +649,6 @@ export class WorktreeMonitor {
       },
       get abortSignal() {
         return monitor._pollAbortController.signal;
-      },
-      get lastWatcherEventAt() {
-        return monitor.lastWatcherEventAt;
       },
       get prevEmittedIsDetached() {
         return monitor._prevEmittedIsDetached;

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -252,11 +252,14 @@ export class WorktreeMonitor {
   private readonly gitStatusPass: GitStatusPass;
 
   // Test-only backdoors preserving pre-split field access onto the stat
-  // baseline cache StatPrecheck now owns for real callers.
-  private get lastStatBaselineAt(): number {
+  // baseline cache StatPrecheck now owns for real callers. Not private: the
+  // only caller is a type-erased `(monitor as unknown as {...})` cast in
+  // WorktreeMonitor.test.ts, which tsc's unused-private-member check can't
+  // see — declaring these public keeps that check from flagging them dead.
+  get lastStatBaselineAt(): number {
     return this.statPrecheck.baselineCapturedAt;
   }
-  private set lastFullStatusAt(value: number) {
+  set lastFullStatusAt(value: number) {
     this.statPrecheck.fullStatusCapturedAt = value;
   }
 

--- a/electron/workspace-host/__tests__/BaseDivergence.test.ts
+++ b/electron/workspace-host/__tests__/BaseDivergence.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGitRaw = vi.fn();
+const { mockCreateHardenedGit, mockCreateWslHardenedGit } = vi.hoisted(() => ({
+  mockCreateHardenedGit: vi.fn(),
+  mockCreateWslHardenedGit: vi.fn(),
+}));
+
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: mockCreateHardenedGit,
+  createWslHardenedGit: mockCreateWslHardenedGit,
+}));
+
+const mockGetGitDir = vi.fn();
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: (...args: unknown[]) => mockGetGitDir(...args),
+}));
+
+import { BaseDivergence, type BaseDivergenceHost } from "../BaseDivergence.js";
+import type { StatPrecheck } from "../StatPrecheck.js";
+
+function makeHost(overrides: Partial<BaseDivergenceHost> = {}): BaseDivergenceHost {
+  return {
+    branch: "feature/x",
+    isMainWorktree: false,
+    mainBranch: "main",
+    linkedPrBaseRef: undefined,
+    path: "/test/worktree",
+    wslInvocation: undefined,
+    abortSignal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+function makeStatPrecheck(): StatPrecheck {
+  return {
+    resolveCommonDirAsync: vi.fn().mockResolvedValue("/test/worktree/.git"),
+    statMtime: vi.fn().mockResolvedValue(1_000),
+  } as unknown as StatPrecheck;
+}
+
+describe("BaseDivergence", () => {
+  beforeEach(() => {
+    mockGitRaw.mockReset();
+    mockCreateHardenedGit.mockReset().mockImplementation(() => ({
+      raw: (...args: unknown[]) => mockGitRaw(...args),
+    }));
+    mockCreateWslHardenedGit.mockReset().mockImplementation(() => ({
+      raw: (...args: unknown[]) => mockGitRaw(...args),
+    }));
+    mockGetGitDir.mockReset().mockResolvedValue("/test/worktree/.git");
+  });
+
+  it("returns null for the main worktree", async () => {
+    const divergence = new BaseDivergence(makeHost({ isMainWorktree: true }), makeStatPrecheck());
+    expect(await divergence.compute(false)).toBeNull();
+  });
+
+  it("returns null when there is no branch", async () => {
+    const divergence = new BaseDivergence(makeHost({ branch: undefined }), makeStatPrecheck());
+    expect(await divergence.compute(false)).toBeNull();
+  });
+
+  it("prefers the linked PR's base branch over mainBranch", async () => {
+    mockGitRaw.mockResolvedValueOnce("2\t3\n");
+    const divergence = new BaseDivergence(
+      makeHost({ linkedPrBaseRef: " release " }),
+      makeStatPrecheck()
+    );
+
+    const result = await divergence.compute(false);
+
+    expect(result?.baseBranchName).toBe("release");
+    expect(mockGitRaw).toHaveBeenCalledWith([
+      "rev-list",
+      "--count",
+      "--left-right",
+      "origin/release...HEAD",
+    ]);
+  });
+
+  it("falls back to mainBranch when there is no linked PR base ref", async () => {
+    mockGitRaw.mockResolvedValueOnce("0\t0\n");
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+    const result = await divergence.compute(false);
+
+    expect(result?.baseBranchName).toBe("main");
+  });
+
+  it("parses ahead/behind counts from the rev-list output", async () => {
+    mockGitRaw.mockResolvedValueOnce("4\t7\n");
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+    const result = await divergence.compute(false);
+
+    expect(result?.behindCount).toBe(4);
+    expect(result?.aheadCount).toBe(7);
+  });
+
+  it("falls back to the local base ref when the remote ref rev-list fails", async () => {
+    mockGitRaw.mockRejectedValueOnce(new Error("unknown revision: origin/main")).mockResolvedValueOnce(
+      "1\t2\n"
+    );
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+    const result = await divergence.compute(false);
+
+    expect(result?.behindCount).toBe(1);
+    expect(mockGitRaw).toHaveBeenNthCalledWith(2, [
+      "rev-list",
+      "--count",
+      "--left-right",
+      "main...HEAD",
+    ]);
+  });
+
+  it("returns null when both the remote and local rev-list fail", async () => {
+    mockGitRaw.mockRejectedValue(new Error("no such ref"));
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+    expect(await divergence.compute(false)).toBeNull();
+  });
+
+  it("sets matchesUpstream true only when @{u} and the base ref resolve to the same commit", async () => {
+    mockGitRaw
+      .mockResolvedValueOnce("0\t0\n")
+      .mockResolvedValueOnce("abc123\nabc123\n");
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+    const result = await divergence.compute(true);
+
+    expect(result?.matchesUpstream).toBe(true);
+  });
+
+  it("sets matchesUpstream false when @{u} and the base ref diverge", async () => {
+    mockGitRaw
+      .mockResolvedValueOnce("0\t0\n")
+      .mockResolvedValueOnce("abc123\ndef456\n");
+    const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
+
+    const result = await divergence.compute(true);
+
+    expect(result?.matchesUpstream).toBe(false);
+  });
+
+  it("reuses the cached result when the stat-derived key is unchanged", async () => {
+    mockGitRaw.mockResolvedValueOnce("0\t0\n");
+    const statPrecheck = makeStatPrecheck();
+    const divergence = new BaseDivergence(makeHost(), statPrecheck);
+
+    await divergence.compute(false);
+    await divergence.compute(false);
+
+    // Only the first compute() should have spawned a git process; the second
+    // reused the cached result via the unchanged stat key.
+    expect(mockGitRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("recomputes when a ref's stat mtime changes", async () => {
+    mockGitRaw.mockResolvedValueOnce("0\t0\n").mockResolvedValueOnce("1\t1\n");
+    const statPrecheck = makeStatPrecheck();
+    const divergence = new BaseDivergence(makeHost(), statPrecheck);
+
+    await divergence.compute(false);
+    vi.mocked(statPrecheck.statMtime).mockResolvedValue(2_000);
+    const second = await divergence.compute(false);
+
+    expect(mockGitRaw).toHaveBeenCalledTimes(2);
+    expect(second?.behindCount).toBe(1);
+  });
+});

--- a/electron/workspace-host/__tests__/BaseDivergence.test.ts
+++ b/electron/workspace-host/__tests__/BaseDivergence.test.ts
@@ -99,9 +99,9 @@ describe("BaseDivergence", () => {
   });
 
   it("falls back to the local base ref when the remote ref rev-list fails", async () => {
-    mockGitRaw.mockRejectedValueOnce(new Error("unknown revision: origin/main")).mockResolvedValueOnce(
-      "1\t2\n"
-    );
+    mockGitRaw
+      .mockRejectedValueOnce(new Error("unknown revision: origin/main"))
+      .mockResolvedValueOnce("1\t2\n");
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
     const result = await divergence.compute(false);
@@ -123,9 +123,7 @@ describe("BaseDivergence", () => {
   });
 
   it("sets matchesUpstream true only when @{u} and the base ref resolve to the same commit", async () => {
-    mockGitRaw
-      .mockResolvedValueOnce("0\t0\n")
-      .mockResolvedValueOnce("abc123\nabc123\n");
+    mockGitRaw.mockResolvedValueOnce("0\t0\n").mockResolvedValueOnce("abc123\nabc123\n");
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
     const result = await divergence.compute(true);
@@ -134,9 +132,7 @@ describe("BaseDivergence", () => {
   });
 
   it("sets matchesUpstream false when @{u} and the base ref diverge", async () => {
-    mockGitRaw
-      .mockResolvedValueOnce("0\t0\n")
-      .mockResolvedValueOnce("abc123\ndef456\n");
+    mockGitRaw.mockResolvedValueOnce("0\t0\n").mockResolvedValueOnce("abc123\ndef456\n");
     const divergence = new BaseDivergence(makeHost(), makeStatPrecheck());
 
     const result = await divergence.compute(true);

--- a/electron/workspace-host/__tests__/GitStatusPass.test.ts
+++ b/electron/workspace-host/__tests__/GitStatusPass.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetWorktreeChangesWithStats = vi.fn();
+const mockInvalidateGitStatusCache = vi.fn();
+const mockGetGitDir = vi.fn();
+const mockGetRepoOperationStateSync = vi.fn().mockReturnValue(undefined);
+
+vi.mock("../../utils/git.js", () => ({
+  getWorktreeChangesWithStats: (...args: unknown[]) => mockGetWorktreeChangesWithStats(...args),
+  invalidateGitStatusCache: (...args: unknown[]) => mockInvalidateGitStatusCache(...args),
+}));
+
+vi.mock("../../utils/gitUtils.js", () => ({
+  getGitDir: (...args: unknown[]) => mockGetGitDir(...args),
+}));
+
+vi.mock("../../utils/gitRepoOperationState.js", () => ({
+  getRepoOperationStateSync: (...args: unknown[]) => mockGetRepoOperationStateSync(...args),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  access: vi.fn().mockRejectedValue(new Error("ENOENT")),
+}));
+
+const { mockCreateHardenedGit, mockCreateWslHardenedGit } = vi.hoisted(() => ({
+  mockCreateHardenedGit: vi.fn(),
+  mockCreateWslHardenedGit: vi.fn(),
+}));
+mockCreateHardenedGit.mockImplementation(() => ({
+  raw: vi.fn(),
+  log: vi.fn().mockResolvedValue({ latest: null }),
+}));
+mockCreateWslHardenedGit.mockImplementation(() => ({
+  raw: vi.fn(),
+  log: vi.fn().mockResolvedValue({ latest: null }),
+}));
+vi.mock("../../utils/hardenedGit.js", () => ({
+  createHardenedGit: mockCreateHardenedGit,
+  createWslHardenedGit: mockCreateWslHardenedGit,
+}));
+
+vi.mock("../../services/worktree/mood.js", () => ({
+  categorizeWorktree: vi.fn().mockResolvedValue("stable"),
+}));
+
+vi.mock("../../services/issueExtractor.js", () => ({
+  extractIssueNumberSync: vi.fn().mockReturnValue(null),
+  extractIssueNumber: vi.fn().mockResolvedValue(null),
+  deriveIssueTitleFromBranch: vi.fn().mockReturnValue(undefined),
+}));
+
+import { GitStatusPass, type GitStatusPassHost } from "../GitStatusPass.js";
+import { StatPrecheck } from "../StatPrecheck.js";
+import { BaseDivergence } from "../BaseDivergence.js";
+import type { WatcherController } from "../WatcherController.js";
+import type { AdaptivePollingStrategy } from "../../services/worktree/index.js";
+import type { NoteFileReader } from "../../services/worktree/index.js";
+
+function makeHost(overrides: Partial<GitStatusPassHost> = {}): GitStatusPassHost {
+  const state = {
+    hasInitialStatus: false,
+    repoState: undefined as import("../../../shared/types/git.js").RepoState | undefined,
+    lastGitStatusCompletedAt: 0,
+    isUpdating: false,
+    branch: "feature/x" as string | undefined,
+    issueNumber: undefined as number | undefined,
+    branchDerivedTitle: undefined as string | undefined,
+    issueTitle: undefined as string | undefined,
+    isDetached: false,
+    head: undefined as string | undefined,
+    mood: "stable" as import("../../../shared/types/worktree.js").WorktreeMood,
+    summary: undefined as string | undefined,
+    worktreeChanges: null as import("../../../shared/types/git.js").WorktreeChanges | null,
+  };
+  return {
+    id: "/test/worktree",
+    path: "/test/worktree",
+    name: "worktree",
+    mainBranch: "main",
+    isCurrent: false,
+    isRunning: true,
+    basePollingInterval: 5_000,
+    wslInvocation: undefined,
+    abortSignal: new AbortController().signal,
+    lastWatcherEventAt: 0,
+    prevEmittedIsDetached: false,
+    prevEmittedHead: undefined,
+    prevEmittedRepoState: undefined,
+    get hasInitialStatus() {
+      return state.hasInitialStatus;
+    },
+    set hasInitialStatus(v) {
+      state.hasInitialStatus = v;
+    },
+    get repoState() {
+      return state.repoState;
+    },
+    set repoState(v) {
+      state.repoState = v;
+    },
+    get lastGitStatusCompletedAt() {
+      return state.lastGitStatusCompletedAt;
+    },
+    set lastGitStatusCompletedAt(v) {
+      state.lastGitStatusCompletedAt = v;
+    },
+    get isUpdating() {
+      return state.isUpdating;
+    },
+    set isUpdating(v) {
+      state.isUpdating = v;
+    },
+    get branch() {
+      return state.branch;
+    },
+    set branch(v) {
+      state.branch = v;
+    },
+    get issueNumber() {
+      return state.issueNumber;
+    },
+    set issueNumber(v) {
+      state.issueNumber = v;
+    },
+    get branchDerivedTitle() {
+      return state.branchDerivedTitle;
+    },
+    set branchDerivedTitle(v) {
+      state.branchDerivedTitle = v;
+    },
+    get issueTitle() {
+      return state.issueTitle;
+    },
+    set issueTitle(v) {
+      state.issueTitle = v;
+    },
+    get isDetached() {
+      return state.isDetached;
+    },
+    set isDetached(v) {
+      state.isDetached = v;
+    },
+    get head() {
+      return state.head;
+    },
+    set head(v) {
+      state.head = v;
+    },
+    get mood() {
+      return state.mood;
+    },
+    set mood(v) {
+      state.mood = v;
+    },
+    get summary() {
+      return state.summary;
+    },
+    set summary(v) {
+      state.summary = v;
+    },
+    get worktreeChanges() {
+      return state.worktreeChanges;
+    },
+    set worktreeChanges(v) {
+      state.worktreeChanges = v;
+    },
+    clearPRInfo: vi.fn(),
+    onBranchChanged: vi.fn(),
+    onRemoved: vi.fn(),
+    stop: vi.fn(),
+    emitUpdate: vi.fn(),
+    ...overrides,
+  };
+}
+
+function makeWatcherController(): WatcherController {
+  return {
+    currentMode: "polling",
+    takePending: vi.fn().mockReturnValue(false),
+    update: vi.fn(),
+    markPending: vi.fn(),
+    flushPendingIfReady: vi.fn(),
+    scheduleDelayedFlush: vi.fn(),
+  } as unknown as WatcherController;
+}
+
+function makePollingStrategy(): AdaptivePollingStrategy {
+  return {
+    recordNoChange: vi.fn(),
+    recordStateChange: vi.fn(),
+  } as unknown as AdaptivePollingStrategy;
+}
+
+function makeNoteReader(): NoteFileReader {
+  return { read: vi.fn().mockResolvedValue({}) } as unknown as NoteFileReader;
+}
+
+function makePass(hostOverrides: Partial<GitStatusPassHost> = {}) {
+  const host = makeHost(hostOverrides);
+  const statPrecheck = new StatPrecheck({ abortSignal: host.abortSignal });
+  const baseDivergence = new BaseDivergence(
+    {
+      branch: host.branch,
+      isMainWorktree: false,
+      mainBranch: host.mainBranch,
+      linkedPrBaseRef: undefined,
+      path: host.path,
+      wslInvocation: host.wslInvocation,
+      abortSignal: host.abortSignal,
+    },
+    statPrecheck
+  );
+  const watcherController = makeWatcherController();
+  const pollingStrategy = makePollingStrategy();
+  const noteReader = makeNoteReader();
+  const pass = new GitStatusPass(
+    host,
+    statPrecheck,
+    baseDivergence,
+    watcherController,
+    pollingStrategy,
+    noteReader
+  );
+  return { pass, host, statPrecheck, watcherController };
+}
+
+describe("GitStatusPass", () => {
+  beforeEach(() => {
+    mockGetWorktreeChangesWithStats.mockReset();
+    mockInvalidateGitStatusCache.mockReset();
+    mockGetGitDir.mockReset().mockResolvedValue(null);
+    mockGetRepoOperationStateSync.mockReset().mockReturnValue(undefined);
+  });
+
+  it("calculateStateHash is a deterministic, order-insensitive numeric digest sensitive to content", () => {
+    const { pass } = makePass();
+    const hashOf = (changes: unknown[]) =>
+      (pass as unknown as { calculateStateHash: (c: unknown) => number }).calculateStateHash({
+        changes,
+      });
+
+    const a = { path: "/w/a.ts", status: "modified", insertions: 1, deletions: 2 };
+    const b = { path: "/w/b.ts", status: "untracked", insertions: 5, deletions: 0 };
+
+    const hash = hashOf([a, b]);
+    expect(typeof hash).toBe("number");
+    expect(hashOf([a, b])).toBe(hash);
+    expect(hashOf([b, a])).toBe(hash);
+    expect(hashOf([a])).not.toBe(hash);
+    expect(hashOf([a, { ...b, insertions: 6 }])).not.toBe(hash);
+  });
+
+  it("is a no-op single-flight guard while a pass is already in flight", async () => {
+    const { pass, host } = makePass({ isUpdating: true });
+    await pass.run(false);
+    expect(mockGetGitDir).not.toHaveBeenCalled();
+    expect(host.isUpdating).toBe(true);
+  });
+
+  it("skips the full check and emits when a blocking git operation sentinel is present", async () => {
+    mockGetGitDir.mockResolvedValue("/test/worktree/.git");
+    mockGetRepoOperationStateSync.mockReturnValue("merge");
+    const { pass, host } = makePass({ hasInitialStatus: true });
+
+    await pass.run(false);
+
+    expect(host.emitUpdate).toHaveBeenCalled();
+    expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
+    expect(host.isUpdating).toBe(false);
+  });
+
+  it("runs a full check when there is no gitDir sentinel and no stat baseline yet", async () => {
+    mockGetGitDir.mockResolvedValue(null);
+    mockGetWorktreeChangesWithStats.mockResolvedValue({
+      changes: [],
+      changedFileCount: 0,
+      tracking: null,
+    });
+    const { pass, host } = makePass();
+
+    await pass.run(false);
+
+    expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+    expect(host.isUpdating).toBe(false);
+  });
+});

--- a/electron/workspace-host/__tests__/GitStatusPass.test.ts
+++ b/electron/workspace-host/__tests__/GitStatusPass.test.ts
@@ -176,7 +176,7 @@ function makeHost(overrides: Partial<GitStatusPassHost> = {}): GitStatusPassHost
 
 function makeWatcherController(): WatcherController {
   return {
-    currentMode: "polling",
+    currentMode: "none",
     takePending: vi.fn().mockReturnValue(false),
     update: vi.fn(),
     markPending: vi.fn(),
@@ -198,7 +198,13 @@ function makeNoteReader(): NoteFileReader {
 
 function makePass(hostOverrides: Partial<GitStatusPassHost> = {}) {
   const host = makeHost(hostOverrides);
-  const statPrecheck = new StatPrecheck({ abortSignal: host.abortSignal });
+  const statPrecheck = new StatPrecheck({
+    abortSignal: host.abortSignal,
+    get branch() {
+      return host.branch;
+    },
+    lastWatcherEventAt: 0,
+  });
   const baseDivergence = new BaseDivergence(
     {
       branch: host.branch,
@@ -270,7 +276,7 @@ describe("GitStatusPass", () => {
     expect(host.isUpdating).toBe(false);
   });
 
-  it("runs a full check when there is no gitDir sentinel and no stat baseline yet", async () => {
+  it("runs a full check when getGitDir resolves no git directory", async () => {
     mockGetGitDir.mockResolvedValue(null);
     mockGetWorktreeChangesWithStats.mockResolvedValue({
       changes: [],
@@ -278,6 +284,21 @@ describe("GitStatusPass", () => {
       tracking: null,
     });
     const { pass, host } = makePass();
+
+    await pass.run(false);
+
+    expect(mockGetWorktreeChangesWithStats).toHaveBeenCalledTimes(1);
+    expect(host.isUpdating).toBe(false);
+  });
+
+  it("runs a full check on the first poll even with a real gitDir, since no stat baseline exists yet", async () => {
+    mockGetGitDir.mockResolvedValue("/test/worktree/.git");
+    mockGetWorktreeChangesWithStats.mockResolvedValue({
+      changes: [],
+      changedFileCount: 0,
+      tracking: null,
+    });
+    const { pass, host } = makePass({ hasInitialStatus: true });
 
     await pass.run(false);
 

--- a/electron/workspace-host/__tests__/GitStatusPass.test.ts
+++ b/electron/workspace-host/__tests__/GitStatusPass.test.ts
@@ -83,7 +83,6 @@ function makeHost(overrides: Partial<GitStatusPassHost> = {}): GitStatusPassHost
     basePollingInterval: 5_000,
     wslInvocation: undefined,
     abortSignal: new AbortController().signal,
-    lastWatcherEventAt: 0,
     prevEmittedIsDetached: false,
     prevEmittedHead: undefined,
     prevEmittedRepoState: undefined,

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -11,8 +11,8 @@ function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilder
     isMainWorktree: false,
     gitDir: undefined,
     summary: undefined,
-    modifiedCount: undefined,
-    mood: undefined,
+    modifiedCount: 0,
+    mood: "stable",
     lastActivityTimestamp: null,
     createdAt: undefined,
     aiNote: undefined,
@@ -179,11 +179,19 @@ describe("SnapshotBuilder", () => {
     expect(snapshot.wslGitEligible).toBe("eligible");
   });
 
-  it("reads isFetchInFlight live from the host at build time", () => {
-    const host = makeHost({ isFetchInFlight: true });
-    const snapshot = new SnapshotBuilder(host).build();
+  it("reads isFetchInFlight live from the host at build time, not cached at construction", () => {
+    // Object spread (used by makeHost's `{...overrides}` merge) evaluates
+    // getters eagerly, so a live getter can't be passed as an override —
+    // attach it directly to the already-built host instead.
+    let isFetchInFlight = false;
+    const host = makeHost();
+    Object.defineProperty(host, "isFetchInFlight", { get: () => isFetchInFlight });
+    const builder = new SnapshotBuilder(host);
 
-    expect(snapshot.isFetchInFlight).toBe(true);
+    expect(builder.build().isFetchInFlight).toBeUndefined();
+
+    isFetchInFlight = true;
+    expect(builder.build().isFetchInFlight).toBe(true);
   });
 
   it("suppresses worktreeMode when local and surfaces it otherwise", () => {

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -190,8 +190,8 @@ describe("SnapshotBuilder", () => {
     expect(new SnapshotBuilder(makeHost({ worktreeMode: "local" })).build().worktreeMode).toBe(
       undefined
     );
-    expect(
-      new SnapshotBuilder(makeHost({ worktreeMode: "remote" })).build().worktreeMode
-    ).toBe("remote");
+    expect(new SnapshotBuilder(makeHost({ worktreeMode: "remote" })).build().worktreeMode).toBe(
+      "remote"
+    );
   });
 });

--- a/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
+++ b/electron/workspace-host/__tests__/SnapshotBuilder.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { SnapshotBuilder, type SnapshotBuilderHost } from "../SnapshotBuilder.js";
+
+function makeHost(overrides: Partial<SnapshotBuilderHost> = {}): SnapshotBuilderHost {
+  return {
+    id: "/test/worktree",
+    path: "/test/worktree",
+    name: "worktree",
+    branch: "feature/x",
+    isCurrent: false,
+    isMainWorktree: false,
+    gitDir: undefined,
+    summary: undefined,
+    modifiedCount: undefined,
+    mood: undefined,
+    lastActivityTimestamp: null,
+    createdAt: undefined,
+    aiNote: undefined,
+    aiNoteTimestamp: undefined,
+    issueNumber: undefined,
+    prNumber: undefined,
+    prUrl: undefined,
+    prState: undefined,
+    prCiStatus: undefined,
+    prTitle: undefined,
+    issueTitle: undefined,
+    branchDerivedTitle: undefined,
+    sourcePrNumber: undefined,
+    prLastUpdatedAt: undefined,
+    issueLastUpdatedAt: undefined,
+    worktreeChanges: null,
+    lifecycleStatus: undefined,
+    lifecyclePhaseResults: [],
+    resourceStatus: undefined,
+    resourceConnectCommand: undefined,
+    resourceProvider: undefined,
+    hasResourceConfig: false,
+    hasStatusCommand: false,
+    hasPauseCommand: false,
+    hasResumeCommand: false,
+    hasTeardownCommand: false,
+    hasProvisionCommand: false,
+    worktreeMode: "local",
+    worktreeEnvironmentLabel: undefined,
+    hasPlanFile: false,
+    planFilePath: undefined,
+    aheadCount: undefined,
+    behindCount: undefined,
+    baseBranchName: null,
+    baseAheadCount: null,
+    baseBehindCount: null,
+    baseMatchesUpstream: undefined,
+    lastFetchedAt: null,
+    lastGitStatusCheckedAt: 0,
+    fetchAuthFailed: false,
+    fetchNetworkFailed: false,
+    isFetchInFlight: false,
+    matchedForgeProviderId: null,
+    isWslPath: false,
+    wslDistro: undefined,
+    wslPosixPath: undefined,
+    wslGitEligible: "unprobed",
+    wslGitOptIn: false,
+    wslGitDismissed: false,
+    linked: undefined,
+    repoState: undefined,
+    isDetached: false,
+    head: undefined,
+    ...overrides,
+  };
+}
+
+describe("SnapshotBuilder", () => {
+  it("falls back to legacy flat PR/issue fields when linked is absent", () => {
+    const host = makeHost({ prNumber: 42, prTitle: "Legacy PR", issueNumber: 7 });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.prNumber).toBe(42);
+    expect(snapshot.prTitle).toBe("Legacy PR");
+    expect(snapshot.issueNumber).toBe(7);
+  });
+
+  it("prefers linked PR/issue fields over legacy flat fields when linked is present", () => {
+    const host = makeHost({
+      prNumber: 42,
+      prTitle: "Legacy PR",
+      issueNumber: 7,
+      linked: {
+        pr: {
+          ref: { number: 99 },
+          url: "https://example.com/pr/99",
+          title: "Linked PR",
+          state: "open",
+        },
+        issue: { ref: { number: 13 }, title: "Linked issue" },
+      } as unknown as SnapshotBuilderHost["linked"],
+    });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.prNumber).toBe(99);
+    expect(snapshot.prTitle).toBe("Linked PR");
+    expect(snapshot.prState).toBe("open");
+    expect(snapshot.issueNumber).toBe(13);
+    expect(snapshot.issueTitle).toBe("Linked issue");
+  });
+
+  it("maps a linked PR's declined state to closed", () => {
+    const host = makeHost({
+      linked: {
+        pr: {
+          ref: { number: 99 },
+          url: "https://example.com/pr/99",
+          title: "Linked PR",
+          state: "declined",
+        },
+        issue: undefined,
+      } as unknown as SnapshotBuilderHost["linked"],
+    });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.prState).toBe("closed");
+  });
+
+  it("maps a legacy flat declined prState to closed when linked is absent", () => {
+    const host = makeHost({
+      prState: "declined" as unknown as SnapshotBuilderHost["prState"],
+    });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.prState).toBe("closed");
+  });
+
+  it("merges resource status with the resource provider", () => {
+    const host = makeHost({
+      resourceStatus: { state: "running" } as unknown as SnapshotBuilderHost["resourceStatus"],
+      resourceProvider: "docker",
+    });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.resourceStatus).toEqual({ state: "running", provider: "docker" });
+  });
+
+  it("synthesizes a provider-only resource status when resourceStatus is absent", () => {
+    const host = makeHost({ resourceProvider: "docker" });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.resourceStatus).toEqual({ provider: "docker" });
+  });
+
+  it("omits boolean capability flags when false and includes them when true", () => {
+    const falseHost = makeHost();
+    expect(new SnapshotBuilder(falseHost).build().hasResourceConfig).toBeUndefined();
+
+    const trueHost = makeHost({ hasResourceConfig: true });
+    expect(new SnapshotBuilder(trueHost).build().hasResourceConfig).toBe(true);
+  });
+
+  it("copies lifecyclePhaseResults defensively and omits when empty", () => {
+    const results = [{ phase: "teardown", status: "success" }] as unknown as NonNullable<
+      SnapshotBuilderHost["lifecyclePhaseResults"]
+    >;
+    const host = makeHost({ lifecyclePhaseResults: results });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.lifecyclePhaseResults).toEqual(results);
+    expect(snapshot.lifecyclePhaseResults).not.toBe(results);
+
+    const emptyHost = makeHost({ lifecyclePhaseResults: [] });
+    expect(new SnapshotBuilder(emptyHost).build().lifecyclePhaseResults).toBeUndefined();
+  });
+
+  it("suppresses WSL fields for non-WSL worktrees but surfaces them when isWslPath", () => {
+    const nonWsl = makeHost({ isWslPath: false, wslGitEligible: "eligible" });
+    expect(new SnapshotBuilder(nonWsl).build().wslGitEligible).toBeUndefined();
+
+    const wsl = makeHost({ isWslPath: true, wslGitEligible: "eligible" });
+    const snapshot = new SnapshotBuilder(wsl).build();
+    expect(snapshot.isWslPath).toBe(true);
+    expect(snapshot.wslGitEligible).toBe("eligible");
+  });
+
+  it("reads isFetchInFlight live from the host at build time", () => {
+    const host = makeHost({ isFetchInFlight: true });
+    const snapshot = new SnapshotBuilder(host).build();
+
+    expect(snapshot.isFetchInFlight).toBe(true);
+  });
+
+  it("suppresses worktreeMode when local and surfaces it otherwise", () => {
+    expect(new SnapshotBuilder(makeHost({ worktreeMode: "local" })).build().worktreeMode).toBe(
+      undefined
+    );
+    expect(
+      new SnapshotBuilder(makeHost({ worktreeMode: "remote" })).build().worktreeMode
+    ).toBe("remote");
+  });
+});

--- a/electron/workspace-host/__tests__/StatPrecheck.test.ts
+++ b/electron/workspace-host/__tests__/StatPrecheck.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  stat: vi.fn().mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+}));
+
+import { readFile, stat } from "fs/promises";
+import { StatPrecheck, type StatPrecheckHost } from "../StatPrecheck.js";
+
+function makeHost(overrides: Partial<StatPrecheckHost> = {}): StatPrecheckHost {
+  return {
+    abortSignal: new AbortController().signal,
+    ...overrides,
+  };
+}
+
+function makeStatResult(mtimeMs: number) {
+  return { mtimeMs } as Awaited<ReturnType<typeof stat>>;
+}
+
+describe("StatPrecheck", () => {
+  beforeEach(() => {
+    vi.mocked(readFile).mockReset().mockRejectedValue(new Error("ENOENT"));
+    vi.mocked(stat)
+      .mockReset()
+      .mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+  });
+
+  it("never skips before a baseline has been recorded", async () => {
+    const precheck = new StatPrecheck(makeHost());
+    const skip = await precheck.shouldSkip("/repo/.git", "main", 0, true);
+    expect(skip).toBe(false);
+  });
+
+  it("skips when a recorded baseline still matches and no watcher event fired since", async () => {
+    vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+    const precheck = new StatPrecheck(makeHost());
+
+    await precheck.recordFullPass("/repo/.git", "main");
+    const skip = await precheck.shouldSkip("/repo/.git", "main", 0, true);
+
+    expect(skip).toBe(true);
+  });
+
+  it("falls through when a stat mtime moved since the baseline", async () => {
+    vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+    const precheck = new StatPrecheck(makeHost());
+    await precheck.recordFullPass("/repo/.git", "main");
+
+    vi.mocked(stat).mockResolvedValue(makeStatResult(2_000));
+    const skip = await precheck.shouldSkip("/repo/.git", "main", 0, true);
+
+    expect(skip).toBe(false);
+  });
+
+  it("falls through when a watcher event fired after the baseline was captured", async () => {
+    vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+    const precheck = new StatPrecheck(makeHost());
+    await precheck.recordFullPass("/repo/.git", "main");
+
+    const afterBaseline = precheck.baselineCapturedAt + 1;
+    const skip = await precheck.shouldSkip("/repo/.git", "main", afterBaseline, true);
+
+    expect(skip).toBe(false);
+  });
+
+  it("is not trustworthy outside recursive coverage once the full-status budget expires", async () => {
+    vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+    const precheck = new StatPrecheck(makeHost());
+    await precheck.recordFullPass("/repo/.git", "main");
+
+    // Within budget the skip still applies without recursive coverage.
+    expect(await precheck.shouldSkip("/repo/.git", "main", 0, false)).toBe(true);
+
+    precheck.fullStatusCapturedAt = Date.now() - 120_001;
+    expect(await precheck.shouldSkip("/repo/.git", "main", 0, false)).toBe(false);
+  });
+
+  it("stays trustworthy under recursive coverage even once the full-status budget expires", async () => {
+    vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+    const precheck = new StatPrecheck(makeHost());
+    await precheck.recordFullPass("/repo/.git", "main");
+
+    precheck.fullStatusCapturedAt = Date.now() - 120_001;
+    expect(await precheck.shouldSkip("/repo/.git", "main", 0, true)).toBe(true);
+  });
+
+  it("drops the baseline on request so the next check falls through", async () => {
+    vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
+    const precheck = new StatPrecheck(makeHost());
+    await precheck.recordFullPass("/repo/.git", "main");
+    expect(await precheck.shouldSkip("/repo/.git", "main", 0, true)).toBe(true);
+
+    precheck.dropBaseline();
+    expect(await precheck.shouldSkip("/repo/.git", "main", 0, true)).toBe(false);
+  });
+
+  it("caches a resolved commondir for the instance lifetime", async () => {
+    vi.mocked(readFile).mockResolvedValueOnce("/repo/.git\n" as unknown as string);
+    const precheck = new StatPrecheck(makeHost());
+
+    const first = await precheck.resolveCommonDirAsync("/repo/.git/worktrees/x");
+    const second = await precheck.resolveCommonDirAsync("/repo/.git/worktrees/x");
+
+    expect(first).toBe("/repo/.git");
+    expect(second).toBe("/repo/.git");
+    expect(vi.mocked(readFile)).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to gitDir when the commondir file is missing", async () => {
+    const precheck = new StatPrecheck(makeHost());
+    const result = await precheck.resolveCommonDirAsync("/repo/.git/worktrees/x");
+    expect(result).toBe("/repo/.git/worktrees/x");
+  });
+
+  it("returns the absent sentinel for ENOENT and propagates other stat errors", async () => {
+    vi.mocked(stat).mockResolvedValueOnce(makeStatResult(1_000));
+    const precheck = new StatPrecheck(makeHost());
+    expect(await precheck.statMtime("/repo/.git/index")).toBe(1_000);
+
+    vi.mocked(stat).mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
+    expect(await precheck.statMtime("/repo/.git/packed-refs")).toBe(-1);
+
+    vi.mocked(stat).mockRejectedValueOnce(
+      Object.assign(new Error("EACCES"), { code: "EACCES" })
+    );
+    await expect(precheck.statMtime("/repo/.git/HEAD")).rejects.toThrow("EACCES");
+  });
+});

--- a/electron/workspace-host/__tests__/StatPrecheck.test.ts
+++ b/electron/workspace-host/__tests__/StatPrecheck.test.ts
@@ -8,9 +8,17 @@ vi.mock("fs/promises", () => ({
 import { readFile, stat } from "fs/promises";
 import { StatPrecheck, type StatPrecheckHost } from "../StatPrecheck.js";
 
-function makeHost(overrides: Partial<StatPrecheckHost> = {}): StatPrecheckHost {
+interface MutableHost {
+  abortSignal: AbortSignal;
+  branch: string | undefined;
+  lastWatcherEventAt: number;
+}
+
+function makeHost(overrides: Partial<MutableHost> = {}): MutableHost & StatPrecheckHost {
   return {
     abortSignal: new AbortController().signal,
+    branch: "main",
+    lastWatcherEventAt: 0,
     ...overrides,
   };
 }
@@ -29,7 +37,7 @@ describe("StatPrecheck", () => {
 
   it("never skips before a baseline has been recorded", async () => {
     const precheck = new StatPrecheck(makeHost());
-    const skip = await precheck.shouldSkip("/repo/.git", "main", 0, true);
+    const skip = await precheck.shouldSkip("/repo/.git", true);
     expect(skip).toBe(false);
   });
 
@@ -37,8 +45,8 @@ describe("StatPrecheck", () => {
     vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
     const precheck = new StatPrecheck(makeHost());
 
-    await precheck.recordFullPass("/repo/.git", "main");
-    const skip = await precheck.shouldSkip("/repo/.git", "main", 0, true);
+    await precheck.recordFullPass("/repo/.git");
+    const skip = await precheck.shouldSkip("/repo/.git", true);
 
     expect(skip).toBe(true);
   });
@@ -46,21 +54,42 @@ describe("StatPrecheck", () => {
   it("falls through when a stat mtime moved since the baseline", async () => {
     vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
     const precheck = new StatPrecheck(makeHost());
-    await precheck.recordFullPass("/repo/.git", "main");
+    await precheck.recordFullPass("/repo/.git");
 
     vi.mocked(stat).mockResolvedValue(makeStatResult(2_000));
-    const skip = await precheck.shouldSkip("/repo/.git", "main", 0, true);
+    const skip = await precheck.shouldSkip("/repo/.git", true);
 
     expect(skip).toBe(false);
   });
 
   it("falls through when a watcher event fired after the baseline was captured", async () => {
     vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
-    const precheck = new StatPrecheck(makeHost());
-    await precheck.recordFullPass("/repo/.git", "main");
+    const host = makeHost();
+    const precheck = new StatPrecheck(host);
+    await precheck.recordFullPass("/repo/.git");
 
-    const afterBaseline = precheck.baselineCapturedAt + 1;
-    const skip = await precheck.shouldSkip("/repo/.git", "main", afterBaseline, true);
+    host.lastWatcherEventAt = precheck.baselineCapturedAt + 1;
+    const skip = await precheck.shouldSkip("/repo/.git", true);
+
+    expect(skip).toBe(false);
+  });
+
+  it("re-reads the host's branch live, not a value snapshotted before the awaits", async () => {
+    // The mtime for refs/heads/<branch> depends on which branch is statted,
+    // so a branch flip changes the resulting baseline unless the host's
+    // current value is read fresh (not captured once up front).
+    vi.mocked(stat).mockImplementation(async (path) => {
+      const p = String(path);
+      if (p.includes("refs/heads/main")) return makeStatResult(1_000);
+      if (p.includes("refs/heads/other")) return makeStatResult(2_000);
+      return makeStatResult(500);
+    });
+    const host = makeHost({ branch: "main" });
+    const precheck = new StatPrecheck(host);
+    await precheck.recordFullPass("/repo/.git");
+
+    host.branch = "other";
+    const skip = await precheck.shouldSkip("/repo/.git", true);
 
     expect(skip).toBe(false);
   });
@@ -68,32 +97,32 @@ describe("StatPrecheck", () => {
   it("is not trustworthy outside recursive coverage once the full-status budget expires", async () => {
     vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
     const precheck = new StatPrecheck(makeHost());
-    await precheck.recordFullPass("/repo/.git", "main");
+    await precheck.recordFullPass("/repo/.git");
 
     // Within budget the skip still applies without recursive coverage.
-    expect(await precheck.shouldSkip("/repo/.git", "main", 0, false)).toBe(true);
+    expect(await precheck.shouldSkip("/repo/.git", false)).toBe(true);
 
     precheck.fullStatusCapturedAt = Date.now() - 120_001;
-    expect(await precheck.shouldSkip("/repo/.git", "main", 0, false)).toBe(false);
+    expect(await precheck.shouldSkip("/repo/.git", false)).toBe(false);
   });
 
   it("stays trustworthy under recursive coverage even once the full-status budget expires", async () => {
     vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
     const precheck = new StatPrecheck(makeHost());
-    await precheck.recordFullPass("/repo/.git", "main");
+    await precheck.recordFullPass("/repo/.git");
 
     precheck.fullStatusCapturedAt = Date.now() - 120_001;
-    expect(await precheck.shouldSkip("/repo/.git", "main", 0, true)).toBe(true);
+    expect(await precheck.shouldSkip("/repo/.git", true)).toBe(true);
   });
 
   it("drops the baseline on request so the next check falls through", async () => {
     vi.mocked(stat).mockResolvedValue(makeStatResult(1_000));
     const precheck = new StatPrecheck(makeHost());
-    await precheck.recordFullPass("/repo/.git", "main");
-    expect(await precheck.shouldSkip("/repo/.git", "main", 0, true)).toBe(true);
+    await precheck.recordFullPass("/repo/.git");
+    expect(await precheck.shouldSkip("/repo/.git", true)).toBe(true);
 
     precheck.dropBaseline();
-    expect(await precheck.shouldSkip("/repo/.git", "main", 0, true)).toBe(false);
+    expect(await precheck.shouldSkip("/repo/.git", true)).toBe(false);
   });
 
   it("caches a resolved commondir for the instance lifetime", async () => {

--- a/electron/workspace-host/__tests__/StatPrecheck.test.ts
+++ b/electron/workspace-host/__tests__/StatPrecheck.test.ts
@@ -119,14 +119,10 @@ describe("StatPrecheck", () => {
     const precheck = new StatPrecheck(makeHost());
     expect(await precheck.statMtime("/repo/.git/index")).toBe(1_000);
 
-    vi.mocked(stat).mockRejectedValueOnce(
-      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-    );
+    vi.mocked(stat).mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
     expect(await precheck.statMtime("/repo/.git/packed-refs")).toBe(-1);
 
-    vi.mocked(stat).mockRejectedValueOnce(
-      Object.assign(new Error("EACCES"), { code: "EACCES" })
-    );
+    vi.mocked(stat).mockRejectedValueOnce(Object.assign(new Error("EACCES"), { code: "EACCES" }));
     await expect(precheck.statMtime("/repo/.git/HEAD")).rejects.toThrow("EACCES");
   });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -237,26 +237,6 @@ describe("WorktreeMonitor", () => {
     expect(mockGetWorktreeChangesWithStats).not.toHaveBeenCalled();
   });
 
-  it("calculateStateHash is a deterministic, order-insensitive numeric digest sensitive to content", () => {
-    const monitor = new WorktreeMonitor(TEST_WORKTREE, TEST_CONFIG, makeCallbacks(), "main");
-    const hashOf = (changes: unknown[]) =>
-      monitor["calculateStateHash"]({ changes } as Parameters<
-        (typeof monitor)["calculateStateHash"]
-      >[0]);
-
-    const a = { path: "/w/a.ts", status: "modified", insertions: 1, deletions: 2 };
-    const b = { path: "/w/b.ts", status: "untracked", insertions: 5, deletions: 0 };
-
-    const hash = hashOf([a, b]);
-    expect(typeof hash).toBe("number");
-    expect(hashOf([a, b])).toBe(hash);
-    expect(hashOf([b, a])).toBe(hash);
-    expect(hashOf([a])).not.toBe(hash);
-    expect(hashOf([a, { ...b, insertions: 6 }])).not.toBe(hash);
-
-    monitor.stop();
-  });
-
   it("calls onUpdate on successful git status", async () => {
     mockGetWorktreeChangesWithStats.mockResolvedValue({
       worktreeId: "/test/worktree",


### PR DESCRIPTION
## Summary

- Splits `electron/workspace-host/WorktreeMonitor.ts` (2249 lines) into four sibling modules, following the existing host-interface-shim pattern already used by `FetchScheduler.ts`, `ResourcePollTimer.ts`, and `WatcherController.ts` in the same directory.
- `WorktreeMonitor.ts` was a god object with roughly 60 fields spread across six loosely related domains (git status, PRs, issues, worktree state/activity, file operations). This pulls four of those domains out into their own files.
- Public exports and behavior are unchanged, no importer needed changes.

Resolves #11008

## Changes

- **`SnapshotBuilder.ts`**: extracts `getSnapshot()`, the pure assembly of the `WorktreeSnapshot` from live monitor state, including the linked-vs-legacy-flat PR/issue field derivation.
- **`StatPrecheck.ts`**: extracts the stat-based baseline/commondir resolution and the decision of whether a full git-status pass can be skipped (previously `resolveCommonDirAsync()`, `buildStatBaseline()`, `statMtime()`, `statBaselineMatches()` plus inline stat-skip logic).
- **`BaseDivergence.ts`**: extracts ahead/behind base-branch divergence computation, its stat-derived cache key builder, and the result cache.
- **`GitStatusPass.ts`**: extracts the ~368-line `updateGitStatus()` poll pass itself. It owns its own output state (`modifiedCount`, `note`, plan file, upstream/base divergence fields, activity timestamp) while reading/writing broader monitor state (`mood`, `summary`, `branch`) via a host interface.
- `WorktreeMonitor.ts` shrinks from 2249 to ~1790 lines.
- Added two small compatibility accessors to `WorktreeMonitor.ts` to preserve direct private-field access that a few existing tests rely on.

## Testing

- Added unit test files for each new module (`SnapshotBuilder.test.ts`, `StatPrecheck.test.ts`, `BaseDivergence.test.ts`, `GitStatusPass.test.ts`), mirroring the existing sibling test convention.
- The existing `WorktreeMonitor.test.ts` (3427 lines) stays green, with one test relocated: a pure `calculateStateHash` unit test now lives in `GitStatusPass.test.ts` since that method moved.
- Two review rounds with Codex (a parallel pass plus a confirmation pass) caught and fixed a genuine behavioral drift bug, where `branch` and `lastWatcherEventAt` were being read too early relative to async gaps in the extracted stat-precheck logic, unlike the original which read them live. Also fixed several cleanliness issues: dead exports, type tightening, test-quality nits.
- All 166 targeted tests plus eslint and prettier are green across 4 commits.